### PR TITLE
fix(form): submit_kind hint for nav-link / tab / menu-item targets (#209 Symptom 4)

### DIFF
--- a/src/mantis_agent/gym/step_handlers/form.py
+++ b/src/mantis_agent/gym/step_handlers/form.py
@@ -59,6 +59,42 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+# Visual-affordance kinds for ``submit`` steps. The decomposer classifies
+# each submit step into one of these so the search prompt sent to
+# ``find_form_target`` frames the target correctly. Default is "button"
+# — the previous unconditional "click the X button to submit the form"
+# wording — so submit steps without a ``kind`` hint behave exactly as
+# before. Adding a new kind requires a template entry here AND a worked
+# example in DECOMPOSE_PROMPT — that friction is intentional. (#209
+# Symptom 4)
+_SUBMIT_KIND_INTENT_TEMPLATES: dict[str, str] = {
+    "nav_link": (
+        "Click the '{label}' navigation link in the sidebar or top-level "
+        "navigation. This is a primary nav item, not a button or form control."
+    ),
+    "tab": "Click the '{label}' tab in the page's tab bar.",
+    "menu_item": "Click the '{label}' menu item — an entry in an open menu, dropdown, or kebab.",
+    "button": "Click the '{label}' button to submit the form.",
+}
+_SUBMIT_KIND_DEFAULT = "button"
+
+
+def _build_submit_search_intent(label: str, kind: str, fallback: str) -> str:
+    """Construct the find_form_target prompt for a submit step.
+
+    Generic primitive — the kind comes from the analysis/decomposition
+    stage, not from any domain knowledge in this handler. Unknown kinds
+    fall back to the default ``button`` framing to preserve existing
+    behaviour for cached plans that predate the ``kind`` hint.
+    """
+    if not label:
+        return fallback
+    template = _SUBMIT_KIND_INTENT_TEMPLATES.get(
+        kind, _SUBMIT_KIND_INTENT_TEMPLATES[_SUBMIT_KIND_DEFAULT],
+    )
+    return template.format(label=label)
+
+
 class ClaudeGuidedFormHandler:
     """Implements :class:`~..step_context.StepHandler` for form-shaped steps.
 
@@ -153,9 +189,8 @@ class ClaudeGuidedFormHandler:
             if isinstance(aliases, str):
                 aliases = [aliases]
             aliases = [str(a).strip() for a in aliases if str(a).strip()]
-            search_intent = (
-                f"Click the '{label}' button to submit the form" if label else step.intent
-            )
+            kind = str(params.get("kind") or _SUBMIT_KIND_DEFAULT).strip().lower() or _SUBMIT_KIND_DEFAULT
+            search_intent = _build_submit_search_intent(label, kind, step.intent)
             # Scroll-and-rescan loop — issue #89 §2. Long forms (CRMs,
             # settings panels) often render the primary submit button below
             # the fold; the previous single-screenshot path declared the

--- a/src/mantis_agent/plan_decomposer.py
+++ b/src/mantis_agent/plan_decomposer.py
@@ -359,15 +359,37 @@ VERB → STEP-TYPE MAPPING (FORM FLOWS):
    "enter X in the Y field", "type X into Y", "fill in Y with X", "set Y to X",
    "input X for Y"
        → fill_field with params={"label": "Y", "value": "X"}.
-   "click the Submit button", "click Save", "click Update Lead", "press Continue",
-   "submit the form", "click the {Leads/Settings/etc} navigation link",
-   "click the {Edit Lead/Cancel} button", "go to the {Y} page"
-   (when {Y} is a tab/nav/menu item, NOT a URL)
-       → submit with params={"label": "<button or link text>"}.
-       Use submit for any SINGLE LABELLED CLICKABLE on a non-listings page —
-       buttons, nav links, tab items, menu items, dock icons, inline
-       action links. The runner uses find_form_target which locates one
-       labelled element by visible text, no listings-grid assumption.
+   submit handles ANY single labelled clickable on a non-listings page —
+   buttons, nav links, tab items, menu items. The runner's
+   find_form_target locates one labelled element by visible text. To
+   help it pick the right element when several share a label, the
+   step MUST include params.kind classifying the visual affordance:
+
+   • params.kind="button" — form-submit / call-to-action buttons
+       "click the Submit button", "click Save", "click Update Lead",
+       "press Continue", "submit the form", "click the {Edit/Cancel} button"
+       → submit with params={"label": "<button text>", "kind": "button"}.
+
+   • params.kind="nav_link" — sidebar / top-nav navigation links and
+                              "go to the X page" in-app transitions
+       "click the {Y} navigation link", "click the {Y} link in the sidebar",
+       "go to the {Y} page" (when {Y} is a tab/nav/menu item, NOT a URL),
+       "open the {Y} section"
+       → submit with params={"label": "Y", "kind": "nav_link"}.
+
+   • params.kind="tab" — horizontal/vertical tab bars on a page
+       "click the {Y} tab", "switch to the {Y} tab"
+       → submit with params={"label": "Y", "kind": "tab"}.
+
+   • params.kind="menu_item" — entries inside an open menu / kebab /
+                               dropdown / context menu
+       "click the {Y} menu item", "select {Y} from the menu",
+       "choose {Y} from the kebab menu"
+       → submit with params={"label": "Y", "kind": "menu_item"}.
+
+   When in doubt, default to params.kind="button". The runner accepts
+   submit steps without a kind and treats them as buttons for
+   backward compatibility.
    "select X from the Y dropdown", "choose X under Y", "pick X in the Y selector"
        → select_option with params={"dropdown_label": "Y", "option_label": "X"}.
    "click the first / next / nth result/row/listing/card/job/product/property"
@@ -544,7 +566,7 @@ class PlanDecomposer:
             domain = m.group(1)
 
         # Check cache — include prompt version in hash to invalidate on schema changes
-        prompt_version = "v20_url_mirror"  # Bump this when DECOMPOSE_PROMPT changes
+        prompt_version = "v21_submit_kind"  # Bump this when DECOMPOSE_PROMPT changes
         plan_hash = hashlib.md5(f"{prompt_version}:{plan_text}".encode()).hexdigest()[:8]
         cache_path = (
             cache_path_template.replace("{hash}", plan_hash)

--- a/tests/test_decomposer_literal_values.py
+++ b/tests/test_decomposer_literal_values.py
@@ -125,6 +125,7 @@ def test_prompt_version_was_bumped() -> None:
     from mantis_agent.plan_decomposer import PlanDecomposer
 
     src = inspect.getsource(PlanDecomposer.decompose_text)
-    assert "v20_url_mirror" in src
+    assert "v21_submit_kind" in src
+    assert "v20_url_mirror" not in src
     assert "v19_literal_values" not in src
     assert "v18_pure_llm" not in src

--- a/tests/test_decomposer_submit_kind.py
+++ b/tests/test_decomposer_submit_kind.py
@@ -1,0 +1,62 @@
+"""Tests for #209 Symptom 4 — decomposer emits ``params.kind`` on submit.
+
+Layer 2 of the kind-aware submit dispatch. The runtime form-handler
+side is covered in ``test_form_submit_kind.py``; here we assert the
+prompt teaches Claude to classify each submit step into the small,
+domain-neutral set of visual affordances the runtime understands.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+from mantis_agent.plan_decomposer import DECOMPOSE_PROMPT, PlanDecomposer
+
+
+# ── Prompt teaches the four kinds ────────────────────────────────────────
+
+
+def test_prompt_names_kind_param_for_submit() -> None:
+    """The submit verb mapping must require a ``kind`` param so the
+    runtime form-handler can frame its search prompt correctly."""
+    text = DECOMPOSE_PROMPT
+    assert "params.kind" in text or '"kind"' in text
+
+
+def test_prompt_documents_each_runtime_kind() -> None:
+    """Every kind the runtime templates must appear as a worked
+    example in the prompt — otherwise the runtime would silently
+    downgrade unknown kinds to button."""
+    text = DECOMPOSE_PROMPT
+    for kind in ("button", "nav_link", "tab", "menu_item"):
+        assert kind in text, f"prompt is missing kind={kind!r}"
+
+
+def test_prompt_documents_default_kind_for_backward_compat() -> None:
+    """When the source plan is ambiguous, the prompt must steer Claude
+    to the ``button`` default rather than guessing."""
+    text_lower = DECOMPOSE_PROMPT.lower()
+    assert "default" in text_lower
+    assert "button" in text_lower
+
+
+def test_prompt_separates_nav_link_from_button_examples() -> None:
+    """The previous prompt collapsed nav-link and button into a single
+    submit example. The new prompt must show them as distinct cases."""
+    text = DECOMPOSE_PROMPT
+    # nav_link is associated with navigation phrasing
+    assert "navigation" in text.lower()
+    # The "go to the X page" in-app phrase is now a nav_link example,
+    # not a generic submit. Keeping both phrases nearby.
+    assert "go to the" in text.lower() or "open the" in text.lower()
+
+
+# ── Cache key bumped so v20 caches re-decompose with kind ───────────────
+
+
+def test_prompt_version_bumped_for_submit_kind() -> None:
+    """A prompt change requires a cache-version bump so previously-
+    decomposed plans get re-decomposed with the new rule."""
+    src = inspect.getsource(PlanDecomposer.decompose_text)
+    assert "v21_submit_kind" in src
+    assert "v20_url_mirror" not in src

--- a/tests/test_form_submit_kind.py
+++ b/tests/test_form_submit_kind.py
@@ -1,0 +1,185 @@
+"""Tests for #209 Symptom 4 — submit-step visual-affordance hints.
+
+The previous unconditional ``Click the '{label}' button to submit the
+form`` wording biased ``find_form_target`` toward button-shaped
+candidates even when the actual target was a sidebar navigation link
+or a tab. The decomposer now classifies each submit step via a small
+``params.kind`` enum (``button`` / ``nav_link`` / ``tab`` /
+``menu_item``); the form handler builds the search prompt from a
+template table keyed on that kind.
+
+Layer 1 (this file): the runtime form handler dispatches on the kind.
+Layer 2 (test_decomposer_submit_kind.py): the decomposer prompt
+teaches Claude to emit the kind. Both layers are domain-neutral.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from mantis_agent.gym.step_context import StepContext
+from mantis_agent.gym.step_handlers.form import (
+    _SUBMIT_KIND_DEFAULT,
+    _SUBMIT_KIND_INTENT_TEMPLATES,
+    ClaudeGuidedFormHandler,
+    _build_submit_search_intent,
+)
+from mantis_agent.plan_decomposer import MicroIntent
+
+
+# ── Pure helper ──────────────────────────────────────────────────────────
+
+
+def test_build_intent_returns_fallback_when_label_empty() -> None:
+    """No label means we cannot template a kind-aware prompt — defer
+    to the step's natural-language intent."""
+    out = _build_submit_search_intent("", "nav_link", fallback="step prose here")
+    assert out == "step prose here"
+
+
+@pytest.mark.parametrize(
+    "kind,expected_token",
+    [
+        ("nav_link", "navigation link"),
+        ("tab", "tab"),
+        ("menu_item", "menu item"),
+        ("button", "button to submit the form"),
+    ],
+)
+def test_build_intent_picks_template_per_kind(kind: str, expected_token: str) -> None:
+    out = _build_submit_search_intent("Leads", kind, fallback="ignored")
+    assert "Leads" in out
+    assert expected_token in out
+
+
+def test_build_intent_unknown_kind_falls_back_to_button_template() -> None:
+    """Forward-compat: a future ``kind`` the runtime doesn't yet know
+    must NOT crash and must NOT use an empty prompt — it falls back to
+    the default (button) framing."""
+    out = _build_submit_search_intent("Save", "frobinator_widget", fallback="x")
+    button_template = _SUBMIT_KIND_INTENT_TEMPLATES[_SUBMIT_KIND_DEFAULT]
+    assert out == button_template.format(label="Save")
+
+
+def test_default_kind_is_button() -> None:
+    """Backward compat — submit steps without ``kind`` predate this PR."""
+    assert _SUBMIT_KIND_DEFAULT == "button"
+    assert "button" in _SUBMIT_KIND_INTENT_TEMPLATES
+
+
+def test_all_known_kinds_have_templates() -> None:
+    """Every kind documented in the decomposer prompt must have a
+    runtime template — otherwise the decomposer can emit a kind the
+    runtime silently downgrades to ``button``."""
+    expected = {"button", "nav_link", "tab", "menu_item"}
+    assert expected.issubset(_SUBMIT_KIND_INTENT_TEMPLATES.keys())
+
+
+# ── Handler dispatch — search_intent observed via the extractor mock ─────
+
+
+class _FakeRunner:
+    def __init__(self) -> None:
+        self.costs: dict[str, float] = {
+            "claude_extract": 0,
+            "gpu_steps": 0,
+            "gpu_seconds": 0,
+        }
+        self._url_history: list[str] = ["https://app.example/x", "https://app.example/x/next"]
+        self.dump_calls: list[tuple[str, Any]] = []
+
+    def _best_effort_current_url(self) -> str:
+        return self._url_history.pop(0) if self._url_history else ""
+
+    def _adaptive_submit_settle(self, *, url_before: str) -> float:
+        return 0.5
+
+    def _safe_screenshot(self) -> Any:
+        return MagicMock()
+
+    def _dump_debug_screenshot(self, name_stem: str, screenshot: Any) -> None:
+        self.dump_calls.append((name_stem, screenshot))
+
+
+def _ctx(runner: _FakeRunner, *, env=None, extractor=None) -> StepContext:
+    return StepContext(
+        env=env or MagicMock(),
+        brain=None,
+        extractor=extractor or MagicMock(),
+        grounding=None,
+        cost_meter=None,
+        dynamic_verifier=None,
+        scanner=None,
+        site_config=None,
+        tool_channel=None,
+        extraction_cache=None,
+        state={"index": 1},
+    )
+
+
+def _run_submit_with_kind(monkeypatch, *, label: str, kind: str | None) -> str:
+    """Drive the handler and return the search_intent it sent to find_form_target."""
+    monkeypatch.setattr("mantis_agent.gym.step_handlers.form.time.sleep", lambda *_: None)
+    monkeypatch.setattr(
+        "mantis_agent.gym.step_handlers.form.random.uniform", lambda a, b: a,
+    )
+
+    runner = _FakeRunner()
+    extractor = MagicMock()
+    extractor.find_form_target.return_value = {"x": 100, "y": 200}
+    env = MagicMock()
+    ctx = _ctx(runner, env=env, extractor=extractor)
+
+    params: dict[str, Any] = {"label": label}
+    if kind is not None:
+        params["kind"] = kind
+    step = MicroIntent(intent="step prose", type="submit", params=params)
+    ClaudeGuidedFormHandler(runner).execute(step, ctx)
+
+    # First call to find_form_target carries the framed search_intent.
+    call_args = extractor.find_form_target.call_args_list[0]
+    return call_args.args[1] if len(call_args.args) > 1 else call_args.kwargs["intent"]
+
+
+def test_handler_uses_nav_link_template_when_kind_nav_link(monkeypatch) -> None:
+    intent = _run_submit_with_kind(monkeypatch, label="Leads", kind="nav_link")
+    assert "navigation link" in intent
+    assert "Leads" in intent
+    assert "submit the form" not in intent  # the wrong-bias wording is gone
+
+
+def test_handler_uses_tab_template_when_kind_tab(monkeypatch) -> None:
+    intent = _run_submit_with_kind(monkeypatch, label="Reports", kind="tab")
+    assert "tab" in intent
+    assert "Reports" in intent
+    assert "submit the form" not in intent
+
+
+def test_handler_uses_menu_item_template_when_kind_menu_item(monkeypatch) -> None:
+    intent = _run_submit_with_kind(monkeypatch, label="Archive", kind="menu_item")
+    assert "menu item" in intent
+    assert "Archive" in intent
+
+
+def test_handler_uses_button_template_when_kind_button(monkeypatch) -> None:
+    intent = _run_submit_with_kind(monkeypatch, label="Save", kind="button")
+    assert "button to submit the form" in intent
+    assert "Save" in intent
+
+
+def test_handler_defaults_to_button_when_kind_missing(monkeypatch) -> None:
+    """Backward compatibility: cached plans from before this PR have no
+    kind. The handler treats them as buttons (the prior wording)."""
+    intent = _run_submit_with_kind(monkeypatch, label="Continue", kind=None)
+    assert "button to submit the form" in intent
+    assert "Continue" in intent
+
+
+def test_handler_normalises_kind_case_and_whitespace(monkeypatch) -> None:
+    """Defensive: Claude sometimes returns ``Nav_Link`` or `` nav_link ``;
+    runtime should match by lowercasing + stripping."""
+    intent = _run_submit_with_kind(monkeypatch, label="Settings", kind=" Nav_Link ")
+    assert "navigation link" in intent


### PR DESCRIPTION
Follow-up to #209 Finding #4. Two-layer change, both layers domain-neutral; per-plan knowledge enters via the analysis (decomposer) stage, not via hardcoded site logic.

## Problem

The form handler unconditionally framed every \`submit\` step as ``Click the '{label}' button to submit the form``. When the decomposer (correctly) routed sidebar nav links and tabs through \`submit\`, that wording biased \`find_form_target\` toward button-shaped candidates, ran the full 4× scroll-to-find-submit cascade (~30s per attempt, ~5 attempts per sub-goal), and gave up. Symptom 4 of #209: \`submit 'Leads'\` failing reliably on a CRM with a left-rail nav.

## Fix

### Layer 1 — generic runtime primitive (\`FormHandler\`)
A small template table keyed on \`params.kind\`:

| kind | template fragment |
|---|---|
| \`button\` (default) | \"button to submit the form\" |
| \`nav_link\` | \"navigation link in the sidebar or top-level navigation\" |
| \`tab\` | \"tab in the page's tab bar\" |
| \`menu_item\` | \"menu item — an entry in an open menu, dropdown, or kebab\" |

Kinds are **visual affordances**, not domain vocabulary — they generalise across CRM, e-commerce, real estate, OS desktops. Unknown kinds fall back to \`button\` (forward-compat). Cached plans without \`kind\` get the prior wording (backward-compat).

### Layer 2 — analysis-stage hint (\`DECOMPOSE_PROMPT\`)
The submit-verb mapping now requires \`params.kind\` per step, with a worked example for each kind. The default is named explicitly so Claude doesn't guess on ambiguous prose. Cache key bumped \`v20_url_mirror\` → \`v21_submit_kind\` so existing caches re-decompose with the kind attached.

## Stay-generic discipline

- \`_SUBMIT_KIND_INTENT_TEMPLATES\` defines four bounded affordances. Adding a fifth requires both a runtime template AND a prompt example — that friction is intentional.
- No site/customer/plan vocabulary in either layer. The kind enum is structurally orthogonal to what the page is about.
- Tests assert (a) every documented runtime kind has a prompt example, and (b) every prompt-named kind has a runtime template — drift in either direction breaks CI.

## Test plan

- [x] \`tests/test_form_submit_kind.py\` — 11 cases: pure helper + parametrised handler dispatch + kind normalisation + unknown-kind fallback + missing-kind backward compat
- [x] \`tests/test_decomposer_submit_kind.py\` — prompt content (each kind named, default explicit, nav_link separated from button) + cache-version bump
- [x] \`tests/test_form_handler.py\` — unaffected (existing submit tests still pass; kind defaults to button)
- [x] \`uv run --extra dev pytest -q\` — **1195 passed** (full suite, ~9.5min)
- [ ] Smoke run against the staffai-test-crm plan to confirm \`submit 'Leads'\` resolves on the first attempt with \`kind=nav_link\`

Closes part of #209 (Finding #4).

## Remaining open from #209

- Finding #2 (verifier vs CDP URL drift) — pure framework bug in \`_runner_helpers._read_current_url\`
- Finding #3 (middle-click newtab capture) — partially mitigated by PR #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)