### PR TITLE
fix(extractor): migrate verify_gate / find_filter / find_form / extract to tool_use schema

### DIFF
--- a/src/mantis_agent/extraction/extractor.py
+++ b/src/mantis_agent/extraction/extractor.py
@@ -34,7 +34,7 @@ import os
 import re
 import time
 from io import BytesIO
-from typing import Any
+from typing import Any, ClassVar
 
 from PIL import Image
 
@@ -470,15 +470,35 @@ class ClaudeExtractor:
     def extract(self, screenshot: Image.Image) -> ExtractionResult:
         """Extract listing data from a detail page screenshot.
 
-        When schema is set, uses dynamic prompts and populates generic fields.
-        Otherwise uses legacy BoatTrader hardcoded prompt.
+        When schema is set, uses dynamic prompts and populates generic
+        fields; the input_schema for the tool_use call is also built
+        dynamically from ``self.schema.fields``. Otherwise uses the
+        legacy hardcoded prompt with the canonical marketplace shape.
+
+        Routes through tool_use schema enforcement so the per-field
+        types (string / boolean) and required-set are server-validated;
+        prose-only or truncated responses become structurally
+        impossible. This is the highest-leverage migration since
+        ``extract`` is called once per detail page in the listings
+        loop.
         """
         prompt = self._get_extract_prompt()
-        text = self._call(screenshot, prompt)
-        parsed = self._parse_json(text)
+        input_schema = self._build_extract_input_schema()
+        parsed = self._call_with_tool_schema(
+            screenshot,
+            prompt,
+            tool_name="report_extracted_listing",
+            tool_description=(
+                "Report the structured fields visible on this detail page."
+            ),
+            input_schema=input_schema,
+            max_tokens=1500,
+        )
 
         if not parsed:
-            return ExtractionResult(raw_response=text, confidence=0.1, _schema=self.schema)
+            return ExtractionResult(
+                raw_response="<no tool_use>", confidence=0.1, _schema=self.schema,
+            )
 
         if self.schema:
             result = self._parse_schema_result(parsed)
@@ -494,9 +514,70 @@ class ClaudeExtractor:
             url=str(parsed.get("url", "")),
             seller=str(parsed.get("seller", "")),
             is_dealer=parse_bool(parsed.get("is_dealer", False)),
-            raw_response=text,
+            raw_response=json.dumps(parsed),
             confidence=0.9,
         )
+
+    # Type lookup for the dynamic extract input_schema. Maps the
+    # ``type`` string the schema fields use to the JSON-Schema type
+    # name Anthropic's tool_use expects. New types added to
+    # ExtractionSchema must extend this map.
+    _EXTRACT_FIELD_JSON_TYPES: ClassVar[dict[str, str]] = {
+        "str": "string",
+        "string": "string",
+        "int": "integer",
+        "integer": "integer",
+        "float": "number",
+        "number": "number",
+        "bool": "boolean",
+        "boolean": "boolean",
+    }
+
+    def _build_extract_input_schema(self) -> dict[str, Any]:
+        """Build the ``extract`` tool_use input_schema dynamically.
+
+        - When ``self.schema`` is set: every schema field becomes a
+          property; the universal ``is_spam`` boolean is appended.
+        - Otherwise: falls back to the legacy marketplace shape
+          (year / make / model / price / phone / url / seller /
+          is_dealer) so callers without a schema still get a
+          validated response.
+        """
+        if self.schema:
+            properties: dict[str, dict[str, Any]] = {}
+            required: list[str] = []
+            for field in self.schema.fields:
+                name = field["name"]
+                json_type = self._EXTRACT_FIELD_JSON_TYPES.get(
+                    str(field.get("type", "str")).lower(), "string",
+                )
+                properties[name] = {"type": json_type}
+                required.append(name)
+            properties["is_spam"] = {"type": "boolean"}
+            required.append("is_spam")
+            return {
+                "type": "object",
+                "properties": properties,
+                "required": required,
+            }
+        # Legacy / no-schema fallback shape.
+        return {
+            "type": "object",
+            "properties": {
+                "year": {"type": "string"},
+                "make": {"type": "string"},
+                "model": {"type": "string"},
+                "price": {"type": "string"},
+                "phone": {"type": "string"},
+                "url": {"type": "string"},
+                "seller": {"type": "string"},
+                "is_dealer": {"type": "boolean"},
+            },
+            "required": [
+                "year", "make", "model", "price",
+                "phone", "url", "seller", "is_dealer",
+            ],
+        }
 
     def extract_scrolled(self, screenshot: Image.Image) -> dict:
         """Extract additional data from a scrolled-down screenshot.
@@ -654,21 +735,43 @@ class ClaudeExtractor:
         """Verify a gate condition from a screenshot.
 
         Used after setup to check if filters were actually applied.
-        Returns (passed, reason).
+        Returns (passed, reason). Routes through tool_use schema so the
+        boolean / string shape is server-validated; any failure mode
+        falls through to ``(False, reason)`` so the runner halts on
+        an unverified gate (safer than silently passing).
         """
         prompt = (
             f"Look at this screenshot ({screenshot.width}x{screenshot.height} pixels).\n\n"
             f"Check this condition: {expected}\n\n"
-            f"Look at the page heading, URL bar, result count, and any active filter tags.\n\n"
-            f"Output ONLY valid JSON:\n"
-            f"{{\"passed\": true/false, \"reason\": \"what you see that confirms or denies the condition\"}}"
+            f"Look at the page heading, URL bar, result count, and any active filter tags."
         )
 
-        text = self._call(screenshot, prompt)
-        parsed = self._parse_json(text)
+        parsed = self._call_with_tool_schema(
+            screenshot,
+            prompt,
+            tool_name="report_gate_verification",
+            tool_description=(
+                "Report whether the gate condition holds based on what is "
+                "visible in the screenshot."
+            ),
+            input_schema={
+                "type": "object",
+                "properties": {
+                    "passed": {
+                        "type": "boolean",
+                        "description": "True iff the condition holds.",
+                    },
+                    "reason": {
+                        "type": "string",
+                        "description": "What you see that confirms or denies the condition.",
+                    },
+                },
+                "required": ["passed", "reason"],
+            },
+        )
 
         if not parsed:
-            return False, f"Could not parse verifier response: {text[:100]}"
+            return False, "verify_gate: tool_use returned no usable result"
 
         passed = bool(parsed.get("passed", False))
         reason = str(parsed.get("reason", ""))
@@ -1046,17 +1149,43 @@ class ClaudeExtractor:
         except Exception:
             pass
 
-        text = self._call(screenshot, prompt)
+        # tool_use schema enforcement — the prompt-only "Output ONLY
+        # valid JSON" pattern produced prose-only / truncated /
+        # malformed responses on the boattrader smoke. Schema-validated
+        # tool_use makes those failure modes structurally impossible.
+        parsed = self._call_with_tool_schema(
+            screenshot,
+            prompt,
+            tool_name="report_filter_target",
+            tool_description=(
+                "Report the chosen filter control's coordinates and how "
+                "to interact with it (click / type / select), or "
+                "not_found if no matching element is visible."
+            ),
+            input_schema={
+                "type": "object",
+                "properties": {
+                    "x": {"type": "integer", "description": "Center X in pixels"},
+                    "y": {"type": "integer", "description": "Center Y in pixels"},
+                    "action": {
+                        "type": "string",
+                        "enum": ["click", "type", "select", "not_found"],
+                    },
+                    "value": {"type": "string"},
+                    "label": {"type": "string"},
+                },
+                "required": ["x", "y", "action", "value", "label"],
+            },
+        )
 
         try:
             with open(self._debug_path(debug_stem, "_response.txt"), "w") as f:
-                f.write(text)
+                f.write(json.dumps(parsed) if parsed is not None else "<no tool_use>")
         except Exception:
             pass
 
-        parsed = self._parse_json(text)
         if not parsed:
-            logger.warning(f"  [claude-filter] parse failed: {text[:200]}")
+            logger.warning("  [claude-filter] tool_use returned no usable result")
             return None
 
         if parsed.get("action") == "not_found":
@@ -1191,17 +1320,42 @@ class ClaudeExtractor:
         except Exception:
             pass
 
-        text = self._call(screenshot, prompt)
+        # tool_use schema enforcement — same shape as find_filter_target
+        # (the form / filter targets are both "find one labelled element
+        # and tell me how to interact with it").
+        parsed = self._call_with_tool_schema(
+            screenshot,
+            prompt,
+            tool_name="report_form_target",
+            tool_description=(
+                "Report the form element matching the task — coordinates "
+                "and interaction (click / type / select), or not_found "
+                "if no matching element is visible on screen."
+            ),
+            input_schema={
+                "type": "object",
+                "properties": {
+                    "x": {"type": "integer", "description": "Center X in pixels"},
+                    "y": {"type": "integer", "description": "Center Y in pixels"},
+                    "action": {
+                        "type": "string",
+                        "enum": ["click", "type", "select", "not_found"],
+                    },
+                    "value": {"type": "string"},
+                    "label": {"type": "string"},
+                },
+                "required": ["x", "y", "action", "value", "label"],
+            },
+        )
 
         try:
             with open(self._debug_path(debug_stem, "_response.txt"), "w") as f:
-                f.write(text)
+                f.write(json.dumps(parsed) if parsed is not None else "<no tool_use>")
         except Exception:
             pass
 
-        parsed = self._parse_json(text)
         if not parsed:
-            logger.warning(f"  [claude-form] parse failed: {text[:200]}")
+            logger.warning("  [claude-form] tool_use returned no usable result")
             return None
 
         if parsed.get("action") == "not_found":

--- a/tests/test_extractor_tool_use_migration.py
+++ b/tests/test_extractor_tool_use_migration.py
@@ -1,0 +1,340 @@
+"""Tests for the tool_use schema rollout across the extractor surface.
+
+#219 introduced the ``_call_with_tool_schema`` seam and migrated
+``find_listing_content_control`` to it. This rollout extends the same
+treatment to:
+
+  • ``verify_gate``       — boolean+string gate result
+  • ``find_filter_target`` — five-field click/type/select target
+  • ``find_form_target``   — five-field, same shape as filter
+  • ``extract``            — dynamic, schema-driven multi-field
+
+Each migration replaces the prompt-only "Output ONLY valid JSON"
+pattern (which produced prose-only / truncated / malformed responses
+in production) with Anthropic's server-validated tool_use shape. The
+tests pin: the helper is invoked with the right tool name + schema,
+the legacy ``_call`` + ``_parse_json`` path is NOT used, and the
+returned value flows through unchanged.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from PIL import Image
+
+from mantis_agent.extraction.extractor import ClaudeExtractor
+from mantis_agent.extraction.schema import ExtractionSchema
+
+
+def _img() -> Image.Image:
+    return Image.new("RGB", (10, 10), color=(255, 255, 255))
+
+
+def _wired(extractor: ClaudeExtractor) -> tuple[MagicMock, MagicMock]:
+    """Replace the tool_use seam + legacy _call. Returns (tool_mock, call_mock).
+
+    Tests assert the tool seam is called and ``_call`` is NOT — that's
+    how we lock in the migration so a future refactor doesn't silently
+    revert to the prompt-only path.
+    """
+    tool = MagicMock()
+    extractor._call_with_tool_schema = tool  # type: ignore[method-assign]
+    call = MagicMock(side_effect=AssertionError("legacy _call must not be used"))
+    extractor._call = call  # type: ignore[method-assign]
+    return tool, call
+
+
+# ── verify_gate ─────────────────────────────────────────────────────────
+
+
+def test_verify_gate_routes_through_tool_schema() -> None:
+    extractor = ClaudeExtractor(api_key="dummy")
+    tool, call = _wired(extractor)
+    tool.return_value = {"passed": True, "reason": "Filters applied"}
+
+    passed, reason = extractor.verify_gate(_img(), "Filters applied")
+
+    tool.assert_called_once()
+    call.assert_not_called()
+    assert passed is True
+    assert reason == "Filters applied"
+
+
+def test_verify_gate_schema_shape() -> None:
+    """The tool's input_schema must lock the boolean / string fields."""
+    extractor = ClaudeExtractor(api_key="dummy")
+    tool, _ = _wired(extractor)
+    tool.return_value = {"passed": False, "reason": "Filters missing"}
+
+    extractor.verify_gate(_img(), "Filters applied")
+
+    schema = tool.call_args.kwargs["input_schema"]
+    assert schema["properties"]["passed"]["type"] == "boolean"
+    assert schema["properties"]["reason"]["type"] == "string"
+    assert set(schema["required"]) == {"passed", "reason"}
+
+
+def test_verify_gate_returns_false_on_no_tool_use() -> None:
+    """Server-side validation can't fail on shape, but the tool_use
+    block can be missing entirely (API regression). The runner halts
+    on a False gate, which is the right safety default."""
+    extractor = ClaudeExtractor(api_key="dummy")
+    tool, _ = _wired(extractor)
+    tool.return_value = None
+
+    passed, reason = extractor.verify_gate(_img(), "anything")
+    assert passed is False
+    assert "tool_use" in reason
+
+
+# ── find_filter_target ──────────────────────────────────────────────────
+
+
+def test_find_filter_target_routes_through_tool_schema() -> None:
+    extractor = ClaudeExtractor(api_key="dummy")
+    tool, call = _wired(extractor)
+    tool.return_value = {
+        "x": 220, "y": 110, "action": "click",
+        "value": "", "label": "Private Seller pill",
+    }
+
+    out = extractor.find_filter_target(_img(), "Click Private Seller filter")
+
+    tool.assert_called_once()
+    call.assert_not_called()
+    assert out == {
+        "x": 220, "y": 110, "action": "click",
+        "value": "", "label": "Private Seller pill",
+    }
+
+
+def test_find_filter_target_schema_includes_full_action_enum() -> None:
+    extractor = ClaudeExtractor(api_key="dummy")
+    tool, _ = _wired(extractor)
+    tool.return_value = {
+        "x": 0, "y": 0, "action": "not_found", "value": "", "label": "x",
+    }
+
+    extractor.find_filter_target(_img(), "x")
+
+    schema = tool.call_args.kwargs["input_schema"]
+    enum = schema["properties"]["action"]["enum"]
+    assert set(enum) == {"click", "type", "select", "not_found"}
+    assert set(schema["required"]) == {"x", "y", "action", "value", "label"}
+
+
+def test_find_filter_target_returns_none_on_not_found() -> None:
+    extractor = ClaudeExtractor(api_key="dummy")
+    tool, _ = _wired(extractor)
+    tool.return_value = {
+        "x": 0, "y": 0, "action": "not_found",
+        "value": "", "label": "no matching filter visible",
+    }
+    assert extractor.find_filter_target(_img(), "Pick X") is None
+
+
+def test_find_filter_target_returns_none_on_zero_coordinates() -> None:
+    """Defensive: even if Claude returns action='click' but emits
+    (0, 0), treat as not-located rather than clicking origin."""
+    extractor = ClaudeExtractor(api_key="dummy")
+    tool, _ = _wired(extractor)
+    tool.return_value = {
+        "x": 0, "y": 0, "action": "click",
+        "value": "", "label": "uncertain",
+    }
+    assert extractor.find_filter_target(_img(), "Pick X") is None
+
+
+def test_find_filter_target_returns_none_on_no_tool_use() -> None:
+    extractor = ClaudeExtractor(api_key="dummy")
+    tool, _ = _wired(extractor)
+    tool.return_value = None
+    assert extractor.find_filter_target(_img(), "Pick X") is None
+
+
+# ── find_form_target ────────────────────────────────────────────────────
+
+
+def test_find_form_target_routes_through_tool_schema() -> None:
+    extractor = ClaudeExtractor(api_key="dummy")
+    tool, call = _wired(extractor)
+    tool.return_value = {
+        "x": 691, "y": 284, "action": "type",
+        "value": "alice", "label": "User ID input field",
+    }
+
+    out = extractor.find_form_target(
+        _img(),
+        "Click the user ID input field and type alice",
+        target_label="user ID",
+        target_value="alice",
+    )
+
+    tool.assert_called_once()
+    call.assert_not_called()
+    assert out == {
+        "x": 691, "y": 284, "action": "type",
+        "value": "alice", "label": "User ID input field",
+    }
+
+
+def test_find_form_target_schema_matches_filter_target_shape() -> None:
+    """``form`` and ``filter`` targets share the same shape — both are
+    'find one labelled element and tell me how to interact'. Pin that
+    parity so a future schema drift on one method gets noticed."""
+    extractor = ClaudeExtractor(api_key="dummy")
+
+    # Capture form schema.
+    tool_form, _ = _wired(extractor)
+    tool_form.return_value = {
+        "x": 0, "y": 0, "action": "not_found",
+        "value": "", "label": "",
+    }
+    extractor.find_form_target(_img(), "x")
+    form_schema = tool_form.call_args.kwargs["input_schema"]
+
+    # Capture filter schema (rewire fresh mocks).
+    tool_filter, _ = _wired(extractor)
+    tool_filter.return_value = {
+        "x": 0, "y": 0, "action": "not_found",
+        "value": "", "label": "",
+    }
+    extractor.find_filter_target(_img(), "x")
+    filter_schema = tool_filter.call_args.kwargs["input_schema"]
+
+    assert form_schema == filter_schema
+
+
+def test_find_form_target_returns_none_on_not_found() -> None:
+    extractor = ClaudeExtractor(api_key="dummy")
+    tool, _ = _wired(extractor)
+    tool.return_value = {
+        "x": 0, "y": 0, "action": "not_found",
+        "value": "", "label": "Cloudflare challenge",
+    }
+    assert extractor.find_form_target(_img(), "Click X") is None
+
+
+def test_find_form_target_returns_none_on_no_tool_use() -> None:
+    extractor = ClaudeExtractor(api_key="dummy")
+    tool, _ = _wired(extractor)
+    tool.return_value = None
+    assert extractor.find_form_target(_img(), "Click X") is None
+
+
+# ── extract (dynamic schema) ───────────────────────────────────────────
+
+
+def test_extract_routes_through_tool_schema_with_legacy_shape() -> None:
+    """Without an ExtractionSchema, ``extract`` falls back to the
+    canonical marketplace-listing input_schema."""
+    extractor = ClaudeExtractor(api_key="dummy")
+    tool, call = _wired(extractor)
+    tool.return_value = {
+        "year": "2024", "make": "Sea Ray", "model": "Sundancer",
+        "price": "$189000", "phone": "786-555-1234",
+        "url": "https://x/boat/1",
+        "seller": "Bob", "is_dealer": False,
+    }
+
+    result = extractor.extract(_img())
+
+    tool.assert_called_once()
+    call.assert_not_called()
+    assert result.year == "2024"
+    assert result.make == "Sea Ray"
+    assert result.is_dealer is False
+    assert result.confidence == 0.9
+
+
+def test_extract_dynamic_schema_built_from_extraction_schema_fields() -> None:
+    """When an ExtractionSchema is set, the tool_use input_schema
+    must include every schema field as a property + the universal
+    ``is_spam`` boolean. Schema field types map to JSON-Schema types
+    (str → string, bool → boolean, int → integer)."""
+    schema = ExtractionSchema(
+        entity_name="job",
+        spam_label="recruiter",
+        fields=[
+            {"name": "title", "type": "str", "required": True},
+            {"name": "company", "type": "str"},
+            {"name": "salary_min", "type": "int"},
+            {"name": "remote", "type": "bool"},
+        ],
+    )
+    extractor = ClaudeExtractor(api_key="dummy", schema=schema)
+    tool, _ = _wired(extractor)
+    tool.return_value = {
+        "title": "Senior SRE", "company": "Acme",
+        "salary_min": 200000, "remote": True, "is_spam": False,
+    }
+
+    extractor.extract(_img())
+
+    input_schema = tool.call_args.kwargs["input_schema"]
+    props = input_schema["properties"]
+    assert props["title"] == {"type": "string"}
+    assert props["company"] == {"type": "string"}
+    assert props["salary_min"] == {"type": "integer"}
+    assert props["remote"] == {"type": "boolean"}
+    assert props["is_spam"] == {"type": "boolean"}
+    # Every property is required — the structure-validating effect is
+    # what makes tool_use stronger than prompt-only "Output JSON".
+    assert set(input_schema["required"]) == set(props.keys())
+
+
+def test_extract_returns_low_confidence_when_tool_returns_none() -> None:
+    extractor = ClaudeExtractor(api_key="dummy")
+    tool, _ = _wired(extractor)
+    tool.return_value = None
+
+    result = extractor.extract(_img())
+    assert result.confidence == 0.1
+    assert "no tool_use" in result.raw_response
+
+
+def test_extract_passes_higher_max_tokens() -> None:
+    """Multi-field extracts can exceed the default 500-token budget;
+    the extract path should request at least 1500 tokens."""
+    extractor = ClaudeExtractor(api_key="dummy")
+    tool, _ = _wired(extractor)
+    tool.return_value = {
+        "year": "", "make": "", "model": "", "price": "",
+        "phone": "", "url": "", "seller": "", "is_dealer": False,
+    }
+
+    extractor.extract(_img())
+    assert tool.call_args.kwargs["max_tokens"] >= 1500
+
+
+# ── Schema → JSON-Schema type mapping ──────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "schema_type,json_type",
+    [
+        ("str", "string"),
+        ("string", "string"),
+        ("int", "integer"),
+        ("integer", "integer"),
+        ("float", "number"),
+        ("number", "number"),
+        ("bool", "boolean"),
+        ("boolean", "boolean"),
+        ("UnknownType", "string"),  # default fallback
+    ],
+)
+def test_extract_field_type_map_is_complete(
+    schema_type: str, json_type: str,
+) -> None:
+    """Every schema field type ExtractionSchema documents must map to
+    a JSON-Schema type the Anthropic tool_use API accepts."""
+    schema = ExtractionSchema(
+        entity_name="thing",
+        fields=[{"name": "value", "type": schema_type}],
+    )
+    extractor = ClaudeExtractor(api_key="dummy", schema=schema)
+    input_schema = extractor._build_extract_input_schema()
+    assert input_schema["properties"]["value"]["type"] == json_type


### PR DESCRIPTION
Completes the structured-output rollout #219 started. Every \`_call\` + \`_parse_json\` site in the extractor that returns a JSON object now routes through \`_call_with_tool_schema\`, eliminating the prose-only / truncated / malformed-JSON failure modes the boattrader smoke surfaced.

## Methods migrated

| Method | Schema | Why this matters |
|---|---|---|
| \`verify_gate\` | \`{passed: bool, reason: string}\` | Setup gate failures used to silently pass-through a parse error as ``False, "could not parse..."``. Now schema-validated; runner halts on real gate failures only. |
| \`find_filter_target\` | \`{x, y, action ∈ [click,type,select,not_found], value, label}\` | Filter-pill click failures were the dominant cause of setup-phase halts (zip code, sort dropdown, etc.) |
| \`find_form_target\` | same shape as filter | Login button + form-fill failures (debug PNGs from staff-crm + boattrader smokes both showed prose+truncated JSON here) |
| \`extract\` (schema-driven) | dynamic from \`ExtractionSchema.fields\` + \`is_spam: bool\` | The highest-leverage call — once per detail page in the listings loop. Multi-field JSON is the most likely to truncate at the old 500-token budget. |
| \`extract\` (no schema) | legacy marketplace shape (year/make/model/price/phone/url/seller/is_dealer) | Backward-compat for callers that don't pass a schema. |

## Dynamic schema construction

\`_build_extract_input_schema\` walks \`ExtractionSchema.fields\` and maps each field's declared \`type\` (\`str\` / \`int\` / \`float\` / \`bool\` / etc.) to the JSON-Schema type Anthropic's tool_use accepts. The mapping is pinned in a \`ClassVar\` table:

\`\`\`python
_EXTRACT_FIELD_JSON_TYPES: ClassVar[dict[str, str]] = {
    \"str\": \"string\", \"string\": \"string\",
    \"int\": \"integer\", \"integer\": \"integer\",
    \"float\": \"number\", \"number\": \"number\",
    \"bool\": \"boolean\", \"boolean\": \"boolean\",
}
\`\`\`

Unknown types fall back to \`\"string\"\` (defensive — a new schema field type lands without a tool_use type counterpart shouldn't crash the call). A parametrised test catches drift: every entry in the table is round-tripped through \`_build_extract_input_schema\`, plus an unknown-type case asserts the fallback.

## Stay-generic discipline

- The seam (\`_call_with_tool_schema\`) and the dynamic schema builder are both **structural primitives** — no plan / domain / customer vocabulary baked in. Recipes' \`ExtractionSchema\` instances drive the per-run shape; the framework just walks them.
- Form / filter targets share an identical schema by design — both are \"find one labelled element and tell me how to interact with it\". A parity test pins this so future drift on one method gets noticed.
- The \`extract\` schema's \`required\` set is the FULL property list (every field is required) — that's the structural-validation effect that makes tool_use stronger than prompt-only \"Output JSON\". Optional fields would let Claude omit them silently and we'd lose the guarantee.

## Test plan

- [x] \`tests/test_extractor_tool_use_migration.py\` — 18 cases:
  - Per-method routing: tool_use seam invoked with the right schema, legacy \`_call\` NOT invoked
  - Schema shapes: action enum complete, required fields, form/filter parity
  - Failure-mode handling: no tool_use → \`None\` for finders, \`(False, \"…\")\` for verify_gate, low-confidence \`ExtractionResult\` for extract
  - Dynamic extract schema fully exercises \`ExtractionSchema.fields\` with field-type → JSON-type mapping
  - Parametrised type-map test (9 cases) catches drift if a new schema field type lands without a tool_use type counterpart
- [x] \`uv run pytest -q\` full suite — **1312 passed** (will be ~6m with PR #220's parallel-default once that lands)
- [ ] End-to-end smoke against staff-crm or lu.ma to confirm the migration holds in production. Boattrader is blocked by Cloudflare's headless detection (separate environmental issue documented in memory; not a code fix).

## Out of scope (next PR)

- **SPA-aware click verifier** — the lu.ma smoke surfaced a real gap: clicks on event cards open a modal/overlay without changing the URL, so URL-only \`is_detail_page\` reports failure even when the click succeeded. Needs a content-change check (screenshot diff or DOM-state) layered on top of the URL check. Separate concern from this extractor migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)