### PR TITLE
feat(trajectory): land world-model schema fields (#120, step 1/3)

### DIFF
--- a/src/mantis_agent/gym/runner.py
+++ b/src/mantis_agent/gym/runner.py
@@ -27,7 +27,7 @@ from typing import Any, Protocol
 from PIL import Image
 
 from ..actions import Action, ActionType
-from ..loop_detector import LoopDetector
+from ..loop_detector import LoopDetector, phash_64
 from .base import GymEnvironment
 
 logger = logging.getLogger(__name__)
@@ -53,7 +53,29 @@ class Brain(Protocol):
 
 @dataclass
 class TrajectoryStep:
-    """A single step in the agent's trajectory."""
+    """A single step in the agent's trajectory.
+
+    The base fields (``action``, ``thinking``, ``reward``, ``feedback``) are
+    populated on every step. The world-model fields (``frame_hash``,
+    ``observed_state``, ``hypothesized_state``, ``predicted_outcome``,
+    ``observed_outcome``) are an extension landed for #120 — they let
+    rewards / SFT pipelines compute world-model error (predicted vs
+    observed delta) per step.
+
+    Fields are optional and default to empty so:
+
+    * Brains that don't yet emit ``predicted_outcome`` produce trajectories
+      with ``predicted_outcome=""``; reward components keyed on it will
+      simply contribute 0.0 instead of erroring.
+    * Existing trajectory consumers (rollout collector, replay, viewer)
+      continue working — no positional arg shift, no required new fields.
+
+    Subsequent PRs in #120 will:
+      1. Update brain prompts to emit ``predicted_outcome`` for click/type/key
+         steps and parse it into the trajectory.
+      2. Add a ``world_model_error`` reward component that compares
+         ``predicted_outcome`` and ``observed_outcome`` per step.
+    """
 
     step: int
     action: Action
@@ -64,6 +86,53 @@ class TrajectoryStep:
     feedback: str = ""
     timestamp: float = field(default_factory=time.time)
     reward_components: dict[str, float] = field(default_factory=dict)
+
+    # ── #120 world-model fields ─────────────────────────────────────────
+    # Perceptual hash of the post-action frame; lets two trajectories at
+    # the same logical state hash-equal even if pixel-level noise differs.
+    # 17 hex chars (16 dHash + 1 brightness bucket) — see loop_detector.phash_64.
+    frame_hash: str = ""
+
+    # Observed environment state after the action: url, title, focused_input,
+    # any other gym_result.info keys the env exposes.
+    observed_state: dict = field(default_factory=dict)
+
+    # The brain's belief about the *current* state before acting (parsed from
+    # thinking / chain-of-thought). Empty string when the brain doesn't emit it.
+    hypothesized_state: str = ""
+
+    # The brain's prediction of what its action will cause (e.g. "modal closes",
+    # "URL navigates to /detail/123", "search field gets focus"). Empty when
+    # the brain doesn't yet emit predictions.
+    predicted_outcome: str = ""
+
+    # The actual observed delta in plain words, derived from feedback +
+    # url/title changes. The reward function compares this to predicted_outcome
+    # to compute world-model error.
+    observed_outcome: str = ""
+
+
+# Subset of ``gym_result.info`` that round-trips into TrajectoryStep
+# observed_state. Excludes high-cardinality / large-blob fields (raw DOM,
+# screenshots, cookies) to keep trajectories small and JSON-friendly.
+_OBSERVED_STATE_KEYS: tuple[str, ...] = (
+    "url",
+    "title",
+    "focused_input",
+    "type_verified",
+    "backtracked",
+    "warning",
+)
+
+
+def _observed_state(info: dict | None) -> dict:
+    """Pick stable, low-cardinality keys from ``gym_result.info`` for the
+    trajectory's ``observed_state`` field. Returns an empty dict when info
+    is missing — callers should treat that as "no signal" rather than error.
+    """
+    if not info:
+        return {}
+    return {k: info[k] for k in _OBSERVED_STATE_KEYS if k in info}
 
 
 @dataclass
@@ -466,11 +535,19 @@ class GymRunner:
 
                 step_log.append(f"Step {step_num}: {action} → {feedback}")
 
+                # #120 world-model schema: capture post-action observation so
+                # follow-on PRs (and offline rollout consumers) can compare
+                # the brain's predicted_outcome to what actually happened.
+                # frame_hash uses the same dHash as the loop detector so two
+                # trajectories at the same logical state hash equal.
                 trajectory.append(TrajectoryStep(
                     step=step_num, action=action, thinking=thinking,
                     reward=step_reward, done=gym_result.done,
                     inference_time=inference_time, feedback=feedback,
                     reward_components=step_components,
+                    frame_hash=phash_64(gym_result.observation.screenshot),
+                    observed_state=_observed_state(gym_result.info),
+                    observed_outcome=feedback,
                 ))
 
                 logger.info(f"Feedback: {feedback}")

--- a/tests/test_trajectory_schema.py
+++ b/tests/test_trajectory_schema.py
@@ -1,0 +1,133 @@
+"""Tests for #120 step 1 — TrajectoryStep world-model schema landing."""
+
+from __future__ import annotations
+
+from PIL import Image
+
+from mantis_agent.actions import Action, ActionType
+from mantis_agent.gym.runner import TrajectoryStep, _OBSERVED_STATE_KEYS, _observed_state
+
+
+# ── Schema defaults ──────────────────────────────────────────────────────
+
+
+def test_trajectory_step_defaults_all_world_model_fields_to_empty() -> None:
+    """A step constructed with only the required fields must have safe
+    defaults for every #120 field — no surprise required-arg shifts."""
+    step = TrajectoryStep(
+        step=1,
+        action=Action(ActionType.CLICK, {"x": 1, "y": 1}),
+        thinking="",
+        reward=0.0,
+        done=False,
+        inference_time=0.0,
+    )
+    assert step.feedback == ""
+    assert step.reward_components == {}
+    assert step.frame_hash == ""
+    assert step.observed_state == {}
+    assert step.hypothesized_state == ""
+    assert step.predicted_outcome == ""
+    assert step.observed_outcome == ""
+
+
+def test_trajectory_step_world_model_fields_are_independent_per_instance() -> None:
+    a = TrajectoryStep(
+        step=1, action=Action(ActionType.CLICK, {"x": 1, "y": 1}),
+        thinking="", reward=0.0, done=False, inference_time=0.0,
+    )
+    b = TrajectoryStep(
+        step=2, action=Action(ActionType.CLICK, {"x": 2, "y": 2}),
+        thinking="", reward=0.0, done=False, inference_time=0.0,
+    )
+    a.observed_state["url"] = "https://x.test/a"
+    a.reward_components["foo"] = 1.0
+    # b's defaults must not leak across instances.
+    assert b.observed_state == {}
+    assert b.reward_components == {}
+
+
+# ── _observed_state helper ───────────────────────────────────────────────
+
+
+def test_observed_state_handles_none() -> None:
+    assert _observed_state(None) == {}
+
+
+def test_observed_state_handles_empty_dict() -> None:
+    assert _observed_state({}) == {}
+
+
+def test_observed_state_picks_only_whitelisted_keys() -> None:
+    info = {
+        "url": "https://x.test/p",
+        "title": "Page",
+        "focused_input": {"placeholder": "search"},
+        # Excluded — high-cardinality / large blobs:
+        "screenshot": b"\x89PNG\r\n...",
+        "cookies": [{"name": "session"}],
+        "raw_html": "<html>...</html>",
+    }
+    state = _observed_state(info)
+    assert state == {
+        "url": "https://x.test/p",
+        "title": "Page",
+        "focused_input": {"placeholder": "search"},
+    }
+
+
+def test_observed_state_includes_warning_and_backtracked() -> None:
+    """Off-site backtrack signal must round-trip into the trajectory so
+    rewards / SFT pipelines can train against it."""
+    info = {
+        "url": "https://x.test/p",
+        "backtracked": True,
+        "warning": "Off-site navigation",
+    }
+    state = _observed_state(info)
+    assert state["backtracked"] is True
+    assert state["warning"] == "Off-site navigation"
+
+
+def test_observed_state_keys_constant_is_low_cardinality_set() -> None:
+    """Sanity: the whitelisted-keys tuple is small and stable — adding a
+    high-cardinality key here would inflate trajectory storage at scale."""
+    assert len(_OBSERVED_STATE_KEYS) <= 10
+    assert "url" in _OBSERVED_STATE_KEYS
+    assert "focused_input" in _OBSERVED_STATE_KEYS
+
+
+# ── Backward compat: positional construction still works ────────────────
+
+
+def test_legacy_positional_construction_still_works() -> None:
+    """Existing code constructs TrajectoryStep with positional args. The
+    #120 fields are appended at the end with defaults so this can't break."""
+    step = TrajectoryStep(
+        1,
+        Action(ActionType.CLICK, {"x": 1, "y": 1}),
+        "thinking text",
+        0.5,
+        False,
+        0.123,
+    )
+    assert step.step == 1
+    assert step.thinking == "thinking text"
+    assert step.reward == 0.5
+    assert step.frame_hash == ""
+
+
+# ── frame_hash via phash_64 ─────────────────────────────────────────────
+
+
+def test_frame_hash_stable_for_identical_screenshots() -> None:
+    """frame_hash uses the same phash_64 as the loop detector — identical
+    images must produce equal hashes so two trajectories at the same logical
+    state can be compared offline."""
+    from mantis_agent.loop_detector import phash_64
+
+    img = Image.new("RGB", (32, 32), (128, 64, 200))
+    h1 = phash_64(img)
+    h2 = phash_64(img.copy())
+    assert h1 == h2
+    assert h1 != ""


### PR DESCRIPTION
## Summary

#120 wants `TrajectoryStep` to carry per-step world-model signal — what the brain *predicted* would happen vs what *did* happen — so rewards / SFT pipelines can train against world-model error. The full feature has three parts; this PR is the foundation.

| Step | What | Status |
|---|---|---|
| **1** | **Schema + auto-populated fields** | **this PR** |
| 2 | Brain-prompt updates so models emit `predicted_outcome` | next |
| 3 | `world_model_error` reward component comparing predicted vs observed | follow-on |

Splitting it this way lets each PR be reviewed independently: the schema lands without behavior change, prompt updates are then a focused brain-by-brain change, and the reward component is a separate scoring concern.

## Fields added

| Field | Source | Purpose |
|---|---|---|
| `frame_hash` | `phash_64(screenshot)` (already used by loop detector) | Two steps at the same logical state hash equal |
| `observed_state` | `_observed_state(gym_result.info)` whitelist | Stable url/title/focused_input/backtracked snapshot |
| `hypothesized_state` | empty for now | Brain's belief about the *current* state (parsed from thinking) |
| `predicted_outcome` | empty for now | Brain's expected delta — populated in step 2 |
| `observed_outcome` | runner's existing `feedback` string | The actual delta in plain words |

The whitelisted `observed_state` keys are deliberately a tiny tuple (≤10) — adding a high-cardinality key here would inflate trajectory storage at scale.

## Backward compat

All new fields have defaults and are appended at the end of the dataclass:

- Existing positional construction still works (verified by test).
- 4 `trajectory.append` sites — only the brain-driven step path populates the new fields. The other 3 (DONE action, direct exec, discovery exec) keep their existing positional construction; defaults handle the rest. Step 2/3 PRs can populate them as the brains learn predictions.
- Trajectory consumers (`rollout_collector`, `convert_rollouts`, `rewards`) keep working — 43 existing tests pass unchanged.

## Test plan

- [x] 9 new unit tests covering: defaults are independent per instance, `observed_state` whitelist (None / empty / large-blob exclusion / warning + backtracked round-trip), constant-stability sanity, legacy positional-construction backward compat, `frame_hash` determinism via the same `phash_64` used by the loop detector
- [x] 43 trajectory-consumer tests pass unchanged
- [x] ruff clean
- [ ] CI on this PR

## What's deliberately *not* in this PR

- Brain prompt updates to emit `predicted_outcome` — needs careful per-brain prompt engineering (Holo3 / Claude / OpenCUA / Gemma4 / llama.cpp each have their own prompt format and reasoning style).
- `world_model_error` reward component — depends on (2) producing non-empty predictions to be testable end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)