### PR TITLE
feat(cli): mantis plan dry-run <path> — second plan-authoring deliverable (#154)

### DIFF
--- a/docs/getting-started/cli.md
+++ b/docs/getting-started/cli.md
@@ -64,6 +64,45 @@ Issues are returned as ``PlanIssue`` records with ``severity``, ``code``,
 auto-fix pass are reusable as a library: ``from
 mantis_agent.graph.plan_validator import PlanValidator``.
 
+### `mantis plan dry-run <path>`
+
+Walk the plan graph and print the step sequence the runner would attempt
+— **no browser, no API calls, no model load**. Pure structural walk.
+Use as the inner authoring loop before paying the 9–13 min Modal/Baseten
+roundtrip.
+
+```
+mantis plan dry-run examples/extract_jobs.json
+```
+
+```
+examples/extract_jobs.json: 3 steps
+  sections: setup=1, —=2
+
+  idx  type               flags          section     intent / target
+  ---- ------------------ -------------- ----------- ----------------------------------------
+  [00] navigate           —              setup       "Open a public Greenhouse-hosted careers page."
+  [01] wait               —              —           "Wait for the listings to render."
+  [02] loop               —              —           "→ step [?] (count=5)"
+```
+
+Annotations:
+
+| Column | Meaning |
+|---|---|
+| **idx** | Zero-based step index — what the runner sees as `step_index`. |
+| **type** | The step's `type` field (navigate, click, paginate, extract_url, ...). |
+| **flags** | `!req` = required (halt on failure), `gate` = verification gate, `cl` = `claude_only`. |
+| **section** | The step's `section` (setup / extraction / pagination / —). |
+| **intent / target** | First 60 chars of `intent`, except for `loop` rows which show `→ step [N] (count=K)`. |
+
+Out-of-range `loop_target` references emit a non-fatal `WARNING` line so
+authors can spot misconfigured loops at dry-run rather than at first
+execution.
+
+`--json` emits the structured form (full step list + section rollup) for
+editor integrations and CI gates.
+
 ## Streaming-agent run (legacy default)
 
 `mantis "<task description>"` continues to work as before — running the
@@ -79,7 +118,5 @@ See `mantis --help` for the full streaming-agent option set.
 
 ## Roadmap (#154)
 
-- `mantis plan dry-run <path>` — walk the plan graph without spawning a
-  browser; emit a flow diagram of branches, gates, loops, max-loops bounds.
 - `mantis init <url> --task "<description>"` — scaffold a starter plan
   via PlanDecomposer; validate and dry-run before writing.

--- a/src/mantis_agent/cli.py
+++ b/src/mantis_agent/cli.py
@@ -1,18 +1,23 @@
 """``mantis`` command-line interface — first-class plan-authoring product surface (#154).
 
-Subcommands (this PR):
+Subcommands:
     plan validate <path>    Run PlanValidator on a JSON micro-plan.
                             Exits 0 on clean, 1 on errors, 2 on warnings only.
+    plan dry-run <path>     Walk the plan graph and print the step sequence
+                            the runner would attempt — no browser, no API
+                            calls, no model load. Annotates gates, loops,
+                            required steps, sections.
 
-Planned follow-ups (#154):
-    plan dry-run <path>     Walk the plan graph without browser/Xvfb.
+Planned follow-up (#154):
     init <url> [--task ...] Scaffold a starter plan via PlanDecomposer.
 
-The CLI is registered as ``mantis = mantis_agent.cli:main`` in
-``pyproject.toml::project.scripts``. Invocation:
+The CLI is wired through ``mantis_agent/main.py``: ``mantis plan ...``
+invocations dispatch to this module BEFORE any heavy import (no
+transformers / torch / mss / pyautogui), so the plan-authoring surface
+stays fast.
 
     mantis plan validate examples/extract_listings.json
-    mantis plan validate -            # read stdin
+    mantis plan dry-run examples/extract_jobs.json
     mantis plan validate path.json --json   # machine-readable output
 """
 
@@ -122,6 +127,140 @@ def _issue_to_dict(issue: Any) -> dict[str, Any]:
     }
 
 
+# ── plan dry-run ──────────────────────────────────────────────────────
+
+
+def _annotate_step(idx: int, step: Any) -> str:
+    """Render one step as a single-line human-readable summary.
+
+    Format::
+
+        [00] navigate           !req           "Navigate to https://example.com..."
+        [01] extract_data       gate  setup    "Verify page has loaded..."
+        [05] loop                     extract  → step [02] (count=10)
+
+    The flag column shows ``!req`` for required, ``gate`` for verification
+    gates, ``cl`` for ``claude_only`` extract steps. The section column
+    shows the step's ``section`` field. Loop steps show their target index
+    and configured count.
+    """
+    flags: list[str] = []
+    if step.required:
+        flags.append("!req")
+    if step.gate:
+        flags.append("gate")
+    if step.claude_only:
+        flags.append("cl")
+    flag_str = " ".join(flags) if flags else "—"
+    section_str = step.section or "—"
+
+    intent_or_target = step.intent.replace("\n", " ").strip()[:60]
+    if step.type == "loop":
+        loop_target = step.loop_target if step.loop_target >= 0 else "?"
+        loop_count = step.loop_count if step.loop_count > 0 else "∞"
+        target_repr = f"→ step [{loop_target:02d}]" if isinstance(loop_target, int) else f"→ step [{loop_target}]"
+        intent_or_target = f"{target_repr} (count={loop_count})"
+
+    return (
+        f"  [{idx:02d}] {step.type:18s} {flag_str:14s} "
+        f"{section_str:11s} \"{intent_or_target}\""
+    )
+
+
+def _section_summary(steps: list[Any]) -> dict[str, int]:
+    """Count steps per section for the header rollup."""
+    counts: dict[str, int] = {}
+    for s in steps:
+        key = s.section or "—"
+        counts[key] = counts.get(key, 0) + 1
+    return counts
+
+
+def cmd_plan_dry_run(args: argparse.Namespace) -> int:
+    """``mantis plan dry-run <path>`` — print the step sequence the runner would attempt.
+
+    No browser, no API calls, no model load. Pure structural walk. Useful
+    as the inner authoring loop before paying the 9-13 min Modal/Baseten
+    roundtrip.
+
+    Returns 0 on a parseable plan, 1 on file or JSON error.
+    """
+    from .plan_decomposer import MicroPlan
+
+    try:
+        payload, label = _load_plan(args.path)
+    except FileNotFoundError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return EXIT_ERROR
+    except json.JSONDecodeError as exc:
+        print(f"error: invalid JSON in {args.path}: {exc}", file=sys.stderr)
+        return EXIT_ERROR
+
+    try:
+        plan = MicroPlan.from_dict(payload)
+    except Exception as exc:  # noqa: BLE001
+        print(f"error: cannot parse plan from {label}: {exc}", file=sys.stderr)
+        return EXIT_ERROR
+
+    if args.json:
+        print(json.dumps({
+            "path": label,
+            "domain": plan.domain,
+            "step_count": len(plan.steps),
+            "sections": _section_summary(plan.steps),
+            "steps": [
+                {
+                    "index": i,
+                    "type": s.type,
+                    "intent": s.intent,
+                    "section": s.section,
+                    "required": s.required,
+                    "gate": s.gate,
+                    "claude_only": s.claude_only,
+                    "loop_target": s.loop_target,
+                    "loop_count": s.loop_count,
+                    "verify": s.verify,
+                    "params": s.params,
+                    "hints": s.hints,
+                }
+                for i, s in enumerate(plan.steps)
+            ],
+        }, indent=2))
+        return EXIT_OK
+
+    sections = _section_summary(plan.steps)
+    section_str = ", ".join(f"{k}={v}" for k, v in sections.items())
+    print(
+        f"{label}: {len(plan.steps)} steps"
+        + (f" — {plan.domain}" if plan.domain else "")
+    )
+    if section_str:
+        print(f"  sections: {section_str}")
+    print()
+    print(f"  {'idx':4s} {'type':18s} {'flags':14s} {'section':11s} intent / target")
+    print(f"  {'-'*4} {'-'*18} {'-'*14} {'-'*11} {'-'*40}")
+    for i, step in enumerate(plan.steps):
+        print(_annotate_step(i, step))
+
+    # Check for non-loop steps that reference an out-of-range loop_target
+    # — surfaces broken plans the same way the runner will at execution
+    # time, so authors see the issue at dry-run.
+    bad_targets: list[tuple[int, int]] = []
+    for i, step in enumerate(plan.steps):
+        if step.type == "loop" and step.loop_target >= 0:
+            if step.loop_target >= len(plan.steps):
+                bad_targets.append((i, step.loop_target))
+    if bad_targets:
+        print()
+        for idx, target in bad_targets:
+            print(
+                f"  WARNING step[{idx}] loop_target={target} is out of range "
+                f"(plan has {len(plan.steps)} steps)"
+            )
+
+    return EXIT_OK
+
+
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="mantis",
@@ -146,6 +285,21 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Emit machine-readable JSON instead of human-formatted lines",
     )
     validate.set_defaults(func=cmd_plan_validate)
+
+    dry_run = plan_sub.add_parser(
+        "dry-run",
+        help="Walk the plan graph and print the step sequence — no browser",
+    )
+    dry_run.add_argument(
+        "path",
+        help="Path to JSON plan file, or '-' to read stdin",
+    )
+    dry_run.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable JSON instead of human-formatted lines",
+    )
+    dry_run.set_defaults(func=cmd_plan_dry_run)
 
     return parser
 

--- a/tests/test_cli_plan_validate.py
+++ b/tests/test_cli_plan_validate.py
@@ -170,3 +170,81 @@ def test_no_args_prints_help_and_errors():
 def test_plan_with_no_subcommand_errors():
     with pytest.raises(SystemExit):
         main(["plan"])
+
+
+# ── plan dry-run ───────────────────────────────────────────────────────
+
+
+def test_dry_run_clean_plan_exits_zero(tmp_plan, capsys):
+    path = tmp_plan(_good_plan())
+    assert main(["plan", "dry-run", path]) == EXIT_OK
+    out = capsys.readouterr().out
+    assert "3 steps" in out
+    # Header columns present
+    assert "idx" in out and "type" in out
+    # Each numbered step row appears
+    assert "[00]" in out and "[01]" in out and "[02]" in out
+
+
+def test_dry_run_annotates_required_and_gate(tmp_plan, capsys):
+    path = tmp_plan(_good_plan())
+    main(["plan", "dry-run", path])
+    out = capsys.readouterr().out
+    # required navigate: !req
+    assert "!req" in out
+    # gate verify on the second step
+    assert "gate" in out
+
+
+def test_dry_run_shows_loop_target_and_count(tmp_plan, capsys):
+    payload = {
+        "steps": [
+            {"intent": "Navigate to https://x.test", "type": "navigate", "section": "setup"},
+            {"intent": "Click an item", "type": "click", "section": "extraction"},
+            {"intent": "Loop back to step 1", "type": "loop",
+             "loop_target": 1, "loop_count": 10},
+        ],
+    }
+    path = tmp_plan(payload)
+    rc = main(["plan", "dry-run", path])
+    assert rc == EXIT_OK
+    out = capsys.readouterr().out
+    assert "→ step [01]" in out
+    assert "count=10" in out
+
+
+def test_dry_run_warns_on_out_of_range_loop_target(tmp_plan, capsys):
+    payload = {
+        "steps": [
+            {"intent": "Navigate to https://x.test", "type": "navigate", "section": "setup"},
+            {"intent": "Loop", "type": "loop", "loop_target": 99, "loop_count": 1},
+        ],
+    }
+    path = tmp_plan(payload)
+    rc = main(["plan", "dry-run", path])
+    # Out-of-range targets are a WARNING, not an exit-code failure — dry-run
+    # is informational.
+    assert rc == EXIT_OK
+    out = capsys.readouterr().out
+    assert "WARNING" in out
+    assert "out of range" in out
+
+
+def test_dry_run_json_output_shape(tmp_plan, capsys):
+    path = tmp_plan(_good_plan())
+    rc = main(["plan", "dry-run", path, "--json"])
+    assert rc == EXIT_OK
+    parsed = json.loads(capsys.readouterr().out)
+    assert parsed["step_count"] == 3
+    assert parsed["domain"] == "example.com"
+    assert isinstance(parsed["sections"], dict)
+    # Each step has the structured fields the human view also surfaces.
+    for step in parsed["steps"]:
+        assert "type" in step and "section" in step and "required" in step
+
+
+def test_dry_run_handles_missing_path(capsys):
+    rc = main(["plan", "dry-run", "/does/not/exist.json"])
+    assert rc == EXIT_ERROR
+    err = capsys.readouterr().err
+    assert "not found" in err


### PR DESCRIPTION
## Summary

The second of three CLI deliverables called out in #154. Walks the plan graph and prints the step sequence the runner would attempt — **no browser, no API calls, no model load**. Pure structural walk so authors can iterate on plan shape before paying the 9–13 min Modal/Baseten roundtrip.

## Surface

```
mantis plan dry-run <path>           # walk + print
mantis plan dry-run -                # read JSON from stdin
mantis plan dry-run <path> --json    # machine-readable output
```

Sample output:

```
examples/extract_jobs.json: 3 steps
  sections: setup=1, —=2

  idx  type               flags          section     intent / target
  ---- ------------------ -------------- ----------- ------------------------------------
  [00] navigate           —              setup       "Open a public Greenhouse..."
  [01] wait               —              —           "Wait for the listings to..."
  [02] loop               —              —           "→ step [?] (count=5)"
```

Annotations:

| Annotation | Meaning |
|---|---|
| ``!req`` | Required step (halt on failure) |
| ``gate`` | Verification gate |
| ``cl`` | ``claude_only`` extract step |
| ``→ step [N] (count=K)`` | Replaces the intent column for loop steps |

Out-of-range ``loop_target`` references print a ``WARNING`` line (non-fatal — dry-run is informational).

## Test plan

- [x] 6 new tests in ``tests/test_cli_plan_validate.py``: clean plan exits 0, !req / gate annotations, loop target + count rendering, out-of-range warning, ``--json`` shape, missing-path exit-1.
- [x] 17/17 CLI tests pass (validate + dry-run combined)
- [x] ``ruff check`` clean
- [x] **Modal news.ycombinator.com smoke**: redeployed + re-ran. ``status=succeeded``, ``cost=\$0.054``, 3 steps — matches baseline. No regression.

## Docs

- ``docs/getting-started/cli.md`` — added the ``dry-run`` section with sample output, annotation table, and ``--json`` note. Removed ``dry-run`` from the roadmap; only ``mantis init`` remains for #154 part 3.

## What's still open on #154

- ``mantis init <url> --task \"...\"`` — scaffold a starter plan via PlanDecomposer.

Refs #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)