### PR TITLE
feat(brain): BrainLadder — primary/fallback wrapper for graceful escalation (#124)

### DIFF
--- a/src/mantis_agent/brain_ladder.py
+++ b/src/mantis_agent/brain_ladder.py
@@ -1,0 +1,208 @@
+"""Brain fallback ladder (#124).
+
+Wraps a primary + fallback brain and exposes the ``Brain`` protocol.
+The runner / harness calls :meth:`force_fallback` after N retries on the
+same step; the next :meth:`think` call routes to the fallback brain
+instead of the primary, with cost attribution attached.
+
+This is the *mechanism*; the *policy* (when to escalate) lives where the
+context is — in the runner or test harness, where action history,
+retry counters, and step state all live. Keeping the ladder dumb means:
+
+* tests can drive escalation deterministically without simulating runner state
+* operators can wire any escalation policy without changing this module
+
+Usage::
+
+    from mantis_agent.brain_ladder import BrainLadder
+    from mantis_agent.brain_protocol import resolve_brain
+
+    ladder = BrainLadder(
+        primary=resolve_brain("holo3"),
+        fallback=resolve_brain("claude"),
+    )
+    runner = MicroPlanRunner(brain=ladder, ...)
+
+    # Inside the runner's retry loop, after detecting a stuck step:
+    if step_retry_counts[step_index] >= 2:
+        ladder.force_fallback()
+
+    # Optionally reset between steps:
+    ladder.reset()
+
+The wrapped :class:`InferenceResult` gets a ``brain_used`` attribute
+(``"primary"`` or ``"fallback"``) so the cost meter can attribute the
+call. Brains that don't carry that field on their result class get one
+attached via ``setattr`` — non-invasive.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from PIL import Image
+
+    from .actions import Action
+    from .brain_protocol import Brain
+
+logger = logging.getLogger(__name__)
+
+
+# Public attribute name set on every InferenceResult that goes through
+# the ladder. Lets the cost meter / dashboards count primary vs fallback
+# calls without needing to subclass each brain's InferenceResult.
+BRAIN_USED_ATTR: str = "brain_used"
+
+
+@dataclass
+class LadderAttempt:
+    """One think() call through the ladder. Carries which brain handled
+    it so callers can dashboard the escalation distribution."""
+
+    brain_used: str  # "primary" | "fallback"
+    duration: float
+
+
+class BrainLadder:
+    """Ladder of two brains. Routes to primary by default; the caller
+    flips a flag to escalate to the fallback for one or more think()
+    calls.
+
+    The wrapper is stateful (the ``_use_fallback`` flag survives across
+    think() calls) but the underlying brains are stateless w.r.t. each
+    other — escalating doesn't reset the fallback brain or share any
+    context between them.
+    """
+
+    def __init__(
+        self,
+        primary: "Brain",
+        fallback: "Brain",
+        *,
+        sticky_fallback: bool = False,
+    ) -> None:
+        """Args:
+            primary: The default brain.
+            fallback: Used when ``force_fallback()`` was called since the
+                last :meth:`reset`.
+            sticky_fallback: If True, once :meth:`force_fallback` is
+                called the ladder stays on the fallback brain until
+                :meth:`reset`. If False (default), the fallback is used
+                for exactly one think() call and the ladder reverts to
+                the primary on the next call. The runner's policy
+                decides which behavior is right per workflow — sticky
+                makes sense after a hard escalation; one-shot makes
+                sense for surgical interventions.
+        """
+        self.primary = primary
+        self.fallback = fallback
+        self.sticky_fallback = sticky_fallback
+        self._use_fallback = False
+        self.attempts: list[LadderAttempt] = []
+
+    # ── Brain protocol ─────────────────────────────────────────────────
+
+    def load(self) -> None:
+        """Load both brains. Each ``load()`` is documented as idempotent
+        on the protocol so calling them eagerly is safe — operators get
+        fast-fail config errors from either side at startup, not after
+        the first escalation."""
+        self.primary.load()
+        try:
+            self.fallback.load()
+        except Exception as exc:  # noqa: BLE001 — fallback can be lazy
+            logger.warning(
+                "BrainLadder fallback failed to load (will retry on first use): %s",
+                exc,
+            )
+
+    def think(
+        self,
+        frames: "list[Image.Image]",
+        task: str,
+        action_history: "list[Action] | None" = None,
+        screen_size: tuple[int, int] = (1920, 1080),
+    ) -> Any:
+        import time as _time
+
+        if self._use_fallback:
+            brain = self.fallback
+            brain_used = "fallback"
+        else:
+            brain = self.primary
+            brain_used = "primary"
+
+        t0 = _time.monotonic()
+        try:
+            result = brain.think(
+                frames=frames,
+                task=task,
+                action_history=action_history,
+                screen_size=screen_size,
+            )
+        finally:
+            self.attempts.append(
+                LadderAttempt(
+                    brain_used=brain_used,
+                    duration=_time.monotonic() - t0,
+                )
+            )
+            # One-shot fallback: after this think(), revert to primary.
+            # Sticky fallback: stay on fallback until reset().
+            if self._use_fallback and not self.sticky_fallback:
+                self._use_fallback = False
+
+        # Annotate the result so cost-attribution sees which brain ran.
+        # ``setattr`` is non-invasive — works on dataclasses, dicts,
+        # SimpleNamespace, anything attribute-settable. If the result is
+        # immutable (frozen dataclass), the attribute set will raise; we
+        # swallow that since attribution is observability, not contract.
+        try:
+            setattr(result, BRAIN_USED_ATTR, brain_used)
+        except (AttributeError, TypeError):
+            logger.debug(
+                "BrainLadder could not annotate result with brain_used "
+                "(immutable type?); cost attribution will rely on .attempts",
+            )
+        return result
+
+    # ── Escalation control ─────────────────────────────────────────────
+
+    def force_fallback(self) -> None:
+        """Route the *next* think() call to the fallback brain.
+
+        Idempotent — calling twice has the same effect as once. Effect
+        clears either after one think() call (default) or on
+        :meth:`reset` (when ``sticky_fallback=True``).
+        """
+        self._use_fallback = True
+
+    def reset(self) -> None:
+        """Drop the fallback flag (and forget the attempt log if you
+        want a fresh per-step view — call :meth:`reset_attempts` for
+        that)."""
+        self._use_fallback = False
+
+    def reset_attempts(self) -> None:
+        """Clear the attempt log. Independent from :meth:`reset` so
+        callers can keep the fallback flag while wiping observability
+        state, or vice versa."""
+        self.attempts.clear()
+
+    # ── Diagnostics ────────────────────────────────────────────────────
+
+    @property
+    def is_using_fallback(self) -> bool:
+        return self._use_fallback
+
+    def primary_calls(self) -> int:
+        return sum(1 for a in self.attempts if a.brain_used == "primary")
+
+    def fallback_calls(self) -> int:
+        return sum(1 for a in self.attempts if a.brain_used == "fallback")
+
+
+__all__ = ["BrainLadder", "LadderAttempt", "BRAIN_USED_ATTR"]

--- a/tests/test_brain_ladder.py
+++ b/tests/test_brain_ladder.py
@@ -1,0 +1,239 @@
+"""Tests for #124 — BrainLadder primary/fallback wrapper."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from mantis_agent.actions import Action, ActionType
+from mantis_agent.brain_ladder import BRAIN_USED_ATTR, BrainLadder, LadderAttempt
+
+
+# ── Fakes ───────────────────────────────────────────────────────────────
+
+
+@dataclass
+class _FakeResult:
+    action: Action
+    raw_output: str = ""
+    thinking: str = ""
+
+
+class _FakeBrain:
+    """Records every think() call so tests can assert routing."""
+
+    def __init__(self, name: str, raises: bool = False) -> None:
+        self.name = name
+        self.calls: list[dict] = []
+        self.loaded = False
+        self.raises = raises
+
+    def load(self) -> None:
+        if self.raises:
+            raise RuntimeError(f"{self.name} load failed")
+        self.loaded = True
+
+    def think(
+        self,
+        frames: Any = None,
+        task: str = "",
+        action_history: Any = None,
+        screen_size: tuple[int, int] = (1920, 1080),
+    ) -> _FakeResult:
+        self.calls.append(
+            {"task": task, "action_history": action_history, "screen_size": screen_size}
+        )
+        return _FakeResult(
+            action=Action(ActionType.CLICK, {"x": 1, "y": 1}),
+            raw_output=f"from-{self.name}",
+        )
+
+
+# ── Default routing ─────────────────────────────────────────────────────
+
+
+def test_default_routes_to_primary() -> None:
+    p, f = _FakeBrain("primary"), _FakeBrain("fallback")
+    ladder = BrainLadder(primary=p, fallback=f)
+    ladder.think(frames=[], task="test")
+    assert len(p.calls) == 1
+    assert len(f.calls) == 0
+
+
+def test_force_fallback_routes_next_call_to_fallback() -> None:
+    p, f = _FakeBrain("primary"), _FakeBrain("fallback")
+    ladder = BrainLadder(primary=p, fallback=f)
+    ladder.force_fallback()
+    ladder.think(frames=[], task="test")
+    assert len(p.calls) == 0
+    assert len(f.calls) == 1
+
+
+def test_force_fallback_is_idempotent() -> None:
+    p, f = _FakeBrain("primary"), _FakeBrain("fallback")
+    ladder = BrainLadder(primary=p, fallback=f)
+    ladder.force_fallback()
+    ladder.force_fallback()
+    ladder.think(frames=[], task="test")
+    assert len(f.calls) == 1
+
+
+# ── One-shot vs sticky behavior ─────────────────────────────────────────
+
+
+def test_one_shot_fallback_reverts_after_single_call() -> None:
+    """Default behavior: fallback is used for exactly one think() call."""
+    p, f = _FakeBrain("primary"), _FakeBrain("fallback")
+    ladder = BrainLadder(primary=p, fallback=f)
+    ladder.force_fallback()
+    ladder.think(frames=[], task="first")   # → fallback
+    ladder.think(frames=[], task="second")  # → primary again
+    ladder.think(frames=[], task="third")   # → primary
+    assert len(p.calls) == 2
+    assert len(f.calls) == 1
+
+
+def test_sticky_fallback_stays_until_reset() -> None:
+    p, f = _FakeBrain("primary"), _FakeBrain("fallback")
+    ladder = BrainLadder(primary=p, fallback=f, sticky_fallback=True)
+    ladder.force_fallback()
+    ladder.think(frames=[], task="first")
+    ladder.think(frames=[], task="second")
+    ladder.think(frames=[], task="third")
+    assert len(p.calls) == 0
+    assert len(f.calls) == 3
+    ladder.reset()
+    ladder.think(frames=[], task="fourth")
+    assert len(p.calls) == 1
+
+
+def test_reset_drops_fallback_flag() -> None:
+    p, f = _FakeBrain("primary"), _FakeBrain("fallback")
+    ladder = BrainLadder(primary=p, fallback=f, sticky_fallback=True)
+    ladder.force_fallback()
+    assert ladder.is_using_fallback is True
+    ladder.reset()
+    assert ladder.is_using_fallback is False
+
+
+# ── Attribution ─────────────────────────────────────────────────────────
+
+
+def test_result_carries_brain_used_primary() -> None:
+    p, f = _FakeBrain("primary"), _FakeBrain("fallback")
+    ladder = BrainLadder(primary=p, fallback=f)
+    result = ladder.think(frames=[], task="test")
+    assert getattr(result, BRAIN_USED_ATTR) == "primary"
+
+
+def test_result_carries_brain_used_fallback() -> None:
+    p, f = _FakeBrain("primary"), _FakeBrain("fallback")
+    ladder = BrainLadder(primary=p, fallback=f)
+    ladder.force_fallback()
+    result = ladder.think(frames=[], task="test")
+    assert getattr(result, BRAIN_USED_ATTR) == "fallback"
+
+
+def test_attempts_log_records_each_call() -> None:
+    p, f = _FakeBrain("primary"), _FakeBrain("fallback")
+    ladder = BrainLadder(primary=p, fallback=f)
+    ladder.think(frames=[], task="a")
+    ladder.force_fallback()
+    ladder.think(frames=[], task="b")
+    ladder.think(frames=[], task="c")  # back to primary
+    assert len(ladder.attempts) == 3
+    assert [a.brain_used for a in ladder.attempts] == ["primary", "fallback", "primary"]
+
+
+def test_attempts_durations_are_non_negative() -> None:
+    p, f = _FakeBrain("primary"), _FakeBrain("fallback")
+    ladder = BrainLadder(primary=p, fallback=f)
+    ladder.think(frames=[], task="a")
+    ladder.think(frames=[], task="b")
+    for a in ladder.attempts:
+        assert isinstance(a, LadderAttempt)
+        assert a.duration >= 0.0
+
+
+def test_primary_and_fallback_call_counts() -> None:
+    p, f = _FakeBrain("primary"), _FakeBrain("fallback")
+    ladder = BrainLadder(primary=p, fallback=f, sticky_fallback=True)
+    ladder.think(frames=[], task="a")
+    ladder.force_fallback()
+    ladder.think(frames=[], task="b")
+    ladder.think(frames=[], task="c")
+    assert ladder.primary_calls() == 1
+    assert ladder.fallback_calls() == 2
+
+
+def test_reset_attempts_clears_log_only() -> None:
+    p, f = _FakeBrain("primary"), _FakeBrain("fallback")
+    ladder = BrainLadder(primary=p, fallback=f, sticky_fallback=True)
+    ladder.force_fallback()
+    ladder.think(frames=[], task="a")
+    assert len(ladder.attempts) == 1
+    ladder.reset_attempts()
+    assert len(ladder.attempts) == 0
+    # Fallback flag unchanged.
+    assert ladder.is_using_fallback is True
+
+
+# ── load() behavior ─────────────────────────────────────────────────────
+
+
+def test_load_initializes_both_brains() -> None:
+    p, f = _FakeBrain("primary"), _FakeBrain("fallback")
+    ladder = BrainLadder(primary=p, fallback=f)
+    ladder.load()
+    assert p.loaded is True
+    assert f.loaded is True
+
+
+def test_load_swallows_fallback_load_failure() -> None:
+    """The fallback may need lazy init (e.g. requires network on first
+    call). A load failure shouldn't block primary use."""
+    p = _FakeBrain("primary")
+    f = _FakeBrain("fallback", raises=True)
+    ladder = BrainLadder(primary=p, fallback=f)
+    # Should NOT raise.
+    ladder.load()
+    assert p.loaded is True
+
+
+def test_load_propagates_primary_failure() -> None:
+    """A primary load failure is fatal — no point continuing."""
+    p = _FakeBrain("primary", raises=True)
+    f = _FakeBrain("fallback")
+    ladder = BrainLadder(primary=p, fallback=f)
+    with pytest.raises(RuntimeError, match="primary"):
+        ladder.load()
+
+
+# ── Brain protocol conformance ──────────────────────────────────────────
+
+
+def test_brain_ladder_satisfies_brain_protocol() -> None:
+    from mantis_agent.brain_protocol import Brain
+
+    p, f = _FakeBrain("primary"), _FakeBrain("fallback")
+    ladder = BrainLadder(primary=p, fallback=f)
+    assert isinstance(ladder, Brain)
+
+
+def test_think_passes_through_args_unmodified() -> None:
+    """The ladder is transparent — it must not transform frames / task /
+    action_history / screen_size on the way through."""
+    p, f = _FakeBrain("primary"), _FakeBrain("fallback")
+    ladder = BrainLadder(primary=p, fallback=f)
+    history = [Action(ActionType.CLICK, {"x": 0, "y": 0})]
+    ladder.think(
+        frames=["frame_marker"],
+        task="MY TASK",
+        action_history=history,
+        screen_size=(800, 600),
+    )
+    assert p.calls[0]["task"] == "MY TASK"
+    assert p.calls[0]["action_history"] is history
+    assert p.calls[0]["screen_size"] == (800, 600)


### PR DESCRIPTION
## Summary

Mantis already deploys 5 brains (Holo3, Claude, OpenCUA, Gemma4, llama.cpp) but the runner is hard-bound to one. When a step persistently fails on the primary brain, there's no clean way to fall back without re-running the whole task.

`BrainLadder` wraps a primary + fallback brain and exposes the existing `Brain` protocol. The runner / harness drives the *policy* (when to escalate); the ladder is dumb mechanism.

## Why keep it dumb

- Tests can drive escalation deterministically without simulating runner state
- Operators can wire any escalation policy without changing this module
- Production wiring (per-step retry counter → escalate) is a separate concern that depends on per-workflow tuning

## API

```python
ladder = BrainLadder(
    primary=resolve_brain("holo3"),
    fallback=resolve_brain("claude"),
    sticky_fallback=False,  # default: one-shot fallback
)
runner = MicroPlanRunner(brain=ladder, ...)

# In retry loop after detecting stuck step:
if step_retry_counts[step_index] >= 2:
    ladder.force_fallback()
```

## One-shot vs sticky

| Mode | Behavior | When to use |
|---|---|---|
| `sticky_fallback=False` (default) | Fallback for one think() call only | Surgical intervention on a single failed step |
| `sticky_fallback=True` | Stays on fallback until `reset()` | Hard escalation after repeated failures |

## Cost attribution

Every result through `ladder.think()` gets a `brain_used` attribute set (`"primary"` or `"fallback"`) via `setattr` — non-invasive, works on dataclasses / dicts / SimpleNamespace alike. The cost meter can read this without subclassing each brain's InferenceResult.

For frozen-dataclass results that reject `setattr`, the ladder swallows the error — attribution falls back to the `.attempts` log (`primary_calls()` / `fallback_calls()`).

## Test plan

- [x] 17 unit tests covering: default routing to primary, `force_fallback` routes one call, idempotent `force_fallback`, one-shot revert vs sticky persistence, `reset` clears flag, `brain_used` attribution (primary + fallback), attempts log structure + duration non-negativity, `primary_calls` / `fallback_calls` counts, `reset_attempts` independence from `reset`, `load` eager-init both, fallback-load-failure swallowed, primary-load-failure propagated, **Brain-protocol conformance via `isinstance`**, `think` args pass through unmodified
- [x] 57 brain-adjacent tests pass (`brain_protocol`, `form_intents`, `no_orphan_submodules`)
- [x] ruff clean
- [ ] CI on this PR

## What's deliberately *not* in this PR

- **Runner integration.** The ladder is drop-in usable from any caller that constructs a brain — host adapters and tests can wrap directly with no `MicroPlanRunner` change. Production wiring would need a per-step retry-counter policy; better as its own focused PR after this baseline ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)