### PR TITLE
feat(runner): adaptive submit settle — poll URL, break on navigation

### DIFF
--- a/src/mantis_agent/gym/micro_runner.py
+++ b/src/mantis_agent/gym/micro_runner.py
@@ -23,7 +23,7 @@ import logging
 import os
 import re
 import time
-from typing import Any, TYPE_CHECKING
+from typing import Any, ClassVar, TYPE_CHECKING
 
 from ..actions import Action, ActionType
 from ..cost_config import CostConfig
@@ -317,6 +317,67 @@ class MicroPlanRunner:
             "  [diff] %s/%s step=%s: %s",
             step.type, outcome, step_result.step_index, delta.summary(),
         )
+
+    # ── Adaptive submit settle ────────────────────────────────────────
+
+    # Maximum total seconds to wait for a submit click's navigation /
+    # state change. Tuned to cover slow CRM logins (3-5s typical) plus
+    # headroom for high-latency tenants. Login redirects faster than
+    # this break out of the polling loop early; only genuinely slow
+    # actions pay the full budget.
+    _SUBMIT_SETTLE_MAX_SECONDS: ClassVar[float] = 8.0
+    _SUBMIT_SETTLE_POLL_SECONDS: ClassVar[float] = 0.5
+    _SUBMIT_SETTLE_MIN_SECONDS: ClassVar[float] = 1.0
+
+    def _best_effort_current_url(self) -> str:
+        """Fetch the env's current URL without raising. Empty string if
+        the env doesn't expose ``current_url`` or the read fails — the
+        adaptive settle then falls through to the timeout-based wait."""
+        env = self.env
+        try:
+            return str(getattr(env, "current_url", "") or "")
+        except Exception as exc:  # noqa: BLE001 — telemetry must never break runs
+            logger.debug("current_url read failed: %s", exc)
+            return ""
+
+    def _adaptive_submit_settle(self, *, url_before: str) -> float:
+        """Wait for a submit click's effect, breaking early on URL change.
+
+        Returns the actual seconds slept so the cost meter can record
+        accurate GPU-seconds.
+
+        Pure-observational: polls the env's CDP-backed ``current_url``,
+        no LLM call, no heuristic on intent text. If the URL never
+        changes the runner's separate state-change verifier (PR #150)
+        will demote the step to fail and the retry loop will kick in
+        with a fresh attempt.
+        """
+        deadline = time.time() + self._SUBMIT_SETTLE_MAX_SECONDS
+        # Always wait at least the minimum — covers fast-redirect SPAs
+        # where the URL changes within a few hundred ms but the page
+        # still needs DOM time to settle for the next find_form_target.
+        time.sleep(self._SUBMIT_SETTLE_MIN_SECONDS)
+        elapsed = self._SUBMIT_SETTLE_MIN_SECONDS
+
+        while time.time() < deadline:
+            current = self._best_effort_current_url()
+            if current and url_before and current != url_before:
+                # URL changed — submit triggered navigation, settle done.
+                logger.debug(
+                    "  [settle] url changed after %.1fs: %s → %s",
+                    elapsed, url_before[:40], current[:40],
+                )
+                return elapsed
+            time.sleep(self._SUBMIT_SETTLE_POLL_SECONDS)
+            elapsed += self._SUBMIT_SETTLE_POLL_SECONDS
+
+        # Hit the budget without observing a URL change. The state-change
+        # verifier downstream will catch this and trigger a retry.
+        logger.debug(
+            "  [settle] no url change within %.1fs (url=%s)",
+            self._SUBMIT_SETTLE_MAX_SECONDS, url_before[:60],
+        )
+        return self._SUBMIT_SETTLE_MAX_SECONDS
 
     def _current_results_page_url(self) -> str:
         """Backward-compat shim — delegates to :class:`BrowserState`."""
@@ -2011,10 +2072,14 @@ class MicroPlanRunner:
             x, y = target["x"], target["y"]
             try:
                 time.sleep(random.uniform(0.4, 0.9))
+                # Snapshot URL before click so the adaptive settle below
+                # can detect the moment the page actually navigates.
+                url_before = self._best_effort_current_url()
                 self.env.step(Action(action_type=ActionType.CLICK, params={"x": x, "y": y}))
+                self.costs["gpu_seconds"] += self._adaptive_submit_settle(
+                    url_before=url_before,
+                )
                 self.costs["gpu_steps"] += 1
-                # Submit usually triggers navigation / save — wait longer.
-                time.sleep(2.5)
                 logger.info(f"  [claude-form] submit '{label[:40]}'")
                 return StepResult(
                     step_index=index, intent=step.intent, success=True,

--- a/tests/test_submit_adaptive_settle.py
+++ b/tests/test_submit_adaptive_settle.py
@@ -1,0 +1,164 @@
+"""Tests for the adaptive submit settle.
+
+Surfaced by the staffcrm v6 verify (run 20260503_132147_0eabfcc4):
+the runner correctly typed the credentials and clicked Sign In, but
+the fixed 2.5s settle wasn't long enough for the CRM's login redirect.
+The state-change verifier (#150) correctly demoted the step to fail —
+but each retry burned the same too-short window.
+
+The fix is adaptive polling: wait up to 8s, breaking out early as
+soon as the URL changes. Fast logins finish in 1-2s and pay almost
+no penalty; slow logins get the full budget. Pure-observational —
+polls the env's CDP-backed ``current_url``, no LLM call.
+
+These tests exercise the polling logic in isolation via a fake env
+(no Modal, no Xvfb).
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from mantis_agent.gym.micro_runner import MicroPlanRunner
+
+
+# ── Fakes ───────────────────────────────────────────────────────────────
+
+
+class _FakeEnvWithUrl:
+    """Stand-in for XdotoolGymEnv that exposes a controllable current_url."""
+
+    def __init__(self, urls: list[str]) -> None:
+        # Each successive read returns the next URL in the list.
+        self._urls = list(urls)
+        self.reads = 0
+
+    @property
+    def current_url(self) -> str:
+        if self.reads < len(self._urls):
+            url = self._urls[self.reads]
+        else:
+            url = self._urls[-1] if self._urls else ""
+        self.reads += 1
+        return url
+
+
+class _FakeEnvNoUrl:
+    """Stand-in env that doesn't expose current_url at all."""
+
+
+class _FakeEnvRaising:
+    """Stand-in env where current_url raises (simulates CDP unreachable)."""
+
+    @property
+    def current_url(self) -> str:
+        raise RuntimeError("CDP unreachable")
+
+
+def _runner_with_env(env: Any) -> MicroPlanRunner:
+    """Build a MicroPlanRunner with just enough state for the settle helpers."""
+    runner = MicroPlanRunner.__new__(MicroPlanRunner)
+    runner.env = env
+    return runner
+
+
+# ── _best_effort_current_url ──────────────────────────────────────────
+
+
+def test_best_effort_url_returns_value_when_env_exposes_it() -> None:
+    runner = _runner_with_env(_FakeEnvWithUrl(["https://x.test/login"]))
+    assert runner._best_effort_current_url() == "https://x.test/login"
+
+
+def test_best_effort_url_returns_empty_when_env_lacks_attr() -> None:
+    runner = _runner_with_env(_FakeEnvNoUrl())
+    assert runner._best_effort_current_url() == ""
+
+
+def test_best_effort_url_returns_empty_on_raise() -> None:
+    runner = _runner_with_env(_FakeEnvRaising())
+    assert runner._best_effort_current_url() == ""
+
+
+# ── _adaptive_submit_settle ──────────────────────────────────────────
+
+
+def test_settle_breaks_early_on_url_change() -> None:
+    """The login pattern: URL was /login, becomes /dashboard mid-settle."""
+    env = _FakeEnvWithUrl([
+        "https://x.test/login",       # poll 1: still on login
+        "https://x.test/dashboard",   # poll 2: navigated! exit
+    ])
+    runner = _runner_with_env(env)
+    t0 = time.monotonic()
+    elapsed = runner._adaptive_submit_settle(url_before="https://x.test/login")
+    real_elapsed = time.monotonic() - t0
+    # Should have stopped well before the 8s max.
+    assert elapsed < 4.0
+    assert real_elapsed < 4.0
+
+
+def test_settle_pays_full_budget_when_url_never_changes() -> None:
+    env = _FakeEnvWithUrl(["https://x.test/login"] * 100)
+    runner = _runner_with_env(env)
+    t0 = time.monotonic()
+    elapsed = runner._adaptive_submit_settle(url_before="https://x.test/login")
+    real_elapsed = time.monotonic() - t0
+    # Returns the max budget (with the min-settle floor applied).
+    assert elapsed >= MicroPlanRunner._SUBMIT_SETTLE_MAX_SECONDS - 1
+    assert real_elapsed >= MicroPlanRunner._SUBMIT_SETTLE_MAX_SECONDS - 1
+
+
+def test_settle_always_waits_minimum() -> None:
+    """Even if the URL changes immediately, we wait at least the min so
+    the page has DOM time before the next find_form_target call."""
+    env = _FakeEnvWithUrl(["https://x.test/already-changed"] * 100)
+    runner = _runner_with_env(env)
+    t0 = time.monotonic()
+    runner._adaptive_submit_settle(url_before="https://x.test/login")
+    real_elapsed = time.monotonic() - t0
+    # Min settle floor is enforced.
+    assert real_elapsed >= MicroPlanRunner._SUBMIT_SETTLE_MIN_SECONDS - 0.05
+
+
+def test_settle_handles_env_without_current_url() -> None:
+    """No URL accessor → polling can't detect change → falls through to
+    full budget. Doesn't raise."""
+    runner = _runner_with_env(_FakeEnvNoUrl())
+    elapsed = runner._adaptive_submit_settle(url_before="https://x.test/login")
+    assert elapsed >= MicroPlanRunner._SUBMIT_SETTLE_MAX_SECONDS - 1
+
+
+def test_settle_handles_empty_url_before() -> None:
+    """If we couldn't capture URL pre-click, we can't detect change.
+    Pay the full budget. Don't raise."""
+    env = _FakeEnvWithUrl(["https://x.test/some-page"])
+    runner = _runner_with_env(env)
+    elapsed = runner._adaptive_submit_settle(url_before="")
+    assert elapsed >= MicroPlanRunner._SUBMIT_SETTLE_MAX_SECONDS - 1
+
+
+def test_settle_returns_elapsed_seconds_for_cost_meter() -> None:
+    """The returned float is consumed by the cost meter — must be a
+    realistic non-negative duration."""
+    env = _FakeEnvWithUrl([
+        "https://x.test/login",
+        "https://x.test/dashboard",
+    ])
+    runner = _runner_with_env(env)
+    elapsed = runner._adaptive_submit_settle(url_before="https://x.test/login")
+    assert isinstance(elapsed, float)
+    assert elapsed >= 0.0
+
+
+# ── Constants are sane ───────────────────────────────────────────────
+
+
+def test_settle_constants_are_reasonable() -> None:
+    """Sanity: max > min, both positive, poll interval smaller than min."""
+    assert MicroPlanRunner._SUBMIT_SETTLE_MAX_SECONDS > MicroPlanRunner._SUBMIT_SETTLE_MIN_SECONDS
+    assert MicroPlanRunner._SUBMIT_SETTLE_MIN_SECONDS > 0
+    assert MicroPlanRunner._SUBMIT_SETTLE_POLL_SECONDS < MicroPlanRunner._SUBMIT_SETTLE_MIN_SECONDS
+    # Max budget should cover a slow CRM login (~5s) plus headroom.
+    assert MicroPlanRunner._SUBMIT_SETTLE_MAX_SECONDS >= 5.0


### PR DESCRIPTION
## Summary

The staffcrm v6 events log:
```
[claude-form] fill_field '' = 'sarah.connor'    ← typed
[claude-form] fill_field '' = 'skynet99'        ← typed
[claude-form] 'Sign In button' at (752,420) action=click
[diff] submit/ok step=3: no change              ← still on /login after 2.5s
[3] demoting to failure (will retry)            ← #150 verifier fires
```

The credentials were typed correctly (#151 preserve-literal-values worked), Sign In was clicked, but the **fixed 2.5s settle wasn't long enough for the CRM's login redirect**. The state-change verifier from #150 correctly demoted the step — but each retry burned the same too-short window.

## Fix: adaptive polling

Replace `time.sleep(2.5)` after submit click with:

```
1. Always wait min (1.0s) so the page has DOM time
2. Poll env.current_url every 0.5s
3. Break early on URL change → fast logins pay almost no penalty
4. Hard-cap at 8.0s → slow logins get the full budget
```

Pure-observational: polls the CDP-backed `current_url`, no LLM call, no heuristic on intent text. Respects the no-hardcoded-semantics directive.

## Defensive design

| Scenario | Behavior |
|---|---|
| CDP unreachable before click (empty `url_before`) | Fall through to full budget |
| Env doesn't expose `current_url` | Fall through to full budget |
| `current_url` accessor raises | Swallowed via `_best_effort_current_url`, full budget |

Cost attribution: returned elapsed seconds round-trip into `self.costs["gpu_seconds"]` so dashboards show actual settle time, not a fixed value.

## Test plan

- [x] 10 new unit tests covering: `best_effort_url` (normal / no-attr / raise), settle breaks early on URL change, full budget when URL never changes, min-settle floor enforced, env-without-current_url fallthrough, empty `url_before` fallthrough, returns float for cost meter, settle constants sanity
- [x] ruff clean
- [ ] CI on this PR
- [ ] Re-deploy Modal + rerun staffcrm verify (v7) — expecting login submit to break early on `/login → /` transition

🤖 Generated with [Claude Code](https://claude.com/claude-code)