### PR TITLE
fix(client): fetch_video must send ?raw=1, not ?polished=false

### DIFF
--- a/src/mantis_agent/client/client.py
+++ b/src/mantis_agent/client/client.py
@@ -288,14 +288,16 @@ class MantisClient:
     ) -> Path:
         """Stream ``GET /v1/runs/{run_id}/video`` to a local file.
 
-        Returns the destination ``Path``. Set ``polished=False`` to fetch
-        the raw recording instead of the captioned / overlay version (when
-        the deployment produced both).
+        Returns the destination ``Path``. The server serves the polished
+        recording by default (title card + captioned footage + outro card);
+        pass ``polished=False`` to fetch the raw screencast without overlays,
+        which the client forwards as the ``?raw=1`` query the server actually
+        reads.
         """
         url = f"{self.endpoint}/v1/runs/{run_id}/video"
         params: dict[str, Any] = {}
         if not polished:
-            params["polished"] = "false"
+            params["raw"] = "1"
         dest = Path(dest_path)
         dest.parent.mkdir(parents=True, exist_ok=True)
         with self._session.get(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -480,18 +480,23 @@ def test_fetch_video_streams_to_disk(tmp_path: Any) -> None:
     dest = c.fetch_video("r1", tmp_path / "out.mp4")
     assert dest.exists()
     assert dest.read_bytes() == b"abcdefghij"
-    # No polished=false on the default call.
+    # Default fetch sends no query params — server defaults to polished.
     method, url, kw = session.calls[0]
     assert method == "GET"
     assert url.endswith("/v1/runs/r1/video")
-    assert "polished" not in (kw.get("params") or {})
+    assert not (kw.get("params") or {})
 
 
-def test_fetch_video_polished_false_passes_param(tmp_path: Any) -> None:
+def test_fetch_video_raw_passes_raw_one(tmp_path: Any) -> None:
+    """polished=False must send ?raw=1 — that's the query param the server
+    actually reads (`request.query_params.get("raw", "")` in
+    baseten_server/routes.py). Pre-fix the client sent ?polished=false,
+    which the server silently ignored, so callers always got the polished
+    version even when they asked for raw."""
     session = _StubSession(queue=[_StubResponse(content_chunks=[b"raw"])])
     c = _client(session)
     c.fetch_video("r1", tmp_path / "raw.mp4", polished=False)
-    assert session.calls[0][2]["params"] == {"polished": "false"}
+    assert session.calls[0][2]["params"] == {"raw": "1"}
 
 
 def test_health_returns_payload() -> None:


### PR DESCRIPTION
## Summary

Bug fix in code that just merged via PR #278.

The video route in \`baseten_server/routes.py:180\` reads the \`raw\` query parameter:

\`\`\`python
raw_only = request.query_params.get(\"raw\", \"\").lower() in {\"1\", \"true\", \"yes\"}
\`\`\`

When \`MantisClient.fetch_video\` was added in PR #278, it sent \`params={\"polished\": \"false\"}\` instead — which the server silently ignored, so callers asking for the raw recording always got the polished one back.

## Fix

Forward \`polished=False\` as \`?raw=1\` to match the server contract. The default \`polished=True\` path is unchanged — still sends no query params, server defaults to polished.

Updated the existing \`test_fetch_video_polished_false_passes_param\` test (renamed to \`test_fetch_video_raw_passes_raw_one\`) to assert the correct query string. All 26 client tests still pass.

## Test plan
- [x] \`uv run python -m pytest tests/test_client.py -v\` — 26 passed in 1.10s
- [x] \`uv run ruff check src/mantis_agent/client/client.py tests/test_client.py\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)