### PR TITLE
docs(cost): document cost model + env-var overrides (#122)

### DIFF
--- a/docs/operations/cost.md
+++ b/docs/operations/cost.md
@@ -1,0 +1,93 @@
+# Cost model (#122)
+
+Per-resource pricing for the CUA runtime lives in
+`src/mantis_agent/cost_config.py` as a `CostConfig` dataclass. Defaults
+match the historical hardcoded rates so existing deployments see no
+change without an env-var override.
+
+## Overridable knobs
+
+All env vars are interpreted as floats. Bad values fail fast (operators
+see the error instead of silent fallback).
+
+| Env var | Default | Purpose |
+|---|---|---|
+| `MANTIS_COST_GPU_HOURLY_USD` | `3.25` | GPU compute, $/hour. Multiply by `gpu_seconds / 3600` for the run's GPU bill. |
+| `MANTIS_COST_CLAUDE_CALL_USD` | `0.003` | Per-Claude-API-call rate. Applied to `claude_extract` + `claude_grounding` counters. |
+| `MANTIS_COST_PROXY_PER_GB_USD` | `5.00` | Egress proxy bandwidth, $/GB. Multiply by `proxy_mb / 1024`. |
+| `MANTIS_COST_GPU_SECONDS_PER_STEP` | `3.0` | Per-step GPU budget used when the runner doesn't measure exact seconds. |
+| `MANTIS_COST_PROXY_MB_PER_NAV` | `5.0` | Estimated proxy MB consumed by one page load. |
+| `MANTIS_COST_PROXY_MB_PER_SCROLL` | `0.5` | Estimated proxy MB per scroll. |
+
+Set these once at deploy time (Modal secret, k8s ConfigMap,
+`docker run -e ...`, Baseten Truss `environment_variables`). Per-tenant
+overrides happen at the `MicroPlanRunner` constructor (`cost_config=`).
+
+## Wiring
+
+```
+CostConfig.from_env()  →  CostMeter(cost_config=...)  →  MicroPlanRunner
+                                       │
+                                       └─ runs cost_meter.totals(),
+                                          emits inflight + final
+                                          gauges/histograms on Prometheus
+```
+
+The `CostMeter` rolls up per-resource counters from the runner's `costs`
+dict (`gpu_steps`, `gpu_seconds`, `claude_extract`, `claude_grounding`,
+`proxy_mb`) and produces the four-tuple `(gpu, claude, proxy, total)`
+in USD.
+
+## Prometheus
+
+Two Prometheus surfaces ship with the cost model — see
+[Metrics](metrics.md) for the full table.
+
+| Metric | Type | Labels |
+|---|---|---|
+| `mantis_run_cost_usd` | histogram | `tenant_id`, `model`, `status` |
+| `mantis_run_cost_usd_inflight` | gauge | `tenant_id`, `component` (`gpu` / `claude` / `proxy` / `total`) |
+
+The histogram captures terminal cost per detached run; the inflight
+gauge updates on every progress log so live runs show up on dashboards
+without waiting for terminal observation.
+
+## Tuning the rates
+
+When upstream prices change (Modal A100 hourly, Anthropic per-token,
+proxy provider) operators can:
+
+1. Update the env var on the deployment (no code change).
+2. Confirm the new rate is live by hitting `/metrics` and reading
+   `mantis_run_cost_usd_inflight` — the next progress emission shows
+   the override.
+3. Tenant-specific rates are out of scope for this surface — pass
+   a custom `CostConfig` instance to `MicroPlanRunner(cost_config=...)`
+   inside the per-tenant request handler.
+
+## Useful queries
+
+```promql
+# Per-tenant cost burn rate ($/hour averaged over the last hour)
+sum by (tenant_id) (
+  increase(mantis_run_cost_usd_sum[1h])
+)
+
+# Cost split by component, last 24h
+sum by (component) (
+  rate(mantis_run_cost_usd_inflight[24h])
+)
+
+# p95 cost per detached run (catches bug-runs blowing past the cap)
+histogram_quantile(0.95,
+  sum by (tenant_id, le) (
+    rate(mantis_run_cost_usd_bucket[1h])
+  )
+)
+```
+
+## Tests
+
+`tests/test_cost_config.py` covers env-override parsing + the three
+cost computation helpers. `tests/test_cost_meter.py` covers the
+roll-up + Prometheus emission surface.

--- a/docs/reference/env-vars.md
+++ b/docs/reference/env-vars.md
@@ -57,6 +57,19 @@ These are global hard caps; tenant config can be tighter, never looser.
 |---|---|---|
 | `MANTIS_WEBHOOK_SECRET_DEFAULT` | unset | Fallback HMAC signing secret when a tenant's `webhook_secret_name` doesn't resolve |
 
+## Cost model (#122)
+
+| Var | Default | Effect |
+|---|---|---|
+| `MANTIS_COST_GPU_HOURLY_USD` | `3.25` | GPU compute, $/hour. Used by `CostConfig.gpu_cost`. |
+| `MANTIS_COST_CLAUDE_CALL_USD` | `0.003` | Per-Claude-API-call rate. Multiplied by `claude_extract` + `claude_grounding` counters. |
+| `MANTIS_COST_PROXY_PER_GB_USD` | `5.00` | Egress proxy bandwidth $/GB. |
+| `MANTIS_COST_GPU_SECONDS_PER_STEP` | `3.0` | Per-step GPU seconds when the runner doesn't measure exact wall time. |
+| `MANTIS_COST_PROXY_MB_PER_NAV` | `5.0` | Estimated proxy MB per page load. |
+| `MANTIS_COST_PROXY_MB_PER_SCROLL` | `0.5` | Estimated proxy MB per scroll. |
+
+See [operations/cost.md](../operations/cost.md) for the full rate-tuning workflow.
+
 ## Trace export (#155)
 
 | Var | Default | Effect |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -116,6 +116,7 @@ nav:
       - Webhooks: operations/webhooks.md
       - URL allowlist: operations/allowlist.md
       - Metrics: operations/metrics.md
+      - Cost model: operations/cost.md
       - Continual fine-tuning: operations/continual-finetuning.md
       - Model promotion: operations/model-promotion.md
       - Independent grounding: operations/independent-grounding.md


### PR DESCRIPTION
## Summary

The remaining gap on #122 was the operator-facing cost docs page — the underlying ``CostConfig`` dataclass + ``CostMeter`` rollup + Prometheus emission already shipped (in PR #161 split + #156 metrics). This PR closes the open documentation acceptance criterion.

## What ships

- ``docs/operations/cost.md`` — full operator page covering:
  - Six ``MANTIS_COST_*`` env-var override knobs with defaults
  - Wiring diagram from ``CostConfig.from_env()`` → ``CostMeter`` → ``MicroPlanRunner``
  - Prometheus surfaces cross-referenced from the metrics page
  - Tuning workflow + per-tenant override hatch
  - Useful PromQL queries (burn-rate, component split, p95 cost)
- ``docs/reference/env-vars.md`` gains a ``Cost model`` section listing every ``MANTIS_COST_*`` knob with one-line effect.
- ``mkdocs.yml`` links the new page in the Operations nav.

## Already shipped on #122 (referenced in PR description for clarity)

- ``CostConfig`` dataclass with env override + ``from_env`` factory: ``src/mantis_agent/cost_config.py``
- ``CostMeter`` rollup + ``mantis_run_cost_usd_inflight`` Prometheus gauge: ``src/mantis_agent/gym/cost_meter.py``
- ``mantis_run_cost_usd`` per-run histogram: ``src/mantis_agent/metrics.py``
- Env-override tests: ``tests/test_cost_config.py`` (6 tests)
- Roll-up tests: ``tests/test_cost_meter.py``

## Test plan

- [x] Docs-only — no test changes required
- [x] **Modal news.ycombinator.com smoke** (per the always-smoke policy): ``status=succeeded``, ``cost=\$0.054``, 3 steps — matches baseline.

## Acceptance criteria from #122

- [x] Tests cover env override (existing ``tests/test_cost_config.py``)
- [x] ``/metrics`` shows new gauges (existing ``mantis_run_cost_usd_inflight`` from earlier PR)
- [x] Docs page ``docs/operations/cost.md`` lists overridable knobs (this PR)

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)