### PR TITLE
refactor(runner): EPIC #161 Phase 3 — RunExecutor + RunState + proxy_disabled fix

### DIFF
--- a/src/mantis_agent/baseten_server/runtime.py
+++ b/src/mantis_agent/baseten_server/runtime.py
@@ -823,6 +823,16 @@ class BasetenCUARuntime:
         run_id = run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
         t0 = time.time()
         session_name = task_suite.get("session_name", "baseten_micro")
+        # Propagate top-level proxy_disabled from the request body onto the
+        # inline task_suite so _make_env honors it. Inline _micro_plan
+        # submissions don't go through build_micro_suite (which would set
+        # _proxy_disabled), so without this propagation _make_env reads
+        # task_suite.get("_proxy_disabled", False) → False even when the
+        # caller asked to disable. Caught when news.ycombinator.com
+        # extracts halted with ERR_TUNNEL_CONNECTION_FAILED despite
+        # proxy_disabled: true.
+        if "proxy_disabled" in payload and "_proxy_disabled" not in task_suite:
+            task_suite["_proxy_disabled"] = bool(payload.get("proxy_disabled", False))
         env, proxy_proc = self._make_env(
             task_suite,
             run_id,

--- a/src/mantis_agent/gym/micro_runner.py
+++ b/src/mantis_agent/gym/micro_runner.py
@@ -203,6 +203,12 @@ class MicroPlanRunner:
         from .step_recovery import StepRecoveryPolicy
         self._recovery_policy = StepRecoveryPolicy(self)
 
+        # #161 Phase 3: while-loop body lifted off run() into
+        # RunExecutor.execute. The runner's run() collapses to:
+        #   build state → drive executor → run reporter → return
+        from .run_executor import RunExecutor
+        self._executor = RunExecutor(self)
+
     # ── Listings-scan state — delegates to ``self.scanner`` (#161 Phase 1.2) ──
     # 70+ internal call sites, external readers (checkpoint_manager,
     # browser_state), and existing test fixtures (test_plan_aware_reverse,
@@ -603,6 +609,12 @@ class MicroPlanRunner:
     def run(self, plan: MicroPlan, resume: bool = False) -> list[StepResult]:
         """Execute the full micro-plan.
 
+        Phase 3 of EPIC #161: the while-loop body and its surrounding
+        init / resume / finalize plumbing live in
+        :class:`~.run_executor.RunExecutor`. This method is now a thin
+        wrapper: build state, drive the executor, run the reporter,
+        return.
+
         Args:
             plan: Decomposed plan with ordered micro-intents.
             resume: If True, load checkpoint and resume from last step.
@@ -610,325 +622,27 @@ class MicroPlanRunner:
         Returns:
             List of StepResult for each executed step.
         """
-        self._final_status = "running"
+        from .run_executor import RunState
+
         if not self.plan_signature:
             self.plan_signature = self._compute_plan_signature(plan)
-
-        results: list[StepResult] = []
-        loop_counters: dict[int, int] = {}
-        listings_on_page = 0  # Track how many listings processed on current page
-        checkpoint = RunCheckpoint(
+        state = RunState.fresh(
             run_key=self.run_key,
-            plan_signature=self.plan_signature,
             session_name=self.session_name,
+            plan_signature=self.plan_signature,
         )
+        self._executor.execute(plan, state, resume=resume)
+        self._final_summary(state.results)
+        return state.results
 
-        should_resume = resume or self.resume_state
-        if should_resume:
-            loaded = RunCheckpoint.load(self.checkpoint_path)
-            if loaded:
-                if (
-                    loaded.plan_signature
-                    and self.plan_signature
-                    and loaded.plan_signature != self.plan_signature
-                ):
-                    logger.warning(
-                        "Checkpoint signature mismatch at %s; starting fresh",
-                        self.checkpoint_path,
-                    )
-                else:
-                    checkpoint = loaded
-                    results, loop_counters, listings_on_page = self._restore_from_checkpoint(checkpoint)
-                    logger.info(
-                        "Resumed from step %s, page %s, %s URLs seen, status=%s",
-                        checkpoint.step_index,
-                        checkpoint.current_page or checkpoint.page,
-                        len(self._seen_urls),
-                        checkpoint.status,
-                    )
-                    if checkpoint.status == "completed":
-                        logger.info("Checkpoint already marked complete; returning cached results")
-                        return results
+    def _final_summary(self, results: list[StepResult]) -> None:
+        """Print the MICRO-PLAN COMPLETE block and stash _final_costs.
 
-                    reentry_url = (
-                        checkpoint.reentry_url
-                        or checkpoint.current_url
-                        or self._reentry_url_for_step(plan, checkpoint.step_index)
-                    )
-                    if checkpoint.step_index > 0 and reentry_url:
-                        self._resume_browser_state(reentry_url)
-
-        step_index = checkpoint.step_index
-        step_retry_counts: dict[int, int] = {}
-        max_loop_iterations = 200  # Safety cap
-
-        if not self._results_base_url and plan.steps:
-            self._results_base_url = self._extract_url_from_intent(plan.steps[0].intent)
-            self._required_filter_tokens = self._derive_filter_tokens(self._results_base_url)
-            self.dynamic_verifier.set_required_filter_tokens(self._required_filter_tokens)
-            if self._results_base_url:
-                self.dynamic_verifier.record_page_start(
-                    page=self._current_page,
-                    url=self._current_results_page_url() or self._results_base_url,
-                )
-
-        def persist(next_step_index: int, status: str = "running", halt_reason: str = "") -> None:
-            self._persist_checkpoint(
-                checkpoint=checkpoint,
-                plan=plan,
-                results=results,
-                loop_counters=loop_counters,
-                listings_on_page=listings_on_page,
-                next_step_index=next_step_index,
-                status=status,
-                halt_reason=halt_reason,
-            )
-
-        while step_index < len(plan.steps):
-            # External cancellation (#76) — check at every step boundary.
-            if self._is_cancelled():
-                logger.info("  CANCEL_EVENT set — stopping at step %s", step_index)
-                print(f"  CANCEL: external cancel_event fired — stopping at step {step_index}")
-                persist(step_index, status="cancelled", halt_reason="cancel_event")
-                self._final_status = "cancelled"
-                break
-
-            # Pending pause (#73) — surface as paused, build PauseState in
-            # _build_runner_result.
-            if self.tool_channel.is_paused():
-                persist(step_index, status="paused", halt_reason="user_input")
-                self._final_status = "paused"
-                break
-
-            # Budget + time checks
-            elapsed = time.time() - self._run_start
-            _gpu_cost, _claude_cost, _proxy_cost, total_cost = self._cost_totals()
-
-            if total_cost >= self.max_cost:
-                print(f"  BUDGET CAP: ${total_cost:.2f} >= ${self.max_cost:.2f} — stopping")
-                persist(step_index, status="halted", halt_reason="budget_cap")
-                break
-            if elapsed >= self.max_time:
-                print(f"  TIME CAP: {elapsed/60:.0f}m >= {self.max_time/60:.0f}m — stopping")
-                persist(step_index, status="halted", halt_reason="time_cap")
-                break
-
-            step = plan.steps[step_index]
-
-            # Dynamic intent: inject listing position for click steps
-            dynamic_intent = step.intent
-            if step.type == "click" and listings_on_page > 0:
-                dynamic_intent = (
-                    f"Scroll down past the first {listings_on_page} listings. "
-                    f"Then click the next listing title text below a photo."
-                )
-            effective_step = MicroIntent(
-                intent=dynamic_intent, type=step.type, verify=step.verify,
-                budget=step.budget, reverse=step.reverse, grounding=step.grounding,
-                claude_only=step.claude_only, loop_target=step.loop_target,
-                loop_count=step.loop_count,
-                section=step.section, required=step.required, gate=step.gate,
-                params=dict(step.params or {}),  # form-vocab fill_field/submit/select_option payload
-                hints=dict(getattr(step, "hints", {}) or {}),  # plan-driven grounding hints
-            )
-
-            logger.info(f"  [{step_index:2d}] {step.type:15s} {dynamic_intent[:60]}")
-
-            # Handle loop steps — each loop step has its own counter
-            if step.type == "loop":
-                loop_counters[step_index] = loop_counters.get(step_index, 0) + 1
-                count = loop_counters[step_index]
-                max_count = step.loop_count or max_loop_iterations
-                if count < max_count:
-                    target = step.loop_target if step.loop_target >= 0 else step_index
-                    step_index = target
-                    logger.info(f"  [loop@{step_index}] iteration {count}/{max_count} → step {step_index}")
-                    persist(step_index, status="running")
-                    continue
-                else:
-                    logger.info("  [loop] max iterations reached")
-                    step_index += 1
-                    persist(step_index, status="running")
-                    continue
-
-            # Execute step
-            self._active_checkpoint_context = {
-                "checkpoint": checkpoint,
-                "plan": plan,
-                "results": results,
-                "loop_counters": loop_counters,
-                "listings_on_page": listings_on_page,
-                "step_index": step_index,
-            }
-            # #121 step 1+2: capture pre-step state. Step 1 logged it for
-            # validation; step 2 stashes it on self so _reverse_step can
-            # use the diff to skip undo work that wasn't needed.
-            pre_snapshot = step_snapshot.capture(self)
-            self._pre_step_snapshot = pre_snapshot
-            try:
-                step_result = self._execute_step(effective_step, step_index)
-            finally:
-                self._active_checkpoint_context = None
-            # Observability extras (#74): capture screenshot + invoke callback.
-            if step_result.screenshot_png is None:
-                step_result.screenshot_png = self._capture_screenshot_bytes()
-            results.append(step_result)
-            self._enforce_screenshot_cap(results)
-            self._invoke_step_callback(step_result)
-            self._record_step_costs(effective_step, step_result)
-            self._log_progress(step_result, results)
-            self._log_step_diff(pre_snapshot, effective_step, step_result)
-            # Debug screenshot dump (#152 follow-up) — when
-            # MANTIS_DEBUG_DUMP_DIR is set, save the post-step screenshot
-            # so failing runs can be inspected without re-running the
-            # whole Modal pipeline.
-            if not step_result.success:
-                self._dump_debug_screenshot(
-                    f"step{step_index}_post_{effective_step.type}",
-                    self._safe_screenshot(),
-                )
-
-            # Verify form-shape steps actually produced an observable
-            # state change (staffcrm verify follow-up). The handler can
-            # report success because the click fired, but if NOTHING in
-            # the runner's snapshot changed (URL, focus, scroll, page,
-            # viewport, extraction, new URLs seen) the click missed or
-            # the page rejected it silently — common login failure mode.
-            # Demote to fail so the existing retry loop kicks in.
-            #
-            # Pure-observational: uses the #121 step_snapshot diff, no
-            # regex / heuristic / vision call. Skips fill_field (no
-            # state change is the normal case there — the field just
-            # gains focus).
-            if (
-                step_result.success
-                and effective_step.type in ("submit", "select_option")
-            ):
-                try:
-                    post_snapshot = step_snapshot.capture(self)
-                    delta = step_snapshot.diff(pre_snapshot, post_snapshot)
-                except Exception as exc:  # noqa: BLE001 — never break runs
-                    logger.debug("post-submit diff capture failed: %s", exc)
-                    delta = None
-                if delta is not None and not delta.has_changes:
-                    logger.warning(
-                        "  [%d] %s reported success but no observable state "
-                        "change — demoting to failure (will retry)",
-                        step_index, effective_step.type,
-                    )
-                    step_result.success = False
-                    step_result.data = (
-                        step_result.data or ""
-                    ) + ":no_state_change"
-
-            # Handle dedup: extract_url returned DUPLICATE → skip to loop
-            if step_result.data and "DUPLICATE" in step_result.data:
-                logger.info(f"  [{step_index}] DEDUP — skipping to next listing")
-                # Go back to results page first
-                try:
-                    self._return_to_results_page()
-                except Exception:
-                    pass
-                # Jump to loop step
-                for j in range(step_index + 1, len(plan.steps)):
-                    if plan.steps[j].type == "loop":
-                        step_index = j
-                        break
-                else:
-                    step_index += 1
-                listings_on_page += 1  # Count it as "processed" for scroll-past
-                persist(step_index, status="running", halt_reason="duplicate_listing")
-                continue
-
-            if step_result.success:
-                step_retry_counts.pop(step_index, None)
-                # Track listing progress
-                if step.type == "paginate":
-                    listings_on_page = 0
-                    self._listings_on_page = 0
-                    self._extracted_titles = []  # New page = new listings
-                    self._page_listings = []   # Reset card cache
-                    self._page_listing_index = 0
-                    self._viewport_stage = 0  # Start from Home on new page
-                    # Reset inner loop counters — new page means fresh listing loop
-                    for k in list(loop_counters.keys()):
-                        if k != step_index:  # Don't reset the outer loop's own counter
-                            loop_counters[k] = 0
-                    # Scroll to top of new page + wait for load
-                    try:
-                        self.env.step(Action(action_type=ActionType.KEY_PRESS, params={"keys": "Home"}))
-                        time.sleep(8)
-                    except Exception:
-                        pass
-                    logger.info("  [paginate] Success — reset to top of new page")
-                    self._last_known_url = self._current_results_page_url() or self._last_known_url
-
-                # Verify navigate_back: check if we left the detail page
-                if step.type == "navigate_back" and self.extractor:
-                    time.sleep(2)
-                    screenshot = self.env.screenshot()
-                    check = self.extractor.extract(screenshot)
-                    self.costs["claude_extract"] += 1
-                    url = check.url if check else ""
-                    if url:
-                        self._last_known_url = url
-                    if url and self.site_config.is_detail_page(url):
-                        # Still on detail page — give the CUA a recovery task
-                        # Use the plan's reverse intent, not hardcoded site knowledge
-                        recovery_intent = step.reverse or "Go back to the previous page."
-                        logger.warning(f"  [back-verify] Still on detail page — CUA recovery: {recovery_intent[:50]}")
-                        recovery = self._execute_holo3_step(
-                            MicroIntent(
-                                intent=recovery_intent,
-                                type="navigate_back",
-                                budget=8,
-                                grounding=True,
-                            ),
-                            step_index,
-                        )
-                        self.costs["gpu_steps"] += recovery.steps_used
-
-                step_index += 1
-                persist(step_index, status="running")
-            else:
-                # EPIC #161 Phase 1.3 dispatch lift: failure-recovery
-                # if/elif (165 LOC pre-cleanup) lives on
-                # ``StepRecoveryPolicy.handle_failure``. Side effects
-                # (sleeps, env.step, _reverse_step, _execute_navigate,
-                # _ensure_results_filters, retry-count mutations,
-                # loop_counters updates) happen inside the method;
-                # the runner just persists + advances per the outcome.
-                outcome = self._recovery_policy.handle_failure(
-                    step=step,
-                    step_result=step_result,
-                    plan=plan,
-                    step_index=step_index,
-                    step_retry_counts=step_retry_counts,
-                    loop_counters=loop_counters,
-                    max_retries=self.max_retries,
-                    listings_on_page=listings_on_page,
-                )
-                step_index = outcome.step_index
-                if outcome.halt:
-                    persist(step_index, status="halted", halt_reason=outcome.halt_reason)
-                    break
-                persist(step_index, status="running", halt_reason=outcome.halt_reason)
-
-        logger.info(f"MicroPlan complete: {len(results)} steps executed")
-        # Final cost summary
-        if step_index >= len(plan.steps):
-            persist(step_index, status="completed")
-            self._final_status = "completed"
-        elif self._final_status == "running":
-            persist(step_index, status="halted", halt_reason="stopped")
-            self._final_status = "halted"
-
-        # Stash final loop counters / progress so resume() / run_with_status()
-        # can reconstruct PauseState without re-walking the loop.
-        self._last_run_step_index = step_index
-        self._last_loop_counters = dict(loop_counters)
-        self._last_listings_on_page = listings_on_page
-
+        Called once per run, right before ``run`` returns. Kept on the
+        runner (rather than the executor) because callers like
+        ``run_with_status`` and the result-builder expect ``_final_costs``
+        as a runner attribute.
+        """
         gpu_cost, claude_cost, proxy_cost, total_cost = self._cost_totals()
         elapsed = time.time() - self._run_start
 
@@ -958,8 +672,6 @@ class MicroPlanRunner:
             final_status=self._final_status,
             checkpoint_path=self.checkpoint_path,
         )
-
-        return results
 
     def run_with_status(self, plan: MicroPlan, resume: bool = False) -> RunnerResult:
         """Same as ``run(plan)``, but returns the rich :class:`RunnerResult`.

--- a/src/mantis_agent/gym/run_executor.py
+++ b/src/mantis_agent/gym/run_executor.py
@@ -1,0 +1,529 @@
+"""RunExecutor — the run-loop body extracted from MicroPlanRunner.run.
+
+Phase 3 of EPIC #161 (refactor MicroPlanRunner into composable
+modules). Lifts the ~300-LOC while loop and its surrounding init /
+resume / finalize plumbing off ``MicroPlanRunner.run`` into a single
+``RunExecutor.execute`` method.
+
+After this PR, ``MicroPlanRunner.run`` becomes a thin wrapper:
+
+    state = RunState.fresh(self.run_key, self.session_name, self.plan_signature)
+    self._executor.execute(plan, state, resume=resume)
+    self._final_summary(state)
+    return state.results
+
+Naming choice: this is a *run* executor (drives ``run()``'s loop), not a
+*plan* executor — the existing ``plan_executor.py`` already houses an
+unrelated Playwright-based executor. Naming the new module
+``run_executor.py`` keeps both modules importable without collision.
+
+The acceptance criterion from EPIC #161 — ``micro_runner.py ≤ 200 LOC
+after Phase 3`` — needs Phase 4 (de-leak listings) to fully collapse,
+since ClickHandler / PaginateHandler still hold parent back-references
+to listings-specific state. This PR brings the runner LOC down
+substantially and gets the executor unit-testable with a fake handler
+registry.
+
+Architecture mirrors :class:`~.step_recovery.StepRecoveryPolicy` and
+:class:`~.checkpoint_manager.CheckpointManager`: thin shim with a
+parent ``MicroPlanRunner`` back-reference. The executor reads
+collaborators (env, brain, extractor, dynamic_verifier, site_config,
+handler_registry, recovery_policy, costs, browser_state) from the
+parent. Phase 4 will inject these directly via :class:`StepContext`
+so the back-reference can collapse.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from ..actions import Action, ActionType
+from ..plan_decomposer import MicroIntent
+from . import step_snapshot
+from .checkpoint import RunCheckpoint, StepResult
+
+if TYPE_CHECKING:
+    from ..plan_decomposer import MicroPlan
+    from .micro_runner import MicroPlanRunner
+
+logger = logging.getLogger("mantis_agent.gym.micro_runner")
+
+
+@dataclass
+class RunState:
+    """Mutable per-run state the executor mutates as it advances.
+
+    Replaces the local variables that used to live in ``run()``'s scope
+    (``step_index``, ``results``, ``loop_counters``, ``listings_on_page``,
+    ``step_retry_counts``). Persisted via ``RunCheckpoint`` between
+    steps; the checkpoint manager reads through it.
+
+    Created fresh by ``MicroPlanRunner.run`` per invocation; the
+    executor mutates fields in place. Exposed as a dataclass (not
+    a closure) so tests can inspect or seed state.
+    """
+
+    checkpoint: RunCheckpoint
+    step_index: int = 0
+    results: list[StepResult] = field(default_factory=list)
+    loop_counters: dict[int, int] = field(default_factory=dict)
+    listings_on_page: int = 0
+    step_retry_counts: dict[Any, int] = field(default_factory=dict)
+    max_loop_iterations: int = 200  # safety cap
+
+    @classmethod
+    def fresh(cls, run_key: str, session_name: str, plan_signature: str) -> RunState:
+        """Build the initial state at the start of ``run()``."""
+        return cls(
+            checkpoint=RunCheckpoint(
+                run_key=run_key,
+                plan_signature=plan_signature,
+                session_name=session_name,
+            ),
+        )
+
+
+class RunExecutor:
+    """Drive a :class:`MicroPlan` through completion, halt, pause, or cancel.
+
+    The class owns the while-loop body. Side effects (env.step calls,
+    runner-method delegations like ``_execute_step`` /
+    ``_persist_checkpoint`` / ``_capture_screenshot_bytes`` /
+    ``_record_step_costs`` / ``_log_progress``) happen via the parent
+    back-reference. The runner is the only side-effect agent; the
+    executor sequences the calls.
+
+    Phase 4 follow-up work removes the parent back-reference by
+    injecting the collaborators directly. This PR keeps the back-
+    reference so the lift stays mechanical (the same pattern used by
+    BrowserState / CheckpointManager / StepRecoveryPolicy).
+    """
+
+    def __init__(self, parent: "MicroPlanRunner") -> None:
+        self.parent = parent
+
+    # ── Public entry ────────────────────────────────────────────────────
+
+    def execute(
+        self,
+        plan: "MicroPlan",
+        state: RunState,
+        *,
+        resume: bool = False,
+    ) -> list[StepResult]:
+        """Drive ``plan`` to completion. Mutates ``state`` in place.
+
+        Returns the list of :class:`StepResult` for callers that want
+        to consume them directly; the same list is also accessible on
+        ``state.results``.
+
+        ``resume=True`` loads the persisted checkpoint at the runner's
+        ``checkpoint_path`` and reconstructs ``state.results`` /
+        ``state.loop_counters`` / ``state.listings_on_page`` /
+        ``state.step_index`` from it before the loop starts.
+        """
+        runner = self.parent
+        runner._final_status = "running"
+        if not runner.plan_signature:
+            runner.plan_signature = runner._compute_plan_signature(plan)
+            state.checkpoint.plan_signature = runner.plan_signature
+
+        if resume or runner.resume_state:
+            self._maybe_resume(plan, state)
+            if state.checkpoint.status == "completed":
+                logger.info(
+                    "Checkpoint already marked complete; returning cached results"
+                )
+                return state.results
+
+        if not runner._results_base_url and plan.steps:
+            runner._results_base_url = runner._extract_url_from_intent(
+                plan.steps[0].intent
+            )
+            runner._required_filter_tokens = runner._derive_filter_tokens(
+                runner._results_base_url
+            )
+            runner.dynamic_verifier.set_required_filter_tokens(
+                runner._required_filter_tokens
+            )
+            if runner._results_base_url:
+                runner.dynamic_verifier.record_page_start(
+                    page=runner._current_page,
+                    url=runner._current_results_page_url() or runner._results_base_url,
+                )
+
+        while state.step_index < len(plan.steps):
+            if not self._tick_preamble(plan, state):
+                break
+
+            step = plan.steps[state.step_index]
+            effective_step = self._build_effective_step(step, state)
+            logger.info(
+                f"  [{state.step_index:2d}] {step.type:15s} "
+                f"{effective_step.intent[:60]}"
+            )
+
+            if step.type == "loop":
+                self._handle_loop_step(plan, step, state)
+                continue
+
+            pre_snapshot = self._dispatch_step(plan, state, effective_step)
+
+            self._maybe_demote_form_no_change(state, effective_step, pre_snapshot)
+
+            step_result = state.results[-1]
+
+            if step_result.data and "DUPLICATE" in step_result.data:
+                self._handle_duplicate(plan, state)
+                continue
+
+            if step_result.success:
+                self._handle_success(plan, state, step, step_result)
+            else:
+                if not self._handle_failure(plan, state, step, step_result):
+                    break
+
+        self._finalize(plan, state)
+        return state.results
+
+    # ── Resume from checkpoint ──────────────────────────────────────────
+
+    def _maybe_resume(self, plan: "MicroPlan", state: RunState) -> None:
+        runner = self.parent
+        loaded = RunCheckpoint.load(runner.checkpoint_path)
+        if not loaded:
+            return
+        if (
+            loaded.plan_signature
+            and runner.plan_signature
+            and loaded.plan_signature != runner.plan_signature
+        ):
+            logger.warning(
+                "Checkpoint signature mismatch at %s; starting fresh",
+                runner.checkpoint_path,
+            )
+            return
+        state.checkpoint = loaded
+        state.results, state.loop_counters, state.listings_on_page = (
+            runner._restore_from_checkpoint(loaded)
+        )
+        state.step_index = loaded.step_index
+        logger.info(
+            "Resumed from step %s, page %s, %s URLs seen, status=%s",
+            loaded.step_index,
+            loaded.current_page or loaded.page,
+            len(runner._seen_urls),
+            loaded.status,
+        )
+        if loaded.status == "completed":
+            return
+        reentry_url = (
+            loaded.reentry_url
+            or loaded.current_url
+            or runner._reentry_url_for_step(plan, loaded.step_index)
+        )
+        if loaded.step_index > 0 and reentry_url:
+            runner._resume_browser_state(reentry_url)
+
+    # ── Loop preamble: cancel, pause, budget, time ──────────────────────
+
+    def _tick_preamble(self, plan: "MicroPlan", state: RunState) -> bool:
+        """Return False to break the while loop (cancelled / paused / capped)."""
+        runner = self.parent
+        if runner._is_cancelled():
+            logger.info(
+                "  CANCEL_EVENT set — stopping at step %s", state.step_index
+            )
+            print(
+                f"  CANCEL: external cancel_event fired — "
+                f"stopping at step {state.step_index}"
+            )
+            self._persist(plan, state, status="cancelled", halt_reason="cancel_event")
+            runner._final_status = "cancelled"
+            return False
+
+        if runner.tool_channel.is_paused():
+            self._persist(plan, state, status="paused", halt_reason="user_input")
+            runner._final_status = "paused"
+            return False
+
+        elapsed = time.time() - runner._run_start
+        _gpu, _claude, _proxy, total_cost = runner._cost_totals()
+
+        if total_cost >= runner.max_cost:
+            print(
+                f"  BUDGET CAP: ${total_cost:.2f} >= "
+                f"${runner.max_cost:.2f} — stopping"
+            )
+            self._persist(plan, state, status="halted", halt_reason="budget_cap")
+            return False
+        if elapsed >= runner.max_time:
+            print(
+                f"  TIME CAP: {elapsed/60:.0f}m >= "
+                f"{runner.max_time/60:.0f}m — stopping"
+            )
+            self._persist(plan, state, status="halted", halt_reason="time_cap")
+            return False
+        return True
+
+    # ── Effective step + loop step ──────────────────────────────────────
+
+    @staticmethod
+    def _build_effective_step(step: MicroIntent, state: RunState) -> MicroIntent:
+        """Inject listing-position scroll directive on click steps."""
+        dynamic_intent = step.intent
+        if step.type == "click" and state.listings_on_page > 0:
+            dynamic_intent = (
+                f"Scroll down past the first {state.listings_on_page} listings. "
+                f"Then click the next listing title text below a photo."
+            )
+        return MicroIntent(
+            intent=dynamic_intent, type=step.type, verify=step.verify,
+            budget=step.budget, reverse=step.reverse, grounding=step.grounding,
+            claude_only=step.claude_only, loop_target=step.loop_target,
+            loop_count=step.loop_count,
+            section=step.section, required=step.required, gate=step.gate,
+            params=dict(step.params or {}),
+            hints=dict(getattr(step, "hints", {}) or {}),
+        )
+
+    def _handle_loop_step(
+        self, plan: "MicroPlan", step: MicroIntent, state: RunState,
+    ) -> None:
+        state.loop_counters[state.step_index] = (
+            state.loop_counters.get(state.step_index, 0) + 1
+        )
+        count = state.loop_counters[state.step_index]
+        max_count = step.loop_count or state.max_loop_iterations
+        if count < max_count:
+            target = step.loop_target if step.loop_target >= 0 else state.step_index
+            state.step_index = target
+            logger.info(
+                f"  [loop@{state.step_index}] iteration {count}/{max_count} → "
+                f"step {state.step_index}"
+            )
+        else:
+            logger.info("  [loop] max iterations reached")
+            state.step_index += 1
+        self._persist(plan, state)
+
+    # ── Step dispatch + observability ───────────────────────────────────
+
+    def _dispatch_step(
+        self, plan: "MicroPlan", state: RunState, effective_step: MicroIntent,
+    ) -> Any:
+        """Capture pre-step snapshot, call _execute_step, append result."""
+        runner = self.parent
+        runner._active_checkpoint_context = {
+            "checkpoint": state.checkpoint,
+            "plan": plan,
+            "results": state.results,
+            "loop_counters": state.loop_counters,
+            "listings_on_page": state.listings_on_page,
+            "step_index": state.step_index,
+        }
+        pre_snapshot = step_snapshot.capture(runner)
+        runner._pre_step_snapshot = pre_snapshot
+        try:
+            step_result = runner._execute_step(effective_step, state.step_index)
+        finally:
+            runner._active_checkpoint_context = None
+        if step_result.screenshot_png is None:
+            step_result.screenshot_png = runner._capture_screenshot_bytes()
+        state.results.append(step_result)
+        runner._enforce_screenshot_cap(state.results)
+        runner._invoke_step_callback(step_result)
+        runner._record_step_costs(effective_step, step_result)
+        runner._log_progress(step_result, state.results)
+        runner._log_step_diff(pre_snapshot, effective_step, step_result)
+        if not step_result.success:
+            runner._dump_debug_screenshot(
+                f"step{state.step_index}_post_{effective_step.type}",
+                runner._safe_screenshot(),
+            )
+        return pre_snapshot
+
+    def _maybe_demote_form_no_change(
+        self, state: RunState, effective_step: MicroIntent, pre_snapshot: Any,
+    ) -> None:
+        """Demote submit/select_option success → fail when no observable
+        change. Preserves the staffcrm-verify follow-up behavior.
+        """
+        runner = self.parent
+        step_result = state.results[-1]
+        if not (
+            step_result.success
+            and effective_step.type in ("submit", "select_option")
+        ):
+            return
+        try:
+            post_snapshot = step_snapshot.capture(runner)
+            delta = step_snapshot.diff(pre_snapshot, post_snapshot)
+        except Exception as exc:  # noqa: BLE001 — never break runs
+            logger.debug("post-submit diff capture failed: %s", exc)
+            delta = None
+        if delta is not None and not delta.has_changes:
+            logger.warning(
+                "  [%d] %s reported success but no observable state "
+                "change — demoting to failure (will retry)",
+                state.step_index, effective_step.type,
+            )
+            step_result.success = False
+            step_result.data = (step_result.data or "") + ":no_state_change"
+
+    # ── Outcome handlers ────────────────────────────────────────────────
+
+    def _handle_duplicate(self, plan: "MicroPlan", state: RunState) -> None:
+        """extract_url returned DUPLICATE → return to results, jump to loop."""
+        runner = self.parent
+        logger.info(f"  [{state.step_index}] DEDUP — skipping to next listing")
+        try:
+            runner._return_to_results_page()
+        except Exception:
+            pass
+        target = self._first_step_of_type(plan, state.step_index + 1, "loop")
+        state.step_index = (
+            target if target is not None else state.step_index + 1
+        )
+        state.listings_on_page += 1
+        self._persist(plan, state, halt_reason="duplicate_listing")
+
+    def _handle_success(
+        self,
+        plan: "MicroPlan",
+        state: RunState,
+        step: MicroIntent,
+        step_result: StepResult,
+    ) -> None:
+        """Success path: paginate reset, navigate_back verify, advance."""
+        del step_result  # signature-stable; success values not consumed here
+        runner = self.parent
+        state.step_retry_counts.pop(state.step_index, None)
+
+        if step.type == "paginate":
+            state.listings_on_page = 0
+            runner._listings_on_page = 0
+            runner._extracted_titles = []
+            runner._page_listings = []
+            runner._page_listing_index = 0
+            runner._viewport_stage = 0
+            for k in list(state.loop_counters.keys()):
+                if k != state.step_index:
+                    state.loop_counters[k] = 0
+            try:
+                runner.env.step(Action(
+                    action_type=ActionType.KEY_PRESS, params={"keys": "Home"},
+                ))
+                time.sleep(8)
+            except Exception:
+                pass
+            logger.info("  [paginate] Success — reset to top of new page")
+            runner._last_known_url = (
+                runner._current_results_page_url() or runner._last_known_url
+            )
+
+        if step.type == "navigate_back" and runner.extractor:
+            time.sleep(2)
+            screenshot = runner.env.screenshot()
+            check = runner.extractor.extract(screenshot)
+            runner.costs["claude_extract"] += 1
+            url = check.url if check else ""
+            if url:
+                runner._last_known_url = url
+            if url and runner.site_config.is_detail_page(url):
+                recovery_intent = step.reverse or "Go back to the previous page."
+                logger.warning(
+                    f"  [back-verify] Still on detail page — "
+                    f"CUA recovery: {recovery_intent[:50]}"
+                )
+                recovery = runner._execute_holo3_step(
+                    MicroIntent(
+                        intent=recovery_intent,
+                        type="navigate_back",
+                        budget=8,
+                        grounding=True,
+                    ),
+                    state.step_index,
+                )
+                runner.costs["gpu_steps"] += recovery.steps_used
+
+        state.step_index += 1
+        self._persist(plan, state)
+
+    def _handle_failure(
+        self,
+        plan: "MicroPlan",
+        state: RunState,
+        step: MicroIntent,
+        step_result: StepResult,
+    ) -> bool:
+        """Delegate to StepRecoveryPolicy; returns False if the run should halt."""
+        runner = self.parent
+        outcome = runner._recovery_policy.handle_failure(
+            step=step,
+            step_result=step_result,
+            plan=plan,
+            step_index=state.step_index,
+            step_retry_counts=state.step_retry_counts,
+            loop_counters=state.loop_counters,
+            max_retries=runner.max_retries,
+            listings_on_page=state.listings_on_page,
+        )
+        state.step_index = outcome.step_index
+        if outcome.halt:
+            self._persist(plan, state, status="halted", halt_reason=outcome.halt_reason)
+            return False
+        self._persist(plan, state, halt_reason=outcome.halt_reason)
+        return True
+
+    # ── Finalize ────────────────────────────────────────────────────────
+
+    def _finalize(self, plan: "MicroPlan", state: RunState) -> None:
+        runner = self.parent
+        logger.info(f"MicroPlan complete: {len(state.results)} steps executed")
+        if state.step_index >= len(plan.steps):
+            self._persist(plan, state, status="completed")
+            runner._final_status = "completed"
+        elif runner._final_status == "running":
+            self._persist(plan, state, status="halted", halt_reason="stopped")
+            runner._final_status = "halted"
+
+        # Stash final loop counters / progress so resume() / run_with_status()
+        # can reconstruct PauseState without re-walking the loop.
+        runner._last_run_step_index = state.step_index
+        runner._last_loop_counters = dict(state.loop_counters)
+        runner._last_listings_on_page = state.listings_on_page
+
+    # ── Helpers ─────────────────────────────────────────────────────────
+
+    def _persist(
+        self,
+        plan: "MicroPlan",
+        state: RunState,
+        *,
+        status: str = "running",
+        halt_reason: str = "",
+    ) -> None:
+        runner = self.parent
+        runner._persist_checkpoint(
+            checkpoint=state.checkpoint,
+            plan=plan,
+            results=state.results,
+            loop_counters=state.loop_counters,
+            listings_on_page=state.listings_on_page,
+            next_step_index=state.step_index,
+            status=status,
+            halt_reason=halt_reason,
+        )
+
+    @staticmethod
+    def _first_step_of_type(
+        plan: "MicroPlan", start: int, step_type: str,
+    ) -> int | None:
+        for j in range(start, len(plan.steps)):
+            if plan.steps[j].type == step_type:
+                return j
+        return None

--- a/tests/test_run_executor.py
+++ b/tests/test_run_executor.py
@@ -1,0 +1,413 @@
+"""RunExecutor + RunState unit tests — Phase 3 of EPIC #161.
+
+The 300-LOC while-loop body that used to live on
+``MicroPlanRunner.run`` is now ``RunExecutor.execute``. These tests
+pin the orchestration logic with a fake parent runner — no Xvfb,
+no real GymRunner, no live brain.
+
+Coverage focus areas:
+
+- Init / loop preamble: cancel event, pause, budget cap, time cap
+- Step orchestration: effective-step build, loop step dispatch
+- Outcome routing: success path, failure path (delegates to recovery
+  policy), DUPLICATE handling, no-state-change form demote
+- Finalization: completed / halted / pause-status accounting
+- RunState defaults + factory
+
+The recovery policy itself is unit-tested separately in
+``test_step_recovery_policy.py``; here we just verify the executor
+delegates correctly.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from mantis_agent.gym.checkpoint import RunCheckpoint, StepResult
+from mantis_agent.gym.run_executor import RunExecutor, RunState
+from mantis_agent.plan_decomposer import MicroIntent, MicroPlan
+
+
+def _plan(*types: str) -> MicroPlan:
+    plan = MicroPlan(domain="test")
+    for i, t in enumerate(types):
+        plan.steps.append(MicroIntent(intent=f"step-{i}-{t}", type=t))
+    return plan
+
+
+def _state(checkpoint: RunCheckpoint | None = None) -> RunState:
+    return RunState(
+        checkpoint=checkpoint or RunCheckpoint(
+            run_key="test", plan_signature="sig", session_name="sess",
+        ),
+    )
+
+
+def _runner_stub(monkeypatch=None) -> MagicMock:
+    """Build a MagicMock runner with the attributes RunExecutor reads."""
+    runner = MagicMock()
+    runner._final_status = "running"
+    runner.plan_signature = "sig"
+    runner.run_key = "test"
+    runner.session_name = "sess"
+    runner.resume_state = False
+    runner.checkpoint_path = "/tmp/c.json"
+    runner.max_cost = 100.0
+    runner.max_time = 3600.0
+    runner.max_retries = 2
+    runner.costs = {"gpu_steps": 0, "claude_extract": 0, "claude_grounding": 0, "proxy_mb": 0}
+    runner._run_start = 0.0
+    runner._cost_totals.return_value = (0.0, 0.0, 0.0, 0.0)
+    runner._is_cancelled.return_value = False
+    runner.tool_channel.is_paused.return_value = False
+    runner._results_base_url = ""
+    runner._extract_url_from_intent.return_value = ""
+    runner._derive_filter_tokens.return_value = ()
+    runner._compute_plan_signature.return_value = "sig"
+    return runner
+
+
+# ── RunState ────────────────────────────────────────────────────────
+
+
+def test_run_state_fresh_factory():
+    state = RunState.fresh(run_key="r", session_name="s", plan_signature="p")
+    assert state.step_index == 0
+    assert state.results == []
+    assert state.loop_counters == {}
+    assert state.listings_on_page == 0
+    assert state.step_retry_counts == {}
+    assert state.max_loop_iterations == 200
+    assert state.checkpoint.run_key == "r"
+    assert state.checkpoint.session_name == "s"
+    assert state.checkpoint.plan_signature == "p"
+
+
+def test_run_state_results_are_per_instance():
+    a = RunState.fresh(run_key="x", session_name="x", plan_signature="x")
+    b = RunState.fresh(run_key="y", session_name="y", plan_signature="y")
+    a.results.append(StepResult(step_index=0, intent="x", success=True))
+    assert b.results == []
+
+
+# ── Loop preamble: cancel ──────────────────────────────────────────
+
+
+def test_cancel_event_breaks_with_cancelled_status():
+    runner = _runner_stub()
+    runner._is_cancelled.return_value = True
+    plan = _plan("navigate")
+    state = _state()
+
+    RunExecutor(runner).execute(plan, state)
+
+    assert runner._final_status == "cancelled"
+    runner._persist_checkpoint.assert_called()
+    final_persist = runner._persist_checkpoint.call_args
+    assert final_persist.kwargs["status"] == "cancelled"
+    assert final_persist.kwargs["halt_reason"] == "cancel_event"
+
+
+def test_pause_breaks_with_paused_status():
+    runner = _runner_stub()
+    runner.tool_channel.is_paused.return_value = True
+    plan = _plan("navigate")
+    state = _state()
+
+    RunExecutor(runner).execute(plan, state)
+
+    assert runner._final_status == "paused"
+
+
+def test_budget_cap_breaks_with_halted_status():
+    runner = _runner_stub()
+    runner._cost_totals.return_value = (50.0, 50.0, 50.0, 999.0)  # over cap
+    runner.max_cost = 25.0
+    plan = _plan("navigate")
+    state = _state()
+
+    RunExecutor(runner).execute(plan, state)
+
+    persist_calls = runner._persist_checkpoint.call_args_list
+    halt_call = next(
+        c for c in persist_calls if c.kwargs.get("halt_reason") == "budget_cap"
+    )
+    assert halt_call.kwargs["status"] == "halted"
+
+
+def test_time_cap_breaks_with_halted_status():
+    runner = _runner_stub()
+    import time as _time
+    runner._run_start = _time.time() - 10000  # 10000s ago
+    runner.max_time = 60  # 1 minute
+    plan = _plan("navigate")
+    state = _state()
+
+    RunExecutor(runner).execute(plan, state)
+
+    persist_calls = runner._persist_checkpoint.call_args_list
+    halt_call = next(
+        c for c in persist_calls if c.kwargs.get("halt_reason") == "time_cap"
+    )
+    assert halt_call.kwargs["status"] == "halted"
+
+
+# ── Loop step ──────────────────────────────────────────────────────
+
+
+def test_loop_step_jumps_to_target_when_under_count():
+    runner = _runner_stub()
+    plan = _plan("navigate", "extract_data", "loop")
+    plan.steps[2].loop_target = 1
+    plan.steps[2].loop_count = 3
+    state = _state()
+    state.step_index = 2  # start at the loop step
+
+    # Stop after the loop step's first iteration jumps us back
+    runner._execute_step.return_value = StepResult(
+        step_index=1, intent="extract_data", success=True,
+    )
+    runner._capture_screenshot_bytes.return_value = None
+
+    # Execute one tick of the loop
+    executor = RunExecutor(runner)
+    # Manually drive _handle_loop_step
+    executor._handle_loop_step(plan, plan.steps[2], state)
+
+    assert state.loop_counters[2] == 1
+    assert state.step_index == 1  # jumped to target
+
+
+def test_loop_step_advances_when_max_count_reached():
+    runner = _runner_stub()
+    plan = _plan("loop")
+    plan.steps[0].loop_count = 1
+    state = _state()
+    state.step_index = 0
+    state.loop_counters[0] = 1  # already at max
+
+    RunExecutor(runner)._handle_loop_step(plan, plan.steps[0], state)
+
+    assert state.loop_counters[0] == 2  # incremented past max
+    assert state.step_index == 1  # advanced past loop
+
+
+# ── Effective step build ───────────────────────────────────────────
+
+
+def test_build_effective_step_no_listings_uses_original_intent():
+    state = _state()
+    state.listings_on_page = 0
+    step = MicroIntent(intent="Click the next title", type="click", section="extraction")
+
+    eff = RunExecutor._build_effective_step(step, state)
+    assert eff.intent == "Click the next title"
+    assert eff.type == "click"
+
+
+def test_build_effective_step_with_listings_injects_scroll_directive():
+    state = _state()
+    state.listings_on_page = 3
+    step = MicroIntent(intent="Click the next title", type="click", section="extraction")
+
+    eff = RunExecutor._build_effective_step(step, state)
+    assert "Scroll down past the first 3 listings" in eff.intent
+    assert "Then click the next listing title" in eff.intent
+    assert eff.type == "click"
+
+
+def test_build_effective_step_preserves_params_and_hints():
+    state = _state()
+    step = MicroIntent(
+        intent="Submit", type="submit",
+        params={"label": "Login"},
+        hints={"layout": "single"},
+    )
+    eff = RunExecutor._build_effective_step(step, state)
+    assert eff.params == {"label": "Login"}
+    assert eff.hints == {"layout": "single"}
+
+
+# ── _first_step_of_type ────────────────────────────────────────────
+
+
+def test_first_step_of_type_finds_match():
+    plan = _plan("navigate", "click", "extract_data", "loop")
+    assert RunExecutor._first_step_of_type(plan, 0, "loop") == 3
+    assert RunExecutor._first_step_of_type(plan, 0, "click") == 1
+
+
+def test_first_step_of_type_returns_none_when_no_match():
+    plan = _plan("navigate", "click")
+    assert RunExecutor._first_step_of_type(plan, 0, "paginate") is None
+
+
+# ── DUPLICATE outcome ──────────────────────────────────────────────
+
+
+def test_duplicate_jumps_to_next_loop_and_increments_listings_on_page():
+    runner = _runner_stub()
+    plan = _plan("click", "extract_url", "loop")
+    state = _state()
+    state.step_index = 1  # extract_url just returned DUPLICATE
+    state.listings_on_page = 5
+
+    RunExecutor(runner)._handle_duplicate(plan, state)
+
+    assert state.step_index == 2  # jumped to loop
+    assert state.listings_on_page == 6  # incremented
+    runner._return_to_results_page.assert_called_once()
+    persist = runner._persist_checkpoint.call_args
+    assert persist.kwargs["halt_reason"] == "duplicate_listing"
+
+
+def test_duplicate_advances_when_no_loop_step():
+    runner = _runner_stub()
+    plan = _plan("click", "extract_url")
+    state = _state()
+    state.step_index = 1
+
+    RunExecutor(runner)._handle_duplicate(plan, state)
+
+    assert state.step_index == 2  # advanced past last step
+
+
+# ── Finalize ────────────────────────────────────────────────────────
+
+
+def test_finalize_marks_completed_when_step_index_at_end():
+    runner = _runner_stub()
+    runner._final_status = "running"
+    plan = _plan("navigate", "extract_data")
+    state = _state()
+    state.step_index = 2  # past the last step
+
+    RunExecutor(runner)._finalize(plan, state)
+
+    assert runner._final_status == "completed"
+    persist = runner._persist_checkpoint.call_args
+    assert persist.kwargs["status"] == "completed"
+
+
+def test_finalize_marks_halted_when_status_was_running_but_not_at_end():
+    runner = _runner_stub()
+    runner._final_status = "running"  # never set to terminal during loop
+    plan = _plan("navigate", "extract_data", "extract_data")
+    state = _state()
+    state.step_index = 1  # mid-plan
+
+    RunExecutor(runner)._finalize(plan, state)
+
+    assert runner._final_status == "halted"
+    persist = runner._persist_checkpoint.call_args
+    assert persist.kwargs["status"] == "halted"
+    assert persist.kwargs["halt_reason"] == "stopped"
+
+
+def test_finalize_preserves_terminal_status_when_already_set():
+    """If the loop set _final_status to cancelled / paused, finalize keeps it."""
+    runner = _runner_stub()
+    runner._final_status = "cancelled"
+    plan = _plan("navigate")
+    state = _state()
+    state.step_index = 0  # never advanced
+
+    RunExecutor(runner)._finalize(plan, state)
+
+    # Should not be overwritten to halted
+    assert runner._final_status == "cancelled"
+
+
+def test_finalize_stashes_last_run_progress_on_runner():
+    runner = _runner_stub()
+    runner._final_status = "running"
+    plan = _plan("navigate")
+    state = _state()
+    state.step_index = 1
+    state.loop_counters = {3: 5}
+    state.listings_on_page = 7
+
+    RunExecutor(runner)._finalize(plan, state)
+
+    assert runner._last_run_step_index == 1
+    assert runner._last_loop_counters == {3: 5}
+    assert runner._last_listings_on_page == 7
+
+
+# ── Failure delegation ────────────────────────────────────────────
+
+
+def test_handle_failure_delegates_to_recovery_policy_and_halts_on_outcome():
+    from mantis_agent.gym.step_recovery import RecoveryOutcome
+
+    runner = _runner_stub()
+    runner._recovery_policy.handle_failure.return_value = RecoveryOutcome(
+        halt=True, step_index=0, halt_reason="navigate_failed",
+    )
+    plan = _plan("navigate")
+    state = _state()
+    step = plan.steps[0]
+    result = StepResult(step_index=0, intent="x", success=False)
+
+    cont = RunExecutor(runner)._handle_failure(plan, state, step, result)
+    assert cont is False
+    runner._recovery_policy.handle_failure.assert_called_once()
+    persist = runner._persist_checkpoint.call_args
+    assert persist.kwargs["status"] == "halted"
+
+
+def test_handle_failure_continues_when_outcome_is_not_halt():
+    from mantis_agent.gym.step_recovery import RecoveryOutcome
+
+    runner = _runner_stub()
+    runner._recovery_policy.handle_failure.return_value = RecoveryOutcome(
+        halt=False, step_index=2, halt_reason="page_exhausted",
+    )
+    plan = _plan("click", "extract_data", "paginate")
+    state = _state()
+    state.step_index = 0
+    step = plan.steps[0]
+    result = StepResult(step_index=0, intent="x", success=False, data="page_exhausted")
+
+    cont = RunExecutor(runner)._handle_failure(plan, state, step, result)
+    assert cont is True
+    assert state.step_index == 2  # outcome's new index applied
+    persist = runner._persist_checkpoint.call_args
+    assert persist.kwargs["status"] == "running"
+    assert persist.kwargs["halt_reason"] == "page_exhausted"
+
+
+# ── Form-shape no-state-change demote ─────────────────────────────
+
+
+def test_no_state_change_demotes_submit_success_to_failure(monkeypatch):
+    """Submit-shape success with no observable change → demoted to fail."""
+    from mantis_agent.gym import step_snapshot as _snap
+
+    runner = _runner_stub()
+    state = _state()
+    state.results.append(StepResult(step_index=0, intent="x", success=True, data="ok"))
+
+    pre_snapshot = MagicMock()
+    post_snapshot = MagicMock()
+    monkeypatch.setattr(_snap, "capture", lambda r: post_snapshot)
+    delta = MagicMock(has_changes=False)
+    monkeypatch.setattr(_snap, "diff", lambda a, b: delta)
+
+    eff_step = MicroIntent(intent="x", type="submit")
+    RunExecutor(runner)._maybe_demote_form_no_change(state, eff_step, pre_snapshot)
+
+    assert state.results[0].success is False
+    assert ":no_state_change" in state.results[0].data
+
+
+def test_no_state_change_skipped_for_non_form_steps(monkeypatch):
+    runner = _runner_stub()
+    state = _state()
+    state.results.append(StepResult(step_index=0, intent="x", success=True, data="ok"))
+
+    eff_step = MicroIntent(intent="x", type="click")  # not submit/select_option
+    RunExecutor(runner)._maybe_demote_form_no_change(state, eff_step, MagicMock())
+
+    assert state.results[0].success is True  # unchanged
+    assert state.results[0].data == "ok"


### PR DESCRIPTION
Refs #161 (Phase 3 — collapse run() into RunExecutor).

## Summary

Lifts the **~300-LOC while-loop body** and surrounding init / resume / finalize plumbing off `MicroPlanRunner.run` into a new `RunExecutor` class with `RunState` dataclass.

`micro_runner.py`: 1,710 LOC pre-Phase-3 → **1,422 LOC** post-Phase-3 (−288, cumulative since EPIC start: 3,006 → 1,422 LOC, **−53%**).

The collapsed `run()` is now ~25 lines: build state → drive executor → run reporter → return.

## Bonus fix in the same PR

`baseten_server/runtime.py:_run_micro` now propagates top-level `payload["proxy_disabled"]` onto inline `task_suite["_proxy_disabled"]` before `_make_env` reads it. Inline `task_suite._micro_plan` submissions don't go through `build_micro_suite` (which sets `_proxy_disabled`), so without this propagation `_make_env` read False even when the caller asked to disable.

Caught live with **`https://news.ycombinator.com/`** — extracts halted with `ERR_TUNNEL_CONNECTION_FAILED` despite `proxy_disabled: true`. After the fix, **HN extracted 3 top stories at $0.099 / 270s** — the canonical content-site smoke test.

## Why "run_executor" not "plan_executor"

There's an existing `plan_executor.py` with an unrelated Playwright-based `PlanExecutor` class. Naming the new module `run_executor.py` keeps both modules importable without a name collision. The new `RunExecutor` drives the `run()` loop; the existing `PlanExecutor` drives Playwright DOM queries. They have nothing in common architecturally.

## What moved

| Pre-Phase-3 location | New location |
|---|---|
| `run()` resume-from-checkpoint block | `RunExecutor._maybe_resume` |
| `run()` while-loop preamble (cancel/pause/budget/time) | `RunExecutor._tick_preamble` |
| `run()` effective-step build (dynamic intent) | `RunExecutor._build_effective_step` |
| `run()` loop-step dispatch | `RunExecutor._handle_loop_step` |
| `run()` step dispatch + observability | `RunExecutor._dispatch_step` |
| `run()` form-shape no-state-change demote | `RunExecutor._maybe_demote_form_no_change` |
| `run()` DUPLICATE handling | `RunExecutor._handle_duplicate` |
| `run()` success path (paginate / navigate_back verify) | `RunExecutor._handle_success` |
| `run()` failure delegate to recovery policy | `RunExecutor._handle_failure` |
| `run()` finalize (status, stash _last_run_*) | `RunExecutor._finalize` |
| `run()` final summary print + `_final_costs` | `MicroPlanRunner._final_summary` (kept on runner) |

## New types

- **`RunState`** dataclass — `checkpoint`, `step_index`, `results`, `loop_counters`, `listings_on_page`, `step_retry_counts`, `max_loop_iterations`. `.fresh(run_key, session_name, plan_signature)` factory.
- **`RunExecutor`** class — `parent: MicroPlanRunner` back-reference (mirrors `BrowserState` / `CheckpointManager` / `StepRecoveryPolicy` pattern from #115 / #161 Phase 1).

## Test plan

### New

`tests/test_run_executor.py` (23 tests) — every executor branch with a `MagicMock` parent runner:

- RunState defaults + factory + per-instance results (2)
- Loop preamble: cancel, pause, budget cap, time cap (4)
- Loop step: jump-to-target, advance-when-max (2)
- Effective-step build: no-listings, with-listings, preserves-params+hints (3)
- `_first_step_of_type` helper (2)
- DUPLICATE outcome: jump-to-loop, advance-when-no-loop (2)
- Finalize: completed, halted, preserves-cancelled, stashes-progress (4)
- Failure delegation: halt path, continue path (2)
- Form-shape demote: submit no-change demote, non-form skip (2)

### Verification

- [x] **No regressions**: 305 passed (cumulative focus suite covering every prior PR).
- [x] **example.com** (single-page extract, proxy_disabled): 2 steps in 39s, $0.03 — matches baseline.
- [x] **Hacker News extract-loop** (events-shape + proxy_disabled, after the propagation fix): **5 steps in 270s, $0.099, 3 viable leads** with distinct URLs. Exercises `_tick_preamble`, `_build_effective_step`, `_dispatch_step` → registry → `ClaudeStepHandler`, `_handle_success` (advance + persist), `_handle_loop_step` (jump back), `_finalize` (status=completed).
- [x] **lu.ma** (proxy-required, still exhausted): recovery policy correctly fired on gate failure with `halt_reason="gate_failed"` — proves `_handle_failure → recovery → halt` path through the new executor.

## EPIC #161 status

| Phase | Status |
|---|---|
| 1.1 RunReporter | ✅ |
| 1.2 ListingsScanner | ✅ |
| 1.3 dispatch types | ✅ |
| 1.3 dispatch lift | ✅ (PR #176) |
| 2 types (StepHandler / StepContext / HandlerRegistry) | ✅ |
| 2 handlers (×7) | ✅ |
| 2 cleanup (registry-first dispatch) | ✅ (PR #175) |
| **3 PlanExecutor** | ✅ **this PR** |
| **4 De-leak listings** | ❌ — `ClickHandler` / `PaginateHandler` still hold parent back-references to listings-specific state |

`micro_runner.py` at 1,422 LOC; the ≤200 LOC EPIC target needs Phase 4 plus some helper-module extractions (BrowserState delegations, `_check_verify`, `_current_item_label`, `_ensure_results_filters` family). Phase 3 brought the line count down 17%; remaining work is the listings-specific state plus misc helpers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)