### PR TITLE
feat(form): row_link / cell_link submit_kinds for table records

### DIFF
--- a/src/mantis_agent/gym/step_handlers/form.py
+++ b/src/mantis_agent/gym/step_handlers/form.py
@@ -74,6 +74,18 @@ _SUBMIT_KIND_INTENT_TEMPLATES: dict[str, str] = {
     ),
     "tab": "Click the '{label}' tab in the page's tab bar.",
     "menu_item": "Click the '{label}' menu item — an entry in an open menu, dropdown, or kebab.",
+    "row_link": (
+        "Click the '{label}' link in a table row's body cell — a record-name "
+        "or detail-link inside a data table that opens that row's detail page. "
+        "This is the row's primary clickable cell text (often blue / underlined), "
+        "NOT a column header, NOT a status badge, NOT a sort/filter control, "
+        "NOT a row checkbox or action icon."
+    ),
+    "cell_link": (
+        "Click the '{label}' link inside a table cell — a hyperlinked value "
+        "embedded in a list/table cell. Click the underlined cell text itself, "
+        "not the surrounding row, header, or any inline action icon."
+    ),
     "button": "Click the '{label}' button to submit the form.",
 }
 _SUBMIT_KIND_DEFAULT = "button"

--- a/src/mantis_agent/plan_decomposer.py
+++ b/src/mantis_agent/plan_decomposer.py
@@ -387,6 +387,30 @@ VERB → STEP-TYPE MAPPING (FORM FLOWS):
        "choose {Y} from the kebab menu"
        → submit with params={"label": "Y", "kind": "menu_item"}.
 
+   • params.kind="row_link" — a record-name link inside a data table
+                              that opens that row's detail page. The
+                              click target is the row's primary cell
+                              text (often a name, ID, or title), NOT
+                              the row checkbox, status badge, sort
+                              header, or inline action icon.
+       "click the lead {Y} to open its detail/edit page",
+       "open the {Y} record from the {leads/orders/tickets} list",
+       "click the first row whose Status is Qualified",
+       "click the row for record X in the table"
+       → submit with params={"label": "Y", "kind": "row_link"}.
+     Use this whenever the source plan describes selecting / opening
+     a single record from a multi-row list/table by its name or by a
+     filtering attribute (status, owner, etc.).
+
+   • params.kind="cell_link" — a hyperlinked value inside a table
+                               cell that isn't the row's primary
+                               record name (e.g. an account-name link
+                               in the Account column, an email link in
+                               the Email column).
+       "click the {account-name} link in the {Account} column",
+       "open the {related record} link in the row"
+       → submit with params={"label": "Y", "kind": "cell_link"}.
+
    When in doubt, default to params.kind="button". The runner accepts
    submit steps without a kind and treats them as buttons for
    backward compatibility.
@@ -566,7 +590,7 @@ class PlanDecomposer:
             domain = m.group(1)
 
         # Check cache — include prompt version in hash to invalidate on schema changes
-        prompt_version = "v21_submit_kind"  # Bump this when DECOMPOSE_PROMPT changes
+        prompt_version = "v22_row_link"  # Bump this when DECOMPOSE_PROMPT changes
         plan_hash = hashlib.md5(f"{prompt_version}:{plan_text}".encode()).hexdigest()[:8]
         cache_path = (
             cache_path_template.replace("{hash}", plan_hash)

--- a/tests/test_decomposer_literal_values.py
+++ b/tests/test_decomposer_literal_values.py
@@ -120,12 +120,20 @@ def test_prompt_still_links_log_in_to_fill_field_then_submit() -> None:
 
 def test_prompt_version_was_bumped() -> None:
     """A prompt change requires a cache-version bump so previously-
-    decomposed plans get re-decomposed with the new rule."""
+    decomposed plans get re-decomposed with the new rule. Each
+    subsequent revision lands its own ``vNN_*`` tag; this test just
+    pins the invariant that no superseded version-string survives in
+    the source — bumping forward and forgetting to update this list
+    re-introduces stale-cache risk silently."""
     import inspect
     from mantis_agent.plan_decomposer import PlanDecomposer
 
     src = inspect.getsource(PlanDecomposer.decompose_text)
-    assert "v21_submit_kind" in src
+    # Current version (PR #216 row_link / cell_link).
+    assert "v22_row_link" in src
+    # Superseded versions must NOT appear — would mean someone
+    # accidentally restored a stale cache key.
+    assert "v21_submit_kind" not in src
     assert "v20_url_mirror" not in src
     assert "v19_literal_values" not in src
     assert "v18_pure_llm" not in src

--- a/tests/test_decomposer_submit_kind.py
+++ b/tests/test_decomposer_submit_kind.py
@@ -28,8 +28,20 @@ def test_prompt_documents_each_runtime_kind() -> None:
     example in the prompt — otherwise the runtime would silently
     downgrade unknown kinds to button."""
     text = DECOMPOSE_PROMPT
-    for kind in ("button", "nav_link", "tab", "menu_item"):
+    for kind in ("button", "nav_link", "tab", "menu_item", "row_link", "cell_link"):
         assert kind in text, f"prompt is missing kind={kind!r}"
+
+
+def test_prompt_documents_row_link_for_table_record_selection() -> None:
+    """Picking a record from a multi-row table is the staff-crm pain
+    point that motivated row_link. The prompt must show the canonical
+    phrasing so Claude routes "click the first Qualified lead" through
+    the row_link template, not button."""
+    text = DECOMPOSE_PROMPT.lower()
+    assert "row_link" in text
+    # Either the verb mapping or example phrasing should mention
+    # "table" or "row" and the pattern of selecting from a list.
+    assert "table" in text or "row" in text
 
 
 def test_prompt_documents_default_kind_for_backward_compat() -> None:
@@ -58,5 +70,5 @@ def test_prompt_version_bumped_for_submit_kind() -> None:
     """A prompt change requires a cache-version bump so previously-
     decomposed plans get re-decomposed with the new rule."""
     src = inspect.getsource(PlanDecomposer.decompose_text)
-    assert "v21_submit_kind" in src
-    assert "v20_url_mirror" not in src
+    assert "v22_row_link" in src
+    assert "v21_submit_kind" not in src

--- a/tests/test_form_submit_kind.py
+++ b/tests/test_form_submit_kind.py
@@ -46,6 +46,8 @@ def test_build_intent_returns_fallback_when_label_empty() -> None:
         ("nav_link", "navigation link"),
         ("tab", "tab"),
         ("menu_item", "menu item"),
+        ("row_link", "table row"),
+        ("cell_link", "table cell"),
         ("button", "button to submit the form"),
     ],
 )
@@ -74,8 +76,22 @@ def test_all_known_kinds_have_templates() -> None:
     """Every kind documented in the decomposer prompt must have a
     runtime template — otherwise the decomposer can emit a kind the
     runtime silently downgrades to ``button``."""
-    expected = {"button", "nav_link", "tab", "menu_item"}
+    expected = {"button", "nav_link", "tab", "menu_item", "row_link", "cell_link"}
     assert expected.issubset(_SUBMIT_KIND_INTENT_TEMPLATES.keys())
+
+
+def test_row_link_template_disambiguates_from_headers_and_badges() -> None:
+    """row_link clicks are the new staff-crm pain point: Holo3 mistargeted
+    column headers / status badges / sort controls when asked to "click
+    the lead with Status=Qualified". The template must explicitly steer
+    away from those non-row-body candidates so find_form_target picks
+    the cell-text link instead."""
+    out = _build_submit_search_intent("Optimus Prime", "row_link", fallback="x")
+    assert "Optimus Prime" in out
+    # Disambiguation cues that materially narrow the target set.
+    assert "row" in out.lower()
+    assert "header" in out.lower()
+    assert "badge" in out.lower() or "status" in out.lower()
 
 
 # ── Handler dispatch — search_intent observed via the extractor mock ─────


### PR DESCRIPTION
## Summary

Adds two new visual-affordance kinds to the submit_kind dispatch (PR #212): **row_link** and **cell_link**. Selecting a record from a multi-row table — the staff-crm "click first Qualified lead" wall — was previously routed through the default button-shaped \`find_form_target\` prompt. Holo3 mistargeted column headers / sort controls / status badges instead of the row's record-name link. The existing nav_link / tab / menu_item kinds don't fit either — those are page-level navigation, not in-table selection.

### New kinds

- **\`row_link\`** — primary record-name link in a table row body cell. Template explicitly steers find_form_target away from headers, badges, sort controls, checkboxes, and action icons.
- **\`cell_link\`** — hyperlinked value embedded in a non-primary cell (e.g. account-name link in the Account column).

Decomposer prompt v22_row_link adds worked examples covering the canonical phrasings (\"click the first row whose Status is Qualified\", \"open the X record from the Y list\"). Cache key bumped from v21 → v22 so prior caches re-decompose under the new rule.

### Net staff-crm trajectory

This commit is the next layer on top of the staff-crm symptom 4 stack (PRs #213/#214/#215). Empirical run-by-run progress against Modal:

| Stack | Furthest step before halt |
|---|---|
| pre-fixes | step 1 (login form fill) |
| + URL propagation (PR #213) | step 6 (Qualified row select) |
| + Save-password popup suppression (PR #214) | step 4 (Industry select) |
| + select_option demotion fix (PR #215) | step 5 (Industry Vertical select) |
| + row_link kind (this PR) | TBD — testing in run #23 |

## Test plan

- [x] \`pytest tests/test_form_submit_kind.py tests/test_decomposer_submit_kind.py tests/test_form_handler.py\` (35 passed)
- [x] \`ruff check\` clean
- [ ] Modal staff-crm smoke (run #23 in flight at PR-write time)

🤖 Generated with [Claude Code](https://claude.com/claude-code)