### PR TITLE
feat(runner): per-context sub-goal budget skip envelope (#254)

### DIFF
--- a/src/mantis_agent/gym/context_budget.py
+++ b/src/mantis_agent/gym/context_budget.py
@@ -16,10 +16,11 @@ Why this had to live runner-side rather than as a host-side
 counter:
 
 - LLM orchestrators don't obey plan-text counting rules. Three
-  separate rule-text patches against staffai's BoatTrader plan
-  ("RETRY POLICY", "FORBIDDEN tile-read list", "AT MOST 3
-  sub-goals per listing") have all been overridden in live runs.
-  The orchestrator treats them as preferences.
+  separate rule-text patches against the host integration's
+  marketplace-listings plan ("RETRY POLICY", "FORBIDDEN tile-read
+  list", "AT MOST 3 sub-goals per listing") have all been
+  overridden in live runs. The orchestrator treats them as
+  preferences.
 - Tool-result envelopes that *change downstream state* are the
   only mechanism that reliably steers orchestrator behavior. The
   #246 / #250 envelopes work end-to-end in production today.

--- a/src/mantis_agent/gym/context_budget.py
+++ b/src/mantis_agent/gym/context_budget.py
@@ -1,0 +1,84 @@
+"""Per-context sub-goal budget (issue #254).
+
+Fourth tactical sibling in the recipe-orchestrator integration
+series — #246 (recipe-rejection skip), #250 (navigation-primitive
+halt skip), #248 (exploration substrate), and now this. Same
+underlying mechanism, third trigger source: the runner tracks how
+many sub-goals (one per :meth:`MicroPlanRunner.run` invocation)
+have executed against a given URL anchor. When the counter would
+exceed a recipe-author bound, the next :meth:`run` short-circuits
+with a synthetic ``StepResult`` carrying ``skip=True /
+skip_reason='listing_budget_exceeded'``. Host's existing skip-
+handling path promotes that to ``status: skipped`` and the
+orchestrator advances past the over-budgeted context.
+
+Why this had to live runner-side rather than as a host-side
+counter:
+
+- LLM orchestrators don't obey plan-text counting rules. Three
+  separate rule-text patches against staffai's BoatTrader plan
+  ("RETRY POLICY", "FORBIDDEN tile-read list", "AT MOST 3
+  sub-goals per listing") have all been overridden in live runs.
+  The orchestrator treats them as preferences.
+- Tool-result envelopes that *change downstream state* are the
+  only mechanism that reliably steers orchestrator behavior. The
+  #246 / #250 envelopes work end-to-end in production today.
+- Mantis sits at the intersection of intent stream + page state +
+  skip envelope emission. Anywhere else in the stack (the recipe
+  doesn't know URLs, the host orchestrator doesn't know its own
+  sub-goal count) is missing one of those signals.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+
+# Closed enumeration — typed for clarity; validated at construction
+# time so a typo'd config doesn't silently fall through to
+# ``emit_skip``.
+OnExceededMode = Literal["emit_skip", "halt", "log_only"]
+
+
+_VALID_MODES: tuple[str, ...] = ("emit_skip", "halt", "log_only")
+
+
+@dataclass
+class ContextBudget:
+    """Per-context sub-goal bound carried on :class:`MicroPlanRunner`.
+
+    ``max_sub_goals_per_url`` — max ``run()`` invocations the runner
+    will execute against a given URL anchor before short-circuiting.
+    ``None`` (default) disables the per-URL bound.
+
+    ``max_sub_goals_per_iteration`` — max ``run()`` invocations
+    across all URLs in the runner's lifetime. Trip this and every
+    subsequent run skips. ``None`` (default) disables.
+
+    ``on_exceeded`` — what happens when a bound trips:
+      * ``"emit_skip"`` (default, production): return a synthetic
+        ``StepResult(skip=True, skip_reason='listing_budget_exceeded')``
+        without invoking the executor. Matches the #246 / #250
+        envelope pattern.
+      * ``"halt"``: return an empty results list and mark
+        ``_final_status='halted'``. Host's halt path applies as
+        usual; no skip-semantic surfaced.
+      * ``"log_only"``: log a WARNING but execute normally. Useful
+        for shadow-mode evaluation — see what bounds we'd hit
+        without changing production behavior.
+    """
+
+    max_sub_goals_per_url: int | None = None
+    max_sub_goals_per_iteration: int | None = None
+    on_exceeded: OnExceededMode = "emit_skip"
+
+    def __post_init__(self) -> None:
+        if self.on_exceeded not in _VALID_MODES:
+            raise ValueError(
+                f"on_exceeded must be one of {_VALID_MODES}, "
+                f"got {self.on_exceeded!r}"
+            )
+
+
+__all__ = ["ContextBudget", "OnExceededMode"]

--- a/src/mantis_agent/gym/micro_runner.py
+++ b/src/mantis_agent/gym/micro_runner.py
@@ -79,6 +79,7 @@ class MicroPlanRunner:
         cost_config: CostConfig | None = None, tenant_id: str = "",
         extraction_cache: Any = None,
         navigation_primitives_emit_skip: set[str] | None = None,
+        context_budget: Any = None,  # ContextBudget | None — typed in body to avoid import cycle
     ):
         self.brain, self.env, self.grounding, self.extractor = (
             brain, env, grounding, extractor
@@ -98,6 +99,15 @@ class MicroPlanRunner:
             if navigation_primitives_emit_skip is not None
             else None
         )
+        # Issue #254: per-context sub-goal budget. Opt-in. When set,
+        # the runner tracks how many ``run()`` calls have executed
+        # against each URL anchor; an over-budget run short-circuits
+        # with a synthetic StepResult carrying ``skip=True,
+        # skip_reason='listing_budget_exceeded'``. Default ``None``
+        # preserves today's unbounded behavior.
+        self.context_budget = context_budget
+        self._sub_goal_count_by_url: dict[str, int] = {}
+        self._sub_goal_count_total: int = 0
         self.on_step, self.max_retries = on_step, max_retries
         self.checkpoint_path, self.run_key = checkpoint_path, run_key
         self.session_name, self.plan_signature = session_name, plan_signature
@@ -176,6 +186,17 @@ class MicroPlanRunner:
 
     def run(self, plan: MicroPlan, resume: bool = False) -> list[StepResult]:
         from .run_executor import RunState
+
+        # Issue #254: per-context sub-goal budget gate. Check BEFORE
+        # executor.execute so an over-budget run never enters the
+        # plan body — the skip envelope is the whole response.
+        # Resume calls bypass the gate (they're continuations, not
+        # fresh sub-goals).
+        if not resume and self.context_budget is not None:
+            envelope = self._check_and_emit_context_budget(plan)
+            if envelope is not None:
+                return envelope
+
         if not self.plan_signature:
             self.plan_signature = self._compute_plan_signature(plan)
         state = RunState.fresh(
@@ -185,6 +206,111 @@ class MicroPlanRunner:
         self._executor.execute(plan, state, resume=resume)
         self._final_summary(state.results)
         return state.results
+
+    def _check_and_emit_context_budget(
+        self, plan: MicroPlan,
+    ) -> list[StepResult] | None:
+        """Increment the per-URL counter and either short-circuit
+        with a skip envelope, halt the runner, or pass through with
+        a warning depending on the configured ``on_exceeded`` mode.
+
+        Returns ``None`` when the run should proceed normally;
+        returns a list of StepResult(s) when the run should
+        short-circuit (the caller treats the list as the run's
+        full output).
+        """
+        cb = self.context_budget
+        if cb is None:
+            return None
+
+        anchor = self._resolve_context_anchor(plan)
+        # Increment counters BEFORE checking — so a budget of N
+        # allows exactly N runs, not N-1. The N+1-th call sees
+        # ``count > max`` and trips.
+        self._sub_goal_count_total += 1
+        count = self._sub_goal_count_by_url.get(anchor, 0) + 1
+        self._sub_goal_count_by_url[anchor] = count
+
+        per_url_exceeded = (
+            cb.max_sub_goals_per_url is not None
+            and count > cb.max_sub_goals_per_url
+        )
+        total_exceeded = (
+            cb.max_sub_goals_per_iteration is not None
+            and self._sub_goal_count_total > cb.max_sub_goals_per_iteration
+        )
+
+        if not (per_url_exceeded or total_exceeded):
+            return None
+
+        reason_bound = "per_url" if per_url_exceeded else "per_iteration"
+
+        if cb.on_exceeded == "log_only":
+            logger.warning(
+                "context budget %s exceeded (anchor=%s count=%d) — log_only "
+                "mode, executing anyway",
+                reason_bound, anchor[:80], count,
+            )
+            return None
+
+        if cb.on_exceeded == "halt":
+            logger.warning(
+                "context budget %s exceeded (anchor=%s count=%d) — halting",
+                reason_bound, anchor[:80], count,
+            )
+            self._final_status = "halted"
+            return []
+
+        # Default: emit_skip — return a synthetic skip envelope.
+        intent_text = (
+            plan.steps[0].intent if plan.steps else ""
+        ) or "context budget exceeded"
+        envelope_data = (
+            f"listing_budget_exceeded:bound={reason_bound}:"
+            f"url={anchor[:120]}:count={count}"
+        )
+        logger.warning(
+            "context budget %s exceeded — emitting skip envelope "
+            "(anchor=%s count=%d)",
+            reason_bound, anchor[:80], count,
+        )
+        return [StepResult(
+            step_index=0, intent=intent_text, success=False,
+            data=envelope_data,
+            skip=True, skip_reason="listing_budget_exceeded",
+        )]
+
+    @staticmethod
+    def _resolve_context_anchor_from_plan(plan: MicroPlan) -> str:
+        """Pull the navigate-step URL from a plan, or the empty
+        string if no navigate is present. Static helper exposed so
+        tests can pin the resolution rule independently of the
+        runner state."""
+        for step in plan.steps:
+            if step.type == "navigate":
+                url = (step.params or {}).get("url", "")
+                if isinstance(url, str) and url:
+                    return url
+        return ""
+
+    def _resolve_context_anchor(self, plan: MicroPlan) -> str:
+        """Decide which URL bucket a given ``run(plan)`` invocation
+        belongs to. Preference order:
+
+        1. The first ``navigate`` step's ``params.url`` — canonical
+           because that's the URL the sub-goal is *targeted at*,
+           not whatever was in the address bar.
+        2. ``self._last_known_url`` — for sub-plans that operate on
+           the page a prior sub-goal opened.
+        3. The fixed sentinel ``"_no_anchor_"`` — keeps the counter
+           working for cold runners with neither signal (rare).
+        """
+        url = self._resolve_context_anchor_from_plan(plan)
+        if url:
+            return url
+        if getattr(self, "_last_known_url", ""):
+            return self._last_known_url
+        return "_no_anchor_"
 
     def run_with_status(
         self, plan: MicroPlan, resume: bool = False,

--- a/tests/test_context_budget_skip_envelope.py
+++ b/tests/test_context_budget_skip_envelope.py
@@ -1,0 +1,364 @@
+"""Tests for issue #254 — per-context sub-goal budget skip envelope.
+
+Fourth tactical sibling to #246 (recipe-rejection skip) and #250
+(navigation-primitive halt skip). Same mechanism, third trigger
+source: the runner tracks how many sub-goals (= ``run()`` calls)
+have executed against a given URL anchor and stamps
+``StepResult.skip=True / skip_reason='listing_budget_exceeded'``
+when the count would exceed the recipe-author's bound.
+
+Three layers being pinned here:
+
+1. ``ContextBudget`` dataclass — opt-in shape carried on the
+   runner. Default ``None`` preserves today's behavior.
+2. ``MicroPlanRunner.__init__`` accepts and stores it; tracks
+   per-URL counter across ``run()`` calls.
+3. ``run()`` short-circuits with a synthetic skip-envelope
+   ``StepResult`` when the counter would exceed the bound. The
+   host's tool surface (per the #246/#250 mechanism) promotes
+   ``skip=True`` to a successful tool result and the orchestrator
+   advances past the over-budgeted context.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from mantis_agent.gym.checkpoint import StepResult
+from mantis_agent.gym.context_budget import ContextBudget
+from mantis_agent.plan_decomposer import MicroIntent, MicroPlan
+
+
+# ── ContextBudget dataclass ─────────────────────────────────────────
+
+
+def test_context_budget_defaults() -> None:
+    """A bare ``ContextBudget()`` is harmless — every limit unset and
+    the on_exceeded mode defaults to ``emit_skip`` (the production
+    behavior aligning with #246 / #250). Callers turn on the bounds
+    they care about explicitly."""
+    b = ContextBudget()
+    assert b.max_sub_goals_per_url is None
+    assert b.max_sub_goals_per_iteration is None
+    assert b.on_exceeded == "emit_skip"
+
+
+def test_context_budget_accepts_overrides() -> None:
+    b = ContextBudget(
+        max_sub_goals_per_url=3,
+        max_sub_goals_per_iteration=10,
+        on_exceeded="halt",
+    )
+    assert b.max_sub_goals_per_url == 3
+    assert b.max_sub_goals_per_iteration == 10
+    assert b.on_exceeded == "halt"
+
+
+def test_context_budget_rejects_invalid_on_exceeded() -> None:
+    """Typo guard — the allowed values are ``emit_skip`` / ``halt`` /
+    ``log_only``. Anything else is a constructor-time error so a
+    typoed config doesn't silently fall through to ``emit_skip``."""
+    with pytest.raises(ValueError, match="on_exceeded"):
+        ContextBudget(on_exceeded="warn")  # type: ignore[arg-type]
+
+
+# ── MicroPlanRunner constructor opt-in ──────────────────────────────
+
+
+def test_runner_default_context_budget_is_none() -> None:
+    """Default preserves today's behavior — no opt-in means no
+    counter, no envelope."""
+    from mantis_agent.gym.micro_runner import MicroPlanRunner
+    runner = MicroPlanRunner(brain=MagicMock(), env=MagicMock())
+    assert runner.context_budget is None
+
+
+def test_runner_accepts_context_budget_kwarg() -> None:
+    from mantis_agent.gym.micro_runner import MicroPlanRunner
+    cb = ContextBudget(max_sub_goals_per_url=3)
+    runner = MicroPlanRunner(
+        brain=MagicMock(), env=MagicMock(), context_budget=cb,
+    )
+    assert runner.context_budget is cb
+    # Per-URL counter starts empty.
+    assert runner._sub_goal_count_by_url == {}
+    assert runner._sub_goal_count_total == 0
+
+
+# ── Skip-envelope emission ──────────────────────────────────────────
+
+
+def _navigate_plan(url: str, intent: str = "Open detail page") -> MicroPlan:
+    return MicroPlan(steps=[
+        MicroIntent(
+            intent=intent, type="navigate",
+            params={"url": url},
+        ),
+    ])
+
+
+def _runner_with_budget(budget: ContextBudget) -> Any:
+    """Build a real MicroPlanRunner and stub its underlying
+    ``_executor.execute`` so we exercise the budget gate without
+    needing a real env / brain. Returns a tuple of
+    ``(runner, executor_call_count_ref)`` so tests can assert on how
+    many times the inner execute was invoked."""
+    from mantis_agent.gym.micro_runner import MicroPlanRunner
+    runner = MicroPlanRunner(
+        brain=MagicMock(), env=MagicMock(), context_budget=budget,
+    )
+    calls = {"n": 0}
+
+    def fake_execute(plan, state, resume=False):
+        calls["n"] += 1
+        state.results.append(StepResult(
+            step_index=0, intent=plan.steps[0].intent if plan.steps else "",
+            success=True,
+        ))
+
+    runner._executor.execute = fake_execute
+    return runner, calls
+
+
+def test_first_n_runs_pass_through_normally() -> None:
+    """A budget of 2 should let the first two ``run()`` calls
+    against the same URL execute normally (counter increments but
+    doesn't yet exceed)."""
+    cb = ContextBudget(max_sub_goals_per_url=2)
+    runner, calls = _runner_with_budget(cb)
+
+    url = "https://www.example.com/boat/abc"
+    r1 = runner.run(_navigate_plan(url))
+    r2 = runner.run(_navigate_plan(url))
+
+    assert calls["n"] == 2
+    assert r1[-1].success is True
+    assert r1[-1].skip is False
+    assert r2[-1].success is True
+    assert r2[-1].skip is False
+    assert runner._sub_goal_count_by_url[url] == 2
+
+
+def test_run_past_budget_returns_skip_envelope() -> None:
+    """The (N+1)th ``run()`` against the same URL must short-circuit
+    without invoking the executor and return a single synthetic
+    StepResult carrying the skip envelope."""
+    cb = ContextBudget(max_sub_goals_per_url=2)
+    runner, calls = _runner_with_budget(cb)
+
+    url = "https://www.example.com/boat/abc"
+    runner.run(_navigate_plan(url))
+    runner.run(_navigate_plan(url))
+    r3 = runner.run(_navigate_plan(url))
+
+    # Executor was called twice; the third call short-circuited.
+    assert calls["n"] == 2
+    assert len(r3) == 1
+    assert r3[0].success is False
+    assert r3[0].skip is True
+    assert r3[0].skip_reason == "listing_budget_exceeded"
+    # The envelope's data carries the URL + count so a host can
+    # surface a useful message instead of just "skipped".
+    assert "listing_budget_exceeded" in r3[0].data
+    assert url in r3[0].data
+
+
+def test_different_urls_get_independent_counters() -> None:
+    """A budget of 2 must not leak across URLs — each anchor gets
+    its own counter."""
+    cb = ContextBudget(max_sub_goals_per_url=2)
+    runner, calls = _runner_with_budget(cb)
+
+    url_a = "https://www.example.com/boat/a"
+    url_b = "https://www.example.com/boat/b"
+    runner.run(_navigate_plan(url_a))
+    runner.run(_navigate_plan(url_a))
+    runner.run(_navigate_plan(url_b))
+    runner.run(_navigate_plan(url_b))
+
+    # All four executor calls landed — neither anchor hit the bound.
+    assert calls["n"] == 4
+    assert runner._sub_goal_count_by_url[url_a] == 2
+    assert runner._sub_goal_count_by_url[url_b] == 2
+
+    # Now exceed each one independently.
+    r_a3 = runner.run(_navigate_plan(url_a))
+    assert r_a3[0].skip is True
+    # URL B is still under budget.
+    r_b3 = runner.run(_navigate_plan(url_b))
+    assert r_b3[0].skip is True
+
+
+def test_max_sub_goals_per_iteration_bounds_across_urls() -> None:
+    """The total-across-all-URLs cap applies on top of the per-URL
+    cap. With ``max_sub_goals_per_iteration=3``, the 4th run skips
+    even if each URL is individually under its per-URL cap."""
+    cb = ContextBudget(
+        max_sub_goals_per_url=100,        # effectively unset
+        max_sub_goals_per_iteration=3,
+    )
+    runner, calls = _runner_with_budget(cb)
+
+    runner.run(_navigate_plan("https://www.example.com/boat/a"))
+    runner.run(_navigate_plan("https://www.example.com/boat/b"))
+    runner.run(_navigate_plan("https://www.example.com/boat/c"))
+    r4 = runner.run(_navigate_plan("https://www.example.com/boat/d"))
+
+    assert calls["n"] == 3
+    assert r4[0].skip is True
+    assert r4[0].skip_reason == "listing_budget_exceeded"
+
+
+def test_on_exceeded_halt_returns_halted_status() -> None:
+    """``on_exceeded='halt'`` returns an empty results list and
+    marks the runner's ``_final_status`` halted. No skip envelope
+    is emitted — the host's halt path applies as usual."""
+    cb = ContextBudget(max_sub_goals_per_url=1, on_exceeded="halt")
+    runner, calls = _runner_with_budget(cb)
+
+    url = "https://www.example.com/boat/abc"
+    runner.run(_navigate_plan(url))
+    r2 = runner.run(_navigate_plan(url))
+
+    assert calls["n"] == 1
+    assert r2 == []
+    assert runner._final_status == "halted"
+
+
+def test_on_exceeded_log_only_lets_run_continue() -> None:
+    """``on_exceeded='log_only'`` runs every sub-goal normally but
+    logs a warning. Useful for shadow-mode evaluation: see what
+    bounds we'd hit without actually changing production behavior."""
+    cb = ContextBudget(max_sub_goals_per_url=1, on_exceeded="log_only")
+    runner, calls = _runner_with_budget(cb)
+
+    url = "https://www.example.com/boat/abc"
+    runner.run(_navigate_plan(url))
+    r2 = runner.run(_navigate_plan(url))
+
+    # Both executed.
+    assert calls["n"] == 2
+    assert r2[-1].skip is False
+
+
+def test_anchor_resolution_prefers_navigate_step_url() -> None:
+    """The anchor URL is read from the first navigate step's
+    ``params.url``. That's the canonical source — the URL the
+    sub-goal is *targeted at*, not whatever happened to be in the
+    address bar before the plan started."""
+    cb = ContextBudget(max_sub_goals_per_url=1)
+    runner, calls = _runner_with_budget(cb)
+    runner._last_known_url = "https://stale.example.com/old"
+
+    target = "https://www.example.com/boat/xyz"
+    runner.run(_navigate_plan(target))
+    r2 = runner.run(_navigate_plan(target))
+
+    # The counter tracked under the navigate URL, not the stale one.
+    # Counter increments on every attempt — the second run trips the
+    # budget but its anchor still got counted (==2 after two attempts).
+    assert runner._sub_goal_count_by_url[target] == 2
+    assert "stale.example.com" not in runner._sub_goal_count_by_url
+    assert r2[0].skip is True
+
+
+def test_anchor_resolution_falls_back_to_last_known_url() -> None:
+    """When a plan has no navigate step (e.g. a sub-plan that
+    operates on the current page only), the anchor is the runner's
+    ``_last_known_url`` at run-time. Lets the host increment the
+    counter for a detail page that was opened by a prior sub-goal."""
+    cb = ContextBudget(max_sub_goals_per_url=1)
+    runner, calls = _runner_with_budget(cb)
+    runner._last_known_url = "https://www.example.com/boat/xyz"
+
+    no_nav = MicroPlan(steps=[
+        MicroIntent(intent="Click Show Phone", type="submit",
+                    params={"label": "Show Phone"}),
+    ])
+    runner.run(no_nav)
+    r2 = runner.run(no_nav)
+
+    # Counter incremented on each attempt (==2 after both runs);
+    # second hit the budget.
+    assert runner._sub_goal_count_by_url["https://www.example.com/boat/xyz"] == 2
+    assert r2[0].skip is True
+
+
+def test_no_anchor_no_counter() -> None:
+    """A plan with no navigate step AND no ``_last_known_url`` (cold
+    runner) gets bucketed under a stable sentinel — the counter
+    still works, all such plans share one bucket. Better than
+    crashing or silently disabling the bound."""
+    cb = ContextBudget(max_sub_goals_per_url=1)
+    runner, calls = _runner_with_budget(cb)
+    runner._last_known_url = ""
+
+    no_nav = MicroPlan(steps=[
+        MicroIntent(intent="Click Show Phone", type="submit"),
+    ])
+    runner.run(no_nav)
+    r2 = runner.run(no_nav)
+
+    # Both plans bucketed under the sentinel.
+    assert r2[0].skip is True
+
+
+def test_default_runner_no_budget_no_envelope() -> None:
+    """A runner constructed without ``context_budget`` runs forever
+    against the same URL. Preserves today's behavior."""
+    from mantis_agent.gym.micro_runner import MicroPlanRunner
+
+    runner = MicroPlanRunner(brain=MagicMock(), env=MagicMock())
+    calls = {"n": 0}
+
+    def fake_execute(plan, state, resume=False):
+        calls["n"] += 1
+        state.results.append(StepResult(
+            step_index=0, intent="x", success=True,
+        ))
+
+    runner._executor.execute = fake_execute
+
+    url = "https://www.example.com/boat/abc"
+    for _ in range(50):
+        runner.run(_navigate_plan(url))
+
+    assert calls["n"] == 50  # all ran; no budget gate
+
+
+def test_skip_envelope_carries_url_anchor_in_data() -> None:
+    """The data field on the skip envelope must surface the URL
+    and the count so a refinement agent / dashboard can attribute
+    skipped runs to the right context anchor."""
+    cb = ContextBudget(max_sub_goals_per_url=1)
+    runner, calls = _runner_with_budget(cb)
+
+    url = "https://www.example.com/boat/abc"
+    runner.run(_navigate_plan(url))
+    r2 = runner.run(_navigate_plan(url))
+
+    assert "url=" in r2[0].data
+    assert "count=" in r2[0].data
+    assert url in r2[0].data
+    # The synthetic step_result is at step_index=0 (the run never
+    # entered the plan's actual steps).
+    assert r2[0].step_index == 0
+
+
+def test_run_with_status_propagates_skip_envelope() -> None:
+    """``run_with_status`` wraps ``run`` — the skip envelope must
+    survive the wrap so callers consuming ``RunnerResult.steps``
+    see the same signal."""
+    cb = ContextBudget(max_sub_goals_per_url=1)
+    runner, calls = _runner_with_budget(cb)
+
+    url = "https://www.example.com/boat/abc"
+    runner.run_with_status(_navigate_plan(url))
+    result = runner.run_with_status(_navigate_plan(url))
+
+    assert len(result.steps) == 1
+    assert result.steps[0].skip is True
+    assert result.steps[0].skip_reason == "listing_budget_exceeded"


### PR DESCRIPTION
Closes #254. Fourth tactical sibling in the recipe-orchestrator integration series (#246 recipe-rejection skip, #250 navigation-primitive halt skip, #248 exploration substrate, this).

## Why
Three separate plan-text counting/prohibition rules in the host integration this week have all been overridden by the LLM orchestrator:
- \`RETRY POLICY\` — orchestrator issued same Step 4 sub-goal 15× before advancing
- \`FORBIDDEN tile-read list\` — orchestrator emitted the exact forbidden phrases anyway
- \`AT MOST 3 sub-goals per listing\` — orchestrator emitted 6+ on a single detail page

LLMs treat plan-text rules as preferences. Tool-result envelopes that *change downstream state* are the only mechanism that reliably steers orchestrator behavior — the #246 / #250 envelopes work end-to-end in production today.

This PR adds the third trigger source for the same skip-envelope mechanism: when sub-goal count against a URL exceeds the recipe-author bound, the runner short-circuits with \`StepResult.skip=True, skip_reason='listing_budget_exceeded'\`. The host's existing skip-handling path (validated by #246/#250) advances the orchestrator past the over-budgeted context.

## Change
- **New module \`mantis_agent.gym.context_budget\`**: \`ContextBudget\` dataclass with \`max_sub_goals_per_url\`, \`max_sub_goals_per_iteration\`, and \`on_exceeded\` mode (\`emit_skip\` default | \`halt\` | \`log_only\`). Constructor validates the mode.
- **\`MicroPlanRunner(context_budget=ContextBudget(...))\`** — opt-in constructor param. Default \`None\` preserves today's unbounded behavior.
- **Budget gate** at the top of \`run()\` BEFORE the executor — increments counters, decides whether to short-circuit. Resume calls bypass the gate.
- **Anchor resolution**: navigate-step URL preferred → \`_last_known_url\` fallback → \`"_no_anchor_"\` sentinel.

## Test plan
- [x] 17 new in \`tests/test_context_budget_skip_envelope.py\` covering: dataclass defaults / overrides / mode validation, constructor opt-in, first-N-pass-through, over-budget skip envelope, independent per-URL counters, per-iteration total cap, all three on_exceeded modes, anchor resolution preference, data field surfaces URL+count, propagation through \`run_with_status\`
- [x] 73 related tests pass (micro_runner_hooks, rejection_skip_intent, nav_halt_skip_envelope, run_with_exploration, docs_client_isolation)
- [x] Ruff clean
- [x] Docs-isolation guard clean
- [ ] Integration on staffai BoatTrader plan: opt in via \`MantisRunnerSession._ensure_runtime\` with \`ContextBudget(max_sub_goals_per_url=3)\`. Expect: agent advances past each listing within 3 sub-goals max; per-listing wall time bounded to 5-10 min instead of 30-60 min.

## Adjacent
- #246 (recipe-rejection skip) — shipped, working
- #250 (navigation-primitive halt skip) — shipped, working
- #248 (exploration substrate) — shipped
- staffai#622 (\`plan_refinement_agent\`) — could consume telemetry from this envelope to refine per-listing budgets autonomously

🤖 Generated with [Claude Code](https://claude.com/claude-code)