### PR TITLE
Remove orphan VWA_configs submodule (unblocks `pip install git+...` for downstream)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,8 @@ site/
 plans/
 tasks/
 internal-docs/
+
+# VisualWebArena upstream — clone next to the repo when running the
+# benchmarking conversion script. Never commit; would re-introduce the
+# orphan-submodule pip-install bug.
+VWA_configs/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,6 @@ line-length = 100
 target-version = "py311"
 extend-exclude = [
     "OSWorld",
-    "VWA_configs",
     "outputs",
     "screenshots",
 ]
@@ -108,7 +107,6 @@ pythonpath = ["."]
 norecursedirs = [
     ".claude",
     "OSWorld",
-    "VWA_configs",
     "outputs",
     "screenshots",
 ]

--- a/scripts/convert_vwa_to_gym.py
+++ b/scripts/convert_vwa_to_gym.py
@@ -1,17 +1,24 @@
 #!/usr/bin/env python3
 """Convert VisualWebArena task configs to gym-anything environment format.
 
-Reads the raw VWA JSON configs (from VWA_configs/config_files/) and produces
-gym-anything-compatible environment directories.
+Reads the raw VWA JSON configs and produces gym-anything-compatible
+environment directories. The configs come from the VisualWebArena
+upstream repo:
 
-Usage:
+    https://github.com/web-arena-x/visualwebarena
+
+Clone it next to this repo (or anywhere) and point ``--vwa-config-dir``
+at the cloned ``config_files/vwa/`` directory:
+
+    git clone https://github.com/web-arena-x/visualwebarena ../vwa
     python scripts/convert_vwa_to_gym.py \
-        --input VWA_configs/config_files/vwa/test_classifieds.raw.json \
+        --input ../vwa/config_files/vwa/test_classifieds.raw.json \
         --output environments/vwa_classifieds \
         --site-url http://localhost:9980
 
     # Convert all VWA sites
     python scripts/convert_vwa_to_gym.py --all \
+        --vwa-config-dir ../vwa/config_files/vwa \
         --classifieds-url http://localhost:9980 \
         --shopping-url http://localhost:7770 \
         --reddit-url http://localhost:9999 \
@@ -280,8 +287,10 @@ def main():
     parser.add_argument("--site-name", help="Site name (auto-detected from filename if omitted)")
 
     parser.add_argument("--all", action="store_true", help="Convert all VWA sites")
-    parser.add_argument("--vwa-config-dir", default="VWA_configs/config_files/vwa",
-                        help="Directory containing VWA raw JSON configs")
+    parser.add_argument("--vwa-config-dir", default="",
+                        help="Directory containing VWA raw JSON configs "
+                             "(clone https://github.com/web-arena-x/visualwebarena "
+                             "and point at its config_files/vwa/)")
     parser.add_argument("--output-base", default="environments",
                         help="Base output directory for all environments")
 

--- a/tests/test_no_orphan_submodules.py
+++ b/tests/test_no_orphan_submodules.py
@@ -1,0 +1,88 @@
+"""Guard against orphan submodule entries in the git index.
+
+A gitlink (mode 160000) without a matching entry in ``.gitmodules`` is
+silently destructive for downstream installers: ``pip install git+...``
+and ``uv add git+...`` both run ``git submodule update --init --recursive``
+unconditionally on git+ URLs, and bail with
+
+    fatal: no submodule mapping found in .gitmodules for path '<path>'
+
+That bug bit the original repo when an old ``VWA_configs`` gitlink stuck
+around without a ``.gitmodules`` entry — every downstream consumer
+(staffai's vision_claude container being the canonical example) had to
+work around it by cloning + ``--no-recurse-submodules`` + ``pip install
+/local/path``, which is fragile and surprising.
+
+The guard:
+  - Greps the index for mode-160000 entries.
+  - Reads ``.gitmodules`` (if it exists) to find which paths are mapped.
+  - Fails if any gitlink lacks a mapping.
+
+If you legitimately want a submodule, add it via ``git submodule add
+<url> <path>`` so ``.gitmodules`` is created and populated. If you don't
+want a submodule, ``git rm --cached <path>`` removes the orphan entry.
+"""
+
+from __future__ import annotations
+
+import configparser
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _gitlinks() -> list[str]:
+    """Paths in the git index registered as submodule gitlinks (mode 160000)."""
+    out = subprocess.run(
+        ["git", "ls-files", "--stage"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    paths: list[str] = []
+    for line in out.stdout.splitlines():
+        # Format: <mode> <sha> <stage>\t<path>
+        if not line.startswith("160000"):
+            continue
+        try:
+            _, rest = line.split("\t", 1)
+        except ValueError:
+            continue
+        paths.append(rest.strip())
+    return paths
+
+
+def _mapped_submodule_paths() -> set[str]:
+    """Paths declared in ``.gitmodules``, if the file exists."""
+    gitmodules = REPO_ROOT / ".gitmodules"
+    if not gitmodules.is_file():
+        return set()
+    parser = configparser.ConfigParser()
+    parser.read(gitmodules)
+    return {
+        parser.get(section, "path")
+        for section in parser.sections()
+        if parser.has_option(section, "path")
+    }
+
+
+def test_no_orphan_submodule_entries():
+    """Every gitlink in the index must have a matching ``.gitmodules`` entry.
+
+    An orphan gitlink breaks ``pip install git+...`` and ``uv add git+...``
+    for every downstream caller. Catch it on the first PR that introduces it.
+    """
+    gitlinks = _gitlinks()
+    mapped = _mapped_submodule_paths()
+    orphans = [path for path in gitlinks if path not in mapped]
+    assert not orphans, (
+        f"Found {len(orphans)} orphan submodule gitlink(s): {orphans!r}\n\n"
+        "Each gitlink (mode 160000) needs a .gitmodules entry, or pip / uv "
+        "installs from this repo will fail with "
+        "'fatal: no submodule mapping found in .gitmodules for path ...'.\n\n"
+        "Fix one of two ways:\n"
+        "  1. Remove the orphan: `git rm --cached <path>`\n"
+        "  2. Convert to a real submodule: `git submodule add <url> <path>`"
+    )

--- a/tests/test_no_orphan_submodules.py
+++ b/tests/test_no_orphan_submodules.py
@@ -7,11 +7,11 @@ unconditionally on git+ URLs, and bail with
 
     fatal: no submodule mapping found in .gitmodules for path '<path>'
 
-That bug bit the original repo when an old ``VWA_configs`` gitlink stuck
-around without a ``.gitmodules`` entry — every downstream consumer
-(staffai's vision_claude container being the canonical example) had to
-work around it by cloning + ``--no-recurse-submodules`` + ``pip install
-/local/path``, which is fragile and surprising.
+This bug previously bit the repo when an unused benchmarking-config
+gitlink stuck around without a ``.gitmodules`` mapping — every
+downstream consumer of ``pip install git+https://.../mantis@<sha>``
+had to work around it by cloning ``--no-recurse-submodules`` and then
+``pip install /local/path``, which is fragile and surprising.
 
 The guard:
   - Greps the index for mode-160000 entries.


### PR DESCRIPTION
## What broke

The repo's git index carried a mode-160000 gitlink at \`VWA_configs\`
without a matching entry in \`.gitmodules\`. Both \`pip\` and \`uv\`
unconditionally run \`git submodule update --init --recursive\` on
\`git+\` URLs and bail with:

\`\`\`
fatal: no submodule mapping found in .gitmodules for path 'VWA_configs'
\`\`\`

This broke the obvious downstream one-liner:

\`\`\`
pip install \"git+https://github.com/mercurialsolo/mantis@<sha>#egg=mantis-agent[orchestrator]\"
\`\`\`

…forcing every consumer (staffai's vision_claude container being the
canonical example) to work around it in their own Dockerfile with
\`git clone --no-recurse-submodules\` + \`pip install /local/path\`.

## Why removing it is safe

\`VWA_configs\` was used by exactly one offline benchmarking script
(\`scripts/convert_vwa_to_gym.py\`) that converts VisualWebArena task
configs into gym-anything environment shapes. Inference doesn't touch
it (\`MicroPlanRunner\`, \`PlanDecomposer\`, \`Holo3Brain\`,
\`ClaudeExtractor\`, \`XdotoolGymEnv\`, \`baseten_server\` — none of
them reference \`VWA_configs/\` paths). The orchestrator extra doesn't
reference it. None of the deployment scripts reference it.

The conversion script's docstring now points at the upstream
[visualwebarena](https://github.com/web-arena-x/visualwebarena) repo so
anyone running the benchmarking conversion clones it next to this repo
themselves.

## Recurrence guard

\`tests/test_no_orphan_submodules.py\` greps the index for mode-160000
entries and fails the build if any lacks a \`.gitmodules\` mapping.
Same shape as the client-token isolation guard — catch the leak on the
first PR that re-introduces it.

## Verification

\`\`\`bash
$ git submodule update --init --recursive
$ echo $?
0
\`\`\`

(Was previously failing with \`fatal: no submodule mapping found...\`.)

## Test plan

- [x] \`tests/test_no_orphan_submodules.py\` passes (1 test).
- [x] \`tests/test_docs_client_isolation.py\` still passes (10 tests).
- [x] mkdocs strict build clean.
- [x] Lint clean.
- [ ] Full unit suite (running; will report).

🤖 Generated with [Claude Code](https://claude.com/claude-code)