### PR TITLE
fix(decomposer): three-layer URL preservation hardening (#209 Symptom 4)

### DIFF
--- a/src/mantis_agent/gym/step_handlers/navigate.py
+++ b/src/mantis_agent/gym/step_handlers/navigate.py
@@ -69,6 +69,19 @@ class NavigateHandler:
         url_match = re.search(r'https?://[^\s"]+', step.intent)
         url = url_match.group() if url_match else ""
 
+        # Defense-in-depth (#209 Symptom 4): when the decomposer paraphrases
+        # the intent and drops the URL, recover from ``params.url`` before
+        # giving up. The repair pass in ``PlanDecomposer`` populates
+        # ``params.url`` whenever the source plan named a URL the step lost.
+        if not url:
+            params_url = str((step.params or {}).get("url", ""))
+            pm = re.search(r'https?://[^\s"]+', params_url)
+            if pm:
+                url = pm.group()
+                logger.info(
+                    f"  [navigate] URL absent from intent; recovered from params.url: {url}"
+                )
+
         if not url:
             logger.warning(f"  [navigate] No URL found in intent: {step.intent[:60]}")
             return StepResult(step_index=index, intent=step.intent, success=False)

--- a/src/mantis_agent/plan_decomposer.py
+++ b/src/mantis_agent/plan_decomposer.py
@@ -386,16 +386,23 @@ RULES:
   region of the page (e.g. left sidebar, top header, modal dialog,
   results card) when it disambiguates. Use the labels the source plan
   itself names — never invent application-specific filter names.
-- For navigate steps: include the FULL URL (http:// or https://) in the intent.
+- For navigate steps: include the FULL URL (http:// or https://) in the intent
+  AND mirror the URL in `params.url`. The duplication is intentional — the
+  runner will recover from `params.url` if the intent string ever drifts.
   CRITICAL RULE — no exceptions:
     • If the source plan DOES contain an http(s):// URL, emit `navigate`
-      with the full URL in the intent.
+      with the full URL in BOTH `intent` and `params.url`.
     • If the source plan does NOT contain an http(s):// URL for a step,
       you MUST emit `submit` with params={"label": "<page name>"}.
       The runner clicks the matching nav link — there is no URL to load.
   WORKED EXAMPLES:
     Source: "1. Go to https://app.example.com/login"
-    → {"type": "navigate", "intent": "Navigate to https://app.example.com/login", ...}
+    → {"type": "navigate", "intent": "Navigate to https://app.example.com/login",
+       "params": {"url": "https://app.example.com/login"}, ...}
+    Source: "1. Navigate to https://app.example.com for billing"
+    (do NOT paraphrase the URL away — keep the literal string)
+    → {"type": "navigate", "intent": "Navigate to https://app.example.com",
+       "params": {"url": "https://app.example.com"}, ...}
     Source: "3. Go the Leads Page"
     → {"type": "submit", "intent": "Open the Leads section",
        "params": {"label": "Leads"}, ...}
@@ -403,8 +410,9 @@ RULES:
     → {"type": "submit", "intent": "Open the Settings section",
        "params": {"label": "Settings"}, ...}
   This rule is verifiable by inspecting your own output: every `navigate`
-  step's intent string MUST contain the substring "http://" or "https://".
-  If it doesn't, the step type is wrong — switch it to `submit`.
+  step's intent string MUST contain the substring "http://" or "https://"
+  AND `params.url` MUST contain the same URL. If it doesn't, the step type
+  is wrong — switch it to `submit`.
 - Extraction steps (reading screen) use claude_only=true
 - For fill_field / submit / select_option, ALWAYS populate `params`
   (label/value/dropdown_label/option_label) using the labels the source
@@ -536,7 +544,7 @@ class PlanDecomposer:
             domain = m.group(1)
 
         # Check cache — include prompt version in hash to invalidate on schema changes
-        prompt_version = "v19_literal_values"  # Bump this when DECOMPOSE_PROMPT changes
+        prompt_version = "v20_url_mirror"  # Bump this when DECOMPOSE_PROMPT changes
         plan_hash = hashlib.md5(f"{prompt_version}:{plan_text}".encode()).hexdigest()[:8]
         cache_path = (
             cache_path_template.replace("{hash}", plan_hash)
@@ -631,6 +639,11 @@ class PlanDecomposer:
 
         # Fix 3: Validate and fix loop targets — must point to the click step
         self._fix_loop_targets(plan)
+        # Fix 4 (#209 Symptom 4): repair urlless navigate steps by injecting
+        # the matching source-plan URL into ``params.url``. The v20 prompt
+        # asks Claude to mirror the URL there already; this pass catches
+        # the residual cases where it paraphrases the URL away entirely.
+        self._repair_navigate_urls(plan)
 
         # Cache the full parsed structure (object or legacy array) so the
         # cached path round-trips through both schemas.
@@ -707,6 +720,88 @@ class PlanDecomposer:
             params=params,
             hints=hints,
         )
+
+    @staticmethod
+    def _repair_navigate_urls(plan: MicroPlan) -> None:
+        """Inject lost source-plan URLs into urlless navigate steps (#209 Symptom 4).
+
+        The v20 ``DECOMPOSE_PROMPT`` instructs Claude to mirror every
+        literal URL from the source plan into both the navigate step's
+        ``intent`` and ``params.url``. Empirically, even with explicit
+        rules and worked examples, Claude occasionally paraphrases the
+        URL away ("Navigate to the leads management system") leaving
+        the runner with no URL to load.
+
+        This pass extracts ``https?://`` URLs from the source plan in
+        source order, walks the decomposed navigate steps, and pairs
+        each urlless navigate step (intent AND params.url both empty
+        of an https URL) with the next unconsumed source URL by
+        injecting it into ``params.url``. The runtime navigate handler
+        falls back to ``params.url`` when the intent lacks a URL, so
+        the repaired step executes correctly.
+
+        A repaired step logs at WARNING (so prompt regressions are
+        visible). An unrepairable step — more urlless navigates than
+        source URLs — logs at ERROR; that's a decomposer bug worth a
+        prompt iteration. Repair is best-effort and never fails the
+        decompose, because production traffic must still flow.
+        """
+        url_re = re.compile(r'https?://[^\s"\'<>]+')
+        source_urls = url_re.findall(plan.source_plan or "")
+        if not source_urls:
+            return
+
+        # Pass 1: build the queue of source URLs the decomposer hasn't
+        # already covered. We walk healthy navigate steps in plan order and
+        # remove the first remaining occurrence of each URL they reference,
+        # so duplicates in the source plan are honoured (each occurrence
+        # can satisfy at most one navigate step).
+        remaining = list(source_urls)
+        for step in plan.steps:
+            if step.type != "navigate":
+                continue
+            covered: str | None = None
+            intent_match = url_re.search(step.intent or "")
+            if intent_match:
+                covered = intent_match.group()
+            elif isinstance(step.params, dict):
+                params_url = step.params.get("url")
+                if isinstance(params_url, str):
+                    pm = url_re.search(params_url)
+                    if pm:
+                        covered = pm.group()
+            if covered and covered in remaining:
+                remaining.remove(covered)
+
+        # Pass 2: repair urlless navigate steps from the unused queue.
+        cursor = 0
+        for i, step in enumerate(plan.steps):
+            if step.type != "navigate":
+                continue
+            if url_re.search(step.intent or ""):
+                continue
+            params = step.params if isinstance(step.params, dict) else {}
+            existing = params.get("url")
+            if isinstance(existing, str) and url_re.search(existing):
+                continue
+
+            if cursor >= len(remaining):
+                logger.error(
+                    f"  [decomposer] navigate step #{i} lost its URL and no "
+                    f"source URL remains to repair from: {step.intent[:80]!r}"
+                )
+                continue
+
+            recovered = remaining[cursor]
+            cursor += 1
+            if not isinstance(step.params, dict):
+                step.params = {}
+            step.params["url"] = recovered
+            logger.warning(
+                f"  [decomposer] navigate step #{i} dropped its URL "
+                f"({step.intent[:60]!r}); repaired with source URL "
+                f"{recovered}. Tighten the decomposer prompt if this recurs."
+            )
 
     @staticmethod
     def _fix_loop_targets(plan: MicroPlan):

--- a/tests/test_decomposer_literal_values.py
+++ b/tests/test_decomposer_literal_values.py
@@ -125,5 +125,6 @@ def test_prompt_version_was_bumped() -> None:
     from mantis_agent.plan_decomposer import PlanDecomposer
 
     src = inspect.getsource(PlanDecomposer.decompose_text)
-    assert "v19_literal_values" in src
+    assert "v20_url_mirror" in src
+    assert "v19_literal_values" not in src
     assert "v18_pure_llm" not in src

--- a/tests/test_decomposer_url_repair.py
+++ b/tests/test_decomposer_url_repair.py
@@ -1,0 +1,165 @@
+"""Tests for #209 Symptom 4 — decomposer URL preservation hardening.
+
+Three layers of defense against the v19 failure mode where Claude
+paraphrases a navigate step's intent and drops the literal URL:
+
+1. The v20 ``DECOMPOSE_PROMPT`` mirrors the URL into ``params.url`` and
+   adds a "Navigate to <URL> for <purpose>" worked example.
+2. ``PlanDecomposer._repair_navigate_urls`` re-scans the source plan
+   for URLs and repairs urlless navigate steps post-decompose.
+3. ``NavigateHandler`` falls back to ``params.url`` when the intent
+   string lacks an ``https://`` substring.
+
+These tests cover layers 1 and 2. Layer 3 is covered in
+``test_navigate_handler.py``.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+from mantis_agent.plan_decomposer import (
+    DECOMPOSE_PROMPT,
+    MicroIntent,
+    MicroPlan,
+    PlanDecomposer,
+)
+
+
+# ── Layer 1: prompt teaches URL mirroring ────────────────────────────────
+
+
+def test_prompt_teaches_url_mirror_into_params_url() -> None:
+    """The CRITICAL block must instruct Claude to put the URL in BOTH
+    intent and params.url so the runtime fallback has something to read."""
+    text = DECOMPOSE_PROMPT
+    assert "params.url" in text or '"url"' in text
+    # Worked example for the paraphrase failure mode from #209.
+    assert "Navigate to https://app.example.com" in text
+
+
+def test_prompt_warns_against_paraphrasing_the_url() -> None:
+    """Sonnet's tendency: rewrite 'Navigate to <URL> for <purpose>' as
+    'Navigate to the X system'. The prompt should call this out."""
+    text_lower = DECOMPOSE_PROMPT.lower()
+    assert "do not paraphrase" in text_lower or "keep the literal" in text_lower
+
+
+def test_prompt_version_bumped_for_url_mirror() -> None:
+    """Bumping the prompt-version cache key forces re-decomposition.
+    If the cache key still says v19, callers will load stale results."""
+    src = inspect.getsource(PlanDecomposer.decompose_text)
+    assert "v20" in src
+    assert "v19_literal_values" not in src
+
+
+# ── Layer 2: post-decompose repair pass ──────────────────────────────────
+
+
+def _make_plan(source: str, steps: list[MicroIntent]) -> MicroPlan:
+    plan = MicroPlan(source_plan=source, domain="example.com")
+    plan.steps = steps
+    return plan
+
+
+def test_repair_injects_source_url_into_urlless_navigate() -> None:
+    """A navigate step that lost its URL gets the source URL written
+    back into params.url so the navigate handler can recover it."""
+    plan = _make_plan(
+        source="1. Navigate to https://crm.example.test/leads for triage\n2. Open Settings",
+        steps=[
+            MicroIntent(intent="Navigate to the leads management system", type="navigate"),
+            MicroIntent(intent="Open the Settings section", type="submit", params={"label": "Settings"}),
+        ],
+    )
+
+    PlanDecomposer._repair_navigate_urls(plan)
+
+    assert plan.steps[0].params == {"url": "https://crm.example.test/leads"}
+    # Submit step is unchanged.
+    assert plan.steps[1].params == {"label": "Settings"}
+
+
+def test_repair_leaves_navigate_alone_when_intent_has_url() -> None:
+    """The repair pass must not over-write a healthy navigate step."""
+    plan = _make_plan(
+        source="1. Go to https://example.com/login",
+        steps=[
+            MicroIntent(intent="Navigate to https://example.com/login", type="navigate"),
+        ],
+    )
+
+    PlanDecomposer._repair_navigate_urls(plan)
+
+    # No params.url injection — intent already has the URL.
+    assert plan.steps[0].params in (None, {})
+
+
+def test_repair_leaves_navigate_alone_when_params_url_already_set() -> None:
+    """If the decomposer wrote params.url already, the repair pass
+    is a no-op (don't double-pop a source URL)."""
+    plan = _make_plan(
+        source="1. Go to https://example.com/login\n2. Visit https://other.example.com",
+        steps=[
+            MicroIntent(
+                intent="Navigate to login",
+                type="navigate",
+                params={"url": "https://example.com/login"},
+            ),
+            MicroIntent(intent="Open the data dashboard", type="navigate"),
+        ],
+    )
+
+    PlanDecomposer._repair_navigate_urls(plan)
+
+    # First step untouched (params.url already healthy).
+    assert plan.steps[0].params == {"url": "https://example.com/login"}
+    # Second step repaired with the SECOND source URL — cursor must skip
+    # the URL that was already covered.
+    assert plan.steps[1].params == {"url": "https://other.example.com"}
+
+
+def test_repair_logs_error_when_more_urlless_navigates_than_source_urls(caplog) -> None:
+    """If Claude paraphrases more navigate URLs away than the source
+    actually had, the unmatched step is left broken and an ERROR is
+    emitted so operators can see the prompt regression."""
+    plan = _make_plan(
+        source="1. Go to https://example.com",
+        steps=[
+            MicroIntent(intent="Navigate to system A", type="navigate"),
+            MicroIntent(intent="Navigate to system B", type="navigate"),
+        ],
+    )
+
+    with caplog.at_level("ERROR", logger="mantis_agent.plan_decomposer"):
+        PlanDecomposer._repair_navigate_urls(plan)
+
+    # First step repaired.
+    assert plan.steps[0].params == {"url": "https://example.com"}
+    # Second step unrepaired; an error log records it.
+    assert plan.steps[1].params in (None, {})
+    assert any("no source URL remains" in r.message for r in caplog.records)
+
+
+def test_repair_is_called_after_fix_loop_targets_in_dispatch() -> None:
+    """The repair pass must run as part of the decompose pipeline,
+    not as an opt-in helper a caller has to invoke separately."""
+    src = inspect.getsource(PlanDecomposer.decompose_text)
+    assert "_repair_navigate_urls" in src
+    fix_pos = src.index("_fix_loop_targets")
+    repair_pos = src.index("_repair_navigate_urls(plan)")
+    assert fix_pos < repair_pos, "Repair must run after loop-target fix"
+
+
+def test_repair_is_noop_when_source_plan_has_no_urls() -> None:
+    """An in-app-only plan (login form + page transitions) has no
+    https URLs; repair must do nothing rather than crash."""
+    plan = _make_plan(
+        source="1. Log in with admin/admin\n2. Open the Reports tab",
+        steps=[
+            MicroIntent(intent="Open the Reports section", type="submit", params={"label": "Reports"}),
+        ],
+    )
+
+    PlanDecomposer._repair_navigate_urls(plan)
+    assert plan.steps[0].params == {"label": "Reports"}

--- a/tests/test_navigate_handler.py
+++ b/tests/test_navigate_handler.py
@@ -129,6 +129,31 @@ def test_navigate_returns_failure_when_intent_lacks_url(monkeypatch):
     env.step.assert_not_called()
 
 
+def test_navigate_falls_back_to_params_url_when_intent_lacks_url(monkeypatch):
+    """#209 Symptom 4 defense-in-depth: when the decomposer paraphrases
+    the intent and drops the URL but leaves it in ``params.url``, the
+    handler must recover from there rather than failing the step."""
+    monkeypatch.delenv("MANTIS_NAV_WAIT_SECONDS", raising=False)
+    monkeypatch.setattr("mantis_agent.gym.step_handlers.navigate.time.sleep", lambda *_: None)
+
+    runner = _FakeRunner()
+    env = MagicMock()
+    ctx = _ctx_with_runner_and_env(runner, env)
+    handler = NavigateHandler(runner)
+
+    step = _step(
+        "Navigate to the leads management system",
+        url="https://crm.example.test/leads",
+    )
+    result = handler.execute(step, ctx)
+
+    assert result.success is True
+    env.reset.assert_called_once_with(
+        task="navigate", start_url="https://crm.example.test/leads"
+    )
+    assert runner._last_known_url == "https://crm.example.test/leads"
+
+
 def test_navigate_returns_failure_when_env_reset_raises(monkeypatch):
     monkeypatch.setattr("mantis_agent.gym.step_handlers.navigate.time.sleep", lambda *_: None)
     runner = _FakeRunner()


### PR DESCRIPTION
Follow-up to #209. Targeted at **Symptom 4 only** — the v19 decomposer prompt reduced URL drops dramatically but Sonnet still occasionally paraphrases away the literal URL ("Navigate to https://crm.example.test/leads" becomes "Navigate to the leads management system") and the runtime has nothing to load. Symptoms 1–3 (click verifier source / middle-click newtab capture / submit-vs-click for nav links) live in different files and warrant separate PRs; see the additional findings posted to #209 for context on each.

## Three orthogonal layers

Each layer is independently useful — even if Claude regresses to the worst case, all three together still produce a working navigate.

### 1. Prompt (`v19_literal_values` → `v20_url_mirror`)
The CRITICAL block now asks for the URL in **both** `intent` and `params.url`, with a worked example specifically for the failure mode the issue called out:

```
Source: "1. Navigate to https://app.example.com for billing"
(do NOT paraphrase the URL away — keep the literal string)
→ {"type": "navigate", "intent": "Navigate to https://app.example.com",
   "params": {"url": "https://app.example.com"}, ...}
```

Cache key bumped so existing callers re-decompose with v20.

### 2. Repair pass — `PlanDecomposer._repair_navigate_urls`
After `_fix_loop_targets`, walk the source plan for `https?://` URLs in source order, dedupe against the URLs that healthy navigate steps already cover, and inject the remaining queue into urlless navigate steps' `params.url`.

- Healthy navigate step (URL in intent or `params.url`) → skipped, its URL is removed from the unconsumed queue.
- Urlless navigate step → next unconsumed source URL written to `params.url`, logged at WARNING.
- More urlless navigates than source URLs → leftover steps stay broken; logged at ERROR so prompt regressions remain visible.

Repair is best-effort and never fails the decompose — production traffic must keep flowing.

### 3. Runtime fallback — `NavigateHandler`
When `intent` lacks an `https://` match, recover from `step.params.url` before failing the step. This is the safety net for any combination of (a) layers 1+2 still failing, (b) hand-authored intents, and (c) cache hits from older prompt versions before v20.

## Test plan
- [x] `tests/test_decomposer_url_repair.py` — new file, 9 tests covering prompt content, repair-pass behaviour (urlless inject, healthy step skip, `params.url` already-set with cursor advancement, error when out of source URLs, no-op on URL-less plans, dispatch order)
- [x] `tests/test_navigate_handler.py` — `params.url` fallback test
- [x] `tests/test_decomposer_literal_values.py` — cache-version bump
- [x] `tests/test_docs_client_isolation.py` — neutralized to `crm.example.test`
- [x] `uv run --extra dev pytest -q` — 1174 passed (full suite, ~9.5min)
- [ ] Smoke run against the staffai-test-crm plan to confirm Symptom 4 doesn't reappear

## Out of scope (per #209 additional findings)
- **Finding #1** — `SiteConfig().is_detail_page()` returns `False` when `detail_page_pattern` is empty. Probable root cause for Symptoms 1+2; needs a `site_config.py` change.
- **Finding #2** — verifier URL source disagreement (CDP `/leads/13` vs verifier `/leads/1`) is likely stale screenshot/OCR fallback in `_runner_helpers._read_current_url`.
- **Finding #4** — `FormHandler` wraps `submit 'Leads'` as "Click the 'Leads' button to submit the form", biasing the extractor away from sidebar nav links.

Each warrants a separate PR.

Closes part of #209 (Symptom 4 only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)