### PR TITLE
Stop probing dead clicks: skip on /login or chrome://newtab/

### DIFF
--- a/src/mantis_agent/gym/step_handlers/click.py
+++ b/src/mantis_agent/gym/step_handlers/click.py
@@ -351,6 +351,31 @@ class ClaudeGuidedClickHandler:
                 return StepResult(step_index=index, intent=step.intent, success=True,
                                 steps_used=1, duration=3.0 + verify_attempt * 3)
 
+            # Auth-wall short-circuit: if the click hijacked the original tab to
+            # a /login page, neither middle-click nor probe-area clicks can
+            # rescue this card — they'll just re-fire on a login form. Bail
+            # immediately and let StepRecoveryPolicy roll back to the results
+            # URL so the next loop iteration starts clean.
+            if url and _looks_like_login_redirect(url):
+                logger.warning(
+                    "  [claude-click] Click redirected to login (url=%s) — "
+                    "bailing out for recovery to roll back",
+                    url[:80],
+                )
+                dynamic_verifier.record_item_completed(
+                    page=runner._current_page,
+                    item=getattr(runner, "_last_click_title", "") or title,
+                    url=url,
+                    success=False,
+                    reason="login_redirect",
+                )
+                if hasattr(runner, '_last_click_title') and runner._last_click_title:
+                    runner._extracted_titles.append(runner._last_click_title)
+                return StepResult(
+                    step_index=index, intent=step.intent, success=False,
+                    data="login_redirect",
+                )
+
             if verify_attempt == 0:
                 logger.info(f"  [claude-click] Not on detail page yet (url={url[:40]}) — retrying verify")
 
@@ -389,6 +414,42 @@ class ClaudeGuidedClickHandler:
                         runner._extracted_titles.append(runner._last_click_title)
                     return StepResult(step_index=index, intent=step.intent, success=True,
                                     steps_used=2 + switch_attempt, duration=9.0)
+
+                # Empty-newtab short-circuit: middle-click on a non-anchor card
+                # region (e.g. whitespace) opens a blank chrome://newtab/.
+                # Repeated ctrl+Tab + probe-area clicks won't recover — the
+                # click target itself isn't a link. Close the empty tab,
+                # mark the card tried, and let recovery move on.
+                if url and _looks_like_blank_newtab(url):
+                    logger.warning(
+                        "  [claude-click] Middle-click landed on blank tab "
+                        "(%s) — aborting fallback chain",
+                        url[:40],
+                    )
+                    try:
+                        env.step(Action(
+                            action_type=ActionType.KEY_PRESS,
+                            params={"keys": "ctrl+w"},
+                        ))
+                        time.sleep(0.5)
+                    except Exception as close_err:
+                        logger.debug(
+                            "  [claude-click] ctrl+w on blank tab failed: %s",
+                            close_err,
+                        )
+                    dynamic_verifier.record_item_completed(
+                        page=runner._current_page,
+                        item=getattr(runner, "_last_click_title", "") or title,
+                        url=url,
+                        success=False,
+                        reason="newtab_blank",
+                    )
+                    if hasattr(runner, '_last_click_title') and runner._last_click_title:
+                        runner._extracted_titles.append(runner._last_click_title)
+                    return StepResult(
+                        step_index=index, intent=step.intent, success=False,
+                        data="newtab_blank",
+                    )
 
                 if switch_attempt == 0:
                     env.step(Action(action_type=ActionType.KEY_PRESS, params={"keys": "ctrl+Tab"}))
@@ -475,6 +536,57 @@ class ClaudeGuidedClickHandler:
         if hasattr(runner, '_last_click_title') and runner._last_click_title:
             runner._extracted_titles.append(runner._last_click_title)
         return StepResult(step_index=index, intent=step.intent, success=False)
+
+
+# ── click-failure URL predicates ──────────────────────────────────────
+
+
+# Path tokens used to detect an auth wall hijacking a card click. Kept
+# conservative — match common SaaS / CRM login routes, not search-result
+# pages that happen to contain "login" as a query parameter.
+_LOGIN_PATH_TOKENS: tuple[str, ...] = (
+    "/login",
+    "/signin",
+    "/sign-in",
+    "/sign_in",
+    "/auth/login",
+    "/oauth/authorize",
+    "/users/sign_in",
+    "/account/login",
+)
+
+
+def _looks_like_login_redirect(url: str) -> bool:
+    """True when the post-click URL is a login wall, not a detail page.
+
+    Used by the click handler to short-circuit the middle-click + probe
+    fallback chain — neither will rescue a click that was hijacked into
+    an auth flow. StepRecoveryPolicy receives ``data="login_redirect"``
+    and rolls back to the prior results URL.
+    """
+    if not url:
+        return False
+    lowered = url.lower()
+    return any(token in lowered for token in _LOGIN_PATH_TOKENS)
+
+
+def _looks_like_blank_newtab(url: str) -> bool:
+    """True when the middle-click landed on Chromium's empty new-tab page.
+
+    Used by the click handler to abort the middle-click + probe chain
+    when the click target wasn't a navigable link. Matches
+    ``chrome://newtab/``, ``about:blank``, and the Edge/Chromium variants
+    that surface in the same scenario.
+    """
+    if not url:
+        return False
+    lowered = url.lower().strip()
+    return (
+        lowered.startswith("chrome://newtab")
+        or lowered.startswith("chrome://new-tab-page")
+        or lowered.startswith("edge://newtab")
+        or lowered.startswith("about:blank")
+    )
 
 
 # ── #181 helpers — independent grounding routing + metric emission ────

--- a/src/mantis_agent/gym/step_recovery.py
+++ b/src/mantis_agent/gym/step_recovery.py
@@ -389,6 +389,40 @@ class StepRecoveryPolicy:
                 halt=False, step_index=new_index, halt_reason="page_exhausted",
             )
 
+        # login_redirect → click hijacked into auth wall. Reload the
+        # filtered results URL to roll back, mark the card tried (handler
+        # already appended to _extracted_titles), and skip to the next
+        # loop iteration so the next card is attempted on a clean page.
+        if step_result.data == "login_redirect":
+            logger_.warning(
+                f"  [{step_index}] LOGIN REDIRECT — rolling back to results URL"
+            )
+            try:
+                runner._ensure_results_filters(step_index, force_reload=True)
+            except Exception as exc:  # noqa: BLE001 — rollback must not raise
+                logger_.warning(
+                    f"  [{step_index}] rollback reload failed: {exc}"
+                )
+            jumped = self._first_step_of_type(plan, step_index + 1, "loop")
+            new_index = jumped if jumped is not None else step_index + 1
+            return RecoveryOutcome(
+                halt=False, step_index=new_index,
+                halt_reason="login_redirect_recovered",
+            )
+
+        # newtab_blank → middle-click opened chrome://newtab/. The handler
+        # already closed the empty tab; treat as a generic skip-this-card
+        # so the next loop iteration runs on the original results tab.
+        if step_result.data == "newtab_blank":
+            logger_.warning(
+                f"  [{step_index}] BLANK NEW TAB — card has no navigable link, skipping"
+            )
+            jumped = self._first_step_of_type(plan, step_index + 1, "loop")
+            new_index = jumped if jumped is not None else step_index + 1
+            return RecoveryOutcome(
+                halt=False, step_index=new_index, halt_reason="newtab_blank",
+            )
+
         # scan_error / page_blocked → bounded retry, then page_blocked reload
         if step_result.data in ("scan_error", "page_blocked"):
             attempt = step_retry_counts.get(step_index, 0) + 1

--- a/tests/test_click_handler.py
+++ b/tests/test_click_handler.py
@@ -189,6 +189,112 @@ def test_all_viewports_exhausted_returns_page_exhausted(monkeypatch):
     assert runner._viewport_stage == 2  # advanced past both stages
 
 
+def test_login_redirect_short_circuits_fallback_chain(monkeypatch):
+    """Plain click that lands on /login → bail with data='login_redirect',
+    no middle-click, no probes, card marked tried."""
+    monkeypatch.setattr("mantis_agent.gym.step_handlers.click.time.sleep", lambda *_: None)
+    monkeypatch.setattr(
+        "mantis_agent.gym.step_handlers.click.random.uniform", lambda *_: 0.0,
+    )
+
+    runner = _FakeRunner()
+    runner._max_viewport_stages = 1
+    extractor = MagicMock()
+    extractor.find_all_listings.return_value = [(100, 200, "Card A")]
+
+    env = MagicMock()
+    env.screen_size = (1280, 800)
+    ctx = _ctx(runner, env=env, extractor=extractor)
+    ctx.site_config.is_detail_page.return_value = False
+    runner._read_current_url = MagicMock(
+        return_value="https://example.com/users/sign_in?redirect=/listings/42",
+    )
+
+    result = ClaudeGuidedClickHandler(runner).execute(_step(), ctx)
+
+    assert result.success is False
+    assert result.data == "login_redirect"
+    # Middle-click was NOT fired — only the initial single-button CLICK.
+    click_actions = [
+        c.args[0]
+        for c in env.step.call_args_list
+        if getattr(c.args[0], "params", {}).get("button") == "middle"
+    ]
+    assert click_actions == []
+    # Card title appended to the skip list so we don't re-attempt it.
+    assert "Card A" in runner._extracted_titles
+    # Verifier saw login_redirect reason
+    completed = ctx.dynamic_verifier.record_item_completed.call_args
+    assert completed.kwargs["reason"] == "login_redirect"
+
+
+def test_blank_newtab_aborts_middle_click_fallback(monkeypatch):
+    """Middle-click landing on chrome://newtab/ → close tab, data='newtab_blank',
+    no probe-area attempts, card marked tried."""
+    monkeypatch.setattr("mantis_agent.gym.step_handlers.click.time.sleep", lambda *_: None)
+    monkeypatch.setattr(
+        "mantis_agent.gym.step_handlers.click.random.uniform", lambda *_: 0.0,
+    )
+
+    runner = _FakeRunner()
+    runner._max_viewport_stages = 1
+    extractor = MagicMock()
+    extractor.find_all_listings.return_value = [(100, 200, "Card B")]
+
+    env = MagicMock()
+    env.screen_size = (1280, 800)
+    ctx = _ctx(runner, env=env, extractor=extractor)
+    ctx.site_config.is_detail_page.return_value = False
+    # Verify reads (4 calls = 2 attempts × {primary, screenshot-fallback}) → "".
+    # Middle-click reads (1+ call) → "chrome://newtab/".
+    runner._read_current_url = MagicMock(
+        side_effect=["", "", "", "", "chrome://newtab/", "chrome://newtab/"],
+    )
+
+    result = ClaudeGuidedClickHandler(runner).execute(_step(), ctx)
+
+    assert result.success is False
+    assert result.data == "newtab_blank"
+    # ctrl+w sent to close the empty tab.
+    keypresses = [
+        c.args[0].params.get("keys")
+        for c in env.step.call_args_list
+        if getattr(c.args[0], "action_type", None)
+        and c.args[0].action_type.name == "KEY_PRESS"
+    ]
+    assert "ctrl+w" in keypresses
+    # No probe-area click — only the initial click + middle-click.
+    click_count = sum(
+        1
+        for c in env.step.call_args_list
+        if getattr(c.args[0], "action_type", None)
+        and c.args[0].action_type.name == "CLICK"
+    )
+    assert click_count == 2  # plain click + middle-click only
+    assert "Card B" in runner._extracted_titles
+    completed = ctx.dynamic_verifier.record_item_completed.call_args
+    assert completed.kwargs["reason"] == "newtab_blank"
+
+
+def test_looks_like_login_redirect_predicate():
+    from mantis_agent.gym.step_handlers.click import _looks_like_login_redirect
+    assert _looks_like_login_redirect("https://app.example.com/login") is True
+    assert _looks_like_login_redirect("https://app.example.com/users/sign_in") is True
+    assert _looks_like_login_redirect("https://app.example.com/oauth/authorize?id=1") is True
+    assert _looks_like_login_redirect("https://example.com/listings/42") is False
+    assert _looks_like_login_redirect("") is False
+
+
+def test_looks_like_blank_newtab_predicate():
+    from mantis_agent.gym.step_handlers.click import _looks_like_blank_newtab
+    assert _looks_like_blank_newtab("chrome://newtab/") is True
+    assert _looks_like_blank_newtab("chrome://new-tab-page/") is True
+    assert _looks_like_blank_newtab("about:blank") is True
+    assert _looks_like_blank_newtab("edge://newtab/") is True
+    assert _looks_like_blank_newtab("https://example.com/") is False
+    assert _looks_like_blank_newtab("") is False
+
+
 def test_handler_filters_already_extracted_titles(monkeypatch):
     """Cards whose titles are in _extracted_titles get filtered out before clicking."""
     monkeypatch.setattr("mantis_agent.gym.step_handlers.click.time.sleep", lambda *_: None)

--- a/tests/test_step_recovery_policy.py
+++ b/tests/test_step_recovery_policy.py
@@ -317,6 +317,76 @@ def test_click_failure_page_blocked_reload_failed_halts(monkeypatch):
     assert outcome.halt_reason == "page_blocked"
 
 
+def test_click_failure_login_redirect_reloads_then_jumps_to_loop(monkeypatch):
+    """login_redirect → _ensure_results_filters(force_reload=True), jump to next loop."""
+    monkeypatch.setattr("mantis_agent.gym.step_recovery.time.sleep", lambda *_: None)
+    runner = _runner_stub()
+    runner._ensure_results_filters.return_value = True
+    policy = StepRecoveryPolicy(runner)
+
+    plan = _plan("click", "extract_data", "loop")
+    outcome = policy.handle_failure(
+        step=plan.steps[0],
+        step_result=_result(data="login_redirect"),
+        plan=plan,
+        step_index=0,
+        step_retry_counts={},
+        loop_counters={},
+        max_retries=2,
+        listings_on_page=0,
+    )
+    assert outcome.halt is False
+    assert outcome.step_index == 2  # loop
+    assert outcome.halt_reason == "login_redirect_recovered"
+    runner._ensure_results_filters.assert_called_once_with(0, force_reload=True)
+
+
+def test_click_failure_login_redirect_swallows_reload_exception(monkeypatch):
+    """Recovery must not propagate a reload exception — log and skip card."""
+    monkeypatch.setattr("mantis_agent.gym.step_recovery.time.sleep", lambda *_: None)
+    runner = _runner_stub()
+    runner._ensure_results_filters.side_effect = RuntimeError("nav blew up")
+    policy = StepRecoveryPolicy(runner)
+
+    plan = _plan("click", "loop")
+    outcome = policy.handle_failure(
+        step=plan.steps[0],
+        step_result=_result(data="login_redirect"),
+        plan=plan,
+        step_index=0,
+        step_retry_counts={},
+        loop_counters={},
+        max_retries=2,
+        listings_on_page=0,
+    )
+    assert outcome.halt is False
+    assert outcome.step_index == 1
+    assert outcome.halt_reason == "login_redirect_recovered"
+
+
+def test_click_failure_newtab_blank_skips_to_loop(monkeypatch):
+    """newtab_blank → no reload (handler closed tab), jump to next loop step."""
+    monkeypatch.setattr("mantis_agent.gym.step_recovery.time.sleep", lambda *_: None)
+    runner = _runner_stub()
+    policy = StepRecoveryPolicy(runner)
+
+    plan = _plan("click", "extract_data", "loop")
+    outcome = policy.handle_failure(
+        step=plan.steps[0],
+        step_result=_result(data="newtab_blank"),
+        plan=plan,
+        step_index=0,
+        step_retry_counts={},
+        loop_counters={},
+        max_retries=2,
+        listings_on_page=0,
+    )
+    assert outcome.halt is False
+    assert outcome.step_index == 2  # loop
+    assert outcome.halt_reason == "newtab_blank"
+    runner._ensure_results_filters.assert_not_called()
+
+
 def test_click_failure_generic_escapes_then_jumps_to_loop(monkeypatch):
     monkeypatch.setattr("mantis_agent.gym.step_recovery.time.sleep", lambda *_: None)
     runner = _runner_stub()


### PR DESCRIPTION
## Summary
- Card clicks that redirect to a login page or open a blank `chrome://newtab/` can't be rescued by the middle-click + probe-area fallback chain. Detect both in `ClaudeGuidedClickHandler`, emit `StepResult.data="login_redirect" / "newtab_blank"`, and let `StepRecoveryPolicy` route accordingly.
- `login_redirect` → `_ensure_results_filters(force_reload=True)` rolls back to the filtered results URL, then jumps to the next loop step.
- `newtab_blank` → handler closes the empty tab with `ctrl+w`; recovery just skips the card and resumes the next loop iteration.

Both cases mark the card title in `_extracted_titles` so the same dead target isn't re-attempted.

## Test plan
- [x] `pytest tests/test_click_handler.py tests/test_step_recovery_policy.py` (33 passed; 4 new tests cover the two predicates + the two new exits)
- [x] Full suite: `pytest tests/ --ignore=tests/test_modal_app.py` (1166 passed, 9m24s)
- [x] `ruff check src/mantis_agent/gym/step_handlers/click.py src/mantis_agent/gym/step_recovery.py tests/test_click_handler.py tests/test_step_recovery_policy.py` (clean)
- [ ] Modal staff-crm smoke (deploying this branch + invoking from staffai, follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)