### PR TITLE
fix(modal-proxy): pin US states with us_<state> prefix per Oxylabs docs

### DIFF
--- a/deploy/modal/modal_plan_runner.py
+++ b/deploy/modal/modal_plan_runner.py
@@ -222,6 +222,20 @@ def _build_oxylabs_username(session: str = "mantis", *, geo: bool = False) -> st
     (``pr.oxylabs.io:10000``). City-level pinning lives on
     ``pr.oxylabs.io:7777`` (``OXYLABS_CITY_ENTRYPOINT``) and only
     works for plans that explicitly support it. Diagnose-then-enable.
+
+    **State format** — Oxylabs docs require US states to be
+    prefixed with the country code: ``us_california``, not
+    ``california``. Canonical example: ``st-us_california-city-los_angeles``.
+    When ``OXYLABS_STATE`` lacks the ``<cc>_`` prefix, this function
+    prepends ``cc.lower() + "_"`` automatically — so operators can
+    set ``OXYLABS_STATE=florida`` and the helper produces the
+    canonical ``st-us_florida``. Without this prefix, Oxylabs treats
+    the state as unknown and silently falls back to random global
+    rotation (observed: ``st-florida`` returned Ukraine and Brazil
+    IPs in production diagnostic).
+
+    **City format** — bare lowercase, with spaces replaced by
+    underscores: ``city-los_angeles`` (not ``city-Los Angeles``).
     """
     raw_user = os.environ.get("OXYLABS_USERNAME", "").strip()
     if not raw_user:
@@ -229,14 +243,29 @@ def _build_oxylabs_username(session: str = "mantis", *, geo: bool = False) -> st
 
     parts = [f"customer-{raw_user}"]
     if geo:
-        for key, label in (
-            ("OXYLABS_COUNTRY", "cc"),
-            ("OXYLABS_STATE", "st"),
-            ("OXYLABS_CITY", "city"),
-        ):
-            v = os.environ.get(key, "").strip()
-            if v:
-                parts += [label, v]
+        cc = os.environ.get("OXYLABS_COUNTRY", "").strip()
+        state = os.environ.get("OXYLABS_STATE", "").strip()
+        city = os.environ.get("OXYLABS_CITY", "").strip()
+
+        if cc:
+            parts += ["cc", cc]
+        if state:
+            # Oxylabs convention: state names are country-prefixed
+            # ("us_california"). If the operator wrote "florida"
+            # without prefix, attach the country code lowercased so
+            # we emit the canonical "us_florida" form. Skip the
+            # auto-prefix if the value already contains "_" (operator
+            # already wrote the canonical form).
+            if "_" in state:
+                formatted_state = state.lower()
+            elif cc:
+                formatted_state = f"{cc.lower()}_{state.lower()}"
+            else:
+                formatted_state = state.lower()
+            parts += ["st", formatted_state]
+        if city:
+            # Bare lowercase, spaces → underscores.
+            parts += ["city", city.lower().replace(" ", "_")]
     if session:
         parts += ["sessid", session]
     return "-".join(parts)

--- a/tests/test_oxylabs_username_format.py
+++ b/tests/test_oxylabs_username_format.py
@@ -21,6 +21,16 @@ import importlib.util
 import sys
 from pathlib import Path
 
+import pytest
+
+# The Modal deploy module has top-level ``import modal`` — when the
+# ``modal`` package isn't installed (CI without [modal] extras, etc.),
+# skip the whole test module rather than fail with ImportError.
+pytest.importorskip(
+    "modal",
+    reason="modal package not installed; deploy module can't be loaded",
+)
+
 
 def _load_helper():
     """Import ``_build_oxylabs_username`` from the Modal deploy

--- a/tests/test_oxylabs_username_format.py
+++ b/tests/test_oxylabs_username_format.py
@@ -1,0 +1,127 @@
+"""Tests for ``_build_oxylabs_username`` username format.
+
+Oxylabs docs require US states to be prefixed with the country
+code (``us_california``, not ``california``). The bug surfaced when
+``diagnose_proxy`` reported the geo-pinned curl returning Ukraine /
+Brazil / France IPs — Oxylabs was treating malformed ``st-florida``
+as unknown and silently falling back to random global rotation.
+
+Canonical Oxylabs example (from their docs):
+    ``customer-USERNAME-cc-US-st-us_california-city-los_angeles``
+
+These tests pin the format the helper produces, including the
+``us_<state>`` auto-prefix when the operator writes the unprefixed
+state name. Codebase has no existing tests for this helper — the
+bug-fix ships its own coverage.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def _load_helper():
+    """Import ``_build_oxylabs_username`` from the Modal deploy
+    module without triggering Modal CLI initialization. The deploy
+    module is named ``deploy.modal.modal_plan_runner`` but isn't a
+    package; load it directly by path."""
+    path = Path(__file__).parent.parent / "deploy" / "modal" / "modal_plan_runner.py"
+    spec = importlib.util.spec_from_file_location("_test_modal_plan_runner", path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["_test_modal_plan_runner"] = mod
+    spec.loader.exec_module(mod)
+    return mod._build_oxylabs_username
+
+
+def _set_env(monkeypatch, **kwargs):
+    """Set OXYLABS_* env vars for the test."""
+    for k, v in kwargs.items():
+        if v is None:
+            monkeypatch.delenv(f"OXYLABS_{k.upper()}", raising=False)
+        else:
+            monkeypatch.setenv(f"OXYLABS_{k.upper()}", v)
+
+
+def test_no_username_returns_empty(monkeypatch) -> None:
+    monkeypatch.delenv("OXYLABS_USERNAME", raising=False)
+    fn = _load_helper()
+    assert fn(session="s") == ""
+
+
+def test_bare_username_with_session(monkeypatch) -> None:
+    """Without ``geo=True``, no cc/st/city slots are appended."""
+    _set_env(monkeypatch, username="acme", country="US", state="florida", city="miami")
+    fn = _load_helper()
+    assert fn(session="run42", geo=False) == "customer-acme-sessid-run42"
+
+
+def test_geo_country_only(monkeypatch) -> None:
+    """Country-only pinning matches Oxylabs canonical
+    ``customer-USERNAME-cc-DE`` form."""
+    _set_env(monkeypatch, username="acme", country="DE", state=None, city=None)
+    fn = _load_helper()
+    assert fn(session="r", geo=True) == "customer-acme-cc-DE-sessid-r"
+
+
+def test_geo_country_and_unprefixed_state_gets_us_prefix(monkeypatch) -> None:
+    """The bug being fixed: ``OXYLABS_STATE=florida`` must produce
+    ``st-us_florida`` (not the malformed ``st-florida`` that
+    Oxylabs silently rejects)."""
+    _set_env(monkeypatch, username="acme", country="US", state="florida", city=None)
+    fn = _load_helper()
+    out = fn(session="r", geo=True)
+    assert out == "customer-acme-cc-US-st-us_florida-sessid-r"
+
+
+def test_geo_preserves_prefixed_state(monkeypatch) -> None:
+    """If the operator already wrote ``us_california`` (canonical
+    form), don't double-prefix it."""
+    _set_env(monkeypatch, username="acme", country="US", state="us_california", city=None)
+    fn = _load_helper()
+    out = fn(session="r", geo=True)
+    assert "us_us_california" not in out
+    assert "st-us_california" in out
+
+
+def test_geo_state_lowercased(monkeypatch) -> None:
+    """Operators may write the state with any casing; we emit
+    lowercase per Oxylabs case-insensitive convention."""
+    _set_env(monkeypatch, username="acme", country="US", state="Florida", city=None)
+    fn = _load_helper()
+    out = fn(session="r", geo=True)
+    assert "st-us_florida" in out
+
+
+def test_geo_city_with_state_canonical_form(monkeypatch) -> None:
+    """Canonical Oxylabs combined-pin example:
+    ``st-us_california-city-los_angeles``. Spaces in city → underscores."""
+    _set_env(monkeypatch, username="acme", country="US",
+             state="california", city="Los Angeles")
+    fn = _load_helper()
+    out = fn(session="r", geo=True)
+    assert out == "customer-acme-cc-US-st-us_california-city-los_angeles-sessid-r"
+
+
+def test_geo_city_alone_no_state(monkeypatch) -> None:
+    """``cc-GB-city-london`` — city without state still works,
+    matches the docs' London example."""
+    _set_env(monkeypatch, username="acme", country="GB", state=None, city="london")
+    fn = _load_helper()
+    out = fn(session="r", geo=True)
+    assert out == "customer-acme-cc-GB-city-london-sessid-r"
+
+
+def test_geo_no_country_falls_back_to_bare_state(monkeypatch) -> None:
+    """If somehow OXYLABS_COUNTRY is unset but state is set, don't
+    invent a country prefix — emit the state as-is (lowercased).
+    Edge case; operators should always set country, but defend in
+    depth."""
+    _set_env(monkeypatch, username="acme", country=None, state="florida", city=None)
+    fn = _load_helper()
+    out = fn(session="r", geo=True)
+    # No "cc-" segment; state emitted as raw lowercase (no auto-prefix
+    # because there's no country code to attach).
+    assert "cc-" not in out
+    assert "st-florida" in out


### PR DESCRIPTION
## The bug

\`_build_oxylabs_username(geo=True)\` in \`deploy/modal/modal_plan_runner.py\` emitted US states bare (\`st-florida\`) instead of country-prefixed (\`st-us_florida\`). Per [Oxylabs docs](https://developers.oxylabs.io/proxies/mobile-proxies/location-settings/select-state):

> "'st' parameter accepts case-insensitive state names prefixed with 'us_'. For example, 'us_california' or 'us_illinois'."

Canonical combined example from the docs: \`st-us_california-city-los_angeles\`.

Without the \`us_\` prefix, Oxylabs treats the state as unknown and silently falls back to random global rotation.

## Live diagnostic evidence

Repeated \`diagnose_proxy\` runs with \`OXYLABS_STATE=florida\` returned non-US IPs:

| Run | Returned IP | Country |
|---|---|---|
| earlier today | 46.219.190.49 | Ukraine |
| earlier today | 191.253.54.8 | Brazil |
| earlier today | 88.121.211.216 | France |

That's the silent-fallback signature — Oxylabs ignored the malformed pin and rotated globally.

## Fix

When \`OXYLABS_STATE\` is set without a country-prefix underscore, auto-prepend \`<cc.lower()>_\` to produce the canonical \`us_florida\` form. Operators who already wrote \`us_california\` are preserved (no double-prefix).

City formatting also tightened: lowercased + spaces-to-underscores so \`OXYLABS_CITY="Los Angeles"\` produces \`city-los_angeles\` per the docs.

## Scope

**Format fix only.** The resolver in \`_resolve_upstream_proxy\` still defaults \`geo=False\` (per the existing safety-belt comment about \`pr.oxylabs.io:10000\` vs \`:7777\` entitlement differences). Enabling \`geo=True\` in production is a follow-up; once that flip happens, this PR is what makes the pin actually land in the configured state.

## Test plan

- [x] 9 new tests in \`tests/test_oxylabs_username_format.py\` covering: no-geo / country-only / state-with-auto-prefix / already-prefixed (no double) / case / city + state canonical form / city without state / no-country edge case
- [x] Ruff clean
- [x] Codebase had no prior tests for this helper — fix ships its own coverage
- [ ] Once the resolver is flipped to \`geo=True\`, \`diagnose_proxy\` should report \`ipify_via_oxylabs_pinned\` as a Florida-geolocated IP (or whatever \`OXYLABS_STATE\` is set to)

## Related

- Discovered while diagnosing why lu.ma's \`/discover\` page served "Browse by Category" instead of "Popular Events / San Francisco" through Modal+Oxylabs — the page is geo-personalized, and our proxy IP was rotating through countries the user never configured.
- Issue #261 (ablation discipline) — this is exactly the kind of buried-misconfiguration the canonical-plan-per-merge approach would have surfaced earlier had a geo-sensitive plan been part of the regression suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)