### PR TITLE
feat(traces): per-run TraceExporter for SFT/DPO labelling (#155 step 1)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -87,6 +87,7 @@ ExtractionResult               Structured output (fields, viability, spam check)
 | `cost_meter.py` | CostMeter -- gpu/claude/proxy cost rollup, Prometheus inflight gauge |
 | `run_reporter.py` | RunReporter -- final summary block + costs dict |
 | `tool_channel.py` | ToolChannel -- pause/resume tool invocation |
+| `trace_exporter.py` | TraceExporter -- per-run JSON trace dump for SFT/DPO labelling, gated on `MANTIS_TRACE_EXPORT_DIR` (#155) |
 | `workflow_runner.py` | WorkflowRunner -- dynamic loops and pagination over GymRunner |
 | `learning_runner.py` | LearningRunner -- verified execution for building playbooks |
 | `xdotool_env.py` | XdotoolGymEnv -- real Chrome + xdotool (zero automation fingerprints) |

--- a/docs/reference/env-vars.md
+++ b/docs/reference/env-vars.md
@@ -57,6 +57,13 @@ These are global hard caps; tenant config can be tighter, never looser.
 |---|---|---|
 | `MANTIS_WEBHOOK_SECRET_DEFAULT` | unset | Fallback HMAC signing secret when a tenant's `webhook_secret_name` doesn't resolve |
 
+## Trace export (#155)
+
+| Var | Default | Effect |
+|---|---|---|
+| `MANTIS_TRACE_EXPORT_DIR` | unset | Enable per-run trace export. When set, every completed / halted / cancelled / paused run writes `<dir>/<tenant_id>/<run_id>.json` with the full step list, costs, status, and predicted/observed outcomes. Empty `tenant_id` falls back to `__shared__/`. Off by default — feature flag for the continual-fine-tuning pipeline. |
+| `MANTIS_TRACE_INCLUDE_SCREENSHOTS` | unset | When truthy (`1`/`true`/`yes`/`on`) and trace export is enabled, also persists per-step PNG screenshots to `<dir>/<tenant_id>/<run_id>_screens/<step:04d>.png`. Default off because screenshot bytes ~100× the on-disk trace size. |
+
 ## Logging
 
 | Var | Default | Effect |

--- a/src/mantis_agent/gym/run_executor.py
+++ b/src/mantis_agent/gym/run_executor.py
@@ -515,6 +515,16 @@ class RunExecutor:
         except Exception as exc:  # noqa: BLE001 — telemetry must not break runs
             logger.debug("loop termination metric emit failed: %s", exc)
 
+        # #155 step 1 — production trace export (gated on MANTIS_TRACE_EXPORT_DIR).
+        # No-op when the env var is unset, so legacy deployments pay nothing.
+        try:
+            from .trace_exporter import TraceExporter
+            TraceExporter.from_env().maybe_export(
+                runner, state.results, status=runner._final_status,
+            )
+        except Exception as exc:  # noqa: BLE001 — telemetry never breaks runs
+            logger.debug("trace export failed: %s", exc)
+
     # ── Helpers ─────────────────────────────────────────────────────────
 
     def _persist(

--- a/src/mantis_agent/gym/trace_exporter.py
+++ b/src/mantis_agent/gym/trace_exporter.py
@@ -1,0 +1,207 @@
+"""TraceExporter — persist production runs for offline analysis + SFT/DPO labelling (#155 step 1).
+
+Each :class:`MicroPlanRunner` invocation that completes (or halts /
+cancels / pauses) emits one structured trace JSON file. The schema is
+versioned so consumers can downgrade gracefully when fields are added.
+
+What's in a trace
+-----------------
+
+* ``schema_version`` — bumped on incompatible changes.
+* Run metadata: ``run_id``, ``tenant_id``, ``session_name``,
+  ``plan_signature``, ``status``, ``started_at`` / ``ended_at``,
+  ``total_time_s``, costs.
+* Step list: every executed :class:`StepResult` with its
+  ``intent`` / ``type`` / ``success`` / ``data`` / ``duration`` /
+  ``reversed`` / ``last_action`` / ``predicted_outcome`` /
+  ``observed_outcome``.
+
+Tenant isolation
+----------------
+
+Trace files land at ``$MANTIS_TRACE_EXPORT_DIR/<tenant_id>/<run_id>.json``.
+Empty tenant ids land under ``__shared__/`` so legacy single-tenant runs
+don't collide with multi-tenant ones. Operators wire tenant-bucket
+sync (S3 / GCS / R2) by tenant directory.
+
+Feature flag
+------------
+
+Off by default. Set ``MANTIS_TRACE_EXPORT_DIR=<path>`` to enable. When
+unset, :meth:`TraceExporter.maybe_export` is a no-op so the runtime
+pays no cost.
+
+Optional ``MANTIS_TRACE_INCLUDE_SCREENSHOTS`` controls whether
+``screenshot_png`` bytes are written alongside the JSON (one PNG per
+step). Default off because screenshot bytes balloon the on-disk size
+~100x and most triage workflows only need the action sequence + costs.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from .checkpoint import StepResult
+
+if TYPE_CHECKING:
+    from .micro_runner import MicroPlanRunner
+
+logger = logging.getLogger(__name__)
+
+
+SCHEMA_VERSION: int = 1
+ENV_DIR: str = "MANTIS_TRACE_EXPORT_DIR"
+ENV_INCLUDE_SCREENSHOTS: str = "MANTIS_TRACE_INCLUDE_SCREENSHOTS"
+
+
+def _action_to_dict(action: Any) -> dict[str, Any] | None:
+    """Render an :class:`Action` (or ``None``) into a JSON-friendly dict."""
+    if action is None:
+        return None
+    return {
+        "action_type": getattr(getattr(action, "action_type", None), "value", ""),
+        "params": dict(getattr(action, "params", {}) or {}),
+    }
+
+
+def _step_to_dict(step: StepResult) -> dict[str, Any]:
+    """Serialize one step result for the trace.
+
+    Drops binary screenshot bytes — those are written separately when
+    ``MANTIS_TRACE_INCLUDE_SCREENSHOTS`` is set, and round-trip through
+    the trace as filename references rather than embedded base64.
+    """
+    return {
+        "step_index": step.step_index,
+        "intent": step.intent,
+        "type": getattr(step, "step_type", "") or "",
+        "success": step.success,
+        "data": step.data,
+        "steps_used": step.steps_used,
+        "duration": step.duration,
+        "reversed": step.reversed,
+        "last_action": _action_to_dict(step.last_action),
+        "predicted_outcome": getattr(step, "predicted_outcome", "") or "",
+        "observed_outcome": getattr(step, "observed_outcome", "") or "",
+    }
+
+
+@dataclass
+class TraceExporter:
+    """Writes per-run trace files when the export feature flag is set."""
+
+    export_dir: str = ""
+    include_screenshots: bool = False
+
+    @classmethod
+    def from_env(cls) -> "TraceExporter":
+        """Build an exporter from the standard env vars. Returns a disabled
+        exporter (``export_dir=""``) when ``MANTIS_TRACE_EXPORT_DIR`` is unset."""
+        return cls(
+            export_dir=os.environ.get(ENV_DIR, "").strip(),
+            include_screenshots=_bool_env(ENV_INCLUDE_SCREENSHOTS),
+        )
+
+    @property
+    def enabled(self) -> bool:
+        return bool(self.export_dir)
+
+    def maybe_export(
+        self,
+        runner: "MicroPlanRunner",
+        results: list[StepResult],
+        *,
+        status: str,
+    ) -> str | None:
+        """Write a trace file when the exporter is enabled. No-op otherwise.
+
+        Returns the JSON path written, or ``None`` when disabled / on
+        error. Telemetry-style: any IO failure is logged but never
+        re-raised — trace export must not break a run.
+        """
+        if not self.enabled:
+            return None
+        try:
+            return self._write(runner, results, status=status)
+        except Exception as exc:  # noqa: BLE001 — telemetry never breaks runs
+            logger.warning("trace export failed: %s", exc)
+            return None
+
+    def _write(
+        self,
+        runner: "MicroPlanRunner",
+        results: list[StepResult],
+        *,
+        status: str,
+    ) -> str:
+        tenant_id = (getattr(runner, "tenant_id", "") or "").strip() or "__shared__"
+        run_id = (
+            getattr(runner, "run_key", "")
+            or getattr(runner, "session_name", "")
+            or "unknown"
+        )
+        base = Path(self.export_dir) / tenant_id
+        base.mkdir(parents=True, exist_ok=True)
+
+        if self.include_screenshots:
+            shots_dir = base / f"{run_id}_screens"
+            shots_dir.mkdir(exist_ok=True)
+            self._write_screenshots(shots_dir, results)
+
+        gpu, claude, proxy, total = runner._cost_totals()
+        ended_at = time.time()
+        started_at = getattr(runner, "_run_start", ended_at)
+        payload = {
+            "schema_version": SCHEMA_VERSION,
+            "run_id": run_id,
+            "tenant_id": tenant_id if tenant_id != "__shared__" else "",
+            "session_name": getattr(runner, "session_name", ""),
+            "plan_signature": getattr(runner, "plan_signature", ""),
+            "status": status or getattr(runner, "_final_status", "unknown"),
+            "started_at": started_at,
+            "ended_at": ended_at,
+            "total_time_s": ended_at - started_at,
+            "costs": {
+                "gpu": round(gpu, 4),
+                "claude": round(claude, 4),
+                "proxy": round(proxy, 4),
+                "total": round(total, 4),
+            },
+            "step_count": len(results),
+            "steps": [_step_to_dict(s) for s in results],
+        }
+
+        out = base / f"{run_id}.json"
+        out.write_text(json.dumps(payload, indent=2) + "\n")
+        logger.debug("wrote trace: %s", out)
+        return str(out)
+
+    def _write_screenshots(
+        self, shots_dir: Path, results: list[StepResult]
+    ) -> None:
+        """Persist post-step screenshot bytes one PNG per step.
+
+        File naming: ``<step_index:04d>.png``. Skips steps without
+        ``screenshot_png`` so the index → file mapping is direct (no
+        gaps to interpret).
+        """
+        for step in results:
+            png = step.screenshot_png
+            if not png:
+                continue
+            (shots_dir / f"{step.step_index:04d}.png").write_bytes(png)
+
+
+def _bool_env(name: str) -> bool:
+    """Treat ``1``, ``true``, ``yes``, ``on`` (case-insensitive) as truthy."""
+    raw = os.environ.get(name, "").strip().lower()
+    return raw in {"1", "true", "yes", "on"}
+
+
+__all__ = ["TraceExporter", "SCHEMA_VERSION", "ENV_DIR", "ENV_INCLUDE_SCREENSHOTS"]

--- a/tests/test_trace_exporter.py
+++ b/tests/test_trace_exporter.py
@@ -1,0 +1,192 @@
+"""Tests for #155 step 1 — TraceExporter.
+
+Pins the schema, the feature-flag-gating, and the tenant-isolation
+contract. The exporter is wired into ``RunExecutor._finalize``; tests
+exercise the exporter directly via a stub runner so they don't need
+Xvfb / Chrome.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from mantis_agent.actions import Action, ActionType
+from mantis_agent.gym.checkpoint import StepResult
+from mantis_agent.gym.trace_exporter import (
+    ENV_DIR,
+    ENV_INCLUDE_SCREENSHOTS,
+    SCHEMA_VERSION,
+    TraceExporter,
+)
+
+
+# ── Helpers ────────────────────────────────────────────────────────────
+
+
+def _runner_stub(
+    *,
+    run_key: str = "rid_abc",
+    tenant_id: str = "t-one",
+    session_name: str = "sess",
+    plan_signature: str = "sig",
+    final_status: str = "completed",
+) -> MagicMock:
+    runner = MagicMock()
+    runner.run_key = run_key
+    runner.tenant_id = tenant_id
+    runner.session_name = session_name
+    runner.plan_signature = plan_signature
+    runner._final_status = final_status
+    runner._run_start = 100.0
+    runner._cost_totals.return_value = (1.0, 2.0, 0.5, 3.5)
+    return runner
+
+
+def _step(idx: int, **overrides) -> StepResult:
+    base = dict(
+        step_index=idx, intent=f"step {idx}", success=True,
+        data="", steps_used=1, duration=0.42, reversed=False,
+    )
+    base.update(overrides)
+    return StepResult(**base)
+
+
+# ── from_env / feature flag ────────────────────────────────────────────
+
+
+def test_from_env_disabled_by_default(monkeypatch):
+    monkeypatch.delenv(ENV_DIR, raising=False)
+    exp = TraceExporter.from_env()
+    assert exp.enabled is False
+
+
+def test_from_env_enabled_when_dir_set(monkeypatch, tmp_path):
+    monkeypatch.setenv(ENV_DIR, str(tmp_path))
+    exp = TraceExporter.from_env()
+    assert exp.enabled is True
+    assert exp.export_dir == str(tmp_path)
+
+
+def test_from_env_include_screenshots_truthy(monkeypatch, tmp_path):
+    monkeypatch.setenv(ENV_DIR, str(tmp_path))
+    monkeypatch.setenv(ENV_INCLUDE_SCREENSHOTS, "true")
+    assert TraceExporter.from_env().include_screenshots is True
+
+
+def test_from_env_include_screenshots_falsy(monkeypatch, tmp_path):
+    monkeypatch.setenv(ENV_DIR, str(tmp_path))
+    monkeypatch.setenv(ENV_INCLUDE_SCREENSHOTS, "no")
+    assert TraceExporter.from_env().include_screenshots is False
+
+
+def test_maybe_export_noop_when_disabled():
+    exp = TraceExporter(export_dir="")
+    runner = _runner_stub()
+    assert exp.maybe_export(runner, [_step(0)], status="completed") is None
+
+
+# ── Schema ─────────────────────────────────────────────────────────────
+
+
+def test_export_writes_json_at_tenant_path(tmp_path):
+    exp = TraceExporter(export_dir=str(tmp_path))
+    runner = _runner_stub(tenant_id="acme", run_key="run123")
+    out = exp.maybe_export(runner, [_step(0), _step(1)], status="completed")
+    assert out is not None
+    out_path = Path(out)
+    # Tenant-scoped path layout
+    assert out_path.parent.name == "acme"
+    assert out_path.name == "run123.json"
+
+
+def test_export_payload_schema_top_level_fields(tmp_path):
+    exp = TraceExporter(export_dir=str(tmp_path))
+    runner = _runner_stub()
+    out = exp.maybe_export(runner, [_step(0)], status="completed")
+    payload = json.loads(Path(out).read_text())
+    assert payload["schema_version"] == SCHEMA_VERSION
+    assert payload["status"] == "completed"
+    assert payload["run_id"] == "rid_abc"
+    assert payload["tenant_id"] == "t-one"
+    assert payload["plan_signature"] == "sig"
+    assert payload["step_count"] == 1
+    assert payload["costs"] == {"gpu": 1.0, "claude": 2.0, "proxy": 0.5, "total": 3.5}
+    # Steps round-trip with the expected fields
+    step = payload["steps"][0]
+    for field in ("step_index", "intent", "success", "data", "duration", "reversed",
+                  "predicted_outcome", "observed_outcome", "last_action"):
+        assert field in step
+
+
+def test_export_serializes_action(tmp_path):
+    exp = TraceExporter(export_dir=str(tmp_path))
+    runner = _runner_stub()
+    step = _step(0)
+    step.last_action = Action(ActionType.CLICK, {"x": 100, "y": 200})
+    out = exp.maybe_export(runner, [step], status="completed")
+    payload = json.loads(Path(out).read_text())
+    action_dict = payload["steps"][0]["last_action"]
+    assert action_dict["action_type"] == "click"
+    assert action_dict["params"] == {"x": 100, "y": 200}
+
+
+def test_export_handles_predicted_observed_outcomes(tmp_path):
+    exp = TraceExporter(export_dir=str(tmp_path))
+    runner = _runner_stub()
+    step = _step(0)
+    # SimpleNamespace lets us tack predicted_outcome on without subclassing
+    step.predicted_outcome = "URL navigates to /detail"  # type: ignore[attr-defined]
+    step.observed_outcome = "page navigated"  # type: ignore[attr-defined]
+    out = exp.maybe_export(runner, [step], status="completed")
+    payload = json.loads(Path(out).read_text())
+    assert payload["steps"][0]["predicted_outcome"] == "URL navigates to /detail"
+    assert payload["steps"][0]["observed_outcome"] == "page navigated"
+
+
+def test_export_empty_tenant_id_falls_back_to_shared(tmp_path):
+    exp = TraceExporter(export_dir=str(tmp_path))
+    runner = _runner_stub(tenant_id="")
+    out = exp.maybe_export(runner, [_step(0)], status="completed")
+    assert Path(out).parent.name == "__shared__"
+    payload = json.loads(Path(out).read_text())
+    # Top-level tenant_id is the empty string for legacy single-tenant runs
+    assert payload["tenant_id"] == ""
+
+
+# ── Screenshot persistence ─────────────────────────────────────────────
+
+
+def test_export_does_not_write_screenshots_by_default(tmp_path):
+    """Without the include flag, screenshot bytes never hit disk."""
+    exp = TraceExporter(export_dir=str(tmp_path), include_screenshots=False)
+    runner = _runner_stub()
+    step = _step(0)
+    step.screenshot_png = b"\x89PNG\r\n\x1a\n" + b"\x00" * 32  # tiny stub
+    exp.maybe_export(runner, [step], status="completed")
+    # No companion screens dir
+    assert not (tmp_path / "t-one" / "rid_abc_screens").exists()
+
+
+def test_export_writes_screenshots_when_flag_set(tmp_path):
+    exp = TraceExporter(export_dir=str(tmp_path), include_screenshots=True)
+    runner = _runner_stub()
+    step = _step(0)
+    step.screenshot_png = b"\x89PNG\r\n\x1a\n" + b"\x00" * 32
+    exp.maybe_export(runner, [step], status="completed")
+    shots_dir = tmp_path / "t-one" / "rid_abc_screens"
+    assert shots_dir.exists()
+    assert (shots_dir / "0000.png").exists()
+
+
+# ── Telemetry safety ───────────────────────────────────────────────────
+
+
+def test_export_swallows_io_failures(tmp_path):
+    """If the exporter raises, the runtime must not crash."""
+    # Pass a path under a non-writable location to force OSError on mkdir.
+    exp = TraceExporter(export_dir="/proc/cannot-write")
+    runner = _runner_stub()
+    # Must not raise. Returns None on failure.
+    assert exp.maybe_export(runner, [_step(0)], status="completed") is None


### PR DESCRIPTION
## Summary

The first of five deliverables called out in #155 — production trace export, gated behind a feature flag so legacy deployments pay nothing. This is the foundation for the continual-fine-tuning pipeline.

## What ships

### ``src/mantis_agent/gym/trace_exporter.py``

| Surface | Purpose |
|---|---|
| ``TraceExporter.from_env()`` | Build an exporter from env vars; off when ``MANTIS_TRACE_EXPORT_DIR`` is unset. |
| ``maybe_export(runner, results, status)`` | Writes ``<dir>/<tenant_id>/<run_id>.json``. No-op when disabled. |
| ``SCHEMA_VERSION`` | Bumped on incompatible changes; consumers can downgrade. |

Schema (``schema_version=1``):

- Run metadata: ``run_id``, ``tenant_id``, ``session_name``, ``plan_signature``, ``status``, ``started_at`` / ``ended_at``, ``total_time_s``, ``costs``.
- Step list: every executed ``StepResult`` with ``intent`` / ``type`` / ``success`` / ``data`` / ``duration`` / ``reversed`` / ``last_action`` / ``predicted_outcome`` / ``observed_outcome``.

### Tenant isolation

Trace files land at ``<dir>/<tenant_id>/<run_id>.json``. Empty tenant ids fall back to ``__shared__/`` so legacy single-tenant runs don't collide with multi-tenant ones. Operators can sync per-tenant directories to S3/GCS/R2 without leaking across tenants.

### Optional screenshot persistence

``MANTIS_TRACE_INCLUDE_SCREENSHOTS=true`` writes per-step PNGs to ``<dir>/<tenant_id>/<run_id>_screens/<step:04d>.png``. Off by default because screenshot bytes ~100× the on-disk trace size and most triage workflows only need the action sequence.

### Telemetry safety

Any IO failure is caught and logged via ``logger.warning`` — trace export is never allowed to break a run. The hook in ``RunExecutor._finalize`` is double-wrapped (exporter-internal try/except + caller try/except).

## Test plan

- [x] 13 new tests in ``tests/test_trace_exporter.py``: feature-flag gating, schema shape, action serialization, predicted/observed round-trip, tenant fallback, screenshot persistence on/off, IO failure swallowed.
- [x] 45/45 across trace + run_executor + observability suites
- [x] ``ruff check`` clean
- [x] **Modal news.ycombinator.com smoke**: redeployed + re-ran. ``status=succeeded``, ``cost=\$0.054``, 3 steps — matches baseline. No regression.

## Docs

- ``docs/reference/env-vars.md`` — new ``Trace export (#155)`` section documenting both env vars + their defaults
- ``docs/architecture.md`` — module map lists ``trace_exporter.py``

## What's still open on #155

| Step | Status |
|---|---|
| 1. Trace export (this PR) | ✅ |
| 2. Labeller (heuristic + human-review CLI) | ⏳ |
| 3. SFT/DPO recipe in ``training/`` | ⏳ |
| 4. Eval harness (held-out OSWorld + tenant set) | ⏳ |
| 5. Shadow-deploy (5% traffic, escalation-rate compare) | ⏳ |

Refs #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)