### PR TITLE
feat(server): X-RateLimit-* response headers (#275)

### DIFF
--- a/docs/operations/rate-limits.md
+++ b/docs/operations/rate-limits.md
@@ -7,6 +7,20 @@ Two dimensions, both per-tenant, both in-process per replica.
 | **Concurrent runs** | `tenant.max_concurrent_runs` | 5 | `429` with `Retry-After: 5` |
 | **Rate** (token bucket) | `tenant.rate_limit_per_minute` | 30 | `429` with `Retry-After: <s-until-token>` |
 
+## Response headers
+
+Every rate-limited response — `POST /v1/predict` (run mode), `POST /v1/cua` — carries the standard `X-RateLimit-*` triple so callers can throttle proactively instead of crashing into 429s:
+
+| Header | Value |
+|---|---|
+| `X-RateLimit-Limit` | The tenant's `rate_limit_per_minute` |
+| `X-RateLimit-Remaining` | Tokens left in the bucket right now (clamped to 0 when overdrawn) |
+| `X-RateLimit-Reset` | Unix timestamp at which the bucket would be back at full capacity |
+
+The headers appear on both 2xx and 429 responses, so a client that hits a 429 can reconcile its local view of the bucket from the same surface. Tenants with `rate_limit_per_minute=0` (rate-limit disabled) get no `X-RateLimit-*` headers — the surface is an explicit promise that the route is rate-limited.
+
+The legacy `Retry-After` header still rides on 429s, in seconds, for clients that already implement Retry-After backoff.
+
 ## How the rate dimension works
 
 A standard token bucket: each tenant has a bucket with `rate_limit_per_minute` capacity, refilled at `rate_limit_per_minute / 60` tokens/sec. Every `POST /v1/predict` (run mode only — polling actions don't consume tokens) takes one token. When the bucket is empty, the request gets `429` with `Retry-After` set to the time until the next token will be available.

--- a/src/mantis_agent/baseten_server/routes.py
+++ b/src/mantis_agent/baseten_server/routes.py
@@ -99,6 +99,51 @@ app = FastAPI(title="Mantis CUA Baseten Workload", docs_url=None, redoc_url=None
 runtime = BasetenCUARuntime()
 
 
+# ── Middleware: standard X-RateLimit-* response headers (#275) ──────────────
+# Each rate-limited route handler stashes the limit / remaining / reset
+# triple on ``request.state.rate_limit_headers`` right after consulting
+# the limiter; this middleware copies them onto the response so callers
+# can throttle proactively instead of crashing into 429s. Routes that
+# don't rate-limit (``/health``, ``/v1/version``, ``/v1/models``,
+# ``/metrics``, ``/v1/runs/{id}/video``) simply don't set the attribute
+# and the middleware is a no-op.
+
+import time as _time  # noqa: E402 — kept near the middleware it powers
+
+
+@app.middleware("http")
+async def _attach_rate_limit_headers(request: Request, call_next):  # type: ignore[no-untyped-def]
+    response = await call_next(request)
+    headers = getattr(request.state, "rate_limit_headers", None)
+    if headers:
+        for name, value in headers.items():
+            response.headers[name] = str(value)
+    return response
+
+
+def _stash_rate_limit_headers(
+    request: Request, decision: Any, tenant_limit: int,
+) -> None:
+    """Record the rate-limit triple on ``request.state`` for the middleware.
+
+    Called from every route that consults the rate limiter, regardless of
+    whether the decision was allow or deny — denied requests still
+    benefit from the headers (alongside the existing ``Retry-After`` on
+    429s).
+    """
+    limit = decision.limit or tenant_limit or 0
+    if not limit:
+        return  # rate-limit disabled for this tenant
+    remaining = max(0, int(decision.rate_remaining))
+    # Unix timestamp when the bucket will be back at full capacity.
+    reset_ts = int(_time.time() + max(0.0, decision.reset_after_seconds))
+    request.state.rate_limit_headers = {
+        "X-RateLimit-Limit": limit,
+        "X-RateLimit-Remaining": remaining,
+        "X-RateLimit-Reset": reset_ts,
+    }
+
+
 # ── Backwards-compat aliases (one-minor-release deprecation) ────────────────
 # Inside this file, route handlers were carved out of the original single-file
 # module that used single-underscore names for everything. The handlers below
@@ -405,6 +450,9 @@ async def _handle_predict(
         rate_decision = limiter.try_consume_rate_token(
             tenant.tenant_id, tenant.rate_limit_per_minute
         )
+        _stash_rate_limit_headers(
+            request, rate_decision, tenant.rate_limit_per_minute,
+        )
         if not rate_decision.allowed:
             mantis_metrics.RATE_LIMIT_REJECTIONS.labels(
                 tenant_id=tenant.tenant_id, kind="rate"
@@ -606,6 +654,9 @@ async def cua_v1(
     limiter = get_rate_limiter()
     rate_decision = limiter.try_consume_rate_token(
         tenant.tenant_id, tenant.rate_limit_per_minute
+    )
+    _stash_rate_limit_headers(
+        request, rate_decision, tenant.rate_limit_per_minute,
     )
     if not rate_decision.allowed:
         mantis_metrics.RATE_LIMIT_REJECTIONS.labels(

--- a/src/mantis_agent/rate_limit.py
+++ b/src/mantis_agent/rate_limit.py
@@ -25,13 +25,22 @@ from typing import Optional
 
 @dataclasses.dataclass
 class RateLimitDecision:
-    """Outcome of a rate-limit check."""
+    """Outcome of a rate-limit check.
+
+    ``limit`` and ``reset_after_seconds`` are populated by
+    :meth:`TenantRateLimiter.try_consume_rate_token` so the FastAPI
+    middleware can surface ``X-RateLimit-Limit`` / ``X-RateLimit-Remaining``
+    / ``X-RateLimit-Reset`` headers (#275) — callers can throttle
+    proactively instead of crashing into 429s.
+    """
 
     allowed: bool
     reason: str = ""
     retry_after_seconds: float = 0.0
     concurrent: int = 0
     rate_remaining: float = 0.0
+    limit: int = 0
+    reset_after_seconds: float = 0.0
 
 
 @dataclasses.dataclass
@@ -102,7 +111,8 @@ class TenantRateLimiter:
         ``retry_after_seconds`` when the bucket is empty."""
         rpm = rate_per_minute if rate_per_minute is not None else self._default_rpm
         if rpm <= 0:
-            # Disabled — no rate limit.
+            # Disabled — no rate limit. ``limit=0`` signals "no cap" to the
+            # header middleware so it skips the surface entirely.
             return RateLimitDecision(allowed=True, rate_remaining=float("inf"))
 
         burst = float(rpm)
@@ -122,16 +132,30 @@ class TenantRateLimiter:
             if state.tokens < 1.0:
                 deficit = 1.0 - state.tokens
                 retry_after = deficit / refill_per_sec
+                # Even on rejection we report the full bucket state so the
+                # 429 response can carry useful X-RateLimit-* headers
+                # alongside Retry-After — callers shouldn't have to flip
+                # between two surfaces to learn the cap.
+                reset_after = (burst - state.tokens) / refill_per_sec
                 return RateLimitDecision(
                     allowed=False,
                     reason=f"rate limit ({rpm}/min) exceeded",
                     retry_after_seconds=max(retry_after, 0.1),
                     rate_remaining=state.tokens,
+                    limit=rpm,
+                    reset_after_seconds=reset_after,
                 )
 
             state.tokens -= 1.0
+            # Time until the bucket is back at full capacity. Used for the
+            # ``X-RateLimit-Reset`` header — converted to a Unix timestamp
+            # at the call site so the limiter itself stays clock-agnostic.
+            reset_after = (burst - state.tokens) / refill_per_sec
             return RateLimitDecision(
-                allowed=True, rate_remaining=state.tokens
+                allowed=True,
+                rate_remaining=state.tokens,
+                limit=rpm,
+                reset_after_seconds=reset_after,
             )
 
     # ── Test / admin helpers ────────────────────────────────────────────

--- a/tests/test_rate_limit_headers.py
+++ b/tests/test_rate_limit_headers.py
@@ -1,0 +1,216 @@
+"""Tests for X-RateLimit-* response headers (#275).
+
+Covered:
+
+- ``RateLimitDecision`` carries ``limit`` and ``reset_after_seconds``.
+- ``try_consume_rate_token`` populates both on allow and deny paths.
+- ``_stash_rate_limit_headers`` writes the canonical triple to
+  ``request.state``.
+- ``_attach_rate_limit_headers`` middleware copies them onto the
+  response — including on 4xx/5xx responses (so 429s carry the headers
+  alongside ``Retry-After``).
+- Routes that don't rate-limit (``/v1/health``, ``/v1/version``, etc.)
+  return no ``X-RateLimit-*`` headers.
+
+The middleware path is exercised against a minimal stub FastAPI app
+that imports the real middleware + stash helper but doesn't drag the
+production routes / runtime / model load.
+"""
+
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.testclient import TestClient
+
+from mantis_agent.baseten_server.routes import (
+    _attach_rate_limit_headers,
+    _stash_rate_limit_headers,
+)
+from mantis_agent.rate_limit import (
+    RateLimitDecision,
+    TenantRateLimiter,
+)
+
+
+# ── RateLimitDecision + limiter populate the new fields ────────────────────
+
+
+def test_rate_limit_decision_has_limit_and_reset() -> None:
+    d = RateLimitDecision(allowed=True)
+    assert d.limit == 0
+    assert d.reset_after_seconds == 0.0
+
+
+def test_try_consume_token_populates_limit_and_reset_on_allow() -> None:
+    limiter = TenantRateLimiter()
+    decision = limiter.try_consume_rate_token("tenant-x", rate_per_minute=60)
+    assert decision.allowed is True
+    assert decision.limit == 60
+    assert decision.rate_remaining == 59.0
+    # One token spent → reset takes 1/refill = 1 sec to recover.
+    assert 0.5 < decision.reset_after_seconds < 2.0
+
+
+def test_try_consume_token_populates_fields_on_deny() -> None:
+    """Even when the bucket is empty, the decision should carry the
+    cap + remaining so the 429 response can surface them. Without
+    this, callers can't tell whether to back off briefly or for a
+    while just from the headers."""
+    limiter = TenantRateLimiter()
+    # Drain the bucket by consuming all tokens.
+    for _ in range(10):
+        limiter.try_consume_rate_token("tenant-y", rate_per_minute=10)
+    decision = limiter.try_consume_rate_token("tenant-y", rate_per_minute=10)
+    assert decision.allowed is False
+    assert decision.limit == 10
+    assert decision.rate_remaining < 1.0
+    # The bucket needs (10 - remaining) tokens to refill at 10/min → ~60s.
+    assert 50.0 < decision.reset_after_seconds < 60.5
+
+
+def test_try_consume_token_disabled_returns_zero_limit() -> None:
+    """rate_per_minute=0 disables rate-limiting. The decision carries
+    limit=0 so the middleware can skip header emission entirely."""
+    limiter = TenantRateLimiter()
+    decision = limiter.try_consume_rate_token("tenant-z", rate_per_minute=0)
+    assert decision.allowed is True
+    assert decision.limit == 0
+
+
+# ── _stash_rate_limit_headers ──────────────────────────────────────────────
+
+
+def test_stash_sets_canonical_triple_on_request_state() -> None:
+    request = SimpleNamespace(state=SimpleNamespace())
+    decision = RateLimitDecision(
+        allowed=True,
+        rate_remaining=27.0,
+        limit=30,
+        reset_after_seconds=6.0,
+    )
+    now = time.time()
+    _stash_rate_limit_headers(request, decision, 30)  # type: ignore[arg-type]
+    headers = request.state.rate_limit_headers
+    assert headers["X-RateLimit-Limit"] == 30
+    assert headers["X-RateLimit-Remaining"] == 27
+    # Reset is a Unix timestamp ~now + reset_after_seconds.
+    assert now + 5 <= headers["X-RateLimit-Reset"] <= now + 8
+
+
+def test_stash_no_op_when_rate_limit_disabled() -> None:
+    """When the tenant has no rate limit (rate_per_minute=0) the
+    decision carries limit=0 and there's no useful header to surface.
+    Stash should skip the assignment so the middleware emits nothing."""
+    request = SimpleNamespace(state=SimpleNamespace())
+    decision = RateLimitDecision(
+        allowed=True, rate_remaining=float("inf"), limit=0,
+    )
+    _stash_rate_limit_headers(request, decision, 0)  # type: ignore[arg-type]
+    assert not hasattr(request.state, "rate_limit_headers")
+
+
+def test_stash_clamps_negative_remaining_to_zero() -> None:
+    """When the bucket is overdrawn (fractional negative tokens), the
+    ``Remaining`` header should report 0, not a negative integer."""
+    request = SimpleNamespace(state=SimpleNamespace())
+    decision = RateLimitDecision(
+        allowed=False,
+        rate_remaining=-0.2,
+        limit=10,
+        reset_after_seconds=1.0,
+    )
+    _stash_rate_limit_headers(request, decision, 10)  # type: ignore[arg-type]
+    assert request.state.rate_limit_headers["X-RateLimit-Remaining"] == 0
+
+
+# ── Middleware integration on a stub FastAPI app ──────────────────────────
+
+
+def _make_stub_app() -> FastAPI:
+    """Stub app that wires the real middleware against synthetic routes.
+
+    Avoids importing the Mantis runtime / model load — the only thing
+    under test is the middleware contract, which is fully decoupled
+    from the heavy plumbing.
+    """
+    app = FastAPI()
+    app.middleware("http")(_attach_rate_limit_headers)
+
+    @app.get("/limited")
+    def limited(request: Request) -> dict:
+        decision = RateLimitDecision(
+            allowed=True,
+            rate_remaining=29.0,
+            limit=30,
+            reset_after_seconds=2.0,
+        )
+        _stash_rate_limit_headers(request, decision, 30)
+        return {"ok": True}
+
+    @app.get("/limited-deny")
+    def limited_deny(request: Request) -> dict:
+        decision = RateLimitDecision(
+            allowed=False,
+            reason="rate limit (30/min) exceeded",
+            retry_after_seconds=2.0,
+            rate_remaining=0.0,
+            limit=30,
+            reset_after_seconds=60.0,
+        )
+        _stash_rate_limit_headers(request, decision, 30)
+        raise HTTPException(
+            status_code=429,
+            detail=decision.reason,
+            headers={"Retry-After": "3"},
+        )
+
+    @app.get("/unlimited")
+    def unlimited() -> dict:
+        # No stash → middleware should be a no-op.
+        return {"ok": True}
+
+    return app
+
+
+def test_middleware_attaches_headers_on_success() -> None:
+    client = TestClient(_make_stub_app())
+    resp = client.get("/limited")
+    assert resp.status_code == 200
+    assert resp.headers["X-RateLimit-Limit"] == "30"
+    assert resp.headers["X-RateLimit-Remaining"] == "29"
+    assert "X-RateLimit-Reset" in resp.headers
+    # Reset is a string-formatted unix timestamp; just spot-check it parses.
+    int(resp.headers["X-RateLimit-Reset"])
+
+
+def test_middleware_attaches_headers_on_429() -> None:
+    """429s carry both ``Retry-After`` (legacy / required for backoff)
+    and the ``X-RateLimit-*`` triple so callers can reconcile their
+    local view of the bucket without having to wait for the next
+    successful response."""
+    client = TestClient(_make_stub_app())
+    resp = client.get("/limited-deny")
+    assert resp.status_code == 429
+    assert resp.headers["Retry-After"] == "3"
+    assert resp.headers["X-RateLimit-Limit"] == "30"
+    assert resp.headers["X-RateLimit-Remaining"] == "0"
+    assert "X-RateLimit-Reset" in resp.headers
+
+
+def test_middleware_noop_on_unlimited_routes() -> None:
+    """Routes that don't stash anything (health probes, version,
+    metrics) must not gain X-RateLimit-* headers — those are an
+    explicit promise that the route is rate-limited."""
+    client = TestClient(_make_stub_app())
+    resp = client.get("/unlimited")
+    assert resp.status_code == 200
+    assert "X-RateLimit-Limit" not in resp.headers
+    assert "X-RateLimit-Remaining" not in resp.headers
+    assert "X-RateLimit-Reset" not in resp.headers


### PR DESCRIPTION
## Summary

Closes #275. Callers had no way to see remaining quota before hitting the wall. Standard practice (GitHub, Stripe, OpenAI) is to attach \`X-RateLimit-Remaining\` / \`Limit\` / \`Reset\` on every response so clients can throttle proactively instead of crashing into 429s.

\`\`\`
HTTP/1.1 200 OK
X-RateLimit-Limit: 30
X-RateLimit-Remaining: 27
X-RateLimit-Reset: 1778539749
\`\`\`

## What changed

- **\`RateLimitDecision\`** gains \`limit\` and \`reset_after_seconds\` fields. \`try_consume_rate_token\` populates both on allow AND deny paths so 429 responses carry the same surface as 2xx.
- **\`_stash_rate_limit_headers(request, decision, tenant_limit)\`** helper writes the canonical triple to \`request.state.rate_limit_headers\`. No-ops when \`rate_per_minute=0\` (rate-limit disabled).
- **\`_attach_rate_limit_headers\` FastAPI middleware** copies the triple onto the response. Wraps the full request/response cycle so 4xx and 5xx responses get the headers too.
- **Both rate-check call sites** (\`_handle_predict\` for \`/v1/predict\` run mode, \`cua_v1\` for \`/v1/cua\`) now call \`_stash_rate_limit_headers\` right after consulting the limiter.
- **\`Retry-After\` stays on 429s** as before, for clients with existing Retry-After backoff logic.

## Tests

10 tests in \`tests/test_rate_limit_headers.py\` (2.5 s, no live server):

- \`RateLimitDecision\` defaults + populated values
- \`try_consume_rate_token\` populates limit + reset_after_seconds on allow / deny / disabled-via-rpm-0
- \`_stash_rate_limit_headers\` writes the triple, no-ops when disabled, clamps negative remaining to 0
- Middleware integration on a stub FastAPI app: 2xx attach, 429 attach alongside Retry-After, no headers on routes that don't stash

## Docs

- \`docs/operations/rate-limits.md\` — new \"Response headers\" section documents the triple, the bucket-disabled case, and the relationship with the legacy \`Retry-After\`.

## Test plan
- [x] \`uv run python -m pytest tests/test_rate_limit_headers.py -v\` — 10 passed in 2.50s
- [x] \`uv run python -m pytest tests/test_rate_limit_headers.py tests/test_video_endpoint.py tests/test_chat_completions_proxy.py -q\` — 25 passed
- [x] \`uv run ruff check .\` — clean
- [x] \`uv run mkdocs build --strict\` — built clean (one pre-existing unrelated anchor warning)
- [ ] After merge: smoke against the live Baseten deployment — \`curl -i \$ENDPOINT/v1/predict ...\` and confirm the three headers ride on the response

🤖 Generated with [Claude Code](https://claude.com/claude-code)