### PR TITLE
verify-loop: diagnostic logging + tolerate method-shaped env.current_url

### DIFF
--- a/src/mantis_agent/gym/micro_runner.py
+++ b/src/mantis_agent/gym/micro_runner.py
@@ -1537,20 +1537,47 @@ class MicroPlanRunner:
         Falls back to ``ClaudeExtractor.extract`` when CDP is unreachable
         (Modal hosts where the port wasn't bound, older Truss images, etc.)
         so existing screenshot-based behaviour still works.
+
+        Diagnostic logging: the path taken (cdp / ocr) is logged at INFO so
+        run traces show which source produced the URL — needed because
+        post-PR-90 the staffai canary still showed ``(url=)`` empty and we
+        couldn't tell whether CDP was unreachable or returned empty itself.
+        Also handles the case where ``env.current_url`` is a *method*
+        instead of a property (a common integration mistake) by calling
+        it when callable.
         """
+        cdp_url = ""
+        cdp_error: Exception | None = None
         try:
-            url = self.env.current_url or ""
-        except Exception:
-            url = ""
-        if url:
-            return url
+            raw = getattr(self.env, "current_url", "")
+            # Tolerate integrations that defined current_url() as a method
+            # rather than a @property — call it instead of returning the
+            # bound-method object (which would be truthy and short-circuit).
+            if callable(raw):
+                raw = raw()
+            cdp_url = (raw or "").strip() if isinstance(raw, str) else ""
+        except Exception as exc:
+            cdp_error = exc
+
+        if cdp_url:
+            logger.info(f"  [url] cdp={cdp_url[:80]}")
+            return cdp_url
+
+        if cdp_error is not None:
+            logger.info(f"  [url] cdp unavailable ({type(cdp_error).__name__}); falling back to OCR")
+        elif screenshot is not None:
+            logger.info("  [url] cdp empty; falling back to OCR")
+
         if screenshot is not None and self.extractor:
             try:
                 verify_data = self.extractor.extract(screenshot)
-            except Exception:
+            except Exception as exc:
+                logger.info(f"  [url] ocr extract failed: {exc}")
                 return ""
             self.costs["claude_extract"] += 1
-            return verify_data.url if verify_data else ""
+            ocr_url = (verify_data.url or "") if verify_data else ""
+            logger.info(f"  [url] ocr={ocr_url[:80] or '<empty>'}")
+            return ocr_url
         return ""
 
     def _execute_navigate(self, step: MicroIntent, index: int) -> StepResult:

--- a/tests/test_form_intents.py
+++ b/tests/test_form_intents.py
@@ -529,6 +529,28 @@ def test_read_current_url_prefers_cdp_over_screenshot():
     extractor.extract.assert_not_called()
 
 
+def test_read_current_url_calls_method_property_for_buggy_envs():
+    """Some integrations define current_url as a method instead of a
+    @property (e.g. ``def current_url(self): return ...``). Attribute
+    access then returns the bound method, which is truthy — without this
+    guard the helper would return a method object as the URL.
+
+    Regression: post-PR-90 the staffai trace still showed ``(url=)`` empty;
+    one viable cause was their VisionClaudeGymEnv defining current_url as
+    a method, which short-circuits the truthy check on the bound method.
+    """
+    env = _FakeEnv()
+    runner = _runner_with_extractor(env, extractor=MagicMock())
+
+    # Define current_url as a callable on the env instance.
+    def fake_method():
+        return "https://example.com/leads/42"
+
+    type(env).current_url = property(lambda self: fake_method)
+    url = runner._read_current_url()
+    assert url == "https://example.com/leads/42"
+
+
 def test_read_current_url_falls_back_to_screenshot_when_cdp_empty():
     """When CDP returns empty (port not bound, container without
     --remote-debugging-port), fall back to the existing screenshot-based


### PR DESCRIPTION
Follow-up on the PR #90 review thread. The CDP fix in #90 was correct in
``main`` (verified at SHA \`164e5c2\` and the merge \`a53dc46\` —
``_read_current_url`` is called first in all three click-verify paths),
but the staffai canary trace still showed ``(url=)`` empty after the
deploy. Two diagnosable causes worth ruling in or out before adding
more click logic.

## 1. Path-of-record logging

The previous helper silently swallowed CDP exceptions and silently
treated CDP-empty as identical to CDP-unreachable. From the runner
trace alone, you couldn't tell which of three things failed:

- CDP raised (port not bound, container without ``--remote-debugging-port``)
- CDP returned an empty list (Chrome started but no page tabs yet)
- The fallback OCR also returned empty (address bar mid-render)

The helper now logs which source produced the URL:

```
[url] cdp=https://crm.example.com/leads/42      ← CDP success
[url] cdp unavailable (URLError); falling back to OCR
[url] cdp empty; falling back to OCR
[url] ocr=https://crm.example.com/leads/42      ← OCR fallback success
[url] ocr=<empty>                               ← OCR fallback failed
```

This lets us look at the next staffai trace and immediately tell whether
their VisionClaudeGymEnv's CDP wiring is being consumed.

## 2. Callable-shaped \`env.current_url\`

Several plausible integration shapes for ``current_url``:

```python
@property
def current_url(self) -> str: return self._cdp_get_url()

# vs

def current_url(self) -> str: return self._cdp_get_url()
```

The previous helper assumed the first. With the second, attribute access
returns the bound-method object, which is truthy — so the helper
returned the *method itself* as the URL, then ``site_config.is_detail_page(method)``
silently returned False and the verify loop fell through to all the
fallback click variants. Without diagnostic logging this is invisible.

The helper now detects ``callable(raw)`` and invokes it, so both shapes
work uniformly. Pinned by a unit test.

## Test plan

- [x] Existing 30 form-intent tests still pass
- [x] New ``test_read_current_url_calls_method_property_for_buggy_envs``
- [x] Ruff clean

## What this doesn't change

PR #90's CDP infrastructure and the verify-loop call sites are unchanged
— this only hardens the helper they already invoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)