### PR TITLE
feat(recipes): overlay primitives + load_site_config (#224 Phase 1)

### DIFF
--- a/docs/getting-started/cli.md
+++ b/docs/getting-started/cli.md
@@ -144,6 +144,115 @@ Exit codes mirror `validate`: 0 clean, 2 warnings only, 1 errors. The
 file is written even when validator finds issues — the validator's
 output tells you what to fix.
 
+### `mantis plan run <path>`
+
+End-to-end execution against a remote Mantis brain (Baseten / Modal /
+custom OpenAI-compatible endpoint) and a local browser. Loads the plan
+(`.txt` → decompose via Claude, `.json` → load directly), wires
+`Holo3Brain` + `ClaudeGrounding` + `ClaudeExtractor` + a browser env
+into `MicroPlanRunner`, and writes `plan.json` + `result.json` to
+`--output-dir`.
+
+```
+export ANTHROPIC_API_KEY="<your key>"
+export MANTIS_API_TOKEN="<tenant token>"
+mantis plan run plans/staff-crm.txt \
+    --platform modal \
+    --endpoint https://workspace--mantis-server-api.modal.run/v1 \
+    --header "X-Mantis-Token=$MANTIS_API_TOKEN" \
+    --output-dir outputs/staff-crm-validation
+```
+
+Output:
+
+```
+  plan: 14 steps → outputs/staff-crm-validation/plan.json
+  brain:   https://workspace--mantis-server-api.modal.run/v1  (platform=modal, model=Hcompany/Holo3-35B-A3B, headers=X-Mantis-Token)
+  browser: playwright (start_url=https://crm.example.test/leads)
+  output:  outputs/staff-crm-validation
+
+  result: 12/14 succeeded (732.4s) — outputs/staff-crm-validation/result.json
+  final URL: https://crm.example.test/leads
+```
+
+Key flags:
+
+| Flag | Default | Purpose |
+|---|---|---|
+| `--platform` | `modal` | `modal` / `baseten` / `custom` — informational; controls the default model name. |
+| `--endpoint` | (required) | OpenAI-compatible v1 base URL of the brain. |
+| `--header KEY=VALUE` | — | Repeatable. Sent on every brain request — typical use: `X-Mantis-Token=…`. |
+| `--browser` | `playwright` | `playwright` (lighter, headless-friendly) or `xdotool` (Xvfb + Chromium, needed for sites that detect headless). |
+| `--headless / --no-headless` | headless | Playwright-only. Pass `--no-headless` to bypass Cloudflare's headless-detection on commerce sites. |
+| `--start-url` | first navigate URL | Initial URL the browser opens. Defaults to the first navigate step's URL. |
+| `--detail-page-pattern` | — | Optional regex injected into `SiteConfig.detail_page_pattern` (per-plan override; framework primitives stay neutral). |
+| `--max-cost` | `10.0` | Hard cap on USD spend (Anthropic + brain). Halts when exceeded. |
+| `--max-time-minutes` | `30` | Wall-clock cap. |
+| `--output-dir` | `outputs/run-<unix>` | Where to write `plan.json` + `result.json` + `checkpoint.json`. |
+| `--resume` | off | Resume from a previous checkpoint at `<output-dir>/checkpoint.json`. |
+
+Exit code is 0 if every step succeeded, 1 if any failed or the runner
+raised. Useful as a CI gate against staging endpoints.
+
+### `mantis plan run-modal <path>`
+
+Like `plan run`, but the **browser, decomposer, grounding, and
+extractor all execute inside Modal** under Xvfb instead of on the
+local machine. The CLI is a thin remote driver — `modal.Function.from_name`
+→ `.remote(...)` → write `result.json` — that submits the plan and
+renders the same per-step rollup the local CLI prints.
+
+When to use it:
+
+- The local headless / xdotool browser hits Cloudflare's bot challenge
+  (BoatTrader, Zillow, Reddit-on-iframe) — Modal's full Chromium under
+  Xvfb + window-manager populates fingerprint signals (`navigator.
+  webdriver`, GPU, fonts) that headless strips.
+- You want consistent egress (a single Modal-side IP and proxy
+  configuration, not whatever your laptop happens to have).
+- You're integrating with another remote system (a host integration's
+  CUA backend) and don't want to round-trip the browser bytes through
+  your laptop.
+
+```
+mantis plan run-modal plans/marketplace-listings.txt \
+    --endpoint https://workspace--mantis-server-api.modal.run/v1 \
+    --header "X-Mantis-Token=$MANTIS_API_TOKEN" \
+    --start-url https://www.marketplace.example/listings/ \
+    --use-proxy --proxy-session marketplace-1 \
+    --output-dir outputs/marketplace-modal
+```
+
+Same flags as `plan run` minus `--platform` / `--browser` / `--headless`
+(always Modal + xdotool + headed under Xvfb), plus:
+
+| Flag | Default | Purpose |
+|---|---|---|
+| `--app-name` | `mantis-plan-runner` | Modal app name. Must match the deployed `deploy/modal/modal_plan_runner.py` app. |
+| `--use-proxy` | off | Route the Modal-side browser through the configured upstream proxy (auth held by an in-container `tinyproxy`). |
+| `--proxy-session` | `mantis` | Session ID for sticky-IP behavior on providers that support it. |
+| `--start-url` | required for text plans | Text plans are decomposed inside Modal so the CLI can't introspect navigate steps; pass it explicitly. JSON plans infer it from the first navigate step. |
+
+Prerequisites:
+
+1. **Deploy the app once:**
+
+   ```
+   uv run modal deploy deploy/modal/modal_plan_runner.py
+   ```
+
+2. **Provision the Modal Secret** named `mantis-plan-runner-secrets`
+   with at least `ANTHROPIC_API_KEY`. Add `MANTIS_API_TOKEN` and the
+   upstream proxy credentials when needed:
+
+   ```
+   modal secret create mantis-plan-runner-secrets \
+       ANTHROPIC_API_KEY=sk-ant-... \
+       MANTIS_API_TOKEN=...
+   ```
+
+See [Modal hosting](../hosting/modal.md) for the full deploy story.
+
 ## Streaming-agent run (legacy default)
 
 `mantis "<task description>"` continues to work as before — running the

--- a/docs/hosting/modal.md
+++ b/docs/hosting/modal.md
@@ -49,8 +49,88 @@ modal volume get osworld-data results/holo3_results_*.json local_results/
 
 The `/v1/predict` Tier-1/Tier-2 features (rate limits, idempotency, webhooks, allowlist, metrics) are only exposed through the FastAPI server — i.e., on Baseten / EKS / GKE / local. Modal entry-points are direct, single-tenant.
 
+## Browser-side runner: `mantis-plan-runner`
+
+The `modal_cua_server.py` app above hosts the **brain** (the Holo3
+GGUF + the FastAPI surface). For plans that need the **browser** to
+run inside Modal too — the canonical case is a Cloudflare-protected
+target where the local headless browser fails detection — there's a
+sister app at `deploy/modal/modal_plan_runner.py`:
+
+```
+uv run modal deploy deploy/modal/modal_plan_runner.py
+```
+
+That image bakes in `xvfb`, `xdotool`, `scrot`, `chromium`, plus
+`openbox` + `tint2` for a normal-desktop window-manager context, plus
+the `mantis_agent` package and a `tinyproxy` auth-holder. The
+deployed app exposes a single `run_plan` function that constructs
+`XdotoolGymEnv` + `Holo3Brain` + `ClaudeGrounding` + `ClaudeExtractor`
+internally, runs `MicroPlanRunner`, and returns the same result
+payload the local `mantis plan run` CLI writes to `result.json`.
+
+### Modal Secret
+
+Create `mantis-plan-runner-secrets` once. Required keys:
+
+```
+modal secret create mantis-plan-runner-secrets \
+    ANTHROPIC_API_KEY=sk-ant-...
+```
+
+Optional keys (add when you need them):
+
+| Key | When |
+|---|---|
+| `MANTIS_API_TOKEN` | If the brain endpoint enforces tenant auth via `X-Mantis-Token`. |
+| `OXYLABS_USERNAME` / `_PASSWORD` / `_ENTRYPOINT` | When proxying the Modal browser through an upstream residential proxy. |
+| `OXYLABS_COUNTRY` / `_STATE` / `_CITY` | Geo pinning, when the upstream plan supports it. |
+| `PRIVATEPROXY_USERNAME` / `_PASSWORD` / `_ENTRYPOINT` | Alternate residential-proxy provider; the runner auto-picks PrivateProxy when both are set. |
+| `MANTIS_PROXY_PROVIDER` | Force `oxylabs` or `privateproxy` when both creds are mounted. |
+
+### Submit a plan
+
+From the laptop CLI:
+
+```
+mantis plan run-modal plans/marketplace-listings.txt \
+    --endpoint https://workspace--mantis-server-api.modal.run/v1 \
+    --header "X-Mantis-Token=$MANTIS_API_TOKEN" \
+    --start-url https://www.marketplace.example/listings/ \
+    --use-proxy
+```
+
+Or ad-hoc via `modal run`:
+
+```
+uv run modal run deploy/modal/modal_plan_runner.py \
+    --plan-path plans/marketplace-listings.txt \
+    --endpoint https://workspace--mantis-server-api.modal.run/v1 \
+    --header X-Mantis-Token=...
+```
+
+### Diagnose proxy issues
+
+The app also ships a `diagnose_proxy` function for ad-hoc upstream
+probing (useful when a smoke run hits `ERR_TUNNEL_CONNECTION_FAILED`
+or Cloudflare 403 inside the container):
+
+```
+uv run python -c "
+import modal, json
+fn = modal.Function.from_name('mantis-plan-runner', 'diagnose_proxy')
+print(json.dumps(fn.remote(session='diag-1'), indent=2))
+"
+```
+
+It returns the Modal egress IP, the IP each upstream proxy resolves
+to, the tinyproxy log tail, and CONNECT response codes — enough to
+distinguish "container can't reach upstream" from "upstream rejected
+auth" from "upstream OK but target site blocked the proxy IP".
+
 ## See also
 
 - `deploy/modal/` — every Modal entry-point in the repo
+- [`mantis plan run-modal`](../getting-started/cli.md#mantis-plan-run-modal-path)
 - [Plan formats](../getting-started/plan-formats.md)
 - [Hosting overview](index.md)

--- a/docs/integrations/recipes.md
+++ b/docs/integrations/recipes.md
@@ -838,6 +838,53 @@ last checkpoint.
 
 ---
 
+## Recipes as overlays (#224 Phase 1)
+
+Recipes are evolving from "primary configuration source" to
+"production-hardening overlay" on top of derived `ExtractionSchema`
+and probe-derived `SiteConfig`. The Phase 1 primitives shipped in
+`mantis_agent` give you the merge half:
+
+```python
+from mantis_agent import recipes
+from mantis_agent.extraction import ExtractionSchema
+from mantis_agent.site_config import SiteConfig
+
+# Derived from plan text (see issue #224 Phase 2 for the producer).
+derived_schema = ExtractionSchema.from_objective(objective_spec)
+derived_site   = SiteConfig.from_probe(probe_result)
+
+# Optional recipe overlay — recipe extends the derived spam / control
+# vocabulary and fills in URL patterns the probe couldn't infer from
+# one screenshot. Returns the derived value unchanged when the recipe
+# has no opinion (no site_config.py, empty pattern strings, etc.).
+schema = derived_schema.overlay(recipes.load_schema("marketplace_listings"))
+site   = derived_site.overlay(recipes.load_site_config("marketplace_listings"))
+```
+
+Merge rules:
+
+| Field | Strategy |
+|---|---|
+| `spam_indicators`, `spam_seller_indicators`, `forbidden_controls`, `allowed_controls` | List union (recipe extends derived, deduplicated). |
+| `entity_name`, `spam_label` | Derived wins once it has departed from the dataclass default; recipe fills in defaults. |
+| `fields`, `required_fields` | Derived always wins — the plan text owns the schema body. |
+| `detail_page_pattern`, `pagination_format`, `results_page_pattern`, `pagination_strip_pattern`, `filtered_results_url`, `domain` | Recipe wins when set (empty string = no opinion). |
+| `gate_verify_prompt` | Derived wins — the plan owns the gate intent. |
+| `pagination_type` | Follows `pagination_format` (the dataclass default `"path_suffix"` can't double as a sentinel). |
+
+`recipes.load_site_config(name)` returns `None` when a recipe ships a
+`SCHEMA` but no `SITE_CONFIG`, so `derived.overlay(None)` is a no-op
+and you don't need an outer guard.
+
+The producer side — `derive_from_plan(plan_text)` and `run_probe(env,
+url)` — lands in subsequent issue-#224 phases. Until then, callers
+that want derive-first behavior can construct `ObjectiveSpec` /
+`ProbeResult` themselves and feed them through `from_objective` /
+`from_probe`.
+
+---
+
 ## Next
 
 - [Generic CUA usage](generic-cua.md) — the request envelope + tenant setup.

--- a/src/mantis_agent/extraction/schema.py
+++ b/src/mantis_agent/extraction/schema.py
@@ -125,3 +125,80 @@ class ExtractionSchema:
     def seller_looks_like_spam(self, seller: str) -> bool:
         seller_lower = seller.lower()
         return any(ind in seller_lower for ind in self.spam_seller_indicators)
+
+    def overlay(self, other: ExtractionSchema | None) -> ExtractionSchema:
+        """Merge a recipe overlay into ``self`` (the derived base).
+
+        Issue #224 Phase 1: ``self`` is the derive-first schema produced
+        from plan text via :meth:`from_objective`; ``other`` is the
+        optional production-hardened recipe carrying empirical tokens
+        (dealer indicators, controls vocabulary) accumulated from real
+        runs. The merge rules favour the derived shape for *what* to
+        extract, the recipe for *how* to defend against site-specific
+        noise:
+
+        - **List fields** (``spam_indicators``, ``spam_seller_indicators``,
+          ``forbidden_controls``, ``allowed_controls``) — overlay UNION
+          (recipe extends the derived list, deduped, derived ordering
+          preserved). The recipe was authored by accreting empirical
+          tokens; dropping derived tokens would discard the plan-text
+          signal.
+        - **Scalar fields** (``entity_name``, ``spam_label``) — recipe
+          wins when it sets a non-default value, otherwise derived
+          stays. Default sentinels: ``entity_name == "listing"``,
+          ``spam_label == "dealer/spam"``.
+        - **Schema body** (``fields``, ``required_fields``) — derived
+          wins. The plan text is the source of truth for *what* is
+          being extracted; recipes don't override that. Recipes that
+          want to override must do it via the explicit
+          ``ExtractionSchema(...)`` constructor before overlay.
+
+        Passing ``other=None`` is a no-op — returns ``self`` unchanged
+        so callers can write::
+
+            schema = ExtractionSchema.from_objective(spec).overlay(
+                recipes.load_schema(name) if name else None
+            )
+
+        without an outer guard.
+        """
+        if other is None:
+            return self
+
+        def _union(base: list, ext: list) -> list:
+            seen: set = set()
+            merged: list = []
+            for item in (*base, *ext):
+                if item in seen:
+                    continue
+                seen.add(item)
+                merged.append(item)
+            return merged
+
+        # Sentinel-aware scalar pick: keep derived once it has departed
+        # from the dataclass default; otherwise take recipe's value.
+        # This makes "default" mean "no opinion" so the recipe can fill
+        # it in, but keeps a derived non-default value sticky against
+        # the recipe.
+        entity = (
+            self.entity_name
+            if self.entity_name and self.entity_name != "listing"
+            else (other.entity_name or self.entity_name)
+        )
+        spam_lbl = (
+            self.spam_label
+            if self.spam_label and self.spam_label != "dealer/spam"
+            else (other.spam_label or self.spam_label)
+        )
+        return ExtractionSchema(
+            entity_name=entity,
+            fields=self.fields,
+            required_fields=self.required_fields,
+            spam_indicators=_union(self.spam_indicators, other.spam_indicators),
+            spam_seller_indicators=_union(
+                self.spam_seller_indicators, other.spam_seller_indicators,
+            ),
+            spam_label=spam_lbl,
+            forbidden_controls=_union(self.forbidden_controls, other.forbidden_controls),
+            allowed_controls=_union(self.allowed_controls, other.allowed_controls),
+        )

--- a/src/mantis_agent/recipes/__init__.py
+++ b/src/mantis_agent/recipes/__init__.py
@@ -5,10 +5,18 @@ provides:
 
 - ``schema.py`` exposing ``SCHEMA: ExtractionSchema``
 - ``plan.json`` — a valid micro-plan
-- optionally ``rewards.py`` (``REWARD: RewardFn``) and ``verifier.py``
+- optionally ``site_config.py`` (``SITE_CONFIG: SiteConfig``),
+  ``rewards.py`` (``REWARD: RewardFn``), and ``verifier.py``
 
 The core never imports from a specific recipe. Plans declare a recipe by
 name; the loader resolves it via ``importlib`` at run time.
+
+Per issue #224 the recipe is shifting from "primary configuration source"
+to "production-hardening overlay" on top of derived ``ExtractionSchema``
+and probe-derived ``SiteConfig``. ``load_schema`` and
+``load_site_config`` are the lookup half; the overlay half lives on the
+respective dataclasses (see ``ExtractionSchema.overlay`` /
+``SiteConfig.overlay``).
 """
 
 from __future__ import annotations
@@ -18,6 +26,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from ..extraction import ExtractionSchema
+    from ..site_config import SiteConfig
 
 
 def load_schema(name: str) -> "ExtractionSchema":
@@ -33,3 +42,38 @@ def load_schema(name: str) -> "ExtractionSchema":
         raise ModuleNotFoundError(
             f"recipe {name!r} does not export SCHEMA in schema.py"
         ) from exc
+
+
+def load_site_config(name: str) -> "SiteConfig | None":
+    """Resolve ``mantis_agent.recipes.<name>.site_config.SITE_CONFIG``.
+
+    Symmetric with :func:`load_schema`. ``site_config.py`` is optional —
+    a recipe may ship a ``SCHEMA`` without a ``SITE_CONFIG`` (e.g. when
+    the URL / pagination shape is generic enough for the probe-derived
+    default to suffice). Returns ``None`` in that case rather than
+    raising, so callers can do::
+
+        site = SiteConfig.from_probe(probe).overlay(
+            recipes.load_site_config(name)
+        )
+
+    and have ``overlay(None)`` behave as a no-op.
+
+    Raises ``ModuleNotFoundError`` only when the recipe directory itself
+    doesn't exist — distinguishing "recipe absent" from "recipe present,
+    no site config".
+    """
+    try:
+        mod = importlib.import_module(f"{__name__}.{name}.site_config")
+    except ModuleNotFoundError as exc:
+        # Distinguish "recipe directory missing" (re-raise) from
+        # "site_config.py missing" (return None). importlib raises the
+        # same exception type for both; we look at the args.
+        missing = getattr(exc, "name", "") or ""
+        if missing.endswith(f".{name}"):
+            raise
+        if missing == f"{__name__}.{name}.site_config":
+            return None
+        # Some other intermediate import error — surface it.
+        raise
+    return getattr(mod, "SITE_CONFIG", None)

--- a/src/mantis_agent/recipes/marketplace_listings/site_config.py
+++ b/src/mantis_agent/recipes/marketplace_listings/site_config.py
@@ -1,0 +1,20 @@
+"""SiteConfig overlay for the marketplace_listings recipe.
+
+Carries URL/pagination patterns and gate-prompt scaffolding for boat-
+trader-style listing sites. Sibling to ``schema.py``: where the schema
+exports ``SCHEMA: ExtractionSchema``, this module exports
+``SITE_CONFIG: SiteConfig``. Both are picked up by the symmetric
+loaders in ``recipes/__init__.py``.
+
+Per issue #224 this is an overlay, not a primary config — it
+extends the probe-derived default with patterns the probe can't
+infer from a single landing screenshot (the detail-URL slug shape is
+the canonical example).
+"""
+
+from __future__ import annotations
+
+from ...site_config import SiteConfig
+
+
+SITE_CONFIG: SiteConfig = SiteConfig.default_boattrader()

--- a/src/mantis_agent/site_config.py
+++ b/src/mantis_agent/site_config.py
@@ -206,6 +206,88 @@ class SiteConfig:
             pagination_strip_pattern=pagination_strip,
         )
 
+    def overlay(self, other: SiteConfig | None) -> SiteConfig:
+        """Merge a recipe overlay into ``self`` (the probe-derived base).
+
+        Issue #224 Phase 1: ``self`` is the runtime-probed config built
+        via :meth:`from_probe`; ``other`` is the optional recipe-side
+        config carrying URL / pagination patterns curated for the
+        domain. The probe sees what the page looks like *right now*,
+        but only one page; the recipe encodes structural knowledge
+        (e.g. detail-URL slug shape) that may not be visible from a
+        single landing screenshot.
+
+        Merge rules:
+
+        - **URL / pagination patterns** — recipe wins when set
+          (``detail_page_pattern``, ``results_page_pattern``,
+          ``pagination_format``, ``pagination_type``,
+          ``pagination_strip_pattern``, ``filtered_results_url``,
+          ``domain``). Empty string on the recipe means "no opinion;
+          keep the probe's guess."
+        - **Gate prompt** — derived wins. The plan text picks the
+          intent for the gate; recipes shouldn't override that
+          unless they explicitly set ``gate_verify_prompt``.
+        - **Booleans / tuples** — recipe wins when its value differs
+          from the dataclass default (``prefer_som_grounding=False``,
+          ``require_independent_grounding=()``).
+
+        Passing ``other=None`` is a no-op so callers can chain::
+
+            site = SiteConfig.from_probe(probe).overlay(
+                recipes.load_site_config(name) if name else None
+            )
+        """
+        if other is None:
+            return self
+
+        def _str_pick(base: str, ext: str) -> str:
+            return ext if ext else base
+
+        return SiteConfig(
+            domain=_str_pick(self.domain, other.domain),
+            detail_page_pattern=_str_pick(
+                self.detail_page_pattern, other.detail_page_pattern,
+            ),
+            results_page_pattern=_str_pick(
+                self.results_page_pattern, other.results_page_pattern,
+            ),
+            pagination_format=_str_pick(
+                self.pagination_format, other.pagination_format,
+            ),
+            # ``pagination_type`` follows ``pagination_format`` — when
+            # the recipe declares a format, it also defines the
+            # accompanying type (path-suffix vs query-param vs
+            # next-button). The dataclass default ``"path_suffix"`` is
+            # not a usable "no opinion" sentinel because it's a real
+            # valid value, so we use ``pagination_format`` as the
+            # opinion indicator instead.
+            pagination_type=(
+                other.pagination_type
+                if other.pagination_format
+                else self.pagination_type
+            ),
+            pagination_strip_pattern=_str_pick(
+                self.pagination_strip_pattern, other.pagination_strip_pattern,
+            ),
+            gate_verify_prompt=(
+                other.gate_verify_prompt
+                if other.gate_verify_prompt
+                else self.gate_verify_prompt
+            ),
+            filtered_results_url=_str_pick(
+                self.filtered_results_url, other.filtered_results_url,
+            ),
+            prefer_som_grounding=(
+                other.prefer_som_grounding or self.prefer_som_grounding
+            ),
+            require_independent_grounding=(
+                other.require_independent_grounding
+                if other.require_independent_grounding
+                else self.require_independent_grounding
+            ),
+        )
+
     def to_dict(self) -> dict[str, str | bool]:
         return {
             "domain": self.domain,

--- a/tests/test_recipe_overlays.py
+++ b/tests/test_recipe_overlays.py
@@ -1,0 +1,321 @@
+"""Tests for issue #224 Phase 1 — overlay primitives + load_site_config.
+
+Three additions exercised here:
+
+1. :meth:`ExtractionSchema.overlay` — derived schema (from plan text)
+   gets recipe overlay merged in. Recipe extends the spam / control
+   lists, derived schema body wins.
+2. :meth:`SiteConfig.overlay` — probe-derived URL patterns get recipe
+   overlay merged in. Recipe wins on URL/pagination patterns; derived
+   gate prompt preserved.
+3. :func:`recipes.load_site_config` — symmetric to ``load_schema``;
+   returns ``None`` when a recipe has no ``site_config.py`` (unlike
+   ``load_schema`` which raises for a missing schema).
+
+These primitives are additive — they don't change behavior for
+existing callers that don't invoke them. The full migration to
+derive-first wiring lands in Phase 2/3/4 (see issue #224).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mantis_agent import recipes
+from mantis_agent.extraction import ExtractionSchema
+from mantis_agent.graph.objective import ObjectiveSpec, OutputField
+from mantis_agent.site_config import SiteConfig
+
+
+# ── ExtractionSchema.overlay ─────────────────────────────────────────────
+
+
+def _derived_property_schema() -> ExtractionSchema:
+    """A representative derived-from-plan schema (no spam tokens — those
+    are the empirical accumulations the recipe overlay supplies)."""
+    return ExtractionSchema.from_objective(
+        ObjectiveSpec(
+            raw_text="Find houses for sale and capture address + price",
+            domains=["zillow.com"],
+            target_entity="property listing",
+            forbidden_actions=["Contact Agent"],
+            allowed_reveal_actions=["Show more"],
+            output_schema=[
+                OutputField(name="address", required=True, example="123 Main St"),
+                OutputField(name="price", required=True, example="$450,000"),
+            ],
+        )
+    )
+
+
+def test_overlay_with_none_is_noop() -> None:
+    """Callers do ``derived.overlay(recipes.load_site_config(name))`` and
+    pass ``None`` when no recipe is named. Must round-trip cleanly."""
+    derived = _derived_property_schema()
+    result = derived.overlay(None)
+    assert result is derived
+
+
+def test_overlay_unions_spam_indicators() -> None:
+    """Recipe extends the derived spam list — derived order preserved
+    and recipe items appended deduplicated. The derived schema can be
+    empty (as it usually is — the plan text rarely names dealer
+    tokens) but must NOT replace the recipe's accreted vocabulary."""
+    derived = ExtractionSchema(
+        entity_name="property listing",
+        spam_indicators=["sponsored"],
+    )
+    recipe = ExtractionSchema(
+        spam_indicators=["sponsored", "dealer", "broker"],
+    )
+    result = derived.overlay(recipe)
+    assert result.spam_indicators == ["sponsored", "dealer", "broker"]
+
+
+def test_overlay_unions_seller_indicators() -> None:
+    derived = ExtractionSchema(spam_seller_indicators=[])
+    recipe = ExtractionSchema(spam_seller_indicators=["llc", "inc"])
+    result = derived.overlay(recipe)
+    assert result.spam_seller_indicators == ["llc", "inc"]
+
+
+def test_overlay_unions_forbidden_and_allowed_controls() -> None:
+    """Lead-form / reveal vocabularies — recipe extends derived. The
+    plan text often enumerates these (``Do NOT click X``); the recipe
+    accretes synonyms found in production runs."""
+    derived = ExtractionSchema(
+        forbidden_controls=["Contact Seller"],
+        allowed_controls=["Show more"],
+    )
+    recipe = ExtractionSchema(
+        forbidden_controls=["Request Info", "Contact Seller"],  # dup
+        allowed_controls=["Show phone", "Show email"],
+    )
+    result = derived.overlay(recipe)
+    assert result.forbidden_controls == [
+        "Contact Seller",
+        "Request Info",
+    ]
+    assert result.allowed_controls == [
+        "Show more",
+        "Show phone",
+        "Show email",
+    ]
+
+
+def test_overlay_preserves_derived_fields_and_required() -> None:
+    """The plan text is the source of truth for *what* is being
+    extracted. Recipe-side ``fields`` / ``required_fields`` MUST NOT
+    silently override the derived shape — that would re-introduce the
+    boattrader-specific ``year, make`` regression #224 calls out."""
+    derived = _derived_property_schema()
+    recipe = ExtractionSchema(
+        fields=[{"name": "year", "type": "str", "required": True, "example": "2020"}],
+        required_fields=["year", "make"],
+    )
+    result = derived.overlay(recipe)
+    assert [f["name"] for f in result.fields] == ["address", "price"]
+    assert result.required_fields == ["address", "price"]
+
+
+def test_overlay_recipe_entity_name_overrides_default() -> None:
+    """Default ``entity_name == 'listing'`` is the sentinel for "no
+    derive opinion"; recipe wins in that case."""
+    derived = ExtractionSchema()  # entity_name="listing" (the default)
+    recipe = ExtractionSchema(entity_name="boat listing")
+    result = derived.overlay(recipe)
+    assert result.entity_name == "boat listing"
+
+
+def test_overlay_keeps_derived_entity_name_when_set() -> None:
+    """Once the derive step has named the entity (anything but the
+    default sentinel), the recipe MUST NOT clobber it."""
+    derived = ExtractionSchema(entity_name="property listing")
+    recipe = ExtractionSchema(entity_name="boat listing")
+    result = derived.overlay(recipe)
+    assert result.entity_name == "property listing"
+
+
+def test_overlay_recipe_spam_label_overrides_default() -> None:
+    derived = ExtractionSchema()  # spam_label="dealer/spam"
+    recipe = ExtractionSchema(spam_label="recruiter")
+    result = derived.overlay(recipe)
+    assert result.spam_label == "recruiter"
+
+
+def test_overlay_keeps_derived_spam_label_when_set() -> None:
+    derived = ExtractionSchema(spam_label="recruiter")
+    recipe = ExtractionSchema(spam_label="dealer")
+    result = derived.overlay(recipe)
+    assert result.spam_label == "recruiter"
+
+
+def test_overlay_with_marketplace_listings_recipe() -> None:
+    """Smoke: end-to-end overlay from a derive-flavoured base into the
+    actual ``marketplace_listings`` recipe. Confirms the recipe's
+    accreted vocabulary (``marinemax``, ``brokerage``, …) reaches the
+    final schema, while the derived schema body is preserved."""
+    derived = _derived_property_schema()
+    overlay = recipes.load_schema("marketplace_listings")
+    merged = derived.overlay(overlay)
+
+    # Derived shape preserved.
+    assert merged.entity_name == "property listing"
+    assert merged.required_fields == ["address", "price"]
+
+    # Recipe vocabulary extended in.
+    assert "marinemax" in merged.spam_indicators
+    assert "brokerage" in merged.spam_seller_indicators
+
+
+# ── SiteConfig.overlay ───────────────────────────────────────────────────
+
+
+def test_site_overlay_with_none_is_noop() -> None:
+    base = SiteConfig(domain="example.com", detail_page_pattern=r"/listing/\d+")
+    assert base.overlay(None) is base
+
+
+def test_site_overlay_recipe_wins_on_url_patterns() -> None:
+    """Probe sees the landing URL but can only guess at the detail-URL
+    slug shape; the recipe knows it for sure."""
+    base = SiteConfig(domain="boattrader.com", results_page_pattern=r"/boats/")
+    overlay = SiteConfig(detail_page_pattern=r"/boat/[\w-]+")
+    result = base.overlay(overlay)
+    assert result.domain == "boattrader.com"
+    assert result.detail_page_pattern == r"/boat/[\w-]+"
+    assert result.results_page_pattern == r"/boats/"
+
+
+def test_site_overlay_pagination_recipe_overrides_when_set() -> None:
+    base = SiteConfig(pagination_format="page={n}", pagination_type="query_param")
+    overlay = SiteConfig(
+        pagination_format="/page-{n}/",
+        pagination_type="path_suffix",
+        pagination_strip_pattern=r"/page-\d+/?$",
+    )
+    result = base.overlay(overlay)
+    assert result.pagination_format == "/page-{n}/"
+    assert result.pagination_type == "path_suffix"
+    assert result.pagination_strip_pattern == r"/page-\d+/?$"
+
+
+def test_site_overlay_empty_recipe_field_keeps_probe_value() -> None:
+    """Recipe's empty string means "no opinion" — the probe-derived
+    value stays."""
+    base = SiteConfig(
+        detail_page_pattern=r"/probe-detail/\d+",
+        pagination_format="page={n}",
+    )
+    overlay = SiteConfig()  # all defaults / empty
+    result = base.overlay(overlay)
+    assert result.detail_page_pattern == r"/probe-detail/\d+"
+    assert result.pagination_format == "page={n}"
+
+
+def test_site_overlay_gate_prompt_derived_wins() -> None:
+    """Gate prompts come from plan text via the decompose stage —
+    recipe should not silently override unless explicitly set."""
+    base = SiteConfig(gate_verify_prompt="Plan-derived gate prompt")
+    overlay = SiteConfig()  # empty gate prompt — no opinion
+    result = base.overlay(overlay)
+    assert result.gate_verify_prompt == "Plan-derived gate prompt"
+
+
+def test_site_overlay_gate_prompt_recipe_overrides_when_set() -> None:
+    base = SiteConfig()  # empty gate
+    overlay = SiteConfig(gate_verify_prompt="Recipe-tuned gate prompt")
+    result = base.overlay(overlay)
+    assert result.gate_verify_prompt == "Recipe-tuned gate prompt"
+
+
+def test_site_overlay_prefer_som_or_combines() -> None:
+    """``prefer_som_grounding`` is OR-style — either the probe inferred
+    a SoM-friendly DOM or the recipe declared one; both are evidence
+    the runner can promote SoM grounding."""
+    base = SiteConfig(prefer_som_grounding=False)
+    overlay = SiteConfig(prefer_som_grounding=True)
+    assert base.overlay(overlay).prefer_som_grounding is True
+
+    base2 = SiteConfig(prefer_som_grounding=True)
+    overlay2 = SiteConfig(prefer_som_grounding=False)
+    assert base2.overlay(overlay2).prefer_som_grounding is True
+
+
+def test_site_overlay_independent_grounding_recipe_wins_when_set() -> None:
+    base = SiteConfig(require_independent_grounding=("listing-card-title",))
+    overlay = SiteConfig(require_independent_grounding=("recipe-card",))
+    assert base.overlay(overlay).require_independent_grounding == ("recipe-card",)
+
+
+def test_site_overlay_independent_grounding_keeps_base_when_recipe_empty() -> None:
+    base = SiteConfig(require_independent_grounding=("base-tag",))
+    overlay = SiteConfig()  # empty tuple
+    assert base.overlay(overlay).require_independent_grounding == ("base-tag",)
+
+
+def test_site_overlay_with_marketplace_listings() -> None:
+    """End-to-end: probe-derived base + recipe overlay produces the
+    expected merged config for boat-trader-style sites."""
+    base = SiteConfig(domain="boattrader.com")  # only domain known from probe
+    overlay = recipes.load_site_config("marketplace_listings")
+    assert overlay is not None  # recipe ships SITE_CONFIG
+    merged = base.overlay(overlay)
+    assert merged.detail_page_pattern == r"/boat/[\w-]+"
+    assert merged.pagination_format == "/page-{n}/"
+    assert merged.filtered_results_url
+
+
+# ── recipes.load_site_config ─────────────────────────────────────────────
+
+
+def test_load_site_config_returns_config_for_marketplace_listings() -> None:
+    config = recipes.load_site_config("marketplace_listings")
+    assert config is not None
+    assert isinstance(config, SiteConfig)
+    assert config.detail_page_pattern == r"/boat/[\w-]+"
+
+
+def test_load_site_config_returns_none_when_recipe_lacks_site_config(
+    tmp_path, monkeypatch,
+) -> None:
+    """A recipe with a schema but no site_config.py must yield None
+    (no exception). Construct an ad-hoc importable package on disk
+    that has only ``schema.py`` to avoid touching the real recipes
+    directory."""
+    import sys
+
+    pkg_root = tmp_path / "ad_hoc_recipes"
+    pkg_root.mkdir()
+    (pkg_root / "__init__.py").write_text("")
+    sub = pkg_root / "halfway"
+    sub.mkdir()
+    (sub / "__init__.py").write_text("")
+    (sub / "schema.py").write_text(
+        "from mantis_agent.extraction import ExtractionSchema\n"
+        "SCHEMA = ExtractionSchema(entity_name='halfway')\n"
+    )
+
+    monkeypatch.syspath_prepend(str(tmp_path))
+    # Import the ad-hoc package once so its name resolves in importlib.
+    import importlib
+    importlib.import_module("ad_hoc_recipes")
+    importlib.import_module("ad_hoc_recipes.halfway")
+
+    # Patch ``recipes.__name__`` lookup by re-pointing load_site_config
+    # at our ad-hoc tree. Simpler: temporarily swap recipes.__name__.
+    monkeypatch.setattr(recipes, "__name__", "ad_hoc_recipes")
+    try:
+        result = recipes.load_site_config("halfway")
+    finally:
+        # Cleanup imported modules so subsequent tests get a fresh state.
+        for k in list(sys.modules):
+            if k.startswith("ad_hoc_recipes"):
+                sys.modules.pop(k, None)
+    assert result is None
+
+
+def test_load_site_config_raises_for_unknown_recipe() -> None:
+    """Recipe directory truly missing — re-raise rather than swallow."""
+    with pytest.raises(ModuleNotFoundError):
+        recipes.load_site_config("definitely_not_a_real_recipe_name_xyz")


### PR DESCRIPTION
Issue #224 Phase 1 — additive, no behavior change for existing callers.

## Summary

- ``ExtractionSchema.overlay(other)`` — merge a recipe overlay into a derive-first base. List fields union (deduped), scalar sentinels (entity_name, spam_label) prefer derived once non-default, schema body (fields/required_fields) always preserved derived.
- ``SiteConfig.overlay(other)`` — recipe wins on URL/pagination patterns when set, derived gate prompt preserved, pagination_type follows pagination_format (the dataclass default ``""path_suffix""`` is itself valid so can't double as a sentinel).
- ``recipes.load_site_config(name)`` — symmetric to ``load_schema``. Returns ``None`` when the recipe directory has no ``site_config.py`` (vs raising) so ``probe.overlay(recipes.load_site_config(name))`` chains cleanly.
- ``recipes/marketplace_listings/site_config.py`` ships a ``SITE_CONFIG`` to demonstrate the symmetric shape.

## Why

Per issue #224, the recipe-by-name pattern works but doesn't scale: every new domain forces a recipe PR upstream before host integrations can do anything beyond neutral defaults. Phase 1 lays the merge primitives so Phase 2 can introduce ``derive_from_plan`` and start producing schemas / configs from plan text + first-paint probe, with recipes as an optional overlay carrying production-tuned tokens (e.g. dealer indicators that accreted from real failures).

## Test plan

- [x] ``pytest tests/test_recipe_overlays.py`` — 23 new cases passing
- [x] ``pytest tests/test_extraction_schema.py tests/test_site_config.py tests/test_recipe_overlays.py`` — 66/66
- [x] Full suite ``pytest -n auto`` — 1373 passed in 5m02s
- [x] ``ruff check`` clean on new + modified files

## Phasing

Phase 2 (``mantis_agent.objective.derive_from_plan``), Phase 3 (``run_probe`` helper), Phase 4 (host-integration migration) ship independently. Existing callers continue to work unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)