### PR TITLE
refactor(gym): extract ToolChannel (#115, step 2/N)

### DIFF
--- a/src/mantis_agent/gym/micro_runner.py
+++ b/src/mantis_agent/gym/micro_runner.py
@@ -39,6 +39,7 @@ from .checkpoint import (
     _PauseRequested,
 )
 from .runner import GymRunner
+from .tool_channel import ToolChannel
 
 from ..plan_decomposer import MicroIntent, MicroPlan
 from ..site_config import SiteConfig
@@ -139,10 +140,10 @@ class MicroPlanRunner:
         self.cancel_event = cancel_event
         self.cost_config = cost_config or CostConfig.from_env()
         self.tenant_id = tenant_id
-        # Registered host tools (#71). Mutated via register_tool().
-        self._tools: dict[str, dict[str, Any]] = {}
-        # Pending pause signal from a tool handler (#73).
-        self._pending_pause: dict[str, Any] | None = None
+        # #115: tool registry + pause state extracted into ToolChannel.
+        # Public ``register_tool``/``list_tools``/``call_tool`` below remain on
+        # the runner and delegate here so external callers don't change.
+        self.tool_channel = ToolChannel()
 
         # Cost tracking
         self.costs = {
@@ -157,58 +158,22 @@ class MicroPlanRunner:
     def dynamic_verification_report(self, status: str | None = None) -> dict[str, Any]:
         return self.dynamic_verifier.report(status=status or self._final_status)
 
-    # ── #71 Tool channel ────────────────────────────────────────────────
+    # ── #71 Tool channel — public API delegates to self.tool_channel ────
     def register_tool(self, name: str, schema: dict[str, Any], handler: Any) -> None:
-        """Register a host-provided tool callable mid-plan.
-
-        Args:
-            name: Tool name (matches what the brain emits in its tool_use blocks).
-            schema: JSON-schema input definition. Compatible with
-                ``GenericToolAdapter.to_params()`` on the host side.
-            handler: ``Callable[[dict[str, Any]], Any]``. Invoked with the
-                kwargs the brain supplied. Return value is surfaced into the
-                step ``data`` field; raised exceptions are caught and surfaced
-                as ``success=False`` step results, never silently swallowed.
-        """
-        if not callable(handler):
-            raise TypeError(f"register_tool handler for {name!r} must be callable")
-        self._tools[name] = {"schema": dict(schema or {}), "handler": handler}
+        """Register a host-provided tool callable mid-plan. See :class:`ToolChannel`."""
+        self.tool_channel.register(name, schema, handler)
 
     def list_tools(self) -> list[dict[str, Any]]:
         """Return registered tools as ``[{"name", "schema"}]`` (for brain prompts)."""
-        return [{"name": n, "schema": t["schema"]} for n, t in self._tools.items()]
+        return self.tool_channel.list()
 
     def call_tool(self, name: str, arguments: dict[str, Any] | None = None) -> Any:
-        """Invoke a registered tool. Raises KeyError if not registered.
-
-        Errors from the handler propagate to the caller; `_invoke_tool` is the
-        loop-internal wrapper that converts errors into StepResult failures.
-        """
-        if name not in self._tools:
-            raise KeyError(f"tool not registered: {name}")
-        return self._tools[name]["handler"](arguments or {})
+        """Invoke a registered tool. Raises KeyError if not registered."""
+        return self.tool_channel.call(name, arguments)
 
     def _invoke_tool(self, name: str, arguments: dict[str, Any]) -> tuple[bool, str]:
         """Run a tool, returning ``(success, data_str)`` for the step result."""
-        try:
-            value = self.call_tool(name, arguments)
-        except _PauseRequested as exc:
-            # Tool requested pause (#73) — propagate so the run() loop can
-            # snapshot and return a PauseState. Don't treat as failure.
-            self._pending_pause = {
-                "tool": name,
-                "arguments": dict(arguments),
-                "reason": exc.reason,
-                "prompt": exc.prompt,
-            }
-            return True, f"tool:{name}:pause"
-        except KeyError as exc:
-            return False, f"tool:{name}:not_registered:{exc}"
-        except Exception as exc:  # noqa: BLE001 — surface, never swallow
-            logger.exception("tool %s raised", name)
-            return False, f"tool:{name}:error:{type(exc).__name__}:{exc}"
-        rendered = "" if value is None else str(value)
-        return True, f"tool:{name}:ok:{rendered[:200]}"
+        return self.tool_channel.invoke(name, arguments)
 
     # ── #74 Observability ──────────────────────────────────────────────
     def _capture_screenshot_bytes(self) -> bytes | None:
@@ -692,7 +657,7 @@ class MicroPlanRunner:
 
             # Pending pause (#73) — surface as paused, build PauseState in
             # _build_runner_result.
-            if self._pending_pause is not None:
+            if self.tool_channel.is_paused():
                 persist(step_index, status="paused", halt_reason="user_input")
                 self._final_status = "paused"
                 break
@@ -1096,7 +1061,7 @@ class MicroPlanRunner:
 
         # Replay results from the snapshot so cost/lead totals stay continuous.
         replayed = [StepResult.from_dict(d) for d in state.step_results]
-        self._pending_pause = None
+        self.tool_channel.clear_pause()
 
         # Rehydrate runner state. The simplest correct approach: load the
         # checkpoint that the original run() persisted (state.checkpoint_path
@@ -1135,10 +1100,10 @@ class MicroPlanRunner:
     ) -> RunnerResult:
         status = self._final_status or "completed"
         cancelled = status == "cancelled"
-        paused = status == "paused" and self._pending_pause is not None
+        paused = status == "paused" and self.tool_channel.is_paused()
         pause_state: PauseState | None = None
         if paused:
-            pp = self._pending_pause or {}
+            pp = self.tool_channel.pending_pause or {}
             pause_state = PauseState(
                 run_key=self.run_key,
                 plan_signature=self.plan_signature

--- a/src/mantis_agent/gym/tool_channel.py
+++ b/src/mantis_agent/gym/tool_channel.py
@@ -1,0 +1,114 @@
+"""Host-tool registration channel for MicroPlanRunner — extracted from
+micro_runner.py (#115, step 2).
+
+Hosts register callables that the brain can invoke mid-plan ("tools").
+This module owns:
+
+* the registry of registered tools and their schemas
+* the safe-invoke wrapper that converts handler errors into structured
+  step results (never silently swallowed)
+* the pause-request slot that a handler can populate by raising
+  :class:`PauseRequested` to suspend the run for user input
+
+Behavior is unchanged from the previous in-place implementation in
+``MicroPlanRunner``. The runner composes a single :class:`ToolChannel` and
+its public ``register_tool`` / ``list_tools`` / ``call_tool`` methods
+delegate here.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from .checkpoint import _PauseRequested
+
+logger = logging.getLogger(__name__)
+
+
+class ToolChannel:
+    """Owns registered host tools + pause state for one MicroPlanRunner.
+
+    A registered tool is ``{name: {"schema": dict, "handler": callable}}``.
+    The handler signature is ``Callable[[dict[str, Any]], Any]``: the brain's
+    parsed kwargs come in, the return value (str-rendered) goes back into the
+    step's ``data`` field.
+
+    The :meth:`invoke` wrapper is what the runner calls during a step. It
+    catches :class:`PauseRequested` and stores a snapshot in
+    :attr:`pending_pause` so the runner's main loop can detect it at the next
+    boundary and emit a :class:`PauseState`. Any other exception becomes a
+    ``(False, "tool:<n>:error:<type>:<msg>")`` step result.
+    """
+
+    def __init__(self) -> None:
+        self._tools: dict[str, dict[str, Any]] = {}
+        self.pending_pause: dict[str, Any] | None = None
+
+    # ── Registration ────────────────────────────────────────────────────
+
+    def register(self, name: str, schema: dict[str, Any], handler: Any) -> None:
+        """Register a host-provided tool callable mid-plan.
+
+        Args:
+            name: Tool name (matches what the brain emits in its tool_use blocks).
+            schema: JSON-schema input definition. Compatible with
+                ``GenericToolAdapter.to_params()`` on the host side.
+            handler: ``Callable[[dict[str, Any]], Any]``. Invoked with the
+                kwargs the brain supplied. Return value is surfaced into the
+                step ``data`` field; raised exceptions are caught and surfaced
+                as ``success=False`` step results, never silently swallowed.
+        """
+        if not callable(handler):
+            raise TypeError(f"register_tool handler for {name!r} must be callable")
+        self._tools[name] = {"schema": dict(schema or {}), "handler": handler}
+
+    def list(self) -> list[dict[str, Any]]:
+        """Return registered tools as ``[{"name", "schema"}]`` (for brain prompts)."""
+        return [{"name": n, "schema": t["schema"]} for n, t in self._tools.items()]
+
+    # ── Invocation ──────────────────────────────────────────────────────
+
+    def call(self, name: str, arguments: dict[str, Any] | None = None) -> Any:
+        """Invoke a registered tool. Raises KeyError if not registered.
+
+        Errors from the handler propagate to the caller; :meth:`invoke` is the
+        loop-internal wrapper that converts errors into StepResult failures.
+        """
+        if name not in self._tools:
+            raise KeyError(f"tool not registered: {name}")
+        return self._tools[name]["handler"](arguments or {})
+
+    def invoke(self, name: str, arguments: dict[str, Any]) -> tuple[bool, str]:
+        """Run a tool, returning ``(success, data_str)`` for the step result."""
+        try:
+            value = self.call(name, arguments)
+        except _PauseRequested as exc:
+            # Tool requested pause (#73) — propagate so the run() loop can
+            # snapshot and return a PauseState. Don't treat as failure.
+            self.pending_pause = {
+                "tool": name,
+                "arguments": dict(arguments),
+                "reason": exc.reason,
+                "prompt": exc.prompt,
+            }
+            return True, f"tool:{name}:pause"
+        except KeyError as exc:
+            return False, f"tool:{name}:not_registered:{exc}"
+        except Exception as exc:  # noqa: BLE001 — surface, never swallow
+            logger.exception("tool %s raised", name)
+            return False, f"tool:{name}:error:{type(exc).__name__}:{exc}"
+        rendered = "" if value is None else str(value)
+        return True, f"tool:{name}:ok:{rendered[:200]}"
+
+    # ── Pause lifecycle ─────────────────────────────────────────────────
+
+    def is_paused(self) -> bool:
+        return self.pending_pause is not None
+
+    def clear_pause(self) -> None:
+        """Drop the pending pause snapshot (called from resume())."""
+        self.pending_pause = None
+
+
+__all__ = ["ToolChannel"]

--- a/tests/test_micro_runner_hooks.py
+++ b/tests/test_micro_runner_hooks.py
@@ -299,12 +299,14 @@ def test_pause_requested_yields_pause_state_via_tool_invocation():
     )
 
     # First invocation triggers a pause — `_invoke_tool` returns success but
-    # records the pending pause for the run loop to surface.
+    # records the pending pause for the run loop to surface. Pause state lives
+    # on the ToolChannel after #115 step 2; the ``_invoke_tool`` shim still
+    # delegates correctly.
     ok, data = r._invoke_tool("request_user_input", {"prompt": "MFA code?"})
     assert ok is True
     assert data.endswith(":pause")
-    assert r._pending_pause is not None
-    assert r._pending_pause["tool"] == "request_user_input"
+    assert r.tool_channel.is_paused()
+    assert r.tool_channel.pending_pause["tool"] == "request_user_input"
 
     # On resume, consume_pause_input returns the staged value.
     r._pause_input = "123456"

--- a/tests/test_tool_channel.py
+++ b/tests/test_tool_channel.py
@@ -1,0 +1,168 @@
+"""Tests for #115 step 2 — ToolChannel extracted from MicroPlanRunner."""
+
+from __future__ import annotations
+
+import pytest
+
+from mantis_agent.gym.checkpoint import PauseRequested
+from mantis_agent.gym.tool_channel import ToolChannel
+
+
+# ── Registration ─────────────────────────────────────────────────────────
+
+
+def test_register_stores_schema_and_handler() -> None:
+    tc = ToolChannel()
+
+    def handler(args: dict) -> str:
+        return "ok"
+
+    tc.register("ask_user", {"type": "object"}, handler)
+    listed = tc.list()
+    assert listed == [{"name": "ask_user", "schema": {"type": "object"}}]
+
+
+def test_register_rejects_non_callable_handler() -> None:
+    tc = ToolChannel()
+    with pytest.raises(TypeError, match="handler"):
+        tc.register("bad", {}, "not-a-function")  # type: ignore[arg-type]
+
+
+def test_register_overwrite_replaces_handler() -> None:
+    tc = ToolChannel()
+    tc.register("t", {}, lambda args: "v1")
+    tc.register("t", {"k": "v"}, lambda args: "v2")
+    assert tc.list() == [{"name": "t", "schema": {"k": "v"}}]
+    assert tc.call("t", {}) == "v2"
+
+
+# ── Direct call ──────────────────────────────────────────────────────────
+
+
+def test_call_invokes_handler_with_arguments() -> None:
+    tc = ToolChannel()
+    received: list[dict] = []
+
+    def handler(args: dict) -> str:
+        received.append(args)
+        return f"ok:{args.get('x')}"
+
+    tc.register("h", {}, handler)
+    out = tc.call("h", {"x": 7})
+    assert out == "ok:7"
+    assert received == [{"x": 7}]
+
+
+def test_call_unregistered_raises_keyerror() -> None:
+    tc = ToolChannel()
+    with pytest.raises(KeyError, match="not registered"):
+        tc.call("nope", {})
+
+
+def test_call_handler_exception_propagates() -> None:
+    tc = ToolChannel()
+
+    def boom(args: dict) -> None:
+        raise RuntimeError("boom")
+
+    tc.register("h", {}, boom)
+    with pytest.raises(RuntimeError, match="boom"):
+        tc.call("h", {})
+
+
+# ── Wrapped invoke (loop-internal) ───────────────────────────────────────
+
+
+def test_invoke_success_returns_ok_payload() -> None:
+    tc = ToolChannel()
+    tc.register("h", {}, lambda args: "result-value")
+    ok, msg = tc.invoke("h", {})
+    assert ok is True
+    assert msg == "tool:h:ok:result-value"
+
+
+def test_invoke_truncates_long_results_to_200_chars() -> None:
+    tc = ToolChannel()
+    tc.register("h", {}, lambda args: "x" * 500)
+    ok, msg = tc.invoke("h", {})
+    assert ok is True
+    # Prefix is "tool:h:ok:" (10 chars) + up to 200 chars of payload.
+    assert len(msg) == 10 + 200
+
+
+def test_invoke_unregistered_returns_failure() -> None:
+    tc = ToolChannel()
+    ok, msg = tc.invoke("missing", {})
+    assert ok is False
+    assert msg.startswith("tool:missing:not_registered:")
+
+
+def test_invoke_handler_error_returns_failure_with_type() -> None:
+    tc = ToolChannel()
+
+    def boom(args: dict) -> None:
+        raise ValueError("bad input")
+
+    tc.register("h", {}, boom)
+    ok, msg = tc.invoke("h", {"a": 1})
+    assert ok is False
+    assert "tool:h:error:ValueError:bad input" in msg
+
+
+# ── Pause request flow ──────────────────────────────────────────────────
+
+
+def test_pause_request_marks_pending_and_returns_ok_pause() -> None:
+    tc = ToolChannel()
+
+    def needs_user(args: dict) -> None:
+        raise PauseRequested(prompt="approve?", reason="user_input")
+
+    tc.register("ask", {}, needs_user)
+    assert tc.is_paused() is False
+    ok, msg = tc.invoke("ask", {"context": "deploy"})
+    assert ok is True
+    assert msg == "tool:ask:pause"
+    assert tc.is_paused() is True
+    assert tc.pending_pause == {
+        "tool": "ask",
+        "arguments": {"context": "deploy"},
+        "reason": "user_input",
+        "prompt": "approve?",
+    }
+
+
+def test_clear_pause_drops_snapshot() -> None:
+    tc = ToolChannel()
+    tc.register("ask", {}, lambda args: (_ for _ in ()).throw(PauseRequested(prompt="?")))
+    tc.invoke("ask", {})
+    assert tc.is_paused() is True
+    tc.clear_pause()
+    assert tc.is_paused() is False
+    assert tc.pending_pause is None
+
+
+def test_pause_arguments_are_copied_not_aliased() -> None:
+    """Mutating the args dict after invoke must not bleed into pending_pause."""
+    tc = ToolChannel()
+    tc.register("ask", {}, lambda args: (_ for _ in ()).throw(PauseRequested(prompt="?")))
+    args = {"k": 1}
+    tc.invoke("ask", args)
+    args["k"] = 999
+    assert tc.pending_pause["arguments"] == {"k": 1}
+
+
+# ── Backward-compat: MicroPlanRunner public surface unchanged ────────────
+
+
+def test_micro_plan_runner_public_methods_delegate_to_tool_channel() -> None:
+    """Ensure the runner's register_tool/list_tools/call_tool still work."""
+    from mantis_agent.gym.micro_runner import MicroPlanRunner
+
+    # Build a runner with no env/brain (ToolChannel doesn't need them).
+    runner = MicroPlanRunner.__new__(MicroPlanRunner)
+    runner.tool_channel = ToolChannel()
+
+    runner.register_tool("h", {"k": "v"}, lambda args: f"ok:{args.get('x')}")
+    assert runner.list_tools() == [{"name": "h", "schema": {"k": "v"}}]
+    assert runner.call_tool("h", {"x": 9}) == "ok:9"


### PR DESCRIPTION
## Summary

Step 2 in the `MicroPlanRunner` split. Extracts the host-tool registration channel and pause slot into a focused `ToolChannel` class. Pure code move + delegation — zero behavior change.

## What moved

To `mantis_agent.gym.tool_channel`:

| Before (on MicroPlanRunner) | After (on ToolChannel) |
|---|---|
| `self._tools: dict` | `self._tools: dict` |
| `self._pending_pause: dict \| None` | `self.pending_pause: dict \| None` |
| `register_tool` | `register` |
| `list_tools` | `list` |
| `call_tool` | `call` |
| `_invoke_tool` | `invoke` |
| (read `self._pending_pause is not None`) | `is_paused()` |
| (write `self._pending_pause = None`) | `clear_pause()` |

`MicroPlanRunner.register_tool` / `list_tools` / `call_tool` / `_invoke_tool` stay as 1-line shims so external callers don't change.

## Why ToolChannel can stand alone

It has no env/brain/runner dependencies. Host integrations can construct one in isolation if they want to script tool registration without a live `MicroPlanRunner` (useful for testing host adapters).

## LOC delta

- `micro_runner.py`: 2866 → 2831 (-35)
- new `tool_channel.py`: 114

LOC reduction is modest because the public methods stay as shims. The bigger wins come from upcoming `BrowserState` / `ListingDedup` extractions which pull entire helper-method clusters out.

## Test plan

- [x] 14 new unit tests in `test_tool_channel.py` covering register / list / call / invoke (success + error + truncate) / pause flow / argument-copy isolation / runner-delegation
- [x] 20 new + `test_checkpoint_module` tests pass
- [x] 32 `test_form_intents` + `test_no_orphan_submodules` tests pass
- [x] ruff clean
- [ ] CI on this PR (includes `test_micro_runner_hooks` which exercises the pause/resume path through the runner)

## Series progress

| Step | What | Status |
|---|---|---|
| 1 | Checkpoint dataclasses | ✅ #129 merged |
| **2** | **ToolChannel** | **this PR** |
| 3 | CostMeter | next |
| 4 | BrowserState | |
| 5 | ListingDedup | |
| 6 | Coordinator → thin Executor | |

🤖 Generated with [Claude Code](https://claude.com/claude-code)