### PR TITLE
feat(extraction): tile vs detail-page extraction context (#236)

### DIFF
--- a/src/mantis_agent/extraction/__init__.py
+++ b/src/mantis_agent/extraction/__init__.py
@@ -32,7 +32,7 @@ from .extractor import (
     ClaudeExtractor,
 )
 from .result import ExtractionResult
-from .schema import ExtractionSchema
+from .schema import ExtractionContext, ExtractionSchema
 from .spam import (
     _contains_dealer_text,
     _parse_bool,
@@ -67,6 +67,7 @@ def __getattr__(name: str) -> Any:  # PEP 562
 
 
 __all__ = [
+    "ExtractionContext",
     "ExtractionSchema",
     "ExtractionResult",
     "ClaudeExtractor",

--- a/src/mantis_agent/extraction/result.py
+++ b/src/mantis_agent/extraction/result.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass, field
 
-from .schema import ExtractionSchema
+from .schema import ExtractionContext, ExtractionSchema
 from .spam import contains_dealer_text, seller_looks_like_dealer
 
 
@@ -81,11 +81,34 @@ class ExtractionResult:
         digits = re.sub(r"\D", "", phone)
         return len(digits) >= 10
 
-    def missing_required_reason(self) -> str:
-        """Return why this extraction is not a usable lead."""
+    def missing_required_reason(
+        self,
+        context: ExtractionContext = ExtractionContext.UNKNOWN,
+    ) -> str:
+        """Return why this extraction is not a usable lead.
+
+        Issue #236: ``context`` selects which required-field contract
+        to enforce. ``DETAIL_PAGE`` uses ``schema.required_fields``
+        (canonical strict set). ``SEARCH_TILE`` uses
+        ``schema.tile_required_fields`` when set — typically just
+        ``["url"]`` so the runner keeps the row to drive a follow-up
+        navigate-into-detail. ``UNKNOWN`` (default) preserves legacy
+        behavior: enforces ``required_fields`` regardless of context.
+
+        When the schema doesn't define ``tile_required_fields`` (empty
+        list), ``SEARCH_TILE`` falls back to ``required_fields`` —
+        recipes that don't opt into the split see no behavior change.
+        """
         if self._schema:
+            if (
+                context == ExtractionContext.SEARCH_TILE
+                and self._schema.tile_required_fields
+            ):
+                fields_to_check = self._schema.tile_required_fields
+            else:
+                fields_to_check = self._schema.required_fields
             missing = [
-                name for name in self._schema.required_fields
+                name for name in fields_to_check
                 if not self.extracted_fields.get(name)
             ]
             return f"missing required field(s): {', '.join(missing)}" if missing else ""

--- a/src/mantis_agent/extraction/schema.py
+++ b/src/mantis_agent/extraction/schema.py
@@ -10,7 +10,29 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass, field
+from enum import Enum
 from typing import Any
+
+
+class ExtractionContext(str, Enum):
+    """Where the extractor is reading from — drives which required-field
+    contract to enforce.
+
+    Issue #236: ``required_fields`` enforced uniformly is the dominant
+    failure mode on listings sites. Search-result tiles often render
+    canonical fields (year, make, ...) only in image alt-text or
+    JSON-LD that vision-mode extraction can't see; rejecting every
+    tile-mode row that lacks them halts the run before any leads are
+    captured. Tagging context lets the schema apply a strict contract
+    on the canonical detail page and a looser one on tiles.
+
+    The string-enum shape lets callers pass either the enum or the
+    raw string (matching the JSON-serialisable plan-step shape).
+    """
+
+    SEARCH_TILE = "search_tile"   # reading a row from a list of cards
+    DETAIL_PAGE = "detail_page"   # reading the canonical entity page
+    UNKNOWN = "unknown"           # default — preserves current behavior
 
 
 @dataclass
@@ -28,6 +50,20 @@ class ExtractionSchema:
     entity_name: str = "listing"  # "boat listing", "job posting", "property"
     fields: list[dict[str, Any]] = field(default_factory=list)  # OutputField-like dicts
     required_fields: list[str] = field(default_factory=list)  # field names for viability
+    # Issue #236: per-context required-field contracts. ``required_fields``
+    # is the strict DETAIL_PAGE contract (canonical entity fields the
+    # detail page must surface). ``tile_required_fields`` is the looser
+    # SEARCH_TILE contract — typically just ``["url"]`` so the runner can
+    # keep the row to drive a follow-up navigate-into-detail. Empty list
+    # ``[]`` opts out of the split (uses ``required_fields`` for both
+    # contexts), preserving existing recipe behavior.
+    tile_required_fields: list[str] = field(default_factory=list)
+    # Informational hint: which fields the search tile is expected to
+    # surface. The runner uses this to decide what NOT to re-read on
+    # the detail page (carry from tile → enrich detail). Recipe-side
+    # only; framework primitives don't enforce it. Empty list = no
+    # carry (today's behavior).
+    tile_carry_fields: list[str] = field(default_factory=list)
     spam_indicators: list[str] = field(default_factory=list)
     spam_seller_indicators: list[str] = field(default_factory=list)
     spam_label: str = "dealer/spam"  # what to call spam (e.g. "dealer", "recruiter")
@@ -58,6 +94,8 @@ class ExtractionSchema:
             entity_name=getattr(objective, "target_entity", "item") or "item",
             fields=fields or cls._default_fields(),
             required_fields=required or ["url"],
+            tile_required_fields=list(getattr(objective, "tile_required_fields", []) or []),
+            tile_carry_fields=list(getattr(objective, "tile_carry_fields", []) or []),
             spam_indicators=spam_text,
             spam_seller_indicators=spam_seller,
             spam_label=spam_label,
@@ -190,10 +228,25 @@ class ExtractionSchema:
             if self.spam_label and self.spam_label != "dealer/spam"
             else (other.spam_label or self.spam_label)
         )
+        # Tile-context fields (#236): derived schema body wins for
+        # ``tile_required_fields`` (the plan text owns the tile contract
+        # the same way it owns ``required_fields``). For
+        # ``tile_carry_fields`` — informational only — recipe extends
+        # derived (recipes accumulate empirical knowledge of which
+        # tile fields actually render across the marketplace's
+        # listing variants).
         return ExtractionSchema(
             entity_name=entity,
             fields=self.fields,
             required_fields=self.required_fields,
+            tile_required_fields=(
+                self.tile_required_fields
+                if self.tile_required_fields
+                else other.tile_required_fields
+            ),
+            tile_carry_fields=_union(
+                self.tile_carry_fields, other.tile_carry_fields,
+            ),
             spam_indicators=_union(self.spam_indicators, other.spam_indicators),
             spam_seller_indicators=_union(
                 self.spam_seller_indicators, other.spam_seller_indicators,

--- a/src/mantis_agent/gym/step_handlers/claude_step.py
+++ b/src/mantis_agent/gym/step_handlers/claude_step.py
@@ -61,6 +61,42 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _resolve_extraction_context(runner: "MicroPlanRunner", data: object | None):
+    """Classify the extracted page as SEARCH_TILE / DETAIL_PAGE / UNKNOWN.
+
+    Issue #236: ``ExtractionResult.missing_required_reason`` accepts a
+    context arg to choose between strict (detail-page) and loose
+    (search-tile) required-field contracts. The cleanest signal is the
+    URL the extractor was reading, classified via the runner's
+    ``SiteConfig.is_detail_page`` / ``is_results_page`` (those already
+    encode the per-domain regex authoring).
+
+    Returns ``ExtractionContext.UNKNOWN`` when no SiteConfig is
+    configured or its patterns are empty — preserves legacy behavior
+    for runs without a configured site.
+    """
+    from ...extraction import ExtractionContext
+
+    site_config = getattr(runner, "site_config", None)
+    if site_config is None:
+        return ExtractionContext.UNKNOWN
+    url = (
+        getattr(data, "url", "")
+        or getattr(runner, "_last_known_url", "")
+        or ""
+    )
+    if not url:
+        return ExtractionContext.UNKNOWN
+    try:
+        if site_config.is_detail_page(url):
+            return ExtractionContext.DETAIL_PAGE
+        if site_config.is_results_page(url):
+            return ExtractionContext.SEARCH_TILE
+    except Exception:  # noqa: BLE001 — never break the extraction path
+        return ExtractionContext.UNKNOWN
+    return ExtractionContext.UNKNOWN
+
+
 class ClaudeStepHandler:
     """Implements :class:`~..step_context.StepHandler` for Claude-only steps.
 
@@ -251,8 +287,19 @@ class ClaudeStepHandler:
                     success=False,
                     data=f"REJECTED_DEALER|{reason}|{data.to_summary()[:160]}",
                 )
-            if data and data.missing_required_reason():
-                reason = data.missing_required_reason()
+            # Issue #236: pick the right required-field contract based
+            # on which kind of page the extractor read. ``DETAIL_PAGE``
+            # enforces the strict canonical set (e.g. year + make for
+            # marketplace listings); ``SEARCH_TILE`` enforces the
+            # looser tile_required_fields set when defined (typically
+            # just ``url``) so the runner keeps the row to drive a
+            # follow-up navigate-into-detail. Source of truth: the
+            # extracted URL classified via SiteConfig. Default
+            # ``UNKNOWN`` when no SiteConfig is configured —
+            # preserves legacy behavior for non-listings sites.
+            extraction_context = _resolve_extraction_context(runner, data)
+            if data and data.missing_required_reason(extraction_context):
+                reason = data.missing_required_reason(extraction_context)
                 logger.info("  [extract] Rejected incomplete lead: %s", reason)
                 runner._last_extracted = {
                     **runner._last_extracted,

--- a/src/mantis_agent/recipes/marketplace_listings/_data.py
+++ b/src/mantis_agent/recipes/marketplace_listings/_data.py
@@ -74,6 +74,19 @@ def fields() -> list[dict[str, Any]]:
 
 
 REQUIRED_FIELDS: tuple[str, ...] = ("year", "make")
+# Issue #236: looser required-field contract for SEARCH_TILE
+# extraction. Tiles often render year/make only in alt-text or
+# JSON-LD (invisible to vision-mode extraction); the strict
+# ``REQUIRED_FIELDS`` set was rejecting every tile row, halting
+# the run with zero leads. Tile mode now needs only ``url`` so
+# the runner can keep the row to drive a follow-up navigation
+# into the detail page where ``REQUIRED_FIELDS`` is enforced.
+TILE_REQUIRED_FIELDS: tuple[str, ...] = ("url",)
+# Informational hint: which fields the search tile is expected to
+# surface. The runner uses this to skip re-reading these on the
+# detail page (carry from tile → enrich detail). url, title,
+# price near-universally render on marketplace tile cards.
+TILE_CARRY_FIELDS: tuple[str, ...] = ("url", "title", "price")
 # "boat listing" is preserved verbatim from the legacy
 # ExtractionSchema.default_boattrader() default. Renaming it would be a
 # behavior change for callers reading entity_name in their own prompts.

--- a/src/mantis_agent/recipes/marketplace_listings/schema.py
+++ b/src/mantis_agent/recipes/marketplace_listings/schema.py
@@ -21,6 +21,13 @@ def _build_schema() -> ExtractionSchema:
         entity_name=_data.ENTITY_NAME,
         fields=_data.fields(),
         required_fields=list(_data.REQUIRED_FIELDS),
+        # Issue #236: opt into the tile-vs-detail required-field
+        # split. Strict ``required_fields`` enforced on detail-page
+        # extraction; ``tile_required_fields`` (just ``url``)
+        # enforced on search-tile extraction so rows survive long
+        # enough to drive the navigate-into-detail follow-up.
+        tile_required_fields=list(_data.TILE_REQUIRED_FIELDS),
+        tile_carry_fields=list(_data.TILE_CARRY_FIELDS),
         spam_indicators=list(_data.DEALER_TEXT_INDICATORS),
         spam_seller_indicators=list(_data.DEALER_SELLER_INDICATORS),
         spam_label=_data.SPAM_LABEL,

--- a/tests/test_claude_step_handler.py
+++ b/tests/test_claude_step_handler.py
@@ -183,7 +183,7 @@ def test_extract_data_viable_writes_to_cache_when_write_enabled(monkeypatch):
         url="https://example.com/listing/777",
         is_viable=lambda: True,
         dealer_reason=lambda: None,
-        missing_required_reason=lambda: None,
+        missing_required_reason=lambda *_a, **_k: None,
         to_summary=lambda: "VIABLE | year:2024 | make:Acme",
         extracted_fields={"year": "2024", "make": "Acme"},
     )
@@ -221,7 +221,7 @@ def test_extract_data_post_extract_dedup_returns_duplicate(monkeypatch):
         url="https://example.com/already-seen",
         is_viable=lambda: True,
         dealer_reason=lambda: None,
-        missing_required_reason=lambda: None,
+        missing_required_reason=lambda *_a, **_k: None,
         to_summary=lambda: "VIABLE | seen",
         extracted_fields={},
     )
@@ -249,7 +249,7 @@ def test_extract_data_rejects_dealer_listing(monkeypatch):
         url="https://example.com/dealer/123",
         is_viable=lambda: False,
         dealer_reason=lambda: "seller looks like dealer: AcmeAuto",
-        missing_required_reason=lambda: None,
+        missing_required_reason=lambda *_a, **_k: None,
         to_summary=lambda: "DEALER | year:2020 | make:Acme | seller:AcmeAuto",
     )
     extractor = MagicMock()
@@ -273,7 +273,7 @@ def test_extract_data_rejects_incomplete_listing(monkeypatch):
         url="https://example.com/incomplete/9",
         is_viable=lambda: False,
         dealer_reason=lambda: None,
-        missing_required_reason=lambda: "missing required field(s): year",
+        missing_required_reason=lambda *_a, **_k: "missing required field(s): year",
         to_summary=lambda: "INCOMPLETE | make:Acme",
     )
     extractor = MagicMock()

--- a/tests/test_extraction_context.py
+++ b/tests/test_extraction_context.py
@@ -1,0 +1,283 @@
+"""Tests for issue #236 — tile vs detail-page extraction context.
+
+The dominant failure mode on listings sites: ``required_fields``
+enforced uniformly rejects every search-tile row when the tile only
+surfaces ``url`` / ``title`` / ``price`` (canonical fields like
+``year``/``make`` live in alt-text or JSON-LD, invisible to vision
+extraction). The recipe-level fix tags context so the strict contract
+applies only on detail-page extractions; tile-mode falls back to a
+looser ``tile_required_fields`` set.
+
+These tests pin:
+
+- :class:`ExtractionContext` enum surface
+- :meth:`ExtractionResult.missing_required_reason` — context-aware
+  field selection, fallback to required_fields when tile contract
+  unset, legacy UNKNOWN preserves prior behavior
+- :class:`ExtractionSchema` overlay merges ``tile_required_fields``
+  / ``tile_carry_fields`` cleanly
+- ``marketplace_listings`` recipe ships the new fields
+- ``_resolve_extraction_context`` helper picks the right enum
+  from a runner / SiteConfig
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from mantis_agent import recipes
+from mantis_agent.extraction import (
+    ExtractionContext,
+    ExtractionResult,
+    ExtractionSchema,
+)
+from mantis_agent.gym.step_handlers.claude_step import _resolve_extraction_context
+from mantis_agent.site_config import SiteConfig
+
+
+# ── ExtractionContext enum ───────────────────────────────────────────────
+
+
+def test_extraction_context_enum_values() -> None:
+    """The string-enum shape lets callers pass either the enum or the
+    raw string — important when the context flows through JSON-shaped
+    plan steps."""
+    assert ExtractionContext.SEARCH_TILE == "search_tile"
+    assert ExtractionContext.DETAIL_PAGE == "detail_page"
+    assert ExtractionContext.UNKNOWN == "unknown"
+
+
+# ── missing_required_reason context routing ─────────────────────────────
+
+
+def _row(**kwargs: str) -> ExtractionResult:
+    schema = kwargs.pop("schema", None)
+    fields = kwargs
+    result = ExtractionResult(extracted_fields=fields, _schema=schema)
+    return result
+
+
+def test_detail_page_enforces_required_fields() -> None:
+    """Detail-page context uses the strict ``required_fields`` set —
+    today's behavior. Missing year on a detail page → rejected."""
+    schema = ExtractionSchema(
+        required_fields=["year", "make"],
+        tile_required_fields=["url"],
+    )
+    row = _row(schema=schema, url="https://x.test/boat/123", make="Sea Ray")
+    reason = row.missing_required_reason(ExtractionContext.DETAIL_PAGE)
+    assert "year" in reason
+
+
+def test_search_tile_enforces_tile_required_fields_when_set() -> None:
+    """Tile context uses ``tile_required_fields`` when defined — a row
+    with ``url`` only passes even though ``year``/``make`` are missing."""
+    schema = ExtractionSchema(
+        required_fields=["year", "make"],
+        tile_required_fields=["url"],
+    )
+    row = _row(schema=schema, url="https://x.test/boats/?page=1")
+    reason = row.missing_required_reason(ExtractionContext.SEARCH_TILE)
+    assert reason == ""
+
+
+def test_search_tile_falls_back_to_required_when_tile_unset() -> None:
+    """Recipes that don't opt into the split (no ``tile_required_fields``)
+    enforce ``required_fields`` for both contexts — preserves legacy
+    behavior."""
+    schema = ExtractionSchema(
+        required_fields=["year", "make"],
+        # tile_required_fields=[] — empty (default)
+    )
+    row = _row(schema=schema, url="https://x.test/boats/", title="Sea Ray")
+    reason = row.missing_required_reason(ExtractionContext.SEARCH_TILE)
+    # No url-only escape — falls back to required_fields strict check.
+    assert "year" in reason and "make" in reason
+
+
+def test_unknown_context_enforces_required_fields() -> None:
+    """``UNKNOWN`` (default for legacy callers) preserves today's
+    behavior — strict ``required_fields`` regardless of page kind."""
+    schema = ExtractionSchema(
+        required_fields=["year", "make"],
+        tile_required_fields=["url"],
+    )
+    row = _row(schema=schema, url="https://x.test/boat/")
+    reason = row.missing_required_reason(ExtractionContext.UNKNOWN)
+    assert "year" in reason and "make" in reason
+
+
+def test_default_argument_is_unknown_for_backwards_compat() -> None:
+    """Existing callers that don't pass a context get UNKNOWN — same
+    behavior they had before #236."""
+    schema = ExtractionSchema(
+        required_fields=["year", "make"],
+        tile_required_fields=["url"],
+    )
+    row = _row(schema=schema, url="https://x.test/boat/")
+    # No context arg — default UNKNOWN — strict enforcement.
+    reason = row.missing_required_reason()
+    assert "year" in reason
+
+
+def test_tile_search_passes_with_url_only() -> None:
+    """End-to-end tile case: row has just ``url`` from the listing
+    card; tile contract requires only ``url``; gate passes."""
+    schema = ExtractionSchema(
+        required_fields=["year", "make", "price"],
+        tile_required_fields=["url"],
+    )
+    row = _row(schema=schema, url="https://boats.test/listing/123")
+    assert row.missing_required_reason(ExtractionContext.SEARCH_TILE) == ""
+
+
+# ── ExtractionSchema overlay merges new fields ──────────────────────────
+
+
+def test_overlay_recipe_extends_tile_carry_fields() -> None:
+    """``tile_carry_fields`` is informational accumulation — recipe
+    extends derived (deduped union)."""
+    derived = ExtractionSchema(
+        entity_name="property listing",
+        tile_carry_fields=["url", "title"],
+    )
+    recipe = ExtractionSchema(
+        tile_carry_fields=["url", "price", "address"],
+    )
+    merged = derived.overlay(recipe)
+    assert merged.tile_carry_fields == ["url", "title", "price", "address"]
+
+
+def test_overlay_keeps_derived_tile_required_fields_when_set() -> None:
+    """Like ``required_fields``, derived owns ``tile_required_fields``
+    once it has a value — recipe doesn't clobber."""
+    derived = ExtractionSchema(tile_required_fields=["url", "title"])
+    recipe = ExtractionSchema(tile_required_fields=["url"])
+    merged = derived.overlay(recipe)
+    assert merged.tile_required_fields == ["url", "title"]
+
+
+def test_overlay_recipe_fills_in_when_derived_tile_required_empty() -> None:
+    """When derived has no opinion on tile contract, recipe fills it in."""
+    derived = ExtractionSchema()  # no tile_required_fields
+    recipe = ExtractionSchema(tile_required_fields=["url"])
+    merged = derived.overlay(recipe)
+    assert merged.tile_required_fields == ["url"]
+
+
+# ── marketplace_listings recipe ships the new fields ────────────────────
+
+
+def test_marketplace_listings_has_tile_required_fields() -> None:
+    schema = recipes.load_schema("marketplace_listings")
+    assert schema.tile_required_fields == ["url"]
+    # Strict required_fields preserved for detail-page mode.
+    assert "year" in schema.required_fields
+    assert "make" in schema.required_fields
+
+
+def test_marketplace_listings_has_tile_carry_fields() -> None:
+    schema = recipes.load_schema("marketplace_listings")
+    assert "url" in schema.tile_carry_fields
+    assert "title" in schema.tile_carry_fields
+    assert "price" in schema.tile_carry_fields
+
+
+def test_marketplace_recipe_tile_extraction_does_not_reject_url_only_row() -> None:
+    """End-to-end against the real recipe: a tile row with just url
+    must NOT be rejected (this is exactly the scenario that halted
+    the BoatTrader → PopYachts plan run before this fix)."""
+    schema = recipes.load_schema("marketplace_listings")
+    row = _row(schema=schema, url="https://boattrader.com/boat/abc")
+    assert row.missing_required_reason(ExtractionContext.SEARCH_TILE) == ""
+
+
+def test_marketplace_recipe_detail_extraction_still_strict() -> None:
+    """Same recipe, detail-page context: strict canonical fields
+    required. A row missing year is rejected — today's behavior
+    preserved for the detail-page case."""
+    schema = recipes.load_schema("marketplace_listings")
+    row = _row(
+        schema=schema, url="https://boattrader.com/boat/abc",
+        make="Sea Ray", model="240 Sundeck",
+    )
+    reason = row.missing_required_reason(ExtractionContext.DETAIL_PAGE)
+    assert "year" in reason
+
+
+# ── _resolve_extraction_context helper ──────────────────────────────────
+
+
+def _runner_with_site(site_config: SiteConfig | None, last_url: str = "") -> MagicMock:
+    runner = MagicMock()
+    runner.site_config = site_config
+    runner._last_known_url = last_url
+    return runner
+
+
+def test_resolve_context_returns_unknown_when_no_site_config() -> None:
+    runner = _runner_with_site(None)
+    data = MagicMock(url="https://x.test/")
+    assert _resolve_extraction_context(runner, data) == ExtractionContext.UNKNOWN
+
+
+def test_resolve_context_classifies_detail_page_from_url() -> None:
+    """SiteConfig.is_detail_page returns True → DETAIL_PAGE."""
+    site = SiteConfig(
+        domain="boattrader.com",
+        detail_page_pattern=r"/boat/[\w-]+",
+    )
+    runner = _runner_with_site(site)
+    data = MagicMock(url="https://boattrader.com/boat/2020-sea-ray-240/")
+    assert _resolve_extraction_context(runner, data) == ExtractionContext.DETAIL_PAGE
+
+
+def test_resolve_context_classifies_search_tile_from_url() -> None:
+    """SiteConfig.is_results_page returns True → SEARCH_TILE."""
+    site = SiteConfig(
+        domain="boattrader.com",
+        results_page_pattern=r"/boats/",
+    )
+    runner = _runner_with_site(site)
+    data = MagicMock(url="https://boattrader.com/boats/by-owner/")
+    assert _resolve_extraction_context(runner, data) == ExtractionContext.SEARCH_TILE
+
+
+def test_resolve_context_falls_back_to_runner_url_when_data_url_missing() -> None:
+    """Some extraction paths produce a result without a URL — fall
+    back to ``runner._last_known_url`` so the classification still
+    fires."""
+    site = SiteConfig(
+        domain="boattrader.com",
+        detail_page_pattern=r"/boat/[\w-]+",
+    )
+    runner = _runner_with_site(
+        site, last_url="https://boattrader.com/boat/2020-x/",
+    )
+    # data has empty url; should use runner's _last_known_url.
+    data = MagicMock(url="")
+    assert _resolve_extraction_context(runner, data) == ExtractionContext.DETAIL_PAGE
+
+
+def test_resolve_context_returns_unknown_on_neither_match() -> None:
+    """URL doesn't match either pattern (e.g. login page, dashboard)
+    — UNKNOWN, falls back to legacy strict enforcement."""
+    site = SiteConfig(
+        domain="boattrader.com",
+        detail_page_pattern=r"/boat/[\w-]+",
+        results_page_pattern=r"/boats/",
+    )
+    runner = _runner_with_site(site)
+    data = MagicMock(url="https://boattrader.com/login")
+    assert _resolve_extraction_context(runner, data) == ExtractionContext.UNKNOWN
+
+
+def test_resolve_context_swallows_site_config_exceptions() -> None:
+    """Defensive: a malformed site config that raises on URL check
+    must not break the extraction path. Fall through to UNKNOWN."""
+    site = MagicMock()
+    site.is_detail_page.side_effect = ValueError("bad regex")
+    site.is_results_page.side_effect = ValueError("bad regex")
+    runner = _runner_with_site(site, last_url="https://x.test/")
+    data = MagicMock(url="https://x.test/")
+    assert _resolve_extraction_context(runner, data) == ExtractionContext.UNKNOWN

--- a/tests/test_extraction_context.py
+++ b/tests/test_extraction_context.py
@@ -186,7 +186,7 @@ def test_marketplace_listings_has_tile_carry_fields() -> None:
 def test_marketplace_recipe_tile_extraction_does_not_reject_url_only_row() -> None:
     """End-to-end against the real recipe: a tile row with just url
     must NOT be rejected (this is exactly the scenario that halted
-    the BoatTrader → PopYachts plan run before this fix)."""
+    the marketplace-listing plan run before this fix)."""
     schema = recipes.load_schema("marketplace_listings")
     row = _row(schema=schema, url="https://boattrader.com/boat/abc")
     assert row.missing_required_reason(ExtractionContext.SEARCH_TILE) == ""


### PR DESCRIPTION
Closes #236. Recipe-side fix replaces ~80 lines of plan-text boilerplate with a 3-line schema declaration.

## Problem

``ExtractionSchema.required_fields`` enforced uniformly across SEARCH_TILE and DETAIL_PAGE extraction. Tiles often render canonical fields (year, make) only inside image alt-text or JSON-LD — invisible to vision extraction. Every tile-mode row was rejected with ``REJECTED_INCOMPLETE | missing required field(s): year, make``; runs halted with zero leads.

## Fix

Tag context. Schema applies strict contract on detail pages, looser ``tile_required_fields`` on tiles.

```python
ExtractionSchema(
    required_fields=['year', 'make'],          # detail-page contract
    tile_required_fields=['url'],              # tile-mode minimum
    tile_carry_fields=['url', 'title', 'price'], # tile surfaces these
)
```

Runner picks context from the page URL via ``SiteConfig.is_detail_page`` / ``is_results_page``. Default ``ExtractionContext.UNKNOWN`` preserves legacy behavior for all existing callers.

## Public surface

- ``ExtractionContext`` (``str, Enum``) — exported from ``mantis_agent.extraction``
- ``ExtractionSchema.tile_required_fields: list[str]`` — looser tile contract
- ``ExtractionSchema.tile_carry_fields: list[str]`` — informational hint
- ``ExtractionResult.missing_required_reason(context=UNKNOWN)`` — context-aware
- ``_resolve_extraction_context(runner, data)`` — helper in claude_step.py

## Recipe

``marketplace_listings`` opts in:
```python
TILE_REQUIRED_FIELDS: tuple[str, ...] = ("url",)
TILE_CARRY_FIELDS: tuple[str, ...] = ("url", "title", "price")
```
Detail-page contract preserved (year, make).

## Backwards compatibility

- Default UNKNOWN context → identical behavior
- Empty ``tile_required_fields`` → SEARCH_TILE falls back to ``required_fields``
- Existing test stubs updated to accept the new optional arg

## Test plan

- [x] 20 new tests in ``tests/test_extraction_context.py``: enum surface, context-aware field selection, tile/detail fallbacks, schema overlay merge, marketplace_listings end-to-end, ``_resolve_extraction_context`` URL classification (incl. exception fallback)
- [x] Full suite ``pytest -n auto`` — 1479/1479 in 8m04s
- [x] ``ruff check`` clean

## Adjacent

- Builds on #225 overlay primitives (extended to merge the new fields)
- Intersects #224 derive-first: when host derives schema from objective, the same context tagging applies via ``ExtractionSchema.from_objective`` reading ``tile_*`` fields from the objective via ``getattr``

🤖 Generated with [Claude Code](https://claude.com/claude-code)