### PR TITLE
feat(gym): wire diff into _reverse_step for plan-aware recovery (#121, step 2/2)

### DIFF
--- a/src/mantis_agent/gym/micro_runner.py
+++ b/src/mantis_agent/gym/micro_runner.py
@@ -135,6 +135,10 @@ class MicroPlanRunner:
         self._last_extracted: dict[str, Any] = {}
         self._opened_detail_in_new_tab: bool = False
         self._active_checkpoint_context: dict[str, Any] | None = None
+        # #121 step 2: snapshot of runner state taken right before
+        # _execute_step, used by _reverse_step to skip undo actions
+        # when the diff shows nothing meaningful changed.
+        self._pre_step_snapshot: step_snapshot.StepStateSnapshot | None = None
         self._final_status: str = "running"
         self.max_cost = max_cost
         self.max_time = max_time_minutes * 60
@@ -550,11 +554,11 @@ class MicroPlanRunner:
                 "listings_on_page": listings_on_page,
                 "step_index": step_index,
             }
-            # #121 step 1: capture pre-step state for plan-aware reverse.
-            # Currently observation-only — the diff lands in logs so we can
-            # validate it on real traces before changing recovery behavior
-            # in the follow-on PR.
+            # #121 step 1+2: capture pre-step state. Step 1 logged it for
+            # validation; step 2 stashes it on self so _reverse_step can
+            # use the diff to skip undo work that wasn't needed.
             pre_snapshot = step_snapshot.capture(self)
+            self._pre_step_snapshot = pre_snapshot
             try:
                 step_result = self._execute_step(effective_step, step_index)
             finally:
@@ -2628,17 +2632,28 @@ class MicroPlanRunner:
         return data, controls_clicked
 
     def _reverse_step(self, step: MicroIntent):
-        """Undo a failed step using predefined reverse actions."""
-        actions = REVERSE_ACTIONS.get(step.type, [])
+        """Undo a failed step. Uses the pre-step snapshot from #121 step 1
+        to skip undo actions when the diff shows nothing meaningful
+        actually changed — preserving partial form-fill progress instead
+        of blanket-firing Escape + Alt+Left.
 
-        # Use step-specific reverse if provided
-        if step.reverse:
-            # Parse "Press Escape then Alt+Left" into actions
-            if "escape" in step.reverse.lower():
-                actions = [("key_press", "Escape")] + actions
-            if "alt+left" in step.reverse.lower():
-                actions.append(("key_press", "alt+Left"))
-
+        Decision tree:
+          • No snapshot available (legacy callers / object.__new__):
+              fall back to the static REVERSE_ACTIONS map exactly as
+              before. Same behavior as pre-#121.
+          • URL did not change AND nothing else meaningful changed:
+              skip reverse entirely. Step "failed" but the page state
+              is identical to what we entered with — there is nothing
+              to undo.
+          • URL did not change AND focus changed AND no scroll/extract
+              progress: light-touch Escape only. Likely a stuck modal
+              or autocomplete dropdown — Alt+Left would dismiss the
+              underlying form.
+          • URL changed: keep the legacy plan (Escape then Alt+Left)
+              because we need to navigate back.
+          • Otherwise: legacy plan.
+        """
+        actions = self._plan_aware_reverse_actions(step)
         for action_type, keys in actions:
             try:
                 self.env.step(Action(
@@ -2648,5 +2663,80 @@ class MicroPlanRunner:
                 time.sleep(0.5)
             except Exception:
                 pass
-
         logger.info(f"  [reverse] {len(actions)} actions applied")
+
+    def _plan_aware_reverse_actions(
+        self, step: MicroIntent
+    ) -> list[tuple[str, str]]:
+        """Decide which keystrokes to fire based on the pre/post-step diff.
+
+        Pure helper — easy to unit test. The runner calls this and then
+        executes whatever it returns.
+        """
+        # #121 step 2: use the diff when available to skip unneeded work.
+        pre = self._pre_step_snapshot
+        if pre is not None:
+            try:
+                post = step_snapshot.capture(self)
+                delta = step_snapshot.diff(pre, post)
+            except Exception as exc:  # noqa: BLE001 — telemetry never breaks runs
+                logger.debug("plan-aware reverse diff failed: %s", exc)
+                delta = None
+            if delta is not None:
+                decision = self._reverse_decision_from_diff(step, delta)
+                if decision is not None:
+                    logger.info(
+                        "  [reverse:plan-aware] %s — diff: %s",
+                        "skip" if not decision else f"{len(decision)} action(s)",
+                        delta.summary(),
+                    )
+                    return decision
+
+        # No snapshot or diff couldn't be computed — fall back to the
+        # pre-#121 static map. Identical behavior for legacy callers.
+        actions = list(REVERSE_ACTIONS.get(step.type, []))
+        if step.reverse:
+            if "escape" in step.reverse.lower():
+                actions = [("key_press", "Escape")] + actions
+            if "alt+left" in step.reverse.lower():
+                actions.append(("key_press", "alt+Left"))
+        return actions
+
+    @staticmethod
+    def _reverse_decision_from_diff(
+        step: MicroIntent,
+        delta: "step_snapshot.StepDiff",
+    ) -> list[tuple[str, str]] | None:
+        """Translate a step diff into reverse keystrokes, or None to mean
+        "no plan-aware decision applicable — use the legacy fallback".
+
+        Returning ``[]`` (empty list) means "skip reverse entirely" —
+        nothing visibly changed so there's nothing to undo.
+        """
+        # Type-specific overrides go first. The runner's own ``step.reverse``
+        # hint is preserved by the legacy fallback path; here we only
+        # short-circuit when the diff is informative enough to act safely.
+        if delta.url_changed:
+            # Navigation happened (intentionally or not). Going back is
+            # the safe undo regardless of step type.
+            return [("key_press", "alt+Left")]
+
+        if delta.extraction_added or delta.new_urls_seen:
+            # Forward progress was made even though the step was marked
+            # "failed". Reverting would destroy the work; skip.
+            return []
+
+        if not delta.has_changes:
+            # Identical state pre/post — nothing happened. No-op skip.
+            return []
+
+        if delta.focus_changed and not (
+            delta.scroll_changed or delta.viewport_changed or delta.page_changed
+        ):
+            # Likely a stuck modal / autocomplete / focused-but-empty input.
+            # Escape dismisses without dropping form context.
+            return [("key_press", "Escape")]
+
+        # Diff was non-trivial but doesn't match a clear pattern — let
+        # the legacy fallback handle it.
+        return None

--- a/tests/test_plan_aware_reverse.py
+++ b/tests/test_plan_aware_reverse.py
@@ -1,0 +1,189 @@
+"""Tests for #121 step 2 — plan-aware reverse decisions.
+
+We focus on the pure helper :meth:`MicroPlanRunner._reverse_decision_from_diff`
+plus an integration test of the higher-level dispatcher
+:meth:`MicroPlanRunner._plan_aware_reverse_actions`. The keystroke-firing
+:meth:`_reverse_step` itself is one ``self.env.step`` per decision — that
+path is exercised by the existing integration suite.
+"""
+
+from __future__ import annotations
+
+from mantis_agent.gym.micro_runner import MicroPlanRunner
+from mantis_agent.gym.step_snapshot import StepDiff, StepStateSnapshot
+from mantis_agent.plan_decomposer import MicroIntent
+
+
+def _step(step_type: str = "click", reverse: str = "") -> MicroIntent:
+    """Tiny MicroIntent constructor with the fields _reverse_step touches."""
+    return MicroIntent(
+        intent="click first listing",
+        type=step_type,
+        reverse=reverse,
+    )
+
+
+# ── _reverse_decision_from_diff ─────────────────────────────────────────
+
+
+def test_url_change_returns_alt_left() -> None:
+    delta = StepDiff(url_changed=True, changed_fields=["url: a → b"])
+    decision = MicroPlanRunner._reverse_decision_from_diff(_step("click"), delta)
+    assert decision == [("key_press", "alt+Left")]
+
+
+def test_extraction_added_skips_reverse() -> None:
+    """Forward progress was made — reverting would destroy work."""
+    delta = StepDiff(
+        extraction_added=True,
+        changed_fields=["last_extracted: https://x.test/a"],
+    )
+    assert MicroPlanRunner._reverse_decision_from_diff(_step("click"), delta) == []
+
+
+def test_new_urls_seen_skips_reverse() -> None:
+    """Even without an extracted-URL change, ``seen_urls +N`` means the
+    step actually discovered something."""
+    delta = StepDiff(new_urls_seen=True, changed_fields=["seen_urls +2"])
+    assert MicroPlanRunner._reverse_decision_from_diff(_step("click"), delta) == []
+
+
+def test_no_changes_skips_reverse() -> None:
+    delta = StepDiff()  # has_changes is False
+    assert MicroPlanRunner._reverse_decision_from_diff(_step("click"), delta) == []
+
+
+def test_focus_only_change_returns_escape_only() -> None:
+    """Modal trap pattern: focus moved (autocomplete opened) but URL,
+    scroll, page all unchanged. Escape dismisses without alt+left."""
+    delta = StepDiff(focus_changed=True, changed_fields=["focused_input"])
+    decision = MicroPlanRunner._reverse_decision_from_diff(_step("type"), delta)
+    assert decision == [("key_press", "Escape")]
+
+
+def test_focus_plus_scroll_falls_back_to_legacy() -> None:
+    """Mixed signal — diff is non-trivial but doesn't match a clean
+    pattern. Returning None tells the dispatcher to use the legacy map."""
+    delta = StepDiff(
+        focus_changed=True,
+        scroll_changed=True,
+        changed_fields=["focused_input", "scroll_state"],
+    )
+    assert MicroPlanRunner._reverse_decision_from_diff(_step("click"), delta) is None
+
+
+def test_viewport_change_alone_falls_back_to_legacy() -> None:
+    delta = StepDiff(viewport_changed=True, changed_fields=["viewport_stage: 0 → 1"])
+    assert MicroPlanRunner._reverse_decision_from_diff(_step("click"), delta) is None
+
+
+def test_page_change_alone_falls_back_to_legacy() -> None:
+    """Page advance without URL change shouldn't happen in normal flow,
+    but if it does the diff isn't conclusive — defer to legacy."""
+    delta = StepDiff(page_changed=True, changed_fields=["page: 1 → 2"])
+    assert MicroPlanRunner._reverse_decision_from_diff(_step("click"), delta) is None
+
+
+# ── _plan_aware_reverse_actions integration ─────────────────────────────
+
+
+def _bare_runner() -> MicroPlanRunner:
+    """Construct a MicroPlanRunner with just the attributes the reverse
+    flow touches. Avoids the heavy __init__."""
+    runner = MicroPlanRunner.__new__(MicroPlanRunner)
+    runner._pre_step_snapshot = None
+    runner._last_known_url = ""
+    runner._current_page = 1
+    runner._viewport_stage = 0
+    runner._scroll_state = {}
+    runner._last_extracted = {}
+    runner._extracted_titles = []
+    runner._seen_urls = set()
+    runner.env = type("E", (), {})()
+    return runner
+
+
+def test_no_snapshot_falls_back_to_legacy_map() -> None:
+    """Backward compat: callers that bypass __init__ (legacy or tests)
+    have no snapshot — the static REVERSE_ACTIONS map kicks in."""
+    runner = _bare_runner()
+    actions = runner._plan_aware_reverse_actions(_step("click"))
+    # Legacy click map: Escape then alt+Left.
+    assert actions == [("key_press", "Escape"), ("key_press", "alt+Left")]
+
+
+def test_no_snapshot_legacy_respects_step_reverse_hint() -> None:
+    runner = _bare_runner()
+    actions = runner._plan_aware_reverse_actions(_step("scroll", reverse="alt+left"))
+    # Scroll legacy: Home + alt+Left appended (per step.reverse hint).
+    assert ("key_press", "alt+Left") in actions
+
+
+def test_snapshot_with_url_change_uses_diff_decision() -> None:
+    runner = _bare_runner()
+    runner._pre_step_snapshot = StepStateSnapshot(url="https://x.test/p1")
+    runner._last_known_url = "https://x.test/p2"  # URL moved
+    actions = runner._plan_aware_reverse_actions(_step("click"))
+    assert actions == [("key_press", "alt+Left")]
+
+
+def test_snapshot_with_no_change_skips_reverse_entirely() -> None:
+    """Step "failed" but state is identical pre/post — nothing to undo."""
+    runner = _bare_runner()
+    runner._pre_step_snapshot = StepStateSnapshot(url="https://x.test/p")
+    runner._last_known_url = "https://x.test/p"  # same
+    actions = runner._plan_aware_reverse_actions(_step("click"))
+    assert actions == []
+
+
+def test_snapshot_with_extraction_added_preserves_work() -> None:
+    """The form-fill partial-success scenario from the issue body."""
+    runner = _bare_runner()
+    runner._pre_step_snapshot = StepStateSnapshot(
+        url="https://x.test/form", last_extracted_url="",
+    )
+    runner._last_known_url = "https://x.test/form"  # same URL
+    runner._last_extracted = {"last_completed_url": "https://x.test/form/done"}
+    actions = runner._plan_aware_reverse_actions(_step("click"))
+    # Forward progress detected — preserve it, skip reverse.
+    assert actions == []
+
+
+def test_snapshot_focus_only_returns_escape_only() -> None:
+    """Modal trap: only focus changed; Escape, no alt+Left."""
+    runner = _bare_runner()
+    pre = StepStateSnapshot(
+        url="https://x.test/f",
+        focused_input_signature="empty",
+    )
+    runner._pre_step_snapshot = pre
+    runner._last_known_url = "https://x.test/f"  # same
+    runner.env.last_focused_input = {"placeholder": "field5", "empty": True}
+    actions = runner._plan_aware_reverse_actions(_step("type"))
+    assert actions == [("key_press", "Escape")]
+
+
+def test_snapshot_capture_failure_falls_back_to_legacy(monkeypatch) -> None:
+    """If post-step capture explodes, the dispatcher must not crash —
+    it falls back to the legacy map."""
+    runner = _bare_runner()
+    runner._pre_step_snapshot = StepStateSnapshot()
+    # Force capture() to raise.
+    import mantis_agent.gym.step_snapshot as mod
+    monkeypatch.setattr(mod, "capture", lambda r: (_ for _ in ()).throw(RuntimeError("boom")))
+    actions = runner._plan_aware_reverse_actions(_step("click"))
+    # Legacy click map is still applied.
+    assert actions == [("key_press", "Escape"), ("key_press", "alt+Left")]
+
+
+def test_snapshot_diff_falls_back_when_decision_is_none() -> None:
+    """A non-trivial but ambiguous diff (focus + scroll changed)
+    should drop to the legacy map."""
+    runner = _bare_runner()
+    pre = StepStateSnapshot(focused_input_signature="empty", scroll_signature="empty")
+    runner._pre_step_snapshot = pre
+    runner.env.last_focused_input = {"placeholder": "f"}
+    runner._scroll_state = {"page_downs": 2}
+    actions = runner._plan_aware_reverse_actions(_step("click"))
+    # Legacy click map.
+    assert actions == [("key_press", "Escape"), ("key_press", "alt+Left")]


### PR DESCRIPTION
## Summary

Final step of #121. Replaces the blanket `REVERSE_ACTIONS` keystroke map with diff-driven decisions so a form step that partially succeeded (typed 3 of 5 fields) doesn't get its work destroyed by Escape + Alt+Left.

Step 1 (#140) landed the snapshot/diff infrastructure as observability. This PR uses it to drive recovery.

## Decision tree

When the pre-step snapshot is available:

| Diff signal | Reverse action |
|---|---|
| URL changed | `alt+Left` (undo navigation) |
| Forward progress (extraction or new URLs) | `[]` (skip — preserve work) |
| No state change | `[]` (skip — nothing to undo) |
| Focus changed only | `Escape` (modal trap) |
| Otherwise | fall back to legacy map |

When no snapshot is available (legacy callers, `object.__new__` tests), behavior is **identical to pre-#121** — the static `REVERSE_ACTIONS` map plus `step.reverse` hint parsing kicks in unchanged.

## Plumbing

- `self._pre_step_snapshot` stashed before each `_execute_step` call. The diff was already captured for logs in step 1; now it persists to reverse time.
- `_reverse_step` now delegates action selection to `_plan_aware_reverse_actions`; the keystroke-firing loop is unchanged.
- `_reverse_decision_from_diff` is a pure `@staticmethod` helper — testable without runner construction.

## Defensive

- Post-step `capture()` failures fall through to the legacy map rather than crashing the run
- An ambiguous diff (e.g. focus + scroll both changed) returns `None` from the decision helper, signaling "use legacy fallback" — the plan-aware path only commits when the diff matches a clean pattern

## Test plan

- [x] 16 new unit tests covering every branch of the decision tree (url-changed / extraction-added / new-urls / no-changes / focus-only / focus+scroll / viewport / page) plus the integration dispatcher (no-snapshot fallback, snapshot-with-each-decision-branch, capture failure resilience, ambiguous-diff legacy fallback, `step.reverse` hint preserved by legacy path)
- [x] ruff clean
- [ ] CI on this PR

## #121 series complete

| Step | What | Status |
|---|---|---|
| 1 | Snapshot + diff infrastructure (logs only) | ✅ #140 |
| **2** | **Diff-driven `_reverse_step` decisions** | **this PR** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)