### PR TITLE
feat(retry): handler escalation — submit→Holo3 on repeated wrong-handler failure

### DIFF
--- a/src/mantis_agent/gym/_runner_helpers.py
+++ b/src/mantis_agent/gym/_runner_helpers.py
@@ -611,6 +611,28 @@ def execute_step(
 ) -> StepResult:
     registry = runner._handler_registry
 
+    # Agentic handler-escalation — issue #224 follow-up. When prior
+    # failures on this step indicate the default handler is the
+    # wrong tool (canonical case: text-matching submit handler keeps
+    # clicking elements that match a label but produce no
+    # navigation), the executor sets
+    # ``runner._step_handler_override[index]`` so the next attempt
+    # routes through a different handler. Currently the only escalation
+    # target is ``"holo3"`` — the brain-grounded loop that operates
+    # on intent prose rather than text-matching specific labels.
+    # General-purpose: the override is set purely from observed
+    # failure patterns, no hardcoded plan content.
+    override = (
+        getattr(runner, "_step_handler_override", {}).get(index)
+        if hasattr(runner, "_step_handler_override") else None
+    )
+    if override == "holo3" and runner.brain is not None:
+        logger.info(
+            f"  [escalation] step {index} routing via Holo3StepHandler "
+            f"(brain-grounded loop) — original step.type={step.type}"
+        )
+        return execute_holo3_step(runner, step, index)
+
     if step.type == "click" and runner.extractor:
         layout_hint = (step.hints or {}).get("layout", "")
         is_listings = (

--- a/src/mantis_agent/gym/micro_runner.py
+++ b/src/mantis_agent/gym/micro_runner.py
@@ -120,6 +120,15 @@ class MicroPlanRunner:
         # by the executor on step success (so a successful retry
         # doesn't bleed warnings into the next step).
         self._step_failure_history: dict[int, list[dict[str, Any]]] = {}
+        # Per-step handler-routing override — set by the executor when
+        # a step has accumulated enough same-kind failures that the
+        # default handler is clearly the wrong tool. Currently the only
+        # value is ``"brain_grounded_click"`` which routes a submit /
+        # fill step through the click handler with brain grounding
+        # (Holo3) instead of Claude text-matching. General-purpose:
+        # triggered purely by observed failure pattern, not plan
+        # content. Cleared on step success.
+        self._step_handler_override: dict[int, str] = {}
         self.max_cost, self.max_time = max_cost, max_time_minutes * 60
         self.step_callback, self.keep_screenshots = step_callback, keep_screenshots
         self.cancel_event = cancel_event

--- a/src/mantis_agent/gym/run_executor.py
+++ b/src/mantis_agent/gym/run_executor.py
@@ -422,6 +422,16 @@ class RunExecutor:
                 kind="no_state_change",
                 reason="snapshot diff and visual verifier both saw no UI change",
             )
+            # Pattern-match the failure history for handler escalation.
+            # When the same step has accumulated 2+ same-kind failures,
+            # the default handler is locked on the wrong element class
+            # (e.g. text-matching a status pill instead of a row link).
+            # The next retry should route through a different handler
+            # — currently Holo3StepHandler, which uses brain grounding
+            # over the intent prose rather than text matching.
+            self._maybe_set_handler_override(
+                runner=runner, step_index=state.step_index,
+            )
         # Always clear the per-step stashes — they're only valid for
         # the immediately following demotion check.
         if hasattr(runner, "_last_submit_pre_screenshot"):
@@ -463,6 +473,55 @@ class RunExecutor:
             "kind": kind,
             "reason": reason,
         })
+
+    @staticmethod
+    def _maybe_set_handler_override(
+        *, runner: Any, step_index: int,
+    ) -> None:
+        """Decide whether the next retry should route through a
+        different handler based on the failure history pattern.
+
+        The escalation triggers when the per-step failure history
+        accumulates 2+ records of the same ``kind`` (currently only
+        ``no_state_change`` triggers escalation — that's the strongest
+        signal that the default handler is finding text matches that
+        don't actually navigate). Sets
+        ``runner._step_handler_override[step_index] = "holo3"`` so the
+        dispatcher routes the next attempt through ``Holo3StepHandler``
+        — the brain-grounded loop that operates on intent prose
+        rather than label text matching.
+
+        General-purpose: triggered purely by observed failure pattern,
+        no hardcoded plan content. Cleared on step success
+        (see :meth:`_handle_success`).
+
+        Side effects: mutates ``runner._step_handler_override`` only.
+        Idempotent — calling twice with the same trigger produces
+        the same override; the dispatcher consumes it once per
+        retry attempt.
+        """
+        if not hasattr(runner, "_step_handler_override"):
+            return
+        history = (
+            runner._step_failure_history.get(step_index, [])
+            if hasattr(runner, "_step_failure_history") else []
+        )
+        # Count kinds eligible for escalation. Only no_state_change
+        # signals "the click happened but the page didn't change" —
+        # the canonical wrong-handler symptom. Other kinds
+        # (form_target_not_found, fill_error, etc.) indicate
+        # different problems where Holo3 wouldn't necessarily help.
+        no_state_changes = sum(
+            1 for r in history if r.get("kind") == "no_state_change"
+        )
+        if no_state_changes >= 2 and runner.brain is not None:
+            runner._step_handler_override[step_index] = "holo3"
+            logger.warning(
+                "  [escalation] step %d: %d×no_state_change → next "
+                "retry will route through Holo3StepHandler (brain "
+                "grounding) instead of the default text-match handler",
+                step_index, no_state_changes,
+            )
 
     def _submit_visually_changed(
         self, runner: Any, effective_step: MicroIntent,
@@ -542,6 +601,11 @@ class RunExecutor:
         # happens to share the same step_index (loops, resumed plans).
         if hasattr(runner, "_step_failure_history"):
             runner._step_failure_history.pop(state.step_index, None)
+        # Same for the handler override — once a step has succeeded,
+        # the override is consumed and a future occurrence of the
+        # same step_index starts with the default routing.
+        if hasattr(runner, "_step_handler_override"):
+            runner._step_handler_override.pop(state.step_index, None)
 
         if step.type == "paginate":
             # Phase 4: listings-scan reset is one method on the scanner now,

--- a/tests/test_handler_escalation.py
+++ b/tests/test_handler_escalation.py
@@ -1,0 +1,342 @@
+"""Tests for the agentic handler-escalation loop (#224 follow-up).
+
+Surfaced by the staff-crm post-PR-#231 rerun: the agentic-retry
+feedback (#230) successfully made the LLM pick different
+coordinates on each retry — but all three coordinates landed in
+the same problematic region (left-edge status-pill column) because
+the form handler's ``find_form_target`` is fundamentally a label-
+text matcher. With the search prompt asking it to find a button
+labeled "Qualified", every match is going to be the visible
+"Qualified" status pill, never the row link.
+
+The fix: when the same step has accumulated 2+ ``no_state_change``
+failures, the default handler is locked on the wrong element class.
+The runtime escalates to ``Holo3StepHandler`` for the next retry —
+brain grounding over intent prose ("click the first lead row whose
+status is qualified") instead of label text matching.
+
+These tests pin:
+
+- ``_maybe_set_handler_override`` decision logic (trigger threshold,
+  kind specificity, no-brain guard)
+- The dispatcher's escalation routing (``execute_step`` reads the
+  override before normal type-based routing)
+- Per-step-index isolation (failures on step 5 don't escalate step 7)
+- Success-path clearing (override cleared after a successful step)
+
+General-purpose contract: the trigger is purely the observed
+failure pattern. No plan-specific terms, no domain hardcoding —
+the same logic kicks in for any submit step that keeps clicking
+elements that don't navigate.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from mantis_agent.gym.checkpoint import StepResult
+from mantis_agent.gym.run_executor import RunExecutor, RunState
+from mantis_agent.gym.step_snapshot import StepStateSnapshot
+from mantis_agent.plan_decomposer import MicroIntent
+
+
+def _make_runner(
+    *,
+    extractor: MagicMock | None = None,
+    brain: MagicMock | None = None,
+    history: list[dict] | None = None,
+) -> MagicMock:
+    runner = MagicMock()
+    runner.extractor = extractor
+    runner.brain = brain or MagicMock()
+    runner._last_submit_pre_screenshot = None
+    runner._last_submit_target = None
+    runner._step_failure_history = {5: history or []}
+    runner._step_handler_override = {}
+    runner.costs = {"claude_extract": 0}
+    runner._last_known_url = "https://crm.test/"
+    runner._current_page = 1
+    runner._viewport_stage = 0
+    runner._scroll_state = {}
+    runner._last_extracted = {}
+    runner._extracted_titles = []
+    runner._seen_urls = set()
+    runner.env = MagicMock()
+    runner.env.last_focused_input = None
+    return runner
+
+
+# ── _maybe_set_handler_override decision logic ───────────────────────────
+
+
+def test_one_failure_does_not_escalate() -> None:
+    """A single failure isn't enough signal to switch handlers — could
+    be a render race or first-time scrolling miss. Wait for the
+    pattern to stabilize over 2+ same-kind failures."""
+    runner = _make_runner(history=[
+        {"x": 39, "y": 137, "label": "Qualified", "kind": "no_state_change"},
+    ])
+    RunExecutor._maybe_set_handler_override(runner=runner, step_index=5)
+    assert 5 not in runner._step_handler_override
+
+
+def test_two_no_state_change_failures_escalate_to_holo3() -> None:
+    """The canonical trigger: 2× ``no_state_change`` on the same step
+    means the click is happening but the page never updates — the
+    default text-match handler is finding wrong elements. Escalate
+    to brain-grounded routing for the next retry."""
+    runner = _make_runner(history=[
+        {"x": 39, "y": 137, "label": "Qualified", "kind": "no_state_change"},
+        {"x": 66, "y": 395, "label": "Qualified", "kind": "no_state_change"},
+    ])
+    RunExecutor._maybe_set_handler_override(runner=runner, step_index=5)
+    assert runner._step_handler_override[5] == "holo3"
+
+
+def test_three_no_state_change_failures_still_escalate() -> None:
+    """Idempotent — re-calling after a third failure keeps the
+    override (the dispatcher consumes it once per retry but the
+    record stays so a later success can clear it cleanly)."""
+    runner = _make_runner(history=[
+        {"x": 1, "y": 1, "label": "X", "kind": "no_state_change"},
+        {"x": 2, "y": 2, "label": "X", "kind": "no_state_change"},
+        {"x": 3, "y": 3, "label": "X", "kind": "no_state_change"},
+    ])
+    RunExecutor._maybe_set_handler_override(runner=runner, step_index=5)
+    assert runner._step_handler_override[5] == "holo3"
+
+
+def test_form_target_not_found_does_not_escalate() -> None:
+    """``form_target_not_found`` indicates the button isn't on the
+    page (rendering issue, button truly missing) — Holo3 wouldn't
+    help there. The escalation is specific to ``no_state_change``
+    which signals "the click happened but the page didn't change."
+    """
+    runner = _make_runner(history=[
+        {"x": None, "y": None, "label": "Save", "kind": "form_target_not_found"},
+        {"x": None, "y": None, "label": "Save", "kind": "form_target_not_found"},
+    ])
+    RunExecutor._maybe_set_handler_override(runner=runner, step_index=5)
+    assert 5 not in runner._step_handler_override
+
+
+def test_mixed_kinds_count_only_no_state_change() -> None:
+    """One ``no_state_change`` plus one ``form_target_not_found``
+    isn't 2× of the same kind — don't escalate. The pattern needs
+    to be stable for the trigger to fire."""
+    runner = _make_runner(history=[
+        {"x": 39, "y": 137, "label": "X", "kind": "no_state_change"},
+        {"x": None, "y": None, "label": "X", "kind": "form_target_not_found"},
+    ])
+    RunExecutor._maybe_set_handler_override(runner=runner, step_index=5)
+    assert 5 not in runner._step_handler_override
+
+
+def test_no_brain_disables_escalation() -> None:
+    """Holo3 brain is the escalation target — without it, escalation
+    is meaningless. Don't set the override; let the default retry
+    path play out instead."""
+    runner = _make_runner(history=[
+        {"x": 1, "y": 1, "label": "X", "kind": "no_state_change"},
+        {"x": 2, "y": 2, "label": "X", "kind": "no_state_change"},
+    ])
+    runner.brain = None
+    RunExecutor._maybe_set_handler_override(runner=runner, step_index=5)
+    assert 5 not in runner._step_handler_override
+
+
+def test_escalation_is_per_step_index() -> None:
+    """Failures on step 5 must not escalate step 7. Each step's
+    history is independent."""
+    runner = _make_runner(history=[
+        {"x": 1, "y": 1, "label": "X", "kind": "no_state_change"},
+        {"x": 2, "y": 2, "label": "X", "kind": "no_state_change"},
+    ])
+    runner._step_failure_history = {5: runner._step_failure_history[5]}
+    RunExecutor._maybe_set_handler_override(runner=runner, step_index=5)
+    RunExecutor._maybe_set_handler_override(runner=runner, step_index=7)
+    assert runner._step_handler_override.get(5) == "holo3"
+    assert 7 not in runner._step_handler_override
+
+
+def test_runner_without_failure_history_attr_is_safe() -> None:
+    """Guard against runners constructed via test fixtures that
+    don't initialise ``_step_failure_history`` / ``_step_handler_override``."""
+    runner = MagicMock()
+    runner.brain = MagicMock()
+    # Deliberately strip the new fields.
+    del runner._step_failure_history
+    del runner._step_handler_override
+    # Must not raise.
+    RunExecutor._maybe_set_handler_override(runner=runner, step_index=5)
+
+
+# ── _maybe_demote_form_no_change records + escalates ───────────────────
+
+
+def test_demote_path_records_and_then_escalates() -> None:
+    """End-to-end: two demoted submits in a row → second demotion
+    triggers escalation. The first demotion records but doesn't
+    escalate (only 1 record); the second demotion records (now
+    2 records) and sets the override."""
+    runner = _make_runner()
+    runner._last_submit_target = {
+        "x": 39, "y": 137, "label": "Qualified", "matched_label": "Qualified",
+    }
+    runner._step_failure_history = {}
+
+    executor = RunExecutor(parent=runner)
+
+    # First demotion attempt.
+    state = RunState.fresh(run_key="t", session_name="t", plan_signature="sig")
+    state.step_index = 5
+    state.results.append(StepResult(
+        step_index=5, intent="Click Qualified lead",
+        success=True, data="submit:Qualified", duration=3.0, steps_used=1,
+    ))
+    pre = StepStateSnapshot(url="https://crm.test/")
+    submit_step = MicroIntent(intent="Click Qualified lead", type="submit")
+
+    executor._maybe_demote_form_no_change(state, submit_step, pre)
+    # First demotion: 1 record, no override yet.
+    assert len(runner._step_failure_history[5]) == 1
+    assert 5 not in runner._step_handler_override
+
+    # Second attempt — different click target.
+    runner._last_submit_target = {
+        "x": 66, "y": 395, "label": "Qualified", "matched_label": "Qualified",
+    }
+    state.results.append(StepResult(
+        step_index=5, intent="Click Qualified lead",
+        success=True, data="submit:Qualified@(66,395)", duration=3.0,
+        steps_used=1,
+    ))
+    executor._maybe_demote_form_no_change(state, submit_step, pre)
+    # Second demotion: 2 records, override now set.
+    assert len(runner._step_failure_history[5]) == 2
+    assert runner._step_handler_override[5] == "holo3"
+
+
+# ── Dispatcher routing reads the override ──────────────────────────────
+
+
+def test_dispatcher_routes_to_holo3_when_override_set() -> None:
+    """``execute_step`` must consult ``_step_handler_override``
+    before normal type-based routing. When set to ``"holo3"``,
+    the step routes through ``Holo3StepHandler`` regardless of
+    the original step.type."""
+    from mantis_agent.gym import _runner_helpers
+
+    runner = MagicMock()
+    runner.brain = MagicMock()
+    runner.extractor = MagicMock()
+    runner._step_handler_override = {5: "holo3"}
+    runner._handler_registry = MagicMock()
+
+    holo3_called = []
+
+    def _stub_holo3(r, step, idx):
+        holo3_called.append((idx, step.type))
+        return StepResult(
+            step_index=idx, intent=step.intent, success=True,
+            data="holo3-completed", duration=5.0, steps_used=3,
+        )
+
+    submit_step = MicroIntent(
+        intent="Click Qualified lead", type="submit",
+        params={"label": "Qualified"},
+    )
+
+    # Patch execute_holo3_step so the test doesn't try to spin up
+    # a real GymRunner.
+    orig = _runner_helpers.execute_holo3_step
+    _runner_helpers.execute_holo3_step = _stub_holo3
+    try:
+        result = _runner_helpers.execute_step(runner, submit_step, 5)
+    finally:
+        _runner_helpers.execute_holo3_step = orig
+
+    assert result.success is True
+    assert result.data == "holo3-completed"
+    # Holo3 was called with the original step (preserves intent /
+    # type for any downstream verification).
+    assert holo3_called == [(5, "submit")]
+    # Default registry handlers were not touched.
+    runner._handler_registry.get.assert_not_called()
+
+
+def test_dispatcher_skips_escalation_when_no_override() -> None:
+    """No override set → normal type-based routing applies. This is
+    the regression test for the unmodified happy path."""
+    from mantis_agent.gym import _runner_helpers
+
+    runner = MagicMock()
+    runner.brain = MagicMock()
+    runner.extractor = MagicMock()
+    runner._step_handler_override = {}  # empty — no escalation
+
+    holo3_called = []
+    _runner_helpers_holo3 = _runner_helpers.execute_holo3_step
+    _runner_helpers.execute_holo3_step = lambda *a: holo3_called.append(a)
+    try:
+        # Use a click step to drive normal listings routing.
+        click_step = MicroIntent(
+            intent="Click next listing", type="click",
+            section="extraction",
+        )
+        # Stub the registry handler the click path hits.
+        registry_handler = MagicMock()
+        registry_handler.execute.return_value = StepResult(
+            step_index=2, intent="Click next listing", success=True,
+        )
+        runner._handler_registry = MagicMock()
+        runner._handler_registry.get.return_value = registry_handler
+
+        # Stub ensure_results_filters so we don't need the full plan/state.
+        orig_ensure = _runner_helpers.ensure_results_filters
+        _runner_helpers.ensure_results_filters = lambda r, i: True
+        try:
+            _runner_helpers.execute_step(runner, click_step, 2)
+        finally:
+            _runner_helpers.ensure_results_filters = orig_ensure
+    finally:
+        _runner_helpers.execute_holo3_step = _runner_helpers_holo3
+
+    # Holo3 was NOT called — normal click routing applied.
+    assert holo3_called == []
+
+
+def test_dispatcher_skips_escalation_when_no_brain() -> None:
+    """Override set but brain is None — fall through to normal
+    routing rather than crash the run."""
+    from mantis_agent.gym import _runner_helpers
+
+    runner = MagicMock()
+    runner.brain = None
+    runner.extractor = MagicMock()
+    runner._step_handler_override = {5: "holo3"}
+
+    # Stub a click step + registry handler.
+    click_step = MicroIntent(
+        intent="Click X", type="click", section="extraction",
+    )
+    registry_handler = MagicMock()
+    registry_handler.execute.return_value = StepResult(
+        step_index=5, intent="Click X", success=True,
+    )
+    runner._handler_registry = MagicMock()
+    runner._handler_registry.get.return_value = registry_handler
+
+    orig_ensure = _runner_helpers.ensure_results_filters
+    _runner_helpers.ensure_results_filters = lambda r, i: True
+    holo3_called = []
+    orig_holo3 = _runner_helpers.execute_holo3_step
+    _runner_helpers.execute_holo3_step = lambda *a: holo3_called.append(a)
+    try:
+        _runner_helpers.execute_step(runner, click_step, 5)
+    finally:
+        _runner_helpers.ensure_results_filters = orig_ensure
+        _runner_helpers.execute_holo3_step = orig_holo3
+
+    # Holo3 was NOT called — no-brain guard fired.
+    assert holo3_called == []


### PR DESCRIPTION
## Summary

Option 2 — when retry feedback (#230) isn't enough, switch handlers entirely. The runtime detects when a step has accumulated 2+ ``no_state_change`` failures and re-routes the next retry through ``Holo3StepHandler`` (brain-grounded loop) instead of the default text-match ``find_form_target``.

## Why

Post-PR-#231 staff-crm rerun confirmed the agentic-retry feedback IS firing — the LLM picked different coordinates each retry: ``(39,137)``, ``(66,395)``, ``(36,395)``. But all three landed in the same problematic region (left-edge status-pill column). Reason: ``find_form_target`` is a label-text matcher. With the prompt asking for a button labeled ``Qualified``, every match is the visible status pill, never the row link.

Holo3 is the right tool for "click the first lead row whose status is qualified" — it's a vision-language model trained for screenshot + intent → click target. It can recognise the row navigation rather than fixating on the status text.

## General-purpose contract

- Trigger is purely observed failure pattern. **No plan-specific terms, no domain hardcoding.** Same trigger fires for any submit step that keeps clicking elements that don't navigate.
- Escalates only on ``no_state_change`` (signals "click happened but page didn't change"). Other kinds (``form_target_not_found``, ``fill_error``) indicate different problems where Holo3 wouldn't help.
- Falls through cleanly when ``runner.brain is None`` — offline / test runs aren't broken.

## Three pieces

- **``micro_runner.__init__``** — new ``_step_handler_override: dict[int, str] = {}``.
- **``run_executor._maybe_set_handler_override``** — called after ``_record_failure_for_retry``. Counts ``no_state_change`` records; sets override to ``"holo3"`` when count >= 2 and brain present. ``_handle_success`` clears the override symmetrically.
- **``_runner_helpers.execute_step``** — checks the override BEFORE normal type-based routing. When set to ``"holo3"``, dispatches via ``execute_holo3_step``.

## Test plan

- [x] ``pytest tests/test_handler_escalation.py`` — 12 cases: trigger threshold, kind specificity, no-brain guard, per-step-index isolation, defensive missing-attributes, end-to-end demote→record→escalate, dispatcher routing (escalation routes / no-override skips / no-brain skips).
- [x] Targeted regression: ``test_agentic_retry_feedback`` + ``test_submit_spa_aware_verify`` + ``test_form_intents`` + ``test_form_handler`` — 82/82.
- [x] Full suite ``pytest -n auto`` — 1438/1438 in 8m36s.
- [x] ``ruff check`` clean.

## Escalation stack so far

| PR | Layer |
|---|---|
| #228 | SPA-aware verify — accepts same-URL UI changes |
| #229 | Agentic scroll search — End/Home before Page_Down sweep |
| #230 | Failure-aware retries — feeds prior targets to next attempt |
| #231 | Observability — coords in result.data, warn-level retry log |
| this | When feedback isn't enough, switch handlers entirely |

🤖 Generated with [Claude Code](https://claude.com/claude-code)