### PR TITLE
refactor(runner): EPIC #161 Phase 2 — extract FilterHandler + Holo3StepHandler

### DIFF
--- a/src/mantis_agent/gym/micro_runner.py
+++ b/src/mantis_agent/gym/micro_runner.py
@@ -43,7 +43,6 @@ from .checkpoint import (
     StepResult,
     _PauseRequested,
 )
-from .runner import GymRunner
 from .tool_channel import ToolChannel
 
 from ..plan_decomposer import MicroIntent, MicroPlan
@@ -1584,152 +1583,15 @@ class MicroPlanRunner:
         return handler.execute(step, ctx)
 
     def _execute_claude_guided_filter(self, step: MicroIntent, index: int) -> StepResult:
-        """Claude identifies filter element → direct click/type via env.step().
+        """Backwards-compat shim — delegates to :class:`ClaudeGuidedFilterHandler`.
 
-        Holo3 is 0% reliable on sidebar filters (clicks wrong elements).
-        Claude reads the screenshot, identifies exact coordinates and action type,
-        then we execute directly — no Holo3 involved.
-
-        If not found in current viewport, scrolls down and retries.
+        Phase 2 of EPIC #161: sidebar filter dispatch lives in
+        ``step_handlers/filter.py`` so it's unit-testable in isolation.
         """
-        import random
-
-        # Reset sidebar to top before each filter step (scroll persists between steps).
-        # Filters are spread across the sidebar: Location near top, Seller Type near bottom.
-        try:
-            for _ in range(10):
-                self.env.step(Action(action_type=ActionType.SCROLL,
-                                   params={"direction": "up", "amount": 5,
-                                           "x": 150, "y": 400}))
-                time.sleep(0.3)
-        except Exception:
-            pass
-        time.sleep(1)
-
-        # Scan sidebar top-to-bottom with small scroll increments.
-        # Check each viewport position for the target filter element.
-        target = None
-        for scroll_attempt in range(8):
-            if scroll_attempt > 0:
-                # Scroll sidebar down in small increments (3 clicks ≈ ~100px)
-                try:
-                    self.env.step(Action(action_type=ActionType.SCROLL,
-                                       params={"direction": "down", "amount": 3,
-                                               "x": 150, "y": 400}))
-                    time.sleep(1)
-                except Exception:
-                    pass
-
-            screenshot = self.env.screenshot()
-            target = self.extractor.find_filter_target(screenshot, step.intent)
-            self.costs["claude_extract"] += 1
-
-            if target:
-                break
-            print(f"  [claude-filter] Not found in viewport {scroll_attempt}, scrolling sidebar")
-
-        if not target:
-            logger.warning("  [claude-filter] Could not find filter element")
-            return StepResult(step_index=index, intent=step.intent, success=False)
-
-        x, y = target["x"], target["y"]
-        action = target["action"]
-        value = target["value"]
-        label = target["label"]
-
-        # Grounding refines coordinates (bounded delta)
-        if self.grounding:
-            grounding_result = self.grounding.ground(screenshot, label or step.intent, x, y)
-            self.costs["claude_grounding"] += 1
-            dx = abs(grounding_result.x - x)
-            dy = abs(grounding_result.y - y)
-            if grounding_result.confidence > 0.5 and dx < 150 and dy < 150:
-                x, y = grounding_result.x, grounding_result.y
-                logger.info(f"  [grounding] filter refined to ({x},{y}) delta=({dx},{dy})")
-            else:
-                logger.info(f"  [grounding] filter rejected: delta=({dx},{dy}) conf={grounding_result.confidence}")
-
-        # Human-like delay before interaction
-        time.sleep(random.uniform(0.5, 1.5))
-
-        try:
-            if action == "click":
-                # Simple click — checkbox, radio, toggle
-                self.env.step(Action(action_type=ActionType.CLICK, params={"x": x, "y": y}))
-                self.costs["gpu_steps"] += 1
-                time.sleep(2)  # Wait for filter to apply
-
-            elif action == "type":
-                # Click input → clear → type value → Enter
-                self.env.step(Action(action_type=ActionType.CLICK, params={"x": x, "y": y}))
-                time.sleep(0.5)
-                # Triple-click to select all existing text
-                self.env.step(Action(action_type=ActionType.CLICK, params={"x": x, "y": y}))
-                time.sleep(0.1)
-                self.env.step(Action(action_type=ActionType.CLICK, params={"x": x, "y": y}))
-                time.sleep(0.3)
-                # Select all and delete
-                self.env.step(Action(action_type=ActionType.KEY_PRESS, params={"keys": "ctrl+a"}))
-                time.sleep(0.2)
-                self.env.step(Action(action_type=ActionType.KEY_PRESS, params={"keys": "Delete"}))
-                time.sleep(0.3)
-                # Type the value
-                if value:
-                    self.env.step(Action(action_type=ActionType.TYPE, params={"text": value}))
-                    time.sleep(0.5)
-                    self.env.step(Action(action_type=ActionType.KEY_PRESS, params={"keys": "Return"}))
-                    time.sleep(3)  # Wait for results to update
-                self.costs["gpu_steps"] += 1
-
-            elif action == "select":
-                # Click dropdown to open → wait → screenshot → find option → click
-                self.env.step(Action(action_type=ActionType.CLICK, params={"x": x, "y": y}))
-                self.costs["gpu_steps"] += 1
-                time.sleep(1.5)
-
-                # Take new screenshot with dropdown open
-                dropdown_shot = self.env.screenshot()
-                # Ask Claude to find the specific option in the dropdown
-                option_target = self.extractor.find_filter_target(
-                    dropdown_shot,
-                    f"Find and click the option '{value}' in the open dropdown menu"
-                )
-                self.costs["claude_extract"] += 1
-
-                if option_target:
-                    ox, oy = option_target["x"], option_target["y"]
-                    time.sleep(random.uniform(0.3, 0.8))
-                    self.env.step(Action(action_type=ActionType.CLICK, params={"x": ox, "y": oy}))
-                    time.sleep(2)
-                else:
-                    # Dropdown option not found — close dropdown
-                    self.env.step(Action(action_type=ActionType.KEY_PRESS, params={"keys": "Escape"}))
-                    time.sleep(0.5)
-                    logger.warning(f"  [claude-filter] Dropdown option '{value}' not found")
-                    return StepResult(step_index=index, intent=step.intent, success=False)
-
-            else:
-                # Unknown action — fall back to click
-                self.env.step(Action(action_type=ActionType.CLICK, params={"x": x, "y": y}))
-                self.costs["gpu_steps"] += 1
-                time.sleep(2)
-
-        except Exception as e:
-            logger.warning(f"  [claude-filter] Action failed: {e}")
-            return StepResult(step_index=index, intent=step.intent, success=False)
-
-        logger.info(f"  [claude-filter] {action}@({x},{y}) '{label[:30]}' value='{value[:20]}'")
-        self._last_known_url = self._current_results_page_url() or self._results_base_url
-        self._set_scroll_state(
-            context="results_after_filter",
-            url=self._last_known_url,
-            page_downs=0,
-            wheel_downs=0,
-        )
-        return StepResult(
-            step_index=index, intent=step.intent, success=True,
-            steps_used=1, duration=3.0,
-        )
+        from .step_handlers.filter import ClaudeGuidedFilterHandler
+        handler = ClaudeGuidedFilterHandler(self)
+        ctx = self._build_step_context(index)
+        return handler.execute(step, ctx)
 
     # ── Form-shaped step types (issue #80) ────────────────────────────
     def _execute_claude_guided_form(self, step: MicroIntent, index: int) -> StepResult:
@@ -1784,43 +1646,18 @@ class MicroPlanRunner:
         self._page_listing_count = value
 
     def _execute_holo3_step(self, step: MicroIntent, index: int) -> StepResult:
-        """Execute a Holo3 micro-intent with fresh GymRunner."""
-        runner = GymRunner(
-            brain=self.brain,
-            env=self.env,
-            max_steps=step.budget,
-            frames_per_inference=1,
-            grounding=self.grounding if step.grounding else None,
-            on_step=self.on_step,
-        )
+        """Backwards-compat shim — delegates to :class:`Holo3StepHandler`.
 
-        result = runner.run(task=step.intent, task_id=f"step_{index}_{step.type}")
-
-        success = result.success
-        self._update_scroll_state_from_trajectory(result, context=f"holo3_{step.type}")
-        current_url = getattr(self.env, "current_url", "") or ""
-        if current_url:
-            self._last_known_url = current_url
-
-        # Post-step verification using Claude (if extractor available)
-        if success and step.verify and self.extractor:
-            screenshot = self.env.screenshot()
-            verify_data = self.extractor.extract(screenshot)
-            self.costs["claude_extract"] += 1
-            if verify_data and getattr(verify_data, "url", ""):
-                self._last_known_url = verify_data.url
-            verified = self._check_verify(step.verify, verify_data, screenshot)
-            if not verified:
-                logger.warning(f"  [verify] Step {index} claimed success but verification FAILED: {step.verify[:60]}")
-                success = False
-
-        return StepResult(
-            step_index=index,
-            intent=step.intent,
-            success=success,
-            steps_used=result.total_steps,
-            duration=result.total_time,
-        )
+        Phase 2 of EPIC #161: Holo3 micro-intent execution (fresh
+        GymRunner + post-step Claude verify) lives in
+        ``step_handlers/holo3.py`` so it's unit-testable in isolation.
+        ``PaginateHandler`` Layer 3 calls this shim until the cleanup
+        PR registers Holo3StepHandler in the registry directly.
+        """
+        from .step_handlers.holo3 import Holo3StepHandler
+        handler = Holo3StepHandler(self)
+        ctx = self._build_step_context(index)
+        return handler.execute(step, ctx)
 
     def _check_verify(self, verify_condition: str, extract_data, screenshot) -> bool:
         """Check if a step's verify condition is met using Claude extraction data.

--- a/src/mantis_agent/gym/step_handlers/filter.py
+++ b/src/mantis_agent/gym/step_handlers/filter.py
@@ -1,0 +1,204 @@
+"""ClaudeGuidedFilterHandler — sidebar filter dispatch.
+
+Phase 2 of EPIC #161, sixth handler extraction. Lifts
+``MicroPlanRunner._execute_claude_guided_filter`` (147 LOC) verbatim
+into a standalone class. The runner method becomes a delegating shim.
+
+Holo3 is 0% reliable on sidebar filters (clicks wrong elements).
+Claude reads the screenshot, identifies exact coordinates and action
+type (``click``/``type``/``select``), then we execute directly — no
+Holo3 involved. If not found in the current viewport, scrolls the
+sidebar down and retries up to 8 times.
+
+Three action types share this body:
+
+- ``click``  — checkbox / radio / toggle. Single click + 2s settle.
+- ``type``   — text-input filter. Click + triple-click + ctrl+a + Delete + TYPE + Return.
+- ``select`` — dropdown filter. Click to open + Claude finds option in
+  open menu + click option. Escape on miss.
+
+What the handler reads from :class:`StepContext`:
+
+- ``env``         — screenshot / step (SCROLL / CLICK / KEY_PRESS / TYPE)
+- ``extractor``   — find_filter_target (Claude vision)
+- ``grounding``   — coordinate refinement (150px delta bound)
+
+What it reads from the runner via parent back-reference:
+
+- ``costs``                       — cost meter aliased dict
+- ``_last_known_url``             — anchor URL after filter applies
+- ``_results_base_url``           — fallback when current URL not set
+- ``_set_scroll_state``           — delegates to BrowserState
+- ``_current_results_page_url``   — delegates to BrowserState
+"""
+
+from __future__ import annotations
+
+import logging
+import random
+import time
+from typing import TYPE_CHECKING
+
+from ...actions import Action, ActionType
+from ..checkpoint import StepResult
+from ..step_context import StepContext
+
+if TYPE_CHECKING:
+    from ..micro_runner import MicroPlanRunner
+    from ...plan_decomposer import MicroIntent
+
+logger = logging.getLogger(__name__)
+
+
+class ClaudeGuidedFilterHandler:
+    """Implements :class:`~..step_context.StepHandler` for ``filter`` steps."""
+
+    step_type = "filter"
+
+    def __init__(self, runner: "MicroPlanRunner") -> None:
+        self.parent = runner
+
+    def execute(self, step: "MicroIntent", ctx: StepContext) -> StepResult:
+        runner = self.parent
+        env = ctx.env
+        extractor = ctx.extractor
+        grounding = ctx.grounding
+        index = int(ctx.state.get("index", 0))
+
+        # Reset sidebar to top before each filter step (scroll persists between steps).
+        # Filters are spread across the sidebar: Location near top, Seller Type near bottom.
+        try:
+            for _ in range(10):
+                env.step(Action(action_type=ActionType.SCROLL,
+                                params={"direction": "up", "amount": 5,
+                                        "x": 150, "y": 400}))
+                time.sleep(0.3)
+        except Exception:
+            pass
+        time.sleep(1)
+
+        # Scan sidebar top-to-bottom with small scroll increments.
+        # Check each viewport position for the target filter element.
+        target = None
+        screenshot = None
+        for scroll_attempt in range(8):
+            if scroll_attempt > 0:
+                # Scroll sidebar down in small increments (3 clicks ≈ ~100px)
+                try:
+                    env.step(Action(action_type=ActionType.SCROLL,
+                                    params={"direction": "down", "amount": 3,
+                                            "x": 150, "y": 400}))
+                    time.sleep(1)
+                except Exception:
+                    pass
+
+            screenshot = env.screenshot()
+            target = extractor.find_filter_target(screenshot, step.intent)
+            runner.costs["claude_extract"] += 1
+
+            if target:
+                break
+            print(f"  [claude-filter] Not found in viewport {scroll_attempt}, scrolling sidebar")
+
+        if not target:
+            logger.warning("  [claude-filter] Could not find filter element")
+            return StepResult(step_index=index, intent=step.intent, success=False)
+
+        x, y = target["x"], target["y"]
+        action = target["action"]
+        value = target["value"]
+        label = target["label"]
+
+        # Grounding refines coordinates (bounded delta)
+        if grounding:
+            grounding_result = grounding.ground(screenshot, label or step.intent, x, y)
+            runner.costs["claude_grounding"] += 1
+            dx = abs(grounding_result.x - x)
+            dy = abs(grounding_result.y - y)
+            if grounding_result.confidence > 0.5 and dx < 150 and dy < 150:
+                x, y = grounding_result.x, grounding_result.y
+                logger.info(f"  [grounding] filter refined to ({x},{y}) delta=({dx},{dy})")
+            else:
+                logger.info(f"  [grounding] filter rejected: delta=({dx},{dy}) conf={grounding_result.confidence}")
+
+        # Human-like delay before interaction
+        time.sleep(random.uniform(0.5, 1.5))
+
+        try:
+            if action == "click":
+                # Simple click — checkbox, radio, toggle
+                env.step(Action(action_type=ActionType.CLICK, params={"x": x, "y": y}))
+                runner.costs["gpu_steps"] += 1
+                time.sleep(2)  # Wait for filter to apply
+
+            elif action == "type":
+                # Click input → clear → type value → Enter
+                env.step(Action(action_type=ActionType.CLICK, params={"x": x, "y": y}))
+                time.sleep(0.5)
+                # Triple-click to select all existing text
+                env.step(Action(action_type=ActionType.CLICK, params={"x": x, "y": y}))
+                time.sleep(0.1)
+                env.step(Action(action_type=ActionType.CLICK, params={"x": x, "y": y}))
+                time.sleep(0.3)
+                # Select all and delete
+                env.step(Action(action_type=ActionType.KEY_PRESS, params={"keys": "ctrl+a"}))
+                time.sleep(0.2)
+                env.step(Action(action_type=ActionType.KEY_PRESS, params={"keys": "Delete"}))
+                time.sleep(0.3)
+                # Type the value
+                if value:
+                    env.step(Action(action_type=ActionType.TYPE, params={"text": value}))
+                    time.sleep(0.5)
+                    env.step(Action(action_type=ActionType.KEY_PRESS, params={"keys": "Return"}))
+                    time.sleep(3)  # Wait for results to update
+                runner.costs["gpu_steps"] += 1
+
+            elif action == "select":
+                # Click dropdown to open → wait → screenshot → find option → click
+                env.step(Action(action_type=ActionType.CLICK, params={"x": x, "y": y}))
+                runner.costs["gpu_steps"] += 1
+                time.sleep(1.5)
+
+                # Take new screenshot with dropdown open
+                dropdown_shot = env.screenshot()
+                # Ask Claude to find the specific option in the dropdown
+                option_target = extractor.find_filter_target(
+                    dropdown_shot,
+                    f"Find and click the option '{value}' in the open dropdown menu"
+                )
+                runner.costs["claude_extract"] += 1
+
+                if option_target:
+                    ox, oy = option_target["x"], option_target["y"]
+                    time.sleep(random.uniform(0.3, 0.8))
+                    env.step(Action(action_type=ActionType.CLICK, params={"x": ox, "y": oy}))
+                    time.sleep(2)
+                else:
+                    # Dropdown option not found — close dropdown
+                    env.step(Action(action_type=ActionType.KEY_PRESS, params={"keys": "Escape"}))
+                    time.sleep(0.5)
+                    logger.warning(f"  [claude-filter] Dropdown option '{value}' not found")
+                    return StepResult(step_index=index, intent=step.intent, success=False)
+
+            else:
+                # Unknown action — fall back to click
+                env.step(Action(action_type=ActionType.CLICK, params={"x": x, "y": y}))
+                runner.costs["gpu_steps"] += 1
+                time.sleep(2)
+
+        except Exception as e:
+            logger.warning(f"  [claude-filter] Action failed: {e}")
+            return StepResult(step_index=index, intent=step.intent, success=False)
+
+        logger.info(f"  [claude-filter] {action}@({x},{y}) '{label[:30]}' value='{value[:20]}'")
+        runner._last_known_url = runner._current_results_page_url() or runner._results_base_url
+        runner._set_scroll_state(
+            context="results_after_filter",
+            url=runner._last_known_url,
+            page_downs=0,
+            wheel_downs=0,
+        )
+        return StepResult(
+            step_index=index, intent=step.intent, success=True,
+            steps_used=1, duration=3.0,
+        )

--- a/src/mantis_agent/gym/step_handlers/holo3.py
+++ b/src/mantis_agent/gym/step_handlers/holo3.py
@@ -1,0 +1,112 @@
+"""Holo3StepHandler — fallback to a fresh GymRunner with Holo3 brain.
+
+Phase 2 of EPIC #161, seventh handler extraction. Lifts
+``MicroPlanRunner._execute_holo3_step`` (38 LOC) verbatim into a
+standalone class. The runner method becomes a delegating shim.
+
+Holo3 is the tactical brain — used as a last resort when Claude can't
+identify a clear coordinate (e.g. ``PaginateHandler`` Layer 3 fallback,
+unknown step types). The handler spins up a fresh :class:`GymRunner`
+bound to the same env / brain / grounding so post-step verification
+has clean state.
+
+Post-step verify uses Claude (not Holo3) when ``step.verify`` is set
+and an extractor is available — the runner's ``_check_verify`` helper
+holds that string-comparison logic and stays on the runner for now
+(it's a 30-LOC pure helper used by other handlers too).
+
+What the handler reads from :class:`StepContext`:
+
+- ``env``         — current_url + screenshot for post-step verify
+- ``brain``       — Holo3 model passed to the new GymRunner
+- ``grounding``   — optional, conditional on ``step.grounding``
+- ``extractor``   — Claude verify when ``step.verify`` is set
+
+What it reads from the runner via parent back-reference:
+
+- ``costs``                                — cost meter aliased dict
+- ``on_step``                              — viewer callback forwarded to GymRunner
+- ``_update_scroll_state_from_trajectory`` — BrowserState delegate
+- ``_last_known_url``                      — updated from env.current_url
+- ``_check_verify``                        — Claude string-match against a viable
+                                             extraction
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from ..checkpoint import StepResult
+from ..runner import GymRunner
+from ..step_context import StepContext
+
+if TYPE_CHECKING:
+    from ..micro_runner import MicroPlanRunner
+    from ...plan_decomposer import MicroIntent
+
+logger = logging.getLogger(__name__)
+
+
+class Holo3StepHandler:
+    """Implements :class:`~..step_context.StepHandler` for Holo3-driven steps.
+
+    Not registered for a specific step type by default — it's invoked
+    by other handlers (PaginateHandler.Layer 3) and by the runner
+    dispatch when no Claude-guided path applies (e.g. ``scroll`` /
+    ``navigate_back``). The cleanup PR will register it for those step
+    types after the recovery dispatch swap lands.
+    """
+
+    step_type = "holo3"
+
+    def __init__(self, runner: "MicroPlanRunner") -> None:
+        self.parent = runner
+
+    def execute(self, step: "MicroIntent", ctx: StepContext) -> StepResult:
+        runner = self.parent
+        env = ctx.env
+        brain = ctx.brain
+        extractor = ctx.extractor
+        grounding = ctx.grounding
+        index = int(ctx.state.get("index", 0))
+
+        gym_runner = GymRunner(
+            brain=brain,
+            env=env,
+            max_steps=step.budget,
+            frames_per_inference=1,
+            grounding=grounding if step.grounding else None,
+            on_step=runner.on_step,
+        )
+
+        result = gym_runner.run(task=step.intent, task_id=f"step_{index}_{step.type}")
+
+        success = result.success
+        runner._update_scroll_state_from_trajectory(result, context=f"holo3_{step.type}")
+        current_url = getattr(env, "current_url", "") or ""
+        if current_url:
+            runner._last_known_url = current_url
+
+        # Post-step verification using Claude (if extractor available)
+        if success and step.verify and extractor:
+            screenshot = env.screenshot()
+            verify_data = extractor.extract(screenshot)
+            runner.costs["claude_extract"] += 1
+            if verify_data and getattr(verify_data, "url", ""):
+                runner._last_known_url = verify_data.url
+            verified = runner._check_verify(step.verify, verify_data, screenshot)
+            if not verified:
+                logger.warning(
+                    f"  [verify] Step {index} claimed success but verification "
+                    f"FAILED: {step.verify[:60]}"
+                )
+                success = False
+
+        return StepResult(
+            step_index=index,
+            intent=step.intent,
+            success=success,
+            steps_used=result.total_steps,
+            duration=result.total_time,
+        )

--- a/tests/test_filter_handler.py
+++ b/tests/test_filter_handler.py
@@ -1,0 +1,172 @@
+"""ClaudeGuidedFilterHandler unit tests — Phase 2 of EPIC #161.
+
+Sidebar filter dispatch with three action types: ``click``, ``type``,
+``select``. Tests pin each branch.
+
+- click action: simple click + 2s settle
+- type action: click + triple-click + ctrl+a + Delete + TYPE + Return
+- select action: open dropdown + Claude finds option + click
+- select with option-not-found: Escape to close + failure
+- target not found after 8 viewport scrolls → failure
+- step_type property
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from mantis_agent.actions import ActionType
+from mantis_agent.gym.step_context import StepContext
+from mantis_agent.gym.step_handlers.filter import ClaudeGuidedFilterHandler
+from mantis_agent.plan_decomposer import MicroIntent
+
+
+class _FakeRunner:
+    def __init__(self) -> None:
+        self.costs: dict[str, float] = {"claude_extract": 0, "claude_grounding": 0, "gpu_steps": 0}
+        self._last_known_url = ""
+        self._results_base_url = "https://example.com/cars"
+        self.scroll_state_calls: list[dict] = []
+
+    def _set_scroll_state(self, **kwargs) -> None:
+        self.scroll_state_calls.append(kwargs)
+
+    def _current_results_page_url(self) -> str:
+        return self._results_base_url
+
+
+def _ctx(runner, *, env=None, extractor=None) -> StepContext:
+    return StepContext(
+        env=env or MagicMock(),
+        brain=None,
+        extractor=extractor or MagicMock(),
+        grounding=None,
+        cost_meter=None,
+        dynamic_verifier=None,
+        scanner=None,
+        site_config=None,
+        tool_channel=None,
+        extraction_cache=None,
+        state={"index": 6},
+    )
+
+
+def _step(intent: str = "Set seller type to private") -> MicroIntent:
+    return MicroIntent(intent=intent, type="filter", section="setup")
+
+
+def test_click_action_succeeds(monkeypatch):
+    monkeypatch.setattr("mantis_agent.gym.step_handlers.filter.time.sleep", lambda *_: None)
+    monkeypatch.setattr("mantis_agent.gym.step_handlers.filter.random.uniform", lambda a, b: a)
+
+    runner = _FakeRunner()
+    extractor = MagicMock()
+    extractor.find_filter_target.return_value = {
+        "x": 100, "y": 200, "action": "click", "value": "", "label": "Private Seller",
+    }
+    env = MagicMock()
+    ctx = _ctx(runner, env=env, extractor=extractor)
+
+    result = ClaudeGuidedFilterHandler(runner).execute(_step(), ctx)
+
+    assert result.success is True
+    assert runner.costs["gpu_steps"] == 1
+    assert runner.costs["claude_extract"] == 1
+    # Final scroll state set after filter applies
+    assert runner.scroll_state_calls
+    assert runner.scroll_state_calls[-1]["context"] == "results_after_filter"
+
+
+def test_type_action_clears_then_types_then_enters(monkeypatch):
+    monkeypatch.setattr("mantis_agent.gym.step_handlers.filter.time.sleep", lambda *_: None)
+    monkeypatch.setattr("mantis_agent.gym.step_handlers.filter.random.uniform", lambda a, b: a)
+
+    runner = _FakeRunner()
+    extractor = MagicMock()
+    extractor.find_filter_target.return_value = {
+        "x": 200, "y": 300, "action": "type", "value": "33101", "label": "Zip Code",
+    }
+    env = MagicMock()
+    ctx = _ctx(runner, env=env, extractor=extractor)
+
+    result = ClaudeGuidedFilterHandler(runner).execute(_step(intent="Enter zip 33101"), ctx)
+
+    assert result.success is True
+    # Examine the env.step calls — filter type does:
+    #   sidebar reset (10x SCROLL up) + initial CLICK + triple-click (3x CLICK) +
+    #   ctrl+a + Delete + TYPE + Return
+    types = [c.args[0].action_type for c in env.step.call_args_list]
+    assert ActionType.TYPE in types
+    type_call = [c for c in env.step.call_args_list if c.args[0].action_type == ActionType.TYPE][0]
+    assert type_call.args[0].params == {"text": "33101"}
+    # Final keypress Return
+    keypress_calls = [c for c in env.step.call_args_list if c.args[0].action_type == ActionType.KEY_PRESS]
+    return_calls = [c for c in keypress_calls if c.args[0].params.get("keys") == "Return"]
+    assert len(return_calls) >= 1
+
+
+def test_select_action_opens_dropdown_picks_option(monkeypatch):
+    monkeypatch.setattr("mantis_agent.gym.step_handlers.filter.time.sleep", lambda *_: None)
+    monkeypatch.setattr("mantis_agent.gym.step_handlers.filter.random.uniform", lambda a, b: a)
+
+    runner = _FakeRunner()
+    extractor = MagicMock()
+    extractor.find_filter_target.side_effect = [
+        # First call: find dropdown
+        {"x": 150, "y": 250, "action": "select", "value": "Florida", "label": "State"},
+        # Second call: find option in opened dropdown
+        {"x": 160, "y": 290, "action": "click", "value": "", "label": "Florida"},
+    ]
+    env = MagicMock()
+    ctx = _ctx(runner, env=env, extractor=extractor)
+
+    result = ClaudeGuidedFilterHandler(runner).execute(_step(intent="Pick state Florida"), ctx)
+
+    assert result.success is True
+    assert runner.costs["claude_extract"] == 2  # dropdown + option
+    # Two clicks for dropdown + option
+    click_calls = [c for c in env.step.call_args_list if c.args[0].action_type == ActionType.CLICK]
+    assert len(click_calls) >= 2
+
+
+def test_select_with_option_not_found_presses_escape(monkeypatch):
+    monkeypatch.setattr("mantis_agent.gym.step_handlers.filter.time.sleep", lambda *_: None)
+    monkeypatch.setattr("mantis_agent.gym.step_handlers.filter.random.uniform", lambda a, b: a)
+
+    runner = _FakeRunner()
+    extractor = MagicMock()
+    extractor.find_filter_target.side_effect = [
+        {"x": 150, "y": 250, "action": "select", "value": "Mars", "label": "State"},
+        None,  # option not found
+    ]
+    env = MagicMock()
+    ctx = _ctx(runner, env=env, extractor=extractor)
+
+    result = ClaudeGuidedFilterHandler(runner).execute(_step(intent="Pick state Mars"), ctx)
+
+    assert result.success is False
+    # Escape was sent to close the dropdown
+    keypress_calls = [c for c in env.step.call_args_list if c.args[0].action_type == ActionType.KEY_PRESS]
+    escape_calls = [c for c in keypress_calls if c.args[0].params.get("keys") == "Escape"]
+    assert len(escape_calls) >= 1
+
+
+def test_target_not_found_after_8_viewport_scrolls(monkeypatch):
+    monkeypatch.setattr("mantis_agent.gym.step_handlers.filter.time.sleep", lambda *_: None)
+
+    runner = _FakeRunner()
+    extractor = MagicMock()
+    extractor.find_filter_target.return_value = None  # never found
+    env = MagicMock()
+    ctx = _ctx(runner, env=env, extractor=extractor)
+
+    result = ClaudeGuidedFilterHandler(runner).execute(_step(), ctx)
+
+    assert result.success is False
+    # 8 viewport scans billed to claude_extract
+    assert runner.costs["claude_extract"] == 8
+
+
+def test_step_type_property():
+    handler = ClaudeGuidedFilterHandler(_FakeRunner())
+    assert handler.step_type == "filter"

--- a/tests/test_holo3_handler.py
+++ b/tests/test_holo3_handler.py
@@ -1,0 +1,175 @@
+"""Holo3StepHandler unit tests — Phase 2 of EPIC #161.
+
+Holo3 is the tactical brain — used as a last resort when Claude can't
+identify a clear coordinate. The handler spins up a fresh GymRunner
+bound to the same env / brain / grounding.
+
+- Success path: GymRunner.run returns success=True, no verify clause →
+  StepResult(success=True) with steps_used + duration forwarded
+- Verify success: extractor.extract returns viable data, _check_verify
+  returns True → success preserved
+- Verify failure: _check_verify returns False → success demoted to
+  False, claude_extract billed
+- env.current_url updates _last_known_url
+- step_type property
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from mantis_agent.gym.step_context import StepContext
+from mantis_agent.gym.step_handlers.holo3 import Holo3StepHandler
+from mantis_agent.plan_decomposer import MicroIntent
+
+
+class _FakeRunner:
+    def __init__(self) -> None:
+        self.costs: dict[str, float] = {"claude_extract": 0}
+        self._last_known_url = ""
+        self.on_step = None
+        self.scroll_traj_calls: list[tuple] = []
+        self.verify_call_args: list = []
+        self.verify_return = True
+
+    def _update_scroll_state_from_trajectory(self, result, *, context: str) -> None:
+        self.scroll_traj_calls.append((result, context))
+
+    def _check_verify(self, condition: str, data, screenshot) -> bool:
+        self.verify_call_args.append((condition, data, screenshot))
+        return self.verify_return
+
+
+def _ctx(runner, *, env=None, brain=None, extractor=None, grounding=None) -> StepContext:
+    return StepContext(
+        env=env or MagicMock(),
+        brain=brain or MagicMock(),
+        extractor=extractor,
+        grounding=grounding,
+        cost_meter=None,
+        dynamic_verifier=None,
+        scanner=None,
+        site_config=None,
+        tool_channel=None,
+        extraction_cache=None,
+        state={"index": 11},
+    )
+
+
+def _step(*, verify: str = "") -> MicroIntent:
+    return MicroIntent(
+        intent="Click the Help link", type="click",
+        budget=8, grounding=True, verify=verify,
+    )
+
+
+@patch("mantis_agent.gym.step_handlers.holo3.GymRunner")
+def test_holo3_success_no_verify(mock_runner_cls):
+    mock_inner = MagicMock()
+    mock_inner.run.return_value = MagicMock(success=True, total_steps=4, total_time=2.5)
+    mock_runner_cls.return_value = mock_inner
+
+    runner = _FakeRunner()
+    env = MagicMock()
+    env.current_url = "https://example.com/help"
+    ctx = _ctx(runner, env=env)
+
+    result = Holo3StepHandler(runner).execute(_step(), ctx)
+
+    assert result.success is True
+    assert result.steps_used == 4
+    assert result.duration == 2.5
+    assert runner._last_known_url == "https://example.com/help"
+    # GymRunner constructed with the right kwargs
+    mock_runner_cls.assert_called_once()
+    kwargs = mock_runner_cls.call_args.kwargs
+    assert kwargs["max_steps"] == 8
+    assert kwargs["frames_per_inference"] == 1
+    # No verify → no claude_extract
+    assert runner.costs["claude_extract"] == 0
+
+
+@patch("mantis_agent.gym.step_handlers.holo3.GymRunner")
+def test_holo3_verify_passes_preserves_success(mock_runner_cls):
+    mock_inner = MagicMock()
+    mock_inner.run.return_value = MagicMock(success=True, total_steps=2, total_time=1.0)
+    mock_runner_cls.return_value = mock_inner
+
+    runner = _FakeRunner()
+    runner.verify_return = True
+    extractor = MagicMock()
+    extract_result = MagicMock(url="https://example.com/help/topic-42")
+    extractor.extract.return_value = extract_result
+    env = MagicMock()
+    env.current_url = "https://example.com/initial"
+    ctx = _ctx(runner, env=env, extractor=extractor)
+
+    result = Holo3StepHandler(runner).execute(_step(verify="page contains help text"), ctx)
+
+    assert result.success is True
+    assert runner.costs["claude_extract"] == 1
+    assert runner.verify_call_args[0][0] == "page contains help text"
+    # extract_result.url overrides env.current_url for last_known_url
+    assert runner._last_known_url == "https://example.com/help/topic-42"
+
+
+@patch("mantis_agent.gym.step_handlers.holo3.GymRunner")
+def test_holo3_verify_fails_demotes_success(mock_runner_cls):
+    mock_inner = MagicMock()
+    mock_inner.run.return_value = MagicMock(success=True, total_steps=2, total_time=1.0)
+    mock_runner_cls.return_value = mock_inner
+
+    runner = _FakeRunner()
+    runner.verify_return = False
+    extractor = MagicMock()
+    extractor.extract.return_value = MagicMock(url="https://example.com/wrong-page")
+    ctx = _ctx(runner, env=MagicMock(), extractor=extractor)
+
+    result = Holo3StepHandler(runner).execute(_step(verify="page contains help text"), ctx)
+
+    assert result.success is False  # demoted
+    assert runner.costs["claude_extract"] == 1
+
+
+@patch("mantis_agent.gym.step_handlers.holo3.GymRunner")
+def test_holo3_failure_short_circuits_verify(mock_runner_cls):
+    """When the inner GymRunner reports failure, verify never runs."""
+    mock_inner = MagicMock()
+    mock_inner.run.return_value = MagicMock(success=False, total_steps=8, total_time=12.0)
+    mock_runner_cls.return_value = mock_inner
+
+    runner = _FakeRunner()
+    extractor = MagicMock()
+    ctx = _ctx(runner, env=MagicMock(), extractor=extractor)
+
+    result = Holo3StepHandler(runner).execute(_step(verify="something"), ctx)
+
+    assert result.success is False
+    assert runner.costs["claude_extract"] == 0
+    extractor.extract.assert_not_called()
+
+
+@patch("mantis_agent.gym.step_handlers.holo3.GymRunner")
+def test_holo3_passes_grounding_only_when_step_grounding_true(mock_runner_cls):
+    mock_inner = MagicMock()
+    mock_inner.run.return_value = MagicMock(success=True, total_steps=1, total_time=0.5)
+    mock_runner_cls.return_value = mock_inner
+
+    runner = _FakeRunner()
+    grounding = MagicMock()
+    ctx = _ctx(runner, env=MagicMock(), grounding=grounding)
+
+    # step.grounding=True
+    Holo3StepHandler(runner).execute(_step(), ctx)
+    assert mock_runner_cls.call_args.kwargs["grounding"] is grounding
+
+    mock_runner_cls.reset_mock()
+    # step.grounding=False
+    step_no_grounding = MicroIntent(intent="x", type="click", budget=4, grounding=False)
+    Holo3StepHandler(runner).execute(step_no_grounding, ctx)
+    assert mock_runner_cls.call_args.kwargs["grounding"] is None
+
+
+def test_step_type_property():
+    handler = Holo3StepHandler(_FakeRunner())
+    assert handler.step_type == "holo3"


### PR DESCRIPTION
Refs #161 (Phase 2 — sixth and seventh handler extractions in one PR).

## Summary

Two complementary handler extractions in a single PR:

- **`ClaudeGuidedFilterHandler`** — sidebar filter dispatch (147 LOC). Three action types share one body: `click` / `type` / `select`. 8-viewport sidebar scroll-and-rescan, grounding refine with 150px delta bound.
- **`Holo3StepHandler`** — Holo3 micro-intent execution (38 LOC). Fresh GymRunner per step, post-step Claude verify.

Combined: **185 LOC out of the runner**. Two new handler modules. 12 new mocked-context unit tests.

`micro_runner.py` is now **1,851 LOC** — down from the pre-Phase-2 baseline of 3,006 (**1,155 LOC removed across 7 handler extractions, −38%**).

## Behaviour preserved verbatim

**Filter:**
- Reset sidebar (10x `SCROLL` up) + 8 viewport scans with small `SCROLL` down increments, `find_filter_target` on each, grounding refine
- Dispatch on action type: `click` → CLICK + 2s settle; `type` → CLICK + triple-click + `ctrl+a` + Delete + TYPE + Return; `select` → CLICK + dropdown screenshot + Claude finds option + option CLICK (Escape on miss)
- URL anchored to `_current_results_page_url() or _results_base_url`; scroll state set to `results_after_filter`

**Holo3:**
- Fresh `GymRunner` with `brain` / `env` / `max_steps=step.budget`
- `grounding` only passed when `step.grounding=True`
- Post-step verify uses Claude when `step.verify` set + extractor available
- Success demoted on verify fail

## Phase 2 progress

| Metric | Pre-Phase-2 | After PR #172 | After this PR |
|---|---|---|---|
| `micro_runner.py` LOC | 3,006 | 1,975 | **1,851** (−1,155 / **−38%**) |
| Handlers extracted | 0 | 5 | **7** |
| Mocked-context unit tests | 0 | 40 | **52** |

## Hand-off chain shrinks

`PaginateHandler.Layer 3` still calls `runner._execute_holo3_step` (now a shim → `Holo3StepHandler`). When the cleanup PR registers `Holo3StepHandler` in the registry directly, PaginateHandler can dispatch via `ctx.handler_registry` instead of the parent back-reference.

Also drops the now-unused `from .runner import GymRunner` import on `micro_runner.py` — Holo3 was its only consumer there. Ruff caught it.

## Test plan

- [x] `tests/test_filter_handler.py` (6 new) — click action, type action (clear + type + Return), select action (open + pick), select option-not-found (Escape close), target not found after 8 sidebar scrolls, `step_type` property.
- [x] `tests/test_holo3_handler.py` (6 new) — success no verify, verify passes (preserves success + records URL), verify fails (demotes success), failure short-circuits verify, grounding only passed when `step.grounding=True`, `step_type` property. Uses `@patch("...holo3.GymRunner")` to mock the inner runner.
- [x] **No regressions in the existing focus suite**: 252 passed (Phase 1 + Phase 2 five prior handlers + listing-dedup + browser-state + checkpoint-manager + plan-aware-reverse + private-seller-filter + micro-runner-hooks + step-snapshot + cost-meter + form-intents + submit-enter-fallback).
- [x] **Live verification on Modal**: deployed branch, ran example.com plan_text. Result: 2 steps in 38s, $0.03 — matches pre-Phase-2 numbers exactly. The plan doesn't include a filter step or Holo3-driven step, so this confirms the broader plan flow isn't disrupted. Filter-driven plans need a sidebar-filter target (boattrader, etc.) and Holo3 fallbacks are exercised by the `PaginateHandler.Layer 3` path; the 12 unit tests cover the action types and verify branches.

## Remaining Phase 2 work

- The small ones: `_execute_close_detail_tab` (16 LOC), gate-step inline body in `_execute_step`
- **Cleanup PR**: register every handler in the registry, rip `_execute_step`'s if/elif, collapse the click-branch layout router, merge the form-types dispatch settle, switch `PaginateHandler.Layer 3` to registry-driven Holo3 dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)