### PR TITLE
feat(recovery): agentic failure-recovery loop — analyse + adapt before halt

### DIFF
--- a/src/mantis_agent/agentic_recovery.py
+++ b/src/mantis_agent/agentic_recovery.py
@@ -1,0 +1,468 @@
+"""Agentic failure-recovery loop — analyse + adapt instead of halting.
+
+When a required step fails terminally (after retries + handler
+escalation), the runner's existing path halts with a HALT reason.
+This module adds the missing layer: ask Claude to analyse the
+failure (step intent + last screenshot + failure data) and decide
+how to recover.
+
+Four recovery modes, in order of cheapness:
+
+1. ``add_hint`` — the step is structurally correct but the search
+   needs a clarifying instruction. Example: ``"the button is
+   labeled 'Save', not 'Update Lead'."`` The hint is appended to
+   the next retry's prompt; the step itself is unchanged.
+
+2. ``edit_step`` — the step has wrong type / params / labels and
+   needs a localised replacement. Example: change a ``submit`` step
+   with ``label='Update Lead'`` to ``submit`` with
+   ``label='Save', aliases=['Submit', 'Update']``. Only the failed
+   step is modified; surrounding plan structure is preserved.
+
+3. ``insert_steps`` — the step's precondition isn't met and a
+   helper sub-flow is needed first (scroll, dismiss modal, navigate
+   back, wait for render). Helper steps splice in BEFORE the failed
+   step; existing loop_target references are renumbered.
+
+4. ``halt`` — the page state genuinely doesn't permit the step
+   (target doesn't exist on the site, anti-bot block, account
+   suspension). No plan tweak would help; surface the failure.
+
+Bounded by per-step + per-run budgets so the recovery loop can't
+run away. The legacy halt path is the fallback when budgets exhaust
+or no Claude key is available.
+
+Public API:
+
+- :class:`RecoveryDecision` — typed dataclass for the four modes
+- :func:`analyse_failure_and_recover` — the Claude tool_use call;
+  returns a ``RecoveryDecision`` on success or ``None`` on any
+  fallback path (no key, API error, schema violation)
+
+The hook point lives in
+:meth:`mantis_agent.gym.step_recovery.StepRecoveryPolicy.handle_failure`
+— this module is decoupled and importable on its own.
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+import os
+from dataclasses import dataclass, field
+from io import BytesIO
+from typing import Any
+
+from PIL import Image
+
+logger = logging.getLogger(__name__)
+
+
+# Bumping this string invalidates any caller that keys recovery
+# decisions by ``(plan_signature, step_index, prompt_version)``. Not
+# used today but reserved so a future caching layer (issue #224
+# Phase 2 pattern) can integrate cleanly.
+RECOVERY_PROMPT_VERSION = "v1"
+
+
+# Per-step + per-run recovery budgets. The policy enforces these
+# before invoking the LLM call so a pathological page / step can't
+# burn the run on recovery alone.
+DEFAULT_MAX_RECOVERIES_PER_STEP = 2
+DEFAULT_MAX_RECOVERIES_PER_RUN = 5
+
+
+@dataclass
+class RecoveryDecision:
+    """The structured response from :func:`analyse_failure_and_recover`.
+
+    ``mode`` is the discriminator. Other fields are populated based
+    on the mode:
+
+    - ``add_hint``  → ``hint`` (str)
+    - ``edit_step`` → ``edited_step`` (dict with ``intent`` / ``type``
+      / ``params``; missing keys preserve the original step's value)
+    - ``insert_steps`` → ``inserted_steps`` (list of step-shaped
+      dicts; spliced BEFORE the failed step)
+    - ``halt`` → no extra fields
+    """
+
+    mode: str  # "add_hint" | "edit_step" | "insert_steps" | "halt"
+    reasoning: str = ""
+    hint: str = ""
+    edited_step: dict[str, Any] = field(default_factory=dict)
+    inserted_steps: list[dict[str, Any]] = field(default_factory=list)
+
+
+_ANALYSIS_TOOL_INPUT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "mode": {
+            "type": "string",
+            "enum": ["add_hint", "edit_step", "insert_steps", "halt"],
+            "description": (
+                "How to recover. Pick the cheapest option that would "
+                "plausibly succeed: add_hint < edit_step < insert_steps "
+                "< halt. Only choose halt when no plan tweak would help "
+                "(target genuinely missing, anti-bot block)."
+            ),
+        },
+        "reasoning": {
+            "type": "string",
+            "description": (
+                "One-sentence explanation of what you saw on the "
+                "screenshot and why this mode fits."
+            ),
+        },
+        "hint": {
+            "type": "string",
+            "description": (
+                "When mode=add_hint: a short clarifying instruction "
+                "appended to the next retry's search prompt. Example: "
+                "'the button is labeled Save not Update Lead.' "
+                "Empty string for other modes."
+            ),
+        },
+        "edited_step": {
+            "type": "object",
+            "description": (
+                "When mode=edit_step: replacement field values for the "
+                "failed step. Provide ONLY the fields that need to "
+                "change. Empty object for other modes."
+            ),
+            "properties": {
+                "intent": {
+                    "type": "string",
+                    "description": "Replacement intent prose, or empty.",
+                },
+                "type": {
+                    "type": "string",
+                    "description": (
+                        "Replacement step type — e.g. submit, click, "
+                        "select_option, fill_field. Empty to keep "
+                        "original."
+                    ),
+                },
+                "params": {
+                    "type": "object",
+                    "description": (
+                        "Replacement params dict. Common keys: label, "
+                        "aliases (list), value, dropdown_label, "
+                        "option_label."
+                    ),
+                },
+            },
+        },
+        "inserted_steps": {
+            "type": "array",
+            "description": (
+                "When mode=insert_steps: helper sub-flow to splice "
+                "BEFORE the failed step. Each entry is a step shape "
+                "with at least 'intent' and 'type'. Empty for other "
+                "modes."
+            ),
+            "items": {
+                "type": "object",
+                "properties": {
+                    "intent": {"type": "string"},
+                    "type": {"type": "string"},
+                    "params": {"type": "object"},
+                },
+                "required": ["intent", "type"],
+            },
+        },
+    },
+    "required": ["mode", "reasoning"],
+}
+
+
+_ANALYSIS_PROMPT_TEMPLATE = """\
+You are analysing a terminal failure in a CUA (Computer Use Agent) plan.
+
+A required step has failed after retries AND after the runner's
+default handler escalation. Your job: look at the screenshot of the
+current page, the failed step's intent / type / params, and the
+failure data, then choose the cheapest recovery that would plausibly
+succeed.
+
+FAILED STEP
+===========
+intent: {intent}
+type:   {step_type}
+params: {params}
+
+FAILURE DATA: {failure_data}
+RETRY ATTEMPTS: {attempts}
+
+PLAN CONTEXT (steps already completed successfully):
+{plan_context}
+
+RECOVERY MODES (pick ONE via the record_recovery tool):
+
+1. add_hint — the step is fundamentally correct but the search
+   needs a clarifying instruction. The hint is appended to the
+   prompt the next retry will pass to its grounder. Use this when
+   you can see what the right element is and just need to tell
+   the searcher to pick it. Example: the failed step said
+   "Click 'Update Lead'" but the actual button reads "Save" — so
+   hint="The save button is labeled 'Save', not 'Update Lead'."
+
+2. edit_step — the step's structure is wrong. Use when:
+   - the step type is wrong (submit when it should be select_option,
+     click when it should be fill_field, etc.)
+   - the labels in params are wrong and the right ones are visible
+     on screen
+   - aliases are needed because the button label varies
+   Provide ONLY the fields to change in ``edited_step``. Existing
+   fields are preserved.
+
+3. insert_steps — a precondition is missing. Use when the step
+   itself is correct but the page isn't ready: a modal is blocking,
+   the form section isn't expanded, scroll is needed, or a previous
+   page-state didn't take. Provide a small sub-flow (1-3 steps) to
+   put the page in the right state. The runner splices these BEFORE
+   the failed step then re-attempts the original step.
+
+4. halt — recovery is impossible. Use when:
+   - the target genuinely doesn't exist on the site
+   - the page shows a hard error (anti-bot, 403, server error)
+   - the step's premise contradicts visible page state
+   No plan tweak would help; surface the failure to the operator.
+
+Be conservative: only halt when truly stuck. add_hint is preferred
+when you can see what the right action is. edit_step is preferred
+when the structure is just slightly off. insert_steps when a
+precondition is missing.
+"""
+
+
+def analyse_failure_and_recover(
+    *,
+    step: Any,
+    failure_data: str,
+    screenshot: Image.Image | None,
+    plan_context: list[str],
+    attempts: int,
+    api_key: str = "",
+    model: str = "claude-haiku-4-5-20251001",
+) -> RecoveryDecision | None:
+    """Ask Claude to analyse a step failure and pick a recovery mode.
+
+    Issue #224 follow-up: replaces the current "retry until budget
+    exhausts then HALT" terminal path with a Claude-mediated decision.
+    On success returns a :class:`RecoveryDecision` the caller applies.
+    On any fallback path (no API key, API error, schema violation,
+    network error) returns ``None`` — the caller is expected to fall
+    back to the legacy halt behaviour.
+
+    Args:
+        step: The :class:`MicroIntent` that failed. ``intent``,
+            ``type``, ``params`` are surfaced into the prompt.
+        failure_data: The ``StepResult.data`` from the last attempt
+            (e.g. ``"form_target_not_found"`` /
+            ``"submit:Login@(540,220):no_state_change"``).
+        screenshot: Last screenshot before halting. Optional —
+            without it Claude reasons from the failure data alone.
+        plan_context: Intent strings of the previously-successful
+            steps in the plan. Helps Claude understand "where in
+            the workflow the failure happened."
+        attempts: How many times this step has been attempted
+            (drives Claude's confidence calibration — many attempts
+            = stronger evidence the structure is wrong).
+        api_key: Anthropic API key. Falls back to the
+            ``ANTHROPIC_API_KEY`` env var.
+        model: Claude model. Defaults to Haiku-tier (the analysis
+            task is structured-JSON lift, not deep reasoning).
+
+    Returns:
+        :class:`RecoveryDecision` on a successful tool_use call,
+        ``None`` on any fallback path. The caller is responsible
+        for budget enforcement (per-step + per-run); this function
+        does NOT track budgets — it just performs the analysis when
+        invoked.
+    """
+    api_key = api_key or os.environ.get("ANTHROPIC_API_KEY", "")
+    if not api_key:
+        logger.warning(
+            "agentic_recovery: no ANTHROPIC_API_KEY — falling back "
+            "to legacy halt path"
+        )
+        return None
+
+    parsed = _call_recovery_tool(
+        step=step,
+        failure_data=failure_data,
+        screenshot=screenshot,
+        plan_context=plan_context,
+        attempts=attempts,
+        api_key=api_key,
+        model=model,
+    )
+    if parsed is None:
+        return None
+
+    return _build_decision(parsed)
+
+
+def _call_recovery_tool(
+    *,
+    step: Any,
+    failure_data: str,
+    screenshot: Image.Image | None,
+    plan_context: list[str],
+    attempts: int,
+    api_key: str,
+    model: str,
+) -> dict | None:
+    """Tool_use call. Returns the validated input dict or ``None``."""
+    import requests
+
+    prompt = _ANALYSIS_PROMPT_TEMPLATE.format(
+        intent=getattr(step, "intent", "")[:300],
+        step_type=getattr(step, "type", ""),
+        params=str(getattr(step, "params", {}) or {})[:300],
+        failure_data=failure_data[:300],
+        attempts=attempts,
+        plan_context=_format_plan_context(plan_context),
+    )
+
+    content: list[dict[str, Any]] = [{"type": "text", "text": prompt}]
+    if screenshot is not None:
+        try:
+            buf = BytesIO()
+            screenshot.save(buf, format="PNG")
+            b64 = base64.b64encode(buf.getvalue()).decode()
+            content.insert(
+                0,
+                {
+                    "type": "image",
+                    "source": {
+                        "type": "base64",
+                        "media_type": "image/png",
+                        "data": b64,
+                    },
+                },
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("recovery: screenshot encode failed: %s", exc)
+
+    try:
+        resp = requests.post(
+            "https://api.anthropic.com/v1/messages",
+            headers={
+                "x-api-key": api_key,
+                "anthropic-version": "2023-06-01",
+                "content-type": "application/json",
+            },
+            json={
+                "model": model,
+                "max_tokens": 1500,
+                "tools": [{
+                    "name": "record_recovery",
+                    "description": (
+                        "Record the recovery decision for the failed "
+                        "step."
+                    ),
+                    "input_schema": _ANALYSIS_TOOL_INPUT_SCHEMA,
+                }],
+                "tool_choice": {"type": "tool", "name": "record_recovery"},
+                "messages": [{"role": "user", "content": content}],
+            },
+            timeout=30,
+        )
+        if resp.status_code != 200:
+            logger.warning(
+                "agentic_recovery API error %s: %s",
+                resp.status_code, resp.text[:300],
+            )
+            return None
+        for block in resp.json().get("content", []):
+            if (
+                block.get("type") == "tool_use"
+                and block.get("name") == "record_recovery"
+            ):
+                tool_input = block.get("input")
+                if isinstance(tool_input, dict):
+                    return tool_input
+        return None
+    except Exception as exc:  # noqa: BLE001 — log + fall back
+        logger.warning("agentic_recovery call failed: %s", exc)
+        return None
+
+
+def _build_decision(data: dict[str, Any]) -> RecoveryDecision:
+    """Coerce a validated tool_use input dict into RecoveryDecision."""
+    mode = str(data.get("mode") or "halt")
+    if mode not in {"add_hint", "edit_step", "insert_steps", "halt"}:
+        # Defensive — schema enforces enum but the LLM occasionally
+        # emits a typo. Treat as halt rather than crash the runner.
+        mode = "halt"
+
+    inserted: list[dict[str, Any]] = []
+    for raw in data.get("inserted_steps") or []:
+        if not isinstance(raw, dict):
+            continue
+        intent = str(raw.get("intent") or "").strip()
+        step_type = str(raw.get("type") or "").strip()
+        if not intent or not step_type:
+            continue
+        inserted.append({
+            "intent": intent,
+            "type": step_type,
+            "params": dict(raw.get("params") or {}),
+        })
+
+    return RecoveryDecision(
+        mode=mode,
+        reasoning=str(data.get("reasoning") or "")[:500],
+        hint=str(data.get("hint") or "")[:500],
+        edited_step=dict(data.get("edited_step") or {}),
+        inserted_steps=inserted,
+    )
+
+
+def _format_plan_context(steps: list[str]) -> str:
+    if not steps:
+        return "  (this is the first step that failed)"
+    return "\n".join(f"  [{i}] {s[:100]}" for i, s in enumerate(steps))
+
+
+# ── Plan-splice helper (exposed for the runner to call on insert_steps) ─
+
+
+def splice_inserted_steps(
+    plan_steps: list[Any],
+    insertion_index: int,
+    inserted: list[Any],
+) -> list[Any]:
+    """Splice ``inserted`` before ``plan_steps[insertion_index]``.
+
+    Loop steps in the plan use absolute step indices via
+    ``loop_target``. After splicing N steps in at index K, every
+    existing step's loop_target X with X >= K must shift to X + N
+    so the loop still points at the correct target.
+
+    Returns a NEW list; ``plan_steps`` is not mutated.
+    """
+    if not inserted:
+        return list(plan_steps)
+
+    n = len(inserted)
+    new_steps: list[Any] = []
+    for i, s in enumerate(plan_steps):
+        if i == insertion_index:
+            new_steps.extend(inserted)
+        # Shift loop targets pointing AT or BEYOND the insertion
+        # index — those steps now live N slots later.
+        loop_target = getattr(s, "loop_target", -1)
+        if loop_target is not None and loop_target >= insertion_index:
+            try:
+                s.loop_target = loop_target + n
+            except AttributeError:
+                pass
+        new_steps.append(s)
+
+    # Edge case: insertion_index == len(plan_steps) — append at end.
+    if insertion_index >= len(plan_steps):
+        new_steps.extend(inserted)
+    return new_steps

--- a/src/mantis_agent/gym/micro_runner.py
+++ b/src/mantis_agent/gym/micro_runner.py
@@ -129,6 +129,15 @@ class MicroPlanRunner:
         # triggered purely by observed failure pattern, not plan
         # content. Cleared on step success.
         self._step_handler_override: dict[int, str] = {}
+        # Agentic-recovery state (issue #224 follow-up). When the
+        # recovery loop returns ``mode=add_hint``, the hint is
+        # appended to ``_recovery_hints[step_index]`` and surfaced in
+        # the next attempt's search prompt. Budget tracking (per-step
+        # + per-run) prevents infinite recovery loops. Cleared on
+        # step success along with failure history / handler override.
+        self._recovery_hints: dict[int, list[str]] = {}
+        self._recovery_attempts_per_step: dict[int, int] = {}
+        self._total_recovery_attempts: int = 0
         self.max_cost, self.max_time = max_cost, max_time_minutes * 60
         self.step_callback, self.keep_screenshots = step_callback, keep_screenshots
         self.cancel_event = cancel_event

--- a/src/mantis_agent/gym/run_executor.py
+++ b/src/mantis_agent/gym/run_executor.py
@@ -606,6 +606,14 @@ class RunExecutor:
         # same step_index starts with the default routing.
         if hasattr(runner, "_step_handler_override"):
             runner._step_handler_override.pop(state.step_index, None)
+        # Same for agentic-recovery hints — once the step has
+        # succeeded, accumulated hints have served their purpose;
+        # don't bleed them into a future occurrence of the same
+        # step_index (loops, resumed plans).
+        if hasattr(runner, "_recovery_hints"):
+            runner._recovery_hints.pop(state.step_index, None)
+        if hasattr(runner, "_recovery_attempts_per_step"):
+            runner._recovery_attempts_per_step.pop(state.step_index, None)
 
         if step.type == "paginate":
             # Phase 4: listings-scan reset is one method on the scanner now,

--- a/src/mantis_agent/gym/step_handlers/form.py
+++ b/src/mantis_agent/gym/step_handlers/form.py
@@ -281,6 +281,37 @@ class ClaudeGuidedFormHandler:
             aliases = [str(a).strip() for a in aliases if str(a).strip()]
             kind = str(params.get("kind") or _SUBMIT_KIND_DEFAULT).strip().lower() or _SUBMIT_KIND_DEFAULT
             search_intent = _build_submit_search_intent(label, kind, step.intent)
+            # Agentic-recovery hints — issue #224 follow-up. When the
+            # last-resort recovery loop returned ``mode=add_hint`` for
+            # a previous attempt at this step, the hint string was
+            # appended to ``runner._recovery_hints[step_index]``.
+            # Surface every accumulated hint into the search prompt
+            # so the next attempt's LLM has them all. Hints come from
+            # Claude analysing the failure screenshot — much more
+            # specific than the generic "avoid these coords" feedback
+            # produced by the snapshot-diff path.
+            # Defensive: only proceed when runner has a real dict of
+            # hints. Test stubs that use MagicMock auto-create the
+            # attribute as a Mock; we don't want to surface bogus
+            # "recovery hints" prose in that case.
+            recovery_hints_dict = getattr(runner, "_recovery_hints", None)
+            recovery_hints: list[str] = []
+            if isinstance(recovery_hints_dict, dict):
+                stored = recovery_hints_dict.get(index, [])
+                if isinstance(stored, list):
+                    recovery_hints = [str(h) for h in stored if h]
+            if recovery_hints:
+                hint_block = "\n".join(f"  - {h}" for h in recovery_hints)
+                search_intent = (
+                    search_intent
+                    + "\n\nRECOVERY HINTS from previous failed attempts:\n"
+                    + hint_block
+                )
+                logger.warning(
+                    "  [claude-form] submit '%s' retry — applying %d "
+                    "recovery hint(s) from agentic-recovery loop",
+                    label, len(recovery_hints),
+                )
             # Agentic retry feedback — issue #224 follow-up. When a
             # previous attempt at this step failed with no_state_change
             # / wrong_target, the runner records the click target + label

--- a/src/mantis_agent/gym/step_recovery.py
+++ b/src/mantis_agent/gym/step_recovery.py
@@ -57,6 +57,8 @@ from typing import Any
 
 from ..actions import Action, ActionType
 
+logger = logging.getLogger(__name__)
+
 
 class RecoveryAction(Enum):
     """Coarse decision the runner should take after a step result.
@@ -227,6 +229,28 @@ class StepRecoveryPolicy:
                     halt=False, step_index=step_index,
                     halt_reason=f"required_retry:{step.type}:{attempt}",
                 )
+            # Before halting, give the agentic recovery loop a chance.
+            # Claude analyses the failure (step + last screenshot +
+            # failure data) and either:
+            #   - returns a hint to augment the next retry's prompt
+            #   - returns an edited version of the step (changed type,
+            #     params, label, aliases)
+            #   - returns helper steps to splice in BEFORE this step
+            #   - returns halt = surface the legacy halt path
+            # Bounded by per-step + per-run budgets so we don't loop
+            # indefinitely. Falls through to the legacy halt path on
+            # any failure of the recovery call itself.
+            recovery_outcome = self._try_agentic_recovery(
+                step=step,
+                step_result=step_result,
+                step_index=step_index,
+                plan=plan,
+                step_retry_counts=step_retry_counts,
+                attempts=attempt,
+            )
+            if recovery_outcome is not None:
+                return recovery_outcome
+
             logger_.error(
                 f"  [{step_index}] REQUIRED step failed after {max_retries} retries — HALTING"
             )
@@ -491,4 +515,190 @@ class StepRecoveryPolicy:
         for j in range(start, len(plan.steps)):
             if plan.steps[j].type == step_type:
                 return j
+        return None
+
+    # ── Agentic failure-recovery loop ───────────────────────────────────
+
+    def _try_agentic_recovery(
+        self,
+        *,
+        step: Any,
+        step_result: Any,
+        step_index: int,
+        plan: Any,
+        step_retry_counts: dict[int | str, int],
+        attempts: int,
+    ) -> RecoveryOutcome | None:
+        """Last-resort: ask Claude to analyse + adapt before HALTING.
+
+        Invoked when a REQUIRED step has exhausted its retry budget
+        (and, if the wrong-handler escalation triggered, that has
+        also failed). Returns a :class:`RecoveryOutcome` describing
+        the next action to take, or ``None`` to fall through to the
+        legacy halt path.
+
+        Budget enforcement (per-step max 2 + per-run max 5) lives
+        here so a pathological step / page can't spend the whole
+        run on recovery alone. Budgets are tracked on the runner so
+        they survive across step retries within the same plan.
+
+        Modes applied:
+
+        - ``add_hint`` — append the hint to the step's
+          ``_recovery_hints[step_index]`` list. The form / click
+          handlers read this on next attempt and surface it in the
+          search prompt. Returns a ``RecoveryOutcome`` that re-runs
+          the same step.
+        - ``edit_step`` — mutate ``plan.steps[step_index]`` with
+          the changed fields (intent / type / params). Returns a
+          ``RecoveryOutcome`` that re-runs the (now edited) step.
+        - ``insert_steps`` — splice helper steps before the failed
+          step via :func:`agentic_recovery.splice_inserted_steps`.
+          Returns a ``RecoveryOutcome`` that jumps to the first
+          inserted step.
+        - ``halt`` — return ``None`` so the caller surfaces the
+          legacy halt path.
+        """
+        runner = self.parent
+
+        # Budget guards. Defensively check that the runner exposes
+        # the recovery-state fields with the right shape — legacy
+        # runners (or test stubs that use MagicMock) won't, and we
+        # should fall through to the legacy halt path rather than
+        # crash with type errors.
+        per_step_dict = getattr(runner, "_recovery_attempts_per_step", None)
+        total_attempts = getattr(runner, "_total_recovery_attempts", None)
+        if not isinstance(per_step_dict, dict) or not isinstance(total_attempts, int):
+            return None
+        from ..agentic_recovery import (
+            DEFAULT_MAX_RECOVERIES_PER_RUN,
+            DEFAULT_MAX_RECOVERIES_PER_STEP,
+        )
+        per_step = per_step_dict.get(step_index, 0)
+        per_run = total_attempts
+        if per_step >= DEFAULT_MAX_RECOVERIES_PER_STEP:
+            logger.info(
+                "  [%d] agentic recovery skipped — per-step budget "
+                "exhausted (%d/%d)",
+                step_index, per_step, DEFAULT_MAX_RECOVERIES_PER_STEP,
+            )
+            return None
+        if per_run >= DEFAULT_MAX_RECOVERIES_PER_RUN:
+            logger.info(
+                "  [%d] agentic recovery skipped — per-run budget "
+                "exhausted (%d/%d)",
+                step_index, per_run, DEFAULT_MAX_RECOVERIES_PER_RUN,
+            )
+            return None
+
+        # Capture screenshot for the analysis. Best-effort — Claude
+        # can reason without it.
+        screenshot = None
+        try:
+            screenshot = runner._safe_screenshot()
+        except Exception:
+            screenshot = None
+
+        # Plan context = intent strings of successful steps before
+        # this one. Helps Claude understand workflow position.
+        plan_context: list[str] = []
+        try:
+            for i, prev in enumerate(plan.steps[:step_index]):
+                plan_context.append(getattr(prev, "intent", "") or "")
+        except Exception:  # noqa: BLE001
+            pass
+
+        from ..agentic_recovery import (
+            analyse_failure_and_recover,
+            splice_inserted_steps,
+        )
+        decision = analyse_failure_and_recover(
+            step=step,
+            failure_data=str(getattr(step_result, "data", "") or ""),
+            screenshot=screenshot,
+            plan_context=plan_context,
+            attempts=attempts,
+        )
+        if decision is None:
+            return None
+
+        # Increment budgets *before* applying so a recovery that
+        # itself triggers another failure doesn't infinite-loop.
+        per_step_dict[step_index] = per_step + 1
+        runner._total_recovery_attempts = per_run + 1
+
+        logger.warning(
+            "  [%d] agentic recovery: mode=%s — %s",
+            step_index, decision.mode, decision.reasoning[:200],
+        )
+
+        if decision.mode == "halt":
+            return None  # fall through to legacy halt
+
+        if decision.mode == "add_hint":
+            if not decision.hint:
+                return None
+            if not hasattr(runner, "_recovery_hints"):
+                runner._recovery_hints = {}
+            runner._recovery_hints.setdefault(step_index, []).append(
+                decision.hint
+            )
+            # Reset retry count so the step gets fresh attempts with
+            # the hint. Keep the recovery budget bumped above so we
+            # don't loop forever.
+            step_retry_counts[step_index] = 0
+            return RecoveryOutcome(
+                halt=False, step_index=step_index,
+                halt_reason=f"recovery_hint:{decision.hint[:60]}",
+            )
+
+        if decision.mode == "edit_step":
+            edited = decision.edited_step or {}
+            if not edited:
+                return None
+            # Mutate the step in place. Only the fields the LLM
+            # supplied; missing fields preserve original values.
+            if "intent" in edited and edited["intent"]:
+                step.intent = str(edited["intent"])
+            if "type" in edited and edited["type"]:
+                step.type = str(edited["type"])
+            if "params" in edited and isinstance(edited["params"], dict):
+                # Merge — recipe-side params extend the existing dict.
+                merged = dict(getattr(step, "params", {}) or {})
+                merged.update(edited["params"])
+                step.params = merged
+            step_retry_counts[step_index] = 0
+            return RecoveryOutcome(
+                halt=False, step_index=step_index,
+                halt_reason=f"recovery_edit:{step.type}",
+            )
+
+        if decision.mode == "insert_steps":
+            if not decision.inserted_steps:
+                return None
+            # Build MicroIntent objects from the dict-shaped specs.
+            from ..plan_decomposer import MicroIntent
+            new_steps = [
+                MicroIntent(
+                    intent=spec["intent"],
+                    type=spec["type"],
+                    params=spec.get("params") or {},
+                    section=getattr(step, "section", "") or "",
+                    required=False,  # helper steps are best-effort
+                )
+                for spec in decision.inserted_steps
+            ]
+            plan.steps = splice_inserted_steps(
+                plan.steps, step_index, new_steps,
+            )
+            # Reset retry count so the (now-deferred) failed step
+            # gets fresh attempts after the helper sub-flow.
+            step_retry_counts[step_index] = 0
+            # Jump to the first inserted step.
+            return RecoveryOutcome(
+                halt=False, step_index=step_index,
+                halt_reason=f"recovery_insert:{len(new_steps)}_steps",
+            )
+
+        # Unknown mode — defensive fallthrough.
         return None

--- a/tests/test_agentic_recovery.py
+++ b/tests/test_agentic_recovery.py
@@ -1,0 +1,474 @@
+"""Tests for the agentic failure-recovery loop (#224 follow-up).
+
+Surfaced by the staff-crm post-PR-#235 rerun: the runner made it
+through 10/13 steps end-to-end (login → leads → filter → click
+lead → edit → set Industry Vertical → ...) but failed at step 10
+``Click the Update Lead button`` with ``form_target_not_found`` —
+the literal label "Update Lead" doesn't exist on the page; the
+real button is labelled "Save".
+
+The recovery loop closes this gap. When a required step terminally
+fails (after retries + handler escalation), Claude analyses the
+failure (step + last screenshot + failure data) and decides
+whether to:
+
+- ``add_hint`` — append a clarifying instruction to the next
+  retry's search prompt
+- ``edit_step`` — mutate the failed step (intent / type / params)
+- ``insert_steps`` — splice helper steps before the failed step
+- ``halt`` — surrender (current behavior)
+
+Bounded by per-step + per-run budgets so a pathological page can't
+spend the whole run on recovery alone.
+
+These tests pin:
+
+- :func:`analyse_failure_and_recover` — the Claude tool_use call
+  shape, response coercion, fallback paths
+- :class:`RecoveryDecision` — the four-mode dataclass
+- :func:`splice_inserted_steps` — plan-splice with loop_target
+  renumbering
+- ``StepRecoveryPolicy._try_agentic_recovery`` integration —
+  applies each mode correctly, enforces budgets, falls through to
+  halt on missing key / unknown mode
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mantis_agent.agentic_recovery import (
+    DEFAULT_MAX_RECOVERIES_PER_RUN,
+    DEFAULT_MAX_RECOVERIES_PER_STEP,
+    _build_decision,
+    analyse_failure_and_recover,
+    splice_inserted_steps,
+)
+from mantis_agent.gym.checkpoint import StepResult
+from mantis_agent.gym.step_recovery import StepRecoveryPolicy
+from mantis_agent.plan_decomposer import MicroIntent, MicroPlan
+
+
+def _tool_response(payload: dict) -> MagicMock:
+    """Build a stubbed Anthropic /v1/messages response in tool_use shape."""
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = {
+        "content": [
+            {
+                "type": "tool_use",
+                "name": "record_recovery",
+                "input": payload,
+            }
+        ]
+    }
+    return resp
+
+
+# ── analyse_failure_and_recover ─────────────────────────────────────────
+
+
+def test_analyse_returns_none_without_api_key(monkeypatch) -> None:
+    """No ``ANTHROPIC_API_KEY`` → return None so the caller falls
+    through to the legacy halt path."""
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    step = MicroIntent(intent="Click Save", type="submit")
+    with patch("requests.post") as mock_post:
+        result = analyse_failure_and_recover(
+            step=step, failure_data="form_target_not_found",
+            screenshot=None, plan_context=[], attempts=2,
+        )
+    assert result is None
+    mock_post.assert_not_called()
+
+
+def test_analyse_returns_none_on_api_error() -> None:
+    """API non-200 → return None; don't propagate."""
+    err = MagicMock(status_code=500, text="upstream timeout")
+    step = MicroIntent(intent="Click Save", type="submit")
+    with patch("requests.post", return_value=err):
+        result = analyse_failure_and_recover(
+            step=step, failure_data="form_target_not_found",
+            screenshot=None, plan_context=[], attempts=2,
+            api_key="k",
+        )
+    assert result is None
+
+
+def test_analyse_returns_none_on_missing_tool_block() -> None:
+    """200 OK but the response has no tool_use block (model emitted
+    prose). Return None rather than crashing."""
+    resp = MagicMock(status_code=200)
+    resp.json.return_value = {"content": [{"type": "text", "text": "no"}]}
+    step = MicroIntent(intent="Click Save", type="submit")
+    with patch("requests.post", return_value=resp):
+        result = analyse_failure_and_recover(
+            step=step, failure_data="form_target_not_found",
+            screenshot=None, plan_context=[], attempts=2,
+            api_key="k",
+        )
+    assert result is None
+
+
+def test_analyse_calls_with_correct_tool_schema() -> None:
+    """The ``tool_choice`` must force the ``record_recovery`` tool and
+    the input_schema must enumerate the four recovery modes."""
+    captured: dict = {}
+
+    def _capture(url, **kwargs):
+        captured["json"] = kwargs.get("json")
+        return _tool_response({"mode": "halt", "reasoning": "x"})
+
+    step = MicroIntent(intent="Click Save", type="submit")
+    with patch("requests.post", side_effect=_capture):
+        analyse_failure_and_recover(
+            step=step, failure_data="x",
+            screenshot=None, plan_context=[], attempts=1,
+            api_key="k",
+        )
+
+    body = captured["json"]
+    assert body["tool_choice"] == {"type": "tool", "name": "record_recovery"}
+    schema = body["tools"][0]["input_schema"]
+    assert set(schema["properties"]["mode"]["enum"]) == {
+        "add_hint", "edit_step", "insert_steps", "halt",
+    }
+    assert "mode" in schema["required"]
+    assert "reasoning" in schema["required"]
+
+
+# ── RecoveryDecision coercion ───────────────────────────────────────────
+
+
+def test_build_decision_add_hint() -> None:
+    decision = _build_decision({
+        "mode": "add_hint",
+        "reasoning": "Button labelled Save",
+        "hint": "the button is labeled 'Save', not 'Update Lead'",
+    })
+    assert decision.mode == "add_hint"
+    assert "Save" in decision.hint
+
+
+def test_build_decision_edit_step() -> None:
+    decision = _build_decision({
+        "mode": "edit_step",
+        "reasoning": "Wrong step type",
+        "edited_step": {
+            "type": "select_option",
+            "params": {"label": "Status", "option_label": "Contacted"},
+        },
+    })
+    assert decision.mode == "edit_step"
+    assert decision.edited_step["type"] == "select_option"
+    assert decision.edited_step["params"]["option_label"] == "Contacted"
+
+
+def test_build_decision_insert_steps_drops_malformed_entries() -> None:
+    """Defensive: tool_use schema requires intent + type but we
+    drop entries that violate that rather than letting them through."""
+    decision = _build_decision({
+        "mode": "insert_steps",
+        "reasoning": "Need to dismiss modal first",
+        "inserted_steps": [
+            {"intent": "Press Escape to dismiss modal", "type": "scroll"},
+            {"intent": "", "type": "scroll"},  # empty intent — drop
+            {"type": "scroll"},  # missing intent — drop
+            "not a dict",  # wrong shape — drop
+        ],
+    })
+    assert decision.mode == "insert_steps"
+    assert len(decision.inserted_steps) == 1
+    assert "Escape" in decision.inserted_steps[0]["intent"]
+
+
+def test_build_decision_halt() -> None:
+    decision = _build_decision({"mode": "halt", "reasoning": "no qualified leads"})
+    assert decision.mode == "halt"
+    assert decision.hint == ""
+    assert decision.edited_step == {}
+    assert decision.inserted_steps == []
+
+
+def test_build_decision_treats_unknown_mode_as_halt() -> None:
+    """LLM occasionally produces a typo despite the enum schema —
+    coerce defensively rather than letting it propagate."""
+    decision = _build_decision({"mode": "wat", "reasoning": "?"})
+    assert decision.mode == "halt"
+
+
+# ── splice_inserted_steps ───────────────────────────────────────────────
+
+
+def test_splice_inserts_at_index() -> None:
+    """Splicing 2 steps before index 3 must produce a list with
+    the originals at indices 0,1,2 then inserted at 3,4 then
+    originals 3,4,... pushed to 5,6,..."""
+    a = MicroIntent(intent="A", type="navigate")
+    b = MicroIntent(intent="B", type="click")
+    c = MicroIntent(intent="C", type="submit")
+    d = MicroIntent(intent="D", type="extract_data")
+    e = MicroIntent(intent="E", type="extract_data")
+    helper1 = MicroIntent(intent="helper1", type="scroll")
+    helper2 = MicroIntent(intent="helper2", type="scroll")
+
+    new = splice_inserted_steps([a, b, c, d, e], 3, [helper1, helper2])
+
+    assert [s.intent for s in new] == ["A", "B", "C", "helper1", "helper2", "D", "E"]
+
+
+def test_splice_renumbers_loop_targets_pointing_at_or_after_insertion() -> None:
+    """Loop steps reference target indices absolutely — splicing
+    helpers in must shift any loop_target >= insertion_index by
+    +len(inserted)."""
+    nav = MicroIntent(intent="Open", type="navigate")
+    click = MicroIntent(intent="Click", type="click")
+    extract = MicroIntent(intent="Extract", type="extract_data")
+    loop = MicroIntent(
+        intent="Loop", type="loop", loop_target=1, loop_count=5,
+    )
+    helper = MicroIntent(intent="helper", type="scroll")
+
+    # Insert 1 helper at index 1 — loop_target=1 must become 2.
+    new = splice_inserted_steps([nav, click, extract, loop], 1, [helper])
+
+    loop_after = [s for s in new if s.type == "loop"][0]
+    assert loop_after.loop_target == 2  # was 1, shifted by +1
+
+
+def test_splice_does_not_renumber_targets_before_insertion() -> None:
+    """A loop pointing at an earlier-than-insertion step must not
+    shift — only targets >= insertion index move."""
+    a = MicroIntent(intent="A", type="navigate")
+    loop = MicroIntent(
+        intent="Loop back", type="loop", loop_target=0, loop_count=3,
+    )
+    c = MicroIntent(intent="C", type="extract_data")
+    helper = MicroIntent(intent="helper", type="scroll")
+
+    # Insert at index 2 — loop_target=0 stays 0.
+    new = splice_inserted_steps([a, loop, c], 2, [helper])
+    loop_after = [s for s in new if s.type == "loop"][0]
+    assert loop_after.loop_target == 0
+
+
+def test_splice_with_empty_inserted_is_no_op() -> None:
+    a = MicroIntent(intent="A", type="navigate")
+    b = MicroIntent(intent="B", type="extract_data")
+    new = splice_inserted_steps([a, b], 1, [])
+    assert [s.intent for s in new] == ["A", "B"]
+
+
+# ── StepRecoveryPolicy._try_agentic_recovery integration ────────────────
+
+
+@pytest.fixture(autouse=True)
+def _ensure_api_key(monkeypatch):
+    """Most policy-integration tests need ``ANTHROPIC_API_KEY`` set so
+    the recovery call reaches the (mocked) Claude path. The two
+    no-key tests opt out by deleting the env var inside the test."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+
+
+def _make_runner_with_recovery_state() -> MagicMock:
+    runner = MagicMock()
+    runner._recovery_attempts_per_step = {}
+    runner._total_recovery_attempts = 0
+    runner._recovery_hints = {}
+    runner._safe_screenshot.return_value = None
+    return runner
+
+
+def _make_plan() -> MicroPlan:
+    return MicroPlan(steps=[
+        MicroIntent(intent="A", type="navigate"),
+        MicroIntent(intent="B", type="fill_field"),
+        MicroIntent(intent="Click Update Lead", type="submit",
+                    params={"label": "Update Lead"}),
+    ])
+
+
+def test_recovery_returns_none_without_api_key(monkeypatch) -> None:
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    runner = _make_runner_with_recovery_state()
+    policy = StepRecoveryPolicy(parent=runner)
+    plan = _make_plan()
+    step = plan.steps[2]
+    result = StepResult(
+        step_index=2, intent=step.intent, success=False,
+        data="form_target_not_found",
+    )
+    outcome = policy._try_agentic_recovery(
+        step=step, step_result=result, step_index=2, plan=plan,
+        step_retry_counts={2: 2}, attempts=2,
+    )
+    assert outcome is None  # legacy halt path
+
+
+def test_recovery_applies_add_hint_mode() -> None:
+    """Successful add_hint recovery: the hint lands on the runner's
+    ``_recovery_hints`` and the outcome re-runs the same step."""
+    runner = _make_runner_with_recovery_state()
+    policy = StepRecoveryPolicy(parent=runner)
+    plan = _make_plan()
+    step = plan.steps[2]
+    result = StepResult(
+        step_index=2, intent=step.intent, success=False,
+        data="form_target_not_found",
+    )
+    payload = {
+        "mode": "add_hint",
+        "reasoning": "Real button is labeled Save",
+        "hint": "The button is labeled 'Save', not 'Update Lead'",
+    }
+    retry_counts = {2: 2}
+    with patch("requests.post", return_value=_tool_response(payload)):
+        outcome = policy._try_agentic_recovery(
+            step=step, step_result=result, step_index=2, plan=plan,
+            step_retry_counts=retry_counts, attempts=2,
+        )
+
+    assert outcome is not None
+    assert outcome.halt is False
+    assert outcome.step_index == 2
+    assert "recovery_hint" in outcome.halt_reason
+    # Hint stashed for the next form-handler invocation to read.
+    assert "Save" in runner._recovery_hints[2][0]
+    # Retry count reset so the step gets fresh attempts WITH the hint.
+    assert retry_counts[2] == 0
+    # Recovery budget bumped.
+    assert runner._recovery_attempts_per_step[2] == 1
+    assert runner._total_recovery_attempts == 1
+
+
+def test_recovery_applies_edit_step_mode() -> None:
+    """edit_step replaces the failed step's intent / type / params
+    in place; the runner re-runs the (now edited) step."""
+    runner = _make_runner_with_recovery_state()
+    policy = StepRecoveryPolicy(parent=runner)
+    plan = _make_plan()
+    step = plan.steps[2]
+    result = StepResult(
+        step_index=2, intent=step.intent, success=False,
+        data="form_target_not_found",
+    )
+    payload = {
+        "mode": "edit_step",
+        "reasoning": "Different label",
+        "edited_step": {
+            "params": {"label": "Save", "aliases": ["Update", "Submit"]},
+        },
+    }
+    with patch("requests.post", return_value=_tool_response(payload)):
+        outcome = policy._try_agentic_recovery(
+            step=step, step_result=result, step_index=2, plan=plan,
+            step_retry_counts={2: 2}, attempts=2,
+        )
+
+    assert outcome is not None
+    assert outcome.halt is False
+    assert "recovery_edit" in outcome.halt_reason
+    # Step mutated in place.
+    assert plan.steps[2].params["label"] == "Save"
+    assert "Update" in plan.steps[2].params["aliases"]
+
+
+def test_recovery_applies_insert_steps_mode() -> None:
+    """insert_steps splices helper steps BEFORE the failed step
+    via splice_inserted_steps. Plan length grows; the failed step
+    still re-runs but now after the helpers."""
+    runner = _make_runner_with_recovery_state()
+    policy = StepRecoveryPolicy(parent=runner)
+    plan = _make_plan()
+    step = plan.steps[2]
+    result = StepResult(
+        step_index=2, intent=step.intent, success=False,
+        data="form_target_not_found",
+    )
+    payload = {
+        "mode": "insert_steps",
+        "reasoning": "Need to dismiss modal first",
+        "inserted_steps": [
+            {"intent": "Press Escape to dismiss any open dialog",
+             "type": "scroll", "params": {}},
+        ],
+    }
+    with patch("requests.post", return_value=_tool_response(payload)):
+        outcome = policy._try_agentic_recovery(
+            step=step, step_result=result, step_index=2, plan=plan,
+            step_retry_counts={2: 2}, attempts=2,
+        )
+
+    assert outcome is not None
+    assert outcome.halt is False
+    # Plan now has 4 steps (3 + 1 helper).
+    assert len(plan.steps) == 4
+    # Helper is at index 2; the original failed step is at 3.
+    assert plan.steps[2].intent.startswith("Press Escape")
+    assert plan.steps[3].params.get("label") == "Update Lead"
+
+
+def test_recovery_halt_mode_falls_through() -> None:
+    """When the LLM picks ``halt`` recovery, the policy returns None
+    so the caller surfaces the legacy halt path."""
+    runner = _make_runner_with_recovery_state()
+    policy = StepRecoveryPolicy(parent=runner)
+    plan = _make_plan()
+    step = plan.steps[2]
+    result = StepResult(
+        step_index=2, intent=step.intent, success=False,
+        data="form_target_not_found",
+    )
+    payload = {"mode": "halt", "reasoning": "Target genuinely missing"}
+    with patch("requests.post", return_value=_tool_response(payload)):
+        outcome = policy._try_agentic_recovery(
+            step=step, step_result=result, step_index=2, plan=plan,
+            step_retry_counts={2: 2}, attempts=2,
+        )
+    assert outcome is None  # legacy halt
+    # But the budget was still bumped — the call happened.
+    assert runner._total_recovery_attempts == 1
+
+
+def test_recovery_per_step_budget_blocks_after_max() -> None:
+    """A step that has already used its per-step recovery budget
+    skips the LLM call and returns None directly. Prevents
+    infinite recovery loops on a single bad step."""
+    runner = _make_runner_with_recovery_state()
+    runner._recovery_attempts_per_step[2] = DEFAULT_MAX_RECOVERIES_PER_STEP
+    policy = StepRecoveryPolicy(parent=runner)
+    plan = _make_plan()
+    step = plan.steps[2]
+    result = StepResult(
+        step_index=2, intent=step.intent, success=False,
+        data="form_target_not_found",
+    )
+    with patch("requests.post") as mock_post:
+        outcome = policy._try_agentic_recovery(
+            step=step, step_result=result, step_index=2, plan=plan,
+            step_retry_counts={2: 2}, attempts=2,
+        )
+    assert outcome is None
+    mock_post.assert_not_called()
+
+
+def test_recovery_per_run_budget_blocks_after_max() -> None:
+    """Total recoveries across all steps capped — once exhausted,
+    no further recovery attempts."""
+    runner = _make_runner_with_recovery_state()
+    runner._total_recovery_attempts = DEFAULT_MAX_RECOVERIES_PER_RUN
+    policy = StepRecoveryPolicy(parent=runner)
+    plan = _make_plan()
+    step = plan.steps[2]
+    result = StepResult(
+        step_index=2, intent=step.intent, success=False, data="x",
+    )
+    with patch("requests.post") as mock_post:
+        outcome = policy._try_agentic_recovery(
+            step=step, step_result=result, step_index=2, plan=plan,
+            step_retry_counts={2: 2}, attempts=2,
+        )
+    assert outcome is None
+    mock_post.assert_not_called()


### PR DESCRIPTION
## Summary

When a required step terminally fails (after retries + handler escalation), Claude analyses the failure (step + last screenshot + failure data) and picks the cheapest viable recovery — instead of the runner halting.

Four modes:

| Mode | When | Effect |
|---|---|---|
| ``add_hint`` | Step structure is correct; needs clarifying instruction | Hint appended to next retry's search prompt |
| ``edit_step`` | Step labels / type / params wrong | Step mutated in place |
| ``insert_steps`` | Precondition missing (scroll / dismiss / navigate) | Helper steps spliced BEFORE failed step; loop_targets renumbered |
| ``halt`` | Truly irrecoverable (target missing, anti-bot) | Current behavior |

## Why

Surfaced by the staff-crm-with-Contacted JSON-plan rerun: the runner made it 10/13 steps end-to-end (login → leads → filter → click lead → edit → set Industry Vertical → ...) but failed at step 10 ``Click the Update Lead button`` with ``form_target_not_found`` — the literal label "Update Lead" doesn't exist on this CRM; the real button is "Save". Every existing layer (retries, SPA-aware verify, agentic scroll, failure-aware retries, handler escalation) is upstream of the "step's labels don't match the actual page" failure mode.

## Bounded by budgets

- Per-step max 2 recoveries — prevents pathological page from burning recovery alone on one bad step
- Per-run max 5 recoveries — total cap per plan execution
- Falls through to legacy halt path on any guard (no key / API error / budget exhausted / unknown mode)

## Six pieces

- ``mantis_agent/agentic_recovery.py`` — new module: ``RecoveryDecision`` dataclass, ``analyse_failure_and_recover`` (Claude tool_use with strict 4-mode schema), ``splice_inserted_steps`` (loop_target-aware splice)
- ``gym/step_recovery.py`` — ``_try_agentic_recovery`` invoked before legacy halt; reads / increments runner budgets; applies the chosen mode
- ``gym/step_handlers/form.py`` — submit branch surfaces accumulated hints into the search prompt
- ``gym/micro_runner.py`` — three new fields: ``_recovery_hints``, ``_recovery_attempts_per_step``, ``_total_recovery_attempts``
- ``gym/run_executor.py`` — ``_handle_success`` clears recovery state on success
- ``tests/test_agentic_recovery.py`` — 20 cases covering every path

## Test plan

- [x] ``pytest tests/test_agentic_recovery.py`` — 20/20 passing
- [x] Full suite ``pytest -n auto`` — 1459 passed in 7m17s
- [x] ``ruff check`` clean
- [x] Existing ``test_step_recovery_policy`` + ``test_agentic_retry_feedback`` still green (defensive against MagicMock-style runner stubs)

## Stack progression

| PR | Layer |
|---|---|
| #228 | SPA-aware verify |
| #229 | Agentic scroll search |
| #230 | Failure-aware retries |
| #231 | Coords + warn-level retry log |
| #232 | Handler escalation (no_state_change × 2 → Holo3) |
| #233 | Bump Holo3 budget on escalation |
| #234 | Pagination-aware prompt + budget bump |
| #235 | Holo3 stop-on-navigation prompt |
| **this** | **When all of the above still fail, Claude analyses + adapts** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)