### PR TITLE
feat(grounding): GroundingCache — bounded TTL cache for click coordinates (#117, step 1/2)

### DIFF
--- a/src/mantis_agent/grounding_cache.py
+++ b/src/mantis_agent/grounding_cache.py
@@ -1,0 +1,218 @@
+"""Coordinate cache for the grounding pipeline (#117, step 1).
+
+Each :class:`ClaudeGrounding` call takes ~5-10s and costs ~$0.003 — and
+listing-card layouts repeat across pages, so the same visual region +
+description pair gets re-grounded constantly. This cache keys results by
+``(perceptual_hash(crop) + description_hash)`` so a hit short-circuits
+the whole network round-trip.
+
+Design choices:
+
+* **Bounded.** The default cap (1024 entries) is large enough to cover a
+  realistic per-domain working set without memory creep during long runs.
+  Eviction is plain LRU — sufficient for the access pattern (recently
+  visited cards keep getting clicked).
+* **TTL'd.** Entries auto-expire after ``ttl_seconds`` (default 1 h) so
+  layouts that change between sessions don't return stale coordinates.
+* **Process-local.** No disk persistence. Adding it would let cache
+  poisoning leak across tenants — out of scope for this PR.
+* **Hash crops, not full screenshots.** A click target near (x, y) only
+  needs the surrounding ~80px region to identify the layout. Cropping
+  before hashing gives the cache a meaningful "this card looks the same"
+  signal even when other parts of the screenshot differ (header banners,
+  page numbers, scroll position).
+
+Wired separately from the grounders so existing :class:`ClaudeGrounding`
+calls keep working unchanged. A follow-on PR will add an opt-in
+``cache=`` constructor arg on the grounders themselves.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import time
+from collections import OrderedDict
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from .grounding import GroundingResult
+from .loop_detector import phash_64
+
+if TYPE_CHECKING:
+    from PIL import Image
+
+logger = logging.getLogger(__name__)
+
+
+# Default crop half-size. The cache hashes a 2*CROP_HALF px box around
+# (initial_x, initial_y). Big enough to capture a listing card or button
+# row; small enough that scrolling doesn't shift content out of frame.
+DEFAULT_CROP_HALF: int = 80
+DEFAULT_MAX_ENTRIES: int = 1024
+DEFAULT_TTL_SECONDS: float = 3600.0
+
+
+@dataclass
+class _CacheEntry:
+    result: GroundingResult
+    expires_at: float
+
+
+class GroundingCache:
+    """Bounded TTL cache keyed by (frame-region hash, description hash).
+
+    Hit/miss counters are public so callers can dashboard them via
+    Prometheus or log them at run end. Counters never reset implicitly —
+    callers can call :meth:`reset_counters` between runs if they want
+    per-run telemetry.
+    """
+
+    def __init__(
+        self,
+        max_entries: int = DEFAULT_MAX_ENTRIES,
+        ttl_seconds: float = DEFAULT_TTL_SECONDS,
+        crop_half: int = DEFAULT_CROP_HALF,
+    ) -> None:
+        if max_entries < 1:
+            raise ValueError(f"max_entries must be >= 1 (got {max_entries})")
+        if ttl_seconds <= 0:
+            raise ValueError(f"ttl_seconds must be > 0 (got {ttl_seconds})")
+        if crop_half < 8:
+            raise ValueError(f"crop_half must be >= 8 (got {crop_half})")
+        self.max_entries = max_entries
+        self.ttl_seconds = ttl_seconds
+        self.crop_half = crop_half
+        self._entries: OrderedDict[str, _CacheEntry] = OrderedDict()
+        self.hits: int = 0
+        self.misses: int = 0
+        self.evictions: int = 0
+        self.expirations: int = 0
+
+    # ── Key construction ────────────────────────────────────────────────
+
+    def make_key(
+        self,
+        screenshot: "Image.Image",
+        description: str,
+        initial_x: int | None = None,
+        initial_y: int | None = None,
+    ) -> str:
+        """Build a cache key from the screenshot + click target.
+
+        Crops a ``crop_half * 2`` box around ``(initial_x, initial_y)`` (or
+        the image center when coordinates are missing) and dHashes it.
+        Description is SHA1'd to a short hex prefix so the key stays
+        bounded regardless of description length.
+        """
+        ix = initial_x if initial_x is not None else screenshot.width // 2
+        iy = initial_y if initial_y is not None else screenshot.height // 2
+        try:
+            crop = self._crop_around(screenshot, ix, iy)
+            frame_hash = phash_64(crop)
+        except Exception as exc:  # noqa: BLE001 — degrade rather than crash
+            logger.debug("crop/phash failed: %s — falling back to full hash", exc)
+            frame_hash = phash_64(screenshot)
+        desc_hash = hashlib.sha1((description or "").encode("utf-8")).hexdigest()[:12]
+        return f"{frame_hash}:{desc_hash}"
+
+    def _crop_around(
+        self, screenshot: "Image.Image", x: int, y: int
+    ) -> "Image.Image":
+        half = self.crop_half
+        left = max(0, x - half)
+        upper = max(0, y - half)
+        right = min(screenshot.width, x + half)
+        lower = min(screenshot.height, y + half)
+        if right <= left or lower <= upper:
+            return screenshot
+        return screenshot.crop((left, upper, right, lower))
+
+    # ── Get / put ──────────────────────────────────────────────────────
+
+    def get(self, key: str) -> GroundingResult | None:
+        """Look up a cache entry. ``None`` on miss or expiry."""
+        entry = self._entries.get(key)
+        if entry is None:
+            self.misses += 1
+            return None
+        if entry.expires_at <= time.time():
+            # Expired — drop it so stale layouts don't keep returning.
+            del self._entries[key]
+            self.expirations += 1
+            self.misses += 1
+            return None
+        # Touch for LRU.
+        self._entries.move_to_end(key)
+        self.hits += 1
+        return entry.result
+
+    def put(self, key: str, result: GroundingResult) -> None:
+        """Store a result. Evicts the oldest entry when at capacity."""
+        if key in self._entries:
+            # Update in place + bump recency.
+            self._entries[key] = _CacheEntry(
+                result=result, expires_at=time.time() + self.ttl_seconds
+            )
+            self._entries.move_to_end(key)
+            return
+        if len(self._entries) >= self.max_entries:
+            self._entries.popitem(last=False)
+            self.evictions += 1
+        self._entries[key] = _CacheEntry(
+            result=result, expires_at=time.time() + self.ttl_seconds
+        )
+
+    # ── Convenience wrapper ─────────────────────────────────────────────
+
+    def lookup_or_compute(
+        self,
+        screenshot: "Image.Image",
+        description: str,
+        compute_fn,
+        initial_x: int | None = None,
+        initial_y: int | None = None,
+    ) -> GroundingResult:
+        """Cache-aware ground call.
+
+        ``compute_fn`` is a 0-arg callable that performs the actual
+        grounding (the expensive Claude API call, OS-Atlas inference, etc.)
+        and returns a :class:`GroundingResult`. Use partial / lambda to
+        bind the args:
+
+            cache.lookup_or_compute(
+                screenshot, description,
+                lambda: claude_grounder.ground(screenshot, description, ix, iy),
+                initial_x=ix, initial_y=iy,
+            )
+        """
+        key = self.make_key(screenshot, description, initial_x, initial_y)
+        cached = self.get(key)
+        if cached is not None:
+            return cached
+        result = compute_fn()
+        self.put(key, result)
+        return result
+
+    # ── Diagnostics ────────────────────────────────────────────────────
+
+    @property
+    def size(self) -> int:
+        return len(self._entries)
+
+    def hit_rate(self) -> float:
+        total = self.hits + self.misses
+        return self.hits / total if total else 0.0
+
+    def reset_counters(self) -> None:
+        self.hits = 0
+        self.misses = 0
+        self.evictions = 0
+        self.expirations = 0
+
+    def clear(self) -> None:
+        self._entries.clear()
+        self.reset_counters()
+
+
+__all__ = ["GroundingCache", "DEFAULT_CROP_HALF", "DEFAULT_MAX_ENTRIES", "DEFAULT_TTL_SECONDS"]

--- a/tests/test_grounding_cache.py
+++ b/tests/test_grounding_cache.py
@@ -1,0 +1,249 @@
+"""Tests for #117 step 1 — GroundingCache."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+from PIL import Image
+
+from mantis_agent.grounding import GroundingResult
+from mantis_agent.grounding_cache import (
+    DEFAULT_CROP_HALF,
+    DEFAULT_MAX_ENTRIES,
+    DEFAULT_TTL_SECONDS,
+    GroundingCache,
+)
+
+
+def _solid_image(color: tuple[int, int, int] = (128, 128, 128), w: int = 256, h: int = 256) -> Image.Image:
+    return Image.new("RGB", (w, h), color)
+
+
+def _result(x: int = 100, y: int = 100, conf: float = 0.9) -> GroundingResult:
+    return GroundingResult(x=x, y=y, confidence=conf, description="cached")
+
+
+# ── Constructor validation ──────────────────────────────────────────────
+
+
+def test_invalid_max_entries_raises() -> None:
+    with pytest.raises(ValueError, match="max_entries"):
+        GroundingCache(max_entries=0)
+
+
+def test_invalid_ttl_raises() -> None:
+    with pytest.raises(ValueError, match="ttl_seconds"):
+        GroundingCache(ttl_seconds=0)
+
+
+def test_invalid_crop_half_raises() -> None:
+    with pytest.raises(ValueError, match="crop_half"):
+        GroundingCache(crop_half=4)
+
+
+def test_default_constants_are_reasonable() -> None:
+    """Sanity: defaults make sense for the intended workload."""
+    assert DEFAULT_CROP_HALF >= 32  # large enough for a card
+    assert DEFAULT_MAX_ENTRIES >= 256  # covers a multi-page session
+    assert DEFAULT_TTL_SECONDS >= 60  # not so short layouts churn
+
+
+# ── Key construction ────────────────────────────────────────────────────
+
+
+def test_make_key_is_deterministic_for_same_inputs() -> None:
+    cache = GroundingCache()
+    img = _solid_image()
+    k1 = cache.make_key(img, "click first listing", 100, 100)
+    k2 = cache.make_key(img.copy(), "click first listing", 100, 100)
+    assert k1 == k2
+
+
+def test_make_key_differs_when_description_differs() -> None:
+    cache = GroundingCache()
+    img = _solid_image()
+    k1 = cache.make_key(img, "click first listing", 100, 100)
+    k2 = cache.make_key(img, "click second listing", 100, 100)
+    assert k1 != k2
+
+
+def test_make_key_uses_local_crop_not_full_image() -> None:
+    """Two screenshots that differ in a far-away region but match around
+    the click target should produce the same key."""
+    cache = GroundingCache(crop_half=40)
+    img_a = _solid_image()
+    # Modify a region far from the click target on img_b only.
+    img_b = img_a.copy()
+    for x in range(0, 30):
+        for y in range(0, 30):
+            img_b.putpixel((x, y), (255, 0, 0))
+    # Click target at (200, 200) — far from the modified top-left region.
+    k_a = cache.make_key(img_a, "click", 200, 200)
+    k_b = cache.make_key(img_b, "click", 200, 200)
+    assert k_a == k_b
+
+
+def test_make_key_handles_missing_coords() -> None:
+    """When initial_x/y are None, the cache should fall back to image center
+    rather than crash."""
+    cache = GroundingCache()
+    img = _solid_image()
+    key = cache.make_key(img, "click", None, None)
+    assert isinstance(key, str)
+    assert len(key) > 0
+
+
+# ── Get / put ───────────────────────────────────────────────────────────
+
+
+def test_miss_then_hit() -> None:
+    cache = GroundingCache()
+    assert cache.get("k") is None
+    assert cache.misses == 1
+    cache.put("k", _result(50, 60))
+    out = cache.get("k")
+    assert out is not None
+    assert out.x == 50 and out.y == 60
+    assert cache.hits == 1
+
+
+def test_put_overwrites_existing_entry() -> None:
+    cache = GroundingCache()
+    cache.put("k", _result(1, 1))
+    cache.put("k", _result(99, 99))
+    out = cache.get("k")
+    assert out is not None
+    assert out.x == 99
+
+
+def test_lru_eviction_when_at_capacity() -> None:
+    cache = GroundingCache(max_entries=2)
+    cache.put("a", _result(1, 1))
+    cache.put("b", _result(2, 2))
+    # Touch "a" so "b" becomes the LRU.
+    cache.get("a")
+    cache.put("c", _result(3, 3))
+    assert cache.size == 2
+    assert cache.get("a") is not None
+    assert cache.get("b") is None  # evicted
+    assert cache.get("c") is not None
+    assert cache.evictions == 1
+
+
+def test_ttl_expiry_drops_entry(monkeypatch: pytest.MonkeyPatch) -> None:
+    cache = GroundingCache(ttl_seconds=10.0)
+    cache.put("k", _result())
+    # Advance time past expiry.
+    real_time = time.time()
+    monkeypatch.setattr(
+        "mantis_agent.grounding_cache.time.time",
+        lambda: real_time + 100.0,
+    )
+    assert cache.get("k") is None
+    assert cache.expirations == 1
+    assert cache.size == 0  # expired entries get cleaned up on access
+
+
+# ── lookup_or_compute ──────────────────────────────────────────────────
+
+
+def test_lookup_or_compute_invokes_compute_fn_on_miss() -> None:
+    cache = GroundingCache()
+    img = _solid_image()
+    calls = []
+
+    def compute() -> GroundingResult:
+        calls.append(None)
+        return _result(123, 456)
+
+    out = cache.lookup_or_compute(img, "click", compute, 50, 50)
+    assert out.x == 123 and out.y == 456
+    assert len(calls) == 1
+
+
+def test_lookup_or_compute_skips_compute_fn_on_hit() -> None:
+    cache = GroundingCache()
+    img = _solid_image()
+    calls = []
+
+    def compute() -> GroundingResult:
+        calls.append(None)
+        return _result(123, 456)
+
+    cache.lookup_or_compute(img, "click", compute, 50, 50)
+    cache.lookup_or_compute(img.copy(), "click", compute, 50, 50)
+    assert len(calls) == 1
+    assert cache.hits == 1
+
+
+def test_lookup_or_compute_caches_distinct_descriptions_separately() -> None:
+    cache = GroundingCache()
+    img = _solid_image()
+    a_calls = []
+    b_calls = []
+
+    cache.lookup_or_compute(
+        img, "click first", lambda: (a_calls.append(None), _result(1, 1))[1], 50, 50
+    )
+    cache.lookup_or_compute(
+        img, "click second", lambda: (b_calls.append(None), _result(2, 2))[1], 50, 50
+    )
+    cache.lookup_or_compute(
+        img, "click first", lambda: (a_calls.append(None), _result(1, 1))[1], 50, 50
+    )
+    # First description was a hit on second call; second description was a miss.
+    assert len(a_calls) == 1
+    assert len(b_calls) == 1
+
+
+# ── Diagnostics ─────────────────────────────────────────────────────────
+
+
+def test_hit_rate_reports_accurate_fraction() -> None:
+    cache = GroundingCache()
+    cache.put("k", _result())
+    cache.get("k")     # hit
+    cache.get("k")     # hit
+    cache.get("miss")  # miss
+    assert cache.hit_rate() == pytest.approx(2 / 3)
+
+
+def test_hit_rate_zero_before_any_access() -> None:
+    cache = GroundingCache()
+    assert cache.hit_rate() == 0.0
+
+
+def test_reset_counters_zeros_metrics_only() -> None:
+    cache = GroundingCache()
+    cache.put("k", _result())
+    cache.get("k")
+    assert cache.hits == 1
+    cache.reset_counters()
+    assert cache.hits == 0
+    assert cache.misses == 0
+    # Entry survives — only counters reset.
+    assert cache.size == 1
+
+
+def test_clear_drops_entries_and_zeros_counters() -> None:
+    cache = GroundingCache()
+    cache.put("k", _result())
+    cache.get("k")
+    cache.clear()
+    assert cache.size == 0
+    assert cache.hits == 0
+
+
+# ── Robustness ──────────────────────────────────────────────────────────
+
+
+def test_crop_failure_falls_back_to_full_image_hash() -> None:
+    """A degenerate crop (out-of-bounds coords) should not raise — the key
+    should still be deterministic via the full-image fallback."""
+    cache = GroundingCache()
+    img = _solid_image(w=64, h=64)
+    # Way out of bounds; _crop_around clamps but worth ensuring no raise.
+    key = cache.make_key(img, "click", 10000, 10000)
+    assert isinstance(key, str)
+    assert len(key) > 0


### PR DESCRIPTION
## Summary

First step of #117. Each `ClaudeGrounding` call costs ~\$0.003 and ~5-10s of latency. Listing-card layouts repeat across pages — the same (visual region + description) gets re-grounded constantly. New `GroundingCache` short-circuits that round-trip when the local crop hashes equal a previous target.

## Design

| Aspect | Choice |
|---|---|
| Key | `phash_64(crop_around(screenshot, ix, iy))` + `sha1(description)[:12]` |
| Crop default | 80px half-radius around click target — big enough for a card/button row, small enough that scrolling doesn't shift it out of frame |
| Storage | LRU `OrderedDict`, default 1024 entries |
| TTL | Default 1h — stale layouts can't return wrong coordinates after a long pause |
| Persistence | Process-local only (disk persistence would let one tenant poison another's cache — out of scope) |

## Integration point

```python
result = cache.lookup_or_compute(
    screenshot, description,
    lambda: claude_grounder.ground(screenshot, description, ix, iy),
    initial_x=ix, initial_y=iy,
)
```

Pure call-site refactor — no inheritance, no grounder modification. Step 2 will add an opt-in `cache=` constructor arg on the grounders themselves and promote SoM grounding as primary on opt-in sites.

## Public counters for dashboards

`cache.hits` / `cache.misses` / `cache.evictions` / `cache.expirations` / `cache.hit_rate()` — operators can wire these to Prometheus to track cost savings.

## Test plan

- [x] 20 new unit tests covering: constructor validation (max_entries / TTL / crop_half rejection), default constants sanity, key determinism, description-difference key separation, far-away pixel changes don't invalidate the local-crop key, missing-coord fallback, miss-then-hit, put-overwrites-existing, LRU eviction at capacity, TTL expiry via monkeypatched `time.time`, `lookup_or_compute` miss/hit dispatching, distinct-description caching, `hit_rate` accuracy, `reset_counters` preserves entries, `clear` drops both, out-of-bounds crop fallback
- [x] `test_loop_detector` (which provides `phash_64`) passes unchanged
- [x] ruff clean
- [ ] CI on this PR

## #117 series progress

| Step | What | Status |
|---|---|---|
| **1** | **`GroundingCache` module** | **this PR** |
| 2 | Promote SoM grounding as primary on opt-in sites + wire cache into grounders | next |

🤖 Generated with [Claude Code](https://claude.com/claude-code)