### PR TITLE
feat(docs): ship plan.schema.json for IDE autocomplete (#268, #269)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The full docs site is at **[mercurialsolo.github.io/mantis](https://mercurialsol
 |---|---|
 | Try it in 5 minutes | [Quickstart](docs/getting-started/quickstart.md) |
 | See what Mantis is good at | [Use cases](docs/getting-started/use-cases.md) — listings, jobs, real-estate, products, news, CRM edits, refunds, social posting, multi-app workflows |
-| Copy-paste a working plan | [Recipes](docs/integrations/recipes.md) — 11 worked examples |
+| Copy-paste a working plan | [Recipes](docs/integrations/recipes.md) — 5 worked examples |
 | Understand the architecture | [Concepts](docs/getting-started/concepts.md) · [Architecture](docs/architecture.md) |
 | Deploy your own instance | [Hosting](docs/hosting/index.md) — Baseten / Modal / EKS / GKE / local |
 | Integrate from your app | [Client](docs/client/index.md) — auth, plans, polling, recordings |

--- a/docs/getting-started/plan-formats.md
+++ b/docs/getting-started/plan-formats.md
@@ -75,6 +75,42 @@ A flat JSON list of step objects executed by `MicroPlanRunner`. Best reliability
 
 Field reference is on the [Concepts](concepts.md#step-types-micro-plan-shape) page.
 
+### IDE autocomplete via JSON Schema
+
+A JSON Schema for the micro-plan format ships at
+[`reference/plan.schema.json`](../reference/plan.schema.json) (also live at
+`https://mercurialsolo.github.io/mantis/reference/plan.schema.json`). Point
+your editor at it and you get autocomplete + inline validation for every
+step field.
+
+**VS Code** — add to `.vscode/settings.json` (or workspace settings):
+
+```jsonc
+{
+  "json.schemas": [
+    {
+      "fileMatch": [
+        "**/plans/**/*.json",
+        "**/recipes/**/plan.json",
+        "**/examples/*.json"
+      ],
+      "url": "https://mercurialsolo.github.io/mantis/reference/plan.schema.json"
+    }
+  ]
+}
+```
+
+**Neovim / coc.nvim** — same shape under `coc-settings.json` (`json.schemas`).
+
+**IntelliJ / PyCharm** — *Preferences → Languages & Frameworks → Schemas
+and DTDs → JSON Schema Mappings*, then add a mapping with the URL above and
+a file pattern matching your plan layout.
+
+The schema is intentionally permissive (`additionalProperties: true`) so
+plan-specific fields don't trip validation — IDE autocomplete still covers
+the well-known step types and fields.
+
+
 Submit it three ways:
 
 ```jsonc

--- a/docs/reference/plan.schema.json
+++ b/docs/reference/plan.schema.json
@@ -1,0 +1,183 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://mercurialsolo.github.io/mantis/reference/plan.schema.json",
+  "title": "Mantis micro-plan",
+  "description": "Top-level shape of a Mantis micro-plan JSON file: a flat array of step objects executed by MicroPlanRunner. Each step must declare an 'intent' (one-sentence description for the brain) and a 'type' (the step kind). Step types accept additional optional fields documented in 'docs/getting-started/plan-formats.md' and 'docs/getting-started/concepts.md'. The schema is intentionally permissive (additionalProperties is true at every level) so plans can carry plan-specific fields without breaking validation — IDE autocomplete still covers the well-known fields.",
+  "type": "array",
+  "items": {
+    "$ref": "#/$defs/Step"
+  },
+  "$defs": {
+    "Step": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["intent", "type"],
+      "properties": {
+        "intent": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Single sentence in natural language. The brain (Holo3 / Claude) reads this verbatim — keep it concrete and one action wide."
+        },
+        "type": {
+          "type": "string",
+          "description": "Step kind. The enum lists the well-known types the runtime understands today; unknown types are not rejected (additionalProperties: true) but will fall back to a generic handler.",
+          "enum": [
+            "navigate",
+            "navigate_back",
+            "wait",
+            "click",
+            "double_click",
+            "scroll",
+            "drag",
+            "key_press",
+            "type_text",
+            "loop",
+            "holo3",
+            "claude",
+            "extract_data",
+            "extract_url",
+            "fill_field",
+            "submit",
+            "select_option",
+            "paginate",
+            "filter",
+            "done"
+          ]
+        },
+        "url": {
+          "type": "string",
+          "description": "Target URL for navigate steps. Plans may use {{template}} placeholders the caller substitutes before submitting."
+        },
+        "wait_for_load": {
+          "type": "boolean",
+          "description": "navigate steps: block until the page reports load complete before returning."
+        },
+        "seconds": {
+          "type": "number",
+          "minimum": 0,
+          "description": "wait steps: number of seconds to sleep before the next step."
+        },
+        "loop_count": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 50,
+          "description": "loop steps: maximum iterations. Server-side cap is MANTIS_MAX_LOOP_ITERATIONS (default 50); higher values are silently clamped."
+        },
+        "loop_target": {
+          "type": "integer",
+          "minimum": -1,
+          "description": "loop steps: zero-based index of the step to jump back to. -1 (default) means 'the step immediately after the matching section start'."
+        },
+        "steps": {
+          "type": "array",
+          "description": "loop steps: inline body executed each iteration. Recursive — nested loops are allowed.",
+          "items": {
+            "$ref": "#/$defs/Step"
+          }
+        },
+        "max_steps": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "holo3 steps: maximum brain actions allowed before forced termination of this step."
+        },
+        "hint": {
+          "type": "string",
+          "description": "holo3 steps: extra detail the brain sees alongside the intent — usually a target-element description or a UI affordance hint."
+        },
+        "budget": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Maximum brain actions for the step (legacy field; prefer 'max_steps' for new plans)."
+        },
+        "section": {
+          "type": "string",
+          "description": "Logical section label (e.g. 'setup', 'extraction', 'pagination'). Sections gate which steps run after a failed gate."
+        },
+        "required": {
+          "type": "boolean",
+          "description": "If true and the step fails after retries, the whole pipeline halts. Default false."
+        },
+        "gate": {
+          "type": "boolean",
+          "description": "If true, this is a verification gate — must pass before the runner advances to the next section. Default false."
+        },
+        "verify": {
+          "type": "string",
+          "description": "Expected outcome of the step in natural language. Surfaced to Claude in the verification prompt."
+        },
+        "claude_only": {
+          "type": "boolean",
+          "description": "If true, skip Holo3 and have Claude read the screenshot directly (used for extract_data / extract_url and verification gates)."
+        },
+        "grounding": {
+          "type": "boolean",
+          "description": "If true, enable ClaudeGrounding for this step — useful when Holo3 mis-clicks a small or visually-ambiguous target."
+        },
+        "reverse": {
+          "type": "string",
+          "description": "Natural-language description of how to undo the step (e.g. 'Press Alt+Left'). Used by the agentic-recovery loop."
+        },
+        "notes": {
+          "type": "string",
+          "description": "Free-form author notes. Ignored by the runtime — useful for documenting plan-specific assumptions."
+        },
+        "extract": {
+          "type": "object",
+          "description": "claude steps: structured extraction schema. The brain returns one row matching 'fields' (or up to 'max_items' rows).",
+          "additionalProperties": true,
+          "properties": {
+            "schema_name": {
+              "type": "string",
+              "description": "Identifier used in logs and CSV output filenames."
+            },
+            "fields": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/ExtractField"
+              },
+              "description": "Ordered list of fields to extract."
+            },
+            "max_items": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "Cap on how many rows the brain may return. Omit for single-row extraction."
+            }
+          }
+        },
+        "params": {
+          "type": "object",
+          "description": "Structured payload for form-shaped step types: fill_field {label, value, aliases?}, submit {label, aliases?}, select_option {dropdown_label, option_label}, navigate {wait_after_load_seconds?}."
+        },
+        "hints": {
+          "type": "object",
+          "description": "Per-step grounding hints. Recognised keys: layout ('listings' | 'single'), spam_indicators, spam_label, entity_name."
+        }
+      }
+    },
+    "ExtractField": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["name", "type"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Field key. Becomes a column in the CSV output."
+        },
+        "type": {
+          "type": "string",
+          "description": "Loose Python type hint: 'str', 'int', 'float', 'bool'.",
+          "enum": ["str", "int", "float", "bool"]
+        },
+        "required": {
+          "type": "boolean",
+          "description": "If true, a row missing this field is dropped as a partial extraction."
+        },
+        "example": {
+          "type": "string",
+          "description": "Example value the brain sees in the extraction prompt."
+        }
+      }
+    }
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,7 @@ dev = [
     "pytest-xdist>=3.8",  # parallel test execution: pytest -n auto (~2x speedup locally)
     "ruff>=0.4",
     "httpx>=0.24",   # FastAPI TestClient
+    "jsonschema>=4.0",  # tests/test_plan_schema.py validates plans against docs/reference/plan.schema.json
 ]
 # MkDocs site builder + plugins.
 docs = [

--- a/tests/test_plan_schema.py
+++ b/tests/test_plan_schema.py
@@ -1,0 +1,81 @@
+"""Self-consistency tests for ``docs/reference/plan.schema.json``.
+
+Two assertions:
+
+1. The shipped schema is itself a valid JSON Schema (Draft 2020-12). Catches
+   typos in the schema file before they reach an end-user's IDE.
+2. Every committed example plan (``examples/*.json``) and recipe plan
+   (``src/mantis_agent/recipes/*/plan.json``) validates against the schema.
+   The schema is permissive (``additionalProperties: true`` everywhere),
+   so this test is a structural smoke check, not a contract on every
+   plan-specific field.
+
+If a new step type or field lands in the shipped plans before the schema
+catches up, this test fails with the exact offending file + JSON Pointer
+to the field that doesn't validate.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_PATH = REPO_ROOT / "docs" / "reference" / "plan.schema.json"
+EXAMPLES_DIR = REPO_ROOT / "examples"
+RECIPES_DIR = REPO_ROOT / "src" / "mantis_agent" / "recipes"
+
+
+def _load_schema() -> dict:
+    with SCHEMA_PATH.open() as fh:
+        return json.load(fh)
+
+
+def _example_plans() -> list[Path]:
+    return sorted(EXAMPLES_DIR.glob("*.json"))
+
+
+def _recipe_plans() -> list[Path]:
+    return sorted(RECIPES_DIR.glob("*/plan.json"))
+
+
+def test_schema_is_well_formed() -> None:
+    """The shipped plan.schema.json itself must be a valid JSON Schema."""
+    schema = _load_schema()
+    Draft202012Validator.check_schema(schema)
+
+
+@pytest.mark.parametrize("plan_path", _example_plans(), ids=lambda p: p.name)
+def test_example_plan_matches_schema(plan_path: Path) -> None:
+    schema = _load_schema()
+    validator = Draft202012Validator(schema)
+    with plan_path.open() as fh:
+        plan = json.load(fh)
+    errors = sorted(validator.iter_errors(plan), key=lambda e: e.absolute_path)
+    if errors:
+        msg = "\n".join(
+            f"  {list(e.absolute_path)}: {e.message}" for e in errors
+        )
+        pytest.fail(f"{plan_path.name} does not match plan.schema.json:\n{msg}")
+
+
+@pytest.mark.parametrize(
+    "plan_path", _recipe_plans(), ids=lambda p: f"{p.parent.name}/plan"
+)
+def test_recipe_plan_matches_schema(plan_path: Path) -> None:
+    schema = _load_schema()
+    validator = Draft202012Validator(schema)
+    with plan_path.open() as fh:
+        plan = json.load(fh)
+    errors = sorted(validator.iter_errors(plan), key=lambda e: e.absolute_path)
+    if errors:
+        msg = "\n".join(
+            f"  {list(e.absolute_path)}: {e.message}" for e in errors
+        )
+        pytest.fail(
+            f"{plan_path.parent.name}/plan.json does not match "
+            f"plan.schema.json:\n{msg}"
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -1446,6 +1446,7 @@ dependencies = [
 [package.optional-dependencies]
 dev = [
     { name = "httpx" },
+    { name = "jsonschema" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-xdist" },
@@ -1515,6 +1516,7 @@ requires-dist = [
     { name = "fastapi", marker = "extra == 'viewer'", specifier = ">=0.100" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.24" },
     { name = "hud-python", marker = "extra == 'hud'", specifier = ">=0.5.34" },
+    { name = "jsonschema", marker = "extra == 'dev'", specifier = ">=4.0" },
     { name = "mantis-agent", extras = ["orchestrator", "server", "local-cua", "viewer", "gpu", "hud"], marker = "extra == 'full'" },
     { name = "mkdocs", marker = "extra == 'docs'", specifier = ">=1.6" },
     { name = "mkdocs-awesome-pages-plugin", marker = "extra == 'docs'", specifier = ">=2.9" },


### PR DESCRIPTION
## Summary

Closes #268, #269. Two related end-user DX improvements bundled because they touch the same docs surface.

**#268 — JSON Schema for plan files**
- `docs/reference/plan.schema.json` — Draft 2020-12 schema for the flat step-array format used by every shipped plan. Required fields (`intent`, `type`) mirror `api_schemas.validate_micro_steps`; the rest are documented optionally for autocomplete. `additionalProperties: true` everywhere so plan-specific fields don't trip validation.
- The schema is published as a static asset at `https://mercurialsolo.github.io/mantis/reference/plan.schema.json` (verified via `mkdocs build --strict`).
- `docs/getting-started/plan-formats.md` — new "IDE autocomplete via JSON Schema" section with VS Code, coc.nvim, and IntelliJ snippets.
- `tests/test_plan_schema.py` — `Draft202012Validator.check_schema` confirms the schema is well-formed; parametrised tests validate every `examples/*.json` and `recipes/*/plan.json` against it (6 tests, 1.3 s).
- `pyproject.toml` + `uv.lock` — `jsonschema>=4.0` added to `[dev]` so the test contract is explicit.

**#269 — recipes count**
- `README.md` — \"11 worked examples\" → \"5 worked examples\". The linked doc \`docs/integrations/recipes.md\` has exactly 5 recipes (1–5).

Also worth flagging on the parent epic: #266 (\`mantis plan validate\` CLI) and #270 (CI plan validation) were already implemented before the audit ran. Both have been closed with pointers to the existing implementations (\`cli.py:81-134\` and \`tests/test_examples_plans.py\`).

## Test plan
- [x] \`uv run python -m pytest tests/test_plan_schema.py tests/test_examples_plans.py -q\` — 12 passed in 1.34s
- [x] \`uv run ruff check .\` — All checks passed
- [x] \`uv run mkdocs build --strict\` — built successfully; \`plan.schema.json\` lands at \`/reference/plan.schema.json\` in the built site
- [x] \`uv run mantis plan validate examples/extract_jobs.json\` — still works (no behavior change to the CLI)
- [ ] Follow-up after merge: copy the workspace-settings snippet into your editor and confirm autocomplete works in a real plan file

🤖 Generated with [Claude Code](https://claude.com/claude-code)