### PR TITLE
feat(extraction): recipe-rejection skip envelope (#246)

### DIFF
--- a/src/mantis_agent/extraction/schema.py
+++ b/src/mantis_agent/extraction/schema.py
@@ -69,6 +69,21 @@ class ExtractionSchema:
     spam_label: str = "dealer/spam"  # what to call spam (e.g. "dealer", "recruiter")
     forbidden_controls: list[str] = field(default_factory=list)  # "Contact Seller", etc.
     allowed_controls: list[str] = field(default_factory=list)  # "Show more", "Show phone"
+    # Issue #246: recipe-rejection → host-facing intent map. Keys are
+    # canonical rejection-reason tokens (``"dealer"``,
+    # ``"incomplete_required"``, ``"parse_error"``…) that the runner
+    # tags every rejection with. Values are intent strings the host
+    # can branch on:
+    #   ``"skip"``         — terminal-for-this-row; host should mark the
+    #                        listing as processed-but-skipped and advance
+    #                        to the next, not retry
+    #   ``"extract_more"`` — caller could enrich on the detail page;
+    #                        runner stays in extraction loop
+    #   ``"retry"``        — transient; safe to retry the same step
+    # Empty default preserves today's behavior (no skip-semantic
+    # surfaces; every rejection looks like a generic step failure).
+    # Recipes opt in by setting their canonical rejections explicitly.
+    rejection_intents: dict[str, str] = field(default_factory=dict)
 
     @classmethod
     def from_objective(cls, objective: Any) -> ExtractionSchema:
@@ -235,6 +250,15 @@ class ExtractionSchema:
         # derived (recipes accumulate empirical knowledge of which
         # tile fields actually render across the marketplace's
         # listing variants).
+        # ``rejection_intents``: derived keys win on conflict
+        # (operator-authored override of recipe defaults), recipe
+        # extends with new keys (recipes accumulate empirical
+        # vertical knowledge of which rejections are terminal vs
+        # retryable). Same shape as the dict-merge primitive used
+        # for tile_carry_fields list union, just dict-flavoured.
+        merged_intents = dict(other.rejection_intents)
+        merged_intents.update(self.rejection_intents)
+
         return ExtractionSchema(
             entity_name=entity,
             fields=self.fields,
@@ -254,4 +278,5 @@ class ExtractionSchema:
             spam_label=spam_lbl,
             forbidden_controls=_union(self.forbidden_controls, other.forbidden_controls),
             allowed_controls=_union(self.allowed_controls, other.allowed_controls),
+            rejection_intents=merged_intents,
         )

--- a/src/mantis_agent/gym/checkpoint.py
+++ b/src/mantis_agent/gym/checkpoint.py
@@ -51,12 +51,23 @@ class StepResult:
     duration: float = 0.0
     reversed: bool = False
 
+    # Issue #246: recipe-rejection skip envelope. ``skip=True`` is the
+    # runner's signal to a hosting orchestrator that a recipe correctly
+    # excluded this row (dealer / spam / similar) and the host should
+    # advance past it, *not* retry the same step. ``skip_reason`` is
+    # the recipe-author key (``"dealer"``, ``"incomplete_required"``,
+    # …) the host can branch on. Both default off so legacy callers
+    # see no change; recipes opt in via ``ExtractionSchema.rejection_intents``.
+    skip: bool = False
+    skip_reason: str | None = None
+
     # Observability extras — populated by MicroPlanRunner; not persisted.
     screenshot_png: bytes | None = field(default=None, repr=False, compare=False)
     last_action: Action | None = field(default=None, repr=False, compare=False)
 
     _PERSISTED: ClassVar[tuple[str, ...]] = (
         "step_index", "intent", "success", "data", "steps_used", "duration", "reversed",
+        "skip", "skip_reason",
     )
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/mantis_agent/gym/step_handlers/claude_step.py
+++ b/src/mantis_agent/gym/step_handlers/claude_step.py
@@ -97,6 +97,30 @@ def _resolve_extraction_context(runner: "MicroPlanRunner", data: object | None):
     return ExtractionContext.UNKNOWN
 
 
+def _resolve_skip_envelope(extractor, *, rejection_key: str) -> tuple[bool, str | None]:
+    """Look up a rejection key in ``extractor.schema.rejection_intents``
+    and return the StepResult skip envelope (``skip``, ``skip_reason``).
+
+    Issue #246: when a recipe annotates a rejection key as
+    ``"skip"``, the rejection is terminal-for-this-row and a host
+    orchestrator should advance past it without retrying. The
+    runner surfaces that intent via ``StepResult.skip=True``;
+    ``skip_reason`` carries the recipe-author key (``"dealer"``,
+    ``"incomplete_required"``, …) so hosts can branch on the
+    specific kind. Any other intent (``"extract_more"``,
+    ``"retry"``) or a missing entry leaves ``skip=False`` —
+    matches today's behavior, host-side retry logic continues to
+    apply.
+    """
+    schema = getattr(extractor, "schema", None)
+    if schema is None:
+        return False, None
+    intent = schema.rejection_intents.get(rejection_key, "")
+    if intent == "skip":
+        return True, rejection_key
+    return False, None
+
+
 class ClaudeStepHandler:
     """Implements :class:`~..step_context.StepHandler` for Claude-only steps.
 
@@ -282,10 +306,14 @@ class ClaudeStepHandler:
                     success=True,
                     reason=f"rejected_dealer:{reason}",
                 )
+                skip, skip_reason = _resolve_skip_envelope(
+                    extractor, rejection_key="dealer",
+                )
                 return StepResult(
                     step_index=index, intent=step.intent,
                     success=False,
                     data=f"REJECTED_DEALER|{reason}|{data.to_summary()[:160]}",
+                    skip=skip, skip_reason=skip_reason,
                 )
             # Issue #236: pick the right required-field contract based
             # on which kind of page the extractor read. ``DETAIL_PAGE``
@@ -315,10 +343,14 @@ class ClaudeStepHandler:
                     success=True,
                     reason=f"rejected_incomplete:{reason}",
                 )
+                skip, skip_reason = _resolve_skip_envelope(
+                    extractor, rejection_key="incomplete_required",
+                )
                 return StepResult(
                     step_index=index, intent=step.intent,
                     success=False,
                     data=f"REJECTED_INCOMPLETE|{reason}|{data.to_summary()[:160]}",
+                    skip=skip, skip_reason=skip_reason,
                 )
             dynamic_verifier.record_item_completed(
                 page=runner._current_page,

--- a/src/mantis_agent/recipes/marketplace_listings/_data.py
+++ b/src/mantis_agent/recipes/marketplace_listings/_data.py
@@ -92,3 +92,21 @@ TILE_CARRY_FIELDS: tuple[str, ...] = ("url", "title", "price")
 # behavior change for callers reading entity_name in their own prompts.
 ENTITY_NAME = "boat listing"
 SPAM_LABEL = "dealer"
+
+# Issue #246: recipe-rejection → host-facing intent.
+#
+# - ``dealer``: terminal-for-this-row. The detail page truly is a
+#   dealer listing (storefront banner, "Contact Dealer" CTAs, dealer
+#   seller name). No future read can turn it into a private-seller
+#   lead. Host should mark the URL as processed-but-skipped and
+#   advance to the next listing — *not* retry the extraction. Live
+#   reproducer: BoatTrader plan d0693cd9 looped 6× on a single
+#   dealer-flagged URL across 90 minutes before this annotation.
+# - ``incomplete_required``: the search tile didn't surface
+#   year/make in rendered text, but the detail page may. Host
+#   should follow up with a deeper read; ``extract_more`` keeps
+#   the row in the extraction loop rather than dropping it.
+REJECTION_INTENTS: dict[str, str] = {
+    "dealer": "skip",
+    "incomplete_required": "extract_more",
+}

--- a/src/mantis_agent/recipes/marketplace_listings/schema.py
+++ b/src/mantis_agent/recipes/marketplace_listings/schema.py
@@ -33,6 +33,7 @@ def _build_schema() -> ExtractionSchema:
         spam_label=_data.SPAM_LABEL,
         forbidden_controls=list(_data.FORBIDDEN_CONTROLS),
         allowed_controls=list(_data.ALLOWED_CONTROLS),
+        rejection_intents=dict(_data.REJECTION_INTENTS),
     )
 
 

--- a/tests/test_rejection_skip_intent.py
+++ b/tests/test_rejection_skip_intent.py
@@ -4,7 +4,7 @@ Ahead of this fix, ``ClaudeStepHandler`` returned a generic
 ``StepResult(success=False, data="REJECTED_DEALER|...")`` whenever
 the extractor flagged a row as a dealer / spam / non-private
 listing. Hosts that orchestrate the agent over a tool surface
-(staffai's hybrid backend) saw an opaque step failure and treated
+(host integration's hybrid backend) saw an opaque step failure and treated
 it as *"extraction is broken, try a different angle"* — the agent
 then re-navigated, scrolled more, and asked Claude to read other
 sections, none of which can succeed because the page genuinely is

--- a/tests/test_rejection_skip_intent.py
+++ b/tests/test_rejection_skip_intent.py
@@ -1,0 +1,302 @@
+"""Tests for issue #246 — recipe-rejection skip-semantic envelope.
+
+Ahead of this fix, ``ClaudeStepHandler`` returned a generic
+``StepResult(success=False, data="REJECTED_DEALER|...")`` whenever
+the extractor flagged a row as a dealer / spam / non-private
+listing. Hosts that orchestrate the agent over a tool surface
+(staffai's hybrid backend) saw an opaque step failure and treated
+it as *"extraction is broken, try a different angle"* — the agent
+then re-navigated, scrolled more, and asked Claude to read other
+sections, none of which can succeed because the page genuinely is
+a dealer listing and the recipe correctly rejects it. Net effect:
+the agent stuck looping on a single dealer-flagged URL, never
+moving on to the next listing.
+
+Recipes know which rejections are *terminal for this row* (dealer,
+spam — host should advance) versus *retryable / informational*
+(incomplete required fields — host could try the detail page).
+This module pins the contract that propagates that knowledge:
+
+1. ``ExtractionSchema.rejection_intents`` — recipe-author dict that
+   maps a rejection-reason key to a host-facing intent string.
+2. ``StepResult.skip`` / ``StepResult.skip_reason`` — runner-side
+   fields populated when the recipe says ``intent == 'skip'``.
+3. ``ClaudeStepHandler`` extract_data branch consults the schema
+   on every rejection and sets ``skip`` accordingly.
+4. ``marketplace_listings`` recipe carries ``{'dealer': 'skip', ...}``
+   so its existing dealer rejections become host-actionable.
+"""
+
+from __future__ import annotations
+
+from dataclasses import fields
+from unittest.mock import MagicMock
+
+from mantis_agent.extraction import ExtractionSchema
+from mantis_agent.extraction.result import ExtractionResult
+from mantis_agent.gym.checkpoint import StepResult
+
+
+# ── StepResult: new fields, defaults, persistence ────────────────
+
+
+def test_step_result_has_skip_and_skip_reason_fields() -> None:
+    names = {f.name for f in fields(StepResult)}
+    assert "skip" in names
+    assert "skip_reason" in names
+
+
+def test_step_result_skip_defaults_to_false() -> None:
+    """Default StepResult must have ``skip=False`` and
+    ``skip_reason=None`` so legacy callers (every existing test +
+    every existing handler) see no change."""
+    r = StepResult(step_index=0, intent="x", success=True)
+    assert r.skip is False
+    assert r.skip_reason is None
+
+
+def test_step_result_skip_round_trips_via_to_dict_from_dict() -> None:
+    """The skip envelope persists through the checkpoint JSON the
+    same way ``data`` / ``steps_used`` do — otherwise resume from
+    a checkpoint loses the host-actionable signal."""
+    r = StepResult(
+        step_index=3, intent="extract row", success=False,
+        data="REJECTED_DEALER|extractor marked as dealer|...",
+        skip=True, skip_reason="dealer",
+    )
+    payload = r.to_dict()
+    assert payload["skip"] is True
+    assert payload["skip_reason"] == "dealer"
+    rt = StepResult.from_dict(payload)
+    assert rt.skip is True
+    assert rt.skip_reason == "dealer"
+
+
+def test_step_result_persisted_tuple_includes_skip_fields() -> None:
+    """``_PERSISTED`` is the explicit allowlist of checkpoint-
+    serialised fields. New fields must be added here or they
+    silently drop on save."""
+    persisted = set(StepResult._PERSISTED)
+    assert "skip" in persisted
+    assert "skip_reason" in persisted
+
+
+# ── ExtractionSchema: rejection_intents ──────────────────────────
+
+
+def test_extraction_schema_has_rejection_intents_field() -> None:
+    s = ExtractionSchema()
+    assert hasattr(s, "rejection_intents")
+    assert s.rejection_intents == {}
+
+
+def test_extraction_schema_rejection_intents_is_per_instance() -> None:
+    """Default factory: each instance gets its own dict, mutating
+    one must not leak into a sibling. Default-factory regression
+    guard for the dataclass."""
+    a = ExtractionSchema()
+    b = ExtractionSchema()
+    a.rejection_intents["dealer"] = "skip"
+    assert "dealer" not in b.rejection_intents
+
+
+def test_extraction_schema_overlay_merges_rejection_intents() -> None:
+    """``overlay()`` is the derive-first composition path
+    (issue #224). When a derived schema (built from the plan
+    text via ``from_objective``) is overlaid with a recipe, the
+    recipe's empirical knowledge of which rejections mean *skip*
+    must reach the runner. Recipe extends derived; derived keys
+    win on conflict (operator-authored override)."""
+    derived = ExtractionSchema(rejection_intents={"dealer": "extract_more"})
+    recipe = ExtractionSchema(rejection_intents={
+        "dealer": "skip",          # would lose to derived
+        "spam": "skip",            # added by recipe
+        "parse_error": "retry",    # added by recipe
+    })
+    merged = derived.overlay(recipe)
+    assert merged.rejection_intents["dealer"] == "extract_more"  # derived wins
+    assert merged.rejection_intents["spam"] == "skip"
+    assert merged.rejection_intents["parse_error"] == "retry"
+
+
+def test_extraction_schema_overlay_with_empty_recipe_intents_keeps_derived() -> None:
+    derived = ExtractionSchema(rejection_intents={"dealer": "skip"})
+    recipe = ExtractionSchema()  # no rejection_intents
+    merged = derived.overlay(recipe)
+    assert merged.rejection_intents == {"dealer": "skip"}
+
+
+# ── marketplace_listings recipe: explicit dealer intent ──────────
+
+
+def test_marketplace_listings_recipe_marks_dealer_as_skip() -> None:
+    """Issue #246's reproducer: BoatTrader detail pages flag as
+    dealer, the runner returned generic step failure, the
+    orchestrator looped. The recipe must annotate dealer rejections
+    as host-actionable skips."""
+    from mantis_agent.recipes.marketplace_listings.schema import SCHEMA
+    assert SCHEMA.rejection_intents.get("dealer") == "skip"
+
+
+def test_marketplace_listings_recipe_distinguishes_incomplete_from_dealer() -> None:
+    """Incomplete-required rejections are different — the row may
+    enrich on the detail page. The host should NOT skip the row;
+    it should drive a follow-up read. Recipe authors annotate this
+    explicitly."""
+    from mantis_agent.recipes.marketplace_listings.schema import SCHEMA
+    assert SCHEMA.rejection_intents.get("incomplete_required") != "skip"
+
+
+# ── ClaudeStepHandler integration: skip propagation ──────────────
+
+
+def _build_step_handler_ctx(*, recipe_schema: ExtractionSchema, dealer: bool, missing: bool):
+    """Construct the minimal MicroPlanRunner / StepContext / mock
+    extractor needed for the extract_data branch. Returns
+    ``(handler, step, ctx)``."""
+    from mantis_agent.gym.step_context import StepContext
+    from mantis_agent.gym.step_handlers.claude_step import ClaudeStepHandler
+    from mantis_agent.plan_decomposer import MicroIntent
+
+    runner = MagicMock()
+    runner.costs = {"claude_extract": 0, "gpu_steps": 0, "gpu_seconds": 0}
+    runner._last_extracted = {}
+    runner._current_page = 1
+    runner.scanner.is_duplicate.return_value = False
+
+    extractor = MagicMock()
+    extractor.schema = recipe_schema
+
+    # ExtractionResult stub with the relevant predicate methods.
+    data = MagicMock(spec=ExtractionResult)
+    data.url = "https://www.example.com/boat/1234"
+    data.dealer_reason.return_value = "extractor marked as dealer" if dealer else ""
+    data.missing_required_reason.return_value = (
+        "missing required field: year" if missing else ""
+    )
+    data.is_viable.return_value = not (dealer or missing)
+    data.to_summary.return_value = "summary"
+    data.raw_response = "raw"
+    data.extracted_fields = {}
+    data.url = "https://www.example.com/boat/1234"
+
+    handler = ClaudeStepHandler(runner)
+
+    # Patch the deep-extract helper so we don't need a real
+    # screenshot pipeline.
+    handler._extract_listing_data_deep = lambda shot, ctx: (data, 1)
+
+    env = MagicMock()
+    env.screenshot.return_value = MagicMock()
+
+    extraction_cache = MagicMock()
+    extraction_cache.read_enabled = False
+    extraction_cache.get.return_value = None
+
+    dynamic_verifier = MagicMock()
+
+    ctx = StepContext(
+        env=env, brain=None, extractor=extractor, grounding=None,
+        cost_meter=None, dynamic_verifier=dynamic_verifier,
+        scanner=runner.scanner, site_config=None,
+        tool_channel=None, extraction_cache=extraction_cache,
+        state={"index": 5},
+    )
+
+    step = MicroIntent(
+        intent="Read structured fields off this boat detail page",
+        type="extract_data",
+        claude_only=True,
+    )
+    return handler, step, ctx
+
+
+def test_dealer_rejection_with_skip_intent_sets_step_result_skip(monkeypatch) -> None:
+    """End-to-end: recipe says ``dealer → skip``, extractor flags a
+    row as dealer, handler returns a StepResult with ``skip=True``
+    and ``skip_reason='dealer'``."""
+    monkeypatch.setattr(
+        "mantis_agent.gym.step_handlers.claude_step.time.sleep",
+        lambda *_: None,
+    )
+    schema = ExtractionSchema(
+        spam_label="dealer",
+        rejection_intents={"dealer": "skip"},
+    )
+    handler, step, ctx = _build_step_handler_ctx(
+        recipe_schema=schema, dealer=True, missing=False,
+    )
+    result = handler.execute(step, ctx)
+
+    assert result.success is False
+    assert result.skip is True
+    assert result.skip_reason == "dealer"
+    assert result.data.startswith("REJECTED_DEALER|")
+
+
+def test_dealer_rejection_without_recipe_intent_does_not_skip(monkeypatch) -> None:
+    """Default empty ``rejection_intents`` preserves today's
+    behavior: a dealer rejection looks like a step failure with
+    ``skip=False`` so legacy callers see no change. The host opts
+    in by setting ``rejection_intents`` on the recipe."""
+    monkeypatch.setattr(
+        "mantis_agent.gym.step_handlers.claude_step.time.sleep",
+        lambda *_: None,
+    )
+    schema = ExtractionSchema(spam_label="dealer")  # no rejection_intents
+    handler, step, ctx = _build_step_handler_ctx(
+        recipe_schema=schema, dealer=True, missing=False,
+    )
+    result = handler.execute(step, ctx)
+
+    assert result.success is False
+    assert result.skip is False
+    assert result.skip_reason is None
+
+
+def test_incomplete_rejection_with_extract_more_intent_does_not_skip(monkeypatch) -> None:
+    """``incomplete_required`` mapped to ``extract_more`` is not a
+    skip — the host should follow up with a deeper read, not move
+    on. ``StepResult.skip`` stays False."""
+    monkeypatch.setattr(
+        "mantis_agent.gym.step_handlers.claude_step.time.sleep",
+        lambda *_: None,
+    )
+    schema = ExtractionSchema(
+        required_fields=["year", "make"],
+        rejection_intents={
+            "dealer": "skip",
+            "incomplete_required": "extract_more",
+        },
+    )
+    handler, step, ctx = _build_step_handler_ctx(
+        recipe_schema=schema, dealer=False, missing=True,
+    )
+    result = handler.execute(step, ctx)
+
+    assert result.success is False
+    assert result.skip is False
+    assert result.skip_reason is None
+    assert result.data.startswith("REJECTED_INCOMPLETE|")
+
+
+def test_incomplete_rejection_with_skip_intent_does_skip(monkeypatch) -> None:
+    """Recipes can choose to treat incomplete-required as
+    terminal-skip for verticals where missing required fields mean
+    the row is fundamentally unsuitable (no future read can
+    enrich it). ``skip`` follows the recipe's annotation."""
+    monkeypatch.setattr(
+        "mantis_agent.gym.step_handlers.claude_step.time.sleep",
+        lambda *_: None,
+    )
+    schema = ExtractionSchema(
+        required_fields=["year", "make"],
+        rejection_intents={"incomplete_required": "skip"},
+    )
+    handler, step, ctx = _build_step_handler_ctx(
+        recipe_schema=schema, dealer=False, missing=True,
+    )
+    result = handler.execute(step, ctx)
+
+    assert result.skip is True
+    assert result.skip_reason == "incomplete_required"


### PR DESCRIPTION
Closes #246. Third in the staffai PR #587 integration series — completes the recipe-orchestrator contract started by #236 (tile vs detail context) and #244 (decomposer verification gate).

## Why
Today, when \`ClaudeExtractor\` rejects a row on a detail page (e.g. \`REJECTED_DEALER\` because the seller is a dealership), the runner returns a generic \`StepResult(success=False)\`. A host orchestrator reads that as *"extraction is broken on this page, try a different angle"* and loops: re-navigate, scroll more, ask Claude to read other sections — none of which can succeed because the page genuinely is a dealer listing and the recipe correctly rejects it.

Live reproducer: BoatTrader plan \`d0693cd9\` looped 6× on a single dealer-flagged URL across 90 minutes (10 reloads, 6 rejections, 1 lead total) before the orchestrator gave up.

Recipes know which rejections are *terminal-for-this-row* (dealer, spam — host should advance) vs *retryable / informational* (incomplete required fields — host could try the detail page). This PR surfaces that knowledge as a structured signal.

## Change
Three layers:

1. **\`StepResult.skip\` / \`StepResult.skip_reason\`** (new persisted fields on the checkpoint dataclass) — runner-side envelope a host reads to decide whether to retry vs advance. Default \`skip=False / skip_reason=None\` preserves today's behavior.

2. **\`ExtractionSchema.rejection_intents\`** — recipe-author dict mapping a rejection-reason key (\`"dealer"\`, \`"incomplete_required"\`, …) to a host-facing intent (\`"skip"\` / \`"extract_more"\` / \`"retry"\`). Default \`{}\` is a no-op for recipes that don't opt in. The \`overlay()\` derive-first composition merges: derived keys win on conflict, recipe extends with new keys.

3. **\`marketplace_listings\` recipe** annotates its empirical rejections: \`{"dealer": "skip", "incomplete_required": "extract_more"}\`. Dealer pages become host-actionable skips; incomplete-required keeps today's "try the detail page" semantics.

The \`ClaudeStepHandler\` \`extract_data\` branch consults \`extractor.schema.rejection_intents[rejection_key]\` on every rejection and populates the StepResult skip envelope. Hosts integrating via the tool surface (e.g. staffai's hybrid backend) see \`skip=true, skip_reason='dealer'\` on dealer rejections and can advance to the next listing in a single tool call instead of looping.

## Test plan
- [x] \`tests/test_rejection_skip_intent.py\` — 14 new tests covering:
  - StepResult fields + persistence (default off, round-trip via to_dict/from_dict, _PERSISTED tuple)
  - ExtractionSchema field + overlay merge semantics (derived wins on conflict, recipe extends)
  - marketplace_listings recipe annotation (dealer→skip, incomplete_required != skip)
  - End-to-end propagation: dealer rejection with \`{"dealer": "skip"}\` → \`StepResult.skip=True, skip_reason="dealer"\`
  - Default empty rejection_intents preserves today's behavior (skip=False)
  - Recipes can opt to treat incomplete-required as terminal-skip too (parameterised)
- [x] Related test groups — 234 tests pass (extraction_schema, recipe_overlays, claude_step_handler, extraction_context, decomposer suite, form handler, select_option verify)
- [x] Docs-isolation guard clean (no customer-token leaks)
- [ ] Integration on staffai BoatTrader plan: re-run \`d0693cd9\` shape post-merge; verify the agent advances past dealer-flagged listings within 1 retry, reaches Step 10 (next-page check), and either paginates or completes within the orchestrator's 50-iteration budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)