### PR TITLE
Add dynamic Claude micro-recovery for CUA runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ secrets*.json
 Thumbs.db
 
 # Project-specific
+.codex_tmp/
 OSWorld/
 uv.lock
 *.gguf

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The full docs site is at **[mercurialsolo.github.io/mantis](https://mercurialsol
 The reference deployment is live on Baseten. With a tenant token from your operator:
 
 ```bash
-export ENDPOINT="https://model-qvvgkneq.api.baseten.co/production"
+export ENDPOINT="https://model-qvvgkneq.api.baseten.co/production/sync"
 export BASETEN_API_KEY="..."
 export MANTIS_API_TOKEN="..."
 
@@ -96,7 +96,12 @@ pip install -e ".[docs]"          # mkdocs + material theme
 ```
 src/mantis_agent/             core library
   api_schemas.py              PredictRequest + plan validation + caps
-  baseten_server.py           FastAPI: /v1/predict + /v1/chat/completions + /metrics
+  baseten_server/             FastAPI server package
+    routes.py                 /v1/predict + /v1/chat/completions + /metrics + /v1/runs/{id}/video
+    runtime.py                BasetenCUARuntime — model + run lifecycle
+    middleware.py             X-Mantis-Token auth + per-tenant secret resolvers
+    paths.py                  per-tenant data / Chrome-profile path resolvers
+    logging_setup.py          JSON log formatter + per-run log handler
   brain_holo3.py              Holo3 inference client
   brain_claude.py             Claude inference client
   extraction.py               ClaudeExtractor (structured data)

--- a/deploy/modal/modal_cua_server.py
+++ b/deploy/modal/modal_cua_server.py
@@ -571,6 +571,20 @@ def _run_holo3_executor(
         use_tool_calling=True,
     )
     brain.load()
+    claude_fallback_brain = None
+    claude_fallback_disabled = bool(task_suite.get("_claude_fallback_disabled", False))
+    if not claude_fallback_disabled:
+        try:
+            from mantis_agent.brain_claude import ClaudeBrain
+            claude_fallback_brain = ClaudeBrain(
+                model=str(task_suite.get("_claude_fallback_model") or "claude-sonnet-4-20250514"),
+                thinking_budget=2048,
+                screen_size=(1280, 720),
+            )
+            claude_fallback_brain.load()
+            print("Claude fallback enabled for failed Holo3 task sections")
+        except Exception as exc:
+            print(f"Claude fallback unavailable for failed Holo3 sections: {exc}")
 
     # Claude Sonnet grounding for click targeting
     from mantis_agent.grounding import ClaudeGrounding
@@ -795,11 +809,16 @@ def _run_holo3_executor(
 
         task_max_steps = task_config.get("max_steps", config.max_steps)
         min_steps = task_config.get("min_steps", 0)
+        fallback_used = getattr(result, "fallback_used", "")
         if "setup" in task_id or "filter" in task_id:
             min_steps = max(min_steps, 5)
 
         # Hybrid mode: use Claude for setup tasks
-        if ("setup" in task_id or "filter" in task_id) and verify_mode:
+        if (
+            ("setup" in task_id or "filter" in task_id)
+            and verify_mode
+            and fallback_used != "claude"
+        ):
             try:
                 from mantis_agent.brain_claude import ClaudeBrain as _CB
                 task_brain = _CB(model="claude-sonnet-4-20250514", thinking_budget=2048, screen_size=(1280, 720))
@@ -813,7 +832,12 @@ def _run_holo3_executor(
                 print(f"  Claude brain failed, using Holo3: {e}")
 
         # Retry if model skipped interaction
-        if result.total_steps <= min_steps and result.success and min_steps > 0:
+        if (
+            result.total_steps <= min_steps
+            and result.success
+            and min_steps > 0
+            and fallback_used != "claude"
+        ):
             print(f"  SKIP-DETECTED: {result.total_steps} steps (min={min_steps}). Retrying...")
             retry_intent = task_config["intent"] + (
                 "\n\nCRITICAL: Your previous attempt called done() without interacting with the page. "
@@ -893,6 +917,8 @@ def _run_holo3_executor(
         run_id=run_id, session_name=session_name,
         model_name="Holo3-35B-A3B", results_prefix="holo3",
         brain=brain, env=env, grounding=grounding, extractor=extractor,
+        fallback_brain=claude_fallback_brain,
+        fallback_label="claude",
         max_steps=max_steps, frames_per_inference=frames_per_inference,
         use_sub_plan=sub_plan,
         site_config=site_cfg,

--- a/src/mantis_agent/baseten_server/routes.py
+++ b/src/mantis_agent/baseten_server/routes.py
@@ -512,20 +512,27 @@ async def _handle_predict(
 @app.post("/v1/predict")
 async def predict_v1(
     request: Request,
-    tenant: TenantConfig = Depends(_require_mantis_token),
+    tenant: TenantConfig = Depends(_require_run_scope),
 ) -> dict[str, Any]:
-    """Tier-1 multi-tenant /predict. Validated, per-tenant capped and isolated."""
+    """Tier-1 multi-tenant /predict. Validated, per-tenant capped and isolated.
+
+    Requires the ``run`` scope on the tenant token — read-only keys
+    (e.g. observers with only ``status`` / ``result`` access) are
+    rejected with 403. Polling actions (``status``/``result``/``logs``/
+    ``cancel``) flow through the same handler, so any caller that needs
+    to poll a run also needs ``run`` scope.
+    """
     return await _handle_predict(request, tenant)
 
 
 @app.post("/predict")
 async def predict(
     request: Request,
-    tenant: TenantConfig = Depends(_require_mantis_token),
+    tenant: TenantConfig = Depends(_require_run_scope),
 ) -> dict[str, Any]:
     """Backwards-compat alias for /v1/predict.
 
     Kept indefinitely for callers built against the v1.0 deployment shape.
-    Identical behavior to /v1/predict.
+    Identical behavior to /v1/predict, including the ``run`` scope check.
     """
     return await _handle_predict(request, tenant)

--- a/src/mantis_agent/gym/runner.py
+++ b/src/mantis_agent/gym/runner.py
@@ -764,6 +764,20 @@ class GymRunner:
                         action = directive
                         last_director_step = step_num
 
+                top_click_guard = self._maybe_redirect_repeated_top_click(
+                    action,
+                    action_history,
+                    task,
+                )
+                if top_click_guard is not None:
+                    logger.warning(
+                        "top-click guard: substituting %s(%s) → %s(%s)",
+                        action.action_type.value, action.params,
+                        top_click_guard.action_type.value, top_click_guard.params,
+                    )
+                    action = top_click_guard
+                    substituted_action = True
+
                 # Grounded click refinement — if grounding model available,
                 # refine click coordinates before execution
                 if action.action_type in (ActionType.CLICK, ActionType.DOUBLE_CLICK):
@@ -1416,6 +1430,69 @@ class GymRunner:
 
         print(f"  [discovery] execution failed for [{idx}]")
         return None
+
+    @staticmethod
+    def _maybe_redirect_repeated_top_click(
+        action: "Action",
+        action_history: list["Action"],
+        task: str,
+    ) -> "Action | None":
+        """Avoid wasting recovery budget on repeated top-of-page clicks.
+
+        This is intentionally domain-agnostic. When the task is trying to move
+        forward (submit/search/save/continue) and the model repeatedly clicks
+        the browser/header area, a small scroll is usually the least invasive
+        way to reveal the in-page control it is looking for.
+        """
+        from ..actions import Action, ActionType
+
+        if action.action_type not in (ActionType.CLICK, ActionType.DOUBLE_CLICK):
+            return None
+
+        task_lower = task.lower() if isinstance(task, str) else ""
+        forward_signals = (
+            "submit",
+            "search",
+            "find ",
+            "continue",
+            "next",
+            "save",
+            "update",
+            "move forward",
+        )
+        if not any(sig in task_lower for sig in forward_signals):
+            return None
+
+        x = int((action.params or {}).get("x", 0))
+        y = int((action.params or {}).get("y", 0))
+        if y > 100:
+            return None
+
+        previous_top_click = next(
+            (
+                a
+                for a in reversed(action_history)
+                if a.action_type in (ActionType.CLICK, ActionType.DOUBLE_CLICK)
+                and int((a.params or {}).get("y", 9999)) <= 100
+            ),
+            None,
+        )
+        if previous_top_click is None:
+            return None
+
+        prev_x = int((previous_top_click.params or {}).get("x", 0))
+        prev_y = int((previous_top_click.params or {}).get("y", 0))
+        if abs(prev_x - x) > 80 or abs(prev_y - y) > 40:
+            return None
+
+        return Action(
+            ActionType.SCROLL,
+            {"direction": "down", "amount": 350},
+            reasoning=(
+                "top-click guard: repeated top/header click during forward "
+                "action; scroll to reveal the in-page control"
+            ),
+        )
 
     @staticmethod
     def _force_fill_post_type_actions(task: str) -> list["Action"]:

--- a/src/mantis_agent/gym/runner.py
+++ b/src/mantis_agent/gym/runner.py
@@ -625,6 +625,7 @@ class GymRunner:
                 # Falls back to None (no substitution) on detector failure
                 # so we never substitute incorrectly.
                 substituted_action = False
+                force_fill_focus_action: Action | None = None
                 forced = self._maybe_force_type_text(
                     action,
                     action_history,
@@ -639,6 +640,7 @@ class GymRunner:
                         f"click({action.params})",
                         len(str(forced.params.get("text", ""))),
                     )
+                    force_fill_focus_action = action
                     action = forced
                     substituted_action = True
                 else:
@@ -655,6 +657,7 @@ class GymRunner:
                             f"click({action.params})",
                             len(str(forced.params.get("text", ""))),
                         )
+                        force_fill_focus_action = action
                         action = forced
                         substituted_action = True
                 # Auto-submit: once at least two form fields have been
@@ -803,27 +806,49 @@ class GymRunner:
                         print(f"  [grounding] FAILED: {e}")
 
                 # Execute action in the environment
+                pre_actions: list[Action] = []
                 post_actions: list[Action] = []
                 force_success_after_action = False
-                if (
+                is_force_fill_type = (
                     action.action_type == ActionType.TYPE
                     and "force-fill" in (action.reasoning or "")
+                )
+                if is_force_fill_type:
+                    if force_fill_focus_action is not None:
+                        pre_actions.append(Action(
+                            force_fill_focus_action.action_type,
+                            dict(force_fill_focus_action.params),
+                            reasoning="force-fill: focus field before typing",
+                        ))
+                    pre_actions.append(
+                        Action(
+                            ActionType.KEY_PRESS,
+                            {"keys": "ctrl+a"},
+                            reasoning="force-fill: replace focused field contents",
+                        )
+                    )
+                    post_actions = self._force_fill_post_type_actions(task)
+                    force_success_after_action = self._force_fill_should_finish_task(
+                        task=task,
+                        initial_value_count=len(force_fill_initial_labels),
+                        pending_value_count=len(force_fill_values),
+                        submitted=force_fill_submitted,
+                    )
+
+                if (
+                    is_force_fill_type
                     and "radius" in (task.lower() if isinstance(task, str) else "")
                 ):
                     force_success_after_action = True
-                    post_actions = [
-                        Action(
-                            ActionType.KEY_PRESS,
-                            {"keys": "Return"},
-                            reasoning="force-fill: accept radius value",
-                        ),
-                        Action(
-                            ActionType.KEY_PRESS,
-                            {"keys": "Tab"},
-                            reasoning="force-fill: commit radius field",
-                        ),
-                    ]
 
+                for pre_action in pre_actions:
+                    logger.warning(
+                        "force-fill: pre-type replace via %s(%s)",
+                        pre_action.action_type.value,
+                        pre_action.params,
+                    )
+                    gym_result = self.env.step(pre_action)
+                    action_history.append(pre_action)
                 gym_result = self.env.step(action)
                 action_history.append(action)
                 for post_action in post_actions:
@@ -836,6 +861,12 @@ class GymRunner:
                     action_history.append(post_action)
                 frame_history.append(gym_result.observation.screenshot)
                 _save_frame(gym_result.observation.screenshot, step_num)
+                for pre_action in pre_actions:
+                    self._loop_detector.record(
+                        pre_action,
+                        url=gym_result.info.get("url", ""),
+                        frame=gym_result.observation.screenshot,
+                    )
                 self._loop_detector.record(
                     action,
                     url=gym_result.info.get("url", ""),
@@ -1385,6 +1416,88 @@ class GymRunner:
 
         print(f"  [discovery] execution failed for [{idx}]")
         return None
+
+    @staticmethod
+    def _force_fill_post_type_actions(task: str) -> list["Action"]:
+        """Browser keystrokes to commit a force-filled field."""
+        from ..actions import Action, ActionType
+
+        task_lower = task.lower() if isinstance(task, str) else ""
+        if "radius" in task_lower:
+            return [
+                Action(
+                    ActionType.KEY_PRESS,
+                    {"keys": "Return"},
+                    reasoning="force-fill: accept radius value",
+                ),
+                Action(
+                    ActionType.KEY_PRESS,
+                    {"keys": "Tab"},
+                    reasoning="force-fill: commit radius field",
+                ),
+            ]
+
+        commit_signals = (
+            "press tab",
+            "commits",
+            "commit",
+            "finish when",
+            "visible in the field",
+            "visibly shows",
+            "field",
+        )
+        if any(sig in task_lower for sig in commit_signals):
+            return [
+                Action(
+                    ActionType.KEY_PRESS,
+                    {"keys": "Tab"},
+                    reasoning="force-fill: commit field",
+                )
+            ]
+        return []
+
+    @staticmethod
+    def _force_fill_should_finish_task(
+        *,
+        task: str,
+        initial_value_count: int,
+        pending_value_count: int,
+        submitted: bool,
+    ) -> bool:
+        """Finish small field-fill sections once the runtime filled them.
+
+        This is intentionally limited to one-value field tasks. Multi-field
+        login/search forms still need submit/navigation behavior from the
+        model or the auto-submit path.
+        """
+        if initial_value_count != 1 or pending_value_count != 0 or submitted:
+            return False
+
+        task_lower = task.lower() if isinstance(task, str) else ""
+        excluded = (
+            "submit",
+            "search button",
+            "find boats",
+            "results page",
+            "log in",
+            "login",
+            "sign in",
+            "password",
+            "credentials",
+        )
+        if any(sig in task_lower for sig in excluded):
+            return False
+
+        completion_signals = (
+            "finish when",
+            "visible in the field",
+            "visibly shows",
+            "press tab",
+            "commit",
+            "zip code",
+            "radius",
+        )
+        return any(sig in task_lower for sig in completion_signals)
 
     @staticmethod
     def _maybe_force_type_after_repeated_form_click(

--- a/src/mantis_agent/gym/runner.py
+++ b/src/mantis_agent/gym/runner.py
@@ -1432,6 +1432,11 @@ class GymRunner:
         return None
 
     @staticmethod
+    def _is_valid_force_fill_click(x: int, y: int) -> bool:
+        """Reject sentinel/browser-chrome clicks before typing plan values."""
+        return x >= 10 and y >= 80
+
+    @staticmethod
     def _maybe_redirect_repeated_top_click(
         action: "Action",
         action_history: list["Action"],
@@ -1635,6 +1640,8 @@ class GymRunner:
 
         px = int((action.params or {}).get("x", 0))
         py = int((action.params or {}).get("y", 0))
+        if not GymRunner._is_valid_force_fill_click(px, py):
+            return None
         prev_x = int((previous_click.params or {}).get("x", 0))
         prev_y = int((previous_click.params or {}).get("y", 0))
         near_equal = abs(px - prev_x) <= 8 and abs(py - prev_y) <= 8
@@ -1698,6 +1705,8 @@ class GymRunner:
 
         px = int((action.params or {}).get("x", 0))
         py = int((action.params or {}).get("y", 0))
+        if not GymRunner._is_valid_force_fill_click(px, py):
+            return None
 
         # Already filled this region? Don't double-consume.
         for ux, uy in force_fill_used_regions:

--- a/src/mantis_agent/gym/workflow_runner.py
+++ b/src/mantis_agent/gym/workflow_runner.py
@@ -296,8 +296,16 @@ class WorkflowRunner:
                  grounding: Any = None,
                  on_step: Any = None,
                  use_sub_plan: bool = False,
-                 extractor: Any = None):
+                 extractor: Any = None,
+                 fallback_brain: Any = None,
+                 fallback_label: str = "fallback",
+                 fallback_micro_retries: int = 2,
+                 fallback_micro_max_steps: int = 6):
         self.brain = brain
+        self.fallback_brain = fallback_brain
+        self.fallback_label = fallback_label
+        self.fallback_micro_retries = fallback_micro_retries
+        self.fallback_micro_max_steps = fallback_micro_max_steps
         self.grounding = grounding
         self.on_step = on_step
         self.use_sub_plan = use_sub_plan
@@ -789,6 +797,41 @@ class WorkflowRunner:
             if result.success or self._check_no_more(result):
                 break
 
+            if self.fallback_brain is not None:
+                for micro_attempt in range(
+                    1, max(int(self.fallback_micro_retries), 0) + 1
+                ):
+                    micro_result = self._run_micro_fallback(
+                        intent=attempt_intent,
+                        task_id=task_id,
+                        failed_result=best_result,
+                        attempt=micro_attempt,
+                        kind="listing extraction/navigation",
+                    )
+                    if not micro_result.success:
+                        best_result = micro_result
+                        continue
+
+                    resume_intent = (
+                        attempt_intent
+                        + "\n\nA bounded recovery micro-step was just applied. "
+                        "Resume this same extraction/navigation step from the "
+                        "current browser state. Do not restart the full plan."
+                    )
+                    result = runner.run(
+                        task=resume_intent,
+                        task_id=(
+                            f"{task_id}_resume_after_"
+                            f"{self.fallback_label}_{micro_attempt}"
+                        ),
+                        start_url="",
+                    )
+                    best_result = result
+                    if result.success or self._check_no_more(result):
+                        break
+                if best_result.success or self._check_no_more(best_result):
+                    break
+
         return best_result
 
     def _run_pagination(self) -> bool:
@@ -864,7 +907,153 @@ class WorkflowRunner:
                 pass
             return True
 
+        if self.fallback_brain is not None:
+            for micro_attempt in range(1, max(int(self.fallback_micro_retries), 0) + 1):
+                micro_result = self._run_micro_fallback(
+                    intent=pagination_task,
+                    task_id="pagination",
+                    failed_result=retry_result,
+                    attempt=micro_attempt,
+                    kind="pagination/navigation",
+                )
+                if not micro_result.success:
+                    continue
+
+                verify_runner = GymRunner(
+                    brain=self.brain,
+                    env=self.env,
+                    max_steps=min(self.config.max_steps_pagination, 10),
+                    frames_per_inference=2,
+                    grounding=self.grounding,
+                    on_step=self.on_step,
+                )
+                verify_result = verify_runner.run(
+                    task=(
+                        "A bounded recovery micro-step was just applied for "
+                        "pagination. Verify whether a next results page is now "
+                        "loaded. If listings for a new page are visible, call "
+                        "done(success=true). If not, take only one small "
+                        "pagination action and then decide."
+                    ),
+                    task_id=f"pagination_resume_after_{self.fallback_label}_{micro_attempt}",
+                    start_url="",
+                )
+                if verify_result.success:
+                    try:
+                        self.env.step(Action(action_type=ActionType.KEY_PRESS, params={"keys": "Home"}))
+                        time.sleep(1.5)
+                    except Exception:
+                        pass
+                    return True
+
         return False
+
+    def _run_micro_fallback(
+        self,
+        *,
+        intent: str,
+        task_id: str,
+        failed_result: Any,
+        attempt: int,
+        kind: str,
+    ) -> Any:
+        """Run a bounded Claude recovery step, then return control to primary."""
+        micro_intent = self._build_loop_micro_fallback_intent(
+            intent=intent,
+            task_id=task_id,
+            failed_result=failed_result,
+            attempt=attempt,
+            kind=kind,
+        )
+        logger.warning(
+            "  %s micro-fallback: %s for %s (attempt %s/%s)",
+            self.fallback_label,
+            kind,
+            task_id,
+            attempt,
+            self.fallback_micro_retries,
+        )
+        runner = GymRunner(
+            brain=self.fallback_brain,
+            env=self.env,
+            max_steps=int(self.fallback_micro_max_steps),
+            frames_per_inference=2,
+            grounding=self.grounding,
+            on_step=self.on_step,
+        )
+        return runner.run(
+            task=micro_intent,
+            task_id=f"{task_id}_{self.fallback_label}_micro_fallback_{attempt}",
+            start_url="",
+        )
+
+    def _build_loop_micro_fallback_intent(
+        self,
+        *,
+        intent: str,
+        task_id: str,
+        failed_result: Any,
+        attempt: int,
+        kind: str,
+    ) -> str:
+        termination = str(getattr(failed_result, "termination_reason", "unknown"))
+        recent = self._recent_failure_context(failed_result)
+        return (
+            "You are handling one stuck browser-control micro-step inside a "
+            "larger extraction loop. Do not execute the full workflow, future "
+            "listings, or the full extraction plan.\n\n"
+            f"LOOP STEP: {task_id}\n"
+            f"MICRO-STEP TYPE: {kind}\n"
+            f"ORIGINAL LOOP GOAL:\n{intent[:2400]}\n\n"
+            f"PRIMARY EXECUTOR FAILURE: {termination}\n"
+            f"RECENT ACTIONS BEFORE FAILURE:\n{recent}\n\n"
+            f"RECOVERY ATTEMPT: {attempt}\n\n"
+            "Your job now:\n"
+            "1. Reason from the current browser screen.\n"
+            "2. Execute only the smallest visible recovery action or short "
+            "action sequence needed to unstick this loop step.\n"
+            "3. Stop immediately after that micro-step with done(success=true). "
+            "The primary executor will resume the original loop step afterward.\n\n"
+            "Constraints:\n"
+            "- Do not process another unrelated listing.\n"
+            "- Do not extract or summarize leads unless the visible current "
+            "micro-step already requires one tiny extraction check.\n"
+            "- If on the wrong page, prefer Escape, Alt+Left, or a single "
+            "in-page navigation action that returns to visible listings.\n"
+            "- If listings are hidden below/above, use a small scroll.\n"
+            "- Do not click the browser toolbar, address bar, tab strip, or "
+            "extension area unless the goal is explicit navigation.\n"
+            "- If no useful recovery action is visible, finish with "
+            "done(success=false) and explain the blocker briefly."
+        )
+
+    @staticmethod
+    def _redacted_action(action: Any) -> str:
+        action_type = getattr(action, "action_type", "")
+        kind = getattr(action_type, "value", str(action_type))
+        params = dict(getattr(action, "params", {}) or {})
+        if kind == "type_text":
+            text = str(params.get("text", ""))
+            params = {"text": f"<{len(text)} chars>"}
+        return f"{kind}({params})"
+
+    @classmethod
+    def _recent_failure_context(cls, result: Any, max_steps: int = 6) -> str:
+        trajectory = list(getattr(result, "trajectory", []) or [])[-max_steps:]
+        if not trajectory:
+            return "No recent action context was recorded."
+
+        lines: list[str] = []
+        for item in trajectory:
+            step = getattr(item, "step", "?")
+            action = cls._redacted_action(getattr(item, "action", None))
+            feedback = str(getattr(item, "feedback", "") or "")
+            if feedback:
+                feedback = feedback.replace("\n", " ")[:180]
+                lines.append(f"- step {step}: {action} -> {feedback}")
+            else:
+                lines.append(f"- step {step}: {action}")
+        return "\n".join(lines)
 
     def _check_no_more(self, result, check_pages: bool = False) -> bool:
         """Check if the model signaled no more items/pages.

--- a/src/mantis_agent/task_loop.py
+++ b/src/mantis_agent/task_loop.py
@@ -44,6 +44,8 @@ class TaskLoopConfig:
     extractor: Any = None
     fallback_brain: Any = None
     fallback_label: str = "fallback"
+    fallback_micro_retries: int = 2
+    fallback_micro_max_steps: int = 6
 
     # ── Execution params ──
     max_steps: int = 30
@@ -256,6 +258,78 @@ def _build_loop_final_detail(
     return detail
 
 
+def _redacted_action(action: Any) -> str:
+    """Summarize an action without leaking typed values."""
+    action_type = getattr(action, "action_type", "")
+    kind = getattr(action_type, "value", str(action_type))
+    params = dict(getattr(action, "params", {}) or {})
+    if kind == "type_text":
+        text = str(params.get("text", ""))
+        params = {"text": f"<{len(text)} chars>"}
+    return f"{kind}({params})"
+
+
+def _recent_failure_context(result: Any, max_steps: int = 6) -> str:
+    trajectory = list(getattr(result, "trajectory", []) or [])[-max_steps:]
+    if not trajectory:
+        return "No recent action context was recorded."
+
+    lines: list[str] = []
+    for item in trajectory:
+        step = getattr(item, "step", "?")
+        action = _redacted_action(getattr(item, "action", None))
+        feedback = str(getattr(item, "feedback", "") or "")
+        if feedback:
+            feedback = feedback.replace("\n", " ")[:180]
+            lines.append(f"- step {step}: {action} -> {feedback}")
+        else:
+            lines.append(f"- step {step}: {action}")
+    return "\n".join(lines)
+
+
+def _build_micro_fallback_intent(
+    *,
+    task_id: str,
+    intent: str,
+    result: Any,
+    attempt: int,
+) -> str:
+    """Build a generic stuck-step prompt for Claude.
+
+    The fallback is deliberately scoped to a micro-step. Claude should repair
+    the current browser state and stop; the primary executor then resumes the
+    original section from that state.
+    """
+    termination = str(getattr(result, "termination_reason", "unknown"))
+    recent = _recent_failure_context(result)
+    return (
+        "You are handling a single stuck browser-control micro-step inside a "
+        "larger workflow. Do not execute the full workflow, future sections, "
+        "or broad multi-step plan.\n\n"
+        f"SECTION ID: {task_id}\n"
+        f"ORIGINAL SECTION GOAL:\n{intent[:2400]}\n\n"
+        f"PRIMARY EXECUTOR FAILURE: {termination}\n"
+        f"RECENT ACTIONS BEFORE FAILURE:\n{recent}\n\n"
+        f"RECOVERY ATTEMPT: {attempt}\n\n"
+        "Your job now:\n"
+        "1. Look at the current browser screen.\n"
+        "2. Execute only the smallest visible action or short action sequence "
+        "needed to unstick this section and make concrete progress toward the "
+        "original section goal.\n"
+        "3. Stop immediately after that micro-step with done(success=true). "
+        "The primary executor will resume the original section afterward.\n\n"
+        "Constraints:\n"
+        "- Do not continue into later workflow sections.\n"
+        "- Do not complete the whole original section unless the only needed "
+        "micro-step itself completes it.\n"
+        "- Do not edit unrelated fields or clear already-correct values.\n"
+        "- Prefer click, scroll, key_press, or wait. Type only when the current "
+        "micro-step is clearly a focused field that requires typing.\n"
+        "- If no useful recovery action is visible, finish with "
+        "done(success=false) and explain the blocker briefly."
+    )
+
+
 # ── Main task loop ────────────────────────────────────────────────
 
 
@@ -414,32 +488,90 @@ def run_task_loop(
             )
 
             if not result.success and config.fallback_brain is not None:
-                fallback_intent = task_config.get("fallback_intent", intent)
-                fallback_max_steps = task_config.get(
-                    "fallback_max_steps",
-                    task_config.get("max_steps", config.max_steps),
+                fallback_retries = int(
+                    task_config.get(
+                        "fallback_micro_retries",
+                        config.fallback_micro_retries,
+                    )
                 )
-                print(
-                    f"  {config.fallback_label} fallback: retrying failed section "
-                    f"'{task_id}'"
+                fallback_max_steps = int(
+                    task_config.get(
+                        "fallback_max_steps",
+                        config.fallback_micro_max_steps,
+                    )
                 )
-                fallback_runner = GymRunner(
-                    brain=config.fallback_brain,
-                    env=config.env,
-                    max_steps=fallback_max_steps,
-                    frames_per_inference=config.frames_per_inference,
-                    grounding=config.grounding,
-                    on_step=on_step,
+                resume_max_steps = int(
+                    task_config.get(
+                        "resume_max_steps",
+                        task_config.get("max_steps", config.max_steps),
+                    )
                 )
-                result = fallback_runner.run(
-                    task=fallback_intent,
-                    task_id=f"{task_id}_{config.fallback_label}_fallback",
-                    start_url=task_config.get("fallback_start_url", ""),
-                )
-                try:
-                    setattr(result, "fallback_used", config.fallback_label)
-                except (AttributeError, TypeError):
-                    pass
+
+                for attempt in range(1, max(fallback_retries, 0) + 1):
+                    fallback_intent = task_config.get("fallback_intent")
+                    if not fallback_intent:
+                        fallback_intent = _build_micro_fallback_intent(
+                            task_id=task_id,
+                            intent=intent,
+                            result=result,
+                            attempt=attempt,
+                        )
+                    print(
+                        f"  {config.fallback_label} micro-fallback: "
+                        f"recovering stuck section '{task_id}' "
+                        f"(attempt {attempt}/{fallback_retries})"
+                    )
+                    fallback_runner = GymRunner(
+                        brain=config.fallback_brain,
+                        env=config.env,
+                        max_steps=fallback_max_steps,
+                        frames_per_inference=config.frames_per_inference,
+                        grounding=config.grounding,
+                        on_step=on_step,
+                    )
+                    micro_result = fallback_runner.run(
+                        task=fallback_intent,
+                        task_id=(
+                            f"{task_id}_{config.fallback_label}"
+                            f"_micro_fallback_{attempt}"
+                        ),
+                        start_url=task_config.get("fallback_start_url", ""),
+                    )
+                    try:
+                        setattr(micro_result, "fallback_used", config.fallback_label)
+                    except (AttributeError, TypeError):
+                        pass
+
+                    if not micro_result.success:
+                        result = micro_result
+                        break
+
+                    print(
+                        f"  Primary resume: retrying section '{task_id}' "
+                        "after micro-fallback"
+                    )
+                    resume_runner = GymRunner(
+                        brain=config.brain,
+                        env=config.env,
+                        max_steps=resume_max_steps,
+                        frames_per_inference=config.frames_per_inference,
+                        grounding=config.grounding,
+                        on_step=on_step,
+                    )
+                    result = resume_runner.run(
+                        task=intent,
+                        task_id=(
+                            f"{task_id}_resume_after_{config.fallback_label}"
+                            f"_{attempt}"
+                        ),
+                        start_url="",
+                    )
+                    try:
+                        setattr(result, "fallback_used", config.fallback_label)
+                    except (AttributeError, TypeError):
+                        pass
+                    if result.success:
+                        break
 
             # Executor-specific post-processing (filter validation, retries, etc.)
             if config.on_task_result:

--- a/src/mantis_agent/task_loop.py
+++ b/src/mantis_agent/task_loop.py
@@ -42,6 +42,8 @@ class TaskLoopConfig:
     env: Any
     grounding: Any = None
     extractor: Any = None
+    fallback_brain: Any = None
+    fallback_label: str = "fallback"
 
     # ── Execution params ──
     max_steps: int = 30
@@ -410,6 +412,29 @@ def run_task_loop(
                 task_id=task_id,
                 start_url=task_config.get("start_url", ""),
             )
+
+            if not result.success and config.fallback_brain is not None:
+                print(
+                    f"  {config.fallback_label} fallback: retrying failed section "
+                    f"'{task_id}'"
+                )
+                fallback_runner = GymRunner(
+                    brain=config.fallback_brain,
+                    env=config.env,
+                    max_steps=task_config.get("max_steps", config.max_steps),
+                    frames_per_inference=config.frames_per_inference,
+                    grounding=config.grounding,
+                    on_step=on_step,
+                )
+                result = fallback_runner.run(
+                    task=intent,
+                    task_id=f"{task_id}_{config.fallback_label}_fallback",
+                    start_url=task_config.get("start_url", ""),
+                )
+                try:
+                    setattr(result, "fallback_used", config.fallback_label)
+                except (AttributeError, TypeError):
+                    pass
 
             # Executor-specific post-processing (filter validation, retries, etc.)
             if config.on_task_result:

--- a/src/mantis_agent/task_loop.py
+++ b/src/mantis_agent/task_loop.py
@@ -46,6 +46,7 @@ class TaskLoopConfig:
     fallback_label: str = "fallback"
     fallback_micro_retries: int = 2
     fallback_micro_max_steps: int = 6
+    stop_on_task_failure: bool = True
 
     # ── Execution params ──
     max_steps: int = 30
@@ -323,6 +324,12 @@ def _build_micro_fallback_intent(
         "- Do not complete the whole original section unless the only needed "
         "micro-step itself completes it.\n"
         "- Do not edit unrelated fields or clear already-correct values.\n"
+        "- Operate inside the web page content. Do not click the browser "
+        "toolbar, address bar, tab strip, or extension area unless the original "
+        "section goal is explicit navigation.\n"
+        "- If the section goal is to submit, continue, save, search, or move "
+        "forward, look for an in-page button/control with that meaning; if it "
+        "is not visible, use a small scroll to reveal it.\n"
         "- Prefer click, scroll, key_press, or wait. Type only when the current "
         "micro-step is clearly a focused field that requires typing.\n"
         "- If no useful recovery action is visible, finish with "
@@ -470,6 +477,13 @@ def run_task_loop(
                 save_progress()
                 if config.on_loop_complete:
                     config.on_loop_complete()
+                if (
+                    not success
+                    and config.stop_on_task_failure
+                    and not task_config.get("continue_on_failure", False)
+                ):
+                    print(f"  Stopping task loop after failed task '{task_id}'")
+                    break
                 continue
 
             # ── Standard task ──
@@ -544,7 +558,7 @@ def run_task_loop(
 
                     if not micro_result.success:
                         result = micro_result
-                        break
+                        continue
 
                     print(
                         f"  Primary resume: retrying section '{task_id}' "
@@ -599,7 +613,11 @@ def run_task_loop(
             )
             print(f"  {'PASS' if success else 'FAIL'} ({result.total_steps} steps)")
 
-            if not success and ("setup" in task_id or "filter" in task_id):
+            if (
+                not success
+                and task_config.get("continue_on_failure")
+                and ("setup" in task_id or "filter" in task_id)
+            ):
                 print(
                     f"  WARNING: Setup '{task_id}' failed — continuing with current page state"
                 )
@@ -622,6 +640,15 @@ def run_task_loop(
             )
 
         save_progress()
+        if (
+            task_details
+            and task_details[-1].get("task_id") == task_id
+            and not task_details[-1].get("success", False)
+            and config.stop_on_task_failure
+            and not task_config.get("continue_on_failure", False)
+        ):
+            print(f"  Stopping task loop after failed task '{task_id}'")
+            break
 
     return scores, task_details
 

--- a/src/mantis_agent/task_loop.py
+++ b/src/mantis_agent/task_loop.py
@@ -414,6 +414,11 @@ def run_task_loop(
             )
 
             if not result.success and config.fallback_brain is not None:
+                fallback_intent = task_config.get("fallback_intent", intent)
+                fallback_max_steps = task_config.get(
+                    "fallback_max_steps",
+                    task_config.get("max_steps", config.max_steps),
+                )
                 print(
                     f"  {config.fallback_label} fallback: retrying failed section "
                     f"'{task_id}'"
@@ -421,15 +426,15 @@ def run_task_loop(
                 fallback_runner = GymRunner(
                     brain=config.fallback_brain,
                     env=config.env,
-                    max_steps=task_config.get("max_steps", config.max_steps),
+                    max_steps=fallback_max_steps,
                     frames_per_inference=config.frames_per_inference,
                     grounding=config.grounding,
                     on_step=on_step,
                 )
                 result = fallback_runner.run(
-                    task=intent,
+                    task=fallback_intent,
                     task_id=f"{task_id}_{config.fallback_label}_fallback",
-                    start_url=task_config.get("start_url", ""),
+                    start_url=task_config.get("fallback_start_url", ""),
                 )
                 try:
                     setattr(result, "fallback_used", config.fallback_label)

--- a/src/mantis_agent/task_loop.py
+++ b/src/mantis_agent/task_loop.py
@@ -50,6 +50,7 @@ class TaskLoopConfig:
 
     # ── Execution params ──
     max_steps: int = 30
+    standard_task_max_steps: int = 15
     frames_per_inference: int = 5
     use_sub_plan: bool = True
     site_config: Any = None  # SiteConfig for URL patterns (passed to callbacks)
@@ -337,6 +338,12 @@ def _build_micro_fallback_intent(
     )
 
 
+def _standard_task_max_steps(task_config: dict[str, Any], config: TaskLoopConfig) -> int:
+    if "max_steps" in task_config:
+        return int(task_config["max_steps"])
+    return min(int(config.max_steps), int(config.standard_task_max_steps))
+
+
 # ── Main task loop ────────────────────────────────────────────────
 
 
@@ -490,7 +497,7 @@ def run_task_loop(
             runner = GymRunner(
                 brain=config.brain,
                 env=config.env,
-                max_steps=task_config.get("max_steps", config.max_steps),
+                max_steps=_standard_task_max_steps(task_config, config),
                 frames_per_inference=config.frames_per_inference,
                 grounding=config.grounding,
                 on_step=on_step,
@@ -517,7 +524,7 @@ def run_task_loop(
                 resume_max_steps = int(
                     task_config.get(
                         "resume_max_steps",
-                        task_config.get("max_steps", config.max_steps),
+                        _standard_task_max_steps(task_config, config),
                     )
                 )
 

--- a/src/mantis_agent/task_loop.py
+++ b/src/mantis_agent/task_loop.py
@@ -461,6 +461,16 @@ def run_task_loop(
                     "grounding": config.grounding,
                     "on_step": on_step,
                     "use_sub_plan": config.use_sub_plan,
+                    "fallback_brain": config.fallback_brain,
+                    "fallback_label": config.fallback_label,
+                    "fallback_micro_retries": task_config.get(
+                        "fallback_micro_retries",
+                        config.fallback_micro_retries,
+                    ),
+                    "fallback_micro_max_steps": task_config.get(
+                        "fallback_max_steps",
+                        config.fallback_micro_max_steps,
+                    ),
                 }
                 if config.extractor:
                     wf_kwargs["extractor"] = config.extractor

--- a/tests/test_runner_force_fill.py
+++ b/tests/test_runner_force_fill.py
@@ -144,3 +144,31 @@ def test_force_fill_does_not_auto_finish_submit_or_login_tasks() -> None:
         pending_value_count=0,
         submitted=False,
     )
+
+
+def test_repeated_top_click_redirects_forward_task_to_scroll() -> None:
+    previous = Action(ActionType.CLICK, {"x": 263, "y": 63})
+    current = Action(ActionType.CLICK, {"x": 275, "y": 64})
+
+    redirected = GymRunner._maybe_redirect_repeated_top_click(
+        current,
+        [previous],
+        "Click the visible Search button to submit the form.",
+    )
+
+    assert redirected is not None
+    assert redirected.action_type == ActionType.SCROLL
+    assert redirected.params == {"direction": "down", "amount": 350}
+
+
+def test_repeated_top_click_guard_ignores_non_forward_tasks() -> None:
+    previous = Action(ActionType.CLICK, {"x": 263, "y": 63})
+    current = Action(ActionType.CLICK, {"x": 275, "y": 64})
+
+    redirected = GymRunner._maybe_redirect_repeated_top_click(
+        current,
+        [previous],
+        "Inspect the page header.",
+    )
+
+    assert redirected is None

--- a/tests/test_runner_force_fill.py
+++ b/tests/test_runner_force_fill.py
@@ -1,6 +1,12 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
+from typing import Any
+
+from PIL import Image
+
 from mantis_agent.actions import Action, ActionType
+from mantis_agent.gym.base import GymEnvironment, GymObservation, GymResult
 from mantis_agent.gym.runner import GymRunner
 
 
@@ -40,3 +46,101 @@ def test_repeated_non_form_click_does_not_force_type() -> None:
 
     assert forced is None
     assert values == [{"label": "zip code", "value": "33101"}]
+
+
+@dataclass
+class _BrainResult:
+    action: Action
+    thinking: str = ""
+    predicted_outcome: str = ""
+
+
+class _ClickBrain:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def think(
+        self,
+        frames: Any,
+        task: str,
+        action_history: Any = None,
+        screen_size: tuple[int, int] = (100, 100),
+    ) -> _BrainResult:
+        self.calls += 1
+        return _BrainResult(Action(ActionType.CLICK, {"x": 169, "y": 445}))
+
+
+class _RecordingEnv(GymEnvironment):
+    def __init__(self) -> None:
+        self.actions: list[Action] = []
+
+    @property
+    def screen_size(self) -> tuple[int, int]:
+        return (100, 100)
+
+    def reset(self, task: str, **kwargs: Any) -> GymObservation:
+        return GymObservation(
+            screenshot=Image.new("RGB", self.screen_size),
+            extras={"url": "https://www.boattrader.com/search/index/"},
+        )
+
+    def step(self, action: Action) -> GymResult:
+        self.actions.append(action)
+        return GymResult(
+            self.reset(""),
+            reward=0.0,
+            done=False,
+            info={"url": "https://www.boattrader.com/search/index/"},
+        )
+
+    def close(self) -> None:
+        pass
+
+
+def test_single_field_force_fill_commits_and_finishes(monkeypatch) -> None:
+    from mantis_agent.gym import holo3_detector
+
+    monkeypatch.setattr(
+        holo3_detector,
+        "extract_form_values",
+        lambda brain, task: [{"label": "zip code", "value": "33101"}],
+    )
+    monkeypatch.setattr(
+        holo3_detector,
+        "detect_focused_field",
+        lambda *args, **kwargs: {
+            "focused": True,
+            "label": "zip code",
+            "type": "text",
+        },
+    )
+
+    brain = _ClickBrain()
+    env = _RecordingEnv()
+    result = GymRunner(brain, env, max_steps=5).run(
+        "Click the ZIP Code field, type 33101, press Tab, and finish when "
+        "33101 is visible in the field."
+    )
+
+    assert result.success is True
+    assert result.termination_reason == "done"
+    assert brain.calls == 1
+    assert [a.action_type for a in env.actions] == [
+        ActionType.CLICK,
+        ActionType.KEY_PRESS,
+        ActionType.TYPE,
+        ActionType.KEY_PRESS,
+    ]
+    assert env.actions[0].params == {"x": 169, "y": 445}
+    assert env.actions[1].params == {"keys": "ctrl+a"}
+    assert env.actions[2].params == {"text": "33101"}
+    assert env.actions[3].params == {"keys": "Tab"}
+
+
+def test_force_fill_does_not_auto_finish_submit_or_login_tasks() -> None:
+    assert not GymRunner._force_fill_should_finish_task(
+        task="Type the password and submit the login form.",
+        initial_value_count=1,
+        pending_value_count=0,
+        submitted=False,
+    )

--- a/tests/test_runner_force_fill.py
+++ b/tests/test_runner_force_fill.py
@@ -48,6 +48,50 @@ def test_repeated_non_form_click_does_not_force_type() -> None:
     assert values == [{"label": "zip code", "value": "33101"}]
 
 
+def test_repeated_form_click_ignores_origin_sentinel() -> None:
+    values = [{"label": "radius", "value": "35"}]
+    previous = Action(ActionType.CLICK, {"x": 0, "y": 0})
+    current = Action(ActionType.CLICK, {"x": 0, "y": 0})
+
+    forced = GymRunner._maybe_force_type_after_repeated_form_click(
+        current,
+        [previous],
+        values,
+        [],
+        "Set the radius to 35 miles.",
+    )
+
+    assert forced is None
+    assert values == [{"label": "radius", "value": "35"}]
+
+
+def test_force_type_text_ignores_origin_sentinel(monkeypatch) -> None:
+    from mantis_agent.gym import holo3_detector
+
+    values = [{"label": "radius", "value": "35"}]
+    monkeypatch.setattr(
+        holo3_detector,
+        "detect_focused_field",
+        lambda *args, **kwargs: {
+            "focused": True,
+            "label": "radius",
+            "type": "text",
+        },
+    )
+
+    forced = GymRunner._maybe_force_type_text(
+        Action(ActionType.CLICK, {"x": 0, "y": 0}),
+        [],
+        values,
+        [],
+        brain=object(),
+        screenshot=Image.new("RGB", (100, 100)),
+    )
+
+    assert forced is None
+    assert values == [{"label": "radius", "value": "35"}]
+
+
 @dataclass
 class _BrainResult:
     action: Action

--- a/tests/test_task_loop_loop_config.py
+++ b/tests/test_task_loop_loop_config.py
@@ -58,7 +58,7 @@ def test_standard_task_uses_fallback_brain_after_primary_failure(
     monkeypatch,
     tmp_path,
 ) -> None:
-    calls: list[object] = []
+    calls: list[dict[str, object]] = []
 
     class FakeEnv:
         current_url = "https://example.test/"
@@ -66,9 +66,17 @@ def test_standard_task_uses_fallback_brain_after_primary_failure(
     class FakeGymRunner:
         def __init__(self, *, brain, **_kwargs):
             self.brain = brain
+            self.max_steps = _kwargs["max_steps"]
 
-        def run(self, **_kwargs):
-            calls.append(self.brain)
+        def run(self, **kwargs):
+            calls.append(
+                {
+                    "brain": self.brain,
+                    "task": kwargs["task"],
+                    "start_url": kwargs.get("start_url", ""),
+                    "max_steps": self.max_steps,
+                }
+            )
             return SimpleNamespace(
                 success=self.brain == "claude",
                 total_steps=3,
@@ -90,10 +98,30 @@ def test_standard_task_uses_fallback_brain_after_primary_failure(
         max_steps=12,
         results_dir=str(tmp_path),
     )
-    tasks = [{"task_id": "fill_filters", "intent": "fill filters"}]
+    tasks = [
+        {
+            "task_id": "fill_filters",
+            "intent": "fill filters",
+            "fallback_intent": "click the visible search button only",
+            "fallback_max_steps": 5,
+        }
+    ]
 
     scores, details = task_loop.run_task_loop(tasks, config)
 
-    assert calls == ["holo3", "claude"]
+    assert calls == [
+        {
+            "brain": "holo3",
+            "task": "fill filters",
+            "start_url": "",
+            "max_steps": 12,
+        },
+        {
+            "brain": "claude",
+            "task": "click the visible search button only",
+            "start_url": "",
+            "max_steps": 5,
+        },
+    ]
     assert scores == [1.0]
     assert details[0]["success"] is True

--- a/tests/test_task_loop_loop_config.py
+++ b/tests/test_task_loop_loop_config.py
@@ -170,3 +170,40 @@ def test_failed_standard_task_stops_loop_by_default(monkeypatch, tmp_path) -> No
     assert calls == ["submit"]
     assert scores == [0.0]
     assert [d["task_id"] for d in details] == ["submit"]
+
+
+def test_standard_task_uses_small_default_step_cap(monkeypatch, tmp_path) -> None:
+    captured: list[int] = []
+
+    class FakeEnv:
+        current_url = "https://example.test/"
+
+    class FakeGymRunner:
+        def __init__(self, *, max_steps, **_kwargs):
+            captured.append(max_steps)
+
+        def run(self, **_kwargs):
+            return SimpleNamespace(
+                success=True,
+                total_steps=1,
+                termination_reason="done",
+                trajectory=[],
+            )
+
+    monkeypatch.setattr(runner_module, "GymRunner", FakeGymRunner)
+
+    config = task_loop.TaskLoopConfig(
+        run_id="run",
+        session_name="session",
+        model_name="model",
+        results_prefix="test",
+        brain="holo3",
+        env=FakeEnv(),
+        max_steps=90,
+        standard_task_max_steps=15,
+        results_dir=str(tmp_path),
+    )
+
+    task_loop.run_task_loop([{"task_id": "submit", "intent": "click submit"}], config)
+
+    assert captured == [15]

--- a/tests/test_task_loop_loop_config.py
+++ b/tests/test_task_loop_loop_config.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 from mantis_agent import task_loop
+from mantis_agent.gym import runner as runner_module
 from mantis_agent.gym import workflow_runner
 
 
@@ -49,3 +52,48 @@ def test_loop_task_passes_extended_loop_config(monkeypatch, tmp_path) -> None:
     assert loop_config.max_steps_per_iteration == 45
     assert loop_config.max_retries_per_iteration == 4
     assert loop_config.max_steps_pagination == 35
+
+
+def test_standard_task_uses_fallback_brain_after_primary_failure(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    calls: list[object] = []
+
+    class FakeEnv:
+        current_url = "https://example.test/"
+
+    class FakeGymRunner:
+        def __init__(self, *, brain, **_kwargs):
+            self.brain = brain
+
+        def run(self, **_kwargs):
+            calls.append(self.brain)
+            return SimpleNamespace(
+                success=self.brain == "claude",
+                total_steps=3,
+                termination_reason="done" if self.brain == "claude" else "loop",
+                trajectory=[],
+            )
+
+    monkeypatch.setattr(runner_module, "GymRunner", FakeGymRunner)
+
+    config = task_loop.TaskLoopConfig(
+        run_id="run",
+        session_name="session",
+        model_name="model",
+        results_prefix="test",
+        brain="holo3",
+        fallback_brain="claude",
+        fallback_label="claude",
+        env=FakeEnv(),
+        max_steps=12,
+        results_dir=str(tmp_path),
+    )
+    tasks = [{"task_id": "fill_filters", "intent": "fill filters"}]
+
+    scores, details = task_loop.run_task_loop(tasks, config)
+
+    assert calls == ["holo3", "claude"]
+    assert scores == [1.0]
+    assert details[0]["success"] is True

--- a/tests/test_task_loop_loop_config.py
+++ b/tests/test_task_loop_loop_config.py
@@ -13,6 +13,10 @@ def test_loop_task_passes_extended_loop_config(monkeypatch, tmp_path) -> None:
     class FakeWorkflowRunner:
         def __init__(self, **kwargs):
             captured["loop_config"] = kwargs["loop_config"]
+            captured["fallback_brain"] = kwargs["fallback_brain"]
+            captured["fallback_label"] = kwargs["fallback_label"]
+            captured["fallback_micro_retries"] = kwargs["fallback_micro_retries"]
+            captured["fallback_micro_max_steps"] = kwargs["fallback_micro_max_steps"]
 
         def run_loop(self):
             return []
@@ -25,6 +29,10 @@ def test_loop_task_passes_extended_loop_config(monkeypatch, tmp_path) -> None:
         model_name="model",
         results_prefix="test",
         brain=object(),
+        fallback_brain="claude",
+        fallback_label="claude",
+        fallback_micro_retries=3,
+        fallback_micro_max_steps=7,
         env=object(),
         max_steps=90,
         results_dir=str(tmp_path),
@@ -52,6 +60,10 @@ def test_loop_task_passes_extended_loop_config(monkeypatch, tmp_path) -> None:
     assert loop_config.max_steps_per_iteration == 45
     assert loop_config.max_retries_per_iteration == 4
     assert loop_config.max_steps_pagination == 35
+    assert captured["fallback_brain"] == "claude"
+    assert captured["fallback_label"] == "claude"
+    assert captured["fallback_micro_retries"] == 3
+    assert captured["fallback_micro_max_steps"] == 7
 
 
 def test_standard_task_uses_fallback_brain_after_primary_failure(

--- a/tests/test_task_loop_loop_config.py
+++ b/tests/test_task_loop_loop_config.py
@@ -128,3 +128,45 @@ def test_standard_task_uses_fallback_brain_after_primary_failure(
     }
     assert scores == [1.0]
     assert details[0]["success"] is True
+
+
+def test_failed_standard_task_stops_loop_by_default(monkeypatch, tmp_path) -> None:
+    calls: list[str] = []
+
+    class FakeEnv:
+        current_url = "https://example.test/"
+
+    class FakeGymRunner:
+        def __init__(self, *, brain, **_kwargs):
+            self.brain = brain
+
+        def run(self, **kwargs):
+            calls.append(kwargs["task_id"])
+            return SimpleNamespace(
+                success=False,
+                total_steps=2,
+                termination_reason="loop",
+                trajectory=[],
+            )
+
+    monkeypatch.setattr(runner_module, "GymRunner", FakeGymRunner)
+
+    config = task_loop.TaskLoopConfig(
+        run_id="run",
+        session_name="session",
+        model_name="model",
+        results_prefix="test",
+        brain="holo3",
+        env=FakeEnv(),
+        results_dir=str(tmp_path),
+    )
+    tasks = [
+        {"task_id": "submit", "intent": "click submit"},
+        {"task_id": "extract", "intent": "extract records"},
+    ]
+
+    scores, details = task_loop.run_task_loop(tasks, config)
+
+    assert calls == ["submit"]
+    assert scores == [0.0]
+    assert [d["task_id"] for d in details] == ["submit"]

--- a/tests/test_task_loop_loop_config.py
+++ b/tests/test_task_loop_loop_config.py
@@ -73,14 +73,16 @@ def test_standard_task_uses_fallback_brain_after_primary_failure(
                 {
                     "brain": self.brain,
                     "task": kwargs["task"],
+                    "task_id": kwargs["task_id"],
                     "start_url": kwargs.get("start_url", ""),
                     "max_steps": self.max_steps,
                 }
             )
+            success = self.brain == "claude" or "resume_after_claude" in kwargs["task_id"]
             return SimpleNamespace(
-                success=self.brain == "claude",
+                success=success,
                 total_steps=3,
-                termination_reason="done" if self.brain == "claude" else "loop",
+                termination_reason="done" if success else "loop",
                 trajectory=[],
             )
 
@@ -94,34 +96,35 @@ def test_standard_task_uses_fallback_brain_after_primary_failure(
         brain="holo3",
         fallback_brain="claude",
         fallback_label="claude",
+        fallback_micro_retries=1,
+        fallback_micro_max_steps=5,
         env=FakeEnv(),
         max_steps=12,
         results_dir=str(tmp_path),
     )
-    tasks = [
-        {
-            "task_id": "fill_filters",
-            "intent": "fill filters",
-            "fallback_intent": "click the visible search button only",
-            "fallback_max_steps": 5,
-        }
-    ]
+    tasks = [{"task_id": "fill_filters", "intent": "fill filters"}]
 
     scores, details = task_loop.run_task_loop(tasks, config)
 
-    assert calls == [
-        {
-            "brain": "holo3",
-            "task": "fill filters",
-            "start_url": "",
-            "max_steps": 12,
-        },
-        {
-            "brain": "claude",
-            "task": "click the visible search button only",
-            "start_url": "",
-            "max_steps": 5,
-        },
-    ]
+    assert calls[0] == {
+        "brain": "holo3",
+        "task": "fill filters",
+        "task_id": "fill_filters",
+        "start_url": "",
+        "max_steps": 12,
+    }
+    assert calls[1]["brain"] == "claude"
+    assert "single stuck browser-control micro-step" in str(calls[1]["task"])
+    assert "fill filters" in str(calls[1]["task"])
+    assert calls[1]["task_id"] == "fill_filters_claude_micro_fallback_1"
+    assert calls[1]["start_url"] == ""
+    assert calls[1]["max_steps"] == 5
+    assert calls[2] == {
+        "brain": "holo3",
+        "task": "fill filters",
+        "task_id": "fill_filters_resume_after_claude_1",
+        "start_url": "",
+        "max_steps": 12,
+    }
     assert scores == [1.0]
     assert details[0]["success"] is True

--- a/tests/test_workflow_runner_recovery_url.py
+++ b/tests/test_workflow_runner_recovery_url.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
+
+from mantis_agent.gym import workflow_runner
 from mantis_agent.gym.workflow_runner import LoopConfig, WorkflowRunner
 
 
@@ -19,3 +22,67 @@ def test_workflow_runner_anchors_recovery_to_current_url_when_start_url_missing(
     )
 
     assert runner.start_url == "https://www.boattrader.com/boats/state-fl/city-miami/zip-33101/"
+
+
+def test_loop_iteration_uses_claude_micro_fallback_then_resumes(monkeypatch) -> None:
+    calls: list[dict[str, object]] = []
+
+    class FakeGymRunner:
+        def __init__(self, *, brain, max_steps, **_kwargs):
+            self.brain = brain
+            self.max_steps = max_steps
+
+        def run(self, **kwargs):
+            calls.append(
+                {
+                    "brain": self.brain,
+                    "task": kwargs["task"],
+                    "task_id": kwargs["task_id"],
+                    "start_url": kwargs.get("start_url", ""),
+                    "max_steps": self.max_steps,
+                }
+            )
+            success = self.brain == "claude" or "resume_after_claude" in kwargs["task_id"]
+            return SimpleNamespace(
+                success=success,
+                termination_reason="done" if success else "loop",
+                trajectory=[],
+                total_steps=1,
+            )
+
+    monkeypatch.setattr(workflow_runner, "GymRunner", FakeGymRunner)
+
+    runner = WorkflowRunner(
+        brain="holo3",
+        fallback_brain="claude",
+        fallback_label="claude",
+        fallback_micro_retries=1,
+        fallback_micro_max_steps=4,
+        env=_Env(),
+        loop_config=LoopConfig(
+            iteration_intent="Process listing.",
+            pagination_intent="Click Next.",
+            max_retries_per_iteration=1,
+            max_steps_per_iteration=10,
+        ),
+        start_url="",
+    )
+
+    result = runner._run_iteration("Process listing.", "iter_1")
+
+    assert result.success is True
+    assert calls[0] == {
+        "brain": "holo3",
+        "task": "Process listing.",
+        "task_id": "iter_1",
+        "start_url": "https://www.boattrader.com/boats/state-fl/city-miami/zip-33101/",
+        "max_steps": 10,
+    }
+    assert calls[1]["brain"] == "claude"
+    assert "larger extraction loop" in str(calls[1]["task"])
+    assert calls[1]["task_id"] == "iter_1_claude_micro_fallback_1"
+    assert calls[1]["start_url"] == ""
+    assert calls[1]["max_steps"] == 4
+    assert calls[2]["brain"] == "holo3"
+    assert calls[2]["task_id"] == "iter_1_resume_after_claude_1"
+    assert calls[2]["start_url"] == ""


### PR DESCRIPTION
Adds bounded Claude micro-fallback for failed Holo3 sections and extraction loops, force-fill hardening, standard section caps, and tests. Keeps Claude interventions scoped to stuck micro-steps, then resumes the primary executor.