### PR TITLE
[codex] Implement CUA screenshot benchmark and gallery recovery

### DIFF
--- a/src/mantis_agent/extraction/extractor.py
+++ b/src/mantis_agent/extraction/extractor.py
@@ -472,6 +472,10 @@ class ClaudeExtractor:
         Returns a dict with x/y/action/label/reason, or None if no safe target
         is visible. This intentionally avoids generic Contact Seller forms.
         """
+        if self.schema is not None and not self.schema.allowed_controls:
+            logger.info("  [content-control] schema has no allowed controls; skipping")
+            return None
+
         debug_stem = "claude_listing_content_control"
         try:
             screenshot.save(self._debug_path(debug_stem, ".png"))

--- a/src/mantis_agent/gym/gallery_trap.py
+++ b/src/mantis_agent/gym/gallery_trap.py
@@ -1,0 +1,144 @@
+"""Gallery/lightbox trap detection and bounded recovery helpers.
+
+The detector is intentionally cheap and dependency-light. It combines
+visual signals from the screenshot with optional text signals from model
+reasoning or OCR-like sources when callers have them.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+
+from PIL import Image
+
+from ..actions import Action, ActionType
+
+
+_GALLERY_TEXT_RE = re.compile(
+    r"\b\d+\s+of\s+\d+\b|"
+    r"\bphoto\s+gallery\b|"
+    r"\bimage\s+gallery\b|"
+    r"\blightbox\b|"
+    r"\bfullscreen\s+photo\b|"
+    r"\bphoto\s+viewer\b|"
+    r"\bimage\s+viewer\b|"
+    r"\bclose\s*[x×]\b",
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True)
+class GalleryTrapDetection:
+    """Result of gallery/lightbox trap detection."""
+
+    detected: bool
+    confidence: float
+    reason: str
+    signals: dict[str, float | bool] = field(default_factory=dict)
+
+
+def detect_gallery_trap(
+    screenshot: Image.Image,
+    *,
+    text: str = "",
+    threshold: float = 0.65,
+) -> GalleryTrapDetection:
+    """Detect likely fullscreen gallery/lightbox state.
+
+    Args:
+        screenshot: Current post-action screenshot.
+        text: Optional model reasoning / OCR text. Textual "1 of N",
+            "lightbox", or "photo gallery" signals are strong evidence.
+        threshold: Minimum confidence required for ``detected=True``.
+
+    The visual heuristic looks for a dark full-screen overlay with a brighter
+    central image area. It deliberately does not classify a uniformly dark page
+    as a gallery unless a text signal is also present.
+    """
+    visual = _visual_gallery_signals(screenshot)
+    text_hit = bool(text and _GALLERY_TEXT_RE.search(text))
+
+    score = 0.0
+    if text_hit:
+        score += 0.70
+    if visual["dark_ratio"] >= 0.45:
+        score += 0.25
+    if visual["border_dark_ratio"] >= 0.65:
+        score += 0.20
+    if visual["center_contrast"] >= 0.18 and visual["center_bright_ratio"] >= 0.12:
+        score += 0.25
+    if visual["uniform_dark"]:
+        score -= 0.20
+
+    score = max(0.0, min(1.0, score))
+    detected = score >= threshold
+    signals: dict[str, float | bool] = {
+        **visual,
+        "text_gallery_signal": text_hit,
+    }
+    reason = _reason(signals, detected)
+    return GalleryTrapDetection(
+        detected=detected,
+        confidence=score,
+        reason=reason,
+        signals=signals,
+    )
+
+
+def gallery_recovery_actions() -> tuple[Action, ...]:
+    """Bounded recovery sequence for an open gallery/lightbox."""
+    return (
+        Action(ActionType.KEY_PRESS, {"keys": "escape"}, reasoning="recover from gallery trap"),
+        Action(ActionType.KEY_PRESS, {"keys": "alt+left"}, reasoning="recover from gallery trap"),
+    )
+
+
+def _visual_gallery_signals(screenshot: Image.Image) -> dict[str, float | bool]:
+    img = screenshot.convert("L").resize((160, 90))
+    pixels = list(img.getdata())
+    total = len(pixels) or 1
+    dark_ratio = sum(1 for p in pixels if p < 55) / total
+
+    w, h = img.size
+    border_pixels: list[int] = []
+    border = max(4, min(w, h) // 10)
+    for y in range(h):
+        for x in range(w):
+            if x < border or x >= w - border or y < border or y >= h - border:
+                border_pixels.append(img.getpixel((x, y)))
+    border_dark_ratio = sum(1 for p in border_pixels if p < 65) / (len(border_pixels) or 1)
+
+    # Center crop approximates the photo pane in common fullscreen galleries.
+    x1, x2 = int(w * 0.22), int(w * 0.78)
+    y1, y2 = int(h * 0.20), int(h * 0.82)
+    center_pixels = [
+        img.getpixel((x, y))
+        for y in range(y1, y2)
+        for x in range(x1, x2)
+    ]
+    center_avg = sum(center_pixels) / (len(center_pixels) or 1)
+    full_avg = sum(pixels) / total
+    center_bright_ratio = sum(1 for p in center_pixels if p > 90) / (len(center_pixels) or 1)
+    center_contrast = max(0.0, (center_avg - full_avg) / 255.0)
+
+    return {
+        "dark_ratio": dark_ratio,
+        "border_dark_ratio": border_dark_ratio,
+        "center_bright_ratio": center_bright_ratio,
+        "center_contrast": center_contrast,
+        "uniform_dark": dark_ratio > 0.95 and center_bright_ratio < 0.03,
+    }
+
+
+def _reason(signals: dict[str, float | bool], detected: bool) -> str:
+    if not detected:
+        return "no gallery trap detected"
+    reasons: list[str] = []
+    if signals.get("text_gallery_signal"):
+        reasons.append("gallery text signal")
+    if float(signals.get("dark_ratio", 0.0)) >= 0.45:
+        reasons.append("dark overlay")
+    if float(signals.get("center_bright_ratio", 0.0)) >= 0.12:
+        reasons.append("central image pane")
+    return ", ".join(reasons) or "gallery-like screenshot"

--- a/src/mantis_agent/gym/runner.py
+++ b/src/mantis_agent/gym/runner.py
@@ -29,6 +29,7 @@ from PIL import Image
 from ..actions import Action, ActionType
 from ..loop_detector import LoopDetector, phash_64
 from .base import GymEnvironment
+from .gallery_trap import detect_gallery_trap, gallery_recovery_actions
 
 logger = logging.getLogger(__name__)
 
@@ -133,6 +134,19 @@ def _observed_state(info: dict | None) -> dict:
     if not info:
         return {}
     return {k: info[k] for k in _OBSERVED_STATE_KEYS if k in info}
+
+
+def _gallery_observed_state(recovery: dict[str, Any] | None) -> dict[str, Any]:
+    """Small trajectory metadata block for gallery-trap recovery."""
+    if not recovery:
+        return {}
+    return {
+        "gallery_trap_detected": True,
+        "gallery_trap_confidence": recovery["confidence"],
+        "gallery_trap_reason": recovery["reason"],
+        "gallery_recovery_actions": recovery["actions"],
+        "gallery_recovery_success": recovery["success"],
+    }
 
 
 @dataclass
@@ -510,6 +524,18 @@ class GymRunner:
                     frame=gym_result.observation.screenshot,
                 )
 
+                gallery_recovery: dict[str, Any] = {}
+                if action.action_type in (ActionType.CLICK, ActionType.DOUBLE_CLICK):
+                    gallery_recovery = self._recover_gallery_trap(
+                        gym_result=gym_result,
+                        detection_text=thinking,
+                        action_history=action_history,
+                        frame_history=frame_history,
+                    )
+                    if gallery_recovery:
+                        gym_result = gallery_recovery["result"]
+                        _save_frame(gym_result.observation.screenshot, step_num)
+
                 # Reward — apply before mutating step_reward / components so the
                 # signal includes this step's action in any history-based terms.
                 step_reward = gym_result.reward
@@ -528,6 +554,12 @@ class GymRunner:
                     action=action, gym_result=gym_result,
                     last_url=last_url, last_title=last_title,
                 )
+                if gallery_recovery:
+                    feedback = (
+                        f"{feedback}; gallery trap detected "
+                        f"({gallery_recovery['confidence']:.2f}); "
+                        f"recovery {'succeeded' if gallery_recovery['success'] else 'failed'}"
+                    )
 
                 focused_input = gym_result.info.get("focused_input")
                 if focused_input is not None:
@@ -551,7 +583,10 @@ class GymRunner:
                     inference_time=inference_time, feedback=feedback,
                     reward_components=step_components,
                     frame_hash=phash_64(gym_result.observation.screenshot),
-                    observed_state=_observed_state(gym_result.info),
+                    observed_state={
+                        **_observed_state(gym_result.info),
+                        **_gallery_observed_state(gallery_recovery),
+                    },
                     observed_outcome=feedback,
                     predicted_outcome=predicted_outcome,
                 ))
@@ -607,6 +642,60 @@ class GymRunner:
             result.total_reward += float(terminal)
 
         return result
+
+    def _recover_gallery_trap(
+        self,
+        *,
+        gym_result: Any,
+        detection_text: str,
+        action_history: list[Action],
+        frame_history: list[Image.Image],
+    ) -> dict[str, Any]:
+        """Detect gallery/lightbox state after a click and recover once.
+
+        Recovery is deliberately bounded: Escape, then Alt+Left only if the
+        gallery is still detected. The original model step remains one
+        trajectory entry; recovery details are stored in observed_state.
+        """
+        detection = detect_gallery_trap(
+            gym_result.observation.screenshot,
+            text=detection_text,
+        )
+        if not detection.detected:
+            return {}
+
+        self._emit(
+            "gallery_trap",
+            confidence=round(detection.confidence, 3),
+            reason=detection.reason,
+        )
+
+        latest = gym_result
+        actions_run: list[str] = []
+        success = False
+        for recovery_action in gallery_recovery_actions():
+            latest = self.env.step(recovery_action)
+            action_history.append(recovery_action)
+            frame_history.append(latest.observation.screenshot)
+            actions_run.append(recovery_action.params.get("keys", ""))
+            self._loop_detector.record(
+                recovery_action,
+                url=latest.info.get("url", ""),
+                frame=latest.observation.screenshot,
+            )
+
+            followup = detect_gallery_trap(latest.observation.screenshot)
+            if not followup.detected:
+                success = True
+                break
+
+        return {
+            "result": latest,
+            "confidence": detection.confidence,
+            "reason": detection.reason,
+            "actions": actions_run,
+            "success": success,
+        }
 
     # ── Prompt construction ──────────────────────────────────────────────
 

--- a/tests/test_extraction_schema.py
+++ b/tests/test_extraction_schema.py
@@ -257,6 +257,21 @@ def test_extractor_dynamic_content_control_prompt():
     assert "Contact Agent" in prompt
 
 
+def test_extractor_skips_content_control_without_allowed_controls(monkeypatch):
+    schema = ExtractionSchema(
+        entity_name="news page",
+        fields=[{"name": "stories", "type": "str", "required": True}],
+        allowed_controls=[],
+    )
+    extractor = ClaudeExtractor(schema=schema)
+
+    def fail_call(*_args, **_kwargs):
+        raise AssertionError("content-control Claude call should be skipped")
+
+    monkeypatch.setattr(extractor, "_call", fail_call)
+    assert extractor.find_listing_content_control(object()) is None
+
+
 def test_extractor_parse_schema_result():
     schema = ExtractionSchema(
         fields=[

--- a/tests/test_gallery_trap.py
+++ b/tests/test_gallery_trap.py
@@ -1,0 +1,140 @@
+"""Tests for gallery/lightbox trap detection and recovery."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+from PIL import Image, ImageDraw
+
+from mantis_agent.actions import Action, ActionType
+from mantis_agent.gym.base import GymObservation, GymResult
+from mantis_agent.gym.gallery_trap import detect_gallery_trap, gallery_recovery_actions
+from mantis_agent.gym.runner import GymRunner
+
+
+def _normal_page() -> Image.Image:
+    img = Image.new("RGB", (320, 180), "white")
+    draw = ImageDraw.Draw(img)
+    draw.rectangle((20, 30, 300, 70), fill=(235, 235, 235))
+    draw.text((30, 42), "2026 Tracker Grizzly 12 Jon", fill=(20, 20, 20))
+    draw.rectangle((20, 90, 120, 150), fill=(40, 100, 180))
+    draw.rectangle((140, 95, 300, 120), fill=(245, 245, 245))
+    return img
+
+
+def _gallery_page() -> Image.Image:
+    img = Image.new("RGB", (320, 180), (8, 8, 8))
+    draw = ImageDraw.Draw(img)
+    draw.rectangle((60, 35, 260, 145), fill=(150, 175, 190))
+    draw.rectangle((70, 45, 250, 135), outline=(220, 230, 235), width=3)
+    draw.text((145, 10), "1 of 68", fill=(240, 240, 240))
+    draw.text((270, 10), "Close X", fill=(240, 240, 240))
+    return img
+
+
+def test_detect_gallery_trap_from_visual_overlay() -> None:
+    detection = detect_gallery_trap(_gallery_page())
+
+    assert detection.detected
+    assert detection.confidence >= 0.65
+    assert "dark" in detection.reason or "central" in detection.reason
+
+
+def test_detect_gallery_trap_from_text_signal() -> None:
+    detection = detect_gallery_trap(_normal_page(), text="The page shows a photo gallery 1 of 85")
+
+    assert detection.detected
+    assert detection.signals["text_gallery_signal"] is True
+
+
+def test_uniform_dark_page_is_not_enough_without_text() -> None:
+    detection = detect_gallery_trap(Image.new("RGB", (320, 180), (2, 2, 2)))
+
+    assert not detection.detected
+
+
+def test_normal_listing_page_is_not_gallery() -> None:
+    detection = detect_gallery_trap(_normal_page())
+
+    assert not detection.detected
+
+
+def test_gallery_recovery_actions_are_bounded() -> None:
+    actions = gallery_recovery_actions()
+
+    assert [a.action_type for a in actions] == [ActionType.KEY_PRESS, ActionType.KEY_PRESS]
+    assert [a.params["keys"] for a in actions] == ["escape", "alt+left"]
+
+
+class _ClickThenGalleryBrain:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def think(self, **_: Any) -> Any:
+        self.calls += 1
+        return SimpleNamespace(
+            action=Action(ActionType.CLICK, {"x": 80, "y": 110}, reasoning="click listing title"),
+            thinking="Click the listing title text.",
+            predicted_outcome="detail page opens",
+        )
+
+
+class _GalleryRecoveryEnv:
+    def __init__(self) -> None:
+        self.actions: list[Action] = []
+        self._screen = _normal_page()
+
+    def reset(self, task: str, **kwargs: Any) -> GymObservation:
+        return GymObservation(screenshot=_normal_page(), extras={"url": "https://example.test/list"})
+
+    def step(self, action: Action) -> GymResult:
+        self.actions.append(action)
+        if action.action_type == ActionType.CLICK:
+            self._screen = _gallery_page()
+            return GymResult(
+                observation=GymObservation(screenshot=self._screen),
+                reward=0.0,
+                done=False,
+                info={"url": "https://example.test/list", "title": "Gallery"},
+            )
+        if action.action_type == ActionType.KEY_PRESS and action.params.get("keys") == "escape":
+            self._screen = _normal_page()
+            return GymResult(
+                observation=GymObservation(screenshot=self._screen),
+                reward=0.0,
+                done=False,
+                info={"url": "https://example.test/detail", "title": "Detail"},
+            )
+        return GymResult(
+            observation=GymObservation(screenshot=self._screen),
+            reward=0.0,
+            done=False,
+            info={"url": "https://example.test/detail", "title": "Detail"},
+        )
+
+    def close(self) -> None:
+        pass
+
+    @property
+    def screen_size(self) -> tuple[int, int]:
+        return (320, 180)
+
+
+def test_runner_recovers_gallery_trap_after_click() -> None:
+    env = _GalleryRecoveryEnv()
+    runner = GymRunner(
+        brain=_ClickThenGalleryBrain(),
+        env=env,
+        max_steps=1,
+        frames_per_inference=1,
+    )
+
+    result = runner.run(task="Click listing title", task_id="gallery")
+
+    assert [a.action_type for a in env.actions] == [ActionType.CLICK, ActionType.KEY_PRESS]
+    assert env.actions[1].params["keys"] == "escape"
+    assert result.trajectory[0].observed_state["gallery_trap_detected"] is True
+    assert result.trajectory[0].observed_state["gallery_recovery_actions"] == ["escape"]
+    assert result.trajectory[0].observed_state["gallery_recovery_success"] is True
+    assert "gallery trap detected" in result.trajectory[0].feedback

--- a/tests/test_screenshot_benchmark.py
+++ b/tests/test_screenshot_benchmark.py
@@ -1,0 +1,138 @@
+"""Tests for the offline screenshot CUA benchmark."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from training.screenshot_benchmark import (
+    Prediction,
+    Region,
+    ScreenshotCase,
+    load_cases,
+    load_predictions,
+    run_with_predictions,
+    score_case,
+    summarize,
+)
+
+
+def test_score_case_accepts_expected_click_in_allowed_region() -> None:
+    case = ScreenshotCase(
+        id="title-click",
+        image="unused.png",
+        task="Click the title text",
+        expected_action_type="click",
+        allowed_regions=(Region("title", 100, 100, 300, 160),),
+        forbidden_regions=(Region("photo", 0, 0, 90, 180),),
+        tags=("title_click",),
+    )
+    pred = Prediction(id="title-click", action_type="click", params={"x": 180, "y": 130})
+
+    result = score_case(case, pred)
+
+    assert result.passed
+    assert result.checks == {
+        "prediction_present": True,
+        "action_type": True,
+        "allowed_region": True,
+        "forbidden_region": True,
+    }
+
+
+def test_score_case_rejects_forbidden_photo_click() -> None:
+    case = ScreenshotCase(
+        id="photo-click",
+        image="unused.png",
+        task="Click title text, not photo",
+        expected_action_type="click",
+        allowed_regions=(Region("title", 100, 100, 300, 160),),
+        forbidden_regions=(Region("photo", 0, 0, 90, 180),),
+        tags=("forbidden_region",),
+    )
+    pred = Prediction(id="photo-click", action_type="click", params={"x": 50, "y": 90})
+
+    result = score_case(case, pred)
+
+    assert not result.passed
+    assert result.checks["allowed_region"] is False
+    assert result.checks["forbidden_region"] is False
+    assert any("forbidden" in failure for failure in result.failures)
+
+
+def test_score_case_checks_done_summary_regex() -> None:
+    case = ScreenshotCase(
+        id="done-format",
+        image="unused.png",
+        task="Return extracted row",
+        expected_action_type="done",
+        expected_text_regex=r"VIABLE\s+\|\s+Year:\s+2026\s+\|\s+Make:\s+Tracker",
+        tags=("done_format",),
+    )
+    pred = Prediction(
+        id="done-format",
+        action_type="done",
+        params={"success": True, "summary": "VIABLE | Year: 2026 | Make: Tracker"},
+    )
+
+    assert score_case(case, pred).passed
+
+
+def test_load_cases_and_predictions_jsonl(tmp_path: Path) -> None:
+    cases_path = tmp_path / "cases.jsonl"
+    preds_path = tmp_path / "predictions.jsonl"
+    cases_path.write_text(
+        json.dumps({
+            "id": "c1",
+            "image": "x.png",
+            "task": "Click",
+            "expected_action_type": "click",
+            "allowed_regions": [{"label": "button", "x1": 1, "y1": 2, "x2": 5, "y2": 8}],
+            "tags": ["smoke"],
+        }) + "\n"
+    )
+    preds_path.write_text(
+        json.dumps({"id": "c1", "action_type": "click", "params": {"x": 3, "y": 4}}) + "\n"
+    )
+
+    cases = load_cases(cases_path)
+    preds = load_predictions(preds_path)
+    results, summary = run_with_predictions(cases, preds)
+
+    assert len(cases) == 1
+    assert cases[0].allowed_regions[0].label == "button"
+    assert results[0].passed
+    assert summary["passed"] == 1
+    assert summary["by_tag"]["smoke"]["pass_rate"] == 1.0
+
+
+def test_summarize_reports_failures_by_tag() -> None:
+    cases = [
+        ScreenshotCase(
+            id="ok",
+            image="unused.png",
+            task="Click",
+            expected_action_type="click",
+            allowed_regions=(Region("ok", 0, 0, 10, 10),),
+            tags=("click",),
+        ),
+        ScreenshotCase(
+            id="bad",
+            image="unused.png",
+            task="Click",
+            expected_action_type="click",
+            allowed_regions=(Region("ok", 0, 0, 10, 10),),
+            tags=("click",),
+        ),
+    ]
+    preds = {
+        "ok": Prediction(id="ok", action_type="click", params={"x": 5, "y": 5}),
+        "bad": Prediction(id="bad", action_type="click", params={"x": 50, "y": 50}),
+    }
+
+    results, summary = run_with_predictions(cases, preds)
+
+    assert [r.passed for r in results] == [True, False]
+    assert summary == summarize(results)
+    assert summary["pass_rate"] == 0.5
+    assert summary["by_tag"]["click"]["passed"] == 1

--- a/training/screenshot_benchmark.py
+++ b/training/screenshot_benchmark.py
@@ -1,0 +1,351 @@
+#!/usr/bin/env python3
+"""Offline screenshot benchmark for CUA action regressions.
+
+The benchmark runs one screenshot + task prompt per case and scores the
+resulting action against simple, verifiable expectations:
+
+* action type
+* click point inside allowed target regions
+* click point outside forbidden regions
+* optional text regex over model output / done summary
+
+Use ``--predictions`` for CI or parser-only checks without a model endpoint.
+Use ``--brain holo3`` to call a live Holo3-compatible endpoint.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Iterable
+
+from PIL import Image
+
+from mantis_agent.actions import Action, ActionType
+
+
+@dataclass(frozen=True)
+class Region:
+    """A rectangular scoring region in screen coordinates."""
+
+    label: str
+    x1: int
+    y1: int
+    x2: int
+    y2: int
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "Region":
+        return cls(
+            label=str(data.get("label", "")),
+            x1=int(data["x1"]),
+            y1=int(data["y1"]),
+            x2=int(data["x2"]),
+            y2=int(data["y2"]),
+        )
+
+    def contains(self, x: int, y: int) -> bool:
+        left, right = sorted((self.x1, self.x2))
+        top, bottom = sorted((self.y1, self.y2))
+        return left <= x <= right and top <= y <= bottom
+
+
+@dataclass(frozen=True)
+class ScreenshotCase:
+    """One offline benchmark case."""
+
+    id: str
+    image: str
+    task: str
+    expected_action_type: str = ""
+    allowed_regions: tuple[Region, ...] = ()
+    forbidden_regions: tuple[Region, ...] = ()
+    expected_text_regex: str = ""
+    tags: tuple[str, ...] = ()
+    screen_size: tuple[int, int] = (1280, 720)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "ScreenshotCase":
+        screen = data.get("screen_size") or [1280, 720]
+        return cls(
+            id=str(data["id"]),
+            image=str(data["image"]),
+            task=str(data["task"]),
+            expected_action_type=str(data.get("expected_action_type", "")),
+            allowed_regions=tuple(
+                Region.from_dict(r) for r in data.get("allowed_regions", [])
+            ),
+            forbidden_regions=tuple(
+                Region.from_dict(r) for r in data.get("forbidden_regions", [])
+            ),
+            expected_text_regex=str(data.get("expected_text_regex", "")),
+            tags=tuple(str(t) for t in data.get("tags", [])),
+            screen_size=(int(screen[0]), int(screen[1])),
+        )
+
+
+@dataclass(frozen=True)
+class Prediction:
+    """One model prediction for a benchmark case."""
+
+    id: str
+    action_type: str
+    params: dict[str, Any] = field(default_factory=dict)
+    text: str = ""
+    thinking: str = ""
+
+    @classmethod
+    def from_action(
+        cls,
+        case_id: str,
+        action: Action,
+        *,
+        text: str = "",
+        thinking: str = "",
+    ) -> "Prediction":
+        return cls(
+            id=case_id,
+            action_type=action.action_type.value,
+            params=dict(action.params),
+            text=text,
+            thinking=thinking,
+        )
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "Prediction":
+        # Accept both our JSONL format and serialized Action-like dicts.
+        action_type = data.get("action_type") or data.get("type")
+        params = data.get("params") or data.get("action_params") or {}
+        return cls(
+            id=str(data["id"]),
+            action_type=str(action_type or ""),
+            params=dict(params),
+            text=str(data.get("text", data.get("raw_output", ""))),
+            thinking=str(data.get("thinking", "")),
+        )
+
+    def action_point(self) -> tuple[int, int] | None:
+        """Return the screen point to score for click-like actions."""
+        if self.action_type not in {ActionType.CLICK.value, ActionType.DOUBLE_CLICK.value}:
+            return None
+        try:
+            return int(self.params["x"]), int(self.params["y"])
+        except Exception:
+            return None
+
+
+@dataclass(frozen=True)
+class CaseResult:
+    """Score for one benchmark case."""
+
+    id: str
+    passed: bool
+    checks: dict[str, bool]
+    failures: tuple[str, ...] = ()
+    tags: tuple[str, ...] = ()
+
+
+def load_cases(path: Path) -> list[ScreenshotCase]:
+    """Load newline-delimited benchmark cases."""
+    cases: list[ScreenshotCase] = []
+    with path.open() as f:
+        for line_no, line in enumerate(f, start=1):
+            if not line.strip():
+                continue
+            try:
+                cases.append(ScreenshotCase.from_dict(json.loads(line)))
+            except Exception as exc:
+                raise ValueError(f"{path}:{line_no}: invalid case: {exc}") from exc
+    return cases
+
+
+def load_predictions(path: Path) -> dict[str, Prediction]:
+    """Load newline-delimited predictions keyed by case id."""
+    predictions: dict[str, Prediction] = {}
+    with path.open() as f:
+        for line_no, line in enumerate(f, start=1):
+            if not line.strip():
+                continue
+            try:
+                pred = Prediction.from_dict(json.loads(line))
+            except Exception as exc:
+                raise ValueError(f"{path}:{line_no}: invalid prediction: {exc}") from exc
+            predictions[pred.id] = pred
+    return predictions
+
+
+def score_case(case: ScreenshotCase, prediction: Prediction | None) -> CaseResult:
+    """Score a single prediction against one case."""
+    checks: dict[str, bool] = {}
+    failures: list[str] = []
+
+    if prediction is None:
+        return CaseResult(
+            id=case.id,
+            passed=False,
+            checks={"prediction_present": False},
+            failures=("missing prediction",),
+            tags=case.tags,
+        )
+    checks["prediction_present"] = True
+
+    if case.expected_action_type:
+        ok = prediction.action_type == case.expected_action_type
+        checks["action_type"] = ok
+        if not ok:
+            failures.append(
+                f"action_type expected {case.expected_action_type!r}, got {prediction.action_type!r}"
+            )
+
+    point = prediction.action_point()
+    if case.allowed_regions:
+        ok = point is not None and any(r.contains(*point) for r in case.allowed_regions)
+        checks["allowed_region"] = ok
+        if not ok:
+            failures.append(
+                "point missing or outside allowed regions"
+                if point is None else f"point {point} outside allowed regions"
+            )
+
+    if case.forbidden_regions:
+        ok = point is None or not any(r.contains(*point) for r in case.forbidden_regions)
+        checks["forbidden_region"] = ok
+        if not ok:
+            failures.append(f"point {point} inside forbidden region")
+
+    if case.expected_text_regex:
+        text = _prediction_text(prediction)
+        ok = re.search(case.expected_text_regex, text, re.IGNORECASE | re.DOTALL) is not None
+        checks["text_regex"] = ok
+        if not ok:
+            failures.append("expected text regex did not match")
+
+    passed = all(checks.values()) if checks else True
+    return CaseResult(
+        id=case.id,
+        passed=passed,
+        checks=checks,
+        failures=tuple(failures),
+        tags=case.tags,
+    )
+
+
+def summarize(results: Iterable[CaseResult]) -> dict[str, Any]:
+    """Aggregate pass rates overall and by tag."""
+    rows = list(results)
+    total = len(rows)
+    passed = sum(1 for r in rows if r.passed)
+    by_tag: dict[str, dict[str, int | float]] = {}
+    for row in rows:
+        for tag in row.tags or ("untagged",):
+            bucket = by_tag.setdefault(tag, {"total": 0, "passed": 0, "pass_rate": 0.0})
+            bucket["total"] = int(bucket["total"]) + 1
+            bucket["passed"] = int(bucket["passed"]) + (1 if row.passed else 0)
+    for bucket in by_tag.values():
+        bucket["pass_rate"] = (
+            float(bucket["passed"]) / float(bucket["total"]) if bucket["total"] else 0.0
+        )
+    return {
+        "total": total,
+        "passed": passed,
+        "failed": total - passed,
+        "pass_rate": (passed / total) if total else 0.0,
+        "by_tag": by_tag,
+    }
+
+
+def run_with_predictions(
+    cases: list[ScreenshotCase],
+    predictions: dict[str, Prediction],
+) -> tuple[list[CaseResult], dict[str, Any]]:
+    results = [score_case(case, predictions.get(case.id)) for case in cases]
+    return results, summarize(results)
+
+
+def run_with_holo3(
+    cases: list[ScreenshotCase],
+    *,
+    base_url: str,
+    model: str,
+    api_key: str,
+    max_cases: int = 0,
+) -> tuple[list[CaseResult], dict[str, Any]]:
+    """Run cases against a live Holo3Brain endpoint."""
+    from mantis_agent.brain_holo3 import Holo3Brain
+
+    brain = Holo3Brain(base_url=base_url, model=model, api_key=api_key)
+    selected = cases[:max_cases] if max_cases > 0 else cases
+    predictions: dict[str, Prediction] = {}
+    for case in selected:
+        image = Image.open(case.image)
+        result = brain.think(
+            frames=[image],
+            task=case.task,
+            action_history=None,
+            screen_size=case.screen_size,
+        )
+        predictions[case.id] = Prediction.from_action(
+            case.id,
+            result.action,
+            text=getattr(result, "raw_output", ""),
+            thinking=getattr(result, "thinking", ""),
+        )
+    return run_with_predictions(selected, predictions)
+
+
+def write_results(path: Path, results: list[CaseResult], summary: dict[str, Any]) -> None:
+    """Write per-case JSONL plus a sibling summary JSON."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w") as f:
+        for result in results:
+            f.write(json.dumps(asdict(result), sort_keys=True) + "\n")
+    summary_path = path.with_suffix(path.suffix + ".summary.json")
+    summary_path.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n")
+
+
+def _prediction_text(prediction: Prediction) -> str:
+    done_summary = ""
+    if prediction.action_type == ActionType.DONE.value:
+        done_summary = str(prediction.params.get("summary", ""))
+    return "\n".join(
+        part for part in [prediction.text, prediction.thinking, done_summary] if part
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--cases", required=True, help="Benchmark cases JSONL")
+    parser.add_argument("--output", required=True, help="Per-case result JSONL")
+    parser.add_argument("--predictions", help="Prediction JSONL keyed by case id")
+    parser.add_argument("--brain", choices=["holo3"], help="Run a live brain instead of predictions")
+    parser.add_argument("--base-url", default="https://api.hcompany.ai/v1")
+    parser.add_argument("--model", default="holo3-35b-a3b")
+    parser.add_argument("--api-key", default="")
+    parser.add_argument("--max-cases", type=int, default=0)
+    args = parser.parse_args()
+
+    cases = load_cases(Path(args.cases))
+    if args.predictions:
+        results, summary = run_with_predictions(cases, load_predictions(Path(args.predictions)))
+    elif args.brain == "holo3":
+        results, summary = run_with_holo3(
+            cases,
+            base_url=args.base_url,
+            model=args.model,
+            api_key=args.api_key,
+            max_cases=args.max_cases,
+        )
+    else:
+        parser.error("provide either --predictions or --brain holo3")
+
+    write_results(Path(args.output), results, summary)
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    sys.exit(0 if summary["failed"] == 0 else 1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- add an offline screenshot benchmark CLI for CUA action regression checks, with prediction-file and live Holo3 modes
- add gallery/lightbox trap detection and bounded Escape/Alt+Left recovery after risky click steps
- record gallery trap recovery metadata on trajectory observed_state and add focused tests

Closes #180.
Closes #182.

## Validation

- PYTHONPATH=src:. uv run pytest tests/test_screenshot_benchmark.py tests/test_gallery_trap.py tests/test_loop_detector.py tests/test_trajectory_schema.py -q
- uv run ruff check training/screenshot_benchmark.py tests/test_screenshot_benchmark.py src/mantis_agent/gym/gallery_trap.py src/mantis_agent/gym/runner.py tests/test_gallery_trap.py