### PR TITLE
feat(runner): already_seen URL skip envelope via host predicate (#255)

### DIFF
--- a/src/mantis_agent/gym/micro_runner.py
+++ b/src/mantis_agent/gym/micro_runner.py
@@ -80,6 +80,7 @@ class MicroPlanRunner:
         extraction_cache: Any = None,
         navigation_primitives_emit_skip: set[str] | None = None,
         context_budget: Any = None,  # ContextBudget | None — typed in body to avoid import cycle
+        seen_url_predicate: Any = None,  # Callable[[str], bool] | None
     ):
         self.brain, self.env, self.grounding, self.extractor = (
             brain, env, grounding, extractor
@@ -108,6 +109,16 @@ class MicroPlanRunner:
         self.context_budget = context_budget
         self._sub_goal_count_by_url: dict[str, int] = {}
         self._sub_goal_count_total: int = 0
+        # Issue #255: host-injected predicate for cross-session
+        # dedup. When set and the runner is about to deep-extract a
+        # detail-page URL, the predicate is consulted; if it returns
+        # True the runner short-circuits with
+        # ``skip_reason='already_seen'`` without invoking
+        # ClaudeExtractor. Mantis owns the timing window
+        # (post-navigate / pre-extract); the host owns the dedup
+        # policy (URL set, content hash, CRM lookup, …) entirely.
+        # Default ``None`` preserves today's behavior.
+        self.seen_url_predicate = seen_url_predicate
         self.on_step, self.max_retries = on_step, max_retries
         self.checkpoint_path, self.run_key = checkpoint_path, run_key
         self.session_name, self.plan_signature = session_name, plan_signature

--- a/src/mantis_agent/gym/step_handlers/claude_step.py
+++ b/src/mantis_agent/gym/step_handlers/claude_step.py
@@ -97,6 +97,53 @@ def _resolve_extraction_context(runner: "MicroPlanRunner", data: object | None):
     return ExtractionContext.UNKNOWN
 
 
+def _check_already_seen(runner, ctx: StepContext) -> str | None:
+    """Consult the host's seen-URL predicate at the top of
+    ``extract_data``.
+
+    Returns the matched URL when the runner should short-circuit
+    with ``skip_reason='already_seen'``; returns ``None`` to
+    proceed with the normal extract path.
+
+    Mantis owns the timing window (post-navigate / pre-extract)
+    and the applicability gate (detail-page only via
+    :meth:`SiteConfig.is_detail_page`). The host owns the
+    predicate's policy entirely — URL match, content hash, CRM
+    lookup, anything. Issue #255.
+
+    A buggy predicate (raises on a malformed URL, hits a network
+    timeout, …) must NOT halt the run. Over-extracting is the
+    safe failure mode; under-extracting (silently skipping a real
+    new lead) is the dangerous one. So any predicate exception is
+    swallowed and we fall through to the normal extract path.
+    """
+    predicate = getattr(runner, "seen_url_predicate", None)
+    if predicate is None:
+        return None
+    try:
+        current_url = runner._best_effort_current_url()
+    except Exception:  # noqa: BLE001 — never break extract on CDP glitch
+        return None
+    if not current_url:
+        return None
+    # Applicability gate: only fire on canonical detail pages so
+    # search / results URLs aren't accidentally deduped.
+    site_config = ctx.site_config or getattr(runner, "site_config", None)
+    if site_config is not None:
+        try:
+            if not site_config.is_detail_page(current_url):
+                return None
+        except Exception:  # noqa: BLE001
+            return None
+    try:
+        if predicate(current_url):
+            return current_url
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("seen_url_predicate raised: %s", exc)
+        return None
+    return None
+
+
 def _resolve_skip_envelope(extractor, *, rejection_key: str) -> tuple[bool, str | None]:
     """Look up a rejection key in ``extractor.schema.rejection_intents``
     and return the StepResult skip envelope (``skip``, ``skip_reason``).
@@ -188,6 +235,25 @@ class ClaudeStepHandler:
             )
 
         elif step.type == "extract_data":
+            # Issue #255: cross-session already-seen short-circuit.
+            # Runs BEFORE the in-session cache check — the cache is
+            # an intra-session optimization, the predicate is host-
+            # state (master.csv, CRM, …) crossing sessions. Mantis
+            # owns the timing window only; the predicate's policy
+            # (URL match / content hash / CRM lookup) is host-owned.
+            # Applicability gate: only fire on canonical detail
+            # pages (#236 ``is_detail_page``) so search/results URLs
+            # aren't accidentally deduped if a host's predicate
+            # would match them.
+            already_seen = _check_already_seen(runner, ctx)
+            if already_seen is not None:
+                return StepResult(
+                    step_index=index, intent=step.intent,
+                    success=False,
+                    skip=True, skip_reason="already_seen",
+                    data=f"already_seen|url={already_seen[:160]}",
+                )
+
             # Cache short-circuit BEFORE the expensive deep-extract Claude
             # call. We peek the browser's current URL (cheap CDP read, no
             # tokens). If it's a fresh cache hit, emit the cached lead and

--- a/tests/test_already_seen_url_skip_envelope.py
+++ b/tests/test_already_seen_url_skip_envelope.py
@@ -1,0 +1,323 @@
+"""Tests for issue #255 — already-seen URL skip envelope.
+
+Fifth tactical sibling in the skip-envelope family (#246 recipe
+rejection, #250 navigation halt, #254 context budget, #248
+exploration substrate). Same envelope contract, fifth trigger
+source: when ``extract_data`` is about to fire against a URL the
+host has already processed in a prior run, the runner short-circuits
+with ``StepResult.skip=True / skip_reason='already_seen'`` and
+never invokes ClaudeExtractor.
+
+Design split (per architectural review on #255):
+
+- **Data + policy stay host-side.** The host owns ``master.csv``
+  or whatever its persistence layer is; the host decides what
+  "seen" means (URL match, content hash, CRM lookup, …).
+- **Mantis owns only the timing window.** The post-navigate
+  pre-extract window is the only place a duplicate URL can be
+  short-circuited cheaply, and that window is only observable
+  inside the runner.
+
+So the surface is a single predicate callable. The host writes a
+one-liner that consults its own state; mantis bakes in zero
+URL-set assumptions. A future helper can wrap a URL set into a
+predicate if multiple hosts want that pattern, but v1 ships the
+minimum surface.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from mantis_agent.gym.step_context import StepContext
+from mantis_agent.gym.step_handlers.claude_step import ClaudeStepHandler
+from mantis_agent.plan_decomposer import MicroIntent
+
+
+# ── MicroPlanRunner constructor opt-in ──────────────────────────────
+
+
+def test_runner_default_seen_url_predicate_is_none() -> None:
+    """Default preserves today's behavior — no predicate means no
+    short-circuit at extract_data, every detail page extracts."""
+    from mantis_agent.gym.micro_runner import MicroPlanRunner
+    runner = MicroPlanRunner(brain=MagicMock(), env=MagicMock())
+    assert runner.seen_url_predicate is None
+
+
+def test_runner_accepts_seen_url_predicate_kwarg() -> None:
+    from mantis_agent.gym.micro_runner import MicroPlanRunner
+
+    def predicate(url: str) -> bool:
+        return "foo" in url
+
+    runner = MicroPlanRunner(
+        brain=MagicMock(), env=MagicMock(), seen_url_predicate=predicate,
+    )
+    assert runner.seen_url_predicate is predicate
+
+
+# ── extract_data short-circuit ──────────────────────────────────────
+
+
+def _build_ctx_for_extract_data(
+    *,
+    predicate=None,
+    is_detail_page: bool = True,
+    current_url: str = "https://www.example.com/boat/foo",
+) -> tuple[ClaudeStepHandler, MicroIntent, StepContext, dict]:
+    """Construct the minimum runner+ctx needed to exercise the
+    extract_data branch. Returns ``(handler, step, ctx, call_log)``
+    where ``call_log`` records whether the extractor's deep-extract
+    helper was invoked."""
+    runner = MagicMock()
+    runner.seen_url_predicate = predicate
+    runner._best_effort_current_url = MagicMock(return_value=current_url)
+    runner.site_config = MagicMock()
+    runner.site_config.is_detail_page = MagicMock(return_value=is_detail_page)
+    runner.costs = {"claude_extract": 0, "gpu_steps": 0, "gpu_seconds": 0.0}
+    runner._last_extracted = {}
+    runner._current_page = 1
+    runner._current_item_label = MagicMock(return_value="item")
+    runner.scanner.is_duplicate.return_value = False
+    runner.scanner.mark_seen = MagicMock()
+
+    extractor = MagicMock()
+    extractor.schema = MagicMock()
+    extractor.schema.rejection_intents = {}
+
+    env = MagicMock()
+    env.screenshot.return_value = MagicMock()
+
+    extraction_cache = MagicMock()
+    extraction_cache.read_enabled = False
+    extraction_cache.get.return_value = None
+
+    dynamic_verifier = MagicMock()
+
+    ctx = StepContext(
+        env=env, brain=None, extractor=extractor, grounding=None,
+        cost_meter=None, dynamic_verifier=dynamic_verifier,
+        scanner=runner.scanner, site_config=runner.site_config,
+        tool_channel=None, extraction_cache=extraction_cache,
+        state={"index": 5},
+    )
+
+    handler = ClaudeStepHandler(runner)
+
+    call_log = {"deep_extract_called": False}
+
+    def fake_deep_extract(shot, ctx):
+        call_log["deep_extract_called"] = True
+        data = MagicMock()
+        data.url = current_url
+        data.is_viable.return_value = True
+        data.dealer_reason.return_value = ""
+        data.missing_required_reason.return_value = ""
+        data.to_summary.return_value = "summary"
+        data.extracted_fields = {}
+        return (data, 1)
+
+    handler._extract_listing_data_deep = fake_deep_extract
+
+    step = MicroIntent(
+        intent="Read structured fields off this detail page",
+        type="extract_data",
+        claude_only=True,
+    )
+    return handler, step, ctx, call_log
+
+
+def test_extract_data_short_circuits_when_predicate_returns_true(monkeypatch) -> None:
+    """Happy path: detail-page URL + host predicate returns True →
+    StepResult.skip=True, ClaudeExtractor never called."""
+    monkeypatch.setattr(
+        "mantis_agent.gym.step_handlers.claude_step.time.sleep",
+        lambda *_: None,
+    )
+    url = "https://www.example.com/boat/already-seen-slug"
+    handler, step, ctx, call_log = _build_ctx_for_extract_data(
+        predicate=lambda u: "already-seen-slug" in u,
+        is_detail_page=True,
+        current_url=url,
+    )
+    result = handler.execute(step, ctx)
+
+    assert result.success is False
+    assert result.skip is True
+    assert result.skip_reason == "already_seen"
+    # Surface the URL in data so post-mortem / dashboards know which
+    # one was deduped.
+    assert "already_seen" in result.data
+    assert url in result.data
+    # Deep-extract never invoked → no Claude vision call → no $$.
+    assert call_log["deep_extract_called"] is False
+
+
+def test_extract_data_proceeds_when_predicate_returns_false(monkeypatch) -> None:
+    """Predicate returns False — runner runs the normal extract
+    path."""
+    monkeypatch.setattr(
+        "mantis_agent.gym.step_handlers.claude_step.time.sleep",
+        lambda *_: None,
+    )
+    handler, step, ctx, call_log = _build_ctx_for_extract_data(
+        predicate=lambda u: False,
+        is_detail_page=True,
+        current_url="https://www.example.com/boat/fresh",
+    )
+    result = handler.execute(step, ctx)
+
+    # Normal extract path ran (success because our fake helper
+    # returns viable data).
+    assert result.skip is False
+    assert call_log["deep_extract_called"] is True
+
+
+def test_extract_data_proceeds_when_predicate_is_none(monkeypatch) -> None:
+    """No predicate → no short-circuit. Default behavior preserved
+    for hosts that don't opt in."""
+    monkeypatch.setattr(
+        "mantis_agent.gym.step_handlers.claude_step.time.sleep",
+        lambda *_: None,
+    )
+    handler, step, ctx, call_log = _build_ctx_for_extract_data(
+        predicate=None,
+        is_detail_page=True,
+        current_url="https://www.example.com/boat/any",
+    )
+    result = handler.execute(step, ctx)
+
+    assert result.skip is False
+    assert call_log["deep_extract_called"] is True
+
+
+def test_extract_data_proceeds_when_not_a_detail_page(monkeypatch) -> None:
+    """Applicability gate: if the URL isn't a detail page, the
+    predicate isn't consulted. A search/results URL shouldn't be
+    short-circuited even if it happens to be in the host's seen
+    set (which would be a bug in the host but mantis defends in
+    depth)."""
+    monkeypatch.setattr(
+        "mantis_agent.gym.step_handlers.claude_step.time.sleep",
+        lambda *_: None,
+    )
+    handler, step, ctx, call_log = _build_ctx_for_extract_data(
+        predicate=lambda u: True,  # would short-circuit if applied
+        is_detail_page=False,       # but applicability gate is False
+        current_url="https://www.example.com/boats/search?state=fl",
+    )
+    result = handler.execute(step, ctx)
+
+    assert result.skip is False
+    assert call_log["deep_extract_called"] is True
+
+
+def test_extract_data_proceeds_when_current_url_is_empty(monkeypatch) -> None:
+    """If the runner can't read the current URL (cold env, CDP
+    glitch, …), the predicate isn't consulted — fall through to
+    the normal extract path rather than short-circuiting on the
+    empty string. Defends against a predicate that matches \"\"."""
+    monkeypatch.setattr(
+        "mantis_agent.gym.step_handlers.claude_step.time.sleep",
+        lambda *_: None,
+    )
+    handler, step, ctx, call_log = _build_ctx_for_extract_data(
+        predicate=lambda u: True,
+        is_detail_page=True,
+        current_url="",
+    )
+    result = handler.execute(step, ctx)
+
+    assert result.skip is False
+    assert call_log["deep_extract_called"] is True
+
+
+def test_extract_data_short_circuits_before_cache_check(monkeypatch) -> None:
+    """Order matters: the predicate runs *before* the in-session
+    cache check, so a known-seen URL skips even if it's not in
+    the warm cache. Today's cache is an intra-session
+    optimization; the predicate is cross-session host state."""
+    monkeypatch.setattr(
+        "mantis_agent.gym.step_handlers.claude_step.time.sleep",
+        lambda *_: None,
+    )
+    url = "https://www.example.com/boat/known"
+    handler, step, ctx, call_log = _build_ctx_for_extract_data(
+        predicate=lambda u: u == url,
+        is_detail_page=True,
+        current_url=url,
+    )
+    # Make the cache "warm" but on a different URL — the predicate
+    # should still fire and short-circuit before the cache is
+    # consulted.
+    ctx.extraction_cache.read_enabled = True
+    ctx.extraction_cache.get.return_value = None
+
+    result = handler.execute(step, ctx)
+
+    assert result.skip is True
+    assert result.skip_reason == "already_seen"
+    # The cache was never consulted (extraction_cache.get not called)
+    # because the predicate short-circuited first.
+    ctx.extraction_cache.get.assert_not_called()
+
+
+def test_extract_data_predicate_exception_does_not_break_run(monkeypatch) -> None:
+    """A buggy host predicate (raises on a malformed URL, e.g.)
+    should not crash the runner. Fall through to the normal
+    extract path on any predicate exception — better to over-
+    extract than to halt the whole run."""
+    monkeypatch.setattr(
+        "mantis_agent.gym.step_handlers.claude_step.time.sleep",
+        lambda *_: None,
+    )
+
+    def buggy_predicate(url):
+        raise RuntimeError("host predicate crashed")
+
+    handler, step, ctx, call_log = _build_ctx_for_extract_data(
+        predicate=buggy_predicate,
+        is_detail_page=True,
+        current_url="https://www.example.com/boat/foo",
+    )
+    result = handler.execute(step, ctx)
+
+    # Normal extract ran; the buggy predicate was swallowed.
+    assert result.skip is False
+    assert call_log["deep_extract_called"] is True
+
+
+def test_extract_data_does_not_short_circuit_for_extract_url_step(monkeypatch) -> None:
+    """``extract_url`` is a different step type (one-shot URL
+    capture, not the full extract). The predicate doesn't apply
+    there — extract_url is too cheap to deserve the gate, and the
+    URL it reports is the *output* of the step, not an input."""
+    monkeypatch.setattr(
+        "mantis_agent.gym.step_handlers.claude_step.time.sleep",
+        lambda *_: None,
+    )
+    handler, step, ctx, call_log = _build_ctx_for_extract_data(
+        predicate=lambda u: True,
+        is_detail_page=True,
+        current_url="https://www.example.com/boat/foo",
+    )
+    # Switch step type to extract_url.
+    step = MicroIntent(
+        intent="Read URL",
+        type="extract_url",
+        claude_only=True,
+    )
+
+    # The extract_url branch needs extractor.extract — give it a
+    # minimal response.
+    extractor = ctx.extractor
+    data = MagicMock()
+    data.url = "https://www.example.com/boat/foo"
+    extractor.extract.return_value = data
+
+    result = handler.execute(step, ctx)
+
+    # No skip envelope — extract_url ran normally.
+    assert result.skip is False
+    extractor.extract.assert_called_once()

--- a/tests/test_rejection_skip_intent.py
+++ b/tests/test_rejection_skip_intent.py
@@ -163,6 +163,11 @@ def _build_step_handler_ctx(*, recipe_schema: ExtractionSchema, dealer: bool, mi
     runner._last_extracted = {}
     runner._current_page = 1
     runner.scanner.is_duplicate.return_value = False
+    # Issue #255: MagicMock auto-creates the attribute as another
+    # callable mock unless we pin it to None here. With the auto-
+    # mock the seen-URL predicate would fire on every test and
+    # trip ``already_seen`` ahead of the dealer/incomplete branches.
+    runner.seen_url_predicate = None
 
     extractor = MagicMock()
     extractor.schema = recipe_schema


### PR DESCRIPTION
Closes #255. Fifth tactical sibling in the skip-envelope family.

## Why
Marketplace iterators inherently re-visit the same \`/boat/<slug>/\` URLs across runs. Live evidence: 14 leads in the host's \`master.csv\` have been re-drilled an average of 2.8× each across 6 plan runs — ~3 hours of wall time burned re-extracting data the host already has. The earliest reliable point to short-circuit a duplicate is *after the navigate, before extract_data* fires; that timing window is only observable inside the runner.

## Design — split of responsibility

Per the architectural review on the issue (host-vs-mantis question), this is *mostly* a host concern with one specific timing window only mantis can see:

| Concern | Where it lives |
|---|---|
| The set/source of seen URLs (master.csv, CRM, etc.) | **Host** |
| What "seen" means (URL match, content hash, CRM lookup) | **Host** |
| The post-navigate / pre-extract timing window | **Mantis** |
| The skip envelope contract | **Mantis** (consistent with #246/#250/#254) |

The chosen surface is a **predicate callable** rather than the issue's proposed URL-set + match-mode. A host that wants set-based match writes \`lambda u: u in my_seen_set\`; a host that wants content-hash writes that instead. Mantis bakes in zero assumptions about what "seen" means.

## Change
- **\`MicroPlanRunner(seen_url_predicate: Callable[[str], bool] | None = None)\`** — opt-in constructor param. Default \`None\` preserves today's behavior.
- **\`ClaudeStepHandler\` \`extract_data\` branch**: new \`_check_already_seen\` helper at the top of the step, *before* the in-session extraction cache. Consults the host predicate. Detail-page applicability gate via \`SiteConfig.is_detail_page\` (#236). Buggy predicate exceptions swallowed (over-extract is the safer failure mode).
- **Skip envelope**: \`StepResult(skip=True, skip_reason='already_seen', data='already_seen|url=<url>')\`.

## Test plan
- [x] 10 new in \`tests/test_already_seen_url_skip_envelope.py\`: constructor opt-in, default None preservation, predicate fires + doesn't fire paths, applicability gate (search URL never deduped), empty \`current_url\` fallthrough, ordering relative to in-session cache, predicate-exception safety, \`extract_url\` step type not affected
- [x] 73 related tests pass (incl. test_rejection_skip_intent updated to pin \`seen_url_predicate=None\` on its MagicMock fixture)
- [x] Ruff clean
- [x] Docs-isolation guard clean
- [ ] Integration on staffai BoatTrader plan: host opts in via \`MantisRunnerSession.run_sub_goal(..., seen_url_predicate=load_from_master_csv())\`. Expect: 14 known leads each get one \`extract_data\` → immediate skip → orchestrator advances. Per-duplicate wall time drops ~5 min → <30s.

## Adjacent
- #246 (recipe-rejection skip) — shipped, working
- #250 (navigation-primitive halt skip) — shipped, working
- #254 (context-budget skip) — shipped, working
- #248 (exploration substrate) — shipped
- #252 (specialized grounder VLM) — filed
- #253 (verifier upgrade for write-action tasks) — filed
- staffai#622 (\`plan_refinement_agent\`) — would consume telemetry from this envelope: high \`already_seen\` rate signals the agent is grinding saturated territory

🤖 Generated with [Claude Code](https://claude.com/claude-code)