### PR TITLE
feat(client): typed Python client `mantis_agent.client` (#267)

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ The base install is intentionally slim. Pick the extras for your use case:
 
 ```bash
 pip install -e .                  # ~5 MB — Pillow only
+pip install -e ".[client]"        # ~10 MB — typed HTTP client (`mantis_agent.client`)
 pip install -e ".[orchestrator]"  # ~10 MB — MicroPlanRunner + remote Holo3 client
 pip install -e ".[server]"        # ~15 MB — FastAPI server + Prometheus
 pip install -e ".[local-cua]"     # ~2 GB  — torch + transformers + pyautogui

--- a/docs/client/index.md
+++ b/docs/client/index.md
@@ -13,59 +13,101 @@ For applications calling a hosted Mantis instance.
 
 Looking for the full HTTP API surface? See [Reference / HTTP API](../api.md).
 
-## Minimal client (Python)
+## Typed Python client
+
+```bash
+pip install "mantis-agent[client]"
+```
 
 ```python
-import os, time, requests
+from mantis_agent.client import MantisClient, PredictRequest
 
-ENDPOINT = os.environ["MANTIS_ENDPOINT"]      # e.g. https://model-qvvgkneq.api.baseten.co/production/sync
-PLATFORM = os.environ["BASETEN_API_KEY"]
-TENANT   = os.environ["MANTIS_API_TOKEN"]
+# Reads MANTIS_ENDPOINT / BASETEN_API_KEY / MANTIS_API_TOKEN from env.
+client = MantisClient.from_env()
 
-def headers():
-    h = {"X-Mantis-Token": TENANT, "Content-Type": "application/json"}
-    if PLATFORM:
-        h["Authorization"] = f"Api-Key {PLATFORM}"
-    return h
-
-def submit(plan_path: str, state_key: str, **opts) -> str:
-    r = requests.post(f"{ENDPOINT}/v1/predict", headers=headers(), json={
-        "detached": True,
-        "micro": plan_path,
-        "state_key": state_key,
-        **opts,
-    }, timeout=60)
-    r.raise_for_status()
-    return r.json()["run_id"]
-
-def poll(run_id: str, every: int = 30) -> dict:
-    while True:
-        r = requests.post(f"{ENDPOINT}/v1/predict", headers=headers(), json={
-            "action": "status", "run_id": run_id,
-        }, timeout=60)
-        r.raise_for_status()
-        body = r.json()
-        if body["status"] in {"succeeded", "failed", "cancelled"}:
-            return body
-        time.sleep(every)
-
-def fetch_result(run_id: str) -> dict:
-    r = requests.post(f"{ENDPOINT}/v1/predict", headers=headers(), json={
-        "action": "result", "run_id": run_id,
-    }, timeout=60)
-    r.raise_for_status()
-    return r.json()
-
-# Usage
-run_id = submit(
-    "plans/example/extract_listings.json",
-    "marketplace-prod",
-    max_cost=2, max_time_minutes=20, record_video=True,
+result = client.run_to_completion(
+    PredictRequest(
+        micro="plans/example/extract_listings.json",
+        state_key="marketplace-prod",
+        max_cost=2,
+        max_time_minutes=20,
+        record_video=True,
+    ),
 )
-final = poll(run_id)
-print(final["summary"])
-result = fetch_result(run_id)
 print(result["result"]["leads"])
 ```
 
-That's the whole integration. The rest of this section is the deep-dive on each piece.
+That's the whole integration. The client wraps the five end-user
+endpoints with typed requests / responses, structured errors, and a
+polling helper. Sync `requests` + `pydantic` only — no FastAPI, no GPU
+deps, no browser.
+
+### Fire-and-poll with status callbacks
+
+For longer runs where you want to surface progress to a UI:
+
+```python
+handle = client.predict(PredictRequest(
+    micro="plans/example/extract_listings.json",
+    state_key="marketplace-prod",
+    record_video=True,
+))
+
+final = client.wait_for_completion(
+    handle.run_id,
+    poll_interval_s=30,
+    on_status=lambda s: print(f"{s.status} — {s.summary or '—'}"),
+)
+print(final.summary)
+
+result = client.result(handle.run_id)
+client.fetch_video(handle.run_id, dest_path="recording.mp4")
+```
+
+### Pure CUA pass-through
+
+For single-instruction Holo3 runs (no Claude decomposition):
+
+```python
+response = client.cua_run(
+    "Open https://example.com and click the docs link",
+    start_url="https://example.com",
+    max_steps=20,
+    detached=False,
+)
+```
+
+### Error handling
+
+Every server failure surfaces as a typed exception so callers can branch
+on the cause without parsing string messages:
+
+```python
+from mantis_agent.client import (
+    MantisAuthError, MantisRateLimitError, MantisAPIError,
+    MantisRunFailed, MantisTimeoutError,
+)
+
+try:
+    result = client.run_to_completion(req, timeout_s=1800)
+except MantisAuthError:
+    # 401 / 403 — bad or missing X-Mantis-Token
+    raise
+except MantisRateLimitError as exc:
+    time.sleep(exc.retry_after_seconds or 60)
+except MantisTimeoutError as exc:
+    # Run is still in flight; cancel or keep polling.
+    client.cancel(exc.run_id)
+except MantisRunFailed as exc:
+    # Terminal failure — exc.status carries the snapshot.
+    print(exc.status.error)
+```
+
+### Raw HTTP
+
+Prefer to drive the API directly? Build a request body following the
+shape on [Sending plans](plans.md) and POST it to `/v1/predict` with
+`Authorization: Api-Key …` + `X-Mantis-Token: …` headers. The typed
+client is a thin wrapper around that — nothing else.
+
+The rest of this section is the deep-dive on each piece.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,14 @@ orchestrator = [
     "requests>=2.28",
     "pydantic>=2",
 ]
+# Typed Python client surface (#267) — `from mantis_agent.client import
+# MantisClient`. Same deps as orchestrator (requests + pydantic), exposed
+# under a friendlier extras name for integrators who just want to call
+# the API. No FastAPI / torch / Pillow / Holo3.
+client = [
+    "requests>=2.28",
+    "pydantic>=2",
+]
 # Server side wants prometheus + the orchestrator deps too.
 metrics = [
     "prometheus-client>=0.20",

--- a/src/mantis_agent/client/__init__.py
+++ b/src/mantis_agent/client/__init__.py
@@ -1,0 +1,72 @@
+"""Typed Python client for the Mantis HTTP API (#267).
+
+Replaces the hand-rolled ``submit() / poll() / fetch_result()`` boilerplate
+documented in ``docs/client/index.md`` with a typed wrapper around the
+five end-user-facing endpoints:
+
+- ``POST /v1/predict`` — submit a plan, plus the ``status / result / logs
+  / cancel`` action variants for an existing ``run_id``.
+- ``POST /v1/cua`` — pure CUA pass-through (no Claude decomposition).
+- ``GET /v1/runs/{run_id}/video`` — fetch the screencast bytes.
+- ``GET /v1/health`` — liveness probe.
+
+The surface is deliberately small. Three example usage shapes:
+
+.. code-block:: python
+
+    from mantis_agent.client import MantisClient, PredictRequest
+
+    # 1. fire-and-poll
+    client = MantisClient.from_env()
+    handle = client.predict(PredictRequest(micro="plans/example/extract_listings.json",
+                                           state_key="marketplace-prod"))
+    final = client.wait_for_completion(handle.run_id)
+    result = client.result(handle.run_id)
+
+    # 2. submit + wait + result in one call
+    result = client.run_to_completion(
+        PredictRequest(micro="plans/example/extract_listings.json",
+                       state_key="marketplace-prod", max_cost=2),
+    )
+
+    # 3. pure CUA pass-through
+    response = client.cua_run("Open https://example.com and click the docs link")
+
+Install with ``pip install mantis-agent[client]`` — pulls only ``requests``
++ ``pydantic``, no FastAPI / torch / Pillow / Holo3.
+"""
+
+from __future__ import annotations
+
+from mantis_agent.api_schemas import (
+    DetachedRunHandle,
+    PredictRequest,
+    PureCUARequest,
+    RunStatus,
+)
+
+from .client import MantisClient
+from .errors import (
+    MantisAPIError,
+    MantisAuthError,
+    MantisError,
+    MantisRateLimitError,
+    MantisRunFailed,
+    MantisTimeoutError,
+)
+
+__all__ = [
+    "MantisClient",
+    # Request / response types re-exported from api_schemas
+    "PredictRequest",
+    "PureCUARequest",
+    "RunStatus",
+    "DetachedRunHandle",
+    # Error hierarchy
+    "MantisError",
+    "MantisAPIError",
+    "MantisAuthError",
+    "MantisRateLimitError",
+    "MantisTimeoutError",
+    "MantisRunFailed",
+]

--- a/src/mantis_agent/client/client.py
+++ b/src/mantis_agent/client/client.py
@@ -1,0 +1,415 @@
+"""``MantisClient`` — typed HTTP wrapper for the Mantis API.
+
+Wraps the five end-user-facing endpoints (``/v1/predict`` + ``status /
+result / logs / cancel`` actions, ``/v1/cua``, ``/v1/runs/{id}/video``,
+``/v1/health``) into a small typed surface so integrators don't rewrite
+the same ``submit() / poll() / fetch_result()`` boilerplate every time.
+
+The client deliberately stays sync and thin: one ``requests.Session``,
+explicit retries are the caller's job, no hidden parallelism. Async / httpx
+support can layer on later without changing the surface.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from typing import Any, Iterable, Optional, Union
+
+import requests
+from pydantic import ValidationError
+
+from mantis_agent.api_schemas import (
+    DetachedRunHandle,
+    PredictRequest,
+    PureCUARequest,
+    RunStatus,
+)
+
+from .errors import (
+    MantisAPIError,
+    MantisAuthError,
+    MantisError,
+    MantisRateLimitError,
+    MantisRunFailed,
+    MantisTimeoutError,
+)
+
+# Terminal status values returned by /v1/predict {action: status}.
+TERMINAL_STATUSES = frozenset({"succeeded", "failed", "cancelled"})
+
+# Default sync timeout for non-polling HTTP calls. Plans can take 5-30+ min
+# in detached mode, but each individual call is cheap; 60 s is generous.
+_DEFAULT_TIMEOUT_S = 60.0
+
+# Default polling cadence — matches the recommended cadence on
+# docs/client/runs-and-polling.md (30 s after the first minute).
+_DEFAULT_POLL_INTERVAL_S = 30.0
+
+
+class MantisClient:
+    """Typed client for the Mantis HTTP API.
+
+    Two ways to construct:
+
+    .. code-block:: python
+
+        client = MantisClient(
+            endpoint="https://model-x.api.baseten.co/production/sync",
+            api_key="...",            # platform key (Baseten); None for Modal
+            mantis_token="...",       # per-tenant Mantis token
+        )
+
+        # Or pull from env (MANTIS_ENDPOINT, BASETEN_API_KEY, MANTIS_API_TOKEN):
+        client = MantisClient.from_env()
+
+    The session is owned by the client; callers can pass their own
+    ``requests.Session`` for connection-pool reuse or custom adapters.
+    """
+
+    def __init__(
+        self,
+        endpoint: str,
+        *,
+        api_key: Optional[str] = None,
+        mantis_token: Optional[str] = None,
+        timeout_s: float = _DEFAULT_TIMEOUT_S,
+        session: Optional[requests.Session] = None,
+        idempotency_key: Optional[str] = None,
+    ) -> None:
+        if not endpoint:
+            raise ValueError("endpoint is required")
+        # Strip a trailing /v1 if the caller pasted the OpenAI-compat base.
+        # We always append /v1/... ourselves.
+        normalized = endpoint.rstrip("/")
+        if normalized.endswith("/v1"):
+            normalized = normalized[: -len("/v1")]
+        self.endpoint = normalized
+        self.api_key = api_key
+        self.mantis_token = mantis_token
+        self.timeout_s = timeout_s
+        self.idempotency_key = idempotency_key
+        self._session = session or requests.Session()
+
+    @classmethod
+    def from_env(cls, **overrides: Any) -> "MantisClient":
+        """Construct from ``MANTIS_ENDPOINT`` / ``BASETEN_API_KEY`` /
+        ``MANTIS_API_TOKEN`` env vars.
+
+        Any keyword passed in ``overrides`` wins over the env value — useful
+        for tests or for talking to a non-default deployment from the same
+        process.
+        """
+        endpoint = overrides.pop("endpoint", None) or os.environ.get(
+            "MANTIS_ENDPOINT", "",
+        )
+        api_key = overrides.pop("api_key", None) or os.environ.get(
+            "BASETEN_API_KEY", "",
+        ) or None
+        mantis_token = overrides.pop("mantis_token", None) or os.environ.get(
+            "MANTIS_API_TOKEN", "",
+        ) or None
+        if not endpoint:
+            raise ValueError(
+                "MANTIS_ENDPOINT is not set; pass endpoint=... or export it.",
+            )
+        return cls(
+            endpoint=endpoint,
+            api_key=api_key,
+            mantis_token=mantis_token,
+            **overrides,
+        )
+
+    # ── HTTP plumbing ───────────────────────────────────────────────────
+
+    def _headers(self, extra: Optional[dict] = None) -> dict:
+        """Build the standard auth headers + caller overrides."""
+        h: dict = {"Content-Type": "application/json"}
+        if self.api_key:
+            h["Authorization"] = f"Api-Key {self.api_key}"
+        if self.mantis_token:
+            h["X-Mantis-Token"] = self.mantis_token
+        if self.idempotency_key:
+            h["Idempotency-Key"] = self.idempotency_key
+        if extra:
+            h.update(extra)
+        return h
+
+    def _raise_for_status(self, resp: requests.Response) -> None:
+        """Convert non-2xx into the typed error hierarchy."""
+        if resp.status_code < 400:
+            return
+        body: Any
+        try:
+            body = resp.json()
+        except ValueError:
+            body = resp.text
+        message = f"HTTP {resp.status_code} from {resp.url}"
+        if resp.status_code in (401, 403):
+            raise MantisAuthError(
+                message, status_code=resp.status_code, response_body=body,
+            )
+        if resp.status_code == 429:
+            retry_after = resp.headers.get("Retry-After")
+            try:
+                retry_after_s = float(retry_after) if retry_after else None
+            except ValueError:
+                retry_after_s = None
+            raise MantisRateLimitError(
+                message,
+                response_body=body,
+                retry_after_seconds=retry_after_s,
+            )
+        raise MantisAPIError(
+            message, status_code=resp.status_code, response_body=body,
+        )
+
+    def _post_predict(self, payload: dict) -> dict:
+        url = f"{self.endpoint}/v1/predict"
+        resp = self._session.post(
+            url, json=payload, headers=self._headers(), timeout=self.timeout_s,
+        )
+        self._raise_for_status(resp)
+        return resp.json()
+
+    # ── Predict + action variants ───────────────────────────────────────
+
+    def predict(self, request: Union[PredictRequest, dict]) -> DetachedRunHandle:
+        """Submit a plan. Returns a :class:`DetachedRunHandle` with ``run_id``.
+
+        ``request`` is either a :class:`PredictRequest` (preferred — gives
+        typed-field validation client-side) or a raw dict for callers that
+        already speak the wire shape. Pydantic ``ValidationError`` from a
+        malformed :class:`PredictRequest` is re-raised verbatim so callers
+        can locate the offending field.
+        """
+        if isinstance(request, PredictRequest):
+            payload = request.model_dump(exclude_none=True)
+        elif isinstance(request, dict):
+            # Validate the dict client-side too so callers get the same
+            # error path. Skip the validation envelope only if the caller
+            # explicitly passed an action-mode dict (status/result/logs/cancel).
+            if not request.get("action"):
+                try:
+                    PredictRequest.model_validate(request)
+                except ValidationError:
+                    raise
+            payload = dict(request)
+        else:
+            raise TypeError(
+                f"request must be PredictRequest or dict, got {type(request).__name__}",
+            )
+        # ``predict`` is for the submit path; force detached unless caller
+        # explicitly opts out. The wait_for_completion helper handles polling.
+        payload.setdefault("detached", True)
+        body = self._post_predict(payload)
+        return DetachedRunHandle.model_validate(body)
+
+    def status(self, run_id: str) -> RunStatus:
+        """``POST /v1/predict {action: status, run_id}`` — current run state."""
+        body = self._post_predict({"action": "status", "run_id": run_id})
+        return RunStatus.model_validate(body)
+
+    def result(self, run_id: str) -> dict:
+        """``POST /v1/predict {action: result, run_id}`` — full result payload.
+
+        Returned as a raw dict because the ``result`` shape is plan-dependent
+        (lead lists, step traces, video metadata) and not centrally typed.
+        """
+        return self._post_predict({"action": "result", "run_id": run_id})
+
+    def logs(self, run_id: str, *, tail: int = 200) -> list[str]:
+        """``POST /v1/predict {action: logs, run_id, tail}`` — recent events.
+
+        Returns the raw ``events`` list straight off the response so callers
+        can grep / pipe / pretty-print at their own discretion.
+        """
+        if tail < 1 or tail > 10_000:
+            raise ValueError("tail must be in [1, 10000]")
+        body = self._post_predict(
+            {"action": "logs", "run_id": run_id, "tail": tail},
+        )
+        events = body.get("events") or body.get("logs") or []
+        if not isinstance(events, list):
+            raise MantisAPIError(
+                f"unexpected logs response shape: {type(events).__name__}",
+                status_code=200,
+                response_body=body,
+            )
+        return [str(e) for e in events]
+
+    def cancel(self, run_id: str) -> dict:
+        """``POST /v1/predict {action: cancel, run_id}`` — request cancellation.
+
+        Cancels are cooperative — the runner finishes its current checkpoint
+        before stopping. Status flips to ``cancelled`` 5-60 s later.
+        """
+        return self._post_predict({"action": "cancel", "run_id": run_id})
+
+    # ── /v1/cua pass-through ────────────────────────────────────────────
+
+    def cua_run(
+        self,
+        instruction: Union[str, PureCUARequest],
+        **kwargs: Any,
+    ) -> dict:
+        """``POST /v1/cua`` — pure Holo3 pass-through (no Claude decomposition).
+
+        Accepts a free-text ``instruction`` (with optional ``**kwargs`` for
+        ``start_url``, ``max_steps``, etc.) or a pre-built
+        :class:`PureCUARequest`. Returns the raw JSON response —
+        either a detached run handle or a sync result depending on
+        ``detached``.
+        """
+        if isinstance(instruction, PureCUARequest):
+            payload = instruction.model_dump(exclude_none=True)
+        else:
+            payload = PureCUARequest(
+                instruction=instruction, **kwargs,
+            ).model_dump(exclude_none=True)
+
+        url = f"{self.endpoint}/v1/cua"
+        resp = self._session.post(
+            url, json=payload, headers=self._headers(), timeout=self.timeout_s,
+        )
+        self._raise_for_status(resp)
+        return resp.json()
+
+    # ── Video + health ──────────────────────────────────────────────────
+
+    def fetch_video(
+        self,
+        run_id: str,
+        dest_path: Union[str, Path],
+        *,
+        polished: bool = True,
+        chunk_size: int = 1 << 16,
+    ) -> Path:
+        """Stream ``GET /v1/runs/{run_id}/video`` to a local file.
+
+        Returns the destination ``Path``. Set ``polished=False`` to fetch
+        the raw recording instead of the captioned / overlay version (when
+        the deployment produced both).
+        """
+        url = f"{self.endpoint}/v1/runs/{run_id}/video"
+        params: dict[str, Any] = {}
+        if not polished:
+            params["polished"] = "false"
+        dest = Path(dest_path)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        with self._session.get(
+            url,
+            params=params,
+            headers=self._headers(),
+            timeout=self.timeout_s,
+            stream=True,
+        ) as resp:
+            self._raise_for_status(resp)
+            with dest.open("wb") as fh:
+                for chunk in resp.iter_content(chunk_size=chunk_size):
+                    if chunk:
+                        fh.write(chunk)
+        return dest
+
+    def health(self) -> dict:
+        """``GET /v1/health`` — liveness probe. Returns the server's payload.
+
+        Useful as a sanity check right after constructing the client; raises
+        :class:`MantisError` if the server isn't reachable.
+        """
+        url = f"{self.endpoint}/v1/health"
+        try:
+            resp = self._session.get(
+                url, headers=self._headers(), timeout=self.timeout_s,
+            )
+        except requests.RequestException as exc:
+            raise MantisError(f"{url} unreachable: {exc}") from exc
+        self._raise_for_status(resp)
+        return resp.json()
+
+    # ── Convenience: polling helpers ────────────────────────────────────
+
+    def wait_for_completion(
+        self,
+        run_id: str,
+        *,
+        poll_interval_s: float = _DEFAULT_POLL_INTERVAL_S,
+        timeout_s: Optional[float] = None,
+        on_status: Optional[Any] = None,
+    ) -> RunStatus:
+        """Poll ``status`` until terminal (``succeeded`` / ``failed`` /
+        ``cancelled``) or until ``timeout_s`` elapses.
+
+        ``on_status`` is an optional callable invoked with each intermediate
+        :class:`RunStatus` snapshot — useful for surfacing a progress
+        indicator in a UI without re-implementing the polling loop.
+        Raises :class:`MantisTimeoutError` on timeout (the run is *not*
+        cancelled — call :meth:`cancel` explicitly if needed).
+        """
+        if poll_interval_s <= 0:
+            raise ValueError("poll_interval_s must be > 0")
+        t0 = time.monotonic()
+        while True:
+            status = self.status(run_id)
+            if on_status is not None:
+                on_status(status)
+            if status.status in TERMINAL_STATUSES:
+                return status
+            elapsed = time.monotonic() - t0
+            if timeout_s is not None and elapsed >= timeout_s:
+                raise MantisTimeoutError(
+                    f"run {run_id} did not reach terminal state in "
+                    f"{timeout_s:.0f}s (last status: {status.status!r})",
+                    run_id=run_id,
+                    elapsed_s=elapsed,
+                )
+            time.sleep(poll_interval_s)
+
+    def run_to_completion(
+        self,
+        request: Union[PredictRequest, dict],
+        *,
+        poll_interval_s: float = _DEFAULT_POLL_INTERVAL_S,
+        timeout_s: Optional[float] = None,
+        on_status: Optional[Any] = None,
+    ) -> dict:
+        """Submit + wait + fetch result in one call.
+
+        Equivalent to ``predict() → wait_for_completion() → result()``.
+        Raises :class:`MantisRunFailed` if the run ends in ``failed`` or
+        ``cancelled``; raises :class:`MantisTimeoutError` if the run
+        doesn't terminate inside ``timeout_s``.
+        """
+        handle = self.predict(request)
+        final = self.wait_for_completion(
+            handle.run_id,
+            poll_interval_s=poll_interval_s,
+            timeout_s=timeout_s,
+            on_status=on_status,
+        )
+        if final.status != "succeeded":
+            raise MantisRunFailed(final)
+        return self.result(handle.run_id)
+
+    # ── Context manager — close the underlying session ─────────────────
+
+    def close(self) -> None:
+        self._session.close()
+
+    def __enter__(self) -> "MantisClient":
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        self.close()
+
+    # Make ``list(client.iter_logs(run_id))`` a clean one-liner if a caller
+    # ever wants page-by-page log retrieval — but only if the server grows
+    # cursor-style pagination. Kept as a placeholder so the surface is
+    # forward-compat-friendly.
+    def iter_logs(self, run_id: str, *, batch: int = 1000) -> Iterable[str]:
+        """Yield log lines in batches of ``batch``. Today this is a single
+        call (server doesn't paginate); structure preserved for future
+        cursor-style pagination.
+        """
+        yield from self.logs(run_id, tail=batch)

--- a/src/mantis_agent/client/errors.py
+++ b/src/mantis_agent/client/errors.py
@@ -1,0 +1,92 @@
+"""Exception hierarchy for the Mantis client.
+
+All client-raised exceptions inherit from :class:`MantisError`, so callers
+can write ``except MantisError`` once and catch every failure shape the
+client can surface (HTTP errors, auth failures, polling timeouts, terminal
+run failures). More specific subclasses let callers branch on the cause
+without parsing string messages.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+
+class MantisError(Exception):
+    """Base class for every exception the Mantis client raises."""
+
+
+class MantisAPIError(MantisError):
+    """Generic HTTP-level failure from the Mantis server.
+
+    Raised when the server returns a non-2xx status code that isn't more
+    specifically classified (auth, rate-limit). Attributes carry the raw
+    HTTP status and the parsed response body so callers can build their
+    own retry / logging logic.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status_code: int,
+        response_body: Any = None,
+    ) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+        self.response_body = response_body
+
+
+class MantisAuthError(MantisAPIError):
+    """401 or 403 from the Mantis server.
+
+    Usually means the ``X-Mantis-Token`` header is missing, expired, or
+    scoped wrong for the requested action — or, for Baseten-hosted
+    deployments, that ``Authorization: Api-Key ...`` is missing.
+    """
+
+
+class MantisRateLimitError(MantisAPIError):
+    """429 from the Mantis server. Carries the server's ``Retry-After``."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status_code: int = 429,
+        response_body: Any = None,
+        retry_after_seconds: Optional[float] = None,
+    ) -> None:
+        super().__init__(
+            message, status_code=status_code, response_body=response_body,
+        )
+        self.retry_after_seconds = retry_after_seconds
+
+
+class MantisTimeoutError(MantisError):
+    """``wait_for_completion`` exceeded the caller-supplied timeout.
+
+    The run is *not* cancelled — it's still in flight on the server. The
+    caller can either poll again or call :meth:`MantisClient.cancel`.
+    """
+
+    def __init__(self, message: str, *, run_id: str, elapsed_s: float) -> None:
+        super().__init__(message)
+        self.run_id = run_id
+        self.elapsed_s = elapsed_s
+
+
+class MantisRunFailed(MantisError):
+    """A run reached a terminal non-success state (``failed`` or ``cancelled``).
+
+    Raised by :meth:`MantisClient.run_to_completion` when the caller asked
+    for the result-shaped convenience flow. The status snapshot is attached
+    so the caller can inspect ``.error`` / ``.summary`` without a second
+    round-trip.
+    """
+
+    def __init__(self, status: Any) -> None:
+        super().__init__(
+            f"run {status.run_id} ended with status={status.status!r}"
+        )
+        self.status = status

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,516 @@
+"""Unit tests for ``mantis_agent.client.MantisClient``.
+
+Uses a stub session (no live HTTP) so the test stays fast, deterministic,
+and works offline. The Mantis FastAPI app is exercised separately in
+``tests/test_video_endpoint.py`` and ``tests/test_chat_completions_proxy.py``
+via ``fastapi.testclient.TestClient``; this file only tests the client
+side of the contract.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Optional
+from unittest.mock import MagicMock
+
+import pytest
+
+from mantis_agent.client import (
+    MantisAPIError,
+    MantisAuthError,
+    MantisClient,
+    MantisRateLimitError,
+    MantisRunFailed,
+    MantisTimeoutError,
+    PredictRequest,
+    RunStatus,
+)
+
+
+class _StubResponse:
+    """Minimal ``requests.Response`` lookalike for the stub session."""
+
+    def __init__(
+        self,
+        status_code: int = 200,
+        json_body: Optional[dict] = None,
+        text: str = "",
+        headers: Optional[dict] = None,
+        content_chunks: Optional[list[bytes]] = None,
+    ) -> None:
+        self.status_code = status_code
+        self._json = json_body
+        self.text = text
+        self.headers = headers or {}
+        self.url = ""  # populated by the stub session
+        self._chunks = content_chunks or []
+
+    def json(self) -> Any:
+        if self._json is None:
+            raise ValueError("no json body")
+        return self._json
+
+    def iter_content(self, chunk_size: int = 1024):  # noqa: ARG002 — match requests sig
+        yield from self._chunks
+
+    def __enter__(self) -> "_StubResponse":
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        return None
+
+
+class _StubSession:
+    """Stand-in for ``requests.Session`` that records calls and replays
+    canned responses. Configure with a ``handler(method, url, **kw)`` callable
+    or a ``queue`` of pre-built :class:`_StubResponse` objects.
+    """
+
+    def __init__(
+        self,
+        handler: Optional[Callable[..., _StubResponse]] = None,
+        queue: Optional[list[_StubResponse]] = None,
+    ) -> None:
+        self.handler = handler
+        self.queue: list[_StubResponse] = list(queue or [])
+        self.calls: list[tuple[str, str, dict]] = []
+
+    def _next(self, method: str, url: str, **kw: Any) -> _StubResponse:
+        self.calls.append((method, url, kw))
+        if self.handler is not None:
+            resp = self.handler(method, url, **kw)
+        elif self.queue:
+            resp = self.queue.pop(0)
+        else:
+            raise AssertionError(
+                f"unexpected {method} {url} — stub has no more responses",
+            )
+        resp.url = url
+        return resp
+
+    def post(self, url: str, **kw: Any) -> _StubResponse:
+        return self._next("POST", url, **kw)
+
+    def get(self, url: str, **kw: Any) -> _StubResponse:
+        return self._next("GET", url, **kw)
+
+    def close(self) -> None:
+        pass
+
+
+def _client(session: _StubSession) -> MantisClient:
+    return MantisClient(
+        endpoint="https://mantis.example/production/sync",
+        api_key="api-key-x",
+        mantis_token="tenant-x",
+        session=session,  # type: ignore[arg-type]
+    )
+
+
+# ── constructor + headers ─────────────────────────────────────────────────
+
+
+def test_endpoint_strips_trailing_v1_and_slash() -> None:
+    session = _StubSession()
+    c = MantisClient(endpoint="https://m.example/v1/", session=session)  # type: ignore[arg-type]
+    assert c.endpoint == "https://m.example"
+
+
+def test_empty_endpoint_rejected() -> None:
+    with pytest.raises(ValueError, match="endpoint is required"):
+        MantisClient(endpoint="")
+
+
+def test_from_env_reads_three_vars(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MANTIS_ENDPOINT", "https://e.example")
+    monkeypatch.setenv("BASETEN_API_KEY", "key-1")
+    monkeypatch.setenv("MANTIS_API_TOKEN", "tok-1")
+    c = MantisClient.from_env(session=_StubSession())  # type: ignore[arg-type]
+    assert c.endpoint == "https://e.example"
+    assert c.api_key == "key-1"
+    assert c.mantis_token == "tok-1"
+
+
+def test_from_env_missing_endpoint_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("MANTIS_ENDPOINT", raising=False)
+    with pytest.raises(ValueError, match="MANTIS_ENDPOINT"):
+        MantisClient.from_env()
+
+
+# ── predict / submit ──────────────────────────────────────────────────────
+
+
+def test_predict_sends_typed_request_and_returns_handle() -> None:
+    session = _StubSession(queue=[
+        _StubResponse(json_body={
+            "status": "queued",
+            "created_at": "2026-04-28T00:00:00Z",
+            "model": "holo3",
+            "mode": "detached",
+            "run_id": "run-abc",
+            "payload": {},
+            "updated_at": "2026-04-28T00:00:00Z",
+            "status_path": "/x/status.json",
+            "result_path": "/x/result.json",
+            "csv_path": "/x/leads.csv",
+            "events_path": "/x/events.log",
+        }),
+    ])
+    c = _client(session)
+    handle = c.predict(
+        PredictRequest(
+            micro="plans/example/extract_listings.json",
+            state_key="abc",
+            max_cost=2,
+        ),
+    )
+    assert handle.run_id == "run-abc"
+    assert handle.status == "queued"
+    method, url, kw = session.calls[0]
+    assert method == "POST"
+    assert url.endswith("/v1/predict")
+    assert kw["headers"]["Authorization"] == "Api-Key api-key-x"
+    assert kw["headers"]["X-Mantis-Token"] == "tenant-x"
+    assert kw["json"]["micro"] == "plans/example/extract_listings.json"
+    assert kw["json"]["state_key"] == "abc"
+    assert kw["json"]["detached"] is True
+
+
+def test_predict_accepts_raw_dict() -> None:
+    session = _StubSession(queue=[
+        _StubResponse(json_body={
+            "status": "queued",
+            "created_at": "x",
+            "model": "holo3",
+            "mode": "detached",
+            "run_id": "run-2",
+            "payload": {},
+            "updated_at": "x",
+            "status_path": "x",
+            "result_path": "x",
+            "csv_path": "x",
+            "events_path": "x",
+        }),
+    ])
+    c = _client(session)
+    handle = c.predict({"micro": "p.json"})
+    assert handle.run_id == "run-2"
+
+
+def test_predict_rejects_garbage_dict() -> None:
+    # A dict missing all the plan-shape fields fails PredictRequest validation.
+    c = _client(_StubSession())
+    with pytest.raises(Exception):  # pydantic ValidationError
+        c.predict({})
+
+
+def test_idempotency_key_added_to_headers() -> None:
+    session = _StubSession(queue=[
+        _StubResponse(json_body={
+            "status": "queued",
+            "created_at": "x",
+            "model": "m",
+            "mode": "detached",
+            "run_id": "r",
+            "payload": {},
+            "updated_at": "x",
+            "status_path": "x",
+            "result_path": "x",
+            "csv_path": "x",
+            "events_path": "x",
+        }),
+    ])
+    c = MantisClient(
+        endpoint="https://m.example",
+        api_key="k",
+        mantis_token="t",
+        idempotency_key="order-7afc3b91",
+        session=session,  # type: ignore[arg-type]
+    )
+    c.predict({"micro": "p.json"})
+    assert session.calls[0][2]["headers"]["Idempotency-Key"] == "order-7afc3b91"
+
+
+# ── action variants ───────────────────────────────────────────────────────
+
+
+def test_status_parses_run_status() -> None:
+    session = _StubSession(queue=[
+        _StubResponse(json_body={
+            "status": "running",
+            "run_id": "r1",
+            "started_at": "2026-04-28T00:00:00Z",
+        }),
+    ])
+    c = _client(session)
+    s = c.status("r1")
+    assert isinstance(s, RunStatus)
+    assert s.status == "running"
+    assert s.run_id == "r1"
+
+
+def test_result_returns_dict() -> None:
+    session = _StubSession(queue=[
+        _StubResponse(json_body={"result": {"leads": ["A", "B"]}}),
+    ])
+    c = _client(session)
+    out = c.result("r1")
+    assert out["result"]["leads"] == ["A", "B"]
+
+
+def test_logs_returns_event_strings() -> None:
+    session = _StubSession(queue=[
+        _StubResponse(json_body={"events": ["event-a", "event-b", "event-c"]}),
+    ])
+    c = _client(session)
+    events = c.logs("r1", tail=3)
+    assert events == ["event-a", "event-b", "event-c"]
+    assert session.calls[0][2]["json"] == {
+        "action": "logs", "run_id": "r1", "tail": 3,
+    }
+
+
+def test_logs_rejects_out_of_range_tail() -> None:
+    c = _client(_StubSession())
+    with pytest.raises(ValueError, match=r"tail must be in"):
+        c.logs("r1", tail=0)
+    with pytest.raises(ValueError, match=r"tail must be in"):
+        c.logs("r1", tail=10_001)
+
+
+def test_cancel_sends_action() -> None:
+    session = _StubSession(queue=[
+        _StubResponse(json_body={"status": "cancelling"}),
+    ])
+    c = _client(session)
+    c.cancel("r1")
+    assert session.calls[0][2]["json"] == {"action": "cancel", "run_id": "r1"}
+
+
+# ── errors ────────────────────────────────────────────────────────────────
+
+
+def test_auth_error_on_401() -> None:
+    session = _StubSession(queue=[
+        _StubResponse(status_code=401, json_body={"detail": "bad token"}),
+    ])
+    c = _client(session)
+    with pytest.raises(MantisAuthError) as ei:
+        c.status("r1")
+    assert ei.value.status_code == 401
+    assert ei.value.response_body == {"detail": "bad token"}
+
+
+def test_rate_limit_carries_retry_after() -> None:
+    session = _StubSession(queue=[
+        _StubResponse(
+            status_code=429,
+            json_body={"detail": "slow down"},
+            headers={"Retry-After": "12.5"},
+        ),
+    ])
+    c = _client(session)
+    with pytest.raises(MantisRateLimitError) as ei:
+        c.status("r1")
+    assert ei.value.retry_after_seconds == 12.5
+
+
+def test_generic_api_error_on_500() -> None:
+    session = _StubSession(queue=[
+        _StubResponse(status_code=500, text="kaboom"),
+    ])
+    c = _client(session)
+    with pytest.raises(MantisAPIError) as ei:
+        c.status("r1")
+    assert ei.value.status_code == 500
+    assert ei.value.response_body == "kaboom"
+
+
+# ── wait_for_completion + run_to_completion ───────────────────────────────
+
+
+def test_wait_for_completion_returns_on_terminal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Three status calls — running, running, succeeded.
+    session = _StubSession(queue=[
+        _StubResponse(json_body={"status": "running", "run_id": "r1"}),
+        _StubResponse(json_body={"status": "running", "run_id": "r1"}),
+        _StubResponse(json_body={
+            "status": "succeeded",
+            "run_id": "r1",
+            "summary": {"viable": 3},
+        }),
+    ])
+    sleeps: list[float] = []
+    monkeypatch.setattr(
+        "mantis_agent.client.client.time.sleep", lambda s: sleeps.append(s),
+    )
+    c = _client(session)
+    final = c.wait_for_completion("r1", poll_interval_s=0.1)
+    assert final.status == "succeeded"
+    assert len(session.calls) == 3
+    assert sleeps == [0.1, 0.1]  # one sleep per non-terminal poll
+
+
+def test_wait_for_completion_raises_on_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = _StubSession(handler=lambda *_a, **_kw: _StubResponse(
+        json_body={"status": "running", "run_id": "r1"},
+    ))
+    # Drive the monotonic clock so we hit the timeout deterministically.
+    ticks = iter([0.0, 0.5, 1.1])
+    monkeypatch.setattr(
+        "mantis_agent.client.client.time.monotonic", lambda: next(ticks),
+    )
+    monkeypatch.setattr(
+        "mantis_agent.client.client.time.sleep", lambda _s: None,
+    )
+    c = _client(session)
+    with pytest.raises(MantisTimeoutError) as ei:
+        c.wait_for_completion("r1", poll_interval_s=0.1, timeout_s=1.0)
+    assert ei.value.run_id == "r1"
+
+
+def test_wait_for_completion_calls_on_status_callback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = _StubSession(queue=[
+        _StubResponse(json_body={"status": "running", "run_id": "r1"}),
+        _StubResponse(json_body={"status": "succeeded", "run_id": "r1"}),
+    ])
+    monkeypatch.setattr(
+        "mantis_agent.client.client.time.sleep", lambda _s: None,
+    )
+    seen: list[str] = []
+    c = _client(session)
+    c.wait_for_completion(
+        "r1", poll_interval_s=0.01, on_status=lambda s: seen.append(s.status),
+    )
+    assert seen == ["running", "succeeded"]
+
+
+def test_run_to_completion_raises_on_failed_terminal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = _StubSession(queue=[
+        # predict
+        _StubResponse(json_body={
+            "status": "queued",
+            "created_at": "x",
+            "model": "m",
+            "mode": "detached",
+            "run_id": "r1",
+            "payload": {},
+            "updated_at": "x",
+            "status_path": "x",
+            "result_path": "x",
+            "csv_path": "x",
+            "events_path": "x",
+        }),
+        # status: failed (terminal)
+        _StubResponse(json_body={
+            "status": "failed",
+            "run_id": "r1",
+            "error": "kaboom",
+        }),
+    ])
+    monkeypatch.setattr(
+        "mantis_agent.client.client.time.sleep", lambda _s: None,
+    )
+    c = _client(session)
+    with pytest.raises(MantisRunFailed) as ei:
+        c.run_to_completion({"micro": "p.json"}, poll_interval_s=0.01)
+    assert ei.value.status.status == "failed"
+
+
+def test_run_to_completion_returns_result_on_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = _StubSession(queue=[
+        _StubResponse(json_body={
+            "status": "queued",
+            "created_at": "x",
+            "model": "m",
+            "mode": "detached",
+            "run_id": "r1",
+            "payload": {},
+            "updated_at": "x",
+            "status_path": "x",
+            "result_path": "x",
+            "csv_path": "x",
+            "events_path": "x",
+        }),
+        _StubResponse(json_body={"status": "succeeded", "run_id": "r1"}),
+        _StubResponse(json_body={"result": {"leads": ["A"]}}),
+    ])
+    monkeypatch.setattr(
+        "mantis_agent.client.client.time.sleep", lambda _s: None,
+    )
+    c = _client(session)
+    out = c.run_to_completion({"micro": "p.json"}, poll_interval_s=0.01)
+    assert out["result"]["leads"] == ["A"]
+
+
+# ── cua / video / health ──────────────────────────────────────────────────
+
+
+def test_cua_run_builds_pure_cua_request() -> None:
+    session = _StubSession(queue=[
+        _StubResponse(json_body={"success": True, "steps": 4}),
+    ])
+    c = _client(session)
+    out = c.cua_run("Click the docs link on example.com", max_steps=5)
+    assert out["success"] is True
+    method, url, kw = session.calls[0]
+    assert method == "POST"
+    assert url.endswith("/v1/cua")
+    assert kw["json"]["instruction"] == "Click the docs link on example.com"
+    assert kw["json"]["max_steps"] == 5
+
+
+def test_fetch_video_streams_to_disk(tmp_path: Any) -> None:
+    chunks = [b"abc", b"defgh", b"ij"]
+    session = _StubSession(queue=[
+        _StubResponse(content_chunks=chunks),
+    ])
+    c = _client(session)
+    dest = c.fetch_video("r1", tmp_path / "out.mp4")
+    assert dest.exists()
+    assert dest.read_bytes() == b"abcdefghij"
+    # No polished=false on the default call.
+    method, url, kw = session.calls[0]
+    assert method == "GET"
+    assert url.endswith("/v1/runs/r1/video")
+    assert "polished" not in (kw.get("params") or {})
+
+
+def test_fetch_video_polished_false_passes_param(tmp_path: Any) -> None:
+    session = _StubSession(queue=[_StubResponse(content_chunks=[b"raw"])])
+    c = _client(session)
+    c.fetch_video("r1", tmp_path / "raw.mp4", polished=False)
+    assert session.calls[0][2]["params"] == {"polished": "false"}
+
+
+def test_health_returns_payload() -> None:
+    session = _StubSession(queue=[
+        _StubResponse(json_body={"status": "ok", "version": "0.1.0"}),
+    ])
+    c = _client(session)
+    out = c.health()
+    assert out == {"status": "ok", "version": "0.1.0"}
+    assert session.calls[0][1].endswith("/v1/health")
+
+
+# ── context manager ───────────────────────────────────────────────────────
+
+
+def test_context_manager_closes_session() -> None:
+    session = MagicMock()
+    with MantisClient(
+        endpoint="https://m.example", session=session,
+    ) as c:
+        assert c.endpoint == "https://m.example"
+    session.close.assert_called_once()

--- a/uv.lock
+++ b/uv.lock
@@ -1444,6 +1444,10 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+client = [
+    { name = "pydantic" },
+    { name = "requests" },
+]
 dev = [
     { name = "httpx" },
     { name = "jsonschema" },
@@ -1528,12 +1532,14 @@ requires-dist = [
     { name = "prometheus-client", marker = "extra == 'metrics'", specifier = ">=0.20" },
     { name = "prometheus-client", marker = "extra == 'server'", specifier = ">=0.20" },
     { name = "pyautogui", marker = "extra == 'local-cua'", specifier = ">=0.9" },
+    { name = "pydantic", marker = "extra == 'client'", specifier = ">=2" },
     { name = "pydantic", marker = "extra == 'orchestrator'", specifier = ">=2" },
     { name = "pydantic", marker = "extra == 'server'", specifier = ">=2" },
     { name = "pymdown-extensions", marker = "extra == 'docs'", specifier = ">=10.7" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.8" },
+    { name = "requests", marker = "extra == 'client'", specifier = ">=2.28" },
     { name = "requests", marker = "extra == 'orchestrator'", specifier = ">=2.28" },
     { name = "requests", marker = "extra == 'server'", specifier = ">=2.28" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4" },
@@ -1542,7 +1548,7 @@ requires-dist = [
     { name = "uvicorn", marker = "extra == 'server'", specifier = ">=0.20" },
     { name = "uvicorn", marker = "extra == 'viewer'", specifier = ">=0.20" },
 ]
-provides-extras = ["orchestrator", "metrics", "server", "local-cua", "viewer", "gpu", "hud", "dev", "docs", "full"]
+provides-extras = ["orchestrator", "client", "metrics", "server", "local-cua", "viewer", "gpu", "hud", "dev", "docs", "full"]
 
 [[package]]
 name = "markdown"


### PR DESCRIPTION
## Summary

Closes #267. Replaces the hand-rolled \`submit() / poll() / fetch_result()\` boilerplate that every integrator copies out of \`docs/client/index.md\` with a typed wrapper around the five end-user endpoints.

**Before (every integrator had this):**

```python
def submit(...): r = requests.post(...); r.raise_for_status(); ...
def poll(...): while True: r = requests.post(...); ...
def fetch_result(...): r = requests.post(...); ...
```

**After:**

```python
from mantis_agent.client import MantisClient, PredictRequest

client = MantisClient.from_env()
result = client.run_to_completion(
    PredictRequest(
        micro=\"plans/example/extract_listings.json\",
        state_key=\"marketplace-prod\",
        max_cost=2,
    ),
)
```

## What's in the box

- **\`MantisClient\`** — sync \`requests.Session\`-backed wrapper. Constructor + \`from_env()\`. Methods: \`predict\`, \`status\`, \`result\`, \`logs\`, \`cancel\`, \`cua_run\`, \`fetch_video\`, \`health\`, \`wait_for_completion\`, \`run_to_completion\`. Context-manager support so the session closes cleanly. \`Idempotency-Key\` header support for retry safety.
- **Typed request/response models** — re-exports \`PredictRequest\`, \`PureCUARequest\`, \`RunStatus\`, \`DetachedRunHandle\` from \`api_schemas\` so callers don't have to import from server-side modules.
- **Typed exception hierarchy** — \`MantisError\` base + \`MantisAPIError\`, \`MantisAuthError\` (401/403), \`MantisRateLimitError\` (429 with \`retry_after_seconds\`), \`MantisTimeoutError\`, \`MantisRunFailed\`. No string-matching needed to branch on failure.
- **\`[client]\` extras alias** — same deps as \`[orchestrator]\` (\`requests\` + \`pydantic\`). No FastAPI / torch / Pillow / Holo3.
- **\`docs/client/index.md\`** — old raw-requests snippet replaced with the typed-client equivalent, plus sections on progress callbacks, CUA pass-through, and structured error handling. Raw-HTTP path is still documented for callers who prefer it.
- **\`tests/test_client.py\`** — 26 unit tests covering header construction, the full action surface, every error class, polling helpers (with monkeypatched \`sleep\` + \`monotonic\` so they run in 1.5 s), video streaming to disk, and context-manager close.

## What's deferred

A standalone \`mantis-client\` wheel on PyPI was mentioned in the issue but kept out of scope for this PR — it requires a separate package skeleton + PyPI publishing pipeline. The current surface lands inside \`mantis-agent\` as \`mantis_agent.client\`, ready to be carved out into its own wheel later without changing the import path.

## Test plan
- [x] \`uv run python -m pytest tests/test_client.py -v\` — 26 passed in 1.52s
- [x] \`uv run python -m pytest tests/test_client.py tests/test_plan_schema.py tests/test_examples_plans.py -q\` — 38 passed in 1.70s
- [x] \`uv run ruff check .\` — All checks passed
- [x] \`uv run mkdocs build --strict\` — built clean (one pre-existing unrelated anchor warning)
- [x] \`uv run python -c \"from mantis_agent.client import MantisClient, PredictRequest, RunStatus, MantisAuthError\"\` — imports clean
- [ ] Follow-up: smoke against the live Baseten deployment once merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)