### PR TITLE
refactor(gym): extract CostMeter (#115, step 3/N)

### DIFF
--- a/src/mantis_agent/gym/cost_meter.py
+++ b/src/mantis_agent/gym/cost_meter.py
@@ -1,0 +1,152 @@
+"""Per-run cost accounting for MicroPlanRunner — extracted from
+micro_runner.py (#115, step 3).
+
+Tracks four counters per run:
+
+* ``gpu_steps``       — number of brain-driven steps
+* ``gpu_seconds``     — derived from ``gpu_steps * cost_config.gpu_seconds_per_step``
+* ``claude_extract``  — Claude API calls for extraction / verification / grounding callthroughs
+* ``claude_grounding``— Claude API calls for click coordinate grounding
+* ``proxy_mb``        — estimated egress bandwidth in megabytes
+
+Rates live in :class:`CostConfig` so deployments can override them via env
+vars; this meter applies them and emits Prometheus inflight gauges.
+
+Backward-compat note: ``MicroPlanRunner.costs`` still exists and points
+at the **same dict** the meter owns. The 60+ scattered ``self.costs[...] += N``
+mutation sites in the runner keep working unchanged because dict
+subscript-assign is in-place. Subsequent splits can migrate those call
+sites to ``meter.add_*()`` helpers; this PR keeps the diff minimal.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import TYPE_CHECKING, Any
+
+from ..cost_config import CostConfig
+
+if TYPE_CHECKING:
+    from ..plan_decomposer import MicroIntent
+    from .checkpoint import StepResult
+
+logger = logging.getLogger(__name__)
+
+
+_INITIAL_COSTS: dict[str, Any] = {
+    "gpu_steps": 0,        # Total Holo3 steps
+    "gpu_seconds": 0.0,    # Approx GPU time
+    "claude_extract": 0,   # Claude extraction calls
+    "claude_grounding": 0, # Claude grounding calls
+    "proxy_mb": 0.0,       # Estimated proxy bandwidth
+}
+
+
+def make_initial_costs() -> dict[str, Any]:
+    """Fresh copy of the initial counters dict. Same shape as the
+    pre-#115 ``MicroPlanRunner.costs`` initializer.
+    """
+    return dict(_INITIAL_COSTS)
+
+
+class CostMeter:
+    """Owns cost counters + rate config + Prometheus inflight gauges.
+
+    The :attr:`costs` dict is the canonical state — mutate it in-place via
+    subscript assignment from anywhere in the runner. ``MicroPlanRunner.costs``
+    is the *same* dict (alias) for backward compat with the runner's many
+    scattered increment sites.
+    """
+
+    def __init__(
+        self,
+        cost_config: CostConfig | None = None,
+        tenant_id: str = "",
+    ) -> None:
+        self.cost_config = cost_config or CostConfig.from_env()
+        self.tenant_id = tenant_id
+        self.costs: dict[str, Any] = make_initial_costs()
+        self.run_start: float = time.time()
+
+    # ── Pure cost computation ───────────────────────────────────────────
+
+    def totals(self) -> tuple[float, float, float, float]:
+        """Return (gpu, claude, proxy, total) USD for the current counters."""
+        cfg = self.cost_config
+        gpu_cost = cfg.gpu_cost(self.costs["gpu_seconds"])
+        claude_cost = cfg.claude_cost(
+            self.costs["claude_extract"] + self.costs["claude_grounding"]
+        )
+        proxy_cost = cfg.proxy_cost(self.costs["proxy_mb"])
+        return gpu_cost, claude_cost, proxy_cost, gpu_cost + claude_cost + proxy_cost
+
+    def elapsed_seconds(self) -> float:
+        return time.time() - self.run_start
+
+    # ── Per-step accounting ─────────────────────────────────────────────
+
+    def record_step(self, step: "MicroIntent", step_result: "StepResult") -> None:
+        """Apply a step's resource usage to the counters.
+
+        Mirrors the pre-#115 ``MicroPlanRunner._record_step_costs`` exactly:
+        GPU time scales with step count, Claude extraction is one call per
+        ``claude_only`` step, grounding is one call per click step,
+        navigation/scroll add proxy MB per the config rate.
+        """
+        cfg = self.cost_config
+        if step_result.steps_used > 0:
+            self.costs["gpu_steps"] += step_result.steps_used
+            self.costs["gpu_seconds"] += step_result.steps_used * cfg.gpu_seconds_per_step
+        if step.claude_only:
+            self.costs["claude_extract"] += 1
+        if step.grounding:
+            self.costs["claude_grounding"] += step_result.steps_used  # ~1 grounding per click
+        if step.type in ("click", "navigate", "paginate"):
+            self.costs["proxy_mb"] += cfg.proxy_mb_per_nav
+        elif step.type == "scroll":
+            self.costs["proxy_mb"] += cfg.proxy_mb_per_scroll
+
+    # ── Restore from checkpoint ─────────────────────────────────────────
+
+    def restore(self, persisted: dict[str, Any] | None) -> None:
+        """Merge persisted counters from a RunCheckpoint into the live dict."""
+        if persisted:
+            self.costs.update(persisted)
+
+    def snapshot(self) -> dict[str, Any]:
+        """Plain-dict copy suitable for ``RunCheckpoint.costs``."""
+        return dict(self.costs)
+
+    # ── Prometheus emission ─────────────────────────────────────────────
+
+    def emit_inflight_gauges(
+        self,
+        gpu_cost: float,
+        claude_cost: float,
+        proxy_cost: float,
+        total_cost: float,
+    ) -> None:
+        """Push running per-component cost to Prometheus (#122).
+
+        Skipped when no tenant_id is set so the registry doesn't get a
+        default-label series for local/script runs.
+        """
+        if not self.tenant_id:
+            return
+        try:
+            from .. import metrics as _metrics
+            for component, value in (
+                ("gpu", gpu_cost),
+                ("claude", claude_cost),
+                ("proxy", proxy_cost),
+                ("total", total_cost),
+            ):
+                _metrics.RUN_COST_USD_INFLIGHT.labels(
+                    tenant_id=self.tenant_id, component=component
+                ).set(value)
+        except Exception as exc:  # noqa: BLE001 — metrics are observability, never fatal
+            logger.debug("inflight cost gauge update failed: %s", exc)
+
+
+__all__ = ["CostMeter", "make_initial_costs"]

--- a/src/mantis_agent/gym/micro_runner.py
+++ b/src/mantis_agent/gym/micro_runner.py
@@ -382,7 +382,13 @@ class MicroPlanRunner:
         self._last_known_url = checkpoint.current_url or checkpoint.reentry_url
         self._scroll_state = dict(checkpoint.scroll_state or {})
         self._last_extracted = dict(checkpoint.last_extracted or {})
-        self.cost_meter.restore(checkpoint.costs)
+        # Preserves the pre-#115 contract: callers that bypass __init__
+        # (e.g. test_private_seller_filter uses object.__new__ + manual
+        # ``runner.costs = {...}``) keep working. CostMeter.restore()
+        # exists for clean composition but the runner's path uses the
+        # in-place dict update so it doesn't require a cost_meter to
+        # be present on the instance.
+        self.costs.update(checkpoint.costs or {})
         if checkpoint.dynamic_coverage:
             self.dynamic_verifier.load_report(checkpoint.dynamic_coverage)
         self._listings_on_page = checkpoint.listings_on_page

--- a/src/mantis_agent/gym/micro_runner.py
+++ b/src/mantis_agent/gym/micro_runner.py
@@ -29,6 +29,7 @@ from typing import Any, TYPE_CHECKING
 
 from ..actions import Action, ActionType
 from ..cost_config import CostConfig
+from .cost_meter import CostMeter
 from .checkpoint import (
     REVERSE_ACTIONS,
     PauseRequested,
@@ -138,22 +139,22 @@ class MicroPlanRunner:
         self.step_callback = step_callback
         self.keep_screenshots = keep_screenshots
         self.cancel_event = cancel_event
-        self.cost_config = cost_config or CostConfig.from_env()
-        self.tenant_id = tenant_id
         # #115: tool registry + pause state extracted into ToolChannel.
         # Public ``register_tool``/``list_tools``/``call_tool`` below remain on
         # the runner and delegate here so external callers don't change.
         self.tool_channel = ToolChannel()
 
-        # Cost tracking
-        self.costs = {
-            "gpu_steps": 0,        # Total Holo3 steps
-            "gpu_seconds": 0.0,    # Approx GPU time
-            "claude_extract": 0,   # Claude extraction calls
-            "claude_grounding": 0, # Claude grounding calls
-            "proxy_mb": 0.0,       # Estimated proxy bandwidth
-        }
-        self._run_start = time.time()
+        # #115 step 3: cost counters + rate config + Prometheus inflight
+        # gauges live on the CostMeter. ``self.costs`` aliases the meter's
+        # canonical dict so the 60+ scattered ``self.costs["..."] += N``
+        # mutation sites in this file continue to work unchanged.
+        # ``self.cost_config`` and ``self.tenant_id`` stay as runner attrs
+        # for any external reader; they mirror the meter's view.
+        self.cost_meter = CostMeter(cost_config=cost_config, tenant_id=tenant_id)
+        self.cost_config = self.cost_meter.cost_config
+        self.tenant_id = self.cost_meter.tenant_id
+        self.costs = self.cost_meter.costs
+        self._run_start = self.cost_meter.run_start
 
     def dynamic_verification_report(self, status: str | None = None) -> dict[str, Any]:
         return self.dynamic_verifier.report(status=status or self._final_status)
@@ -258,14 +259,8 @@ class MicroPlanRunner:
         ).hexdigest()
 
     def _cost_totals(self) -> tuple[float, float, float, float]:
-        cfg = self.cost_config
-        gpu_cost = cfg.gpu_cost(self.costs["gpu_seconds"])
-        claude_cost = cfg.claude_cost(
-            self.costs["claude_extract"] + self.costs["claude_grounding"]
-        )
-        proxy_cost = cfg.proxy_cost(self.costs["proxy_mb"])
-        total_cost = gpu_cost + claude_cost + proxy_cost
-        return gpu_cost, claude_cost, proxy_cost, total_cost
+        """Backward-compat shim — delegates to :meth:`CostMeter.totals`."""
+        return self.cost_meter.totals()
 
     @classmethod
     def _unique_leads_from_results(cls, results: list[StepResult]) -> list[str]:
@@ -275,18 +270,8 @@ class MicroPlanRunner:
         return list(unique.values())
 
     def _record_step_costs(self, step: MicroIntent, step_result: StepResult) -> None:
-        cfg = self.cost_config
-        if step_result.steps_used > 0:
-            self.costs["gpu_steps"] += step_result.steps_used
-            self.costs["gpu_seconds"] += step_result.steps_used * cfg.gpu_seconds_per_step
-        if step.claude_only:
-            self.costs["claude_extract"] += 1
-        if step.grounding:
-            self.costs["claude_grounding"] += step_result.steps_used  # ~1 grounding per click
-        if step.type in ("click", "navigate", "paginate"):
-            self.costs["proxy_mb"] += cfg.proxy_mb_per_nav
-        elif step.type == "scroll":
-            self.costs["proxy_mb"] += cfg.proxy_mb_per_scroll
+        """Backward-compat shim — delegates to :meth:`CostMeter.record_step`."""
+        self.cost_meter.record_step(step, step_result)
 
     def _log_progress(self, step_result: StepResult, results: list[StepResult]) -> None:
         gpu_cost, claude_cost, proxy_cost, total_cost = self._cost_totals()
@@ -306,29 +291,8 @@ class MicroPlanRunner:
     def _emit_cost_gauges(
         self, gpu_cost: float, claude_cost: float, proxy_cost: float, total_cost: float
     ) -> None:
-        """Push the running per-component cost to Prometheus (#122).
-
-        Skipped when no tenant_id is set so we don't pollute the registry with
-        a default-label series for local/script runs.
-        """
-        if not self.tenant_id:
-            return
-        try:
-            from .. import metrics as _metrics
-            _metrics.RUN_COST_USD_INFLIGHT.labels(
-                tenant_id=self.tenant_id, component="gpu"
-            ).set(gpu_cost)
-            _metrics.RUN_COST_USD_INFLIGHT.labels(
-                tenant_id=self.tenant_id, component="claude"
-            ).set(claude_cost)
-            _metrics.RUN_COST_USD_INFLIGHT.labels(
-                tenant_id=self.tenant_id, component="proxy"
-            ).set(proxy_cost)
-            _metrics.RUN_COST_USD_INFLIGHT.labels(
-                tenant_id=self.tenant_id, component="total"
-            ).set(total_cost)
-        except Exception as exc:  # noqa: BLE001 — metrics are observability, never fatal
-            logger.debug("inflight cost gauge update failed: %s", exc)
+        """Backward-compat shim — delegates to :meth:`CostMeter.emit_inflight_gauges`."""
+        self.cost_meter.emit_inflight_gauges(gpu_cost, claude_cost, proxy_cost, total_cost)
 
     def _current_results_page_url(self) -> str:
         if not self._results_base_url:
@@ -418,7 +382,7 @@ class MicroPlanRunner:
         self._last_known_url = checkpoint.current_url or checkpoint.reentry_url
         self._scroll_state = dict(checkpoint.scroll_state or {})
         self._last_extracted = dict(checkpoint.last_extracted or {})
-        self.costs.update(checkpoint.costs or {})
+        self.cost_meter.restore(checkpoint.costs)
         if checkpoint.dynamic_coverage:
             self.dynamic_verifier.load_report(checkpoint.dynamic_coverage)
         self._listings_on_page = checkpoint.listings_on_page

--- a/tests/test_cost_meter.py
+++ b/tests/test_cost_meter.py
@@ -1,0 +1,237 @@
+"""Tests for #115 step 3 — CostMeter extracted from MicroPlanRunner."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+
+import pytest
+
+from mantis_agent.cost_config import CostConfig
+from mantis_agent.gym.cost_meter import CostMeter, make_initial_costs
+
+
+# ── Tiny stand-ins for MicroIntent / StepResult ─────────────────────────
+
+
+@dataclass
+class _FakeStep:
+    type: str = "click"
+    claude_only: bool = False
+    grounding: bool = False
+
+
+@dataclass
+class _FakeStepResult:
+    steps_used: int = 0
+
+
+# ── Initial state ───────────────────────────────────────────────────────
+
+
+def test_make_initial_costs_returns_zeros() -> None:
+    c = make_initial_costs()
+    assert c == {
+        "gpu_steps": 0,
+        "gpu_seconds": 0.0,
+        "claude_extract": 0,
+        "claude_grounding": 0,
+        "proxy_mb": 0.0,
+    }
+
+
+def test_make_initial_costs_returns_fresh_dict_per_call() -> None:
+    a = make_initial_costs()
+    b = make_initial_costs()
+    a["gpu_steps"] = 99
+    assert b["gpu_steps"] == 0
+
+
+def test_meter_default_uses_costconfig_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MANTIS_COST_GPU_HOURLY_USD", "1.50")
+    meter = CostMeter()
+    assert meter.cost_config.gpu_hourly_usd == 1.50
+
+
+def test_meter_initial_run_start_is_close_to_now() -> None:
+    before = time.time()
+    meter = CostMeter()
+    after = time.time()
+    assert before <= meter.run_start <= after
+
+
+# ── Cost totals ─────────────────────────────────────────────────────────
+
+
+def test_totals_zero_for_fresh_meter() -> None:
+    meter = CostMeter()
+    assert meter.totals() == (0.0, 0.0, 0.0, 0.0)
+
+
+def test_totals_combines_components_via_cost_config() -> None:
+    cfg = CostConfig(
+        gpu_hourly_usd=4.0,
+        claude_call_usd=0.01,
+        proxy_per_gb_usd=2.0,
+    )
+    meter = CostMeter(cost_config=cfg)
+    meter.costs["gpu_seconds"] = 3600  # 1 hour → $4
+    meter.costs["claude_extract"] = 5  # → $0.05
+    meter.costs["claude_grounding"] = 5  # → $0.05
+    meter.costs["proxy_mb"] = 1024  # 1 GB → $2
+    gpu, claude, proxy, total = meter.totals()
+    assert gpu == pytest.approx(4.0)
+    assert claude == pytest.approx(0.10)
+    assert proxy == pytest.approx(2.0)
+    assert total == pytest.approx(6.10)
+
+
+# ── Per-step accounting ─────────────────────────────────────────────────
+
+
+def test_record_step_adds_gpu_seconds_per_steps_used() -> None:
+    cfg = CostConfig(gpu_seconds_per_step=4.0)
+    meter = CostMeter(cost_config=cfg)
+    meter.record_step(_FakeStep(), _FakeStepResult(steps_used=3))
+    assert meter.costs["gpu_steps"] == 3
+    assert meter.costs["gpu_seconds"] == 12.0
+
+
+def test_record_step_no_gpu_when_steps_used_zero() -> None:
+    meter = CostMeter()
+    meter.record_step(_FakeStep(), _FakeStepResult(steps_used=0))
+    assert meter.costs["gpu_steps"] == 0
+    assert meter.costs["gpu_seconds"] == 0.0
+
+
+def test_record_step_increments_claude_extract_only_when_claude_only() -> None:
+    meter = CostMeter()
+    meter.record_step(_FakeStep(claude_only=True), _FakeStepResult())
+    meter.record_step(_FakeStep(claude_only=False), _FakeStepResult())
+    assert meter.costs["claude_extract"] == 1
+
+
+def test_record_step_increments_grounding_per_steps_used() -> None:
+    meter = CostMeter()
+    meter.record_step(_FakeStep(grounding=True), _FakeStepResult(steps_used=2))
+    assert meter.costs["claude_grounding"] == 2
+
+
+def test_record_step_proxy_mb_for_nav_types() -> None:
+    cfg = CostConfig(proxy_mb_per_nav=7.0, proxy_mb_per_scroll=0.25)
+    meter = CostMeter(cost_config=cfg)
+    for kind in ("click", "navigate", "paginate"):
+        meter.record_step(_FakeStep(type=kind), _FakeStepResult())
+    meter.record_step(_FakeStep(type="scroll"), _FakeStepResult())
+    meter.record_step(_FakeStep(type="extract_data"), _FakeStepResult())
+    assert meter.costs["proxy_mb"] == pytest.approx(3 * 7.0 + 0.25)
+
+
+# ── Snapshot / restore ──────────────────────────────────────────────────
+
+
+def test_snapshot_returns_independent_copy() -> None:
+    meter = CostMeter()
+    meter.costs["gpu_steps"] = 5
+    snap = meter.snapshot()
+    snap["gpu_steps"] = 999
+    assert meter.costs["gpu_steps"] == 5
+
+
+def test_restore_merges_persisted_counters() -> None:
+    meter = CostMeter()
+    meter.restore({"gpu_steps": 10, "claude_extract": 3})
+    assert meter.costs["gpu_steps"] == 10
+    assert meter.costs["claude_extract"] == 3
+    # Untouched keys keep their initial values.
+    assert meter.costs["proxy_mb"] == 0.0
+
+
+def test_restore_with_none_is_noop() -> None:
+    meter = CostMeter()
+    meter.costs["gpu_steps"] = 7
+    meter.restore(None)
+    assert meter.costs["gpu_steps"] == 7
+
+
+# ── Inflight gauge emission ─────────────────────────────────────────────
+
+
+def test_emit_skipped_when_no_tenant_id() -> None:
+    """No tenant_id ⇒ no Prometheus interaction at all (registry stays clean)."""
+    meter = CostMeter(tenant_id="")
+    # Should not raise even if metrics module is missing/broken — exercises
+    # the early-return guard.
+    meter.emit_inflight_gauges(1.0, 2.0, 3.0, 6.0)
+
+
+def test_emit_calls_prometheus_when_tenant_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: list[tuple[str, str, float]] = []
+
+    class _Gauge:
+        def labels(self, **kwargs):
+            return _LabeledGauge(kwargs)
+
+    class _LabeledGauge:
+        def __init__(self, kwargs: dict) -> None:
+            self.kwargs = kwargs
+
+        def set(self, value: float) -> None:
+            captured.append(
+                (self.kwargs["tenant_id"], self.kwargs["component"], value)
+            )
+
+    from mantis_agent import metrics as real_metrics
+    monkeypatch.setattr(real_metrics, "RUN_COST_USD_INFLIGHT", _Gauge())
+
+    meter = CostMeter(tenant_id="tenant-A")
+    meter.emit_inflight_gauges(1.0, 2.0, 3.0, 6.0)
+    assert ("tenant-A", "gpu", 1.0) in captured
+    assert ("tenant-A", "claude", 2.0) in captured
+    assert ("tenant-A", "proxy", 3.0) in captured
+    assert ("tenant-A", "total", 6.0) in captured
+    assert len(captured) == 4
+
+
+def test_emit_swallows_metrics_exceptions(monkeypatch: pytest.MonkeyPatch) -> None:
+    """If prometheus_client fails, the runner shouldn't crash."""
+    class _BrokenGauge:
+        def labels(self, **kwargs):
+            raise RuntimeError("prometheus exploded")
+
+    from mantis_agent import metrics as real_metrics
+    monkeypatch.setattr(real_metrics, "RUN_COST_USD_INFLIGHT", _BrokenGauge())
+
+    meter = CostMeter(tenant_id="t")
+    # Should not raise.
+    meter.emit_inflight_gauges(1, 2, 3, 6)
+
+
+# ── Backward-compat: MicroPlanRunner aliases meter state ─────────────────
+
+
+def test_runner_costs_aliases_meter_costs() -> None:
+    """MicroPlanRunner.costs must be the same dict as cost_meter.costs."""
+    from mantis_agent.gym.micro_runner import MicroPlanRunner
+
+    runner = MicroPlanRunner.__new__(MicroPlanRunner)
+    runner.cost_meter = CostMeter()
+    runner.costs = runner.cost_meter.costs
+
+    runner.costs["gpu_steps"] += 5
+    assert runner.cost_meter.costs["gpu_steps"] == 5
+
+
+def test_runner_cost_totals_delegates_to_meter() -> None:
+    from mantis_agent.gym.micro_runner import MicroPlanRunner
+
+    runner = MicroPlanRunner.__new__(MicroPlanRunner)
+    runner.cost_meter = CostMeter()
+    runner.costs = runner.cost_meter.costs
+
+    runner.costs["gpu_seconds"] = 1800  # 30 min default = $1.625
+    gpu, claude, proxy, total = runner._cost_totals()
+    assert gpu == pytest.approx(1.625)
+    assert claude == 0.0
+    assert proxy == 0.0
+    assert total == pytest.approx(1.625)


### PR DESCRIPTION
## Summary

Step 3 in the `MicroPlanRunner` split. Pulls per-run cost accounting into a focused `CostMeter` class. Pure code move + delegation — zero behavior change.

## What moved

To `mantis_agent.gym.cost_meter`:

- counter dict initializer (`make_initial_costs`)
- `totals()` — per-component USD totals (was `_cost_totals`)
- `elapsed_seconds()` — convenience over `run_start`
- `record_step(step, step_result)` — applies a step's resource usage (was `_record_step_costs`)
- `restore(persisted)` / `snapshot()` — checkpoint round-trip helpers
- `emit_inflight_gauges(...)` — Prometheus per-component gauge update (was `_emit_cost_gauges`)

## The aliasing trick

`MicroPlanRunner` has 60+ scattered `self.costs["..."] += N` sites scattered across the file. Touching all of them in one PR would be huge and risky. Instead:

```python
self.cost_meter = CostMeter(cost_config=cost_config, tenant_id=tenant_id)
self.costs = self.cost_meter.costs   # SAME dict, not a copy
```

In-place dict subscript-assign works transparently through the alias, so the 60+ existing increment sites need no edits. Subsequent splits can migrate them to `meter.add_*()` helpers if useful, but this PR keeps the diff minimal.

`self.cost_config`, `self.tenant_id`, and `self._run_start` are mirrored from the meter for backward compat with any external reader.

## LOC delta

- `micro_runner.py`: 2831 → 2795 (-36)
- new `cost_meter.py`: 152

## Test plan

- [x] 19 new unit tests in `test_cost_meter.py` covering initial state, totals computation, per-step accounting (gpu/claude/grounding/proxy), snapshot/restore, gauge emit-vs-skip, prometheus-exception swallowing, runner-aliasing identity
- [x] 47 new + adjacent tests pass (cost_meter, cost_config, tool_channel, checkpoint_module)
- [x] ruff clean
- [ ] CI on this PR (includes `test_micro_runner_hooks` which exercises cost record paths via the runner)

## Series progress

| Step | What | Status |
|---|---|---|
| 1 | Checkpoint dataclasses | ✅ #129 merged |
| 2 | ToolChannel | ✅ #130 merged |
| **3** | **CostMeter** | **this PR** |
| 4 | BrowserState | next |
| 5 | ListingDedup | |
| 6 | Coordinator → thin Executor | |

🤖 Generated with [Claude Code](https://claude.com/claude-code)