### PR TITLE
feat(gym): StreamerGymEnv adapter for GymEnvironment ABC (#119, step 1/2)

### DIFF
--- a/src/mantis_agent/gym/streamer_env.py
+++ b/src/mantis_agent/gym/streamer_env.py
@@ -1,0 +1,190 @@
+"""StreamerGymEnv — bridge ScreenStreamer + ActionExecutor to the GymEnvironment ABC (#119, step 1).
+
+The repo currently runs two separate agent loops:
+  * ``StreamingCUA`` (in ``mantis_agent.agent``) drives a host desktop via
+    a continuous async :class:`~mantis_agent.streamer.ScreenStreamer` and
+    fires actions through :class:`~mantis_agent.executor.ActionExecutor`.
+  * ``GymRunner`` (in ``mantis_agent.gym.runner``) drives any
+    :class:`~mantis_agent.gym.base.GymEnvironment` and contains the
+    feature-rich logic (plan persistence, feedback strings, hybrid DOM
+    execution, grounding, loop detection, world-model trajectory schema).
+
+#119 wants one canonical loop. Instead of choosing between the two
+observation models, this PR ships a thin **adapter** that makes the
+streamer + executor pair satisfy the :class:`GymEnvironment` interface:
+
+  reset(task)   → capture one frame (no async loop needed for sync stepping)
+  step(action)  → executor.execute → settle → capture
+  close()       → no-op (the underlying objects are stateless across runs)
+  screen_size   → reported by the streamer's first capture
+
+This is **purely additive** — no existing caller starts using it
+automatically. The follow-on PR (#119 step 2) migrates ``StreamingCUA``
+to delegate to ``GymRunner`` via this adapter, with an opt-in flag so
+any OSWorld benchmark regression is reviewable in isolation.
+
+Why use ``ScreenStreamer.capture_once`` instead of the continuous async
+loop:
+  * The :class:`GymEnvironment` contract is sync (``step`` returns the
+    post-action observation directly). Async continuous capture buys
+    nothing in that mode — and would force the adapter into an event
+    loop the runner doesn't want.
+  * The streamer's ``capture_once()`` already does the right thing: pulls
+    one mss frame, applies the configured scale, returns immediately.
+  * Callers that want async continuous capture (i.e. ``StreamingCUA``)
+    keep using the streamer directly.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import TYPE_CHECKING, Any
+
+from ..actions import Action
+from .base import GymEnvironment, GymObservation, GymResult
+
+if TYPE_CHECKING:
+    from ..executor import ActionExecutor
+    from ..streamer import ScreenStreamer
+
+logger = logging.getLogger(__name__)
+
+
+# Default screen-size used before the first capture. Matches the rest of
+# the codebase (1920x1080 is the default everywhere a screen size is
+# guessed). Replaced by the actual size after reset()/step() runs the
+# first capture_once().
+_DEFAULT_SCREEN_SIZE: tuple[int, int] = (1920, 1080)
+
+
+class StreamerGymEnv(GymEnvironment):
+    """:class:`GymEnvironment` that drives a host desktop via a
+    :class:`ScreenStreamer` (capture) + :class:`ActionExecutor` (input).
+
+    Args:
+        streamer: A :class:`ScreenStreamer` for screenshot capture. If
+            ``None``, one is created with default settings on first use.
+            The continuous async loop is NOT started — only
+            :meth:`capture_once` is called.
+        executor: An :class:`ActionExecutor` for keyboard/mouse input.
+            If ``None``, one is created with default settings on first use.
+        settle_time: Seconds to sleep between executing an action and
+            capturing the post-action frame. Matches the existing
+            ``StreamingCUA.settle_time`` default of 0.5s.
+
+    All three constructor args are optional and default to lazy
+    construction so tests can pass mocks without dragging in the heavy
+    ``[local-cua]`` extras.
+    """
+
+    def __init__(
+        self,
+        streamer: "ScreenStreamer | None" = None,
+        executor: "ActionExecutor | None" = None,
+        settle_time: float = 0.5,
+    ) -> None:
+        self._streamer = streamer
+        self._executor = executor
+        self.settle_time = settle_time
+        # Set on the first capture_once(). Until then we report a
+        # sensible default so callers reading screen_size() pre-reset
+        # still get a valid tuple.
+        self._screen_size: tuple[int, int] = _DEFAULT_SCREEN_SIZE
+        self._closed = False
+
+    # ── Lazy construction ─────────────────────────────────────────────
+
+    def _get_streamer(self) -> "ScreenStreamer":
+        if self._streamer is None:
+            from ..streamer import ScreenStreamer
+            self._streamer = ScreenStreamer()
+        return self._streamer
+
+    def _get_executor(self) -> "ActionExecutor":
+        if self._executor is None:
+            from ..executor import ActionExecutor
+            self._executor = ActionExecutor()
+        return self._executor
+
+    # ── GymEnvironment protocol ────────────────────────────────────────
+
+    def reset(self, task: str, **kwargs: Any) -> GymObservation:
+        """Capture a single frame to represent the initial state. No
+        device-level reset happens — the host desktop persists between
+        runs and the caller is responsible for navigating to the right
+        starting URL / app.
+
+        ``kwargs`` is accepted for protocol compatibility (the runner
+        passes ``task_id``, ``start_url``, ``seed``) but ignored — the
+        host desktop has no concept of task IDs or seeded resets.
+        """
+        if self._closed:
+            raise RuntimeError("StreamerGymEnv is closed; create a new instance")
+        streamer = self._get_streamer()
+        # capture_once also updates self._screen_size as a side effect
+        # of mss.monitors[N] introspection.
+        frame = streamer.capture_once()
+        if streamer.screen_size != (0, 0):
+            self._screen_size = streamer.screen_size
+        # Sync the executor's clamp bounds with the actual screen.
+        try:
+            self._get_executor().screen_bounds = self._screen_size
+        except Exception as exc:  # noqa: BLE001 — observability, not contract
+            logger.debug("could not sync executor.screen_bounds: %s", exc)
+        return GymObservation(screenshot=frame.image)
+
+    def step(self, action: Action) -> GymResult:
+        """Execute an action, wait for settle, capture and return.
+
+        ``info`` is intentionally minimal in this adapter — the streamer
+        has no concept of URL / focused_input the way a Playwright env
+        does. Reward is always 0.0 (the runner injects per-task rewards
+        via :class:`RewardFn`); ``done`` is always False (only the brain's
+        ``ActionType.DONE`` terminates a host-desktop session).
+        """
+        if self._closed:
+            raise RuntimeError("StreamerGymEnv is closed; create a new instance")
+        execution = self._get_executor().execute(action)
+        if not execution.success and execution.error:
+            logger.warning("StreamerGymEnv action failed: %s", execution.error)
+        if self.settle_time > 0:
+            time.sleep(self.settle_time)
+        frame = self._get_streamer().capture_once()
+        info: dict[str, Any] = {
+            "execution_success": execution.success,
+            "execution_duration": execution.duration,
+        }
+        if execution.error:
+            info["execution_error"] = execution.error
+        return GymResult(
+            observation=GymObservation(screenshot=frame.image),
+            reward=0.0,
+            done=False,
+            info=info,
+        )
+
+    def close(self) -> None:
+        """Mark the env closed. ScreenStreamer / ActionExecutor have no
+        explicit teardown in their sync paths — they're idempotent objects.
+        ``close()`` is here to satisfy the ABC and to fail-fast on use-
+        after-close from buggy callers."""
+        self._closed = True
+
+    @property
+    def screen_size(self) -> tuple[int, int]:
+        return self._screen_size
+
+    # ── Convenience for #74 / observability ───────────────────────────
+
+    def screenshot(self):
+        """One-shot capture — used by the screenshot-cap observability
+        path in :class:`MicroPlanRunner`. Equivalent to ``step()`` minus
+        the action and settle, returning the PIL image directly.
+        """
+        if self._closed:
+            raise RuntimeError("StreamerGymEnv is closed; create a new instance")
+        return self._get_streamer().capture_once().image
+
+
+__all__ = ["StreamerGymEnv"]

--- a/tests/test_streamer_env.py
+++ b/tests/test_streamer_env.py
@@ -1,0 +1,290 @@
+"""Tests for #119 step 1 — StreamerGymEnv adapter."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+
+import pytest
+from PIL import Image
+
+from mantis_agent.actions import Action, ActionType
+from mantis_agent.gym.base import GymEnvironment, GymObservation, GymResult
+from mantis_agent.gym.streamer_env import StreamerGymEnv
+
+
+# ── Fakes (avoid pulling in mss / pyautogui from the [local-cua] extras) ──
+
+
+@dataclass
+class _FakeFrame:
+    image: Image.Image
+    timestamp: float = 0.0
+    index: int = 0
+
+
+class _FakeStreamer:
+    """Stand-in for :class:`ScreenStreamer` — produces deterministic frames."""
+
+    def __init__(self, viewport: tuple[int, int] = (320, 240)) -> None:
+        self._viewport = viewport
+        self.screen_size = viewport
+        self.captures = 0
+
+    def capture_once(self) -> _FakeFrame:
+        self.captures += 1
+        # Vary color so tests can distinguish frames if needed.
+        shade = (self.captures * 17) % 256
+        img = Image.new("RGB", self._viewport, (shade, shade, shade))
+        return _FakeFrame(image=img, timestamp=time.time(), index=self.captures - 1)
+
+
+class _FakeExecutor:
+    """Stand-in for :class:`ActionExecutor`."""
+
+    @dataclass
+    class _Result:
+        action: Action
+        success: bool = True
+        duration: float = 0.0
+        error: str = ""
+
+    def __init__(self, fail_with: str = "") -> None:
+        self.executed: list[Action] = []
+        self.screen_bounds: tuple[int, int] = (1920, 1080)
+        self._fail_with = fail_with
+
+    def execute(self, action: Action) -> "_FakeExecutor._Result":
+        self.executed.append(action)
+        if self._fail_with:
+            return self._Result(action=action, success=False, error=self._fail_with)
+        return self._Result(action=action, success=True, duration=0.001)
+
+
+def _env(streamer: _FakeStreamer | None = None, executor: _FakeExecutor | None = None,
+         settle_time: float = 0.0) -> StreamerGymEnv:
+    """Construct an env with sensible test defaults — settle_time=0
+    keeps tests fast."""
+    return StreamerGymEnv(
+        streamer=streamer or _FakeStreamer(),
+        executor=executor or _FakeExecutor(),
+        settle_time=settle_time,
+    )
+
+
+# ── Protocol conformance ────────────────────────────────────────────────
+
+
+def test_streamer_env_is_a_gym_environment() -> None:
+    env = _env()
+    assert isinstance(env, GymEnvironment)
+
+
+# ── reset() ─────────────────────────────────────────────────────────────
+
+
+def test_reset_returns_initial_observation() -> None:
+    env = _env()
+    obs = env.reset(task="any task")
+    assert isinstance(obs, GymObservation)
+    assert obs.screenshot is not None
+
+
+def test_reset_captures_one_frame() -> None:
+    streamer = _FakeStreamer()
+    env = _env(streamer=streamer)
+    env.reset(task="t")
+    assert streamer.captures == 1
+
+
+def test_reset_syncs_screen_size_from_streamer() -> None:
+    streamer = _FakeStreamer(viewport=(1280, 720))
+    env = _env(streamer=streamer)
+    env.reset(task="t")
+    assert env.screen_size == (1280, 720)
+
+
+def test_reset_propagates_screen_size_to_executor_bounds() -> None:
+    streamer = _FakeStreamer(viewport=(1280, 720))
+    executor = _FakeExecutor()
+    env = _env(streamer=streamer, executor=executor)
+    env.reset(task="t")
+    assert executor.screen_bounds == (1280, 720)
+
+
+def test_reset_accepts_kwargs_without_complaint() -> None:
+    """Protocol passes task_id / start_url / seed — adapter ignores them."""
+    env = _env()
+    env.reset(task="t", task_id="id", start_url="https://x", seed=42)
+
+
+def test_reset_after_close_raises() -> None:
+    env = _env()
+    env.close()
+    with pytest.raises(RuntimeError, match="closed"):
+        env.reset(task="t")
+
+
+# ── step() ──────────────────────────────────────────────────────────────
+
+
+def test_step_executes_the_action() -> None:
+    executor = _FakeExecutor()
+    env = _env(executor=executor)
+    env.reset(task="t")
+    action = Action(ActionType.CLICK, {"x": 50, "y": 50})
+    env.step(action)
+    assert executor.executed == [action]
+
+
+def test_step_returns_result_with_post_action_screenshot() -> None:
+    streamer = _FakeStreamer()
+    env = _env(streamer=streamer)
+    env.reset(task="t")
+    captures_after_reset = streamer.captures
+    result = env.step(Action(ActionType.CLICK, {"x": 1, "y": 1}))
+    assert isinstance(result, GymResult)
+    assert result.observation.screenshot is not None
+    # One capture per step on top of reset's capture.
+    assert streamer.captures == captures_after_reset + 1
+
+
+def test_step_records_execution_metadata_in_info() -> None:
+    env = _env()
+    env.reset(task="t")
+    result = env.step(Action(ActionType.WAIT, {"seconds": 0.1}))
+    assert result.info["execution_success"] is True
+    assert isinstance(result.info["execution_duration"], float)
+
+
+def test_step_records_execution_error_in_info() -> None:
+    executor = _FakeExecutor(fail_with="permission denied")
+    env = _env(executor=executor)
+    env.reset(task="t")
+    result = env.step(Action(ActionType.CLICK, {"x": 1, "y": 1}))
+    assert result.info["execution_success"] is False
+    assert result.info["execution_error"] == "permission denied"
+
+
+def test_step_reward_is_zero_done_is_false_by_default() -> None:
+    """The streamer adapter has no per-task reward signal — runner
+    injects rewards via RewardFn. Same for done — only ActionType.DONE
+    terminates a host-desktop session."""
+    env = _env()
+    env.reset(task="t")
+    result = env.step(Action(ActionType.CLICK, {"x": 1, "y": 1}))
+    assert result.reward == 0.0
+    assert result.done is False
+
+
+def test_step_settle_time_is_observed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A non-zero settle_time should result in a sleep between execute
+    and capture. We mock time.sleep to verify."""
+    sleep_calls: list[float] = []
+    import mantis_agent.gym.streamer_env as mod
+    monkeypatch.setattr(mod.time, "sleep", lambda s: sleep_calls.append(s))
+    env = StreamerGymEnv(
+        streamer=_FakeStreamer(), executor=_FakeExecutor(), settle_time=0.5,
+    )
+    env.reset(task="t")
+    env.step(Action(ActionType.CLICK, {"x": 1, "y": 1}))
+    assert 0.5 in sleep_calls
+
+
+def test_step_settle_time_zero_skips_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
+    sleep_calls: list[float] = []
+    import mantis_agent.gym.streamer_env as mod
+    monkeypatch.setattr(mod.time, "sleep", lambda s: sleep_calls.append(s))
+    env = _env(settle_time=0.0)
+    env.reset(task="t")
+    env.step(Action(ActionType.CLICK, {"x": 1, "y": 1}))
+    assert sleep_calls == []
+
+
+def test_step_after_close_raises() -> None:
+    env = _env()
+    env.reset(task="t")
+    env.close()
+    with pytest.raises(RuntimeError, match="closed"):
+        env.step(Action(ActionType.CLICK, {"x": 1, "y": 1}))
+
+
+# ── close() ─────────────────────────────────────────────────────────────
+
+
+def test_close_is_idempotent() -> None:
+    env = _env()
+    env.close()
+    env.close()  # Should not raise
+
+
+def test_close_marks_env_unusable() -> None:
+    env = _env()
+    env.reset(task="t")
+    env.close()
+    with pytest.raises(RuntimeError):
+        env.step(Action(ActionType.CLICK, {"x": 1, "y": 1}))
+
+
+# ── screen_size ─────────────────────────────────────────────────────────
+
+
+def test_screen_size_default_before_reset() -> None:
+    env = _env()
+    # Default reported before any capture happens. Sane fallback so
+    # callers that read screen_size pre-reset don't crash.
+    assert env.screen_size == (1920, 1080)
+
+
+def test_screen_size_updates_after_reset() -> None:
+    streamer = _FakeStreamer(viewport=(640, 480))
+    env = _env(streamer=streamer)
+    env.reset(task="t")
+    assert env.screen_size == (640, 480)
+
+
+# ── screenshot() (#74 observability convenience) ────────────────────────
+
+
+def test_screenshot_returns_pil_image() -> None:
+    env = _env()
+    env.reset(task="t")
+    img = env.screenshot()
+    assert isinstance(img, Image.Image)
+
+
+def test_screenshot_after_close_raises() -> None:
+    env = _env()
+    env.close()
+    with pytest.raises(RuntimeError):
+        env.screenshot()
+
+
+# ── Lazy construction (no [local-cua] extras needed) ────────────────────
+
+
+def test_default_construction_does_not_create_streamer_or_executor() -> None:
+    """Lazy: until reset/step/screenshot is called, no real streamer or
+    executor is constructed. Important so tests in the slim install
+    don't pull in mss/pyautogui."""
+    env = StreamerGymEnv()
+    # Internals are still None.
+    assert env._streamer is None
+    assert env._executor is None
+
+
+# ── Integration: drives a full episode ──────────────────────────────────
+
+
+def test_full_episode_drives_executor_and_collects_frames() -> None:
+    """Sanity: 5-action episode produces 5 distinct frames + 5 executions."""
+    streamer = _FakeStreamer()
+    executor = _FakeExecutor()
+    env = _env(streamer=streamer, executor=executor)
+    env.reset(task="t")
+    for i in range(5):
+        env.step(Action(ActionType.CLICK, {"x": i, "y": i}))
+    # 1 reset capture + 5 step captures = 6 captures.
+    assert streamer.captures == 6
+    # 5 executions (no execute() on reset).
+    assert len(executor.executed) == 5


### PR DESCRIPTION
## Summary

#119 wants one canonical agent loop. The repo currently runs two:

- **`StreamingCUA`** — drives a host desktop via `ScreenStreamer` + `ActionExecutor`
- **`GymRunner`** — drives any `GymEnvironment`, with all the feature-rich logic (plan persistence, feedback strings, hybrid DOM execution, grounding, loop detection, world-model trajectory schema, plan-aware reverse)

Instead of forcing a choice between the two observation models, this PR ships a thin adapter that makes the streamer + executor pair satisfy the `GymEnvironment` interface.

Pure additive — no existing caller starts using it automatically. Step 2 will migrate `StreamingCUA` to delegate to `GymRunner` via this adapter, with an opt-in flag so any OSWorld benchmark regression is reviewable in isolation.

## API mapping

| `GymEnvironment` method | `StreamerGymEnv` implementation |
|---|---|
| `reset(task)` | `capture_once()` to seed the buffer |
| `step(action)` | `executor.execute` → `time.sleep(settle_time)` → `capture_once()` |
| `close()` | Idempotent fail-fast guard |
| `screen_size` | Reported by the streamer's first capture |
| `screenshot()` (extra, for #74) | One-shot capture, used by `MicroPlanRunner` observability |

## Why `capture_once` over the continuous async loop

- `GymEnvironment` is sync; async continuous capture buys nothing and would force the adapter into an event loop the runner doesn't want
- `capture_once` already does the right thing: pulls one mss frame, applies scale, returns immediately
- Callers that want async continuous capture (`StreamingCUA` today) keep using the streamer directly

## Lazy construction

`ScreenStreamer` / `ActionExecutor` are constructed on first use rather than in `__init__`, so test fakes can substitute them without dragging in the `[local-cua]` extras (mss, pyautogui).

## Test plan

- [x] 23 unit tests covering: `GymEnvironment` protocol conformance via `isinstance`, reset returns initial obs / captures one frame / syncs `screen_size` from streamer / propagates to executor bounds / accepts `task_id+start_url+seed` kwargs / raises after close, step executes action / returns post-action screenshot / records execution metadata in info / records errors / reward=0 + done=False by default / `settle_time` observed via mocked `time.sleep` / settle=0 skips sleep / raises after close, close idempotent + fail-fast, `screen_size` default before reset + updates after reset, `screenshot()` returns PIL Image / raises after close, **lazy construction (no real streamer/executor until first use)**, full 5-step episode integration
- [x] ruff clean
- [ ] CI on this PR

## #119 series progress

| Step | What | Status |
|---|---|---|
| **1** | **`StreamerGymEnv` adapter** | **this PR** |
| 2 | Migrate `StreamingCUA` to delegate to `GymRunner` via the adapter | next |

🤖 Generated with [Claude Code](https://claude.com/claude-code)