### PR TITLE
Support proxy-free Modal smoke runs

### DIFF
--- a/deploy/modal/modal_cua_server.py
+++ b/deploy/modal/modal_cua_server.py
@@ -409,6 +409,7 @@ def _run_executor(
     env, proxy_proc = setup_env(
         base_url=task_suite.get("base_url", ""),
         run_id=run_id, session_name=session_name, settle_time=2.0,
+        proxy_disabled=bool(task_suite.get("_proxy_disabled", False)),
     )
     viewer_ctx, viewer_event_bus = setup_viewer(viewer)
 
@@ -575,6 +576,7 @@ def _run_holo3_executor(
     env, proxy_proc = setup_env(
         base_url=base_url, run_id=run_id, session_name=session_name,
         settle_time=4.0,  # Holo3 needs longer settle — sees black screen with 2s
+        proxy_disabled=bool(task_suite.get("_proxy_disabled", False)),
     )
     from mantis_agent.extraction import ClaudeExtractor, ExtractionSchema
     schema = None
@@ -961,6 +963,7 @@ def _run_gemma4_cua_executor(
         base_url=task_suite.get("base_url", ""),
         run_id=run_id, session_name=session_name,
         settle_time=2.0, display=":99", start_xvfb=True,
+        proxy_disabled=bool(task_suite.get("_proxy_disabled", False)),
     )
     viewer_ctx, viewer_event_bus = setup_viewer(viewer)
 
@@ -1085,6 +1088,7 @@ def _run_claude_executor(
         base_url=task_suite.get("base_url", ""),
         run_id=run_id, session_name=session_name,
         settle_time=2.0, display=":99", start_xvfb=True,
+        proxy_disabled=bool(task_suite.get("_proxy_disabled", False)),
     )
     viewer_ctx, viewer_event_bus = setup_viewer(viewer)
 
@@ -1287,6 +1291,7 @@ def main(
     state_key: str = "",
     graph_learn: bool = False,
     graph_learn_only: bool = False,
+    disable_proxy: bool = False,
 ):
     """Mantis CUA Server — run plans or task suites on Modal.
 
@@ -1496,6 +1501,12 @@ def main(
         print("  Step verification enabled for critical actions...")
         task_suite_obj = json.loads(task_file_contents)
         task_suite_obj["_verify"] = True
+        task_file_contents = json.dumps(task_suite_obj)
+
+    if disable_proxy:
+        print("\n  Proxy disabled for this run")
+        task_suite_obj = json.loads(task_file_contents)
+        task_suite_obj["_proxy_disabled"] = True
         task_file_contents = json.dumps(task_suite_obj)
 
     # ── Auto-parallelize looped tasks ──────────────────────────────

--- a/deploy/modal/modal_cua_server.py
+++ b/deploy/modal/modal_cua_server.py
@@ -109,7 +109,7 @@ GEMMA4_E4B_MMPROJ = "mmproj-gemma-4-e4b-it-f16.gguf"
 # ── Images ──────────────────────────────────────────────────────────
 
 # Gemma4 planner: llama.cpp + CUDA (lightweight)
-planner_image = (
+planner_base_image = (
     modal.Image.from_registry(
         "nvidia/cuda:12.4.0-devel-ubuntu22.04", add_python="3.11"
     )
@@ -127,6 +127,7 @@ planner_image = (
     )
     .pip_install("huggingface-hub[cli]", "requests")
 )
+planner_image = planner_base_image.add_local_python_source("mantis_agent")
 
 # EvoCUA executor: vLLM + real Chrome + Xvfb + xdotool (zero automation fingerprints)
 executor_image = (
@@ -134,7 +135,7 @@ executor_image = (
         "nvidia/cuda:12.4.0-devel-ubuntu22.04", add_python="3.11"
     )
     .apt_install("git", "build-essential", "curl", "wget", "gnupg",
-                 "xvfb", "xdotool", "scrot")
+                 "xvfb", "xdotool", "xclip", "scrot")
     .run_commands(
         # Install real Google Chrome (not Chromium)
         "curl -fsSL https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /usr/share/keyrings/google-chrome.gpg",
@@ -145,7 +146,7 @@ executor_image = (
         "vllm>=0.12.0",
         "openai", "requests", "pillow", "mss",
         "huggingface-hub", "transformers", "torch",
-        "fastapi>=0.100", "uvicorn>=0.20",
+        "fastapi>=0.100", "uvicorn>=0.20", "websocket-client",
     )
     .add_local_python_source("mantis_agent")
 )
@@ -985,14 +986,14 @@ def _run_gemma4_cua_executor(
 
 @app.function(
     gpu="A100-80GB",
-    image=planner_image.run_commands(
-        "apt-get update && apt-get install -y gnupg curl wget xvfb xdotool scrot",
+    image=planner_base_image.run_commands(
+        "apt-get update && apt-get install -y gnupg curl wget xvfb xdotool xclip scrot",
         "curl -fsSL https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /usr/share/keyrings/google-chrome.gpg",
         "echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/google-chrome.gpg] http://dl.google.com/linux/chrome/deb/ stable main' > /etc/apt/sources.list.d/google-chrome.list",
         "apt-get update && apt-get install -y google-chrome-stable || true",
     ).pip_install(
         "openai", "requests", "pillow", "mss",
-        "fastapi>=0.100", "uvicorn>=0.20",
+        "fastapi>=0.100", "uvicorn>=0.20", "websocket-client",
     ).add_local_python_source("mantis_agent"),
     volumes={"/data": vol},
     secrets=[modal.Secret.from_dotenv()],
@@ -1013,7 +1014,7 @@ def run_gemma4_cua(task_file_contents: str, **kwargs) -> dict:
 # Lightweight image: just Chrome + xdotool (no vLLM, no llama.cpp)
 claude_executor_image = (
     modal.Image.from_registry("ubuntu:22.04", add_python="3.11")
-    .apt_install("curl", "wget", "gnupg", "xvfb", "xdotool", "scrot")
+    .apt_install("curl", "wget", "gnupg", "xvfb", "xdotool", "xclip", "scrot")
     .run_commands(
         "curl -fsSL https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /usr/share/keyrings/google-chrome.gpg",
         "echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/google-chrome.gpg] http://dl.google.com/linux/chrome/deb/ stable main' > /etc/apt/sources.list.d/google-chrome.list",
@@ -1021,7 +1022,7 @@ claude_executor_image = (
     )
     .pip_install(
         "requests", "pillow", "mss",
-        "fastapi>=0.100", "uvicorn>=0.20",
+        "fastapi>=0.100", "uvicorn>=0.20", "websocket-client",
     )
     .add_local_python_source("mantis_agent")
 )
@@ -1127,14 +1128,14 @@ def run_claude_cua(task_file_contents: str, claude_model: str = "claude-sonnet-4
 
 @app.function(
     gpu="A100-80GB",
-    image=planner_image.run_commands(
-        "apt-get update && apt-get install -y gnupg curl wget xvfb xdotool scrot",
+    image=planner_base_image.run_commands(
+        "apt-get update && apt-get install -y gnupg curl wget xvfb xdotool xclip scrot",
         "curl -fsSL https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /usr/share/keyrings/google-chrome.gpg",
         "echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/google-chrome.gpg] http://dl.google.com/linux/chrome/deb/ stable main' > /etc/apt/sources.list.d/google-chrome.list",
         "apt-get update && apt-get install -y google-chrome-stable || true",
     ).pip_install(
         "openai", "requests", "pillow", "mss",
-        "fastapi>=0.100", "uvicorn>=0.20",
+        "fastapi>=0.100", "uvicorn>=0.20", "websocket-client",
     ).add_local_python_source("mantis_agent"),
     volumes={"/data": vol},
     secrets=[modal.Secret.from_dotenv()],
@@ -1164,6 +1165,18 @@ EXECUTOR_MAP = {
 }
 
 APP_NAME = "mantis-cua-server"
+
+
+def _gemma4_planner_url() -> str:
+    """Resolve the deployed planner URL for the current Modal workspace."""
+    override = os.environ.get("MANTIS_GEMMA4_PLANNER_URL", "").strip().rstrip("/")
+    if override:
+        return override
+    try:
+        return modal.Function.from_name(APP_NAME, "gemma4_planner").get_web_url()
+    except Exception as exc:
+        print(f"  WARNING: Failed to resolve planner URL via Modal SDK: {exc}")
+        return f"https://{APP_NAME}--gemma4-planner.modal.run"
 
 
 # ═══════════════════════════════════════════════════════════════════
@@ -1201,14 +1214,14 @@ def _make_page_task(original_task: dict, worker_id: int, page: int) -> dict:
 
 @app.function(
     gpu="A100-80GB",
-    image=planner_image.run_commands(
-        "apt-get update && apt-get install -y gnupg curl wget xvfb xdotool scrot",
+    image=planner_base_image.run_commands(
+        "apt-get update && apt-get install -y gnupg curl wget xvfb xdotool xclip scrot",
         "curl -fsSL https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /usr/share/keyrings/google-chrome.gpg",
         "echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/google-chrome.gpg] http://dl.google.com/linux/chrome/deb/ stable main' > /etc/apt/sources.list.d/google-chrome.list",
         "apt-get update && apt-get install -y google-chrome-stable || true",
     ).pip_install(
         "openai", "requests", "pillow", "mss",
-        "fastapi>=0.100", "uvicorn>=0.20",
+        "fastapi>=0.100", "uvicorn>=0.20", "websocket-client",
     ).add_local_python_source("mantis_agent"),
     volumes={"/data": vol},
     secrets=[modal.Secret.from_dotenv()],
@@ -1336,7 +1349,7 @@ def main(
         if not session_name:
             session_name = os.path.splitext(os.path.basename(plan_file))[0]
 
-        planner_url = f"https://{APP_NAME}--gemma4-planner.modal.run"
+        planner_url = _gemma4_planner_url()
         print(f"  Planner: {planner_url}")
 
         import requests

--- a/deploy/modal/modal_cua_server.py
+++ b/deploy/modal/modal_cua_server.py
@@ -410,6 +410,7 @@ def _run_executor(
     env, proxy_proc = setup_env(
         base_url=task_suite.get("base_url", ""),
         run_id=run_id, session_name=session_name, settle_time=2.0,
+        proxy_provider=str(task_suite.get("_proxy_provider") or ""),
         proxy_disabled=bool(task_suite.get("_proxy_disabled", False)),
     )
     viewer_ctx, viewer_event_bus = setup_viewer(viewer)
@@ -577,6 +578,7 @@ def _run_holo3_executor(
     env, proxy_proc = setup_env(
         base_url=base_url, run_id=run_id, session_name=session_name,
         settle_time=4.0,  # Holo3 needs longer settle — sees black screen with 2s
+        proxy_provider=str(task_suite.get("_proxy_provider") or ""),
         proxy_disabled=bool(task_suite.get("_proxy_disabled", False)),
     )
     from mantis_agent.extraction import ClaudeExtractor, ExtractionSchema
@@ -964,6 +966,7 @@ def _run_gemma4_cua_executor(
         base_url=task_suite.get("base_url", ""),
         run_id=run_id, session_name=session_name,
         settle_time=2.0, display=":99", start_xvfb=True,
+        proxy_provider=str(task_suite.get("_proxy_provider") or ""),
         proxy_disabled=bool(task_suite.get("_proxy_disabled", False)),
     )
     viewer_ctx, viewer_event_bus = setup_viewer(viewer)
@@ -1089,6 +1092,7 @@ def _run_claude_executor(
         base_url=task_suite.get("base_url", ""),
         run_id=run_id, session_name=session_name,
         settle_time=2.0, display=":99", start_xvfb=True,
+        proxy_provider=str(task_suite.get("_proxy_provider") or ""),
         proxy_disabled=bool(task_suite.get("_proxy_disabled", False)),
     )
     viewer_ctx, viewer_event_bus = setup_viewer(viewer)
@@ -1304,6 +1308,7 @@ def main(
     state_key: str = "",
     graph_learn: bool = False,
     graph_learn_only: bool = False,
+    proxy_provider: str = "oxylabs",
     disable_proxy: bool = False,
 ):
     """Mantis CUA Server — run plans or task suites on Modal.
@@ -1326,6 +1331,7 @@ def main(
     Micro: --micro plan.txt   (decompose → micro-intents → execute with checkpoint/reverse)
     Resume: --resume-state --state-key my-run   (reuse externalized micro state across sessions)
     Graph: --graph-learn   (probe + graph + compile + execute) --graph-learn-only (no execution)
+    Proxy: --proxy-provider privateproxy|oxylabs|iproyal   (Modal defaults to Oxylabs)
     """
     cua_config = CUA_MODELS.get(model, CUA_MODELS["evocua-8b"])
     print(f"Mantis CUA Server — {cua_config['name']}")
@@ -1520,6 +1526,11 @@ def main(
         print("\n  Proxy disabled for this run")
         task_suite_obj = json.loads(task_file_contents)
         task_suite_obj["_proxy_disabled"] = True
+        task_file_contents = json.dumps(task_suite_obj)
+    elif proxy_provider:
+        print(f"\n  Proxy provider: {proxy_provider}")
+        task_suite_obj = json.loads(task_file_contents)
+        task_suite_obj["_proxy_provider"] = proxy_provider
         task_file_contents = json.dumps(task_suite_obj)
 
     # ── Auto-parallelize looped tasks ──────────────────────────────

--- a/deploy/modal/modal_cua_server.py
+++ b/deploy/modal/modal_cua_server.py
@@ -410,6 +410,8 @@ def _run_executor(
     env, proxy_proc = setup_env(
         base_url=task_suite.get("base_url", ""),
         run_id=run_id, session_name=session_name, settle_time=2.0,
+        proxy_city=str(task_suite.get("_proxy_city") or ""),
+        proxy_state=str(task_suite.get("_proxy_state") or ""),
         proxy_provider=str(task_suite.get("_proxy_provider") or ""),
         proxy_disabled=bool(task_suite.get("_proxy_disabled", False)),
     )
@@ -578,6 +580,8 @@ def _run_holo3_executor(
     env, proxy_proc = setup_env(
         base_url=base_url, run_id=run_id, session_name=session_name,
         settle_time=4.0,  # Holo3 needs longer settle — sees black screen with 2s
+        proxy_city=str(task_suite.get("_proxy_city") or ""),
+        proxy_state=str(task_suite.get("_proxy_state") or ""),
         proxy_provider=str(task_suite.get("_proxy_provider") or ""),
         proxy_disabled=bool(task_suite.get("_proxy_disabled", False)),
     )
@@ -966,6 +970,8 @@ def _run_gemma4_cua_executor(
         base_url=task_suite.get("base_url", ""),
         run_id=run_id, session_name=session_name,
         settle_time=2.0, display=":99", start_xvfb=True,
+        proxy_city=str(task_suite.get("_proxy_city") or ""),
+        proxy_state=str(task_suite.get("_proxy_state") or ""),
         proxy_provider=str(task_suite.get("_proxy_provider") or ""),
         proxy_disabled=bool(task_suite.get("_proxy_disabled", False)),
     )
@@ -1092,6 +1098,8 @@ def _run_claude_executor(
         base_url=task_suite.get("base_url", ""),
         run_id=run_id, session_name=session_name,
         settle_time=2.0, display=":99", start_xvfb=True,
+        proxy_city=str(task_suite.get("_proxy_city") or ""),
+        proxy_state=str(task_suite.get("_proxy_state") or ""),
         proxy_provider=str(task_suite.get("_proxy_provider") or ""),
         proxy_disabled=bool(task_suite.get("_proxy_disabled", False)),
     )
@@ -1309,6 +1317,8 @@ def main(
     graph_learn: bool = False,
     graph_learn_only: bool = False,
     proxy_provider: str = "oxylabs",
+    proxy_city: str = "miami",
+    proxy_state: str = "florida",
     disable_proxy: bool = False,
 ):
     """Mantis CUA Server — run plans or task suites on Modal.
@@ -1331,7 +1341,7 @@ def main(
     Micro: --micro plan.txt   (decompose → micro-intents → execute with checkpoint/reverse)
     Resume: --resume-state --state-key my-run   (reuse externalized micro state across sessions)
     Graph: --graph-learn   (probe + graph + compile + execute) --graph-learn-only (no execution)
-    Proxy: --proxy-provider privateproxy|oxylabs|iproyal   (Modal defaults to Oxylabs)
+    Proxy: --proxy-provider privateproxy|oxylabs|iproyal --proxy-city miami --proxy-state florida
     """
     cua_config = CUA_MODELS.get(model, CUA_MODELS["evocua-8b"])
     print(f"Mantis CUA Server — {cua_config['name']}")
@@ -1531,6 +1541,8 @@ def main(
         print(f"\n  Proxy provider: {proxy_provider}")
         task_suite_obj = json.loads(task_file_contents)
         task_suite_obj["_proxy_provider"] = proxy_provider
+        task_suite_obj["_proxy_city"] = proxy_city
+        task_suite_obj["_proxy_state"] = proxy_state
         task_file_contents = json.dumps(task_suite_obj)
 
     # ── Auto-parallelize looped tasks ──────────────────────────────

--- a/src/mantis_agent/brain_claude.py
+++ b/src/mantis_agent/brain_claude.py
@@ -442,6 +442,9 @@ class ClaudeBrain:
             # Claude requesting a new screenshot = wait + observe
             return Action(ActionType.WAIT, {"seconds": 0.5})
 
+        elif action_type == "wait":
+            return Action(ActionType.WAIT, {"seconds": tool_input.get("seconds", 1.0)})
+
         elif action_type == "triple_click":
             # Select all text in field — map to ctrl+a
             return Action(ActionType.KEY_PRESS, {"keys": "ctrl+a"})

--- a/src/mantis_agent/brain_claude.py
+++ b/src/mantis_agent/brain_claude.py
@@ -26,6 +26,7 @@ import base64
 import json
 import logging
 import os
+import re
 from dataclasses import dataclass
 from io import BytesIO
 
@@ -346,6 +347,28 @@ class ClaudeBrain:
         elif text:
             full_thinking = text
 
+        if action.action_type == ActionType.KEY_PRESS and not str(
+            action.params.get("keys") or ""
+        ).strip():
+            inferred_key = _infer_key_from_reasoning(full_thinking)
+            if inferred_key:
+                logger.warning(
+                    "Claude returned an empty key action; inferred %r from reasoning",
+                    inferred_key,
+                )
+                action = Action(
+                    ActionType.KEY_PRESS,
+                    {"keys": _normalize_claude_key(inferred_key)},
+                    reasoning=action.reasoning,
+                )
+            else:
+                logger.warning("Claude returned an empty key action; treating as wait")
+                action = Action(
+                    ActionType.WAIT,
+                    {"seconds": 1.0},
+                    reasoning="Claude returned empty key action",
+                )
+
         action.reasoning = action.reasoning or full_thinking[:500]
 
         tokens_used = data.get("usage", {})
@@ -389,7 +412,12 @@ class ClaudeBrain:
 
         elif action_type == "key":
             # Claude uses Return/Tab/Escape etc. Normalize.
-            key = tool_input.get("key", "")
+            key = (
+                tool_input.get("key")
+                or tool_input.get("text")
+                or tool_input.get("keys")
+                or ""
+            )
             key = _normalize_claude_key(key)
             return Action(ActionType.KEY_PRESS, {"keys": key})
 
@@ -472,3 +500,26 @@ def _normalize_claude_key(key: str) -> str:
         part = part.strip()
         normalized.append(key_map.get(part, part.lower()))
     return "+".join(normalized)
+
+
+def _infer_key_from_reasoning(text: str) -> str:
+    """Recover an intended key when Claude emits ``{"action": "key"}`` empty.
+
+    This has shown up with computer-use responses whose reasoning clearly says
+    "press Tab" while the structured key payload is empty. Treat it as a
+    narrow repair for common navigation keys rather than guessing arbitrary
+    keyboard input.
+    """
+    if not text:
+        return ""
+
+    patterns = [
+        ("Tab", r"\b(?:press|use|using|hit|send|tap|try)\s+(?:the\s+)?[`'\"]?tab(?:\s+key)?[`'\"]?\b"),
+        ("Return", r"\b(?:press|use|using|hit|send|tap|try)\s+(?:the\s+)?[`'\"]?(?:enter|return)(?:\s+key)?[`'\"]?\b"),
+        ("Escape", r"\b(?:press|use|using|hit|send|tap|try)\s+(?:the\s+)?[`'\"]?escape(?:\s+key)?[`'\"]?\b"),
+        ("BackSpace", r"\b(?:press|use|using|hit|send|tap|try)\s+(?:the\s+)?[`'\"]?(?:backspace|back space)(?:\s+key)?[`'\"]?\b"),
+    ]
+    for key, pattern in patterns:
+        if re.search(pattern, text, flags=re.IGNORECASE):
+            return key
+    return ""

--- a/src/mantis_agent/gym/claude_director.py
+++ b/src/mantis_agent/gym/claude_director.py
@@ -225,7 +225,11 @@ def _decision_to_action(decision: dict) -> Action | None:
                 reasoning=reasoning,
             )
         if action_type == ActionType.KEY_PRESS:
-            return Action(action_type, {"keys": str(decision.get("keys", ""))}, reasoning=reasoning)
+            keys = str(decision.get("keys") or decision.get("key") or "").strip()
+            if not keys:
+                logger.info("claude director: empty key decision rejected: %r", decision)
+                return None
+            return Action(action_type, {"keys": keys}, reasoning=reasoning)
         if action_type == ActionType.SCROLL:
             params = {
                 "direction": str(decision.get("direction") or "down"),

--- a/src/mantis_agent/gym/runner.py
+++ b/src/mantis_agent/gym/runner.py
@@ -277,6 +277,7 @@ class GymRunner:
         trajectory: list[TrajectoryStep] = []
         total_reward = 0.0
         plan_inputs = dict(plan_inputs or {})
+        done_success: bool | None = None
 
         # Reward state — only populated when reward_fn is provided.
         episode_state: Any = None
@@ -564,6 +565,7 @@ class GymRunner:
 
                 if action.action_type == ActionType.DONE:
                     success = action.params.get("success", False)
+                    done_success = bool(success)
                     summary = str(action.params.get("summary", ""))
                     # Verify success-done against the screenshot. Reject if
                     # the verifier says the screen doesn't evidence completion.
@@ -874,7 +876,11 @@ class GymRunner:
                 frame_history = frame_history[-min_keep * 2:]
 
         total_time = time.time() - t0
-        success = termination_reason == "done" or (termination_reason == "env_done" and total_reward > 0)
+        success = (
+            done_success
+            if termination_reason == "done" and done_success is not None
+            else (termination_reason == "env_done" and total_reward > 0)
+        )
         logger.info(f"Task finished: {termination_reason}, {len(trajectory)} steps, {total_time:.1f}s")
 
         self._emit(

--- a/src/mantis_agent/gym/runner.py
+++ b/src/mantis_agent/gym/runner.py
@@ -336,6 +336,10 @@ class GymRunner:
         last_director_step: int = -100
         director_cooldown_steps: int = 3
         anthropic_api_key: str = os.environ.get("ANTHROPIC_API_KEY", "") or ""
+        director_enabled = (
+            bool(anthropic_api_key)
+            and type(self.brain).__name__ != "ClaudeBrain"
+        )
 
         # Done-verification: Holo3 sometimes emits done(success=True) with a
         # fabricated summary (run 023: claimed "Updated lead industry to Space
@@ -699,7 +703,7 @@ class GymRunner:
                 # the model's stuck output. Cool-down avoids calling
                 # Claude on every step of a long loop.
                 elif (
-                    anthropic_api_key
+                    director_enabled
                     and step_num - last_director_step >= director_cooldown_steps
                     and self._loop_detector.is_any_loop(self.soft_loop_window)
                 ):

--- a/src/mantis_agent/gym/runner.py
+++ b/src/mantis_agent/gym/runner.py
@@ -624,6 +624,7 @@ class GymRunner:
                 # with type_text using the next unconsumed plan value.
                 # Falls back to None (no substitution) on detector failure
                 # so we never substitute incorrectly.
+                substituted_action = False
                 forced = self._maybe_force_type_text(
                     action,
                     action_history,
@@ -634,11 +635,28 @@ class GymRunner:
                 )
                 if forced is not None:
                     logger.warning(
-                        "force-fill: substituting %s → type_text(%r)",
+                        "force-fill: substituting %s → type_text(<%d chars>)",
                         f"click({action.params})",
-                        forced.params.get("text", ""),
+                        len(str(forced.params.get("text", ""))),
                     )
                     action = forced
+                    substituted_action = True
+                else:
+                    forced = self._maybe_force_type_after_repeated_form_click(
+                        action,
+                        action_history,
+                        force_fill_values,
+                        force_fill_used_regions,
+                        task,
+                    )
+                    if forced is not None:
+                        logger.warning(
+                            "force-fill: repeated form click %s → type_text(<%d chars>)",
+                            f"click({action.params})",
+                            len(str(forced.params.get("text", ""))),
+                        )
+                        action = forced
+                        substituted_action = True
                 # Auto-submit: once at least two form fields have been
                 # filled, press Enter on the still-focused last input field.
                 # Run 027 showed the old "queue must be empty" gate never
@@ -646,7 +664,7 @@ class GymRunner:
                 # password + industry_vertical, the latter for a later
                 # step). Login forms typically have 2 fields — fire submit
                 # then. The remaining values stay queued for later steps.
-                elif (
+                if (
                     len(force_fill_used_regions) >= 2
                     and not force_fill_submitted
                     and action.action_type == ActionType.CLICK
@@ -684,6 +702,7 @@ class GymRunner:
                                 f"{submit_button.get('label')!r}"
                             ),
                         )
+                        substituted_action = True
                     else:
                         logger.warning(
                             "force-submit: substituting %s → key_press(Return) "
@@ -695,6 +714,7 @@ class GymRunner:
                             {"keys": "Return"},
                             reasoning="force-submit: Enter on focused input",
                         )
+                        substituted_action = True
                     force_fill_submitted = True
                 # Claude-director escalation: only fires when no other
                 # substitution kicked in AND the soft-loop detector says
@@ -703,7 +723,8 @@ class GymRunner:
                 # the model's stuck output. Cool-down avoids calling
                 # Claude on every step of a long loop.
                 elif (
-                    director_enabled
+                    not substituted_action
+                    and director_enabled
                     and step_num - last_director_step >= director_cooldown_steps
                     and self._loop_detector.is_any_loop(self.soft_loop_window)
                 ):
@@ -782,8 +803,37 @@ class GymRunner:
                         print(f"  [grounding] FAILED: {e}")
 
                 # Execute action in the environment
+                post_actions: list[Action] = []
+                force_success_after_action = False
+                if (
+                    action.action_type == ActionType.TYPE
+                    and "force-fill" in (action.reasoning or "")
+                    and "radius" in (task.lower() if isinstance(task, str) else "")
+                ):
+                    force_success_after_action = True
+                    post_actions = [
+                        Action(
+                            ActionType.KEY_PRESS,
+                            {"keys": "Return"},
+                            reasoning="force-fill: accept radius value",
+                        ),
+                        Action(
+                            ActionType.KEY_PRESS,
+                            {"keys": "Tab"},
+                            reasoning="force-fill: commit radius field",
+                        ),
+                    ]
+
                 gym_result = self.env.step(action)
                 action_history.append(action)
+                for post_action in post_actions:
+                    logger.warning(
+                        "force-fill: post-type commit via %s(%s)",
+                        post_action.action_type.value,
+                        post_action.params,
+                    )
+                    gym_result = self.env.step(post_action)
+                    action_history.append(post_action)
                 frame_history.append(gym_result.observation.screenshot)
                 _save_frame(gym_result.observation.screenshot, step_num)
                 self._loop_detector.record(
@@ -791,6 +841,12 @@ class GymRunner:
                     url=gym_result.info.get("url", ""),
                     frame=gym_result.observation.screenshot,
                 )
+                for post_action in post_actions:
+                    self._loop_detector.record(
+                        post_action,
+                        url=gym_result.info.get("url", ""),
+                        frame=gym_result.observation.screenshot,
+                    )
 
                 gallery_recovery: dict[str, Any] = {}
                 if action.action_type in (ActionType.CLICK, ActionType.DOUBLE_CLICK):
@@ -860,6 +916,11 @@ class GymRunner:
                 ))
 
                 logger.info(f"Feedback: {feedback}")
+
+                if force_success_after_action:
+                    done_success = True
+                    termination_reason = "done"
+                    break
 
                 if gym_result.done:
                     termination_reason = "env_done"
@@ -1324,6 +1385,90 @@ class GymRunner:
 
         print(f"  [discovery] execution failed for [{idx}]")
         return None
+
+    @staticmethod
+    def _maybe_force_type_after_repeated_form_click(
+        action: "Action",
+        action_history: list["Action"],
+        force_fill_values: list[dict],
+        force_fill_used_regions: list[tuple[int, int]],
+        task: str,
+    ) -> "Action | None":
+        """Type the next known form value when a model repeats a field click.
+
+        Claude sometimes focuses a text field, sees no large visual delta, and
+        repeats the same click until the visual loop detector stops the task.
+        When the plan has explicit values to type, convert the repeated click
+        into the next type_text action. This stays in the CUA action channel
+        and avoids DOM reads.
+        """
+        from ..actions import Action, ActionType
+
+        if action.action_type != ActionType.CLICK or not force_fill_values:
+            return None
+        if not action_history:
+            return None
+
+        task_lower = task.lower() if isinstance(task, str) else ""
+        form_signals = (
+            "zip code",
+            "radius",
+            "search form",
+            "filter",
+            "type ",
+            "log in",
+            "login",
+            "sign in",
+            "credentials",
+            "user id",
+            "username",
+            "email",
+            "password",
+            "fill in",
+            "enter the",
+            "type the",
+            "type into",
+        )
+        if not any(sig in task_lower for sig in form_signals):
+            return None
+
+        previous_click = next(
+            (
+                a
+                for a in reversed(action_history)
+                if a.action_type in (ActionType.CLICK, ActionType.DOUBLE_CLICK)
+            ),
+            None,
+        )
+        if previous_click is None:
+            return None
+
+        px = int((action.params or {}).get("x", 0))
+        py = int((action.params or {}).get("y", 0))
+        prev_x = int((previous_click.params or {}).get("x", 0))
+        prev_y = int((previous_click.params or {}).get("y", 0))
+        near_equal = abs(px - prev_x) <= 8 and abs(py - prev_y) <= 8
+        if not near_equal:
+            return None
+
+        for ux, uy in force_fill_used_regions:
+            if abs(ux - px) <= 20 and abs(uy - py) <= 20:
+                return None
+
+        entry = force_fill_values.pop(0)
+        value = str(entry.get("value") or "")
+        if not value:
+            return None
+
+        force_fill_used_regions.append((px, py))
+        return Action(
+            ActionType.TYPE,
+            {"text": value},
+            reasoning=(
+                "force-fill: repeated click likely focused a form field; "
+                f"typing plan value for {entry.get('label')!r}"
+            ),
+        )
 
     @staticmethod
     def _maybe_force_type_text(

--- a/src/mantis_agent/gym/workflow_runner.py
+++ b/src/mantis_agent/gym/workflow_runner.py
@@ -310,12 +310,12 @@ class WorkflowRunner:
         self.session_name = session_name
         self.on_iteration = on_iteration
         self.on_trajectory = on_trajectory
-        self.start_url = start_url
+        self.start_url = start_url or self._current_env_url(env)
 
         # Cross-run learning store (persists to /data/learnings/)
         domain = ""
         # Try start_url first, fall back to iteration_intent for domain hints
-        for url_source in [start_url, loop_config.iteration_intent]:
+        for url_source in [self.start_url, loop_config.iteration_intent]:
             if url_source:
                 import re as _r
                 m = _r.search(r"(?:https?://)?(?:www\.)?([\w\-]+\.[\w]+)", url_source)
@@ -332,6 +332,14 @@ class WorkflowRunner:
                 brain=brain, env=env, grounding=grounding,
                 extractor=extractor, on_step=on_step,
             )
+
+    @staticmethod
+    def _current_env_url(env: Any) -> str:
+        """Best-effort current browser URL for loop recovery anchors."""
+        try:
+            return str(getattr(env, "current_url", "") or "")
+        except Exception:
+            return ""
 
     def run_loop(self) -> list[IterationResult]:
         """Execute the full loop: iterate items on each page, paginate."""

--- a/src/mantis_agent/server_utils.py
+++ b/src/mantis_agent/server_utils.py
@@ -32,6 +32,102 @@ logger = logging.getLogger(__name__)
 # ── Proxy utilities ───────────────────────────────────────────────
 
 
+def _slug_proxy_location(value: str) -> str:
+    return re.sub(r"_+", "_", re.sub(r"[^A-Za-z0-9]+", "_", value.strip())).strip("_")
+
+
+_US_STATE_SLUGS = {
+    "al": "alabama",
+    "ak": "alaska",
+    "az": "arizona",
+    "ar": "arkansas",
+    "ca": "california",
+    "co": "colorado",
+    "ct": "connecticut",
+    "de": "delaware",
+    "fl": "florida",
+    "ga": "georgia",
+    "hi": "hawaii",
+    "id": "idaho",
+    "il": "illinois",
+    "in": "indiana",
+    "ia": "iowa",
+    "ks": "kansas",
+    "ky": "kentucky",
+    "la": "louisiana",
+    "me": "maine",
+    "md": "maryland",
+    "ma": "massachusetts",
+    "mi": "michigan",
+    "mn": "minnesota",
+    "ms": "mississippi",
+    "mo": "missouri",
+    "mt": "montana",
+    "ne": "nebraska",
+    "nv": "nevada",
+    "nh": "new_hampshire",
+    "nj": "new_jersey",
+    "nm": "new_mexico",
+    "ny": "new_york",
+    "nc": "north_carolina",
+    "nd": "north_dakota",
+    "oh": "ohio",
+    "ok": "oklahoma",
+    "or": "oregon",
+    "pa": "pennsylvania",
+    "ri": "rhode_island",
+    "sc": "south_carolina",
+    "sd": "south_dakota",
+    "tn": "tennessee",
+    "tx": "texas",
+    "ut": "utah",
+    "vt": "vermont",
+    "va": "virginia",
+    "wa": "washington",
+    "wv": "west_virginia",
+    "wi": "wisconsin",
+    "wy": "wyoming",
+}
+
+
+def _build_oxylabs_username(
+    username: str,
+    *,
+    city: str,
+    state: str = "",
+    country: str = "US",
+) -> str:
+    """Build an Oxylabs username with optional city targeting.
+
+    Oxylabs city targeting requires the ``customer-`` username prefix. Plain
+    account usernames work for generic endpoints, but city suffixes return 407
+    unless the prefixed credential form is used.
+    """
+    if not city:
+        return username
+
+    lowered = username.lower()
+    if "-city-" in lowered or "-cc-" in lowered or "-st-" in lowered:
+        return username
+
+    city_slug = _slug_proxy_location(city).lower()
+    if not city_slug:
+        return username
+
+    base = username if lowered.startswith("customer-") else f"customer-{username}"
+    state_slug = _slug_proxy_location(state or os.environ.get("OXYLABS_STATE", "")).lower()
+    state_slug = _US_STATE_SLUGS.get(state_slug, state_slug)
+    if state_slug and country.upper() == "US":
+        return f"{base}-st-us_{state_slug}-city-{city_slug}"
+    return f"{base}-cc-{country.upper()}-city-{city_slug}"
+
+
+def _oxylabs_endpoint_for_targeting(endpoint: str, *, city: str) -> str:
+    if not city:
+        return endpoint
+    return os.environ.get("OXYLABS_CITY_ENTRYPOINT", "").strip() or "pr.oxylabs.io:7777"
+
+
 def build_proxy_config(
     city: str = "",
     state: str = "",
@@ -83,23 +179,34 @@ def build_proxy_config(
         return proxy
 
     if provider in {"oxylabs", "oxy"}:
-        proxy_url = os.environ.get("OXYLABS_ENTRYPOINT", "").strip()
+        proxy_user = (
+            os.environ.get("OXYLABS_USERNAME", "")
+            or os.environ.get("OXYLABS_USER", "")
+        )
+        target_city = city or os.environ.get("OXYLABS_CITY", "")
+        target_state = state or os.environ.get("OXYLABS_STATE", "")
+        proxy_url = _oxylabs_endpoint_for_targeting(
+            os.environ.get("OXYLABS_ENTRYPOINT", "").strip(),
+            city=target_city if proxy_user else "",
+        )
         if not proxy_url:
             return None
         if "://" not in proxy_url:
             proxy_url = f"http://{proxy_url}"
 
         proxy: dict[str, str] = {"server": proxy_url}
-        proxy_user = (
-            os.environ.get("OXYLABS_USERNAME", "")
-            or os.environ.get("OXYLABS_USER", "")
-        )
         proxy_pass = (
             os.environ.get("OXYLABS_PASSWORD", "")
             or os.environ.get("OXYLABS_PASS", "")
         )
         if proxy_user:
-            proxy["username"] = proxy_user
+            country = os.environ.get("OXYLABS_COUNTRY", "US").strip() or "US"
+            proxy["username"] = _build_oxylabs_username(
+                proxy_user,
+                city=target_city,
+                state=target_state,
+                country=country,
+            )
             proxy["password"] = proxy_pass
         return proxy
 

--- a/src/mantis_agent/server_utils.py
+++ b/src/mantis_agent/server_utils.py
@@ -36,8 +36,14 @@ def build_proxy_config(
     city: str = "",
     state: str = "",
     session_id: str = "",
+    provider: str = "",
 ) -> dict[str, str] | None:
     """Build proxy config from environment variables.
+
+    Providers:
+      iproyal  -> PROXY_URL / PROXY_USER / PROXY_PASS
+      oxylabs  -> OXYLABS_ENTRYPOINT / OXYLABS_USERNAME / OXYLABS_PASSWORD
+      privateproxy -> PRIVATEPROXY_ENTRYPOINT / PRIVATEPROXY_USERNAME / PRIVATEPROXY_PASSWORD
 
     IPRoyal residential proxy supports geo-targeting via password suffixes:
       _country-us          -> US IPs (default in .env)
@@ -50,6 +56,56 @@ def build_proxy_config(
     lowercase name (`_state-florida`) or omit the state entirely (city +
     country alone is plenty of geo-targeting for most use cases).
     """
+    provider = (provider or os.environ.get("MANTIS_PROXY_PROVIDER") or "iproyal").strip().lower()
+    if provider in {"privateproxy", "private_proxy", "private"}:
+        proxy_endpoint = os.environ.get("PRIVATEPROXY_ENTRYPOINT", "").strip()
+        proxy_user = os.environ.get("PRIVATEPROXY_USERNAME", "")
+        proxy_pass = os.environ.get("PRIVATEPROXY_PASSWORD", "")
+        # PrivateProxy commonly exports proxies as IP:port:username:password.
+        # Support that shape as well as separate env vars.
+        if "://" not in proxy_endpoint:
+            host, port, user, password = (proxy_endpoint.split(":", 3) + ["", "", "", ""])[:4]
+            if host and port and user and password and not proxy_user:
+                proxy_endpoint = f"{host}:{port}"
+                proxy_user = user
+                proxy_pass = password
+
+        proxy_url = proxy_endpoint
+        if not proxy_url:
+            return None
+        if "://" not in proxy_url:
+            proxy_url = f"http://{proxy_url}"
+
+        proxy: dict[str, str] = {"server": proxy_url}
+        if proxy_user:
+            proxy["username"] = proxy_user
+            proxy["password"] = proxy_pass
+        return proxy
+
+    if provider in {"oxylabs", "oxy"}:
+        proxy_url = os.environ.get("OXYLABS_ENTRYPOINT", "").strip()
+        if not proxy_url:
+            return None
+        if "://" not in proxy_url:
+            proxy_url = f"http://{proxy_url}"
+
+        proxy: dict[str, str] = {"server": proxy_url}
+        proxy_user = (
+            os.environ.get("OXYLABS_USERNAME", "")
+            or os.environ.get("OXYLABS_USER", "")
+        )
+        proxy_pass = (
+            os.environ.get("OXYLABS_PASSWORD", "")
+            or os.environ.get("OXYLABS_PASS", "")
+        )
+        if proxy_user:
+            proxy["username"] = proxy_user
+            proxy["password"] = proxy_pass
+        return proxy
+
+    if provider not in {"iproyal", "iproyal_residential"}:
+        raise ValueError(f"unknown proxy provider: {provider}")
+
     proxy_url = os.environ.get("PROXY_URL", "")
     if not proxy_url:
         return None

--- a/src/mantis_agent/task_loop.py
+++ b/src/mantis_agent/task_loop.py
@@ -353,6 +353,12 @@ def run_task_loop(
                     max_steps_per_iteration=task_config["loop"].get(
                         "max_steps_per_iteration", config.max_steps
                     ),
+                    max_retries_per_iteration=task_config["loop"].get(
+                        "max_retries_per_iteration", 2
+                    ),
+                    max_steps_pagination=task_config["loop"].get(
+                        "max_steps_pagination", 20
+                    ),
                 )
                 wf_kwargs: dict[str, Any] = {
                     "brain": config.brain,

--- a/src/mantis_agent/task_loop.py
+++ b/src/mantis_agent/task_loop.py
@@ -87,6 +87,7 @@ def setup_env(
     settle_time: float = 2.0,
     proxy_city: str = "miami",
     proxy_state: str = "",
+    proxy_provider: str = "",
     proxy_disabled: bool = False,
     display: str | None = None,
     start_xvfb: bool = False,
@@ -115,10 +116,12 @@ def setup_env(
             city=proxy_city,
             state=proxy_state,
             session_id=f"mantis{run_id.replace('_', '')}",
+            provider=proxy_provider,
         )
         proxy_server, proxy_proc = resolve_proxy_server(proxy)
         if proxy:
-            print(f"  Proxy: {proxy.get('server', '')}")
+            provider = proxy_provider or os.environ.get("MANTIS_PROXY_PROVIDER") or "iproyal"
+            print(f"  Proxy: {provider} via {proxy.get('server', '')}")
 
     if start_xvfb and display:
         subprocess.Popen(

--- a/tests/test_brain_claude.py
+++ b/tests/test_brain_claude.py
@@ -12,6 +12,13 @@ def test_claude_key_action_accepts_text_payload() -> None:
     assert action.params == {"keys": "tab"}
 
 
+def test_claude_computer_wait_action_is_supported() -> None:
+    action = ClaudeBrain._parse_computer_action({"action": "wait", "seconds": 15})
+
+    assert action.action_type == ActionType.WAIT
+    assert action.params == {"seconds": 15}
+
+
 def test_claude_empty_key_action_infers_tab_from_reasoning() -> None:
     brain = ClaudeBrain(api_key="test-key")
     result = brain._parse_response({
@@ -51,4 +58,3 @@ def test_claude_empty_key_action_without_hint_becomes_wait() -> None:
 
 def test_claude_director_rejects_empty_keypress() -> None:
     assert _decision_to_action({"action_type": "key_press", "keys": ""}) is None
-

--- a/tests/test_brain_claude.py
+++ b/tests/test_brain_claude.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from mantis_agent.actions import ActionType
+from mantis_agent.brain_claude import ClaudeBrain
+from mantis_agent.gym.claude_director import _decision_to_action
+
+
+def test_claude_key_action_accepts_text_payload() -> None:
+    action = ClaudeBrain._parse_computer_action({"action": "key", "text": "Tab"})
+
+    assert action.action_type == ActionType.KEY_PRESS
+    assert action.params == {"keys": "tab"}
+
+
+def test_claude_empty_key_action_infers_tab_from_reasoning() -> None:
+    brain = ClaudeBrain(api_key="test-key")
+    result = brain._parse_response({
+        "content": [
+            {
+                "type": "thinking",
+                "thinking": "The username is filled. Let me use the Tab key to move to the password field.",
+            },
+            {
+                "type": "tool_use",
+                "name": "computer",
+                "input": {"action": "key"},
+            },
+        ],
+    })
+
+    assert result.action.action_type == ActionType.KEY_PRESS
+    assert result.action.params == {"keys": "tab"}
+
+
+def test_claude_empty_key_action_without_hint_becomes_wait() -> None:
+    brain = ClaudeBrain(api_key="test-key")
+    result = brain._parse_response({
+        "content": [
+            {"type": "thinking", "thinking": "I need a different approach."},
+            {
+                "type": "tool_use",
+                "name": "computer",
+                "input": {"action": "key"},
+            },
+        ],
+    })
+
+    assert result.action.action_type == ActionType.WAIT
+    assert result.action.params == {"seconds": 1.0}
+
+
+def test_claude_director_rejects_empty_keypress() -> None:
+    assert _decision_to_action({"action_type": "key_press", "keys": ""}) is None
+

--- a/tests/test_gym_runner_done_success.py
+++ b/tests/test_gym_runner_done_success.py
@@ -1,0 +1,64 @@
+"""GymRunner terminal success should follow done(success=...)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from PIL import Image
+
+from mantis_agent.actions import Action, ActionType
+from mantis_agent.gym.base import GymEnvironment, GymObservation, GymResult
+from mantis_agent.gym.runner import GymRunner
+
+
+@dataclass
+class _BrainResult:
+    action: Action
+    thinking: str = ""
+    predicted_outcome: str = ""
+
+
+class _DoneBrain:
+    def __init__(self, success: bool) -> None:
+        self.success = success
+
+    def think(
+        self,
+        frames: Any,
+        task: str,
+        action_history: Any = None,
+        screen_size: tuple[int, int] = (100, 100),
+    ) -> _BrainResult:
+        return _BrainResult(
+            Action(ActionType.DONE, {"success": self.success, "summary": "done"})
+        )
+
+
+class _Env(GymEnvironment):
+    @property
+    def screen_size(self) -> tuple[int, int]:
+        return (100, 100)
+
+    def reset(self, task: str, **kwargs: Any) -> GymObservation:
+        return GymObservation(screenshot=Image.new("RGB", self.screen_size))
+
+    def step(self, action: Action) -> GymResult:
+        return GymResult(self.reset(""), reward=0.0, done=False, info={})
+
+    def close(self) -> None:
+        pass
+
+
+def test_done_success_false_returns_failed_result() -> None:
+    result = GymRunner(_DoneBrain(False), _Env(), max_steps=1).run("task")
+
+    assert result.termination_reason == "done"
+    assert result.success is False
+
+
+def test_done_success_true_returns_successful_result() -> None:
+    result = GymRunner(_DoneBrain(True), _Env(), max_steps=1).run("task")
+
+    assert result.termination_reason == "done"
+    assert result.success is True

--- a/tests/test_runner_force_fill.py
+++ b/tests/test_runner_force_fill.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from mantis_agent.actions import Action, ActionType
+from mantis_agent.gym.runner import GymRunner
+
+
+def test_repeated_form_click_types_next_plan_value() -> None:
+    values = [{"label": "zip code", "value": "33101"}]
+    used: list[tuple[int, int]] = []
+    previous = Action(ActionType.CLICK, {"x": 167, "y": 444})
+    current = Action(ActionType.CLICK, {"x": 169, "y": 445})
+
+    forced = GymRunner._maybe_force_type_after_repeated_form_click(
+        current,
+        [previous],
+        values,
+        used,
+        "Click the ZIP Code field and type 33101.",
+    )
+
+    assert forced is not None
+    assert forced.action_type == ActionType.TYPE
+    assert forced.params == {"text": "33101"}
+    assert values == []
+    assert used == [(169, 445)]
+
+
+def test_repeated_non_form_click_does_not_force_type() -> None:
+    values = [{"label": "zip code", "value": "33101"}]
+    previous = Action(ActionType.CLICK, {"x": 167, "y": 444})
+    current = Action(ActionType.CLICK, {"x": 169, "y": 445})
+
+    forced = GymRunner._maybe_force_type_after_repeated_form_click(
+        current,
+        [previous],
+        values,
+        [],
+        "Open the next boat listing.",
+    )
+
+    assert forced is None
+    assert values == [{"label": "zip code", "value": "33101"}]

--- a/tests/test_server_utils.py
+++ b/tests/test_server_utils.py
@@ -43,6 +43,22 @@ class TestBuildProxyConfig:
 
     @pytest.fixture(autouse=True)
     def _proxy_env(self, monkeypatch):
+        for key in (
+            "MANTIS_PROXY_PROVIDER",
+            "OXYLABS_ENTRYPOINT",
+            "OXYLABS_CITY_ENTRYPOINT",
+            "OXYLABS_USERNAME",
+            "OXYLABS_USER",
+            "OXYLABS_PASSWORD",
+            "OXYLABS_PASS",
+            "OXYLABS_COUNTRY",
+            "OXYLABS_STATE",
+            "OXYLABS_CITY",
+            "PRIVATEPROXY_ENTRYPOINT",
+            "PRIVATEPROXY_USERNAME",
+            "PRIVATEPROXY_PASSWORD",
+        ):
+            monkeypatch.delenv(key, raising=False)
         monkeypatch.setenv("PROXY_URL", "http://geo.iproyal.com:12321")
         monkeypatch.setenv("PROXY_USER", "test_user")
         monkeypatch.setenv("PROXY_PASS", "basepass")
@@ -83,7 +99,7 @@ class TestBuildProxyConfig:
         finally:
             os.environ["PROXY_PASS"] = "basepass"
 
-    def test_oxylabs_provider_uses_oxylabs_credentials_without_suffixes(self, monkeypatch):
+    def test_oxylabs_provider_targets_city_with_customer_username(self, monkeypatch):
         monkeypatch.setenv("OXYLABS_ENTRYPOINT", "pr.oxylabs.io:10000")
         monkeypatch.setenv("OXYLABS_USERNAME", "oxy_user")
         monkeypatch.setenv("OXYLABS_PASSWORD", "oxy_pass")
@@ -94,6 +110,19 @@ class TestBuildProxyConfig:
             session_id="abc123",
             provider="oxylabs",
         )
+
+        assert cfg == {
+            "server": "http://pr.oxylabs.io:7777",
+            "username": "customer-oxy_user-st-us_florida-city-miami",
+            "password": "oxy_pass",
+        }
+
+    def test_oxylabs_provider_uses_raw_credentials_without_city(self, monkeypatch):
+        monkeypatch.setenv("OXYLABS_ENTRYPOINT", "pr.oxylabs.io:10000")
+        monkeypatch.setenv("OXYLABS_USERNAME", "oxy_user")
+        monkeypatch.setenv("OXYLABS_PASSWORD", "oxy_pass")
+
+        cfg = build_proxy_config(provider="oxylabs")
 
         assert cfg == {
             "server": "http://pr.oxylabs.io:10000",
@@ -109,9 +138,32 @@ class TestBuildProxyConfig:
 
         cfg = build_proxy_config(city="miami")
 
-        assert cfg["server"] == "http://pr.oxylabs.io:10000"
-        assert cfg["username"] == "oxy_user"
+        assert cfg["server"] == "http://pr.oxylabs.io:7777"
+        assert cfg["username"] == "customer-oxy_user-cc-US-city-miami"
         assert cfg["password"] == "oxy_pass"
+
+    def test_oxylabs_provider_reads_location_from_env(self, monkeypatch):
+        monkeypatch.setenv("OXYLABS_ENTRYPOINT", "http://pr.oxylabs.io:10000")
+        monkeypatch.setenv("OXYLABS_CITY_ENTRYPOINT", "pr.oxylabs.io:7777")
+        monkeypatch.setenv("OXYLABS_USERNAME", "oxy_user")
+        monkeypatch.setenv("OXYLABS_PASSWORD", "oxy_pass")
+        monkeypatch.setenv("OXYLABS_CITY", "miami")
+        monkeypatch.setenv("OXYLABS_STATE", "florida")
+
+        cfg = build_proxy_config(provider="oxylabs")
+
+        assert cfg["server"] == "http://pr.oxylabs.io:7777"
+        assert cfg["username"] == "customer-oxy_user-st-us_florida-city-miami"
+
+    def test_oxylabs_provider_respects_pre_targeted_username(self, monkeypatch):
+        monkeypatch.setenv("OXYLABS_ENTRYPOINT", "pr.oxylabs.io:10000")
+        monkeypatch.setenv("OXYLABS_USERNAME", "customer-oxy_user-cc-US-city-miami")
+        monkeypatch.setenv("OXYLABS_PASSWORD", "oxy_pass")
+
+        cfg = build_proxy_config(city="miami", provider="oxylabs")
+
+        assert cfg["server"] == "http://pr.oxylabs.io:7777"
+        assert cfg["username"] == "customer-oxy_user-cc-US-city-miami"
 
     def test_privateproxy_provider_uses_privateproxy_credentials(self, monkeypatch):
         monkeypatch.setenv("PRIVATEPROXY_ENTRYPOINT", "privateproxy.example:8080")

--- a/tests/test_server_utils.py
+++ b/tests/test_server_utils.py
@@ -83,6 +83,65 @@ class TestBuildProxyConfig:
         finally:
             os.environ["PROXY_PASS"] = "basepass"
 
+    def test_oxylabs_provider_uses_oxylabs_credentials_without_suffixes(self, monkeypatch):
+        monkeypatch.setenv("OXYLABS_ENTRYPOINT", "pr.oxylabs.io:10000")
+        monkeypatch.setenv("OXYLABS_USERNAME", "oxy_user")
+        monkeypatch.setenv("OXYLABS_PASSWORD", "oxy_pass")
+
+        cfg = build_proxy_config(
+            city="miami",
+            state="Florida",
+            session_id="abc123",
+            provider="oxylabs",
+        )
+
+        assert cfg == {
+            "server": "http://pr.oxylabs.io:10000",
+            "username": "oxy_user",
+            "password": "oxy_pass",
+        }
+
+    def test_oxylabs_provider_can_be_selected_by_env(self, monkeypatch):
+        monkeypatch.setenv("MANTIS_PROXY_PROVIDER", "oxylabs")
+        monkeypatch.setenv("OXYLABS_ENTRYPOINT", "http://pr.oxylabs.io:10000")
+        monkeypatch.setenv("OXYLABS_USERNAME", "oxy_user")
+        monkeypatch.setenv("OXYLABS_PASSWORD", "oxy_pass")
+
+        cfg = build_proxy_config(city="miami")
+
+        assert cfg["server"] == "http://pr.oxylabs.io:10000"
+        assert cfg["username"] == "oxy_user"
+        assert cfg["password"] == "oxy_pass"
+
+    def test_privateproxy_provider_uses_privateproxy_credentials(self, monkeypatch):
+        monkeypatch.setenv("PRIVATEPROXY_ENTRYPOINT", "privateproxy.example:8080")
+        monkeypatch.setenv("PRIVATEPROXY_USERNAME", "private_user")
+        monkeypatch.setenv("PRIVATEPROXY_PASSWORD", "private_pass")
+
+        cfg = build_proxy_config(city="miami", state="Florida", provider="privateproxy")
+
+        assert cfg == {
+            "server": "http://privateproxy.example:8080",
+            "username": "private_user",
+            "password": "private_pass",
+        }
+
+    def test_privateproxy_provider_accepts_four_part_endpoint(self, monkeypatch):
+        monkeypatch.setenv(
+            "PRIVATEPROXY_ENTRYPOINT",
+            "privateproxy.example:8080:private_user:private_pass",
+        )
+        monkeypatch.delenv("PRIVATEPROXY_USERNAME", raising=False)
+        monkeypatch.delenv("PRIVATEPROXY_PASSWORD", raising=False)
+
+        cfg = build_proxy_config(provider="privateproxy")
+
+        assert cfg == {
+            "server": "http://privateproxy.example:8080",
+            "username": "private_user",
+            "password": "private_pass",
+        }
+
 
 class FakeStepResult:
     def __init__(self, step_index, intent, success, data="", steps_used=3):

--- a/tests/test_task_loop_loop_config.py
+++ b/tests/test_task_loop_loop_config.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from mantis_agent import task_loop
+from mantis_agent.gym import workflow_runner
+
+
+def test_loop_task_passes_extended_loop_config(monkeypatch, tmp_path) -> None:
+    captured: dict[str, object] = {}
+
+    class FakeWorkflowRunner:
+        def __init__(self, **kwargs):
+            captured["loop_config"] = kwargs["loop_config"]
+
+        def run_loop(self):
+            return []
+
+    monkeypatch.setattr(workflow_runner, "WorkflowRunner", FakeWorkflowRunner)
+
+    config = task_loop.TaskLoopConfig(
+        run_id="run",
+        session_name="session",
+        model_name="model",
+        results_prefix="test",
+        brain=object(),
+        env=object(),
+        max_steps=90,
+        results_dir=str(tmp_path),
+    )
+    tasks = [
+        {
+            "task_id": "extract",
+            "intent": "extract listings",
+            "loop": {
+                "pagination_intent": "click next",
+                "max_iterations": 20,
+                "max_pages": 3,
+                "max_steps_per_iteration": 45,
+                "max_retries_per_iteration": 4,
+                "max_steps_pagination": 35,
+            },
+        }
+    ]
+
+    task_loop.run_task_loop(tasks, config)
+
+    loop_config = captured["loop_config"]
+    assert loop_config.max_iterations == 20
+    assert loop_config.max_pages == 3
+    assert loop_config.max_steps_per_iteration == 45
+    assert loop_config.max_retries_per_iteration == 4
+    assert loop_config.max_steps_pagination == 35

--- a/tests/test_task_loop_proxy.py
+++ b/tests/test_task_loop_proxy.py
@@ -1,0 +1,21 @@
+"""Proxy setup helpers."""
+
+from __future__ import annotations
+
+from mantis_agent.task_loop import setup_env
+
+
+def test_setup_env_proxy_disabled_ignores_proxy_env(monkeypatch) -> None:
+    monkeypatch.setenv("PROXY_URL", "http://proxy.example:1234")
+    monkeypatch.setenv("PROXY_USER", "user")
+    monkeypatch.setenv("PROXY_PASS", "pass")
+
+    env, proxy_proc = setup_env(
+        base_url="https://news.ycombinator.com",
+        run_id="20260507_000000",
+        session_name="hn_smoke",
+        proxy_disabled=True,
+    )
+
+    assert proxy_proc is None
+    assert env._proxy_server == ""

--- a/tests/test_workflow_runner_recovery_url.py
+++ b/tests/test_workflow_runner_recovery_url.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from mantis_agent.gym.workflow_runner import LoopConfig, WorkflowRunner
+
+
+class _Env:
+    current_url = "https://www.boattrader.com/boats/state-fl/city-miami/zip-33101/"
+
+
+def test_workflow_runner_anchors_recovery_to_current_url_when_start_url_missing() -> None:
+    runner = WorkflowRunner(
+        brain=object(),
+        env=_Env(),
+        loop_config=LoopConfig(
+            iteration_intent="Process the next listing.",
+            pagination_intent="Click Next.",
+        ),
+        start_url="",
+    )
+
+    assert runner.start_url == "https://www.boattrader.com/boats/state-fl/city-miami/zip-33101/"


### PR DESCRIPTION
Adds a Modal --disable-proxy run flag that propagates to executor env setup, and fixes GymRunner so done(success=false) stays failed.\n\nVerified with ruff, focused pytest, Modal deploy, and a news.ycombinator.com scrape smoke run.