### PR TITLE
docs: document the skip-envelope family + recipe schema additions

### DIFF
--- a/docs/integrations/embedding-microplanrunner.md
+++ b/docs/integrations/embedding-microplanrunner.md
@@ -175,6 +175,153 @@ result = runner.resume(state, user_input="123456", plan=plan)
 Plan-signature mismatch on resume raises `ValueError`: you can't resume a
 different plan than the one that paused.
 
+## The skip-envelope family — advance vs. retry signals
+
+Hosts that wrap mantis in a tool surface (e.g. an LLM orchestrator
+calling `MantisBrowserTool.run_sub_goal(...)`) routinely face the same
+question on every halted / rejected sub-goal: "should the orchestrator
+retry, or advance to the next position?"
+
+Plan-text rules like *"never re-issue Step 4 with the same
+position_on_page"* don't bind LLM orchestrator behavior reliably — they
+get treated as preferences and overridden. Tool-result envelopes that
+change the orchestrator's downstream state are the durable mechanism.
+
+`StepResult` carries two fields for this:
+
+```python
+@dataclass
+class StepResult:
+    ...
+    skip: bool = False         # advance, don't retry — runner says this run is terminal-for-this-context
+    skip_reason: str | None = None  # canonical token the host branches on
+```
+
+When `skip=True`, the host's tool wrapper promotes the result to
+`status: skipped` (a successful tool result with an advance semantic),
+which the orchestrator already handles cleanly. When `skip=False`,
+today's success/failure semantics apply.
+
+Five opt-in trigger sources populate the envelope. All defaults preserve
+today's unbounded behavior — runs that don't opt in see no change:
+
+### a) Recipe-rejection intents ([#246](https://github.com/mercurialsolo/mantis/pull/247))
+
+Recipes annotate which rejection reasons mean *terminal-for-this-row*
+(`"skip"`) vs *retryable / enrichable* (`"extract_more"` / `"retry"`):
+
+```python
+from mantis_agent.extraction import ExtractionSchema
+
+ExtractionSchema(
+    spam_indicators=[...],
+    spam_label="dealer",
+    rejection_intents={
+        "dealer":              "skip",           # terminal — host advances
+        "incomplete_required": "extract_more",   # may enrich on detail page
+    },
+)
+```
+
+When `ClaudeExtractor` flags a row as dealer/spam (recipe-defined), the
+runner stamps `skip=True, skip_reason="dealer"` and the host advances
+past the listing instead of treating the rejection as a step failure to
+retry. `marketplace_listings` ships with this pre-wired.
+
+### b) Navigation-primitive halts ([#250](https://github.com/mercurialsolo/mantis/pull/251))
+
+When a click / submit / scroll / navigate / gate step exhausts retries
+and halts, the host can opt to convert that into a skip signal so the
+orchestrator advances rather than re-attempting the same intent:
+
+```python
+runner = MicroPlanRunner(
+    ...,
+    navigation_primitives_emit_skip={"click", "submit", "scroll", "navigate", "gate"},
+)
+```
+
+On halt, if the failed step's type is in the set and the step doesn't
+already carry a recipe-rejection `skip_reason` (those win on conflict),
+the runner stamps `skip=True, skip_reason="navigation_failed"`. Default
+`None` preserves today's halt-as-failure semantics.
+
+### c) Per-context sub-goal budget ([#254](https://github.com/mercurialsolo/mantis/pull/256))
+
+Bound how many sub-goals (= `run()` calls) can fire against the same
+URL anchor before the runner short-circuits:
+
+```python
+from mantis_agent.gym.context_budget import ContextBudget
+
+runner = MicroPlanRunner(
+    ...,
+    context_budget=ContextBudget(
+        max_sub_goals_per_url=3,         # bound per detail-page URL
+        max_sub_goals_per_iteration=10,  # global cap across all URLs
+        on_exceeded="emit_skip",         # vs "halt" / "log_only"
+    ),
+)
+```
+
+When the (N+1)th `run()` would fire against a URL that already has N
+sub-goals, the runner short-circuits *before* invoking the executor and
+returns `StepResult(skip=True, skip_reason="listing_budget_exceeded")`.
+Anchor resolution: navigate-step URL → `_last_known_url` → sentinel.
+
+### d) Already-seen URL predicate ([#255](https://github.com/mercurialsolo/mantis/pull/257))
+
+Cross-session dedup: pass a predicate the runner consults at the top
+of `extract_data` to skip URLs the host has already processed in prior
+runs:
+
+```python
+def seen(url: str) -> bool:
+    return url in already_extracted_urls  # or content_hash / CRM lookup
+
+runner = MicroPlanRunner(
+    ...,
+    seen_url_predicate=seen,
+)
+```
+
+The predicate is consulted *after* navigate but *before*
+ClaudeExtractor fires — saves the deep-extract Claude call entirely.
+Applicability gated by `SiteConfig.is_detail_page(url)` so search /
+results URLs aren't accidentally deduped. The host owns the dedup
+policy (URL match, content hash, CRM lookup, anything); mantis just
+provides the timing window.
+
+### Putting it together — what the host sees
+
+```python
+result = runner.run_with_status(plan)
+
+for step in result.steps:
+    if step.skip:
+        # advance: terminal-for-this-context; don't retry
+        log.info("skipped step %d: %s", step.step_index, step.skip_reason)
+        continue
+    if step.success:
+        process_lead(step.data)
+    else:
+        # legitimate failure — host's retry policy applies
+        ...
+```
+
+The canonical `skip_reason` values are:
+
+| `skip_reason` | Trigger | When |
+|---|---|---|
+| `"dealer"` (or any recipe key) | Recipe-rejection intents | Extractor flagged the row + recipe says `"skip"` |
+| `"navigation_failed"` | Navigation-primitive halt | Step type in opt-in set + recovery exhausted |
+| `"listing_budget_exceeded"` | Context budget | (N+1)th sub-goal against same URL anchor |
+| `"already_seen"` | Already-seen predicate | Predicate returned True at top of `extract_data` |
+
+A more-specific recipe reason (`"dealer"`) always wins over a generic
+runner reason (`"navigation_failed"`) — once a `StepResult` carries a
+`skip_reason`, later layers don't overwrite it.
+
 ## Coordinate-space contract
 
 The brain emits `(x, y)` in the **same pixel space as the screenshot it

--- a/docs/integrations/recipes.md
+++ b/docs/integrations/recipes.md
@@ -869,6 +869,9 @@ Merge rules:
 | `spam_indicators`, `spam_seller_indicators`, `forbidden_controls`, `allowed_controls` | List union (recipe extends derived, deduplicated). |
 | `entity_name`, `spam_label` | Derived wins once it has departed from the dataclass default; recipe fills in defaults. |
 | `fields`, `required_fields` | Derived always wins — the plan text owns the schema body. |
+| `tile_required_fields` ([#236](https://github.com/mercurialsolo/mantis/pull/237)) | Derived wins when set; recipe fills in defaults. Looser required-field contract for `SEARCH_TILE` extraction context — typically just `["url"]` so rows survive long enough to drive a follow-up navigate-into-detail. |
+| `tile_carry_fields` ([#236](https://github.com/mercurialsolo/mantis/pull/237)) | List union (recipe extends derived). Informational hint for which fields the tile is expected to surface. |
+| `rejection_intents` ([#246](https://github.com/mercurialsolo/mantis/pull/247)) | Dict merge — derived keys win on conflict (operator override), recipe extends with new keys. Maps a rejection reason (`"dealer"`, `"incomplete_required"`) to a host-facing intent (`"skip"` / `"extract_more"` / `"retry"`). The runner stamps `StepResult.skip=True / skip_reason=<reason>` when the recipe says `"skip"` — see [embedding-microplanrunner.md](embedding-microplanrunner.md#the-skip-envelope-family--advance-vs-retry-signals). |
 | `detail_page_pattern`, `pagination_format`, `results_page_pattern`, `pagination_strip_pattern`, `filtered_results_url`, `domain` | Recipe wins when set (empty string = no opinion). |
 | `gate_verify_prompt` | Derived wins — the plan owns the gate intent. |
 | `pagination_type` | Follows `pagination_format` (the dataclass default `"path_suffix"` can't double as a sentinel). |

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -139,7 +139,36 @@ crashing*, NOT that the agent achieved its goal. Always inspect
 `summary.dynamic_verification_summary.verdict` (or the per-step trace in
 the `result` payload) to determine actual success.
 
-`result` returns the full lead list and per-step trace.
+`result` returns the full lead list and per-step trace. Each per-step
+record carries the skip envelope (issues #246/#250/#254/#255):
+
+```jsonc
+{
+  "step_index": 4,
+  "intent": "Extract row",
+  "success": false,
+  "data": "REJECTED_DEALER|extractor marked as dealer|...",
+  "skip": true,                  // advance, don't retry
+  "skip_reason": "dealer"        // canonical reason — host branches on this
+}
+```
+
+Canonical `skip_reason` values:
+
+| Value | Trigger |
+|---|---|
+| `"dealer"` (or any recipe key) | Recipe-rejection intents (`rejection_intents` — §3.1a, #246) |
+| `"navigation_failed"` | Navigation-primitive halt — library-only opt-in (#250) |
+| `"listing_budget_exceeded"` | Per-context sub-goal budget — library-only opt-in (#254) |
+| `"already_seen"` | Already-seen URL predicate — library-only opt-in (#255) |
+
+The HTTP-API surface controls `skip_reason="dealer"` (and any other
+key) via `extraction_schema.rejection_intents`. The other three
+trigger sources require the library-shaped integration — see
+`docs/integrations/embedding-microplanrunner.md`. Branch on
+`step.skip` *before* `step.success` so terminal-for-this-context
+results aren't retried.
+
 `logs` returns the last `tail` events written by the runner (default 200,
 max 10000).
 
@@ -163,6 +192,50 @@ signature, and reuses the cached MicroPlan for subsequent identical
 requests. **Decomposition assumes a marketplace-listing extraction shape
 by default** — for non-marketplace targets (brand homepages, content
 sites), author a custom `micro` plan instead.
+
+### 3.1a `extraction_schema` — what the extractor reads and rejects
+
+Pass alongside any plan shape. Controls per-listing extraction + the
+recipe-side rejection envelope (issue #236 / #246). All fields
+optional; defaults preserve marketplace-listings behavior.
+
+```jsonc
+"extraction_schema": {
+  "entity_name": "boat listing",
+  "fields": [
+    {"name": "year",  "type": "str", "required": true,  "example": "2018"},
+    {"name": "make",  "type": "str", "required": true,  "example": "Sea Ray"},
+    {"name": "price", "type": "str", "required": false, "example": "$42,500"},
+    {"name": "url",   "type": "str", "required": false, "example": "site.com/boat/..."}
+  ],
+  "required_fields": ["year", "make"],           // strict DETAIL_PAGE contract
+  "tile_required_fields": ["url"],               // looser SEARCH_TILE contract (#236)
+  "spam_indicators": ["dealer website", "more from this dealer"],
+  "spam_seller_indicators": ["marine", "yacht", "brokerage", "inc"],
+  "spam_label": "dealer",
+  "forbidden_controls": ["Contact Seller", "Request Info"],
+  "allowed_controls": ["Show Phone", "Show more"],
+  "rejection_intents": {                         // #246 — recipe → host signal
+    "dealer":              "skip",               // terminal — host advances past listing
+    "incomplete_required": "extract_more"        // may enrich on detail page
+  }
+}
+```
+
+Per-field merge semantics on overlay (when both derived + recipe
+present): list fields union, scalar fields fall back from default,
+`fields`/`required_fields` derived-wins, `rejection_intents` derived
+keys win on conflict (recipe extends with new keys). See
+`docs/integrations/recipes.md` for the full merge table.
+
+The `rejection_intents` map drives `StepResult.skip / skip_reason`
+in the result payload (§2.2). When the extractor flags a row with a
+reason whose intent is `"skip"`, the per-step trace carries
+`skip=true, skip_reason="<reason>"` and a host wrapping mantis in a
+tool surface promotes that to a successful `status: skipped` tool
+result (advance, don't retry). See
+`docs/integrations/embedding-microplanrunner.md` for the full skip-
+envelope family.
 
 ### 3.2 `micro` — hand-authored micro-plan (recommended for production)
 


### PR DESCRIPTION
Five tactical PRs over the past week landed five new host-side opt-ins that the existing integration docs don't surface. A host integrating mantis from scratch had no way to discover them without reading the code or the issue threads.

## Doc additions

**\`embedding-microplanrunner.md\`** — new section *The skip-envelope family — advance vs. retry signals* after the four-knobs reference, covering:

- \`StepResult.skip\` / \`skip_reason\` — the envelope contract hosts read
- **Five trigger sources** with concrete code:
  - Recipe-rejection intents (\`ExtractionSchema.rejection_intents\`) — [#246](https://github.com/mercurialsolo/mantis/pull/247)
  - Navigation-primitive halts (\`navigation_primitives_emit_skip\`) — [#250](https://github.com/mercurialsolo/mantis/pull/251)
  - Per-context sub-goal budget (\`ContextBudget\`) — [#254](https://github.com/mercurialsolo/mantis/pull/256)
  - Already-seen URL predicate (\`seen_url_predicate\`) — [#255](https://github.com/mercurialsolo/mantis/pull/257)
- Precedence note: more-specific recipe reasons win over generic runner reasons
- Canonical \`skip_reason\` table for host-side branching

**\`recipes.md\`** — extend the overlay merge-rules table to cover the new schema fields:

- \`tile_required_fields\`, \`tile_carry_fields\` (#236)
- \`rejection_intents\` (#246) — cross-links to embedding doc for the downstream \`StepResult.skip\` contract

## Test plan
- [x] No new files, no nav changes — purely additive to existing pages
- [x] Customer-token scan clean
- [ ] CI mkdocs-strict — local docs venv is stale (broken interpreter path); relying on CI
- [ ] Onboarding test: another host integrator can find the skip envelope from \`integrations/embedding-microplanrunner.md\` without reading the source

🤖 Generated with [Claude Code](https://claude.com/claude-code)