### PR TITLE
feat(form): vision-affordance fallback after label-match exhausts

### DIFF
--- a/src/mantis_agent/extraction/extractor.py
+++ b/src/mantis_agent/extraction/extractor.py
@@ -1600,3 +1600,171 @@ class ClaudeExtractor:
         }
         logger.info(f"  [claude-form] '{result['label'][:40]}' at ({x},{y}) action={result['action']}")
         return result
+
+    def find_target_by_affordance(
+        self,
+        screenshot: Image.Image,
+        intent: str,
+    ) -> dict | None:
+        """Locate the right element for an intent by VISUAL AFFORDANCE
+        rather than any specific label or hardcoded action assumption.
+
+        The label-driven ``find_form_target`` requires the caller to
+        know the element's literal text (or one of its aliases). That
+        doesn't work for:
+
+        - non-English UIs (``Enregistrer`` / ``Speichern`` / ``保存``)
+        - icon-only controls (checkmark / floppy / paper-plane glyphs)
+        - product-specific labels the plan author couldn't predict
+        - elements whose visual position is recognisable but whose
+          label is partially obscured / abbreviated
+
+        This method is the visual-fallback partner. It DOES NOT assume
+        the target is a button / submit / action — it reads the
+        intent prose and asks Claude "what element on this page best
+        matches this intent, by visual affordance?". The intent
+        determines the element type:
+
+        - "Click Save" → primary action button
+        - "Enter password in Password field" → text input
+        - "Pick High from Priority dropdown" → dropdown control
+        - "Toggle the Enable Notifications switch" → toggle / checkbox
+
+        Claude reads the intent, identifies the affordance category,
+        and returns coordinates + the OBSERVED label / description so
+        the runner can log what it actually found (in any language /
+        for any icon).
+
+        Used as a fallback by the form handler when the cheaper
+        label-match search has exhausted. Returns the same result
+        shape as ``find_form_target`` — when ``action`` is
+        ``"not_found"`` the helper returns ``None`` so the caller
+        falls through to existing failure paths.
+        """
+        prompt = (
+            f"Look at this screenshot ({screenshot.width}x{screenshot.height} pixels).\n\n"
+            f"INTENT (read this carefully — it tells you what kind of "
+            f"element to find): {intent}\n\n"
+            f"The label-driven search for this intent already failed: no "
+            f"element matched the literal label / alias the plan "
+            f"specified. The intent prose ABOVE is the source of truth "
+            f"for what the runner is trying to do — read it, infer the "
+            f"element type that fits, and locate that element by VISUAL "
+            f"AFFORDANCE rather than text matching.\n\n"
+            f"Element-type heuristics (use the intent verbs to choose):\n"
+            f"- ``click`` / ``open`` / ``submit`` / ``save`` / ``confirm`` "
+            f"/ ``select [a row / lead / item]`` — find a button, link, "
+            f"or clickable card. Primary action buttons are typically "
+            f"coloured / filled, in form footers or sticky toolbars; "
+            f"secondary buttons (Cancel, Reset, Back) are typically "
+            f"grey / outline.\n"
+            f"- ``enter`` / ``type`` / ``fill`` / ``input`` — find a "
+            f"text input or textarea. Match the intent's field name to "
+            f"the visible label adjacent to (above / left of / "
+            f"placeholder inside) the input box.\n"
+            f"- ``pick`` / ``choose`` / ``select [option] from [dropdown]`` "
+            f"— find a dropdown / select control (visible chevron or "
+            f"current value).\n"
+            f"- ``toggle`` / ``check`` / ``enable`` / ``disable`` — "
+            f"find a checkbox / toggle / radio.\n\n"
+            f"LANGUAGE-AGNOSTIC: the element's visible label may be in "
+            f"any language (English, French, German, Japanese, etc) "
+            f"or icon-only. Match by AFFORDANCE — shape, position, "
+            f"styling — not by specific words. The intent's reference "
+            f"to a field or button name is a HINT (semantic match) "
+            f"rather than a literal text-match requirement.\n\n"
+            f"NO HARDCODED ACTION ASSUMPTIONS: don't assume the target "
+            f"is necessarily a submit button. If the intent is "
+            f"``Enter the password``, the target is the password "
+            f"input, NOT the Login button. The intent verb is the "
+            f"final word.\n\n"
+            f"If you see no element on screen that plausibly matches "
+            f"the intent, return action=not_found and describe in "
+            f"``label`` what is visible. The runner will route that "
+            f"to its existing failure / recovery path.\n\n"
+            f"Return CENTER coordinates of the chosen element along "
+            f"with the EXACT TEXT or icon description visible on it. "
+            f"Set ``action`` to one of ``click`` / ``type`` / "
+            f"``select`` based on what the runner should do next "
+            f"(matching the verb in the intent)."
+        )
+        parsed = self._call_with_tool_schema(
+            screenshot,
+            prompt,
+            tool_name="report_target_by_affordance",
+            tool_description=(
+                "Report the location, observed label, and recommended "
+                "action for the element best matching the intent — "
+                "identified by visual affordance, not label match."
+            ),
+            input_schema={
+                "type": "object",
+                "properties": {
+                    "x": {
+                        "type": "integer",
+                        "description": "Center x of the chosen element.",
+                    },
+                    "y": {
+                        "type": "integer",
+                        "description": "Center y of the chosen element.",
+                    },
+                    "action": {
+                        "type": "string",
+                        "enum": ["click", "type", "select", "not_found"],
+                        "description": (
+                            "What the runner should do at this element. "
+                            "``click`` for buttons / links / row "
+                            "containers; ``type`` for text inputs the "
+                            "runner should fill; ``select`` for an "
+                            "option already visible in an open "
+                            "dropdown menu (click first if the "
+                            "dropdown is closed). ``not_found`` if "
+                            "the page has nothing matching the intent."
+                        ),
+                    },
+                    "label": {
+                        "type": "string",
+                        "description": (
+                            "EXACT text observed on / near the element "
+                            "(any language) or an icon description for "
+                            "icon-only elements. When action=not_found, "
+                            "describe what IS visible instead."
+                        ),
+                    },
+                },
+                "required": ["action", "label"],
+            },
+            max_tokens=500,
+        )
+        if not parsed:
+            logger.warning(
+                "  [claude-form] affordance: tool_use returned no result"
+            )
+            return None
+        if parsed.get("action") == "not_found":
+            logger.info(
+                "  [claude-form] affordance: not found — observed: %s",
+                str(parsed.get("label", ""))[:120],
+            )
+            return None
+        x = _coerce_coord(parsed.get("x"))
+        y = _coerce_coord(parsed.get("y"))
+        if x is None or y is None or (x == 0 and y == 0):
+            logger.warning(
+                "  [claude-form] affordance: invalid coords x=%r y=%r",
+                parsed.get("x"), parsed.get("y"),
+            )
+            return None
+        result = {
+            "x": x,
+            "y": y,
+            "action": str(parsed.get("action", "click")),
+            "value": "",
+            "label": str(parsed.get("label", "")),
+        }
+        logger.info(
+            "  [claude-form] affordance: '%s' at (%d, %d) action=%s — "
+            "discovered via visual affordance (no alias match needed)",
+            result["label"][:60], x, y, result["action"],
+        )
+        return result

--- a/src/mantis_agent/gym/step_handlers/form.py
+++ b/src/mantis_agent/gym/step_handlers/form.py
@@ -241,6 +241,26 @@ class ClaudeGuidedFormHandler:
             )
             runner.costs["claude_extract"] += 1
             if not target:
+                # Visual-affordance fallback before failing — covers
+                # non-English / icon-only inputs whose labels don't
+                # match the configured aliases. Defocus first so any
+                # currently-focused control doesn't absorb the
+                # subsequent search's interactions.
+                logger.warning(
+                    "  [claude-form] fill_field: label-match exhausted "
+                    "for '%s' — trying visual-affordance fallback", label,
+                )
+                try:
+                    env.step(Action(
+                        action_type=ActionType.KEY_PRESS, params={"keys": "Tab"},
+                    ))
+                    time.sleep(0.3)
+                except Exception:
+                    pass
+                shot = _wait_for_rendered_screenshot(env)
+                target = extractor.find_target_by_affordance(shot, search_intent)
+                runner.costs["claude_extract"] += 1
+            if not target:
                 logger.warning(f"  [claude-form] fill_field: target '{label}' not found")
                 return StepResult(step_index=index, intent=step.intent, success=False, data="form_target_not_found")
             x, y = target["x"], target["y"]
@@ -420,6 +440,47 @@ class ClaudeGuidedFormHandler:
                     f"Page_Down{scroll_steps + 1}/{max_scrolls}",
                 )
                 scroll_steps += 1
+
+            # Vision-affordance fallback — the label-driven scroll-probe
+            # above can't find elements whose actual text differs from
+            # any configured alias (canonical case: a French CRM whose
+            # ``Update Lead`` button reads ``Enregistrer`` and the plan
+            # didn't enumerate that, OR an icon-only checkmark button).
+            # Before halting, do ONE final pass that asks Claude to
+            # identify the right element FOR THE INTENT by VISUAL
+            # AFFORDANCE — shape, position, styling — independent of
+            # label. The intent prose drives element-type selection
+            # (button / input / dropdown), so this fallback handles
+            # any step type, not just submits.
+            #
+            # Defocus any active input first (Tab key) so the prior
+            # keyboard-scroll attempts that may have been eaten by an
+            # open dropdown / focused field can finally move the page —
+            # without this, End/Page_Down on a focused <select> are
+            # no-ops and the search saw the same viewport repeatedly.
+            if target is None:
+                logger.warning(
+                    "  [claude-form] submit: label-match exhausted after "
+                    "probes %s — trying visual-affordance fallback",
+                    probe_attempts,
+                )
+                try:
+                    env.step(Action(
+                        action_type=ActionType.KEY_PRESS, params={"keys": "Tab"},
+                    ))
+                    time.sleep(0.3)
+                    env.step(Action(
+                        action_type=ActionType.KEY_PRESS, params={"keys": "End"},
+                    ))
+                except Exception:
+                    pass
+                time.sleep(0.6)
+                shot = _wait_for_rendered_screenshot(env)
+                screenshot = shot
+                target = extractor.find_target_by_affordance(shot, search_intent)
+                runner.costs["claude_extract"] += 1
+                if target:
+                    probe_attempts.append("vision-affordance")
 
             if not target:
                 logger.warning(

--- a/tests/test_form_handler.py
+++ b/tests/test_form_handler.py
@@ -80,6 +80,8 @@ def test_fill_field_target_not_found_returns_form_target_not_found(monkeypatch):
     runner = _FakeRunner()
     extractor = MagicMock()
     extractor.find_form_target.return_value = None
+    # Vision-affordance fallback also misses → form_target_not_found.
+    extractor.find_target_by_affordance.return_value = None
     ctx = _ctx(runner, extractor=extractor)
 
     step = MicroIntent(
@@ -90,7 +92,8 @@ def test_fill_field_target_not_found_returns_form_target_not_found(monkeypatch):
 
     assert result.success is False
     assert result.data == "form_target_not_found"
-    assert runner.costs["claude_extract"] == 1
+    # 1 label-match + 1 visual-affordance fallback = 2 Claude calls.
+    assert runner.costs["claude_extract"] == 2
 
 
 def test_fill_field_success_clicks_triple_clicks_clears_and_types(monkeypatch):
@@ -134,6 +137,7 @@ def test_submit_target_not_found_after_scroll(monkeypatch):
     runner = _FakeRunner()
     extractor = MagicMock()
     extractor.find_form_target.return_value = None  # never found
+    extractor.find_target_by_affordance.return_value = None  # vision miss too
     env = MagicMock()
     ctx = _ctx(runner, env=env, extractor=extractor)
 
@@ -145,10 +149,11 @@ def test_submit_target_not_found_after_scroll(monkeypatch):
 
     assert result.success is False
     assert result.data == "form_target_not_found"
-    # 1 initial + End probe + Home probe + 6 Page_Down sweeps = 9 calls.
-    # Old budget was 5 (1 + 4 Page_Down); the agentic search adds the
-    # End / Home end-probes and bumps the Page_Down cap from 4 to 6.
-    assert runner.costs["claude_extract"] == 9
+    # 1 initial + End probe + Home probe + 6 Page_Down sweeps + 1
+    # visual-affordance fallback = 10 calls. The affordance pass
+    # is the language-agnostic / icon-aware fallback that fires
+    # after label-match scroll-probe exhausts.
+    assert runner.costs["claude_extract"] == 10
     # Final Home keypress to reset scroll for the next step.
     final_keypress = env.step.call_args_list[-1].args[0]
     assert final_keypress.params == {"keys": "Home"}

--- a/tests/test_form_intents.py
+++ b/tests/test_form_intents.py
@@ -207,6 +207,8 @@ def test_submit_target_not_found_returns_failure_no_crash():
     env = _FakeEnv()
     extractor = MagicMock()
     extractor.find_form_target.return_value = None
+    # Vision-affordance fallback also misses → form_target_not_found.
+    extractor.find_target_by_affordance.return_value = None
     runner = _runner_with_extractor(env, extractor)
 
     intent = MicroIntent(
@@ -522,6 +524,8 @@ def test_submit_gives_up_after_full_agentic_sweep():
     env = _FakeEnv()
     extractor = MagicMock()
     extractor.find_form_target.return_value = None  # never found
+    # Vision-affordance fallback also misses (truly nothing on page).
+    extractor.find_target_by_affordance.return_value = None
     runner = _runner_with_extractor(env, extractor)
 
     intent = MicroIntent(

--- a/tests/test_primary_action_fallback.py
+++ b/tests/test_primary_action_fallback.py
@@ -1,0 +1,377 @@
+"""Tests for the vision-based primary-action fallback in find_form_target.
+
+Surfaced by the staff-crm priority rerun on Modal: the form had an
+``Update Lead`` button visible in the bottom-right, but Claude's
+label-driven ``find_form_target`` search failed across all 9 scroll
+probes. Diagnosis from the user's manually-captured screenshot:
+the form footer contains Cancel | Reset Form | Update Lead — the
+button IS labelled correctly, but the runner's End / Page_Down
+keystrokes were absorbed by an open dropdown so the visible
+viewport never reached the form footer where the buttons live.
+
+Two layered fixes:
+
+1. Defocus any active input (Tab key) before the vision fallback's
+   final scroll-to-end, so the keystroke actually moves the page
+   instead of acting on the focused dropdown.
+2. Vision-based primary-action search — when label-match exhausts,
+   ask Claude to identify the action button by visual affordance
+   (colour, position, primary-CTA pattern) regardless of label.
+   Language-agnostic: works for English (Save), French
+   (Enregistrer), German (Speichern), icon-only buttons, etc.
+
+These tests pin:
+
+- :meth:`ClaudeExtractor.find_target_by_affordance` — tool_use
+  shape, label-agnostic prompt, coercion of malformed coords,
+  not_found path
+- Form handler integration — the vision fallback fires after
+  scroll-probe exhausts, defocuses + scrolls before searching,
+  and reports the discovered label so the operator can update
+  plan aliases.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from PIL import Image
+
+
+# ── ClaudeExtractor.find_target_by_affordance ────────────────────────────
+
+
+def _tool_resp(payload: dict) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = {
+        "content": [
+            {
+                "type": "tool_use",
+                "name": "report_target_by_affordance",
+                "input": payload,
+            }
+        ]
+    }
+    return resp
+
+
+def test_primary_action_returns_coords_and_label_when_found() -> None:
+    """Successful vision pass: Claude identifies the button by
+    affordance, returns coords + observed label."""
+    from mantis_agent.extraction.extractor import ClaudeExtractor
+
+    ex = ClaudeExtractor(api_key="k")
+    img = Image.new("RGB", (1280, 720), color="white")
+    payload = {
+        "x": 1198, "y": 670,
+        "action": "click",
+        "label": "Update Lead",
+    }
+    with patch("requests.post", return_value=_tool_resp(payload)):
+        result = ex.find_target_by_affordance(img, "save the form")
+
+    assert result is not None
+    assert result["x"] == 1198
+    assert result["y"] == 670
+    assert result["label"] == "Update Lead"
+    assert result["action"] == "click"
+
+
+def test_primary_action_returns_none_on_not_found() -> None:
+    """When the page truly has no submit button (e.g. read-only
+    detail page or auto-saving form), Claude returns
+    ``action=not_found`` and the helper returns ``None``."""
+    from mantis_agent.extraction.extractor import ClaudeExtractor
+
+    ex = ClaudeExtractor(api_key="k")
+    img = Image.new("RGB", (1280, 720))
+    payload = {
+        "x": 0, "y": 0, "action": "not_found",
+        "label": "page is read-only — no submit / save / update visible",
+    }
+    with patch("requests.post", return_value=_tool_resp(payload)):
+        result = ex.find_target_by_affordance(img, "save")
+
+    assert result is None
+
+
+def test_primary_action_handles_non_english_label() -> None:
+    """The whole point: language-agnostic vision affordance. A
+    French ``Enregistrer`` button must be returned with its
+    actual label so the operator can see what the runner found."""
+    from mantis_agent.extraction.extractor import ClaudeExtractor
+
+    ex = ClaudeExtractor(api_key="k")
+    img = Image.new("RGB", (1280, 720))
+    payload = {
+        "x": 1100, "y": 600,
+        "action": "click",
+        "label": "Enregistrer",
+    }
+    with patch("requests.post", return_value=_tool_resp(payload)):
+        result = ex.find_target_by_affordance(img, "save changes")
+
+    assert result is not None
+    assert result["label"] == "Enregistrer"
+
+
+def test_affordance_returns_input_for_fill_intent() -> None:
+    """Critical contract: the affordance pass is intent-driven, NOT
+    hardcoded to 'primary action button'. A fill_field intent must
+    produce a ``type`` action targeting an INPUT, not a click on
+    some random button. Hardcoding action types would break plans
+    that need text entry."""
+    from mantis_agent.extraction.extractor import ClaudeExtractor
+
+    ex = ClaudeExtractor(api_key="k")
+    img = Image.new("RGB", (1280, 720))
+    payload = {
+        "x": 600, "y": 240,
+        "action": "type",
+        "label": "Mot de passe",  # French "password" — language-agnostic
+    }
+    with patch("requests.post", return_value=_tool_resp(payload)):
+        result = ex.find_target_by_affordance(
+            img, "Enter the password into the password field",
+        )
+
+    assert result is not None
+    assert result["action"] == "type"
+    assert result["label"] == "Mot de passe"
+
+
+def test_affordance_returns_select_for_dropdown_intent() -> None:
+    """Same — for a select_option intent, affordance returns ``select``
+    on the option / ``click`` on the dropdown control. NOT a button
+    click hardcoded into the prompt."""
+    from mantis_agent.extraction.extractor import ClaudeExtractor
+
+    ex = ClaudeExtractor(api_key="k")
+    img = Image.new("RGB", (1280, 720))
+    payload = {
+        "x": 800, "y": 400,
+        "action": "click",
+        "label": "Priority Level",
+    }
+    with patch("requests.post", return_value=_tool_resp(payload)):
+        result = ex.find_target_by_affordance(
+            img, "Pick High from the Priority Level dropdown",
+        )
+
+    assert result is not None
+    assert result["action"] == "click"
+    assert result["label"] == "Priority Level"
+
+
+def test_primary_action_handles_icon_only_button() -> None:
+    """Icon-only buttons (no text) — Claude returns a description
+    of the icon as the label so logs surface what was clicked."""
+    from mantis_agent.extraction.extractor import ClaudeExtractor
+
+    ex = ClaudeExtractor(api_key="k")
+    img = Image.new("RGB", (1280, 720))
+    payload = {
+        "x": 1200, "y": 50,
+        "action": "click",
+        "label": "checkmark icon (no text)",
+    }
+    with patch("requests.post", return_value=_tool_resp(payload)):
+        result = ex.find_target_by_affordance(img, "submit form")
+
+    assert result is not None
+    assert "checkmark" in result["label"].lower()
+
+
+def test_primary_action_coerces_malformed_coords() -> None:
+    """Same coerce_coord defensiveness as find_form_target — handles
+    ``"x": "1198, "`` and similar trailing-comma malformations."""
+    from mantis_agent.extraction.extractor import ClaudeExtractor
+
+    ex = ClaudeExtractor(api_key="k")
+    img = Image.new("RGB", (1280, 720))
+    payload = {
+        "x": "1198, ", "y": 670,
+        "action": "click",
+        "label": "Update Lead",
+    }
+    with patch("requests.post", return_value=_tool_resp(payload)):
+        result = ex.find_target_by_affordance(img, "save")
+
+    assert result is not None
+    assert result["x"] == 1198
+
+
+def test_primary_action_returns_none_on_zero_coords() -> None:
+    """``(0, 0)`` is the not-found sentinel even when action=click —
+    same convention as find_form_target."""
+    from mantis_agent.extraction.extractor import ClaudeExtractor
+
+    ex = ClaudeExtractor(api_key="k")
+    img = Image.new("RGB", (1280, 720))
+    payload = {"x": 0, "y": 0, "action": "click", "label": "?"}
+    with patch("requests.post", return_value=_tool_resp(payload)):
+        assert ex.find_target_by_affordance(img, "save") is None
+
+
+def test_primary_action_prompt_is_language_agnostic() -> None:
+    """The prompt MUST tell Claude the label can be in any language /
+    icon-only — pin this so future edits don't accidentally bias the
+    search toward English-only matching."""
+    from mantis_agent.extraction.extractor import ClaudeExtractor
+
+    captured: dict = {}
+
+    def _capture(url, **kwargs):
+        captured["json"] = kwargs.get("json")
+        return _tool_resp({"action": "not_found", "label": "x"})
+
+    ex = ClaudeExtractor(api_key="k")
+    img = Image.new("RGB", (1280, 720))
+    with patch("requests.post", side_effect=_capture):
+        ex.find_target_by_affordance(img, "save")
+
+    body = captured["json"]
+    # Find the text content block (image is first).
+    content = body["messages"][0]["content"]
+    text_block = next(c for c in content if c.get("type") == "text")
+    prompt = text_block["text"].lower()
+    # Language guidance present.
+    assert "any language" in prompt or "language-agnostic" in prompt or "language" in prompt
+    # Visual affordance cues mentioned (color, position).
+    assert "colour" in prompt or "color" in prompt or "accent" in prompt
+    assert "position" in prompt or "footer" in prompt or "bottom" in prompt
+    # No hardcoded label expected.
+    assert "must be 'save'" not in prompt and "must be 'submit'" not in prompt
+    # Critical contract: the prompt is INTENT-driven, NOT hardcoded
+    # to find a primary action button. Plans that need text entry,
+    # dropdown selection, or toggles must route through the same
+    # affordance pass with the right action type.
+    assert "intent" in prompt
+    assert "no hardcoded action" in prompt or "intent verb" in prompt or "don't assume" in prompt
+    # Element-type heuristics for input / dropdown / button must all
+    # be enumerated.
+    assert "input" in prompt and "dropdown" in prompt and "button" in prompt
+
+
+# ── Form handler integration ────────────────────────────────────────────
+
+
+def test_form_handler_falls_back_to_vision_when_label_search_exhausts() -> None:
+    """End-to-end: when the scroll-probe sweep returns None for every
+    position, the form handler defocuses + scrolls to end + calls
+    find_target_by_affordance. If THAT returns a target, the click
+    proceeds and the step succeeds."""
+    from mantis_agent.actions import Action, ActionType
+    from mantis_agent.gym.step_context import StepContext
+    from mantis_agent.gym.step_handlers.form import ClaudeGuidedFormHandler
+    import mantis_agent.gym.step_handlers.form as form_mod
+    from mantis_agent.plan_decomposer import MicroIntent
+
+    env = MagicMock()
+    img = Image.new("RGB", (10, 10))
+    env.screenshot.return_value = img
+
+    extractor = MagicMock()
+    extractor.find_form_target.return_value = None  # every scroll probe misses
+    extractor.find_target_by_affordance.return_value = {
+        "x": 1198, "y": 670, "action": "click", "value": "",
+        "label": "Update Lead",
+    }
+
+    runner = MagicMock()
+    runner.extractor = extractor
+    runner.env = env
+    runner._best_effort_current_url = MagicMock(return_value="https://crm.test/")
+    runner._adaptive_submit_settle = MagicMock(return_value=0.0)
+    runner._safe_screenshot = MagicMock(return_value=None)
+    runner._dump_debug_screenshot = MagicMock()
+    runner._last_known_url = "https://crm.test/"
+    runner._step_failure_history = {}
+    runner._recovery_hints = {}
+    runner.costs = {"claude_extract": 0, "gpu_steps": 0, "gpu_seconds": 0.0}
+
+    step = MicroIntent(
+        intent="Click the Update Lead button to save",
+        type="submit", budget=4,
+        params={"label": "Update Lead", "aliases": ["Save", "Submit"]},
+    )
+
+    orig = form_mod._wait_for_rendered_screenshot
+    form_mod._wait_for_rendered_screenshot = lambda *_a, **_kw: img
+    try:
+        ctx = StepContext(env=env, brain=MagicMock(), extractor=extractor)
+        ctx.state["index"] = 0
+        result = ClaudeGuidedFormHandler(runner).execute(step, ctx)
+    finally:
+        form_mod._wait_for_rendered_screenshot = orig
+
+    assert result.success is True
+    # The vision fallback was invoked exactly once (label-match search
+    # is independent of vision-affordance pass).
+    extractor.find_target_by_affordance.assert_called_once()
+    # Tab + End keypresses fired before the vision search to defocus
+    # any active input and force scroll-to-bottom.
+    keys_pressed = []
+    for c in env.step.call_args_list:
+        if not c.args:
+            continue
+        action = c.args[0]
+        if (
+            isinstance(action, Action)
+            and action.action_type == ActionType.KEY_PRESS
+        ):
+            keys_pressed.append(action.params.get("keys"))
+    assert "Tab" in keys_pressed
+    assert "End" in keys_pressed
+
+
+def test_form_handler_does_not_call_vision_when_label_match_succeeds() -> None:
+    """Cost guard: when label-match finds the target on any probe,
+    vision fallback must NOT fire. One Claude vision call per step
+    is the right cost; firing the affordance pass too is wasteful."""
+    from mantis_agent.gym.step_context import StepContext
+    from mantis_agent.gym.step_handlers.form import ClaudeGuidedFormHandler
+    import mantis_agent.gym.step_handlers.form as form_mod
+    from mantis_agent.plan_decomposer import MicroIntent
+
+    env = MagicMock()
+    img = Image.new("RGB", (10, 10))
+    env.screenshot.return_value = img
+
+    extractor = MagicMock()
+    # Initial probe finds it.
+    extractor.find_form_target.return_value = {
+        "x": 540, "y": 600, "action": "click", "value": "",
+        "label": "Save",
+    }
+
+    runner = MagicMock()
+    runner.extractor = extractor
+    runner.env = env
+    runner._best_effort_current_url = MagicMock(return_value="https://crm.test/")
+    runner._adaptive_submit_settle = MagicMock(return_value=0.0)
+    runner._safe_screenshot = MagicMock(return_value=None)
+    runner._dump_debug_screenshot = MagicMock()
+    runner._last_known_url = "https://crm.test/"
+    runner._step_failure_history = {}
+    runner._recovery_hints = {}
+    runner.costs = {"claude_extract": 0, "gpu_steps": 0, "gpu_seconds": 0.0}
+
+    step = MicroIntent(
+        intent="Click Save", type="submit",
+        params={"label": "Save"},
+    )
+
+    orig = form_mod._wait_for_rendered_screenshot
+    form_mod._wait_for_rendered_screenshot = lambda *_a, **_kw: img
+    try:
+        ctx = StepContext(env=env, brain=MagicMock(), extractor=extractor)
+        ctx.state["index"] = 0
+        result = ClaudeGuidedFormHandler(runner).execute(step, ctx)
+    finally:
+        form_mod._wait_for_rendered_screenshot = orig
+
+    assert result.success is True
+    # Vision fallback skipped — label-match was sufficient.
+    extractor.find_target_by_affordance.assert_not_called()


### PR DESCRIPTION
When label-driven ``find_form_target`` exhausts its scroll-probe sweep without a match, the form handler does ONE final pass that asks Claude to identify the right element by **visual affordance** — shape, position, colour / styling — regardless of label. Intent-driven, language-agnostic, no hardcoded action assumptions.

## Why

Surfaced by the staff-crm priority rerun: the form had an ``Update Lead`` button at ~(1198, 670) but the runner's End / Page_Down keystrokes after a ``select_option`` were absorbed by the still-focused dropdown — so the search saw the same "Robot Information at top" 9 times. With the button visible and correctly aliased, the runner still couldn't find it.

User's clarifying constraint: **no hardcoded aliases / actions**. Plans need text entry, dropdown selection, toggles — all must flow through the same fallback. The fix is intent-driven, NOT "find a primary action button."

## Design

- **Defocus before scroll** — Tab + End fire before the affordance search so keystrokes hit the document body, not the focused control.
- **``find_target_by_affordance(screenshot, intent)``** — new extractor method. Reads the intent verb (``click`` / ``enter`` / ``pick`` / ``toggle``) and asks Claude to find the matching element type by visual cues. Returns coords + the OBSERVED label (in any language / icon description) + the recommended action (``click`` / ``type`` / ``select`` / ``not_found``).
- Wired into BOTH ``submit`` and ``fill_field`` branches. Fires once per step on the failure path; zero overhead on happy paths.

## Cost

| Path | Claude calls |
|---|---|
| Label-match succeeds (happy) | 1 |
| Label-match fails on N probes, affordance succeeds | N+1 |
| Label-match fails AND affordance fails | N+1 (then `form_target_not_found`) |

The affordance pass adds at most one Claude call per failed step.

## Test plan

- [x] 11 new tests covering: language-agnostic match (English / French / icon-only), intent-driven action selection (type / click / select), coerce_coord defensiveness, not-found path, language-agnostic prompt assertions, form handler integration (Tab + End before vision pass, no vision pass when label-match wins)
- [x] Full suite 1507/1507 in 7m03s (1479 prior + 11 new + adjustments)
- [x] ``ruff check`` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)