### PR TITLE
feat(speculation): primitive for overlapping brain.think with action settle (#118, step 1/2)

### DIFF
--- a/src/mantis_agent/speculation.py
+++ b/src/mantis_agent/speculation.py
@@ -1,0 +1,245 @@
+"""Speculative brain inference primitive (#118, step 1).
+
+Currently, the runner's perception → reasoning → action cycle is fully
+serial: action.execute() → settle_time → frames captured → brain.think().
+For click/type-heavy paths the brain is idle during the entire settle
+window, even though the streamer keeps producing frames it could already
+reason about.
+
+This module ships the **building block** for overlap: a :class:`Speculation`
+wrapping a `brain.think()` call started before the action settles, with
+a :meth:`is_valid` check the runner can use to decide between trusting
+the speculative output and discarding it.
+
+Validation strategy: a perceptual hash distance check between the frame
+the speculation started with and the frame after settle. If they're
+"close enough" (default: equal — the conservative choice) the
+speculation is valid. The runner can tune the threshold per workflow.
+
+Pure infrastructure — does not touch the runner. A follow-on PR wires
+this into the GymRunner / MicroPlanRunner loops with explicit opt-in
+config so a regression on the OSWorld 83% path is reviewable in
+isolation.
+"""
+
+from __future__ import annotations
+
+import logging
+from concurrent.futures import Future, ThreadPoolExecutor
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Callable
+
+from .loop_detector import phash_64
+
+if TYPE_CHECKING:
+    from PIL import Image
+
+logger = logging.getLogger(__name__)
+
+
+# Module-level thread pool. We use a single shared pool across all live
+# Speculation instances to bound concurrency at the process level rather
+# than per-runner. Default of 2 workers is enough for the agent's serial
+# step pattern — speculative + actual think() never overlap by more
+# than one cycle.
+_DEFAULT_WORKERS: int = 2
+_executor: ThreadPoolExecutor | None = None
+
+
+def _get_executor() -> ThreadPoolExecutor:
+    """Lazy-init the shared executor. Idempotent."""
+    global _executor
+    if _executor is None:
+        _executor = ThreadPoolExecutor(
+            max_workers=_DEFAULT_WORKERS,
+            thread_name_prefix="speculation",
+        )
+    return _executor
+
+
+def shutdown_executor(wait: bool = True) -> None:
+    """Stop the speculation pool — for clean process shutdown / tests."""
+    global _executor
+    if _executor is not None:
+        _executor.shutdown(wait=wait)
+        _executor = None
+
+
+# ── Hamming distance over the dHash bits ────────────────────────────────
+
+
+def _hamming_distance(a: str, b: str) -> int:
+    """Compare two phash_64 hex digests by bit difference. Both arguments
+    must be the same length (17 hex chars in current dHash format). Empty
+    or unequal-length inputs return a large number so callers always treat
+    them as "different".
+    """
+    if not a or not b or len(a) != len(b):
+        return 64  # treat as max-distance
+    try:
+        ai = int(a, 16)
+        bi = int(b, 16)
+    except ValueError:
+        return 64
+    return bin(ai ^ bi).count("1")
+
+
+def frames_close_enough(
+    hash_at_start: str,
+    hash_after_settle: str,
+    *,
+    max_hamming_distance: int = 0,
+) -> bool:
+    """Default validation predicate.
+
+    With ``max_hamming_distance=0`` (the conservative default) only
+    pixel-equivalent frames pass — useful when the brain's reasoning is
+    very position-sensitive. Loosen the bound (e.g. 4-8) when the
+    workflow tolerates animations and minor rendering differences.
+    """
+    return _hamming_distance(hash_at_start, hash_after_settle) <= max_hamming_distance
+
+
+# ── Speculation handle ─────────────────────────────────────────────────
+
+
+@dataclass
+class _SpeculationStats:
+    """Per-speculation metrics for dashboards. Optional read by callers."""
+
+    submitted_at: float
+    frame_hash_at_start: str
+    valid_on_check: bool | None = None
+    distance_on_check: int | None = None
+
+
+class Speculation:
+    """Pending ``brain.think()`` call started before the action settled.
+
+    Lifecycle:
+      1. ``start(brain, frames, ...)`` — submit on a worker thread.
+      2. The runner executes the action and waits for settle.
+      3. After settle: ``is_valid(post_frame)`` decides if the speculative
+         result is usable.
+      4. ``result()`` blocks until the future completes (typically
+         already done by the time we check).
+      5. If invalidated: ``cancel()`` releases the worker.
+
+    The class is intentionally NOT a context manager — the runner needs
+    to make the validity decision asynchronously w.r.t. the speculative
+    call's lifecycle, and a `with` block would defeat that.
+    """
+
+    def __init__(
+        self,
+        future: Future,
+        frame_hash_at_start: str,
+        submitted_at: float,
+    ) -> None:
+        self._future = future
+        self._frame_hash_at_start = frame_hash_at_start
+        self.stats = _SpeculationStats(
+            submitted_at=submitted_at,
+            frame_hash_at_start=frame_hash_at_start,
+        )
+
+    # ── Validation ─────────────────────────────────────────────────────
+
+    def is_valid(
+        self,
+        post_settle_frame: "Image.Image",
+        validator: Callable[[str, str], bool] = frames_close_enough,
+    ) -> bool:
+        """Compare the post-settle frame to the frame the speculation
+        started with. Returns True when the validator says they're close
+        enough that the speculative result is still meaningful.
+
+        Records the distance + decision on ``self.stats`` for dashboards.
+        """
+        try:
+            after_hash = phash_64(post_settle_frame)
+        except Exception as exc:  # noqa: BLE001 — observability never breaks runs
+            logger.debug("speculation post-frame hash failed: %s", exc)
+            self.stats.valid_on_check = False
+            return False
+        ok = bool(validator(self._frame_hash_at_start, after_hash))
+        self.stats.valid_on_check = ok
+        self.stats.distance_on_check = _hamming_distance(
+            self._frame_hash_at_start, after_hash
+        )
+        return ok
+
+    # ── Result access ──────────────────────────────────────────────────
+
+    def result(self, timeout: float | None = None) -> Any:
+        """Block until the speculative think() call returns. ``timeout``
+        is in seconds; ``None`` means wait forever.
+
+        Re-raises any exception the underlying think() raised.
+        """
+        return self._future.result(timeout=timeout)
+
+    def done(self) -> bool:
+        return self._future.done()
+
+    def cancel(self) -> bool:
+        """Best-effort cancel. Returns whether cancellation succeeded —
+        a future already executing on a worker can't be canceled. Safe
+        to call regardless; returns False if the call already started.
+        """
+        return self._future.cancel()
+
+
+# ── Entry point ────────────────────────────────────────────────────────
+
+
+def start(
+    brain: Any,
+    frames: "list[Image.Image]",
+    task: str,
+    action_history: Any = None,
+    screen_size: tuple[int, int] = (1920, 1080),
+) -> Speculation:
+    """Kick off a speculative ``brain.think()`` call.
+
+    Computes the frame_hash up-front so :meth:`Speculation.is_valid`
+    can compare against the post-settle frame without re-hashing the
+    initial frame.
+
+    Returns a :class:`Speculation` handle the runner can poll. The
+    underlying call runs on the shared module thread pool; canceled
+    speculations release the worker as soon as `cancel()` is called
+    (only effective if the worker hasn't picked up the future yet).
+    """
+    import time
+
+    if not frames:
+        # No frames means the validator can't compare — degrade safely
+        # by returning a Speculation whose hash is empty so any
+        # post-frame check fails the validator.
+        last_frame_hash = ""
+    else:
+        last_frame_hash = phash_64(frames[-1])
+
+    submitted_at = time.monotonic()
+
+    future = _get_executor().submit(
+        brain.think,
+        frames=frames,
+        task=task,
+        action_history=action_history,
+        screen_size=screen_size,
+    )
+    return Speculation(
+        future=future,
+        frame_hash_at_start=last_frame_hash,
+        submitted_at=submitted_at,
+    )
+
+
+__all__ = [
+    "Speculation",
+    "frames_close_enough",
+    "shutdown_executor",
+    "start",
+]

--- a/tests/test_speculation.py
+++ b/tests/test_speculation.py
@@ -1,0 +1,257 @@
+"""Tests for #118 step 1 — speculative brain inference primitive."""
+
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+from PIL import Image
+
+from mantis_agent.actions import Action, ActionType
+from mantis_agent.speculation import (
+    Speculation,
+    _hamming_distance,
+    frames_close_enough,
+    shutdown_executor,
+    start,
+)
+
+
+# ── Fakes ───────────────────────────────────────────────────────────────
+
+
+@dataclass
+class _FakeResult:
+    action: Action
+
+
+class _BlockingBrain:
+    """Brain that blocks on a barrier so tests can inspect state mid-call."""
+
+    def __init__(self, sleep_s: float = 0.0) -> None:
+        self.calls: list[dict] = []
+        self.sleep_s = sleep_s
+        self.barrier = threading.Event()
+        self.result_value = _FakeResult(action=Action(ActionType.CLICK, {"x": 1, "y": 1}))
+
+    def think(self, **kw: Any) -> _FakeResult:
+        self.calls.append(kw)
+        if self.sleep_s:
+            time.sleep(self.sleep_s)
+        self.barrier.set()
+        return self.result_value
+
+
+class _RaisingBrain:
+    def think(self, **kw: Any) -> Any:
+        raise RuntimeError("brain exploded")
+
+
+def _img(color: tuple[int, int, int] = (128, 128, 128)) -> Image.Image:
+    return Image.new("RGB", (32, 32), color)
+
+
+def _white() -> Image.Image:
+    return _img((255, 255, 255))
+
+
+def _black() -> Image.Image:
+    return _img((0, 0, 0))
+
+
+@pytest.fixture(autouse=True)
+def _shutdown_after_each_test():
+    """Ensure the module-level executor is torn down between tests so
+    one test's pending futures can't bleed into another."""
+    yield
+    shutdown_executor(wait=True)
+
+
+# ── _hamming_distance ──────────────────────────────────────────────────
+
+
+def test_hamming_zero_for_equal_strings() -> None:
+    assert _hamming_distance("abcd1234", "abcd1234") == 0
+
+
+def test_hamming_counts_bit_differences() -> None:
+    # 0xff vs 0x00 → 8 bits differ.
+    assert _hamming_distance("ff", "00") == 8
+
+
+def test_hamming_max_for_empty_or_mismatched_lengths() -> None:
+    assert _hamming_distance("", "abc") == 64
+    assert _hamming_distance("abc", "abcd") == 64
+
+
+def test_hamming_max_for_invalid_hex() -> None:
+    """Defensive: a malformed hash (non-hex chars) returns max distance
+    rather than crashing the validator."""
+    assert _hamming_distance("zzzz", "abcd") == 64
+
+
+# ── frames_close_enough ─────────────────────────────────────────────────
+
+
+def test_frames_close_enough_zero_distance_passes() -> None:
+    assert frames_close_enough("abcdef0123456789a", "abcdef0123456789a") is True
+
+
+def test_frames_close_enough_default_strict() -> None:
+    """Default tolerance is 0 — any single-bit difference fails."""
+    h1 = "0" * 17
+    h2 = "1" + "0" * 16
+    assert frames_close_enough(h1, h2) is False
+
+
+def test_frames_close_enough_loosened_threshold() -> None:
+    h1 = "0" * 17
+    h2 = "f" + "0" * 16  # 4 bits different
+    assert frames_close_enough(h1, h2, max_hamming_distance=4) is True
+    assert frames_close_enough(h1, h2, max_hamming_distance=3) is False
+
+
+# ── Speculation lifecycle ──────────────────────────────────────────────
+
+
+def test_start_kicks_off_brain_think() -> None:
+    brain = _BlockingBrain(sleep_s=0.01)
+    spec = start(brain, frames=[_white()], task="test")
+    assert isinstance(spec, Speculation)
+    # Wait for the worker to actually invoke the brain.
+    brain.barrier.wait(timeout=2.0)
+    assert len(brain.calls) == 1
+
+
+def test_speculation_result_returns_brain_output() -> None:
+    brain = _BlockingBrain()
+    spec = start(brain, frames=[_white()], task="test")
+    result = spec.result(timeout=2.0)
+    assert result is brain.result_value
+
+
+def test_speculation_passes_args_through() -> None:
+    brain = _BlockingBrain()
+    history = [Action(ActionType.CLICK, {"x": 0, "y": 0})]
+    spec = start(
+        brain,
+        frames=[_white(), _black()],
+        task="MY TASK",
+        action_history=history,
+        screen_size=(800, 600),
+    )
+    spec.result(timeout=2.0)
+    call = brain.calls[0]
+    assert call["task"] == "MY TASK"
+    assert call["action_history"] is history
+    assert call["screen_size"] == (800, 600)
+    assert len(call["frames"]) == 2
+
+
+def test_speculation_propagates_brain_exceptions() -> None:
+    brain = _RaisingBrain()
+    spec = start(brain, frames=[_white()], task="test")
+    with pytest.raises(RuntimeError, match="brain exploded"):
+        spec.result(timeout=2.0)
+
+
+def test_speculation_done_reports_completion() -> None:
+    brain = _BlockingBrain()
+    spec = start(brain, frames=[_white()], task="test")
+    spec.result(timeout=2.0)
+    assert spec.done() is True
+
+
+# ── Validation ─────────────────────────────────────────────────────────
+
+
+def test_is_valid_true_for_identical_post_frame() -> None:
+    brain = _BlockingBrain()
+    img = _white()
+    spec = start(brain, frames=[img], task="test")
+    spec.result(timeout=2.0)  # ensure the call completed
+    # Same image → same dHash → valid.
+    assert spec.is_valid(img.copy()) is True
+    assert spec.stats.valid_on_check is True
+
+
+def test_is_valid_false_for_different_post_frame() -> None:
+    brain = _BlockingBrain()
+    spec = start(brain, frames=[_white()], task="test")
+    spec.result(timeout=2.0)
+    assert spec.is_valid(_black()) is False
+    assert spec.stats.valid_on_check is False
+
+
+def test_is_valid_records_distance() -> None:
+    brain = _BlockingBrain()
+    spec = start(brain, frames=[_white()], task="test")
+    spec.result(timeout=2.0)
+    spec.is_valid(_black())
+    assert spec.stats.distance_on_check is not None
+    assert spec.stats.distance_on_check > 0
+
+
+def test_is_valid_with_custom_validator() -> None:
+    """Custom validator: always-true predicate makes any post-frame valid."""
+    brain = _BlockingBrain()
+    spec = start(brain, frames=[_white()], task="test")
+    spec.result(timeout=2.0)
+    assert spec.is_valid(_black(), validator=lambda a, b: True) is True
+
+
+def test_is_valid_handles_corrupt_frame_safely() -> None:
+    """A frame that can't be hashed (e.g. None) must not crash is_valid."""
+    brain = _BlockingBrain()
+    spec = start(brain, frames=[_white()], task="test")
+    spec.result(timeout=2.0)
+    # Pass a non-image; phash_64 should fail and is_valid should return False.
+    assert spec.is_valid(None) is False  # type: ignore[arg-type]
+
+
+# ── Empty frames ────────────────────────────────────────────────────────
+
+
+def test_start_with_empty_frames_falls_back_safely() -> None:
+    """No frames means the speculation can't validate later — but
+    starting it shouldn't raise. The validator will fail on any post
+    frame so the runner discards correctly."""
+    brain = _BlockingBrain()
+    spec = start(brain, frames=[], task="test")
+    spec.result(timeout=2.0)
+    assert spec.is_valid(_white()) is False
+
+
+# ── Stats ──────────────────────────────────────────────────────────────
+
+
+def test_stats_records_submitted_at() -> None:
+    brain = _BlockingBrain()
+    before = time.monotonic()
+    spec = start(brain, frames=[_white()], task="test")
+    after = time.monotonic()
+    assert before <= spec.stats.submitted_at <= after
+
+
+def test_stats_records_frame_hash_at_start() -> None:
+    brain = _BlockingBrain()
+    spec = start(brain, frames=[_white()], task="test")
+    assert spec.stats.frame_hash_at_start != ""
+    # 17 hex chars — matches loop_detector.phash_64 format.
+    assert len(spec.stats.frame_hash_at_start) == 17
+
+
+# ── Cancellation ────────────────────────────────────────────────────────
+
+
+def test_cancel_returns_bool() -> None:
+    """Cancel returns whether cancellation succeeded. We don't assert the
+    value because the worker may have already started; we just verify the
+    method works without error."""
+    brain = _BlockingBrain()
+    spec = start(brain, frames=[_white()], task="test")
+    out = spec.cancel()
+    assert isinstance(out, bool)


### PR DESCRIPTION
## Summary

#118 wants to overlap `brain.think()` with `executor.execute()` + settle so the brain isn't idle during the action's settle window. The integration needs care — wrong validation lets stale speculative results drive the next action and could regress the OSWorld 83% score path.

This PR ships the **building block**: a `Speculation` class that wraps a concurrent `brain.think()` call with a frame-hash validity check. Pure infrastructure — no runner integration, no behavior change.

## API surface

```python
from mantis_agent import speculation

# Just before action.execute() + settle:
spec = speculation.start(brain, frames, task, action_history, screen_size)

# Action runs, frames captured during settle...

# After settle:
if spec.is_valid(post_settle_frame, validator=speculation.frames_close_enough):
    result = spec.result(timeout=2.0)        # already done — instant
else:
    spec.cancel()
    result = brain.think(...)                # synchronous fallback
```

## Defensive design

- Empty frames list → speculation with `frame_hash=""` → validator always fails → safe "treat as invalid" semantics, no crash
- Hash-of-corrupt-frame inside `is_valid` is caught and reported invalid — observability never breaks runs
- Mismatched-length / non-hex hashes return max distance (64) so the validator never silently treats them as equal

## Concurrency model

A shared module-level `ThreadPoolExecutor` (default 2 workers) bounds concurrency at the process level. The agent's serial step pattern means speculative + actual `think()` never overlap by more than one cycle, so 2 workers is sufficient.

## Test plan

- [x] 21 unit tests covering: Hamming distance correctness (zero / bit-count / mismatched-length / invalid-hex), `frames_close_enough` strict default + loosened threshold, lifecycle (start kicks off think, result returns brain output, args pass-through, exception propagation, done reporting), validation (identical / different / custom validator / corrupt frame / records distance + decision on stats), empty-frames safe degradation, stats (`submitted_at` + `frame_hash_at_start` present), `cancel` return type
- [x] 42 new + adjacent tests pass (`speculation`, `loop_detector`, `brain_protocol`)
- [x] ruff clean
- [ ] CI on this PR

## What's deliberately *not* in this PR

- **Runner integration.** Step 2 will wire this into the `GymRunner` / `MicroPlanRunner` loops behind an opt-in flag so any OSWorld regression is reviewable in isolation from the primitive.

## #118 series progress

| Step | What | Status |
|---|---|---|
| **1** | **`Speculation` primitive** | **this PR** |
| 2 | Runner integration behind opt-in flag | next |

🤖 Generated with [Claude Code](https://claude.com/claude-code)