### PR TITLE
feat(training): eval_harness — promotion gate via win-rate compare (#155 step 4)

### DIFF
--- a/docs/operations/continual-finetuning.md
+++ b/docs/operations/continual-finetuning.md
@@ -14,12 +14,14 @@ are JSON / JSONL on disk so the stages can be moved between machines
                        — Holo3 chat format, label-filtered
 [4] train     training/train_holo3_distill.py → weights/
                        — single-A100 SFT
-[5] deploy    swap weights into the runtime; shadow-test against
+[5] eval      training/eval_harness.py → reports/{baseline,candidate}.json
+                       → compare → win-rate gate
+[6] deploy    swap weights into the runtime; shadow-test against
               current production at 5% traffic before full rollout
 ```
 
-Steps 1–3 ship today. Steps 4 (recipe wiring) and 5 (shadow-deploy
-harness) are tracked as separate deliverables under #155.
+Steps 1–4 ship today. Step 5 (shadow-deploy harness) is tracked as a
+separate deliverable under #155.
 
 ## 1. Trace export
 
@@ -95,7 +97,62 @@ python training/train_holo3_distill.py \
 
 (See `training/modal_train_holo3.py` for the Modal-managed variant.)
 
-## 5. Shadow-deploy
+## 5. Eval harness
+
+`training/eval_harness.py` (#155 step 4) gates promotion on win-rate
+against the current production weights. Two-stage protocol:
+
+```
+# 1. Evaluate the baseline (current production endpoint).
+python -m training.eval_harness run \
+    --tasks tasks/eval_set.json \
+    --output reports/baseline.json \
+    --runner https://prod--mantis-server-api.modal.run \
+    --token "$BASELINE_TOKEN"
+
+# 2. Evaluate the candidate (new weights mounted on a separate endpoint).
+python -m training.eval_harness run \
+    --tasks tasks/eval_set.json \
+    --output reports/candidate.json \
+    --runner https://candidate--mantis-server-api.modal.run \
+    --token "$CANDIDATE_TOKEN"
+
+# 3. Compare. Exits 1 when candidate has more losses than wins.
+python -m training.eval_harness compare \
+    --baseline reports/baseline.json \
+    --candidate reports/candidate.json \
+    --output reports/compare.json
+```
+
+Eval task shape (one JSON file with a list of tasks):
+
+```jsonc
+[
+  {
+    "task_id": "hn_extract_top_3",
+    "task_text": "Extract the top 3 stories",
+    "url": "https://news.ycombinator.com",
+    "criteria": [
+      {"type": "task_success"},
+      {"type": "output_contains", "value": "Show HN"}
+    ]
+  }
+]
+```
+
+Criteria types: `task_success`, `status_eq`, `url_contains`,
+`output_contains`. A task passes when **every** criterion is
+satisfied. Unknown types fail closed so a malformed task can never
+silently green-light a regression.
+
+The Python API lets you swap the runner for a unit-test stub or a
+custom Modal-side launcher::
+
+    from training.eval_harness import EvalTask, run_eval, compare
+    report = run_eval(my_runner, tasks, name="my_eval")
+    delta = compare(baseline_report, report)
+
+## 6. Shadow-deploy
 
 Pending — the pattern is described in #155 (5% traffic split + escalation
 rate compare) but the deployment harness is a follow-up PR.

--- a/tests/test_eval_harness.py
+++ b/tests/test_eval_harness.py
@@ -1,0 +1,264 @@
+"""Tests for #155 step 4 — eval harness.
+
+Pin the criterion contract, the runner-error containment behavior, the
+report aggregation math, and the compare-mode delta logic. Runner is
+mocked so tests don't make HTTP calls.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+_TRAINING = Path(__file__).resolve().parent.parent / "training"
+sys.path.insert(0, str(_TRAINING))
+
+from eval_harness import (  # noqa: E402
+    EvalCompare,
+    EvalCriterion,
+    EvalReport,
+    EvalRunOutcome,
+    EvalTask,
+    EvalTaskResult,
+    compare,
+    load_report,
+    load_tasks,
+    run_eval,
+)
+
+
+# ── Helpers ────────────────────────────────────────────────────────────
+
+
+def _outcome(
+    task_id: str,
+    *,
+    success: bool = True,
+    status: str = "succeeded",
+    url: str = "",
+    output: str = "",
+    error: str = "",
+) -> EvalRunOutcome:
+    return EvalRunOutcome(
+        task_id=task_id, success=success, status=status,
+        url=url, output=output, error=error,
+    )
+
+
+def _task(
+    task_id: str = "t1",
+    *,
+    criteria: list[dict[str, Any]] | None = None,
+) -> EvalTask:
+    return EvalTask(
+        task_id=task_id,
+        criteria=[EvalCriterion(**c) for c in (criteria or [])],
+    )
+
+
+# ── EvalCriterion ──────────────────────────────────────────────────────
+
+
+def test_criterion_task_success_uses_outcome_success():
+    crit = EvalCriterion(type="task_success")
+    assert crit.evaluate(_outcome("t1", success=True)) is True
+    assert crit.evaluate(_outcome("t1", success=False)) is False
+
+
+def test_criterion_url_contains_substring_match():
+    crit = EvalCriterion(type="url_contains", value="/item?id=")
+    assert crit.evaluate(_outcome("t1", url="https://hn.com/item?id=42")) is True
+    assert crit.evaluate(_outcome("t1", url="https://hn.com/")) is False
+
+
+def test_criterion_output_contains_substring_match():
+    crit = EvalCriterion(type="output_contains", value="Show HN")
+    assert crit.evaluate(_outcome("t1", output="title: Show HN: foo")) is True
+    assert crit.evaluate(_outcome("t1", output="something else")) is False
+
+
+def test_criterion_status_eq_exact_match():
+    crit = EvalCriterion(type="status_eq", value="succeeded")
+    assert crit.evaluate(_outcome("t1", status="succeeded")) is True
+    assert crit.evaluate(_outcome("t1", status="failed")) is False
+
+
+def test_unknown_criterion_fails_closed():
+    """Unknown criterion type must NOT silently pass — promotion gating
+    must never let a malformed task accidentally green-light a regression."""
+    crit = EvalCriterion(type="nonsense_check", value="x")
+    assert crit.evaluate(_outcome("t1", success=True)) is False
+
+
+# ── run_eval ───────────────────────────────────────────────────────────
+
+
+def test_run_eval_empty_criteria_defaults_to_task_success():
+    """A task with no criteria passes iff the runner returns success."""
+    runner = lambda t: _outcome(t.task_id, success=True)  # noqa: E731
+    report = run_eval(runner, [_task("t1")])
+    assert report.pass_count == 1
+    assert report.fail_count == 0
+    assert report.pass_rate == 1.0
+
+
+def test_run_eval_all_criteria_must_pass():
+    runner = lambda t: _outcome(t.task_id, success=True, url="https://x.test/")  # noqa: E731
+    task = _task("t1", criteria=[
+        {"type": "task_success"},
+        {"type": "url_contains", "value": "missing-substring"},
+    ])
+    report = run_eval(runner, [task])
+    assert report.pass_count == 0
+    assert report.fail_count == 1
+
+
+def test_run_eval_runner_exception_counts_as_error_and_fail():
+    def boom(_: EvalTask) -> EvalRunOutcome:
+        raise RuntimeError("upstream broke")
+
+    report = run_eval(boom, [_task("t1"), _task("t2")])
+    assert report.task_count == 2
+    assert report.error_count == 2
+    assert report.fail_count == 2
+    assert report.pass_count == 0
+
+
+def test_run_eval_per_criterion_results_recorded():
+    runner = lambda t: _outcome(t.task_id, success=True, url="https://hn.com/item?id=1")  # noqa: E731
+    task = _task("t1", criteria=[
+        {"type": "task_success"},
+        {"type": "url_contains", "value": "/item?id="},
+    ])
+    report = run_eval(runner, [task])
+    assert report.pass_count == 1
+    crit_results = report.results[0].criterion_results
+    assert len(crit_results) == 2
+    assert all(c["passed"] for c in crit_results)
+
+
+def test_run_eval_report_to_dict_round_trip(tmp_path):
+    runner = lambda t: _outcome(t.task_id, success=True)  # noqa: E731
+    report = run_eval(runner, [_task("t1"), _task("t2")], name="smoke")
+    out = tmp_path / "report.json"
+    out.write_text(json.dumps(report.to_dict()))
+    loaded = load_report(out)
+    assert loaded.name == "smoke"
+    assert loaded.task_count == 2
+    assert loaded.pass_count == 2
+
+
+# ── load_tasks ─────────────────────────────────────────────────────────
+
+
+def test_load_tasks_accepts_bare_array(tmp_path):
+    path = tmp_path / "tasks.json"
+    path.write_text(json.dumps([
+        {"task_id": "a"},
+        {"task_id": "b", "criteria": [{"type": "task_success"}]},
+    ]))
+    tasks = load_tasks(path)
+    assert [t.task_id for t in tasks] == ["a", "b"]
+
+
+def test_load_tasks_accepts_wrapper_dict(tmp_path):
+    path = tmp_path / "tasks.json"
+    path.write_text(json.dumps({"tasks": [{"task_id": "a"}]}))
+    assert len(load_tasks(path)) == 1
+
+
+# ── compare ────────────────────────────────────────────────────────────
+
+
+def _report(
+    name: str,
+    rows: list[tuple[str, bool]],
+) -> EvalReport:
+    """Build a stub report from (task_id, passed) tuples."""
+    report = EvalReport(name=name)
+    for task_id, passed in rows:
+        report.results.append(EvalTaskResult(
+            task_id=task_id, passed=passed, outcome=_outcome(task_id, success=passed),
+        ))
+    report.task_count = len(rows)
+    report.pass_count = sum(1 for _, p in rows if p)
+    report.fail_count = report.task_count - report.pass_count
+    report.pass_rate = report.pass_count / max(report.task_count, 1)
+    return report
+
+
+def test_compare_aligns_by_task_id_and_counts_disagreements():
+    baseline = _report("base", [("a", True), ("b", False), ("c", True)])
+    candidate = _report("cand", [("a", True), ("b", True), ("c", False)])
+    cmp_ = compare(baseline, candidate)
+    assert cmp_.candidate_wins == 1   # b: F → T
+    assert cmp_.candidate_losses == 1  # c: T → F
+    assert cmp_.win_rate == 0.5
+    assert "b" in cmp_.improvements
+    assert "c" in cmp_.regressions
+
+
+def test_compare_ignores_tasks_only_on_one_side():
+    baseline = _report("base", [("a", True), ("b", False)])
+    candidate = _report("cand", [("a", True), ("c", True)])  # c missing from base
+    cmp_ = compare(baseline, candidate)
+    assert cmp_.common_task_count == 1
+    assert cmp_.candidate_wins == 0
+    assert cmp_.candidate_losses == 0
+
+
+def test_compare_no_disagreement_returns_neutral_win_rate():
+    baseline = _report("base", [("a", True), ("b", True)])
+    candidate = _report("cand", [("a", True), ("b", True)])
+    cmp_ = compare(baseline, candidate)
+    assert cmp_.candidate_wins == 0
+    assert cmp_.candidate_losses == 0
+    # No disagreements → win-rate degenerates to 0.5 (neutral, not 0).
+    assert cmp_.win_rate == 0.5
+
+
+def test_compare_delta_reflects_pass_rate_difference():
+    baseline = _report("base", [("a", True), ("b", False)])
+    candidate = _report("cand", [("a", True), ("b", True)])
+    cmp_ = compare(baseline, candidate)
+    assert cmp_.delta == 0.5  # candidate goes 0.5 → 1.0
+
+
+def test_compare_to_dict_round_trip():
+    cmp_ = EvalCompare(
+        baseline_pass_rate=0.5, candidate_pass_rate=0.75, delta=0.25,
+        common_task_count=4, candidate_wins=2, candidate_losses=1,
+        win_rate=0.6667,
+        regressions=["c"], improvements=["a", "b"],
+    )
+    payload = cmp_.to_dict()
+    assert payload["regressions"] == ["c"]
+    assert payload["delta"] == 0.25
+
+
+# ── End-to-end: tasks → run → compare ─────────────────────────────────
+
+
+def test_end_to_end_pipeline(tmp_path):
+    """Stub two brains. The candidate is strictly better on one task and
+    strictly worse on another — a realistic 'mixed result' eval."""
+    tasks = [
+        _task("t1", criteria=[{"type": "task_success"}]),
+        _task("t2", criteria=[{"type": "task_success"}]),
+    ]
+
+    def baseline_runner(task: EvalTask) -> EvalRunOutcome:
+        return _outcome(task.task_id, success=(task.task_id == "t2"))
+
+    def candidate_runner(task: EvalTask) -> EvalRunOutcome:
+        return _outcome(task.task_id, success=(task.task_id == "t1"))
+
+    base_report = run_eval(baseline_runner, tasks)
+    cand_report = run_eval(candidate_runner, tasks)
+    cmp_ = compare(base_report, cand_report)
+    assert cmp_.candidate_wins == 1
+    assert cmp_.candidate_losses == 1
+    assert cmp_.delta == 0.0  # equal pass-rates

--- a/training/eval_harness.py
+++ b/training/eval_harness.py
@@ -1,0 +1,540 @@
+#!/usr/bin/env python3
+"""Eval harness — gate model promotions on win-rate vs the current production weights (#155 step 4).
+
+Drops into the continual-fine-tuning loop alongside the trace export +
+labeller + SFT converter (steps 1–3). Produces structured pass/fail
+reports for one model on a set of tasks, plus a compare-mode that
+tells you whether a candidate beats the baseline by the configured
+margin.
+
+Two-stage protocol
+------------------
+
+::
+
+    [1] eval baseline  → eval_harness.run_eval(baseline_brain, tasks) → baseline.json
+    [2] eval candidate → eval_harness.run_eval(candidate_brain, tasks) → candidate.json
+    [3] compare        → eval_harness.compare(baseline.json, candidate.json) → win_rate, deltas
+
+The harness is deliberately I/O-shaped: it consumes JSON eval-task
+specs, invokes a caller-supplied "runner" callable, and writes JSON
+reports. That keeps it useful both for local quick checks (mocked
+runner in tests) and for production-style runs on Modal A100.
+
+EvalTask shape
+--------------
+
+::
+
+    {
+      "task_id": "hn_extract_top_3",
+      "plan_text": "...",                     # OR
+      "micro_plan": [...],                    # OR
+      "url": "https://news.ycombinator.com",  # plus task_text
+      "task_text": "Extract the top 3 stories",
+      "criteria": [
+        {"type": "task_success"},                            # success terminator fired
+        {"type": "url_contains", "value": "/item?id="},
+        {"type": "output_contains", "value": "Show HN"}
+      ],
+      "max_cost": 0.5,
+      "max_steps": 30
+    }
+
+A task passes when *every* criterion in ``criteria`` is satisfied. An
+empty criteria list is treated as ``[{"type": "task_success"}]``.
+
+The runner callable
+-------------------
+
+The harness doesn't know how to run a plan — it delegates to a callable
+the caller provides::
+
+    def runner(task: EvalTask) -> EvalRunOutcome: ...
+
+For SFT-cycle eval, hosts wire this to the production HTTP endpoint with
+the candidate brain's weights mounted. For unit tests, hosts wire it to
+a stub that returns a deterministic outcome.
+
+CLI
+---
+
+This module also runs as a script for batch eval + compare modes:
+
+    python -m training.eval_harness run \\
+        --tasks tasks/hn_smoke.json \\
+        --output reports/baseline.json \\
+        --runner http://localhost:18080
+
+    python -m training.eval_harness compare \\
+        --baseline reports/baseline.json \\
+        --candidate reports/candidate.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Iterable
+
+logger = logging.getLogger(__name__)
+
+
+# ── Eval task + outcome schemas ──────────────────────────────────────
+
+
+@dataclass
+class EvalCriterion:
+    """One pass/fail check applied to a single :class:`EvalRunOutcome`.
+
+    ``type`` is one of:
+      - ``task_success``    — the runner reported terminal success
+      - ``url_contains``    — final ``url`` includes ``value`` (substring)
+      - ``output_contains`` — final ``output`` text includes ``value``
+      - ``status_eq``       — final ``status`` == ``value``
+    """
+
+    type: str
+    value: str = ""
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "EvalCriterion":
+        return cls(type=payload.get("type", ""), value=str(payload.get("value", "")))
+
+    def evaluate(self, outcome: "EvalRunOutcome") -> bool:
+        if self.type == "task_success":
+            return bool(outcome.success)
+        if self.type == "status_eq":
+            return outcome.status == self.value
+        if self.type == "url_contains":
+            return self.value in (outcome.url or "")
+        if self.type == "output_contains":
+            return self.value in (outcome.output or "")
+        # Unknown criterion → fail closed so a malformed task can never
+        # accidentally promote a regression.
+        logger.warning("unknown EvalCriterion type %r — failing closed", self.type)
+        return False
+
+
+@dataclass
+class EvalTask:
+    """One row in an eval set. Mirrors the shape ``run_eval`` consumes."""
+
+    task_id: str
+    task_text: str = ""
+    plan_text: str = ""
+    micro_plan: list[dict[str, Any]] = field(default_factory=list)
+    url: str = ""
+    criteria: list[EvalCriterion] = field(default_factory=list)
+    max_cost: float = 1.0
+    max_steps: int = 30
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "EvalTask":
+        return cls(
+            task_id=str(payload.get("task_id", "")),
+            task_text=str(payload.get("task_text", "")),
+            plan_text=str(payload.get("plan_text", "")),
+            micro_plan=list(payload.get("micro_plan") or []),
+            url=str(payload.get("url", "")),
+            criteria=[
+                EvalCriterion.from_dict(c)
+                for c in (payload.get("criteria") or [])
+            ],
+            max_cost=float(payload.get("max_cost", 1.0)),
+            max_steps=int(payload.get("max_steps", 30)),
+            metadata=dict(payload.get("metadata") or {}),
+        )
+
+
+@dataclass
+class EvalRunOutcome:
+    """Result of running ONE eval task against ONE brain.
+
+    The caller-supplied runner returns this; the harness applies criteria
+    on top to compute the boolean ``passed`` field. Keeping ``success``,
+    ``status``, ``url``, and ``output`` separate from ``passed`` lets a
+    single runner output be checked against multiple criteria sets
+    without re-running the task.
+    """
+
+    task_id: str
+    success: bool = False
+    status: str = ""
+    url: str = ""
+    output: str = ""
+    cost: float = 0.0
+    duration_s: float = 0.0
+    error: str = ""
+    raw: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class EvalTaskResult:
+    """One row in :class:`EvalReport.results` — outcome + per-criterion verdicts."""
+
+    task_id: str
+    passed: bool
+    outcome: EvalRunOutcome
+    criterion_results: list[dict[str, Any]] = field(default_factory=list)
+
+
+@dataclass
+class EvalReport:
+    """Full report from one ``run_eval`` invocation."""
+
+    name: str = ""
+    started_at: float = 0.0
+    ended_at: float = 0.0
+    task_count: int = 0
+    pass_count: int = 0
+    fail_count: int = 0
+    error_count: int = 0
+    pass_rate: float = 0.0
+    results: list[EvalTaskResult] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "started_at": self.started_at,
+            "ended_at": self.ended_at,
+            "task_count": self.task_count,
+            "pass_count": self.pass_count,
+            "fail_count": self.fail_count,
+            "error_count": self.error_count,
+            "pass_rate": round(self.pass_rate, 4),
+            "results": [
+                {
+                    "task_id": r.task_id,
+                    "passed": r.passed,
+                    "criterion_results": r.criterion_results,
+                    "outcome": asdict(r.outcome),
+                }
+                for r in self.results
+            ],
+        }
+
+
+# ── Core entry: run_eval ──────────────────────────────────────────────
+
+
+RunnerFn = Callable[[EvalTask], EvalRunOutcome]
+
+
+def _evaluate_criteria(
+    task: EvalTask, outcome: EvalRunOutcome,
+) -> tuple[bool, list[dict[str, Any]]]:
+    """Apply each criterion. Empty criteria list → pass on task_success."""
+    crits = task.criteria or [EvalCriterion(type="task_success")]
+    results: list[dict[str, Any]] = []
+    all_passed = True
+    for c in crits:
+        ok = c.evaluate(outcome)
+        results.append({"type": c.type, "value": c.value, "passed": ok})
+        if not ok:
+            all_passed = False
+    return all_passed, results
+
+
+def run_eval(
+    runner: RunnerFn,
+    tasks: Iterable[EvalTask],
+    *,
+    name: str = "eval",
+) -> EvalReport:
+    """Run every task through ``runner``; build a structured report.
+
+    The runner is responsible for everything Mantis-specific (HTTP
+    submit, polling, error handling). The harness only:
+      - times the run
+      - applies criteria on the returned outcome
+      - aggregates pass/fail/error counts
+
+    A runner exception is captured into ``EvalRunOutcome.error`` and
+    counts as a fail (never a hard exit) so one broken task doesn't
+    terminate the whole run.
+    """
+    report = EvalReport(name=name, started_at=time.time())
+    for task in tasks:
+        try:
+            outcome = runner(task)
+        except Exception as exc:  # noqa: BLE001 — never let a task crash the loop
+            logger.warning("runner raised on task=%s: %s", task.task_id, exc)
+            outcome = EvalRunOutcome(task_id=task.task_id, error=str(exc))
+            report.error_count += 1
+        passed, crit_results = _evaluate_criteria(task, outcome)
+        if outcome.error:
+            passed = False
+        report.results.append(EvalTaskResult(
+            task_id=task.task_id,
+            passed=passed,
+            outcome=outcome,
+            criterion_results=crit_results,
+        ))
+        if passed:
+            report.pass_count += 1
+        else:
+            report.fail_count += 1
+    report.task_count = len(report.results)
+    report.pass_rate = (
+        report.pass_count / report.task_count if report.task_count else 0.0
+    )
+    report.ended_at = time.time()
+    return report
+
+
+def load_tasks(path: Path) -> list[EvalTask]:
+    """Read tasks from a JSON file. Accepts ``[...]`` or ``{"tasks": [...]}``."""
+    raw = json.loads(path.read_text())
+    if isinstance(raw, dict):
+        raw = raw.get("tasks", [])
+    if not isinstance(raw, list):
+        raise ValueError(f"{path}: expected list of tasks or {{'tasks': [...]}}")
+    return [EvalTask.from_dict(item) for item in raw]
+
+
+# ── compare ───────────────────────────────────────────────────────────
+
+
+@dataclass
+class EvalCompare:
+    """Output of :func:`compare` — baseline vs candidate diff.
+
+    ``win_rate`` is candidate's pass-count among tasks where the two
+    sides disagree, divided by the size of the disagreement set. A
+    win_rate of 0.0 means the candidate lost every disagreement, 0.5
+    is even, 1.0 means it won every disagreement.
+
+    Promotion gating is the caller's policy — ``EvalCompare`` exposes
+    the inputs (rates + per-task verdicts) without baking in a threshold.
+    """
+
+    baseline_pass_rate: float
+    candidate_pass_rate: float
+    delta: float
+    common_task_count: int
+    candidate_wins: int  # baseline failed, candidate passed
+    candidate_losses: int  # baseline passed, candidate failed
+    win_rate: float
+    regressions: list[str] = field(default_factory=list)
+    improvements: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "baseline_pass_rate": round(self.baseline_pass_rate, 4),
+            "candidate_pass_rate": round(self.candidate_pass_rate, 4),
+            "delta": round(self.delta, 4),
+            "common_task_count": self.common_task_count,
+            "candidate_wins": self.candidate_wins,
+            "candidate_losses": self.candidate_losses,
+            "win_rate": round(self.win_rate, 4),
+            "regressions": list(self.regressions),
+            "improvements": list(self.improvements),
+        }
+
+
+def compare(baseline: EvalReport, candidate: EvalReport) -> EvalCompare:
+    """Diff two reports. Aligns by ``task_id`` and reports per-side counts.
+
+    Tasks that appear in only one report are ignored — promotion
+    decisions should run both sides on the same eval set.
+    """
+    base_by_id = {r.task_id: r for r in baseline.results}
+    cand_by_id = {r.task_id: r for r in candidate.results}
+    common = set(base_by_id.keys()) & set(cand_by_id.keys())
+
+    wins, losses = 0, 0
+    regressions: list[str] = []
+    improvements: list[str] = []
+    for task_id in sorted(common):
+        b = base_by_id[task_id].passed
+        c = cand_by_id[task_id].passed
+        if c and not b:
+            wins += 1
+            improvements.append(task_id)
+        elif b and not c:
+            losses += 1
+            regressions.append(task_id)
+    disagreements = wins + losses
+    win_rate = wins / disagreements if disagreements else 0.5
+    return EvalCompare(
+        baseline_pass_rate=baseline.pass_rate,
+        candidate_pass_rate=candidate.pass_rate,
+        delta=candidate.pass_rate - baseline.pass_rate,
+        common_task_count=len(common),
+        candidate_wins=wins,
+        candidate_losses=losses,
+        win_rate=win_rate,
+        regressions=regressions,
+        improvements=improvements,
+    )
+
+
+def load_report(path: Path) -> EvalReport:
+    payload = json.loads(path.read_text())
+    report = EvalReport(
+        name=str(payload.get("name", "")),
+        started_at=float(payload.get("started_at", 0.0)),
+        ended_at=float(payload.get("ended_at", 0.0)),
+        task_count=int(payload.get("task_count", 0)),
+        pass_count=int(payload.get("pass_count", 0)),
+        fail_count=int(payload.get("fail_count", 0)),
+        error_count=int(payload.get("error_count", 0)),
+        pass_rate=float(payload.get("pass_rate", 0.0)),
+    )
+    for row in payload.get("results", []):
+        outcome_raw = row.get("outcome", {})
+        outcome = EvalRunOutcome(
+            task_id=str(outcome_raw.get("task_id", row.get("task_id", ""))),
+            success=bool(outcome_raw.get("success", False)),
+            status=str(outcome_raw.get("status", "")),
+            url=str(outcome_raw.get("url", "")),
+            output=str(outcome_raw.get("output", "")),
+            cost=float(outcome_raw.get("cost", 0.0)),
+            duration_s=float(outcome_raw.get("duration_s", 0.0)),
+            error=str(outcome_raw.get("error", "")),
+            raw=dict(outcome_raw.get("raw") or {}),
+        )
+        report.results.append(EvalTaskResult(
+            task_id=str(row.get("task_id", outcome.task_id)),
+            passed=bool(row.get("passed", False)),
+            outcome=outcome,
+            criterion_results=list(row.get("criterion_results") or []),
+        ))
+    return report
+
+
+# ── CLI ───────────────────────────────────────────────────────────────
+
+
+def _http_runner_factory(endpoint: str, token: str = "") -> RunnerFn:
+    """Build a runner that submits each task through the production
+    ``/v1/predict`` endpoint and polls until terminal. Used by the
+    ``run`` subcommand. Lazy: only imported when the CLI actually fires.
+    """
+    import requests
+
+    def _run(task: EvalTask) -> EvalRunOutcome:
+        body: dict[str, Any] = {
+            "detached": False,
+            "max_cost": task.max_cost,
+            "max_time_minutes": max(1, task.max_steps),
+        }
+        if task.micro_plan:
+            body["task_suite"] = {
+                "session_name": task.task_id,
+                "_micro_plan": task.micro_plan,
+            }
+        elif task.plan_text:
+            body["plan_text"] = task.plan_text
+        else:
+            body["plan_text"] = task.task_text or task.task_id
+        if task.url:
+            body.setdefault("task_suite", {}).setdefault("_micro_plan", [
+                {"intent": f"Navigate to {task.url}", "type": "navigate",
+                 "section": "setup", "required": True},
+            ])
+        headers = {"Content-Type": "application/json"}
+        if token:
+            headers["X-Mantis-Token"] = token
+        t0 = time.time()
+        resp = requests.post(
+            f"{endpoint.rstrip('/')}/v1/predict",
+            json=body, headers=headers, timeout=600,
+        )
+        duration = time.time() - t0
+        if resp.status_code != 200:
+            return EvalRunOutcome(
+                task_id=task.task_id, error=f"http {resp.status_code}: {resp.text[:200]}",
+                duration_s=duration,
+            )
+        data = resp.json()
+        return EvalRunOutcome(
+            task_id=task.task_id,
+            success=bool(data.get("success", data.get("viable", 0) > 0)),
+            status=str(data.get("status", "")),
+            url=str(data.get("final_url", "")),
+            output=json.dumps(data.get("leads") or data.get("result") or {}),
+            cost=float((data.get("costs") or {}).get("total", 0.0)),
+            duration_s=duration,
+            raw=data,
+        )
+
+    return _run
+
+
+def _cmd_run(args: argparse.Namespace) -> int:
+    tasks = load_tasks(Path(args.tasks))
+    runner = _http_runner_factory(args.runner, token=args.token)
+    report = run_eval(runner, tasks, name=args.name or Path(args.tasks).stem)
+    out = Path(args.output)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(report.to_dict(), indent=2) + "\n")
+    print(
+        f"  {report.name}: passed {report.pass_count}/{report.task_count} "
+        f"({report.pass_rate:.1%}), errors={report.error_count}"
+    )
+    return 0
+
+
+def _cmd_compare(args: argparse.Namespace) -> int:
+    baseline = load_report(Path(args.baseline))
+    candidate = load_report(Path(args.candidate))
+    cmp = compare(baseline, candidate)
+    if args.output:
+        Path(args.output).parent.mkdir(parents=True, exist_ok=True)
+        Path(args.output).write_text(json.dumps(cmp.to_dict(), indent=2) + "\n")
+    print(
+        f"  baseline pass-rate: {cmp.baseline_pass_rate:.1%}\n"
+        f"  candidate pass-rate: {cmp.candidate_pass_rate:.1%}\n"
+        f"  delta: {cmp.delta:+.1%}\n"
+        f"  common tasks: {cmp.common_task_count}\n"
+        f"  wins: {cmp.candidate_wins}  losses: {cmp.candidate_losses}\n"
+        f"  win-rate (among disagreements): {cmp.win_rate:.1%}"
+    )
+    if cmp.regressions:
+        print(f"  regressions: {', '.join(cmp.regressions)}")
+    return 1 if cmp.candidate_losses > cmp.candidate_wins else 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    run = sub.add_parser("run", help="Run an eval set through an HTTP runner")
+    run.add_argument("--tasks", required=True, help="Path to eval tasks JSON")
+    run.add_argument("--output", required=True, help="Output report JSON")
+    run.add_argument("--runner", required=True,
+                     help="HTTP endpoint (e.g. https://...modal.run)")
+    run.add_argument("--token", default="",
+                     help="X-Mantis-Token (defaults to env MANTIS_API_TOKEN)")
+    run.add_argument("--name", default="",
+                     help="Report name (default: tasks file stem)")
+    run.set_defaults(func=_cmd_run)
+
+    cmp = sub.add_parser(
+        "compare", help="Compare baseline + candidate reports",
+    )
+    cmp.add_argument("--baseline", required=True)
+    cmp.add_argument("--candidate", required=True)
+    cmp.add_argument(
+        "--output", default="",
+        help="Optional output JSON (compare summary)",
+    )
+    cmp.set_defaults(func=_cmd_compare)
+
+    args = parser.parse_args(argv)
+    if not args.token and args.command == "run":
+        import os
+        args.token = os.environ.get("MANTIS_API_TOKEN", "")
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

The fourth deliverable from #155 — gate model promotions on a held-out eval set, comparing candidate weights against baseline pass-rates and reporting per-task wins / losses / regressions.

## What ships

### ``training/eval_harness.py``

Two-stage protocol:

```
[1] eval baseline  → run_eval(baseline_runner, tasks) → baseline.json
[2] eval candidate → run_eval(candidate_runner, tasks) → candidate.json
[3] compare        → compare(baseline, candidate) → wins / losses / win_rate
```

CLI:

```
python -m training.eval_harness run \
    --tasks tasks/eval.json --output reports/baseline.json \
    --runner https://prod--mantis-server-api.modal.run

python -m training.eval_harness compare \
    --baseline reports/baseline.json \
    --candidate reports/candidate.json
```

### Schema

``EvalCriterion.type`` ∈ ``task_success | status_eq | url_contains | output_contains``. A task passes when **every** criterion is satisfied. Unknown criterion types **fail closed** so a malformed eval task can never silently green-light a regression.

``EvalCompare`` exposes per-side pass-rates, the disagreement set (wins / losses), and the per-task lists of regressions / improvements. Promotion gating is the caller's policy — the harness gives the inputs without baking in a threshold.

### Runner contract

Stays caller-supplied so the harness is testable without HTTP:

```python
def my_runner(task: EvalTask) -> EvalRunOutcome: ...
report = run_eval(my_runner, tasks)
```

The CLI bundles a default HTTP runner for production use.

## Test plan

- [x] 18 new tests in ``tests/test_eval_harness.py``: five criterion contracts (incl. unknown-fails-closed), run_eval default + AND + exception containment + per-criterion result recording + report round-trip, load_tasks bare-array + wrapper-dict shapes, compare id alignment + one-sided ignored + no-disagreement neutral win-rate + delta math + dict round-trip, end-to-end mixed-result pipeline.
- [x] 18/18 pass
- [x] ``ruff check`` clean
- [x] **Modal news.ycombinator.com smoke**: redeployed + re-ran. ``status=succeeded``, ``cost=\$0.054``, 3 steps — matches baseline. No regression.

## Docs

- ``docs/operations/continual-finetuning.md`` — promoted ``eval`` to step 5 in the pipeline diagram, added the full CLI walkthrough + task-shape example. Step 6 (shadow-deploy) marked pending.

## What's still open on #155

| Step | Status |
|---|---|
| 1. Trace export | ✅ PR #194 |
| 2. Labeller | ✅ PR #195 |
| 3. SFT/DPO recipe | ✅ PR #196 |
| 4. Eval harness (this PR) | ✅ |
| 5. Shadow-deploy (5% traffic, escalation-rate compare) | ⏳ |

Refs #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)