### PR TITLE
feat(grounding): Prometheus metrics + shared cache wiring + SoM site flag (#117)

### DIFF
--- a/src/mantis_agent/baseten_server/runtime.py
+++ b/src/mantis_agent/baseten_server/runtime.py
@@ -106,6 +106,13 @@ class BasetenCUARuntime:
         self.lock = threading.Lock()
         self.detached_threads: dict[str, threading.Thread] = {}
         self.loaded = False
+        # #117: process-level shared grounding cache. Listing-card layouts
+        # repeat both across pages within a run AND across runs / tenants on
+        # the same site, so a single cache amortises Claude grounding cost
+        # across the whole server lifetime. Bounded by GroundingCache's LRU
+        # cap; entries TTL out at 1 h by default.
+        from ..grounding_cache import GroundingCache
+        self.grounding_cache: GroundingCache = GroundingCache()
 
     def load(self) -> None:
         if self.loaded:
@@ -883,7 +890,7 @@ class BasetenCUARuntime:
                 except Exception as e:
                     logger.warning("Baseten: probe enhancement failed: %s", e)
 
-            grounding = ClaudeGrounding()
+            grounding = ClaudeGrounding(cache=self.grounding_cache)
             schema = None
             objective_data = task_suite.get("_objective")
             if objective_data:
@@ -976,7 +983,7 @@ class BasetenCUARuntime:
         if click_log is not None:
             from mantis_agent.presentation import ClickRecordingEnv
             env = ClickRecordingEnv(env, click_log)
-        grounding = ClaudeGrounding()
+        grounding = ClaudeGrounding(cache=self.grounding_cache)
 
         try:
             config = TaskLoopConfig(

--- a/src/mantis_agent/grounding_cache.py
+++ b/src/mantis_agent/grounding_cache.py
@@ -73,6 +73,7 @@ class GroundingCache:
         max_entries: int = DEFAULT_MAX_ENTRIES,
         ttl_seconds: float = DEFAULT_TTL_SECONDS,
         crop_half: int = DEFAULT_CROP_HALF,
+        tenant_id: str = "",
     ) -> None:
         if max_entries < 1:
             raise ValueError(f"max_entries must be >= 1 (got {max_entries})")
@@ -83,6 +84,8 @@ class GroundingCache:
         self.max_entries = max_entries
         self.ttl_seconds = ttl_seconds
         self.crop_half = crop_half
+        # #117: Prometheus label for hits/misses/size. Empty = cross-tenant.
+        self.tenant_id = tenant_id
         self._entries: OrderedDict[str, _CacheEntry] = OrderedDict()
         self.hits: int = 0
         self.misses: int = 0
@@ -135,16 +138,20 @@ class GroundingCache:
         entry = self._entries.get(key)
         if entry is None:
             self.misses += 1
+            self._emit_miss()
             return None
         if entry.expires_at <= time.time():
             # Expired — drop it so stale layouts don't keep returning.
             del self._entries[key]
             self.expirations += 1
             self.misses += 1
+            self._emit_miss()
+            self._emit_size()
             return None
         # Touch for LRU.
         self._entries.move_to_end(key)
         self.hits += 1
+        self._emit_hit()
         return entry.result
 
     def put(self, key: str, result: GroundingResult) -> None:
@@ -159,9 +166,47 @@ class GroundingCache:
         if len(self._entries) >= self.max_entries:
             self._entries.popitem(last=False)
             self.evictions += 1
+            self._emit_eviction()
         self._entries[key] = _CacheEntry(
             result=result, expires_at=time.time() + self.ttl_seconds
         )
+        self._emit_size()
+
+    # ── Prometheus emission ─────────────────────────────────────────────
+    #
+    # Wrapped in try/except so a metrics-config failure (prometheus_client
+    # missing, registry exhausted, label cardinality error) never breaks
+    # the grounding hot path.
+
+    def _emit_hit(self) -> None:
+        try:
+            from .metrics import GROUNDING_CACHE_HITS_TOTAL
+            GROUNDING_CACHE_HITS_TOTAL.labels(tenant_id=self.tenant_id).inc()
+        except Exception as exc:  # noqa: BLE001 — telemetry never breaks runs
+            logger.debug("grounding cache hit metric emit failed: %s", exc)
+
+    def _emit_miss(self) -> None:
+        try:
+            from .metrics import GROUNDING_CACHE_MISSES_TOTAL
+            GROUNDING_CACHE_MISSES_TOTAL.labels(tenant_id=self.tenant_id).inc()
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("grounding cache miss metric emit failed: %s", exc)
+
+    def _emit_eviction(self) -> None:
+        try:
+            from .metrics import GROUNDING_CACHE_EVICTIONS_TOTAL
+            GROUNDING_CACHE_EVICTIONS_TOTAL.labels(tenant_id=self.tenant_id).inc()
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("grounding cache eviction metric emit failed: %s", exc)
+
+    def _emit_size(self) -> None:
+        try:
+            from .metrics import GROUNDING_CACHE_SIZE
+            GROUNDING_CACHE_SIZE.labels(tenant_id=self.tenant_id).set(
+                len(self._entries)
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("grounding cache size metric emit failed: %s", exc)
 
     # ── Convenience wrapper ─────────────────────────────────────────────
 

--- a/src/mantis_agent/metrics.py
+++ b/src/mantis_agent/metrics.py
@@ -216,6 +216,37 @@ STEP_LATENCY_SECONDS = _histogram(
     buckets=(0.05, 0.1, 0.25, 0.5, 1.0, 2.0, 5.0, 10.0, 20.0, 30.0),
 )
 
+# ── Grounding cache (#117) ──────────────────────────────────────────────
+#
+# Each ClaudeGrounding call costs ~$0.003-0.01 and ~5-10s. Listing-card
+# layouts repeat across pages so caching by perceptual_hash(crop) +
+# description_hash short-circuits the API call. These counters let
+# operators dashboard hit-rate + cost savings.
+
+GROUNDING_CACHE_HITS_TOTAL = _counter(
+    "mantis_grounding_cache_hits_total",
+    "Cache hits on the grounding coordinate cache.",
+    ("tenant_id",),
+)
+
+GROUNDING_CACHE_MISSES_TOTAL = _counter(
+    "mantis_grounding_cache_misses_total",
+    "Cache misses on the grounding coordinate cache (incl. expirations).",
+    ("tenant_id",),
+)
+
+GROUNDING_CACHE_SIZE = _gauge(
+    "mantis_grounding_cache_size",
+    "Current number of entries in the grounding cache.",
+    ("tenant_id",),
+)
+
+GROUNDING_CACHE_EVICTIONS_TOTAL = _counter(
+    "mantis_grounding_cache_evictions_total",
+    "LRU evictions from the grounding cache (capacity hits).",
+    ("tenant_id",),
+)
+
 
 def publish_prompt_versions() -> None:
     """Set the prompt-version gauge for every registered prompt (#127).

--- a/src/mantis_agent/site_config.py
+++ b/src/mantis_agent/site_config.py
@@ -43,6 +43,15 @@ class SiteConfig:
     # Filter recovery
     filtered_results_url: str = ""  # URL to navigate to if filters are lost
 
+    # #117: opt-in Set-of-Mark grounding promotion. When True, the runner
+    # should overlay numbered DOM-derived candidate boxes and ask the
+    # brain "which N?" instead of going through Claude grounding. Default
+    # False because SoM is layout-sensitive and only safe on sites whose
+    # DOM exposes stable, click-able candidate elements (cards, buttons,
+    # links). Lays the groundwork for a follow-up PR that wires the
+    # promotion path through gym/runner.py:_try_discovery_execution.
+    prefer_som_grounding: bool = False
+
     def is_detail_page(self, url: str) -> bool:
         """Check if URL matches the detail page pattern."""
         if not self.detail_page_pattern:
@@ -139,7 +148,7 @@ class SiteConfig:
             pagination_strip_pattern=pagination_strip,
         )
 
-    def to_dict(self) -> dict[str, str]:
+    def to_dict(self) -> dict[str, str | bool]:
         return {
             "domain": self.domain,
             "detail_page_pattern": self.detail_page_pattern,
@@ -149,6 +158,7 @@ class SiteConfig:
             "pagination_strip_pattern": self.pagination_strip_pattern,
             "gate_verify_prompt": self.gate_verify_prompt,
             "filtered_results_url": self.filtered_results_url,
+            "prefer_som_grounding": self.prefer_som_grounding,
         }
 
     @classmethod

--- a/tests/test_observability_metrics.py
+++ b/tests/test_observability_metrics.py
@@ -159,6 +159,62 @@ def test_loop_termination_metric_increments_for_each_status():
 # ── BRAIN_ESCALATION_TOTAL ─────────────────────────────────────────────
 
 
+# ── GroundingCache metrics (#117) ──────────────────────────────────────
+
+
+def test_grounding_cache_emits_hit_and_miss_counters():
+    """Cache get/put cycles bump the labelled counters."""
+    from PIL import Image
+
+    from mantis_agent.grounding import GroundingResult
+    from mantis_agent.grounding_cache import GroundingCache
+    from mantis_agent.metrics import (
+        GROUNDING_CACHE_HITS_TOTAL,
+        GROUNDING_CACHE_MISSES_TOTAL,
+    )
+
+    cache = GroundingCache(tenant_id="t-grounding")
+    img = Image.new("RGB", (256, 256), (50, 50, 50))
+    result = GroundingResult(x=10, y=20, confidence=0.9, description="d")
+
+    miss_before = _counter_value(
+        GROUNDING_CACHE_MISSES_TOTAL, tenant_id="t-grounding",
+    )
+    hit_before = _counter_value(
+        GROUNDING_CACHE_HITS_TOTAL, tenant_id="t-grounding",
+    )
+
+    key = cache.make_key(img, "click first card", initial_x=80, initial_y=80)
+    assert cache.get(key) is None  # miss
+    cache.put(key, result)
+    assert cache.get(key) is not None  # hit
+
+    miss_after = _counter_value(
+        GROUNDING_CACHE_MISSES_TOTAL, tenant_id="t-grounding",
+    )
+    hit_after = _counter_value(
+        GROUNDING_CACHE_HITS_TOTAL, tenant_id="t-grounding",
+    )
+    assert miss_after - miss_before == pytest.approx(1.0)
+    assert hit_after - hit_before == pytest.approx(1.0)
+
+
+def test_grounding_cache_emits_eviction_counter_at_capacity():
+    from mantis_agent.grounding import GroundingResult
+    from mantis_agent.grounding_cache import GroundingCache
+    from mantis_agent.metrics import GROUNDING_CACHE_EVICTIONS_TOTAL
+
+    cache = GroundingCache(max_entries=2, tenant_id="t-evict")
+    r = GroundingResult(x=1, y=1, confidence=0.9)
+
+    before = _counter_value(GROUNDING_CACHE_EVICTIONS_TOTAL, tenant_id="t-evict")
+    cache.put("a", r)
+    cache.put("b", r)
+    cache.put("c", r)  # evicts "a"
+    after = _counter_value(GROUNDING_CACHE_EVICTIONS_TOTAL, tenant_id="t-evict")
+    assert after - before == pytest.approx(1.0)
+
+
 def test_brain_escalation_metric_increments_on_ladder_think():
     """Smoke test the brain ladder emits one escalation counter per
     ``think()`` call, labelled with which brain handled the call."""


### PR DESCRIPTION
## Summary

Closes the cache-side of #117 acceptance. The coordinate cache infra already existed (``src/mantis_agent/grounding_cache.py``); this PR exposes it on Prometheus, wires a shared cache into the production runtime so listing-card layouts hit cache across pages / runs / tenants, and adds the ``prefer_som_grounding`` SiteConfig flag for the SoM-promotion follow-up.

## New metric handles

| Metric | Type | Labels |
|---|---|---|
| ``mantis_grounding_cache_hits_total`` | counter | tenant_id |
| ``mantis_grounding_cache_misses_total`` | counter | tenant_id |
| ``mantis_grounding_cache_evictions_total`` | counter | tenant_id |
| ``mantis_grounding_cache_size`` | gauge | tenant_id |

Emission lives inside ``GroundingCache.get/put`` — no caller change needed. All wrapped in try/except so a metrics failure never breaks the grounding hot path.

## Shared cache wiring

``Runtime`` (``baseten_server/runtime.py``) now constructs a single process-level ``GroundingCache`` at ``__init__`` time and passes it to both ``ClaudeGrounding(cache=...)`` instantiations. Listing-card layouts repeat across pages within a run, across runs on the same site, and across tenants on common sites — a single cache amortises Claude grounding cost (~\$0.005 + ~5–10 s saved per hit) over the full server lifetime. Bounded by the existing LRU cap (1024 entries) with 1 h TTL.

## SiteConfig flag

``prefer_som_grounding: bool = False`` lays groundwork for the #117 step 1 promotion (Set-of-Mark as primary on SoM-friendly sites). Default False → behavior unchanged. Serialized through ``to_dict`` / ``from_dict``. The runtime hook in ``gym/runner.py:_try_discovery_execution`` lands in a follow-up.

## Test plan

- [x] 2 new metric-emission tests in ``tests/test_observability_metrics.py``
- [x] 51/51 across observability, grounding-cache, grounding-cache-wiring, site-config
- [x] ``ruff check`` clean
- [x] **Modal verification on news.ycombinator.com**: redeployed + re-ran HN smoke. ``status=succeeded``, ``cost=\$0.054``, 3 steps — matches baseline. No regression.

## Acceptance criteria (from #117)

- [x] Site-config flag ``prefer_som_grounding`` — added (defaults False)
- [x] Grounding cache with TTL + size cap, hit/miss counters on Prometheus — counters live, cache wired in runtime
- [ ] Cost report shows grounding-call savings — needs a longer run with repeated card layouts; HN smoke is too short to demonstrate (3 steps, no listings click). Next site-specific run on lu.ma / boattrader will surface savings via the new ``mantis_grounding_cache_hits_total`` metric.
- [ ] Set-of-Mark promotion path (#117 step 1) — flag is in place; runtime promotion is a follow-up PR (will hook into ``gym/runner.py:_try_discovery_execution``)

Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)