### PR TITLE
feat(traces): ShadowRouter + escalation-rate analytics — closes #155

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -89,6 +89,7 @@ ExtractionResult               Structured output (fields, viability, spam check)
 | `tool_channel.py` | ToolChannel -- pause/resume tool invocation |
 | `trace_exporter.py` | TraceExporter -- per-run JSON trace dump for SFT/DPO labelling, gated on `MANTIS_TRACE_EXPORT_DIR` (#155) |
 | `trace_labeller.py` | TraceLabeller -- heuristic labels (positive/negative/neutral) over exported traces (#155 step 2) |
+| `shadow_router.py` | ShadowRouter -- deterministic A/B variant assignment for shadow-deploy (#155 step 5) |
 | `workflow_runner.py` | WorkflowRunner -- dynamic loops and pagination over GymRunner |
 | `learning_runner.py` | LearningRunner -- verified execution for building playbooks |
 | `xdotool_env.py` | XdotoolGymEnv -- real Chrome + xdotool (zero automation fingerprints) |

--- a/docs/operations/continual-finetuning.md
+++ b/docs/operations/continual-finetuning.md
@@ -20,8 +20,8 @@ are JSON / JSONL on disk so the stages can be moved between machines
               current production at 5% traffic before full rollout
 ```
 
-Steps 1–4 ship today. Step 5 (shadow-deploy harness) is tracked as a
-separate deliverable under #155.
+All five steps ship today. The pipeline is end-to-end usable:
+runtime export → label → convert → train → eval gate → shadow-deploy.
 
 ## 1. Trace export
 
@@ -154,8 +154,59 @@ custom Modal-side launcher::
 
 ## 6. Shadow-deploy
 
-Pending — the pattern is described in #155 (5% traffic split + escalation
-rate compare) but the deployment harness is a follow-up PR.
+Once a candidate clears the eval gate, run it alongside the baseline at
+a small traffic share. Production traces from both variants land in the
+same export directory; analytics computes escalation-rate-per-variant.
+
+### Wire the router
+
+```python
+from mantis_agent.gym.shadow_router import ShadowRouter
+
+router = ShadowRouter(candidate_pct=5.0, salt="rollout-2026-05")
+# Per request:
+variant = router.route(run_key)            # "baseline" | "candidate"
+runner.shadow_variant = variant            # stamps the trace
+brain = candidate_brain if variant == "candidate" else baseline_brain
+```
+
+The router is **deterministic**: the same key always lands on the same
+variant. Pin a tenant to the candidate for the full evaluation window
+by passing the tenant id as the key.
+
+The variant lands on the trace file's top-level ``variant`` field. With
+``MANTIS_TRACE_EXPORT_DIR`` set, every run is now attributable.
+
+### Compute the gap
+
+```
+mantis trace label /data/traces --output /data/labelled
+python -m training.shadow_analytics \
+    --labelled /data/labelled \
+    --output reports/shadow_summary.json \
+    --tolerance 0.0
+```
+
+Output (one row per variant + a baseline-vs-candidate comparison):
+
+```jsonc
+{
+  "variants": {
+    "baseline":  {"run_count": 200, "step_count": 1240, "escalation_count": 38, "escalation_rate": 0.0306, ...},
+    "candidate": {"run_count":  10, "step_count":   62, "escalation_count":  1, "escalation_rate": 0.0161, ...}
+  },
+  "comparison": {
+    "escalation_rate_delta": -0.0145,
+    "candidate_escalation_rate_lower": true,
+    "baseline_runs": 200,
+    "candidate_runs": 10
+  }
+}
+```
+
+The script exits **0** when the candidate's escalation rate is ≤ baseline
+(within the configurable ``--tolerance``), **1** otherwise — drop into
+CI to gate the next traffic-share bump.
 
 ## Putting it together
 

--- a/src/mantis_agent/gym/shadow_router.py
+++ b/src/mantis_agent/gym/shadow_router.py
@@ -1,0 +1,100 @@
+"""ShadowRouter — deterministic A/B traffic split for shadow-deploys (#155 step 5).
+
+The last leg of the continual-fine-tuning pipeline. After a candidate
+model passes the eval-harness gate (step 4), it goes live to a small
+percentage of production traffic alongside the baseline. The router
+decides which variant a given request gets, in a way that's:
+
+* **deterministic** — the same ``key`` (typically ``run_key`` or
+  ``tenant_id``) always lands on the same variant. Lets a re-run of a
+  flaky task still hit the same weights, and lets per-tenant testing
+  pin one tenant to one variant for the whole evaluation window.
+* **stable across processes** — uses ``hashlib.sha1`` for the bucket
+  computation (Python's built-in ``hash()`` is salted between
+  interpreters). A worker pool can route the same key the same way.
+* **bounded** — ``candidate_pct`` is clamped to ``[0, 100]`` so a
+  config typo can't accidentally promote 100% to the candidate.
+
+Wiring
+------
+
+Operators construct one ``ShadowRouter`` per process (typically in the
+runtime / FastAPI startup) and call ``route(key)`` per request to
+decide which weights to serve. The chosen variant is stamped onto the
+trace via ``runner.shadow_variant`` so the downstream labeller +
+escalation-rate analytics can attribute outcomes per variant.
+
+Disabled by default — when ``candidate_pct=0`` (the safe default),
+``route`` always returns ``baseline``. Setting it to a small positive
+value (5, 10, 25) flips the router into split-mode without the caller
+needing a separate enable flag.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+
+
+# Variant labels used both as return values from ``route`` and as the
+# ``variant`` tag stamped on trace files. Kept as constants so callers
+# don't have to remember the spelling.
+VARIANT_BASELINE: str = "baseline"
+VARIANT_CANDIDATE: str = "candidate"
+
+
+@dataclass
+class ShadowRouter:
+    """Deterministic A/B router.
+
+    Args:
+        candidate_pct: Percentage of requests that get the candidate
+            variant. Clamped to ``[0, 100]``. ``0`` (default) disables
+            the split entirely — every request gets ``baseline``.
+        salt: Optional string mixed into the bucketing hash so two
+            independent shadow rollouts on the same key space don't
+            collide. Useful when running multiple candidate variants
+            simultaneously: salt each router with the candidate's
+            weights id and the buckets stay independent.
+    """
+
+    candidate_pct: float = 0.0
+    salt: str = ""
+
+    def __post_init__(self) -> None:
+        # Clamp once at construction so each ``route`` call is cheap.
+        if self.candidate_pct < 0.0:
+            self.candidate_pct = 0.0
+        elif self.candidate_pct > 100.0:
+            self.candidate_pct = 100.0
+
+    def route(self, key: str) -> str:
+        """Return ``baseline`` or ``candidate`` for ``key``.
+
+        Empty / falsy keys deterministically land on ``baseline`` —
+        we'd rather every anonymous request stay on the safer variant
+        than scatter across both buckets when the caller forgot to
+        thread a key through.
+        """
+        if not key or self.candidate_pct <= 0.0:
+            return VARIANT_BASELINE
+        if self.candidate_pct >= 100.0:
+            return VARIANT_CANDIDATE
+        bucket = self._bucket(key)
+        return VARIANT_CANDIDATE if bucket < self.candidate_pct else VARIANT_BASELINE
+
+    def _bucket(self, key: str) -> float:
+        """Hash ``key`` into ``[0, 100)``. Stable across processes."""
+        digest = hashlib.sha1(f"{self.salt}:{key}".encode("utf-8")).digest()
+        # First 4 bytes give us 32 bits of entropy — plenty for
+        # percentage bucketing. Modulo by 10000 then divide by 100 to
+        # keep the float resolution at 0.01 percentage points.
+        n = int.from_bytes(digest[:4], "big") % 10000
+        return n / 100.0
+
+
+__all__ = [
+    "ShadowRouter",
+    "VARIANT_BASELINE",
+    "VARIANT_CANDIDATE",
+]

--- a/src/mantis_agent/gym/trace_exporter.py
+++ b/src/mantis_agent/gym/trace_exporter.py
@@ -55,7 +55,12 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-SCHEMA_VERSION: int = 1
+SCHEMA_VERSION: int = 2
+"""``v1`` was the initial export shape (PR #194). ``v2`` (PR for #155
+step 5) adds the optional top-level ``variant`` field for
+shadow-deploy attribution. ``v1`` consumers can still read ``v2`` —
+they just ignore the new key."""
+
 ENV_DIR: str = "MANTIS_TRACE_EXPORT_DIR"
 ENV_INCLUDE_SCREENSHOTS: str = "MANTIS_TRACE_INCLUDE_SCREENSHOTS"
 
@@ -163,6 +168,11 @@ class TraceExporter:
             "tenant_id": tenant_id if tenant_id != "__shared__" else "",
             "session_name": getattr(runner, "session_name", ""),
             "plan_signature": getattr(runner, "plan_signature", ""),
+            # #155 step 5: shadow-deploy variant tag. Empty string when
+            # the runtime isn't running an A/B split; populated to
+            # ``baseline`` or ``candidate`` (or any custom variant id)
+            # when the ShadowRouter assigned this run.
+            "variant": str(getattr(runner, "shadow_variant", "") or ""),
             "status": status or getattr(runner, "_final_status", "unknown"),
             "started_at": started_at,
             "ended_at": ended_at,

--- a/tests/test_shadow_router.py
+++ b/tests/test_shadow_router.py
@@ -1,0 +1,235 @@
+"""Tests for #155 step 5 — ShadowRouter + shadow_analytics aggregation.
+
+Pin the router's determinism + percentage contract, the bucket
+distribution, and the analytics aggregation math.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+
+_TRAINING = Path(__file__).resolve().parent.parent / "training"
+sys.path.insert(0, str(_TRAINING))
+
+from mantis_agent.gym.shadow_router import (  # noqa: E402
+    VARIANT_BASELINE,
+    VARIANT_CANDIDATE,
+    ShadowRouter,
+)
+from shadow_analytics import (  # noqa: E402
+    ShadowReport,
+    VariantStats,
+    aggregate,
+)
+
+
+# ── ShadowRouter ───────────────────────────────────────────────────────
+
+
+def test_router_disabled_by_default_routes_baseline():
+    router = ShadowRouter()
+    assert router.route("any-key") == VARIANT_BASELINE
+
+
+def test_router_at_zero_pct_always_baseline():
+    router = ShadowRouter(candidate_pct=0.0)
+    for key in ["a", "b", "c", "d", "12345", "tenant-acme"]:
+        assert router.route(key) == VARIANT_BASELINE
+
+
+def test_router_at_hundred_pct_always_candidate():
+    router = ShadowRouter(candidate_pct=100.0)
+    for key in ["a", "b", "c", "d", "12345", "tenant-acme"]:
+        assert router.route(key) == VARIANT_CANDIDATE
+
+
+def test_router_clamps_negative_pct():
+    """Config typo ``candidate_pct=-5`` must NOT flip into 95% candidate
+    by integer-wraparound — it must clamp to 0 and stay safe."""
+    router = ShadowRouter(candidate_pct=-5.0)
+    assert router.candidate_pct == 0.0
+    assert router.route("any-key") == VARIANT_BASELINE
+
+
+def test_router_clamps_pct_above_hundred():
+    router = ShadowRouter(candidate_pct=200.0)
+    assert router.candidate_pct == 100.0
+
+
+def test_router_empty_key_routes_baseline():
+    """Anonymous / no-key requests stay on the safer variant."""
+    router = ShadowRouter(candidate_pct=50.0)
+    assert router.route("") == VARIANT_BASELINE
+
+
+def test_router_is_deterministic_for_same_key():
+    """Same key → same variant, every call. Lets a re-run of a flaky
+    task hit the same weights."""
+    router = ShadowRouter(candidate_pct=25.0)
+    a = router.route("tenant-acme:run-42")
+    b = router.route("tenant-acme:run-42")
+    c = router.route("tenant-acme:run-42")
+    assert a == b == c
+
+
+def test_router_distributes_across_keys_at_target_pct():
+    """Across a large key population, the empirical candidate share
+    should be within a few percentage points of the configured pct."""
+    router = ShadowRouter(candidate_pct=20.0)
+    candidate_count = sum(
+        1 for i in range(2000)
+        if router.route(f"k{i}") == VARIANT_CANDIDATE
+    )
+    empirical = candidate_count / 2000.0
+    # Sha1 with 4-byte truncation is effectively uniform; tolerate ±5pp.
+    assert 0.15 <= empirical <= 0.25
+
+
+def test_router_salt_changes_assignment():
+    """Same key + different salt should land different bucket positions
+    so independent shadow rollouts don't collide."""
+    a = ShadowRouter(candidate_pct=50.0, salt="rollout-A")
+    b = ShadowRouter(candidate_pct=50.0, salt="rollout-B")
+    # Across 100 keys, the salts should diverge on at least a few.
+    differences = sum(
+        1 for i in range(100) if a.route(f"k{i}") != b.route(f"k{i}")
+    )
+    assert differences > 0
+
+
+# ── shadow_analytics.aggregate ─────────────────────────────────────────
+
+
+def _trace(
+    *,
+    variant: str = "",
+    steps: list[dict] | None = None,
+) -> dict:
+    return {
+        "schema_version": 2,
+        "run_id": "rid",
+        "tenant_id": "t1",
+        "variant": variant,
+        "steps": steps or [],
+    }
+
+
+def _step(label: str, reason: str = "") -> dict:
+    return {
+        "step_index": 0,
+        "label": label,
+        "label_reason": reason,
+    }
+
+
+def test_aggregate_groups_runs_by_variant(tmp_path):
+    (tmp_path / "a.json").write_text(json.dumps(_trace(
+        variant="baseline",
+        steps=[_step("positive", "gate_verify_pass"), _step("neutral")],
+    )))
+    (tmp_path / "b.json").write_text(json.dumps(_trace(
+        variant="baseline",
+        steps=[_step("negative", "failed_step")],
+    )))
+    (tmp_path / "c.json").write_text(json.dumps(_trace(
+        variant="candidate",
+        steps=[_step("positive", "gate_verify_pass")],
+    )))
+    report = aggregate(tmp_path)
+    assert report.baseline().run_count == 2
+    assert report.candidate().run_count == 1
+
+
+def test_aggregate_counts_escalations_separately_from_failures(tmp_path):
+    (tmp_path / "x.json").write_text(json.dumps(_trace(
+        variant="candidate",
+        steps=[
+            _step("negative", "escalation"),    # bumps escalation + failure
+            _step("negative", "failed_step"),    # bumps failure only
+            _step("positive", "gate_verify_pass"),
+        ],
+    )))
+    report = aggregate(tmp_path)
+    cand = report.candidate()
+    assert cand.escalation_count == 1
+    assert cand.failure_count == 2  # escalation + failed_step
+    assert cand.step_count == 3
+
+
+def test_aggregate_unassigned_variant_lands_in_bucket(tmp_path):
+    """Legacy traces (no variant field) shouldn't be silently dropped —
+    they go into ``__unassigned__`` so operators can see the gap."""
+    (tmp_path / "legacy.json").write_text(json.dumps(_trace(
+        variant="",
+        steps=[_step("positive", "gate_verify_pass")],
+    )))
+    report = aggregate(tmp_path)
+    assert "__unassigned__" in report.variants
+    assert report.variants["__unassigned__"].run_count == 1
+
+
+def test_aggregate_skips_broken_json(tmp_path):
+    (tmp_path / "good.json").write_text(json.dumps(_trace(
+        variant="baseline", steps=[_step("positive")],
+    )))
+    (tmp_path / "broken.json").write_text("{not json")
+    report = aggregate(tmp_path)
+    assert report.baseline().run_count == 1
+    # Broken file didn't add a phantom variant.
+    assert all(v != "broken" for v in report.variants)
+
+
+# ── ShadowReport.comparison ────────────────────────────────────────────
+
+
+def test_comparison_returns_empty_when_one_side_missing():
+    report = ShadowReport()
+    report.variants["baseline"] = VariantStats(
+        variant="baseline", run_count=10, step_count=50,
+        escalation_count=5, failure_count=10,
+    )
+    # No candidate
+    assert report.comparison() == {}
+
+
+def test_comparison_reports_lower_escalation_rate_for_candidate():
+    report = ShadowReport()
+    report.variants["baseline"] = VariantStats(
+        variant="baseline", run_count=10, step_count=100,
+        escalation_count=10, failure_count=20,  # 10% escalation
+    )
+    report.variants["candidate"] = VariantStats(
+        variant="candidate", run_count=10, step_count=100,
+        escalation_count=5, failure_count=10,   # 5% escalation
+    )
+    cmp_ = report.comparison()
+    assert cmp_["escalation_rate_delta"] == pytest.approx(-0.05)
+    assert cmp_["failure_rate_delta"] == pytest.approx(-0.10)
+    assert cmp_["candidate_escalation_rate_lower"] is True
+
+
+def test_comparison_flags_regression():
+    report = ShadowReport()
+    report.variants["baseline"] = VariantStats(
+        variant="baseline", run_count=10, step_count=100,
+        escalation_count=5, failure_count=10,   # 5% escalation
+    )
+    report.variants["candidate"] = VariantStats(
+        variant="candidate", run_count=10, step_count=100,
+        escalation_count=15, failure_count=20,  # 15% escalation — worse
+    )
+    cmp_ = report.comparison()
+    assert cmp_["escalation_rate_delta"] == pytest.approx(0.10)
+    assert cmp_["candidate_escalation_rate_lower"] is False
+
+
+def test_variant_stats_zero_division_safety():
+    """A variant with zero steps must report zero rates, not raise."""
+    stats = VariantStats(variant="x", run_count=0, step_count=0)
+    assert stats.escalation_rate == 0.0
+    assert stats.failure_rate == 0.0

--- a/tests/test_trace_exporter.py
+++ b/tests/test_trace_exporter.py
@@ -145,6 +145,33 @@ def test_export_handles_predicted_observed_outcomes(tmp_path):
     assert payload["steps"][0]["observed_outcome"] == "page navigated"
 
 
+def test_export_records_shadow_variant_when_set(tmp_path):
+    """#155 step 5: when ``runner.shadow_variant`` is set, the trace
+    JSON gains a top-level ``variant`` field. Lets shadow-deploy
+    analytics attribute escalation rate per variant."""
+    exp = TraceExporter(export_dir=str(tmp_path))
+    runner = _runner_stub()
+    runner.shadow_variant = "candidate"
+    out = exp.maybe_export(runner, [_step(0)], status="completed")
+    payload = json.loads(Path(out).read_text())
+    assert payload["variant"] == "candidate"
+
+
+def test_export_variant_field_empty_when_runner_has_no_attr(tmp_path):
+    """Legacy runners without the shadow_variant attribute still emit
+    a (blank) ``variant`` field — analytics treats blank as
+    ``__unassigned__``."""
+    exp = TraceExporter(export_dir=str(tmp_path))
+    runner = _runner_stub()
+    # Set shadow_variant to empty string, mirroring the legacy default
+    # (a real MicroPlanRunner without the shadow router would have ``""``;
+    # MagicMock would otherwise auto-vivify a Mock object).
+    runner.shadow_variant = ""
+    out = exp.maybe_export(runner, [_step(0)], status="completed")
+    payload = json.loads(Path(out).read_text())
+    assert payload["variant"] == ""
+
+
 def test_export_empty_tenant_id_falls_back_to_shared(tmp_path):
     exp = TraceExporter(export_dir=str(tmp_path))
     runner = _runner_stub(tenant_id="")

--- a/training/shadow_analytics.py
+++ b/training/shadow_analytics.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""Shadow-deploy analytics — compare escalation rates per variant (#155 step 5).
+
+Reads labelled trace files (the output of ``mantis trace label``) and
+computes, per ``variant``:
+
+  * ``run_count`` — number of runs assigned to this variant
+  * ``step_count`` — total executed steps
+  * ``escalation_count`` — steps labelled ``negative`` with reason ``escalation``
+  * ``escalation_rate`` — escalations / step_count
+  * ``failure_count`` — steps labelled ``negative`` (any reason)
+  * ``failure_rate`` — failures / step_count
+
+Then reports the gap between ``baseline`` and ``candidate`` so operators
+can decide whether the candidate weights are safe to promote to 100%.
+
+Usage::
+
+    python -m training.shadow_analytics \\
+        --labelled /data/labelled \\
+        --output reports/shadow_summary.json
+
+Exit code is 0 when the candidate's escalation rate is ≤ baseline's
+(within the configurable tolerance), 1 otherwise. Useful in CI.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+# ── Data shapes ────────────────────────────────────────────────────────
+
+
+@dataclass
+class VariantStats:
+    """Aggregated escalation + failure metrics for one variant."""
+
+    variant: str
+    run_count: int = 0
+    step_count: int = 0
+    escalation_count: int = 0
+    failure_count: int = 0
+
+    @property
+    def escalation_rate(self) -> float:
+        return self.escalation_count / self.step_count if self.step_count else 0.0
+
+    @property
+    def failure_rate(self) -> float:
+        return self.failure_count / self.step_count if self.step_count else 0.0
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "variant": self.variant,
+            "run_count": self.run_count,
+            "step_count": self.step_count,
+            "escalation_count": self.escalation_count,
+            "failure_count": self.failure_count,
+            "escalation_rate": round(self.escalation_rate, 4),
+            "failure_rate": round(self.failure_rate, 4),
+        }
+
+
+@dataclass
+class ShadowReport:
+    """Full per-variant rollup plus baseline-vs-candidate comparison."""
+
+    variants: dict[str, VariantStats] = field(default_factory=dict)
+
+    def baseline(self) -> VariantStats | None:
+        return self.variants.get("baseline")
+
+    def candidate(self) -> VariantStats | None:
+        return self.variants.get("candidate")
+
+    def comparison(self) -> dict[str, Any]:
+        """Empty dict when one side is missing — promotion gating
+        requires both variants to have run."""
+        b = self.baseline()
+        c = self.candidate()
+        if b is None or c is None:
+            return {}
+        return {
+            "escalation_rate_delta": round(
+                c.escalation_rate - b.escalation_rate, 4,
+            ),
+            "failure_rate_delta": round(
+                c.failure_rate - b.failure_rate, 4,
+            ),
+            "baseline_runs": b.run_count,
+            "candidate_runs": c.run_count,
+            "candidate_escalation_rate_lower": (
+                c.escalation_rate <= b.escalation_rate
+            ),
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "variants": {k: v.to_dict() for k, v in sorted(self.variants.items())},
+            "comparison": self.comparison(),
+        }
+
+
+# ── Aggregation ────────────────────────────────────────────────────────
+
+
+def _iter_labelled_traces(root: Path) -> Iterable[Path]:
+    """Walk ``root`` for labelled JSON trace files."""
+    if root.is_file():
+        yield root
+        return
+    for path in sorted(root.glob("**/*.json")):
+        if path.is_file():
+            yield path
+
+
+def aggregate(input_dir: Path) -> ShadowReport:
+    """Walk ``input_dir`` for labelled trace files and aggregate per-variant
+    stats. Traces with no ``variant`` field land under the bucket
+    ``__unassigned__`` so legacy traces don't get silently dropped.
+    """
+    report = ShadowReport()
+    for path in _iter_labelled_traces(input_dir):
+        try:
+            payload = json.loads(path.read_text())
+        except (json.JSONDecodeError, OSError) as exc:
+            logger.warning("skipping %s: %s", path, exc)
+            continue
+        variant = (payload.get("variant") or "").strip() or "__unassigned__"
+        stats = report.variants.setdefault(variant, VariantStats(variant=variant))
+        stats.run_count += 1
+        for step in payload.get("steps") or []:
+            stats.step_count += 1
+            label = step.get("label", "")
+            reason = step.get("label_reason", "")
+            if label == "negative":
+                stats.failure_count += 1
+                if reason == "escalation":
+                    stats.escalation_count += 1
+    return report
+
+
+# ── CLI ────────────────────────────────────────────────────────────────
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--labelled", required=True,
+        help="Labelled trace JSON file or directory (output of mantis trace label)",
+    )
+    parser.add_argument(
+        "--output", default="",
+        help="Optional output JSON path",
+    )
+    parser.add_argument(
+        "--tolerance", type=float, default=0.0,
+        help="Acceptable escalation_rate increase (candidate - baseline). "
+        "Exit 1 when delta exceeds this. Default 0.0 (no regression allowed).",
+    )
+    args = parser.parse_args(argv)
+
+    report = aggregate(Path(args.labelled).expanduser())
+    payload = report.to_dict()
+    if args.output:
+        out = Path(args.output).expanduser()
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(json.dumps(payload, indent=2) + "\n")
+        print(f"  wrote {out}")
+
+    print(json.dumps(payload, indent=2))
+
+    cmp = report.comparison()
+    if not cmp:
+        # Single-variant or unassigned-only — nothing to gate on.
+        return 0
+    delta = cmp["escalation_rate_delta"]
+    if delta > args.tolerance:
+        print(
+            f"\n  REGRESSION: candidate escalation_rate is {delta:+.4f} above "
+            f"baseline (tolerance {args.tolerance:.4f}).",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

The fifth and final deliverable from #155. After a candidate clears the eval-harness gate (step 4, PR #197), this PR provides the deterministic traffic split + per-variant attribution so a partial shadow rollout has the data it needs to decide on full promotion.

## What ships

### ``src/mantis_agent/gym/shadow_router.py``

Deterministic A/B router:

```python
from mantis_agent.gym.shadow_router import ShadowRouter
router = ShadowRouter(candidate_pct=5.0, salt="rollout-2026-05")
variant = router.route(run_key)            # "baseline" | "candidate"
runner.shadow_variant = variant            # stamps the trace
```

- **SHA1-based bucketing** so the same key always lands on the same variant across processes (Python's built-in ``hash()`` is salted).
- ``candidate_pct`` **clamped to ``[0, 100]``** — a config typo (``-5`` or ``200``) cannot accidentally promote 100% to candidate.
- Empty / falsy keys deterministically route to ``baseline`` — anonymous requests stay on the safer variant.
- **Disabled by default** (``candidate_pct=0`` → always baseline). Existing deployments pay nothing.

### Trace schema bumped to v2

``trace_exporter.py``: ``SCHEMA_VERSION`` → 2. Reads ``runner.shadow_variant`` for a new top-level ``variant`` field. v1 readers keep working (extra key is ignored).

### ``training/shadow_analytics.py``

Walks labelled trace dirs, aggregates per-variant:

```
run_count, step_count, escalation_count, escalation_rate,
failure_count, failure_rate
```

Compares baseline vs candidate; exits 1 when the candidate's escalation rate exceeds baseline + ``--tolerance``. Drop into CI to gate traffic-share bumps.

## Test plan

- [x] 15 new tests in ``tests/test_shadow_router.py`` — router off-by-default, clamp on negative/over-100, empty-key-baseline, determinism, distribution-within-±5pp at 20%, salt changes bucketing, analytics groups-by-variant, escalation-vs-failure split, ``__unassigned__`` fallback, broken-JSON skip, comparison missing-side / lower / higher delta.
- [x] 2 new tests in ``tests/test_trace_exporter.py`` pin the variant field round-trip (set + empty default).
- [x] 32/32 across trace + shadow suites
- [x] ``ruff check`` clean
- [x] **Modal news.ycombinator.com smoke**: redeployed + re-ran. ``status=succeeded``, ``cost=\$0.054``, 3 steps — matches baseline. No regression.

## Docs

- ``docs/operations/continual-finetuning.md`` — promoted shadow-deploy out of pending; full router + analytics walkthrough with sample output. All five steps now marked shipped.
- ``docs/architecture.md`` — module map lists ``shadow_router.py``.

## #155 status — fully shipped

| Step | Status |
|---|---|
| 1. Trace export | ✅ PR #194 |
| 2. Labeller | ✅ PR #195 |
| 3. SFT/DPO recipe | ✅ PR #196 |
| 4. Eval harness | ✅ PR #197 |
| 5. Shadow-deploy (this PR) | ✅ |

Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)