### PR TITLE
refactor(runner): EPIC #161 Phase 2 — NavigateHandler + registry-first dispatch

### DIFF
--- a/src/mantis_agent/gym/micro_runner.py
+++ b/src/mantis_agent/gym/micro_runner.py
@@ -190,6 +190,13 @@ class MicroPlanRunner:
         # via self.parent — same back-reference pattern as BrowserState.
         self.checkpoint_manager = CheckpointManager(self)
 
+        # #161 Phase 2: per-type step handler registry. Dispatch in
+        # ``_execute_step`` consults this first; types without a handler
+        # fall through to the legacy if/elif. Handlers are migrated one
+        # at a time as separate PRs land.
+        from .step_handlers import default_registry as _default_registry
+        self._handler_registry = _default_registry(self)
+
     # ── Listings-scan state — delegates to ``self.scanner`` (#161 Phase 1.2) ──
     # 70+ internal call sites, external readers (checkpoint_manager,
     # browser_state), and existing test fixtures (test_plan_aware_reverse,
@@ -1339,8 +1346,42 @@ class MicroPlanRunner:
             )
             return False
 
+    def _build_step_context(self, index: int) -> "StepContext":
+        """Build a :class:`~.step_context.StepContext` for the next step.
+
+        Handlers are pure functions of (step, ctx); the runner is the
+        only thing that knows the current step index. We tuck it into
+        ``ctx.state["index"]`` so the handler signature stays
+        ``execute(step, ctx) -> StepResult`` per the protocol.
+        """
+        from .step_context import StepContext
+        return StepContext(
+            env=self.env,
+            brain=self.brain,
+            extractor=self.extractor,
+            grounding=self.grounding,
+            cost_meter=self.cost_meter,
+            dynamic_verifier=self.dynamic_verifier,
+            scanner=self.scanner,
+            site_config=self.site_config,
+            tool_channel=self.tool_channel,
+            extraction_cache=self.extraction_cache,
+            state={"index": index},
+        )
+
     def _execute_step(self, step: MicroIntent, index: int) -> StepResult:
-        """Execute a single micro-intent."""
+        """Execute a single micro-intent.
+
+        Registry-first dispatch (#161 Phase 2): step types whose handler
+        has been migrated to ``step_handlers/<type>.py`` are dispatched
+        through the registry. Types without a registered handler fall
+        through to the legacy if/elif below — that branch shrinks one
+        handler at a time as Phase 2 progresses.
+        """
+        registered = self._handler_registry.get(step.type)
+        if registered is not None:
+            ctx = self._build_step_context(index)
+            return registered.execute(step, ctx)
 
         # Navigate steps: use env.reset() with URL instead of Holo3
         if step.type == "navigate":
@@ -1508,53 +1549,21 @@ class MicroPlanRunner:
         return ""
 
     def _execute_navigate(self, step: MicroIntent, index: int) -> StepResult:
-        """Navigate to a URL using env.reset() — no Holo3 steps needed.
+        """Backwards-compat shim — delegates to :class:`NavigateHandler`.
 
-        Waits for page load and handles Cloudflare challenges (auto-solve in 5-10s).
-
-        First-paint wait resolution order (first hit wins):
-          1. step.params["wait_after_load_seconds"] — plan-driven override
-          2. env MANTIS_NAV_WAIT_SECONDS                — deployment-wide override
-          3. 18s default                                — covers Cloudflare auto-solve
+        Kept on the runner so external callers (tests, host integrations)
+        that invoke ``runner._execute_navigate(step, index)`` directly
+        continue to work. Phase 2 cleanup PR will remove this once all
+        callers go through the registry.
         """
-        import re
-        url_match = re.search(r'https?://[^\s"]+', step.intent)
-        url = url_match.group() if url_match else ""
-
-        if not url:
-            logger.warning(f"  [navigate] No URL found in intent: {step.intent[:60]}")
-            return StepResult(step_index=index, intent=step.intent, success=False)
-
-        try:
-            wait_seconds = float(
-                (step.params or {}).get("wait_after_load_seconds")
-                or os.environ.get("MANTIS_NAV_WAIT_SECONDS")
-                or 18
-            )
-        except (TypeError, ValueError):
-            wait_seconds = 18.0
-        wait_seconds = max(0.0, min(wait_seconds, 120.0))
-
-        logger.info(f"  [navigate] Loading {url} (first-paint wait {wait_seconds:.0f}s)")
-        try:
-            self.env.reset(task="navigate", start_url=url)
-            # Wait for Cloudflare challenge to auto-solve + page render
-            time.sleep(wait_seconds)
-            self.env.step(Action(action_type=ActionType.KEY_PRESS, params={"keys": "Home"}))
-            time.sleep(2)
-            # Store as base URL for pagination (results page, not detail page)
-            self._results_base_url = url
-            self._required_filter_tokens = self._derive_filter_tokens(url)
-            self._current_page = 1
-            self._last_known_url = url
-            self._reset_results_scan_state()
-            self._set_scroll_state(context="results_top", url=url, page_downs=0, wheel_downs=0)
-            self.dynamic_verifier.set_required_filter_tokens(self._required_filter_tokens)
-            self.dynamic_verifier.record_page_start(page=self._current_page, url=url)
-            return StepResult(step_index=index, intent=step.intent, success=True)
-        except Exception as e:
-            logger.error(f"  [navigate] Failed: {e}")
-            return StepResult(step_index=index, intent=step.intent, success=False)
+        handler = self._handler_registry.get("navigate")
+        if handler is None:
+            # Registry didn't include navigate — shouldn't happen in production
+            # but keep a safe fallback for tests that strip the registry.
+            from .step_handlers.navigate import NavigateHandler
+            handler = NavigateHandler(self)
+        ctx = self._build_step_context(index)
+        return handler.execute(step, ctx)
 
     def _execute_claude_guided_click(self, step: MicroIntent, index: int) -> StepResult:
         """Claude finds ALL listings once per page, clicks them one by one.

--- a/src/mantis_agent/gym/micro_runner.py
+++ b/src/mantis_agent/gym/micro_runner.py
@@ -52,6 +52,7 @@ from ..verification.dynamic_plan_verifier import DynamicPlanVerifier
 
 if TYPE_CHECKING:
     from ..extraction import ClaudeExtractor
+    from .step_context import StepContext
 
 logger = logging.getLogger(__name__)
 

--- a/src/mantis_agent/gym/step_handlers/__init__.py
+++ b/src/mantis_agent/gym/step_handlers/__init__.py
@@ -1,0 +1,54 @@
+"""Per-type step handlers — Phase 2 of EPIC #161.
+
+Each module under ``step_handlers/`` implements one
+:class:`~..step_context.StepHandler` for a specific
+``MicroIntent.type``. The runner's ``_execute_step`` consults the
+registry first; types whose handler hasn't been extracted yet fall
+through to the legacy if/elif in the runner.
+
+Handlers are unit-testable in isolation: take a :class:`StepContext`
+with mocked collaborators (``env``, ``extractor``, ``brain``,
+``cost_meter``, ``scanner``, ``dynamic_verifier``, ``site_config``)
+and return a :class:`StepResult`. No Xvfb, no GymRunner, no live
+brain — that's the explicit acceptance criterion of EPIC #161.
+
+Migration policy:
+- One handler per PR (or one PR for a tight cluster like form
+  variants — submit / fill_field / select_option).
+- Each PR moves the handler body verbatim from the runner to the
+  handler module, leaving a delegating shim on the runner so
+  external callers (tests, host integrations) keep working.
+- After all handlers are migrated, a final cleanup PR rips the
+  legacy if/elif and the per-type runner methods entirely.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ..step_context import HandlerRegistry
+from .navigate import NavigateHandler
+
+if TYPE_CHECKING:
+    from ..micro_runner import MicroPlanRunner
+
+
+__all__ = ["default_registry", "NavigateHandler"]
+
+
+def default_registry(runner: "MicroPlanRunner") -> HandlerRegistry:
+    """Build the default registry bound to one runner instance.
+
+    Handlers that need access to runner-only state (e.g.
+    ``_current_page``, ``_last_known_url``, ``_reset_results_scan_state``)
+    take the runner as a back-reference at construction. This mirrors the
+    BrowserState / CheckpointManager pattern from #115 — a thin shim that
+    can be tested with a fake parent.
+
+    Returns a registry with the handlers that have been migrated so far.
+    Step types not in the returned registry continue to be dispatched by
+    the legacy branches in ``MicroPlanRunner._execute_step``.
+    """
+    reg = HandlerRegistry()
+    reg.register(NavigateHandler(runner))
+    return reg

--- a/src/mantis_agent/gym/step_handlers/navigate.py
+++ b/src/mantis_agent/gym/step_handlers/navigate.py
@@ -1,0 +1,122 @@
+"""NavigateHandler — drive the browser to a URL and arm the listings scanner.
+
+First real handler extraction under EPIC #161 Phase 2. The body is a
+verbatim lift from ``MicroPlanRunner._execute_navigate``; the runner
+keeps a thin delegating shim so existing tests and external callers
+(host integrations, tools that drive the runner directly) continue
+to work unchanged.
+
+What the handler reads from :class:`StepContext`:
+
+- ``env``               — for ``reset(task=..., start_url=...)`` and ``step(KEY_PRESS)``
+- ``scanner``           — to set ``results_base_url`` and ``required_filter_tokens``
+- ``dynamic_verifier``  — to seed the per-page check schedule
+
+What the handler reads from the runner (via parent back-reference):
+
+- ``_derive_filter_tokens``   — static method on the runner; pure function over URL string
+- ``_current_page``           — runner state, set to 1 on navigate
+- ``_last_known_url``         — runner state, set to the navigated URL
+- ``_reset_results_scan_state`` — runner method, clears scanner viewport / page-listing cache
+- ``browser_state.set_scroll_state`` — re-seats scroll context to ``results_top``
+
+The runner state attributes (``_current_page``, ``_last_known_url``,
+``_scroll_state``) are *not* on the scanner today — they live on the
+runner because BrowserState (#115 step 4) was the first split. Phase 4
+of #161 can promote them onto a unified ``RunState`` dataclass; for now
+we read/write through the parent reference, the same pattern
+:class:`~.browser_state.BrowserState` already uses.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import time
+from typing import TYPE_CHECKING
+
+from ...actions import Action, ActionType
+from ..checkpoint import StepResult
+from ..step_context import StepContext
+
+if TYPE_CHECKING:
+    from ..micro_runner import MicroPlanRunner
+    from ...plan_decomposer import MicroIntent
+
+logger = logging.getLogger(__name__)
+
+
+class NavigateHandler:
+    """Implements :class:`~..step_context.StepHandler` for ``navigate`` steps.
+
+    Verbatim port of ``MicroPlanRunner._execute_navigate``: same URL
+    extraction regex, same wait-resolution order (step.params >
+    MANTIS_NAV_WAIT_SECONDS env > 18s default), same env.reset call,
+    same Home key + 2s settle, same scanner / dynamic-verifier
+    bookkeeping. The only structural difference is that ``index`` is
+    read from ``ctx.state["index"]`` so the handler signature matches
+    the protocol.
+    """
+
+    step_type = "navigate"
+
+    def __init__(self, runner: "MicroPlanRunner") -> None:
+        self.parent = runner
+
+    def execute(self, step: "MicroIntent", ctx: StepContext) -> StepResult:
+        index = int(ctx.state.get("index", 0))
+        url_match = re.search(r'https?://[^\s"]+', step.intent)
+        url = url_match.group() if url_match else ""
+
+        if not url:
+            logger.warning(f"  [navigate] No URL found in intent: {step.intent[:60]}")
+            return StepResult(step_index=index, intent=step.intent, success=False)
+
+        try:
+            wait_seconds = float(
+                (step.params or {}).get("wait_after_load_seconds")
+                or os.environ.get("MANTIS_NAV_WAIT_SECONDS")
+                or 18
+            )
+        except (TypeError, ValueError):
+            wait_seconds = 18.0
+        wait_seconds = max(0.0, min(wait_seconds, 120.0))
+
+        logger.info(f"  [navigate] Loading {url} (first-paint wait {wait_seconds:.0f}s)")
+        env = ctx.env
+        scanner = ctx.scanner
+        dynamic_verifier = ctx.dynamic_verifier
+        runner = self.parent
+
+        try:
+            env.reset(task="navigate", start_url=url)
+            # Wait for Cloudflare challenge to auto-solve + page render
+            time.sleep(wait_seconds)
+            env.step(Action(action_type=ActionType.KEY_PRESS, params={"keys": "Home"}))
+            time.sleep(2)
+
+            # Anchor the results scan state to this URL.
+            if scanner is not None:
+                scanner.results_base_url = url
+                scanner.required_filter_tokens = runner._derive_filter_tokens(url)
+            else:  # legacy fallback for tests that pass ctx without scanner
+                runner._results_base_url = url
+                runner._required_filter_tokens = runner._derive_filter_tokens(url)
+
+            runner._current_page = 1
+            runner._last_known_url = url
+            runner._reset_results_scan_state()
+            runner.browser_state.set_scroll_state(
+                context="results_top", url=url, page_downs=0, wheel_downs=0,
+            )
+
+            if dynamic_verifier is not None:
+                dynamic_verifier.set_required_filter_tokens(
+                    runner._required_filter_tokens
+                )
+                dynamic_verifier.record_page_start(page=runner._current_page, url=url)
+            return StepResult(step_index=index, intent=step.intent, success=True)
+        except Exception as e:
+            logger.error(f"  [navigate] Failed: {e}")
+            return StepResult(step_index=index, intent=step.intent, success=False)

--- a/tests/test_navigate_handler.py
+++ b/tests/test_navigate_handler.py
@@ -1,0 +1,225 @@
+"""NavigateHandler unit tests — Phase 2 of EPIC #161.
+
+Demonstrates the explicit acceptance criterion: a handler can be unit
+tested with a mocked StepContext, no Xvfb, no GymRunner, no real
+ClaudeExtractor. The whole point of Phase 2 is making this pattern
+possible.
+
+Asserts that the handler:
+- Sets results_base_url + required_filter_tokens on the scanner
+- Calls env.reset with the right task and url
+- Sends Home keypress and 2s settle
+- Seeds the dynamic verifier with the page-start record
+- Returns success=False when the intent text has no URL (no env calls made)
+- Returns success=False when env.reset raises
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from mantis_agent.actions import ActionType
+from mantis_agent.gym.checkpoint import StepResult
+from mantis_agent.gym.listings_scanner import ListingsScanner
+from mantis_agent.gym.step_context import StepContext
+from mantis_agent.gym.step_handlers.navigate import NavigateHandler
+from mantis_agent.plan_decomposer import MicroIntent
+
+
+class _FakeRunner:
+    """Minimal back-reference. NavigateHandler reads 5 attributes / 2 methods."""
+
+    def __init__(self) -> None:
+        self._current_page = 0
+        self._last_known_url = ""
+        self._results_base_url = ""
+        self._required_filter_tokens: tuple[str, ...] = ()
+        self.reset_scan_calls = 0
+        self.browser_state = MagicMock()
+
+    def _derive_filter_tokens(self, url: str) -> tuple[str, ...]:
+        # Match the runner's actual implementation: pull URL path tokens
+        # excluding "boats" and page numbers. Tests pin specific inputs.
+        import re
+        m = re.search(r"https?://[^/]+/([^?#]+)", url)
+        if not m:
+            return ()
+        out = []
+        for tok in m.group(1).strip("/").split("/"):
+            if not tok or tok in {"boats"} or tok.startswith("page-"):
+                continue
+            out.append(tok.lower())
+        return tuple(out)
+
+    def _reset_results_scan_state(self) -> None:
+        self.reset_scan_calls += 1
+
+
+def _ctx_with_runner_and_env(runner: _FakeRunner, env: Any) -> StepContext:
+    scanner = ListingsScanner()
+    dynamic_verifier = MagicMock()
+    return StepContext(
+        env=env,
+        brain=None,
+        extractor=None,
+        grounding=None,
+        cost_meter=None,
+        dynamic_verifier=dynamic_verifier,
+        scanner=scanner,
+        site_config=None,
+        tool_channel=None,
+        extraction_cache=None,
+        state={"index": 3},
+    )
+
+
+def _step(intent: str, **params: Any) -> MicroIntent:
+    return MicroIntent(intent=intent, type="navigate", params=params or None)
+
+
+def test_navigate_extracts_url_and_calls_env_reset(monkeypatch):
+    monkeypatch.delenv("MANTIS_NAV_WAIT_SECONDS", raising=False)
+    monkeypatch.setattr("mantis_agent.gym.step_handlers.navigate.time.sleep", lambda *_: None)
+
+    runner = _FakeRunner()
+    env = MagicMock()
+    ctx = _ctx_with_runner_and_env(runner, env)
+    handler = NavigateHandler(runner)
+
+    result = handler.execute(_step("Go to https://www.example.com/cars"), ctx)
+
+    assert result.success is True
+    assert isinstance(result, StepResult)
+    assert result.step_index == 3
+
+    env.reset.assert_called_once_with(task="navigate", start_url="https://www.example.com/cars")
+    home_call = env.step.call_args_list[0]
+    sent_action = home_call.args[0]
+    assert sent_action.action_type == ActionType.KEY_PRESS
+    assert sent_action.params == {"keys": "Home"}
+
+    # Scanner anchored to the URL; runner state seeded.
+    assert ctx.scanner is not None
+    assert ctx.scanner.results_base_url == "https://www.example.com/cars"
+    assert ctx.scanner.required_filter_tokens == ("cars",)
+    assert runner._current_page == 1
+    assert runner._last_known_url == "https://www.example.com/cars"
+    assert runner.reset_scan_calls == 1
+    runner.browser_state.set_scroll_state.assert_called_once()
+
+    # Dynamic verifier seeded with required filter tokens + page start
+    ctx.dynamic_verifier.set_required_filter_tokens.assert_called_once_with(())  # runner copy is empty in fake
+    ctx.dynamic_verifier.record_page_start.assert_called_once_with(
+        page=1, url="https://www.example.com/cars",
+    )
+
+
+def test_navigate_returns_failure_when_intent_lacks_url(monkeypatch):
+    monkeypatch.setattr("mantis_agent.gym.step_handlers.navigate.time.sleep", lambda *_: None)
+    runner = _FakeRunner()
+    env = MagicMock()
+    ctx = _ctx_with_runner_and_env(runner, env)
+    handler = NavigateHandler(runner)
+
+    result = handler.execute(_step("just text, no link here"), ctx)
+
+    assert result.success is False
+    env.reset.assert_not_called()
+    env.step.assert_not_called()
+
+
+def test_navigate_returns_failure_when_env_reset_raises(monkeypatch):
+    monkeypatch.setattr("mantis_agent.gym.step_handlers.navigate.time.sleep", lambda *_: None)
+    runner = _FakeRunner()
+    env = MagicMock()
+    env.reset.side_effect = RuntimeError("Cloudflare timeout")
+    ctx = _ctx_with_runner_and_env(runner, env)
+    handler = NavigateHandler(runner)
+
+    result = handler.execute(_step("Open https://x.example.com/"), ctx)
+
+    assert result.success is False
+    # env.reset was attempted; subsequent calls (env.step Home) didn't happen
+    env.reset.assert_called_once()
+    env.step.assert_not_called()
+
+
+def test_navigate_respects_step_param_wait_seconds(monkeypatch):
+    sleep_calls: list[float] = []
+    monkeypatch.setattr(
+        "mantis_agent.gym.step_handlers.navigate.time.sleep",
+        lambda s: sleep_calls.append(s),
+    )
+    monkeypatch.delenv("MANTIS_NAV_WAIT_SECONDS", raising=False)
+
+    runner = _FakeRunner()
+    env = MagicMock()
+    ctx = _ctx_with_runner_and_env(runner, env)
+    handler = NavigateHandler(runner)
+
+    handler.execute(_step("Go to https://x.example.com/", wait_after_load_seconds=42), ctx)
+
+    # First sleep is the page-load wait (clamped to [0, 120]); second is the Home settle.
+    assert sleep_calls[0] == 42.0
+    assert sleep_calls[1] == 2
+
+
+def test_navigate_clamps_wait_seconds_to_max(monkeypatch):
+    sleep_calls: list[float] = []
+    monkeypatch.setattr(
+        "mantis_agent.gym.step_handlers.navigate.time.sleep",
+        lambda s: sleep_calls.append(s),
+    )
+    monkeypatch.delenv("MANTIS_NAV_WAIT_SECONDS", raising=False)
+
+    runner = _FakeRunner()
+    env = MagicMock()
+    ctx = _ctx_with_runner_and_env(runner, env)
+    handler = NavigateHandler(runner)
+
+    handler.execute(_step("Go to https://x.example.com/", wait_after_load_seconds=999), ctx)
+
+    assert sleep_calls[0] == 120.0  # hard cap
+
+
+def test_navigate_falls_back_to_env_var_for_wait(monkeypatch):
+    sleep_calls: list[float] = []
+    monkeypatch.setattr(
+        "mantis_agent.gym.step_handlers.navigate.time.sleep",
+        lambda s: sleep_calls.append(s),
+    )
+    monkeypatch.setenv("MANTIS_NAV_WAIT_SECONDS", "7")
+
+    runner = _FakeRunner()
+    env = MagicMock()
+    ctx = _ctx_with_runner_and_env(runner, env)
+    handler = NavigateHandler(runner)
+
+    handler.execute(_step("Open https://x.example.com/"), ctx)
+    assert sleep_calls[0] == 7.0
+
+
+def test_navigate_uses_18s_default_wait(monkeypatch):
+    sleep_calls: list[float] = []
+    monkeypatch.setattr(
+        "mantis_agent.gym.step_handlers.navigate.time.sleep",
+        lambda s: sleep_calls.append(s),
+    )
+    monkeypatch.delenv("MANTIS_NAV_WAIT_SECONDS", raising=False)
+
+    runner = _FakeRunner()
+    env = MagicMock()
+    ctx = _ctx_with_runner_and_env(runner, env)
+    handler = NavigateHandler(runner)
+
+    handler.execute(_step("Open https://x.example.com/"), ctx)
+    assert sleep_calls[0] == 18.0
+
+
+def test_navigate_step_type_property_is_navigate():
+    handler = NavigateHandler(_FakeRunner())
+    assert handler.step_type == "navigate"

--- a/tests/test_navigate_handler.py
+++ b/tests/test_navigate_handler.py
@@ -16,11 +16,8 @@ Asserts that the handler:
 
 from __future__ import annotations
 
-import os
 from typing import Any
 from unittest.mock import MagicMock
-
-import pytest
 
 from mantis_agent.actions import ActionType
 from mantis_agent.gym.checkpoint import StepResult


### PR DESCRIPTION
Refs #161 (Phase 2 — first handler extraction).

## Summary

Phase 2 begins. Extracts `_execute_navigate` from the runner into a real `NavigateHandler` class under the new `step_handlers/` package and wires registry-first dispatch into `_execute_step`. Step types whose handler hasn't migrated yet fall through to the existing if/elif — that branch shrinks one handler at a time as the rest of Phase 2 lands.

## What this PR proves

The explicit Phase-2 acceptance criterion from EPIC #161:

> Each handler has its own test file with mocked context (no Xvfb required)

`tests/test_navigate_handler.py` runs 8 tests against `NavigateHandler.execute(step, ctx)` with a fully mocked `StepContext`. No Xvfb, no GymRunner, no real ClaudeExtractor, no live brain. Each subsequent handler PR follows the same playbook.

## Behavior

Verbatim port of the runner method — same URL extraction regex, same wait-resolution order (`step.params["wait_after_load_seconds"]` > `MANTIS_NAV_WAIT_SECONDS` env var > 18s default, clamped to `[0, 120]`), same `env.reset` call, same `Home` key + 2s settle, same scanner / dynamic-verifier bookkeeping, same exception handling.

The runner's `_execute_navigate` stays as a delegating shim so external callers (tests, host integrations driving the runner directly) keep working unchanged. Final cleanup PR rips the shim once every type is migrated.

## Architecture

```
gym/
  step_handlers/                   ← new package
    __init__.py                    ← default_registry(runner) factory
    navigate.py                    ← NavigateHandler (full body extraction)
  micro_runner.py
    __init__:  self._handler_registry = default_registry(self)
    _build_step_context(index):    ← new helper, builds StepContext
    _execute_step(step, index):    ← registry-first; legacy if/elif fallback
    _execute_navigate(step, idx):  ← thin shim → handler.execute(step, ctx)
```

`NavigateHandler` reads collaborators from `StepContext` (env, scanner, dynamic_verifier) and runner state via a parent back-reference (mirrors `BrowserState` / `CheckpointManager` pattern from #115). Phase 4 promotes the back-referenced state (`_current_page`, `_last_known_url`) onto a unified `RunState` dataclass.

## Test plan

- [x] `tests/test_navigate_handler.py` (8 new) — mocked-context unit tests covering: URL extraction + env.reset + scanner state + dynamic verifier seeding (`test_navigate_extracts_url_and_calls_env_reset`), missing-URL early return (`test_navigate_returns_failure_when_intent_lacks_url`), env.reset exception path (`test_navigate_returns_failure_when_env_reset_raises`), `wait_after_load_seconds` step param (`test_navigate_respects_step_param_wait_seconds`), 120s clamp (`test_navigate_clamps_wait_seconds_to_max`), env-var fallback (`test_navigate_falls_back_to_env_var_for_wait`), 18s default (`test_navigate_uses_18s_default_wait`), `step_type` property (`test_navigate_step_type_property_is_navigate`).
- [x] **No regressions in the existing focus suite**: 164 passed in `test_listing_dedup` + `test_browser_state` + `test_checkpoint_manager` + `test_plan_aware_reverse` + `test_private_seller_filter` + `test_micro_runner_hooks` + `test_step_snapshot` + `test_cost_meter` + Phase-1/Phase-2-types suites from #167.
- [x] **Live verification on Modal**: deployed branch, ran `example.com` plan_text. Log source `mantis_agent.gym.step_handlers.navigate` confirms registry dispatch is exercising the new code path. Run completed in identical 39s / $0.03 / 2 steps as pre-Phase-2.

## Follow-up PRs (same playbook)

One handler per PR — extracting the heaviest first reduces the legacy if/elif fastest:

- `ClickHandler` (listings + form variants from `_execute_claude_guided_click`)
- `ClaudeStepHandler` (extract_url / extract_data from `_execute_claude_step`)
- `FormHandler` (submit / fill_field / select_option from `_execute_claude_guided_form`)
- `PaginateHandler` (`_execute_paginate_layered` + `_execute_claude_guided_paginate`)
- `FilterHandler`
- `GateHandler`
- `Holo3StepHandler`, `ScrollHandler`, `NavigateBackHandler`

Final cleanup PR rips `_execute_step`'s if/elif and the per-type runner methods entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)