### PR TITLE
feat(gym): step snapshot + diff infrastructure for plan-aware reverse (#121, step 1/2)

### DIFF
--- a/src/mantis_agent/gym/micro_runner.py
+++ b/src/mantis_agent/gym/micro_runner.py
@@ -31,6 +31,7 @@ from .browser_state import BrowserState
 from .checkpoint_manager import CheckpointManager
 from .cost_meter import CostMeter
 from .listing_dedup import ListingDedup
+from . import step_snapshot
 from .checkpoint import (
     REVERSE_ACTIONS,
     PauseRequested,
@@ -288,6 +289,31 @@ class MicroPlanRunner:
         """Backward-compat shim — delegates to :meth:`CostMeter.emit_inflight_gauges`."""
         self.cost_meter.emit_inflight_gauges(gpu_cost, claude_cost, proxy_cost, total_cost)
 
+    def _log_step_diff(
+        self,
+        pre_snapshot: "step_snapshot.StepStateSnapshot",
+        step: MicroIntent,
+        step_result: StepResult,
+    ) -> None:
+        """Compute pre/post step diff and log it (#121 step 1).
+
+        Observation-only for this PR — the next PR in #121 uses the diff
+        to drive plan-aware reverse decisions. Logging here lets us
+        validate the diff is correct on real traces before changing
+        recovery behavior.
+        """
+        try:
+            post_snapshot = step_snapshot.capture(self)
+            delta = step_snapshot.diff(pre_snapshot, post_snapshot)
+        except Exception as exc:  # noqa: BLE001 — observability must not break runs
+            logger.debug("step diff capture failed: %s", exc)
+            return
+        outcome = "ok" if step_result.success else "fail"
+        logger.info(
+            "  [diff] %s/%s step=%s: %s",
+            step.type, outcome, step_result.step_index, delta.summary(),
+        )
+
     def _current_results_page_url(self) -> str:
         """Backward-compat shim — delegates to :class:`BrowserState`."""
         return self.browser_state.current_results_page_url()
@@ -524,6 +550,11 @@ class MicroPlanRunner:
                 "listings_on_page": listings_on_page,
                 "step_index": step_index,
             }
+            # #121 step 1: capture pre-step state for plan-aware reverse.
+            # Currently observation-only — the diff lands in logs so we can
+            # validate it on real traces before changing recovery behavior
+            # in the follow-on PR.
+            pre_snapshot = step_snapshot.capture(self)
             try:
                 step_result = self._execute_step(effective_step, step_index)
             finally:
@@ -536,6 +567,7 @@ class MicroPlanRunner:
             self._invoke_step_callback(step_result)
             self._record_step_costs(effective_step, step_result)
             self._log_progress(step_result, results)
+            self._log_step_diff(pre_snapshot, effective_step, step_result)
 
             # Handle dedup: extract_url returned DUPLICATE → skip to loop
             if step_result.data and "DUPLICATE" in step_result.data:

--- a/src/mantis_agent/gym/step_snapshot.py
+++ b/src/mantis_agent/gym/step_snapshot.py
@@ -1,0 +1,196 @@
+"""Per-step state snapshot + diff helpers for plan-aware reverse (#121, step 1).
+
+The current ``MicroPlanRunner._reverse_step`` blindly fires keystrokes
+from a static ``REVERSE_ACTIONS`` map regardless of what the failed step
+*actually* accomplished. For form steps that partially succeeded (typed
+3 of 5 fields), Escape + Alt+Left destroys the work and the next attempt
+re-types everything.
+
+This module lands the **observability** half of the fix:
+
+* :class:`StepStateSnapshot` captures the pre-step state in a small,
+  hashable shape.
+* :func:`capture` reads the live runner state into a snapshot.
+* :func:`diff` computes the observed delta between two snapshots.
+
+A follow-on PR uses the diff to decide reverse actions; this PR just
+makes the signal visible in logs so we can validate the diff is correct
+on real traces before changing recovery behavior.
+
+State fields tracked:
+
+* ``url``                 — last known URL (from ``runner._last_known_url``)
+* ``current_page``        — pagination cursor
+* ``viewport_stage``      — scroll viewport stage (0=top, 1=Page_Down, ...)
+* ``focused_input``       — placeholder/name/value of the currently focused field
+* ``scroll_signature``    — hash of the runner's scroll_state dict
+* ``last_extracted_url``  — URL from the most recent extraction record
+
+The snapshot is intentionally a *thin* view of runner state. We don't
+copy the full ``_scroll_state`` / ``_last_extracted`` dicts — that would
+inflate trajectory storage and complicate equality checks. The signature
+hashes are sufficient for diff detection.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from .micro_runner import MicroPlanRunner
+
+logger = logging.getLogger(__name__)
+
+
+def _hash_dict(d: dict[str, Any] | None) -> str:
+    """Stable hex digest of a dict — used for scroll_state / focused_input
+    equality. Empty/None inputs produce a constant sentinel so two no-state
+    snapshots compare equal."""
+    if not d:
+        return "empty"
+    try:
+        payload = json.dumps(d, sort_keys=True, default=str)
+    except (TypeError, ValueError):
+        # Defensive: anything non-JSON-able falls through to a string repr.
+        payload = repr(d)
+    return hashlib.sha1(payload.encode("utf-8")).hexdigest()[:12]
+
+
+@dataclass(frozen=True)
+class StepStateSnapshot:
+    """Frozen view of runner state at a single point in time.
+
+    Frozen so accidental mutation can't break diff comparisons. All
+    fields default to neutral values so partial snapshots (e.g. taken
+    before the runner has fully initialized) still compare cleanly.
+    """
+
+    url: str = ""
+    current_page: int = 1
+    viewport_stage: int = 0
+    focused_input_signature: str = "empty"
+    scroll_signature: str = "empty"
+    last_extracted_url: str = ""
+    extracted_titles_count: int = 0
+    seen_urls_count: int = 0
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serializable form for logs / trajectory persistence."""
+        return {
+            "url": self.url,
+            "current_page": self.current_page,
+            "viewport_stage": self.viewport_stage,
+            "focused_input_sig": self.focused_input_signature,
+            "scroll_sig": self.scroll_signature,
+            "last_extracted_url": self.last_extracted_url,
+            "extracted_titles_count": self.extracted_titles_count,
+            "seen_urls_count": self.seen_urls_count,
+        }
+
+
+@dataclass
+class StepDiff:
+    """Observed delta between two snapshots — input to reverse decisions.
+
+    Each boolean is set when the corresponding aspect of state changed.
+    The :attr:`changed_fields` list gives a human-readable summary for
+    logs.
+    """
+
+    url_changed: bool = False
+    page_changed: bool = False
+    viewport_changed: bool = False
+    focus_changed: bool = False
+    scroll_changed: bool = False
+    extraction_added: bool = False
+    new_urls_seen: bool = False
+    changed_fields: list[str] = field(default_factory=list)
+
+    @property
+    def has_changes(self) -> bool:
+        return bool(self.changed_fields)
+
+    def summary(self) -> str:
+        return ", ".join(self.changed_fields) if self.changed_fields else "no change"
+
+
+# ── Capture ──────────────────────────────────────────────────────────────
+
+
+def capture(runner: "MicroPlanRunner") -> StepStateSnapshot:
+    """Read runner state into a frozen snapshot.
+
+    Runs synchronously and is cheap (a few attribute reads + 2 SHA1s),
+    so it's safe to call before every step.
+    """
+    focused_input = None
+    # Some env adapters expose a current focused-input record; others don't.
+    try:
+        focused_input = runner.env.last_focused_input  # type: ignore[attr-defined]
+    except AttributeError:
+        focused_input = None
+
+    last_extracted = getattr(runner, "_last_extracted", {}) or {}
+    return StepStateSnapshot(
+        url=getattr(runner, "_last_known_url", "") or "",
+        current_page=int(getattr(runner, "_current_page", 1) or 1),
+        viewport_stage=int(getattr(runner, "_viewport_stage", 0) or 0),
+        focused_input_signature=_hash_dict(focused_input),
+        scroll_signature=_hash_dict(getattr(runner, "_scroll_state", {})),
+        last_extracted_url=str(last_extracted.get("last_completed_url", "") or ""),
+        extracted_titles_count=len(getattr(runner, "_extracted_titles", []) or []),
+        seen_urls_count=len(getattr(runner, "_seen_urls", set()) or set()),
+    )
+
+
+# ── Diff ─────────────────────────────────────────────────────────────────
+
+
+def diff(before: StepStateSnapshot, after: StepStateSnapshot) -> StepDiff:
+    """Compute the observed delta between two snapshots.
+
+    Pure function — order matters (before, after) but neither argument
+    is mutated. Returns a :class:`StepDiff` with one bool per dimension
+    that changed plus a human-readable summary list for logs.
+    """
+    out = StepDiff()
+    if before.url != after.url:
+        out.url_changed = True
+        out.changed_fields.append(f"url: {before.url[:40]} → {after.url[:40]}")
+    if before.current_page != after.current_page:
+        out.page_changed = True
+        out.changed_fields.append(
+            f"page: {before.current_page} → {after.current_page}"
+        )
+    if before.viewport_stage != after.viewport_stage:
+        out.viewport_changed = True
+        out.changed_fields.append(
+            f"viewport_stage: {before.viewport_stage} → {after.viewport_stage}"
+        )
+    if before.focused_input_signature != after.focused_input_signature:
+        out.focus_changed = True
+        out.changed_fields.append("focused_input")
+    if before.scroll_signature != after.scroll_signature:
+        out.scroll_changed = True
+        out.changed_fields.append("scroll_state")
+    if (
+        after.last_extracted_url
+        and after.last_extracted_url != before.last_extracted_url
+    ):
+        out.extraction_added = True
+        out.changed_fields.append(
+            f"last_extracted: {after.last_extracted_url[:40]}"
+        )
+    if after.seen_urls_count > before.seen_urls_count:
+        out.new_urls_seen = True
+        out.changed_fields.append(
+            f"seen_urls +{after.seen_urls_count - before.seen_urls_count}"
+        )
+    return out
+
+
+__all__ = ["StepStateSnapshot", "StepDiff", "capture", "diff"]

--- a/tests/test_step_snapshot.py
+++ b/tests/test_step_snapshot.py
@@ -1,0 +1,271 @@
+"""Tests for #121 step 1 — StepStateSnapshot + diff helpers."""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from mantis_agent.gym.step_snapshot import (
+    StepStateSnapshot,
+    _hash_dict,
+    capture,
+    diff,
+)
+
+
+# ── _hash_dict ──────────────────────────────────────────────────────────
+
+
+def test_hash_dict_empty_returns_sentinel() -> None:
+    assert _hash_dict(None) == "empty"
+    assert _hash_dict({}) == "empty"
+
+
+def test_hash_dict_stable_across_calls() -> None:
+    a = _hash_dict({"k": "v", "n": 1})
+    b = _hash_dict({"k": "v", "n": 1})
+    assert a == b
+
+
+def test_hash_dict_order_independent() -> None:
+    a = _hash_dict({"a": 1, "b": 2})
+    b = _hash_dict({"b": 2, "a": 1})
+    assert a == b
+
+
+def test_hash_dict_differs_on_value_change() -> None:
+    a = _hash_dict({"k": "old"})
+    b = _hash_dict({"k": "new"})
+    assert a != b
+
+
+def test_hash_dict_handles_non_json_safely() -> None:
+    """Anything that JSON can't serialize should fall through to a repr-based
+    digest rather than raise."""
+
+    class _Weird:
+        pass
+
+    h = _hash_dict({"obj": _Weird()})
+    assert isinstance(h, str)
+    assert len(h) == 12
+
+
+# ── StepStateSnapshot ──────────────────────────────────────────────────
+
+
+def test_snapshot_is_frozen() -> None:
+    snap = StepStateSnapshot()
+    with pytest.raises(FrozenInstanceError):
+        snap.url = "https://x.test"  # type: ignore[misc]
+
+
+def test_snapshot_to_dict_is_serializable() -> None:
+    snap = StepStateSnapshot(
+        url="https://x.test", current_page=2, viewport_stage=1,
+        focused_input_signature="sig123", scroll_signature="scr456",
+        last_extracted_url="https://x.test/a",
+        extracted_titles_count=5, seen_urls_count=10,
+    )
+    d = snap.to_dict()
+    assert d["url"] == "https://x.test"
+    assert d["current_page"] == 2
+    assert d["focused_input_sig"] == "sig123"
+
+
+def test_snapshot_defaults_compare_equal() -> None:
+    """Two no-state snapshots should be indistinguishable so the diff
+    against a fresh runner is empty."""
+    a = StepStateSnapshot()
+    b = StepStateSnapshot()
+    assert a == b
+
+
+# ── capture ─────────────────────────────────────────────────────────────
+
+
+class _FakeRunner:
+    def __init__(self, **attrs: object) -> None:
+        # Defaults match a freshly-init'd MicroPlanRunner.
+        self._last_known_url = ""
+        self._current_page = 1
+        self._viewport_stage = 0
+        self._scroll_state = {}
+        self._last_extracted = {}
+        self._extracted_titles = []
+        self._seen_urls = set()
+        self.env = type("E", (), {})()
+        for k, v in attrs.items():
+            setattr(self, k, v)
+
+
+def test_capture_neutral_runner_yields_default_snapshot() -> None:
+    runner = _FakeRunner()
+    snap = capture(runner)  # type: ignore[arg-type]
+    assert snap.url == ""
+    assert snap.current_page == 1
+    assert snap.viewport_stage == 0
+    assert snap.focused_input_signature == "empty"
+    assert snap.scroll_signature == "empty"
+
+
+def test_capture_reflects_runtime_state() -> None:
+    runner = _FakeRunner(
+        _last_known_url="https://x.test/p2",
+        _current_page=2,
+        _viewport_stage=1,
+        _scroll_state={"page_downs": 3, "context": "results"},
+        _last_extracted={"last_completed_url": "https://x.test/detail/1"},
+        _extracted_titles=["a", "b"],
+        _seen_urls={"u1", "u2", "u3"},
+    )
+    snap = capture(runner)  # type: ignore[arg-type]
+    assert snap.url == "https://x.test/p2"
+    assert snap.current_page == 2
+    assert snap.viewport_stage == 1
+    assert snap.scroll_signature != "empty"
+    assert snap.last_extracted_url == "https://x.test/detail/1"
+    assert snap.extracted_titles_count == 2
+    assert snap.seen_urls_count == 3
+
+
+def test_capture_reads_focused_input_when_env_exposes_it() -> None:
+    runner = _FakeRunner()
+    runner.env.last_focused_input = {"placeholder": "search", "empty": True}
+    snap = capture(runner)  # type: ignore[arg-type]
+    assert snap.focused_input_signature != "empty"
+
+
+def test_capture_handles_env_without_focused_input_attr() -> None:
+    """Adapters that don't expose last_focused_input must not crash."""
+    runner = _FakeRunner()
+    # Default env has no last_focused_input attribute.
+    snap = capture(runner)  # type: ignore[arg-type]
+    assert snap.focused_input_signature == "empty"
+
+
+# ── diff ─────────────────────────────────────────────────────────────────
+
+
+def test_diff_equal_snapshots_has_no_changes() -> None:
+    a = StepStateSnapshot(url="https://x.test", current_page=1)
+    b = StepStateSnapshot(url="https://x.test", current_page=1)
+    delta = diff(a, b)
+    assert delta.has_changes is False
+    assert delta.summary() == "no change"
+
+
+def test_diff_url_change_flagged() -> None:
+    a = StepStateSnapshot(url="https://x.test/p1")
+    b = StepStateSnapshot(url="https://x.test/p2")
+    delta = diff(a, b)
+    assert delta.url_changed is True
+    assert any("url:" in s for s in delta.changed_fields)
+
+
+def test_diff_page_advance_flagged() -> None:
+    a = StepStateSnapshot(current_page=1)
+    b = StepStateSnapshot(current_page=2)
+    delta = diff(a, b)
+    assert delta.page_changed is True
+
+
+def test_diff_focus_change_flagged_via_signature() -> None:
+    a = StepStateSnapshot(focused_input_signature="empty")
+    b = StepStateSnapshot(focused_input_signature="sigA")
+    delta = diff(a, b)
+    assert delta.focus_changed is True
+
+
+def test_diff_scroll_change_flagged_via_signature() -> None:
+    a = StepStateSnapshot(scroll_signature="empty")
+    b = StepStateSnapshot(scroll_signature="scr1")
+    delta = diff(a, b)
+    assert delta.scroll_changed is True
+
+
+def test_diff_viewport_advance_flagged() -> None:
+    a = StepStateSnapshot(viewport_stage=0)
+    b = StepStateSnapshot(viewport_stage=2)
+    delta = diff(a, b)
+    assert delta.viewport_changed is True
+
+
+def test_diff_extraction_added_only_when_after_has_url() -> None:
+    """The extracted-url change should fire only when ``after`` has a URL,
+    not on the inverse (clearing the field)."""
+    # Forward: empty → set  (extraction happened)
+    a = StepStateSnapshot(last_extracted_url="")
+    b = StepStateSnapshot(last_extracted_url="https://x.test/listing/1")
+    delta_fwd = diff(a, b)
+    assert delta_fwd.extraction_added is True
+
+    # Inverse: set → empty  (treated as no extraction added)
+    delta_rev = diff(b, a)
+    assert delta_rev.extraction_added is False
+
+
+def test_diff_seen_urls_increase_flagged() -> None:
+    a = StepStateSnapshot(seen_urls_count=5)
+    b = StepStateSnapshot(seen_urls_count=8)
+    delta = diff(a, b)
+    assert delta.new_urls_seen is True
+    assert any("seen_urls +3" in s for s in delta.changed_fields)
+
+
+def test_diff_seen_urls_decrease_not_flagged() -> None:
+    """Counters only flag forward progress — running the same step twice
+    should not produce a delta from a count drop (which shouldn't happen
+    anyway, but defensive)."""
+    a = StepStateSnapshot(seen_urls_count=8)
+    b = StepStateSnapshot(seen_urls_count=5)
+    delta = diff(a, b)
+    assert delta.new_urls_seen is False
+
+
+def test_diff_summary_combines_multiple_changes() -> None:
+    a = StepStateSnapshot(
+        url="https://x.test/p1", current_page=1, viewport_stage=0,
+    )
+    b = StepStateSnapshot(
+        url="https://x.test/p2", current_page=2, viewport_stage=1,
+    )
+    summary = diff(a, b).summary()
+    assert "url:" in summary
+    assert "page:" in summary
+    assert "viewport_stage:" in summary
+
+
+def test_diff_does_not_mutate_inputs() -> None:
+    """``diff()`` is pure — neither argument changes."""
+    a = StepStateSnapshot(url="https://x.test")
+    b = StepStateSnapshot(url="https://x.test/p2")
+    a_repr = repr(a)
+    b_repr = repr(b)
+    diff(a, b)
+    assert repr(a) == a_repr
+    assert repr(b) == b_repr
+
+
+# ── Worked example: the form-fill partial-success scenario ──────────────
+
+
+def test_form_fill_partial_success_diff_signals_focus_only() -> None:
+    """Scenario from #121 issue body: a form step that typed 3 of 5 fields.
+    The diff should show focus changed but URL did not — telling the
+    follow-on plan-aware reverse to NOT fire alt+left."""
+    before = StepStateSnapshot(
+        url="https://x.test/form",
+        focused_input_signature="empty",
+        scroll_signature="scr0",
+    )
+    after = StepStateSnapshot(
+        url="https://x.test/form",  # same — type didn't navigate
+        focused_input_signature="sig_field5",  # last typed field still focused
+        scroll_signature="scr0",
+    )
+    delta = diff(before, after)
+    assert delta.url_changed is False
+    assert delta.focus_changed is True
+    assert delta.has_changes is True


### PR DESCRIPTION
## Summary

#121 wants plan-aware reverse — replace the static `REVERSE_ACTIONS` keystroke map with diff-driven decisions so a form step that partially succeeded doesn't get its work destroyed by a blanket Escape + Alt+Left.

This PR lands the **observability** half: snapshot pre-step state, compute the post-step diff, log it. Behavior unchanged — the next PR in #121 uses the diff to drive `_reverse_step` decisions.

## What this lands

New module `mantis_agent.gym.step_snapshot`:

| Symbol | Purpose |
|---|---|
| `StepStateSnapshot` (frozen dataclass) | Thin view of runner state: `url`, `current_page`, `viewport_stage`, `focused_input_signature`, `scroll_signature`, `last_extracted_url`, `extracted_titles_count`, `seen_urls_count` |
| `capture(runner)` | Cheap (a few attribute reads + 2 SHA1s) snapshot |
| `diff(before, after) → StepDiff` | Pure function with one bool per changed dimension + a human-readable `changed_fields` list |

`MicroPlanRunner` integration: one pre-step `capture()` call before `_execute_step`, plus a new `_log_step_diff()` invoked after each step result.

## Why split #121 into two PRs

The current `_reverse_step` is so embedded in the recovery flow that changing its decision logic in one PR would be hard to review and risky to roll back. Logging the diff first lets us validate it on real traces before changing recovery behavior. The follow-on PR can then reference concrete diff examples in commit messages.

This is the same gradual-rollout pattern used for #120: schema landing → brain prompt → reward component, each in its own PR.

## Defensive design

- Snapshot is `frozen=True` so accidental mutation can't break diff equality
- `_hash_dict` falls through to `repr()` for non-JSON values rather than raising — observability never breaks runs
- `capture()` reads optional `env.last_focused_input` via `try/except` so envs without that attribute keep working
- `_log_step_diff` wraps the whole flow in a broad except — observability failures don't abort runs

## Test plan

- [x] 24 new unit tests covering: `_hash_dict` (empty / order-independent / non-JSON safety), snapshot frozen-ness + serializability + default equality, `capture` neutral-runner / runtime-state / focused-input presence + absence, `diff` equal / url / page / focus / scroll / viewport / extraction-added direction-asymmetry / seen-urls-increase-only / multi-change summary / pure-function input invariance, **the form-fill partial-success scenario from the issue body**
- [x] 110 new + extracted-module tests pass (snapshot, checkpoint, browser_state, cost_meter, tool_channel, listing_dedup, checkpoint_manager)
- [x] ruff clean
- [ ] CI on this PR

## #121 series progress

| Step | What | Status |
|---|---|---|
| **1** | **Snapshot + diff infrastructure (logs only)** | **this PR** |
| 2 | Wire diff into `_reverse_step` for plan-aware recovery | next |

🤖 Generated with [Claude Code](https://claude.com/claude-code)