### PR TITLE
feat(api): add /v1/cua route — Mantis as Holo3 pass-through

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -12,6 +12,7 @@ and the [any-agent integration playbook](integrations/any-agent.md).
 |---|---|---|
 | `POST /v1/predict` | `X-Mantis-Token` (run scope) | Run a plan, poll status, fetch result. The high-level orchestrator. |
 | `POST /predict` | `X-Mantis-Token` (run scope) | Backwards-compat alias for `/v1/predict`. Identical behavior. |
+| `POST /v1/cua` | `X-Mantis-Token` (run scope) | Pure CUA pass-through — Mantis as a thin Holo3 driver. No decomposition, no Claude. See [Pure CUA mode](client/pure-cua.md). |
 | `POST /v1/chat/completions` | `X-Mantis-Token` (run scope) | OpenAI-compat reverse proxy to in-pod Holo3 (raw inference). |
 | `GET /v1/models` | open | OpenAI-compat model list. Returns `holo3`. |
 | `GET /v1/health`, `GET /health` | open | Liveness/readiness probe. |

--- a/docs/client/index.md
+++ b/docs/client/index.md
@@ -6,6 +6,7 @@ For applications calling a hosted Mantis instance.
 |---|---|
 | [Authentication](auth.md) | Getting a token, request headers, scope, error responses |
 | [Sending plans](plans.md) | Request body shape for each plan format, run options, caps |
+| [Pure CUA mode](pure-cua.md) | Holo3 pass-through via `/v1/cua` — no decomposition, no Claude |
 | [Runs and polling](runs-and-polling.md) | Detached runs, status/result/logs/cancel actions, idempotency, webhooks |
 | [Recordings](recordings.md) | Requesting screencasts, downloading polished or raw, action overlays |
 | [Errors](errors.md) | Error codes, retry guidance, debugging |

--- a/docs/client/pure-cua.md
+++ b/docs/client/pure-cua.md
@@ -1,0 +1,189 @@
+# Pure CUA mode (`/v1/cua`)
+
+Use this when you want Mantis to be a **thin pass-through for Holo3** —
+no plan decomposition, no Claude grounding, no Claude extraction. The
+instruction is handed verbatim to the brain, which drives the headed
+browser inside the deployment via xdotool.
+
+If you've used `/v1/predict`, the mental model is: same auth, same
+tenant caps, same allowlist, same rate limit / concurrency / recording
+plumbing — but the inside of the container is a single
+`brain ↔ XdotoolGymEnv` loop instead of the orchestrated
+`MicroPlanRunner`.
+
+## When to use it
+
+| Pick `/v1/cua` when… | Pick `/v1/predict` when… |
+|---|---|
+| You want to benchmark Holo3's intrinsic plan-following | You want reliable multi-step extraction with verification |
+| You're integrating Mantis as a "Holo3-on-Modal" backend for an existing CUA harness | You're building an end-to-end extraction pipeline |
+| You don't have an Anthropic key on the deployment | You want Claude-quality grounding on small click targets |
+| You want zero Claude spend per run | You're OK with ~$0.005/click for grounding accuracy |
+
+The tradeoff: without `ClaudeGrounding`, click coordinates come straight
+from Holo3's smart-resize model space (converted to screen pixels in
+`brain_holo3._model_coords_to_screen`). On small targets accuracy drops
+versus the grounded path. That's the whole point of "pure CUA" — you're
+measuring what the brain can do unassisted.
+
+## Action surface
+
+What the brain can emit, all executed by xdotool against the headed
+Chrome inside Xvfb:
+
+| Verb | Args | Effect |
+|---|---|---|
+| `click` | `x`, `y` | Single click at screen pixel `(x, y)` |
+| `double_click` | `x`, `y` | Double-click |
+| `type_text` | `text` | Type into the focused element |
+| `key_press` | `key` | Single key or chord (e.g. `"ctrl+a"`, `"enter"`) |
+| `scroll` | direction, amount | Scroll the viewport |
+| `drag` | `start_x`, `start_y`, `end_x`, `end_y` | Drag from start to end |
+| `wait` | `seconds` | Sleep — useful for slow page transitions |
+| `done` | `success`, `summary` | Terminate the loop |
+
+Parsing supports five fallback strategies — OpenAI tool_calls, Holo3
+native `Action: name({...})` text, JSON action blob, pyautogui-style
+calls, and bare keywords (`DONE` / `FAIL`). You don't configure this;
+the brain handles it.
+
+## Request
+
+```bash
+curl -X POST "$ENDPOINT/v1/cua" \
+  -H "X-Mantis-Token: $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "instruction": "Find tomorrow’s music events on lu.ma and click the first one",
+    "start_url": "https://lu.ma/discover",
+    "max_steps": 25,
+    "settle_time": 4.0
+  }'
+```
+
+### Body fields
+
+| Field | Default | Effect |
+|---|---|---|
+| `instruction` | — *(required)* | Free-text instruction handed verbatim to the brain |
+| `start_url` | `""` | Initial URL the browser navigates to before the first inference |
+| `max_steps` | `30` | Cap on brain↔env iterations; server-clamped to `MANTIS_MAX_STEPS_PER_PLAN` |
+| `frames_per_inference` | `1` | Screenshots fed to the brain per step. Holo3 wants 1 |
+| `settle_time` | `2.0` | Seconds to wait after each action before re-screenshotting |
+| `detached` | `false` | Queue as background; return `run_id` to poll via `/v1/predict` actions |
+| `state_key` | unset | Reuses the Chrome profile + tenant dir tied to this key |
+| `max_cost` | `25.0` | USD cap (mostly informational — pure CUA spends nothing on Claude) |
+| `max_time_minutes` | `60` | Wall-clock cap; clamped against tenant cap |
+| `proxy_city` / `proxy_state` | unset | Geo override (allowlist-gated) |
+| `proxy_disabled` | `false` | Skip the residential proxy entirely |
+| `record_video` | `false` | Capture screencast; fetch via `GET /v1/runs/{run_id}/video` |
+| `video_format` | `"mp4"` | One of `mp4`, `webm`, `gif` |
+| `video_fps` | `5` | Capture rate `[1, 30]` |
+
+### Sync response
+
+```jsonc
+{
+  "run_id": "20260511_143215",
+  "mode": "pure_cua",
+  "provider": "baseten",
+  "session_name": "pure_cua",
+  "model": "holo3",
+  "instruction": "Find tomorrow's music events on lu.ma…",
+  "start_url": "https://lu.ma/discover",
+  "success": true,
+  "termination_reason": "done",         // or "max_steps" / "loop" / "env_done"
+  "steps": 18,
+  "duration_s": 142,
+  "elapsed_seconds": 142.36,
+  "trajectory_len": 18
+}
+```
+
+### Detached response
+
+When `"detached": true`, the response matches `/v1/predict`'s detached
+shape — a `queued` envelope with `status_path` / `result_path` /
+`events_path` pointers. Poll via the standard polling actions on
+`/v1/predict`:
+
+```bash
+curl -X POST "$ENDPOINT/v1/predict" \
+  -H "X-Mantis-Token: $TOKEN" \
+  -d '{"action": "status", "run_id": "<run_id>"}'
+```
+
+The result JSON written to disk has the same shape as the sync
+response above.
+
+## CLI
+
+The `mantis cua run` subcommand is a thin HTTP shim — no local browser,
+no Anthropic key, no Playwright. It just POSTs to `/v1/cua`:
+
+```bash
+export MANTIS_ENDPOINT="https://workspace--app-fn.modal.run"
+export MANTIS_TOKEN="<tenant_token>"
+
+mantis cua run "Find tomorrow's music events on lu.ma and click the first one" \
+  --start-url https://lu.ma/discover \
+  --max-steps 25 \
+  --settle-time 4.0
+```
+
+Useful flags:
+
+| Flag | Purpose |
+|---|---|
+| `--endpoint` | Mantis deployment base URL (overrides `MANTIS_ENDPOINT`) |
+| `--token` | Per-tenant token (overrides `MANTIS_TOKEN`) |
+| `--header KEY=VALUE` | Add HTTP header (e.g. `Authorization=Api-Key …` on Baseten) |
+| `--start-url` | Initial URL for the browser |
+| `--max-steps` | Cap on the CUA loop |
+| `--settle-time` | Seconds to wait after each action |
+| `--state-key` | Namespace Chrome profile + checkpoint dir |
+| `--detached` | Queue as background; print `run_id` and exit |
+| `--proxy-disabled` | Skip the residential proxy |
+| `--record-video` | Capture screencast |
+| `--json` | Print the raw response JSON instead of a summary |
+
+Exit code is `0` on `success=true`, `1` otherwise. Same as `mantis plan run`.
+
+## How this differs from `/v1/predict` under the hood
+
+```
+/v1/predict   →   _task_suite_from_payload   →   MicroPlanRunner
+                                                    ├── ClaudeExtractor    (extract / verify)
+                                                    ├── ClaudeGrounding    (refine click coords)
+                                                    └── Holo3Brain         (tactical actions)
+                                                          └── GymRunner ↔ XdotoolGymEnv
+
+/v1/cua       →   _run_pure_cua              →   GymRunner
+                                                    └── Holo3Brain         (all actions)
+                                                          └── XdotoolGymEnv
+```
+
+Concretely: `_run_pure_cua` instantiates `GymRunner(brain=self.brain,
+grounding=None)` and calls `runner.run(task=<instruction>)`. There is
+no extractor, no decomposer, no per-step verification. Whatever the
+brain emits, xdotool executes.
+
+## What you give up
+
+- **No structured extraction.** The response is `success` /
+  `steps` / `duration_s` / `termination_reason` — there's no `leads`
+  array, no extracted data. The brain ends by emitting `done` with a
+  free-text summary; if you need structured data, parse the trajectory
+  events or use `/v1/predict` with an `extraction_schema`.
+- **No grounding correction.** Holo3 occasionally picks coordinates a
+  few pixels off the target. `/v1/predict` recovers via Claude; `/v1/cua`
+  doesn't.
+- **No section / gate / loop semantics.** It's one open-ended loop until
+  `done` or `max_steps`.
+- **No skip envelope.** The `skip` / `skip_reason` fields documented in
+  [Sending plans](plans.md) are produced by `MicroPlanRunner`. They
+  don't appear on `/v1/cua` responses.
+
+If any of those are dealbreakers, you want `/v1/predict`. If they're
+fine, `/v1/cua` is the cheapest, simplest way to drive Holo3 on Modal /
+Baseten.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -683,6 +683,7 @@ the allowlist for that tenant. Always include both `example.com` and
 
 | Path                          | Auth                  | Purpose                                                                      |
 |-------------------------------|-----------------------|------------------------------------------------------------------------------|
+| `POST /v1/cua`                | `X-Mantis-Token`      | **Pure CUA pass-through.** Mantis as a thin Holo3 driver — no decomposition, no Claude. See §9a. |
 | `POST /v1/chat/completions`   | `X-Mantis-Token`      | OpenAI-compat reverse proxy to in-pod Holo3. Raw inference, no orchestration.|
 | `GET /v1/models`              | open                  | Returns `{ "data": [{"id": "holo3", ...}] }`                                 |
 | `GET /v1/health`, `GET /health` | open                | Liveness probe. Returns `{ "ok": true, "model": "holo3" }`                   |
@@ -693,6 +694,105 @@ For raw Holo3 inference (no plan orchestration), `POST /v1/chat/completions`
 is OpenAI-compatible — useful for clients that want to run their own
 perception-action loop and use Holo3 as the brain.
 
+### 9a. `POST /v1/cua` — Holo3 pass-through (Mantis as a thin CUA driver)
+
+When you want Holo3 to drive the browser directly with **zero Claude
+spend** and **no decomposition** — Mantis becomes a hosted brain ↔
+xdotool loop. Useful for benchmarks measuring intrinsic plan-following,
+or for plugging Mantis into an external CUA harness that already owns
+its own planner.
+
+```
+/v1/predict  →  MicroPlanRunner  →  ClaudeExtractor + ClaudeGrounding + Holo3Brain  →  GymRunner
+/v1/cua      →  _run_pure_cua    →                                       Holo3Brain  →  GymRunner
+```
+
+Concretely: `grounding=None` and `extractor=None` are passed into
+`GymRunner`, so click coords come straight out of Holo3's smart-resize
+space (mapped to screen pixels in `brain_holo3._model_coords_to_screen`).
+No Claude calls anywhere in the path.
+
+**Action surface available to the brain** (executed by xdotool against
+the headed Chrome inside Xvfb):
+
+```
+click(x, y) · double_click(x, y) · type_text(text) · key_press(key)
+· scroll(direction, amount) · drag(start_x, start_y, end_x, end_y)
+· wait(seconds) · done(success, summary)
+```
+
+**Request:**
+
+```bash
+curl -X POST "$ENDPOINT/v1/cua" \
+  -H "X-Mantis-Token: $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "instruction": "Find tomorrow’s music events on lu.ma and click the first one",
+    "start_url": "https://lu.ma/discover",
+    "max_steps": 25,
+    "settle_time": 4.0
+  }'
+```
+
+**Body fields:**
+
+| Field | Default | Effect |
+|---|---|---|
+| `instruction` | — *(required)* | Free-text instruction handed verbatim to the brain |
+| `start_url` | `""` | Initial URL the browser navigates to before the first inference |
+| `max_steps` | `30` | Cap on brain↔env iterations; clamped to `MANTIS_MAX_STEPS_PER_PLAN` |
+| `frames_per_inference` | `1` | Screenshots per step (Holo3 wants 1) |
+| `settle_time` | `2.0` | Seconds to wait after each action |
+| `detached` | `false` | Queue as background; return `run_id` to poll via `/v1/predict` actions |
+| `state_key` | unset | Reuses Chrome profile + tenant dir tied to this key |
+| `max_cost` / `max_time_minutes` | tenant caps | Same clamping as `/v1/predict` |
+| `proxy_city` / `proxy_state` / `proxy_disabled` | unset / unset / `false` | Same proxy controls as `/v1/predict` |
+| `record_video` / `video_format` / `video_fps` | `false` / `mp4` / `5` | Same screencast controls as `/v1/predict` |
+
+**Sync response:**
+
+```jsonc
+{
+  "run_id": "20260511_143215",
+  "mode": "pure_cua",
+  "model": "holo3",
+  "instruction": "Find tomorrow's music events on lu.ma…",
+  "start_url": "https://lu.ma/discover",
+  "success": true,
+  "termination_reason": "done",     // or "max_steps" / "loop" / "env_done"
+  "steps": 18,
+  "duration_s": 142,
+  "trajectory_len": 18
+}
+```
+
+**Detached:** same `queued` envelope as `/v1/predict` detached mode;
+poll via `POST /v1/predict {"action": "status", "run_id": "..."}`.
+
+**Tradeoffs to know:**
+
+- No structured-extraction output — no `leads` array, no skip envelope.
+  If you need data rows, use `/v1/predict` with an `extraction_schema`.
+- No grounding correction. Holo3's coords sometimes land a few pixels
+  off small targets; `/v1/cua` won't recover, `/v1/predict` will.
+- No section / gate / loop semantics. One open-ended loop until `done`
+  or `max_steps`.
+
+**CLI shim:**
+
+```bash
+mantis cua run "Find tomorrow's music events on lu.ma and click the first one" \
+  --endpoint https://workspace--app-fn.modal.run \
+  --token   "$MANTIS_TOKEN" \
+  --start-url https://lu.ma/discover \
+  --max-steps 25 \
+  --settle-time 4.0
+```
+
+Exit code 0 on `success=true`, 1 otherwise. `--json` prints the raw
+response. `--detached` queues and returns immediately.
+
 ---
 
 ## 10. Pointers (for deeper reading)
@@ -702,6 +802,7 @@ perception-action loop and use Holo3 as the brain.
 - [docs/operations/tenant-keys.md](operations/tenant-keys.md) — issuing / rotating / revoking tokens
 - [docs/operations/allowlist.md](operations/allowlist.md) — `allowed_domains` enforcement detail
 - [docs/client/auth.md](client/auth.md) — caller-side auth setup
+- [docs/client/pure-cua.md](client/pure-cua.md) — Pure CUA mode / Holo3 pass-through deep-dive (§9a)
 - [docs/integrations/embedding-microplanrunner.md](integrations/embedding-microplanrunner.md) — library-shaped integration (driving `MicroPlanRunner` in your own process)
 - [docs/architecture.md](architecture.md) — internals and data flow
 - [src/mantis_agent/api_schemas.py](../src/mantis_agent/api_schemas.py) — authoritative pydantic schemas for the request body

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -105,6 +105,7 @@ nav:
       - client/index.md
       - Authentication: client/auth.md
       - Sending plans: client/plans.md
+      - Pure CUA mode: client/pure-cua.md
       - Runs and polling: client/runs-and-polling.md
       - Recordings: client/recordings.md
       - Errors: client/errors.md

--- a/src/mantis_agent/api_schemas.py
+++ b/src/mantis_agent/api_schemas.py
@@ -147,6 +147,58 @@ class PredictRequest(BaseModel):
         return self
 
 
+class PureCUARequest(BaseModel):
+    """``POST /v1/cua`` — pure CUA loop: brain ↔ XdotoolGymEnv, no Claude.
+
+    Bypasses ``PlanDecomposer``, ``ClaudeGrounding`` and ``ClaudeExtractor``
+    entirely. The configured brain (Holo3 / Gemma4) emits screen-space
+    actions (``click`` / ``double_click`` / ``type_text`` / ``key_press`` /
+    ``scroll`` / ``drag`` / ``wait`` / ``done``) which the gym env executes
+    directly via xdotool against the headed Chrome inside Xvfb.
+
+    Use when you want to measure the brain's intrinsic plan-following and
+    grounding accuracy on a single instruction, with zero Claude assist.
+    """
+
+    model_config = {"extra": "allow"}
+
+    # Single free-text instruction handed verbatim to the brain.
+    instruction: str = Field(..., min_length=1)
+
+    # Browser bootstrap.
+    start_url: str = ""
+    settle_time: float = Field(default=2.0, ge=0.0, le=30.0)
+
+    # GymRunner knobs.
+    max_steps: int = Field(default=30, ge=1, le=MAX_STEPS_PER_PLAN)
+    frames_per_inference: int = Field(default=1, ge=1, le=8)
+
+    # Run options (mirrors PredictRequest shape so tenant caps clamp the
+    # same way).
+    detached: bool = False
+    state_key: Optional[str] = None
+    max_cost: float = Field(default=MAX_COST_USD, gt=0)
+    max_time_minutes: int = Field(default=MAX_RUNTIME_MINUTES, gt=0)
+
+    # Proxy controls.
+    proxy_city: Optional[str] = None
+    proxy_state: Optional[str] = None
+    proxy_disabled: bool = False
+
+    # Screencast.
+    record_video: bool = False
+    video_format: Literal["mp4", "webm", "gif"] = "mp4"
+    video_fps: int = Field(default=5, ge=1, le=30)
+
+    @model_validator(mode="after")
+    def _clamp_caps(self) -> "PureCUARequest":
+        if self.max_cost > MAX_COST_USD:
+            self.max_cost = MAX_COST_USD
+        if self.max_time_minutes > MAX_RUNTIME_MINUTES:
+            self.max_time_minutes = MAX_RUNTIME_MINUTES
+        return self
+
+
 def validate_micro_steps(steps: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Validate a parsed micro-plan against MAX_STEPS / MAX_LOOP_ITERATIONS.
 

--- a/src/mantis_agent/baseten_server/routes.py
+++ b/src/mantis_agent/baseten_server/routes.py
@@ -45,6 +45,7 @@ from ..api_schemas import (
     MAX_COST_USD,
     MAX_RUNTIME_MINUTES,
     PredictRequest,
+    PureCUARequest,
     assert_hosts_allowed,
     extract_navigate_hosts,
 )
@@ -536,3 +537,137 @@ async def predict(
     Identical behavior to /v1/predict, including the ``run`` scope check.
     """
     return await _handle_predict(request, tenant)
+
+
+@app.post("/v1/cua")
+async def cua_v1(
+    request: Request,
+    tenant: TenantConfig = Depends(_require_run_scope),
+) -> dict[str, Any]:
+    """Pure CUA loop — brain ↔ XdotoolGymEnv only, no Claude.
+
+    Mantis is a pure pass-through for the configured brain (Holo3):
+
+    * No ``PlanDecomposer`` — the instruction is handed verbatim.
+    * No ``ClaudeGrounding`` — click coords come straight from the brain.
+    * No ``ClaudeExtractor`` — no post-step verification.
+
+    Action surface available to the brain (executed by xdotool against
+    the headed Chrome inside Xvfb): ``click``, ``double_click``,
+    ``type_text``, ``key_press``, ``scroll``, ``drag``, ``wait``,
+    ``done``. Same per-tenant auth / cap / allowlist / rate-limit /
+    concurrency / webhook plumbing as ``/v1/predict``.
+    """
+    try:
+        raw = await request.json()
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail="request body must be JSON") from exc
+    if not isinstance(raw, dict):
+        raise HTTPException(status_code=400, detail="request body must be a JSON object")
+
+    try:
+        req = PureCUARequest.model_validate(raw)
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail=f"invalid request: {exc}") from exc
+
+    payload = req.model_dump(exclude_none=True)
+    payload["max_cost"] = min(
+        float(payload.get("max_cost", MAX_COST_USD)),
+        tenant.max_cost_per_run,
+    )
+    payload["max_time_minutes"] = min(
+        int(payload.get("max_time_minutes", MAX_RUNTIME_MINUTES)),
+        tenant.max_time_minutes_per_run,
+    )
+    payload["state_key"] = _tenant_state_key(tenant, payload.get("state_key"))
+
+    os.environ["ANTHROPIC_API_KEY"] = _resolve_anthropic_key(tenant)
+    os.environ["MANTIS_TENANT_ID"] = tenant.tenant_id
+    profile_dir = _tenant_chrome_profile(tenant, payload["state_key"])
+    os.environ["MANTIS_CHROME_PROFILE_DIR"] = str(profile_dir)
+
+    # URL allowlist: enforce on start_url + any URL embedded in the
+    # instruction. Mirrors /predict's per-tenant gate.
+    if tenant.allowed_domains:
+        plan_obj = {
+            "base_url": payload.get("start_url", ""),
+            "tasks": [{"intent": payload["instruction"]}],
+        }
+        try:
+            hosts = extract_navigate_hosts(plan_obj)
+            assert_hosts_allowed(hosts, tenant.is_domain_allowed)
+        except PermissionError as exc:
+            mantis_metrics.PREDICT_REQUESTS.labels(
+                tenant_id=tenant.tenant_id, mode="cua", outcome="denied_allowlist"
+            ).inc()
+            raise HTTPException(status_code=403, detail=str(exc)) from exc
+
+    # Rate limit + concurrency — same plumbing as /predict run mode.
+    limiter = get_rate_limiter()
+    rate_decision = limiter.try_consume_rate_token(
+        tenant.tenant_id, tenant.rate_limit_per_minute
+    )
+    if not rate_decision.allowed:
+        mantis_metrics.RATE_LIMIT_REJECTIONS.labels(
+            tenant_id=tenant.tenant_id, kind="rate"
+        ).inc()
+        mantis_metrics.PREDICT_REQUESTS.labels(
+            tenant_id=tenant.tenant_id, mode="cua", outcome="rate_limited"
+        ).inc()
+        raise HTTPException(
+            status_code=429,
+            detail=rate_decision.reason,
+            headers={"Retry-After": str(int(rate_decision.retry_after_seconds) + 1)},
+        )
+
+    decision = limiter.try_acquire_concurrency_slot(
+        tenant.tenant_id, tenant.max_concurrent_runs
+    )
+    if not decision.allowed:
+        mantis_metrics.RATE_LIMIT_REJECTIONS.labels(
+            tenant_id=tenant.tenant_id, kind="concurrent"
+        ).inc()
+        mantis_metrics.PREDICT_REQUESTS.labels(
+            tenant_id=tenant.tenant_id, mode="cua", outcome="rate_limited"
+        ).inc()
+        raise HTTPException(
+            status_code=429,
+            detail=decision.reason,
+            headers={"Retry-After": str(int(decision.retry_after_seconds) + 1)},
+        )
+    mantis_metrics.CONCURRENT_RUNS.labels(tenant_id=tenant.tenant_id).set(
+        decision.concurrent
+    )
+
+    logger.info(
+        "cua tenant=%s state_key=%s detached=%s start_url=%s",
+        tenant.tenant_id,
+        payload["state_key"],
+        payload.get("detached", False),
+        payload.get("start_url", ""),
+    )
+
+    try:
+        response = await run_in_threadpool(runtime.run_pure_cua, payload)
+        mantis_metrics.PREDICT_REQUESTS.labels(
+            tenant_id=tenant.tenant_id, mode="cua", outcome="ok"
+        ).inc()
+        return response
+    except ValueError as exc:
+        mantis_metrics.PREDICT_REQUESTS.labels(
+            tenant_id=tenant.tenant_id, mode="cua", outcome="bad_request"
+        ).inc()
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except HTTPException:
+        raise
+    except Exception as exc:
+        mantis_metrics.PREDICT_REQUESTS.labels(
+            tenant_id=tenant.tenant_id, mode="cua", outcome="error"
+        ).inc()
+        logger.exception("cua failed tenant=%s", tenant.tenant_id)
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+    finally:
+        limiter.release_concurrency_slot(tenant.tenant_id)
+        mantis_metrics.CONCURRENT_RUNS.labels(tenant_id=tenant.tenant_id).set(
+            limiter.get_concurrent(tenant.tenant_id)
+        )

--- a/src/mantis_agent/baseten_server/runtime.py
+++ b/src/mantis_agent/baseten_server/runtime.py
@@ -349,11 +349,14 @@ class BasetenCUARuntime:
             with self.lock:
                 self._append_detached_event(run_id, "running")
                 self._write_detached_status(run_id, {"status": "running", "started_at": _utc_now()})
-                task_suite = self._task_suite_from_payload(payload)
-                if task_suite.get("_micro_plan"):
-                    result = self._run_micro(task_suite, payload, run_id=run_id)
+                if payload.get("_mode") == "pure_cua":
+                    result = self._run_pure_cua(payload, run_id=run_id)
                 else:
-                    result = self._run_tasks(task_suite, payload, run_id=run_id)
+                    task_suite = self._task_suite_from_payload(payload)
+                    if task_suite.get("_micro_plan"):
+                        result = self._run_micro(task_suite, payload, run_id=run_id)
+                    else:
+                        result = self._run_tasks(task_suite, payload, run_id=run_id)
                 self._save_detached_result(run_id, result)
                 self._write_detached_status(
                     run_id,
@@ -1043,6 +1046,102 @@ class BasetenCUARuntime:
                     recorder.stop()
                 except Exception:
                     logger.exception("recorder stop in finally failed")
+
+    def run_pure_cua(self, payload: dict[str, Any]) -> dict[str, Any]:
+        """Entrypoint for ``POST /v1/cua``.
+
+        Pure CUA loop: the configured brain (Holo3 / Gemma4) drives
+        :class:`GymRunner` against ``XdotoolGymEnv`` directly. No
+        ``PlanDecomposer``, no ``ClaudeGrounding``, no ``ClaudeExtractor``
+        — every action the brain emits (click / type_text / scroll /
+        drag / key_press / wait / done) is executed verbatim by xdotool.
+
+        Detached mode reuses the standard worker pool; the dispatch in
+        :meth:`_run_detached_worker` branches on ``_mode == 'pure_cua'``
+        and re-enters :meth:`_run_pure_cua` from inside the worker.
+        """
+        self.load()
+        payload = {**payload, "_mode": "pure_cua"}
+        if payload.get("detached"):
+            return self._start_detached(payload)
+        with self.lock:
+            return self._run_pure_cua(payload)
+
+    def _run_pure_cua(
+        self,
+        payload: dict[str, Any],
+        run_id: str | None = None,
+    ) -> dict[str, Any]:
+        from mantis_agent.gym.runner import GymRunner
+
+        run_id = run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+        t0 = time.time()
+        instruction = str(payload.get("instruction") or "").strip()
+        if not instruction:
+            raise ValueError("instruction is required")
+        start_url = str(payload.get("start_url") or "")
+        max_steps = int(payload.get("max_steps", 30))
+        frames = int(payload.get("frames_per_inference", 1))
+        settle_time = float(payload.get("settle_time", 4.0 if self.model_kind == "holo3" else 2.0))
+
+        # _make_env reads proxy + base_url off a task_suite-shaped dict;
+        # build a minimal one here rather than threading a separate path.
+        session_name = "pure_cua"
+        task_suite: dict[str, Any] = {
+            "session_name": session_name,
+            "base_url": start_url,
+            "_proxy_city": payload.get("proxy_city") or "",
+            "_proxy_state": payload.get("proxy_state") or "",
+            "_proxy_disabled": bool(payload.get("proxy_disabled", False)),
+        }
+        env, proxy_proc = self._make_env(task_suite, run_id, settle_time=settle_time)
+        recorder, click_log = self._maybe_record(payload, run_id)
+        if click_log is not None:
+            from mantis_agent.presentation import ClickRecordingEnv
+            env = ClickRecordingEnv(env, click_log)
+
+        try:
+            runner = GymRunner(
+                brain=self.brain,
+                env=env,
+                max_steps=max_steps,
+                frames_per_inference=frames,
+                grounding=None,  # pure CUA: no Claude grounding
+            )
+            gym_result = runner.run(
+                task=instruction,
+                task_id="cua",
+                start_url=start_url,
+            )
+            elapsed = time.time() - t0
+            trajectory = list(getattr(gym_result, "trajectory", []) or [])
+            result: dict[str, Any] = {
+                "run_id": run_id,
+                "mode": "pure_cua",
+                "provider": "baseten",
+                "session_name": session_name,
+                "model": self.model_kind,
+                "instruction": instruction,
+                "start_url": start_url,
+                "success": bool(gym_result.success),
+                "termination_reason": getattr(gym_result, "termination_reason", ""),
+                "steps": int(gym_result.total_steps),
+                "duration_s": round(elapsed),
+                "elapsed_seconds": elapsed,
+                "trajectory_len": len(trajectory),
+            }
+            self._attach_recording_metadata(result, recorder, click_log=click_log)
+            self._save_result(result, prefix="pure_cua")
+            return result
+        finally:
+            if recorder is not None and getattr(recorder, "result", None) is None:
+                try:
+                    recorder.stop()
+                except Exception:
+                    logger.exception("recorder stop in finally failed")
+            env.close()
+            if proxy_proc:
+                proxy_proc.terminate()
 
     def _save_result(self, result: dict[str, Any], prefix: str) -> None:
         save_result_json(result, _data_root() / "results", prefix)

--- a/src/mantis_agent/cli.py
+++ b/src/mantis_agent/cli.py
@@ -1060,6 +1060,121 @@ def cmd_plan_run_modal(args: argparse.Namespace) -> int:
     return EXIT_OK if failures == 0 else EXIT_ERROR
 
 
+def cmd_cua_run(args: argparse.Namespace) -> int:
+    """``mantis cua run`` — pure CUA pass-through to ``POST /v1/cua``.
+
+    No decomposition, no Claude grounding, no Claude extraction. The
+    instruction is handed verbatim to the brain (Holo3) running on the
+    Mantis deployment, which drives ``XdotoolGymEnv`` directly via the
+    Holo3 action surface (click / type_text / scroll / drag / key_press /
+    wait / done).
+
+    Unlike ``mantis plan run``, this subcommand does NOT pull in
+    Playwright, Anthropic, or any local brain — it's a thin HTTP shim.
+    The server-side ``/v1/cua`` route owns the env + brain + runner.
+
+    Exits 0 on ``success=true`` in the response, 1 otherwise.
+    """
+    import os
+
+    import requests
+
+    endpoint = (args.endpoint or os.environ.get("MANTIS_ENDPOINT", "")).rstrip("/")
+    if not endpoint:
+        print(
+            "error: --endpoint is required (or set MANTIS_ENDPOINT). "
+            "Pass the deployment base URL, e.g. "
+            "https://workspace--app-fn.modal.run",
+            file=sys.stderr,
+        )
+        return EXIT_ERROR
+    # Strip a trailing ``/v1`` if a user pasted the OpenAI-style base.
+    if endpoint.endswith("/v1"):
+        endpoint = endpoint[: -len("/v1")]
+    url = f"{endpoint}/v1/cua"
+
+    token = args.token or os.environ.get("MANTIS_TOKEN", "")
+    if not token:
+        print(
+            "error: --token is required (or set MANTIS_TOKEN). "
+            "This is the per-tenant Mantis token (X-Mantis-Token).",
+            file=sys.stderr,
+        )
+        return EXIT_ERROR
+
+    try:
+        extra_headers = _parse_extra_headers(args.header)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return EXIT_ERROR
+
+    body: dict[str, Any] = {
+        "instruction": args.instruction,
+        "start_url": args.start_url or "",
+        "max_steps": args.max_steps,
+        "frames_per_inference": args.frames_per_inference,
+        "settle_time": args.settle_time,
+        "detached": args.detached,
+        "proxy_disabled": args.proxy_disabled,
+        "record_video": args.record_video,
+    }
+    if args.state_key:
+        body["state_key"] = args.state_key
+    if args.proxy_city:
+        body["proxy_city"] = args.proxy_city
+    if args.proxy_state:
+        body["proxy_state"] = args.proxy_state
+
+    headers = {
+        "Content-Type": "application/json",
+        "X-Mantis-Token": token,
+        **extra_headers,
+    }
+
+    print(f"POST {url}")
+    print(f"  instruction: {args.instruction[:80]}{'…' if len(args.instruction) > 80 else ''}")
+    if args.start_url:
+        print(f"  start_url:   {args.start_url}")
+    print(f"  max_steps:   {args.max_steps}  detached: {args.detached}")
+
+    try:
+        resp = requests.post(url, json=body, headers=headers, timeout=args.timeout)
+    except requests.RequestException as exc:
+        print(f"error: request failed: {exc}", file=sys.stderr)
+        return EXIT_ERROR
+
+    if resp.status_code >= 400:
+        print(f"error: HTTP {resp.status_code}: {resp.text[:500]}", file=sys.stderr)
+        return EXIT_ERROR
+
+    try:
+        result = resp.json()
+    except ValueError:
+        print(f"error: non-JSON response: {resp.text[:500]}", file=sys.stderr)
+        return EXIT_ERROR
+
+    if args.json:
+        print(json.dumps(result, indent=2))
+        return EXIT_OK if result.get("success") else EXIT_ERROR
+
+    # Detached: surface the run handle the same way /v1/predict does.
+    if result.get("mode") == "detached" or result.get("status") == "queued":
+        print(f"  run_id:      {result.get('run_id', '?')}")
+        print(f"  status:      {result.get('status', 'queued')}")
+        print(f"  status_path: {result.get('status_path', '')}")
+        return EXIT_OK
+
+    success = bool(result.get("success"))
+    print()
+    print("═" * 60)
+    print(f"  {'SUCCESS' if success else 'FAILED'}  steps={result.get('steps', '?')}  "
+          f"duration={result.get('duration_s', '?')}s  "
+          f"termination={result.get('termination_reason', '?')}")
+    print(f"  run_id: {result.get('run_id', '?')}")
+    print("═" * 60)
+    return EXIT_OK if success else EXIT_ERROR
+
+
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="mantis",
@@ -1348,6 +1463,117 @@ def _build_parser() -> argparse.ArgumentParser:
              "Defaults to outputs/run-modal-<unix-timestamp>.",
     )
     run_modal.set_defaults(func=cmd_plan_run_modal)
+
+    # ── cua: pure Holo3 pass-through (no decomposition, no Claude) ──
+    cua = sub.add_parser(
+        "cua",
+        help="Pure CUA pass-through: forward an instruction to /v1/cua "
+             "(brain ↔ XdotoolGymEnv, no Claude).",
+    )
+    cua_sub = cua.add_subparsers(dest="cua_command", required=True)
+
+    cua_run = cua_sub.add_parser(
+        "run",
+        help="POST /v1/cua with a single instruction — Mantis becomes "
+             "a thin pass-through for Holo3.",
+    )
+    cua_run.add_argument(
+        "instruction",
+        help="Natural-language instruction handed verbatim to the brain.",
+    )
+    cua_run.add_argument(
+        "--endpoint",
+        default=None,
+        help="Mantis deployment base URL (e.g. "
+             "https://workspace--app-fn.modal.run). Trailing /v1 is stripped. "
+             "Env: MANTIS_ENDPOINT.",
+    )
+    cua_run.add_argument(
+        "--token",
+        default=None,
+        help="Per-tenant Mantis token (sent as X-Mantis-Token). "
+             "Env: MANTIS_TOKEN.",
+    )
+    cua_run.add_argument(
+        "--header",
+        action="append",
+        default=None,
+        metavar="KEY=VALUE",
+        help="Additional HTTP header. Repeat for multiple.",
+    )
+    cua_run.add_argument(
+        "--start-url",
+        default="",
+        help="Initial URL for the browser inside the deployment.",
+    )
+    cua_run.add_argument(
+        "--max-steps",
+        type=int,
+        default=30,
+        help="Maximum CUA loop steps before forced termination "
+             "(default: 30, server cap: MANTIS_MAX_STEPS_PER_PLAN).",
+    )
+    cua_run.add_argument(
+        "--frames-per-inference",
+        type=int,
+        default=1,
+        help="Frames the brain sees per inference (default: 1 — Holo3 "
+             "uses one screenshot per step).",
+    )
+    cua_run.add_argument(
+        "--settle-time",
+        type=float,
+        default=2.0,
+        help="Seconds to wait after each action before re-screenshotting "
+             "(default: 2.0; bump for slow sites).",
+    )
+    cua_run.add_argument(
+        "--state-key",
+        default=None,
+        help="Optional state key to namespace the Chrome profile / "
+             "checkpoint dir on the deployment.",
+    )
+    cua_run.add_argument(
+        "--detached",
+        action="store_true",
+        help="Queue as a background run and return a run_id immediately. "
+             "Poll via /v1/predict with action=status.",
+    )
+    cua_run.add_argument(
+        "--proxy-city",
+        default=None,
+        help="Override the deployment's default proxy city (allowlist-gated).",
+    )
+    cua_run.add_argument(
+        "--proxy-state",
+        default=None,
+        help="Override the deployment's default proxy state.",
+    )
+    cua_run.add_argument(
+        "--proxy-disabled",
+        action="store_true",
+        help="Skip the upstream proxy entirely (use for test sites that "
+             "don't need bot-detection bypass).",
+    )
+    cua_run.add_argument(
+        "--record-video",
+        action="store_true",
+        help="Record a screencast of the run; fetch via "
+             "GET /v1/runs/{run_id}/video.",
+    )
+    cua_run.add_argument(
+        "--timeout",
+        type=float,
+        default=900.0,
+        help="HTTP timeout for the sync call in seconds (default: 900). "
+             "Ignored when --detached is set.",
+    )
+    cua_run.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit the raw response JSON instead of a human summary.",
+    )
+    cua_run.set_defaults(func=cmd_cua_run)
 
     trace = sub.add_parser("trace", help="Trace tooling subcommands (#155)")
     trace_sub = trace.add_subparsers(dest="trace_command", required=True)

--- a/src/mantis_agent/main.py
+++ b/src/mantis_agent/main.py
@@ -116,7 +116,7 @@ def main() -> None:
     # heavy import. The streaming-agent path below still pulls in
     # transformers / torch / mss / pyautogui — none of those should load
     # when the user runs ``mantis plan validate`` or ``mantis trace label``.
-    if len(sys.argv) >= 2 and sys.argv[1] in {"plan", "trace"}:
+    if len(sys.argv) >= 2 and sys.argv[1] in {"plan", "trace", "cua"}:
         from .cli import main as cli_main
         sys.exit(cli_main(sys.argv[1:]))
 


### PR DESCRIPTION
## Summary

- New **`POST /v1/cua`** endpoint runs a pure CUA loop — `brain ↔ XdotoolGymEnv` only. Bypasses `PlanDecomposer`, `ClaudeGrounding`, and `ClaudeExtractor` so the configured brain (Holo3) drives the headed Chrome via the gym action surface (`click`, `double_click`, `type_text`, `key_press`, `scroll`, `drag`, `wait`, `done`) directly. Mantis becomes a thin Holo3-on-Modal backend for external CUA harnesses, or a benchmark surface for intrinsic plan-following with zero Claude assist.
- **`mantis cua run`** CLI shim — pure HTTP forwarder. No local Playwright / Anthropic / brain imports. Reads `MANTIS_ENDPOINT` / `MANTIS_TOKEN` envs; `--detached`, `--record-video`, `--proxy-disabled`, `--json` all supported.
- Docs: new `docs/client/pure-cua.md` deep-dive, llms.txt §9a, plus updates to `docs/api.md`, client index, and mkdocs nav so the mode is discoverable.

## Design notes

- Same per-tenant auth / cap / allowlist / rate-limit / concurrency / recording plumbing as `/v1/predict`. Allowlist scans `start_url` + URLs embedded in the instruction via the existing `extract_navigate_hosts` helper.
- Detached runs reuse the standard worker pool: `_run_detached_worker` branches on `_mode == "pure_cua"` before falling through to the existing `_micro` / `_tasks` dispatch. Polling works through the existing `/v1/predict` `action=status|result|logs|cancel` surface — no new poll endpoint.
- `_run_pure_cua` reuses `_make_env` / `_maybe_record` / `_attach_recording_metadata` / `_save_result`, so video / proxy / state-key behavior matches `/v1/predict` byte-for-byte.
- Tradeoffs flagged in the docs: no structured extraction, no grounding correction on small targets, no section/gate/loop semantics, no skip envelope. Users who need any of those keep using `/v1/predict`.

## Test plan

- [x] 246 schema / predict / cli tests still pass (`uv run pytest -k 'baseten or schema or predict or cli'`)
- [x] `PureCUARequest` validates + clamps caps
- [x] FastAPI registers `POST /v1/cua` at import time
- [x] `mantis cua run --help` renders the full flag surface
- [ ] Smoke against a live Modal deployment: `mantis cua run "go to lu.ma and click the first event" --start-url https://lu.ma/discover` (per the project's lu.ma-default smoke preference)
- [ ] Verify detached + `/v1/predict action=status` polling end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)