### PR TITLE
[codex] Wire submit detector into force-submit path

### DIFF
--- a/src/mantis_agent/gym/holo3_detector.py
+++ b/src/mantis_agent/gym/holo3_detector.py
@@ -48,7 +48,7 @@ def _first_json(text: str, pattern: re.Pattern[str]) -> Any | None:
         return None
 
 
-def _log_extracted(values: list[dict]) -> None:
+def _log_extracted(values: list[dict[str, str]]) -> None:
     """Log each extracted value (label only — never log secret values)."""
     if not values:
         return
@@ -56,7 +56,7 @@ def _log_extracted(values: list[dict]) -> None:
     logger.info("extract_form_values: %d values: %s", len(values), pairs)
 
 
-def extract_form_values(brain: Any, task: str) -> list[dict]:
+def extract_form_values(brain: Any, task: str) -> list[dict[str, str]]:
     """Ask Holo3 to extract every {label, value} the plan instructs to type.
 
     Returns a list of ``{"label": str, "value": str}`` dicts in the order
@@ -94,7 +94,7 @@ def extract_form_values(brain: Any, task: str) -> list[dict]:
     parsed = _first_json(raw, _JSON_ARR_RE)
     if not isinstance(parsed, list):
         return []
-    out: list[dict] = []
+    out: list[dict[str, str]] = []
     for item in parsed:
         if not isinstance(item, dict):
             continue
@@ -214,7 +214,7 @@ def find_submit_button(
     brain: Any,
     screenshot: Image.Image,
     plan_intent: str | None = None,
-) -> dict | None:
+) -> dict[str, int | str] | None:
     """Ask Holo3 to locate a submit / login / update button on screen.
 
     Returns ``{x, y, label}`` (absolute pixel coords at the button center)

--- a/src/mantis_agent/gym/runner.py
+++ b/src/mantis_agent/gym/runner.py
@@ -306,12 +306,13 @@ class GymRunner:
         # Force-fill state: when Holo3 click-loops on a form field, the runner
         # substitutes the click with type_text using a value extracted from
         # the plan. Values come from Holo3 itself (one-shot LLM extraction,
-        # CUA-pure — no regex, no DOM access). When the queue empties, the
-        # runner makes one Holo3 vision call to find the submit button and
-        # injects a click on it (the well-known "doesn't submit after
-        # typing" failure mode).
+        # CUA-pure — no regex, no DOM access). When enough form fields have
+        # been filled, the runner asks Holo3 vision for the visible submit
+        # button and falls back to Return if the detector cannot find one.
         from . import holo3_detector
-        force_fill_values: list[str] = holo3_detector.extract_form_values(self.brain, task)
+        force_fill_values: list[dict[str, str]] = holo3_detector.extract_form_values(
+            self.brain, task,
+        )
         force_fill_used_regions: list[tuple[int, int]] = []
         force_fill_submitted: bool = False
         # Snapshot the initial labels so the Claude director can compute
@@ -644,16 +645,50 @@ class GymRunner:
                     and not force_fill_submitted
                     and action.action_type == ActionType.CLICK
                 ):
-                    logger.warning(
-                        "force-submit: substituting %s → key_press(Return) "
-                        "(form fully filled, Enter submits the focused input)",
-                        f"click({action.params})",
-                    )
-                    action = Action(
-                        ActionType.KEY_PRESS,
-                        {"keys": "Return"},
-                        reasoning="force-submit: Enter on focused input",
-                    )
+                    submit_button: dict[str, int | str] | None = None
+                    screenshot = frame_history[-1] if frame_history else None
+                    if screenshot is not None:
+                        try:
+                            submit_button = holo3_detector.find_submit_button(
+                                self.brain,
+                                screenshot,
+                                plan_intent=task,
+                            )
+                        except Exception as exc:
+                            logger.warning("force-submit detector raised: %s", exc)
+
+                    if submit_button is not None:
+                        logger.warning(
+                            "force-submit: substituting %s → click submit button %r "
+                            "at (%s,%s)",
+                            f"click({action.params})",
+                            submit_button.get("label"),
+                            submit_button.get("x"),
+                            submit_button.get("y"),
+                        )
+                        action = Action(
+                            ActionType.CLICK,
+                            {
+                                "x": int(submit_button["x"]),
+                                "y": int(submit_button["y"]),
+                                "button": "left",
+                            },
+                            reasoning=(
+                                "force-submit: click detected submit button "
+                                f"{submit_button.get('label')!r}"
+                            ),
+                        )
+                    else:
+                        logger.warning(
+                            "force-submit: substituting %s → key_press(Return) "
+                            "(form fully filled; submit button not detected)",
+                            f"click({action.params})",
+                        )
+                        action = Action(
+                            ActionType.KEY_PRESS,
+                            {"keys": "Return"},
+                            reasoning="force-submit: Enter on focused input",
+                        )
                     force_fill_submitted = True
                 # Claude-director escalation: only fires when no other
                 # substitution kicked in AND the soft-loop detector says

--- a/tests/test_holo3_detector.py
+++ b/tests/test_holo3_detector.py
@@ -1,0 +1,36 @@
+"""Tests for Holo3 vision-detector helper parsing."""
+
+from __future__ import annotations
+
+from PIL import Image
+
+from mantis_agent.gym.holo3_detector import find_submit_button
+
+
+class _VisionBrain:
+    def __init__(self, response: str) -> None:
+        self.response = response
+        self.prompts: list[str] = []
+
+    def detect_with_image(self, prompt: str, image: Image.Image) -> str:
+        self.prompts.append(prompt)
+        return self.response
+
+
+def test_find_submit_button_parses_visible_button() -> None:
+    brain = _VisionBrain(
+        'analysis ignored {"found": true, "x": 42, "y": 99, "label": "Sign in"}'
+    )
+    image = Image.new("RGB", (100, 100))
+
+    out = find_submit_button(brain, image, plan_intent="Log in to the dashboard")
+
+    assert out == {"x": 42, "y": 99, "label": "Sign in"}
+    assert "Log in to the dashboard" in brain.prompts[0]
+
+
+def test_find_submit_button_returns_none_when_not_found() -> None:
+    brain = _VisionBrain('{"found": false, "x": 0, "y": 0, "label": ""}')
+    image = Image.new("RGB", (100, 100))
+
+    assert find_submit_button(brain, image) is None


### PR DESCRIPTION
## Summary

- Correct the `force_fill_values` type annotation to match the `{label, value}` dicts returned by the Holo3 detector.
- Wire `find_submit_button()` into the runner's force-submit path so it clicks a detected submit button when available, while preserving the existing Return-key fallback.
- Add focused parser coverage for `find_submit_button()`.

## Impact

This removes stale type information and makes the Holo3 submit-button detector part of the runtime flow instead of dead helper code. If the detector cannot find a button or raises, the runner still falls back to `key_press(Return)`.

## Validation

- `uv run ruff check .`
- `uv run python -m pytest tests/test_holo3_detector.py tests/test_decompose_flag.py tests/test_submit_enter_fallback_debug_dump.py tests/test_gallery_trap.py`