### PR TITLE
chore(gitignore): ignore reports/ — local benchmark/eval output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ logs/
 cache/
 results/
 outputs/
+reports/
 screenshots/
 
 # Run output artifacts (CSVs at repo root); CSVs under tasks/ and plans/ stay tracked


### PR DESCRIPTION
## Summary

Add ``reports/`` to ``.gitignore``. Generated locally by ``training/eval_harness.py``, ``training/shadow_analytics.py``, and the ``mantis trace label`` workflow as a working dir for report JSON. Stored locally only — never committed.

One-line change. Splits cleanly out of PR #201 (cost-docs) which was already merged before this commit landed.