### PR TITLE
proxy_disabled flag for non-proxied test sites

### DIFF
--- a/src/mantis_agent/baseten_server.py
+++ b/src/mantis_agent/baseten_server.py
@@ -712,6 +712,7 @@ class BasetenCUARuntime:
             checkpoint_dir=str(data_root / "checkpoints"),
             proxy_city=str(payload.get("proxy_city") or os.environ.get("MANTIS_PROXY_CITY", "")),
             proxy_state=str(payload.get("proxy_state") or os.environ.get("MANTIS_PROXY_STATE", "")),
+            proxy_disabled=bool(payload.get("proxy_disabled", False)),
             objective=objective_dict,
         )
         return suite
@@ -728,6 +729,7 @@ class BasetenCUARuntime:
             settle_time=settle_time,
             proxy_city=str(task_suite.get("_proxy_city") or ""),
             proxy_state=str(task_suite.get("_proxy_state") or ""),
+            proxy_disabled=bool(task_suite.get("_proxy_disabled", False)),
             browser=os.environ.get("MANTIS_BROWSER", "google-chrome"),
             profile_dir=str(data_root / "chrome-profile"),
             save_screenshots_dir=str(data_root / "screenshots"),

--- a/src/mantis_agent/gym/micro_runner.py
+++ b/src/mantis_agent/gym/micro_runner.py
@@ -819,6 +819,7 @@ class MicroPlanRunner:
                 claude_only=step.claude_only, loop_target=step.loop_target,
                 loop_count=step.loop_count,
                 section=step.section, required=step.required, gate=step.gate,
+                params=dict(step.params or {}),  # form-vocab fill_field/submit/select_option payload
             )
 
             logger.info(f"  [{step_index:2d}] {step.type:15s} {dynamic_intent[:60]}")

--- a/src/mantis_agent/server_utils.py
+++ b/src/mantis_agent/server_utils.py
@@ -422,6 +422,7 @@ def build_micro_suite(
     checkpoint_dir: str = "/data/checkpoints",
     proxy_city: str = "",
     proxy_state: str = "",
+    proxy_disabled: bool = False,
     objective: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Build a task_suite dict for micro-intent execution.
@@ -447,6 +448,7 @@ def build_micro_suite(
         "_plan_signature": signature,
         "_proxy_city": proxy_city,
         "_proxy_state": proxy_state,
+        "_proxy_disabled": bool(proxy_disabled),
         "_micro_plan": micro_plan_steps,
         "tasks": [],
     }

--- a/src/mantis_agent/task_loop.py
+++ b/src/mantis_agent/task_loop.py
@@ -87,6 +87,7 @@ def setup_env(
     settle_time: float = 2.0,
     proxy_city: str = "miami",
     proxy_state: str = "",
+    proxy_disabled: bool = False,
     display: str | None = None,
     start_xvfb: bool = False,
     browser: str = "google-chrome",
@@ -96,18 +97,28 @@ def setup_env(
 ) -> tuple[Any, Any]:
     """Set up proxy + XdotoolGymEnv.
 
+    Args:
+        proxy_disabled: When True, skip the upstream proxy entirely. Use for
+            test/internal sites that don't need bot-detection bypass and
+            shouldn't depend on the residential proxy's availability.
+
     Returns (env, proxy_proc_or_None).
     """
     from .gym.xdotool_env import XdotoolGymEnv
 
-    proxy = build_proxy_config(
-        city=proxy_city,
-        state=proxy_state,
-        session_id=f"mantis{run_id.replace('_', '')}",
-    )
-    proxy_server, proxy_proc = resolve_proxy_server(proxy)
-    if proxy:
-        print(f"  Proxy: {proxy.get('server', '')}")
+    if proxy_disabled:
+        proxy = None
+        proxy_server, proxy_proc = "", None
+        print("  Proxy: DISABLED (proxy_disabled=true)")
+    else:
+        proxy = build_proxy_config(
+            city=proxy_city,
+            state=proxy_state,
+            session_id=f"mantis{run_id.replace('_', '')}",
+        )
+        proxy_server, proxy_proc = resolve_proxy_server(proxy)
+        if proxy:
+            print(f"  Proxy: {proxy.get('server', '')}")
 
     if start_xvfb and display:
         subprocess.Popen(

--- a/tests/test_form_intents.py
+++ b/tests/test_form_intents.py
@@ -301,3 +301,45 @@ def test_execute_step_routes_fill_field_to_form_dispatch():
 
     runner._execute_claude_guided_form.assert_called_once()
     assert result.success is True
+
+
+def test_run_loop_preserves_params_on_effective_step():
+    """Regression: the run loop builds an `effective_step` per iteration that
+    only copies a subset of MicroIntent fields. ``params`` must be in that
+    subset — without it, every form step lands at the dispatch with an empty
+    params dict and no value to type / button label to find. Caught in
+    production E2E against staffai-test-crm where login fired but typed empty
+    strings into the User ID and Password fields.
+    """
+    env = _FakeEnv()
+    extractor = MagicMock()
+    extractor.find_form_target.return_value = {
+        "x": 100, "y": 50, "action": "click", "value": "", "label": "User ID",
+    }
+    runner = _runner_with_extractor(env, extractor)
+
+    # Capture every dispatch invocation so we can inspect the effective_step.
+    dispatched: list[MicroIntent] = []
+
+    def spy(step: MicroIntent, index: int) -> StepResult:
+        dispatched.append(step)
+        return StepResult(step_index=index, intent=step.intent, success=True)
+
+    runner._execute_claude_guided_form = spy  # type: ignore[method-assign]
+
+    plan = MicroPlan(domain="test")
+    plan.steps.append(
+        MicroIntent(
+            intent="Enter the user ID",
+            type="fill_field",
+            section="setup",
+            required=False,  # avoid required-retry path
+            params={"label": "User ID", "value": "sarah.connor"},
+        )
+    )
+
+    runner.run(plan)
+
+    assert len(dispatched) == 1
+    effective = dispatched[0]
+    assert effective.params == {"label": "User ID", "value": "sarah.connor"}


### PR DESCRIPTION
## Summary

Adds a per-request \`proxy_disabled\` flag so domains that don't need bot-detection bypass can run independent of upstream proxy (IPRoyal) availability.

## Why

The IPRoyal residential proxy starts container-wide whenever \`PROXY_URL\` is set as a Modal/Baseten secret. There was no way to opt out at request time — every navigate routed through the local forwarder, so any IPRoyal credential rotation or quota event broke every workflow.

Concrete trigger: the issue-80 vision_claude E2E. \`staffai-test-crm.exe.xyz\` is an internal test instance with no bot detection; it should not depend on the residential proxy. With this flag, those runs proceed even if IPRoyal is unavailable.

## Surface

\`POST /v1/predict\` accepts \`{"proxy_disabled": true}\` alongside the existing \`proxy_city\` / \`proxy_state\` knobs. Plumbs through \`build_micro_suite\` → \`_make_env\` → \`task_loop.setup_env\`. \`setup_env(proxy_disabled=True)\` skips \`build_proxy_config\` + the local forwarder entirely, leaving Chrome with no \`--proxy-server\` flag.

## Test plan

- [x] \`uv run pytest tests/test_server_utils.py tests/test_form_intents.py -q\` — 26 passed
- [x] \`uv run ruff check src/mantis_agent\` — clean
- [x] Defaults unchanged — runs that don't pass the flag behave identically (existing tests still green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)