### PR TITLE
refactor(runner): EPIC #161 Phase 2 — extract PaginateHandler (3-layer Next-page)

### DIFF
--- a/src/mantis_agent/gym/micro_runner.py
+++ b/src/mantis_agent/gym/micro_runner.py
@@ -1747,213 +1747,30 @@ class MicroPlanRunner:
         return handler.execute(step, ctx)
 
     def _execute_paginate_layered(self, step: MicroIntent, index: int) -> StepResult:
-        """Layered pagination: URL-based → Claude-guided → Holo3 fallback.
+        """Backwards-compat shim — delegates to :class:`PaginateHandler`.
 
-        Layer 1: URL-based — if we can detect the current page URL pattern,
-                 construct page N+1 URL and navigate directly. Fastest, no
-                 risk of clicking sidebar filters.
-        Layer 2: Claude-guided — End key then Page_Up to get pagination bar
-                 in view. Claude finds Next button coordinates.
-        Layer 3: Holo3 — simple 1-sentence task as last resort.
+        Phase 2 of EPIC #161: layered pagination (URL-based →
+        Claude-guided → Holo3 fallback) lives in
+        ``step_handlers/paginate.py`` so it's unit-testable in
+        isolation. The runner shim stays so external callers (test
+        fixtures, host integrations) keep working unchanged.
         """
-
-        # Track current page number
-        if not hasattr(self, '_current_page'):
-            self._current_page = 1
-        current_page = self._current_page
-
-        # ── Layer 1: URL-based pagination ──
-        # Use the stored results base URL (from initial navigate), NOT the current page URL
-        # (which might be a detail page after extraction)
-        base_url = getattr(self, '_results_base_url', '')
-        if base_url and self.site_config.pagination_format:
-            next_page = self._current_page + 1
-            next_url = self.site_config.paginated_url(base_url, next_page)
-
-            # Ensure full URL
-            if not next_url.startswith("http"):
-                next_url = f"https://www.{next_url}"
-
-            logger.info(f"  [paginate] Layer 1: URL-based → {next_url[:80]}")
-            try:
-                self.env.reset(task="paginate_url", start_url=next_url)
-                time.sleep(10)
-                self.env.step(Action(action_type=ActionType.KEY_PRESS, params={"keys": "Home"}))
-                time.sleep(2)
-                self._current_page = next_page
-                self._last_known_url = next_url
-                self._set_scroll_state(context="results_top", url=next_url, page_downs=0, wheel_downs=0)
-                self.dynamic_verifier.record_pagination(
-                    page=current_page,
-                    success=True,
-                    method="url",
-                    next_url=next_url,
-                )
-                self.dynamic_verifier.record_page_start(page=next_page, url=next_url)
-                return StepResult(step_index=index, intent=step.intent, success=True,
-                                steps_used=0, data=f"url_paginate_page{next_page}")
-            except Exception as e:
-                logger.warning(f"  [paginate] Layer 1 failed: {e}")
-                self.dynamic_verifier.record_pagination(
-                    page=current_page,
-                    success=False,
-                    method="url",
-                    next_url=next_url,
-                    reason=f"url_navigation_failed:{e}",
-                )
-
-        # ── Layer 2: Claude-guided ──
-        logger.info("  [paginate] Layer 2: Claude-guided (End → Page_Up)")
-        claude_result = self._execute_claude_guided_paginate(step, index)
-        if claude_result.success:
-            self._current_page += 1
-            self._last_known_url = self._current_results_page_url()
-            self._set_scroll_state(context="results_top", url=self._last_known_url, page_downs=0, wheel_downs=0)
-            self.dynamic_verifier.record_pagination(
-                page=current_page,
-                success=True,
-                method="claude_guided",
-                next_url=self._last_known_url,
-            )
-            self.dynamic_verifier.record_page_start(page=self._current_page, url=self._last_known_url)
-            return claude_result
-
-        # ── Layer 3: Holo3 fallback ──
-        logger.info("  [paginate] Layer 3: Holo3 fallback")
-        # Scroll to a calculated position: End then 2x Page_Up to avoid sidebar
-        try:
-            self.env.step(Action(action_type=ActionType.KEY_PRESS, params={"keys": "Home"}))
-            time.sleep(0.5)
-            # Scroll down ~80% of the page (past listings, before footer/sidebar bottom)
-            for _ in range(6):
-                self.env.step(Action(action_type=ActionType.KEY_PRESS, params={"keys": "Page_Down"}))
-                time.sleep(0.5)
-        except Exception:
-            pass
-
-        holo_result = self._execute_holo3_step(
-            MicroIntent(
-                intent="Click the Next page button or the next page number.",
-                type="paginate",
-                budget=8,
-                grounding=True,
-            ),
-            index,
-        )
-        if holo_result.success:
-            self._current_page += 1
-            self._last_known_url = self._current_results_page_url()
-            self._set_scroll_state(context="results_top", url=self._last_known_url, page_downs=0, wheel_downs=0)
-            self.dynamic_verifier.record_pagination(
-                page=current_page,
-                success=True,
-                method="holo3",
-                next_url=self._last_known_url,
-            )
-            self.dynamic_verifier.record_page_start(page=self._current_page, url=self._last_known_url)
-        else:
-            self.dynamic_verifier.record_pagination(
-                page=current_page,
-                success=False,
-                method="all_layers",
-                reason="next_control_not_found",
-            )
-        return holo_result
+        from .step_handlers.paginate import PaginateHandler
+        handler = PaginateHandler(self)
+        ctx = self._build_step_context(index)
+        return handler.execute(step, ctx)
 
     def _execute_claude_guided_paginate(self, step: MicroIntent, index: int) -> StepResult:
-        """Claude finds Next button → Holo3 clicks it.
+        """Backwards-compat shim — delegates to :meth:`PaginateHandler._claude_guided_paginate`.
 
-        Scrolls near the bottom, Claude finds pagination, retry on error, bounded grounding.
+        Layer 2 of the layered pagination strategy. Some tests
+        previously exercised this directly; the shim keeps that path
+        working while the body is unit-testable on the handler.
         """
-        # Clear focus traps such as open menus or overlays before repositioning.
-        try:
-            self.env.step(Action(action_type=ActionType.KEY_PRESS, params={"keys": "Escape"}))
-            time.sleep(0.5)
-        except Exception:
-            pass
-
-        # Go to bottom first so the pagination bar is likely on screen.
-        try:
-            self.env.step(Action(action_type=ActionType.KEY_PRESS, params={"keys": "End"}))
-            time.sleep(3)
-        except Exception:
-            pass
-
-        # Find pagination target with retry. On retry, move slightly up so the
-        # pagination bar is not flush with the screen edge or hidden by footer UI.
-        target = None
-        screenshot = None
-        for attempt in range(3):
-            if attempt == 1:
-                try:
-                    self.env.step(Action(action_type=ActionType.KEY_PRESS, params={"keys": "Page_Up"}))
-                    time.sleep(1.5)
-                except Exception:
-                    pass
-            elif attempt == 2:
-                try:
-                    self.env.step(Action(action_type=ActionType.KEY_PRESS, params={"keys": "End"}))
-                    time.sleep(2)
-                    self.env.step(Action(action_type=ActionType.KEY_PRESS, params={"keys": "Page_Up"}))
-                    time.sleep(1.5)
-                except Exception:
-                    pass
-
-            screenshot = self.env.screenshot()
-            target = self.extractor.find_paginate_target(screenshot)
-            self.costs["claude_extract"] += 1
-
-            if isinstance(target, tuple) and len(target) == 3:
-                break
-            if isinstance(target, tuple) and target[0] == "not_found":
-                logger.warning(f"  [claude-paginate] no control visible on attempt {attempt+1}/3")
-                continue
-            if isinstance(target, tuple) and target[0] == "error":
-                logger.warning(f"  [claude-paginate] parse/error on attempt {attempt+1}/3")
-                continue
-
-            logger.warning(f"  [claude-paginate] empty response on attempt {attempt+1}/3")
-
-        if not isinstance(target, tuple) or len(target) != 3:
-            logger.info("  [claude-paginate] No Next control found after retries")
-            return StepResult(step_index=index, intent=step.intent, success=False)
-
-        x, y, label = target
-
-        # Grounding with delta bound
-        if self.grounding:
-            grounding_result = self.grounding.ground(screenshot, f"pagination control {label or 'Next'}", x, y)
-            self.costs["claude_grounding"] += 1
-            dx = abs(grounding_result.x - x)
-            dy = abs(grounding_result.y - y)
-            if grounding_result.confidence > 0.5 and dx < 150 and dy < 150:
-                x, y = grounding_result.x, grounding_result.y
-                logger.info(f"  [grounding] paginate refined to ({x}, {y}) delta=({dx},{dy})")
-            else:
-                logger.info(f"  [grounding] paginate rejected: delta=({dx},{dy}) conf={grounding_result.confidence}")
-
-        # Click
-        try:
-            self.env.step(Action(action_type=ActionType.CLICK, params={"x": x, "y": y}))
-            self.costs["gpu_steps"] += 1
-            self.costs["gpu_seconds"] += 4
-            self.costs["proxy_mb"] += 5.0
-        except Exception as e:
-            logger.warning(f"  [claude-paginate] Click failed: {e}")
-            return StepResult(step_index=index, intent=step.intent, success=False)
-
-        # Wait for page load, then scroll to top
-        time.sleep(8)
-        try:
-            self.env.step(Action(action_type=ActionType.KEY_PRESS, params={"keys": "Home"}))
-            time.sleep(2)
-        except Exception:
-            pass
-
-        logger.info(f"  [claude-paginate] Clicked '{label[:20]}' at ({x}, {y})")
-        self._listings_on_page = 0  # Reset for new page
-        self._set_scroll_state(context="pagination_clicked", page_downs=0, wheel_downs=0)
-        return StepResult(step_index=index, intent=step.intent, success=True, steps_used=1)
+        from .step_handlers.paginate import PaginateHandler
+        handler = PaginateHandler(self)
+        ctx = self._build_step_context(index)
+        return handler._claude_guided_paginate(step, ctx, index)
 
     @property
     def _listings_on_page(self):

--- a/src/mantis_agent/gym/step_handlers/paginate.py
+++ b/src/mantis_agent/gym/step_handlers/paginate.py
@@ -1,0 +1,291 @@
+"""PaginateHandler — layered Next-page strategy.
+
+Phase 2 of EPIC #161, fifth handler extraction. Combines the two
+pagination methods on the runner that work as a unit:
+
+- ``_execute_paginate_layered`` — three-layer fallback orchestrator
+  (URL-based → Claude-guided → Holo3 fallback) with success bookkeeping
+  per layer
+- ``_execute_claude_guided_paginate`` — Layer 2 implementation (Escape
+  → End → Claude finds Next → grounding refine → click → 8s settle)
+
+Lifted into one cohesive handler so the layered strategy and its
+implementation live in the same module. The Holo3 fallback layer
+calls back into the runner for now (``runner._execute_holo3_step``) —
+that hand-off goes away when Holo3StepHandler is extracted in a
+follow-up PR.
+
+What the handler reads from :class:`StepContext`:
+
+- ``env``               — screenshot / step / reset
+- ``extractor``         — find_paginate_target (Claude vision)
+- ``grounding``         — coordinate refinement
+- ``dynamic_verifier``  — record_pagination / record_page_start
+- ``site_config``       — pagination_format / paginated_url
+
+What it reads from the runner via parent back-reference:
+
+- ``costs``                     — cost meter aliased dict
+- ``_current_page``             — pagination counter
+- ``_results_base_url``         — anchor URL set by NavigateHandler
+- ``_last_known_url``
+- ``_listings_on_page``         — counter, reset on success
+- ``_set_scroll_state``         — delegates to BrowserState
+- ``_current_results_page_url`` — delegates to BrowserState
+- ``_execute_holo3_step``       — Layer 3 fallback (will move when
+                                  Holo3StepHandler lands)
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import TYPE_CHECKING
+
+from ...actions import Action, ActionType
+from ..checkpoint import StepResult
+from ..step_context import StepContext
+
+if TYPE_CHECKING:
+    from ..micro_runner import MicroPlanRunner
+    from ...plan_decomposer import MicroIntent
+
+logger = logging.getLogger(__name__)
+
+
+class PaginateHandler:
+    """Implements :class:`~..step_context.StepHandler` for ``paginate`` steps.
+
+    Three layers, applied in order:
+
+    1. **URL-based** — fastest, most reliable. Detects current page URL
+       pattern, constructs page N+1 URL, navigates directly. Skips if
+       ``site_config.pagination_format`` is unset.
+    2. **Claude-guided** — Escape clears focus traps, End scrolls to
+       footer, Claude finds Next-button coordinates, grounding refines,
+       click + 8s settle.
+    3. **Holo3 fallback** — calculated scroll then a 1-sentence
+       Holo3 task. Last resort when Claude can't see pagination.
+    """
+
+    step_type = "paginate"
+
+    def __init__(self, runner: "MicroPlanRunner") -> None:
+        self.parent = runner
+
+    def execute(self, step: "MicroIntent", ctx: StepContext) -> StepResult:
+        runner = self.parent
+        env = ctx.env
+        dynamic_verifier = ctx.dynamic_verifier
+        site_config = ctx.site_config
+        index = int(ctx.state.get("index", 0))
+
+        # Track current page number
+        if not hasattr(runner, "_current_page"):
+            runner._current_page = 1
+        current_page = runner._current_page
+
+        # ── Layer 1: URL-based pagination ──
+        # Use the stored results base URL (from initial navigate), NOT the current page URL
+        # (which might be a detail page after extraction)
+        base_url = getattr(runner, "_results_base_url", "")
+        if base_url and site_config.pagination_format:
+            next_page = runner._current_page + 1
+            next_url = site_config.paginated_url(base_url, next_page)
+
+            # Ensure full URL
+            if not next_url.startswith("http"):
+                next_url = f"https://www.{next_url}"
+
+            logger.info(f"  [paginate] Layer 1: URL-based → {next_url[:80]}")
+            try:
+                env.reset(task="paginate_url", start_url=next_url)
+                time.sleep(10)
+                env.step(Action(action_type=ActionType.KEY_PRESS, params={"keys": "Home"}))
+                time.sleep(2)
+                runner._current_page = next_page
+                runner._last_known_url = next_url
+                runner._set_scroll_state(context="results_top", url=next_url, page_downs=0, wheel_downs=0)
+                dynamic_verifier.record_pagination(
+                    page=current_page,
+                    success=True,
+                    method="url",
+                    next_url=next_url,
+                )
+                dynamic_verifier.record_page_start(page=next_page, url=next_url)
+                return StepResult(step_index=index, intent=step.intent, success=True,
+                                steps_used=0, data=f"url_paginate_page{next_page}")
+            except Exception as e:
+                logger.warning(f"  [paginate] Layer 1 failed: {e}")
+                dynamic_verifier.record_pagination(
+                    page=current_page,
+                    success=False,
+                    method="url",
+                    next_url=next_url,
+                    reason=f"url_navigation_failed:{e}",
+                )
+
+        # ── Layer 2: Claude-guided ──
+        logger.info("  [paginate] Layer 2: Claude-guided (End → Page_Up)")
+        claude_result = self._claude_guided_paginate(step, ctx, index)
+        if claude_result.success:
+            runner._current_page += 1
+            runner._last_known_url = runner._current_results_page_url()
+            runner._set_scroll_state(context="results_top", url=runner._last_known_url, page_downs=0, wheel_downs=0)
+            dynamic_verifier.record_pagination(
+                page=current_page,
+                success=True,
+                method="claude_guided",
+                next_url=runner._last_known_url,
+            )
+            dynamic_verifier.record_page_start(page=runner._current_page, url=runner._last_known_url)
+            return claude_result
+
+        # ── Layer 3: Holo3 fallback ──
+        logger.info("  [paginate] Layer 3: Holo3 fallback")
+        # Scroll to a calculated position: End then 2x Page_Up to avoid sidebar
+        try:
+            env.step(Action(action_type=ActionType.KEY_PRESS, params={"keys": "Home"}))
+            time.sleep(0.5)
+            # Scroll down ~80% of the page (past listings, before footer/sidebar bottom)
+            for _ in range(6):
+                env.step(Action(action_type=ActionType.KEY_PRESS, params={"keys": "Page_Down"}))
+                time.sleep(0.5)
+        except Exception:
+            pass
+
+        # Late import to avoid a cycle: holo3 fallback still lives on the
+        # runner. When Holo3StepHandler lands, this dispatches via
+        # ctx.handler_registry instead of the parent back-reference.
+        from ...plan_decomposer import MicroIntent as _MicroIntent
+        holo_result = runner._execute_holo3_step(
+            _MicroIntent(
+                intent="Click the Next page button or the next page number.",
+                type="paginate",
+                budget=8,
+                grounding=True,
+            ),
+            index,
+        )
+        if holo_result.success:
+            runner._current_page += 1
+            runner._last_known_url = runner._current_results_page_url()
+            runner._set_scroll_state(context="results_top", url=runner._last_known_url, page_downs=0, wheel_downs=0)
+            dynamic_verifier.record_pagination(
+                page=current_page,
+                success=True,
+                method="holo3",
+                next_url=runner._last_known_url,
+            )
+            dynamic_verifier.record_page_start(page=runner._current_page, url=runner._last_known_url)
+        else:
+            dynamic_verifier.record_pagination(
+                page=current_page,
+                success=False,
+                method="all_layers",
+                reason="next_control_not_found",
+            )
+        return holo_result
+
+    def _claude_guided_paginate(
+        self, step: "MicroIntent", ctx: StepContext, index: int,
+    ) -> StepResult:
+        """Layer 2 — Claude finds Next button → click + grounding refine.
+
+        Scrolls near the bottom, Claude finds pagination, retry on
+        error, bounded grounding delta.
+        """
+        runner = self.parent
+        env = ctx.env
+        extractor = ctx.extractor
+        grounding = ctx.grounding
+
+        # Clear focus traps such as open menus or overlays before repositioning.
+        try:
+            env.step(Action(action_type=ActionType.KEY_PRESS, params={"keys": "Escape"}))
+            time.sleep(0.5)
+        except Exception:
+            pass
+
+        # Go to bottom first so the pagination bar is likely on screen.
+        try:
+            env.step(Action(action_type=ActionType.KEY_PRESS, params={"keys": "End"}))
+            time.sleep(3)
+        except Exception:
+            pass
+
+        # Find pagination target with retry. On retry, move slightly up so the
+        # pagination bar is not flush with the screen edge or hidden by footer UI.
+        target = None
+        screenshot = None
+        for attempt in range(3):
+            if attempt == 1:
+                try:
+                    env.step(Action(action_type=ActionType.KEY_PRESS, params={"keys": "Page_Up"}))
+                    time.sleep(1.5)
+                except Exception:
+                    pass
+            elif attempt == 2:
+                try:
+                    env.step(Action(action_type=ActionType.KEY_PRESS, params={"keys": "End"}))
+                    time.sleep(2)
+                    env.step(Action(action_type=ActionType.KEY_PRESS, params={"keys": "Page_Up"}))
+                    time.sleep(1.5)
+                except Exception:
+                    pass
+
+            screenshot = env.screenshot()
+            target = extractor.find_paginate_target(screenshot)
+            runner.costs["claude_extract"] += 1
+
+            if isinstance(target, tuple) and len(target) == 3:
+                break
+            if isinstance(target, tuple) and target[0] == "not_found":
+                logger.warning(f"  [claude-paginate] no control visible on attempt {attempt+1}/3")
+                continue
+            if isinstance(target, tuple) and target[0] == "error":
+                logger.warning(f"  [claude-paginate] parse/error on attempt {attempt+1}/3")
+                continue
+
+            logger.warning(f"  [claude-paginate] empty response on attempt {attempt+1}/3")
+
+        if not isinstance(target, tuple) or len(target) != 3:
+            logger.info("  [claude-paginate] No Next control found after retries")
+            return StepResult(step_index=index, intent=step.intent, success=False)
+
+        x, y, label = target
+
+        # Grounding with delta bound
+        if grounding:
+            grounding_result = grounding.ground(screenshot, f"pagination control {label or 'Next'}", x, y)
+            runner.costs["claude_grounding"] += 1
+            dx = abs(grounding_result.x - x)
+            dy = abs(grounding_result.y - y)
+            if grounding_result.confidence > 0.5 and dx < 150 and dy < 150:
+                x, y = grounding_result.x, grounding_result.y
+                logger.info(f"  [grounding] paginate refined to ({x}, {y}) delta=({dx},{dy})")
+            else:
+                logger.info(f"  [grounding] paginate rejected: delta=({dx},{dy}) conf={grounding_result.confidence}")
+
+        # Click
+        try:
+            env.step(Action(action_type=ActionType.CLICK, params={"x": x, "y": y}))
+            runner.costs["gpu_steps"] += 1
+            runner.costs["gpu_seconds"] += 4
+            runner.costs["proxy_mb"] += 5.0
+        except Exception as e:
+            logger.warning(f"  [claude-paginate] Click failed: {e}")
+            return StepResult(step_index=index, intent=step.intent, success=False)
+
+        # Wait for page load, then scroll to top
+        time.sleep(8)
+        try:
+            env.step(Action(action_type=ActionType.KEY_PRESS, params={"keys": "Home"}))
+            time.sleep(2)
+        except Exception:
+            pass
+
+        logger.info(f"  [claude-paginate] Clicked '{label[:20]}' at ({x}, {y})")
+        runner._listings_on_page = 0  # Reset for new page
+        runner._set_scroll_state(context="pagination_clicked", page_downs=0, wheel_downs=0)
+        return StepResult(step_index=index, intent=step.intent, success=True, steps_used=1)

--- a/tests/test_paginate_handler.py
+++ b/tests/test_paginate_handler.py
@@ -1,0 +1,240 @@
+"""PaginateHandler unit tests — Phase 2 of EPIC #161.
+
+Three-layer pagination: URL-based → Claude-guided → Holo3 fallback.
+Tests pin the layer-selection logic and per-layer success bookkeeping.
+
+- Layer 1 success: pagination_format set + env.reset succeeds → bypasses
+  Layer 2/3, increments _current_page, records pagination(method="url")
+- Layer 1 skip when pagination_format unset → falls through to Layer 2
+- Layer 1 fail (env.reset raises) → falls through to Layer 2; failure
+  recorded with reason
+- Layer 2 Claude paginate: target found tuple → grounding refine →
+  click → success; _listings_on_page reset to 0
+- Layer 2 Claude paginate: 3 attempts of 'not_found' → returns failure,
+  then Layer 3 Holo3 fallback runs
+- Holo3 fallback success bookkeeping (record_pagination(method="holo3"))
+- Holo3 fallback failure → final record_pagination(method="all_layers",
+  reason="next_control_not_found")
+- step_type property
+
+No Xvfb, no GymRunner, no real ClaudeExtractor.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+from mantis_agent.gym.step_context import StepContext
+from mantis_agent.gym.step_handlers.paginate import PaginateHandler
+from mantis_agent.plan_decomposer import MicroIntent
+
+
+class _FakeRunner:
+    def __init__(self) -> None:
+        self.costs: dict[str, float] = {
+            "claude_extract": 0,
+            "claude_grounding": 0,
+            "gpu_steps": 0,
+            "gpu_seconds": 0,
+            "proxy_mb": 0.0,
+        }
+        self._current_page = 1
+        self._results_base_url = "https://example.com/cars"
+        self._last_known_url = ""
+        self._page_listing_count = 0
+        self.scroll_state_calls: list[dict] = []
+        self.holo_fallback_called = False
+        self._holo_result_success = True
+
+    @property
+    def _listings_on_page(self) -> int:
+        return self._page_listing_count
+
+    @_listings_on_page.setter
+    def _listings_on_page(self, value: int) -> None:
+        self._page_listing_count = value
+
+    def _set_scroll_state(self, **kwargs) -> None:
+        self.scroll_state_calls.append(kwargs)
+
+    def _current_results_page_url(self) -> str:
+        return self._results_base_url
+
+    def _execute_holo3_step(self, step, index):
+        from mantis_agent.gym.checkpoint import StepResult
+        self.holo_fallback_called = True
+        return StepResult(step_index=index, intent=step.intent, success=self._holo_result_success)
+
+
+def _ctx(runner, *, env=None, extractor=None, grounding=None, site_config=None) -> StepContext:
+    return StepContext(
+        env=env or MagicMock(),
+        brain=None,
+        extractor=extractor or MagicMock(),
+        grounding=grounding,
+        cost_meter=None,
+        dynamic_verifier=MagicMock(),
+        scanner=None,
+        site_config=site_config or MagicMock(),
+        tool_channel=None,
+        extraction_cache=None,
+        state={"index": 9},
+    )
+
+
+def _step() -> MicroIntent:
+    return MicroIntent(intent="Go to next page", type="paginate")
+
+
+# ── Layer 1: URL-based ──────────────────────────────────────────────
+
+
+def test_layer1_url_pagination_success(monkeypatch):
+    monkeypatch.setattr("mantis_agent.gym.step_handlers.paginate.time.sleep", lambda *_: None)
+
+    runner = _FakeRunner()
+    site_config = MagicMock()
+    site_config.pagination_format = "/page-{n}"
+    site_config.paginated_url.return_value = "https://example.com/cars/page-2"
+    env = MagicMock()
+    ctx = _ctx(runner, env=env, site_config=site_config)
+
+    result = PaginateHandler(runner).execute(_step(), ctx)
+
+    assert result.success is True
+    assert result.data == "url_paginate_page2"
+    assert runner._current_page == 2
+    assert runner._last_known_url == "https://example.com/cars/page-2"
+    env.reset.assert_called_once_with(task="paginate_url", start_url="https://example.com/cars/page-2")
+    # Layers 2/3 not invoked
+    assert runner.holo_fallback_called is False
+    record = ctx.dynamic_verifier.record_pagination.call_args
+    assert record.kwargs["method"] == "url"
+    assert record.kwargs["success"] is True
+
+
+def test_layer1_skipped_when_pagination_format_unset_falls_to_layer2(monkeypatch):
+    monkeypatch.setattr("mantis_agent.gym.step_handlers.paginate.time.sleep", lambda *_: None)
+
+    runner = _FakeRunner()
+    site_config = MagicMock()
+    site_config.pagination_format = ""  # disabled
+    extractor = MagicMock()
+    # Layer 2 finds Next button immediately
+    extractor.find_paginate_target.return_value = (500, 600, "Next")
+    env = MagicMock()
+    ctx = _ctx(runner, env=env, extractor=extractor, site_config=site_config)
+
+    result = PaginateHandler(runner).execute(_step(), ctx)
+
+    assert result.success is True
+    assert runner._current_page == 2
+    # No env.reset call (Layer 1 skipped)
+    env.reset.assert_not_called()
+
+
+def test_layer1_failure_falls_through_to_layer2(monkeypatch):
+    monkeypatch.setattr("mantis_agent.gym.step_handlers.paginate.time.sleep", lambda *_: None)
+
+    runner = _FakeRunner()
+    site_config = MagicMock()
+    site_config.pagination_format = "/page-{n}"
+    site_config.paginated_url.return_value = "https://example.com/cars/page-2"
+    env = MagicMock()
+    env.reset.side_effect = RuntimeError("network blip")
+    extractor = MagicMock()
+    extractor.find_paginate_target.return_value = (500, 600, "Next")
+    ctx = _ctx(runner, env=env, extractor=extractor, site_config=site_config)
+
+    result = PaginateHandler(runner).execute(_step(), ctx)
+
+    assert result.success is True  # Layer 2 saved us
+    # Two pagination records: first url=fail, then claude_guided=success
+    calls = ctx.dynamic_verifier.record_pagination.call_args_list
+    assert len(calls) == 2
+    assert calls[0].kwargs["method"] == "url"
+    assert calls[0].kwargs["success"] is False
+    assert calls[1].kwargs["method"] == "claude_guided"
+    assert calls[1].kwargs["success"] is True
+
+
+# ── Layer 2: Claude-guided ──────────────────────────────────────────
+
+
+def test_layer2_claude_target_found_clicks_and_resets_listings_count(monkeypatch):
+    monkeypatch.setattr("mantis_agent.gym.step_handlers.paginate.time.sleep", lambda *_: None)
+
+    runner = _FakeRunner()
+    runner._page_listing_count = 7  # pre-set: should reset to 0
+    site_config = MagicMock()
+    site_config.pagination_format = ""
+    extractor = MagicMock()
+    extractor.find_paginate_target.return_value = (250, 700, "Next")
+    env = MagicMock()
+    ctx = _ctx(runner, env=env, extractor=extractor, site_config=site_config)
+
+    result = PaginateHandler(runner).execute(_step(), ctx)
+
+    assert result.success is True
+    assert runner._listings_on_page == 0  # reset for new page
+    assert runner.costs["gpu_steps"] == 1
+    assert runner.costs["gpu_seconds"] == 4
+    assert runner.costs["claude_extract"] == 1
+
+
+def test_layer2_target_not_found_after_3_attempts_falls_to_layer3(monkeypatch):
+    monkeypatch.setattr("mantis_agent.gym.step_handlers.paginate.time.sleep", lambda *_: None)
+
+    runner = _FakeRunner()
+    runner._holo_result_success = True
+    site_config = MagicMock()
+    site_config.pagination_format = ""
+    extractor = MagicMock()
+    extractor.find_paginate_target.return_value = ("not_found",)
+    env = MagicMock()
+    ctx = _ctx(runner, env=env, extractor=extractor, site_config=site_config)
+
+    result = PaginateHandler(runner).execute(_step(), ctx)
+
+    assert result.success is True
+    # 3 Layer 2 attempts billed + Holo3 fallback (which succeeded)
+    assert runner.costs["claude_extract"] == 3
+    assert runner.holo_fallback_called is True
+    # Last record_pagination call: holo3 success
+    last_call = ctx.dynamic_verifier.record_pagination.call_args_list[-1]
+    assert last_call.kwargs["method"] == "holo3"
+    assert last_call.kwargs["success"] is True
+
+
+# ── Layer 3: Holo3 fallback ─────────────────────────────────────────
+
+
+def test_layer3_failure_records_all_layers_failure(monkeypatch):
+    monkeypatch.setattr("mantis_agent.gym.step_handlers.paginate.time.sleep", lambda *_: None)
+
+    runner = _FakeRunner()
+    runner._holo_result_success = False  # last layer also fails
+    site_config = MagicMock()
+    site_config.pagination_format = ""
+    extractor = MagicMock()
+    extractor.find_paginate_target.return_value = ("not_found",)
+    env = MagicMock()
+    ctx = _ctx(runner, env=env, extractor=extractor, site_config=site_config)
+
+    result = PaginateHandler(runner).execute(_step(), ctx)
+
+    assert result.success is False
+    assert runner.holo_fallback_called is True
+    # Final pagination record: all_layers + reason
+    last_call = ctx.dynamic_verifier.record_pagination.call_args_list[-1]
+    assert last_call.kwargs["method"] == "all_layers"
+    assert last_call.kwargs["reason"] == "next_control_not_found"
+
+
+# ── Misc ────────────────────────────────────────────────────────────
+
+
+def test_step_type_property():
+    handler = PaginateHandler(_FakeRunner())
+    assert handler.step_type == "paginate"

--- a/tests/test_paginate_handler.py
+++ b/tests/test_paginate_handler.py
@@ -22,7 +22,6 @@ No Xvfb, no GymRunner, no real ClaudeExtractor.
 
 from __future__ import annotations
 
-from typing import Any
 from unittest.mock import MagicMock
 
 from mantis_agent.gym.step_context import StepContext


### PR DESCRIPTION
Refs #161 (Phase 2 — fifth handler extraction).

## Summary

Lifts the two pagination methods that work as a unit — `_execute_paginate_layered` (113 LOC) and `_execute_claude_guided_paginate` (94 LOC) — into one cohesive `PaginateHandler` class under `step_handlers/paginate.py`. The runner methods become delegating shims; the legacy 207-LOC combined body is removed.

`micro_runner.py` is now **1,975 LOC** — down from the pre-Phase-2 baseline of 3,006 (**1,031 LOC removed across 5 handler extractions**).

## Behaviour preserved verbatim

Three layers, applied in order:

- **Layer 1 (URL-based)** — fastest. Detects `site_config.pagination_format`, constructs page N+1 URL via `paginated_url`, navigates directly with `env.reset`, 10s settle + `Home`.
- **Layer 2 (Claude-guided)** — `Escape` clears focus traps, `End` scrolls to footer, 3-attempt `find_paginate_target` loop with `Page_Up` retry on miss, grounding refine with 150px delta bound, click + 8s settle, `_listings_on_page` reset.
- **Layer 3 (Holo3 fallback)** — calculated 6x `Page_Down` scroll, then `runner._execute_holo3_step(MicroIntent("Click the Next page button…", type="paginate", grounding=True))`. The Holo3 hand-off goes away when `Holo3StepHandler` is extracted in a follow-up PR.

## Phase 2 progress

| Metric | Pre-Phase-2 | After PR #171 | After this PR |
|---|---|---|---|
| `micro_runner.py` LOC | 3,006 | 2,197 | **1,975** (−1,031 / −34%) |
| Handlers extracted | 0 | 4 | **5** (Navigate, Click, Form, ClaudeStep, Paginate) |
| Mocked-context unit tests | 0 | 33 | **40** |
| Step types backed by handlers | 0 | 7 | **8** (+ paginate) |

## Test plan

- [x] `tests/test_paginate_handler.py` (7 new) — mocked-context unit tests:
  - Layer 1 URL-based success (assert `_current_page=2` + `record_pagination(method="url", success=True)`)
  - Layer 1 skip when `pagination_format` unset → falls through to Layer 2
  - Layer 1 failure (env.reset raises) → falls through to Layer 2; both records emitted
  - Layer 2 click + `_listings_on_page` reset to 0
  - Layer 2 `target_not_found` 3 attempts → falls to Layer 3; Holo3 success bookkeeping
  - Layer 3 failure → final `record_pagination(method="all_layers", reason="next_control_not_found")`
  - `step_type` property
- [x] **No regressions in the existing focus suite**: 240 passed (Phase 1 + Phase 2 four prior handlers + listing-dedup + browser-state + checkpoint-manager + plan-aware-reverse + private-seller-filter + micro-runner-hooks + step-snapshot + cost-meter + form-intents + submit-enter-fallback).
- [x] **Live verification on Modal**: deployed branch, ran example.com plan_text. Result: 2 steps in 39s, $0.03 — matches pre-Phase-2 numbers exactly. The plan doesn't include a `paginate` step (single-page extract), so this confirms the broader plan flow isn't disrupted. Pagination-driven plans (multi-page marketplace extraction) need a target with paginated results to exercise the layered fallback end-to-end; the 7 unit tests cover all three layers and their bookkeeping.

## Follow-up PRs

- `FilterHandler` (`_execute_claude_guided_filter`, 149 LOC)
- `Holo3StepHandler` (`_execute_holo3_step`, 39 LOC) — once this lands, the `runner._execute_holo3_step` back-reference in PaginateHandler.Layer 3 collapses to a registry call
- The small ones: `_execute_close_detail_tab`, gate-step inline body
- Cleanup PR: register every handler, rip `_execute_step`'s if/elif, collapse the click-branch layout router, merge form-types dispatch settle

🤖 Generated with [Claude Code](https://claude.com/claude-code)