### PR TITLE
feat(escalation): pagination-aware Holo3 prompt + budget bump 15→25

### DIFF
--- a/src/mantis_agent/gym/_runner_helpers.py
+++ b/src/mantis_agent/gym/_runner_helpers.py
@@ -628,14 +628,54 @@ def execute_step(
     )
     if override == "holo3" and runner.brain is not None:
         # Bump the budget on escalation — the canonical case is
-        # "scroll down to find an off-screen target then click it"
-        # which needs 5-15 brain turns, not the submit step's
-        # default 3-5. Without the bump, Holo3 correctly identifies
-        # the right approach (scroll + observe + click) but runs
-        # out of inferences before reaching the target.
-        escalated_budget = max(step.budget, 15)
+        # "scroll down to find an off-screen target then click it",
+        # but in CRM / settings flows the target may also live on a
+        # LATER page that requires pagination. 25 brain turns covers
+        # scroll + paginate + multi-page search without being
+        # extravagant; the original submit budget (3-5) was nowhere
+        # near enough.
+        escalated_budget = max(step.budget, 25)
+
+        # Augment the task prose with failure context. Holo3 sees the
+        # screenshots and reasons about page state directly, but
+        # giving it the prior failure trace means it doesn't re-pick
+        # the same wrong elements the form handler already tried, and
+        # gets explicit licence to paginate when the visible viewport
+        # has no matching target. The escalation only fires after
+        # 2+ confirmed no-state-change clicks, so the failure trace
+        # is already information the brain needs.
+        history = (
+            getattr(runner, "_step_failure_history", {}).get(index, [])
+            if hasattr(runner, "_step_failure_history") else []
+        )
+        augmented_intent = step.intent
+        if history:
+            wrong_targets = [
+                f"({r.get('x', '?')}, {r.get('y', '?')}) labelled "
+                f"'{r.get('label', '?')}'"
+                for r in history[-3:]
+            ]
+            augmented_intent = (
+                f"{step.intent}\n\n"
+                f"CONTEXT: previous attempts to satisfy this step clicked "
+                f"on these targets without changing the page UI: "
+                f"{', '.join(wrong_targets)}. "
+                f"That means those clicks landed on text that LOOKED like "
+                f"the target (status badge, filter chip, label) but is "
+                f"not actually the navigable element. Possible reasons:\n"
+                f"  - the real target is below the fold (scroll down to find it)\n"
+                f"  - the real target is on a LATER page (use pagination "
+                f"controls — Next button, page-number links, or scroll "
+                f"the table to load more rows)\n"
+                f"  - the visible page state genuinely has zero matching "
+                f"items; check filter / sort / status indicators to "
+                f"confirm before giving up\n"
+                f"Pick a different element or navigation action than the "
+                f"prior attempts."
+            )
+
         escalated_step = MicroIntent(
-            intent=step.intent, type=step.type,
+            intent=augmented_intent, type=step.type,
             verify=step.verify, budget=escalated_budget,
             reverse=step.reverse, grounding=step.grounding,
             section=step.section, required=step.required,
@@ -650,7 +690,8 @@ def execute_step(
         logger.warning(
             f"  [escalation] step {index} routing via Holo3StepHandler "
             f"(brain-grounded loop, budget={escalated_budget}, "
-            f"was={step.budget}) — original step.type={step.type}"
+            f"was={step.budget}, history={len(history)} prior failure(s)) "
+            f"— original step.type={step.type}"
         )
         return execute_holo3_step(runner, escalated_step, index)
 

--- a/tests/test_handler_escalation.py
+++ b/tests/test_handler_escalation.py
@@ -266,17 +266,79 @@ def test_dispatcher_routes_to_holo3_when_override_set() -> None:
 
     assert result.success is True
     assert result.data == "holo3-completed"
-    # Holo3 was called with the original step type / intent —
-    # we don't morph the step into a click, just route differently.
+    # Holo3 was called preserving the original step.type — we don't
+    # morph the step into a click, just route differently.
     assert holo3_called == [(5, "submit")]
     # The synthesised step that reached Holo3 has a bumped budget.
-    # Original budget=4 is too tight for "scroll down to find off-
-    # screen target + click"; the escalation path bumps to >= 15.
-    assert captured_step[0].intent == "Click Qualified lead"
+    # Original budget=4 is too tight for "scroll down then maybe
+    # paginate to find off-screen target"; escalation bumps to >= 25.
     assert captured_step[0].type == "submit"
-    assert captured_step[0].budget >= 15
+    assert captured_step[0].budget >= 25
+    # Intent prose preserved at the start (no history → no augment).
+    assert captured_step[0].intent.startswith("Click Qualified lead")
     # Default registry handlers were not touched.
     runner._handler_registry.get.assert_not_called()
+
+
+def test_dispatcher_augments_intent_with_failure_history_when_present() -> None:
+    """When the runner has accumulated failure records for this step,
+    the dispatcher's escalation path must surface them in the
+    Holo3-bound task prose. Holo3 sees screenshots directly, but
+    giving it the failure trace means it doesn't re-try the same
+    wrong elements and gets explicit licence to paginate when the
+    visible viewport has no matching target."""
+    from mantis_agent.gym import _runner_helpers
+
+    runner = MagicMock()
+    runner.brain = MagicMock()
+    runner.extractor = MagicMock()
+    runner._step_handler_override = {5: "holo3"}
+    runner._step_failure_history = {
+        5: [
+            {"x": 39, "y": 137, "label": "Qualified",
+             "matched_label": "Qualified",
+             "kind": "no_state_change", "reason": ""},
+            {"x": 66, "y": 395, "label": "Qualified",
+             "matched_label": "Qualified",
+             "kind": "no_state_change", "reason": ""},
+        ],
+    }
+    runner._handler_registry = MagicMock()
+
+    captured_step: list = []
+
+    def _capture(r, step_arg, idx):
+        captured_step.append(step_arg)
+        return StepResult(
+            step_index=idx, intent=step_arg.intent, success=True,
+            data="holo3-completed",
+        )
+
+    submit_step = MicroIntent(
+        intent="Click the first lead row whose Status is Qualified",
+        type="submit", budget=4,
+        params={"label": "Qualified"},
+    )
+    orig = _runner_helpers.execute_holo3_step
+    _runner_helpers.execute_holo3_step = _capture
+    try:
+        _runner_helpers.execute_step(runner, submit_step, 5)
+    finally:
+        _runner_helpers.execute_holo3_step = orig
+
+    augmented = captured_step[0].intent
+    # Intent prose retains the original task as the leading clause.
+    assert augmented.startswith(
+        "Click the first lead row whose Status is Qualified"
+    )
+    # Failure context appended.
+    assert "previous attempts" in augmented.lower()
+    assert "(39, 137)" in augmented
+    assert "(66, 395)" in augmented
+    # Pagination guidance present so Holo3 explores beyond the
+    # current viewport when the target genuinely isn't on screen.
+    assert "pagination" in augmented.lower() or "later page" in augmented.lower()
+    assert "scroll" in augmented.lower()
 
 
 def test_dispatcher_skips_escalation_when_no_override() -> None:


### PR DESCRIPTION
## Summary

Two layered improvements to the escalation path so it actually navigates to off-page targets instead of giving up when the current viewport has no matches:

1. **Budget bump 15 → 25**. Canonical case widens from "scroll on current page" to "scroll AND paginate AND click across multiple pages."
2. **Failure-aware task prose**. The dispatcher augments Holo3's task description with the prior failed click targets and explicit guidance to scroll / paginate when the visible viewport has no matching item.

## Why

Post-PR #233 staff-crm rerun confirmed escalation triggers correctly:
```
[escalation] step 5 routing via Holo3StepHandler (brain-grounded loop, budget=15, was=4)
```
And Holo3 diagnosed the truth via reasoning trace:
> "stuck clicking row 227 (Aegis Guard) which has status 'New', but needs to find a row with status 'Qualified' which is not visible in the current view."

So the form handler had been clicking visual labels (filter chips, breadcrumbs, status pills on wrong rows). Holo3 sees the page state correctly. But the budget (15) ran out before it could scroll-and-paginate enough, and without explicit guidance Holo3 doesn't know that prior attempts already mis-clicked the same labels.

## General-purpose contract

Still no plan-specific terms or domain hardcoding. The augmentation is purely a function of observed failure history — same logic applies to any submit step where the default text-matcher keeps mis-clicking.

## Test plan

- [x] ``pytest tests/test_handler_escalation.py`` — 13 cases, including new ``test_dispatcher_augments_intent_with_failure_history_when_present`` pinning the augmentation block + pagination guidance.
- [x] Existing dispatcher-routing test updated to assert budget >= 25 (was >= 15).
- [x] Full suite ``pytest -n auto`` — 1439 passed in 8m04s.
- [x] ``ruff check`` clean.

## Stack so far

| PR | Layer |
|---|---|
| #228 | SPA-aware verify |
| #229 | End/Home before Page_Down sweep |
| #230 | Failure-aware retries |
| #231 | Coords in result.data |
| #232 | Switch handler on repeated wrong-handler signal |
| #233 | Bump Holo3 budget |
| this | Pagination-aware prompt + further budget bump |

🤖 Generated with [Claude Code](https://claude.com/claude-code)