### PR TITLE
fix(decomposer): tolerant JSON extraction for prose-wrapped responses (#112)

### DIFF
--- a/src/mantis_agent/plan_decomposer.py
+++ b/src/mantis_agent/plan_decomposer.py
@@ -39,6 +39,83 @@ from typing import Any, ClassVar
 logger = logging.getLogger(__name__)
 
 
+def _extract_json_payload(text: str) -> Any:
+    """Robustly extract the first JSON object or array from a model response.
+
+    Handles three response shapes Claude empirically produces:
+
+      1. Pure JSON:           ``{"shapes": [...], "steps": [...]}``
+      2. Code-fenced JSON:    ``\\`\\`\\`json\\n {...} \\n\\`\\`\\``` (with or without ``json`` tag)
+      3. Prose-wrapped JSON:  ``"Here's the decomposition:\\n{...}\\nLet me know..."``
+
+    Returns the parsed Python object (dict or list), or ``None`` when no
+    JSON could be found. The caller decides what to do with None — typically
+    raises with the offending text so operators can debug.
+
+    Issue #112 documented Claude's habit of prepending prose before the
+    JSON fence. The previous parser only handled fence-wrapped output;
+    this version finds the outermost balanced ``{...}`` or ``[...]``.
+    """
+    if not text:
+        return None
+    s = text.strip()
+
+    # Strip code fences if present.
+    if s.startswith("```"):
+        # Drop the opening fence (which may include a language tag).
+        s = s.split("\n", 1)[1] if "\n" in s else s[3:]
+    if s.endswith("```"):
+        s = s.rsplit("```", 1)[0]
+    s = s.strip()
+
+    # Fast path: the cleaned text is already valid JSON.
+    try:
+        return json.loads(s)
+    except (json.JSONDecodeError, ValueError):
+        pass
+
+    # Fallback: scan left-to-right for the first balanced JSON object OR
+    # array. Either kind is acceptable — we prefer whichever comes first
+    # because Claude's typical preamble is "Here's the result:\n\n{...}"
+    # and we want the JSON immediately following it. String-literal state
+    # tracking prevents braces inside intent strings from confusing the
+    # depth counter.
+    closer_for = {"{": "}", "[": "]"}
+    for start in range(len(s)):
+        opener = s[start]
+        if opener not in closer_for:
+            continue
+        closer = closer_for[opener]
+        depth = 0
+        in_str = False
+        escape = False
+        for i in range(start, len(s)):
+            ch = s[i]
+            if escape:
+                escape = False
+                continue
+            if ch == "\\" and in_str:
+                escape = True
+                continue
+            if ch == '"':
+                in_str = not in_str
+                continue
+            if in_str:
+                continue
+            if ch == opener:
+                depth += 1
+            elif ch == closer:
+                depth -= 1
+                if depth == 0:
+                    candidate = s[start : i + 1]
+                    try:
+                        return json.loads(candidate)
+                    except (json.JSONDecodeError, ValueError):
+                        # Balanced but not valid JSON — keep scanning.
+                        break
+    return None
+
+
 @dataclass
 class MicroIntent:
     """A single atomic instruction for the CUA executor."""
@@ -332,7 +409,14 @@ STEP TYPES:
                  (budget=6, params={"dropdown_label": "<dropdown name>",
                                     "option_label": "<option text>"})
 
-OUTPUT FORMAT — emit ONLY one valid JSON object with these top-level keys:
+OUTPUT FORMAT — emit ONE valid JSON object and nothing else.
+
+CRITICAL: do NOT include prose preamble ("Here's the decomposition:"),
+classification commentary ("I'll classify this as..."), epilogue
+("Let me know if..."), or markdown fences. The first character of your
+response MUST be `{` and the last MUST be `}`.
+
+Schema:
 
 {
   "shapes": ["listings" | "form" | "workflow" | "inspect", ...],
@@ -404,7 +488,7 @@ class PlanDecomposer:
             domain = m.group(1)
 
         # Check cache — include prompt version in hash to invalidate on schema changes
-        prompt_version = "v16_llm_shapes"  # Bump this when DECOMPOSE_PROMPT changes
+        prompt_version = "v17_strict_json"  # Bump this when DECOMPOSE_PROMPT changes
         plan_hash = hashlib.md5(f"{prompt_version}:{plan_text}".encode()).hexdigest()[:8]
         cache_path = (
             cache_path_template.replace("{hash}", plan_hash)
@@ -461,15 +545,18 @@ class PlanDecomposer:
                 text = block["text"].strip()
                 break
 
-        # Parse JSON
-        text = text.strip()
-        if text.startswith("```"):
-            text = text.split("\n", 1)[1]
-        if text.endswith("```"):
-            text = text.rsplit("```", 1)[0]
-        text = text.strip()
-
-        parsed = json.loads(text)
+        # Parse JSON — tolerant of:
+        #   • bare ```json / ``` fences (legacy)
+        #   • prose preamble before the JSON ("Here's the decomposition:")
+        #   • prose epilogue after the JSON
+        # Issue #112: Claude often prepends explanation text. Robustly find
+        # the outermost JSON object or array in the response.
+        parsed = _extract_json_payload(text)
+        if parsed is None:
+            raise RuntimeError(
+                f"Decomposer response did not contain parseable JSON. "
+                f"First 300 chars: {text[:300]!r}"
+            )
         # Two accepted response shapes:
         #   {"shapes": [...], "steps": [...]}  ← preferred (LLM classified)
         #   [...]                              ← legacy bare array

--- a/tests/test_decomposer_json_extraction.py
+++ b/tests/test_decomposer_json_extraction.py
@@ -1,0 +1,199 @@
+"""Tests for #112 — robust JSON extraction from Claude responses.
+
+The decomposer's earlier parser only handled clean responses or
+``\\`\\`\\`json``-fenced output. Claude empirically also produces:
+
+  • prose preamble: "Here's the decomposition: {...}"
+  • prose epilogue: "{...} Let me know if you need adjustments."
+  • mixed:          "I'll classify this plan as workflow.\\n\\n{...}"
+
+These tests verify the parser pulls the JSON out of all three shapes.
+Surfaced by the staffcrm rerun (run 20260503_110305_5287bc9c)
+where Claude prepended a classification sentence before the JSON
+object and the strict ``json.loads`` failed.
+"""
+
+from __future__ import annotations
+
+from mantis_agent.plan_decomposer import _extract_json_payload
+
+
+# ── Pure JSON (fast path) ───────────────────────────────────────────────
+
+
+def test_pure_json_object() -> None:
+    out = _extract_json_payload('{"shapes": ["form"], "steps": []}')
+    assert out == {"shapes": ["form"], "steps": []}
+
+
+def test_pure_json_array() -> None:
+    out = _extract_json_payload('[{"type": "navigate"}]')
+    assert out == [{"type": "navigate"}]
+
+
+def test_pure_json_with_surrounding_whitespace() -> None:
+    out = _extract_json_payload('  \n\n  {"a": 1}  \n  ')
+    assert out == {"a": 1}
+
+
+# ── Code fences ─────────────────────────────────────────────────────────
+
+
+def test_fenced_json_with_language_tag() -> None:
+    text = '```json\n{"shapes": ["form"], "steps": []}\n```'
+    assert _extract_json_payload(text) == {"shapes": ["form"], "steps": []}
+
+
+def test_fenced_json_without_language_tag() -> None:
+    text = '```\n{"shapes": ["form"]}\n```'
+    assert _extract_json_payload(text) == {"shapes": ["form"]}
+
+
+def test_fenced_json_array() -> None:
+    text = '```json\n[{"intent": "click"}]\n```'
+    assert _extract_json_payload(text) == [{"intent": "click"}]
+
+
+# ── Prose-wrapped JSON (the staffcrm rerun failure mode) ────────────────
+
+
+def test_prose_preamble_before_object() -> None:
+    text = (
+        "Here's the decomposition for the staffcrm plan:\n\n"
+        '{"shapes": ["workflow", "form"], "steps": [{"type": "navigate"}]}'
+    )
+    out = _extract_json_payload(text)
+    assert out == {"shapes": ["workflow", "form"], "steps": [{"type": "navigate"}]}
+
+
+def test_prose_epilogue_after_object() -> None:
+    text = (
+        '{"shapes": ["form"], "steps": []}\n\n'
+        "Let me know if you need any adjustments to the step types."
+    )
+    out = _extract_json_payload(text)
+    assert out == {"shapes": ["form"], "steps": []}
+
+
+def test_prose_both_sides() -> None:
+    text = (
+        "I'll classify this as a workflow plan:\n\n"
+        '{"shapes": ["workflow"], "steps": [{"intent": "go"}]}\n\n'
+        "Each step is atomic and within the budget."
+    )
+    out = _extract_json_payload(text)
+    assert out == {"shapes": ["workflow"], "steps": [{"intent": "go"}]}
+
+
+def test_prose_wrapped_array() -> None:
+    text = (
+        "Here are the steps:\n\n"
+        '[{"type": "navigate", "intent": "Go to login"}]'
+    )
+    out = _extract_json_payload(text)
+    assert out == [{"type": "navigate", "intent": "Go to login"}]
+
+
+# ── String-literal brace handling ───────────────────────────────────────
+
+
+def test_braces_inside_string_literals_dont_confuse_parser() -> None:
+    """The intent text might contain literal braces — make sure the
+    balanced-brace scanner doesn't get fooled."""
+    text = (
+        "Result:\n"
+        '{"steps": [{"intent": "Click \\"Update Lead\\" button"}]}'
+    )
+    out = _extract_json_payload(text)
+    assert out == {"steps": [{"intent": 'Click "Update Lead" button'}]}
+
+
+def test_escaped_quotes_in_string_literals() -> None:
+    text = '{"key": "value with \\"quotes\\" inside"}'
+    out = _extract_json_payload(text)
+    assert out == {"key": 'value with "quotes" inside'}
+
+
+# ── Failure modes ───────────────────────────────────────────────────────
+
+
+def test_returns_none_for_empty_input() -> None:
+    assert _extract_json_payload("") is None
+    assert _extract_json_payload("   \n\n  ") is None
+
+
+def test_returns_none_for_pure_prose() -> None:
+    assert _extract_json_payload(
+        "I'm sorry, I can't decompose this plan."
+    ) is None
+
+
+def test_returns_none_for_unbalanced_braces() -> None:
+    """Truly malformed JSON (no balanced object or array anywhere) should
+    fail cleanly, not raise."""
+    out = _extract_json_payload("Here is the start: { not closed and ( not closed")
+    assert out is None
+
+
+def test_unbalanced_outer_with_balanced_inner_returns_inner() -> None:
+    """Lenient on purpose: if Claude got cut off mid-response but a complete
+    inner array survived, surface what we have. The runtime parser will
+    raise with a useful message if the recovered fragment is the wrong
+    shape (e.g. shapes-only with no steps)."""
+    out = _extract_json_payload('Here is the start: {"shapes": ["form"]')
+    # Recovers the inner array even though the outer object was truncated.
+    assert out == ["form"]
+
+
+# ── Realistic Claude responses (regression fixtures) ────────────────────
+
+
+def test_realistic_response_with_shape_classification_preamble() -> None:
+    """The actual failure pattern from the staffcrm rerun. Claude often
+    explains its classification before emitting the JSON."""
+    text = """\
+The plan describes a multi-step CRM workflow with login + navigation +
+form-edit. I'll classify it as both `workflow` and `form` shapes.
+
+```json
+{
+  "shapes": ["form", "workflow"],
+  "steps": [
+    {"type": "navigate", "intent": "Go to login URL"}
+  ]
+}
+```
+
+This decomposition follows the workflow pattern."""
+    out = _extract_json_payload(text)
+    assert isinstance(out, dict)
+    assert out["shapes"] == ["form", "workflow"]
+    assert len(out["steps"]) == 1
+
+
+def test_realistic_response_legacy_array_with_preamble() -> None:
+    """Backward-compat: legacy bare-array response with prose preamble
+    still parses correctly."""
+    text = """\
+Here are the micro-intents for this plan:
+
+[
+  {"type": "navigate", "intent": "Go to login"},
+  {"type": "fill_field", "intent": "Enter username"}
+]
+"""
+    out = _extract_json_payload(text)
+    assert isinstance(out, list)
+    assert len(out) == 2
+
+
+def test_finds_first_balanced_object_when_multiple_present() -> None:
+    """If the response has multiple JSON-like blocks, take the first one
+    that parses (the canonical decomposition output)."""
+    text = (
+        "Maybe like this: {invalid json here}\n\n"
+        "Actually the right answer is:\n\n"
+        '{"shapes": ["form"]}'
+    )
+    out = _extract_json_payload(text)
+    assert out == {"shapes": ["form"]}


### PR DESCRIPTION
## Summary

The staffcrm rerun (run `20260503_110305_5287bc9c`) failed in 16s with `json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)`. Claude prepended a classification sentence before the JSON object and the strict `json.loads(text)` rejected the whole response. This is exactly the failure mode tracked in issue #112: "PlanDecomposer often prepends prose before the JSON fence."

The new four-shape prompt may have made it worse by inviting Claude to "explain" the classification before emitting it.

## Two fixes

### 1. Tolerant `_extract_json_payload` helper

Scans the response for the first balanced JSON object or array. Handles:
- Pure JSON (fast path)
- Code-fenced JSON (with or without language tag)
- Prose preamble: `"Here's the decomposition: {...}"`
- Prose epilogue: `"{...} Let me know if..."`
- Both: `"I'll classify this as workflow:\n\n{...}\n\nNote that..."`

String-literal state tracking prevents braces inside intent strings from confusing the depth counter. Returns `None` when no parseable JSON is present.

### 2. Tightened prompt

Explicit instruction: "do NOT include prose preamble / classification commentary / epilogue / markdown fences. First character MUST be `{`, last MUST be `}`."

Belt-and-suspenders — if Claude still slips up, the parser tolerates it; ideally Claude follows the rule and we never need the parser fallback.

## Test plan

- [x] 18 new unit tests covering: pure JSON / code-fenced variants, prose preamble + epilogue + both, string-literal escaping, empty input, pure prose, truly malformed JSON, lenient recovery of balanced inner from unbalanced outer, **realistic Claude responses with classification preamble** (the exact staffcrm failure pattern), legacy bare-array preserved through prose wrapper, multiple JSON-like blocks (first valid wins)
- [x] 93 decomposer-adjacent tests pass
- [x] ruff clean
- [ ] CI on this PR
- [ ] Re-deploy Modal and rerun staffcrm verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)