### PR TITLE
staffai integration follow-up: Baseten URL fix + workload script + onboarding recipes

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -159,7 +159,7 @@ last `tail` events written by the runner (default 200, max 10000).
 OpenAI-compatible reverse proxy to the in-pod Holo3 server. **For raw inference only** — no plan orchestration, no Claude grounding, no checkpointing. Designed for clients that want to run their own perception-action loop and use Holo3 as the brain.
 
 ```bash
-curl -X POST "https://model-qvvgkneq.api.baseten.co/production/v1/chat/completions" \
+curl -X POST "https://model-qvvgkneq.api.baseten.co/production/sync/v1/chat/completions" \
   -H "Authorization: Api-Key $BASETEN_API_KEY" \
   -H "X-Mantis-Token: $MANTIS_API_TOKEN" \
   -H "Content-Type: application/json" \
@@ -201,7 +201,9 @@ OpenAI-compatible model listing.
 ```bash
 TOKEN=$(read -srp "MANTIS_API_TOKEN: " v && echo "$v")
 BTKEY="$BASETEN_API_KEY"
-ENDPOINT="https://model-qvvgkneq.api.baseten.co/production"
+# Baseten gateway forwards /sync/<any path> to the container. /predict is
+# the legacy default route (equivalent to /sync/predict).
+ENDPOINT="https://model-qvvgkneq.api.baseten.co/production/sync"
 
 # 1. Launch detached run
 RESP=$(curl -fsS -X POST "$ENDPOINT/v1/predict" \

--- a/docs/client/index.md
+++ b/docs/client/index.md
@@ -17,7 +17,7 @@ Looking for the full HTTP API surface? See [Reference / HTTP API](../api.md).
 ```python
 import os, time, requests
 
-ENDPOINT = os.environ["MANTIS_ENDPOINT"]      # e.g. https://model-qvvgkneq.api.baseten.co/production
+ENDPOINT = os.environ["MANTIS_ENDPOINT"]      # e.g. https://model-qvvgkneq.api.baseten.co/production/sync
 PLATFORM = os.environ["BASETEN_API_KEY"]
 TENANT   = os.environ["MANTIS_API_TOKEN"]
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -11,7 +11,9 @@ If someone has already deployed Mantis (or you're using the public Baseten refer
 ```bash
 export BASETEN_API_KEY="<your baseten api key>"
 export MANTIS_API_TOKEN="<your mantis tenant token>"
-export ENDPOINT="https://model-qvvgkneq.api.baseten.co/production"
+# Baseten forwards /sync/<any path> to the container's FastAPI app. The
+# legacy /predict route still works (gateway treats it as /sync/predict).
+export ENDPOINT="https://model-qvvgkneq.api.baseten.co/production/sync"
 ```
 
 ## 1. Submit the plan

--- a/docs/integration-vision_claude.md
+++ b/docs/integration-vision_claude.md
@@ -288,8 +288,13 @@ mantis_endpoint: str = Field(
     default="",
     description=(
         "Base URL of the Mantis service (without /v1 suffix). "
-        "Same shape regardless of host — Baseten model URL, Modal web "
-        "endpoint, or your own ingress."
+        "Same shape regardless of host — Baseten gateway URL, Modal web "
+        "endpoint, or your own ingress. "
+        "On Baseten, append `/sync` to the model URL so the gateway "
+        "forwards /v1/chat/completions to the container — e.g. "
+        "https://model-qvvgkneq.api.baseten.co/production/sync. "
+        "Modal/EKS/GKE deployments expose the FastAPI app directly with "
+        "no /sync prefix."
     ),
 )
 mantis_api_token: SecretStr = Field(

--- a/docs/integrations/generic-cua.md
+++ b/docs/integrations/generic-cua.md
@@ -1,0 +1,277 @@
+# Generic CUA over HTTP — any site, any data shape
+
+Use Mantis as a **language-agnostic extraction service**. No Python install,
+no library embedding — just `/v1/predict` with a plan and your own data
+shape. This is the right doc if you're building an extraction pipeline
+for jobs, products, profiles, news, real-estate, or any site that follows
+the **search → click → extract → loop** pattern.
+
+> Companion: [Recipes](recipes.md) for copy-paste templates of common
+> patterns. [Embedding MicroPlanRunner](embedding-microplanrunner.md) if
+> you'd rather drive the runner in-process from Python.
+
+---
+
+## Onboarding in 5 steps
+
+1. Get an `X-Mantis-Token` from the Mantis operator (one tenant key per app).
+2. Set `allowed_domains` on the tenant (wildcards: `*.greenhouse.io`).
+3. Author or generate a micro-plan for your target site.
+4. Optionally: define a custom `ExtractionSchema` in the plan payload.
+5. POST to `/v1/predict` with `detached: true`; poll `/predict` with
+   `action: status` until the run completes; then `action: result`.
+
+The three values you need:
+
+```bash
+export MANTIS_ENDPOINT="https://model-qvvgkneq.api.baseten.co/production/sync"
+export MANTIS_API_TOKEN="..."        # the X-Mantis-Token your operator issued
+export BASETEN_API_KEY="..."         # only needed when fronted by the Baseten gateway
+```
+
+For Modal / EKS / GKE deployments, drop the `BASETEN_API_KEY` — Mantis
+self-hosted enforces auth purely via `X-Mantis-Token`.
+
+---
+
+## The four plan shapes — pick one
+
+| Shape | Field | Best for |
+|---|---|---|
+| Plain English | `plan_text: "Extract the first 5 jobs from..."` | One-shots, prototyping. Server decomposes via Claude (cached after first call). |
+| Hand-authored micro-plan | `micro: <inline-json-list-of-steps>` or `micro: "plans/path.json"` | Production extraction at high volume. Maximum reliability. |
+| Multi-task batch | `task_suite: { tasks: [...] }` | Several independent tasks in one submission. |
+| Pre-baked file | `task_file: "tasks/myorg/foo.json"` | The plan ships in the container image. |
+
+Decision tree is in [Sending plans](../client/plans.md#decision-tree).
+
+---
+
+## Example 1 — One-shot extraction with `plan_text`
+
+The fastest path. You hand it English; it figures out the structure.
+
+```bash
+curl -fsS -X POST "$MANTIS_ENDPOINT/v1/predict" \
+  -H "Authorization: Api-Key $BASETEN_API_KEY" \
+  -H "X-Mantis-Token: $MANTIS_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "detached": true,
+    "plan_text": "Go to https://news.ycombinator.com/ and extract the title, points, and comment count of the top 5 stories",
+    "state_key": "hn-top5",
+    "max_cost": 1,
+    "max_time_minutes": 10
+  }'
+```
+
+Returns:
+
+```jsonc
+{
+  "run_id": "20260429_103045_a1b2c3d4",
+  "status": "queued"
+}
+```
+
+Poll `/predict` with `{"action":"status","run_id":"..."}` until status is
+`succeeded` / `failed` / `cancelled`, then fetch results with
+`{"action":"result","run_id":"..."}`. Full polling pattern in
+[Runs and polling](../client/runs-and-polling.md).
+
+---
+
+## Example 2 — Hand-authored micro-plan with custom schema
+
+When the same workflow runs many times, hand-author the plan once. Inline
+JSON is supported in the `micro` field — you don't need to ship a file
+in the image.
+
+```bash
+curl -fsS -X POST "$MANTIS_ENDPOINT/v1/predict" \
+  -H "Authorization: Api-Key $BASETEN_API_KEY" \
+  -H "X-Mantis-Token: $MANTIS_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d @- <<'JSON'
+{
+  "detached": true,
+  "state_key": "greenhouse-ml-sf-prod",
+  "max_cost": 4,
+  "max_time_minutes": 30,
+  "extraction_schema": {
+    "entity_name": "job posting",
+    "fields": [
+      {"name": "title",      "type": "str", "required": true,  "example": "ML Engineer"},
+      {"name": "team",       "type": "str", "required": false, "example": "Search & Ranking"},
+      {"name": "location",   "type": "str", "required": false, "example": "San Francisco"},
+      {"name": "url",        "type": "str", "required": true,  "example": "boards.greenhouse.io/..."},
+      {"name": "department", "type": "str", "required": false, "example": "Engineering"}
+    ],
+    "required_fields": ["title", "url"],
+    "spam_indicators": ["recruiter", "staffing agency"],
+    "spam_label": "recruiter spam"
+  },
+  "micro": [
+    {"intent": "Navigate to https://boards.greenhouse.io/openai/jobs?department=Engineering&location=San+Francisco",
+     "type": "navigate", "budget": 3, "section": "setup", "required": true},
+    {"intent": "Verify page shows OpenAI engineering job listings filtered to San Francisco",
+     "type": "extract_data", "claude_only": true, "budget": 0, "section": "setup",
+     "gate": true,
+     "verify": "Page is the OpenAI Greenhouse jobs board, filtered to Engineering+San Francisco, with at least one listing visible"},
+    {"intent": "Click the next un-extracted job posting title",
+     "type": "click", "budget": 8, "grounding": true, "section": "extraction"},
+    {"intent": "Read the URL from the address bar",
+     "type": "extract_url", "claude_only": true, "budget": 0, "section": "extraction"},
+    {"intent": "Scroll down to read the full job description",
+     "type": "scroll", "budget": 5, "section": "extraction"},
+    {"intent": "Extract title, team, location, department, url",
+     "type": "extract_data", "claude_only": true, "budget": 0, "section": "extraction"},
+    {"intent": "Re-navigate to the search page at https://boards.greenhouse.io/openai/jobs?department=Engineering&location=San+Francisco",
+     "type": "navigate", "budget": 3, "section": "extraction"},
+    {"intent": "Loop back to click the next job",
+     "type": "loop", "loop_target": 2, "loop_count": 10, "section": "extraction"}
+  ]
+}
+JSON
+```
+
+Notes on the schema:
+
+- **`extraction_schema`** is read by `ClaudeExtractor` to drive the
+  per-listing JSON output and the spam detector. Field shape mirrors
+  `mantis_agent.extraction.ExtractionSchema`.
+- **`required_fields`** controls viability — listings missing any of these
+  are dropped from the result. `["title", "url"]` is the minimum useful
+  shape; relax it for noisier sites.
+- **`spam_indicators`** and **`spam_label`** customize the detector. For
+  jobs, recruiter spam is the analog of dealer spam in the boats domain.
+- The plan uses `re-navigate` (a fresh `navigate` step) instead of
+  `navigate_back` to return to the results page — this is more reliable
+  than the browser back button when the model isn't sure.
+
+---
+
+## Example 3 — Custom site config for unusual URL patterns
+
+`SiteConfig` tells the runner which URLs are detail pages vs. results
+pages, and how pagination works. Most sites are auto-detected by the site prober;
+for unusual sites,
+ship a `site_config` block alongside the plan:
+
+```jsonc
+{
+  "detached": true,
+  "state_key": "redfin-sf-condos-v1",
+  "site_config": {
+    "domain": "redfin.com",
+    "detail_page_pattern": "/CA/[\\w-]+/.*?/home/\\d+",
+    "results_page_pattern": "/city/\\d+/CA/San-Francisco/filter/",
+    "pagination_format": "page-{n}/",
+    "pagination_type": "path_suffix",
+    "pagination_strip_pattern": "page-\\d+/?$",
+    "filtered_results_url": "https://www.redfin.com/city/17151/CA/San-Francisco/filter/property-type=condo,price-min=500k"
+  },
+  "micro": [ /* steps reference $RESULTS_URL = filtered_results_url */ ]
+}
+```
+
+`site_config` is what tells the runner that going to `…/home/12345`
+means "we're on a detail page" (so it knows to scroll + extract) and
+that pagination is `…/page-2/`, not `?page=2`.
+
+Reference: `mantis_agent.site_config.SiteConfig` (full field list).
+
+---
+
+## Tenant configuration the operator does once
+
+Before any extraction starts, the Mantis operator issues a tenant key
+with the shape:
+
+```jsonc
+{
+  "tenant_keys": {
+    "<your-x-mantis-token>": {
+      "tenant_id": "your_org",
+      "scopes": ["run", "status", "result", "logs"],
+      "max_concurrent_runs": 3,
+      "max_cost_per_run": 5.0,
+      "max_time_minutes_per_run": 30,
+      "anthropic_secret_name": "anthropic_api_key_your_org",
+      "allowed_domains": [
+        "*.greenhouse.io",
+        "*.lever.co",
+        "boards.example.com"
+      ],
+      "webhook_url": "https://your-app.example.com/mantis-webhook",
+      "webhook_secret_name": "your_org_webhook_secret"
+    }
+  }
+}
+```
+
+`allowed_domains` is enforced per-request — plans that try to navigate
+outside the wildcard list are rejected before any GPU time is spent.
+`webhook_url` is fired when each detached run completes. Full setup in
+[Tenant keys](../operations/tenant-keys.md).
+
+---
+
+## What you get back
+
+Every successful run produces:
+
+```jsonc
+{
+  "run_id": "20260429_103045_a1b2c3d4",
+  "status": "succeeded",
+  "summary": {
+    "viable": 7,                 // listings that passed the spam + required-fields gates
+    "leads": [
+      "VIABLE | title: ML Engineer | team: Search | location: San Francisco | url: ...",
+      "VIABLE | title: ML Engineer Manager | ...",
+      ...
+    ],
+    "leads_with_phone": 0,       // for schemas that include a phone field
+    "cost_total": 0.42,
+    "cost_breakdown": {
+      "gpu":    0.12,
+      "claude": 0.12,
+      "proxy":  0.18
+    },
+    "dynamic_verification_summary": { /* coverage report — discovered vs attempted vs completed */ }
+  },
+  "csv_path": "/workspace/mantis-data/results/.../leads.csv",
+  "events_path": "/workspace/mantis-data/runs/.../events.log",
+  "video_path": "/workspace/mantis-data/runs/.../recording.mp4"  // when record_video: true
+}
+```
+
+Leads come back as pipe-delimited strings keyed by your schema's field
+names. CSV and recording are downloadable via dedicated endpoints — see
+[Recordings](../client/recordings.md) and [Runs and polling](../client/runs-and-polling.md).
+
+---
+
+## What's NOT supported (today)
+
+- **File uploads.** No `LAUNCH_APP`-equivalent for `<input type="file">`.
+- **Multi-tab orchestration.** Plans run on one tab; opening new tabs via
+  `Ctrl+T` works but isn't first-class.
+- **CAPTCHA / hCaptcha.** Holo3 cannot solve these. Residential proxy
+  + Cloudflare auto-pass usually works; hard challenges don't.
+- **Plans >200 steps in one submission.** Server hard cap. Chunk into
+  multiple runs sharing the same `state_key` to use checkpoint resume.
+
+For these, [Library embedding](embedding-microplanrunner.md) gives you
+escape hatches via `register_tool` (host-provided tools the model can
+call) and `PauseRequested` (human-in-the-loop pause).
+
+---
+
+## Next
+
+- [Recipes](recipes.md) — copy-paste plans for common patterns.
+- [Sending plans](../client/plans.md) — full request schema.
+- [Runs and polling](../client/runs-and-polling.md) — async lifecycle.
+- [Tenant keys](../operations/tenant-keys.md) — operator setup.

--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -1,9 +1,29 @@
 # Integrations
 
-Specific runbooks for plugging Mantis into other systems.
+Mantis ships as a library and a service. The right integration shape depends
+on what you're building.
 
-| | What it covers |
-|---|---|
-| [vision_claude](../integration-vision_claude.md) | Replacing Anthropic Computer Use with Mantis as the perception+reasoning backend in StaffAI's vision_claude agent. Uses the orchestrator-only path: vision_claude keeps Xvfb + Chrome + the mounted profile; Mantis exposes Holo3 inference over `/v1/chat/completions`. |
+## Decision flow
 
-If you're integrating from a fresh codebase, the [Client](../client/index.md) section is the right starting point. Use the integration runbooks in this section for established codebases that already have their own desktop / browser / agent loop.
+```
+Need to call Mantis from your existing app?
+  ├─ Just need extraction from a website        → HTTP only          (5 min onboarding)
+  ├─ Have your own Python desktop / Xvfb stack  → Library embedding  (~150 LoC adapter)
+  └─ Custom CUA backend in someone else's product → Host integration  (parity layer)
+```
+
+## The five integration patterns
+
+| Pattern | When | Doc |
+|---|---|---|
+| **Quickstart** — curl, plan_text, get leads back | First time, want to see it work in 5 minutes | [Quickstart](../getting-started/quickstart.md) |
+| **Generic CUA over HTTP** — your own domain, your own ExtractionSchema, all via `/v1/predict` | Building an extraction pipeline for any site (jobs, products, listings, profiles, etc.) without writing Python or hosting Mantis | [Generic CUA usage](generic-cua.md) |
+| **Recipes** — copy-paste micro-plans for common patterns (jobs, e-commerce, news, real-estate) | You want a working starting point for a typical pattern, not theory | [Recipes](recipes.md) |
+| **Library embedding** — `MicroPlanRunner` in your own Python process, your own `GymEnvironment` | You already own a desktop / Xvfb / Chrome stack and want Mantis as the brain | [Embedding MicroPlanRunner](embedding-microplanrunner.md) |
+| **vision_claude / staffai** — the canonical parity-layer integration | Replacing Anthropic Computer Use in StaffAI's vision_claude. Specific patches in `staffai_tools/vision_claude/`. | [vision_claude integration](../integration-vision_claude.md) + [parity addendum](../staffai-vision_claude-parity.md) |
+
+## What's host-agnostic vs. host-specific
+
+The library surface (`mantis_agent.MicroPlanRunner`, `PauseRequested`, `register_tool`, `step_callback`, `cancel_event`) makes no assumptions about what host you're running in. The vision_claude parity addendum is staffai-specific by design (file paths, line numbers, backend-factory wiring), but every primitive it uses is exposed for any host.
+
+If you're integrating a fresh codebase that has no existing browser stack, the [Client](../client/index.md) section + the recipes here are the right starting point. If you're plugging Mantis into an established codebase that already runs Xvfb, Chrome, or its own agent loop, [Embedding MicroPlanRunner](embedding-microplanrunner.md) is the doc you want.

--- a/docs/integrations/recipes.md
+++ b/docs/integrations/recipes.md
@@ -1,0 +1,302 @@
+# Recipes — copy-paste plans for common patterns
+
+Working starting points for the four extraction patterns most teams
+onboard with. Each recipe is a complete `/v1/predict` request body —
+swap the URL and the schema fields and you have a working pipeline.
+
+> Same pattern across all four: **navigate → gate → click → extract_url
+> → scroll → extract_data → re-navigate → loop**. The structure is
+> universal; what changes is the schema and the start URL.
+
+For the full request envelope (auth, polling, results), see
+[Generic CUA usage](generic-cua.md). For when each piece kicks in, see
+[Concepts](../getting-started/concepts.md).
+
+---
+
+## Recipe 1 — Job listings (Greenhouse / Lever / Workday-style)
+
+**Best for:** boards with `/jobs/<id>` detail URLs and filterable list pages.
+
+```bash
+curl -fsS -X POST "$MANTIS_ENDPOINT/v1/predict" \
+  -H "Authorization: Api-Key $BASETEN_API_KEY" \
+  -H "X-Mantis-Token: $MANTIS_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d @- <<'JSON'
+{
+  "detached": true,
+  "state_key": "greenhouse-openai-eng-sf",
+  "max_cost": 4,
+  "max_time_minutes": 30,
+  "extraction_schema": {
+    "entity_name": "job posting",
+    "fields": [
+      {"name": "title",      "type": "str", "required": true,  "example": "Software Engineer"},
+      {"name": "team",       "type": "str", "required": false, "example": "Infrastructure"},
+      {"name": "location",   "type": "str", "required": false, "example": "San Francisco, CA"},
+      {"name": "department", "type": "str", "required": false, "example": "Engineering"},
+      {"name": "url",        "type": "str", "required": true,  "example": "boards.greenhouse.io/..."}
+    ],
+    "required_fields": ["title", "url"],
+    "spam_indicators": ["recruiter", "staffing agency", "third party"],
+    "spam_label": "recruiter spam"
+  },
+  "micro": [
+    {"intent": "Navigate to https://boards.greenhouse.io/openai/jobs?department=Engineering&location=San+Francisco",
+     "type": "navigate", "budget": 3, "section": "setup", "required": true},
+    {"intent": "Verify page is the OpenAI Greenhouse engineering board, San Francisco filter active, listings visible",
+     "type": "extract_data", "claude_only": true, "budget": 0, "section": "setup",
+     "gate": true,
+     "verify": "Page shows engineering job listings filtered to San Francisco"},
+    {"intent": "Click the next un-extracted job posting title",
+     "type": "click", "budget": 8, "grounding": true, "section": "extraction"},
+    {"intent": "Read URL from address bar",
+     "type": "extract_url", "claude_only": true, "budget": 0, "section": "extraction"},
+    {"intent": "Scroll down to read the description",
+     "type": "scroll", "budget": 5, "section": "extraction"},
+    {"intent": "Extract title, team, location, department, url",
+     "type": "extract_data", "claude_only": true, "budget": 0, "section": "extraction"},
+    {"intent": "Re-navigate to the search page at https://boards.greenhouse.io/openai/jobs?department=Engineering&location=San+Francisco",
+     "type": "navigate", "budget": 3, "section": "extraction"},
+    {"intent": "Loop to next listing",
+     "type": "loop", "loop_target": 2, "loop_count": 10, "section": "extraction"}
+  ]
+}
+JSON
+```
+
+Lever variant: same shape, replace start URL with
+`https://jobs.lever.co/<company>/?team=Engineering&location=...` and
+the gate verify text accordingly.
+
+---
+
+## Recipe 2 — E-commerce product catalog (Amazon / Shopify-style)
+
+**Best for:** product detail pages with `price`, `rating`, `availability` fields.
+
+```bash
+curl -fsS -X POST "$MANTIS_ENDPOINT/v1/predict" \
+  -H "Authorization: Api-Key $BASETEN_API_KEY" \
+  -H "X-Mantis-Token: $MANTIS_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d @- <<'JSON'
+{
+  "detached": true,
+  "state_key": "amazon-mech-keyboards",
+  "max_cost": 3,
+  "max_time_minutes": 25,
+  "extraction_schema": {
+    "entity_name": "product",
+    "fields": [
+      {"name": "name",         "type": "str", "required": true,  "example": "Keychron K6 Wireless"},
+      {"name": "price",        "type": "str", "required": true,  "example": "$89.99"},
+      {"name": "rating",       "type": "str", "required": false, "example": "4.5/5 (1,234)"},
+      {"name": "availability", "type": "str", "required": false, "example": "In Stock"},
+      {"name": "brand",        "type": "str", "required": false, "example": "Keychron"},
+      {"name": "url",          "type": "str", "required": true,  "example": "amazon.com/dp/..."}
+    ],
+    "required_fields": ["name", "price", "url"]
+  },
+  "site_config": {
+    "domain": "amazon.com",
+    "detail_page_pattern": "/dp/[A-Z0-9]+",
+    "results_page_pattern": "/s\\?",
+    "pagination_format": "page={n}",
+    "pagination_type": "query_param",
+    "pagination_strip_pattern": "[?&]page=\\d+"
+  },
+  "micro": [
+    {"intent": "Navigate to https://www.amazon.com/s?k=mechanical+keyboard",
+     "type": "navigate", "budget": 3, "section": "setup", "required": true},
+    {"intent": "Verify page is Amazon search results for mechanical keyboards",
+     "type": "extract_data", "claude_only": true, "budget": 0, "section": "setup",
+     "gate": true, "verify": "Page is an Amazon search results page for mechanical keyboards with multiple products visible"},
+    {"intent": "Click the next un-extracted product title (skip sponsored tiles)",
+     "type": "click", "budget": 8, "grounding": true, "section": "extraction"},
+    {"intent": "Read URL from address bar",
+     "type": "extract_url", "claude_only": true, "budget": 0, "section": "extraction"},
+    {"intent": "Scroll down to see price + availability + reviews",
+     "type": "scroll", "budget": 5, "section": "extraction"},
+    {"intent": "Extract name, price, rating, availability, brand, url",
+     "type": "extract_data", "claude_only": true, "budget": 0, "section": "extraction"},
+    {"intent": "Re-navigate to https://www.amazon.com/s?k=mechanical+keyboard",
+     "type": "navigate", "budget": 3, "section": "extraction"},
+    {"intent": "Loop to next product",
+     "type": "loop", "loop_target": 2, "loop_count": 8, "section": "extraction"},
+    {"intent": "Click Next page",
+     "type": "paginate", "budget": 10, "grounding": true, "section": "pagination"},
+    {"intent": "Loop back to extract products on the new page",
+     "type": "loop", "loop_target": 2, "loop_count": 3, "section": "pagination"}
+  ]
+}
+JSON
+```
+
+Note the **two-level loop**: the inner loop walks listings on a page;
+the outer loop paginates and re-runs the inner loop.
+
+---
+
+## Recipe 3 — News articles (any newsroom site)
+
+**Best for:** structured headline + byline + body extraction.
+
+```bash
+curl -fsS -X POST "$MANTIS_ENDPOINT/v1/predict" \
+  -H "Authorization: Api-Key $BASETEN_API_KEY" \
+  -H "X-Mantis-Token: $MANTIS_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d @- <<'JSON'
+{
+  "detached": true,
+  "state_key": "techcrunch-ai-recent",
+  "max_cost": 2,
+  "max_time_minutes": 20,
+  "extraction_schema": {
+    "entity_name": "news article",
+    "fields": [
+      {"name": "headline",  "type": "str", "required": true,  "example": "OpenAI launches..."},
+      {"name": "byline",    "type": "str", "required": false, "example": "Jane Doe"},
+      {"name": "published", "type": "str", "required": false, "example": "2026-04-29T12:00:00Z"},
+      {"name": "summary",   "type": "str", "required": false, "example": "first paragraph"},
+      {"name": "url",       "type": "str", "required": true,  "example": "techcrunch.com/2026/..."}
+    ],
+    "required_fields": ["headline", "url"]
+  },
+  "micro": [
+    {"intent": "Navigate to https://techcrunch.com/category/artificial-intelligence/",
+     "type": "navigate", "budget": 3, "section": "setup", "required": true},
+    {"intent": "Verify page is the TechCrunch AI category index with headlines visible",
+     "type": "extract_data", "claude_only": true, "budget": 0, "section": "setup",
+     "gate": true, "verify": "Page is TechCrunch's AI category page with multiple article headlines"},
+    {"intent": "Click the next un-extracted article headline",
+     "type": "click", "budget": 8, "grounding": true, "section": "extraction"},
+    {"intent": "Read URL from address bar",
+     "type": "extract_url", "claude_only": true, "budget": 0, "section": "extraction"},
+    {"intent": "Scroll past the lede paragraph",
+     "type": "scroll", "budget": 3, "section": "extraction"},
+    {"intent": "Extract headline, byline, published, summary (first paragraph), url",
+     "type": "extract_data", "claude_only": true, "budget": 0, "section": "extraction"},
+    {"intent": "Re-navigate to https://techcrunch.com/category/artificial-intelligence/",
+     "type": "navigate", "budget": 3, "section": "extraction"},
+    {"intent": "Loop to next article",
+     "type": "loop", "loop_target": 2, "loop_count": 5, "section": "extraction"}
+  ]
+}
+JSON
+```
+
+For paywalled sources, supply login via the embedding path
+([`register_tool`](embedding-microplanrunner.md)) — the HTTP-only path
+doesn't have a credential-injection primitive.
+
+---
+
+## Recipe 4 — Real estate listings (Zillow / Redfin / Trulia-style)
+
+**Best for:** listings with `address`, `price`, `beds/baths/sqft`, `listing agent`.
+
+```bash
+curl -fsS -X POST "$MANTIS_ENDPOINT/v1/predict" \
+  -H "Authorization: Api-Key $BASETEN_API_KEY" \
+  -H "X-Mantis-Token: $MANTIS_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d @- <<'JSON'
+{
+  "detached": true,
+  "state_key": "zillow-sf-condos-1m-2m",
+  "max_cost": 5,
+  "max_time_minutes": 35,
+  "extraction_schema": {
+    "entity_name": "real estate listing",
+    "fields": [
+      {"name": "address",      "type": "str", "required": true,  "example": "123 Main St, San Francisco, CA 94105"},
+      {"name": "price",        "type": "str", "required": true,  "example": "$1,250,000"},
+      {"name": "beds",         "type": "str", "required": false, "example": "2"},
+      {"name": "baths",        "type": "str", "required": false, "example": "2"},
+      {"name": "sqft",         "type": "str", "required": false, "example": "1,100"},
+      {"name": "agent",        "type": "str", "required": false, "example": "Jane Smith, Compass"},
+      {"name": "url",          "type": "str", "required": true,  "example": "zillow.com/homedetails/..."}
+    ],
+    "required_fields": ["address", "price", "url"],
+    "spam_indicators": ["3D Home", "Zestimate-only", "off-market"],
+    "spam_label": "non-listing"
+  },
+  "site_config": {
+    "domain": "zillow.com",
+    "detail_page_pattern": "/homedetails/[\\w-]+/\\d+_zpid",
+    "results_page_pattern": "/homes/for_sale/",
+    "pagination_format": "/{n}_p/",
+    "pagination_type": "path_suffix"
+  },
+  "micro": [
+    {"intent": "Navigate to https://www.zillow.com/homes/for_sale/San-Francisco-CA/condos_dom/?price=1000000-2000000",
+     "type": "navigate", "budget": 3, "section": "setup", "required": true},
+    {"intent": "Verify page is the SF condos for sale, $1M-$2M price range, with listings visible",
+     "type": "extract_data", "claude_only": true, "budget": 0, "section": "setup",
+     "gate": true, "verify": "Zillow SF condos $1M-$2M, multiple property cards visible"},
+    {"intent": "Click the next un-extracted listing card",
+     "type": "click", "budget": 8, "grounding": true, "section": "extraction"},
+    {"intent": "Read URL from address bar",
+     "type": "extract_url", "claude_only": true, "budget": 0, "section": "extraction"},
+    {"intent": "Scroll to property facts and listing agent",
+     "type": "scroll", "budget": 6, "section": "extraction"},
+    {"intent": "Extract address, price, beds, baths, sqft, agent, url",
+     "type": "extract_data", "claude_only": true, "budget": 0, "section": "extraction"},
+    {"intent": "Re-navigate to https://www.zillow.com/homes/for_sale/San-Francisco-CA/condos_dom/?price=1000000-2000000",
+     "type": "navigate", "budget": 3, "section": "extraction"},
+    {"intent": "Loop to next listing",
+     "type": "loop", "loop_target": 2, "loop_count": 12, "section": "extraction"}
+  ]
+}
+JSON
+```
+
+Real estate sites are aggressive about Cloudflare; if you see `gate_failed`
+in the result, increase `proxy_city` / `proxy_state` to a residential
+target close to the listing geography.
+
+---
+
+## Picking the right `loop_count` and `max_cost`
+
+Rough calibration (Holo3 / Claude / IPRoyal proxy on the Baseten H100):
+
+| Items wanted | Recommended `loop_count` | Wall time | Typical cost |
+|---|---|---|---|
+| 3-5 | 5-8 | 6-10 min | $0.50-$1.00 |
+| 10 | 15 | 15-20 min | $1.50-$2.50 |
+| 20 | 30 | 30-40 min | $3-$5 |
+| 50+ | Chunk via state_key resume | n/a | n/a |
+
+Bump `loop_count` higher than your target (1.5×) — it absorbs failures on
+spam-skipped listings and dead detail pages. Hard caps:
+`MANTIS_MAX_LOOP_ITERATIONS=50`, `MANTIS_MAX_STEPS_PER_PLAN=200`.
+
+For >50 items, split into multiple `/v1/predict` runs sharing the same
+`state_key` and pass `resume_state: true` — the runner picks up at the
+last checkpoint.
+
+---
+
+## Anti-patterns to avoid
+
+| Don't | Do instead |
+|---|---|
+| `navigate_back` (browser back button) — Holo3 misclicks it ~30% | Use a fresh `navigate` step to the search URL |
+| Plans without a `gate` step after `navigate` | Always add a Claude-verified gate so you halt fast on Cloudflare/wrong-page |
+| `max_cost: 0.50` | Hits the cap mid-extraction; budget at least $1.50 for a 10-listing run |
+| Hardcoding `"Sponsored"` skip logic in `intent` strings | Set `spam_indicators` in the schema; the runner skips automatically |
+| `claude_only: false` on extract_data | Holo3 isn't a vision-language model; always use Claude for extraction |
+
+---
+
+## Next
+
+- [Generic CUA usage](generic-cua.md) — the request envelope + tenant setup.
+- [Embedding MicroPlanRunner](embedding-microplanrunner.md) — when you
+  need pause/resume, host tools, or library-level control.
+- [Plan formats](../getting-started/plan-formats.md) — every micro-step
+  field documented.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -115,6 +115,8 @@ nav:
       - Metrics: operations/metrics.md
   - Integrations:
       - integrations/index.md
+      - Generic CUA over HTTP: integrations/generic-cua.md
+      - Recipes (jobs, e-commerce, news, real-estate): integrations/recipes.md
       - Embedding MicroPlanRunner: integrations/embedding-microplanrunner.md
       - vision_claude: integration-vision_claude.md
       - vision_claude — parity addendum: staffai-vision_claude-parity.md

--- a/scripts/baseten_workload.py
+++ b/scripts/baseten_workload.py
@@ -39,6 +39,13 @@ def baseten_api_key() -> str:
     raise SystemExit("Missing BASETEN_API_KEY, BASETEN_KEY, or HAI_API_KEY in environment/.env")
 
 
+def mantis_api_token() -> str:
+    value = os.environ.get("MANTIS_API_TOKEN", "").strip()
+    if not value:
+        raise SystemExit("Missing MANTIS_API_TOKEN in environment/.env (set on container's Baseten secrets).")
+    return value
+
+
 def endpoint(args: argparse.Namespace) -> str:
     if getattr(args, "endpoint", None):
         return args.endpoint
@@ -60,6 +67,7 @@ def post_json(args: argparse.Namespace, payload: dict[str, Any]) -> dict[str, An
         data=body,
         headers={
             "Authorization": f"Api-Key {baseten_api_key()}",
+            "X-Mantis-Token": mantis_api_token(),
             "Content-Type": "application/json",
         },
         method="POST",


### PR DESCRIPTION
## Summary

Three commits that landed on the `staffai-integration` branch *after* PR #78 was merged. Re-targeted from `main` as a clean follow-up.

| SHA | Commit | Why it matters |
|---|---|---|
| cd42163 | `scripts/baseten_workload.py`: send X-Mantis-Token on every request | **Functional**: without this, the workload CLI returns 401 against any tenant-keyed deployment. Same patch that unblocked the BoatTrader E2E earlier. |
| 9d60295 | docs: correct Baseten gateway URL pattern (`/production/sync` prefix) | **Docs accuracy**: the gateway only forwards `/v1/*` paths under `/sync`. Today's docs still tell users to hit `…/production/v1/chat/completions` which returns 404. Verified empirically against the live deployment. |
| 7e3f00b | docs: integration onboarding paths + recipes (generic-cua, recipes, index rewrite) | **New content**: closes the gap between Quickstart (5-min curl) and vision_claude (host integration). Adds Generic-CUA-over-HTTP onboarding doc and four copy-paste recipes (jobs, e-commerce, news, real-estate). |

## Test plan

- [x] `uv run mkdocs build --strict` — clean
- [x] `uv run ruff check scripts/baseten_workload.py` — clean
- [x] Live verification — `scripts/baseten_workload.py status …` against the deployed Baseten endpoint returns 500 (handler reached) instead of 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)