### PR TITLE
refactor(gym): extract ListingDedup helpers (#115, step 5/N)

### DIFF
--- a/src/mantis_agent/gym/listing_dedup.py
+++ b/src/mantis_agent/gym/listing_dedup.py
@@ -1,0 +1,100 @@
+"""Lead/listing deduplication helpers — extracted from micro_runner.py
+(#115, step 5).
+
+Owns the pure parsing helpers (lead-key extraction, phone validation,
+counts) that classify and deduplicate VIABLE extraction rows. These are
+``@staticmethod`` / ``@classmethod`` on :class:`ListingDedup` so callers
+that don't want a runner instance (tests, host adapters) can use them
+directly:
+
+    >>> from mantis_agent.gym.listing_dedup import ListingDedup
+    >>> ListingDedup.lead_key("VIABLE | Year: 2024 | URL: https://x.test/a")
+    'https://x.test/a'
+
+The runner's per-page memory (``_seen_urls``, ``_extracted_titles``,
+``_page_listings``, ``_page_listing_index``, ``_last_extracted``) stays
+on the runner for now — there are 53 scattered access sites and
+migrating them all in one PR would be unreviewable. Method bodies that
+operate on those attributes can be added here in subsequent steps.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .checkpoint import StepResult
+
+
+_VIABLE_PREFIX = "VIABLE"
+_PHONE_NULL_VALUES: frozenset[str] = frozenset(
+    {"", "none", "n/a", "na", "unknown", "not visible", "not shown"}
+)
+
+
+class ListingDedup:
+    """Pure helpers for classifying / deduplicating VIABLE lead rows.
+
+    The static methods are the canonical implementation; the runner's
+    same-named ``_static_helpers`` stay as 1-line shims for backward compat.
+    """
+
+    # ── Filtering / extraction ──────────────────────────────────────────
+
+    @staticmethod
+    def successful_lead_data(results: list["StepResult"]) -> list[str]:
+        """Return the ``data`` field of every ``success`` step that yielded
+        a ``VIABLE`` extraction row."""
+        return [
+            r.data for r in results
+            if r.success and (r.data or "").startswith(_VIABLE_PREFIX)
+        ]
+
+    @staticmethod
+    def lead_key(data: str) -> str:
+        """Stable dedup key. Prefers the URL inside the row; falls back to
+        the first 100 chars when no URL is present (defensive — VIABLE rows
+        always carry a URL in practice)."""
+        url_match = re.search(r"URL:\s*([^|]+)", data)
+        if url_match:
+            return url_match.group(1).strip()
+        return data[:100]
+
+    @staticmethod
+    def lead_has_phone(data: str) -> bool:
+        """Heuristic: a VIABLE row counts as having a phone if it carries a
+        ``Phone:`` field whose value is neither a null sentinel nor short
+        enough to be a price misread (≥10 digits)."""
+        phone_match = re.search(r"Phone:\s*([^|]+)", data, flags=re.IGNORECASE)
+        if not phone_match:
+            return False
+        phone = phone_match.group(1).strip().lower()
+        if phone in _PHONE_NULL_VALUES:
+            return False
+        return len(re.sub(r"\D", "", phone)) >= 10
+
+    # ── Aggregations ────────────────────────────────────────────────────
+
+    @classmethod
+    def unique_leads_from_results(cls, results: list["StepResult"]) -> list[str]:
+        """Deduplicated ``data`` strings for VIABLE rows, keyed by URL."""
+        unique: dict[str, str] = {}
+        for lead in cls.successful_lead_data(results):
+            unique[cls.lead_key(lead)] = lead
+        return list(unique.values())
+
+    @classmethod
+    def lead_counts(cls, results: list["StepResult"]) -> tuple[int, int]:
+        """Return ``(unique_leads, phone_leads)`` over ``results``."""
+        leads_by_key: dict[str, str] = {}
+        for data in cls.successful_lead_data(results):
+            leads_by_key[cls.lead_key(data)] = data
+        total = len(leads_by_key)
+        with_phone = sum(
+            1 for data in leads_by_key.values() if cls.lead_has_phone(data)
+        )
+        return total, with_phone
+
+
+__all__ = ["ListingDedup"]

--- a/src/mantis_agent/gym/micro_runner.py
+++ b/src/mantis_agent/gym/micro_runner.py
@@ -31,6 +31,7 @@ from ..actions import Action, ActionType
 from ..cost_config import CostConfig
 from .browser_state import BrowserState
 from .cost_meter import CostMeter
+from .listing_dedup import ListingDedup
 from .checkpoint import (
     REVERSE_ACTIONS,
     PauseRequested,
@@ -273,10 +274,8 @@ class MicroPlanRunner:
 
     @classmethod
     def _unique_leads_from_results(cls, results: list[StepResult]) -> list[str]:
-        unique: dict[str, str] = {}
-        for lead in cls._successful_lead_data(results):
-            unique[cls._lead_key(lead)] = lead
-        return list(unique.values())
+        """Backward-compat shim — delegates to :class:`ListingDedup`."""
+        return ListingDedup.unique_leads_from_results(results)
 
     def _record_step_costs(self, step: MicroIntent, step_result: StepResult) -> None:
         """Backward-compat shim — delegates to :meth:`CostMeter.record_step`."""
@@ -1010,36 +1009,23 @@ class MicroPlanRunner:
 
     @staticmethod
     def _successful_lead_data(results: list[StepResult]) -> list[str]:
-        return [
-            r.data for r in results
-            if r.success and (r.data or "").startswith("VIABLE")
-        ]
+        """Backward-compat shim — delegates to :class:`ListingDedup`."""
+        return ListingDedup.successful_lead_data(results)
 
     @staticmethod
     def _lead_key(data: str) -> str:
-        url_match = re.search(r"URL:\s*([^|]+)", data)
-        if url_match:
-            return url_match.group(1).strip()
-        return data[:100]
+        """Backward-compat shim — delegates to :class:`ListingDedup`."""
+        return ListingDedup.lead_key(data)
 
     @staticmethod
     def _lead_has_phone(data: str) -> bool:
-        phone_match = re.search(r"Phone:\s*([^|]+)", data, flags=re.IGNORECASE)
-        if not phone_match:
-            return False
-        phone = phone_match.group(1).strip().lower()
-        if phone in {"", "none", "n/a", "na", "unknown", "not visible", "not shown"}:
-            return False
-        return len(re.sub(r"\D", "", phone)) >= 10
+        """Backward-compat shim — delegates to :class:`ListingDedup`."""
+        return ListingDedup.lead_has_phone(data)
 
     @classmethod
     def _lead_counts(cls, results: list[StepResult]) -> tuple[int, int]:
-        leads_by_key = {}
-        for data in cls._successful_lead_data(results):
-            leads_by_key[cls._lead_key(data)] = data
-        total = len(leads_by_key)
-        with_phone = sum(1 for data in leads_by_key.values() if cls._lead_has_phone(data))
-        return total, with_phone
+        """Backward-compat shim — delegates to :class:`ListingDedup`."""
+        return ListingDedup.lead_counts(results)
 
     @staticmethod
     def _extract_url_from_intent(intent: str) -> str:

--- a/tests/test_listing_dedup.py
+++ b/tests/test_listing_dedup.py
@@ -1,0 +1,167 @@
+"""Tests for #115 step 5 — ListingDedup extracted from MicroPlanRunner."""
+
+from __future__ import annotations
+
+from mantis_agent.gym.checkpoint import StepResult
+from mantis_agent.gym.listing_dedup import ListingDedup
+
+
+def _viable(data: str, *, success: bool = True, idx: int = 0) -> StepResult:
+    return StepResult(step_index=idx, intent="extract", success=success, data=data)
+
+
+# ── successful_lead_data ─────────────────────────────────────────────────
+
+
+def test_successful_lead_data_keeps_only_viable_success_rows() -> None:
+    rows = [
+        _viable("VIABLE | URL: https://x.test/a", idx=1),
+        _viable("REJECTED | spam | URL: https://x.test/b", idx=2),
+        _viable("VIABLE | URL: https://x.test/c", success=False, idx=3),
+        _viable("", idx=4),
+        _viable("VIABLE | URL: https://x.test/d", idx=5),
+    ]
+    out = ListingDedup.successful_lead_data(rows)
+    assert out == [
+        "VIABLE | URL: https://x.test/a",
+        "VIABLE | URL: https://x.test/d",
+    ]
+
+
+def test_successful_lead_data_handles_none_data() -> None:
+    rows = [_viable(None, idx=1)]  # type: ignore[arg-type]
+    rows[0].data = None  # type: ignore[assignment]
+    assert ListingDedup.successful_lead_data(rows) == []
+
+
+# ── lead_key ─────────────────────────────────────────────────────────────
+
+
+def test_lead_key_extracts_url_field() -> None:
+    assert (
+        ListingDedup.lead_key("VIABLE | Year: 2024 | URL: https://x.test/a/b")
+        == "https://x.test/a/b"
+    )
+
+
+def test_lead_key_falls_back_to_first_100_chars_when_no_url() -> None:
+    data = "VIABLE | Year: 2024 | Make: Sea Ray | (no url field present)" + "x" * 200
+    assert ListingDedup.lead_key(data) == data[:100]
+
+
+def test_lead_key_strips_whitespace_around_url() -> None:
+    assert (
+        ListingDedup.lead_key("VIABLE | URL:   https://x.test/  ")
+        == "https://x.test/"
+    )
+
+
+# ── lead_has_phone ──────────────────────────────────────────────────────
+
+
+def test_lead_has_phone_detects_full_us_number() -> None:
+    assert (
+        ListingDedup.lead_has_phone("VIABLE | URL: x | Phone: 786-555-1234")
+        is True
+    )
+
+
+def test_lead_has_phone_rejects_null_sentinels() -> None:
+    for sentinel in ("none", "N/A", "Unknown", "not visible", "not shown", ""):
+        row = f"VIABLE | URL: x | Phone: {sentinel}"
+        assert ListingDedup.lead_has_phone(row) is False, sentinel
+
+
+def test_lead_has_phone_rejects_when_field_missing() -> None:
+    assert ListingDedup.lead_has_phone("VIABLE | URL: x | Year: 2024") is False
+
+
+def test_lead_has_phone_requires_at_least_10_digits() -> None:
+    assert ListingDedup.lead_has_phone("VIABLE | URL: x | Phone: 555-1234") is False
+    assert ListingDedup.lead_has_phone("VIABLE | URL: x | Phone: 555-555-1234") is True
+
+
+def test_lead_has_phone_strips_format_chars() -> None:
+    assert (
+        ListingDedup.lead_has_phone("VIABLE | URL: x | Phone: (555) 555.1234")
+        is True
+    )
+
+
+# ── unique_leads_from_results ───────────────────────────────────────────
+
+
+def test_unique_leads_dedups_by_url() -> None:
+    rows = [
+        _viable("VIABLE | URL: https://x.test/a | Phone: 555-555-1234", idx=1),
+        # Same URL, different metadata — second occurrence wins.
+        _viable("VIABLE | URL: https://x.test/a | Phone: none", idx=2),
+        _viable("VIABLE | URL: https://x.test/b | Phone: 555-555-9999", idx=3),
+    ]
+    out = ListingDedup.unique_leads_from_results(rows)
+    assert len(out) == 2
+    keys = {ListingDedup.lead_key(r) for r in out}
+    assert keys == {"https://x.test/a", "https://x.test/b"}
+
+
+def test_unique_leads_empty_when_no_viable_rows() -> None:
+    rows = [
+        _viable("REJECTED | spam", idx=1),
+        _viable("", idx=2),
+    ]
+    assert ListingDedup.unique_leads_from_results(rows) == []
+
+
+# ── lead_counts ─────────────────────────────────────────────────────────
+
+
+def test_lead_counts_returns_unique_and_phone_totals() -> None:
+    rows = [
+        _viable("VIABLE | URL: https://x.test/a | Phone: 786-555-1234", idx=1),
+        _viable("VIABLE | URL: https://x.test/b | Phone: none", idx=2),
+        # Duplicate URL — should not double-count.
+        _viable("VIABLE | URL: https://x.test/a | Phone: 786-555-1234", idx=3),
+        _viable("VIABLE | URL: https://x.test/c | Phone: 305-555-9999", idx=4),
+    ]
+    total, with_phone = ListingDedup.lead_counts(rows)
+    assert total == 3
+    assert with_phone == 2
+
+
+def test_lead_counts_zero_when_no_viable() -> None:
+    assert ListingDedup.lead_counts([_viable("REJECTED | spam", idx=1)]) == (0, 0)
+
+
+def test_lead_counts_handles_dedup_when_same_url_has_phone_in_one_record() -> None:
+    """Last record per URL wins (dict assignment) — verifies we count
+    by the *kept* row, not the first occurrence."""
+    rows = [
+        # First occurrence has phone…
+        _viable("VIABLE | URL: https://x.test/a | Phone: 786-555-1234", idx=1),
+        # …second occurrence overwrites with phone=none. Count reflects last.
+        _viable("VIABLE | URL: https://x.test/a | Phone: none", idx=2),
+    ]
+    total, with_phone = ListingDedup.lead_counts(rows)
+    assert total == 1
+    assert with_phone == 0
+
+
+# ── Backward-compat: MicroPlanRunner shims still resolve ───────────────
+
+
+def test_runner_static_helpers_delegate_to_listing_dedup() -> None:
+    from mantis_agent.gym.micro_runner import MicroPlanRunner
+
+    rows = [
+        _viable("VIABLE | URL: https://x.test/a | Phone: 786-555-1234", idx=1),
+        _viable("VIABLE | URL: https://x.test/b | Phone: none", idx=2),
+    ]
+    assert MicroPlanRunner._lead_counts(rows) == (2, 1)
+    assert MicroPlanRunner._unique_leads_from_results(rows) == [
+        "VIABLE | URL: https://x.test/a | Phone: 786-555-1234",
+        "VIABLE | URL: https://x.test/b | Phone: none",
+    ]
+    assert MicroPlanRunner._lead_key("VIABLE | URL: https://x.test/a") == (
+        "https://x.test/a"
+    )
+    assert MicroPlanRunner._lead_has_phone("VIABLE | Phone: 555-555-1234") is True


### PR DESCRIPTION
## Summary

Step 5 in the `MicroPlanRunner` split. Pulls the lead-row classification + deduplication helpers (parse VIABLE rows, extract URL keys, phone detection, count aggregation) into a focused `ListingDedup` class. Pure code move + delegation — zero behavior change.

## What moved

To `mantis_agent.gym.listing_dedup`:

| Before (on MicroPlanRunner) | After (on ListingDedup) |
|---|---|
| `_successful_lead_data` | `successful_lead_data` |
| `_lead_key` | `lead_key` |
| `_lead_has_phone` | `lead_has_phone` |
| `_unique_leads_from_results` | `unique_leads_from_results` |
| `_lead_counts` | `lead_counts` |

The phone null-sentinel set (`{"none", "n/a", ...}`) and VIABLE prefix are now module-level constants for reuse and testability.

## Why state stays on the runner this round

Same trade-off as BrowserState: `_seen_urls`, `_extracted_titles`, `_page_listings`, `_page_listing_index`, `_last_extracted` have **53 scattered access sites** in micro_runner.py. Migrating ownership in this PR would be unreviewable. The static helpers extract cleanly without touching state. Subsequent steps can migrate incrementally.

## LOC delta

- `micro_runner.py`: 2710 → 2696 (-14)
- new `listing_dedup.py`: 100

LOC reduction is modest because these are pure static helpers — the real win is having them isolated, doctest-able, and reusable from host adapters without instantiating a runner.

## Test plan

- [x] 16 new unit tests in `test_listing_dedup.py` covering filter rules + None handling, URL extract + fallback + whitespace, phone null-sentinels / format chars / digit count / missing field, dedup-by-URL with last-write-wins, count aggregation including dedup-with-phone-loss edge case, runner-shim delegation
- [x] 84 new + adjacent tests pass (listing_dedup, browser_state, cost_meter, tool_channel, checkpoint, private_seller_filter)
- [x] `test_private_seller_filter` (which exercises `MicroPlanRunner._lead_counts` directly) passes unchanged via the shim
- [x] ruff clean
- [ ] CI on this PR

## Series progress

| Step | What | Status |
|---|---|---|
| 1 | Checkpoint dataclasses | ✅ #129 merged |
| 2 | ToolChannel | ✅ #130 merged |
| 3 | CostMeter | ✅ #131 merged |
| 4 | BrowserState | ✅ #132 merged |
| **5** | **ListingDedup** | **this PR** |
| 6 | Coordinator → thin Executor | next (final) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)