### PR TITLE
feat(objective): derive_from_plan producer (#224 Phase 2)

### DIFF
--- a/src/mantis_agent/graph/objective.py
+++ b/src/mantis_agent/graph/objective.py
@@ -79,7 +79,14 @@ Rules:
 
 @dataclass
 class ObjectiveSpec:
-    """Structured description of what the user wants to accomplish."""
+    """Structured description of what the user wants to accomplish.
+
+    The fields below ``output_schema`` are populated by the
+    derive-first producer (``mantis_agent.objective.derive_from_plan``)
+    and consumed by ``ExtractionSchema.from_objective`` when building
+    the schema. They default to empty so legacy callers that only
+    populate the original fields keep working unchanged.
+    """
 
     raw_text: str
     domains: list[str] = field(default_factory=list)
@@ -90,6 +97,13 @@ class ObjectiveSpec:
     allowed_reveal_actions: list[str] = field(default_factory=list)
     output_schema: list[OutputField] = field(default_factory=list)
     completion: CompletionCondition = field(default_factory=CompletionCondition)
+    # Issue #224 Phase 2: derive-time fields lifted from plan text.
+    # ``ExtractionSchema.from_objective`` already reads them via
+    # getattr, so these defaults make the round-trip safe.
+    viability_definition: str = ""
+    spam_text_indicators: list[str] = field(default_factory=list)
+    spam_seller_indicators: list[str] = field(default_factory=list)
+    spam_label: str = ""
     objective_hash: str = ""
 
     def __post_init__(self):
@@ -247,6 +261,10 @@ class ObjectiveSpec:
                 "max_items": self.completion.max_items,
                 "max_pages": self.completion.max_pages,
             },
+            "viability_definition": self.viability_definition,
+            "spam_text_indicators": self.spam_text_indicators,
+            "spam_seller_indicators": self.spam_seller_indicators,
+            "spam_label": self.spam_label,
             "objective_hash": self.objective_hash,
         }
 
@@ -271,5 +289,9 @@ class ObjectiveSpec:
             allowed_reveal_actions=data.get("allowed_reveal_actions", []),
             output_schema=output_schema,
             completion=completion,
+            viability_definition=data.get("viability_definition", ""),
+            spam_text_indicators=data.get("spam_text_indicators", []),
+            spam_seller_indicators=data.get("spam_seller_indicators", []),
+            spam_label=data.get("spam_label", ""),
             objective_hash=data.get("objective_hash", ""),
         )

--- a/src/mantis_agent/objective.py
+++ b/src/mantis_agent/objective.py
@@ -1,0 +1,388 @@
+"""Derive-first ObjectiveSpec producer (issue #224 Phase 2).
+
+The Phase 1 overlay primitives (``ExtractionSchema.overlay`` /
+``SiteConfig.overlay`` / ``recipes.load_site_config``) gave callers
+the merge half of the derive-first config story. This module ships
+the producer half: :func:`derive_from_plan` lifts the structured
+:class:`ObjectiveSpec` shape directly from the plan text the user
+authored, so host integrations can do::
+
+    from mantis_agent import objective, recipes
+    from mantis_agent.extraction import ExtractionSchema
+
+    spec   = objective.derive_from_plan(plan_text)
+    schema = ExtractionSchema.from_objective(spec).overlay(
+        recipes.load_schema(name) if name else None
+    )
+
+without picking a recipe per template plan. Most plans don't name a
+recipe; the ones that do treat it as a *hardening hint* — empirical
+spam tokens accumulated from production runs — not as the primary
+config selector.
+
+The lift is a single Anthropic ``tool_use`` call with a strict input
+schema, so the response is server-side-validated as JSON of the
+right shape (no fragile prose parsing). Calls are cached
+in-process by ``hash(plan_text + DERIVE_PROMPT_VERSION)`` — repeated
+runs in the same process are free, and bumping the prompt version
+forces a uniform cache miss.
+
+Top-level re-exports of :class:`ObjectiveSpec`,
+:class:`OutputField`, :class:`CompletionCondition` keep
+``from mantis_agent.objective import ...`` ergonomic for callers
+that don't want to know which submodule the dataclasses physically
+live in.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+from typing import Any
+
+from .graph.objective import (
+    CompletionCondition,
+    ObjectiveSpec,
+    OutputField,
+)
+
+__all__ = [
+    "CompletionCondition",
+    "DERIVE_PROMPT_VERSION",
+    "ObjectiveSpec",
+    "OutputField",
+    "derive_from_plan",
+]
+
+logger = logging.getLogger(__name__)
+
+
+# Bumping this string invalidates every cached entry — use when the
+# prompt or tool schema below changes in a way that makes prior
+# parses incorrect (renamed fields, tightened required-flag rules,
+# new mandatory output keys, etc.).
+DERIVE_PROMPT_VERSION = "v1"
+
+
+# In-process cache keyed by sha256(DERIVE_PROMPT_VERSION + plan_text).
+# Bounded loosely — a single process rarely processes more than a
+# handful of unique plans, and ``ObjectiveSpec`` instances are small
+# so the memory cost is trivial. Cleared by tests via
+# :func:`_reset_cache_for_tests`.
+_DERIVE_CACHE: dict[str, ObjectiveSpec] = {}
+
+
+_DERIVE_TOOL_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "target_entity": {
+            "type": "string",
+            "description": (
+                "What kind of item the plan extracts, in the user's "
+                "vocabulary. Examples: 'boat listing', 'job posting', "
+                "'real estate listing', 'product', 'user profile'. "
+                "Empty string only if truly indeterminate."
+            ),
+        },
+        "domains": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": (
+                "Target website domains mentioned in the plan, e.g. "
+                "['boattrader.com']. Strip ``www.`` prefixes."
+            ),
+        },
+        "output_fields": {
+            "type": "array",
+            "description": (
+                "Every field the plan extracts. Use ``required=true`` ONLY "
+                "when the plan calls the field out as REQUIRED, VIABLE-"
+                "blocking, or 'must have'. Otherwise ``required=false``. "
+                "Conservative is correct — over-marking required fields "
+                "produces false rejections downstream."
+            ),
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "type": {
+                        "type": "string",
+                        "enum": ["str", "int", "bool", "float"],
+                    },
+                    "required": {"type": "boolean"},
+                    "example": {
+                        "type": "string",
+                        "description": (
+                            "A representative value from the plan or a "
+                            "sensible synthesised one. Empty string OK."
+                        ),
+                    },
+                },
+                "required": ["name"],
+            },
+        },
+        "forbidden_actions": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": (
+                "Every UI label the plan tells the agent NOT to click "
+                "('Do NOT click X', 'STRICTLY PROHIBITED'). Empty if "
+                "the plan doesn't enumerate any."
+            ),
+        },
+        "allowed_reveal_actions": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": (
+                "Every UI label the plan tells the agent IT MAY click "
+                "to surface hidden info ('Show more', 'Show phone', "
+                "'View details'). Empty if not enumerated."
+            ),
+        },
+        "viability_definition": {
+            "type": "string",
+            "description": (
+                "The plan's viability rule, paraphrased to one "
+                "sentence. Example: 'A listing is VIABLE only if the "
+                "seller's phone number appears in the description.' "
+                "Empty if the plan does not define viability."
+            ),
+        },
+        "spam_text_indicators": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": (
+                "Plan-enumerated spam / dealer text tokens. Most plans "
+                "don't enumerate these — leave empty when the plan is "
+                "silent. Do NOT invent dealer names like 'marinemax' "
+                "unless the plan explicitly lists them."
+            ),
+        },
+        "spam_seller_indicators": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": (
+                "Plan-enumerated seller-name spam indicators (e.g. "
+                "'llc', 'inc', 'brokerage'). Same rule: empty unless "
+                "the plan enumerates them."
+            ),
+        },
+        "spam_label": {
+            "type": "string",
+            "description": (
+                "What the plan calls non-organic listings, e.g. "
+                "'dealer', 'recruiter', 'broker spam'. Empty if "
+                "unspecified."
+            ),
+        },
+    },
+    "required": ["target_entity", "output_fields"],
+}
+
+
+_DERIVE_PROMPT = """\
+Read the CUA (Computer Use Agent) plan below and lift its semantic
+shape into a structured ObjectiveSpec via the ``record_objective``
+tool.
+
+PLAN TEXT
+=========
+{plan_text}
+=========
+
+Be precise:
+
+- ``output_fields``: include every field the plan extracts. Use
+  ``required: true`` ONLY when the plan explicitly calls a field out
+  as REQUIRED / VIABLE / "must have". Default new fields to
+  ``required: false``.
+- ``forbidden_actions`` / ``allowed_reveal_actions``: only include
+  UI labels the plan literally enumerates. Don't paraphrase.
+- ``viability_definition``: paraphrase the plan's viability rule
+  if any; empty string otherwise.
+- ``spam_text_indicators`` / ``spam_seller_indicators`` / ``spam_label``:
+  leave empty unless the plan explicitly enumerates dealer / spam
+  tokens. The recipe overlay layer (``recipes.load_schema``) is
+  where empirical-from-production tokens live; the plan-derived
+  spec must not invent them.
+"""
+
+
+def derive_from_plan(
+    plan_text: str,
+    *,
+    api_key: str = "",
+    model: str = "claude-haiku-4-5-20251001",
+) -> ObjectiveSpec:
+    """Lift an :class:`ObjectiveSpec` from a free-text CUA plan.
+
+    Issue #224 Phase 2 producer: a single Claude tool_use call lifts
+    the structured fields downstream consumers
+    (:meth:`ExtractionSchema.from_objective`,
+    :class:`PlanDecomposer`) need. Result is cached in-process
+    keyed by ``sha256(prompt_version + plan_text)`` so repeated
+    invocations for the same plan are free.
+
+    Args:
+        plan_text: Free-text plan body. Multi-paragraph; arbitrary
+            shape. The plans/ directory is the canonical source.
+        api_key: Anthropic API key. Falls back to the
+            ``ANTHROPIC_API_KEY`` env var. When neither is set, a
+            heuristic fallback produces a minimal-but-valid spec
+            so the call doesn't hard-fail in offline contexts.
+        model: Anthropic model identifier. Defaults to a
+            Haiku-tier model — the lift task is small and the cost
+            difference vs Sonnet/Opus matters for plans that get
+            decomposed on every CI run.
+
+    Returns:
+        :class:`ObjectiveSpec` populated with the derive-time
+        fields (``target_entity``, ``output_schema``,
+        ``forbidden_actions``, ``allowed_reveal_actions``,
+        ``viability_definition``, ``spam_*``). Empty list / string
+        for fields the plan didn't address — the overlay layer
+        is where the recipe fills them in.
+
+    Cache lifecycle: per-process, never expires within a process.
+    Bump :data:`DERIVE_PROMPT_VERSION` when the schema or prompt
+    semantics change to invalidate every entry uniformly.
+    """
+    cache_key = _cache_key(plan_text)
+    cached = _DERIVE_CACHE.get(cache_key)
+    if cached is not None:
+        return cached
+
+    api_key = api_key or os.environ.get("ANTHROPIC_API_KEY", "")
+    if not api_key:
+        logger.warning(
+            "derive_from_plan: no ANTHROPIC_API_KEY — falling back to "
+            "heuristic ObjectiveSpec.parse. Pass api_key= or set the "
+            "env var for the tool_use lift."
+        )
+        spec = ObjectiveSpec.parse(plan_text, api_key="")
+        _DERIVE_CACHE[cache_key] = spec
+        return spec
+
+    parsed = _call_derive_tool(plan_text, api_key=api_key, model=model)
+    if parsed is None:
+        logger.warning(
+            "derive_from_plan: tool_use lift returned no validated "
+            "input — falling back to heuristic ObjectiveSpec.parse"
+        )
+        spec = ObjectiveSpec.parse(plan_text, api_key="")
+    else:
+        spec = _build_spec_from_tool_input(plan_text, parsed)
+
+    _DERIVE_CACHE[cache_key] = spec
+    return spec
+
+
+def _cache_key(plan_text: str) -> str:
+    return hashlib.sha256(
+        (DERIVE_PROMPT_VERSION + "\n" + plan_text).encode("utf-8")
+    ).hexdigest()
+
+
+def _call_derive_tool(
+    plan_text: str,
+    *,
+    api_key: str,
+    model: str,
+) -> dict | None:
+    """Single Anthropic tool_use call. Returns the validated input
+    dict, or ``None`` on any API / network / shape mismatch."""
+    import requests
+
+    try:
+        resp = requests.post(
+            "https://api.anthropic.com/v1/messages",
+            headers={
+                "x-api-key": api_key,
+                "anthropic-version": "2023-06-01",
+                "content-type": "application/json",
+            },
+            json={
+                "model": model,
+                "max_tokens": 1500,
+                "tools": [{
+                    "name": "record_objective",
+                    "description": (
+                        "Record the structured ObjectiveSpec lifted "
+                        "from the plan."
+                    ),
+                    "input_schema": _DERIVE_TOOL_SCHEMA,
+                }],
+                "tool_choice": {"type": "tool", "name": "record_objective"},
+                "messages": [{
+                    "role": "user",
+                    "content": _DERIVE_PROMPT.format(plan_text=plan_text),
+                }],
+            },
+            timeout=30,
+        )
+        if resp.status_code != 200:
+            logger.warning(
+                "derive_from_plan API error %s: %s",
+                resp.status_code,
+                resp.text[:500],
+            )
+            return None
+        for block in resp.json().get("content", []):
+            if (
+                block.get("type") == "tool_use"
+                and block.get("name") == "record_objective"
+            ):
+                tool_input = block.get("input")
+                if isinstance(tool_input, dict):
+                    return tool_input
+        return None
+    except Exception as exc:  # noqa: BLE001 — log + fall back
+        logger.warning("derive_from_plan call failed: %s", exc)
+        return None
+
+
+def _build_spec_from_tool_input(
+    raw_text: str, data: dict[str, Any],
+) -> ObjectiveSpec:
+    """Coerce a validated tool_use input dict into ObjectiveSpec.
+
+    The tool schema accepts arrays of partially-typed objects, but the
+    dataclass wants strict :class:`OutputField` instances. We also
+    drop fields with empty ``name`` defensively.
+    """
+    output_fields: list[OutputField] = []
+    for f in data.get("output_fields") or []:
+        if not isinstance(f, dict):
+            continue
+        name = (f.get("name") or "").strip()
+        if not name:
+            continue
+        output_fields.append(
+            OutputField(
+                name=name,
+                type=str(f.get("type") or "str"),
+                required=bool(f.get("required", False)),
+                example=str(f.get("example") or ""),
+            )
+        )
+
+    return ObjectiveSpec(
+        raw_text=raw_text,
+        domains=list(data.get("domains") or []),
+        target_entity=str(data.get("target_entity") or ""),
+        forbidden_actions=list(data.get("forbidden_actions") or []),
+        allowed_reveal_actions=list(data.get("allowed_reveal_actions") or []),
+        output_schema=output_fields,
+        viability_definition=str(data.get("viability_definition") or ""),
+        spam_text_indicators=list(data.get("spam_text_indicators") or []),
+        spam_seller_indicators=list(data.get("spam_seller_indicators") or []),
+        spam_label=str(data.get("spam_label") or ""),
+    )
+
+
+def _reset_cache_for_tests() -> None:
+    """Test-only hook: clear the in-process cache so each test starts
+    from a clean slate. Production callers must not call this — the
+    cache is per-process by design."""
+    _DERIVE_CACHE.clear()

--- a/tests/test_derive_from_plan.py
+++ b/tests/test_derive_from_plan.py
@@ -1,0 +1,343 @@
+"""Tests for the derive-first ObjectiveSpec producer (#224 Phase 2).
+
+Pin the wiring contract: tool_use call shape, response coercion,
+caching by plan text + prompt version, fallback to the heuristic
+parser when the API key is missing or the call errors. The actual
+LLM lift is exercised by integration tests against a real key —
+these tests stub ``requests.post`` so they run offline.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mantis_agent import objective as objective_mod
+from mantis_agent.objective import (
+    DERIVE_PROMPT_VERSION,
+    ObjectiveSpec,
+    OutputField,
+    derive_from_plan,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    """Every test gets a fresh per-process cache."""
+    objective_mod._reset_cache_for_tests()
+    yield
+    objective_mod._reset_cache_for_tests()
+
+
+def _tool_response(input_payload: dict[str, Any]) -> MagicMock:
+    """Build a stubbed Anthropic /v1/messages response in tool_use shape."""
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = {
+        "content": [
+            {
+                "type": "tool_use",
+                "name": "record_objective",
+                "input": input_payload,
+            }
+        ]
+    }
+    return resp
+
+
+# ── Module surface ───────────────────────────────────────────────────────
+
+
+def test_module_re_exports_objective_dataclasses() -> None:
+    """``from mantis_agent.objective import ObjectiveSpec`` must work
+    so callers don't need to know the dataclasses physically live in
+    the ``graph`` submodule."""
+    from mantis_agent.objective import (
+        CompletionCondition,
+        ObjectiveSpec as ReExported,
+        OutputField as ReExportedField,
+    )
+    from mantis_agent.graph.objective import ObjectiveSpec as Canonical
+
+    assert ReExported is Canonical
+    assert ReExportedField.__name__ == "OutputField"
+    assert CompletionCondition.__name__ == "CompletionCondition"
+
+
+# ── Successful tool_use lift ─────────────────────────────────────────────
+
+
+def test_derive_lifts_target_entity_and_required_fields() -> None:
+    """The plan calls phone REQUIRED for viability — derived schema
+    must mark phone required and leave year non-required."""
+    payload = {
+        "target_entity": "boat listing",
+        "domains": ["example.com"],
+        "output_fields": [
+            {"name": "phone", "type": "str", "required": True, "example": "(305) 555-1234"},
+            {"name": "year", "type": "int", "required": False, "example": "2018"},
+        ],
+        "forbidden_actions": ["Contact Seller"],
+        "allowed_reveal_actions": ["Show phone"],
+        "viability_definition": "VIABLE only if a phone number is in the description.",
+        "spam_text_indicators": [],
+        "spam_seller_indicators": [],
+        "spam_label": "",
+    }
+    with patch("requests.post", return_value=_tool_response(payload)):
+        spec = derive_from_plan("plan body", api_key="k")
+
+    assert isinstance(spec, ObjectiveSpec)
+    assert spec.target_entity == "boat listing"
+    assert spec.domains == ["example.com"]
+    assert [(f.name, f.required) for f in spec.output_schema] == [
+        ("phone", True),
+        ("year", False),
+    ]
+    assert spec.forbidden_actions == ["Contact Seller"]
+    assert spec.allowed_reveal_actions == ["Show phone"]
+    assert "phone number" in spec.viability_definition
+    # Plan didn't enumerate spam tokens — both lists must stay empty.
+    assert spec.spam_text_indicators == []
+    assert spec.spam_seller_indicators == []
+
+
+def test_derive_drops_fields_with_empty_name() -> None:
+    """Defensive: tool_use schema requires ``name`` but a malformed
+    Anthropic response could still produce a stray entry. Coercion
+    silently drops it rather than letting it pollute the schema."""
+    payload = {
+        "target_entity": "x",
+        "output_fields": [
+            {"name": "", "type": "str", "required": True},
+            {"name": "title", "type": "str", "required": True},
+        ],
+    }
+    with patch("requests.post", return_value=_tool_response(payload)):
+        spec = derive_from_plan("plan", api_key="k")
+
+    assert [f.name for f in spec.output_schema] == ["title"]
+
+
+def test_derive_passes_tool_schema_to_anthropic() -> None:
+    """Tool definition must include all derive-time fields and
+    ``tool_choice`` must force the ``record_objective`` tool — that's
+    what makes the response server-side-validated as JSON."""
+    captured: dict[str, Any] = {}
+
+    def _capture(url, **kwargs):
+        captured["url"] = url
+        captured["json"] = kwargs.get("json")
+        return _tool_response({"target_entity": "x", "output_fields": []})
+
+    with patch("requests.post", side_effect=_capture):
+        derive_from_plan("plan", api_key="k")
+
+    assert captured["url"] == "https://api.anthropic.com/v1/messages"
+    body = captured["json"]
+    assert body["tool_choice"] == {"type": "tool", "name": "record_objective"}
+
+    schema = body["tools"][0]["input_schema"]
+    expected_keys = {
+        "target_entity",
+        "domains",
+        "output_fields",
+        "forbidden_actions",
+        "allowed_reveal_actions",
+        "viability_definition",
+        "spam_text_indicators",
+        "spam_seller_indicators",
+        "spam_label",
+    }
+    assert set(schema["properties"].keys()) == expected_keys
+    assert "target_entity" in schema["required"]
+    assert "output_fields" in schema["required"]
+
+
+# ── Caching ──────────────────────────────────────────────────────────────
+
+
+def test_derive_caches_by_plan_text() -> None:
+    """Same plan text → one Anthropic call. Repeated runs in the same
+    process are free."""
+    payload = {"target_entity": "x", "output_fields": []}
+    mock = MagicMock(return_value=_tool_response(payload))
+    with patch("requests.post", side_effect=mock):
+        spec1 = derive_from_plan("identical plan body", api_key="k")
+        spec2 = derive_from_plan("identical plan body", api_key="k")
+
+    assert mock.call_count == 1
+    assert spec1 is spec2
+
+
+def test_derive_cache_distinguishes_different_plans() -> None:
+    """Distinct plan texts → distinct cache entries."""
+    payload1 = {"target_entity": "boat listing", "output_fields": []}
+    payload2 = {"target_entity": "job posting", "output_fields": []}
+
+    responses = [_tool_response(payload1), _tool_response(payload2)]
+    mock = MagicMock(side_effect=responses)
+    with patch("requests.post", side_effect=mock):
+        spec1 = derive_from_plan("plan A", api_key="k")
+        spec2 = derive_from_plan("plan B", api_key="k")
+
+    assert mock.call_count == 2
+    assert spec1.target_entity == "boat listing"
+    assert spec2.target_entity == "job posting"
+
+
+def test_derive_cache_key_uses_prompt_version() -> None:
+    """Cache key must include ``DERIVE_PROMPT_VERSION`` so bumping
+    the version invalidates every entry uniformly."""
+    plan = "plan body"
+    expected = hashlib.sha256(
+        (DERIVE_PROMPT_VERSION + "\n" + plan).encode("utf-8")
+    ).hexdigest()
+    actual = objective_mod._cache_key(plan)
+    assert actual == expected
+
+
+# ── Fallback paths ───────────────────────────────────────────────────────
+
+
+def test_derive_falls_back_when_api_key_missing(monkeypatch) -> None:
+    """No API key → return heuristic ObjectiveSpec.parse output.
+    Must NOT make any HTTP call."""
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    with patch("requests.post") as mock:
+        spec = derive_from_plan("Extract listings from https://example.com/things")
+
+    mock.assert_not_called()
+    assert isinstance(spec, ObjectiveSpec)
+    # Heuristic picks up the URL.
+    assert "example.com" in spec.domains
+
+
+def test_derive_falls_back_on_api_error() -> None:
+    """API non-200 → fall back to heuristic parser, don't raise."""
+    err_resp = MagicMock(status_code=500, text="upstream timeout")
+    with patch("requests.post", return_value=err_resp):
+        spec = derive_from_plan("plan", api_key="k")
+
+    assert isinstance(spec, ObjectiveSpec)
+    # Heuristic returns a minimal spec.
+    assert spec.raw_text == "plan"
+
+
+def test_derive_falls_back_on_missing_tool_block() -> None:
+    """Response is 200 but contains no tool_use block (model returned
+    prose) — fall back rather than crashing."""
+    resp = MagicMock(status_code=200)
+    resp.json.return_value = {
+        "content": [{"type": "text", "text": "I refuse to call the tool"}]
+    }
+    with patch("requests.post", return_value=resp):
+        spec = derive_from_plan("plan", api_key="k")
+
+    assert isinstance(spec, ObjectiveSpec)
+    assert spec.raw_text == "plan"
+
+
+def test_derive_falls_back_on_request_exception() -> None:
+    """Network error mid-call → fall back, don't propagate."""
+    with patch("requests.post", side_effect=ConnectionError("net down")):
+        spec = derive_from_plan("plan", api_key="k")
+
+    assert isinstance(spec, ObjectiveSpec)
+
+
+# ── Integration with downstream consumers ───────────────────────────────
+
+
+def test_derived_spec_feeds_extraction_schema() -> None:
+    """End-to-end: ``derive_from_plan`` → ``ExtractionSchema.from_objective``
+    must produce a usable schema. This is the canonical Phase 2/3 pipeline
+    callers will write."""
+    from mantis_agent.extraction import ExtractionSchema
+
+    payload = {
+        "target_entity": "property listing",
+        "output_fields": [
+            {"name": "address", "type": "str", "required": True, "example": "123 Main St"},
+            {"name": "price", "type": "str", "required": True, "example": "$450,000"},
+            {"name": "beds", "type": "int", "required": False, "example": "3"},
+        ],
+        "forbidden_actions": ["Contact Agent"],
+        "allowed_reveal_actions": ["Show more"],
+        "viability_definition": "Viable if address and price are visible",
+        "spam_text_indicators": [],
+        "spam_seller_indicators": [],
+        "spam_label": "",
+    }
+    with patch("requests.post", return_value=_tool_response(payload)):
+        spec = derive_from_plan("Find houses for sale on Zillow", api_key="k")
+
+    schema = ExtractionSchema.from_objective(spec)
+
+    assert schema.entity_name == "property listing"
+    assert schema.required_fields == ["address", "price"]
+    assert "Contact Agent" in schema.forbidden_controls
+    assert "Show more" in schema.allowed_controls
+    # Spam fields populated empty — recipe overlay is where production
+    # tokens accumulate, not the derived spec.
+    assert schema.spam_indicators == []
+
+
+def test_derived_spec_overlays_with_marketplace_recipe() -> None:
+    """Phase 1 + Phase 2 wired together: derive a property-flavoured
+    spec, then overlay the marketplace_listings recipe — the recipe's
+    spam vocabulary extends the (empty) derived list, but the derived
+    schema body wins."""
+    from mantis_agent import recipes
+    from mantis_agent.extraction import ExtractionSchema
+
+    payload = {
+        "target_entity": "property listing",
+        "output_fields": [
+            {"name": "address", "type": "str", "required": True, "example": ""},
+            {"name": "price", "type": "str", "required": True, "example": ""},
+        ],
+        "forbidden_actions": [],
+        "allowed_reveal_actions": [],
+        "viability_definition": "",
+        "spam_text_indicators": [],
+        "spam_seller_indicators": [],
+        "spam_label": "",
+    }
+    with patch("requests.post", return_value=_tool_response(payload)):
+        spec = derive_from_plan("plan", api_key="k")
+
+    derived = ExtractionSchema.from_objective(spec)
+    merged = derived.overlay(recipes.load_schema("marketplace_listings"))
+
+    # Schema body from derive (NOT boat-listing's year/make).
+    assert merged.entity_name == "property listing"
+    assert merged.required_fields == ["address", "price"]
+    # Recipe vocabulary extends the empty derived lists.
+    assert "marinemax" in merged.spam_indicators
+    assert "brokerage" in merged.spam_seller_indicators
+
+
+# ── ObjectiveSpec round-trip ────────────────────────────────────────────
+
+
+def test_objective_spec_round_trips_new_fields() -> None:
+    """The new derive-time fields must round-trip through to_dict /
+    from_dict so saved specs survive process boundaries."""
+    spec = ObjectiveSpec(
+        raw_text="plan",
+        target_entity="boat listing",
+        output_schema=[OutputField(name="phone", required=True)],
+        viability_definition="phone present",
+        spam_text_indicators=["dealer"],
+        spam_seller_indicators=["llc"],
+        spam_label="dealer",
+    )
+    restored = ObjectiveSpec.from_dict(spec.to_dict())
+    assert restored.viability_definition == "phone present"
+    assert restored.spam_text_indicators == ["dealer"]
+    assert restored.spam_seller_indicators == ["llc"]
+    assert restored.spam_label == "dealer"


### PR DESCRIPTION
Issue #224 Phase 2 — additive producer that pairs with the Phase 1 overlay primitives shipped in #225.

## Summary

- ``mantis_agent.objective`` — new module exporting ``derive_from_plan`` plus the canonical re-exports of ``ObjectiveSpec`` / ``OutputField`` / ``CompletionCondition``. ``from mantis_agent.objective import ...`` is now the recommended import path.
- ``derive_from_plan(plan_text)`` — single Anthropic ``tool_use`` call with a strict input schema enforcing the response shape server-side. Replaces the legacy ``ObjectiveSpec.parse`` prose-parsing for the lift task; legacy heuristic remains as a fallback for offline / no-key contexts. Defaults to a Haiku-tier model since the lift task is small and gets re-run on every CI pass.
- In-process cache keyed by ``sha256(DERIVE_PROMPT_VERSION + plan_text)``. Repeated calls on the same plan body in the same process are free; bumping the prompt version invalidates every entry uniformly.
- ``ObjectiveSpec`` extended with ``viability_definition``, ``spam_text_indicators``, ``spam_seller_indicators``, ``spam_label`` — all default empty so existing direct-construction callers keep working unchanged. ``ExtractionSchema.from_objective`` already reads these via ``getattr`` with default, so the round-trip is safe today.

## Why

Phase 1 gave callers the merge primitives. Without a producer that lifts the structured spec from plan text, host integrations still have to pick a recipe by name (the gap the issue calls out). With ``derive_from_plan`` they can write::

    from mantis_agent import objective, recipes
    from mantis_agent.extraction import ExtractionSchema

    spec   = objective.derive_from_plan(plan_text)
    schema = ExtractionSchema.from_objective(spec).overlay(
        recipes.load_schema(name) if name else None
    )

— no domain string in host code, recipe is an optional hardening hint.

## Test plan

- [x] ``pytest tests/test_derive_from_plan.py`` — 14 cases: tool_use call shape, caching contract, prompt-version invalidation hash, all fallback paths (no key / API non-200 / no tool_use block / network error), end-to-end pipeline through ExtractionSchema.from_objective + recipes.overlay.
- [x] Full suite ``pytest -n auto`` — 1387 passed in 7m02s (1373 prior + 14 new).
- [x] ``ruff check`` clean on new + modified files.

## Phasing

Phase 3 (``run_probe`` helper) and Phase 4 (host-integration migration) ship independently. Existing callers continue to work unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)