### PR TITLE
feat(holo3): emit predicted_outcome alongside action (#120, step 2/3)

### DIFF
--- a/src/mantis_agent/brain_holo3.py
+++ b/src/mantis_agent/brain_holo3.py
@@ -115,6 +115,32 @@ def _image_to_base64(img: Image.Image) -> str:
     return base64.b64encode(buf.getvalue()).decode("utf-8")
 
 
+_PREDICTED_LINE_RE = re.compile(
+    r"^\s*Predicted\s*:\s*(.+?)\s*$",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+
+def _extract_predicted_outcome(text: str) -> str:
+    """Pull the first ``Predicted: <delta>`` line out of a Holo3 response.
+
+    The Holo3 system prompt asks for an optional trailing line in this
+    format. The brain may omit it (e.g. for done() steps, or when it
+    genuinely doesn't know). Returns ``""`` when no line is present so
+    the trajectory's ``predicted_outcome`` stays at its default — see #120.
+
+    Trims trailing punctuation/quotes that often appear when the model
+    paraphrases the example. Caps at 240 chars to keep trajectories bounded.
+    """
+    if not text:
+        return ""
+    match = _PREDICTED_LINE_RE.search(text)
+    if not match:
+        return ""
+    line = match.group(1).strip().strip('"').strip("'").strip()
+    return line[:240]
+
+
 @dataclass
 class InferenceResult:
     """Result from a single brain inference cycle."""
@@ -122,6 +148,9 @@ class InferenceResult:
     raw_output: str
     thinking: str = ""
     tokens_used: int = 0
+    # #120 step 2: brain's prediction of what its action will cause.
+    # Empty when the model didn't emit a "Predicted:" line.
+    predicted_outcome: str = ""
 
 
 # ── Brain ───────────────────────────────────────────────────────────────────
@@ -350,6 +379,10 @@ class Holo3Brain:
         thinking = message.get("reasoning_content", "") or ""
         content_text = message.get("content", "") or ""
 
+        # #120 step 2: extract the optional "Predicted: <delta>" line the
+        # prompt asks for. Empty when the model didn't emit it.
+        predicted = _extract_predicted_outcome(content_text)
+
         if not thinking and "<think>" in content_text:
             think_match = re.search(r"<think>(.*?)</think>", content_text, re.DOTALL)
             if think_match:
@@ -380,6 +413,7 @@ class Holo3Brain:
                 raw_output=raw_output,
                 thinking=thinking,
                 tokens_used=data.get("usage", {}).get("total_tokens", 0),
+                predicted_outcome=predicted,
             )
 
         # Strategy 2: Holo3 "Action: name({...})" or "Action: name(key=val)" text format
@@ -395,6 +429,7 @@ class Holo3Brain:
                 raw_output=raw_output,
                 thinking=thinking,
                 tokens_used=data.get("usage", {}).get("total_tokens", 0),
+                predicted_outcome=predicted,
             )
 
         # Strategy 3: JSON action {"action": "click", ...} in content text
@@ -408,6 +443,7 @@ class Holo3Brain:
                 raw_output=raw_output,
                 thinking=thinking,
                 tokens_used=data.get("usage", {}).get("total_tokens", 0),
+                predicted_outcome=predicted,
             )
 
         # Strategy 4: pyautogui-style text (pyautogui.click, etc.)
@@ -421,6 +457,7 @@ class Holo3Brain:
                 raw_output=raw_output,
                 thinking=thinking,
                 tokens_used=data.get("usage", {}).get("total_tokens", 0),
+                predicted_outcome=predicted,
             )
 
         # Strategy 5: terminate / DONE / FAIL keywords
@@ -435,6 +472,7 @@ class Holo3Brain:
                 raw_output=raw_output,
                 thinking=thinking,
                 tokens_used=data.get("usage", {}).get("total_tokens", 0),
+                predicted_outcome=predicted,
             )
 
         if "DONE" in content_text.upper():
@@ -453,6 +491,7 @@ class Holo3Brain:
             raw_output=raw_output,
             thinking=thinking,
             tokens_used=data.get("usage", {}).get("total_tokens", 0),
+            predicted_outcome=predicted,
         )
 
     def _convert_coords(self, action_name: str, args: dict, screen_size: tuple[int, int]) -> dict:

--- a/src/mantis_agent/gym/runner.py
+++ b/src/mantis_agent/gym/runner.py
@@ -432,6 +432,11 @@ class GymRunner:
                 action = result.action
                 thinking = getattr(result, "thinking", "")
                 last_thinking = thinking  # Persist for next step's prompt
+                # #120 step 2: Holo3 (and other brains as they adopt the
+                # prompt change) now emits predicted_outcome alongside
+                # action + thinking. Brains that don't yet emit it return
+                # "" — TrajectoryStep field defaults handle that.
+                predicted_outcome = getattr(result, "predicted_outcome", "")
                 logger.info(f"Action: {action} ({inference_time:.2f}s)")
 
                 self._emit("step", step=step_num, max_steps=self.max_steps)
@@ -548,6 +553,7 @@ class GymRunner:
                     frame_hash=phash_64(gym_result.observation.screenshot),
                     observed_state=_observed_state(gym_result.info),
                     observed_outcome=feedback,
+                    predicted_outcome=predicted_outcome,
                 ))
 
                 logger.info(f"Feedback: {feedback}")

--- a/src/mantis_agent/prompts/__init__.py
+++ b/src/mantis_agent/prompts/__init__.py
@@ -123,6 +123,7 @@ You are a computer use agent. You observe screenshots and perform actions to com
 RESPONSE FORMAT — Every response must follow this structure:
 1. One brief sentence of reasoning (what you see and plan to do)
 2. One action call
+3. One line starting with "Predicted:" describing what you expect to happen after the action — one short sentence about the visible delta (URL change, modal opens, field focuses, page loads, etc.). Skip this only for done().
 
 ACTIONS — use exactly one per response:
 click(x=<int>, y=<int>)
@@ -136,6 +137,7 @@ done(success=false, summary="<reason>")
 EXAMPLE RESPONSE:
 I see the search results page with boat listings. I'll click the title of the first listing.
 click(x=640, y=320)
+Predicted: page navigates to the first listing's detail URL and the title becomes the boat's name.
 
 EXAMPLE DONE RESPONSE (extraction):
 I found the boat details: 2024 Sea Ray Sundancer, $189,000, phone 786-555-1234.
@@ -149,7 +151,8 @@ RULES:
 - When extracting data, include ALL details in the done() summary: Year, Make, Model, Price, Phone (or "none"), Type, URL.
 - NEVER repeat the same action 3 times. Try something different.
 - NEVER just describe what you plan to do — you MUST output an action call.
-- If stuck for 5+ actions, call done(success=false, summary="stuck: <what happened>").\
+- If stuck for 5+ actions, call done(success=false, summary="stuck: <what happened>").
+- The "Predicted:" line is one short sentence. If you genuinely don't know what will happen, omit the line — do NOT guess.\
 """
 
 

--- a/tests/test_holo3_predicted_outcome.py
+++ b/tests/test_holo3_predicted_outcome.py
@@ -1,0 +1,186 @@
+"""Tests for #120 step 2 — Holo3 brain emits predicted_outcome.
+
+Covers the parser, the prompt instruction, and the InferenceResult schema
+change. Live network calls to Holo3 are not exercised here — that's a
+separate integration test path.
+"""
+
+from __future__ import annotations
+
+import re
+
+from mantis_agent.brain_holo3 import (
+    InferenceResult,
+    _PREDICTED_LINE_RE,
+    _extract_predicted_outcome,
+)
+
+
+# ── _extract_predicted_outcome ──────────────────────────────────────────
+
+
+def test_extract_returns_empty_on_missing_line() -> None:
+    text = "I'll click the listing.\nclick(x=640, y=320)"
+    assert _extract_predicted_outcome(text) == ""
+
+
+def test_extract_returns_empty_on_blank_input() -> None:
+    assert _extract_predicted_outcome("") == ""
+    assert _extract_predicted_outcome("   \n  \n") == ""
+
+
+def test_extract_basic_one_liner() -> None:
+    text = (
+        "I'll click the first listing.\n"
+        "click(x=640, y=320)\n"
+        "Predicted: page navigates to the detail URL and the title becomes the boat's name."
+    )
+    out = _extract_predicted_outcome(text)
+    assert out == (
+        "page navigates to the detail URL and the title becomes the boat's name."
+    )
+
+
+def test_extract_strips_quotes_and_trailing_whitespace() -> None:
+    text = 'click(x=1, y=1)\nPredicted: "modal closes"   \n'
+    assert _extract_predicted_outcome(text) == "modal closes"
+
+
+def test_extract_is_case_insensitive() -> None:
+    text = "click(x=1, y=1)\nPREDICTED: URL changes to /detail/123"
+    assert _extract_predicted_outcome(text) == "URL changes to /detail/123"
+
+
+def test_extract_caps_at_240_chars() -> None:
+    long = "x" * 500
+    text = f"click(x=1, y=1)\nPredicted: {long}"
+    out = _extract_predicted_outcome(text)
+    assert len(out) == 240
+
+
+def test_extract_grabs_first_predicted_line_when_multiple() -> None:
+    text = (
+        "click(x=1, y=1)\n"
+        "Predicted: first thing happens\n"
+        "Predicted: second thing\n"
+    )
+    assert _extract_predicted_outcome(text) == "first thing happens"
+
+
+def test_extract_handles_no_space_after_colon() -> None:
+    text = "click(x=1, y=1)\nPredicted:URL changes"
+    assert _extract_predicted_outcome(text) == "URL changes"
+
+
+def test_extract_handles_extra_space_around_colon() -> None:
+    text = "click(x=1, y=1)\nPredicted   :   URL changes"
+    assert _extract_predicted_outcome(text) == "URL changes"
+
+
+# ── Prompt instruction ──────────────────────────────────────────────────
+
+
+def test_holo3_system_prompt_requests_predicted_line() -> None:
+    """The system prompt must explicitly tell the model to emit Predicted:."""
+    from mantis_agent.prompts import HOLO3_SYSTEM
+    assert "Predicted:" in HOLO3_SYSTEM
+    # And the example shows the format too.
+    assert re.search(r"Predicted:\s+\S+", HOLO3_SYSTEM)
+
+
+def test_holo3_system_prompt_allows_omission_when_uncertain() -> None:
+    """The brain shouldn't be forced to hallucinate when it doesn't know."""
+    from mantis_agent.prompts import HOLO3_SYSTEM
+    # The rule "if you don't know, omit the line" prevents hallucinated predictions.
+    assert "omit" in HOLO3_SYSTEM.lower() or "skip" in HOLO3_SYSTEM.lower()
+
+
+def test_holo3_system_prompt_change_invalidates_prompt_version() -> None:
+    """#127 prompt versioning + #120 prompt edit: the SHA should differ
+    from a baseline that doesn't ask for Predicted:."""
+    from mantis_agent.prompts import prompt_version
+
+    sha = prompt_version("holo3_system")
+    # 8 hex chars, deterministic.
+    assert len(sha) == 8
+    # Stability: two calls return the same SHA.
+    assert prompt_version("holo3_system") == sha
+
+
+# ── InferenceResult schema ──────────────────────────────────────────────
+
+
+def test_inference_result_defaults_predicted_outcome_to_empty() -> None:
+    from mantis_agent.actions import Action, ActionType
+    r = InferenceResult(
+        action=Action(ActionType.CLICK, {"x": 1, "y": 1}),
+        raw_output="",
+    )
+    assert r.predicted_outcome == ""
+
+
+def test_inference_result_carries_predicted_outcome_field() -> None:
+    from mantis_agent.actions import Action, ActionType
+    r = InferenceResult(
+        action=Action(ActionType.CLICK, {"x": 1, "y": 1}),
+        raw_output="",
+        predicted_outcome="modal closes",
+    )
+    assert r.predicted_outcome == "modal closes"
+
+
+# ── _parse_response integration ─────────────────────────────────────────
+
+
+def _fake_holo3_response(content: str) -> dict:
+    """Minimal dict shape that Holo3Brain._parse_response expects."""
+    return {
+        "choices": [
+            {
+                "message": {
+                    "content": content,
+                    "tool_calls": [],
+                }
+            }
+        ],
+        "usage": {"total_tokens": 0},
+    }
+
+
+def test_parse_response_extracts_predicted_from_text_path() -> None:
+    """Parser strategy 2 (Action: name(...) text) — predicted line is captured."""
+    from mantis_agent.brain_holo3 import Holo3Brain
+
+    brain = Holo3Brain(api_key="dummy")
+    response = _fake_holo3_response(
+        "I'll click the first listing.\n"
+        "Action: click({'x': 100, 'y': 200})\n"
+        "Predicted: page navigates to the detail URL"
+    )
+    result = brain._parse_response(response, screen_size=(1280, 720))
+    # Don't assert on action shape — coordinate-conversion math depends on
+    # Qwen smart-resize; we only care that predicted_outcome propagated.
+    assert result.predicted_outcome == "page navigates to the detail URL"
+
+
+def test_parse_response_no_predicted_line_yields_empty_field() -> None:
+    """Brains that don't emit Predicted: must produce predicted_outcome=""."""
+    from mantis_agent.brain_holo3 import Holo3Brain
+
+    brain = Holo3Brain(api_key="dummy")
+    response = _fake_holo3_response(
+        "I'll click.\nAction: click({'x': 100, 'y': 200})"
+    )
+    result = brain._parse_response(response, screen_size=(1280, 720))
+    assert result.predicted_outcome == ""
+
+
+# ── Sanity: regex compiles and matches expected lines ───────────────────
+
+
+def test_predicted_line_regex_compiled() -> None:
+    assert _PREDICTED_LINE_RE.search("Predicted: foo") is not None
+    assert _PREDICTED_LINE_RE.search("predicted: foo") is not None
+    assert _PREDICTED_LINE_RE.search("PREDICTED: foo") is not None
+    # Negative: ensure we don't match arbitrary "predicted" mentions inside prose.
+    assert _PREDICTED_LINE_RE.search("the model predicted nothing useful") is None


### PR DESCRIPTION
## Summary

Step 2 of the world-model schema. The Holo3 brain (production default) now asks the model for a one-line prediction of what its action will cause, parses it from the response, and propagates it into `TrajectoryStep.predicted_outcome` (landed in step 1, #135).

## Changes

| File | Change |
|---|---|
| `prompts/__init__.py` | `HOLO3_SYSTEM` extended with a third optional line `Predicted: <delta>`. Example shows the format. Explicit rule "if you don't know, omit — do NOT guess" prevents hallucinated predictions. |
| `brain_holo3.py` | `InferenceResult.predicted_outcome: str = ""` field. New `_extract_predicted_outcome(text)` helper. All 6 `InferenceResult` construction sites in `_parse_response` thread the parsed prediction through. |
| `gym/runner.py` | Reads `result.predicted_outcome` via `getattr` (backward-compat with un-updated brains → default `""`). Populates `TrajectoryStep.predicted_outcome` at the brain-driven step path. |

## Why opt-in via prompt edit (not a constructor flag)

- Adds to the existing prompt without changing action format. Brains not yet updated still produce valid trajectories with empty predictions — step 1's schema design (every world-model field defaults to `""`) was made for exactly this gradual rollout.
- #127 prompt versioning means the prompt SHA changes when this lands, so dashboards can correlate any score regression with the rollout.

## Test plan

- [x] 17 new unit tests covering: parser handles missing/blank input, basic one-liner, quote-stripping, case-insensitivity, length cap, multi-line first-match wins, no-space and extra-space variants, prompt instruction presence + omission rule, prompt SHA stability, `InferenceResult` schema defaults + field carrying, `_parse_response` integration (Action: text path with + without Predicted:), regex compilation + negative match against arbitrary "predicted" prose mentions
- [x] 55 new + adjacent tests pass (`trajectory_schema`, `prompts`, `prompt_versions`, `brain_protocol`)
- [x] ruff clean
- [ ] CI on this PR

## What's deliberately *not* in this PR

- Other 4 brains (Claude, OpenCUA, Gemma4, llama.cpp) — each has its own prompt format and parsing path; rolling them out one at a time keeps blast radius contained
- `world_model_error` reward component (step 3) — depends on having multiple brains producing predictions to be testable end-to-end

## #120 series progress

| Step | What | Status |
|---|---|---|
| 1 | Schema landing | ✅ #135 |
| **2** | **Holo3 emits `predicted_outcome`** | **this PR** |
| 3 | `world_model_error` reward component | next |
| (later) | Other 4 brains adopt the prediction line | follow-on |

🤖 Generated with [Claude Code](https://claude.com/claude-code)