### PR TITLE
feat(prompts): externalize brain SYSTEM_PROMPTs + MANTIS_PROMPTS_DIR override (#99)

### DIFF
--- a/docs/reference/env-vars.md
+++ b/docs/reference/env-vars.md
@@ -35,9 +35,11 @@ These are global hard caps; tenant config can be tighter, never looser.
 | Var | Default | Effect |
 |---|---|---|
 | `MANTIS_LLAMA_PORT` | 18080 | Internal port the in-pod llama.cpp server binds to. The `/v1/chat/completions` proxy forwards here. |
-| `MANTIS_MODEL` | (set by Truss) | Model kind: `holo3`, `gemma4`, `evocua-32b`, etc. |
+| `MANTIS_BRAIN` | `holo3` | Brain backend selector. One of `holo3`, `claude`, `opencua`, `llamacpp`, `gemma4`, `agent-s`. Wins over the legacy `MANTIS_MODEL`. |
+| `MANTIS_MODEL` | (set by Truss) | Legacy alias of `MANTIS_BRAIN` for one minor release. `gemma4-cua` aliases to `gemma4`. |
 | `MANTIS_HOLO3_MODEL_DIR` | `/models/holo3` | Where Holo3 GGUF weights are mounted. |
 | `ANTHROPIC_API_KEY` | unset | Default Anthropic key. Per-tenant `anthropic_secret_name` overrides per request. |
+| `MANTIS_PROMPTS_DIR` | unset | Override directory for prompt files. When set, the loader reads `<dir>/<name>.txt` before falling back to the in-tree constant — lets a tenant tune wording without forking the wheel. Names: `system_v1`, `gemma4_system`, `holo3_system`, `claude_system`, `opencua_system`, `llamacpp_system`. |
 
 ## Proxy (IPRoyal)
 

--- a/src/mantis_agent/brain.py
+++ b/src/mantis_agent/brain.py
@@ -22,6 +22,7 @@ from PIL import Image
 from transformers import AutoModelForMultimodalLM, AutoProcessor
 
 from .actions import TOOLS, Action, ActionType, parse_tool_call
+from .prompts import load_prompt
 
 logger = logging.getLogger(__name__)
 
@@ -52,26 +53,9 @@ def _resolve_model_path(model_name: str) -> str:
                 return path
     return model_name
 
-SYSTEM_PROMPT = """\
-You are a computer use agent. You observe the screen and perform actions to complete tasks.
-
-You receive a sequence of recent screen frames showing how the display has changed over time.
-The LAST frame is the current screen state. Earlier frames show what happened before.
-
-Your job:
-1. OBSERVE the current screen state carefully
-2. REASON about what to do next given the task and what you see
-3. CALL exactly one tool to perform an action
-
-Important guidelines:
-- Coordinates are in absolute screen pixels
-- Look at the last frame for current state; earlier frames for context
-- If something is loading or animating, call wait() to observe the result
-- If you cannot find an element, try scrolling to reveal it
-- When the task is complete, call done(success=true, summary="...")
-- If you're stuck after multiple attempts, call done(success=false, summary="...")
-- Be precise with click coordinates — aim for the center of the target element\
-"""
+# Sourced from mantis_agent.prompts.GEMMA4_SYSTEM. Override per-tenant via
+# MANTIS_PROMPTS_DIR/gemma4_system.txt.
+SYSTEM_PROMPT = load_prompt("gemma4_system")
 
 
 @dataclass

--- a/src/mantis_agent/brain_claude.py
+++ b/src/mantis_agent/brain_claude.py
@@ -33,44 +33,13 @@ import requests
 from PIL import Image
 
 from .actions import Action, ActionType
+from .prompts import load_prompt
 
 logger = logging.getLogger(__name__)
 
-SYSTEM_PROMPT = """\
-You are a computer use agent. You observe the screen and perform actions to complete tasks.
-
-You receive a sequence of recent screen frames showing how the display has changed over time.
-The LAST frame is the current screen state. Earlier frames show what happened before.
-
-Your job:
-1. OBSERVE the current screen state carefully
-2. REASON step by step about what to do next
-3. CALL exactly one tool to perform the next action
-
-# Core rules
-- Coordinates are absolute screen pixels. Aim for the CENTER of the target element.
-- Look at the LAST frame for current state. Earlier frames show what changed.
-- Execute ONE action per turn. After each action, observe the result before acting again.
-
-# Form filling — CRITICAL
-- To fill a form: click the input field ONCE to focus it, then call type() with the value.
-- Do NOT click an input field multiple times. One click focuses it — then immediately type.
-- After typing, move to the next field: click the next input, or press key('Tab').
-- To submit a form: press key('Enter') — this is the most reliable method.
-- If you already clicked a field and see it is focused, your NEXT action must be type() — not another click.
-
-# Avoiding loops
-- NEVER repeat the same action more than twice. If clicking the same spot twice doesn't work, try a different approach.
-- If you're stuck: try scrolling, pressing Tab, clicking a different element, or using keyboard shortcuts.
-
-# Completion
-- When the task is complete, call done(success=true, summary="...").
-- If stuck after multiple attempts, call done(success=false, summary="...").
-
-# Waiting
-- If a page is loading or animating, call wait() to observe the result.
-- After submitting a form, call wait(seconds=2) before checking the result.\
-"""
+# Sourced from mantis_agent.prompts.CLAUDE_SYSTEM. Override per-tenant via
+# MANTIS_PROMPTS_DIR/claude_system.txt.
+SYSTEM_PROMPT = load_prompt("claude_system")
 
 # Claude computer_use tool + our custom done/wait tools
 CLAUDE_TOOLS = [

--- a/src/mantis_agent/brain_holo3.py
+++ b/src/mantis_agent/brain_holo3.py
@@ -45,45 +45,14 @@ import requests
 from PIL import Image
 
 from .actions import TOOLS, Action, ActionType, parse_tool_call
+from .prompts import load_prompt
 
 logger = logging.getLogger(__name__)
 
 # ── System prompt (tool-calling style, adapted from LlamaCppBrain) ──────────
-
-SYSTEM_PROMPT = """\
-You are a computer use agent. You observe screenshots and perform actions to complete tasks.
-
-RESPONSE FORMAT — Every response must follow this structure:
-1. One brief sentence of reasoning (what you see and plan to do)
-2. One action call
-
-ACTIONS — use exactly one per response:
-click(x=<int>, y=<int>)
-type_text(text="<string>")
-key_press(keys="<string>")
-scroll(direction="down", amount=5)
-wait(seconds=2)
-done(success=true, summary="<detailed result>")
-done(success=false, summary="<reason>")
-
-EXAMPLE RESPONSE:
-I see the search results page with boat listings. I'll click the title of the first listing.
-click(x=640, y=320)
-
-EXAMPLE DONE RESPONSE (extraction):
-I found the boat details: 2024 Sea Ray Sundancer, $189,000, phone 786-555-1234.
-done(success=true, summary="VIABLE | Year: 2024 | Make: Sea Ray | Model: Sundancer | Price: $189000 | Phone: 786-555-1234 | Type: Express Cruiser | URL: https://www.boattrader.com/boat/1234")
-
-RULES:
-- Coordinates are absolute screen pixels. Aim for the CENTER of elements.
-- Click input fields ONCE to focus, then type_text(). Use key_press(keys="tab") between fields.
-- key_press(keys="alt+left") to go back in browser.
-- scroll(direction="down", amount=5) to reveal content below.
-- When extracting data, include ALL details in the done() summary: Year, Make, Model, Price, Phone (or "none"), Type, URL.
-- NEVER repeat the same action 3 times. Try something different.
-- NEVER just describe what you plan to do — you MUST output an action call.
-- If stuck for 5+ actions, call done(success=false, summary="stuck: <what happened>").\
-"""
+# Sourced from mantis_agent.prompts.HOLO3_SYSTEM. Override per-tenant via
+# MANTIS_PROMPTS_DIR/holo3_system.txt.
+SYSTEM_PROMPT = load_prompt("holo3_system")
 
 # ── OpenAI function-calling tool format ─────────────────────────────────────
 

--- a/src/mantis_agent/brain_llamacpp.py
+++ b/src/mantis_agent/brain_llamacpp.py
@@ -35,45 +35,13 @@ import requests
 from PIL import Image
 
 from .actions import TOOLS, Action, ActionType, parse_tool_call
+from .prompts import load_prompt
 
 logger = logging.getLogger(__name__)
 
-SYSTEM_PROMPT = """\
-You are a computer use agent. You observe the screen and perform actions to complete tasks.
-
-You receive a sequence of recent screen frames showing how the display has changed over time.
-The LAST frame is the current screen state. Earlier frames show what happened before.
-
-Your job:
-1. OBSERVE the current screen state carefully
-2. REASON step by step about what to do next
-3. CALL exactly one tool to perform the next action
-
-# Core rules
-- Coordinates are absolute screen pixels. Aim for the CENTER of the target element.
-- Look at the LAST frame for current state. Earlier frames show what changed.
-- Execute ONE action per turn. After each action, observe the result before acting again.
-
-# Form filling — CRITICAL
-- To fill a form: click the input field ONCE to focus it, then call type_text() with the value.
-- Do NOT click an input field multiple times. One click focuses it — then immediately type.
-- After typing, move to the next field: click the next input, or press key_press('Tab').
-- To submit a form: press key_press('Enter') — this is the most reliable method. Only click the Submit button if Enter doesn't work.
-- If you already clicked a field and see it is focused, your NEXT action must be type_text() — not another click.
-
-# Avoiding loops
-- NEVER repeat the same action more than twice. If clicking the same spot twice doesn't work, try a different approach.
-- If you're stuck: try scrolling, pressing Tab, clicking a different element, or using keyboard shortcuts.
-- Read the task description carefully — it tells you what value to type and where.
-
-# Completion
-- When the task is complete, call done(success=true, summary="...").
-- If stuck after multiple attempts, call done(success=false, summary="...").
-
-# Waiting
-- If a page is loading or animating, call wait() to observe the result.
-- After submitting a form, call wait(seconds=2) before checking the result.\
-"""
+# Sourced from mantis_agent.prompts.LLAMACPP_SYSTEM. Override per-tenant via
+# MANTIS_PROMPTS_DIR/llamacpp_system.txt.
+SYSTEM_PROMPT = load_prompt("llamacpp_system")
 
 # Convert our tool schemas to OpenAI function-calling format
 OPENAI_TOOLS = [

--- a/src/mantis_agent/brain_opencua.py
+++ b/src/mantis_agent/brain_opencua.py
@@ -33,41 +33,13 @@ import requests
 from PIL import Image
 
 from .actions import Action, ActionType
+from .prompts import load_prompt
 
 logger = logging.getLogger(__name__)
 
-SYSTEM_PROMPT = """\
-You are a computer use agent performing multi-step browser workflows. You observe screenshots and output exactly ONE action per turn.
-
-Available actions:
-- pyautogui.click(x=<int>, y=<int>) — click at coordinates (CENTER of target element)
-- pyautogui.doubleClick(x=<int>, y=<int>) — double click
-- pyautogui.typewrite('<text>') — type text into the currently focused field
-- pyautogui.hotkey('<key1>', '<key2>') — press key combo (e.g. ctrl+a, alt+left)
-- pyautogui.press('<key>') — press single key (enter, tab, backspace, escape)
-- pyautogui.scroll(<amount>) — scroll (negative = down, positive = up)
-- terminate('success') — task complete, include ALL results in the message
-- terminate('failure') — task cannot be completed
-
-Core rules:
-- Click the CENTER of target elements precisely
-- After clicking an input field, IMMEDIATELY use typewrite() — do NOT click again
-- NEVER repeat the same action more than twice — try a different approach
-- Press tab to move between form fields, enter to submit forms
-
-Browser navigation:
-- hotkey('alt', 'left') — go back
-- hotkey('ctrl', 'w') — close current tab
-- hotkey('ctrl', 'tab') — switch tabs
-- scroll(-5) to see more content below
-
-Data extraction:
-- Read ALL text visually from the screenshot
-- Phone numbers: (555) 555-5555, 555-555-5555, or 10+ consecutive digits
-- Read prices, years, makes, models from page titles and content
-- Read the current URL from the browser address bar
-- When reporting results, include EVERY piece of extracted data\
-"""
+# Sourced from mantis_agent.prompts.OPENCUA_SYSTEM. Override per-tenant via
+# MANTIS_PROMPTS_DIR/opencua_system.txt.
+SYSTEM_PROMPT = load_prompt("opencua_system")
 
 
 def _image_to_base64(img: Image.Image) -> str:

--- a/src/mantis_agent/prompts/__init__.py
+++ b/src/mantis_agent/prompts/__init__.py
@@ -1,20 +1,32 @@
 """Externalized prompts for the Mantis agent.
 
 Prompts live as Python string constants in this module so they ship cleanly
-through Modal's ``add_local_python_source`` (which only includes ``.py`` files).
-This keeps the prompt content out of ``deploy/modal/modal_osworld_direct.py`` and gives us
-one place to iterate on prompt wording, A/B test versions, and review changes.
+through Modal's ``add_local_python_source`` (which only includes ``.py``
+files). One file is the source of truth, easy to diff in code review and
+A/B-test wording without forking a brain module.
 
 Adding a new prompt:
-    1. Create a new constant ``PROMPT_<NAME>`` below
-    2. Reference it via :func:`load_prompt`
+    1. Define a module-level constant ``MY_PROMPT = "..."`` below
+    2. Register it in :data:`_PROMPTS`
+    3. Reference it from the call site via :func:`load_prompt`
 
-Substitution uses simple double-underscore placeholders like ``__SCREEN_WIDTH__``
+Substitution uses double-underscore placeholders like ``__SCREEN_WIDTH__``
 so the prompt body can freely contain ``{`` and ``}`` (e.g. JSON examples)
 without escaping.
+
+Operator override
+-----------------
+Set the env var ``MANTIS_PROMPTS_DIR=/path/to/prompts`` to swap an
+individual prompt without forking the package. The loader looks up
+``<dir>/<name>.txt`` first; if found, the file content overrides the
+in-tree constant. This lets a tenant tune wording (entity name, locale)
+without redeploying the wheel.
 """
 
 from __future__ import annotations
+
+import os
+from pathlib import Path
 
 
 SYSTEM_V1 = """\
@@ -82,27 +94,246 @@ First reflect on what you see in the screenshot, then output your code.\
 """
 
 
-_PROMPTS = {
+GEMMA4_SYSTEM = """\
+You are a computer use agent. You observe the screen and perform actions to complete tasks.
+
+You receive a sequence of recent screen frames showing how the display has changed over time.
+The LAST frame is the current screen state. Earlier frames show what happened before.
+
+Your job:
+1. OBSERVE the current screen state carefully
+2. REASON about what to do next given the task and what you see
+3. CALL exactly one tool to perform an action
+
+Important guidelines:
+- Coordinates are in absolute screen pixels
+- Look at the last frame for current state; earlier frames for context
+- If something is loading or animating, call wait() to observe the result
+- If you cannot find an element, try scrolling to reveal it
+- When the task is complete, call done(success=true, summary="...")
+- If you're stuck after multiple attempts, call done(success=false, summary="...")
+- Be precise with click coordinates — aim for the center of the target element\
+"""
+
+
+HOLO3_SYSTEM = """\
+You are a computer use agent. You observe screenshots and perform actions to complete tasks.
+
+RESPONSE FORMAT — Every response must follow this structure:
+1. One brief sentence of reasoning (what you see and plan to do)
+2. One action call
+
+ACTIONS — use exactly one per response:
+click(x=<int>, y=<int>)
+type_text(text="<string>")
+key_press(keys="<string>")
+scroll(direction="down", amount=5)
+wait(seconds=2)
+done(success=true, summary="<detailed result>")
+done(success=false, summary="<reason>")
+
+EXAMPLE RESPONSE:
+I see the search results page with boat listings. I'll click the title of the first listing.
+click(x=640, y=320)
+
+EXAMPLE DONE RESPONSE (extraction):
+I found the boat details: 2024 Sea Ray Sundancer, $189,000, phone 786-555-1234.
+done(success=true, summary="VIABLE | Year: 2024 | Make: Sea Ray | Model: Sundancer | Price: $189000 | Phone: 786-555-1234 | Type: Express Cruiser | URL: https://www.boattrader.com/boat/1234")
+
+RULES:
+- Coordinates are absolute screen pixels. Aim for the CENTER of elements.
+- Click input fields ONCE to focus, then type_text(). Use key_press(keys="tab") between fields.
+- key_press(keys="alt+left") to go back in browser.
+- scroll(direction="down", amount=5) to reveal content below.
+- When extracting data, include ALL details in the done() summary: Year, Make, Model, Price, Phone (or "none"), Type, URL.
+- NEVER repeat the same action 3 times. Try something different.
+- NEVER just describe what you plan to do — you MUST output an action call.
+- If stuck for 5+ actions, call done(success=false, summary="stuck: <what happened>").\
+"""
+
+
+CLAUDE_SYSTEM = """\
+You are a computer use agent. You observe the screen and perform actions to complete tasks.
+
+You receive a sequence of recent screen frames showing how the display has changed over time.
+The LAST frame is the current screen state. Earlier frames show what happened before.
+
+Your job:
+1. OBSERVE the current screen state carefully
+2. REASON step by step about what to do next
+3. CALL exactly one tool to perform the next action
+
+# Core rules
+- Coordinates are absolute screen pixels. Aim for the CENTER of the target element.
+- Look at the LAST frame for current state. Earlier frames show what changed.
+- Execute ONE action per turn. After each action, observe the result before acting again.
+
+# Form filling — CRITICAL
+- To fill a form: click the input field ONCE to focus it, then call type() with the value.
+- Do NOT click an input field multiple times. One click focuses it — then immediately type.
+- After typing, move to the next field: click the next input, or press key('Tab').
+- To submit a form: press key('Enter') — this is the most reliable method.
+- If you already clicked a field and see it is focused, your NEXT action must be type() — not another click.
+
+# Avoiding loops
+- NEVER repeat the same action more than twice. If clicking the same spot twice doesn't work, try a different approach.
+- If you're stuck: try scrolling, pressing Tab, clicking a different element, or using keyboard shortcuts.
+
+# Completion
+- When the task is complete, call done(success=true, summary="...").
+- If stuck after multiple attempts, call done(success=false, summary="...").
+
+# Waiting
+- If a page is loading or animating, call wait() to observe the result.
+- After submitting a form, call wait(seconds=2) before checking the result.\
+"""
+
+
+OPENCUA_SYSTEM = """\
+You are a computer use agent performing multi-step browser workflows. You observe screenshots and output exactly ONE action per turn.
+
+Available actions:
+- pyautogui.click(x=<int>, y=<int>) — click at coordinates (CENTER of target element)
+- pyautogui.doubleClick(x=<int>, y=<int>) — double click
+- pyautogui.typewrite('<text>') — type text into the currently focused field
+- pyautogui.hotkey('<key1>', '<key2>') — press key combo (e.g. ctrl+a, alt+left)
+- pyautogui.press('<key>') — press single key (enter, tab, backspace, escape)
+- pyautogui.scroll(<amount>) — scroll (negative = down, positive = up)
+- terminate('success') — task complete, include ALL results in the message
+- terminate('failure') — task cannot be completed
+
+Core rules:
+- Click the CENTER of target elements precisely
+- After clicking an input field, IMMEDIATELY use typewrite() — do NOT click again
+- NEVER repeat the same action more than twice — try a different approach
+- Press tab to move between form fields, enter to submit forms
+
+Browser navigation:
+- hotkey('alt', 'left') — go back
+- hotkey('ctrl', 'w') — close current tab
+- hotkey('ctrl', 'tab') — switch tabs
+- scroll(-5) to see more content below
+
+Data extraction:
+- Read ALL text visually from the screenshot
+- Phone numbers: (555) 555-5555, 555-555-5555, or 10+ consecutive digits
+- Read prices, years, makes, models from page titles and content
+- Read the current URL from the browser address bar
+- When reporting results, include EVERY piece of extracted data\
+"""
+
+
+LLAMACPP_SYSTEM = """\
+You are a computer use agent. You observe the screen and perform actions to complete tasks.
+
+You receive a sequence of recent screen frames showing how the display has changed over time.
+The LAST frame is the current screen state. Earlier frames show what happened before.
+
+Your job:
+1. OBSERVE the current screen state carefully
+2. REASON step by step about what to do next
+3. CALL exactly one tool to perform the next action
+
+# Core rules
+- Coordinates are absolute screen pixels. Aim for the CENTER of the target element.
+- Look at the LAST frame for current state. Earlier frames show what changed.
+- Execute ONE action per turn. After each action, observe the result before acting again.
+
+# Form filling — CRITICAL
+- To fill a form: click the input field ONCE to focus it, then call type_text() with the value.
+- Do NOT click an input field multiple times. One click focuses it — then immediately type.
+- After typing, move to the next field: click the next input, or press key_press('Tab').
+- To submit a form: press key_press('Enter') — this is the most reliable method. Only click the Submit button if Enter doesn't work.
+- If you already clicked a field and see it is focused, your NEXT action must be type_text() — not another click.
+
+# Avoiding loops
+- NEVER repeat the same action more than twice. If clicking the same spot twice doesn't work, try a different approach.
+- If you're stuck: try scrolling, pressing Tab, clicking a different element, or using keyboard shortcuts.
+- Read the task description carefully — it tells you what value to type and where.
+
+# Completion
+- When the task is complete, call done(success=true, summary="...").
+- If stuck after multiple attempts, call done(success=false, summary="...").
+
+# Waiting
+- If a page is loading or animating, call wait() to observe the result.
+- After submitting a form, call wait(seconds=2) before checking the result.\
+"""
+
+
+_PROMPTS: dict[str, str] = {
     "system_v1": SYSTEM_V1,
+    "gemma4_system": GEMMA4_SYSTEM,
+    "holo3_system": HOLO3_SYSTEM,
+    "claude_system": CLAUDE_SYSTEM,
+    "opencua_system": OPENCUA_SYSTEM,
+    "llamacpp_system": LLAMACPP_SYSTEM,
 }
 
 
+def _override_dir() -> Path | None:
+    """Resolve ``MANTIS_PROMPTS_DIR`` to a Path if set and existing."""
+    raw = os.environ.get("MANTIS_PROMPTS_DIR", "").strip()
+    if not raw:
+        return None
+    p = Path(raw).expanduser()
+    return p if p.is_dir() else None
+
+
 def load_prompt(name: str, **substitutions: object) -> str:
-    """Load a prompt by name and substitute placeholders.
+    """Load a prompt by name and substitute ``__KEY__`` placeholders.
 
-    Placeholders use the form ``__KEY__`` (uppercase). Substitution keys are
-    normalized to uppercase.
+    Resolution order:
 
-    Example:
+    1. ``MANTIS_PROMPTS_DIR/<name>.txt`` if the env var is set and the
+       file exists. Lets operators override individual prompts without
+       forking the wheel.
+    2. The in-tree constant registered under ``name`` in ``_PROMPTS``.
+
+    Substitution keys are normalised to uppercase. Values are
+    ``str()``-coerced.
+
+    Example::
+
         load_prompt("system_v1", screen_width=1280, screen_height=720, password="hunter2")
+
+    Raises ``KeyError`` if the name is unknown and no override file exists.
     """
-    if name not in _PROMPTS:
-        raise KeyError(f"Unknown prompt: {name}. Available: {list(_PROMPTS)}")
-    text = _PROMPTS[name]
+    text: str | None = None
+
+    override = _override_dir()
+    if override is not None:
+        candidate = override / f"{name}.txt"
+        if candidate.is_file():
+            text = candidate.read_text(encoding="utf-8")
+
+    if text is None:
+        try:
+            text = _PROMPTS[name]
+        except KeyError as exc:
+            raise KeyError(
+                f"Unknown prompt: {name!r}. Available: {sorted(_PROMPTS)}; "
+                f"override dir: {override or '(unset)'}"
+            ) from exc
+
     for key, value in substitutions.items():
         placeholder = f"__{key.upper()}__"
         text = text.replace(placeholder, str(value))
     return text.strip()
 
 
-__all__ = ["load_prompt", "SYSTEM_V1"]
+def list_prompts() -> list[str]:
+    """Names of all in-tree prompts, sorted. Override files are not enumerated."""
+    return sorted(_PROMPTS)
+
+
+__all__ = [
+    "load_prompt",
+    "list_prompts",
+    "SYSTEM_V1",
+    "GEMMA4_SYSTEM",
+    "HOLO3_SYSTEM",
+    "CLAUDE_SYSTEM",
+    "OPENCUA_SYSTEM",
+    "LLAMACPP_SYSTEM",
+]

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1,0 +1,105 @@
+"""Tests for mantis_agent.prompts.load_prompt + MANTIS_PROMPTS_DIR override."""
+
+from __future__ import annotations
+
+import pytest
+
+from mantis_agent.prompts import (
+    CLAUDE_SYSTEM,
+    GEMMA4_SYSTEM,
+    HOLO3_SYSTEM,
+    LLAMACPP_SYSTEM,
+    OPENCUA_SYSTEM,
+    list_prompts,
+    load_prompt,
+)
+
+
+def test_list_prompts_contains_each_brain_system():
+    expected = {
+        "system_v1",
+        "gemma4_system",
+        "holo3_system",
+        "claude_system",
+        "opencua_system",
+        "llamacpp_system",
+    }
+    assert expected.issubset(set(list_prompts()))
+
+
+@pytest.mark.parametrize(
+    "name,const",
+    [
+        ("gemma4_system", GEMMA4_SYSTEM),
+        ("holo3_system", HOLO3_SYSTEM),
+        ("claude_system", CLAUDE_SYSTEM),
+        ("opencua_system", OPENCUA_SYSTEM),
+        ("llamacpp_system", LLAMACPP_SYSTEM),
+    ],
+)
+def test_brain_prompts_round_trip_via_loader(name: str, const: str):
+    """``load_prompt(name)`` must equal the in-tree constant after .strip()."""
+    assert load_prompt(name) == const.strip()
+
+
+def test_load_prompt_substitutes_placeholders():
+    out = load_prompt("system_v1", screen_width=1280, screen_height=720, password="hunter2")
+    assert "1280x720" in out
+    assert "hunter2" in out
+    assert "__SCREEN_WIDTH__" not in out
+    assert "__PASSWORD__" not in out
+
+
+def test_load_prompt_unknown_name_raises():
+    with pytest.raises(KeyError) as excinfo:
+        load_prompt("nonexistent")
+    assert "nonexistent" in str(excinfo.value)
+    assert "Available" in str(excinfo.value)
+
+
+def test_override_dir_takes_precedence(tmp_path, monkeypatch):
+    """A file at ``$MANTIS_PROMPTS_DIR/<name>.txt`` overrides the constant."""
+    override_dir = tmp_path / "prompts"
+    override_dir.mkdir()
+    (override_dir / "claude_system.txt").write_text(
+        "CUSTOM CLAUDE PROMPT FOR TENANT XYZ", encoding="utf-8"
+    )
+
+    monkeypatch.setenv("MANTIS_PROMPTS_DIR", str(override_dir))
+    assert load_prompt("claude_system") == "CUSTOM CLAUDE PROMPT FOR TENANT XYZ"
+
+
+def test_override_dir_falls_back_when_file_missing(tmp_path, monkeypatch):
+    """If the override dir lacks the requested name, fall through to constant."""
+    override_dir = tmp_path / "prompts"
+    override_dir.mkdir()
+    # Only override 'holo3_system'; ask for 'claude_system'
+    (override_dir / "holo3_system.txt").write_text("custom holo3", encoding="utf-8")
+
+    monkeypatch.setenv("MANTIS_PROMPTS_DIR", str(override_dir))
+    assert load_prompt("claude_system") == CLAUDE_SYSTEM.strip()
+    assert load_prompt("holo3_system") == "custom holo3"
+
+
+def test_override_dir_unset_uses_constants_only(monkeypatch):
+    monkeypatch.delenv("MANTIS_PROMPTS_DIR", raising=False)
+    assert load_prompt("opencua_system") == OPENCUA_SYSTEM.strip()
+
+
+def test_override_dir_pointing_at_missing_path_is_ignored(tmp_path, monkeypatch):
+    monkeypatch.setenv("MANTIS_PROMPTS_DIR", str(tmp_path / "does-not-exist"))
+    # No file exists; loader falls through to the constant.
+    assert load_prompt("opencua_system") == OPENCUA_SYSTEM.strip()
+
+
+def test_override_dir_supports_substitutions(tmp_path, monkeypatch):
+    """Substitutions still apply after the override loads from disk."""
+    override_dir = tmp_path / "prompts"
+    override_dir.mkdir()
+    (override_dir / "system_v1.txt").write_text(
+        "Screen: __SCREEN_WIDTH__x__SCREEN_HEIGHT__", encoding="utf-8"
+    )
+
+    monkeypatch.setenv("MANTIS_PROMPTS_DIR", str(override_dir))
+    out = load_prompt("system_v1", screen_width=800, screen_height=600)
+    assert out == "Screen: 800x600"


### PR DESCRIPTION
Closes #99 (partial — see "Out of scope" below).

## Summary

Each brain (`brain.py`, `brain_holo3.py`, `brain_claude.py`, `brain_opencua.py`, `brain_llamacpp.py`) used to inline a 20-36 line triple-quoted `SYSTEM_PROMPT`. That made prompt diffs noisy in review and made per-tenant wording overrides impossible without forking the wheel.

This PR moves all five into the existing `mantis_agent.prompts` module and adds a `MANTIS_PROMPTS_DIR` file-override hook so operators can swap a single prompt without redeploying.

## What changed

### Prompt catalog
- `prompts/__init__.py` registers five new constants (`GEMMA4_SYSTEM`, `HOLO3_SYSTEM`, `CLAUDE_SYSTEM`, `OPENCUA_SYSTEM`, `LLAMACPP_SYSTEM`) alongside the existing `SYSTEM_V1`.
- New `list_prompts()` helper enumerates available names.

### Brains use the loader
Each brain replaces:
```python
SYSTEM_PROMPT = """\
You are a computer use agent...
"""
```
with:
```python
SYSTEM_PROMPT = load_prompt("<name>_system")
```

~150 lines of triple-quoted text move out of the brain modules.

### Operator override
`load_prompt()` grows a `MANTIS_PROMPTS_DIR` hook. When the env var points at a directory, the loader reads `<dir>/<name>.txt` before falling back to the in-tree constant. Substitutions still apply after the override loads.

## Why Python constants instead of `.txt` files in tree?

The original `prompts/__init__.py` docstring is explicit: *"Prompts live as Python string constants in this module so they ship cleanly through Modal's `add_local_python_source` (which only includes `.py` files)."*

Preserving that invariant. The `.txt` path is reserved for **runtime operator overrides**, where the override dir is mounted into the container — best of both: review-friendly diff in tree, file-based override at runtime.

## Test plan

- [x] `pytest tests/ -q` → **370 passed** locally on Python 3.11 (was 357 after #98; +13 new prompt tests)
- [x] `ruff check` clean on every touched file
- [x] New tests cover: round-trip per brain, placeholder substitution, override precedence, missing-file fallback, missing-dir fallback, substitution-after-override
- [ ] CI matrix on 3.11 + 3.12 (will surface on PR run)

## Docs

- `docs/reference/env-vars.md` documents `MANTIS_BRAIN` (PR #103 follow-up) and the new `MANTIS_PROMPTS_DIR` with the catalog of overridable names.

## Out of scope (sub-tasks deferred to follow-up PRs)

- **Templated prompts inside `extraction.py`** (~400 lines around `_get_extract_prompt` / `_get_multi_extract_prompt`). They interpolate `ExtractionSchema` state at call time, so they need a template-with-context shape — bigger refactor.
- **`grounding.py`, `opus_planner.py`** — same shape concern.
- **Snapshot test** that catches silent template breakage. The per-brain round-trip tests cover the static prompts; templated prompts will need their own coverage in the follow-up.

## Acceptance criteria progress (from #99)

- [x] Five inline brain prompts moved out of source
- [x] `load_prompt()` works as the universal entry-point
- [x] Operator override via `MANTIS_PROMPTS_DIR`
- [x] Test coverage for the loader contract
- [ ] No multi-line triple-quoted prompt string remains anywhere in `src/mantis_agent/` — partial; the templated prompts in `extraction.py` / `grounding.py` / `opus_planner.py` are deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
