### PR TITLE
fix(escalation): bump Holo3 budget for scroll-and-find on escalated steps

### DIFF
--- a/src/mantis_agent/gym/_runner_helpers.py
+++ b/src/mantis_agent/gym/_runner_helpers.py
@@ -627,11 +627,32 @@ def execute_step(
         if hasattr(runner, "_step_handler_override") else None
     )
     if override == "holo3" and runner.brain is not None:
-        logger.info(
-            f"  [escalation] step {index} routing via Holo3StepHandler "
-            f"(brain-grounded loop) — original step.type={step.type}"
+        # Bump the budget on escalation — the canonical case is
+        # "scroll down to find an off-screen target then click it"
+        # which needs 5-15 brain turns, not the submit step's
+        # default 3-5. Without the bump, Holo3 correctly identifies
+        # the right approach (scroll + observe + click) but runs
+        # out of inferences before reaching the target.
+        escalated_budget = max(step.budget, 15)
+        escalated_step = MicroIntent(
+            intent=step.intent, type=step.type,
+            verify=step.verify, budget=escalated_budget,
+            reverse=step.reverse, grounding=step.grounding,
+            section=step.section, required=step.required,
+            gate=step.gate, claude_only=step.claude_only,
+            loop_target=step.loop_target,
+            loop_count=step.loop_count,
+            params=step.params, hints=step.hints,
         )
-        return execute_holo3_step(runner, step, index)
+        # WARNING level so the trace survives Modal's INFO-suppressed
+        # log capture. Firing this is the canonical signal that the
+        # agentic-handler-escalation path engaged on a retry attempt.
+        logger.warning(
+            f"  [escalation] step {index} routing via Holo3StepHandler "
+            f"(brain-grounded loop, budget={escalated_budget}, "
+            f"was={step.budget}) — original step.type={step.type}"
+        )
+        return execute_holo3_step(runner, escalated_step, index)
 
     if step.type == "click" and runner.extractor:
         layout_hint = (step.hints or {}).get("layout", "")

--- a/tests/test_handler_escalation.py
+++ b/tests/test_handler_escalation.py
@@ -244,13 +244,21 @@ def test_dispatcher_routes_to_holo3_when_override_set() -> None:
 
     submit_step = MicroIntent(
         intent="Click Qualified lead", type="submit",
+        budget=4,  # the typical submit budget — too tight for scroll-and-find
         params={"label": "Qualified"},
     )
 
     # Patch execute_holo3_step so the test doesn't try to spin up
-    # a real GymRunner.
+    # a real GymRunner. Capture the synthesized step so we can
+    # assert the escalation budget bump.
+    captured_step: list = []
+
+    def _stub_holo3_capture(r, step_arg, idx):
+        captured_step.append(step_arg)
+        return _stub_holo3(r, step_arg, idx)
+
     orig = _runner_helpers.execute_holo3_step
-    _runner_helpers.execute_holo3_step = _stub_holo3
+    _runner_helpers.execute_holo3_step = _stub_holo3_capture
     try:
         result = _runner_helpers.execute_step(runner, submit_step, 5)
     finally:
@@ -258,9 +266,15 @@ def test_dispatcher_routes_to_holo3_when_override_set() -> None:
 
     assert result.success is True
     assert result.data == "holo3-completed"
-    # Holo3 was called with the original step (preserves intent /
-    # type for any downstream verification).
+    # Holo3 was called with the original step type / intent —
+    # we don't morph the step into a click, just route differently.
     assert holo3_called == [(5, "submit")]
+    # The synthesised step that reached Holo3 has a bumped budget.
+    # Original budget=4 is too tight for "scroll down to find off-
+    # screen target + click"; the escalation path bumps to >= 15.
+    assert captured_step[0].intent == "Click Qualified lead"
+    assert captured_step[0].type == "submit"
+    assert captured_step[0].budget >= 15
     # Default registry handlers were not touched.
     runner._handler_registry.get.assert_not_called()
 


### PR DESCRIPTION
## Summary

When the dispatcher escalates a failed submit to ``Holo3StepHandler`` (#232), synthesise a new ``MicroIntent`` with ``budget=max(step.budget, 15)``. All other fields preserved — only the budget changes, only on escalation.

## Why

Post-PR-#232 staff-crm rerun confirmed escalation IS working AND Holo3 correctly diagnoses the real problem. The reasoning trace from the brain:

> *"The agent is stuck clicking the same coordinates repeatedly; I need to scroll down to find a lead row with 'Qualified' status, which is not visible in the current view showing only 'Contacted', 'New', 'Proposal', and 'Negotiation' statuses."*

So the form handler kept clicking labels that looked like "Qualified" — but they're filter chips and breadcrumbs, not actual Qualified rows. The real Qualified leads are below the fold. Holo3 sees this and tries to scroll. Scroll-and-find needs 5-15 brain turns; the original submit step's budget (typically 3-5) ran out before reaching the target.

## Test plan

- [x] All 12 escalation tests pass (one updated to assert budget >= 15 on routed step)
- [x] ``ruff check`` clean
- Stack with prior PRs:

  | PR | Layer |
  |---|---|
  | #228 | SPA-aware verify |
  | #229 | End/Home before Page_Down sweep |
  | #230 | Failure-aware retries |
  | #231 | Coords in result.data |
  | #232 | Switch handler on repeated wrong-handler signal |
  | this | Give the new handler enough budget to actually fix it |

🤖 Generated with [Claude Code](https://claude.com/claude-code)