### PR TITLE
feat(brain): MockBrain for plan authoring without GPU (#274)

### DIFF
--- a/docs/getting-started/plan-formats.md
+++ b/docs/getting-started/plan-formats.md
@@ -75,6 +75,25 @@ A flat JSON list of step objects executed by `MicroPlanRunner`. Best reliability
 
 Field reference is on the [Concepts](concepts.md#step-types-micro-plan-shape) page.
 
+### Iterate on plan structure without GPU or API cost
+
+Use `MANTIS_BRAIN=mock` to point the runner at a deterministic stub
+brain that returns `DONE` on every `think()` call — every click / scroll
+/ holo3 step succeeds immediately, so the run walks through your plan's
+sections, gates, and loops without burning Holo3 inference or Anthropic
+credits.
+
+```bash
+MANTIS_BRAIN=mock mantis plan dry-run plans/example/extract_listings.json
+```
+
+This catches the structural bugs — wrong loop_target index, gate
+predicate in the wrong section, missing `navigate` URL — long before
+you submit the plan to a paid deployment. ClaudeExtractor and
+ClaudeGrounding are independent of the brain, so plans that lean on
+extraction still need `ANTHROPIC_API_KEY` for those steps; everything
+else runs free.
+
 ### IDE autocomplete via JSON Schema
 
 A JSON Schema for the micro-plan format ships at

--- a/docs/reference/env-vars.md
+++ b/docs/reference/env-vars.md
@@ -35,7 +35,7 @@ These are global hard caps; tenant config can be tighter, never looser.
 | Var | Default | Effect |
 |---|---|---|
 | `MANTIS_LLAMA_PORT` | 18080 | Internal port the in-pod llama.cpp server binds to. The `/v1/chat/completions` proxy forwards here. |
-| `MANTIS_BRAIN` | `holo3` | Brain backend selector. One of `holo3`, `claude`, `opencua`, `llamacpp`, `gemma4`, `agent-s`. Wins over the legacy `MANTIS_MODEL`. |
+| `MANTIS_BRAIN` | `holo3` | Brain backend selector. One of `holo3`, `claude`, `opencua`, `llamacpp`, `gemma4`, `agent-s`, `mock`. Wins over the legacy `MANTIS_MODEL`. `mock` is a deterministic always-DONE stub for plan authoring without GPU / API cost (#274). |
 | `MANTIS_MODEL` | (set by Truss) | Legacy alias of `MANTIS_BRAIN` for one minor release. `gemma4-cua` aliases to `gemma4`. |
 | `MANTIS_HOLO3_MODEL_DIR` | `/models/holo3` | Where Holo3 GGUF weights are mounted. |
 | `ANTHROPIC_API_KEY` | unset | Default Anthropic key. Per-tenant `anthropic_secret_name` overrides per request. |

--- a/src/mantis_agent/brain_mock.py
+++ b/src/mantis_agent/brain_mock.py
@@ -1,0 +1,123 @@
+"""MockBrain — deterministic placeholder for plan authoring (#274).
+
+When ``MANTIS_BRAIN=mock`` the brain registry returns this class instead
+of Holo3 / Claude / OpenCUA. Every ``think()`` call returns a
+``DONE`` action with zero LLM calls, so plan authors can iterate on
+plan **structure** (section transitions, gate predicates, loop
+termination) against a real :class:`MicroPlanRunner` without paying
+for inference or running a GPU.
+
+**Scope**: this mocks the perception-action brain only. Verification
+gates, ClaudeExtractor, and ClaudeGrounding are independent
+Claude-backed components and continue to call the Anthropic API
+unless they're stubbed separately. Plans that lean heavily on
+extraction will still need ``ANTHROPIC_API_KEY``; plans that just
+walk a navigate/click/scroll/loop skeleton run free under mock.
+
+The brain has no dependency on torch / transformers / requests /
+anthropic. Importing this module is cheap (no module-level side
+effects beyond the dataclass / class definitions), so the slim
+``mantis-agent`` install can use it without pulling GPU deps.
+
+Example:
+
+.. code-block:: bash
+
+    # Fast structural-only run of a plan — no inference.
+    MANTIS_BRAIN=mock mantis plan dry-run plans/example/extract_listings.json
+
+    # Or call the runner with a mock brain from Python:
+    >>> import os
+    >>> os.environ["MANTIS_BRAIN"] = "mock"
+    >>> from mantis_agent.brain_protocol import resolve_brain_from_env
+    >>> brain = resolve_brain_from_env()
+    >>> brain.load()
+    >>> result = brain.think(frames=[], task="click the button")
+    >>> result.action.action_type.value
+    'done'
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from .actions import Action, ActionType
+
+if TYPE_CHECKING:
+    from PIL import Image
+
+
+@dataclass
+class InferenceResult:
+    """Result from a single MockBrain inference cycle.
+
+    Mirrors the public fields the other brains return so the runner
+    treats a mock result identically to a real one. ``thinking`` and
+    ``tokens_used`` exist for compatibility with downstream code that
+    pulls them; they're always empty / zero for mock.
+    """
+
+    action: Action
+    raw_output: str
+    thinking: str = ""
+    tokens_used: int = 0
+
+
+class MockBrain:
+    """Always-DONE brain for plan authoring without inference cost.
+
+    Returns a ``DONE`` action on every ``think()`` call so the runner
+    accepts the current step as complete and advances to the next.
+    This is enough to exercise section / gate / loop semantics in
+    :class:`MicroPlanRunner` without burning Holo3 + Claude credits.
+
+    Construction is free — no weights, no clients, no env vars to
+    resolve. ``load()`` is a no-op so the brain plugs into the existing
+    runner contract.
+
+    Args:
+        reasoning: String embedded in every returned ``Action.reasoning``
+            so the trace makes it obvious the run was mocked. Override
+            for tests that need to distinguish multiple mocks.
+    """
+
+    model = "mock"
+    model_name = "mock"
+
+    def __init__(self, reasoning: str = "mock brain: structural-only run") -> None:
+        self.reasoning = reasoning
+        self._think_count = 0
+
+    def load(self) -> None:
+        """No-op. Mock has no weights, clients, or external resources."""
+        return None
+
+    def think(
+        self,
+        frames: "list[Image.Image] | None" = None,
+        task: str = "",
+        action_history: "list[Action] | None" = None,
+        screen_size: tuple[int, int] = (1920, 1080),
+        **_kwargs: Any,
+    ) -> InferenceResult:
+        """Return a deterministic ``DONE`` action.
+
+        ``frames`` and ``action_history`` are accepted to match the
+        :class:`Brain` protocol but ignored — the mock has no perception
+        and no state beyond a ``_think_count`` counter exposed in the
+        raw_output for traceability.
+        """
+        self._think_count += 1
+        action = Action(
+            action_type=ActionType.DONE,
+            params={},
+            reasoning=self.reasoning,
+        )
+        return InferenceResult(
+            action=action,
+            raw_output=(
+                f"[mock think #{self._think_count}] task={task!r} "
+                f"frames={len(frames or [])} → DONE"
+            ),
+        )

--- a/src/mantis_agent/brain_protocol.py
+++ b/src/mantis_agent/brain_protocol.py
@@ -147,6 +147,15 @@ def _agents_factory() -> Brain:
     return AgentSBrain()
 
 
+def _mock_factory() -> Brain:
+    # Plan-authoring stub (#274). Pure-Python, no GPU / network — see
+    # brain_mock.py for the contract. Slim installs that only have
+    # ``mantis-agent[orchestrator]`` (no torch / transformers / anthropic)
+    # can still resolve ``MANTIS_BRAIN=mock``.
+    from .brain_mock import MockBrain
+    return MockBrain()
+
+
 def _register_builtins() -> None:
     """Register the in-tree brains. Idempotent."""
     register_brain("holo3", _holo3_factory)
@@ -155,6 +164,7 @@ def _register_builtins() -> None:
     register_brain("llamacpp", _llamacpp_factory)
     register_brain("gemma4", _gemma4_factory)
     register_brain("agent-s", _agents_factory)
+    register_brain("mock", _mock_factory)
 
 
 _register_builtins()

--- a/tests/test_brain_mock.py
+++ b/tests/test_brain_mock.py
@@ -1,0 +1,148 @@
+"""Tests for the MockBrain plan-authoring stub (#274).
+
+The mock brain is meant to be cheap (no GPU, no API), deterministic
+(every think() returns DONE), and resolvable through the public
+brain-registry surface so plan authors can flip ``MANTIS_BRAIN=mock``
+and run their plans against a real :class:`MicroPlanRunner` without
+paying for inference.
+
+These tests pin the contract:
+
+- ``MockBrain()`` constructs without side effects.
+- ``load()`` is a no-op (safe to call repeatedly).
+- ``think()`` always returns a DONE action.
+- ``MockBrain`` satisfies the runtime-checked :class:`Brain` protocol.
+- The registry resolves ``MANTIS_BRAIN=mock`` and
+  ``MANTIS_MODEL=mock`` to the same factory.
+- Importing the module pulls no GPU / network deps.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from mantis_agent.actions import ActionType
+from mantis_agent.brain_mock import MockBrain
+from mantis_agent.brain_protocol import (
+    Brain,
+    list_brains,
+    resolve_brain,
+    resolve_from_env,
+)
+
+
+def test_mock_brain_constructs_cheaply() -> None:
+    brain = MockBrain()
+    assert brain.model == "mock"
+    assert brain.model_name == "mock"
+    # Counter starts at zero — every think() bumps it for trace visibility.
+    assert brain._think_count == 0
+
+
+def test_mock_brain_load_is_noop() -> None:
+    brain = MockBrain()
+    brain.load()
+    brain.load()  # idempotent
+    assert brain._think_count == 0
+
+
+def test_mock_brain_think_returns_done() -> None:
+    brain = MockBrain()
+    brain.load()
+    result = brain.think(task="click the next listing")
+    assert result.action.action_type is ActionType.DONE
+    assert result.action.params == {}
+    assert "mock brain" in result.action.reasoning
+    assert "task='click the next listing'" in result.raw_output
+
+
+def test_mock_brain_think_count_increments() -> None:
+    brain = MockBrain()
+    brain.think(task="t1")
+    brain.think(task="t2")
+    brain.think(task="t3")
+    assert brain._think_count == 3
+
+
+def test_mock_brain_accepts_full_kwarg_surface() -> None:
+    """Match the Brain protocol — runner passes frames + history + screen_size."""
+    brain = MockBrain()
+    result = brain.think(
+        frames=[],
+        task="anything",
+        action_history=[],
+        screen_size=(1280, 720),
+    )
+    assert result.action.action_type is ActionType.DONE
+
+
+def test_mock_brain_satisfies_brain_protocol() -> None:
+    assert isinstance(MockBrain(), Brain)
+
+
+# ── Registry integration ──────────────────────────────────────────────────
+
+
+def test_mock_brain_registered_under_mock_name() -> None:
+    assert "mock" in list_brains()
+
+
+def test_resolve_brain_mock_returns_mock_instance() -> None:
+    brain = resolve_brain("mock")
+    assert isinstance(brain, MockBrain)
+
+
+def test_resolve_from_env_picks_mock(monkeypatch) -> None:
+    monkeypatch.setenv("MANTIS_BRAIN", "mock")
+    monkeypatch.delenv("MANTIS_MODEL", raising=False)
+    brain = resolve_from_env()
+    assert isinstance(brain, MockBrain)
+
+
+def test_resolve_from_env_legacy_model_var(monkeypatch) -> None:
+    """``MANTIS_MODEL`` is the legacy alias; both should map to mock."""
+    monkeypatch.delenv("MANTIS_BRAIN", raising=False)
+    monkeypatch.setenv("MANTIS_MODEL", "mock")
+    brain = resolve_from_env()
+    assert isinstance(brain, MockBrain)
+
+
+# ── Import-cost guard ─────────────────────────────────────────────────────
+
+
+def test_mock_module_has_no_heavyweight_imports() -> None:
+    """Pulling brain_mock should not transitively load torch / transformers
+    / requests / anthropic. The slim install ships without those — if the
+    mock brain accidentally references one, ``MANTIS_BRAIN=mock`` fails
+    inside ``[orchestrator]`` deployments and the mock loses its point.
+
+    We can't fully sandbox the import in a single process (other modules
+    may have already loaded those packages), so the test only fails if
+    a *fresh* import of brain_mock would pull them in. We check by
+    re-importing the module under sys.modules introspection.
+    """
+    # Drop the mock module from sys.modules so reimporting it surfaces any
+    # top-level imports it introduces.
+    sys.modules.pop("mantis_agent.brain_mock", None)
+    forbidden = {"torch", "transformers", "anthropic", "requests"}
+    before = {m for m in forbidden if m in sys.modules}
+    import mantis_agent.brain_mock  # noqa: F401 — side-effect: imports
+    after = {m for m in forbidden if m in sys.modules}
+    introduced = after - before
+    assert not introduced, (
+        f"brain_mock imported forbidden heavy deps: {sorted(introduced)}"
+    )
+
+
+# ── Friendly error when an unknown brain is selected ──────────────────────
+
+
+def test_unknown_brain_name_lists_mock_in_the_available_list() -> None:
+    """The mock brain only helps plan authors if they can discover it.
+    Resolving an unknown name should error with a list that includes
+    'mock' so the user sees it as an option."""
+    with pytest.raises(KeyError) as ei:
+        resolve_brain("does-not-exist")
+    assert "mock" in str(ei.value)


### PR DESCRIPTION
## Summary

Closes #274. Adds a deterministic stub brain so plan authors can iterate on plan **structure** (section transitions, gate predicates, loop termination) without burning Holo3 GPU + Anthropic credits on every iteration.

\`MANTIS_BRAIN=mock\` now resolves \`MockBrain\` — every \`think()\` call returns a \`DONE\` action, so every click / scroll / holo3 step succeeds immediately and the runner walks the plan skeleton in milliseconds.

\`\`\`bash
MANTIS_BRAIN=mock mantis plan dry-run plans/example/extract_listings.json
\`\`\`

## Scope

This mocks the perception-action brain only. ClaudeExtractor and ClaudeGrounding are independent Claude-backed components and continue to call the Anthropic API unless they're stubbed separately. Plans that lean heavily on extraction still need \`ANTHROPIC_API_KEY\` for those steps; everything else runs free.

## What's in the box

- \`src/mantis_agent/brain_mock.py\` — \`MockBrain\` + \`InferenceResult\`. Pure-Python, zero heavyweight imports (no torch / transformers / requests / anthropic). Resolvable from a slim \`mantis-agent[orchestrator]\` install.
- \`src/mantis_agent/brain_protocol.py\` — \`mock\` registered alongside \`holo3\`, \`claude\`, \`opencua\`, etc.
- \`tests/test_brain_mock.py\` — 12 tests covering:
  - Construction, load no-op, always-DONE think(), counter increment
  - Full kwarg surface accepted (frames + action_history + screen_size)
  - \`isinstance(MockBrain(), Brain)\` — protocol conformance
  - Registry lookup + \`MANTIS_BRAIN=mock\` + legacy \`MANTIS_MODEL=mock\` env resolution
  - **Import-cost guard**: re-importing \`brain_mock\` pulls no forbidden deps (torch / transformers / requests / anthropic)
  - Friendly \`KeyError\` on unknown brain names mentions \`mock\` as an option
- \`docs/getting-started/plan-formats.md\` — new section \"Iterate on plan structure without GPU or API cost\" with the caveat about extraction.
- \`docs/reference/env-vars.md\` — \`mock\` added to the \`MANTIS_BRAIN\` enum.

## Test plan
- [x] \`uv run python -m pytest tests/test_brain_mock.py -v\` — 12 passed in 2.06s
- [x] \`uv run ruff check .\` — clean
- [x] \`uv run mkdocs build --strict\` — built clean (one pre-existing unrelated anchor warning)
- [ ] After merge: run a full plan end-to-end with \`MANTIS_BRAIN=mock\` to validate the structural-only path works through MicroPlanRunner

🤖 Generated with [Claude Code](https://claude.com/claude-code)