### PR TITLE
refactor(prompts): externalise action-side prompts to .txt files

### DIFF
--- a/src/mantis_agent/agentic_recovery.py
+++ b/src/mantis_agent/agentic_recovery.py
@@ -176,83 +176,10 @@ _ANALYSIS_TOOL_INPUT_SCHEMA: dict[str, Any] = {
 }
 
 
-_ANALYSIS_PROMPT_TEMPLATE = """\
-You are analysing a terminal failure in a CUA (Computer Use Agent) plan.
-
-A required step has failed after retries AND after the runner's
-default handler escalation. Your job: look at the screenshot of the
-current page, the failed step's intent / type / params, and the
-failure data, then choose the cheapest recovery that would plausibly
-succeed.
-
-FAILED STEP
-===========
-intent: {intent}
-type:   {step_type}
-params: {params}
-
-FAILURE DATA: {failure_data}
-RETRY ATTEMPTS: {attempts}
-
-PLAN CONTEXT (steps already completed successfully):
-{plan_context}
-
-RECOVERY MODES (pick ONE via the record_recovery tool):
-
-1. add_hint — the step is fundamentally correct but the search
-   needs a clarifying instruction. The hint is appended to the
-   prompt the next retry will pass to its grounder. Use this when
-   you can see what the right element is and just need to tell
-   the searcher to pick it. Example: the failed step said
-   "Click 'Update Lead'" but the actual button reads "Save" — so
-   hint="The save button is labeled 'Save', not 'Update Lead'."
-
-2. edit_step — the step's structure is wrong. Use when:
-   - the step type is wrong (submit when it should be select_option,
-     click when it should be fill_field, etc.)
-   - the labels in params are wrong and the right ones are visible
-     on screen
-   - aliases are needed because the button label varies
-   Provide ONLY the fields to change in ``edited_step``. Existing
-   fields are preserved.
-
-3. insert_steps — a precondition is missing. Use when the step
-   itself is correct but the page isn't ready: a modal is blocking,
-   the form section isn't expanded, scroll is needed, or a previous
-   page-state didn't take. Provide a small sub-flow (1-3 steps) to
-   put the page in the right state. The runner splices these BEFORE
-   the failed step then re-attempts the original step.
-
-4. halt — recovery is impossible. Use when:
-   - the target genuinely doesn't exist on the site
-   - the page shows a hard error (anti-bot, 403, server error)
-   - the step's premise contradicts visible page state
-   - **PROGRESS EVIDENCE** — multiple prior retries (RETRY ATTEMPTS
-     >= 2) tried scrolling / clicking but the page state shown in
-     the screenshot still looks like the SAME content the earlier
-     attempts saw. If three scrolls down and the "Robot Information"
-     section is still at the top, the form likely has no further
-     content below — the requested target may not exist on this page
-     state. Prefer halt over insert_steps when this signal is
-     present; another scroll is unlikely to reach a section that
-     hasn't moved across multiple attempts.
-   No plan tweak would help; surface the failure to the operator.
-
-Be conservative on insert_steps: each insertion takes ~30 seconds
-and consumes per-run recovery budget. If you've seen evidence that
-the same approach already failed (RETRY ATTEMPTS shows the runner
-already tried), prefer halt or edit_step over inserting MORE steps
-of the same kind.
-
-Decision priority when multiple modes plausibly fit:
-- The screenshot clearly shows the right element with a different
-  label → add_hint (cheapest, often sufficient)
-- The step type / labels are obviously off → edit_step
-- A precondition is needed AND prior attempts didn't already try
-  this precondition → insert_steps
-- Prior attempts already tried scroll/dismiss/wait and the page
-  state hasn't visibly progressed → halt (don't loop)
-"""
+# Recovery analysis prompt body lives at
+# ``src/mantis_agent/prompts/files/recovery_analysis.txt``. Operators
+# can override via ``MANTIS_PROMPTS_DIR=/path/to/prompts`` without
+# editing this module.
 
 
 def analyse_failure_and_recover(
@@ -336,7 +263,10 @@ def _call_recovery_tool(
     """Tool_use call. Returns the validated input dict or ``None``."""
     import requests
 
-    prompt = _ANALYSIS_PROMPT_TEMPLATE.format(
+    from .prompts import load_prompt
+
+    prompt = load_prompt(
+        "recovery_analysis",
         intent=getattr(step, "intent", "")[:300],
         step_type=getattr(step, "type", ""),
         params=str(getattr(step, "params", {}) or {})[:300],

--- a/src/mantis_agent/extraction/extractor.py
+++ b/src/mantis_agent/extraction/extractor.py
@@ -1471,50 +1471,20 @@ class ClaudeExtractor:
             + ", ".join(f'"{a}"' for a in aliases)
             if aliases else ""
         )
-        prompt = (
-            f"Look at this screenshot ({screenshot.width}x{screenshot.height} pixels).\n\n"
-            f"TASK: {intent}"
-            f"{target_clause}{value_clause}{alias_clause}\n\n"
-            f"This page is NOT a listings/search-results grid. It is a form, "
-            f"login/edit page, settings panel, dialog, or similar. Exactly ONE "
-            f"element on screen matches the task — find it.\n\n"
-            f"Match by SHAPE first, then by visible label:\n"
-            f"- Text input: a labelled box you can type into (label is above, "
-            f"  to the left, or rendered as placeholder text inside).\n"
-            f"- Button: a clickable element with visible text — match the button\n"
-            f"  whose text matches (or semantically matches) the task target_label.\n"
-            f"- Dropdown / <select>: shows the current value with a chevron.\n"
-            f"- Option inside an opened dropdown: an overlay menu above the page content.\n"
-            f"- Checkbox / radio: a small toggle with a label adjacent.\n\n"
-            f"Match by DESTINATION, not by exact text. A click on a nav "
-            f"link, button, or tab is a request to reach a specific section "
-            f"of the application — the on-screen rendering of that section's "
-            f"label may include visual decorations the source plan didn't "
-            f"mention (counts, badges, icons, status indicators, qualifier "
-            f"words). You are a vision-language model: read the visible "
-            f"text in context and decide whether each candidate's underlying "
-            f"destination matches target_label. Use the surrounding layout "
-            f"(primary nav vs submenu, sidebar vs header) to disambiguate "
-            f"when multiple candidates are present — the canonical "
-            f"destination is the most specific match in the highest-priority "
-            f"region of the page.\n\n"
-            f"If you find no on-screen element whose underlying destination "
-            f"semantically matches target_label, return action=not_found "
-            f"with a precise description in `label` of what the page shows "
-            f"instead — that's how the runner learns whether to retry, "
-            f"scroll, or surface a planning error.\n\n"
-            f"Determine the interaction:\n"
-            f"- \"click\" for buttons, links, checkbox/radio/toggle, or to OPEN a dropdown.\n"
-            f"- \"type\" for text inputs (the runner will click the field, clear, then type).\n"
-            f"- \"select\" for picking an option from a dropdown that is already open "
-            f"(if the dropdown is closed, return action=click on the dropdown control first).\n\n"
-            f"Return the CENTER coordinates of the target element. Output ONLY valid JSON:\n"
-            f"{{\"x\": N, \"y\": N, \"action\": \"click|type|select\", "
-            f"\"value\": \"text to type or option to select or empty\", "
-            f"\"label\": \"what element you found\"}}\n"
-            f"If the target is not visible anywhere on the page:\n"
-            f"{{\"x\": 0, \"y\": 0, \"action\": \"not_found\", "
-            f"\"value\": \"\", \"label\": \"describe what you see instead\"}}"
+        # Prompt body lives at
+        # ``mantis_agent/prompts/files/find_form_target.txt`` so plan
+        # authors / operators can A/B-test wording without forking
+        # this module. Caller-supplied placeholders below.
+        from ..prompts import load_prompt
+
+        prompt = load_prompt(
+            "find_form_target",
+            screen_width=screenshot.width,
+            screen_height=screenshot.height,
+            intent=intent,
+            target_clause=target_clause,
+            value_clause=value_clause,
+            alias_clause=alias_clause,
         )
 
         debug_stem = "claude_form"

--- a/src/mantis_agent/objective.py
+++ b/src/mantis_agent/objective.py
@@ -181,32 +181,10 @@ _DERIVE_TOOL_SCHEMA: dict[str, Any] = {
 }
 
 
-_DERIVE_PROMPT = """\
-Read the CUA (Computer Use Agent) plan below and lift its semantic
-shape into a structured ObjectiveSpec via the ``record_objective``
-tool.
-
-PLAN TEXT
-=========
-{plan_text}
-=========
-
-Be precise:
-
-- ``output_fields``: include every field the plan extracts. Use
-  ``required: true`` ONLY when the plan explicitly calls a field out
-  as REQUIRED / VIABLE / "must have". Default new fields to
-  ``required: false``.
-- ``forbidden_actions`` / ``allowed_reveal_actions``: only include
-  UI labels the plan literally enumerates. Don't paraphrase.
-- ``viability_definition``: paraphrase the plan's viability rule
-  if any; empty string otherwise.
-- ``spam_text_indicators`` / ``spam_seller_indicators`` / ``spam_label``:
-  leave empty unless the plan explicitly enumerates dealer / spam
-  tokens. The recipe overlay layer (``recipes.load_schema``) is
-  where empirical-from-production tokens live; the plan-derived
-  spec must not invent them.
-"""
+# Derive-objective prompt body lives at
+# ``src/mantis_agent/prompts/files/derive_objective.txt``. Operators
+# can override via ``MANTIS_PROMPTS_DIR=/path/to/prompts`` without
+# editing this module.
 
 
 def derive_from_plan(
@@ -284,6 +262,18 @@ def _cache_key(plan_text: str) -> str:
     ).hexdigest()
 
 
+def _render_derive_prompt(plan_text: str) -> str:
+    """Render the derive-objective prompt with the plan body inlined.
+
+    Indirected so the prompt body can live as a ``.txt`` file under
+    ``mantis_agent/prompts/files/``. Operators tune wording via
+    ``MANTIS_PROMPTS_DIR`` overrides without forking this module.
+    """
+    from .prompts import load_prompt
+
+    return load_prompt("derive_objective", plan_text=plan_text)
+
+
 def _call_derive_tool(
     plan_text: str,
     *,
@@ -316,7 +306,7 @@ def _call_derive_tool(
                 "tool_choice": {"type": "tool", "name": "record_objective"},
                 "messages": [{
                     "role": "user",
-                    "content": _DERIVE_PROMPT.format(plan_text=plan_text),
+                    "content": _render_derive_prompt(plan_text),
                 }],
             },
             timeout=30,

--- a/src/mantis_agent/prompts/__init__.py
+++ b/src/mantis_agent/prompts/__init__.py
@@ -44,6 +44,13 @@ _PROMPT_NAMES: tuple[str, ...] = (
     "claude_system",
     "opencua_system",
     "llamacpp_system",
+    # Action-side prompts (issue #224 + agentic-recovery follow-ups).
+    # Externalised so plan authors / operators can A/B-test the wording
+    # without forking Python modules. ``MANTIS_PROMPTS_DIR`` overrides
+    # apply to these the same way as the system templates.
+    "recovery_analysis",
+    "derive_objective",
+    "find_form_target",
 )
 
 # Placeholder defaults applied before caller-supplied substitutions. Keeps

--- a/src/mantis_agent/prompts/files/derive_objective.txt
+++ b/src/mantis_agent/prompts/files/derive_objective.txt
@@ -1,0 +1,24 @@
+Read the CUA (Computer Use Agent) plan below and lift its semantic
+shape into a structured ObjectiveSpec via the ``record_objective``
+tool.
+
+PLAN TEXT
+=========
+__PLAN_TEXT__
+=========
+
+Be precise:
+
+- ``output_fields``: include every field the plan extracts. Use
+  ``required: true`` ONLY when the plan explicitly calls a field out
+  as REQUIRED / VIABLE / "must have". Default new fields to
+  ``required: false``.
+- ``forbidden_actions`` / ``allowed_reveal_actions``: only include
+  UI labels the plan literally enumerates. Don't paraphrase.
+- ``viability_definition``: paraphrase the plan's viability rule
+  if any; empty string otherwise.
+- ``spam_text_indicators`` / ``spam_seller_indicators`` / ``spam_label``:
+  leave empty unless the plan explicitly enumerates dealer / spam
+  tokens. The recipe overlay layer (``recipes.load_schema``) is
+  where empirical-from-production tokens live; the plan-derived
+  spec must not invent them.

--- a/src/mantis_agent/prompts/files/find_form_target.txt
+++ b/src/mantis_agent/prompts/files/find_form_target.txt
@@ -1,0 +1,49 @@
+Look at this screenshot (__SCREEN_WIDTH__x__SCREEN_HEIGHT__ pixels).
+
+TASK: __INTENT____TARGET_CLAUSE____VALUE_CLAUSE____ALIAS_CLAUSE__
+
+This page is NOT a listings/search-results grid. It is a form,
+login/edit page, settings panel, dialog, or similar. Exactly ONE
+element on screen matches the task — find it.
+
+Match by SHAPE first, then by visible label:
+- Text input: a labelled box you can type into (label is above,
+  to the left, or rendered as placeholder text inside).
+- Button: a clickable element with visible text — match the button
+  whose text matches (or semantically matches) the task target_label.
+- Dropdown / <select>: shows the current value with a chevron.
+- Option inside an opened dropdown: an overlay menu above the page content.
+- Checkbox / radio: a small toggle with a label adjacent.
+
+Match by DESTINATION, not by exact text. A click on a nav
+link, button, or tab is a request to reach a specific section
+of the application — the on-screen rendering of that section's
+label may include visual decorations the source plan didn't
+mention (counts, badges, icons, status indicators, qualifier
+words). You are a vision-language model: read the visible
+text in context and decide whether each candidate's underlying
+destination matches target_label. Use the surrounding layout
+(primary nav vs submenu, sidebar vs header) to disambiguate
+when multiple candidates are present — the canonical
+destination is the most specific match in the highest-priority
+region of the page.
+
+If you find no on-screen element whose underlying destination
+semantically matches target_label, return action=not_found
+with a precise description in `label` of what the page shows
+instead — that's how the runner learns whether to retry,
+scroll, or surface a planning error.
+
+Determine the interaction:
+- "click" for buttons, links, checkbox/radio/toggle, or to OPEN a dropdown.
+- "type" for text inputs (the runner will click the field, clear, then type).
+- "select" for picking an option from a dropdown that is already open
+  (if the dropdown is closed, return action=click on the dropdown control first).
+
+Return the CENTER coordinates of the target element. Output ONLY valid JSON:
+{"x": N, "y": N, "action": "click|type|select",
+ "value": "text to type or option to select or empty",
+ "label": "what element you found"}
+If the target is not visible anywhere on the page:
+{"x": 0, "y": 0, "action": "not_found",
+ "value": "", "label": "describe what you see instead"}

--- a/src/mantis_agent/prompts/files/recovery_analysis.txt
+++ b/src/mantis_agent/prompts/files/recovery_analysis.txt
@@ -1,0 +1,75 @@
+You are analysing a terminal failure in a CUA (Computer Use Agent) plan.
+
+A required step has failed after retries AND after the runner's
+default handler escalation. Your job: look at the screenshot of the
+current page, the failed step's intent / type / params, and the
+failure data, then choose the cheapest recovery that would plausibly
+succeed.
+
+FAILED STEP
+===========
+intent: __INTENT__
+type:   __STEP_TYPE__
+params: __PARAMS__
+
+FAILURE DATA: __FAILURE_DATA__
+RETRY ATTEMPTS: __ATTEMPTS__
+
+PLAN CONTEXT (steps already completed successfully):
+__PLAN_CONTEXT__
+
+RECOVERY MODES (pick ONE via the record_recovery tool):
+
+1. add_hint — the step is fundamentally correct but the search
+   needs a clarifying instruction. The hint is appended to the
+   prompt the next retry will pass to its grounder. Use this when
+   you can see what the right element is and just need to tell
+   the searcher to pick it. Example: the failed step said
+   "Click 'Update Lead'" but the actual button reads "Save" — so
+   hint="The save button is labeled 'Save', not 'Update Lead'."
+
+2. edit_step — the step's structure is wrong. Use when:
+   - the step type is wrong (submit when it should be select_option,
+     click when it should be fill_field, etc.)
+   - the labels in params are wrong and the right ones are visible
+     on screen
+   - aliases are needed because the button label varies
+   Provide ONLY the fields to change in ``edited_step``. Existing
+   fields are preserved.
+
+3. insert_steps — a precondition is missing. Use when the step
+   itself is correct but the page isn't ready: a modal is blocking,
+   the form section isn't expanded, scroll is needed, or a previous
+   page-state didn't take. Provide a small sub-flow (1-3 steps) to
+   put the page in the right state. The runner splices these BEFORE
+   the failed step then re-attempts the original step.
+
+4. halt — recovery is impossible. Use when:
+   - the target genuinely doesn't exist on the site
+   - the page shows a hard error (anti-bot, 403, server error)
+   - the step's premise contradicts visible page state
+   - **PROGRESS EVIDENCE** — multiple prior retries (RETRY ATTEMPTS
+     >= 2) tried scrolling / clicking but the page state shown in
+     the screenshot still looks like the SAME content the earlier
+     attempts saw. If three scrolls down and the "Robot Information"
+     section is still at the top, the form likely has no further
+     content below — the requested target may not exist on this page
+     state. Prefer halt over insert_steps when this signal is
+     present; another scroll is unlikely to reach a section that
+     hasn't moved across multiple attempts.
+   No plan tweak would help; surface the failure to the operator.
+
+Be conservative on insert_steps: each insertion takes ~30 seconds
+and consumes per-run recovery budget. If you've seen evidence that
+the same approach already failed (RETRY ATTEMPTS shows the runner
+already tried), prefer halt or edit_step over inserting MORE steps
+of the same kind.
+
+Decision priority when multiple modes plausibly fit:
+- The screenshot clearly shows the right element with a different
+  label → add_hint (cheapest, often sufficient)
+- The step type / labels are obviously off → edit_step
+- A precondition is needed AND prior attempts didn't already try
+  this precondition → insert_steps
+- Prior attempts already tried scroll/dismiss/wait and the page
+  state hasn't visibly progressed → halt (don't loop)

--- a/tests/test_agentic_recovery.py
+++ b/tests/test_agentic_recovery.py
@@ -119,9 +119,10 @@ def test_prompt_includes_progress_evidence_guidance_for_halt() -> None:
     haven't moved the page. This was the priority-field gap: Claude
     chose add_hint when halt was the right call because the prompt
     didn't enumerate "page hasn't moved" as a halt signal."""
-    from mantis_agent.agentic_recovery import _ANALYSIS_PROMPT_TEMPLATE
+    from mantis_agent.prompts import load_prompt
 
-    rendered = _ANALYSIS_PROMPT_TEMPLATE.format(
+    rendered = load_prompt(
+        "recovery_analysis",
         intent="x", step_type="submit", params="{}",
         failure_data="x", attempts=3, plan_context="",
     )

--- a/tests/test_form_target_nav_tolerance.py
+++ b/tests/test_form_target_nav_tolerance.py
@@ -13,15 +13,23 @@ hardcoded example list.
 
 from __future__ import annotations
 
-import inspect
-
-from mantis_agent.extraction.extractor import ClaudeExtractor
+from mantis_agent.prompts import load_prompt
 
 
 def _grab_form_target_prompt() -> str:
-    """Pull the find_form_target source text. The actual prompt is
-    constructed at call time — inspecting source captures the templates."""
-    return inspect.getsource(ClaudeExtractor.find_form_target)
+    """Render the find_form_target prompt with placeholders filled.
+
+    The body lives at ``prompts/files/find_form_target.txt`` —
+    rendered via ``load_prompt`` so callers / tests both see the
+    canonical resolved text (including any ``MANTIS_PROMPTS_DIR``
+    override). Synthetic substitution values just make placeholders
+    resolve; the asserts below check the static content.
+    """
+    return load_prompt(
+        "find_form_target",
+        screen_width=1280, screen_height=720,
+        intent="x", target_clause="", value_clause="", alias_clause="",
+    )
 
 
 # ── Principled instruction language ────────────────────────────────────

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -50,6 +50,61 @@ def test_load_prompt_substitutes_placeholders():
     assert "__PASSWORD__" not in out
 
 
+def test_action_side_prompts_registered():
+    """Externalised action-side prompts must be enumerated in
+    ``list_prompts()`` so the operator-override path
+    (``MANTIS_PROMPTS_DIR``) can reach them, and so SHA-versioned
+    telemetry surfaces them."""
+    names = set(list_prompts())
+    assert "recovery_analysis" in names
+    assert "derive_objective" in names
+    assert "find_form_target" in names
+
+
+def test_recovery_analysis_substitutes_placeholders():
+    rendered = load_prompt(
+        "recovery_analysis",
+        intent="Click Update Lead",
+        step_type="submit",
+        params="{'label': 'Update Lead'}",
+        failure_data="form_target_not_found",
+        attempts=3,
+        plan_context="  [0] Login\n  [1] Open Edit",
+    )
+    assert "Click Update Lead" in rendered
+    assert "form_target_not_found" in rendered
+    assert "Open Edit" in rendered
+    # No unrendered tokens leak into the model prompt.
+    assert "__INTENT__" not in rendered
+    assert "__STEP_TYPE__" not in rendered
+    assert "__PLAN_CONTEXT__" not in rendered
+
+
+def test_derive_objective_substitutes_placeholders():
+    rendered = load_prompt(
+        "derive_objective", plan_text="A demo plan body.",
+    )
+    assert "A demo plan body." in rendered
+    assert "__PLAN_TEXT__" not in rendered
+
+
+def test_find_form_target_substitutes_placeholders():
+    rendered = load_prompt(
+        "find_form_target",
+        screen_width=1920, screen_height=1080,
+        intent="Click Save",
+        target_clause="\nThe target element label is: \"Save\"",
+        value_clause="",
+        alias_clause="",
+    )
+    assert "1920x1080" in rendered
+    assert "Click Save" in rendered
+    assert "Save" in rendered
+    # Empty placeholder clauses collapse cleanly (no leftover token).
+    assert "__VALUE_CLAUSE__" not in rendered
+    assert "__ALIAS_CLAUSE__" not in rendered
+
+
 def test_load_prompt_unknown_name_raises():
     with pytest.raises(KeyError) as excinfo:
         load_prompt("nonexistent")


### PR DESCRIPTION
Inline f-strings buried in Python modules made prompt experimentation painful — diffs are obscured by escape rules, A/B testing required forking the module, locale variants were impossible. The system-prompt loader (``mantis_agent.prompts.load_prompt``) already supports ``MANTIS_PROMPTS_DIR`` operator overrides + ``__KEY__`` placeholder substitution. This PR moves three high-leverage action-side prompts under the same machinery.

## Externalised

| File | Source |
|---|---|
| ``prompts/files/recovery_analysis.txt`` | Agentic recovery failure-analysis prompt (PR #237 + #239 — most-edited prompt in the codebase) |
| ``prompts/files/derive_objective.txt`` | Derive-from-plan tool_use prompt |
| ``prompts/files/find_form_target.txt`` | Form-element-finder prompt with semantic-match reasoning |

## Operator override path

```bash
MANTIS_PROMPTS_DIR=/etc/mantis/prompts ./run
```

Drop a tweaked ``recovery_analysis.txt`` in that directory; the loader picks it up at module import. SHA-versioned telemetry (``current_prompt_versions()``) automatically tracks it. No wheel rebuild needed.

## Behaviour

Identical. Each call site is a one-line ``load_prompt`` substitution with the same dynamic fields the f-string injected.

## Tests

- 4 new cases in ``test_prompts.py`` pin substitution + placeholder cleanup for each new prompt
- ``test_agentic_recovery.py`` — prompt-content assertion now hits the rendered body via ``load_prompt`` (matches what the runtime sees)
- ``test_form_target_nav_tolerance.py`` — ``_grab_form_target_prompt`` renders via ``load_prompt`` rather than ``inspect.getsource``
- Full suite 1500/1500 in 7m02s
- ``ruff check`` clean

## Follow-up

The remaining inline prompts (``EXTRACT_PROMPT`` / ``EXTRACT_SCROLLED_PROMPT`` / ``EXTRACT_MULTI_SCREENSHOT_PROMPT`` / ``FIND_LISTING_CONTENT_CONTROL_PROMPT`` constants in ``extractor.py``, ``find_filter_target`` / ``find_target_by_affordance`` / ``verify_post_click_navigation`` inline prompts) are next-pass candidates — same mechanism, more file moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)