### PR TITLE
feat(cli): mantis plan run-modal — full stack inside Modal under Xvfb

### DIFF
--- a/deploy/modal/modal_plan_runner.py
+++ b/deploy/modal/modal_plan_runner.py
@@ -1,0 +1,397 @@
+"""Modal-side ``MicroPlanRunner`` host — full mantis stack inside a container.
+
+The local ``mantis plan run`` CLI runs Playwright on the dev laptop and
+talks to a remote brain. That works for unit-of-work testing but it
+doesn't reproduce the host integration's production architecture, where
+the BROWSER also runs inside a Modal container under Xvfb so the
+chromium-detection signals (no DISPLAY, missing GPU, ``navigator.
+webdriver``, …) that Cloudflare keys on are absent.
+
+This module deploys ``mantis-plan-runner`` — a Modal app exposing a
+single function that constructs ``XdotoolGymEnv`` (Xvfb-backed real
+Chromium) + ``Holo3Brain`` (HTTP to the brain endpoint) +
+``ClaudeGrounding`` + ``ClaudeExtractor``, runs ``MicroPlanRunner``
+end-to-end, and returns the same result dict the local CLI writes to
+``result.json``. The local ``mantis plan run-modal`` subcommand
+submits the plan and renders the same per-step rollup the local CLI
+prints.
+
+## Deploy
+
+    uv run modal deploy deploy/modal/modal_plan_runner.py
+
+That gives you an app named ``mantis-plan-runner`` whose ``run_plan``
+function is callable via ``modal.Function.lookup`` from any local
+process. The image bakes in xvfb, xdotool, scrot, chromium, and the
+``mantis_agent`` package; first cold-start is ~60 s after deploy.
+
+## Required Modal Secret
+
+Mount a Modal Secret named ``mantis-plan-runner-secrets`` containing:
+
+    ANTHROPIC_API_KEY=sk-ant-...
+    MANTIS_API_TOKEN=...                # optional — used as the
+                                         # X-Mantis-Token header on
+                                         # the brain endpoint when no
+                                         # caller-supplied headers
+    OXYLABS_USERNAME=...                # optional — only consulted
+    OXYLABS_PASSWORD=...                # when ``use_proxy=True``
+    OXYLABS_ENTRYPOINT=pr.oxylabs.io:10000
+    OXYLABS_COUNTRY=US
+    OXYLABS_STATE=florida               # optional
+    OXYLABS_CITY=miami                  # optional
+
+Create / update::
+
+    modal secret create mantis-plan-runner-secrets \\
+        ANTHROPIC_API_KEY=sk-ant-... \\
+        MANTIS_API_TOKEN=...
+
+## Calling from the CLI
+
+    uv run mantis plan run-modal plans/staff-crm.txt \\
+        --endpoint https://workspace--mantis-server-api.modal.run/v1 \\
+        --header X-Mantis-Token=... \\
+        --output-dir outputs/staff-crm-modal-validation
+
+The CLI is a thin remote driver — same args as ``mantis plan run``,
+plus ``--app-name`` (default ``mantis-plan-runner``) to override the
+deployed function name.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import time
+from typing import Any
+
+import modal
+
+
+APP_NAME = "mantis-plan-runner"
+
+# Lightweight image: just what XdotoolGymEnv + ClaudeExtractor +
+# ClaudeGrounding + Holo3Brain need. No CUDA, no llama.cpp, no
+# OSWorld — those live in the brain-side image (modal_mantis_server).
+runner_image = (
+    modal.Image.debian_slim(python_version="3.11")
+    .apt_install(
+        # Browser + automation tools (XdotoolGymEnv requires these).
+        "xvfb",
+        "xdotool",
+        "scrot",
+        "chromium",
+        "chromium-driver",
+        "x11-utils",
+        # CDP read for current-URL — used by _runner_helpers.read_current_url.
+        "curl",
+        # Fonts for realistic rendering (Cloudflare flags missing fonts).
+        "fonts-liberation",
+        "fonts-noto-color-emoji",
+        "libnss3",
+        "libxss1",
+        "libasound2",
+    )
+    .pip_install(
+        # Pinned to the orchestrator extras + a few extras XdotoolGymEnv pulls.
+        "pillow>=10.0",
+        "requests>=2.28",
+        "pydantic>=2",
+        "anthropic>=0.34",
+        "mss>=9.0",
+        "python-dotenv",
+    )
+    .add_local_python_source("mantis_agent")
+    .add_local_dir(
+        "src/mantis_agent/prompts/files",
+        remote_path="/root/mantis_agent/prompts/files",
+    )
+)
+
+app = modal.App(APP_NAME)
+
+
+# ── Helper: bring up Xvfb on :99 once per container ──────────────────
+
+
+_XVFB_DISPLAY = ":99"
+_XVFB_VIEWPORT = (1280, 720)
+
+
+def _ensure_xvfb_running() -> None:
+    """Start Xvfb on the canonical display if it isn't already.
+
+    Modal containers don't ship with X. ``XdotoolGymEnv`` can spawn
+    its own Xvfb (when ``display=None``) but inside a function we
+    benefit from spinning it up once and reusing across calls in
+    the same warm container. The display number is fixed at ``:99``
+    matching staffai's convention.
+    """
+    # Fast path: another invocation in this container already booted Xvfb.
+    if os.environ.get("DISPLAY") == _XVFB_DISPLAY and _xvfb_alive():
+        return
+
+    width, height = _XVFB_VIEWPORT
+    subprocess.Popen(
+        [
+            "Xvfb",
+            _XVFB_DISPLAY,
+            "-screen", "0", f"{width}x{height}x24",
+            "-ac",
+            "+extension", "RANDR",
+        ],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    os.environ["DISPLAY"] = _XVFB_DISPLAY
+    # Wait briefly for Xvfb to come up — xdpyinfo confirms.
+    deadline = time.time() + 10
+    while time.time() < deadline:
+        if _xvfb_alive():
+            return
+        time.sleep(0.2)
+    raise RuntimeError(
+        f"Xvfb did not come up on {_XVFB_DISPLAY} within 10s — "
+        "check that xvfb is installed in the image."
+    )
+
+
+def _xvfb_alive() -> bool:
+    try:
+        proc = subprocess.run(
+            ["xdpyinfo", "-display", _XVFB_DISPLAY],
+            capture_output=True,
+            timeout=3,
+        )
+        return proc.returncode == 0
+    except Exception:
+        return False
+
+
+# ── Helper: build the Oxylabs proxy dict from Modal-Secret env ──────
+
+
+def _build_oxylabs_proxy_url(session: str = "mantis") -> str | None:
+    """Build the canonical ``http://customer-…:pass@host:port`` URL.
+
+    Reads ``OXYLABS_*`` env vars from the mounted Modal Secret. Returns
+    None when the proxy is not requested or credentials are missing —
+    callers should treat that as "direct connection" rather than
+    erroring.
+    """
+    entrypoint = os.environ.get("OXYLABS_ENTRYPOINT", "").strip()
+    raw_user = os.environ.get("OXYLABS_USERNAME", "").strip()
+    password = os.environ.get("OXYLABS_PASSWORD", "").strip()
+    if not entrypoint or not raw_user or not password:
+        return None
+
+    parts = [f"customer-{raw_user}"]
+    for key, label in (
+        ("OXYLABS_COUNTRY", "cc"),
+        ("OXYLABS_STATE", "st"),
+        ("OXYLABS_CITY", "city"),
+    ):
+        v = os.environ.get(key, "").strip()
+        if v:
+            parts += [label, v]
+    if session:
+        parts += ["sessid", session]
+    username = "-".join(parts)
+
+    # Same scheme normalisation as the local CLI.
+    if "://" not in entrypoint:
+        entrypoint = f"http://{entrypoint}"
+    # Splice in user:pass.
+    scheme, _, rest = entrypoint.partition("://")
+    return f"{scheme}://{username}:{password}@{rest}"
+
+
+# ── The function ─────────────────────────────────────────────────────
+
+
+@app.function(
+    image=runner_image,
+    secrets=[modal.Secret.from_name("mantis-plan-runner-secrets")],
+    cpu=2.0,
+    memory=4096,
+    timeout=1800,  # hard 30-min cap per plan
+)
+def run_plan(
+    *,
+    plan_text: str | None = None,
+    plan_json: dict | None = None,
+    brain_endpoint: str,
+    brain_extra_headers: dict[str, str] | None = None,
+    brain_model: str = "Hcompany/Holo3-35B-A3B",
+    start_url: str,
+    detail_page_pattern: str = "",
+    max_cost_usd: float = 10.0,
+    max_time_minutes: int = 30,
+    use_proxy: bool = False,
+    proxy_session: str = "mantis",
+    session_name: str = "mantis_run",
+) -> dict:
+    """Run :class:`MicroPlanRunner` end-to-end inside this container.
+
+    Either ``plan_text`` (decomposed via Claude) or ``plan_json``
+    (pre-decomposed micro-plan dict) must be provided. ``plan_json``
+    short-circuits the decompose call — useful when the local CLI
+    has already paid that cost or when calling from a cached plan.
+
+    Returns the same result-payload dict the local CLI writes to
+    ``result.json``: ``plan_signature``, ``session``, ``step_count``,
+    ``successes``, ``failures``, ``elapsed_seconds``, ``final_url``,
+    ``costs``, ``steps``.
+    """
+    # Imports are inside the function so the CLI can ``modal.Function
+    # .lookup`` without paying the heavy import cost client-side.
+    from mantis_agent.brain_holo3 import Holo3Brain
+    from mantis_agent.extraction import ClaudeExtractor
+    from mantis_agent.grounding import ClaudeGrounding
+    from mantis_agent.gym.micro_runner import MicroPlanRunner
+    from mantis_agent.gym.xdotool_env import XdotoolGymEnv
+    from mantis_agent.plan_decomposer import MicroPlan, PlanDecomposer
+    from mantis_agent.site_config import SiteConfig
+
+    if not plan_text and not plan_json:
+        raise ValueError("run_plan: pass either plan_text or plan_json")
+
+    # 1. Resolve / decompose plan.
+    if plan_json is not None:
+        plan = MicroPlan.from_dict(plan_json)
+    else:
+        anthropic_key = os.environ.get("ANTHROPIC_API_KEY", "")
+        if not anthropic_key:
+            raise RuntimeError(
+                "ANTHROPIC_API_KEY missing from Modal Secret — "
+                "decomposing plan_text requires Claude access"
+            )
+        plan = PlanDecomposer().decompose_text(plan_text)
+
+    if not plan.steps:
+        raise RuntimeError("decomposed plan has no steps")
+
+    # 2. Bring up Xvfb + build env. XdotoolGymEnv spawns Chromium itself
+    # on the display we just provisioned.
+    _ensure_xvfb_running()
+    proxy_url = _build_oxylabs_proxy_url(proxy_session) if use_proxy else None
+    env = XdotoolGymEnv(
+        start_url=start_url,
+        viewport=_XVFB_VIEWPORT,
+        browser="chromium",
+        display=_XVFB_DISPLAY,
+        proxy_server=proxy_url or "",
+    )
+
+    # 3. Brain + Claude extractor / grounding.
+    brain = Holo3Brain(
+        base_url=brain_endpoint,
+        model=brain_model,
+        extra_headers=brain_extra_headers or None,
+    )
+    grounding = ClaudeGrounding()
+    extractor = ClaudeExtractor()
+
+    # 4. Site config — neutral by default; per-plan tightening via
+    # ``--detail-page-pattern`` flows through here.
+    site_config = SiteConfig(detail_page_pattern=detail_page_pattern or "")
+
+    # 5. Pre-warm env at start_url before runner.run, mirroring the
+    # local CLI's prewarm contract from PR #218.
+    env.reset(task="modal_plan_run", start_url=start_url)
+
+    # 6. Construct + run runner.
+    runner = MicroPlanRunner(
+        brain=brain,
+        env=env,
+        grounding=grounding,
+        extractor=extractor,
+        site_config=site_config,
+        run_key=session_name,
+        session_name=session_name,
+        max_cost=max_cost_usd,
+        max_time_minutes=max_time_minutes,
+    )
+    t0 = time.time()
+    step_results = runner.run(plan, resume=False)
+    elapsed = time.time() - t0
+
+    # 7. Build the same result-payload shape the local CLI writes.
+    successes = sum(1 for r in step_results if r.success)
+    failures = len(step_results) - successes
+    final_url = getattr(runner, "_last_known_url", "")
+
+    return {
+        "plan_signature": runner.plan_signature,
+        "session": session_name,
+        "step_count": len(step_results),
+        "successes": successes,
+        "failures": failures,
+        "elapsed_seconds": round(elapsed, 2),
+        "final_url": final_url,
+        "costs": dict(getattr(runner, "costs", {})),
+        "steps": [
+            {
+                "index": r.step_index,
+                "intent": r.intent,
+                "success": r.success,
+                "data": getattr(r, "data", ""),
+                "duration": getattr(r, "duration", 0.0),
+                "steps_used": getattr(r, "steps_used", 0),
+            }
+            for r in step_results
+        ],
+    }
+
+
+# ── Entrypoint for ``modal run`` (ad-hoc invocation, no deploy needed) ─
+
+
+@app.local_entrypoint()
+def cli(
+    plan_path: str,
+    endpoint: str,
+    header: str = "",
+    start_url: str = "",
+    detail_page_pattern: str = "",
+    use_proxy: bool = False,
+    proxy_session: str = "mantis",
+    output_dir: str = "outputs/modal-run",
+):
+    """Ad-hoc: ``uv run modal run deploy/modal/modal_plan_runner.py --plan-path …``.
+
+    For repeated runs, prefer ``mantis plan run-modal`` which uses the
+    deployed function directly (no per-call image build).
+    """
+    plan_text: str | None = None
+    plan_json: dict | None = None
+    if plan_path.endswith(".json"):
+        with open(plan_path) as fh:
+            plan_json = json.load(fh)
+    else:
+        with open(plan_path) as fh:
+            plan_text = fh.read()
+
+    headers: dict[str, str] = {}
+    if header:
+        for entry in header.split(","):
+            k, _, v = entry.partition("=")
+            if k and v:
+                headers[k.strip()] = v.strip()
+
+    result = run_plan.remote(
+        plan_text=plan_text,
+        plan_json=plan_json,
+        brain_endpoint=endpoint,
+        brain_extra_headers=headers or None,
+        start_url=start_url,
+        detail_page_pattern=detail_page_pattern,
+        use_proxy=use_proxy,
+        proxy_session=proxy_session,
+    )
+    os.makedirs(output_dir, exist_ok=True)
+    with open(os.path.join(output_dir, "result.json"), "w") as fh:
+        json.dump(result, fh, indent=2)
+    print(json.dumps(result, indent=2))

--- a/deploy/modal/modal_plan_runner.py
+++ b/deploy/modal/modal_plan_runner.py
@@ -65,7 +65,6 @@ import json
 import os
 import subprocess
 import time
-from typing import Any
 
 import modal
 

--- a/deploy/modal/modal_plan_runner.py
+++ b/deploy/modal/modal_plan_runner.py
@@ -84,8 +84,19 @@ runner_image = (
         "chromium",
         "chromium-driver",
         "x11-utils",
+        # Window manager + panel for a normal desktop context. Without
+        # a WM, Chromium's window has no decorations / focus handling
+        # and Cloudflare's bot-score classifier flags the fingerprint
+        # as automation-driven (the challenge page never auto-resolves).
+        "openbox",
+        "tint2",
         # CDP read for current-URL — used by _runner_helpers.read_current_url.
         "curl",
+        # Local HTTP proxy with upstream auth: Chromium's --proxy-server flag
+        # does not reliably honor embedded user:pass@ credentials, so we run
+        # tinyproxy inside the container, point Chrome at 127.0.0.1:8888
+        # (no auth), and let tinyproxy hold the Oxylabs auth and forward.
+        "tinyproxy",
         # Fonts for realistic rendering (Cloudflare flags missing fonts).
         "fonts-liberation",
         "fonts-noto-color-emoji",
@@ -126,7 +137,7 @@ def _ensure_xvfb_running() -> None:
     its own Xvfb (when ``display=None``) but inside a function we
     benefit from spinning it up once and reusing across calls in
     the same warm container. The display number is fixed at ``:99``
-    matching staffai's convention.
+    by convention.
     """
     # Fast path: another invocation in this container already booted Xvfb.
     if os.environ.get("DISPLAY") == _XVFB_DISPLAY and _xvfb_alive():
@@ -149,12 +160,30 @@ def _ensure_xvfb_running() -> None:
     deadline = time.time() + 10
     while time.time() < deadline:
         if _xvfb_alive():
-            return
+            break
         time.sleep(0.2)
-    raise RuntimeError(
-        f"Xvfb did not come up on {_XVFB_DISPLAY} within 10s — "
-        "check that xvfb is installed in the image."
+    else:
+        raise RuntimeError(
+            f"Xvfb did not come up on {_XVFB_DISPLAY} within 10s — "
+            "check that xvfb is installed in the image."
+        )
+
+    # Once Xvfb is alive, bring up a window manager so Chromium has a
+    # normal desktop context — Cloudflare's bot-score classifier looks
+    # at window decoration / focus signals; without a WM the browser
+    # presents as automation-driven and the JS challenge never
+    # auto-resolves. Both spawn detached and inherit DISPLAY=:99 from
+    # the env we just set.
+    subprocess.Popen(
+        ["openbox"],
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
     )
+    subprocess.Popen(
+        ["tint2"],
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+    )
+    # Brief settle so WM grabs the X server before Chromium starts.
+    time.sleep(0.5)
 
 
 def _xvfb_alive() -> bool:
@@ -169,42 +198,162 @@ def _xvfb_alive() -> bool:
         return False
 
 
-# ── Helper: build the Oxylabs proxy dict from Modal-Secret env ──────
+# ── Helper: spawn tinyproxy as a local auth-holder ──────────────────
 
 
-def _build_oxylabs_proxy_url(session: str = "mantis") -> str | None:
-    """Build the canonical ``http://customer-…:pass@host:port`` URL.
+_TINYPROXY_PORT = 8888
+_TINYPROXY_CONFIG = "/tmp/tinyproxy.conf"
+_TINYPROXY_LOG = "/tmp/tinyproxy.log"
+_TINYPROXY_PID = "/tmp/tinyproxy.pid"
 
-    Reads ``OXYLABS_*`` env vars from the mounted Modal Secret. Returns
-    None when the proxy is not requested or credentials are missing —
-    callers should treat that as "direct connection" rather than
-    erroring.
+
+def _build_oxylabs_username(session: str = "mantis", *, geo: bool = False) -> str:
+    """Compose the ``customer-USER[-cc-…]-sessid-S`` username.
+
+    Reads ``OXYLABS_USERNAME`` and the optional country/state/city/
+    session pins. Returns an empty string when no username is set —
+    callers should treat that as "no proxy" and bring the browser up
+    on direct egress.
+
+    The ``geo`` flag controls whether the ``cc-/st-/city-`` slots are
+    appended. The default (``False``) is intentional: Oxylabs returns
+    502 on tunnel CONNECT when the user's plan doesn't support
+    city-level pinning on the standard residential entrypoint
+    (``pr.oxylabs.io:10000``). City-level pinning lives on
+    ``pr.oxylabs.io:7777`` (``OXYLABS_CITY_ENTRYPOINT``) and only
+    works for plans that explicitly support it. Diagnose-then-enable.
     """
-    entrypoint = os.environ.get("OXYLABS_ENTRYPOINT", "").strip()
     raw_user = os.environ.get("OXYLABS_USERNAME", "").strip()
-    password = os.environ.get("OXYLABS_PASSWORD", "").strip()
-    if not entrypoint or not raw_user or not password:
-        return None
+    if not raw_user:
+        return ""
 
     parts = [f"customer-{raw_user}"]
-    for key, label in (
-        ("OXYLABS_COUNTRY", "cc"),
-        ("OXYLABS_STATE", "st"),
-        ("OXYLABS_CITY", "city"),
-    ):
-        v = os.environ.get(key, "").strip()
-        if v:
-            parts += [label, v]
+    if geo:
+        for key, label in (
+            ("OXYLABS_COUNTRY", "cc"),
+            ("OXYLABS_STATE", "st"),
+            ("OXYLABS_CITY", "city"),
+        ):
+            v = os.environ.get(key, "").strip()
+            if v:
+                parts += [label, v]
     if session:
         parts += ["sessid", session]
-    username = "-".join(parts)
+    return "-".join(parts)
 
-    # Same scheme normalisation as the local CLI.
-    if "://" not in entrypoint:
-        entrypoint = f"http://{entrypoint}"
-    # Splice in user:pass.
-    scheme, _, rest = entrypoint.partition("://")
-    return f"{scheme}://{username}:{password}@{rest}"
+
+def _resolve_upstream_proxy() -> tuple[str, str, str] | None:
+    """Pick the upstream proxy provider for tinyproxy to forward to.
+
+    Returns ``(username, password, host_port)`` tuple ready to splice
+    into the tinyproxy ``upstream`` directive, or ``None`` if no
+    provider creds are mounted.
+
+    Selection logic, in order:
+    1. ``MANTIS_PROXY_PROVIDER`` env override (``oxylabs`` / ``privateproxy``)
+    2. PrivateProxy when its three vars are set (more reliable in our
+       testing — BoatTrader's Cloudflare flags Oxylabs residential pool
+       IPs as bot traffic, returning 403 on CONNECT)
+    3. Oxylabs fallback with bare ``customer-USER`` (no geo pins —
+       city-level pinning needs a different entrypoint and plan)
+    """
+    pp_user = os.environ.get("PRIVATEPROXY_USERNAME", "").strip()
+    pp_pass = os.environ.get("PRIVATEPROXY_PASSWORD", "").strip()
+    pp_entry = os.environ.get("PRIVATEPROXY_ENTRYPOINT", "").strip()
+    pp_complete = bool(pp_user and pp_pass and pp_entry)
+
+    ox_pass = os.environ.get("OXYLABS_PASSWORD", "").strip()
+    ox_entry = os.environ.get("OXYLABS_ENTRYPOINT", "").strip()
+    ox_user = _build_oxylabs_username("mantis-resolve")  # placeholder session
+    ox_complete = bool(ox_pass and ox_entry and ox_user)
+
+    forced = os.environ.get("MANTIS_PROXY_PROVIDER", "").strip().lower()
+    if forced == "oxylabs" and ox_complete:
+        return (ox_user.replace("sessid-mantis-resolve", "sessid-{session}"),
+                ox_pass, ox_entry.split("://", 1)[-1])
+    if forced == "privateproxy" and pp_complete:
+        return (pp_user, pp_pass, pp_entry.split("://", 1)[-1])
+
+    if pp_complete:
+        return (pp_user, pp_pass, pp_entry.split("://", 1)[-1])
+    if ox_complete:
+        return (ox_user.replace("sessid-mantis-resolve", "sessid-{session}"),
+                ox_pass, ox_entry.split("://", 1)[-1])
+    return None
+
+
+def _ensure_tinyproxy_running(session: str = "mantis") -> str | None:
+    """Start tinyproxy with the resolved upstream and return ``host:port``.
+
+    Chromium's ``--proxy-server=URL`` does not reliably honor embedded
+    ``user:pass@`` credentials — it produces ``ERR_NO_SUPPORTED_PROXIES``
+    on most Chromium builds. Workaround: tinyproxy listens locally with
+    no auth, holds the upstream auth, and forwards CONNECT tunnels
+    (with a ``Proxy-Authorization`` header) to the upstream proxy.
+
+    Upstream selection is delegated to :func:`_resolve_upstream_proxy` —
+    PrivateProxy preferred over Oxylabs because BoatTrader-style
+    Cloudflare configs flag Oxylabs residential pool IPs as bot
+    traffic.
+
+    Returns ``"127.0.0.1:8888"`` on success, or ``None`` if no
+    upstream is available or tinyproxy fails to come up.
+    """
+    upstream = _resolve_upstream_proxy()
+    if not upstream:
+        return None
+    username_template, password, upstream_host_port = upstream
+    # The username MAY contain a ``{session}`` placeholder when the
+    # provider supports sticky sessions (Oxylabs). Substitute now.
+    username = username_template.format(session=session) if "{session}" in username_template else username_template
+
+    # Write a fresh config every call so a different ``proxy_session``
+    # actually rotates the upstream sessid (tinyproxy has no API to
+    # change the upstream creds at runtime).
+    config = (
+        f"Port {_TINYPROXY_PORT}\n"
+        "Listen 127.0.0.1\n"
+        "Timeout 300\n"
+        "MaxClients 32\n"
+        "StartServers 2\n"
+        f"LogFile \"{_TINYPROXY_LOG}\"\n"
+        f"PidFile \"{_TINYPROXY_PID}\"\n"
+        # Connect-level logging gives us the upstream CONNECT request /
+        # response codes — needed to diagnose 502s without flooding logs.
+        "LogLevel Connect\n"
+        # Forward all traffic (including HTTPS via CONNECT) to Oxylabs.
+        f"upstream http {username}:{password}@{upstream_host_port}\n"
+    )
+    with open(_TINYPROXY_CONFIG, "w") as fh:
+        fh.write(config)
+
+    # Stop any previous tinyproxy (warm container reuse) before starting.
+    try:
+        if os.path.exists(_TINYPROXY_PID):
+            with open(_TINYPROXY_PID) as fh:
+                old_pid = int(fh.read().strip() or "0")
+            if old_pid:
+                os.kill(old_pid, 15)
+                time.sleep(0.3)
+    except Exception:
+        pass
+
+    subprocess.Popen(
+        ["tinyproxy", "-c", _TINYPROXY_CONFIG],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+    # Wait briefly for tinyproxy to bind the port.
+    deadline = time.time() + 5
+    while time.time() < deadline:
+        try:
+            import socket  # local import — only needed when proxy is used
+            with socket.create_connection(("127.0.0.1", _TINYPROXY_PORT), timeout=0.5):
+                return f"127.0.0.1:{_TINYPROXY_PORT}"
+        except Exception:
+            time.sleep(0.2)
+    return None
 
 
 # ── The function ─────────────────────────────────────────────────────
@@ -272,16 +421,22 @@ def run_plan(
     if not plan.steps:
         raise RuntimeError("decomposed plan has no steps")
 
-    # 2. Bring up Xvfb + build env. XdotoolGymEnv spawns Chromium itself
-    # on the display we just provisioned.
+    # 2. Bring up Xvfb + (optionally) tinyproxy, then build env.
+    # XdotoolGymEnv spawns Chromium itself on the display we
+    # provisioned. Chromium's ``--proxy-server`` flag does NOT
+    # reliably honor embedded ``user:pass@`` auth — to use the
+    # Oxylabs proxy we run tinyproxy locally as the auth holder
+    # and point Chromium at ``127.0.0.1:8888`` (no auth). When
+    # ``use_proxy=False`` (or Oxylabs Secret is missing), Chromium
+    # connects directly via Modal egress.
     _ensure_xvfb_running()
-    proxy_url = _build_oxylabs_proxy_url(proxy_session) if use_proxy else None
+    proxy_host_port = _ensure_tinyproxy_running(proxy_session) if use_proxy else None
     env = XdotoolGymEnv(
         start_url=start_url,
         viewport=_XVFB_VIEWPORT,
         browser="chromium",
         display=_XVFB_DISPLAY,
-        proxy_server=proxy_url or "",
+        proxy_server=proxy_host_port or "",
     )
 
     # 3. Brain + Claude extractor / grounding.
@@ -298,8 +453,13 @@ def run_plan(
     site_config = SiteConfig(detail_page_pattern=detail_page_pattern or "")
 
     # 5. Pre-warm env at start_url before runner.run, mirroring the
-    # local CLI's prewarm contract from PR #218.
+    # local CLI's prewarm contract from PR #218. Then sleep 15s to
+    # let any Cloudflare JS challenge resolve before the first
+    # verifier hits the page — without this delay, CF-protected
+    # sites show "Performing security verification" on the first
+    # screenshot and the gate step rejects with ``gate:FAIL:Error 403``.
     env.reset(task="modal_plan_run", start_url=start_url)
+    time.sleep(15)
 
     # 6. Construct + run runner.
     runner = MicroPlanRunner(
@@ -343,6 +503,165 @@ def run_plan(
             for r in step_results
         ],
     }
+
+
+# ── Diagnostic: probe the proxy stack from inside the container ─────
+
+
+@app.function(
+    image=runner_image,
+    secrets=[modal.Secret.from_name("mantis-plan-runner-secrets")],
+    cpu=1.0,
+    memory=2048,
+    timeout=120,
+)
+def diagnose_proxy(session: str = "diag") -> dict:
+    """Boot tinyproxy + curl through it to validate the upstream auth.
+
+    Returns a structured diagnostic dict with:
+    - ``has_credentials``: bool — Modal Secret has Oxylabs vars
+    - ``tinyproxy_started``: bool — local listener bound :8888
+    - ``tinyproxy_log``: str — last 2KB of tinyproxy log
+    - ``ipify_via_proxy``: str — body of ``GET https://api.ipify.org?format=text``
+      routed through tinyproxy (or the curl error)
+    - ``ipify_via_oxylabs_direct``: str — same URL via curl --proxy http://user:pass@host:port
+      (skips tinyproxy entirely; tests Oxylabs auth in isolation)
+    - ``ipify_direct``: str — body of the same URL on direct egress
+    - ``upstream_username_template``: str — what we'd send to Oxylabs (no pwd)
+    """
+    out: dict = {}
+    out["has_credentials"] = all(
+        os.environ.get(k, "").strip()
+        for k in ("OXYLABS_USERNAME", "OXYLABS_PASSWORD", "OXYLABS_ENTRYPOINT")
+    )
+    username = _build_oxylabs_username(session)
+    out["upstream_username_template"] = username
+
+    # Direct egress IP first — confirms basic connectivity.
+    try:
+        proc = subprocess.run(
+            ["curl", "-sS", "-m", "10", "https://api.ipify.org?format=text"],
+            capture_output=True, timeout=15,
+        )
+        out["ipify_direct"] = proc.stdout.decode().strip() or proc.stderr.decode()
+    except Exception as exc:
+        out["ipify_direct"] = f"ERROR: {exc}"
+
+    # Test Oxylabs auth directly via curl (skips tinyproxy). We try both
+    # the geo-pinned username and a bare ``customer-USER`` form — if the
+    # bare form works but the pinned one doesn't, the Oxylabs plan
+    # doesn't have city-level pinning rights. We also URL-escape the
+    # password since ``+`` is a special char in URL auth fields.
+    import urllib.parse
+    entrypoint = os.environ.get("OXYLABS_ENTRYPOINT", "").strip()
+    password = os.environ.get("OXYLABS_PASSWORD", "").strip()
+    if entrypoint and password and username:
+        host_port = entrypoint.split("://", 1)[-1]
+        bare_user = f"customer-{os.environ.get('OXYLABS_USERNAME', '').strip()}"
+        pwd_quoted = urllib.parse.quote(password, safe="")
+        for label, user in (("pinned", username), ("bare", bare_user)):
+            try:
+                proc = subprocess.run(
+                    [
+                        "curl", "-sS", "-m", "15", "-w", "\nHTTP %{http_code}",
+                        "--proxy", f"http://{user}:{pwd_quoted}@{host_port}",
+                        "--proxy-anyauth",
+                        "https://api.ipify.org?format=text",
+                    ],
+                    capture_output=True, timeout=20,
+                )
+                stdout = proc.stdout.decode().strip()
+                stderr = proc.stderr.decode().strip()
+                out[f"ipify_via_oxylabs_{label}"] = (
+                    stdout or f"STDERR: {stderr} (rc={proc.returncode})"
+                )
+            except Exception as exc:
+                out[f"ipify_via_oxylabs_{label}"] = f"ERROR: {exc}"
+
+    # Also try the dedicated city-level entrypoint (Oxylabs ports 7777
+    # for city-pinning vs 10000 for country-only).
+    city_entry = os.environ.get("OXYLABS_CITY_ENTRYPOINT", "").strip()
+    if city_entry and password and username:
+        try:
+            city_host_port = city_entry.split("://", 1)[-1]
+            pwd_quoted = urllib.parse.quote(password, safe="")
+            proc = subprocess.run(
+                [
+                    "curl", "-sS", "-m", "15", "-w", "\nHTTP %{http_code}",
+                    "--proxy", f"http://{username}:{pwd_quoted}@{city_host_port}",
+                    "--proxy-anyauth",
+                    "https://api.ipify.org?format=text",
+                ],
+                capture_output=True, timeout=20,
+            )
+            stdout = proc.stdout.decode().strip()
+            stderr = proc.stderr.decode().strip()
+            out["ipify_via_oxylabs_city_entry"] = (
+                stdout or f"STDERR: {stderr} (rc={proc.returncode})"
+            )
+        except Exception as exc:
+            out["ipify_via_oxylabs_city_entry"] = f"ERROR: {exc}"
+
+    # Also try PrivateProxy as the alternate provider — user keeps both
+    # in .env, so when Oxylabs is down we want clear evidence.
+    pp_user = os.environ.get("PRIVATEPROXY_USERNAME", "").strip()
+    pp_pass = os.environ.get("PRIVATEPROXY_PASSWORD", "").strip()
+    pp_entry = os.environ.get("PRIVATEPROXY_ENTRYPOINT", "").strip()
+    if pp_user and pp_pass and pp_entry:
+        try:
+            pp_host_port = pp_entry.split("://", 1)[-1]
+            pp_pass_q = urllib.parse.quote(pp_pass, safe="")
+            proc = subprocess.run(
+                [
+                    "curl", "-sS", "-m", "15", "-w", "\nHTTP %{http_code}",
+                    "--proxy", f"http://{pp_user}:{pp_pass_q}@{pp_host_port}",
+                    "--proxy-anyauth",
+                    "https://api.ipify.org?format=text",
+                ],
+                capture_output=True, timeout=20,
+            )
+            stdout = proc.stdout.decode().strip()
+            stderr = proc.stderr.decode().strip()
+            out["ipify_via_privateproxy"] = (
+                stdout or f"STDERR: {stderr} (rc={proc.returncode})"
+            )
+        except Exception as exc:
+            out["ipify_via_privateproxy"] = f"ERROR: {exc}"
+    else:
+        out["ipify_via_privateproxy"] = "no privateproxy creds"
+
+    proxy_host_port = _ensure_tinyproxy_running(session)
+    out["tinyproxy_started"] = bool(proxy_host_port)
+    out["tinyproxy_host_port"] = proxy_host_port or ""
+
+    # Give tinyproxy a moment to be fully ready, then probe.
+    if proxy_host_port:
+        try:
+            proc = subprocess.run(
+                [
+                    "curl", "-sS", "-m", "20",
+                    "--proxy", f"http://{proxy_host_port}",
+                    "https://api.ipify.org?format=text",
+                ],
+                capture_output=True, timeout=25,
+            )
+            stdout = proc.stdout.decode().strip()
+            stderr = proc.stderr.decode().strip()
+            out["ipify_via_proxy"] = stdout or f"STDERR: {stderr} (rc={proc.returncode})"
+        except Exception as exc:
+            out["ipify_via_proxy"] = f"ERROR: {exc}"
+    else:
+        out["ipify_via_proxy"] = "tinyproxy not started"
+
+    # Read tinyproxy log tail.
+    try:
+        with open(_TINYPROXY_LOG) as fh:
+            content = fh.read()
+        out["tinyproxy_log"] = content[-2048:]
+    except Exception as exc:
+        out["tinyproxy_log"] = f"<unreadable: {exc}>"
+
+    return out
 
 
 # ── Entrypoint for ``modal run`` (ad-hoc invocation, no deploy needed) ─

--- a/src/mantis_agent/cli.py
+++ b/src/mantis_agent/cli.py
@@ -850,7 +850,6 @@ def cmd_plan_run_modal(args: argparse.Namespace) -> int:
     plan source, and per-run knobs (start URL, detail-page pattern,
     cost / time caps, proxy toggle).
     """
-    import os
     import time as _time
 
     plan_path = Path(args.path)

--- a/src/mantis_agent/cli.py
+++ b/src/mantis_agent/cli.py
@@ -832,6 +832,166 @@ def cmd_plan_run(args: argparse.Namespace) -> int:
     return EXIT_OK if failures == 0 else EXIT_ERROR
 
 
+def cmd_plan_run_modal(args: argparse.Namespace) -> int:
+    """``mantis plan run-modal <plan>`` — execute a plan inside Modal.
+
+    Thin remote driver: looks up the deployed ``run_plan`` function on
+    ``--app-name`` (default ``mantis-plan-runner``, see
+    ``deploy/modal/modal_plan_runner.py``), submits the plan + brain
+    config, and writes the returned result-payload to
+    ``<output-dir>/result.json``. The browser, decomposer (if needed),
+    grounding, and extractor all run on Modal — so Cloudflare-protected
+    sites that block local headless Chromium pass through normally
+    because the Modal image runs full Chromium under Xvfb.
+
+    The remote function reads ``ANTHROPIC_API_KEY`` and the optional
+    Oxylabs credentials from the ``mantis-plan-runner-secrets`` Modal
+    Secret — pass-through args here are limited to the brain endpoint,
+    plan source, and per-run knobs (start URL, detail-page pattern,
+    cost / time caps, proxy toggle).
+    """
+    import os
+    import time as _time
+
+    plan_path = Path(args.path)
+    if not plan_path.exists():
+        print(f"error: plan file not found: {args.path}", file=sys.stderr)
+        return EXIT_ERROR
+
+    plan_text: str | None = None
+    plan_json: dict | None = None
+    if _looks_like_text_plan(plan_path):
+        plan_text = plan_path.read_text(encoding="utf-8")
+        if not plan_text.strip():
+            print(f"error: plan file is empty: {plan_path}", file=sys.stderr)
+            return EXIT_ERROR
+    else:
+        try:
+            with plan_path.open() as fh:
+                plan_json = json.load(fh)
+        except json.JSONDecodeError as exc:
+            print(f"error: invalid JSON in {plan_path}: {exc}", file=sys.stderr)
+            return EXIT_ERROR
+
+    endpoint = args.endpoint
+    if not endpoint:
+        print(
+            "error: --endpoint is required (the brain URL Modal will hit)",
+            file=sys.stderr,
+        )
+        return EXIT_ERROR
+
+    try:
+        extra_headers = _parse_extra_headers(args.header)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return EXIT_ERROR
+
+    try:
+        import modal  # type: ignore[import-not-found]
+    except ImportError:
+        print(
+            "error: modal SDK not installed. `pip install modal` or "
+            "use the [modal] extras to enable run-modal.",
+            file=sys.stderr,
+        )
+        return EXIT_ERROR
+
+    try:
+        run_plan_fn = modal.Function.lookup(args.app_name, "run_plan")
+    except Exception as exc:  # noqa: BLE001 — modal raises various types
+        print(
+            f"error: cannot resolve Modal function "
+            f"{args.app_name}/run_plan: {exc}. Deploy first via "
+            "`uv run modal deploy deploy/modal/modal_plan_runner.py`.",
+            file=sys.stderr,
+        )
+        return EXIT_ERROR
+
+    # Output dir + start_url derivation. We need a MicroPlan object to
+    # find the first navigate URL when --start-url is omitted, but only
+    # for json plans — text plans get decomposed inside Modal so we
+    # require an explicit --start-url in that case.
+    start_url = args.start_url or ""
+    if not start_url and plan_json is not None:
+        from .plan_decomposer import MicroPlan
+        try:
+            mp = MicroPlan.from_dict(plan_json)
+        except Exception as exc:  # noqa: BLE001
+            print(f"error: cannot parse plan from {plan_path}: {exc}", file=sys.stderr)
+            return EXIT_ERROR
+        start_url = _resolve_first_navigate_url(mp)
+    if not start_url:
+        print(
+            "error: --start-url is required for text plans (decomposer "
+            "runs in Modal so we can't introspect plan steps locally)",
+            file=sys.stderr,
+        )
+        return EXIT_ERROR
+
+    output_dir = Path(args.output_dir or f"outputs/run-modal-{int(_time.time())}")
+    output_dir.mkdir(parents=True, exist_ok=True)
+    if plan_json is not None:
+        (output_dir / "plan.json").write_text(
+            json.dumps(plan_json, indent=2) + "\n", encoding="utf-8",
+        )
+    else:
+        (output_dir / "plan.txt").write_text(plan_text or "", encoding="utf-8")
+
+    session_name = plan_path.stem
+
+    print(f"  app:     {args.app_name} (modal)")
+    print(f"  brain:   {endpoint}")
+    print(f"  plan:    {plan_path.name} → {output_dir}")
+    print(f"  start:   {start_url}")
+    print()
+
+    t0 = _time.time()
+    try:
+        result = run_plan_fn.remote(
+            plan_text=plan_text,
+            plan_json=plan_json,
+            brain_endpoint=endpoint,
+            brain_extra_headers=extra_headers or None,
+            brain_model=args.model or _platform_default_model("modal"),
+            start_url=start_url,
+            detail_page_pattern=args.detail_page_pattern or "",
+            max_cost_usd=float(args.max_cost),
+            max_time_minutes=int(args.max_time_minutes),
+            use_proxy=bool(args.use_proxy),
+            proxy_session=args.proxy_session,
+            session_name=session_name,
+        )
+    except Exception as exc:  # noqa: BLE001 — modal invocation errors
+        print(f"error: Modal run_plan raised: {exc}", file=sys.stderr)
+        return EXIT_ERROR
+    elapsed = _time.time() - t0
+
+    if not isinstance(result, dict):
+        print(
+            f"error: unexpected result shape from Modal: {type(result).__name__}",
+            file=sys.stderr,
+        )
+        return EXIT_ERROR
+
+    (output_dir / "result.json").write_text(
+        json.dumps(result, indent=2) + "\n", encoding="utf-8",
+    )
+
+    successes = int(result.get("successes", 0))
+    step_count = int(result.get("step_count", 0))
+    failures = int(result.get("failures", step_count - successes))
+    final_url = result.get("final_url", "")
+    print(
+        f"  result: {successes}/{step_count} succeeded "
+        f"(remote {result.get('elapsed_seconds', 0)}s, wall {elapsed:.1f}s) — "
+        f"{output_dir / 'result.json'}"
+    )
+    if final_url:
+        print(f"  final URL: {final_url}")
+    return EXIT_OK if failures == 0 else EXIT_ERROR
+
+
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="mantis",
@@ -1014,6 +1174,91 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Resume from checkpoint at --output-dir/checkpoint.json if present.",
     )
     run.set_defaults(func=cmd_plan_run)
+
+    run_modal = plan_sub.add_parser(
+        "run-modal",
+        help="Execute a plan inside Modal (browser + extractor + grounding "
+             "all run remotely under Xvfb — bypasses local Cloudflare blocks)",
+    )
+    run_modal.add_argument(
+        "path",
+        help="Path to plan file. .json → pre-decomposed micro-plan; "
+             "any other extension → natural-language plan, decomposed "
+             "by Claude inside Modal.",
+    )
+    run_modal.add_argument(
+        "--app-name",
+        default="mantis-plan-runner",
+        help="Modal app name. Must match the deployed "
+             "deploy/modal/modal_plan_runner.py app (default: "
+             "mantis-plan-runner).",
+    )
+    run_modal.add_argument(
+        "--endpoint",
+        default=None,
+        required=True,
+        help="OpenAI-compatible v1 base URL of the brain. Modal calls "
+             "this endpoint over HTTP, so it must be reachable from "
+             "Modal's egress.",
+    )
+    run_modal.add_argument(
+        "--model",
+        default=None,
+        help="Brain model name (default: Hcompany/Holo3-35B-A3B for modal).",
+    )
+    run_modal.add_argument(
+        "--header",
+        action="append",
+        default=None,
+        metavar="KEY=VALUE",
+        help="Additional HTTP header sent with every brain request "
+             "(e.g. X-Mantis-Token=…). Repeat for multiple.",
+    )
+    run_modal.add_argument(
+        "--start-url",
+        default=None,
+        help="Initial URL for the browser. Required for text plans "
+             "(decomposer runs in Modal, so the CLI can't introspect "
+             "the navigate step locally). Optional for JSON plans.",
+    )
+    run_modal.add_argument(
+        "--detail-page-pattern",
+        default=None,
+        help="Optional regex injected into SiteConfig.detail_page_pattern. "
+             "When unset the framework falls back to the generic "
+             "path-extension heuristic (#211).",
+    )
+    run_modal.add_argument(
+        "--max-cost",
+        type=float,
+        default=10.0,
+        help="Hard cap on USD spend (Anthropic + brain) inside Modal "
+             "(default: 10.0).",
+    )
+    run_modal.add_argument(
+        "--max-time-minutes",
+        type=int,
+        default=30,
+        help="Hard wall-clock cap inside Modal (default: 30 min).",
+    )
+    run_modal.add_argument(
+        "--use-proxy",
+        action="store_true",
+        help="Route the Modal-side browser through Oxylabs (creds from "
+             "the mantis-plan-runner-secrets Modal Secret).",
+    )
+    run_modal.add_argument(
+        "--proxy-session",
+        default="mantis",
+        help="Oxylabs session ID for sticky-IP behavior (default: mantis).",
+    )
+    run_modal.add_argument(
+        "--output-dir",
+        default=None,
+        help="Where to write plan.json / plan.txt + result.json. "
+             "Defaults to outputs/run-modal-<unix-timestamp>.",
+    )
+    run_modal.set_defaults(func=cmd_plan_run_modal)
 
     trace = sub.add_parser("trace", help="Trace tooling subcommands (#155)")
     trace_sub = trace.add_subparsers(dest="trace_command", required=True)

--- a/src/mantis_agent/cli.py
+++ b/src/mantis_agent/cli.py
@@ -897,7 +897,7 @@ def cmd_plan_run_modal(args: argparse.Namespace) -> int:
         return EXIT_ERROR
 
     try:
-        run_plan_fn = modal.Function.lookup(args.app_name, "run_plan")
+        run_plan_fn = modal.Function.from_name(args.app_name, "run_plan")
     except Exception as exc:  # noqa: BLE001 — modal raises various types
         print(
             f"error: cannot resolve Modal function "

--- a/tests/test_cli_plan_run_modal.py
+++ b/tests/test_cli_plan_run_modal.py
@@ -75,7 +75,7 @@ def _make_modal_stub(remote_result: dict | None = None) -> tuple[types.ModuleTyp
             },
         ],
     }
-    function_ns = types.SimpleNamespace(lookup=MagicMock(return_value=run_plan_mock))
+    function_ns = types.SimpleNamespace(from_name=MagicMock(return_value=run_plan_mock))
     stub = types.ModuleType("modal")
     stub.Function = function_ns  # type: ignore[attr-defined]
     return stub, run_plan_mock
@@ -123,7 +123,7 @@ def test_run_modal_fails_when_lookup_raises(tmp_path: Path, capsys, monkeypatch)
     """A misspelled --app-name (or undeployed app) must produce a clear
     diagnostic instead of leaking the modal SDK's exception text alone."""
     stub, run_plan_mock = _make_modal_stub()
-    stub.Function.lookup.side_effect = RuntimeError("app not found")  # type: ignore[attr-defined]
+    stub.Function.from_name.side_effect = RuntimeError("app not found")  # type: ignore[attr-defined]
     monkeypatch.setitem(sys.modules, "modal", stub)
 
     plan_path = _write_json_plan(tmp_path / "plan.json")
@@ -313,7 +313,7 @@ def test_run_modal_uses_custom_app_name(
     ])
     assert code == EXIT_OK
 
-    lookup_args = modal_stub["stub"].Function.lookup.call_args.args
+    lookup_args = modal_stub["stub"].Function.from_name.call_args.args
     assert lookup_args == ("mantis-staging", "run_plan")
 
 

--- a/tests/test_cli_plan_run_modal.py
+++ b/tests/test_cli_plan_run_modal.py
@@ -1,0 +1,420 @@
+"""Tests for the ``mantis plan run-modal`` CLI subcommand.
+
+The remote driver delegates execution to a deployed Modal function, so
+we don't exercise the full end-to-end path here. Instead we pin the
+CLI's wiring contract: argument validation, plan loading (text → submit
+text, JSON → submit dict), header propagation, output-dir scaffolding,
+exit codes, and the start-url requirement for text plans.
+
+``modal.Function.lookup`` is patched via ``sys.modules`` because the
+import lives inside ``cmd_plan_run_modal`` so the rest of the CLI stays
+fast for users who don't have the modal SDK installed.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from mantis_agent.cli import EXIT_ERROR, EXIT_OK, main
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────
+
+
+def _write_json_plan(path: Path, *, with_url: bool = True) -> Path:
+    payload = {
+        "steps": [
+            {
+                "intent": (
+                    "Navigate to https://crm.example.test/leads"
+                    if with_url
+                    else "Open the leads dashboard"
+                ),
+                "type": "navigate" if with_url else "submit",
+                "section": "setup",
+                "required": True,
+            },
+        ],
+        "source_plan": "Open the leads dashboard",
+        "domain": "crm.example.test",
+    }
+    path.write_text(json.dumps(payload))
+    return path
+
+
+def _make_modal_stub(remote_result: dict | None = None) -> tuple[types.ModuleType, MagicMock]:
+    """Build a minimal ``modal`` module stub with ``Function.lookup``.
+
+    Returns ``(stub_module, run_plan_mock)`` so tests can introspect
+    what kwargs the CLI submitted to the remote function.
+    """
+    run_plan_mock = MagicMock()
+    run_plan_mock.remote.return_value = remote_result or {
+        "plan_signature": "abc12345",
+        "session": "plan",
+        "step_count": 1,
+        "successes": 1,
+        "failures": 0,
+        "elapsed_seconds": 12.3,
+        "final_url": "https://crm.example.test/leads",
+        "costs": {"claude_extract": 0.0, "gpu_steps": 1},
+        "steps": [
+            {
+                "index": 0,
+                "intent": "Navigate to https://crm.example.test/leads",
+                "success": True,
+                "data": "",
+                "duration": 1.0,
+                "steps_used": 1,
+            },
+        ],
+    }
+    function_ns = types.SimpleNamespace(lookup=MagicMock(return_value=run_plan_mock))
+    stub = types.ModuleType("modal")
+    stub.Function = function_ns  # type: ignore[attr-defined]
+    return stub, run_plan_mock
+
+
+@pytest.fixture
+def modal_stub(monkeypatch):
+    stub, run_plan_mock = _make_modal_stub()
+    monkeypatch.setitem(sys.modules, "modal", stub)
+    yield {"stub": stub, "run_plan": run_plan_mock}
+
+
+# ── Argument validation ──────────────────────────────────────────────────
+
+
+def test_run_modal_fails_when_plan_missing(tmp_path: Path, capsys, modal_stub) -> None:
+    code = main([
+        "plan", "run-modal", str(tmp_path / "missing.json"),
+        "--endpoint", "https://example/v1",
+    ])
+    assert code == EXIT_ERROR
+    err = capsys.readouterr().err
+    assert "plan file not found" in err
+    modal_stub["run_plan"].remote.assert_not_called()
+
+
+def test_run_modal_fails_when_modal_not_installed(tmp_path: Path, capsys, monkeypatch) -> None:
+    """When the modal SDK isn't installed, surface a clear error rather
+    than letting an ImportError bubble up unannotated."""
+    plan_path = _write_json_plan(tmp_path / "plan.json")
+    # Force ImportError by inserting a None entry — Python treats None
+    # in sys.modules as "this import is blocked".
+    monkeypatch.setitem(sys.modules, "modal", None)
+    code = main([
+        "plan", "run-modal", str(plan_path),
+        "--endpoint", "https://example/v1",
+        "--output-dir", str(tmp_path / "out"),
+    ])
+    assert code == EXIT_ERROR
+    err = capsys.readouterr().err
+    assert "modal SDK not installed" in err
+
+
+def test_run_modal_fails_when_lookup_raises(tmp_path: Path, capsys, monkeypatch) -> None:
+    """A misspelled --app-name (or undeployed app) must produce a clear
+    diagnostic instead of leaking the modal SDK's exception text alone."""
+    stub, run_plan_mock = _make_modal_stub()
+    stub.Function.lookup.side_effect = RuntimeError("app not found")  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "modal", stub)
+
+    plan_path = _write_json_plan(tmp_path / "plan.json")
+    code = main([
+        "plan", "run-modal", str(plan_path),
+        "--app-name", "wrong-name",
+        "--endpoint", "https://example/v1",
+        "--output-dir", str(tmp_path / "out"),
+    ])
+    assert code == EXIT_ERROR
+    err = capsys.readouterr().err
+    assert "cannot resolve Modal function" in err
+    assert "wrong-name/run_plan" in err
+
+
+def test_run_modal_requires_start_url_for_text_plans(
+    tmp_path: Path, capsys, modal_stub,
+) -> None:
+    """Text plans get decomposed inside Modal — the CLI can't introspect
+    the navigate step locally, so --start-url must be supplied."""
+    plan_path = tmp_path / "plan.txt"
+    plan_path.write_text("Open the boattrader listings page and extract titles.")
+    code = main([
+        "plan", "run-modal", str(plan_path),
+        "--endpoint", "https://example/v1",
+        "--output-dir", str(tmp_path / "out"),
+    ])
+    assert code == EXIT_ERROR
+    err = capsys.readouterr().err
+    assert "--start-url is required for text plans" in err
+
+
+def test_run_modal_rejects_malformed_header(
+    tmp_path: Path, capsys, modal_stub,
+) -> None:
+    plan_path = _write_json_plan(tmp_path / "plan.json")
+    code = main([
+        "plan", "run-modal", str(plan_path),
+        "--endpoint", "https://example/v1",
+        "--header", "MissingEqualsSign",
+        "--output-dir", str(tmp_path / "out"),
+    ])
+    assert code == EXIT_ERROR
+    err = capsys.readouterr().err
+    assert "KEY=VALUE" in err
+
+
+# ── Wiring: kwargs passed to run_plan.remote ─────────────────────────────
+
+
+def test_run_modal_submits_json_plan_as_dict(
+    tmp_path: Path, modal_stub,
+) -> None:
+    plan_path = _write_json_plan(tmp_path / "plan.json")
+    code = main([
+        "plan", "run-modal", str(plan_path),
+        "--endpoint", "https://example/v1",
+        "--output-dir", str(tmp_path / "out"),
+    ])
+    assert code == EXIT_OK
+
+    kwargs = modal_stub["run_plan"].remote.call_args.kwargs
+    assert isinstance(kwargs["plan_json"], dict)
+    assert kwargs["plan_json"]["steps"][0]["type"] == "navigate"
+    assert kwargs["plan_text"] is None
+    # JSON plans get the start-url inferred from the navigate step.
+    assert kwargs["start_url"] == "https://crm.example.test/leads"
+    assert kwargs["brain_endpoint"] == "https://example/v1"
+
+
+def test_run_modal_submits_text_plan_as_string(
+    tmp_path: Path, modal_stub,
+) -> None:
+    plan_path = tmp_path / "plan.txt"
+    plan_path.write_text("Extract titles from the boattrader listings page.")
+    code = main([
+        "plan", "run-modal", str(plan_path),
+        "--endpoint", "https://example/v1",
+        "--start-url", "https://www.boattrader.com/boats",
+        "--output-dir", str(tmp_path / "out"),
+    ])
+    assert code == EXIT_OK
+
+    kwargs = modal_stub["run_plan"].remote.call_args.kwargs
+    assert kwargs["plan_json"] is None
+    assert "boattrader" in kwargs["plan_text"]
+    assert kwargs["start_url"] == "https://www.boattrader.com/boats"
+
+
+def test_run_modal_threads_extra_headers(
+    tmp_path: Path, modal_stub,
+) -> None:
+    plan_path = _write_json_plan(tmp_path / "plan.json")
+    code = main([
+        "plan", "run-modal", str(plan_path),
+        "--endpoint", "https://example/v1",
+        "--header", "X-Mantis-Token=secret123",
+        "--header", "X-Tenant=acme",
+        "--output-dir", str(tmp_path / "out"),
+    ])
+    assert code == EXIT_OK
+
+    kwargs = modal_stub["run_plan"].remote.call_args.kwargs
+    assert kwargs["brain_extra_headers"] == {
+        "X-Mantis-Token": "secret123",
+        "X-Tenant": "acme",
+    }
+
+
+def test_run_modal_threads_proxy_flags(
+    tmp_path: Path, modal_stub,
+) -> None:
+    plan_path = _write_json_plan(tmp_path / "plan.json")
+    code = main([
+        "plan", "run-modal", str(plan_path),
+        "--endpoint", "https://example/v1",
+        "--use-proxy",
+        "--proxy-session", "boattrader-1",
+        "--output-dir", str(tmp_path / "out"),
+    ])
+    assert code == EXIT_OK
+
+    kwargs = modal_stub["run_plan"].remote.call_args.kwargs
+    assert kwargs["use_proxy"] is True
+    assert kwargs["proxy_session"] == "boattrader-1"
+
+
+def test_run_modal_threads_cost_and_time_caps(
+    tmp_path: Path, modal_stub,
+) -> None:
+    plan_path = _write_json_plan(tmp_path / "plan.json")
+    code = main([
+        "plan", "run-modal", str(plan_path),
+        "--endpoint", "https://example/v1",
+        "--max-cost", "2.5",
+        "--max-time-minutes", "5",
+        "--output-dir", str(tmp_path / "out"),
+    ])
+    assert code == EXIT_OK
+
+    kwargs = modal_stub["run_plan"].remote.call_args.kwargs
+    assert kwargs["max_cost_usd"] == 2.5
+    assert kwargs["max_time_minutes"] == 5
+
+
+def test_run_modal_threads_detail_page_pattern(
+    tmp_path: Path, modal_stub,
+) -> None:
+    plan_path = _write_json_plan(tmp_path / "plan.json")
+    code = main([
+        "plan", "run-modal", str(plan_path),
+        "--endpoint", "https://example/v1",
+        "--detail-page-pattern", r"/leads/\d+",
+        "--output-dir", str(tmp_path / "out"),
+    ])
+    assert code == EXIT_OK
+
+    kwargs = modal_stub["run_plan"].remote.call_args.kwargs
+    assert kwargs["detail_page_pattern"] == r"/leads/\d+"
+
+
+def test_run_modal_uses_explicit_start_url_over_plan(
+    tmp_path: Path, modal_stub,
+) -> None:
+    plan_path = _write_json_plan(tmp_path / "plan.json")
+    code = main([
+        "plan", "run-modal", str(plan_path),
+        "--endpoint", "https://example/v1",
+        "--start-url", "https://other.example.test/dashboard",
+        "--output-dir", str(tmp_path / "out"),
+    ])
+    assert code == EXIT_OK
+
+    kwargs = modal_stub["run_plan"].remote.call_args.kwargs
+    assert kwargs["start_url"] == "https://other.example.test/dashboard"
+
+
+def test_run_modal_uses_custom_app_name(
+    tmp_path: Path, modal_stub,
+) -> None:
+    plan_path = _write_json_plan(tmp_path / "plan.json")
+    code = main([
+        "plan", "run-modal", str(plan_path),
+        "--app-name", "mantis-staging",
+        "--endpoint", "https://example/v1",
+        "--output-dir", str(tmp_path / "out"),
+    ])
+    assert code == EXIT_OK
+
+    lookup_args = modal_stub["stub"].Function.lookup.call_args.args
+    assert lookup_args == ("mantis-staging", "run_plan")
+
+
+# ── Output / exit codes ──────────────────────────────────────────────────
+
+
+def test_run_modal_writes_result_json_for_json_plan(
+    tmp_path: Path, modal_stub,
+) -> None:
+    plan_path = _write_json_plan(tmp_path / "plan.json")
+    out_dir = tmp_path / "out"
+    code = main([
+        "plan", "run-modal", str(plan_path),
+        "--endpoint", "https://example/v1",
+        "--output-dir", str(out_dir),
+    ])
+    assert code == EXIT_OK
+
+    plan_out = out_dir / "plan.json"
+    result_out = out_dir / "result.json"
+    assert plan_out.exists()
+    assert result_out.exists()
+
+    result = json.loads(result_out.read_text())
+    assert result["successes"] == 1
+    assert result["step_count"] == 1
+    assert result["final_url"] == "https://crm.example.test/leads"
+
+
+def test_run_modal_writes_plan_txt_for_text_plan(
+    tmp_path: Path, modal_stub,
+) -> None:
+    plan_path = tmp_path / "plan.txt"
+    plan_path.write_text("Hello plan body.")
+    out_dir = tmp_path / "out"
+    code = main([
+        "plan", "run-modal", str(plan_path),
+        "--endpoint", "https://example/v1",
+        "--start-url", "https://example.test",
+        "--output-dir", str(out_dir),
+    ])
+    assert code == EXIT_OK
+
+    assert (out_dir / "plan.txt").read_text() == "Hello plan body."
+    assert (out_dir / "result.json").exists()
+
+
+def test_run_modal_returns_error_when_remote_reports_failures(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    stub, run_plan_mock = _make_modal_stub(remote_result={
+        "plan_signature": "abc",
+        "session": "plan",
+        "step_count": 2,
+        "successes": 1,
+        "failures": 1,
+        "elapsed_seconds": 5.0,
+        "final_url": "",
+        "costs": {},
+        "steps": [],
+    })
+    monkeypatch.setitem(sys.modules, "modal", stub)
+
+    plan_path = _write_json_plan(tmp_path / "plan.json")
+    code = main([
+        "plan", "run-modal", str(plan_path),
+        "--endpoint", "https://example/v1",
+        "--output-dir", str(tmp_path / "out"),
+    ])
+    assert code == EXIT_ERROR
+
+
+def test_run_modal_returns_error_when_remote_raises(
+    tmp_path: Path, capsys, monkeypatch,
+) -> None:
+    stub, run_plan_mock = _make_modal_stub()
+    run_plan_mock.remote.side_effect = RuntimeError("modal container OOM")
+    monkeypatch.setitem(sys.modules, "modal", stub)
+
+    plan_path = _write_json_plan(tmp_path / "plan.json")
+    code = main([
+        "plan", "run-modal", str(plan_path),
+        "--endpoint", "https://example/v1",
+        "--output-dir", str(tmp_path / "out"),
+    ])
+    assert code == EXIT_ERROR
+    err = capsys.readouterr().err
+    assert "Modal run_plan raised" in err
+
+
+def test_run_modal_endpoint_is_required_argparse_level(
+    tmp_path: Path, capsys, modal_stub,
+) -> None:
+    """``--endpoint`` is marked ``required=True`` in argparse — omitting
+    it should cause argparse to bail with exit-code 2 before our handler
+    runs (no Modal call). Argparse writes its error to stderr; we only
+    assert the handler didn't reach the SDK."""
+    plan_path = _write_json_plan(tmp_path / "plan.json")
+    with pytest.raises(SystemExit):
+        main([
+            "plan", "run-modal", str(plan_path),
+            "--output-dir", str(tmp_path / "out"),
+        ])
+    modal_stub["run_plan"].remote.assert_not_called()


### PR DESCRIPTION
## Summary

- New Modal app `mantis-plan-runner` (`deploy/modal/modal_plan_runner.py`) hosts the full mantis stack — XdotoolGymEnv + ClaudeGrounding + ClaudeExtractor + Holo3Brain wired into MicroPlanRunner — inside a debian_slim image with xvfb/xdotool/scrot/chromium. Bypasses Cloudflare's headless detection because the container browser runs against a real Xvfb display rather than headless Chromium.
- New CLI subcommand `mantis plan run-modal` (`cmd_plan_run_modal` in `src/mantis_agent/cli.py`) is a thin remote driver: `modal.Function.lookup` → `.remote(...)` → write `result.json`. Same per-step rollup as local `plan run`. Text plans require `--start-url` (decomposer runs in Modal so we can't introspect locally); JSON plans infer it from the first navigate step.
- 18 wiring-contract tests in `tests/test_cli_plan_run_modal.py` cover argparse validation, plan-source forwarding, header/proxy/cost-cap propagation, exit codes, modal SDK absence, and lookup-failure surfacing. Modal is stubbed via `sys.modules` so the tests don't need the real SDK.

## Why

Local `mantis plan run` against Cloudflare-protected sites (boattrader is the canonical case) gets the JS challenge regardless of proxy/IP/geo because headless Chromium strips `navigator.webdriver`, plugin list, GPU/audio fingerprints. Modal containers under Xvfb populate all of that and pass through. This PR makes that production path callable via a single CLI command instead of an ad-hoc `modal run` invocation.

## Deploy + secret

```bash
uv run modal deploy deploy/modal/modal_plan_runner.py
modal secret create mantis-plan-runner-secrets \
    ANTHROPIC_API_KEY=... \
    MANTIS_API_TOKEN=... \
    OXYLABS_USERNAME=... OXYLABS_PASSWORD=... OXYLABS_ENTRYPOINT=pr.oxylabs.io:10000
```

## Usage

```bash
uv run mantis plan run-modal plans/boattrader_scrape \
    --endpoint https://workspace--mantis-server-api.modal.run/v1 \
    --header X-Mantis-Token=... \
    --start-url https://www.boattrader.com/boats \
    --use-proxy --proxy-session boattrader-1 \
    --output-dir outputs/boattrader-modal
```

## Test plan

- [x] Targeted: `pytest tests/test_cli_plan_run_modal.py` — 18 passed
- [x] Full suite: `pytest -n auto` — 1305 passed
- [ ] Deploy app + create secret, run `mantis plan run-modal` against boattrader_scrape with the live `mantis-server` brain endpoint, confirm CF challenge passes and extraction loop completes (separate validation pass after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)