### PR TITLE
docs(quickstart): cross-link auth.md from prerequisites (#273)

### DIFF
--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -6,7 +6,14 @@ If someone has already deployed Mantis (or you're using the public Baseten refer
 
 - `curl`, `jq`
 - A **Baseten API key** (`BASETEN_API_KEY`) for the gateway
-- A **Mantis tenant token** (`MANTIS_API_TOKEN`) issued by your operator — see [Tenant keys](../operations/tenant-keys.md) if you're the operator
+- A **Mantis tenant token** (`MANTIS_API_TOKEN`) issued by your operator
+
+The auth model is a two-layer setup (gateway + container). Full reference:
+
+- New integrator — what to put in which header, scopes, error codes:
+  [Authentication](../client/auth.md).
+- Operator — generating tokens, the keys-file format, rotation:
+  [Tenant keys](../operations/tenant-keys.md).
 
 ```bash
 export BASETEN_API_KEY="<your baseten api key>"


### PR DESCRIPTION
## Summary

Closes #273. The quickstart prerequisites bullet for the tenant token only pointed at \`operations/tenant-keys.md\` — the operator-side runbook for generating and rotating tokens. New integrators landing on the quickstart actually wanted the client-side reference (which header to use, what scopes mean, what 401 vs 403 indicates), which lives in \`client/auth.md\`.

Both links are now explicit so readers can branch by role:

- **Integrator** → \`client/auth.md\`
- **Operator** → \`operations/tenant-keys.md\`

One-line file change, no behavior, no code.

## Test plan
- [x] \`uv run mkdocs build --strict\` — built clean (one pre-existing unrelated anchor warning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)