### PR TITLE
fix(decomposer): route verification extract_data through gate path (#244)

### DIFF
--- a/src/mantis_agent/plan_decomposer.py
+++ b/src/mantis_agent/plan_decomposer.py
@@ -503,6 +503,13 @@ RULES:
 - Set section="setup", section="extraction", or section="pagination"
 - Set required=true for all setup/filter/form steps (this is the default)
 - Set gate=true for the verification step at the end of setup
+- Set gate=true on EVERY verification-flavored extract_data step,
+  not just end-of-setup gates. If the step's intent contains any of
+  "verify", "confirm", "check that", "make sure", "wait for",
+  "read the URL", "ensure" — it is a verification step. Set
+  gate=true so the runner dispatches to verify_gate (no recipe
+  schema validation). Authoritative extraction (read structured
+  fields, scrape, harvest data) keeps gate=false.
 
 LOOP STRUCTURE:
   Extraction loop: click → URL → scroll → extract → back → loop(target=click, count=N)
@@ -527,7 +534,26 @@ STEP TYPES:
 - click: Click an element on a listings/results page (budget=8, grounding=true)
 - scroll: Scroll until target content visible (budget=10, section="extraction")
 - extract_url: Read URL from address bar (claude_only=true, budget=0, section="extraction")
-- extract_data: Inspect page and read structured data or verify state (claude_only=true, budget=0)
+- extract_data: Inspect page and read structured data OR verify state.
+                CRITICAL — these are TWO DISTINCT MODES (issue #244):
+                  • Authoritative extraction (claude_only=true, gate=false):
+                    runs the recipe-schema-validated deep-extract path.
+                    Use when the source plan asks to *read structured
+                    fields* off a detail/listing page (year, make,
+                    price, title, lead name, …) for downstream use.
+                  • Verification (claude_only=true, gate=true):
+                    runs the verify_gate path — Claude reads the
+                    screenshot and answers PASS/FAIL with a reason.
+                    NO recipe schema, NO required-fields validation,
+                    NO REJECTED_INCOMPLETE cascade. Use whenever the
+                    source plan asks to *verify, confirm, check, make
+                    sure, wait for, read the URL* — anything that
+                    asserts a condition holds rather than producing a
+                    structured row of data.
+                Get this wrong and the plan halts on a search/list
+                page where the schema's required fields don't exist
+                in the rendered text. Set gate=true on every
+                verification extract_data, not just end-of-setup.
 - navigate_back: Go back (budget=3, section="extraction")
 - paginate: Click Next page (budget=10, grounding=true, section="pagination")
 - loop: Jump back to step index (loop_target=N, loop_count=max)
@@ -626,7 +652,7 @@ class PlanDecomposer:
             domain = m.group(1)
 
         # Check cache — include prompt version in hash to invalidate on schema changes
-        prompt_version = "v23_skip_runtime_hints"  # Bump this when DECOMPOSE_PROMPT changes
+        prompt_version = "v24_verification_gate"  # Bump this when DECOMPOSE_PROMPT changes
         plan_hash = hashlib.md5(f"{prompt_version}:{plan_text}".encode()).hexdigest()[:8]
         cache_path = (
             cache_path_template.replace("{hash}", plan_hash)
@@ -753,6 +779,38 @@ class PlanDecomposer:
     # Always claude-grounded; no listings find_all. See issue #80.
     FORM_STEP_TYPES = ("fill_field", "submit", "select_option")
 
+    # Verification-language triggers (issue #244). When an
+    # ``extract_data`` step's intent contains any of these substrings
+    # (case-insensitive) and the source dict didn't set ``gate``
+    # explicitly, ``_build_intent`` auto-promotes ``gate=True`` so
+    # the runner dispatches the step through ``verify_gate`` rather
+    # than the deep-extract / recipe-schema path. Without this,
+    # auto-injected verification steps like *"Verify the page
+    # loaded"* hit the marketplace_listings recipe schema on a
+    # search-results URL and reject as REJECTED_INCOMPLETE,
+    # halting the plan.
+    _VERIFICATION_INTENT_TRIGGERS = (
+        "verify",
+        "confirm",
+        "check that",
+        "make sure",
+        "wait for",
+        "read the url",
+        "ensure",
+    )
+
+    @staticmethod
+    def _is_verification_intent(intent: str) -> bool:
+        """Return True iff ``intent`` reads as verification language —
+        i.e. asserting a state holds rather than reading authoritative
+        structured data. Case-insensitive substring match against
+        :data:`_VERIFICATION_INTENT_TRIGGERS`. Used by
+        :meth:`_build_intent` as the safety net behind issue #244."""
+        if not intent:
+            return False
+        text = intent.casefold()
+        return any(t in text for t in PlanDecomposer._VERIFICATION_INTENT_TRIGGERS)
+
     @staticmethod
     def _build_intent(s: dict) -> MicroIntent:
         """Build a MicroIntent from a raw dict — used by both cache and fresh paths."""
@@ -783,6 +841,18 @@ class PlanDecomposer:
         if not isinstance(hints, dict):
             hints = {}
 
+        # Issue #244: auto-promote verification ``extract_data`` to
+        # ``gate=True`` when the source dict didn't say either way.
+        # Explicit operator overrides (``gate`` present in ``s``)
+        # always win — the heuristic must not silently flip a
+        # plan-author's deliberate choice.
+        if "gate" in s:
+            gate = bool(s["gate"])
+        elif step_type == "extract_data" and PlanDecomposer._is_verification_intent(s.get("intent", "")):
+            gate = True
+        else:
+            gate = False
+
         return MicroIntent(
             intent=s.get("intent", ""),
             type=step_type,
@@ -798,7 +868,7 @@ class PlanDecomposer:
             loop_count=s.get("loop_count", 0),
             section=section,
             required=s.get("required", default_required),
-            gate=s.get("gate", False),
+            gate=gate,
             params=params,
             hints=hints,
         )

--- a/tests/test_decomposer_literal_values.py
+++ b/tests/test_decomposer_literal_values.py
@@ -129,10 +129,11 @@ def test_prompt_version_was_bumped() -> None:
     from mantis_agent.plan_decomposer import PlanDecomposer
 
     src = inspect.getsource(PlanDecomposer.decompose_text)
-    # Current version (skip runtime hints / wait instructions).
-    assert "v23_skip_runtime_hints" in src
+    # Current version (route verification extract_data through gate).
+    assert "v24_verification_gate" in src
     # Superseded versions must NOT appear — would mean someone
     # accidentally restored a stale cache key.
+    assert "v23_skip_runtime_hints" not in src
     assert "v22_row_link" not in src
     assert "v21_submit_kind" not in src
     assert "v20_url_mirror" not in src

--- a/tests/test_decomposer_runtime_hints.py
+++ b/tests/test_decomposer_runtime_hints.py
@@ -90,11 +90,16 @@ def test_prompt_omit_rule_extends_to_capability_constraints() -> None:
 # ── Cache key bumped so v22 caches re-decompose under v23 ─────────────
 
 
-def test_cache_version_bumped_to_v23() -> None:
+def test_cache_version_bumped_past_v23() -> None:
     """A prompt change requires a cache-version bump so previously-
-    decomposed plans get re-decomposed under the new rule."""
+    decomposed plans get re-decomposed under the new rule. v23 was
+    the runtime-hints rule; v24 (issue #244) supersedes it by also
+    routing verification extract_data through the gate path. The
+    runtime-hints rule itself is preserved in the v24 prompt — this
+    test just guards against stale-cache regression by asserting we
+    moved past v23."""
     src = inspect.getsource(PlanDecomposer.decompose_text)
-    assert "v23_skip_runtime_hints" in src
+    assert "v23_skip_runtime_hints" not in src
     assert "v22_row_link" not in src
 
 

--- a/tests/test_decomposer_verification_gate.py
+++ b/tests/test_decomposer_verification_gate.py
@@ -1,0 +1,265 @@
+"""Tests for issue #244 — verification ``extract_data`` must route
+through the gate path, not authoritative-extraction.
+
+The decomposer routinely auto-inserts an ``extract_data`` micro-step
+at the end of multi-step plans (e.g. *"Verify the page loaded"*,
+*"Read the URL in the address bar and confirm..."*). Until this fix,
+those steps lacked ``gate=True`` and fell through to the deep-extract
+code path that applies the recipe schema. On a search/listing URL
+that has no ``year``/``make`` (or whatever the recipe requires) the
+extractor rejects the row and the entire plan halts. Three rounds
+of host-side prompt patches (staffai PR #587 BoatTrader template)
+couldn't reliably stop the orchestrator from emitting verification
+sub-goals in natural English.
+
+Two-layer fix:
+
+1. **Prompt** — DECOMPOSE_PROMPT now carries an explicit
+   "VERIFICATION VS AUTHORITATIVE EXTRACTION" section. Any
+   ``extract_data`` step whose intent reads as verification
+   ("verify", "confirm", "check that", "wait for", etc.) MUST set
+   ``gate=True``. Authoritative extraction (read structured data,
+   scrape, harvest fields) keeps today's behavior.
+
+2. **Runtime safety net** in ``PlanDecomposer._build_intent`` — if
+   the LLM emits an ``extract_data`` step with verification-language
+   intent and no explicit ``gate`` field, auto-promote ``gate=True``.
+   The prompt is the primary signal; the heuristic is a cheap
+   second defence so a single missed prompt cue can't halt a plan.
+
+The runner-side dispatch in ``_runner_helpers.py:run_dispatch``
+already routes ``step.gate=True`` to ``extractor.verify_gate``
+(boolean+reason, no schema) before the extract_data deep-extract
+path — so flipping ``gate=True`` is enough to bypass schema
+rejection without touching the runner.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+from mantis_agent.plan_decomposer import (
+    DECOMPOSE_PROMPT,
+    MicroPlan,
+    PlanDecomposer,
+)
+
+
+# ── Prompt-layer guards ───────────────────────────────────────────
+
+
+def test_prompt_distinguishes_verification_from_authoritative_extraction() -> None:
+    """DECOMPOSE_PROMPT must carry an explicit section spelling out
+    the two modes — without it Claude routinely conflates them."""
+    text = DECOMPOSE_PROMPT
+    text_lower = text.lower()
+    # Either the section header or the principle name.
+    assert (
+        "verification" in text_lower
+        and ("authoritative" in text_lower or "schema" in text_lower)
+    )
+
+
+def test_prompt_says_verification_extract_data_must_set_gate_true() -> None:
+    """The prompt must state the rule plainly so Claude doesn't
+    have to infer it from end-of-setup wording (which is where the
+    rule lived prior to this fix and got missed for mid-plan
+    verifications)."""
+    text = DECOMPOSE_PROMPT
+    text_lower = text.lower()
+    # Look for the rule near the verification language.
+    assert "gate=true" in text_lower
+    # The rule is not just for end-of-setup gates — must apply to
+    # any verification-flavored extract_data step.
+    assert "verify" in text_lower or "confirm" in text_lower
+
+
+def test_prompt_lists_verification_trigger_phrases() -> None:
+    """The prompt enumerates the canonical trigger phrases so Claude
+    has concrete pattern-match anchors. The list is the same
+    heuristic the runtime safety net applies (see test_build_intent
+    cases below)."""
+    text_lower = DECOMPOSE_PROMPT.lower()
+    # At least three of the canonical triggers must appear.
+    triggers = ["verify", "confirm", "check that", "make sure", "wait for", "read the url"]
+    hits = sum(1 for t in triggers if t in text_lower)
+    assert hits >= 3, f"only {hits} verification triggers in prompt"
+
+
+def test_prompt_calls_out_recipe_schema_rejection_failure_mode() -> None:
+    """The rule should explain WHY emitting verification as plain
+    extract_data breaks — the recipe-schema rejection cascade.
+    Future prompt rewrites that drop the rule but keep the
+    surrounding structure re-introduce the same bug; the rationale
+    text is the guard."""
+    text = DECOMPOSE_PROMPT
+    # Either "schema" or the canonical reject keyword from the
+    # extractor must appear so the reasoning is preserved.
+    assert "schema" in text.lower() or "REJECTED_INCOMPLETE" in text
+
+
+def test_cache_version_bumped() -> None:
+    """A prompt change requires a cache-version bump so previously-
+    decomposed plans get re-decomposed under the new rule."""
+    src = inspect.getsource(PlanDecomposer.decompose_text)
+    # The new version MUST differ from the previous one and reference
+    # this fix (issue #244 / verification gate).
+    assert "v23_skip_runtime_hints" not in src
+    assert "v24" in src
+
+
+# ── Runtime safety net (PlanDecomposer._build_intent) ────────────
+
+
+def _step(intent: str, type_: str = "extract_data", **extra) -> dict:
+    base = {"intent": intent, "type": type_}
+    base.update(extra)
+    return base
+
+
+def test_build_intent_promotes_verify_intent_to_gate() -> None:
+    """An ``extract_data`` step whose intent starts with *Verify*
+    must come out with ``gate=True`` even if the LLM forgot to set
+    it. The runner dispatches ``gate=True`` to the verify-gate
+    path, bypassing recipe-schema rejection."""
+    s = PlanDecomposer._build_intent(
+        _step("Verify the page heading shows the expected filters")
+    )
+    assert s.type == "extract_data"
+    assert s.gate is True
+    # claude_only stays True so the verify_gate dispatch (which does
+    # require a screenshot) still fires.
+    assert s.claude_only is True
+
+
+def test_build_intent_promotes_confirm_intent_to_gate() -> None:
+    s = PlanDecomposer._build_intent(
+        _step("Confirm the lead detail page shows Priority High")
+    )
+    assert s.gate is True
+
+
+def test_build_intent_promotes_check_that_intent_to_gate() -> None:
+    s = PlanDecomposer._build_intent(
+        _step("Check that the URL contains /leads/")
+    )
+    assert s.gate is True
+
+
+def test_build_intent_promotes_make_sure_intent_to_gate() -> None:
+    s = PlanDecomposer._build_intent(
+        _step("Make sure the form saved successfully")
+    )
+    assert s.gate is True
+
+
+def test_build_intent_promotes_read_url_intent_to_gate() -> None:
+    """The exact phrasing from issue #244's BoatTrader reproducer:
+    ``Read the URL in the address bar and confirm the page shows
+    boat listing cards``. This intent decomposed into an
+    extract_data without gate, ran the marketplace_listings
+    extractor on the search URL, and got rejected."""
+    s = PlanDecomposer._build_intent(
+        _step("Read the URL in the address bar and confirm boat listings show")
+    )
+    assert s.gate is True
+
+
+def test_build_intent_promotes_wait_for_intent_to_gate() -> None:
+    s = PlanDecomposer._build_intent(
+        _step("Wait for the search results page to fully load")
+    )
+    assert s.gate is True
+
+
+def test_build_intent_keeps_authoritative_extract_data_ungated() -> None:
+    """An ``extract_data`` whose intent reads as authoritative
+    extraction (read fields, scrape, harvest) must NOT be promoted
+    — that's the existing deep-extract path the recipe schema is
+    designed for."""
+    s = PlanDecomposer._build_intent(
+        _step("Read structured listing fields (year, make, price) from this card")
+    )
+    assert s.gate is False
+
+    s2 = PlanDecomposer._build_intent(
+        _step("Extract the boat detail page including title, price, and seller info")
+    )
+    assert s2.gate is False
+
+    s3 = PlanDecomposer._build_intent(
+        _step("Scrape the visible job listings into the result set")
+    )
+    assert s3.gate is False
+
+
+def test_build_intent_respects_explicit_gate_false_override() -> None:
+    """If the source plan / cached JSON explicitly sets
+    ``gate=False``, the heuristic must NOT silently flip it. An
+    operator override is the most reliable signal — defending
+    against autonomous flipping prevents the heuristic from
+    becoming unrideable."""
+    s = PlanDecomposer._build_intent({
+        "intent": "Verify the page loaded",
+        "type": "extract_data",
+        "gate": False,
+    })
+    # Explicitly set False stays False — no auto-promotion.
+    assert s.gate is False
+
+
+def test_build_intent_respects_explicit_gate_true() -> None:
+    s = PlanDecomposer._build_intent({
+        "intent": "Verify the page loaded",
+        "type": "extract_data",
+        "gate": True,
+    })
+    assert s.gate is True
+
+
+def test_build_intent_does_not_promote_non_extract_data_step_types() -> None:
+    """The auto-promotion is scoped to ``extract_data`` — the only
+    step type that fans into the schema-reject cascade. A submit/
+    fill_field/select_option step with ``Verify`` in its intent
+    should keep its declared gate (default False) — those types
+    don't reach the deep-extract path anyway."""
+    for step_type in ("submit", "fill_field", "select_option", "navigate", "click"):
+        s = PlanDecomposer._build_intent(
+            _step("Verify by clicking Save", type_=step_type)
+        )
+        assert s.gate is False, f"{step_type!r} got auto-promoted but shouldn't"
+
+
+def test_build_intent_case_insensitive_trigger_match() -> None:
+    """The verification triggers shouldn't be brittle to casing —
+    Claude sometimes lowercases instructions."""
+    for intent in (
+        "VERIFY the page rendered",
+        "verify the page rendered",
+        "Confirm The page rendered",
+    ):
+        s = PlanDecomposer._build_intent(_step(intent))
+        assert s.gate is True
+
+
+# ── End-to-end: from_dict surface ─────────────────────────────────
+
+
+def test_micro_plan_from_dict_applies_promotion_through_build_intent() -> None:
+    """``MicroPlan.from_dict`` runs every step through ``_build_intent``
+    so cached JSON plans (which is how this hits production via
+    the staffai integration's plan_json shortcut) also benefit
+    from the safety net."""
+    payload = {
+        "steps": [
+            {"intent": "Navigate to https://www.example.com",
+             "type": "navigate",
+             "params": {"url": "https://www.example.com"}},
+            {"intent": "Verify the page rendered the expected header",
+             "type": "extract_data"},
+        ],
+    }
+    plan = MicroPlan.from_dict(payload)
+    assert plan.steps[0].type == "navigate"
+    assert plan.steps[1].type == "extract_data"
+    assert plan.steps[1].gate is True

--- a/tests/test_decomposer_verification_gate.py
+++ b/tests/test_decomposer_verification_gate.py
@@ -8,7 +8,7 @@ those steps lacked ``gate=True`` and fell through to the deep-extract
 code path that applies the recipe schema. On a search/listing URL
 that has no ``year``/``make`` (or whatever the recipe requires) the
 extractor rejects the row and the entire plan halts. Three rounds
-of host-side prompt patches (staffai PR #587 BoatTrader template)
+of host-side prompt patches (host-integration template)
 couldn't reliably stop the orchestrator from emitting verification
 sub-goals in natural English.
 
@@ -248,7 +248,7 @@ def test_build_intent_case_insensitive_trigger_match() -> None:
 def test_micro_plan_from_dict_applies_promotion_through_build_intent() -> None:
     """``MicroPlan.from_dict`` runs every step through ``_build_intent``
     so cached JSON plans (which is how this hits production via
-    the staffai integration's plan_json shortcut) also benefit
+    the host integration's plan_json shortcut) also benefit
     from the safety net."""
     payload = {
         "steps": [


### PR DESCRIPTION
Closes #244.

## Why
The decomposer routinely auto-inserts an `extract_data` micro-step when the orchestrator's sub-goal contains verification phrases (e.g. *"Verify the page loaded"*, *"Read the URL in the address bar and confirm…"*). Without `gate=true`, those steps fall through to the deep-extract code path, run ClaudeExtractor against the recipe schema, and reject as `REJECTED_INCOMPLETE` when the search/list page doesn't have the required structured fields. Plan halts.

Three rounds of host-side prompt patches in [staffai PR #587](https://github.com/StaffAI-Inc/staffai/pull/587) couldn't reliably stop the orchestrator from emitting verification sub-goals in natural English. Decomposer-side fix replaces ~80 lines of host-plan boilerplate with a runner-side heuristic.

## Change
Two-layer fix:

1. **Prompt** (`DECOMPOSE_PROMPT`) — now carries an explicit *VERIFICATION VS AUTHORITATIVE EXTRACTION* distinction in the `extract_data` step-type definition, plus a parallel rule in the RULES block. Any verification-language `extract_data` step MUST set `gate=true`, not just end-of-setup gates.

2. **Runtime safety net** (`PlanDecomposer._build_intent`) — when the source dict didn't set `gate` explicitly and the step is `extract_data` whose intent contains a verification trigger (`verify`, `confirm`, `check that`, `make sure`, `wait for`, `read the URL`, `ensure`), auto-promote `gate=True`. Explicit operator overrides (`gate` present in the dict — True or False) always win.

The runner already routes `step.gate=True` to `extractor.verify_gate` (boolean+reason, no schema) before the deep-extract path — so flipping `gate=True` is sufficient to bypass schema rejection without touching the runner. ([\`_runner_helpers.py:729\`](https://github.com/mercurialsolo/mantis/blob/main/src/mantis_agent/gym/_runner_helpers.py#L729))

Cache version bumped from `v23_skip_runtime_hints` → `v24_verification_gate` so previously-decomposed plans get re-decomposed under the new rule.

## Test plan
- [x] `tests/test_decomposer_verification_gate.py` — 17 new tests:
  - **Prompt-layer**: distinction present, `gate=true` rule explicit, trigger phrases enumerated, schema-rejection rationale preserved, cache version bumped
  - **Runtime safety net**: per-trigger promotion (verify/confirm/check that/make sure/wait for/read the URL), explicit-override respect (both directions), scoping to `extract_data` only, case-insensitive matching, end-to-end through `MicroPlan.from_dict`
- [x] All 104 decomposer tests pass (existing + new)
- [x] Full suite (\`pytest tests/\`) — exit 0
- [ ] Integration on staffai BoatTrader plan: 0 schema-rejection events between Step 2 (navigate) and Step 4 (drill-in). Today's count: 9 in 12 minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)