### PR TITLE
Plan enhancement loop: probe + enhance + section decompose + validate

### DIFF
--- a/modal_cua_server.py
+++ b/modal_cua_server.py
@@ -597,6 +597,52 @@ def _run_holo3_executor(
         for s in micro_plan_data:
             micro_plan.steps.append(MicroIntent(**s))
 
+        # If objective is available, run site probe to enhance the plan
+        # This runs INSIDE the container where env/browser is available
+        objective_data = task_suite.get("_objective")
+        if objective_data and env:
+            try:
+                from mantis_agent.graph.objective import ObjectiveSpec as _OS
+                from mantis_agent.graph.probe import SiteProber, ProbeResult
+                from mantis_agent.graph.enhancer import PlanEnhancer
+                from mantis_agent.graph import GraphCompiler, PlanValidator
+                from mantis_agent.graph.graph import WorkflowGraph
+                from mantis_agent.verification.playbook import Playbook
+
+                obj = _OS.from_dict(objective_data)
+                if obj.start_url:
+                    print(f"\n  === SITE PROBE (inside container) ===")
+                    prober = SiteProber(env=env)
+                    probe = prober.probe(obj.start_url, obj)
+                    print(f"  Probe: {probe.page_type}, {len(probe.filters_detected)} filters, {probe.estimated_listings_per_page} listings/page")
+
+                    # Re-enhance with probe data
+                    enhancer = PlanEnhancer()
+                    enhancement = enhancer.enhance(obj, probe)
+                    phases, edges = enhancer.build_enhanced_phases(obj, probe, enhancement)
+                    print(f"  Enhanced: {len(phases)} phases, nav={enhancement.get('navigation_url', '')[:60]}")
+
+                    # Recompile
+                    graph = WorkflowGraph(
+                        objective=obj, phases=phases, edges=edges,
+                        playbook=Playbook(domain=obj.domains[0] if obj.domains else "", listings_per_page=probe.estimated_listings_per_page or 25),
+                        domain=obj.domains[0] if obj.domains else "",
+                        objective_hash=obj.objective_hash,
+                    )
+                    compiler = GraphCompiler()
+                    micro_plan = compiler.compile(graph)
+
+                    # Validate
+                    validator = PlanValidator()
+                    issues = validator.validate(micro_plan, objective=obj)
+                    if issues:
+                        micro_plan = validator.enhance(micro_plan, objective=obj)
+
+                    print(f"  Probe-enhanced plan: {len(micro_plan.steps)} steps")
+                    print(micro_plan.summary())
+            except Exception as e:
+                print(f"  Probe enhancement failed (using original plan): {e}")
+
         resume_state = bool(task_suite.get("_resume_state", False))
         state_key = task_suite.get("_state_key", "")
         checkpoint_path = task_suite.get("_checkpoint_path") or f"/data/checkpoints/micro_{session_name}_{run_id}.json"

--- a/plans/boattrader/extract_only_micro_893a034e.json
+++ b/plans/boattrader/extract_only_micro_893a034e.json
@@ -1,0 +1,140 @@
+[
+  {
+    "step": 1,
+    "type": "navigate",
+    "intent": "Navigate to BoatTrader boats search page at https://www.boattrader.com/boats/",
+    "budget": 3,
+    "section": "setup",
+    "required": true
+  },
+  {
+    "step": 2,
+    "type": "filter",
+    "intent": "Click Private Seller option in seller type filter",
+    "budget": 8,
+    "grounding": true,
+    "section": "setup",
+    "required": true,
+    "reverse": "Click Private Seller in seller type filter"
+  },
+  {
+    "step": 3,
+    "type": "filter",
+    "intent": "Enter zip code 33101 in location field",
+    "budget": 8,
+    "grounding": true,
+    "section": "setup",
+    "required": true,
+    "reverse": "Type 33101 in location search box"
+  },
+  {
+    "step": 4,
+    "type": "filter",
+    "intent": "Set radius to 25 miles in distance filter",
+    "budget": 8,
+    "grounding": true,
+    "section": "setup",
+    "required": true,
+    "reverse": "Select 25 miles from radius dropdown"
+  },
+  {
+    "step": 5,
+    "type": "filter",
+    "intent": "Set minimum price to 35000 in price filter",
+    "budget": 8,
+    "grounding": true,
+    "section": "setup",
+    "required": true,
+    "reverse": "Enter 35000 in minimum price field"
+  },
+  {
+    "step": 6,
+    "type": "filter",
+    "intent": "Select Recently Updated newest first in sort dropdown",
+    "budget": 8,
+    "grounding": true,
+    "section": "setup",
+    "required": true,
+    "reverse": "Click Recently Updated in sort options"
+  },
+  {
+    "step": 7,
+    "type": "extract_data",
+    "intent": "Verify page shows private seller filters applied and reasonable result count under 5000",
+    "budget": 0,
+    "claude_only": true,
+    "section": "setup",
+    "gate": true,
+    "reverse": "Check page heading mentions private/by owner and result count is reasonable"
+  },
+  {
+    "step": 8,
+    "type": "click",
+    "intent": "Click listing title text to open boat detail page",
+    "budget": 8,
+    "grounding": true,
+    "section": "extraction",
+    "reverse": "Click the boat listing title text"
+  },
+  {
+    "step": 9,
+    "type": "extract_url",
+    "intent": "Read current URL from browser address bar",
+    "budget": 0,
+    "claude_only": true,
+    "section": "extraction",
+    "reverse": "Read URL from address bar"
+  },
+  {
+    "step": 10,
+    "type": "scroll",
+    "intent": "Scroll down past photo gallery to description section",
+    "budget": 10,
+    "section": "extraction",
+    "reverse": "Scroll down multiple times past photos"
+  },
+  {
+    "step": 11,
+    "type": "extract_data",
+    "intent": "Extract year, make, model, price, phone, seller name from expanded description and contact areas",
+    "budget": 0,
+    "claude_only": true,
+    "section": "extraction",
+    "reverse": "Read boat details and phone from description section"
+  },
+  {
+    "step": 12,
+    "type": "navigate_back",
+    "intent": "Go back to search results page",
+    "budget": 3,
+    "section": "extraction",
+    "reverse": "Press Alt+Left to go back"
+  },
+  {
+    "step": 13,
+    "type": "loop",
+    "intent": "Process next listing on current page",
+    "loop_target": 8,
+    "loop_count": 200,
+    "section": "extraction",
+    "reverse": "Return to click next listing step"
+  },
+  {
+    "step": 14,
+    "type": "paginate",
+    "intent": "Click Next page button to continue to next results page",
+    "budget": 10,
+    "grounding": true,
+    "section": "pagination",
+    "reverse": "Click Next page navigation button"
+  },
+  {
+    "step": 15,
+    "type": "loop",
+    "intent": "Continue processing listings on next page",
+    "loop_target": 8,
+    "loop_count": 50,
+    "section": "pagination",
+    "reverse": "Return to listing extraction loop"
+  }
+]

--- a/src/mantis_agent/graph/__init__.py
+++ b/src/mantis_agent/graph/__init__.py
@@ -22,6 +22,8 @@ from .store import GraphStore
 from .compiler import GraphCompiler
 from .learner import GraphLearner
 from .plan_validator import PlanValidator
+from .enhancer import PlanEnhancer
+from .section_decomposer import SectionDecomposer, ExecutionSection
 
 __all__ = [
     "CompletionCondition",

--- a/src/mantis_agent/graph/compiler.py
+++ b/src/mantis_agent/graph/compiler.py
@@ -163,17 +163,20 @@ class GraphCompiler:
         step_type = _ROLE_TO_TYPE.get(phase.role, "click")
         section = _ROLE_TO_SECTION.get(phase.role, "extraction")
 
-        # Override type based on intent template content
+        # Override type based on intent template content — but only for
+        # generic roles (SETUP, EXTRACTION). Specific roles like PAGINATION
+        # already have the correct type from the role mapping.
         intent = phase.intent_template
-        if intent.lower().startswith("navigate to"):
-            step_type = "navigate"
-            section = "setup"
-        elif "read the url" in intent.lower() or "address bar" in intent.lower():
-            step_type = "extract_url"
-        elif "scroll" in intent.lower():
-            step_type = "scroll"
-        elif "go back" in intent.lower():
-            step_type = "navigate_back"
+        if phase.role not in (PhaseRole.PAGINATION, PhaseRole.RETURN):
+            if intent.lower().startswith("navigate to"):
+                step_type = "navigate"
+                section = "setup"
+            elif "read the url" in intent.lower() or "address bar" in intent.lower():
+                step_type = "extract_url"
+            elif "scroll" in intent.lower():
+                step_type = "scroll"
+            elif "go back" in intent.lower():
+                step_type = "navigate_back"
 
         return MicroIntent(
             intent=intent,

--- a/src/mantis_agent/graph/enhancer.py
+++ b/src/mantis_agent/graph/enhancer.py
@@ -156,7 +156,9 @@ class PlanEnhancer:
         try:
             data = json.loads(text)
             # Validate and fill defaults
-            data.setdefault("navigation_url", objective.start_url or "")
+            # Try URL-based filter encoding
+            nav_url = data.get("navigation_url") or objective.start_url or ""
+            data["navigation_url"] = self._try_build_filtered_url(nav_url, objective)
             data.setdefault("filter_strategy", [])
             data.setdefault("card_description", "")
             data.setdefault("detail_scrolls", 5)
@@ -174,26 +176,52 @@ class PlanEnhancer:
         """Heuristic enhancement when API is unavailable."""
         url = objective.start_url or ""
 
-        # Try to detect URL-based filter encoding from existing URL patterns
+        # Try to build a filtered URL from the objective text
+        # Many sites encode filters as URL path segments or query params.
+        # Look for clues in the objective text and probe data.
+        url = self._try_build_filtered_url(url, objective)
+
+        # Determine filter strategy per filter
+        # If the URL was enhanced with filter segments, mark those as "url" method
+        url_lower = url.lower()
         filter_strategy = []
         for filt in objective.required_filters:
+            filt_lower = filt.lower()
             method = "unknown"
-            # Check if the filter keyword appears in any detected filter options
-            for detected in probe.filters_detected:
-                options = [o.lower() for o in detected.get("options", [])]
-                if filt.lower() in " ".join(options):
-                    location = detected.get("location", "")
-                    if "sidebar" in location.lower():
-                        method = "sidebar"
-                    elif "dropdown" in location.lower() or "select" in location.lower():
-                        method = "dropdown"
-                    else:
-                        method = "sidebar"
-                    break
+
+            # Check if this filter got encoded into the URL
+            url_encoded = False
+            if "by-owner" in url_lower and filt_lower in ("private seller", "by owner"):
+                url_encoded = True
+            elif "zip-" in url_lower and filt_lower in ("zip", "location", "zip code"):
+                url_encoded = True
+            elif "price-" in url_lower and filt_lower in ("price", "min price", "minimum price"):
+                url_encoded = True
+            elif "city-" in url_lower and filt_lower in ("city", "location"):
+                url_encoded = True
+            elif "state-" in url_lower and filt_lower in ("state", "location"):
+                url_encoded = True
+
+            if url_encoded:
+                method = "url"
+            else:
+                # Check probe-detected filters
+                for detected in probe.filters_detected:
+                    options = [o.lower() for o in detected.get("options", [])]
+                    if filt_lower in " ".join(options):
+                        location = detected.get("location", "")
+                        if "sidebar" in location.lower():
+                            method = "sidebar"
+                        elif "dropdown" in location.lower() or "select" in location.lower():
+                            method = "dropdown"
+                        else:
+                            method = "sidebar"
+                        break
+
             filter_strategy.append({
                 "filter": filt,
                 "method": method,
-                "detail": f"Apply {filt} via {method}",
+                "detail": f"Encoded in URL" if method == "url" else f"Apply {filt} via {method}",
             })
 
         # Pagination detection
@@ -227,6 +255,71 @@ class PlanEnhancer:
             "pagination_method": pag_method,
             "pagination_detail": pag_detail,
         }
+
+    def _try_build_filtered_url(self, base_url: str, objective: ObjectiveSpec) -> str:
+        """Try to build a URL with filters encoded in the path.
+
+        Scans the objective text for filter values (zip codes, price,
+        seller type keywords) and attempts to encode them as URL segments.
+        Returns the enhanced URL, or the original if no pattern detected.
+        """
+        if not base_url:
+            return base_url
+
+        raw = objective.raw_text.lower()
+        url = base_url.rstrip("/")
+        segments: list[str] = []
+
+        # Detect common URL-encodable filter patterns from the objective text
+        # Private seller / by owner
+        if "private seller" in raw or "by owner" in raw or "by-owner" in raw:
+            if "/by-owner" not in url:
+                segments.append("by-owner")
+
+        # Zip code
+        zip_match = re.search(r"(?:zip\s*(?:code)?\s*)(\d{5})", raw)
+        if zip_match:
+            zipcode = zip_match.group(1)
+            if f"zip-{zipcode}" not in url:
+                segments.append(f"zip-{zipcode}")
+
+        # State
+        state_match = re.search(r"\b(florida|california|texas|new york|miami)\b", raw)
+        if state_match:
+            state_name = state_match.group(1)
+            state_map = {
+                "florida": "state-fl", "california": "state-ca",
+                "texas": "state-tx", "new york": "state-ny",
+            }
+            state_seg = state_map.get(state_name, "")
+            if state_seg and state_seg not in url:
+                segments.append(state_seg)
+
+        # City
+        city_match = re.search(r"\b(?:near|in)\s+(\w+)(?:\s+(?:fl|ca|tx|ny))?\b", raw)
+        if city_match:
+            city = city_match.group(1).lower()
+            if city not in ("the", "a", "an", "all") and f"city-{city}" not in url:
+                segments.append(f"city-{city}")
+
+        # Price
+        price_match = re.search(r"\$\s*([\d,]+)", raw)
+        if price_match:
+            price = price_match.group(1).replace(",", "")
+            if f"price-{price}" not in url:
+                segments.append(f"price-{price}")
+
+        if not segments:
+            return base_url
+
+        # Append segments to URL path
+        enhanced = url
+        for seg in segments:
+            enhanced = f"{enhanced}/{seg}"
+        enhanced += "/"
+
+        logger.info("PlanEnhancer: built filtered URL: %s", enhanced)
+        return enhanced
 
     def build_enhanced_phases(
         self,

--- a/src/mantis_agent/graph/enhancer.py
+++ b/src/mantis_agent/graph/enhancer.py
@@ -1,0 +1,413 @@
+"""PlanEnhancer — fill gaps in vague plans using site probe results.
+
+Takes an ObjectiveSpec + ProbeResult and produces concrete, executable
+PhaseNodes. Resolves ambiguity:
+  - "Apply filter: private seller" → detected as URL-based → "Navigate to .../by-owner/"
+  - "Scroll to description" → probe found 3 viewports → "Scroll 3 times past gallery"
+  - "Extract phone" → probe found collapsed sections → "Click 'Show more' then read"
+
+The enhancer uses Claude Sonnet to reason about the best approach given
+what the probe discovered. No brain model needed.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from typing import Any
+
+from .graph import (
+    PhaseEdge,
+    PhaseNode,
+    PhaseRole,
+    Postcondition,
+    Precondition,
+    RepeatMode,
+    WorkflowGraph,
+)
+from .objective import ObjectiveSpec
+from .probe import ProbeResult
+
+logger = logging.getLogger(__name__)
+
+
+ENHANCE_PROMPT = """\
+You are enhancing a CUA (Computer Use Agent) plan with concrete site knowledge.
+
+OBJECTIVE:
+{objective_text}
+
+SITE PROBE RESULTS (what we found on the page):
+{probe_json}
+
+REQUIRED FILTERS: {filters}
+TARGET ENTITY: {entity}
+
+Based on the probe results, determine the BEST approach for each step:
+
+1. FILTER STRATEGY: How should each filter be applied?
+   Options for each filter:
+   - "url": Filter can be encoded in the URL path/params (most reliable)
+   - "sidebar": Filter is a clickable option in a sidebar/panel
+   - "dropdown": Filter is in a select/dropdown control
+   - "search": Filter requires typing in a search box
+   - "unknown": Not detected in probe
+
+2. NAVIGATION URL: What is the best starting URL?
+   If filters can be URL-encoded, build the full filtered URL.
+   If not, use the base results page URL.
+
+3. LISTING CLICK TARGET: How should listing cards be clicked?
+   Describe the card layout based on probe results.
+
+4. DETAIL PAGE ACTIONS: What needs to happen on the detail page?
+   - How many scrolls to reach key content?
+   - Are there expandable sections? Which ones?
+   - Where is contact/phone information?
+
+5. PAGINATION: How does pagination work?
+   - URL-based (/page-N/), query param (?page=N), or button click?
+
+Output ONLY valid JSON:
+{{
+  "navigation_url": "full URL with filters if possible",
+  "filter_strategy": [
+    {{"filter": "filter name", "method": "url|sidebar|dropdown|search", "detail": "how to apply"}}
+  ],
+  "card_description": "how listing cards look on this site",
+  "detail_scrolls": 3,
+  "expandable_sections": ["section names"],
+  "expand_controls": ["Show more", "Read more"],
+  "phone_location": "where phone numbers appear",
+  "pagination_method": "url_path|url_query|button_click",
+  "pagination_detail": "e.g. /page-N/ appended to path"
+}}
+"""
+
+
+class PlanEnhancer:
+    """Fill gaps in vague plans using site probe knowledge."""
+
+    def __init__(self, api_key: str = "", model: str = "claude-sonnet-4-20250514"):
+        self.api_key = api_key or os.environ.get("ANTHROPIC_API_KEY", "")
+        self.model = model
+
+    def enhance(
+        self,
+        objective: ObjectiveSpec,
+        probe: ProbeResult,
+    ) -> dict[str, Any]:
+        """Analyze objective + probe results and return enhancement data.
+
+        Returns a dict with concrete details for plan generation:
+          navigation_url, filter_strategy, card_description,
+          detail_scrolls, expandable_sections, pagination_method, etc.
+        """
+        if not self.api_key:
+            logger.warning("PlanEnhancer: no API key, using heuristic enhancement")
+            return self._enhance_heuristic(objective, probe)
+
+        prompt = ENHANCE_PROMPT.format(
+            objective_text=objective.raw_text[:1500],
+            probe_json=json.dumps(probe.to_dict(), indent=2)[:2000],
+            filters=", ".join(objective.required_filters) or "none specified",
+            entity=objective.target_entity or "listing",
+        )
+
+        try:
+            import requests
+
+            resp = requests.post(
+                "https://api.anthropic.com/v1/messages",
+                headers={
+                    "x-api-key": self.api_key,
+                    "anthropic-version": "2023-06-01",
+                    "content-type": "application/json",
+                },
+                json={
+                    "model": self.model,
+                    "max_tokens": 1024,
+                    "messages": [{"role": "user", "content": prompt}],
+                },
+                timeout=30,
+            )
+            if resp.status_code == 200:
+                text = ""
+                for block in resp.json().get("content", []):
+                    if block.get("type") == "text":
+                        text = block["text"].strip()
+                        break
+                return self._parse_response(text, objective, probe)
+        except Exception as e:
+            logger.warning("PlanEnhancer API call failed: %s", e)
+
+        return self._enhance_heuristic(objective, probe)
+
+    def _parse_response(self, text: str, objective: ObjectiveSpec, probe: ProbeResult) -> dict[str, Any]:
+        """Parse Claude's enhancement response."""
+        text = text.strip()
+        if text.startswith("```"):
+            text = text.split("\n", 1)[1]
+        if text.endswith("```"):
+            text = text.rsplit("```", 1)[0]
+        text = text.strip()
+        try:
+            data = json.loads(text)
+            # Validate and fill defaults
+            data.setdefault("navigation_url", objective.start_url or "")
+            data.setdefault("filter_strategy", [])
+            data.setdefault("card_description", "")
+            data.setdefault("detail_scrolls", 5)
+            data.setdefault("expandable_sections", [])
+            data.setdefault("expand_controls", ["Show more", "Read more"])
+            data.setdefault("phone_location", "")
+            data.setdefault("pagination_method", "button_click")
+            data.setdefault("pagination_detail", "")
+            return data
+        except json.JSONDecodeError:
+            logger.warning("PlanEnhancer: failed to parse response")
+            return self._enhance_heuristic(objective, probe)
+
+    def _enhance_heuristic(self, objective: ObjectiveSpec, probe: ProbeResult) -> dict[str, Any]:
+        """Heuristic enhancement when API is unavailable."""
+        url = objective.start_url or ""
+
+        # Try to detect URL-based filter encoding from existing URL patterns
+        filter_strategy = []
+        for filt in objective.required_filters:
+            method = "unknown"
+            # Check if the filter keyword appears in any detected filter options
+            for detected in probe.filters_detected:
+                options = [o.lower() for o in detected.get("options", [])]
+                if filt.lower() in " ".join(options):
+                    location = detected.get("location", "")
+                    if "sidebar" in location.lower():
+                        method = "sidebar"
+                    elif "dropdown" in location.lower() or "select" in location.lower():
+                        method = "dropdown"
+                    else:
+                        method = "sidebar"
+                    break
+            filter_strategy.append({
+                "filter": filt,
+                "method": method,
+                "detail": f"Apply {filt} via {method}",
+            })
+
+        # Pagination detection
+        pagination = probe.pagination_controls or {}
+        pag_type = pagination.get("type", "next_button")
+        pag_method = "button_click"
+        pag_detail = ""
+        if pag_type == "numbered":
+            # Try to infer from URL
+            if "/page-" in url:
+                pag_method = "url_path"
+                pag_detail = "/page-{n}/"
+            else:
+                pag_method = "url_query"
+                pag_detail = "page={n}"
+
+        # Detail page info
+        detail_info = probe.detail_page_pattern or {}
+        expandable = detail_info.get("expandable_sections", [])
+        expand_controls = detail_info.get("expand_controls", ["Show more", "Read more"])
+        phone_location = detail_info.get("phone_location", "")
+
+        return {
+            "navigation_url": url,
+            "filter_strategy": filter_strategy,
+            "card_description": probe.listing_container.get("description", ""),
+            "detail_scrolls": 5,
+            "expandable_sections": expandable,
+            "expand_controls": expand_controls,
+            "phone_location": phone_location,
+            "pagination_method": pag_method,
+            "pagination_detail": pag_detail,
+        }
+
+    def build_enhanced_phases(
+        self,
+        objective: ObjectiveSpec,
+        probe: ProbeResult,
+        enhancement: dict[str, Any],
+    ) -> tuple[dict[str, PhaseNode], list[PhaseEdge]]:
+        """Build concrete PhaseNodes from enhancement data.
+
+        Returns (phases_dict, edges_list) ready for WorkflowGraph.
+        """
+        nav_url = enhancement.get("navigation_url") or objective.start_url or ""
+        entity = objective.target_entity or "listing"
+        filter_strategy = enhancement.get("filter_strategy", [])
+
+        phases: dict[str, PhaseNode] = {}
+
+        # ── Navigate ──
+        # If filters are URL-encoded, use the filtered URL directly
+        url_filters = [f for f in filter_strategy if f.get("method") == "url"]
+        if url_filters and nav_url:
+            phases["navigate"] = PhaseNode(
+                id="navigate",
+                role=PhaseRole.SETUP,
+                intent_template=f"Navigate to filtered results at {nav_url}",
+                budget=3,
+                required=True,
+                postconditions=[Postcondition(description="Filtered results page loaded")],
+            )
+        else:
+            phases["navigate"] = PhaseNode(
+                id="navigate",
+                role=PhaseRole.SETUP,
+                intent_template=f"Navigate to {nav_url}",
+                budget=3,
+                required=True,
+                postconditions=[Postcondition(description="Page loaded")],
+            )
+
+        # ── Filter steps (only for non-URL filters) ──
+        filter_ids: list[str] = []
+        non_url_filters = [f for f in filter_strategy if f.get("method") != "url"]
+        for i, filt in enumerate(non_url_filters):
+            fid = f"filter_{i}"
+            filter_ids.append(fid)
+            method = filt.get("method", "unknown")
+            detail = filt.get("detail", "")
+            filter_name = filt.get("filter", "")
+
+            if method == "sidebar":
+                intent = f"Click {filter_name} option in the sidebar filter panel"
+            elif method == "dropdown":
+                intent = f"Select {filter_name} from the dropdown menu"
+            elif method == "search":
+                intent = f"Type {filter_name} in the search box and press Enter"
+            else:
+                intent = f"Apply filter: {filter_name}"
+
+            phases[fid] = PhaseNode(
+                id=fid,
+                role=PhaseRole.SETUP,
+                intent_template=intent,
+                budget=8,
+                grounding=True,
+                required=True,
+            )
+
+        # ── Gate ──
+        all_filters = ", ".join(f.get("filter", "") for f in filter_strategy) or "required filters"
+        phases["verify_scope"] = PhaseNode(
+            id="verify_scope",
+            role=PhaseRole.GATE,
+            intent_template=f"Verify page shows {entity} results with {all_filters} applied",
+            claude_only=True,
+            budget=0,
+            gate=True,
+            preconditions=[Precondition(description=f"Filters applied: {all_filters}")],
+            postconditions=[Postcondition(
+                description=f"Page shows filtered {entity} results",
+                verify_prompt=f"Page shows {entity} results with these filters active: {all_filters}. Result count should be reasonable (not unfiltered).",
+            )],
+        )
+
+        # ── Extraction phases ──
+        card_desc = enhancement.get("card_description", "")
+        click_intent = f"Click an organic {entity} title; skip sponsored and dealer cards"
+        if card_desc:
+            click_intent = f"Click the title text of an organic {entity} card ({card_desc}); skip sponsored cards"
+
+        phases["admit_candidate"] = PhaseNode(
+            id="admit_candidate",
+            role=PhaseRole.ADMISSION,
+            intent_template=click_intent,
+            budget=8,
+            grounding=True,
+            repeat=RepeatMode.FOR_EACH,
+            source_phase="discover_candidates",
+        )
+        phases["extract_url"] = PhaseNode(
+            id="extract_url",
+            role=PhaseRole.EXTRACTION,
+            intent_template="Read the URL from browser address bar",
+            claude_only=True,
+            budget=0,
+            repeat=RepeatMode.FOR_EACH,
+            source_phase="discover_candidates",
+        )
+
+        # Scroll with concrete count from probe
+        scroll_count = enhancement.get("detail_scrolls", 5)
+        phases["scroll_to_details"] = PhaseNode(
+            id="scroll_to_details",
+            role=PhaseRole.EXTRACTION,
+            intent_template=f"Scroll down {scroll_count} times toward the description and detail sections",
+            budget=max(scroll_count + 2, 10),
+            repeat=RepeatMode.FOR_EACH,
+            source_phase="discover_candidates",
+        )
+
+        # Extraction with expand info
+        expand_sections = enhancement.get("expandable_sections", [])
+        expand_controls = enhancement.get("expand_controls", [])
+        phone_location = enhancement.get("phone_location", "")
+        extract_detail = "inspect contact area, expand collapsed sections, then extract structured data"
+        if expand_sections:
+            sections_str = ", ".join(expand_sections[:3])
+            extract_detail = f"expand {sections_str} if collapsed, inspect contact area, then extract structured data"
+        if phone_location:
+            extract_detail += f". Phone numbers may be in {phone_location}"
+
+        phases["extract_fields"] = PhaseNode(
+            id="extract_fields",
+            role=PhaseRole.EXTRACTION,
+            intent_template=f"Reject spam, {extract_detail}",
+            claude_only=True,
+            budget=0,
+            repeat=RepeatMode.FOR_EACH,
+            source_phase="discover_candidates",
+        )
+        phases["return_to_results"] = PhaseNode(
+            id="return_to_results",
+            role=PhaseRole.RETURN,
+            intent_template="Go back to search results page",
+            budget=3,
+            repeat=RepeatMode.FOR_EACH,
+            source_phase="discover_candidates",
+        )
+
+        # ── Pagination ──
+        pag_method = enhancement.get("pagination_method", "button_click")
+        if pag_method == "button_click":
+            pag_intent = "Click Next page button to continue to next results page"
+        elif pag_method == "url_path":
+            pag_intent = "Click Next page link or page number to load the next results page"
+        else:
+            pag_intent = "Click the next page control to load more results"
+
+        phases["paginate"] = PhaseNode(
+            id="paginate",
+            role=PhaseRole.PAGINATION,
+            intent_template=pag_intent,
+            budget=10,
+            grounding=True,
+            repeat=RepeatMode.UNTIL_EXHAUSTED,
+        )
+
+        # ── Edges ──
+        edges: list[PhaseEdge] = []
+        prev = "navigate"
+        for fid in filter_ids:
+            edges.append(PhaseEdge(source=prev, target=fid))
+            prev = fid
+        edges.append(PhaseEdge(source=prev, target="verify_scope"))
+        edges.extend([
+            PhaseEdge(source="verify_scope", target="admit_candidate"),
+            PhaseEdge(source="admit_candidate", target="extract_url"),
+            PhaseEdge(source="extract_url", target="scroll_to_details"),
+            PhaseEdge(source="scroll_to_details", target="extract_fields"),
+            PhaseEdge(source="extract_fields", target="return_to_results"),
+            PhaseEdge(source="return_to_results", target="paginate", condition="exhausted"),
+            PhaseEdge(source="paginate", target="admit_candidate"),
+        ])
+
+        return phases, edges

--- a/src/mantis_agent/graph/enhancer.py
+++ b/src/mantis_agent/graph/enhancer.py
@@ -109,8 +109,21 @@ class PlanEnhancer:
             logger.warning("PlanEnhancer: no API key, using heuristic enhancement")
             return self._enhance_heuristic(objective, probe)
 
+        # Try URL-based filter encoding as a hint for Claude
+        candidate_url = self._try_build_filtered_url(
+            objective.start_url or "", objective
+        )
+        url_hint = ""
+        if candidate_url != (objective.start_url or ""):
+            url_hint = (
+                f"\n\nURL FILTER HINT: I attempted to build a filtered URL: {candidate_url}\n"
+                f"If this site encodes filters as URL path segments, use this or correct the format.\n"
+                f"If the site does NOT use URL-based filters, ignore this hint and use sidebar/dropdown methods.\n"
+                f"IMPORTANT: Get the URL segment order correct for this specific site."
+            )
+
         prompt = ENHANCE_PROMPT.format(
-            objective_text=objective.raw_text[:1500],
+            objective_text=objective.raw_text[:1500] + url_hint,
             probe_json=json.dumps(probe.to_dict(), indent=2)[:2000],
             filters=", ".join(objective.required_filters) or "none specified",
             entity=objective.target_entity or "listing",
@@ -158,7 +171,22 @@ class PlanEnhancer:
             # Validate and fill defaults
             # Try URL-based filter encoding
             nav_url = data.get("navigation_url") or objective.start_url or ""
-            data["navigation_url"] = self._try_build_filtered_url(nav_url, objective)
+            enhanced_url = self._try_build_filtered_url(nav_url, objective)
+            data["navigation_url"] = enhanced_url
+
+            # Mark filters as "url" if they appear encoded in the nav URL
+            url_lower = enhanced_url.lower()
+            for fs in data.get("filter_strategy", []):
+                filt_lower = fs.get("filter", "").lower()
+                if any(seg in url_lower for seg in [
+                    "by-owner", "by_owner",
+                ] if filt_lower in ("private seller", "by owner")) or (
+                    "zip-" in url_lower and filt_lower in ("zip", "location", "zip code")
+                ) or (
+                    "price-" in url_lower and filt_lower in ("price", "min price", "minimum price")
+                ):
+                    fs["method"] = "url"
+                    fs["detail"] = "Encoded in URL"
             data.setdefault("filter_strategy", [])
             data.setdefault("card_description", "")
             data.setdefault("detail_scrolls", 5)
@@ -311,6 +339,18 @@ class PlanEnhancer:
 
         if not segments:
             return base_url
+
+        # Sort segments in canonical order: state → city → zip → by-owner → price
+        # This matches the URL pattern used by BoatTrader and similar sites
+        ORDER = {"state-": 0, "city-": 1, "zip-": 2, "by-owner": 3, "price-": 4}
+
+        def seg_order(seg: str) -> int:
+            for prefix, rank in ORDER.items():
+                if seg.startswith(prefix) or seg == prefix.rstrip("-"):
+                    return rank
+            return 5
+
+        segments.sort(key=seg_order)
 
         # Append segments to URL path
         enhanced = url

--- a/src/mantis_agent/graph/learner.py
+++ b/src/mantis_agent/graph/learner.py
@@ -123,7 +123,19 @@ class GraphLearner:
         n_samples: int = 3,
         force_relearn: bool = False,
     ) -> WorkflowGraph:
-        """Full learning pipeline. Returns cached graph if available."""
+        """Full learning pipeline with enhancement loop.
+
+        Pipeline:
+          1. Parse objective → ObjectiveSpec
+          2. Check cache → GraphStore
+          3. Probe site → SiteProber (no brain needed)
+          4. Enhance plan → PlanEnhancer (fill gaps using probe knowledge)
+          5. Build enhanced graph → concrete phases with site knowledge
+          6. Section decompose → verify Holo3-sized chunks
+          7. Validate → PlanValidator structural checks
+          8. Optionally run verified sample (1-3 items with brain)
+          9. Cache the learned graph → GraphStore
+        """
         # 1. Parse objective
         objective = ObjectiveSpec.parse(objective_text, api_key=self.api_key)
         if start_url and not objective.start_url:
@@ -150,19 +162,72 @@ class GraphLearner:
             prober = SiteProber(env=self.env, api_key=self.api_key)
             probe = prober.probe(objective.start_url, objective)
 
-        # 4. Generate graph skeleton
-        graph = self._generate_skeleton(objective, probe)
+        # 4. Enhance plan — fill gaps using probe knowledge
+        from .enhancer import PlanEnhancer
+        enhancer = PlanEnhancer(api_key=self.api_key)
+        enhancement = enhancer.enhance(objective, probe)
+        logger.info(
+            "GraphLearner: enhanced — nav_url=%s, %d filter strategies, pagination=%s",
+            enhancement.get("navigation_url", "")[:60],
+            len(enhancement.get("filter_strategy", [])),
+            enhancement.get("pagination_method", "unknown"),
+        )
 
-        # 5. Optionally run verified sample
+        # 5. Build enhanced graph with concrete phases
+        phases, edges = enhancer.build_enhanced_phases(objective, probe, enhancement)
+
+        playbook = Playbook(domain=domain)
+        if probe.estimated_listings_per_page:
+            playbook.listings_per_page = probe.estimated_listings_per_page
+
+        graph = WorkflowGraph(
+            objective=objective,
+            phases=phases,
+            edges=edges,
+            playbook=playbook,
+            domain=domain,
+            objective_hash=objective.objective_hash,
+            created_at=datetime.now(timezone.utc).isoformat(),
+        )
+
+        # 6. Section decompose — verify Holo3-sized chunks
+        from .section_decomposer import SectionDecomposer
+        decomposer = SectionDecomposer()
+        sections = decomposer.decompose(phases)
+        graph.learning_samples = 0  # Will be updated by sample run
+        logger.info(
+            "GraphLearner: %d sections, dependency chain: %s",
+            len(sections),
+            " → ".join(s.id for s in sections),
+        )
+
+        # 7. Validate compiled plan
+        from .compiler import GraphCompiler
+        from .plan_validator import PlanValidator
+        compiler = GraphCompiler()
+        micro_plan = compiler.compile(graph)
+        validator = PlanValidator()
+        issues = validator.validate(micro_plan, objective=objective)
+        if issues:
+            logger.info("GraphLearner: validator found %d issues, applying fixes", len(issues))
+            for issue in issues:
+                logger.info("  [%s] %s: %s", issue.severity, issue.code, issue.message)
+            micro_plan = validator.enhance(micro_plan, objective=objective)
+            # Re-compile graph from fixed plan would be complex;
+            # the validator fixes are applied to the MicroPlan directly
+            # which is what gets executed.
+
+        # 8. Optionally run verified sample
         if self.brain and self.env and n_samples > 0:
             self._run_sample(graph, n_samples)
 
-        # 6. Cache
+        # 9. Cache
         self.store.save(graph)
         logger.info(
-            "GraphLearner: saved graph (%d phases, %d edges)",
+            "GraphLearner: saved enhanced graph (%d phases, %d edges, %d sections)",
             len(graph.phases),
             len(graph.edges),
+            len(sections),
         )
         return graph
 

--- a/src/mantis_agent/graph/objective.py
+++ b/src/mantis_agent/graph/objective.py
@@ -188,16 +188,24 @@ class ObjectiveSpec:
         """Fallback parser — extract what we can without API."""
         domains: list[str] = []
         start_url = ""
+        # Extract full URLs with paths first
+        for url_match in re.finditer(r"https?://[^\s,)]+", text):
+            url = url_match.group(0).rstrip("/.,;:)")
+            if not start_url:
+                start_url = url
+            # Extract domain from URL
+            domain_match = re.search(r"(?:www\.)?([\w\-]+\.[\w]+)", url)
+            if domain_match:
+                domain = domain_match.group(1)
+                if domain not in domains:
+                    domains.append(domain)
+        # Also extract bare domain mentions
         for match in re.finditer(
-            r"(?:https?://)?(?:www\.)?([\w\-]+\.[\w]+)", text
+            r"(?:www\.)?([\w\-]+\.(?:com|org|net|io|co))\b", text
         ):
             domain = match.group(1)
             if domain not in domains:
                 domains.append(domain)
-            if not start_url:
-                full = match.group(0)
-                if full.startswith("http"):
-                    start_url = full
 
         filters: list[str] = []
         for keyword in [

--- a/src/mantis_agent/graph/plan_validator.py
+++ b/src/mantis_agent/graph/plan_validator.py
@@ -178,10 +178,20 @@ class PlanValidator:
             return issues
         filter_steps = [s for s in steps if s.type == "filter"]
         if not filter_steps:
-            issues.append(PlanIssue(
-                severity="warning", code="no_filter_steps",
-                message=f"Objective requires {len(required_filters)} filters but plan has no filter steps: {required_filters}",
-            ))
+            # Check if filters are encoded in the navigate URL
+            navigate_steps = [s for s in steps if s.type == "navigate"]
+            url_has_filters = False
+            if navigate_steps:
+                nav_url = navigate_steps[0].intent.lower()
+                url_has_filters = "filtered" in nav_url or any(
+                    kw.replace(" ", "-") in nav_url
+                    for kw in ("by-owner", "by owner", "private", "zip-", "price-")
+                )
+            if not url_has_filters:
+                issues.append(PlanIssue(
+                    severity="warning", code="no_filter_steps",
+                    message=f"Objective requires {len(required_filters)} filters but plan has no filter steps: {required_filters}",
+                ))
         return issues
 
     def _check_gate(self, steps: list[MicroIntent]) -> list[PlanIssue]:

--- a/src/mantis_agent/graph/section_decomposer.py
+++ b/src/mantis_agent/graph/section_decomposer.py
@@ -1,0 +1,159 @@
+"""SectionDecomposer — group plan phases into Holo3-sized execution sections.
+
+Holo3 passes 100% on isolated 3-8 step tasks but fails when instructions
+are combined. This module groups verified PhaseNodes into logical sections,
+each small enough for the executor, with explicit dependency chains.
+
+Each section has:
+  - precondition: what must be true before it runs
+  - steps: 1-8 PhaseNodes (the work)
+  - postcondition: what should be true after
+  - depends_on: which sections must complete first
+
+The dependency chain ensures sections execute in order:
+  setup_section → gate_section → extraction_section (loops) → pagination_section
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+from .graph import PhaseNode, PhaseRole, RepeatMode
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ExecutionSection:
+    """A group of phases small enough for Holo3 to execute."""
+
+    id: str
+    name: str  # "setup", "gate", "extraction", "pagination"
+    phases: list[PhaseNode] = field(default_factory=list)
+    precondition: str = ""
+    postcondition: str = ""
+    depends_on: list[str] = field(default_factory=list)
+    is_loop: bool = False  # True if this section repeats
+    loop_source: str = ""  # Section ID that provides items
+
+    def step_count(self) -> int:
+        return sum(max(p.budget, 1) for p in self.phases)
+
+    def summary(self) -> str:
+        phase_ids = [p.id for p in self.phases]
+        deps = f" (depends: {', '.join(self.depends_on)})" if self.depends_on else ""
+        loop = " [LOOP]" if self.is_loop else ""
+        return f"  {self.id:20s} {len(self.phases)} phases, ~{self.step_count()} steps{loop}{deps}"
+
+
+class SectionDecomposer:
+    """Group PhaseNodes into Holo3-sized execution sections."""
+
+    def decompose(
+        self,
+        phases: dict[str, PhaseNode],
+        max_steps_per_section: int = 15,
+    ) -> list[ExecutionSection]:
+        """Group phases into sections with dependency chains.
+
+        Returns ordered list of ExecutionSections.
+        """
+        sections: list[ExecutionSection] = []
+
+        # ── Collect by role ──
+        setup_phases = [p for p in phases.values() if p.role == PhaseRole.SETUP and not p.gate]
+        gate_phases = [p for p in phases.values() if p.gate or p.role == PhaseRole.GATE]
+        extraction_phases = [
+            p for p in phases.values()
+            if p.role in (PhaseRole.ADMISSION, PhaseRole.EXTRACTION, PhaseRole.REJECTION)
+            and p.repeat == RepeatMode.FOR_EACH
+        ]
+        return_phases = [p for p in phases.values() if p.role == PhaseRole.RETURN]
+        pagination_phases = [p for p in phases.values() if p.role == PhaseRole.PAGINATION]
+
+        # ── Setup section (navigate + filters) ──
+        if setup_phases:
+            # Split into sub-sections if too many steps
+            current_batch: list[PhaseNode] = []
+            batch_steps = 0
+            batch_idx = 0
+
+            for phase in setup_phases:
+                phase_steps = max(phase.budget, 1)
+                if batch_steps + phase_steps > max_steps_per_section and current_batch:
+                    sid = f"setup_{batch_idx}" if batch_idx > 0 else "setup"
+                    dep = [f"setup_{batch_idx - 1}"] if batch_idx > 0 else []
+                    sections.append(ExecutionSection(
+                        id=sid, name="setup",
+                        phases=list(current_batch),
+                        precondition="Browser ready" if batch_idx == 0 else "Previous setup complete",
+                        postcondition="Setup steps applied",
+                        depends_on=dep,
+                    ))
+                    current_batch = []
+                    batch_steps = 0
+                    batch_idx += 1
+                current_batch.append(phase)
+                batch_steps += phase_steps
+
+            if current_batch:
+                sid = f"setup_{batch_idx}" if batch_idx > 0 else "setup"
+                dep = [f"setup_{batch_idx - 1}"] if batch_idx > 0 else []
+                sections.append(ExecutionSection(
+                    id=sid, name="setup",
+                    phases=current_batch,
+                    precondition="Browser ready" if batch_idx == 0 else "Previous setup complete",
+                    postcondition="Setup steps applied",
+                    depends_on=dep,
+                ))
+
+        # ── Gate section ──
+        if gate_phases:
+            last_setup = sections[-1].id if sections else ""
+            sections.append(ExecutionSection(
+                id="gate",
+                name="gate",
+                phases=gate_phases,
+                precondition="All filters applied",
+                postcondition="Filters verified active, page shows filtered results",
+                depends_on=[last_setup] if last_setup else [],
+            ))
+
+        # ── Extraction section (the loop body) ──
+        if extraction_phases or return_phases:
+            loop_phases = list(extraction_phases) + list(return_phases)
+            gate_dep = "gate" if any(s.id == "gate" for s in sections) else ""
+            sections.append(ExecutionSection(
+                id="extraction",
+                name="extraction",
+                phases=loop_phases,
+                precondition="On filtered results page, candidate card visible",
+                postcondition="Item data extracted, returned to results page",
+                depends_on=[gate_dep] if gate_dep else [],
+                is_loop=True,
+                loop_source="discovery",
+            ))
+
+        # ── Pagination section ──
+        if pagination_phases:
+            sections.append(ExecutionSection(
+                id="pagination",
+                name="pagination",
+                phases=pagination_phases,
+                precondition="Current page exhausted (all items processed)",
+                postcondition="Next results page loaded",
+                depends_on=["extraction"],
+                is_loop=True,
+                loop_source="extraction",
+            ))
+
+        logger.info(
+            "SectionDecomposer: %d phases -> %d sections",
+            len(phases), len(sections),
+        )
+        for section in sections:
+            logger.info(section.summary())
+
+        return sections

--- a/test_plan_enhancement.py
+++ b/test_plan_enhancement.py
@@ -1,0 +1,212 @@
+"""Tests for the plan enhancement pipeline."""
+
+from mantis_agent.graph import GraphCompiler, PlanValidator
+from mantis_agent.graph.enhancer import PlanEnhancer
+from mantis_agent.graph.section_decomposer import SectionDecomposer, ExecutionSection
+from mantis_agent.graph.objective import ObjectiveSpec, OutputField
+from mantis_agent.graph.probe import ProbeResult
+from mantis_agent.graph.graph import WorkflowGraph, PhaseRole, RepeatMode
+from mantis_agent.verification.playbook import Playbook
+
+
+def _boattrader_probe() -> ProbeResult:
+    return ProbeResult(
+        url="https://www.boattrader.com/boats/",
+        domain="boattrader.com",
+        page_type="search_results",
+        filters_detected=[
+            {"name": "Seller Type", "options": ["Private Seller"], "location": "URL path: by-owner"},
+        ],
+        listing_container={"description": "cards with photo + title + price"},
+        pagination_controls={"type": "numbered"},
+        estimated_listings_per_page=25,
+        detail_page_pattern={
+            "expandable_sections": ["Description", "More Details"],
+            "expand_controls": ["Show", "Read more"],
+            "phone_location": "In Description section",
+        },
+    )
+
+
+def _build_enhanced_plan(objective_text, domain, filters, probe=None):
+    spec = ObjectiveSpec(
+        raw_text=objective_text,
+        domains=[domain],
+        start_url=f"https://www.{domain}/",
+        target_entity="listing",
+        required_filters=filters,
+    )
+    probe = probe or ProbeResult(domain=domain)
+    enhancer = PlanEnhancer()
+    enhancement = enhancer._enhance_heuristic(spec, probe)
+    phases, edges = enhancer.build_enhanced_phases(spec, probe, enhancement)
+    graph = WorkflowGraph(
+        objective=spec, phases=phases, edges=edges,
+        playbook=Playbook(domain=domain, listings_per_page=20),
+        domain=domain, objective_hash=spec.objective_hash,
+    )
+    compiler = GraphCompiler()
+    plan = compiler.compile(graph)
+    return spec, plan, phases
+
+
+# ── PlanEnhancer ──
+
+
+def test_enhancer_heuristic_detects_sidebar_filters():
+    spec = ObjectiveSpec(raw_text="test", required_filters=["private seller", "zip"])
+    probe = ProbeResult(
+        filters_detected=[
+            {"name": "Seller", "options": ["Private Seller"], "location": "sidebar"},
+        ],
+    )
+    enhancer = PlanEnhancer()
+    result = enhancer._enhance_heuristic(spec, probe)
+    strategies = result["filter_strategy"]
+    seller_strat = [s for s in strategies if s["filter"] == "private seller"]
+    assert seller_strat[0]["method"] == "sidebar"
+
+
+def test_enhancer_builds_concrete_phases():
+    spec = ObjectiveSpec(
+        raw_text="test", domains=["example.com"],
+        start_url="https://example.com/search",
+        target_entity="job posting",
+        required_filters=["remote"],
+    )
+    probe = ProbeResult(domain="example.com")
+    enhancer = PlanEnhancer()
+    enhancement = enhancer._enhance_heuristic(spec, probe)
+    phases, edges = enhancer.build_enhanced_phases(spec, probe, enhancement)
+
+    assert "navigate" in phases
+    assert "verify_scope" in phases
+    assert phases["verify_scope"].gate is True
+    assert "job posting" in phases["verify_scope"].intent_template
+
+
+def test_enhancer_url_filters_skip_sidebar_steps():
+    """When all filters are URL-encoded, no sidebar filter steps are created."""
+    spec = ObjectiveSpec(
+        raw_text="test", domains=["example.com"],
+        start_url="https://example.com/results?type=private",
+        required_filters=["private"],
+    )
+    probe = ProbeResult(domain="example.com")
+    enhancer = PlanEnhancer()
+    # Simulate: the enhancer API returns url-method filters
+    enhancement = {
+        "navigation_url": "https://example.com/results?type=private",
+        "filter_strategy": [{"filter": "private", "method": "url", "detail": "in URL query"}],
+        "card_description": "",
+        "detail_scrolls": 3,
+        "expandable_sections": [],
+        "expand_controls": [],
+        "phone_location": "",
+        "pagination_method": "button_click",
+        "pagination_detail": "",
+    }
+    phases, edges = enhancer.build_enhanced_phases(spec, probe, enhancement)
+
+    # Should have navigate with filtered URL, no filter_N steps
+    assert "filtered results" in phases["navigate"].intent_template
+    filter_steps = [pid for pid in phases if pid.startswith("filter_")]
+    assert len(filter_steps) == 0
+
+
+def test_enhancer_detail_page_knowledge():
+    spec = ObjectiveSpec(raw_text="test", required_filters=[])
+    probe = _boattrader_probe()
+    enhancer = PlanEnhancer()
+    enhancement = enhancer._enhance_heuristic(spec, probe)
+
+    assert enhancement["expandable_sections"] == ["Description", "More Details"]
+    assert enhancement["phone_location"] == "In Description section"
+
+
+# ── SectionDecomposer ──
+
+
+def test_section_decomposer_creates_sections():
+    _, plan, phases = _build_enhanced_plan("test", "example.com", ["filter1", "filter2"])
+    decomposer = SectionDecomposer()
+    sections = decomposer.decompose(phases)
+
+    section_names = [s.name for s in sections]
+    assert "setup" in section_names
+    assert "gate" in section_names
+    assert "extraction" in section_names
+    assert "pagination" in section_names
+
+
+def test_section_dependencies():
+    _, plan, phases = _build_enhanced_plan("test", "example.com", ["filter1"])
+    decomposer = SectionDecomposer()
+    sections = decomposer.decompose(phases)
+
+    gate = [s for s in sections if s.name == "gate"][0]
+    extraction = [s for s in sections if s.name == "extraction"][0]
+    pagination = [s for s in sections if s.name == "pagination"][0]
+
+    # Gate depends on setup
+    assert any("setup" in d for d in gate.depends_on)
+    # Extraction depends on gate
+    assert "gate" in extraction.depends_on
+    # Pagination depends on extraction
+    assert "extraction" in pagination.depends_on
+
+
+def test_extraction_section_is_loop():
+    _, plan, phases = _build_enhanced_plan("test", "example.com", [])
+    decomposer = SectionDecomposer()
+    sections = decomposer.decompose(phases)
+
+    extraction = [s for s in sections if s.name == "extraction"][0]
+    assert extraction.is_loop is True
+
+
+# ── Full pipeline validation ──
+
+
+def test_boattrader_enhanced_plan_validates_clean():
+    text = open("plans/boattrader/extract_only.txt").read()
+    spec, plan, phases = _build_enhanced_plan(
+        text, "boattrader.com",
+        ["private seller", "by owner", "zip", "price", "location"],
+        probe=_boattrader_probe(),
+    )
+    validator = PlanValidator()
+    issues = validator.validate(plan, objective=spec)
+    assert len(issues) == 0, f"Expected 0 issues, got: {[i.code for i in issues]}"
+
+
+def test_enhanced_plan_has_correct_structure():
+    text = open("plans/boattrader/extract_only.txt").read()
+    spec, plan, _ = _build_enhanced_plan(
+        text, "boattrader.com",
+        ["private seller", "by owner", "zip", "price", "location"],
+        probe=_boattrader_probe(),
+    )
+
+    # Has navigate
+    assert plan.steps[0].type == "navigate"
+    # Has gate
+    gates = [s for s in plan.steps if s.gate]
+    assert len(gates) == 1
+    # Has extraction loop
+    extraction_loops = [s for s in plan.steps if s.type == "loop" and s.section == "extraction"]
+    assert len(extraction_loops) == 1
+    # Has pagination
+    paginate_steps = [s for s in plan.steps if s.type == "paginate"]
+    assert len(paginate_steps) == 1
+    # Has navigate_back
+    back_steps = [s for s in plan.steps if s.type == "navigate_back"]
+    assert len(back_steps) == 1
+
+
+def test_enhanced_plan_paginate_is_paginate_type():
+    """Regression: paginate step must have type=paginate, not type=navigate."""
+    _, plan, _ = _build_enhanced_plan("test", "example.com", [])
+    paginate_steps = [s for s in plan.steps if s.section == "pagination" and s.type != "loop"]
+    assert len(paginate_steps) == 1
+    assert paginate_steps[0].type == "paginate"


### PR DESCRIPTION
## Summary

Adds a closed-loop plan enhancement pipeline that takes a vague text plan and produces a concrete, validated MicroPlan:

1. **PlanEnhancer** — fills gaps using site probe knowledge. Resolves filter mechanisms (URL vs sidebar vs dropdown), builds filtered URLs from objective text, includes concrete card descriptions, expandable section names, and phone locations.

2. **SectionDecomposer** — groups phases into Holo3-sized execution sections (3-8 steps each) with preconditions, postconditions, and dependency chains.

3. **In-container SiteProber** — when the objective is available, probes the actual site inside the Modal/Baseten container (where the browser is available) and re-enhances the plan with real page data before execution.

4. **URL filter builder** — scans objective text for URL-encodable filter values (by-owner, zip-NNNNN, price-NNNNN) and builds pre-filtered URLs, eliminating unreliable sidebar clicking.

## Verified end-to-end

`plans/boattrader/extract_only.txt` (plain text) → **1 viable lead extracted with phone** on Modal:

```
Local:  ObjectiveSpec → PlanEnhancer (Claude) → filtered URL
Remote: SiteProber (16 filters, 12 listings/page) → re-enhance
Remote: 12-step MicroPlan → gate PASS → extraction → 1 lead
```

## Test plan

- [x] 105 tests pass (10 new enhancement tests + 95 existing)
- [x] BoatTrader text plan produces correct URL-filtered plan
- [x] Zillow objective produces sidebar filter steps (non-URL filters preserved)
- [x] Modal extraction: 1 lead from text plan via probe-enhanced pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)