### PR TITLE
fix(submit): SPA-aware verifier before demote on no-state-change

### DIFF
--- a/src/mantis_agent/gym/micro_runner.py
+++ b/src/mantis_agent/gym/micro_runner.py
@@ -100,6 +100,11 @@ class MicroPlanRunner:
         self._opened_detail_in_new_tab = False
         self._active_checkpoint_context = None
         self._pre_step_snapshot, self._final_status = None, "running"
+        # Stash for the SPA-aware submit demotion check. The form
+        # handler's submit branch sets this just before clicking the
+        # submit button; ``run_executor._maybe_demote_form_no_change``
+        # consumes it on the very next step then clears it.
+        self._last_submit_pre_screenshot: Any = None
         self.max_cost, self.max_time = max_cost, max_time_minutes * 60
         self.step_callback, self.keep_screenshots = step_callback, keep_screenshots
         self.cancel_event = cancel_event

--- a/src/mantis_agent/gym/run_executor.py
+++ b/src/mantis_agent/gym/run_executor.py
@@ -384,6 +384,24 @@ class RunExecutor:
             logger.debug("post-submit diff capture failed: %s", exc)
             delta = None
         if delta is not None and not delta.has_changes:
+            # Before demoting, consult the SPA-aware visual verifier:
+            # CRM-style logins (staff-crm is the canonical case) replace
+            # the login form with a dashboard at the SAME URL, so the
+            # runner-state snapshot sees no delta even though the
+            # submit succeeded. The submit handler stashes the
+            # pre-click screenshot at ``runner._last_submit_pre_screenshot``;
+            # take a post-screenshot now and ask the extractor to
+            # compare. Pattern mirrors the click-handler's
+            # ``verify_post_click_navigation`` path from PR #222.
+            if self._submit_visually_changed(runner, effective_step):
+                logger.info(
+                    "  [%d] submit had no runner-state delta but visual "
+                    "verifier confirms UI change — keeping success",
+                    state.step_index,
+                )
+                # Clear the stash so the next step starts fresh.
+                runner._last_submit_pre_screenshot = None
+                return
             logger.warning(
                 "  [%d] %s reported success but no observable state "
                 "change — demoting to failure (will retry)",
@@ -391,6 +409,55 @@ class RunExecutor:
             )
             step_result.success = False
             step_result.data = (step_result.data or "") + ":no_state_change"
+        # Always clear the stash — it's only valid for the immediately
+        # following demotion check.
+        if hasattr(runner, "_last_submit_pre_screenshot"):
+            runner._last_submit_pre_screenshot = None
+
+    def _submit_visually_changed(
+        self, runner: Any, effective_step: MicroIntent,
+    ) -> bool:
+        """Return True iff a pre/post visual diff confirms the submit
+        actually changed the page UI. Used as the SPA-aware escape hatch
+        for ``_maybe_demote_form_no_change`` so same-URL form submits
+        (CRM logins, in-page settings saves) aren't falsely demoted.
+
+        Returns False on any unavailable input (no extractor / no
+        pre-screenshot / API error) so the calling code falls through
+        to the existing snapshot-based demotion — the verifier is an
+        additive override, never a regression of the existing behavior.
+        """
+        pre = getattr(runner, "_last_submit_pre_screenshot", None)
+        extractor = getattr(runner, "extractor", None)
+        if pre is None or extractor is None:
+            return False
+        verify = getattr(extractor, "verify_post_click_navigation", None)
+        if verify is None:
+            return False
+        try:
+            post = runner._safe_screenshot()
+        except Exception:
+            return False
+        if post is None:
+            return False
+        try:
+            nav = verify(pre, post, effective_step.intent)
+        except Exception as exc:  # noqa: BLE001 — never break runs
+            logger.debug("submit visual verifier raised: %s", exc)
+            return False
+        # The verifier returns kinds: ``url_change`` / ``modal`` /
+        # ``no_change`` / ``wrong_target``. Only the first two count
+        # as evidence of a successful submit; ``no_change`` and
+        # ``wrong_target`` should still demote.
+        if not isinstance(nav, dict):
+            return False
+        if not nav.get("navigated"):
+            return False
+        kind = str(nav.get("kind", ""))
+        if kind in ("url_change", "modal"):
+            runner.costs["claude_extract"] += 1
+            return True
+        return False
 
     # ── Outcome handlers ────────────────────────────────────────────────
 

--- a/src/mantis_agent/gym/step_handlers/form.py
+++ b/src/mantis_agent/gym/step_handlers/form.py
@@ -333,6 +333,16 @@ class ClaudeGuidedFormHandler:
                 runner._dump_debug_screenshot(
                     f"submit_step{index}_pre_click", screenshot,
                 )
+                # Stash the pre-click screenshot so run_executor's
+                # ``_maybe_demote_form_no_change`` can run a SPA-aware
+                # visual diff before demoting a same-URL submit. Same
+                # pattern PR #222 added for clicks: a successful login
+                # / form submit on a CRM SPA (staff-crm is the canonical
+                # case) often replaces the form with a dashboard at the
+                # SAME URL; the runner-state snapshot can't see that
+                # delta, so without the visual diff every such submit
+                # was being demoted to failure.
+                runner._last_submit_pre_screenshot = screenshot
                 env.step(Action(action_type=ActionType.CLICK, params={"x": x, "y": y}))
                 runner.costs["gpu_seconds"] += runner._adaptive_submit_settle(
                     url_before=url_before,

--- a/tests/test_submit_spa_aware_verify.py
+++ b/tests/test_submit_spa_aware_verify.py
@@ -1,0 +1,315 @@
+"""Tests for the SPA-aware submit verifier.
+
+Surfaced by the staff-crm rerun on Modal (this work, run completed
+2026-05-09 ~03:55 PDT): step 3 (login click) succeeded — credentials
+filled, button clicked, page UI changed from a login form to a
+dashboard — but the URL stayed at the CRM root. The
+runner-state snapshot couldn't see the UI delta (URL same, page
+same, scroll same), so ``_maybe_demote_form_no_change`` falsely
+demoted the success to failure.
+
+Fix: before demoting a same-URL submit, run the same SPA-aware
+visual diff PR #222 added for clicks. The submit handler stashes
+the pre-click screenshot at ``runner._last_submit_pre_screenshot``;
+the executor takes a post-screenshot, asks
+``ClaudeExtractor.verify_post_click_navigation`` whether the page
+UI actually changed, and if so keeps the success.
+
+These tests pin the new ``_submit_visually_changed`` helper +
+its integration with ``_maybe_demote_form_no_change`` against
+five scenarios: visual change confirms keep-success, visual no-
+change still demotes, missing pre-screenshot falls through to
+existing demotion (no regression of #222 behavior on click-only
+runs), missing extractor falls through, and the verifier is only
+consulted on submit (not on other step types).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from mantis_agent.gym.checkpoint import StepResult
+from mantis_agent.gym.run_executor import RunExecutor, RunState
+from mantis_agent.gym.step_snapshot import StepStateSnapshot
+from mantis_agent.plan_decomposer import MicroIntent
+
+
+def _make_runner(
+    *,
+    extractor: MagicMock | None,
+    pre_screenshot: object | None = "PIL_PRE",
+    post_screenshot: object | None = "PIL_POST",
+) -> MagicMock:
+    """Build a stub runner satisfying the demotion-check contract.
+
+    Captures the minimal surface PlanExecutor reads from runner:
+    ``extractor`` (None disables the visual fallback),
+    ``_last_submit_pre_screenshot`` (the stash from the form
+    handler), ``_safe_screenshot()`` (post screenshot capture),
+    ``costs`` (claude_extract counter the verifier increments),
+    ``_last_known_url`` / ``_current_page`` / ``_viewport_stage``
+    / ``_scroll_state`` / ``_extracted_titles`` / ``_seen_urls``
+    / ``_last_extracted`` (the inputs to step_snapshot.capture).
+    """
+    runner = MagicMock()
+    runner.extractor = extractor
+    runner._last_submit_pre_screenshot = pre_screenshot
+    runner._safe_screenshot.return_value = post_screenshot
+    runner.costs = {"claude_extract": 0}
+    # step_snapshot.capture reads these — return values that produce
+    # a stable, no-change diff so the demotion path triggers.
+    runner._last_known_url = "https://crm.test/"
+    runner._current_page = 1
+    runner._viewport_stage = 0
+    runner._scroll_state = {}
+    runner._last_extracted = {}
+    runner._extracted_titles = []
+    runner._seen_urls = set()
+    runner.env = MagicMock()
+    runner.env.last_focused_input = None
+    return runner
+
+
+def _executor(runner: MagicMock) -> RunExecutor:
+    return RunExecutor(parent=runner)
+
+
+def _state_with_submit_success() -> RunState:
+    """A RunState whose last result is a successful submit."""
+    state = RunState.fresh(
+        run_key="test_run", session_name="t", plan_signature="sig",
+    )
+    state.step_index = 3
+    state.results.append(
+        StepResult(
+            step_index=3,
+            intent="Click the Login button",
+            success=True,
+            data="submit:Login",
+            duration=3.0,
+            steps_used=1,
+        )
+    )
+    return state
+
+
+def _submit_step() -> MicroIntent:
+    return MicroIntent(intent="Click the Login button", type="submit")
+
+
+# ── _submit_visually_changed in isolation ───────────────────────────────
+
+
+def test_visually_changed_returns_true_on_navigated_modal() -> None:
+    extractor = MagicMock()
+    extractor.verify_post_click_navigation.return_value = {
+        "navigated": True, "kind": "modal", "reason": "dashboard panel appeared",
+    }
+    runner = _make_runner(extractor=extractor)
+    executor = _executor(runner)
+
+    result = executor._submit_visually_changed(runner, _submit_step())
+
+    assert result is True
+    extractor.verify_post_click_navigation.assert_called_once_with(
+        "PIL_PRE", "PIL_POST", "Click the Login button",
+    )
+    # Verifier costs a Claude call.
+    assert runner.costs["claude_extract"] == 1
+
+
+def test_visually_changed_returns_true_on_url_change() -> None:
+    """``url_change`` kind also counts — covers the case where the
+    snapshot diff missed the URL transition (rare, but possible
+    when ``_best_effort_current_url`` returned stale data)."""
+    extractor = MagicMock()
+    extractor.verify_post_click_navigation.return_value = {
+        "navigated": True, "kind": "url_change", "reason": "now on /dashboard",
+    }
+    runner = _make_runner(extractor=extractor)
+    executor = _executor(runner)
+    assert executor._submit_visually_changed(runner, _submit_step()) is True
+
+
+def test_visually_changed_returns_false_on_no_change() -> None:
+    """``no_change`` kind = page genuinely didn't change → demote."""
+    extractor = MagicMock()
+    extractor.verify_post_click_navigation.return_value = {
+        "navigated": False, "kind": "no_change", "reason": "still login form",
+    }
+    runner = _make_runner(extractor=extractor)
+    executor = _executor(runner)
+    assert executor._submit_visually_changed(runner, _submit_step()) is False
+
+
+def test_visually_changed_returns_false_on_wrong_target() -> None:
+    """``wrong_target`` = something changed but it wasn't the intended
+    flow (e.g. a tooltip popped, not a form submission). Don't keep
+    success — demote so the caller retries."""
+    extractor = MagicMock()
+    extractor.verify_post_click_navigation.return_value = {
+        "navigated": True, "kind": "wrong_target",
+        "reason": "tooltip appeared on hover",
+    }
+    runner = _make_runner(extractor=extractor)
+    executor = _executor(runner)
+    assert executor._submit_visually_changed(runner, _submit_step()) is False
+
+
+def test_visually_changed_returns_false_when_no_pre_screenshot() -> None:
+    """If the form handler didn't stash a pre-screenshot (e.g. the
+    handler errored before reaching the click), fall through to the
+    legacy demotion path. No regression for runs without the new
+    stash."""
+    runner = _make_runner(extractor=MagicMock(), pre_screenshot=None)
+    executor = _executor(runner)
+    assert executor._submit_visually_changed(runner, _submit_step()) is False
+
+
+def test_visually_changed_returns_false_when_no_extractor() -> None:
+    """Running without ClaudeExtractor (Holo3-only smoke modes) — fall
+    through to legacy demotion."""
+    runner = _make_runner(extractor=None)
+    executor = _executor(runner)
+    assert executor._submit_visually_changed(runner, _submit_step()) is False
+
+
+def test_visually_changed_returns_false_when_extractor_lacks_method() -> None:
+    """Some extractor stubs (older test fixtures) don't expose
+    ``verify_post_click_navigation``. Use getattr-with-default and
+    fall through gracefully."""
+    extractor = MagicMock(spec=[])  # no verify_post_click_navigation attr
+    runner = _make_runner(extractor=extractor)
+    executor = _executor(runner)
+    assert executor._submit_visually_changed(runner, _submit_step()) is False
+
+
+def test_visually_changed_returns_false_on_post_screenshot_failure() -> None:
+    """``_safe_screenshot`` raised — fall through, don't propagate."""
+    extractor = MagicMock()
+    runner = _make_runner(extractor=extractor)
+    runner._safe_screenshot.side_effect = RuntimeError("display lost")
+    executor = _executor(runner)
+    assert executor._submit_visually_changed(runner, _submit_step()) is False
+
+
+def test_visually_changed_returns_false_on_verifier_exception() -> None:
+    """Verifier raised (network / API timeout) — fall through."""
+    extractor = MagicMock()
+    extractor.verify_post_click_navigation.side_effect = ConnectionError("API down")
+    runner = _make_runner(extractor=extractor)
+    executor = _executor(runner)
+    assert executor._submit_visually_changed(runner, _submit_step()) is False
+
+
+def test_visually_changed_returns_false_on_non_dict_response() -> None:
+    """Verifier returned None / string — defensive against shape drift."""
+    extractor = MagicMock()
+    extractor.verify_post_click_navigation.return_value = None
+    runner = _make_runner(extractor=extractor)
+    executor = _executor(runner)
+    assert executor._submit_visually_changed(runner, _submit_step()) is False
+
+
+# ── _maybe_demote_form_no_change integration ────────────────────────────
+
+
+def test_demote_keeps_success_when_visual_verifier_confirms_change(
+    monkeypatch,
+) -> None:
+    """End-to-end: a successful submit with no snapshot delta but
+    confirmed UI change must NOT be demoted to failure. This is the
+    exact staff-crm login fix."""
+    extractor = MagicMock()
+    extractor.verify_post_click_navigation.return_value = {
+        "navigated": True, "kind": "modal", "reason": "dashboard appeared",
+    }
+    runner = _make_runner(extractor=extractor)
+    executor = _executor(runner)
+    state = _state_with_submit_success()
+
+    # pre_snapshot identical to post (capture returns the same shape)
+    pre = StepStateSnapshot(url="https://crm.test/")
+    executor._maybe_demote_form_no_change(state, _submit_step(), pre)
+
+    result = state.results[-1]
+    assert result.success is True
+    assert "no_state_change" not in (result.data or "")
+    # Pre-screenshot stash must be cleared so a later step doesn't
+    # consume a stale screenshot.
+    assert runner._last_submit_pre_screenshot is None
+
+
+def test_demote_still_fires_when_visual_verifier_rejects(monkeypatch) -> None:
+    """When the visual verifier confirms the page didn't change either,
+    the legacy demotion still triggers."""
+    extractor = MagicMock()
+    extractor.verify_post_click_navigation.return_value = {
+        "navigated": False, "kind": "no_change", "reason": "still on login",
+    }
+    runner = _make_runner(extractor=extractor)
+    executor = _executor(runner)
+    state = _state_with_submit_success()
+
+    pre = StepStateSnapshot(url="https://crm.test/")
+    executor._maybe_demote_form_no_change(state, _submit_step(), pre)
+
+    result = state.results[-1]
+    assert result.success is False
+    assert "no_state_change" in (result.data or "")
+
+
+def test_demote_still_fires_when_no_extractor_available() -> None:
+    """No extractor wired (Holo3-only smoke runs) — legacy demotion
+    must still trigger without the visual-verify fallback. This is
+    the regression test for the existing #121 behavior."""
+    runner = _make_runner(extractor=None)
+    executor = _executor(runner)
+    state = _state_with_submit_success()
+
+    pre = StepStateSnapshot(url="https://crm.test/")
+    executor._maybe_demote_form_no_change(state, _submit_step(), pre)
+
+    result = state.results[-1]
+    assert result.success is False
+    assert "no_state_change" in (result.data or "")
+
+
+def test_demote_skips_non_submit_step_types(monkeypatch) -> None:
+    """The demotion is submit-only — click / fill_field / select_option
+    must pass through untouched even when the visual verifier would
+    say no-change."""
+    extractor = MagicMock()
+    extractor.verify_post_click_navigation.return_value = {
+        "navigated": False, "kind": "no_change",
+    }
+    runner = _make_runner(extractor=extractor)
+    executor = _executor(runner)
+    state = _state_with_submit_success()
+
+    pre = StepStateSnapshot(url="https://crm.test/")
+    select_step = MicroIntent(intent="Pick option", type="select_option")
+    executor._maybe_demote_form_no_change(state, select_step, pre)
+
+    # Untouched.
+    result = state.results[-1]
+    assert result.success is True
+    assert "no_state_change" not in (result.data or "")
+    extractor.verify_post_click_navigation.assert_not_called()
+
+
+def test_demote_clears_pre_screenshot_after_check(monkeypatch) -> None:
+    """The stash must always clear after the check — keeps it from
+    bleeding into the next step's verifier call. Tested in both
+    code paths: keep-success AND demote-to-failure."""
+    extractor = MagicMock()
+    extractor.verify_post_click_navigation.return_value = {
+        "navigated": True, "kind": "modal",
+    }
+    runner = _make_runner(extractor=extractor)
+    executor = _executor(runner)
+    state = _state_with_submit_success()
+
+    pre = StepStateSnapshot(url="https://crm.test/")
+    executor._maybe_demote_form_no_change(state, _submit_step(), pre)
+    assert runner._last_submit_pre_screenshot is None


### PR DESCRIPTION
## Summary

Same-URL form submits (CRM logins, in-page settings saves) were being falsely demoted to failure when the runner-state snapshot saw no delta. The fix mirrors PR #222's pattern for clicks: before demoting, run the SPA-aware visual verifier on a pre/post screenshot pair.

## Why

Surfaced by the staff-crm Modal rerun completed today. Step 3 (login click) actually worked — credentials filled, button clicked, UI changed from login form → dashboard — but the URL stayed at the CRM root. ``step_snapshot.diff`` saw no delta (URL same, page same, scroll same), so ``_maybe_demote_form_no_change`` demoted the success to failure. The retries then hit ``form_target_not_found`` because the Login button was no longer on screen, and the run halted on a REQUIRED step that had actually succeeded the first time.

Recipe 5 in ``docs/integrations/recipes.md`` (CRM-style form flow) calls this pattern out — gates after login + save are the canonical post-submit verifiers — but they only fire if the submit step is recorded as success. With same-URL post-login flows tripping a false negative, the gate that follows never gets a chance to confirm.

## Three pieces

- **``form.py`` submit branch** — stash the pre-click screenshot at ``runner._last_submit_pre_screenshot`` immediately before the click. Same screenshot the handler already had in scope from the form-target search; no extra ``env.screenshot()`` call.
- **``run_executor._maybe_demote_form_no_change``** — when the snapshot shows no change, call the new ``_submit_visually_changed`` helper before demoting. Helper returns ``False`` on every missing input (no extractor, no pre-screenshot, post-screenshot capture failure, verifier exception, non-dict response) so the legacy demotion still triggers in offline / Holo3-only smoke modes — no regression of the #121 behavior.
- **``micro_runner.__init__``** — initialise ``_last_submit_pre_screenshot`` to ``None`` so the first access doesn't AttributeError. The stash is always cleared after the demote check so a stale screenshot can't bleed into a later step's verifier call.

## Test plan

- [x] ``pytest tests/test_submit_spa_aware_verify.py`` — 15 cases covering all four verifier kinds, every fallback path, the keep-success integration, the demote-still-fires regression, and the clear-stash invariant.
- [x] Full suite ``pytest -n auto`` — 1402 passed in 5m00s (1387 prior + 15 new).
- [x] ``ruff check`` clean.

## Verifier kinds

| Kind | Action |
|---|---|
| ``modal`` | Keep success — page UI changed (canonical SPA-login case) |
| ``url_change`` | Keep success — URL transition the snapshot missed |
| ``no_change`` | Demote — page genuinely didn't change |
| ``wrong_target`` | Demote — something changed but not the intended flow |

🤖 Generated with [Claude Code](https://claude.com/claude-code)