### PR TITLE
feat(extract): adaptive content-settle on deep-extract path (#259)

### DIFF
--- a/src/mantis_agent/gym/_runner_helpers.py
+++ b/src/mantis_agent/gym/_runner_helpers.py
@@ -144,6 +144,128 @@ def dump_debug_screenshot(
         logger.debug("debug screenshot dump failed: %s", exc)
 
 
+def screenshot_pixel_diff_fraction(a: Any, b: Any, brightness_step: int = 8) -> float:
+    """Fraction of pixels that differ between two screenshots
+    (downsampled, grayscale). Issue #259 — primitive for adaptive
+    content-settle on the deep-extract path.
+
+    Cheap heuristic: downsample to 64×64, convert to grayscale,
+    count pixels whose brightness diverged by more than
+    ``brightness_step``. 1-step shifts (JPEG re-encode artifacts,
+    cursor blinks) stay under the threshold; real content changes
+    (new text appearing, image swap, modal overlay) cross it
+    decisively.
+
+    Returns 1.0 (conservative — assume changed) for any failure
+    case: size mismatch, invalid input, exception during compare.
+    Callers treat 1.0 as "page is still changing, keep polling".
+    """
+    if a is None or b is None:
+        return 1.0
+    try:
+        if getattr(a, "size", None) != getattr(b, "size", None):
+            return 1.0
+        from PIL import Image  # local import — pillow may not be loaded yet
+        a_small = a.convert("L").resize((64, 64), Image.NEAREST)
+        b_small = b.convert("L").resize((64, 64), Image.NEAREST)
+    except Exception:
+        return 1.0
+    try:
+        a_data = list(a_small.getdata())
+        b_data = list(b_small.getdata())
+    except Exception:
+        return 1.0
+    if not a_data or len(a_data) != len(b_data):
+        return 1.0
+    diff = sum(1 for x, y in zip(a_data, b_data) if abs(x - y) > brightness_step)
+    return diff / len(a_data)
+
+
+def adaptive_content_settle(
+    env: Any,
+    *,
+    min_seconds: float = 0.3,
+    max_seconds: float = 2.0,
+    poll_seconds: float = 0.3,
+    diff_threshold: float = 0.02,
+) -> float:
+    """Poll-based settle that exits when consecutive screenshots
+    stabilize. Symmetric to :func:`adaptive_submit_settle` but
+    polls *screenshot stability* instead of URL change.
+
+    Used after actions that may trigger lazy-load, animation, or
+    XHR-driven DOM updates — the four fixed-sleep sites in
+    ``_extract_listing_data_deep`` (issue #259). Worst-case the
+    helper pays ``max_seconds`` (the original fixed-sleep value).
+    Best-case (static page) it exits at
+    ``min_seconds + poll_seconds`` (~0.6s) — the floor reflects
+    the truth that even a stable page needs at least one render
+    tick.
+
+    Args:
+        env: Object with a ``screenshot()`` method returning a
+            PIL Image. Any exception during screenshot capture
+            falls through to a fixed-sleep equivalent — better to
+            over-pay than to halt the deep-extract.
+        min_seconds: Always wait at least this long. Captures the
+            initial-render reality on every page.
+        max_seconds: Worst-case cap. Pages that genuinely keep
+            changing (long XHR, animations) pay this and proceed.
+        poll_seconds: Wall time between consecutive screenshot
+            polls. ~0.2–0.3s is the right zone — small enough to
+            exit promptly, large enough that the screenshot cost
+            doesn't dominate.
+        diff_threshold: Pixel-diff fraction below which two
+            consecutive screenshots count as "settled". 0.02 (2%
+            of downsampled pixels) is generous enough that
+            animation tails / cursor blinks don't extend the
+            settle.
+
+    Returns:
+        Actual elapsed wall-clock seconds. Callers add to
+        ``runner.costs['gpu_seconds']`` for telemetry.
+    """
+    if diff_threshold < 0:
+        raise ValueError(f"diff_threshold must be >= 0, got {diff_threshold}")
+    if min_seconds > max_seconds:
+        raise ValueError(
+            f"min_seconds ({min_seconds}) must be <= max_seconds ({max_seconds})"
+        )
+
+    start = time.time()
+    time.sleep(min_seconds)
+
+    try:
+        prev = env.screenshot()
+    except Exception as exc:
+        logger.debug("adaptive_content_settle: screenshot raised — fall through (%s)", exc)
+        # Fall through to fixed-sleep equivalent — better to
+        # over-pay than to halt.
+        remaining = max_seconds - (time.time() - start)
+        if remaining > 0:
+            time.sleep(remaining)
+        return time.time() - start
+
+    while True:
+        elapsed = time.time() - start
+        if elapsed >= max_seconds:
+            return elapsed
+        time.sleep(min(poll_seconds, max_seconds - elapsed))
+        try:
+            cur = env.screenshot()
+        except Exception:
+            break
+        if screenshot_pixel_diff_fraction(prev, cur) < diff_threshold:
+            return time.time() - start
+        prev = cur
+
+    # Loop broke on exception — pay remaining max_seconds budget.
+    remaining = max_seconds - (time.time() - start)
+    if remaining > 0:
+        time.sleep(remaining)
+    return time.time() - start
+
+
 def adaptive_submit_settle(runner: "MicroPlanRunner", *, url_before: str) -> float:
     deadline = time.time() + _SUBMIT_SETTLE_MAX_SECONDS
     time.sleep(_SUBMIT_SETTLE_MIN_SECONDS)

--- a/src/mantis_agent/gym/step_handlers/claude_step.py
+++ b/src/mantis_agent/gym/step_handlers/claude_step.py
@@ -194,10 +194,12 @@ class ClaudeStepHandler:
         if not extractor:
             return StepResult(step_index=index, intent=step.intent, success=False)
 
-        # Pre-settle — page may still be rendering after scroll. Lifted
-        # from MicroPlanRunner._execute_step's claude_only branch in EPIC
-        # #161 cleanup so registry-first dispatch produces identical timing.
-        time.sleep(1)
+        # Pre-settle — page may still be rendering after scroll.
+        # Issue #259: adaptive — exits early when consecutive
+        # screenshots stabilize (typical ~0.3-0.4s on static pages),
+        # caps at the original 1.0s on pages that keep changing.
+        from .._runner_helpers import adaptive_content_settle
+        adaptive_content_settle(env, min_seconds=0.2, max_seconds=1.0)
 
         screenshot = env.screenshot()
 
@@ -470,9 +472,13 @@ class ClaudeStepHandler:
 
         # Start from the top so the final prompt sees title, price, seller card,
         # and any safe contact/phone reveal controls before scanning details.
+        # Issue #259: adaptive — browsers re-layout when jumping to top
+        # (sticky nav, hero image, JS widgets). Static pages exit ~0.5s;
+        # JS-heavy pages still pay the full 1.5s cap.
         try:
             env.step(Action(action_type=ActionType.KEY_PRESS, params={"keys": "Home"}))
-            time.sleep(1.5)
+            from .._runner_helpers import adaptive_content_settle
+            adaptive_content_settle(env, min_seconds=0.3, max_seconds=1.5)
         except Exception:
             pass
         runner._set_scroll_state(
@@ -518,7 +524,14 @@ class ClaudeStepHandler:
                             params={"x": target["x"], "y": target["y"]},
                         ))
                         controls_clicked += 1
-                        time.sleep(2)
+                        # Issue #259: reveal click triggers XHR +
+                        # DOM update + reveal animation. JS-backed
+                        # reveals (BoatTrader Show Phone, etc) need
+                        # the full 2s; static-content reveals
+                        # ("Show more" expanding existing DOM) exit
+                        # at ~0.6s.
+                        from .._runner_helpers import adaptive_content_settle
+                        adaptive_content_settle(env, min_seconds=0.5, max_seconds=2.0)
                         capture(
                             f"after {target.get('action', 'expand')} "
                             f"{target.get('label', '')[:40]}"
@@ -546,7 +559,12 @@ class ClaudeStepHandler:
             if viewport < max_viewports - 1:
                 try:
                     env.step(Action(action_type=ActionType.KEY_PRESS, params={"keys": "Page_Down"}))
-                    time.sleep(1)
+                    # Issue #259: lazy-load below-the-fold content
+                    # typically completes in <500ms; pages with
+                    # heavy virtualized lists or image lazy-load
+                    # still get the full 1s cap.
+                    from .._runner_helpers import adaptive_content_settle
+                    adaptive_content_settle(env, min_seconds=0.2, max_seconds=1.0)
                 except Exception:
                     break
 

--- a/tests/test_adaptive_content_settle.py
+++ b/tests/test_adaptive_content_settle.py
@@ -1,0 +1,219 @@
+"""Tests for issue #259 — adaptive content-settle in deep-extract.
+
+Replaces the four fixed-duration ``time.sleep(...)`` calls in
+``_extract_listing_data_deep`` (claude_step.py) with pixel-diff
+polling. Same shape as ``_adaptive_submit_settle`` in
+``_runner_helpers.py`` — bounded poll with early exit on a
+stability signal.
+
+Two layers:
+
+1. ``screenshot_pixel_diff_fraction`` — primitive pixel-diff
+   helper. Cheap downsample-and-compare; returns the fraction of
+   pixels that changed beyond a brightness threshold.
+2. ``adaptive_content_settle(env, max_seconds=..., ...)`` —
+   bounded poll. Exits when two consecutive screenshots stabilize
+   under ``diff_threshold``. Respects the ``min_seconds`` floor
+   (initial render always needs some wall time) and the
+   ``max_seconds`` cap (worst-case stays at the original fixed-
+   sleep duration).
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock
+
+import pytest
+from PIL import Image
+
+from mantis_agent.gym._runner_helpers import (
+    adaptive_content_settle,
+    screenshot_pixel_diff_fraction,
+)
+
+
+# ── Pixel-diff primitive ────────────────────────────────────────────
+
+
+def _solid(color: int, size: tuple[int, int] = (320, 200)) -> Image.Image:
+    """Solid grayscale image."""
+    return Image.new("L", size, color).convert("RGB")
+
+
+def test_pixel_diff_identical_images_is_zero() -> None:
+    img = _solid(128)
+    assert screenshot_pixel_diff_fraction(img, img) == 0.0
+
+
+def test_pixel_diff_completely_different_images_is_near_one() -> None:
+    """Black vs white — every pixel crosses any reasonable
+    brightness threshold."""
+    a = _solid(0)
+    b = _solid(255)
+    assert screenshot_pixel_diff_fraction(a, b) > 0.95
+
+
+def test_pixel_diff_small_brightness_change_is_zero() -> None:
+    """A 1-step brightness shift across the whole image must be
+    below the noise threshold — JPEG re-encoding or cursor-blink
+    artifacts shouldn't count as change."""
+    a = _solid(128)
+    b = _solid(129)
+    assert screenshot_pixel_diff_fraction(a, b) < 0.01
+
+
+def test_pixel_diff_size_mismatch_returns_conservative_one() -> None:
+    """Different-sized screenshots can't be compared element-wise.
+    Return 1.0 (assume changed) so the caller keeps polling."""
+    a = _solid(128, size=(320, 200))
+    b = _solid(128, size=(640, 400))
+    assert screenshot_pixel_diff_fraction(a, b) == 1.0
+
+
+def test_pixel_diff_handles_bad_input_gracefully() -> None:
+    """Non-image input shouldn't crash — return conservative 1.0."""
+    assert screenshot_pixel_diff_fraction(None, _solid(128)) == 1.0
+    assert screenshot_pixel_diff_fraction(_solid(128), None) == 1.0
+
+
+# ── Adaptive settle ─────────────────────────────────────────────────
+
+
+class _StableEnv:
+    """Env stub that returns the same screenshot every time —
+    settle should exit at the floor."""
+
+    def __init__(self, color: int = 128) -> None:
+        self._img = _solid(color)
+        self.screenshot_count = 0
+
+    def screenshot(self) -> Image.Image:
+        self.screenshot_count += 1
+        return self._img
+
+
+class _ChangingEnv:
+    """Env stub that returns a different screenshot every call —
+    settle should pay max_seconds because the page never settles."""
+
+    def __init__(self) -> None:
+        self._step = 0
+        self.screenshot_count = 0
+
+    def screenshot(self) -> Image.Image:
+        self.screenshot_count += 1
+        # Alternate between black and white — guaranteed full
+        # pixel-diff between consecutive calls.
+        color = 0 if self._step % 2 == 0 else 255
+        self._step += 1
+        return _solid(color)
+
+
+class _SettlingEnv:
+    """Env stub that changes for the first 2 polls then stabilizes
+    — settle should exit shortly after the page calms down."""
+
+    def __init__(self) -> None:
+        self._step = 0
+        self.screenshot_count = 0
+
+    def screenshot(self) -> Image.Image:
+        self.screenshot_count += 1
+        if self._step < 2:
+            color = 0 if self._step % 2 == 0 else 255
+        else:
+            color = 200  # stable from step 2 onward
+        self._step += 1
+        return _solid(color)
+
+
+def test_settle_stable_page_exits_at_min_seconds(monkeypatch) -> None:
+    """Stable page (consecutive screenshots identical) → settle
+    returns shortly after min_seconds. Tolerance for poll_seconds
+    because the loop takes one poll to confirm stability."""
+    env = _StableEnv()
+    start = time.time()
+    elapsed = adaptive_content_settle(
+        env, min_seconds=0.1, max_seconds=1.0, poll_seconds=0.1,
+    )
+    wall = time.time() - start
+    # At least the min floor; well under the max cap.
+    assert elapsed >= 0.1
+    assert elapsed < 0.5
+    assert wall < 0.5
+
+
+def test_settle_changing_page_pays_max_seconds() -> None:
+    """Page that keeps changing — settle pays the full max cap."""
+    env = _ChangingEnv()
+    elapsed = adaptive_content_settle(
+        env, min_seconds=0.05, max_seconds=0.4, poll_seconds=0.1,
+    )
+    # Hit the cap (within tolerance for poll granularity).
+    assert elapsed >= 0.4 - 0.15
+
+
+def test_settle_settling_page_exits_when_stable() -> None:
+    """Page that changes for 2 polls then stabilizes → settle
+    exits a poll or two after stabilization, well before max."""
+    env = _SettlingEnv()
+    elapsed = adaptive_content_settle(
+        env, min_seconds=0.05, max_seconds=2.0, poll_seconds=0.1,
+    )
+    # Should exit somewhere around min + 2 polls + stabilization = ~0.4s
+    assert elapsed < 1.5
+
+
+def test_settle_handles_screenshot_exception(monkeypatch) -> None:
+    """env.screenshot() raising falls through to the fixed-sleep
+    equivalent — better to over-pay than to halt the deep-extract."""
+    env = MagicMock()
+    env.screenshot.side_effect = RuntimeError("CDP glitch")
+    elapsed = adaptive_content_settle(
+        env, min_seconds=0.05, max_seconds=0.3, poll_seconds=0.1,
+    )
+    # Paid roughly max_seconds (with tolerance).
+    assert elapsed >= 0.2
+
+
+def test_settle_respects_min_seconds_floor() -> None:
+    """Even with a perfectly-stable page, the floor still applies
+    — first render needs some wall time regardless of pixel-diff."""
+    env = _StableEnv()
+    elapsed = adaptive_content_settle(
+        env, min_seconds=0.3, max_seconds=1.0, poll_seconds=0.1,
+    )
+    assert elapsed >= 0.3
+
+
+def test_settle_returns_actual_elapsed() -> None:
+    """Telemetry contract: returned value reflects real wall-clock
+    spent, not the configured max_seconds — callers add this to
+    runner.costs['gpu_seconds']."""
+    env = _StableEnv()
+    elapsed = adaptive_content_settle(
+        env, min_seconds=0.1, max_seconds=2.0, poll_seconds=0.1,
+    )
+    # Must be the real elapsed, not just max_seconds.
+    assert elapsed < 1.0
+
+
+# ── Validation of arguments ────────────────────────────────────────
+
+
+def test_settle_rejects_invalid_diff_threshold() -> None:
+    env = _StableEnv()
+    with pytest.raises(ValueError):
+        adaptive_content_settle(
+            env, min_seconds=0.1, max_seconds=1.0,
+            poll_seconds=0.1, diff_threshold=-0.1,
+        )
+
+
+def test_settle_rejects_min_greater_than_max() -> None:
+    env = _StableEnv()
+    with pytest.raises(ValueError):
+        adaptive_content_settle(
+            env, min_seconds=2.0, max_seconds=1.0, poll_seconds=0.1,
+        )

--- a/tests/test_already_seen_url_skip_envelope.py
+++ b/tests/test_already_seen_url_skip_envelope.py
@@ -135,6 +135,10 @@ def test_extract_data_short_circuits_when_predicate_returns_true(monkeypatch) ->
         "mantis_agent.gym.step_handlers.claude_step.time.sleep",
         lambda *_: None,
     )
+    monkeypatch.setattr(
+        "mantis_agent.gym._runner_helpers.adaptive_content_settle",
+        lambda *a, **kw: 0.0,
+    )
     url = "https://www.example.com/boat/already-seen-slug"
     handler, step, ctx, call_log = _build_ctx_for_extract_data(
         predicate=lambda u: "already-seen-slug" in u,
@@ -161,6 +165,10 @@ def test_extract_data_proceeds_when_predicate_returns_false(monkeypatch) -> None
         "mantis_agent.gym.step_handlers.claude_step.time.sleep",
         lambda *_: None,
     )
+    monkeypatch.setattr(
+        "mantis_agent.gym._runner_helpers.adaptive_content_settle",
+        lambda *a, **kw: 0.0,
+    )
     handler, step, ctx, call_log = _build_ctx_for_extract_data(
         predicate=lambda u: False,
         is_detail_page=True,
@@ -180,6 +188,10 @@ def test_extract_data_proceeds_when_predicate_is_none(monkeypatch) -> None:
     monkeypatch.setattr(
         "mantis_agent.gym.step_handlers.claude_step.time.sleep",
         lambda *_: None,
+    )
+    monkeypatch.setattr(
+        "mantis_agent.gym._runner_helpers.adaptive_content_settle",
+        lambda *a, **kw: 0.0,
     )
     handler, step, ctx, call_log = _build_ctx_for_extract_data(
         predicate=None,
@@ -202,6 +214,10 @@ def test_extract_data_proceeds_when_not_a_detail_page(monkeypatch) -> None:
         "mantis_agent.gym.step_handlers.claude_step.time.sleep",
         lambda *_: None,
     )
+    monkeypatch.setattr(
+        "mantis_agent.gym._runner_helpers.adaptive_content_settle",
+        lambda *a, **kw: 0.0,
+    )
     handler, step, ctx, call_log = _build_ctx_for_extract_data(
         predicate=lambda u: True,  # would short-circuit if applied
         is_detail_page=False,       # but applicability gate is False
@@ -222,6 +238,10 @@ def test_extract_data_proceeds_when_current_url_is_empty(monkeypatch) -> None:
         "mantis_agent.gym.step_handlers.claude_step.time.sleep",
         lambda *_: None,
     )
+    monkeypatch.setattr(
+        "mantis_agent.gym._runner_helpers.adaptive_content_settle",
+        lambda *a, **kw: 0.0,
+    )
     handler, step, ctx, call_log = _build_ctx_for_extract_data(
         predicate=lambda u: True,
         is_detail_page=True,
@@ -241,6 +261,10 @@ def test_extract_data_short_circuits_before_cache_check(monkeypatch) -> None:
     monkeypatch.setattr(
         "mantis_agent.gym.step_handlers.claude_step.time.sleep",
         lambda *_: None,
+    )
+    monkeypatch.setattr(
+        "mantis_agent.gym._runner_helpers.adaptive_content_settle",
+        lambda *a, **kw: 0.0,
     )
     url = "https://www.example.com/boat/known"
     handler, step, ctx, call_log = _build_ctx_for_extract_data(
@@ -272,6 +296,10 @@ def test_extract_data_predicate_exception_does_not_break_run(monkeypatch) -> Non
         "mantis_agent.gym.step_handlers.claude_step.time.sleep",
         lambda *_: None,
     )
+    monkeypatch.setattr(
+        "mantis_agent.gym._runner_helpers.adaptive_content_settle",
+        lambda *a, **kw: 0.0,
+    )
 
     def buggy_predicate(url):
         raise RuntimeError("host predicate crashed")
@@ -296,6 +324,10 @@ def test_extract_data_does_not_short_circuit_for_extract_url_step(monkeypatch) -
     monkeypatch.setattr(
         "mantis_agent.gym.step_handlers.claude_step.time.sleep",
         lambda *_: None,
+    )
+    monkeypatch.setattr(
+        "mantis_agent.gym._runner_helpers.adaptive_content_settle",
+        lambda *a, **kw: 0.0,
     )
     handler, step, ctx, call_log = _build_ctx_for_extract_data(
         predicate=lambda u: True,

--- a/tests/test_claude_step_handler.py
+++ b/tests/test_claude_step_handler.py
@@ -175,6 +175,7 @@ def test_extract_data_cache_hit_skips_deep_extract():
 
 def test_extract_data_viable_writes_to_cache_when_write_enabled(monkeypatch):
     monkeypatch.setattr("mantis_agent.gym.step_handlers.claude_step.time.sleep", lambda *_: None)
+    monkeypatch.setattr("mantis_agent.gym._runner_helpers.adaptive_content_settle", lambda *a, **kw: 0.0)
 
     runner = _FakeRunner()
     extractor = MagicMock()
@@ -212,6 +213,7 @@ def test_extract_data_viable_writes_to_cache_when_write_enabled(monkeypatch):
 def test_extract_data_post_extract_dedup_returns_duplicate(monkeypatch):
     """Deep extract returns a URL we've already seen → DUPLICATE marker."""
     monkeypatch.setattr("mantis_agent.gym.step_handlers.claude_step.time.sleep", lambda *_: None)
+    monkeypatch.setattr("mantis_agent.gym._runner_helpers.adaptive_content_settle", lambda *a, **kw: 0.0)
 
     runner = _FakeRunner()
     runner._seen_urls.add("https://example.com/already-seen")
@@ -239,6 +241,7 @@ def test_extract_data_post_extract_dedup_returns_duplicate(monkeypatch):
 
 def test_extract_data_rejects_dealer_listing(monkeypatch):
     monkeypatch.setattr("mantis_agent.gym.step_handlers.claude_step.time.sleep", lambda *_: None)
+    monkeypatch.setattr("mantis_agent.gym._runner_helpers.adaptive_content_settle", lambda *a, **kw: 0.0)
 
     runner = _FakeRunner()
     # When extract_multi returns a non-viable result, the deep-extract
@@ -267,6 +270,7 @@ def test_extract_data_rejects_dealer_listing(monkeypatch):
 
 def test_extract_data_rejects_incomplete_listing(monkeypatch):
     monkeypatch.setattr("mantis_agent.gym.step_handlers.claude_step.time.sleep", lambda *_: None)
+    monkeypatch.setattr("mantis_agent.gym._runner_helpers.adaptive_content_settle", lambda *a, **kw: 0.0)
 
     runner = _FakeRunner()
     incomplete_data = MagicMock(
@@ -302,6 +306,7 @@ def test_extractor_missing_returns_failure():
 
 def test_unknown_step_type_returns_failure(monkeypatch):
     monkeypatch.setattr("mantis_agent.gym.step_handlers.claude_step.time.sleep", lambda *_: None)
+    monkeypatch.setattr("mantis_agent.gym._runner_helpers.adaptive_content_settle", lambda *a, **kw: 0.0)
     runner = _FakeRunner()
     extractor = MagicMock()
     ctx = _ctx(runner, extractor=extractor)

--- a/tests/test_rejection_skip_intent.py
+++ b/tests/test_rejection_skip_intent.py
@@ -224,6 +224,10 @@ def test_dealer_rejection_with_skip_intent_sets_step_result_skip(monkeypatch) ->
         "mantis_agent.gym.step_handlers.claude_step.time.sleep",
         lambda *_: None,
     )
+    monkeypatch.setattr(
+        "mantis_agent.gym._runner_helpers.adaptive_content_settle",
+        lambda *a, **kw: 0.0,
+    )
     schema = ExtractionSchema(
         spam_label="dealer",
         rejection_intents={"dealer": "skip"},
@@ -248,6 +252,10 @@ def test_dealer_rejection_without_recipe_intent_does_not_skip(monkeypatch) -> No
         "mantis_agent.gym.step_handlers.claude_step.time.sleep",
         lambda *_: None,
     )
+    monkeypatch.setattr(
+        "mantis_agent.gym._runner_helpers.adaptive_content_settle",
+        lambda *a, **kw: 0.0,
+    )
     schema = ExtractionSchema(spam_label="dealer")  # no rejection_intents
     handler, step, ctx = _build_step_handler_ctx(
         recipe_schema=schema, dealer=True, missing=False,
@@ -266,6 +274,10 @@ def test_incomplete_rejection_with_extract_more_intent_does_not_skip(monkeypatch
     monkeypatch.setattr(
         "mantis_agent.gym.step_handlers.claude_step.time.sleep",
         lambda *_: None,
+    )
+    monkeypatch.setattr(
+        "mantis_agent.gym._runner_helpers.adaptive_content_settle",
+        lambda *a, **kw: 0.0,
     )
     schema = ExtractionSchema(
         required_fields=["year", "make"],
@@ -293,6 +305,10 @@ def test_incomplete_rejection_with_skip_intent_does_skip(monkeypatch) -> None:
     monkeypatch.setattr(
         "mantis_agent.gym.step_handlers.claude_step.time.sleep",
         lambda *_: None,
+    )
+    monkeypatch.setattr(
+        "mantis_agent.gym._runner_helpers.adaptive_content_settle",
+        lambda *a, **kw: 0.0,
     )
     schema = ExtractionSchema(
         required_fields=["year", "make"],


### PR DESCRIPTION
Closes #259. Replaces four fixed-duration \`time.sleep()\` calls in \`_extract_listing_data_deep\` (claude_step.py) with pixel-diff-based adaptive settling.

## Why

\`_extract_listing_data_deep\` carries ~10–15s of fixed-duration sleeps per detail-page extraction — each set to the *worst-case* observed pattern on JS-heavy / XHR-backed pages. That guarantees correctness but pays the worst-case cost on every page, including static ones where the page settles in <300ms.

The submit handler already does adaptive settling via \`_adaptive_submit_settle\` (polls URL change, exits early). The deep-extract path predates that pattern and was never migrated.

## Change

**Two helpers** in \`_runner_helpers.py\` (symmetric to \`adaptive_submit_settle\`):

- \`screenshot_pixel_diff_fraction(a, b)\` — cheap downsample-and-compare (64×64 grayscale, brightness threshold). Returns 0–1 fraction of changed pixels. Conservative 1.0 on any failure case so callers keep polling.
- \`adaptive_content_settle(env, min_seconds, max_seconds, poll_seconds, diff_threshold)\` — bounded poll, exits when two consecutive screenshots differ by < threshold. Returns actual elapsed for telemetry. \`env.screenshot()\` exceptions fall through to fixed-sleep equivalent (better to over-pay than to halt).

**Wired into the four sleep sites** in \`_extract_listing_data_deep\`:

| Site | Old | New (min / max) | Typical static-page exit |
|---|---|---|---|
| Pre-settle | 1.0s | 0.2 / 1.0 | ~0.3s |
| Home key settle | 1.5s | 0.3 / 1.5 | ~0.5s |
| Reveal-click settle | 2.0s × N | 0.5 / 2.0 × N | ~0.6s (or full on XHR-backed) |
| Page_Down settle | 1.0s × 5 | 0.2 / 1.0 × 5 | ~0.3s × 5 |

**Estimated impact:** ~5s saved per static-page extraction (~50% of the sleep budget). JS-heavy pages pay the same as before — settle hits \`max_seconds\`.

## Non-regressive by construction

- \`max_seconds\` caps preserve the original behavior — pages that genuinely need the full duration still get it
- Pixel-diff threshold is intentionally generous (2% of downsampled pixels) so animation tails / cursor blinks don't extend the settle
- \`env.screenshot()\` exceptions fall through to fixed-sleep equivalent

## Test plan

- [x] \`tests/test_adaptive_content_settle.py\` — 13 new tests: pixel-diff (identical / different / size mismatch / bad input), settle behavior (stable / changing / settling pages, min floor, max cap, screenshot exception, telemetry, argument validation)
- [x] Existing fixtures updated (\`test_claude_step_handler.py\`, \`test_rejection_skip_intent.py\`, \`test_already_seen_url_skip_envelope.py\`) to mock \`adaptive_content_settle\` as a no-op (same pattern as existing \`_adaptive_submit_settle\` mocking)
- [x] 76 related tests pass in 3s (down from 27s with the wall-clock issue) + 149 broader tests pass
- [x] Ruff clean
- [x] Docs-isolation guard clean
- [ ] Production validation on the next BoatTrader plan run — expect per-extraction wall time to drop ~3–5s on static detail pages with no behavior regression on JS-heavy ones

## Adjacent

- #252 (specialized grounder VLM) — the durable cost-cut for the Claude API latency that *also* lives in this path (6 per-viewport vision calls + 1 multi-extract). Adaptive settle is the in-band fix; #252 is the structural one.
- \`adaptive_submit_settle\` (\`_runner_helpers.py:147\`) — the existing pattern this PR mirrors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)