### PR TITLE
fix(escalation): tell Holo3 to emit done on navigation (defensive layer)

### DIFF
--- a/src/mantis_agent/gym/_runner_helpers.py
+++ b/src/mantis_agent/gym/_runner_helpers.py
@@ -671,7 +671,16 @@ def execute_step(
                 f"items; check filter / sort / status indicators to "
                 f"confirm before giving up\n"
                 f"Pick a different element or navigation action than the "
-                f"prior attempts."
+                f"prior attempts.\n\n"
+                f"SUCCESS CRITERION: the step is COMPLETE the moment the "
+                f"page navigates (URL changes, or the visible content "
+                f"clearly transitions from a list / form to a detail / "
+                f"target view). The MOMENT that happens, emit a `done` "
+                f"action with success=true and a one-line summary. Do "
+                f"NOT take any further actions on the new page — that "
+                f"would undo the navigation you just achieved. Subsequent "
+                f"plan steps will operate on the new view; your job ends "
+                f"when the navigation succeeds."
             )
 
         escalated_step = MicroIntent(

--- a/tests/test_handler_escalation.py
+++ b/tests/test_handler_escalation.py
@@ -339,6 +339,14 @@ def test_dispatcher_augments_intent_with_failure_history_when_present() -> None:
     # current viewport when the target genuinely isn't on screen.
     assert "pagination" in augmented.lower() or "later page" in augmented.lower()
     assert "scroll" in augmented.lower()
+    # Stop-on-success guidance present so Holo3 emits ``done`` the
+    # moment navigation succeeds rather than continuing to act on
+    # the new page (which would undo the navigation).
+    assert "done" in augmented.lower()
+    assert (
+        "navigates" in augmented.lower()
+        or "navigation" in augmented.lower()
+    )
 
 
 def test_dispatcher_skips_escalation_when_no_override() -> None:


### PR DESCRIPTION
## Summary

Defensive prompt enhancement — adds explicit "stop on navigation" guidance to the escalation task prose so Holo3 emits a ``done`` action the moment URL changes / view transitions, instead of continuing to act and potentially navigating back.

## Why

The staff-crm-with-Contacted rerun revealed Holo3 successfully navigated to a lead detail page (Record ID 5), then navigated AWAY because it didn't recognise it had achieved the goal. The brain's reasoning trace:

> *"we are currently on a detail page (Record ID 5) and need to see the table of contacted leads."*

So Holo3 conflated "the current task" with "the broader plan context" — kept acting past success.

## Two layers, not one

This PR is the **prompt-engineering fallback**. The next PR (follow-up) adds **runner-side completion detection**: URL transition + Claude visual verifier auto-injects DONE so the runner doesn't depend on Holo3's self-awareness alone. The prompt layer handles the "Holo3 sees the signal" path; the runner layer handles the "Holo3 misses the signal" path.

## Test plan

- [x] 13 escalation tests pass (one updated to assert the success-criterion guidance is present in the augmented intent)
- [x] ``ruff check`` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)