### PR TITLE
fix(extractor): tool_use schema enforcement for find_listing_content_control

### DIFF
--- a/src/mantis_agent/extraction/extractor.py
+++ b/src/mantis_agent/extraction/extractor.py
@@ -199,11 +199,20 @@ class ClaudeExtractor:
             f"seller-supplied text or contact information.\n\n"
             f"Prefer these safe targets:\n- {allowed}\n\n"
             f"Do NOT choose: {forbidden}\n\n"
-            f"Return the center of the best target. Output ONLY valid JSON:\n"
-            f"{{\"x\": N, \"y\": N, \"action\": \"expand_description|show_phone|none\", "
-            f"\"label\": \"visible text\", \"reason\": \"brief reason\"}}\n\n"
-            f"If no safe control is visible, output:\n"
-            f"{{\"x\": 0, \"y\": 0, \"action\": \"none\", \"label\": \"\", \"reason\": \"none visible\"}}"
+            f"OUTPUT FORMAT — strict JSON, no prose preamble, no commentary,\n"
+            f"no markdown fence. The shape is exactly five string-keyed\n"
+            f"fields. ``x`` and ``y`` are separate integer keys — never a\n"
+            f"tuple, never two unlabeled positional values like\n"
+            f"``\"x\": 302, 43``.\n\n"
+            f"If a safe control IS visible — concrete example:\n"
+            f"{{\"x\": 740, \"y\": 320, \"action\": \"expand_description\", "
+            f"\"label\": \"Show more\", \"reason\": \"see-more chevron in description\"}}\n\n"
+            f"If NO safe control is visible — exact response:\n"
+            f"{{\"x\": 0, \"y\": 0, \"action\": \"none\", \"label\": \"\", \"reason\": \"none visible\"}}\n\n"
+            f"Substitute the integers, label, and reason with what you "
+            f"actually see — keep every key spelled exactly as shown above. "
+            f"Allowed values for ``action``: expand_description, show_phone, "
+            f"none."
         )
 
     def _parse_schema_result(self, data: dict[str, Any]) -> ExtractionResult:
@@ -239,7 +248,7 @@ class ClaudeExtractor:
                 continue
         return os.path.join("/tmp", f"{stem}_{int(time.time())}{suffix}")
 
-    def _call(self, screenshot: Image.Image, prompt: str, max_tokens: int = 200) -> str:
+    def _call(self, screenshot: Image.Image, prompt: str, max_tokens: int = 500) -> str:
         """Call Claude API with screenshot + prompt."""
         import requests
 
@@ -285,6 +294,95 @@ class ClaudeExtractor:
         except Exception as e:
             logger.warning(f"ClaudeExtractor failed: {e}")
         return ""
+
+    def _call_with_tool_schema(
+        self,
+        screenshot: Image.Image,
+        prompt: str,
+        *,
+        tool_name: str,
+        tool_description: str,
+        input_schema: dict[str, Any],
+        max_tokens: int = 500,
+    ) -> dict | None:
+        """Call Claude API and force the response into a JSON-Schema-validated tool_use.
+
+        Anthropic's ``tool_use`` with ``tool_choice={\"type\": \"tool\", \"name\": ...}``
+        forces the model to emit a ``tool_use`` content block whose
+        ``input`` field is server-side-validated against ``input_schema``.
+        Replaces the previous prompt-only \"output ONLY valid JSON\"
+        approach which the model inconsistently honoured — empirical
+        failures from the boattrader smoke included prose-only responses
+        (no JSON at all), prose-then-truncated-JSON (max_tokens cliff),
+        and malformed JSON like ``{\"x\": 302, 43, \"y\": 43, ...}`` (extra
+        positional value before the next key). Schema enforcement makes
+        all three failure modes impossible.
+
+        Returns the validated input dict, or ``None`` on any API / network
+        / shape mismatch (caller logs and treats as not_found, same as
+        the legacy ``_parse_json`` failure path).
+
+        ``prompt`` is still passed for the screen-content guidance — only
+        the response shape is schema-locked. Generic primitive: every
+        extractor call site that wants structured output should use this
+        instead of ``_call`` + ``_parse_json``.
+        """
+        import requests
+
+        if not self.api_key:
+            logger.warning("ClaudeExtractor: no API key")
+            return None
+
+        buf = BytesIO()
+        screenshot.save(buf, format="PNG")
+        b64 = base64.b64encode(buf.getvalue()).decode()
+
+        try:
+            resp = requests.post(
+                "https://api.anthropic.com/v1/messages",
+                headers={
+                    "x-api-key": self.api_key,
+                    "anthropic-version": "2023-06-01",
+                    "content-type": "application/json",
+                },
+                json={
+                    "model": self.model,
+                    "max_tokens": max_tokens,
+                    "tools": [{
+                        "name": tool_name,
+                        "description": tool_description,
+                        "input_schema": input_schema,
+                    }],
+                    "tool_choice": {"type": "tool", "name": tool_name},
+                    "messages": [{
+                        "role": "user",
+                        "content": [
+                            {"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": b64}},
+                            {"type": "text", "text": prompt},
+                        ],
+                    }],
+                },
+                timeout=30,
+            )
+            if resp.status_code != 200:
+                logger.warning(
+                    "ClaudeExtractor tool_use API error %s: %s",
+                    resp.status_code,
+                    resp.text[:500],
+                )
+                return None
+            for block in resp.json().get("content", []):
+                if block.get("type") == "tool_use" and block.get("name") == tool_name:
+                    tool_input = block.get("input")
+                    if isinstance(tool_input, dict):
+                        return tool_input
+            logger.warning(
+                "ClaudeExtractor tool_use returned no %s tool block in response",
+                tool_name,
+            )
+        except Exception as e:
+            logger.warning(f"ClaudeExtractor tool_use failed: {e}")
+        return None
 
     def _call_many(
         self,
@@ -488,17 +586,43 @@ class ClaudeExtractor:
         except Exception:
             pass
 
-        text = self._call(screenshot, prompt)
+        # Force structured output via tool_use schema validation. The
+        # previous _call + _parse_json path produced prose-only,
+        # truncated-JSON, and tuple-style malformed JSON failures during
+        # the boattrader smoke; tool_use eliminates all three by schema-
+        # validating the response server-side.
+        allowed_actions = list(self.schema.allowed_controls) + ["none"] if self.schema else [
+            "expand_description", "show_phone", "none",
+        ]
+        parsed = self._call_with_tool_schema(
+            screenshot,
+            prompt,
+            tool_name="report_content_control",
+            tool_description=(
+                "Report the chosen content-reveal control on the listing "
+                "page (or 'none' if no safe target is visible)."
+            ),
+            input_schema={
+                "type": "object",
+                "properties": {
+                    "x": {"type": "integer", "description": "Center X in pixels"},
+                    "y": {"type": "integer", "description": "Center Y in pixels"},
+                    "action": {"type": "string", "enum": allowed_actions},
+                    "label": {"type": "string"},
+                    "reason": {"type": "string"},
+                },
+                "required": ["x", "y", "action", "label", "reason"],
+            },
+        )
 
         try:
             with open(self._debug_path(debug_stem, "_response.txt"), "w") as f:
-                f.write(text)
+                f.write(json.dumps(parsed) if parsed is not None else "<no tool_use>")
         except Exception:
             pass
 
-        parsed = self._parse_json(text)
         if not parsed:
-            logger.warning(f"  [content-control] parse failed: {text[:200]}")
+            logger.warning("  [content-control] tool_use returned no usable result")
             return None
 
         action = str(parsed.get("action", "none"))

--- a/tests/test_extractor_token_budget.py
+++ b/tests/test_extractor_token_budget.py
@@ -1,0 +1,336 @@
+"""Tests for the extractor's per-call max_tokens budget.
+
+The boattrader smoke from PR #218's CLI surfaced a real failure
+mode: ``find_listing_content_control`` calls ``self._call(...)`` with
+the default ``max_tokens=200``. Claude's vision prompts often produce
+a prose preamble before the JSON answer ("I need to look for
+controls that expand content..."). With only 200 tokens of budget,
+the prose consumes the entire output and the trailing JSON is
+truncated mid-string — the parser fails and the step halts.
+
+Confirmed in /tmp/mantis_debug:
+- Response 1: prose + ``{"x": 302, "y": 204, "action": "expand",
+  "label": "Price", "reason": "Filter section with``  ← truncated.
+- Response 2: prose + valid JSON (lucky, fit in budget).
+- Response 3: pure JSON (lucky, no prose).
+- Response 4: ``{"action": "none"}`` (Claude said nothing visible).
+
+Generic fix: raise the default to 500. Anthropic only bills generated
+tokens, so concise responses still cost ~the same; verbose ones are
+no longer truncated.
+
+Tests pin the new default and confirm callers that override (e.g.
+``extract`` at 1500 for multi-field JSON) are still honoured.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+from mantis_agent.extraction.extractor import ClaudeExtractor
+
+
+def test_default_max_tokens_is_500() -> None:
+    """The default max_tokens of ``_call`` must be at least large
+    enough to fit the prose-then-JSON pattern Claude empirically
+    produces. 200 was not enough; 500 is conservative headroom."""
+    sig = inspect.signature(ClaudeExtractor._call)
+    default = sig.parameters["max_tokens"].default
+    assert default >= 500, (
+        f"_call default max_tokens={default}; must be >= 500 to avoid "
+        "truncating prose-then-JSON responses (boattrader smoke #218)"
+    )
+
+
+def test_default_was_raised_from_legacy_200() -> None:
+    """Forward-only guard: regressing back to 200 reintroduces the
+    truncation cascade. Spelled out so a future bisect doesn't
+    silently revert."""
+    sig = inspect.signature(ClaudeExtractor._call)
+    default = sig.parameters["max_tokens"].default
+    assert default != 200, (
+        "_call default reverted to 200 — see boattrader smoke from "
+        "PR #218 for the truncation failure mode this guards against"
+    )
+
+
+def test_explicit_max_tokens_override_is_honoured() -> None:
+    """Higher-budget call sites (e.g. ``extract`` at 1500 for multi-
+    field JSON; ``find_filter_target`` at 350; ``listing_url`` at 450)
+    pass max_tokens explicitly. The default bump must not collapse
+    those overrides — the parameter is still a kwarg, not a hardcode."""
+    src = inspect.getsource(ClaudeExtractor._call)
+    # Function signature still accepts max_tokens as a parameter.
+    assert "max_tokens" in src
+    # And forwards it into the API request body (no constant override).
+    assert '"max_tokens": max_tokens' in src
+
+
+# ── Content-control prompt — concrete example + anti-malformed guard ────
+
+
+def test_content_control_prompt_has_concrete_worked_example() -> None:
+    """Claude follows concrete examples better than placeholder ``N``
+    templates. The worked example must use literal integer values
+    (the smoke that triggered this fix saw Claude emit
+    ``{\"x\": 302, 43, \"y\": 43, ...}`` — extra positional value —
+    when the prompt only showed ``\"x\": N``)."""
+    from mantis_agent.extraction.extractor import ClaudeExtractor
+    from mantis_agent.extraction.schema import ExtractionSchema
+
+    schema = ExtractionSchema(
+        entity_name="boat",
+        allowed_controls=("expand_description", "show_phone"),
+        forbidden_controls=("contact seller", "request info"),
+        fields=[],
+    )
+    extractor = ClaudeExtractor(api_key="dummy", schema=schema)
+    prompt = extractor._get_content_control_prompt()
+    # Concrete example with real integers, not ``N``.
+    assert '"x": 740' in prompt
+    assert '"y": 320' in prompt
+    # Sentinel "no visible control" example uses zero coordinates.
+    assert '"x": 0, "y": 0' in prompt
+
+
+def test_content_control_prompt_warns_against_tuple_style_xy() -> None:
+    """The smoke saw Claude emit ``{\"x\": 302, 43, \"y\": 43, ...}``
+    — an extra unlabeled positional value before ``y``. The prompt
+    must explicitly call this out so future runs don't repeat."""
+    from mantis_agent.extraction.extractor import ClaudeExtractor
+    from mantis_agent.extraction.schema import ExtractionSchema
+
+    schema = ExtractionSchema(
+        entity_name="boat",
+        allowed_controls=("expand_description",),
+        forbidden_controls=("contact seller",),
+        fields=[],
+    )
+    extractor = ClaudeExtractor(api_key="dummy", schema=schema)
+    prompt = extractor._get_content_control_prompt()
+    text_lower = prompt.lower()
+    # Either word that captures the warning intent.
+    assert "tuple" in text_lower or "positional" in text_lower
+    # And the explicit anti-pattern shape from the smoke.
+    assert "302, 43" in prompt or "unlabeled" in text_lower
+
+
+def test_content_control_prompt_demands_no_prose_preamble() -> None:
+    """The prompt must explicitly forbid the prose-preamble pattern
+    that triggered max_tokens truncation in the previous smoke."""
+    from mantis_agent.extraction.extractor import ClaudeExtractor
+    from mantis_agent.extraction.schema import ExtractionSchema
+
+    schema = ExtractionSchema(
+        entity_name="boat",
+        allowed_controls=("expand_description",),
+        forbidden_controls=("contact seller",),
+        fields=[],
+    )
+    extractor = ClaudeExtractor(api_key="dummy", schema=schema)
+    prompt = extractor._get_content_control_prompt()
+    text_lower = prompt.lower()
+    assert "no prose" in text_lower or "no commentary" in text_lower
+
+
+# ── tool_use schema enforcement (Anthropic structured output) ──────────
+
+
+def test_call_with_tool_schema_helper_exists() -> None:
+    """The new helper is the canonical seam for structured-output
+    extractor calls. Replaces the prompt-only \"output ONLY valid
+    JSON\" pattern that the boattrader smoke proved unreliable."""
+    from mantis_agent.extraction.extractor import ClaudeExtractor
+
+    assert hasattr(ClaudeExtractor, "_call_with_tool_schema")
+    sig = inspect.signature(ClaudeExtractor._call_with_tool_schema)
+    # Required keyword-only args.
+    for arg in ("tool_name", "tool_description", "input_schema"):
+        assert arg in sig.parameters
+        assert sig.parameters[arg].kind == inspect.Parameter.KEYWORD_ONLY
+
+
+def test_call_with_tool_schema_forces_tool_choice(monkeypatch) -> None:
+    """The Anthropic request must set ``tool_choice`` to the named tool
+    so Claude is FORCED to emit the schema-validated tool_use block.
+    Without forcing, Claude can fall back to text content (the failure
+    mode this whole helper is supposed to prevent)."""
+    from PIL import Image
+
+    from mantis_agent.extraction.extractor import ClaudeExtractor
+
+    captured: dict = {}
+
+    class _FakeResponse:
+        status_code = 200
+
+        @staticmethod
+        def json() -> dict:
+            return {
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "name": "test_tool",
+                        "input": {"x": 100, "y": 200, "ok": True},
+                    },
+                ],
+            }
+
+    def fake_post(url, headers, json, timeout):  # noqa: A002 — match requests sig
+        captured["body"] = json
+        return _FakeResponse()
+
+    import requests as real_requests
+    monkeypatch.setattr(real_requests, "post", fake_post)
+
+    extractor = ClaudeExtractor(api_key="dummy")
+    img = Image.new("RGB", (10, 10), color=(255, 255, 255))
+    out = extractor._call_with_tool_schema(
+        img,
+        "find the thing",
+        tool_name="test_tool",
+        tool_description="report the thing",
+        input_schema={
+            "type": "object",
+            "properties": {
+                "x": {"type": "integer"},
+                "y": {"type": "integer"},
+                "ok": {"type": "boolean"},
+            },
+            "required": ["x", "y", "ok"],
+        },
+    )
+
+    # Forced tool-choice with the named tool.
+    assert captured["body"]["tool_choice"] == {"type": "tool", "name": "test_tool"}
+    # Tool definition is in the request.
+    assert captured["body"]["tools"][0]["name"] == "test_tool"
+    assert "input_schema" in captured["body"]["tools"][0]
+    # Validated tool_use input flows back as the helper's return.
+    assert out == {"x": 100, "y": 200, "ok": True}
+
+
+def test_call_with_tool_schema_returns_none_on_no_tool_use_block(monkeypatch) -> None:
+    """Defensive: if Anthropic returns a response without the expected
+    tool_use block (e.g. API regression, misconfigured request), the
+    helper returns None so the caller can fall back to its existing
+    not_found handling. No crash."""
+    from PIL import Image
+
+    from mantis_agent.extraction.extractor import ClaudeExtractor
+
+    class _FakeResponse:
+        status_code = 200
+
+        @staticmethod
+        def json() -> dict:
+            return {"content": [{"type": "text", "text": "I refuse to use the tool."}]}
+
+    import requests as real_requests
+    monkeypatch.setattr(real_requests, "post", lambda *a, **k: _FakeResponse())
+
+    extractor = ClaudeExtractor(api_key="dummy")
+    img = Image.new("RGB", (10, 10), color=(255, 255, 255))
+    out = extractor._call_with_tool_schema(
+        img, "x", tool_name="t", tool_description="d",
+        input_schema={"type": "object"},
+    )
+    assert out is None
+
+
+def test_call_with_tool_schema_returns_none_on_api_error(monkeypatch) -> None:
+    """Non-200 responses must NOT crash — they propagate as None and
+    the caller's not_found handling kicks in."""
+    from PIL import Image
+
+    from mantis_agent.extraction.extractor import ClaudeExtractor
+
+    class _Err:
+        status_code = 500
+        text = "internal error"
+
+    import requests as real_requests
+    monkeypatch.setattr(real_requests, "post", lambda *a, **k: _Err())
+
+    extractor = ClaudeExtractor(api_key="dummy")
+    img = Image.new("RGB", (10, 10), color=(255, 255, 255))
+    out = extractor._call_with_tool_schema(
+        img, "x", tool_name="t", tool_description="d",
+        input_schema={"type": "object"},
+    )
+    assert out is None
+
+
+def test_find_listing_content_control_uses_tool_schema(monkeypatch) -> None:
+    """Integration: the content-control finder must route through the
+    schema-enforced helper, not the legacy ``_call`` + ``_parse_json``
+    pair. Pin the wiring so a future refactor doesn't silently revert."""
+    from unittest.mock import MagicMock
+
+    from PIL import Image
+
+    from mantis_agent.extraction.extractor import ClaudeExtractor
+    from mantis_agent.extraction.schema import ExtractionSchema
+
+    schema = ExtractionSchema(
+        entity_name="boat",
+        allowed_controls=("expand_description", "show_phone"),
+        forbidden_controls=("contact seller",),
+        fields=[],
+    )
+    extractor = ClaudeExtractor(api_key="dummy", schema=schema)
+    extractor._call_with_tool_schema = MagicMock(  # type: ignore[method-assign]
+        return_value={
+            "x": 740, "y": 320, "action": "expand_description",
+            "label": "Show more", "reason": "see-more chevron",
+        },
+    )
+    extractor._call = MagicMock(  # type: ignore[method-assign]
+        side_effect=AssertionError("legacy _call must not be used"),
+    )
+
+    img = Image.new("RGB", (1280, 720), color=(255, 255, 255))
+    result = extractor.find_listing_content_control(img)
+
+    extractor._call_with_tool_schema.assert_called_once()
+    extractor._call.assert_not_called()
+    assert result == {
+        "x": 740, "y": 320, "action": "expand_description",
+        "label": "Show more", "reason": "see-more chevron",
+    }
+    # The schema's allowed_controls + "none" sentinel must be the
+    # enum the tool's input_schema accepts — that's how the structured
+    # output stays plan-driven (per #209's analysis-stage discipline).
+    call_kwargs = extractor._call_with_tool_schema.call_args.kwargs
+    enum = call_kwargs["input_schema"]["properties"]["action"]["enum"]
+    assert "expand_description" in enum
+    assert "show_phone" in enum
+    assert "none" in enum
+
+
+def test_find_listing_content_control_returns_none_when_tool_returns_none_action(monkeypatch) -> None:
+    """If Claude reports ``action=none`` via the tool_use block, the
+    finder returns None — same contract the legacy path had."""
+    from unittest.mock import MagicMock
+
+    from PIL import Image
+
+    from mantis_agent.extraction.extractor import ClaudeExtractor
+    from mantis_agent.extraction.schema import ExtractionSchema
+
+    schema = ExtractionSchema(
+        entity_name="boat",
+        allowed_controls=("expand_description",),
+        forbidden_controls=("contact seller",),
+        fields=[],
+    )
+    extractor = ClaudeExtractor(api_key="dummy", schema=schema)
+    extractor._call_with_tool_schema = MagicMock(  # type: ignore[method-assign]
+        return_value={
+            "x": 0, "y": 0, "action": "none",
+            "label": "", "reason": "none visible",
+        },
+    )
+
+    img = Image.new("RGB", (10, 10), color=(255, 255, 255))
+    assert extractor.find_listing_content_control(img) is None


### PR DESCRIPTION
Generic robustness fix surfaced by the boattrader smoke from PR #218's CLI. Same architectural pattern: framework primitive stays domain-neutral; per-plan vocabulary enters via the analysis stage (here, \`ExtractionSchema.allowed_controls\`).

## Three failure modes (all confirmed in /tmp/mantis_debug)

The current prompt-only \"Output ONLY valid JSON\" approach fails in three distinct ways:

1. **Prose-only response** — Claude reasoned aloud and never emitted a JSON object: \"I need to look for controls that expand content...\". \`_parse_json\`'s regex found nothing.
2. **Truncated JSON** — prose preamble consumed the 200-token budget, leaving the trailing JSON cut off mid-string: \`\"reason\": \"Filter section with\` ← truncated, no closing brace.
3. **Malformed JSON** — Claude emitted \`{\"x\": 302, 43, \"y\": 43, \"action\": \"expand\", ...}\` — extra unlabeled positional value before \`\"y\":\`. No regex / parser can recover; the fix has to be on the request side.

## Fix

### Primary: schema-enforced \`tool_use\`
Anthropic's \`tool_choice={\"type\": \"tool\", \"name\": ...}\` forces the model to emit a \`tool_use\` block whose \`input\` is **server-side-validated** against the tool's \`input_schema\`. All three failure modes become structurally impossible: the response is always a \`tool_use\`, the input dict is always schema-shaped, and the model can't drift into prose.

New primitive \`_call_with_tool_schema(screenshot, prompt, *, tool_name, tool_description, input_schema, max_tokens=500)\` — generic seam any future structured-output call site can adopt. \`find_listing_content_control\` routes through it; the schema's \`action\` enum is built from \`ExtractionSchema.allowed_controls + [\"none\"]\` so plan-driven control vocabularies flow into the input_schema automatically (per the architectural directive — no plan vocabulary baked in).

### Secondary: defense-in-depth on legacy paths
- Bumped \`_call\` default \`max_tokens\` 200 → 500. Anthropic only bills generated tokens; the bump is free for short responses and prevents truncation on prose-prefix runs that haven't migrated to tool_use yet (\`find_form_target\`, \`verify_gate\`, …).
- Tightened \`_get_content_control_prompt\`: concrete worked example (literal \`x=740 y=320\` instead of placeholder \`N\`), explicit anti-tuple warning naming the exact malformed shape from the smoke, \"no prose preamble\" directive at the top.

## Stay-generic discipline

- \`_call_with_tool_schema\` is a structural primitive — caller supplies the schema, the helper plumbs it through. No domain knowledge.
- The schema's enum for \`action\` is sourced from \`ExtractionSchema.allowed_controls\` so the plan / recipe controls the vocabulary, not the framework.
- Other \`_call\` sites (\`find_form_target\`, \`find_filter_target\`, \`verify_gate\`, \`extract\`, …) are intentionally left on the legacy path for this PR. Each carries its own prompt + parser quirks; converting piecewise is mechanical from here. The seam is in place.

## Test plan

- [x] \`tests/test_extractor_token_budget.py\` — 12 cases:
  - default \`max_tokens\` >= 500; explicit overrides still honoured
  - content-control prompt: concrete worked example, anti-tuple warning, no-prose directive
  - \`_call_with_tool_schema\`: helper exists with kwarg-only params; forces \`tool_choice\`; returns input dict from \`tool_use\` block; returns \`None\` on missing tool_use, on text-only fallback, and on non-200 API errors
  - \`find_listing_content_control\` routes through the tool-schema helper (legacy \`_call\` MUST NOT be invoked); the schema enum matches \`ExtractionSchema.allowed_controls + [\"none\"]\`; returns \`None\` when tool reports \`action=\"none\"\`
- [x] Full pytest suite — **1287 passed**
- [ ] **Smoke against boattrader bench plan** — re-ran. Got past PR #218's prewarm blocker, decomposed into a 36-step plan. Step 0 (\`extract_data: \"Wait 15 seconds for BoatTrader page to fully load\"\`) failed for an unrelated decomposer-side reason: the bench plan's first instruction is \"wait 15 seconds\" but the decomposer's step-type vocabulary has no \`wait\`, so it picked \`extract_data\` — which then runs the marketplace-listings extractor on a search-results page and rejects with \`REJECTED_INCOMPLETE\` (no listing to extract). Separate finding worth a follow-up; orthogonal to this PR's robustness fix.

## Out of scope

- Decomposer-side: \"wait N seconds\" instructions decomposing as \`extract_data\` instead of a no-op or runtime-settle hint. Surfaced by this smoke; needs a focused decomposer prompt update.
- Migrating other \`_call\` sites (\`find_form_target\`, \`find_filter_target\`, \`verify_gate\`, \`extract\`, …) to \`_call_with_tool_schema\`. The seam is in place; each conversion is its own mechanical change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)