### PR TITLE
feat(click): SPA-aware post-click verifier — accept same-URL modal opens

### DIFF
--- a/src/mantis_agent/extraction/extractor.py
+++ b/src/mantis_agent/extraction/extractor.py
@@ -384,6 +384,89 @@ class ClaudeExtractor:
             logger.warning(f"ClaudeExtractor tool_use failed: {e}")
         return None
 
+    def _call_with_tool_schema_multi(
+        self,
+        screenshots: list[Image.Image],
+        prompt: str,
+        *,
+        tool_name: str,
+        tool_description: str,
+        input_schema: dict[str, Any],
+        labels: list[str] | None = None,
+        max_tokens: int = 500,
+    ) -> dict | None:
+        """Multi-screenshot variant of :meth:`_call_with_tool_schema`.
+
+        Same schema-validated tool_use enforcement, but bundles a list
+        of screenshots into a single messages payload. Used by paths
+        that need to compare images (e.g. post-click navigation
+        verification: before-click vs after-click). Each image is
+        prefixed with its label so the model can refer to them in
+        prose: "Screenshot 1: BEFORE click", "Screenshot 2: AFTER click".
+
+        Returns the validated input dict, or ``None`` on API / shape
+        mismatch — caller treats as fall-through (no answer).
+        """
+        import requests
+
+        if not self.api_key:
+            logger.warning("ClaudeExtractor: no API key")
+            return None
+
+        labels = labels or []
+        content: list[dict] = [{"type": "text", "text": prompt}]
+        for i, screenshot in enumerate(screenshots, 1):
+            label = labels[i - 1] if i - 1 < len(labels) else f"screenshot {i}"
+            buf = BytesIO()
+            screenshot.save(buf, format="PNG")
+            b64 = base64.b64encode(buf.getvalue()).decode()
+            content.append({"type": "text", "text": f"Screenshot {i}: {label}"})
+            content.append({
+                "type": "image",
+                "source": {"type": "base64", "media_type": "image/png", "data": b64},
+            })
+
+        try:
+            resp = requests.post(
+                "https://api.anthropic.com/v1/messages",
+                headers={
+                    "x-api-key": self.api_key,
+                    "anthropic-version": "2023-06-01",
+                    "content-type": "application/json",
+                },
+                json={
+                    "model": self.model,
+                    "max_tokens": max_tokens,
+                    "tools": [{
+                        "name": tool_name,
+                        "description": tool_description,
+                        "input_schema": input_schema,
+                    }],
+                    "tool_choice": {"type": "tool", "name": tool_name},
+                    "messages": [{"role": "user", "content": content}],
+                },
+                timeout=45,
+            )
+            if resp.status_code != 200:
+                logger.warning(
+                    "ClaudeExtractor multi tool_use API error %s: %s",
+                    resp.status_code,
+                    resp.text[:500],
+                )
+                return None
+            for block in resp.json().get("content", []):
+                if block.get("type") == "tool_use" and block.get("name") == tool_name:
+                    tool_input = block.get("input")
+                    if isinstance(tool_input, dict):
+                        return tool_input
+            logger.warning(
+                "ClaudeExtractor multi tool_use returned no %s tool block",
+                tool_name,
+            )
+        except Exception as e:
+            logger.warning(f"ClaudeExtractor multi tool_use failed: {e}")
+        return None
+
     def _call_many(
         self,
         screenshots: list[Image.Image],
@@ -649,6 +732,92 @@ class ClaudeExtractor:
             "label": label,
             "reason": reason,
         }
+
+    def verify_post_click_navigation(
+        self,
+        before_screenshot: Image.Image,
+        after_screenshot: Image.Image,
+        intent: str,
+    ) -> dict | None:
+        """Decide whether a click opened detail content (URL or modal).
+
+        Generic SPA-aware fallback for the click verifier. The URL-based
+        :meth:`SiteConfig.is_detail_page` check correctly handles full-
+        page-navigation sites (URL changes when a row click lands on a
+        detail page). It misses single-page apps where clicks open a
+        modal or overlay without changing the URL — lu.ma's event cards
+        are the canonical case: ``/discover`` stays in the address bar
+        but the visible content changes from a grid of cards to a single
+        event detail panel.
+
+        Calling pattern: invoke this AFTER the URL check returns False
+        and BEFORE escalating to middle-click / probe-area clicks. If
+        ``navigated=True``, accept the click as successful even though
+        the URL didn't change. Generic primitive — no plan vocabulary,
+        works for any SPA whose clicks open content in place.
+
+        Returns a dict with keys ``navigated`` (bool), ``kind`` (one of
+        ``url_change`` / ``modal`` / ``no_change`` / ``wrong_target``),
+        and ``reason`` (string) — or ``None`` on API / network failure
+        (caller treats None as "couldn't determine; fall through to
+        existing escalation").
+        """
+        prompt = (
+            "Compare these two screenshots taken before and after a "
+            f"single click. The intent of the click was: {intent!r}.\n\n"
+            "Decide whether the click successfully landed the user on "
+            "detail-or-target content.\n\n"
+            "Return ``navigated=true`` if EITHER:\n"
+            "  • The page navigated to a different URL/page (full-page "
+            "load) showing the target content, OR\n"
+            "  • The same URL stayed but a modal / overlay / panel "
+            "opened showing the target content (typical SPA pattern).\n\n"
+            "Return ``navigated=false`` if:\n"
+            "  • The page is essentially unchanged (click missed or "
+            "did nothing), OR\n"
+            "  • The page changed BUT to the wrong destination (login "
+            "wall, error, ad, unrelated section)."
+        )
+        return self._call_with_tool_schema_multi(
+            [before_screenshot, after_screenshot],
+            prompt,
+            tool_name="report_post_click_navigation",
+            tool_description=(
+                "Report whether a click successfully landed on detail/"
+                "target content, including the case where a SPA opens a "
+                "modal without changing the URL."
+            ),
+            input_schema={
+                "type": "object",
+                "properties": {
+                    "navigated": {
+                        "type": "boolean",
+                        "description": (
+                            "True iff the click landed on the intended "
+                            "detail content (URL change OR same-URL modal)."
+                        ),
+                    },
+                    "kind": {
+                        "type": "string",
+                        "enum": [
+                            "url_change",
+                            "modal",
+                            "no_change",
+                            "wrong_target",
+                        ],
+                    },
+                    "reason": {
+                        "type": "string",
+                        "description": (
+                            "What you see in the AFTER frame that "
+                            "confirms or denies navigation."
+                        ),
+                    },
+                },
+                "required": ["navigated", "kind", "reason"],
+            },
+            labels=["BEFORE click", "AFTER click"],
+        )
 
     def verify_gate(self, screenshot: Image.Image, expected: str) -> tuple[bool, str]:
         """Verify a gate condition from a screenshot.

--- a/src/mantis_agent/gym/step_handlers/click.py
+++ b/src/mantis_agent/gym/step_handlers/click.py
@@ -303,6 +303,18 @@ class ClaudeGuidedClickHandler:
         elif title.strip().lower() == "unknown":
             logger.info("  [grounding] skipped for unknown-title card; using scan coordinates")
 
+        # Capture the BEFORE-click frame for SPA-aware verification —
+        # if the URL check after click fails, the framework falls back
+        # to comparing this frame with the AFTER frame to decide whether
+        # the click landed on a same-URL modal/overlay (the lu.ma /
+        # generic-SPA pattern). Defensive: failure to capture downgrades
+        # the SPA fallback to a no-op rather than the click itself.
+        pre_click_screenshot: Any = None
+        try:
+            pre_click_screenshot = env.screenshot()
+        except Exception:
+            pre_click_screenshot = None
+
         # Click
         try:
             env.step(Action(action_type=ActionType.CLICK, params={"x": x, "y": y}))
@@ -382,6 +394,65 @@ class ClaudeGuidedClickHandler:
                     "  [claude-click] Not on detail page yet (url=%s) — retrying verify",
                     url_for_log(url),
                 )
+
+        # SPA-aware fallback (lu.ma / single-page apps that open detail
+        # content in a modal without changing the URL). The URL check
+        # above only succeeds when the click triggers a full-page
+        # navigation; for SPA modals the URL stays put and the URL
+        # check returns False even though the click succeeded. Compare
+        # the BEFORE / AFTER screenshots via the extractor's tool_use
+        # verifier and accept the click when navigation is confirmed
+        # (URL change OR same-URL modal opened). Skipped when the
+        # extractor or the pre-click frame is unavailable; falls
+        # through to middle-click in that case.
+        if extractor is not None and pre_click_screenshot is not None:
+            try:
+                post_click_screenshot = env.screenshot()
+            except Exception:
+                post_click_screenshot = None
+            if post_click_screenshot is not None:
+                nav = extractor.verify_post_click_navigation(
+                    pre_click_screenshot,
+                    post_click_screenshot,
+                    step.intent,
+                )
+                runner.costs["claude_extract"] += 1
+                if nav and nav.get("navigated") is True:
+                    kind = str(nav.get("kind", "modal"))
+                    reason = str(nav.get("reason", ""))[:120]
+                    logger.info(
+                        "  [claude-click] SPA-aware verify accepted click "
+                        "(kind=%s): %s",
+                        kind, reason,
+                    )
+                    accepted_url = url or runner._results_base_url
+                    runner._last_known_url = accepted_url
+                    dynamic_verifier.record_item_opened(
+                        page=runner._current_page,
+                        item=getattr(runner, "_last_click_title", "") or title,
+                        url=accepted_url,
+                    )
+                    runner._last_extracted = {
+                        **runner._last_extracted,
+                        "last_clicked_title": getattr(runner, "_last_click_title", ""),
+                        "last_attempted_url": accepted_url,
+                        "last_attempted_at": time.time(),
+                        "last_attempted_step": index,
+                        "last_click_verify_kind": kind,
+                    }
+                    runner._set_scroll_state(
+                        context="detail_top",
+                        url=accepted_url,
+                        page_downs=0,
+                        wheel_downs=0,
+                    )
+                    runner._listings_on_page += 1
+                    if hasattr(runner, '_last_click_title') and runner._last_click_title:
+                        runner._extracted_titles.append(runner._last_click_title)
+                    return StepResult(
+                        step_index=index, intent=step.intent, success=True,
+                        steps_used=1, duration=9.0,
+                    )
 
         logger.info("  [claude-click] Plain click did not navigate — trying middle-click fallback")
         try:

--- a/tests/test_click_spa_aware_verify.py
+++ b/tests/test_click_spa_aware_verify.py
@@ -1,0 +1,381 @@
+"""Tests for the SPA-aware post-click verifier.
+
+Surfaced by the lu.ma smoke during PR #220's validation: clicks on
+event cards open a detail panel without changing the URL. The URL-
+based ``SiteConfig.is_detail_page`` check correctly handles full-
+page-navigation sites (CRM row → ``/leads/13`` URL change) but
+returns False for SPA modals where ``window.location`` stays put.
+
+Generic fix: a new ``ClaudeExtractor.verify_post_click_navigation``
+that compares before/after screenshots via tool_use schema and
+decides whether the click landed on detail content (URL change OR
+same-URL modal). Wired into the click handler's plain-click verify
+gate as a fallback after the URL check returns False but before
+middle-click escalation runs. No plan vocabulary; works for any SPA.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from PIL import Image
+
+from mantis_agent.extraction.extractor import ClaudeExtractor
+
+
+def _img(color: tuple[int, int, int] = (255, 255, 255)) -> Image.Image:
+    return Image.new("RGB", (10, 10), color=color)
+
+
+# ── verify_post_click_navigation primitive ─────────────────────────────
+
+
+def test_verify_post_click_routes_through_multi_tool_schema() -> None:
+    """The verifier MUST use the schema-validated multi-image helper —
+    NOT the legacy _call / _call_many / _parse_json path. Pin it so a
+    refactor doesn't silently regress to prose-only."""
+    extractor = ClaudeExtractor(api_key="dummy")
+    multi = MagicMock()
+    extractor._call_with_tool_schema_multi = multi  # type: ignore[method-assign]
+    extractor._call = MagicMock(  # type: ignore[method-assign]
+        side_effect=AssertionError("legacy _call must not be used"),
+    )
+    extractor._call_many = MagicMock(  # type: ignore[method-assign]
+        side_effect=AssertionError("legacy _call_many must not be used"),
+    )
+    multi.return_value = {
+        "navigated": True, "kind": "modal",
+        "reason": "Event detail panel covering the page",
+    }
+
+    out = extractor.verify_post_click_navigation(
+        _img(), _img((40, 50, 130)),
+        intent="Click the first event card",
+    )
+
+    multi.assert_called_once()
+    assert out == {
+        "navigated": True, "kind": "modal",
+        "reason": "Event detail panel covering the page",
+    }
+
+
+def test_verify_post_click_schema_locks_the_kind_enum() -> None:
+    """The kind enum must include all four canonical outcomes so
+    the click handler can reason about WHY the verifier said yes/no.
+    'wrong_target' specifically lets us distinguish "click did
+    something but not what we wanted" from "click did nothing"."""
+    extractor = ClaudeExtractor(api_key="dummy")
+    multi = MagicMock()
+    extractor._call_with_tool_schema_multi = multi  # type: ignore[method-assign]
+    multi.return_value = {"navigated": False, "kind": "no_change", "reason": "x"}
+
+    extractor.verify_post_click_navigation(_img(), _img(), intent="x")
+
+    schema = multi.call_args.kwargs["input_schema"]
+    enum = schema["properties"]["kind"]["enum"]
+    assert set(enum) == {"url_change", "modal", "no_change", "wrong_target"}
+    assert set(schema["required"]) == {"navigated", "kind", "reason"}
+
+
+def test_verify_post_click_passes_before_after_labels() -> None:
+    """Each screenshot must be labelled so the model can refer to
+    them in its decision. Without labels the model can't tell the
+    images apart."""
+    extractor = ClaudeExtractor(api_key="dummy")
+    multi = MagicMock()
+    extractor._call_with_tool_schema_multi = multi  # type: ignore[method-assign]
+    multi.return_value = {"navigated": True, "kind": "modal", "reason": "x"}
+
+    extractor.verify_post_click_navigation(_img(), _img(), intent="x")
+
+    labels = multi.call_args.kwargs["labels"]
+    assert labels[0] == "BEFORE click"
+    assert labels[1] == "AFTER click"
+
+
+def test_verify_post_click_returns_none_on_no_tool_use() -> None:
+    """API regression / network failure → None. Caller treats as
+    'couldn't determine; fall through to middle-click escalation'
+    rather than guessing yes/no."""
+    extractor = ClaudeExtractor(api_key="dummy")
+    extractor._call_with_tool_schema_multi = MagicMock(return_value=None)  # type: ignore[method-assign]
+
+    assert extractor.verify_post_click_navigation(_img(), _img(), "x") is None
+
+
+# ── _call_with_tool_schema_multi helper itself ─────────────────────────
+
+
+def test_multi_tool_schema_helper_passes_all_images_to_anthropic(monkeypatch) -> None:
+    """The helper bundles N screenshots as base64 image content blocks
+    in a SINGLE messages payload, alongside the prompt + per-image
+    label texts. Lets Claude reason across frames."""
+    captured = {}
+
+    class _FakeResponse:
+        status_code = 200
+
+        @staticmethod
+        def json() -> dict:
+            return {
+                "content": [
+                    {
+                        "type": "tool_use", "name": "t",
+                        "input": {"navigated": True, "kind": "modal", "reason": "ok"},
+                    },
+                ],
+            }
+
+    def fake_post(url, headers, json, timeout):  # noqa: A002
+        captured["body"] = json
+        return _FakeResponse()
+
+    import requests as real_requests
+    monkeypatch.setattr(real_requests, "post", fake_post)
+
+    extractor = ClaudeExtractor(api_key="dummy")
+    out = extractor._call_with_tool_schema_multi(
+        [_img(), _img((40, 50, 130))],
+        "Compare these.",
+        tool_name="t",
+        tool_description="d",
+        input_schema={
+            "type": "object",
+            "properties": {
+                "navigated": {"type": "boolean"},
+                "kind": {"type": "string"},
+                "reason": {"type": "string"},
+            },
+            "required": ["navigated", "kind", "reason"],
+        },
+        labels=["A", "B"],
+    )
+
+    assert out == {"navigated": True, "kind": "modal", "reason": "ok"}
+    # Tool choice forced; tool definition included with the schema.
+    assert captured["body"]["tool_choice"] == {"type": "tool", "name": "t"}
+    # Two image blocks + two label texts + one prompt text = 5 content
+    # entries, both image blocks present.
+    content = captured["body"]["messages"][0]["content"]
+    image_blocks = [b for b in content if b.get("type") == "image"]
+    assert len(image_blocks) == 2
+
+
+# ── Click handler integration ──────────────────────────────────────────
+
+
+def test_click_handler_falls_back_to_spa_verifier_when_url_check_fails(
+    monkeypatch,
+) -> None:
+    """End-to-end: when the URL-based is_detail_page returns False
+    after a click, the handler invokes the SPA verifier. If it
+    returns navigated=True, the click is accepted as success and
+    middle-click escalation is NOT run."""
+    monkeypatch.setattr("mantis_agent.gym.step_handlers.click.time.sleep", lambda *_: None)
+    monkeypatch.setattr(
+        "mantis_agent.gym.step_handlers.click.random.uniform", lambda *_: 0.0,
+    )
+
+    from mantis_agent.gym.listings_scanner import ListingsScanner
+    from mantis_agent.gym.step_context import StepContext
+    from mantis_agent.gym.step_handlers.click import ClaudeGuidedClickHandler
+    from mantis_agent.plan_decomposer import MicroIntent
+
+    class _FakeRunner:
+        def __init__(self) -> None:
+            self.scanner = ListingsScanner()
+            self.costs: dict[str, float] = {
+                "claude_extract": 0,
+                "claude_grounding": 0,
+                "gpu_steps": 0,
+                "gpu_seconds": 0,
+                "proxy_mb": 0.0,
+            }
+            self._current_page = 1
+            self._last_known_url = ""
+            self._last_extracted: dict = {}
+            self._last_click_title = ""
+            self._opened_detail_in_new_tab = False
+            self._page_listing_count = 0
+            self.scroll_state_calls: list[dict] = []
+
+        @property
+        def _page_listings(self): return self.scanner.page_listings
+        @_page_listings.setter
+        def _page_listings(self, v): self.scanner.page_listings = v
+        @property
+        def _page_listing_index(self): return self.scanner.page_listing_index
+        @_page_listing_index.setter
+        def _page_listing_index(self, v): self.scanner.page_listing_index = v
+        @property
+        def _viewport_stage(self): return self.scanner.viewport_stage
+        @_viewport_stage.setter
+        def _viewport_stage(self, v): self.scanner.viewport_stage = v
+        @property
+        def _max_viewport_stages(self): return self.scanner.max_viewport_stages
+        @_max_viewport_stages.setter
+        def _max_viewport_stages(self, v): self.scanner.max_viewport_stages = v
+        @property
+        def _results_base_url(self): return self.scanner.results_base_url
+        @_results_base_url.setter
+        def _results_base_url(self, v): self.scanner.results_base_url = v
+        @property
+        def _extracted_titles(self): return self.scanner.extracted_titles
+        @_extracted_titles.setter
+        def _extracted_titles(self, v): self.scanner.extracted_titles = v
+        @property
+        def _listings_on_page(self): return self._page_listing_count
+        @_listings_on_page.setter
+        def _listings_on_page(self, v): self._page_listing_count = v
+
+        def _set_scroll_state(self, **kw): self.scroll_state_calls.append(kw)
+        def _current_results_page_url(self): return self.scanner.results_base_url
+        def _read_current_url(self, *args, **kw): return "https://lu.ma/discover"
+
+    runner = _FakeRunner()
+    runner._max_viewport_stages = 1
+    runner._results_base_url = "https://lu.ma/discover"
+
+    extractor = MagicMock()
+    extractor.find_all_listings.return_value = [(440, 320, "Some Event")]
+    extractor.verify_post_click_navigation.return_value = {
+        "navigated": True, "kind": "modal",
+        "reason": "Event detail panel opened over the discover grid",
+    }
+
+    env = MagicMock()
+    env.screen_size = (1280, 800)
+    env.screenshot.return_value = _img((40, 50, 130))
+
+    ctx = StepContext(
+        env=env, brain=None, extractor=extractor, grounding=None,
+        cost_meter=None, dynamic_verifier=MagicMock(),
+        scanner=runner.scanner, site_config=MagicMock(),
+        tool_channel=None, extraction_cache=None,
+        state={"index": 4},
+    )
+    # URL check returns False (lu.ma /discover stays in URL on click).
+    ctx.site_config.is_detail_page.return_value = False
+
+    step = MicroIntent(
+        intent="Click the first event card",
+        type="click",
+        section="extraction",
+    )
+    result = ClaudeGuidedClickHandler(runner).execute(step, ctx)
+
+    # SPA verifier fired exactly once.
+    extractor.verify_post_click_navigation.assert_called_once()
+    # And the click was accepted as success.
+    assert result.success is True
+    # No middle-click happened — the handler accepted on SPA verifier.
+    middle_clicks = [
+        c for c in env.step.call_args_list
+        if getattr(c.args[0], "params", {}).get("button") == "middle"
+    ]
+    assert middle_clicks == []
+    # Detail bookkeeping ran: scroll state advanced to detail_top.
+    detail_top = [
+        s for s in runner.scroll_state_calls if s.get("context") == "detail_top"
+    ]
+    assert len(detail_top) == 1
+
+
+def test_click_handler_does_not_run_spa_verifier_when_url_check_passes(
+    monkeypatch,
+) -> None:
+    """Common case: URL check passes → no SPA verifier call (saves a
+    Claude call per successful detail-page navigation). The verifier
+    is a fallback, not always-on."""
+    monkeypatch.setattr("mantis_agent.gym.step_handlers.click.time.sleep", lambda *_: None)
+    monkeypatch.setattr(
+        "mantis_agent.gym.step_handlers.click.random.uniform", lambda *_: 0.0,
+    )
+
+    from mantis_agent.gym.listings_scanner import ListingsScanner
+    from mantis_agent.gym.step_context import StepContext
+    from mantis_agent.gym.step_handlers.click import ClaudeGuidedClickHandler
+    from mantis_agent.plan_decomposer import MicroIntent
+
+    class _FakeRunner:
+        def __init__(self) -> None:
+            self.scanner = ListingsScanner()
+            self.costs: dict[str, float] = {
+                "claude_extract": 0,
+                "claude_grounding": 0,
+                "gpu_steps": 0,
+                "gpu_seconds": 0,
+                "proxy_mb": 0.0,
+            }
+            self._current_page = 1
+            self._last_known_url = ""
+            self._last_extracted: dict = {}
+            self._last_click_title = ""
+            self._opened_detail_in_new_tab = False
+            self._page_listing_count = 0
+            self.scroll_state_calls: list[dict] = []
+
+        @property
+        def _page_listings(self): return self.scanner.page_listings
+        @_page_listings.setter
+        def _page_listings(self, v): self.scanner.page_listings = v
+        @property
+        def _page_listing_index(self): return self.scanner.page_listing_index
+        @_page_listing_index.setter
+        def _page_listing_index(self, v): self.scanner.page_listing_index = v
+        @property
+        def _viewport_stage(self): return self.scanner.viewport_stage
+        @_viewport_stage.setter
+        def _viewport_stage(self, v): self.scanner.viewport_stage = v
+        @property
+        def _max_viewport_stages(self): return self.scanner.max_viewport_stages
+        @_max_viewport_stages.setter
+        def _max_viewport_stages(self, v): self.scanner.max_viewport_stages = v
+        @property
+        def _results_base_url(self): return self.scanner.results_base_url
+        @_results_base_url.setter
+        def _results_base_url(self, v): self.scanner.results_base_url = v
+        @property
+        def _extracted_titles(self): return self.scanner.extracted_titles
+        @_extracted_titles.setter
+        def _extracted_titles(self, v): self.scanner.extracted_titles = v
+        @property
+        def _listings_on_page(self): return self._page_listing_count
+        @_listings_on_page.setter
+        def _listings_on_page(self, v): self._page_listing_count = v
+
+        def _set_scroll_state(self, **kw): self.scroll_state_calls.append(kw)
+        def _current_results_page_url(self): return self.scanner.results_base_url
+        def _read_current_url(self, *args, **kw): return "https://crm.example.test/leads/13"
+
+    runner = _FakeRunner()
+    runner._max_viewport_stages = 1
+    runner._results_base_url = "https://crm.example.test/leads"
+
+    extractor = MagicMock()
+    extractor.find_all_listings.return_value = [(440, 320, "Lead row")]
+    extractor.verify_post_click_navigation = MagicMock(
+        side_effect=AssertionError("SPA verifier must not run on URL match"),
+    )
+
+    env = MagicMock()
+    env.screen_size = (1280, 800)
+
+    ctx = StepContext(
+        env=env, brain=None, extractor=extractor, grounding=None,
+        cost_meter=None, dynamic_verifier=MagicMock(),
+        scanner=runner.scanner, site_config=MagicMock(),
+        tool_channel=None, extraction_cache=None,
+        state={"index": 4},
+    )
+    # URL check passes — full page navigation case.
+    ctx.site_config.is_detail_page.return_value = True
+
+    step = MicroIntent(
+        intent="Click the first lead", type="click", section="extraction",
+    )
+    result = ClaudeGuidedClickHandler(runner).execute(step, ctx)
+
+    assert result.success is True
+    extractor.verify_post_click_navigation.assert_not_called()


### PR DESCRIPTION
Closes the framework gap surfaced by the lu.ma smoke during PR #220 validation. Generic primitive, no plan / domain vocabulary.

## Problem

Lu.ma — and any single-page app where clicks open content in modals/overlays without changing the URL — defeats the URL-based ``SiteConfig.is_detail_page`` check from #211. Concretely:

- User clicks an event card on ``https://lu.ma/discover``.
- Click succeeds: a detail panel opens covering the discover grid.
- ``window.location`` stays at ``/discover``.
- ``is_detail_page(\"/discover\", base_url=\"/discover\")`` returns False.
- Click handler treats this as failure → falls through to middle-click → 5 probe-area clicks → halts.

Confirmed in the lu.ma smoke: ``find_all_listings`` correctly identified 6 event cards with proper coordinates. Holo3 clicked them. URL stayed at ``/discover``. Verifier reported failure on EVERY click.

## Fix — two layers

### 1. ``ClaudeExtractor.verify_post_click_navigation(before, after, intent)``
Tool_use schema-validated comparison of two screenshots. Returns:

\`\`\`json
{
  \"navigated\": true,
  \"kind\": \"modal\",                  // url_change | modal | no_change | wrong_target
  \"reason\": \"Event detail panel covering the discover grid\"
}
\`\`\`

The ``kind`` enum makes the four outcomes distinguishable so the runner's retry policy (in a follow-up) can react differently to *click did nothing* vs *click hit the wrong target*.

### 2. ``_call_with_tool_schema_multi``
Sibling of the single-image helper from #219. Bundles N screenshots as base64 image content blocks in one Anthropic request, alongside the prompt + per-image label texts. Generic primitive any N-image structured-output call site can adopt.

### Click handler integration
- Capture BEFORE-click screenshot just prior to ``env.step CLICK``.
- After the 2-attempt URL verify gate fails (and login-redirect short-circuit doesn't fire), invoke the SPA verifier.
- On ``navigated=True`` → accept as success, **skip middle-click escalation entirely**.
- On ``no answer / navigated=False`` → existing escalation chain runs unchanged.

## Cost & stay-generic discipline

- The verifier is a **fallback**, not always-on. Common case (URL matches) is unaffected — zero extra Claude calls per click.
- One extra Claude extract call ONLY when URL check fails. In return: skip 2× middle-click + up to 5× probe-area clicks (~13s + Claude grounding cost saved per missed event).
- No plan vocabulary in the verifier. The four ``kind`` outcomes are structural states (URL change, modal, no change, wrong target), not site-specific.
- The schema's ``required`` set is the FULL property list — same structural-validation discipline as the migrations from #221.

## Test plan

- [x] \`tests/test_click_spa_aware_verify.py\` — 6 integration + helper tests:
  - Verifier routes through schema-validated multi-image helper; legacy \`_call\` / \`_call_many\` MUST NOT be invoked
  - Kind enum locks all four canonical outcomes; required fields pinned
  - BEFORE / AFTER labels passed correctly
  - \`None\` on no tool_use → caller falls through to middle-click escalation
  - End-to-end: SPA verifier fires AND middle-click does NOT run when URL check fails but verifier accepts
  - End-to-end: SPA verifier does NOT run when URL check passes (cost-saving — common case unaffected)
  - Underlying \`_call_with_tool_schema_multi\` correctly bundles N images + tool_choice + schema in one Anthropic request
- [x] \`uv run pytest -q\` full suite — **1294 passed**
- [ ] End-to-end smoke against lu.ma to confirm modal-open clicks now succeed (was failing on URL-only verifier in the previous smoke)

## Stack alignment

This is the third PR in the structured-output rollout sequence:

1. **#219** — \`_call_with_tool_schema\` seam + content-control migration
2. **#221** — \`verify_gate\` / \`find_filter_target\` / \`find_form_target\` / \`extract\` migration to the seam
3. **#222 (this)** — \`verify_post_click_navigation\` + \`_call_with_tool_schema_multi\` for SPA-aware click verification

After this lands, **every structured-output call in the extractor is schema-validated server-side**. The seam is the canonical primitive; new call sites should use it from day one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)