### PR TITLE
refactor(gym): extract BrowserState helpers (#115, step 4/N)

### DIFF
--- a/src/mantis_agent/gym/browser_state.py
+++ b/src/mantis_agent/gym/browser_state.py
@@ -1,0 +1,226 @@
+"""Browser-state helpers for MicroPlanRunner — extracted from
+micro_runner.py (#115, step 4).
+
+Owns the scroll-position / viewport-stage / pagination-URL machinery used
+to re-enter a browser session after a checkpoint resume or a navigation
+detour. The runner keeps the underlying state attributes
+(``_scroll_state``, ``_viewport_stage``, ``_current_page``,
+``_last_known_url``, ``_results_base_url``, ``_required_filter_tokens``,
+``_opened_detail_in_new_tab``) for now — there are 170+ scattered
+read/write sites inside the runner and migrating them all in one PR
+would be unreviewable. This split moves the **method bodies** out and
+leaves the state references where they are.
+
+Behavior is unchanged from the previous in-place implementation. The
+runner composes a single :class:`BrowserState` and the previous
+``_current_results_page_url`` / ``_reentry_url_for_step`` /
+``_set_scroll_state`` / ``_update_scroll_state_from_trajectory`` /
+``_restore_scroll_position`` / ``_resume_browser_state`` methods become
+one-line shims that delegate here.
+
+Future steps in #115 can migrate state ownership into this class with a
+property-descriptor shim or by refactoring the call sites in batches.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import time
+from typing import TYPE_CHECKING, Any
+
+from ..actions import Action, ActionType
+
+if TYPE_CHECKING:
+    from ..plan_decomposer import MicroPlan
+    from .micro_runner import MicroPlanRunner
+
+logger = logging.getLogger(__name__)
+
+
+class BrowserState:
+    """Stateless helper bound to one :class:`MicroPlanRunner` instance.
+
+    Methods read/write the runner's underlying attributes through the
+    ``parent`` back-reference. This keeps the 170+ scattered state-access
+    sites in micro_runner.py untouched — only the method bodies move here.
+    """
+
+    def __init__(self, parent: "MicroPlanRunner") -> None:
+        self.parent = parent
+
+    # ── URL composition ─────────────────────────────────────────────────
+
+    def current_results_page_url(self) -> str:
+        p = self.parent
+        if not p._results_base_url:
+            return ""
+        if p._current_page <= 1:
+            base_clean = re.sub(
+                p.site_config.pagination_strip_pattern or r"/page-\d+/?$",
+                "",
+                p._results_base_url.rstrip("/"),
+            )
+            return f"{base_clean}/"
+        return p.site_config.paginated_url(p._results_base_url, p._current_page)
+
+    def reentry_url_for_step(
+        self, plan: "MicroPlan", next_step_index: int
+    ) -> str:
+        p = self.parent
+        next_step = (
+            plan.steps[next_step_index]
+            if 0 <= next_step_index < len(plan.steps)
+            else None
+        )
+        results_url = self.current_results_page_url() or p._results_base_url
+        if next_step and next_step.type in {"click", "paginate", "loop", "filter"}:
+            return results_url or p._last_known_url
+        if next_step and next_step.type in {
+            "extract_url", "scroll", "extract_data", "navigate_back",
+        }:
+            return p._last_known_url or results_url
+        return p._last_known_url or results_url
+
+    # ── Scroll state ────────────────────────────────────────────────────
+
+    def set_scroll_state(
+        self,
+        *,
+        context: str,
+        url: str = "",
+        page_downs: int | None = None,
+        wheel_downs: int | None = None,
+        viewport_stage: int | None = None,
+        label: str = "",
+        flush: bool = False,
+    ) -> None:
+        p = self.parent
+        state = dict(p._scroll_state)
+        state["context"] = context
+        state["url"] = url or p._last_known_url or self.current_results_page_url()
+        state["updated_at"] = time.time()
+        if page_downs is not None:
+            state["page_downs"] = max(0, page_downs)
+        if wheel_downs is not None:
+            state["wheel_downs"] = max(0, wheel_downs)
+        if viewport_stage is not None:
+            state["viewport_stage"] = max(0, viewport_stage)
+        if label:
+            state["label"] = label
+        p._scroll_state = state
+        if flush:
+            p._checkpoint_active_progress(f"scroll_state:{context}")
+
+    def update_scroll_state_from_trajectory(
+        self, result: Any, context: str
+    ) -> None:
+        p = self.parent
+        page_downs = int(p._scroll_state.get("page_downs", 0) or 0)
+        wheel_downs = int(p._scroll_state.get("wheel_downs", 0) or 0)
+        for item in getattr(result, "trajectory", []) or []:
+            action = getattr(item, "action", None)
+            if not action:
+                continue
+            if action.action_type == ActionType.KEY_PRESS:
+                keys = str(
+                    action.params.get("keys") or action.params.get("key") or ""
+                ).lower()
+                if "home" in keys:
+                    page_downs = 0
+                    wheel_downs = 0
+                elif "page_down" in keys or "pagedown" in keys:
+                    page_downs += 1
+                elif "page_up" in keys or "pageup" in keys:
+                    page_downs = max(0, page_downs - 1)
+                elif keys == "end":
+                    p._scroll_state["end_reached"] = True
+            elif action.action_type == ActionType.SCROLL:
+                direction = str(action.params.get("direction", "down")).lower()
+                amount = int(action.params.get("amount", 3) or 0)
+                if direction == "down":
+                    wheel_downs += amount
+                elif direction == "up":
+                    wheel_downs = max(0, wheel_downs - amount)
+        self.set_scroll_state(
+            context=context,
+            page_downs=page_downs,
+            wheel_downs=wheel_downs,
+            viewport_stage=p._viewport_stage,
+        )
+
+    def restore_scroll_position(self) -> None:
+        """Replay logical scroll depth after URL re-entry in screen-only envs."""
+        p = self.parent
+        if not p._scroll_state:
+            return
+        state_url = str(p._scroll_state.get("url") or "")
+        current_url = p._last_known_url or self.current_results_page_url()
+        if state_url and current_url:
+            def normalize(url: str) -> str:
+                return re.sub(r"^https?://(www\.)?", "", url).rstrip("/")
+
+            if normalize(state_url) != normalize(current_url):
+                logger.info(
+                    "  [resume] Skipping scroll restore for different URL "
+                    "(state=%s current=%s)",
+                    state_url[:80],
+                    current_url[:80],
+                )
+                return
+        page_downs = int(p._scroll_state.get("page_downs", 0) or 0)
+        wheel_downs = int(p._scroll_state.get("wheel_downs", 0) or 0)
+        if page_downs <= 0 and wheel_downs <= 0:
+            return
+        try:
+            p.env.step(Action(action_type=ActionType.KEY_PRESS, params={"keys": "Home"}))
+            time.sleep(0.5)
+            for _ in range(min(page_downs, 12)):
+                p.env.step(
+                    Action(action_type=ActionType.KEY_PRESS, params={"keys": "Page_Down"})
+                )
+                time.sleep(0.3)
+            if wheel_downs:
+                p.env.step(
+                    Action(
+                        action_type=ActionType.SCROLL,
+                        params={"direction": "down", "amount": min(wheel_downs, 40)},
+                    )
+                )
+                time.sleep(0.5)
+            logger.info(
+                "  [resume] Restored scroll depth page_downs=%s wheel_downs=%s context=%s",
+                page_downs,
+                wheel_downs,
+                p._scroll_state.get("context", ""),
+            )
+        except Exception as e:
+            logger.warning("  [resume] Failed to restore scroll position: %s", e)
+
+    # ── Browser-session resume ──────────────────────────────────────────
+
+    def resume_browser_state(self, url: str) -> bool:
+        """Re-enter the browser at ``url`` and replay scroll depth."""
+        p = self.parent
+        if not url:
+            return False
+        logger.info("  [resume] Re-entering browser state at %s", url[:140])
+        try:
+            p.env.reset(task="resume", start_url=url)
+            time.sleep(12)
+            try:
+                p.env.step(
+                    Action(action_type=ActionType.KEY_PRESS, params={"keys": "Home"})
+                )
+                time.sleep(1)
+            except Exception:
+                pass
+            p._last_known_url = url
+            self.restore_scroll_position()
+            return True
+        except Exception as e:
+            logger.warning("  [resume] Failed to restore browser at %s: %s", url[:120], e)
+            return False
+
+
+__all__ = ["BrowserState"]

--- a/src/mantis_agent/gym/micro_runner.py
+++ b/src/mantis_agent/gym/micro_runner.py
@@ -29,6 +29,7 @@ from typing import Any, TYPE_CHECKING
 
 from ..actions import Action, ActionType
 from ..cost_config import CostConfig
+from .browser_state import BrowserState
 from .cost_meter import CostMeter
 from .checkpoint import (
     REVERSE_ACTIONS,
@@ -155,6 +156,14 @@ class MicroPlanRunner:
         self.tenant_id = self.cost_meter.tenant_id
         self.costs = self.cost_meter.costs
         self._run_start = self.cost_meter.run_start
+
+        # #115 step 4: scroll/viewport/url helpers live on BrowserState.
+        # State attributes (_scroll_state, _viewport_stage, _current_page,
+        # _last_known_url, _results_base_url, _required_filter_tokens) stay
+        # on the runner — there are 170+ scattered access sites; migrating
+        # them all in one PR would be unreviewable. Helper methods below
+        # delegate here so the bodies live in one place.
+        self.browser_state = BrowserState(self)
 
     def dynamic_verification_report(self, status: str | None = None) -> dict[str, Any]:
         return self.dynamic_verifier.report(status=status or self._final_status)
@@ -295,25 +304,12 @@ class MicroPlanRunner:
         self.cost_meter.emit_inflight_gauges(gpu_cost, claude_cost, proxy_cost, total_cost)
 
     def _current_results_page_url(self) -> str:
-        if not self._results_base_url:
-            return ""
-        if self._current_page <= 1:
-            base_clean = re.sub(
-                self.site_config.pagination_strip_pattern or r"/page-\d+/?$",
-                "",
-                self._results_base_url.rstrip("/"),
-            )
-            return f"{base_clean}/"
-        return self.site_config.paginated_url(self._results_base_url, self._current_page)
+        """Backward-compat shim — delegates to :class:`BrowserState`."""
+        return self.browser_state.current_results_page_url()
 
     def _reentry_url_for_step(self, plan: MicroPlan, next_step_index: int) -> str:
-        next_step = plan.steps[next_step_index] if 0 <= next_step_index < len(plan.steps) else None
-        results_url = self._current_results_page_url() or self._results_base_url
-        if next_step and next_step.type in {"click", "paginate", "loop", "filter"}:
-            return results_url or self._last_known_url
-        if next_step and next_step.type in {"extract_url", "scroll", "extract_data", "navigate_back"}:
-            return self._last_known_url or results_url
-        return self._last_known_url or results_url
+        """Backward-compat shim — delegates to :class:`BrowserState`."""
+        return self.browser_state.reentry_url_for_step(plan, next_step_index)
 
     def _persist_checkpoint(
         self,
@@ -422,115 +418,28 @@ class MicroPlanRunner:
         label: str = "",
         flush: bool = False,
     ) -> None:
-        state = dict(self._scroll_state)
-        state["context"] = context
-        state["url"] = url or self._last_known_url or self._current_results_page_url()
-        state["updated_at"] = time.time()
-        if page_downs is not None:
-            state["page_downs"] = max(0, page_downs)
-        if wheel_downs is not None:
-            state["wheel_downs"] = max(0, wheel_downs)
-        if viewport_stage is not None:
-            state["viewport_stage"] = max(0, viewport_stage)
-        if label:
-            state["label"] = label
-        self._scroll_state = state
-        if flush:
-            self._checkpoint_active_progress(f"scroll_state:{context}")
-
-    def _update_scroll_state_from_trajectory(self, result: Any, context: str) -> None:
-        page_downs = int(self._scroll_state.get("page_downs", 0) or 0)
-        wheel_downs = int(self._scroll_state.get("wheel_downs", 0) or 0)
-        for item in getattr(result, "trajectory", []) or []:
-            action = getattr(item, "action", None)
-            if not action:
-                continue
-            if action.action_type == ActionType.KEY_PRESS:
-                keys = str(action.params.get("keys") or action.params.get("key") or "").lower()
-                if "home" in keys:
-                    page_downs = 0
-                    wheel_downs = 0
-                elif "page_down" in keys or "pagedown" in keys:
-                    page_downs += 1
-                elif "page_up" in keys or "pageup" in keys:
-                    page_downs = max(0, page_downs - 1)
-                elif keys == "end":
-                    self._scroll_state["end_reached"] = True
-            elif action.action_type == ActionType.SCROLL:
-                direction = str(action.params.get("direction", "down")).lower()
-                amount = int(action.params.get("amount", 3) or 0)
-                if direction == "down":
-                    wheel_downs += amount
-                elif direction == "up":
-                    wheel_downs = max(0, wheel_downs - amount)
-        self._set_scroll_state(
+        """Backward-compat shim — delegates to :class:`BrowserState`."""
+        self.browser_state.set_scroll_state(
             context=context,
+            url=url,
             page_downs=page_downs,
             wheel_downs=wheel_downs,
-            viewport_stage=self._viewport_stage,
+            viewport_stage=viewport_stage,
+            label=label,
+            flush=flush,
         )
 
-    def _restore_scroll_position(self) -> None:
-        """Replay logical scroll depth after URL re-entry in screen-only envs."""
-        if not self._scroll_state:
-            return
-        state_url = str(self._scroll_state.get("url") or "")
-        current_url = self._last_known_url or self._current_results_page_url()
-        if state_url and current_url:
-            def normalize(url: str) -> str:
-                return re.sub(r"^https?://(www\.)?", "", url).rstrip("/")
+    def _update_scroll_state_from_trajectory(self, result: Any, context: str) -> None:
+        """Backward-compat shim — delegates to :class:`BrowserState`."""
+        self.browser_state.update_scroll_state_from_trajectory(result, context)
 
-            if normalize(state_url) != normalize(current_url):
-                logger.info(
-                    "  [resume] Skipping scroll restore for different URL "
-                    "(state=%s current=%s)",
-                    state_url[:80],
-                    current_url[:80],
-                )
-                return
-        page_downs = int(self._scroll_state.get("page_downs", 0) or 0)
-        wheel_downs = int(self._scroll_state.get("wheel_downs", 0) or 0)
-        if page_downs <= 0 and wheel_downs <= 0:
-            return
-        try:
-            self.env.step(Action(action_type=ActionType.KEY_PRESS, params={"keys": "Home"}))
-            time.sleep(0.5)
-            for _ in range(min(page_downs, 12)):
-                self.env.step(Action(action_type=ActionType.KEY_PRESS, params={"keys": "Page_Down"}))
-                time.sleep(0.3)
-            if wheel_downs:
-                self.env.step(Action(
-                    action_type=ActionType.SCROLL,
-                    params={"direction": "down", "amount": min(wheel_downs, 40)},
-                ))
-                time.sleep(0.5)
-            logger.info(
-                "  [resume] Restored scroll depth page_downs=%s wheel_downs=%s context=%s",
-                page_downs,
-                wheel_downs,
-                self._scroll_state.get("context", ""),
-            )
-        except Exception as e:
-            logger.warning("  [resume] Failed to restore scroll position: %s", e)
+    def _restore_scroll_position(self) -> None:
+        """Backward-compat shim — delegates to :class:`BrowserState`."""
+        self.browser_state.restore_scroll_position()
 
     def _resume_browser_state(self, url: str) -> bool:
-        if not url:
-            return False
-        logger.info("  [resume] Re-entering browser state at %s", url[:140])
-        try:
-            self.env.reset(task="resume", start_url=url)
-            time.sleep(12)
-            try:
-                self.env.step(Action(action_type=ActionType.KEY_PRESS, params={"keys": "Home"}))
-                time.sleep(1)
-            except Exception:
-                pass
-            self._last_known_url = url
-            self._restore_scroll_position()
-            return True
-        except Exception as e:
-            logger.warning("  [resume] Failed to restore browser at %s: %s", url[:120], e)
-            return False
+        """Backward-compat shim — delegates to :class:`BrowserState`."""
+        return self.browser_state.resume_browser_state(url)
 
     def run(self, plan: MicroPlan, resume: bool = False) -> list[StepResult]:
         """Execute the full micro-plan.

--- a/tests/test_browser_state.py
+++ b/tests/test_browser_state.py
@@ -1,0 +1,280 @@
+"""Tests for #115 step 4 — BrowserState extracted from MicroPlanRunner."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from mantis_agent.actions import Action, ActionType
+from mantis_agent.gym.browser_state import BrowserState
+
+
+# ── Fake parent (mirrors MicroPlanRunner attribute surface) ─────────────
+
+
+class _FakeSiteConfig:
+    """Minimal SiteConfig stand-in for URL composition tests."""
+
+    pagination_strip_pattern = r"/page-\d+/?$"
+
+    def paginated_url(self, base: str, page: int) -> str:
+        return f"{base.rstrip('/')}/page-{page}/"
+
+
+class _FakeEnv:
+    """Records env.reset / env.step calls so resume tests can assert order."""
+
+    def __init__(self) -> None:
+        self.reset_calls: list[dict] = []
+        self.step_calls: list[Action] = []
+        self.fail_reset = False
+
+    def reset(self, **kwargs: Any) -> None:
+        if self.fail_reset:
+            raise RuntimeError("env.reset boom")
+        self.reset_calls.append(kwargs)
+
+    def step(self, action: Action) -> None:
+        self.step_calls.append(action)
+
+
+class _FakeRunner:
+    """Just the attributes BrowserState reads/writes."""
+
+    def __init__(self) -> None:
+        self.site_config = _FakeSiteConfig()
+        self.env = _FakeEnv()
+        self._scroll_state: dict[str, Any] = {}
+        self._viewport_stage: int = 0
+        self._results_base_url: str = ""
+        self._current_page: int = 1
+        self._last_known_url: str = ""
+        self.checkpoint_calls: list[str] = []
+
+    def _checkpoint_active_progress(self, reason: str) -> None:
+        self.checkpoint_calls.append(reason)
+
+
+def _bs() -> tuple[BrowserState, _FakeRunner]:
+    runner = _FakeRunner()
+    return BrowserState(runner), runner
+
+
+# ── current_results_page_url ────────────────────────────────────────────
+
+
+def test_current_results_page_url_empty_when_no_base() -> None:
+    bs, _ = _bs()
+    assert bs.current_results_page_url() == ""
+
+
+def test_current_results_page_url_strips_pagination_on_page_one() -> None:
+    bs, r = _bs()
+    r._results_base_url = "https://x.test/listings/page-3/"
+    r._current_page = 1
+    assert bs.current_results_page_url() == "https://x.test/listings/"
+
+
+def test_current_results_page_url_uses_paginated_url_for_higher_pages() -> None:
+    bs, r = _bs()
+    r._results_base_url = "https://x.test/listings/"
+    r._current_page = 4
+    assert bs.current_results_page_url() == "https://x.test/listings/page-4/"
+
+
+# ── reentry_url_for_step ────────────────────────────────────────────────
+
+
+class _FakeStep:
+    def __init__(self, type_: str) -> None:
+        self.type = type_
+
+
+class _FakePlan:
+    def __init__(self, *types: str) -> None:
+        self.steps = [_FakeStep(t) for t in types]
+
+
+def test_reentry_url_results_for_click_step() -> None:
+    bs, r = _bs()
+    r._results_base_url = "https://x.test/r/"
+    r._current_page = 2
+    r._last_known_url = "https://x.test/detail/123"
+    plan = _FakePlan("filter", "click", "scroll")
+    # Click step → results URL.
+    assert bs.reentry_url_for_step(plan, 1) == "https://x.test/r/page-2/"
+
+
+def test_reentry_url_last_known_for_extract_step() -> None:
+    bs, r = _bs()
+    r._results_base_url = "https://x.test/r/"
+    r._last_known_url = "https://x.test/detail/123"
+    plan = _FakePlan("click", "extract_data")
+    assert bs.reentry_url_for_step(plan, 1) == "https://x.test/detail/123"
+
+
+def test_reentry_url_falls_back_when_no_step_at_index() -> None:
+    bs, r = _bs()
+    r._last_known_url = "https://x.test/last"
+    plan = _FakePlan("click")
+    # next_step_index out of range → fallback chain
+    assert bs.reentry_url_for_step(plan, 99) == "https://x.test/last"
+
+
+# ── set_scroll_state ────────────────────────────────────────────────────
+
+
+def test_set_scroll_state_writes_full_state_dict() -> None:
+    bs, r = _bs()
+    r._last_known_url = "https://x.test/p1"
+    bs.set_scroll_state(context="results", page_downs=2, wheel_downs=5, label="vp1")
+    s = r._scroll_state
+    assert s["context"] == "results"
+    assert s["url"] == "https://x.test/p1"
+    assert s["page_downs"] == 2
+    assert s["wheel_downs"] == 5
+    assert s["label"] == "vp1"
+    assert "updated_at" in s
+
+
+def test_set_scroll_state_clamps_negatives_to_zero() -> None:
+    bs, r = _bs()
+    bs.set_scroll_state(context="x", page_downs=-3, wheel_downs=-99, viewport_stage=-1)
+    assert r._scroll_state["page_downs"] == 0
+    assert r._scroll_state["wheel_downs"] == 0
+    assert r._scroll_state["viewport_stage"] == 0
+
+
+def test_set_scroll_state_with_flush_calls_checkpoint() -> None:
+    bs, r = _bs()
+    bs.set_scroll_state(context="results", flush=True)
+    assert r.checkpoint_calls == ["scroll_state:results"]
+
+
+# ── update_scroll_state_from_trajectory ─────────────────────────────────
+
+
+class _FakeStepRecord:
+    def __init__(self, action: Action) -> None:
+        self.action = action
+
+
+class _FakeResult:
+    def __init__(self, actions: list[Action]) -> None:
+        self.trajectory = [_FakeStepRecord(a) for a in actions]
+
+
+def test_update_scroll_state_counts_page_down_and_home_reset() -> None:
+    bs, r = _bs()
+    actions = [
+        Action(ActionType.KEY_PRESS, {"keys": "Page_Down"}),
+        Action(ActionType.KEY_PRESS, {"keys": "Page_Down"}),
+        Action(ActionType.KEY_PRESS, {"keys": "Home"}),  # resets to 0
+        Action(ActionType.KEY_PRESS, {"keys": "Page_Down"}),
+    ]
+    bs.update_scroll_state_from_trajectory(_FakeResult(actions), context="x")
+    assert r._scroll_state["page_downs"] == 1
+
+
+def test_update_scroll_state_handles_scroll_down_amount() -> None:
+    bs, r = _bs()
+    actions = [
+        Action(ActionType.SCROLL, {"direction": "down", "amount": 5}),
+        Action(ActionType.SCROLL, {"direction": "down", "amount": 3}),
+        Action(ActionType.SCROLL, {"direction": "up", "amount": 2}),
+    ]
+    bs.update_scroll_state_from_trajectory(_FakeResult(actions), context="x")
+    assert r._scroll_state["wheel_downs"] == 6
+
+
+def test_update_scroll_state_marks_end_reached_on_end_key() -> None:
+    bs, r = _bs()
+    actions = [Action(ActionType.KEY_PRESS, {"keys": "End"})]
+    bs.update_scroll_state_from_trajectory(_FakeResult(actions), context="x")
+    assert r._scroll_state.get("end_reached") is True
+
+
+# ── restore_scroll_position ─────────────────────────────────────────────
+
+
+def test_restore_scroll_position_no_state_is_noop() -> None:
+    bs, r = _bs()
+    bs.restore_scroll_position()
+    assert r.env.step_calls == []
+
+
+def test_restore_scroll_position_skips_when_url_differs() -> None:
+    bs, r = _bs()
+    r._scroll_state = {"url": "https://x.test/a/", "page_downs": 3}
+    r._last_known_url = "https://x.test/b/"
+    bs.restore_scroll_position()
+    # Different URL — skip everything.
+    assert r.env.step_calls == []
+
+
+def test_restore_scroll_position_replays_page_downs() -> None:
+    bs, r = _bs()
+    r._scroll_state = {
+        "url": "https://x.test/a/",
+        "page_downs": 3,
+        "wheel_downs": 0,
+    }
+    r._last_known_url = "https://x.test/a/"
+    bs.restore_scroll_position()
+    # Home + 3 Page_Down presses
+    keys = [a.params.get("keys") for a in r.env.step_calls]
+    assert keys == ["Home", "Page_Down", "Page_Down", "Page_Down"]
+
+
+def test_restore_scroll_position_caps_page_downs_at_12() -> None:
+    bs, r = _bs()
+    r._scroll_state = {"url": "https://x.test/a/", "page_downs": 50}
+    r._last_known_url = "https://x.test/a/"
+    bs.restore_scroll_position()
+    keys = [a.params.get("keys") for a in r.env.step_calls]
+    assert keys.count("Page_Down") == 12
+
+
+# ── resume_browser_state ────────────────────────────────────────────────
+
+
+def test_resume_browser_state_empty_url_returns_false() -> None:
+    bs, _ = _bs()
+    assert bs.resume_browser_state("") is False
+
+
+def test_resume_browser_state_returns_false_on_env_error(monkeypatch) -> None:
+    bs, r = _bs()
+    r.env.fail_reset = True
+    # Speed up: avoid the 12s sleep in the success path; we don't reach it
+    # because env.reset raises first.
+    assert bs.resume_browser_state("https://x.test/x") is False
+
+
+def test_resume_browser_state_updates_last_known_url(monkeypatch) -> None:
+    bs, r = _bs()
+    # Stub time.sleep to avoid the 12s wait in the resume path.
+    import mantis_agent.gym.browser_state as bs_mod
+    monkeypatch.setattr(bs_mod.time, "sleep", lambda _s: None)
+    ok = bs.resume_browser_state("https://x.test/restored")
+    assert ok is True
+    assert r._last_known_url == "https://x.test/restored"
+    assert r.env.reset_calls == [{"task": "resume", "start_url": "https://x.test/restored"}]
+
+
+# ── Backward-compat: MicroPlanRunner shims still work ──────────────────
+
+
+def test_runner_shims_delegate_to_browser_state() -> None:
+    from mantis_agent.gym.micro_runner import MicroPlanRunner
+
+    runner = MicroPlanRunner.__new__(MicroPlanRunner)
+    runner.site_config = _FakeSiteConfig()
+    runner.env = _FakeEnv()
+    runner._scroll_state = {}
+    runner._viewport_stage = 0
+    runner._results_base_url = "https://x.test/r/"
+    runner._current_page = 3
+    runner._last_known_url = ""
+    runner.browser_state = BrowserState(runner)
+
+    assert runner._current_results_page_url() == "https://x.test/r/page-3/"

--- a/tests/test_private_seller_filter.py
+++ b/tests/test_private_seller_filter.py
@@ -184,6 +184,7 @@ def test_checkpoint_load_ignores_unknown_fields(tmp_path):
 
 
 def test_current_results_page_url_preserves_filtered_page_number():
+    from mantis_agent.gym.browser_state import BrowserState
     from mantis_agent.site_config import SiteConfig
 
     runner = object.__new__(MicroPlanRunner)
@@ -192,6 +193,9 @@ def test_current_results_page_url_preserves_filtered_page_number():
         "https://www.boattrader.com/boats/state-fl/city-miami/zip-33101/by-owner/price-35000/"
     )
     runner._current_page = 3
+    # #115 step 4: URL composition lives on BrowserState; tests that bypass
+    # __init__ must wire it up explicitly.
+    runner.browser_state = BrowserState(runner)
 
     assert runner._current_results_page_url() == (
         "https://www.boattrader.com/boats/state-fl/city-miami/zip-33101/by-owner/price-35000/page-3/"


### PR DESCRIPTION
## Summary

Step 4 in the `MicroPlanRunner` split. Pulls scroll-position / viewport / pagination-URL helpers into a focused `BrowserState` class. Pure code move + delegation — zero behavior change.

## What moved

To `mantis_agent.gym.browser_state`:

| Before (on MicroPlanRunner) | After (on BrowserState) |
|---|---|
| `_current_results_page_url` | `current_results_page_url` |
| `_reentry_url_for_step` | `reentry_url_for_step` |
| `_set_scroll_state` | `set_scroll_state` |
| `_update_scroll_state_from_trajectory` | `update_scroll_state_from_trajectory` |
| `_restore_scroll_position` | `restore_scroll_position` |
| `_resume_browser_state` | `resume_browser_state` |

## Why state stays on the runner this round

`_scroll_state`, `_viewport_stage`, `_current_page`, `_last_known_url`, `_results_base_url`, `_required_filter_tokens` have **170+ scattered read/write sites** in micro_runner.py. Migrating ownership in one PR would be unreviewable.

The helper-with-back-reference pattern moves the *method bodies* cleanly (~85 LOC out of micro_runner.py) without touching state references. `BrowserState` takes `parent: MicroPlanRunner` and reads/writes state through it. Subsequent steps in #115 can migrate ownership incrementally — via property descriptors or batched call-site refactors.

## LOC delta

- `micro_runner.py`: 2795 → 2710 (-85)  ← biggest single step yet
- new `browser_state.py`: 226

## Test plan

- [x] 20 new unit tests in `test_browser_state.py` covering URL composition, reentry routing, scroll-state writes / clamping / flush, trajectory-based scroll updates, restore-skip-on-different-url, page_down cap, resume-empty / resume-error / resume-success, runner-shim delegation
- [x] 68 new + adjacent tests pass (cost_meter, tool_channel, checkpoint, private_seller_filter)
- [x] One existing test (`test_current_results_page_url_preserves_filtered_page_number`) updated — it uses `object.__new__` to bypass `__init__`, so it now sets `runner.browser_state = BrowserState(runner)` explicitly
- [x] ruff clean
- [ ] CI on this PR (includes `test_micro_runner_hooks` which exercises pause/resume paths through the runner)

## Series progress

| Step | What | Status |
|---|---|---|
| 1 | Checkpoint dataclasses | ✅ #129 merged |
| 2 | ToolChannel | ✅ #130 merged |
| 3 | CostMeter | ✅ #131 merged |
| **4** | **BrowserState** | **this PR** |
| 5 | ListingDedup | next |
| 6 | Coordinator → thin Executor | |

🤖 Generated with [Claude Code](https://claude.com/claude-code)