### PR TITLE
chore(form): surface click coords + warn-level retry log for diagnosis

### DIFF
--- a/src/mantis_agent/gym/step_handlers/form.py
+++ b/src/mantis_agent/gym/step_handlers/form.py
@@ -314,7 +314,11 @@ class ClaudeGuidedFormHandler:
                     "kind of element (e.g. the row container instead of the "
                     "status pill, the link rather than the surrounding text)."
                 )
-                logger.info(
+                # Log at WARNING so the trace is visible in Modal's
+                # default INFO-suppressed log capture; this firing is
+                # the canonical signal that the agentic-retry loop
+                # actually engaged on a retry attempt.
+                logger.warning(
                     f"  [claude-form] submit '{label}' retry — feeding "
                     f"{len(failure_history)} prior failure(s) into search prompt"
                 )
@@ -480,11 +484,17 @@ class ClaudeGuidedFormHandler:
                 if url_after_click and url_after_click != url_before:
                     runner._last_known_url = url_after_click
 
-                logger.info(f"  [claude-form] submit '{label[:40]}'")
+                logger.info(f"  [claude-form] submit '{label[:40]}' at ({x}, {y})")
+                # Include the click coordinates in result.data so a
+                # post-mortem (or the agentic-retry feedback) can see
+                # whether successive retries actually picked different
+                # targets. Without coordinates, two failed retries with
+                # ``submit:Login`` data look identical even when they
+                # clicked different pixels.
                 return StepResult(
                     step_index=index, intent=step.intent, success=True,
                     steps_used=1, duration=3.0,
-                    data=f"submit:{label[:40]}",
+                    data=f"submit:{label[:40]}@({x},{y})",
                 )
             except Exception as e:
                 logger.warning(f"  [claude-form] submit failed: {e}")


### PR DESCRIPTION
Small observability follow-up to PR #230. The post-merge staff-crm rerun showed step 5/6 failing 3× with identical ``submit:Qualified:no_state_change`` data, but without coordinates we can't tell whether the agentic-retry feedback is making the LLM pick different targets across retries.

- ``submit:Login@(540,220)`` instead of ``submit:Login`` — three retries on the same label become distinguishable.
- ``[claude-form] submit 'X' retry — feeding N prior failure(s)`` bumped from ``info`` to ``warning`` so it survives Modal's INFO-suppressed log capture.

Existing tests assert ``result.data.startswith("submit:")`` so the format change is backwards-compatible.

70/70 affected tests pass, ruff clean.
🤖 Generated with [Claude Code](https://claude.com/claude-code)