### PR TITLE
Tier 2 hardening + [orchestrator] extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,22 +143,44 @@ Key fields: `section` (setup/extraction/pagination), `required` (retry then halt
 
 ## Quick Start
 
+The base install is intentionally slim. Pick the extras for your use case:
+
 ```bash
-# Install core
+# Slim base (~5 MB) — just enough to import mantis_agent.{actions, gym.base, site_config}
 pip install -e .
 
-# With viewer support
+# Orchestrator only — MicroPlanRunner + Claude clients + remote Holo3 over HTTP.
+# This is what callers like vision_claude install. No GPU, no torch.
+pip install -e ".[orchestrator]"
+
+# Self-hosted FastAPI server (Baseten / EKS / GKE)
+pip install -e ".[server]"
+
+# Local in-process CUA — pulls torch + transformers + pyautogui + mss
+pip install -e ".[local-cua]"
+
+# Live web viewer
 pip install -e ".[viewer]"
 
-# With GPU acceleration
-pip install -e ".[gpu]"
+# Everything (full development setup)
+pip install -e ".[full]"
 
-# Run locally
+# Run locally (requires [local-cua])
 mantis "Open Firefox and search for cats" --model google/gemma-4-E4B-it
 
 # Run with live viewer
 mantis --viewer "Open Firefox and search for cats"
 ```
+
+## Install footprint
+
+| Extras | What you get | Wheel size (approx.) |
+|---|---|---|
+| (none) | Pillow only | ~5 MB |
+| `[orchestrator]` | + requests + pydantic | ~10 MB |
+| `[server]` | + fastapi + uvicorn + pydantic + requests | ~15 MB |
+| `[local-cua]` | + torch + transformers + pyautogui + mss | ~2 GB |
+| `[full]` | All of the above | ~2.1 GB |
 
 ### Development
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -14,6 +14,7 @@ vision_claude integration walkthrough see
 | `POST /v1/chat/completions` | `X-Mantis-Token` (run scope) | OpenAI-compat reverse proxy to in-pod Holo3 (raw inference). |
 | `GET /v1/models` | open | OpenAI-compat model list. Returns `holo3`. |
 | `GET /v1/health`, `GET /health` | open | Liveness/readiness probe. |
+| `GET /metrics` | open | Prometheus scrape endpoint. Returns 503 if `prometheus_client` not installed. |
 
 When deployed behind Baseten, all requests must also carry
 `Authorization: Api-Key <BASETEN_API_KEY>` (gateway auth, separate from
@@ -373,11 +374,95 @@ For comparison, equivalent Claude-only CUA flow ~$0.50–$1.50 per listing.
 - **`/v1/chat/completions`** is unstreamed in v1. Streaming SSE is a Tier 2 follow-up.
 - **Single Anthropic-key per tenant** at request time (re-resolved on every call).
 
+## Tier 2 features (rate limits, idempotency, webhooks, allowlist, metrics)
+
+### Rate limits
+
+Two dimensions, both enforced per-tenant:
+
+| Dimension | Source | Behavior on exceed |
+|---|---|---|
+| **Concurrent runs** | `tenant.max_concurrent_runs` (default 5) | `429 Too Many Requests` with `Retry-After: 5` |
+| **Rate** (token bucket) | `tenant.rate_limit_per_minute` (default 30) | `429` with `Retry-After: <seconds-until-token>` |
+
+State is in-process per replica. Behind a load balancer with N replicas, the effective per-tenant cap is roughly `N × configured_cap`. For strict cluster-wide limits, deploy a single replica or swap to a Redis-backed limiter (planned Tier 2.5).
+
+### Idempotency keys
+
+Send `Idempotency-Key: <unique-string>` on `POST /v1/predict`. The server caches `(tenant_id, key) → run_id` with a 24-hour TTL. Subsequent retries with the same key return the original `run_id` without starting a new run.
+
+```bash
+curl -X POST "$ENDPOINT/v1/predict" \
+  -H "Authorization: Api-Key $BTKEY" \
+  -H "X-Mantis-Token: $TOK" \
+  -H "Idempotency-Key: order-7afc3b91" \
+  -H "Content-Type: application/json" \
+  -d '{...}'
+```
+
+The cache is sidecar-backed (`$MANTIS_DATA_DIR/idempotency/<tenant_id>/<key_hash>.json`) so a replica restart preserves it.
+
+### Webhook callbacks
+
+Two ways to receive run-completion notifications:
+
+1. **Per-tenant default** — set `webhook_url` and `webhook_secret_name` in the tenant keys file.
+2. **Per-request override** — pass `callback_url` in the `/v1/predict` body.
+
+When the run reaches a terminal state (`succeeded`, `failed`, `cancelled`), the server POSTs:
+
+```jsonc
+{
+  "run_id": "20260428_021432_076255ef",
+  "tenant_id": "vision_claude_prod",
+  "status": "succeeded",
+  "summary": { ... same shape as /v1/predict status response ... },
+  "delivered_at": "2026-04-28T02:24:01.648Z"
+}
+```
+
+With an HMAC-SHA256 signature in `X-Mantis-Signature: sha256=<hex>` (signed with the tenant's webhook secret). 3 retries with exponential backoff (1s, 5s, 30s) if the receiver returns non-2xx or fails to connect.
+
+Verify the signature on receipt:
+
+```python
+import hmac, hashlib
+def verify(body: bytes, header_sig: str, secret: str) -> bool:
+    expected = "sha256=" + hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+    return hmac.compare_digest(expected, header_sig)
+```
+
+### URL allowlist enforcement
+
+If a tenant has `allowed_domains` set in the keys file, every plan submitted via `/v1/predict` is scanned for `navigate`-type URLs and `task_suite.base_url` / `task.start_url`. Off-list hosts return `403 Forbidden` before any run starts:
+
+```jsonc
+{
+  "detail": "plan references host(s) not in tenant allowlist: evil.com"
+}
+```
+
+Wildcards: `*.boattrader.com` matches any subdomain but not `boattrader.com.evil.com`. Empty `allowed_domains` (the default) skips this check.
+
+### Prometheus metrics
+
+`GET /metrics` returns Prometheus text format. Metric names + labels:
+
+| Metric | Type | Labels | Notes |
+|---|---|---|---|
+| `mantis_predict_requests_total` | counter | `tenant_id`, `mode`, `outcome` | mode = `run\|status\|result\|logs\|cancel`; outcome = `ok\|bad_request\|rate_limited\|denied_allowlist\|idempotent_hit\|error` |
+| `mantis_chat_completions_total` | counter | `tenant_id`, `outcome` | outcome = `ok\|status_4xx\|status_5xx\|upstream_error` |
+| `mantis_run_duration_seconds` | histogram | `tenant_id`, `model`, `status` | Buckets: 10s … 3600s |
+| `mantis_run_cost_usd` | histogram | `tenant_id`, `model`, `status` | Buckets: $0.01 … $25 |
+| `mantis_concurrent_runs` | gauge | `tenant_id` | Currently in-flight runs |
+| `mantis_rate_limit_rejections_total` | counter | `tenant_id`, `kind` | kind = `rate\|concurrent` |
+
+If `prometheus_client` isn't installed in the container (e.g., orchestrator-only install), `/metrics` returns `503` and all metric calls become no-ops — the rest of the API is unaffected.
+
 ## Tier roadmap
 
-This API is at Tier 1 (multi-tenant safe). Upcoming:
+This API is at **Tier 2** — production-quality multi-tenant. Upcoming:
 
-- **Tier 2:** rate limits, idempotency keys, webhook callbacks, runtime URL allowlists, Prometheus/OTel metrics.
 - **Tier 3:** billing records, admin API, multi-region.
 
 See [`PROPOSAL-mantis-cua-replaces-vision_claude.md`](PROPOSAL-mantis-cua-replaces-vision_claude.md) for the bigger architectural picture and migration plan.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,38 +3,64 @@ name = "mantis-agent"
 version = "0.1.0"
 description = "Mantis — a small creature with world-class vision that watches patiently and acts with speed and precision"
 requires-python = ">=3.11"
+# Slim base: just what is needed to import mantis_agent.{actions, gym.base, site_config, ...}
+# without dragging in GPU, browser, or desktop deps. Add an extras group below
+# for the use case you actually need.
 dependencies = [
-    "transformers>=4.52",
-    "torch>=2.1",
-    "mss>=9.0",
-    "pyautogui>=0.9",
     "pillow>=10.0",
 ]
 
 [project.optional-dependencies]
-dev = [
-    "pytest>=8.0",
-    "pytest-asyncio>=0.23",
-    "ruff>=0.4",
+# Orchestrator-only — for callers that run MicroPlanRunner in their own
+# process and talk to a remote Mantis Holo3 service over /v1/chat/completions
+# plus Anthropic over /v1/messages. No GPU, no in-process llama.cpp, no
+# browser. This is what vision_claude installs.
+orchestrator = [
+    "requests>=2.28",
+    "pydantic>=2",
 ]
-gpu = [
-    "accelerate>=0.30",
-    "bitsandbytes>=0.43",
-]
-hud = [
-    "hud-python>=0.5.34",
-    "openai>=1.0",
-    "modal>=0.73",
-]
-viewer = [
-    "fastapi>=0.100",
-    "uvicorn>=0.20",
-]
+# Self-host the FastAPI server that fronts /predict and /v1/chat/completions.
+# Used by the Baseten / EKS / GKE deployments.
 server = [
     "fastapi>=0.100",
     "uvicorn>=0.20",
     "pydantic>=2",
     "requests>=2.28",
+]
+# In-process Holo3 + desktop. Pulls torch / transformers / pyautogui / mss.
+# Use this when running the agent loop locally with its own Xvfb.
+local-cua = [
+    "transformers>=4.52",
+    "torch>=2.1",
+    "mss>=9.0",
+    "pyautogui>=0.9",
+]
+# Live web viewer (MJPEG + action log).
+viewer = [
+    "fastapi>=0.100",
+    "uvicorn>=0.20",
+]
+# Optional GPU acceleration extras (4-bit quantization, accelerate runtime).
+gpu = [
+    "accelerate>=0.30",
+    "bitsandbytes>=0.43",
+]
+# HUD evaluation harness.
+hud = [
+    "hud-python>=0.5.34",
+    "openai>=1.0",
+    "modal>=0.73",
+]
+# Test / lint tooling.
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.23",
+    "ruff>=0.4",
+    "httpx>=0.24",   # FastAPI TestClient
+]
+# Convenience: install everything.
+full = [
+    "mantis-agent[orchestrator,server,local-cua,viewer,gpu,hud]",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,10 @@ orchestrator = [
     "requests>=2.28",
     "pydantic>=2",
 ]
+# Server side wants prometheus + the orchestrator deps too.
+metrics = [
+    "prometheus-client>=0.20",
+]
 # Self-host the FastAPI server that fronts /predict and /v1/chat/completions.
 # Used by the Baseten / EKS / GKE deployments.
 server = [
@@ -26,6 +30,7 @@ server = [
     "uvicorn>=0.20",
     "pydantic>=2",
     "requests>=2.28",
+    "prometheus-client>=0.20",
 ]
 # In-process Holo3 + desktop. Pulls torch / transformers / pyautogui / mss.
 # Use this when running the agent loop locally with its own Xvfb.

--- a/src/mantis_agent/api_schemas.py
+++ b/src/mantis_agent/api_schemas.py
@@ -149,6 +149,66 @@ def validate_micro_steps(steps: list[dict[str, Any]]) -> list[dict[str, Any]]:
     return clamped
 
 
+_URL_RE = __import__("re").compile(r"https?://([^/\s\"'`)>]+)")
+
+
+def extract_navigate_hosts(plan: list[dict[str, Any]] | dict[str, Any]) -> list[str]:
+    """Pull all unique hostnames referenced by ``navigate``-type steps.
+
+    Used to enforce the per-tenant allowlist before the plan starts.
+    Inspects micro-plan step lists ({intent, type, ...}) and task-suite
+    dicts ({tasks: [{intent, start_url, ...}]}). Returns a sorted, unique
+    list of lowercase hosts.
+    """
+    hosts: set[str] = set()
+
+    def _add_url(url: str | None) -> None:
+        if not url:
+            return
+        m = _URL_RE.search(url)
+        if m:
+            hosts.add(m.group(1).lower())
+
+    def _scan_intent(text: str | None) -> None:
+        if not text:
+            return
+        for m in _URL_RE.finditer(text):
+            hosts.add(m.group(1).lower())
+
+    if isinstance(plan, dict):
+        # task-suite shape
+        _add_url(plan.get("base_url"))
+        for task in plan.get("tasks") or []:
+            if isinstance(task, dict):
+                _add_url(task.get("start_url"))
+                _scan_intent(task.get("intent"))
+    elif isinstance(plan, list):
+        # micro-plan shape
+        for step in plan:
+            if not isinstance(step, dict):
+                continue
+            _scan_intent(step.get("intent"))
+            _add_url(step.get("url"))
+
+    return sorted(hosts)
+
+
+def assert_hosts_allowed(
+    hosts: list[str],
+    allowed_predicate,
+) -> None:
+    """Raise ``PermissionError`` if any host fails ``allowed_predicate``.
+
+    ``allowed_predicate`` is typically ``tenant.is_domain_allowed``. Empty
+    ``hosts`` list is a no-op (e.g. a plan with no navigate URLs).
+    """
+    rejected = [h for h in hosts if not allowed_predicate(h)]
+    if rejected:
+        raise PermissionError(
+            f"plan references host(s) not in tenant allowlist: {', '.join(rejected)}"
+        )
+
+
 # ── Response payloads ───────────────────────────────────────────────────────
 class DetachedRunHandle(BaseModel):
     """Returned from /predict when detached=True."""

--- a/src/mantis_agent/baseten_server.py
+++ b/src/mantis_agent/baseten_server.py
@@ -25,7 +25,7 @@ import hmac
 import requests
 
 try:
-    from fastapi import Depends, FastAPI, Header, HTTPException, Request
+    from fastapi import Depends, FastAPI, Header, HTTPException, Request, Response
     from fastapi.responses import JSONResponse
     from starlette.concurrency import run_in_threadpool
 except ImportError as exc:  # pragma: no cover - container-only deps
@@ -39,10 +39,15 @@ from mantis_agent.api_schemas import (
     MAX_COST_USD,
     MAX_RUNTIME_MINUTES,
     PredictRequest,
+    assert_hosts_allowed,
+    extract_navigate_hosts,
     validate_micro_steps,
 )
 from mantis_agent.gym.runner import GymRunner
 from mantis_agent.gym.xdotool_env import XdotoolGymEnv
+from mantis_agent.idempotency import get_idempotency_cache
+from mantis_agent import metrics as mantis_metrics
+from mantis_agent.rate_limit import get_rate_limiter
 from mantis_agent.server_utils import (
     build_micro_result,
     build_micro_suite,
@@ -64,6 +69,7 @@ from mantis_agent.tenant_auth import (
     TenantConfig,
     get_key_store,
 )
+from mantis_agent.webhooks import WebhookPayload, deliver_webhook_async
 
 class _JsonLogFormatter(logging.Formatter):
     """One-line JSON-per-record formatter that attaches tenant_id and run_id
@@ -903,6 +909,20 @@ def health_v1() -> dict[str, Any]:
     return {"ok": runtime.loaded, "model": runtime.model_kind}
 
 
+@app.get("/metrics")
+def metrics_endpoint() -> Any:
+    """Prometheus scrape endpoint.
+
+    Returns 503 if prometheus_client isn't installed in the container.
+    """
+    if not mantis_metrics.is_available():
+        raise HTTPException(status_code=503, detail="prometheus_client not installed")
+    return Response(
+        content=mantis_metrics.render_text(),
+        media_type=mantis_metrics.CONTENT_TYPE_LATEST,
+    )
+
+
 @app.get("/v1/models")
 def models() -> dict[str, Any]:
     """OpenAI-compatible model listing.
@@ -981,8 +1001,16 @@ async def chat_completions_proxy(
             timeout=180,
         )
     except requests.RequestException as exc:
+        mantis_metrics.CHAT_COMPLETIONS.labels(
+            tenant_id=tenant.tenant_id, outcome="upstream_error"
+        ).inc()
         logger.exception("v1/chat/completions upstream error tenant=%s", tenant.tenant_id)
         raise HTTPException(status_code=502, detail=f"upstream error: {exc}") from exc
+
+    mantis_metrics.CHAT_COMPLETIONS.labels(
+        tenant_id=tenant.tenant_id,
+        outcome="ok" if 200 <= r.status_code < 300 else f"status_{r.status_code // 100}xx",
+    ).inc()
 
     try:
         payload = r.json()
@@ -1001,9 +1029,18 @@ async def _handle_predict(
 ) -> dict[str, Any]:
     """Shared handler for /predict and /v1/predict.
 
-    Validates the payload through Pydantic, enforces server-side caps,
-    namespaces state_key + chrome-profile per tenant, and threads the
-    tenant-resolved Anthropic key into the runtime context.
+    Tier-1 + Tier-2 pipeline:
+
+    1. Pydantic validation, global cap clamp.
+    2. Per-tenant cap clamp.
+    3. State-key + Chrome-profile namespacing per tenant.
+    4. Per-tenant Anthropic key resolution.
+    5. (Tier-2) URL allowlist enforcement on the plan.
+    6. (Tier-2) Idempotency-key cache lookup.
+    7. (Tier-2) Rate-limit token consumption.
+    8. (Tier-2) Concurrency-slot acquisition (released in finally).
+    9. (Tier-2) Webhook callback registered with the runtime if requested.
+    10. Forward to the runtime.
     """
     try:
         raw = await request.json()
@@ -1017,8 +1054,6 @@ async def _handle_predict(
     except Exception as exc:
         raise HTTPException(status_code=400, detail=f"invalid request: {exc}") from exc
 
-    # Per-tenant cap clamp (in addition to the global cap PredictRequest already
-    # applied). Tenant config is the most-specific limit.
     payload = req.model_dump(exclude_none=True)
     payload["max_cost"] = min(
         float(payload.get("max_cost", MAX_COST_USD)),
@@ -1028,32 +1063,151 @@ async def _handle_predict(
         int(payload.get("max_time_minutes", MAX_RUNTIME_MINUTES)),
         tenant.max_time_minutes_per_run,
     )
-
-    # State-key namespacing. Caller cannot override its tenant prefix.
     payload["state_key"] = _tenant_state_key(tenant, payload.get("state_key"))
 
-    # Per-tenant Anthropic key + chrome profile path are exposed via env so the
-    # runtime (and any in-process Claude clients) read them transparently.
     os.environ["ANTHROPIC_API_KEY"] = _resolve_anthropic_key(tenant)
     os.environ["MANTIS_TENANT_ID"] = tenant.tenant_id
     profile_dir = _tenant_chrome_profile(tenant, payload["state_key"])
     os.environ["MANTIS_CHROME_PROFILE_DIR"] = str(profile_dir)
 
+    is_run_mode = req.action is None
+
+    # ── Tier-2: URL allowlist ────────────────────────────────────────────
+    if is_run_mode and tenant.allowed_domains:
+        plan_obj: Any = None
+        if req.task_suite is not None:
+            plan_obj = req.task_suite
+        elif req.task_file_contents:
+            try:
+                plan_obj = json.loads(req.task_file_contents)
+            except json.JSONDecodeError:
+                plan_obj = None
+        if plan_obj is not None:
+            try:
+                hosts = extract_navigate_hosts(plan_obj)
+                assert_hosts_allowed(hosts, tenant.is_domain_allowed)
+            except PermissionError as exc:
+                mantis_metrics.PREDICT_REQUESTS.labels(
+                    tenant_id=tenant.tenant_id, mode="run", outcome="denied_allowlist"
+                ).inc()
+                raise HTTPException(status_code=403, detail=str(exc)) from exc
+
+    # ── Tier-2: Idempotency-key cache ────────────────────────────────────
+    idempotency_key = request.headers.get("Idempotency-Key", "").strip()
+    if is_run_mode and idempotency_key:
+        cached = get_idempotency_cache().get(tenant.tenant_id, idempotency_key)
+        if cached is not None:
+            logger.info(
+                "predict idempotency-hit tenant=%s key=%s run_id=%s",
+                tenant.tenant_id, idempotency_key, cached.run_id,
+            )
+            mantis_metrics.PREDICT_REQUESTS.labels(
+                tenant_id=tenant.tenant_id, mode="run", outcome="idempotent_hit"
+            ).inc()
+            return cached.response
+
+    # ── Tier-2: Rate limit (token bucket) — applied to run-mode only ─────
+    limiter = get_rate_limiter()
+    if is_run_mode:
+        rate_decision = limiter.try_consume_rate_token(
+            tenant.tenant_id, tenant.rate_limit_per_minute
+        )
+        if not rate_decision.allowed:
+            mantis_metrics.RATE_LIMIT_REJECTIONS.labels(
+                tenant_id=tenant.tenant_id, kind="rate"
+            ).inc()
+            mantis_metrics.PREDICT_REQUESTS.labels(
+                tenant_id=tenant.tenant_id, mode="run", outcome="rate_limited"
+            ).inc()
+            raise HTTPException(
+                status_code=429,
+                detail=rate_decision.reason,
+                headers={"Retry-After": str(int(rate_decision.retry_after_seconds) + 1)},
+            )
+
+    # ── Tier-2: Concurrency slot ─────────────────────────────────────────
+    concurrency_acquired = False
+    if is_run_mode:
+        decision = limiter.try_acquire_concurrency_slot(
+            tenant.tenant_id, tenant.max_concurrent_runs
+        )
+        if not decision.allowed:
+            mantis_metrics.RATE_LIMIT_REJECTIONS.labels(
+                tenant_id=tenant.tenant_id, kind="concurrent"
+            ).inc()
+            mantis_metrics.PREDICT_REQUESTS.labels(
+                tenant_id=tenant.tenant_id, mode="run", outcome="rate_limited"
+            ).inc()
+            raise HTTPException(
+                status_code=429,
+                detail=decision.reason,
+                headers={"Retry-After": str(int(decision.retry_after_seconds) + 1)},
+            )
+        concurrency_acquired = True
+        mantis_metrics.CONCURRENT_RUNS.labels(tenant_id=tenant.tenant_id).set(
+            decision.concurrent
+        )
+
+    # ── Tier-2: Webhook URL — caller may override the tenant default ─────
+    webhook_url = (
+        raw.get("callback_url") or tenant.webhook_url or ""
+    ).strip()
+    if webhook_url:
+        payload["_webhook_url"] = webhook_url
+        payload["_webhook_secret_name"] = tenant.webhook_secret_name
+        payload["_tenant_id"] = tenant.tenant_id
+
     logger.info(
-        "predict tenant=%s scope=run state_key=%s detached=%s",
+        "predict tenant=%s scope=run state_key=%s detached=%s action=%s",
         tenant.tenant_id,
         payload["state_key"],
         payload.get("detached", True),
+        req.action or "run",
     )
 
     try:
-        return await run_in_threadpool(runtime.run, payload)
+        response = await run_in_threadpool(runtime.run, payload)
+        mode = req.action or "run"
+        mantis_metrics.PREDICT_REQUESTS.labels(
+            tenant_id=tenant.tenant_id, mode=mode, outcome="ok"
+        ).inc()
+        if is_run_mode and idempotency_key and isinstance(response, dict):
+            get_idempotency_cache().store(
+                tenant.tenant_id, idempotency_key, response.get("run_id", ""), response
+            )
+        if is_run_mode and webhook_url and isinstance(response, dict):
+            run_id = response.get("run_id", "")
+            if response.get("status") in {"succeeded", "failed", "cancelled"}:
+                deliver_webhook_async(
+                    webhook_url,
+                    WebhookPayload(
+                        run_id=run_id,
+                        tenant_id=tenant.tenant_id,
+                        status=str(response.get("status", "")),
+                        summary=response.get("summary") or {},
+                    ),
+                    secret_name=tenant.webhook_secret_name,
+                )
+        return response
     except ValueError as exc:
-        # Validation errors from the runner (bad plan shape, etc.)
+        mantis_metrics.PREDICT_REQUESTS.labels(
+            tenant_id=tenant.tenant_id, mode="run", outcome="bad_request"
+        ).inc()
         raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except HTTPException:
+        raise
     except Exception as exc:
+        mantis_metrics.PREDICT_REQUESTS.labels(
+            tenant_id=tenant.tenant_id, mode="run", outcome="error"
+        ).inc()
         logger.exception("predict failed tenant=%s", tenant.tenant_id)
         raise HTTPException(status_code=500, detail=str(exc)) from exc
+    finally:
+        if concurrency_acquired:
+            limiter.release_concurrency_slot(tenant.tenant_id)
+            mantis_metrics.CONCURRENT_RUNS.labels(tenant_id=tenant.tenant_id).set(
+                limiter.get_concurrent(tenant.tenant_id)
+            )
 
 
 @app.post("/v1/predict")

--- a/src/mantis_agent/idempotency.py
+++ b/src/mantis_agent/idempotency.py
@@ -1,0 +1,144 @@
+"""Tier 2 idempotency-key cache.
+
+When a caller sends the same ``Idempotency-Key`` header twice for the same
+tenant, the server returns the original ``run_id`` instead of starting a
+new run. Useful for retried POSTs where the network failed but the run
+was actually accepted.
+
+Storage: per-process dict + JSON sidecar in the data volume so a replica
+restart preserves the cache. The sidecar layout is:
+
+    $MANTIS_DATA_DIR/idempotency/<tenant_id>/<key_hash>.json
+
+Each entry expires after ``DEFAULT_TTL_SECONDS`` (24h). Expired entries
+are pruned lazily on read.
+
+For multi-replica strict idempotency, swap this for a Redis KV
+backed by SET NX EX semantics. The interface (``get`` / ``store``) is
+designed to make that swap a one-file change.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger("mantis_agent.idempotency")
+
+DEFAULT_TTL_SECONDS = 24 * 60 * 60
+
+
+def _hash_key(key: str) -> str:
+    return hashlib.sha256(key.encode("utf-8")).hexdigest()[:32]
+
+
+@dataclass(frozen=True)
+class CachedRun:
+    run_id: str
+    response: dict[str, Any]
+    stored_at: float
+
+    def is_fresh(self, ttl_seconds: float = DEFAULT_TTL_SECONDS) -> bool:
+        return (time.time() - self.stored_at) < ttl_seconds
+
+
+class IdempotencyCache:
+    """Per-tenant idempotency-key store, keyed by SHA-256 of the user key."""
+
+    def __init__(self, root_dir: Path | str | None = None) -> None:
+        if root_dir is None:
+            root_dir = os.environ.get("MANTIS_IDEMPOTENCY_DIR")
+        if root_dir is None:
+            data = Path(os.environ.get("MANTIS_DATA_DIR", "/workspace/mantis-data"))
+            root_dir = data / "idempotency"
+        self._root = Path(root_dir)
+        self._lock = threading.Lock()
+        self._mem: dict[tuple[str, str], CachedRun] = {}
+
+    def _path_for(self, tenant_id: str, key_hash: str) -> Path:
+        d = self._root / tenant_id
+        d.mkdir(parents=True, exist_ok=True)
+        return d / f"{key_hash}.json"
+
+    def get(self, tenant_id: str, key: str) -> CachedRun | None:
+        if not key:
+            return None
+        kh = _hash_key(key)
+        cache_key = (tenant_id, kh)
+        with self._lock:
+            cached = self._mem.get(cache_key)
+            if cached is not None and cached.is_fresh():
+                return cached
+            # Try sidecar
+            path = self._path_for(tenant_id, kh)
+            if not path.exists():
+                return None
+            try:
+                raw = json.loads(path.read_text())
+            except (OSError, json.JSONDecodeError):
+                return None
+            cached = CachedRun(
+                run_id=raw.get("run_id", ""),
+                response=raw.get("response") or {},
+                stored_at=float(raw.get("stored_at", 0.0)),
+            )
+            if not cached.is_fresh():
+                # Prune lazily
+                try:
+                    path.unlink()
+                except OSError:
+                    pass
+                self._mem.pop(cache_key, None)
+                return None
+            self._mem[cache_key] = cached
+            return cached
+
+    def store(self, tenant_id: str, key: str, run_id: str, response: dict[str, Any]) -> None:
+        if not key or not run_id:
+            return
+        kh = _hash_key(key)
+        cache_key = (tenant_id, kh)
+        cached = CachedRun(run_id=run_id, response=response, stored_at=time.time())
+        with self._lock:
+            self._mem[cache_key] = cached
+            try:
+                self._path_for(tenant_id, kh).write_text(
+                    json.dumps(
+                        {
+                            "run_id": run_id,
+                            "response": response,
+                            "stored_at": cached.stored_at,
+                        }
+                    )
+                )
+            except OSError as exc:
+                logger.warning(
+                    "idempotency: failed to write sidecar for tenant=%s key=%s: %s",
+                    tenant_id,
+                    kh,
+                    exc,
+                )
+
+
+# Module-level singleton.
+_CACHE: IdempotencyCache | None = None
+
+
+def get_idempotency_cache() -> IdempotencyCache:
+    global _CACHE
+    if _CACHE is None:
+        _CACHE = IdempotencyCache()
+    return _CACHE
+
+
+def reset_idempotency_cache() -> None:
+    """Test helper."""
+    global _CACHE
+    _CACHE = None

--- a/src/mantis_agent/metrics.py
+++ b/src/mantis_agent/metrics.py
@@ -1,0 +1,126 @@
+"""Tier 2 Prometheus metrics for the Mantis CUA service.
+
+Lightweight wrappers around prometheus_client. Soft-imported so the
+[orchestrator] extras (which omit prometheus_client) don't break library
+imports — when the dep is absent, all of these become no-ops and
+``/metrics`` returns 503.
+
+Counters / histograms / gauges, all labeled by tenant when applicable:
+
+* ``mantis_predict_requests_total{tenant_id, mode, outcome}``
+* ``mantis_run_duration_seconds{tenant_id, model, status}``
+* ``mantis_run_cost_usd{tenant_id, model, status}``
+* ``mantis_concurrent_runs{tenant_id}``
+* ``mantis_chat_completions_total{tenant_id, status}``
+* ``mantis_rate_limit_rejections_total{tenant_id, kind}``
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger("mantis_agent.metrics")
+
+try:
+    from prometheus_client import (
+        CONTENT_TYPE_LATEST,
+        Counter,
+        Gauge,
+        Histogram,
+        generate_latest,
+    )
+    _PROM_AVAILABLE = True
+except ImportError:  # pragma: no cover - depends on extras
+    _PROM_AVAILABLE = False
+    CONTENT_TYPE_LATEST = "text/plain; version=0.0.4; charset=utf-8"
+
+    def generate_latest(*_args: Any, **_kw: Any) -> bytes:  # type: ignore[no-redef]
+        return b""
+
+
+class _NullMetric:
+    """No-op stand-in when prometheus_client isn't installed."""
+
+    def labels(self, **_kw: Any) -> "_NullMetric":
+        return self
+
+    def inc(self, *_args: Any, **_kw: Any) -> None:
+        pass
+
+    def dec(self, *_args: Any, **_kw: Any) -> None:
+        pass
+
+    def observe(self, *_args: Any, **_kw: Any) -> None:
+        pass
+
+    def set(self, *_args: Any, **_kw: Any) -> None:
+        pass
+
+
+def _counter(name: str, doc: str, labels: tuple[str, ...]) -> Any:
+    if _PROM_AVAILABLE:
+        return Counter(name, doc, labels)
+    return _NullMetric()
+
+
+def _gauge(name: str, doc: str, labels: tuple[str, ...]) -> Any:
+    if _PROM_AVAILABLE:
+        return Gauge(name, doc, labels)
+    return _NullMetric()
+
+
+def _histogram(name: str, doc: str, labels: tuple[str, ...], buckets: tuple[float, ...]) -> Any:
+    if _PROM_AVAILABLE:
+        return Histogram(name, doc, labels, buckets=buckets)
+    return _NullMetric()
+
+
+# ── Metric handles ──────────────────────────────────────────────────────────
+PREDICT_REQUESTS = _counter(
+    "mantis_predict_requests_total",
+    "Count of /predict + /v1/predict invocations.",
+    ("tenant_id", "mode", "outcome"),
+)
+
+CHAT_COMPLETIONS = _counter(
+    "mantis_chat_completions_total",
+    "Count of /v1/chat/completions invocations forwarded to Holo3.",
+    ("tenant_id", "outcome"),
+)
+
+RUN_DURATION_SECONDS = _histogram(
+    "mantis_run_duration_seconds",
+    "End-to-end duration of detached runs in seconds.",
+    ("tenant_id", "model", "status"),
+    buckets=(10, 30, 60, 120, 300, 600, 1200, 1800, 3600),
+)
+
+RUN_COST_USD = _histogram(
+    "mantis_run_cost_usd",
+    "Per-run total cost in USD (GPU + Claude + Proxy).",
+    ("tenant_id", "model", "status"),
+    buckets=(0.01, 0.05, 0.10, 0.25, 0.50, 1.0, 2.5, 5.0, 10.0, 25.0),
+)
+
+CONCURRENT_RUNS = _gauge(
+    "mantis_concurrent_runs",
+    "Currently in-flight runs per tenant.",
+    ("tenant_id",),
+)
+
+RATE_LIMIT_REJECTIONS = _counter(
+    "mantis_rate_limit_rejections_total",
+    "Requests rejected by the per-tenant rate limiter.",
+    ("tenant_id", "kind"),
+)
+
+
+def is_available() -> bool:
+    """True if prometheus_client is installed and metrics are live."""
+    return _PROM_AVAILABLE
+
+
+def render_text() -> bytes:
+    """Render the current registry to Prometheus text-format bytes."""
+    return generate_latest()

--- a/src/mantis_agent/rate_limit.py
+++ b/src/mantis_agent/rate_limit.py
@@ -1,0 +1,158 @@
+"""In-process rate limiter for Tier 2 multi-tenant hardening.
+
+Two dimensions:
+
+* **Concurrency**: count of in-flight runs per tenant; rejects when at
+  ``tenant.max_concurrent_runs``. Tracked as a simple dict + lock.
+* **Rate** (token bucket): refilled at ``rate_limit_per_minute / 60`` tokens
+  per second up to a burst of ``rate_limit_per_minute``. Each accepted
+  request consumes one token.
+
+Thread-safe (uses a single ``threading.Lock``). State is process-local —
+behind a load balancer with N replicas, each replica tracks its own
+counters so the effective per-tenant cap is ``N * configured_cap``. For
+strict cluster-wide limits, swap this module for a Redis-backed limiter
+(future Tier 2.5).
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import threading
+import time
+from typing import Optional
+
+
+@dataclasses.dataclass
+class RateLimitDecision:
+    """Outcome of a rate-limit check."""
+
+    allowed: bool
+    reason: str = ""
+    retry_after_seconds: float = 0.0
+    concurrent: int = 0
+    rate_remaining: float = 0.0
+
+
+@dataclasses.dataclass
+class _ConcurrencyState:
+    in_flight: int = 0
+
+
+@dataclasses.dataclass
+class _BucketState:
+    tokens: float
+    last_refill_ts: float
+
+
+class TenantRateLimiter:
+    """Per-tenant rate + concurrency limiter.
+
+    Args:
+        default_rpm: Default rate-per-minute for tenants whose config does
+            not specify one (read from ``tenant.rate_limit_per_minute`` if
+            present, else this default).
+    """
+
+    def __init__(self, default_rpm: int = 30) -> None:
+        self._default_rpm = default_rpm
+        self._lock = threading.Lock()
+        self._concurrency: dict[str, _ConcurrencyState] = {}
+        self._buckets: dict[str, _BucketState] = {}
+
+    # ── Concurrency ─────────────────────────────────────────────────────
+    def try_acquire_concurrency_slot(
+        self, tenant_id: str, max_concurrent: int
+    ) -> RateLimitDecision:
+        """Reserve a concurrency slot for ``tenant_id`` if available.
+
+        Caller MUST call :meth:`release_concurrency_slot` once the run
+        finishes (success, failure, or cancellation).
+        """
+        with self._lock:
+            state = self._concurrency.setdefault(tenant_id, _ConcurrencyState())
+            if state.in_flight >= max_concurrent:
+                return RateLimitDecision(
+                    allowed=False,
+                    reason=f"max_concurrent_runs ({max_concurrent}) exceeded",
+                    retry_after_seconds=5.0,
+                    concurrent=state.in_flight,
+                )
+            state.in_flight += 1
+            return RateLimitDecision(allowed=True, concurrent=state.in_flight)
+
+    def release_concurrency_slot(self, tenant_id: str) -> None:
+        with self._lock:
+            state = self._concurrency.get(tenant_id)
+            if state and state.in_flight > 0:
+                state.in_flight -= 1
+
+    def get_concurrent(self, tenant_id: str) -> int:
+        with self._lock:
+            state = self._concurrency.get(tenant_id)
+            return state.in_flight if state else 0
+
+    # ── Rate (token bucket) ─────────────────────────────────────────────
+    def try_consume_rate_token(
+        self,
+        tenant_id: str,
+        rate_per_minute: Optional[int] = None,
+    ) -> RateLimitDecision:
+        """Try to consume one rate token; returns ``allowed=False`` with
+        ``retry_after_seconds`` when the bucket is empty."""
+        rpm = rate_per_minute if rate_per_minute is not None else self._default_rpm
+        if rpm <= 0:
+            # Disabled — no rate limit.
+            return RateLimitDecision(allowed=True, rate_remaining=float("inf"))
+
+        burst = float(rpm)
+        refill_per_sec = rpm / 60.0
+        now = time.monotonic()
+        with self._lock:
+            state = self._buckets.get(tenant_id)
+            if state is None:
+                state = _BucketState(tokens=burst, last_refill_ts=now)
+                self._buckets[tenant_id] = state
+            else:
+                elapsed = now - state.last_refill_ts
+                if elapsed > 0:
+                    state.tokens = min(burst, state.tokens + elapsed * refill_per_sec)
+                    state.last_refill_ts = now
+
+            if state.tokens < 1.0:
+                deficit = 1.0 - state.tokens
+                retry_after = deficit / refill_per_sec
+                return RateLimitDecision(
+                    allowed=False,
+                    reason=f"rate limit ({rpm}/min) exceeded",
+                    retry_after_seconds=max(retry_after, 0.1),
+                    rate_remaining=state.tokens,
+                )
+
+            state.tokens -= 1.0
+            return RateLimitDecision(
+                allowed=True, rate_remaining=state.tokens
+            )
+
+    # ── Test / admin helpers ────────────────────────────────────────────
+    def reset(self) -> None:
+        with self._lock:
+            self._concurrency.clear()
+            self._buckets.clear()
+
+
+# Module-level singleton; the server reuses this across requests.
+_LIMITER: TenantRateLimiter | None = None
+
+
+def get_rate_limiter() -> TenantRateLimiter:
+    global _LIMITER
+    if _LIMITER is None:
+        _LIMITER = TenantRateLimiter()
+    return _LIMITER
+
+
+def reset_rate_limiter() -> None:
+    """Test helper: drop the singleton so a fresh state is constructed."""
+    global _LIMITER
+    _LIMITER = None

--- a/src/mantis_agent/tenant_auth.py
+++ b/src/mantis_agent/tenant_auth.py
@@ -49,8 +49,11 @@ class TenantConfig:
     max_concurrent_runs: int = 5
     max_cost_per_run: float = 25.0
     max_time_minutes_per_run: int = 60
+    rate_limit_per_minute: int = 30
     anthropic_secret_name: str = "anthropic_api_key"
     allowed_domains: tuple[str, ...] = ()  # empty = no allowlist (legacy)
+    webhook_url: str = ""  # if set, server POSTs run-completion notifications here
+    webhook_secret_name: str = ""  # secret name for HMAC-signing webhook bodies
 
     def has_scope(self, scope: str) -> bool:
         return scope in self.scopes
@@ -79,6 +82,7 @@ DEFAULT_TENANT = TenantConfig(
     max_concurrent_runs=5,
     max_cost_per_run=25.0,
     max_time_minutes_per_run=60,
+    rate_limit_per_minute=30,
     anthropic_secret_name="anthropic_api_key",
     allowed_domains=(),
 )
@@ -131,10 +135,15 @@ class TenantKeyStore:
                 max_time_minutes_per_run=int(
                     raw.get("max_time_minutes_per_run", DEFAULT_TENANT.max_time_minutes_per_run)
                 ),
+                rate_limit_per_minute=int(
+                    raw.get("rate_limit_per_minute", DEFAULT_TENANT.rate_limit_per_minute)
+                ),
                 anthropic_secret_name=str(
                     raw.get("anthropic_secret_name", DEFAULT_TENANT.anthropic_secret_name)
                 ),
                 allowed_domains=tuple(raw.get("allowed_domains") or ()),
+                webhook_url=str(raw.get("webhook_url") or ""),
+                webhook_secret_name=str(raw.get("webhook_secret_name") or ""),
             )
         return out
 

--- a/src/mantis_agent/webhooks.py
+++ b/src/mantis_agent/webhooks.py
@@ -1,0 +1,175 @@
+"""Tier 2 webhook callbacks for run-completion notifications.
+
+When a tenant has a webhook URL configured (either at tenant level via
+``TenantConfig.webhook_url`` or per-request via ``callback_url`` in the
+PredictRequest), the server POSTs a JSON body to that URL once the run
+reaches a terminal state.
+
+Body shape:
+
+    {
+      "run_id": "...",
+      "tenant_id": "...",
+      "status": "succeeded|failed|cancelled",
+      "summary": { ... },
+      "delivered_at": "<ISO8601>"
+    }
+
+Delivery is signed with HMAC-SHA256 in ``X-Mantis-Signature`` so the
+receiver can verify authenticity. The signing secret is read from a
+container secret named by ``TenantConfig.webhook_secret_name`` (per tenant)
+or by the ``MANTIS_WEBHOOK_SECRET_DEFAULT`` env var.
+
+Retries: 3 attempts with exponential backoff (1s, 5s, 30s). Best-effort —
+delivery state is logged but not persisted; callers should also be able
+to poll ``/v1/predict {action: status, run_id}`` if they miss a webhook.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import logging
+import os
+import threading
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import requests
+
+logger = logging.getLogger("mantis_agent.webhooks")
+
+DEFAULT_RETRY_DELAYS_SECONDS = (1.0, 5.0, 30.0)
+DEFAULT_TIMEOUT_SECONDS = 10.0
+
+
+@dataclass
+class WebhookPayload:
+    run_id: str
+    tenant_id: str
+    status: str
+    summary: dict[str, Any]
+
+    def to_body(self) -> dict[str, Any]:
+        return {
+            "run_id": self.run_id,
+            "tenant_id": self.tenant_id,
+            "status": self.status,
+            "summary": self.summary,
+            "delivered_at": datetime.now(timezone.utc).isoformat(),
+        }
+
+
+def _read_secret(name: str) -> str:
+    if not name:
+        return ""
+    path = Path("/secrets") / name
+    try:
+        return path.read_text().strip()
+    except OSError:
+        return ""
+
+
+def _resolve_signing_secret(secret_name: str) -> str:
+    if secret_name:
+        v = _read_secret(secret_name)
+        if v:
+            return v
+    return os.environ.get("MANTIS_WEBHOOK_SECRET_DEFAULT", "").strip()
+
+
+def sign_body(body_bytes: bytes, secret: str) -> str:
+    """Return the hex-encoded HMAC-SHA256 of ``body_bytes`` under ``secret``."""
+    if not secret:
+        return ""
+    return hmac.new(secret.encode("utf-8"), body_bytes, hashlib.sha256).hexdigest()
+
+
+def deliver_webhook_sync(
+    url: str,
+    payload: WebhookPayload,
+    secret: str = "",
+    retry_delays: tuple[float, ...] = DEFAULT_RETRY_DELAYS_SECONDS,
+    timeout: float = DEFAULT_TIMEOUT_SECONDS,
+    session: requests.Session | None = None,
+) -> bool:
+    """Deliver one webhook. Blocks until success or all retries exhausted.
+
+    Returns True on a 2xx response, False otherwise.
+    """
+    if not url:
+        return False
+    body = json.dumps(payload.to_body(), separators=(",", ":")).encode("utf-8")
+    sig = sign_body(body, secret) if secret else ""
+    headers = {
+        "Content-Type": "application/json",
+        "User-Agent": "mantis-cua/webhook",
+    }
+    if sig:
+        headers["X-Mantis-Signature"] = f"sha256={sig}"
+
+    sess = session or requests
+    attempts = (0,) + retry_delays
+    last_status: int | str = "no-attempt"
+    for i, delay in enumerate(attempts):
+        if delay:
+            time.sleep(delay)
+        try:
+            r = sess.post(url, data=body, headers=headers, timeout=timeout)
+        except requests.RequestException as exc:
+            last_status = f"connection-error: {exc}"
+            logger.warning(
+                "webhook attempt %d/%d failed run_id=%s url=%s err=%s",
+                i + 1, len(attempts), payload.run_id, url, exc,
+            )
+            continue
+        last_status = r.status_code
+        if 200 <= r.status_code < 300:
+            logger.info(
+                "webhook delivered run_id=%s tenant=%s url=%s status=%d attempt=%d",
+                payload.run_id, payload.tenant_id, url, r.status_code, i + 1,
+            )
+            return True
+        logger.warning(
+            "webhook attempt %d/%d non-2xx run_id=%s url=%s status=%d",
+            i + 1, len(attempts), payload.run_id, url, r.status_code,
+        )
+    logger.error(
+        "webhook GAVE UP run_id=%s tenant=%s url=%s last=%s",
+        payload.run_id, payload.tenant_id, url, last_status,
+    )
+    return False
+
+
+def deliver_webhook_async(
+    url: str,
+    payload: WebhookPayload,
+    secret_name: str = "",
+    retry_delays: tuple[float, ...] = DEFAULT_RETRY_DELAYS_SECONDS,
+) -> threading.Thread:
+    """Fire-and-forget webhook delivery in a daemon thread.
+
+    Returns the thread for tests that need to ``join()`` on completion.
+    """
+    secret = _resolve_signing_secret(secret_name)
+
+    def _run() -> None:
+        try:
+            deliver_webhook_sync(url, payload, secret=secret, retry_delays=retry_delays)
+        except Exception:  # noqa: BLE001 — webhook errors should never break the runner
+            logger.exception(
+                "webhook thread crashed run_id=%s url=%s",
+                payload.run_id, url,
+            )
+
+    t = threading.Thread(
+        target=_run,
+        name=f"mantis-webhook-{payload.run_id[:8]}",
+        daemon=True,
+    )
+    t.start()
+    return t

--- a/tests/test_tier2_hardening.py
+++ b/tests/test_tier2_hardening.py
@@ -1,0 +1,258 @@
+"""Tier 2 hardening tests: rate limits, idempotency, webhooks, allowlist, metrics."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import threading
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytest.importorskip("pydantic")
+
+from mantis_agent.api_schemas import (
+    assert_hosts_allowed,
+    extract_navigate_hosts,
+)
+from mantis_agent.idempotency import IdempotencyCache, reset_idempotency_cache
+from mantis_agent import metrics as mantis_metrics
+from mantis_agent.rate_limit import TenantRateLimiter, reset_rate_limiter
+from mantis_agent.tenant_auth import TenantConfig
+from mantis_agent.webhooks import WebhookPayload, deliver_webhook_sync, sign_body
+
+
+# ── Rate limiter ────────────────────────────────────────────────────────────
+def test_rate_limiter_allows_within_burst():
+    rl = TenantRateLimiter()
+    decisions = [rl.try_consume_rate_token("t1", rate_per_minute=60) for _ in range(60)]
+    assert all(d.allowed for d in decisions)
+
+
+def test_rate_limiter_rejects_over_burst():
+    rl = TenantRateLimiter()
+    for _ in range(30):
+        d = rl.try_consume_rate_token("t1", rate_per_minute=30)
+        assert d.allowed
+    d = rl.try_consume_rate_token("t1", rate_per_minute=30)
+    assert not d.allowed
+    assert d.retry_after_seconds > 0
+
+
+def test_rate_limiter_zero_rpm_disables_limit():
+    rl = TenantRateLimiter()
+    for _ in range(1000):
+        d = rl.try_consume_rate_token("t1", rate_per_minute=0)
+        assert d.allowed
+
+
+def test_rate_limiter_per_tenant_isolation():
+    rl = TenantRateLimiter()
+    for _ in range(5):
+        assert rl.try_consume_rate_token("a", rate_per_minute=5).allowed
+    assert not rl.try_consume_rate_token("a", rate_per_minute=5).allowed
+    # Other tenant has its own bucket
+    assert rl.try_consume_rate_token("b", rate_per_minute=5).allowed
+
+
+def test_concurrency_acquire_and_release():
+    rl = TenantRateLimiter()
+    d1 = rl.try_acquire_concurrency_slot("t1", max_concurrent=2)
+    d2 = rl.try_acquire_concurrency_slot("t1", max_concurrent=2)
+    d3 = rl.try_acquire_concurrency_slot("t1", max_concurrent=2)
+    assert d1.allowed and d2.allowed
+    assert not d3.allowed
+    assert d3.retry_after_seconds > 0
+    rl.release_concurrency_slot("t1")
+    d4 = rl.try_acquire_concurrency_slot("t1", max_concurrent=2)
+    assert d4.allowed
+
+
+def test_concurrency_release_floor_at_zero():
+    rl = TenantRateLimiter()
+    rl.release_concurrency_slot("t1")
+    rl.release_concurrency_slot("t1")
+    assert rl.get_concurrent("t1") == 0
+
+
+# ── Idempotency cache ──────────────────────────────────────────────────────
+def test_idempotency_get_returns_none_for_unknown_key(tmp_path: Path):
+    cache = IdempotencyCache(root_dir=tmp_path)
+    assert cache.get("t1", "unseen-key") is None
+
+
+def test_idempotency_store_then_get(tmp_path: Path):
+    cache = IdempotencyCache(root_dir=tmp_path)
+    cache.store("t1", "key1", "20260428_xyz", {"status": "queued", "run_id": "20260428_xyz"})
+    cached = cache.get("t1", "key1")
+    assert cached is not None
+    assert cached.run_id == "20260428_xyz"
+    assert cached.response["status"] == "queued"
+
+
+def test_idempotency_per_tenant_isolation(tmp_path: Path):
+    cache = IdempotencyCache(root_dir=tmp_path)
+    cache.store("t1", "shared-key", "run-A", {"run_id": "run-A"})
+    cache.store("t2", "shared-key", "run-B", {"run_id": "run-B"})
+    assert cache.get("t1", "shared-key").run_id == "run-A"
+    assert cache.get("t2", "shared-key").run_id == "run-B"
+
+
+def test_idempotency_survives_process_restart(tmp_path: Path):
+    cache1 = IdempotencyCache(root_dir=tmp_path)
+    cache1.store("t1", "persistent", "rid", {"run_id": "rid"})
+    # Fresh cache reads the sidecar
+    cache2 = IdempotencyCache(root_dir=tmp_path)
+    cached = cache2.get("t1", "persistent")
+    assert cached is not None and cached.run_id == "rid"
+
+
+def test_idempotency_empty_key_is_noop(tmp_path: Path):
+    cache = IdempotencyCache(root_dir=tmp_path)
+    cache.store("t1", "", "rid", {"run_id": "rid"})
+    cache.store("t1", "real-key", "", {})  # empty run_id also rejected
+    assert cache.get("t1", "") is None
+
+
+def test_idempotency_expired_entry_pruned(tmp_path: Path):
+    cache = IdempotencyCache(root_dir=tmp_path)
+    cache.store("t1", "old", "rid", {"run_id": "rid"})
+    # Manipulate the stored timestamp to look ancient
+    sidecar = next((tmp_path / "t1").glob("*.json"))
+    raw = json.loads(sidecar.read_text())
+    raw["stored_at"] = 0  # epoch
+    sidecar.write_text(json.dumps(raw))
+    cache._mem.clear()  # force re-read from disk
+    assert cache.get("t1", "old") is None
+
+
+# ── Webhook delivery + signing ──────────────────────────────────────────────
+def test_webhook_signature_matches_hmac():
+    body = b'{"foo":"bar"}'
+    sig = sign_body(body, "shared-secret")
+    # Reproduce manually
+    import hashlib
+    import hmac as _hmac
+    expected = _hmac.new(b"shared-secret", body, hashlib.sha256).hexdigest()
+    assert sig == expected
+
+
+def test_webhook_signature_empty_secret_returns_empty():
+    assert sign_body(b'{}', "") == ""
+
+
+def _ok_response(status=200):
+    r = MagicMock()
+    r.status_code = status
+    r.text = "ok"
+    return r
+
+
+def test_webhook_delivers_on_first_try():
+    payload = WebhookPayload(run_id="r1", tenant_id="t1", status="succeeded", summary={})
+    sess = MagicMock()
+    sess.post.return_value = _ok_response(200)
+    ok = deliver_webhook_sync(
+        "https://example.com/hook", payload, secret="s",
+        retry_delays=(0.0,), session=sess,
+    )
+    assert ok
+    sess.post.assert_called_once()
+    # Signature header is present
+    call_kwargs = sess.post.call_args.kwargs
+    assert "X-Mantis-Signature" in call_kwargs["headers"]
+
+
+def test_webhook_retries_on_5xx_then_succeeds():
+    payload = WebhookPayload(run_id="r1", tenant_id="t1", status="failed", summary={})
+    sess = MagicMock()
+    sess.post.side_effect = [_ok_response(503), _ok_response(503), _ok_response(200)]
+    ok = deliver_webhook_sync(
+        "https://example.com/hook", payload, secret="s",
+        retry_delays=(0.0, 0.0), session=sess,
+    )
+    assert ok
+    assert sess.post.call_count == 3
+
+
+def test_webhook_gives_up_after_all_retries_fail():
+    payload = WebhookPayload(run_id="r1", tenant_id="t1", status="failed", summary={})
+    sess = MagicMock()
+    sess.post.return_value = _ok_response(503)
+    ok = deliver_webhook_sync(
+        "https://example.com/hook", payload, secret="s",
+        retry_delays=(0.0, 0.0), session=sess,
+    )
+    assert not ok
+    assert sess.post.call_count == 3
+
+
+def test_webhook_no_url_is_noop():
+    payload = WebhookPayload(run_id="r1", tenant_id="t1", status="succeeded", summary={})
+    assert not deliver_webhook_sync("", payload)
+
+
+# ── URL allowlist enforcement ──────────────────────────────────────────────
+def test_extract_hosts_from_micro_plan():
+    plan = [
+        {"intent": "Navigate to https://www.boattrader.com/boats/state-fl/",
+         "type": "navigate"},
+        {"intent": "Click listing", "type": "click"},
+        {"intent": "Read URL", "type": "extract_url"},
+    ]
+    hosts = extract_navigate_hosts(plan)
+    assert "www.boattrader.com" in hosts
+
+
+def test_extract_hosts_from_task_suite():
+    suite = {
+        "base_url": "https://staffai-test-crm.exe.xyz",
+        "tasks": [
+            {"task_id": "login", "intent": "Go to https://staffai-test-crm.exe.xyz",
+             "start_url": "https://staffai-test-crm.exe.xyz"},
+        ],
+    }
+    hosts = extract_navigate_hosts(suite)
+    assert "staffai-test-crm.exe.xyz" in hosts
+
+
+def test_assert_hosts_allowed_passes_when_all_match():
+    t = TenantConfig(tenant_id="t1", allowed_domains=("*.boattrader.com",))
+    assert_hosts_allowed(["www.boattrader.com"], t.is_domain_allowed)
+
+
+def test_assert_hosts_allowed_raises_on_off_list():
+    t = TenantConfig(tenant_id="t1", allowed_domains=("*.boattrader.com",))
+    with pytest.raises(PermissionError, match="evil.com"):
+        assert_hosts_allowed(["www.boattrader.com", "evil.com"], t.is_domain_allowed)
+
+
+def test_assert_hosts_allowed_empty_list_is_noop():
+    t = TenantConfig(tenant_id="t1", allowed_domains=("only.example.com",))
+    # No URLs in the plan = nothing to check
+    assert_hosts_allowed([], t.is_domain_allowed)
+
+
+# ── Metrics module ──────────────────────────────────────────────────────────
+def test_metrics_handles_support_inc_set_observe():
+    # Whether or not prometheus_client is installed, every metric handle must
+    # support .labels(...).inc() / .set() / .observe() without raising. Don't
+    # reload the module — that double-registers Counters in the global
+    # CollectorRegistry.
+    mantis_metrics.PREDICT_REQUESTS.labels(
+        tenant_id="t-metrics-test", mode="run", outcome="ok"
+    ).inc()
+    mantis_metrics.RATE_LIMIT_REJECTIONS.labels(
+        tenant_id="t-metrics-test", kind="rate"
+    ).inc()
+    mantis_metrics.CONCURRENT_RUNS.labels(tenant_id="t-metrics-test").set(2)
+    mantis_metrics.RUN_DURATION_SECONDS.labels(
+        tenant_id="t-metrics-test", model="holo3", status="succeeded"
+    ).observe(123.4)
+
+
+def test_metrics_render_text_returns_bytes():
+    out = mantis_metrics.render_text()
+    assert isinstance(out, bytes)


### PR DESCRIPTION
## Summary

Tier 2 multi-tenant hardening (rate limits, idempotency, webhooks, URL allowlist, Prometheus metrics) plus the `[orchestrator]` pyproject extras restructure that lets library consumers install without dragging torch/transformers along.

**10 files changed, 1189 insertions, 157/157 tests pass (132 baseline + 25 new Tier 2 tests).**

Stacks on top of `main` (PRs #62, #63, #64 already merged). All Tier 2 features are off-by-default — single-tenant deployments behave identically until the relevant tenant config fields are populated.

## What's new — Tier 2 features

| Concern | Implementation | Toggle |
|---|---|---|
| **Rate limits** | `TenantRateLimiter` — token-bucket per tenant + concurrency gauge. 429 with `Retry-After`. | `tenant.rate_limit_per_minute`, `tenant.max_concurrent_runs` |
| **Idempotency** | File-backed `{(tenant, sha256(key)) → run_id}` cache, 24h TTL, survives replica restart. | `Idempotency-Key` header on `/v1/predict` |
| **Webhooks** | Fire-and-forget HMAC-signed POST on terminal run status. 3-retry exponential backoff (1s, 5s, 30s). | `tenant.webhook_url` or per-request `callback_url` |
| **URL allowlist** | Extracts hosts from `navigate` steps + `task_suite.base_url` + `task.start_url`; rejects 403 if any host is off-list. | `tenant.allowed_domains` |
| **Metrics** | Prometheus counters/histograms/gauges labeled by tenant. `/metrics` endpoint. | install `[metrics]` or `[server]` extras (includes `prometheus-client`) |

## What's new — `[orchestrator]` extras

Slim install footprint for library consumers (vision_claude etc.):

| Extras | Wheel size | What's in it |
|---|---|---|
| (none) | ~5 MB | Pillow only |
| `[orchestrator]` | ~10 MB | + requests + pydantic — enough for MicroPlanRunner + remote Holo3 |
| `[server]` | ~15 MB | + fastapi + uvicorn + prometheus-client |
| `[local-cua]` | ~2 GB | + torch + transformers + pyautogui + mss |
| `[full]` | ~2.1 GB | All of the above |

Base `dependencies` shrunk to `[pillow]`. Heavy deps moved to `[local-cua]` extras. README updated with a footprint table.

**Verified:** all orchestrator-surface modules (`actions`, `gym.{base, runner, micro_runner}`, `brain_holo3`, `brain_claude`, `extraction`, `grounding`, `plan_decomposer`, `site_config`, `api_schemas`, `tenant_auth`) import cleanly with the slim base.

## Multi-tenant config (Tier 2 fields)

```jsonc
{
  "tenant_keys": {
    "<x-mantis-token>": {
      "tenant_id": "vision_claude_prod",
      "scopes": ["run", "status", "result", "logs"],
      "max_concurrent_runs": 3,
      "max_cost_per_run": 5.0,
      "max_time_minutes_per_run": 30,
      "rate_limit_per_minute": 60,           // NEW
      "anthropic_secret_name": "anthropic_api_key_vision_claude",
      "allowed_domains": ["*.boattrader.com", "staffai-test-crm.exe.xyz"],
      "webhook_url": "https://callbacks.example.com/mantis",   // NEW
      "webhook_secret_name": "webhook_secret_vision_claude"    // NEW
    }
  }
}
```

## API additions

| Path | Status | Purpose |
|---|---|---|
| `GET /metrics` | new | Prometheus scrape. Returns 503 if `prometheus_client` not installed. |
| `Idempotency-Key` header on `POST /v1/predict` | new | Returns cached `run_id` on retry. |
| `callback_url` field in `/v1/predict` body | new | Per-request webhook override. |

All other endpoints (`/v1/predict`, `/predict`, `/v1/chat/completions`, `/v1/models`, `/v1/health`, `/health`) unchanged.

## Test plan

- [x] `pytest tests/` — 157/157 pass (132 baseline + 25 new Tier 2 tests)
- [x] All orchestrator-surface modules import with slim base dependencies
- [x] Rate limiter: bursts, isolation, concurrency acquire/release
- [x] Idempotency: store/get, per-tenant isolation, sidecar persistence, expiration
- [x] Webhooks: signature math, 1st-try success, retry-then-success, give-up after retries, no-URL noop
- [x] Allowlist: micro-plan + task-suite host extraction, wildcard match, off-list rejection
- [x] Metrics: handle methods work with or without `prometheus_client`
- [ ] Reviewer: deploy to Baseten dev, send a request with `Idempotency-Key`, retry and confirm cache hit
- [ ] Reviewer: configure a tenant with `rate_limit_per_minute: 5`, send 10 rapid requests, confirm 429 on the 6th
- [ ] Reviewer: set up `webhook_url` for a tenant, run a 3-listing extraction, confirm webhook arrives + signature verifies

## What's NOT in this PR

- Multi-replica strict rate limits (would need Redis backend) — tracked as Tier 2.5
- Tier 3 (billing records, admin API, multi-region) — separate roadmap
- Streaming SSE for `/v1/chat/completions` — small follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)