### PR TITLE
feat(server): enable Swagger UI + add /v1/version (#271, #272)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -16,8 +16,11 @@ and the [any-agent integration playbook](integrations/any-agent.md).
 | `POST /v1/chat/completions` | `X-Mantis-Token` (run scope) | OpenAI-compat reverse proxy to in-pod Holo3 (raw inference). |
 | `GET /v1/models` | open | OpenAI-compat model list. Returns `holo3`. |
 | `GET /v1/health`, `GET /health` | open | Liveness/readiness probe. |
+| `GET /v1/version` | open | Runtime version snapshot — `version`, `model`, `ready`, `git_sha`, `build_time`. Useful for pinning client behavior to a specific build. |
 | `GET /metrics` | open | Prometheus scrape endpoint. Returns 503 if `prometheus_client` not installed. |
 | `GET /v1/runs/{run_id}/video` | `X-Mantis-Token` | Download the screencast captured during a run. Returns 404 if `record_video` was not requested. |
+| `GET /docs`, `GET /redoc` | open | Interactive Swagger UI / Redoc viewer over `/openapi.json`. Disable on production tenant fleets with `MANTIS_ENABLE_DOCS_UI=0`. |
+| `GET /openapi.json` | open | Machine-readable OpenAPI spec. Always served, even when the interactive UIs are disabled — this is what client SDKs and IDE plugins consume. |
 
 When deployed behind Baseten, all requests must also carry
 `Authorization: Api-Key <BASETEN_API_KEY>` (gateway auth, separate from

--- a/docs/client/auth.md
+++ b/docs/client/auth.md
@@ -38,8 +38,10 @@ The same headers go on every endpoint:
 
 Open / un-auth'd endpoints (no tokens needed):
 - `GET /health`, `GET /v1/health` — platform liveness probes
+- `GET /v1/version` — runtime version snapshot
 - `GET /v1/models` — model discovery
 - `GET /metrics` — Prometheus scrape
+- `GET /docs`, `GET /redoc`, `GET /openapi.json` — interactive API explorer (UIs gated by `MANTIS_ENABLE_DOCS_UI` on the server)
 
 ## Scopes
 

--- a/docs/reference/env-vars.md
+++ b/docs/reference/env-vars.md
@@ -84,6 +84,14 @@ See [operations/cost.md](../operations/cost.md) for the full rate-tuning workflo
 | `LOG_LEVEL` | `INFO` | Standard Python logging level |
 | `MANTIS_LOG_FORMAT` | `json` | `json` (default) emits one-line JSON per record with `tenant_id` enrichment; `plain` reverts to ad-hoc format |
 
+## API documentation surface
+
+| Var | Default | Effect |
+|---|---|---|
+| `MANTIS_ENABLE_DOCS_UI` | `1` | Serve `/docs` (Swagger) and `/redoc` (Redoc) over the FastAPI app. Set to `0` / `false` / `no` / `off` on production tenant fleets that don't want the interactive UIs exposed publicly. `/openapi.json` is served regardless. |
+| `MANTIS_GIT_SHA` | unset | Surfaced verbatim in `GET /v1/version` so clients can pin to a specific build. Typically populated by the deploy pipeline. |
+| `MANTIS_BUILD_TIME` | unset | Surfaced verbatim in `GET /v1/version`. Populated by the deploy pipeline. |
+
 ## Context (set per request, not per deployment)
 
 The handler sets these on every `/v1/predict` so downstream code (the runtime, the JSON log formatter) can read them via `os.environ`. **Don't rely on them being set at deployment time.**

--- a/src/mantis_agent/baseten_server/routes.py
+++ b/src/mantis_agent/baseten_server/routes.py
@@ -95,7 +95,33 @@ logger = logging.getLogger("mantis_agent.baseten_server")
 
 # ── Module-level singletons ─────────────────────────────────────────────────
 
-app = FastAPI(title="Mantis CUA Baseten Workload", docs_url=None, redoc_url=None)
+# Interactive API docs at /docs (Swagger UI) and /redoc are on by default
+# so self-hosters get a browsable surface for free. Set
+# ``MANTIS_ENABLE_DOCS_UI=0`` on production tenant fleets that don't want
+# the UI exposed publicly. ``/openapi.json`` stays on regardless — it's
+# what client SDKs and IDE plugins consume.
+_DOCS_UI_ENABLED = os.environ.get("MANTIS_ENABLE_DOCS_UI", "1").lower() in {
+    "1",
+    "true",
+    "yes",
+    "on",
+}
+
+from .. import __version__ as _mantis_version  # noqa: E402 — kept near app config
+
+app = FastAPI(
+    title="Mantis CUA",
+    description=(
+        "Perception-reasoning-action agent for computer use. Drives a "
+        "real browser via Holo3 + Claude. See the docs at "
+        "https://mercurialsolo.github.io/mantis/ — this surface is the "
+        "live HTTP API. Auth: `X-Mantis-Token` per tenant, plus "
+        "`Authorization: Api-Key …` when fronted by a Baseten gateway."
+    ),
+    version=_mantis_version,
+    docs_url="/docs" if _DOCS_UI_ENABLED else None,
+    redoc_url="/redoc" if _DOCS_UI_ENABLED else None,
+)
 runtime = BasetenCUARuntime()
 
 
@@ -156,6 +182,25 @@ def health_v1() -> dict[str, Any]:
     /v1/health is the same payload available under the public API path.
     """
     return {"ok": runtime.loaded, "model": runtime.model_kind}
+
+
+@app.get("/v1/version")
+def version_info() -> dict[str, Any]:
+    """Runtime version snapshot — useful when multiple deployments serve
+    different builds and a client needs to pin behavior to a specific one.
+
+    ``git_sha`` and ``build_time`` are populated by the deploy pipeline via
+    ``MANTIS_GIT_SHA`` / ``MANTIS_BUILD_TIME`` env vars (empty strings when
+    running outside a build context). No auth required — version info is
+    safe to expose alongside ``/health``.
+    """
+    return {
+        "version": _mantis_version,
+        "model": runtime.model_kind,
+        "ready": runtime.loaded,
+        "git_sha": os.environ.get("MANTIS_GIT_SHA", ""),
+        "build_time": os.environ.get("MANTIS_BUILD_TIME", ""),
+    }
 
 
 @app.get("/v1/runs/{run_id}/video")

--- a/tests/test_version_and_docs_ui.py
+++ b/tests/test_version_and_docs_ui.py
@@ -1,0 +1,106 @@
+"""Integration tests for the operator-facing surface added in #271 + #272.
+
+Covered:
+
+- ``GET /v1/version`` returns the runtime version + git/build env passthrough.
+- ``GET /docs`` and ``GET /redoc`` are served by default, gated off by
+  ``MANTIS_ENABLE_DOCS_UI=0`` for production tenant fleets that don't want
+  the interactive UI exposed.
+- ``GET /openapi.json`` is always served (FastAPI default) and reflects
+  the title / version we configured on the FastAPI app.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("pydantic")
+
+from fastapi.testclient import TestClient
+
+from mantis_agent import __version__ as MANTIS_VERSION
+from mantis_agent import tenant_auth as ta_mod
+
+
+def _build_client(monkeypatch, tmp_path):
+    """Boot a fresh TestClient with single-tenant auth wired up."""
+    monkeypatch.setenv("MANTIS_API_TOKEN", "test-token")
+    monkeypatch.delenv("MANTIS_TENANT_KEYS_PATH", raising=False)
+    monkeypatch.setenv("MANTIS_DATA_DIR", str(tmp_path / "mantis-data"))
+    ta_mod.reset_key_store()
+
+    from mantis_agent import baseten_server as bs
+
+    importlib.reload(bs)
+    return TestClient(bs.app)
+
+
+# ── /v1/version ──────────────────────────────────────────────────────────
+
+
+def test_version_returns_runtime_snapshot(monkeypatch, tmp_path):
+    client = _build_client(monkeypatch, tmp_path)
+    resp = client.get("/v1/version")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["version"] == MANTIS_VERSION
+    # ``model`` and ``ready`` come from the runtime singleton — booted in
+    # TestClient land without a model load, so they're empty / False.
+    assert "model" in body
+    assert "ready" in body
+    assert "git_sha" in body
+    assert "build_time" in body
+
+
+def test_version_includes_build_env_passthrough(monkeypatch, tmp_path):
+    monkeypatch.setenv("MANTIS_GIT_SHA", "abc1234")
+    monkeypatch.setenv("MANTIS_BUILD_TIME", "2026-05-11T20:00:00Z")
+    client = _build_client(monkeypatch, tmp_path)
+    body = client.get("/v1/version").json()
+    assert body["git_sha"] == "abc1234"
+    assert body["build_time"] == "2026-05-11T20:00:00Z"
+
+
+def test_version_does_not_require_auth(monkeypatch, tmp_path):
+    """``/v1/version`` is open like ``/health`` — no X-Mantis-Token needed."""
+    client = _build_client(monkeypatch, tmp_path)
+    resp = client.get("/v1/version")  # no headers
+    assert resp.status_code == 200
+
+
+# ── Swagger / Redoc / OpenAPI ────────────────────────────────────────────
+
+
+def test_docs_ui_enabled_by_default(monkeypatch, tmp_path):
+    monkeypatch.delenv("MANTIS_ENABLE_DOCS_UI", raising=False)
+    client = _build_client(monkeypatch, tmp_path)
+    assert client.get("/docs").status_code == 200
+    assert client.get("/redoc").status_code == 200
+
+
+@pytest.mark.parametrize("flag", ["0", "false", "no", "off"])
+def test_docs_ui_disabled_by_env(monkeypatch, tmp_path, flag):
+    monkeypatch.setenv("MANTIS_ENABLE_DOCS_UI", flag)
+    client = _build_client(monkeypatch, tmp_path)
+    # FastAPI returns 404 when the corresponding *_url is None.
+    assert client.get("/docs").status_code == 404
+    assert client.get("/redoc").status_code == 404
+
+
+def test_openapi_json_always_served_and_reflects_metadata(
+    monkeypatch, tmp_path,
+):
+    # Even with the UI disabled, the spec is still available — that's what
+    # client SDKs and IDE plugins consume.
+    monkeypatch.setenv("MANTIS_ENABLE_DOCS_UI", "0")
+    client = _build_client(monkeypatch, tmp_path)
+    resp = client.get("/openapi.json")
+    assert resp.status_code == 200
+    spec = resp.json()
+    assert spec["info"]["title"] == "Mantis CUA"
+    assert spec["info"]["version"] == MANTIS_VERSION
+    # The new /v1/version endpoint should be visible in the spec.
+    assert "/v1/version" in spec["paths"]

--- a/tests/test_version_and_docs_ui.py
+++ b/tests/test_version_and_docs_ui.py
@@ -26,14 +26,29 @@ from mantis_agent import tenant_auth as ta_mod
 
 
 def _build_client(monkeypatch, tmp_path):
-    """Boot a fresh TestClient with single-tenant auth wired up."""
+    """Boot a fresh TestClient with single-tenant auth wired up.
+
+    Reloading ``baseten_server`` (the package) alone is not enough — the
+    package's ``__init__.py`` does ``from .routes import app``, which
+    just re-fetches the existing binding from the already-cached
+    ``routes`` submodule. ``_DOCS_UI_ENABLED`` is evaluated at
+    ``routes`` import-time, so we must reload the ``routes`` submodule
+    explicitly to make the test's ``MANTIS_ENABLE_DOCS_UI`` env override
+    take effect. Without this, parallel CI workers that imported
+    ``baseten_server.routes`` for a prior test see the FastAPI app
+    constructed with the env unset (docs on by default) regardless of
+    what the current test patches — passes locally on a clean worker
+    but flakes in CI under pytest-xdist with hot module caches.
+    """
     monkeypatch.setenv("MANTIS_API_TOKEN", "test-token")
     monkeypatch.delenv("MANTIS_TENANT_KEYS_PATH", raising=False)
     monkeypatch.setenv("MANTIS_DATA_DIR", str(tmp_path / "mantis-data"))
     ta_mod.reset_key_store()
 
     from mantis_agent import baseten_server as bs
+    from mantis_agent.baseten_server import routes as bs_routes
 
+    importlib.reload(bs_routes)
     importlib.reload(bs)
     return TestClient(bs.app)
 


### PR DESCRIPTION
## Summary

Closes #271 and #272. Two server-side P2 end-user-DX changes bundled — same file, related themes.

**#271 — interactive API docs**
- Flip the FastAPI app from \`docs_url=None, redoc_url=None\` to serving \`/docs\` and \`/redoc\` by default, gated on \`MANTIS_ENABLE_DOCS_UI=1\`. Production tenant fleets that don't want a public UI can set \`MANTIS_ENABLE_DOCS_UI=0\` (or \`false\` / \`no\` / \`off\`).
- \`/openapi.json\` is **always** served regardless — that's what client SDKs and IDE plugins consume.
- Populate the FastAPI \`title\` / \`description\` / \`version\` from \`mantis_agent.__version__\` so the rendered spec is informative.

**#272 — runtime version discovery**
- New \`GET /v1/version\` returns \`{version, model, ready, git_sha, build_time}\`. No auth required (sibling of \`/v1/health\`).
- \`MANTIS_GIT_SHA\` / \`MANTIS_BUILD_TIME\` env vars are surfaced verbatim so the deploy pipeline can pin clients to specific builds.

## What's in the box
- \`src/mantis_agent/baseten_server/routes.py\` — FastAPI app re-config + \`/v1/version\` handler.
- \`tests/test_version_and_docs_ui.py\` — 9 tests covering the version snapshot, env passthrough, no-auth requirement, UI enabled-by-default, parametrised UI disable flags, and \`/openapi.json\` reflecting the new metadata.
- \`docs/api.md\` — new endpoints in the endpoint table.
- \`docs/client/auth.md\` — un-auth endpoint list updated.
- \`docs/reference/env-vars.md\` — new \"API documentation surface\" section.

## Test plan
- [x] \`uv run python -m pytest tests/test_version_and_docs_ui.py -v\` — 9 passed in 2.88s
- [x] \`uv run python -m pytest tests/test_version_and_docs_ui.py tests/test_video_endpoint.py -q\` — 16 passed
- [x] \`uv run ruff check src/mantis_agent/baseten_server/routes.py tests/test_version_and_docs_ui.py\` — clean
- [x] \`uv run mkdocs build --strict\` — built clean (one pre-existing unrelated anchor warning)
- [ ] Smoke against the live Baseten deployment after merge: \`curl \$ENDPOINT/v1/version\`, then open \`\$ENDPOINT/docs\` in a browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)