### PR TITLE
feat(brain): SpeculativeBrain — drop-in wrapper for overlapping think() (#118, step 2/2)

### DIFF
--- a/src/mantis_agent/speculative_brain.py
+++ b/src/mantis_agent/speculative_brain.py
@@ -1,0 +1,229 @@
+"""Drop-in Brain wrapper that overlaps think() with the action settle window (#118, step 2).
+
+Each call to ``SpeculativeBrain.think(frames, ...)`` follows this protocol:
+
+  1. If there's a pending speculation from the previous call AND the
+     ``frames[-1]`` we just received matches the frame the speculation
+     started with (per :func:`speculation.frames_close_enough`), the
+     speculative result is consumed — saves the entire synchronous
+     ``think()`` round-trip.
+  2. Otherwise, fall through to a synchronous ``inner_brain.think()``.
+  3. Either way, kick off a *new* speculation using the just-received
+     frames so the *next* call has something to consume.
+
+The bet is that, for many steps, the screen between two consecutive
+``think()`` calls stays equivalent — either the action was a visual
+no-op (e.g. typing into a focused field), or the page had already
+settled by the time the previous call returned. When that bet wins,
+the runner skips a serial blocking round-trip on the brain.
+
+This is **opt-in** — wrap a brain to enable it, leave it bare for the
+old serial behavior. The wrapper satisfies the :class:`Brain` protocol
+so the runner doesn't change. Cost-attribution dashboards can read
+``result.brain_used`` (set to ``"speculative"`` or ``"synchronous"``)
+to track hit rates.
+
+Why this is safe:
+- Validation uses the same dHash as the loop detector. With strict
+  default tolerance (Hamming distance 0), only pixel-equivalent frames
+  pass — speculative results never drive an action when the screen
+  visibly changed.
+- Any speculation exception is treated as an invalidation — the
+  synchronous path always takes over.
+- A pending speculation is canceled on invalidation so workers free up.
+
+A future revision could loosen the validator (e.g. distance ≤ 4) when
+the workflow tolerates animations; that's per-deployment tuning, not
+a property of the wrapper.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any, Callable
+
+from . import speculation
+
+if TYPE_CHECKING:
+    from PIL import Image
+
+    from .actions import Action
+    from .brain_protocol import Brain
+
+logger = logging.getLogger(__name__)
+
+
+# Public attribute set on every InferenceResult that comes through the
+# wrapper. Lets cost-attribution see which path was taken without
+# subclassing each brain's result type.
+BRAIN_USED_ATTR: str = "brain_used"
+
+
+class SpeculativeBrain:
+    """Wraps a :class:`Brain` so consecutive ``think()`` calls can overlap.
+
+    Args:
+        inner: The underlying brain. Must expose the standard
+            :class:`Brain` protocol.
+        validator: Predicate ``(hash_at_start, hash_after_settle) -> bool``
+            that decides whether a pending speculation is still valid.
+            Defaults to :func:`speculation.frames_close_enough` with the
+            strict ``max_hamming_distance=0`` tolerance.
+
+    Attributes (read-only counters):
+        hits — speculative results that validated and were consumed
+        misses — pending speculations whose post-frame failed validation
+        synchronous_starts — calls that fell through to sync think()
+                             because no pending speculation existed
+                             (typically just the first call after a reset)
+    """
+
+    def __init__(
+        self,
+        inner: "Brain",
+        *,
+        validator: Callable[[str, str], bool] = speculation.frames_close_enough,
+    ) -> None:
+        self.inner = inner
+        self.validator = validator
+        self._pending: speculation.Speculation | None = None
+        self.hits: int = 0
+        self.misses: int = 0
+        self.synchronous_starts: int = 0
+
+    # ── Brain protocol ─────────────────────────────────────────────────
+
+    def load(self) -> None:
+        """Defer entirely to the wrapped brain — no extra setup needed."""
+        self.inner.load()
+
+    def think(
+        self,
+        frames: "list[Image.Image]",
+        task: str,
+        action_history: "list[Action] | None" = None,
+        screen_size: tuple[int, int] = (1920, 1080),
+    ) -> Any:
+        """Either consume a validated speculation or fall through to a
+        synchronous ``inner.think()``. In both cases, kick off a new
+        speculation against ``frames`` for the next call to consume.
+        """
+        result, brain_used = self._consume_pending(frames, task, action_history, screen_size)
+
+        # Annotate result with attribution. Wrapped brains may return
+        # frozen dataclasses or arbitrary types; setattr failures fall
+        # through to the counters for observability.
+        try:
+            setattr(result, BRAIN_USED_ATTR, brain_used)
+        except (AttributeError, TypeError):
+            logger.debug(
+                "SpeculativeBrain could not annotate result with brain_used "
+                "(immutable type?); attribution will rely on counters",
+            )
+
+        # Kick off the next speculation. Even when the previous one was
+        # consumed, we want a new one queued for the *next* call.
+        self._pending = self._launch_next(frames, task, action_history, screen_size)
+        return result
+
+    # ── Internals ──────────────────────────────────────────────────────
+
+    def _consume_pending(
+        self,
+        frames: "list[Image.Image]",
+        task: str,
+        action_history: "list[Action] | None",
+        screen_size: tuple[int, int],
+    ) -> tuple[Any, str]:
+        """Try to consume a pending speculation. Returns ``(result, brain_used)``."""
+        pending = self._pending
+        self._pending = None  # we either consume it or discard it; either way clear
+
+        if pending is None:
+            # No prior speculation queued — first call after reset.
+            self.synchronous_starts += 1
+            return self._call_sync(frames, task, action_history, screen_size), "synchronous"
+
+        if not frames:
+            # Nothing to validate against — discard speculation and go sync.
+            pending.cancel()
+            self.misses += 1
+            return self._call_sync(frames, task, action_history, screen_size), "synchronous"
+
+        try:
+            valid = pending.is_valid(frames[-1], validator=self.validator)
+        except Exception as exc:  # noqa: BLE001 — observability never breaks runs
+            logger.debug("speculation validation failed: %s — falling through to sync", exc)
+            valid = False
+
+        if not valid:
+            pending.cancel()
+            self.misses += 1
+            return self._call_sync(frames, task, action_history, screen_size), "synchronous"
+
+        # Validated — wait for the future and use its result. This
+        # typically returns immediately because the speculation has been
+        # running during the action's settle window.
+        try:
+            result = pending.result()
+        except Exception as exc:  # noqa: BLE001 — synchronous fallback on any error
+            logger.warning(
+                "speculative think() raised — falling back to synchronous: %s", exc,
+            )
+            self.misses += 1
+            return self._call_sync(frames, task, action_history, screen_size), "synchronous"
+
+        self.hits += 1
+        return result, "speculative"
+
+    def _call_sync(
+        self,
+        frames: "list[Image.Image]",
+        task: str,
+        action_history: "list[Action] | None",
+        screen_size: tuple[int, int],
+    ) -> Any:
+        return self.inner.think(
+            frames=frames,
+            task=task,
+            action_history=action_history,
+            screen_size=screen_size,
+        )
+
+    def _launch_next(
+        self,
+        frames: "list[Image.Image]",
+        task: str,
+        action_history: "list[Action] | None",
+        screen_size: tuple[int, int],
+    ) -> speculation.Speculation:
+        """Submit the next speculation. Frames are passed by reference;
+        callers should not mutate them while the speculation is in
+        flight (the runner doesn't, so this is safe by convention)."""
+        return speculation.start(
+            self.inner,
+            frames=frames,
+            task=task,
+            action_history=action_history,
+            screen_size=screen_size,
+        )
+
+    # ── Lifecycle ──────────────────────────────────────────────────────
+
+    def reset(self) -> None:
+        """Drop any pending speculation and zero the counters. Useful at
+        the start of a new task / episode so per-run hit rates are clean.
+        Doesn't tear down the underlying brain."""
+        if self._pending is not None:
+            self._pending.cancel()
+            self._pending = None
+        self.hits = 0
+        self.misses = 0
+        self.synchronous_starts = 0
+
+    def hit_rate(self) -> float:
+        total = self.hits + self.misses + self.synchronous_starts
+        return self.hits / total if total else 0.0
+
+
+__all__ = ["SpeculativeBrain", "BRAIN_USED_ATTR"]

--- a/tests/test_speculative_brain.py
+++ b/tests/test_speculative_brain.py
@@ -1,0 +1,292 @@
+"""Tests for #118 step 2 — SpeculativeBrain wrapper."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+from PIL import Image
+
+from mantis_agent.actions import Action, ActionType
+from mantis_agent.speculation import shutdown_executor
+from mantis_agent.speculative_brain import BRAIN_USED_ATTR, SpeculativeBrain
+
+
+# ── Fakes ───────────────────────────────────────────────────────────────
+
+
+@dataclass
+class _FakeResult:
+    action: Action
+    raw_output: str = ""
+    n: int = 0
+
+
+class _CountingBrain:
+    """Records every think() call and returns a numbered result."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+        self.loaded = False
+
+    def load(self) -> None:
+        self.loaded = True
+
+    def think(
+        self,
+        frames: Any = None,
+        task: str = "",
+        action_history: Any = None,
+        screen_size: tuple[int, int] = (1920, 1080),
+    ) -> _FakeResult:
+        n = len(self.calls)
+        self.calls.append({"task": task, "screen_size": screen_size})
+        return _FakeResult(
+            action=Action(ActionType.CLICK, {"x": 1, "y": 1}),
+            raw_output=f"call-{n}",
+            n=n,
+        )
+
+
+class _RaisingBrain:
+    """First call raises, subsequent calls return normally — lets us
+    exercise the speculative-exception → sync-fallback path."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def load(self) -> None: ...
+
+    def think(self, **kw: Any) -> _FakeResult:
+        self.calls += 1
+        if self.calls == 1:
+            raise RuntimeError("first call boom")
+        return _FakeResult(action=Action(ActionType.WAIT, {}))
+
+
+def _white() -> Image.Image:
+    return Image.new("RGB", (32, 32), (255, 255, 255))
+
+
+def _black() -> Image.Image:
+    return Image.new("RGB", (32, 32), (0, 0, 0))
+
+
+@pytest.fixture(autouse=True)
+def _shutdown_executor_after_test() -> None:
+    yield
+    shutdown_executor(wait=True)
+
+
+# ── First call always synchronous ───────────────────────────────────────
+
+
+def test_first_call_is_synchronous() -> None:
+    brain = _CountingBrain()
+    wrapper = SpeculativeBrain(brain)
+    result = wrapper.think(frames=[_white()], task="t")
+    # The visible call to inner.think — speculation was queued but not consumed.
+    assert getattr(result, BRAIN_USED_ATTR) == "synchronous"
+    assert wrapper.synchronous_starts == 1
+    assert wrapper.hits == 0
+
+
+# ── Validated speculation — hit ─────────────────────────────────────────
+
+
+def test_consecutive_calls_with_identical_frames_hit_speculation() -> None:
+    brain = _CountingBrain()
+    wrapper = SpeculativeBrain(brain)
+    # First call: synchronous, queues speculation against frames=[_white()].
+    wrapper.think(frames=[_white()], task="t")
+    # Second call: same frames → speculation valid → hit.
+    result = wrapper.think(frames=[_white()], task="t")
+    assert getattr(result, BRAIN_USED_ATTR) == "speculative"
+    assert wrapper.hits == 1
+
+
+def test_multiple_consecutive_hits_with_stable_screen() -> None:
+    brain = _CountingBrain()
+    wrapper = SpeculativeBrain(brain)
+    wrapper.think(frames=[_white()], task="t")  # sync 1
+    wrapper.think(frames=[_white()], task="t")  # spec hit 1
+    wrapper.think(frames=[_white()], task="t")  # spec hit 2
+    wrapper.think(frames=[_white()], task="t")  # spec hit 3
+    assert wrapper.hits == 3
+    assert wrapper.synchronous_starts == 1
+
+
+# ── Invalidated speculation — miss ──────────────────────────────────────
+
+
+def test_changed_frame_invalidates_speculation() -> None:
+    brain = _CountingBrain()
+    wrapper = SpeculativeBrain(brain)
+    wrapper.think(frames=[_white()], task="t")  # sync; queues against white
+    # Second call with a black frame — invalidated.
+    result = wrapper.think(frames=[_black()], task="t")
+    assert getattr(result, BRAIN_USED_ATTR) == "synchronous"
+    assert wrapper.misses == 1
+
+
+def test_empty_frames_treated_as_invalidation() -> None:
+    """Some loops can produce a frameless step (loading state). Speculation
+    can't validate, so fall through to sync — never crash."""
+    brain = _CountingBrain()
+    wrapper = SpeculativeBrain(brain)
+    wrapper.think(frames=[_white()], task="t")
+    result = wrapper.think(frames=[], task="t")
+    assert getattr(result, BRAIN_USED_ATTR) == "synchronous"
+    assert wrapper.misses == 1
+
+
+# ── Mixed pattern ───────────────────────────────────────────────────────
+
+
+def test_mixed_hit_miss_pattern() -> None:
+    brain = _CountingBrain()
+    wrapper = SpeculativeBrain(brain)
+    wrapper.think(frames=[_white()], task="t")  # sync (start)
+    wrapper.think(frames=[_white()], task="t")  # hit
+    wrapper.think(frames=[_black()], task="t")  # miss → sync
+    wrapper.think(frames=[_black()], task="t")  # hit (matches prior black)
+    assert wrapper.hits == 2
+    assert wrapper.misses == 1
+    assert wrapper.synchronous_starts == 1
+
+
+# ── hit_rate ────────────────────────────────────────────────────────────
+
+
+def test_hit_rate_initially_zero() -> None:
+    wrapper = SpeculativeBrain(_CountingBrain())
+    assert wrapper.hit_rate() == 0.0
+
+
+def test_hit_rate_reflects_counters() -> None:
+    brain = _CountingBrain()
+    wrapper = SpeculativeBrain(brain)
+    # 1 sync + 3 hits → 3/4 = 0.75
+    wrapper.think(frames=[_white()], task="t")
+    wrapper.think(frames=[_white()], task="t")
+    wrapper.think(frames=[_white()], task="t")
+    wrapper.think(frames=[_white()], task="t")
+    assert wrapper.hit_rate() == pytest.approx(3 / 4)
+
+
+# ── reset ───────────────────────────────────────────────────────────────
+
+
+def test_reset_clears_counters_and_pending() -> None:
+    brain = _CountingBrain()
+    wrapper = SpeculativeBrain(brain)
+    wrapper.think(frames=[_white()], task="t")
+    wrapper.think(frames=[_white()], task="t")
+    assert wrapper.hits >= 1
+    wrapper.reset()
+    assert wrapper.hits == 0
+    assert wrapper.misses == 0
+    assert wrapper.synchronous_starts == 0
+    # First post-reset call must be synchronous (no pending).
+    result = wrapper.think(frames=[_white()], task="t")
+    assert getattr(result, BRAIN_USED_ATTR) == "synchronous"
+
+
+# ── Brain protocol conformance ─────────────────────────────────────────
+
+
+def test_speculative_brain_satisfies_brain_protocol() -> None:
+    from mantis_agent.brain_protocol import Brain
+
+    wrapper = SpeculativeBrain(_CountingBrain())
+    assert isinstance(wrapper, Brain)
+
+
+def test_load_forwards_to_inner() -> None:
+    brain = _CountingBrain()
+    wrapper = SpeculativeBrain(brain)
+    wrapper.load()
+    assert brain.loaded is True
+
+
+def test_think_passes_args_through_to_inner() -> None:
+    brain = _CountingBrain()
+    wrapper = SpeculativeBrain(brain)
+    wrapper.think(
+        frames=[_white()],
+        task="MY TASK",
+        action_history=[Action(ActionType.CLICK, {"x": 0, "y": 0})],
+        screen_size=(800, 600),
+    )
+    # First call ran synchronously — args should propagate.
+    assert brain.calls[0]["task"] == "MY TASK"
+    assert brain.calls[0]["screen_size"] == (800, 600)
+
+
+# ── Exception handling ─────────────────────────────────────────────────
+
+
+def test_speculative_exception_falls_back_to_sync() -> None:
+    """If the speculative future raised, the wrapper must fall back to a
+    fresh synchronous call rather than re-raising."""
+    brain = _RaisingBrain()
+    wrapper = SpeculativeBrain(brain)
+    # First sync call raises — that propagates (caller's responsibility).
+    with pytest.raises(RuntimeError):
+        wrapper.think(frames=[_white()], task="t")
+    # The wrapper queued a speculation that will also raise. Next call
+    # should detect the speculative failure and fall through to a
+    # NEW sync call (which succeeds).
+    result = wrapper.think(frames=[_white()], task="t")
+    # We don't assert brain_used here — depending on timing the second
+    # call may be a sync-after-speculative-error or a sync-no-pending.
+    # What matters: it didn't raise.
+    assert result is not None
+
+
+# ── Custom validator ───────────────────────────────────────────────────
+
+
+def test_loosened_validator_accepts_close_frames() -> None:
+    """A validator that always says-true makes every post-frame valid —
+    useful for workflows that tolerate animations."""
+    brain = _CountingBrain()
+    wrapper = SpeculativeBrain(brain, validator=lambda a, b: True)
+    wrapper.think(frames=[_white()], task="t")  # sync
+    result = wrapper.think(frames=[_black()], task="t")  # would normally miss
+    assert getattr(result, BRAIN_USED_ATTR) == "speculative"
+
+
+# ── End-to-end: simulated session metrics ──────────────────────────────
+
+
+def test_realistic_session_hit_rate_for_stable_screen() -> None:
+    """Simulate a workflow where the screen stabilizes (page loaded; agent
+    is doing form fills with no visual delta between consecutive views).
+    Most calls after the first should be speculative hits."""
+    brain = _CountingBrain()
+    wrapper = SpeculativeBrain(brain)
+    # 11 calls, all on the same frame.
+    wrapper.think(frames=[_white()], task="t")  # sync start
+    for _ in range(10):
+        wrapper.think(frames=[_white()], task="t")
+    # 10 hits + 1 sync start = ~91% hit rate.
+    assert wrapper.hits == 10
+    assert wrapper.synchronous_starts == 1
+    assert wrapper.misses == 0
+    assert wrapper.hit_rate() > 0.9
+
+
+def test_alternating_frames_produces_mostly_misses() -> None:
+    """Sanity check the inverse: if every frame is different, every prior
+    speculation invalidates. The wrapper degrades to ~all sync calls."""
+    brain = _CountingBrain()
+    wrapper = SpeculativeBrain(brain)
+    # Pattern: white, black, white, black, ...
+    wrapper.think(frames=[_white()], task="t")  # sync start
+    for i in range(10):
+        wrapper.think(frames=[_white() if i % 2 else _black()], task="t")
+    # Every post-start call invalidates the prior speculation.
+    assert wrapper.hits == 0
+    assert wrapper.misses == 10


### PR DESCRIPTION
## Summary

Final step of #118. Builds on the `Speculation` primitive from step 1 (#143) to provide an opt-in `Brain` wrapper that overlaps consecutive `think()` calls, eliminating a synchronous round-trip when the screen between two calls stays equivalent.

## Wrapper semantics

| Scenario | Action | `brain_used` |
|---|---|---|
| First call (no pending speculation) | Synchronous `inner.think()`, queue spec | `"synchronous"` |
| Subsequent call, frames match prior spec | Use spec result | `"speculative"` |
| Subsequent call, frames differ | Cancel spec, synchronous fallback | `"synchronous"` |
| Empty frames | Cancel spec (can't validate), synchronous fallback | `"synchronous"` |
| Speculation raised an exception | Synchronous fallback | `"synchronous"` |

In every case a fresh speculation is queued against the just-received frames so the NEXT call has something to consume.

## Why this is safe

- Strict default validator (Hamming distance 0) means speculative results never drive an action when the screen visibly changed
- Any speculation exception is treated as an invalidation — the synchronous path always takes over
- Pending speculations are canceled on invalidation so workers free up
- **Opt-in only.** Existing callers wrap their brain only when they want the behavior; bare brains still produce identical serial flows

## API

```python
from mantis_agent.speculative_brain import SpeculativeBrain
from mantis_agent.brain_protocol import resolve_brain

wrapped = SpeculativeBrain(resolve_brain("holo3"))
runner = MicroPlanRunner(brain=wrapped, ...)

# Cost attribution
assert wrapped.hits + wrapped.misses + wrapped.synchronous_starts == total_calls
print(f"speculative hit rate: {wrapped.hit_rate():.1%}")
```

## Test plan

- [x] 16 unit tests covering: first-call always synchronous, multiple consecutive hits with stable screen, frame change → miss + sync, empty frames treated as invalidation, mixed hit/miss/sync pattern, `hit_rate` computation (initial + post-pattern), `reset` clears state, Brain protocol conformance via `isinstance`, `load` forwards to inner, args pass-through, **speculative-exception → sync-fallback**, loosened validator path, realistic session: >90% hit rate on stable screen, 0% hits on alternating frames
- [x] 62 brain-adjacent tests pass (`speculative_brain`, `speculation`, `brain_protocol`, `brain_ladder`)
- [x] ruff clean
- [ ] CI on this PR

## What's deliberately *not* in this PR

- **Runner integration via env var.** `SpeculativeBrain` is drop-in wherever a `Brain` is constructed — host adapters, `modal_cua_server`, `baseten_server` can all wrap their brain instance to opt into the behavior. Wiring it via `MANTIS_SPECULATIVE=1` is a separate small PR.
- **OSWorld benchmark validation.** The wrapper preserves correctness under strict validation; performance gains depend on workload and should be measured per deployment.

## #118 series complete

| Step | What | Status |
|---|---|---|
| 1 | `Speculation` primitive | ✅ #143 |
| **2** | **`SpeculativeBrain` wrapper** | **this PR** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)