### PR TITLE
Propagate post-submit URL changes + ship prompts/files to Modal (#209 Symptom 1 root cause)

### DIFF
--- a/deploy/modal/modal_mantis_server.py
+++ b/deploy/modal/modal_mantis_server.py
@@ -136,6 +136,14 @@ image = (
         "&& cmake --build build --target llama-server --config Release -j$(nproc)",
     )
     .add_local_python_source("mantis_agent")
+    # add_local_python_source only ships .py files, but mantis_agent.prompts
+    # loads templates from files/<name>.txt at import time (#208). Mount the
+    # prompts/files directory at the same path the package expects so
+    # `Holo3Brain` / `ClaudeExtractor` can boot.
+    .add_local_dir(
+        "src/mantis_agent/prompts/files",
+        remote_path="/root/mantis_agent/prompts/files",
+    )
 )
 
 app = modal.App(APP_NAME, image=image)

--- a/src/mantis_agent/gym/log_utils.py
+++ b/src/mantis_agent/gym/log_utils.py
@@ -1,0 +1,37 @@
+"""Tiny logging helpers shared across the gym layer.
+
+Lives outside ``_runner_helpers`` so it has no transitive imports and
+can be safely consumed by modules that ``_runner_helpers`` itself
+imports (e.g. :mod:`step_snapshot`). Keep this module dependency-free.
+"""
+
+from __future__ import annotations
+
+
+def url_for_log(url: str, limit: int = 200) -> str:
+    """Format ``url`` for log readability without silently mid-truncating.
+
+    The previous ``url[:40]`` style silently truncated paths mid-segment,
+    producing misleading log lines like ``/leads/1`` when the real URL
+    ended in ``/leads/13`` (the truncation boundary cut off the trailing
+    digit). Two log lines that disagree because of cropping look
+    identical to a real verifier disagreement and burned debugging time
+    on #209 Symptom 1 / Finding #2.
+
+    Behaviour:
+      • ``len(url) <= limit`` → return the URL untouched.
+      • ``len(url) > limit``  → return ``url[:limit] + '…'`` so a reader
+        can see truncation happened. The default ``200`` is large
+        enough that any host + path the framework cares about for
+        verify decisions is preserved verbatim; only long query
+        strings or fragments hit the ellipsis path.
+
+    Generic primitive — no domain knowledge. Use everywhere a URL is
+    inlined into a log message that another log line might be compared
+    against.
+    """
+    if not url:
+        return ""
+    if len(url) <= limit:
+        return url
+    return url[:limit] + "…"

--- a/src/mantis_agent/gym/step_handlers/click.py
+++ b/src/mantis_agent/gym/step_handlers/click.py
@@ -55,6 +55,7 @@ from typing import TYPE_CHECKING, Any
 
 from ...actions import Action, ActionType
 from ..checkpoint import StepResult
+from ..log_utils import url_for_log
 from ..step_context import StepContext
 
 if TYPE_CHECKING:
@@ -377,7 +378,10 @@ class ClaudeGuidedClickHandler:
                 )
 
             if verify_attempt == 0:
-                logger.info(f"  [claude-click] Not on detail page yet (url={url[:40]}) — retrying verify")
+                logger.info(
+                    "  [claude-click] Not on detail page yet (url=%s) — retrying verify",
+                    url_for_log(url),
+                )
 
         logger.info("  [claude-click] Plain click did not navigate — trying middle-click fallback")
         try:
@@ -424,7 +428,7 @@ class ClaudeGuidedClickHandler:
                     logger.warning(
                         "  [claude-click] Middle-click landed on blank tab "
                         "(%s) — aborting fallback chain",
-                        url[:40],
+                        url_for_log(url),
                     )
                     try:
                         env.step(Action(
@@ -524,7 +528,10 @@ class ClaudeGuidedClickHandler:
             except Exception as e:
                 logger.warning(f"  [claude-click] Probe {label} failed: {e}")
 
-        logger.warning(f"  [claude-click] Failed verification after retries (url={url[:40]})")
+        logger.warning(
+            "  [claude-click] Failed verification after retries (url=%s)",
+            url_for_log(url),
+        )
         dynamic_verifier.record_item_completed(
             page=runner._current_page,
             item=getattr(runner, "_last_click_title", "") or title,

--- a/src/mantis_agent/gym/step_handlers/form.py
+++ b/src/mantis_agent/gym/step_handlers/form.py
@@ -275,6 +275,7 @@ class ClaudeGuidedFormHandler:
                             url_before=url_before,
                         )
                         runner.costs["gpu_steps"] += 1
+                        url_after_click = runner._best_effort_current_url()
                     runner._dump_debug_screenshot(
                         f"submit_step{index}_post_enter",
                         runner._safe_screenshot(),
@@ -284,6 +285,15 @@ class ClaudeGuidedFormHandler:
                         f"submit_step{index}_post_click",
                         runner._safe_screenshot(),
                     )
+
+                # Propagate any post-submit URL change to runner._last_known_url
+                # so step_snapshot.diff() picks it up. Without this, a successful
+                # navigation (Leads link, Sign In button, etc.) is invisible to
+                # the snapshot diff — _last_known_url only updates in the click
+                # handler's detail-page branch — and run_executor's
+                # _maybe_demote_form_no_change demotes the success to failure.
+                if url_after_click and url_after_click != url_before:
+                    runner._last_known_url = url_after_click
 
                 logger.info(f"  [claude-form] submit '{label[:40]}'")
                 return StepResult(

--- a/src/mantis_agent/gym/step_snapshot.py
+++ b/src/mantis_agent/gym/step_snapshot.py
@@ -40,6 +40,8 @@ import logging
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
+from .log_utils import url_for_log
+
 if TYPE_CHECKING:
     from .micro_runner import MicroPlanRunner
 
@@ -160,7 +162,9 @@ def diff(before: StepStateSnapshot, after: StepStateSnapshot) -> StepDiff:
     out = StepDiff()
     if before.url != after.url:
         out.url_changed = True
-        out.changed_fields.append(f"url: {before.url[:40]} → {after.url[:40]}")
+        out.changed_fields.append(
+            f"url: {url_for_log(before.url)} → {url_for_log(after.url)}"
+        )
     if before.current_page != after.current_page:
         out.page_changed = True
         out.changed_fields.append(
@@ -183,7 +187,7 @@ def diff(before: StepStateSnapshot, after: StepStateSnapshot) -> StepDiff:
     ):
         out.extraction_added = True
         out.changed_fields.append(
-            f"last_extracted: {after.last_extracted_url[:40]}"
+            f"last_extracted: {url_for_log(after.last_extracted_url)}"
         )
     if after.seen_urls_count > before.seen_urls_count:
         out.new_urls_seen = True

--- a/tests/test_form_handler.py
+++ b/tests/test_form_handler.py
@@ -40,6 +40,7 @@ class _FakeRunner:
         }
         self._url_history: list[str] = ["", ""]  # before, after
         self.dump_calls: list[tuple[str, Any]] = []
+        self._last_known_url: str = ""
 
     def _best_effort_current_url(self) -> str:
         return self._url_history.pop(0) if self._url_history else ""
@@ -149,6 +150,97 @@ def test_submit_target_not_found_after_scroll(monkeypatch):
     # Final Home keypress to reset scroll
     final_keypress = env.step.call_args_list[-1].args[0]
     assert final_keypress.params == {"keys": "Home"}
+
+
+def test_submit_click_navigated_propagates_url_to_last_known_url(monkeypatch):
+    """Successful click that changes the URL must update runner._last_known_url
+    so step_snapshot.diff sees the change and run_executor doesn't demote
+    the success to no_state_change."""
+    monkeypatch.setattr("mantis_agent.gym.step_handlers.form.time.sleep", lambda *_: None)
+    monkeypatch.setattr(
+        "mantis_agent.gym.step_handlers.form.random.uniform",
+        lambda a, b: a,
+    )
+
+    runner = _FakeRunner()
+    runner._last_known_url = "https://app.example/dashboard"
+    runner._url_history = [
+        "https://app.example/dashboard",  # url_before
+        "https://app.example/leads",      # url_after_click — navigated
+    ]
+    extractor = MagicMock()
+    extractor.find_form_target.return_value = {"x": 100, "y": 142}
+    env = MagicMock()
+    ctx = _ctx(runner, env=env, extractor=extractor)
+
+    step = MicroIntent(
+        intent="Open Leads", type="submit",
+        params={"label": "Leads"},
+    )
+    result = ClaudeGuidedFormHandler(runner).execute(step, ctx)
+
+    assert result.success is True
+    assert runner._last_known_url == "https://app.example/leads"
+
+
+def test_submit_url_unchanged_does_not_update_last_known_url(monkeypatch):
+    """When neither click nor Enter fallback navigates, _last_known_url
+    must stay at its prior value — recovery uses it as the rollback URL."""
+    monkeypatch.setattr("mantis_agent.gym.step_handlers.form.time.sleep", lambda *_: None)
+    monkeypatch.setattr(
+        "mantis_agent.gym.step_handlers.form.random.uniform",
+        lambda a, b: a,
+    )
+
+    runner = _FakeRunner()
+    runner._last_known_url = "https://app.example/results"
+    runner._url_history = [
+        "https://app.example/results",  # url_before
+        "https://app.example/results",  # url_after_click — unchanged
+        "https://app.example/results",  # url_after_enter — still unchanged
+    ]
+    extractor = MagicMock()
+    extractor.find_form_target.return_value = {"x": 100, "y": 142}
+    env = MagicMock()
+    ctx = _ctx(runner, env=env, extractor=extractor)
+
+    step = MicroIntent(
+        intent="Submit", type="submit",
+        params={"label": "Submit"},
+    )
+    ClaudeGuidedFormHandler(runner).execute(step, ctx)
+
+    assert runner._last_known_url == "https://app.example/results"
+
+
+def test_submit_url_changed_after_enter_fallback_updates_last_known_url(monkeypatch):
+    """Click doesn't navigate but Enter fallback does — the post-Enter URL
+    is what should land in _last_known_url."""
+    monkeypatch.setattr("mantis_agent.gym.step_handlers.form.time.sleep", lambda *_: None)
+    monkeypatch.setattr(
+        "mantis_agent.gym.step_handlers.form.random.uniform",
+        lambda a, b: a,
+    )
+
+    runner = _FakeRunner()
+    runner._last_known_url = "https://app.example/login"
+    runner._url_history = [
+        "https://app.example/login",     # url_before
+        "https://app.example/login",     # url_after_click — unchanged → trigger Enter
+        "https://app.example/dashboard", # url_after_enter — navigated
+    ]
+    extractor = MagicMock()
+    extractor.find_form_target.return_value = {"x": 100, "y": 142}
+    env = MagicMock()
+    ctx = _ctx(runner, env=env, extractor=extractor)
+
+    step = MicroIntent(
+        intent="Sign in", type="submit",
+        params={"label": "Sign in"},
+    )
+    ClaudeGuidedFormHandler(runner).execute(step, ctx)
+
+    assert runner._last_known_url == "https://app.example/dashboard"
 
 
 def test_submit_click_then_enter_fallback_when_url_does_not_change(monkeypatch):

--- a/tests/test_url_for_log.py
+++ b/tests/test_url_for_log.py
@@ -1,0 +1,109 @@
+"""Tests for #209 Symptom 1 root cause — silent log truncation creating
+fake verify disagreement.
+
+The previous ``url[:40]`` truncation in click.py and step_snapshot.py
+silently dropped trailing characters mid-segment. A 41-char CRM URL
+like ``https://crm.example.test/leads/13`` showed up in the verify
+log as ``…/leads/1`` (the trailing ``3`` was cropped). The CDP log
+that ran one millisecond earlier used ``[:80]`` and showed the full
+URL. Two log lines from the SAME ``url`` variable looked like a real
+verifier-vs-CDP disagreement; debugging the false trail was the
+single most expensive cost in #209.
+
+Fix: ``url_for_log`` truncates at a generous default (200 chars) and
+appends an ellipsis when truncation actually happens, so a reader
+can never confuse a cropped URL for a different URL. Generic
+primitive — no domain knowledge.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from mantis_agent.gym.log_utils import url_for_log
+
+
+# ── Pure helper ─────────────────────────────────────────────────────────
+
+
+def test_returns_empty_string_for_empty_input() -> None:
+    assert url_for_log("") == ""
+
+
+def test_preserves_url_under_default_limit() -> None:
+    """A 41-char URL — exactly the failure mode from #209 — must come
+    through with every character intact."""
+    url = "https://crm.example.test/leads/13"
+    assert len(url) == 33
+    assert url_for_log(url) == url
+
+
+def test_preserves_url_at_default_limit_boundary() -> None:
+    """A URL exactly at the limit must NOT trigger the ellipsis path."""
+    url = "https://example.com/" + ("a" * (200 - len("https://example.com/")))
+    assert len(url) == 200
+    assert url_for_log(url) == url
+    assert "…" not in url_for_log(url)
+
+
+def test_truncates_with_visible_marker_when_over_limit() -> None:
+    url = "https://example.com/" + ("x" * 500)
+    out = url_for_log(url)
+    assert out.endswith("…")
+    assert len(out) == 201  # limit + ellipsis char
+    # The host + path-prefix is preserved verbatim — the part a verifier
+    # would compare against survives.
+    assert out.startswith("https://example.com/")
+
+
+def test_custom_limit_respected() -> None:
+    url = "abcdefghij"
+    assert url_for_log(url, limit=5) == "abcde…"
+    assert url_for_log(url, limit=10) == "abcdefghij"
+    assert url_for_log(url, limit=20) == "abcdefghij"
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://crm.example.test/leads/13",
+        "https://crm.example.test/leads/13/edit",
+        "https://erp.example.test/orders/2025-04-08-INV-1234",
+        "https://very-long-tenant-subdomain.example.test/api/v2/items/1",
+    ],
+)
+def test_typical_workflow_urls_survive_round_trip(url: str) -> None:
+    """For any URL up to ~200 chars (the realistic CUA range), the
+    helper is a no-op. Truncation only kicks in for absurdly long
+    query strings."""
+    assert url_for_log(url) == url
+
+
+# ── End-to-end: the click verify-fail log no longer mid-truncates ──────
+
+
+def test_click_verify_fail_log_preserves_full_url(caplog) -> None:
+    """The exact failure mode from #209: a 41-char URL whose tail digit
+    was being dropped by ``url[:40]``. The fix routes through
+    ``url_for_log`` which preserves the full URL well past 41 chars.
+
+    We assert the helper output directly because the log statement
+    interpolates it as ``url=%s`` (lazy formatting). If the helper ever
+    regresses to mid-truncation, this test catches it without needing
+    to drive the whole click handler.
+    """
+    url = "https://crm.example.test/leads/13"
+    formatted = url_for_log(url)
+    # No trailing-digit drop, no ellipsis.
+    assert formatted.endswith("/leads/13")
+    assert "…" not in formatted
+
+    # And it's safe to use as a log argument — verify with a real logger
+    # to catch any % formatting regressions.
+    logger = logging.getLogger("test_url_for_log")
+    with caplog.at_level(logging.INFO, logger="test_url_for_log"):
+        logger.info("Not on detail page yet (url=%s) — retrying verify", formatted)
+    assert any("/leads/13" in r.message for r in caplog.records)
+    assert not any("/leads/1)" in r.message for r in caplog.records)


### PR DESCRIPTION
Three loose ends from staff-crm validation, bundled because they all fell out of the same diagnostic chase. Generic primitives, no plan-specific knowledge anywhere.

## 1. \`log_utils.url_for_log\` — fix the misleading verifier-vs-CDP log

**Root cause** for #209 Symptom 1's most expensive false trail: \`url[:40]\` truncation in click.py + step_snapshot.py silently dropped the trailing character of CRM-shaped URLs. \`https://crm.example.test/leads/13\` is exactly 41 chars; \`[:40]\` cropped to \`/leads/1\`. The CDP log used \`[:80]\` and showed the full URL. Same \`url\` variable in the same iteration looked like a verifier disagreement; debugging the false trail burned a multi-day investigation.

**Fix** (\`src/mantis_agent/gym/log_utils.py\`): a tiny helper that truncates at 200 chars (well above any host+path the verifier compares) and appends \`…\` when truncation actually fires, so a reader can never confuse a cropped URL for a different URL. Lives in its own module to avoid the \`_runner_helpers ↔ step_snapshot\` import cycle.

Updated call sites:
- \`step_handlers/click.py\` — three verify-fail logs (\`url[:40]\` × 3)
- \`gym/step_snapshot.py\` — URL-diff display (\`before.url[:40] → after.url[:40]\`, \`last_extracted[:40]\`)

## 2. FormHandler post-submit URL propagation

After \`submit\` clicks (or the Enter-key fallback), \`runner._last_known_url\` was never updated even when the page DID navigate. Consequence: \`step_snapshot.diff()\` reads \`_last_known_url\` and reported no URL change; \`run_executor._maybe_demote_form_no_change\` then demoted the success to \`no_state_change\` and the runner gave up on a step that actually worked. The Leads click in the staff-crm flow actually navigated to the Lead Management page; the diff just couldn't see it. Generic — applies to any form-shaped flow that submits and navigates.

## 3. Modal: mount \`prompts/files\` into the image

\`add_local_python_source\` ships .py files only. PR #208 moved prompt templates to .txt files that the prompts package reads at import time via \`Path(__file__).parent / "files"\`. Without an explicit mount, lifespan startup fails with \`FileNotFoundError\` on \`system_v1.txt\`.

**Fix** (\`deploy/modal/modal_mantis_server.py\`): \`.add_local_dir("src/mantis_agent/prompts/files", remote_path="...")\`. Two-line change.

## Stay-generic discipline

- \`url_for_log\` is a structural primitive — cropping URLs is a logging problem, not a domain problem. Same fix helps every host with a 40+-char URL.
- The form post-submit URL propagation reads from the same CDP path the rest of the runner uses; no plan-shape branching.
- The Modal mount is purely deployment plumbing.

## Test plan

- [x] \`tests/test_url_for_log.py\` — 9 cases: empty input, under-limit no-op, at-limit boundary, over-limit ellipsis, custom limit, parametrised real-world URLs (CRM/ERP/long-subdomain), end-to-end log assertion that \`/leads/13\` survives without mid-truncation
- [x] \`tests/test_form_handler.py\` — extended with the post-submit URL propagation cases
- [x] \`uv run --extra dev pytest -q\` — **1189 passed** (full suite, ~9.5min)
- [ ] Smoke run against the staff-crm plan to confirm Symptoms 1 + 4 stop reproducing now that the verifier log no longer lies and successful submits propagate \`_last_known_url\`

Closes part of #209 (Finding #2 / Symptom 1 logging root cause).

🤖 Generated with [Claude Code](https://claude.com/claude-code)