### PR TITLE
fix(decomposer): preserve literal values from source plan in fill_field/select_option

### DIFF
--- a/src/mantis_agent/plan_decomposer.py
+++ b/src/mantis_agent/plan_decomposer.py
@@ -318,9 +318,44 @@ other repeated page items, structure the plan so the runtime can prove coverage:
    - Do not hardcode a fixed item count unless the user explicitly provides one;
      use a bounded loop with runtime exhaustion checks.
 
+CRITICAL — PRESERVE LITERAL VALUES FROM THE SOURCE PLAN.
+Whenever the source plan names a literal value the user wants entered
+(a username, password, email, API key, search term, comment, dropdown
+choice, etc.), that value MUST appear verbatim in `params.value` (or
+`params.option_label` for selects) of the corresponding step. Never
+emit a fill_field with an empty `value` when the source provided one
+— the runner will type "" into the field and the form will be empty.
+
+WORKED EXAMPLES — credential / value preservation:
+  Source: "Log in with user ID alice password hunter2"
+  → Two fill_field steps + one submit:
+      [{"type": "fill_field", "intent": "Enter alice in the user ID field",
+        "params": {"label": "user ID", "value": "alice"}, ...},
+       {"type": "fill_field", "intent": "Enter hunter2 in the password field",
+        "params": {"label": "password", "value": "hunter2"}, ...},
+       {"type": "submit", "intent": "Click the Sign In button to authenticate",
+        "params": {"label": "Sign In"}, ...}]
+  Source: "Set the search box to acme corp"
+  → {"type": "fill_field", "intent": "Type acme corp into the search box",
+     "params": {"label": "search box", "value": "acme corp"}, ...}
+  Source: "Update the Industry to Space Exploration"
+  → {"type": "select_option", "intent": "Pick Space Exploration from Industry",
+     "params": {"dropdown_label": "Industry",
+                "option_label": "Space Exploration"}, ...}
+
+Self-check after generation: for every fill_field/select_option step,
+look at the source phrase that produced it. Did it name a literal
+value? If yes, that string MUST appear in `params.value` /
+`params.option_label`. If the source didn't provide a value (e.g. the
+plan says "Enter your password" with no actual password), still emit
+`fill_field` but expect the runner to use a placeholder or fail with
+an explicit message — better than silently typing "".
+
 VERB → STEP-TYPE MAPPING (FORM FLOWS):
    "log in", "sign in", "authenticate"
-       → fill_field for each credential, then submit for the login button.
+       → fill_field for each credential (with the literal username and
+         password preserved in params.value as shown above), then
+         submit for the login button.
    "enter X in the Y field", "type X into Y", "fill in Y with X", "set Y to X",
    "input X for Y"
        → fill_field with params={"label": "Y", "value": "X"}.
@@ -501,7 +536,7 @@ class PlanDecomposer:
             domain = m.group(1)
 
         # Check cache — include prompt version in hash to invalidate on schema changes
-        prompt_version = "v18_pure_llm"  # Bump this when DECOMPOSE_PROMPT changes
+        prompt_version = "v19_literal_values"  # Bump this when DECOMPOSE_PROMPT changes
         plan_hash = hashlib.md5(f"{prompt_version}:{plan_text}".encode()).hexdigest()[:8]
         cache_path = (
             cache_path_template.replace("{hash}", plan_hash)

--- a/tests/test_decomposer_literal_values.py
+++ b/tests/test_decomposer_literal_values.py
@@ -1,0 +1,129 @@
+"""Tests for literal-value preservation in the decomposer prompt.
+
+A real CRM-workflow run revealed the runner was emitting
+``[claude-form] fill_field '' = ''`` for both credential fields. The
+decomposer was producing fill_field steps with empty `params.value`
+even though the source plan named the username and password.
+
+The fix tightens the prompt with a CRITICAL rule + worked examples
+showing exactly how literal values must round-trip into
+`params.value` / `params.option_label`. These tests assert the prompt
+content; behavior validation happens via Modal verify reruns.
+
+Tests use neutral placeholders (alice / hunter2 / acme corp) — never
+real customer credentials. The repo guards against customer-token
+leaks via tests/test_docs_client_isolation.py.
+"""
+
+from __future__ import annotations
+
+from mantis_agent.plan_decomposer import DECOMPOSE_PROMPT
+
+
+# ── The CRITICAL rule is present and prominent ─────────────────────────
+
+
+def test_prompt_has_critical_literal_value_rule() -> None:
+    text_lower = DECOMPOSE_PROMPT.lower()
+    # The rule should be flagged with attention markers ("CRITICAL", "MUST")
+    # so Claude doesn't gloss over it.
+    assert "critical" in text_lower
+    assert "preserve literal values" in text_lower or "literal value" in text_lower
+
+
+def test_prompt_warns_against_empty_fill_field_value() -> None:
+    """Explicit anti-example: do not emit fill_field with empty value
+    when the source provided one."""
+    text_lower = DECOMPOSE_PROMPT.lower()
+    assert "empty" in text_lower
+    assert (
+        "type \"\"" in DECOMPOSE_PROMPT
+        or 'value of ""' in text_lower
+        or "empty `value`" in text_lower
+    )
+
+
+# ── Worked example: login credentials ─────────────────────────────────
+
+
+def test_prompt_includes_login_credentials_worked_example() -> None:
+    """The login pattern is shown with neutral placeholder credentials so
+    Claude has a template to follow."""
+    text = DECOMPOSE_PROMPT
+    # Neutral placeholders — must NOT be real customer credentials.
+    assert '"value": "alice"' in text
+    assert '"value": "hunter2"' in text
+
+
+def test_prompt_login_example_includes_submit_step() -> None:
+    """A complete login sequence is fill_field × 2 + submit. The example
+    must show all three so Claude sees the whole pattern."""
+    text = DECOMPOSE_PROMPT
+    assert '"submit"' in text
+    assert "Sign In" in text
+
+
+# ── Worked example: free-text input (search box etc.) ──────────────────
+
+
+def test_prompt_includes_search_box_worked_example() -> None:
+    """Generic literal-value preservation for any free-text input."""
+    text = DECOMPOSE_PROMPT
+    text_lower = text.lower()
+    assert "search box" in text_lower
+    assert '"value": "acme corp"' in text
+
+
+# ── Worked example: dropdown / select_option ───────────────────────────
+
+
+def test_prompt_includes_dropdown_worked_example() -> None:
+    """Preservation rule applies to select_option's option_label too."""
+    text = DECOMPOSE_PROMPT
+    # Neutral domain-agnostic choice example.
+    assert "Space Exploration" in text
+    assert '"option_label"' in text
+
+
+# ── Self-check rule ────────────────────────────────────────────────────
+
+
+def test_prompt_includes_self_check_rule_for_literal_values() -> None:
+    """Claude should verify its own output: every fill_field generated
+    from a value-bearing source phrase must carry that value."""
+    text_lower = DECOMPOSE_PROMPT.lower()
+    assert "self-check" in text_lower
+    assert "literal value" in text_lower or "must appear" in text_lower
+
+
+# ── Backward compat — existing rules still in the prompt ───────────────
+
+
+def test_prompt_still_documents_fill_field_params_shape() -> None:
+    text = DECOMPOSE_PROMPT
+    assert "fill_field" in text
+    assert "label" in text
+    assert "value" in text
+
+
+def test_prompt_still_links_log_in_to_fill_field_then_submit() -> None:
+    """The verb mapping for 'log in' must still point at fill_field +
+    submit (not deprecated)."""
+    text_lower = DECOMPOSE_PROMPT.lower()
+    assert "log in" in text_lower or "sign in" in text_lower
+    assert "fill_field" in text_lower
+    assert "submit" in text_lower
+
+
+# ── Cache-key invalidation ─────────────────────────────────────────────
+
+
+def test_prompt_version_was_bumped() -> None:
+    """A prompt change requires a cache-version bump so previously-
+    decomposed plans get re-decomposed with the new rule."""
+    import inspect
+    from mantis_agent.plan_decomposer import PlanDecomposer
+
+    src = inspect.getsource(PlanDecomposer.decompose_text)
+    assert "v19_literal_values" in src
+    assert "v18_pure_llm" not in src


### PR DESCRIPTION
## Summary

Diagnosed via the staffcrm v5 events log:

```
[ 1] fill_field  Enter user ID in the login field
[claude-form] fill_field '' = ''     ← EMPTY value typed!
[ 2] fill_field  Enter password in the password field
[claude-form] fill_field '' = ''     ← SAME!
[ 3] submit  Click the login button
[diff] submit/ok step=3: no change   ← (correct: empty form submits to nothing)
```

The decomposer was producing fill_field steps with `params.value=""` even though the source plan said "Log in with user ID `<user>` password `<pw>`". Result: empty form submission → server rejection → the page stayed on /login → all the downstream steps failed too.

The earlier prompt said "ALWAYS populate `params` (label/value/...)" but that wasn't strong enough. Claude was rephrasing "Log in with X password Y" as "Enter user ID" / "Enter password" while dropping the literal X and Y values.

## Fix

Tighten the prompt with:

1. **CRITICAL block** — explicit "literal values MUST appear verbatim in `params.value`" rule
2. **Worked examples** — three concrete patterns (credential pair, free-text input, dropdown) using neutral placeholders
3. **Self-check rule** — Claude verifies its own output: every value-bearing source phrase must round-trip into `params.value` / `params.option_label`

Cache version bumped `v18_pure_llm` → `v19_literal_values` so previously-decomposed plans get re-decomposed with the new rule.

## Customer-token compliance

All worked examples use neutral placeholders (`alice` / `hunter2` / `acme corp` / `Space Exploration`) — never real customer credentials. The repo's `test_docs_client_isolation` guard catches any leak; this PR passes that test.

## Test plan

- [x] 10 new unit tests covering: CRITICAL-rule presence, anti-empty-fill_field warning, login worked example with neutral placeholders, login-includes-submit, search-box example, dropdown example, self-check rule, fill_field params shape preservation, log-in-to-fill_field-then-submit verb mapping, prompt cache key bump
- [x] 98 decomposer-adjacent tests pass
- [x] `test_docs_client_isolation` passes (no customer-token leak)
- [x] ruff clean
- [ ] CI on this PR
- [ ] Re-deploy Modal + rerun staffcrm verify (v6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)