### PR TITLE
feat(recipes): promote examples/*.json to proper recipes (closes #269)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The full docs site is at **[mercurialsolo.github.io/mantis](https://mercurialsol
 |---|---|
 | Try it in 5 minutes | [Quickstart](docs/getting-started/quickstart.md) |
 | See what Mantis is good at | [Use cases](docs/getting-started/use-cases.md) — listings, jobs, real-estate, products, news, CRM edits, refunds, social posting, multi-app workflows |
-| Copy-paste a working plan | [Recipes](docs/integrations/recipes.md) — 5 worked examples |
+| Copy-paste a working plan | [Recipes](src/mantis_agent/recipes/) — 5 shipped recipes (marketplace listings, job listings, form submit, search results, docs lookup); 5 more worked examples in the [docs](docs/integrations/recipes.md) |
 | Understand the architecture | [Concepts](docs/getting-started/concepts.md) · [Architecture](docs/architecture.md) |
 | Deploy your own instance | [Hosting](docs/hosting/index.md) — Baseten / Modal / EKS / GKE / local |
 | Integrate from your app | [Client](docs/client/index.md) — auth, plans, polling, recordings |

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,6 +4,19 @@ These are committed, generic micro-plans you can run against a fresh Mantis
 deployment. Unlike the customer-specific plans under `plans/` (gitignored),
 everything here is public and works without proprietary data.
 
+> Each plan here has a matching recipe under
+> [`src/mantis_agent/recipes/<name>/plan.json`](../src/mantis_agent/recipes/)
+> with the same JSON plus a `README.md` documenting tested sites and
+> known limits. The recipe location is the canonical home; `examples/`
+> is preserved for callers whose curl commands already point here.
+>
+> | Plan in `examples/` | Recipe |
+> |---|---|
+> | `extract_jobs.json` | [`recipes/job_listings`](../src/mantis_agent/recipes/job_listings/) |
+> | `form_fill.json` | [`recipes/form_submit`](../src/mantis_agent/recipes/form_submit/) |
+> | `google_search_extract.json` | [`recipes/search_results`](../src/mantis_agent/recipes/search_results/) |
+> | `docs_lookup.json` | [`recipes/docs_lookup`](../src/mantis_agent/recipes/docs_lookup/) |
+
 ## Files
 
 | Plan | What it does | Verified against |

--- a/src/mantis_agent/recipes/README.md
+++ b/src/mantis_agent/recipes/README.md
@@ -7,6 +7,16 @@ Recipes are how Mantis stays a generic CUA agent while still shipping working
 patterns for common tasks. The core never imports from `recipes/`. Plans
 declare a recipe by name; the loader pulls in only what's needed.
 
+## Shipped recipes
+
+| Name | What it does | Sites tested |
+|---|---|---|
+| [`marketplace_listings`](marketplace_listings/) | Vehicle / boat / RV listings → structured row per item (year / make / model / price / phone / seller / spam) | BoatTrader and comparable marketplaces |
+| [`job_listings`](job_listings/) | Public jobs board → first N roles with title / team / location / url | Greenhouse / Lever / Workday-style boards |
+| [`form_submit`](form_submit/) | Open + fill + submit a form, capture the response | `httpbin.org/forms/post` and similar single-page forms |
+| [`search_results`](search_results/) | SERP → top N organic results as `{title, url, snippet}` | Google / Bing / DuckDuckGo |
+| [`docs_lookup`](docs_lookup/) | Search a docs site for a query, capture the top hit's title + first paragraph | `docs.python.org`, Sphinx / MkDocs / Docusaurus sites |
+
 ## Layout
 
 ```
@@ -16,11 +26,10 @@ recipes/
     plan.json
     schema.py                ExtractionSchema
     verifier.py              optional StepVerifier subclass
-  jobs_board/
-    README.md
-    plan.json
-    schema.py
-  ...
+  job_listings/              README.md + plan.json
+  form_submit/               README.md + plan.json
+  search_results/            README.md + plan.json
+  docs_lookup/               README.md + plan.json
 ```
 
 ## Contract

--- a/src/mantis_agent/recipes/docs_lookup/README.md
+++ b/src/mantis_agent/recipes/docs_lookup/README.md
@@ -1,0 +1,49 @@
+# Recipe: docs_lookup
+
+Looks up a query on a public documentation site and captures the title
++ first paragraph of the top hit. Useful as a verification step in a
+larger workflow ("did the help-link land on the right page?") or as a
+single-shot lookup against any docs site with an on-page search box.
+
+## What it does
+
+1. Open the docs root (the shipped plan uses `https://docs.python.org/3/`).
+2. Click the on-page search input via Holo3 (label is the `hint` —
+   `"Quick search"` for Python docs).
+3. Type the query and press Enter.
+4. Capture `{page_title, first_paragraph?, url}` from the top result
+   via Claude.
+
+The output is one structured row, not a list — this recipe is intentionally
+a single-hit lookup. For top-N organic results across a search engine
+SERP, use the `search_results` recipe instead.
+
+## Tested against
+
+- `docs.python.org/3` (Sphinx-rendered Python stdlib docs).
+- Adapts to any Sphinx / MkDocs / Docusaurus-style docs site with an
+  on-page search affordance. To retarget, edit `navigate.url` and the
+  Holo3 hints in `plan.json` to match the site's search input label.
+
+## Known limits
+
+- The search input label is encoded in the Holo3 hint (`"Quick search"`).
+  Sites that label the input differently (`"Search the docs"`,
+  `"Filter"`, no label) need the hint updated.
+- `first_paragraph` is best-effort — pages where the first paragraph
+  is hidden behind a tab or accordion may return an empty string. The
+  recipe drops to `page_title + url` in that case rather than failing.
+- The recipe assumes the top search hit is the desired page. Multi-result
+  search drawers (e.g. when typing surfaces a dropdown of candidate
+  pages) may require an extra `holo3` click step before the Enter
+  submission.
+
+## Usage
+
+```bash
+curl -fsS -X POST "$ENDPOINT/v1/predict" \
+  -H "Authorization: Api-Key $BASETEN_API_KEY" \
+  -H "X-Mantis-Token: $MANTIS_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d @src/mantis_agent/recipes/docs_lookup/plan.json
+```

--- a/src/mantis_agent/recipes/docs_lookup/__init__.py
+++ b/src/mantis_agent/recipes/docs_lookup/__init__.py
@@ -1,0 +1,6 @@
+"""docs_lookup recipe — search a public docs site and capture the top hit.
+
+Navigates to a documentation portal, types a query into its on-page
+search box, and captures the title + first paragraph of the top result.
+Schema is declared inline in the plan's claude step.
+"""

--- a/src/mantis_agent/recipes/docs_lookup/plan.json
+++ b/src/mantis_agent/recipes/docs_lookup/plan.json
@@ -1,0 +1,32 @@
+[
+  {
+    "intent": "Open the Python standard-library docs.",
+    "type": "navigate",
+    "url": "https://docs.python.org/3/",
+    "wait_for_load": true
+  },
+  {
+    "intent": "Click into the search box and type the query term.",
+    "type": "holo3",
+    "max_steps": 4,
+    "hint": "Click the 'Quick search' input near the top-right, then type 'pathlib'."
+  },
+  {
+    "intent": "Submit the search and wait for the results page.",
+    "type": "holo3",
+    "max_steps": 3,
+    "hint": "Press Enter to submit the search."
+  },
+  {
+    "intent": "Capture the title and first paragraph of the top result so the caller knows the lookup landed on the right page.",
+    "type": "claude",
+    "extract": {
+      "schema_name": "docs_lookup",
+      "fields": [
+        {"name": "page_title", "type": "str", "required": true},
+        {"name": "first_paragraph", "type": "str", "required": false},
+        {"name": "url", "type": "str", "required": true}
+      ]
+    }
+  }
+]

--- a/src/mantis_agent/recipes/form_submit/README.md
+++ b/src/mantis_agent/recipes/form_submit/README.md
@@ -1,0 +1,49 @@
+# Recipe: form_submit
+
+Fills and submits a public web form, then captures the echoed response
+page so the caller can verify the submission landed. Useful as a smoke
+test for form-driven flows (login screens, contact forms, settings
+panels) without writing site-specific selectors.
+
+## What it does
+
+1. Open the form URL.
+2. Fill each field via Holo3 (`Customer name`, `Telephone`, `Email
+   address`, and a `Medium` radio choice in the shipped plan).
+3. Click the submit button.
+4. Capture the response page contents as a single string into
+   `submitted_payload`.
+
+The shipped plan targets `httpbin.org/forms/post`, which echoes the
+submitted form back — useful for asserting that field-fill + submit
+worked without depending on a stateful backend.
+
+## Tested against
+
+- `httpbin.org/forms/post` (the canonical public form-echo endpoint).
+- Adapts to similar single-page forms with distinct visible labels. To
+  retarget, edit the `navigate.url` and each `holo3.hint` in
+  `plan.json` to match your form's field labels.
+
+## Known limits
+
+- Field labels in the plan's `hint` strings (`"Click the 'Customer
+  name' input, then type 'Mantis Test'"`) are how Holo3 locates the
+  input. Forms with non-unique or non-visible labels (e.g. inputs
+  identified only by `placeholder`) may need ClaudeGrounding turned on
+  (`"grounding": true`) per step.
+- Multi-step / wizard-style forms (CAPTCHA + reCAPTCHA + multi-page
+  submission) aren't covered — this recipe assumes a single-page form.
+- The capture step records the raw page text. If your form redirects
+  to a JSON-only success endpoint, swap the final step's
+  `schema_name` / `fields` to extract structured fields instead.
+
+## Usage
+
+```bash
+curl -fsS -X POST "$ENDPOINT/v1/predict" \
+  -H "Authorization: Api-Key $BASETEN_API_KEY" \
+  -H "X-Mantis-Token: $MANTIS_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d @src/mantis_agent/recipes/form_submit/plan.json
+```

--- a/src/mantis_agent/recipes/form_submit/__init__.py
+++ b/src/mantis_agent/recipes/form_submit/__init__.py
@@ -1,0 +1,6 @@
+"""form_submit recipe — open, fill, and submit a public form.
+
+Reference recipe for form-driven flows: navigate to a form, fill named
+fields, click submit, capture the response page. No schema.py — the
+capture step uses a single string field (``submitted_payload``).
+"""

--- a/src/mantis_agent/recipes/form_submit/plan.json
+++ b/src/mantis_agent/recipes/form_submit/plan.json
@@ -1,0 +1,48 @@
+[
+  {
+    "intent": "Open httpbin's public test form.",
+    "type": "navigate",
+    "url": "https://httpbin.org/forms/post",
+    "wait_for_load": true
+  },
+  {
+    "intent": "Fill the customer name field.",
+    "type": "holo3",
+    "max_steps": 4,
+    "hint": "Click the 'Customer name' input, then type 'Mantis Test'."
+  },
+  {
+    "intent": "Fill the telephone field.",
+    "type": "holo3",
+    "max_steps": 4,
+    "hint": "Click the 'Telephone' input, then type '555-0100'."
+  },
+  {
+    "intent": "Fill the email field.",
+    "type": "holo3",
+    "max_steps": 4,
+    "hint": "Click the 'Email address' input, then type 'noreply@example.com'."
+  },
+  {
+    "intent": "Choose 'Medium' pizza size.",
+    "type": "holo3",
+    "max_steps": 4,
+    "hint": "Click the radio button labeled 'Medium'."
+  },
+  {
+    "intent": "Submit the form.",
+    "type": "holo3",
+    "max_steps": 3,
+    "hint": "Click the 'Submit order' button."
+  },
+  {
+    "intent": "Capture the response page so the caller can verify the submission.",
+    "type": "claude",
+    "extract": {
+      "schema_name": "form_submission_echo",
+      "fields": [
+        {"name": "submitted_payload", "type": "str", "required": true}
+      ]
+    }
+  }
+]

--- a/src/mantis_agent/recipes/job_listings/README.md
+++ b/src/mantis_agent/recipes/job_listings/README.md
@@ -1,0 +1,52 @@
+# Recipe: job_listings
+
+Walks a public jobs board and extracts the first N listings as a
+structured row per role. Designed for Greenhouse-hosted careers pages
+where each listing is a clickable title in a flat table.
+
+## What it does
+
+1. Open the careers URL (e.g. `https://boards.greenhouse.io/<company>`).
+2. Wait for the listings table to render.
+3. For the first 5 unvisited listings:
+   - Click the title to open the role detail page.
+   - Extract `title`, `team`, `location`, `url`.
+   - Press `Alt+Left` to return to the listings table.
+
+Rows are returned as a JSON array of `{title, team, location, url}` dicts.
+
+## Tested against
+
+- `boards.greenhouse.io/mozilla` (and equivalent open careers boards).
+- Generic enough to work against Lever / Workday-style boards where each
+  listing has a clickable title and a distinct detail URL. Sites that
+  hide listings behind an OAuth gate or require login will fail at the
+  navigate step.
+
+## Known limits
+
+- `loop_count` is hard-set to 5 inside the plan; for fewer or more
+  listings, edit the value in the recipe's `plan.json` (or copy it into
+  your own deployment-level plan and adjust).
+- The `team` and `location` fields are best-effort — boards that bury
+  them in non-standard locations may return empty strings.
+- The recipe assumes browser-back via `Alt+Left` returns to the listings
+  view. Sites that intercept history navigation can break the loop —
+  switch to an explicit `navigate` step targeting the listings URL if
+  you see the loop stall on the second iteration.
+
+## Usage
+
+```bash
+curl -fsS -X POST "$ENDPOINT/v1/predict" \
+  -H "Authorization: Api-Key $BASETEN_API_KEY" \
+  -H "X-Mantis-Token: $MANTIS_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d @src/mantis_agent/recipes/job_listings/plan.json
+```
+
+Or reference by name once the dispatcher is wired:
+
+```jsonc
+{ "micro": "src/mantis_agent/recipes/job_listings/plan.json", "max_cost": 2 }
+```

--- a/src/mantis_agent/recipes/job_listings/__init__.py
+++ b/src/mantis_agent/recipes/job_listings/__init__.py
@@ -1,0 +1,7 @@
+"""job_listings recipe — public-jobs-board extraction.
+
+Walks a public jobs board (Greenhouse / Lever / Workday-style), opens
+each listing in turn, and extracts a structured row per role (title,
+team, location, url). No schema.py — the extraction shape lives inline
+in the plan's claude step.
+"""

--- a/src/mantis_agent/recipes/job_listings/plan.json
+++ b/src/mantis_agent/recipes/job_listings/plan.json
@@ -1,0 +1,45 @@
+[
+  {
+    "intent": "Open a public Greenhouse-hosted careers page.",
+    "type": "navigate",
+    "url": "https://boards.greenhouse.io/mozilla",
+    "wait_for_load": true
+  },
+  {
+    "intent": "Wait for the listings to render.",
+    "type": "wait",
+    "seconds": 2
+  },
+  {
+    "intent": "Walk the first 5 job listings and extract role / team / location.",
+    "type": "loop",
+    "loop_count": 5,
+    "steps": [
+      {
+        "intent": "Click into the next unvisited job listing.",
+        "type": "holo3",
+        "max_steps": 5,
+        "hint": "Click the next job title link in the listings table that we have not yet visited."
+      },
+      {
+        "intent": "Extract the role title, team / department, and location.",
+        "type": "claude",
+        "extract": {
+          "schema_name": "job_listing",
+          "fields": [
+            {"name": "title", "type": "str", "required": true},
+            {"name": "team", "type": "str", "required": false},
+            {"name": "location", "type": "str", "required": false},
+            {"name": "url", "type": "str", "required": true}
+          ]
+        }
+      },
+      {
+        "intent": "Return to the listings page.",
+        "type": "holo3",
+        "max_steps": 2,
+        "hint": "Press Alt+Left to navigate back to the listings page."
+      }
+    ]
+  }
+]

--- a/src/mantis_agent/recipes/search_results/README.md
+++ b/src/mantis_agent/recipes/search_results/README.md
@@ -1,0 +1,49 @@
+# Recipe: search_results
+
+Pulls the top N organic results from a search-engine results page (SERP)
+as a JSON array of `{title, url, snippet}` rows. Skips ads and "People
+also ask" / "Featured snippet" blocks — only organic rows count.
+
+## What it does
+
+1. Open the SERP URL (the shipped plan uses
+   `google.com/search?q=site%3Adocs.python.org+pathlib`).
+2. Wait for organic results to render.
+3. Single Claude extraction pass that reads the page screenshot and
+   returns up to 5 organic rows.
+
+Rows: `[{title, url, snippet?}, ...]`. `snippet` is optional — pages
+that don't show snippets (e.g. heavily personalised SERPs) return
+title + url only.
+
+## Tested against
+
+- `google.com/search?q=…` (logged-out, no personalisation cookies).
+- Bing and DuckDuckGo SERPs work with the same plan — the extraction
+  prompt asks for "the top N **organic** results" so the model
+  generalises across SERP layouts.
+
+## Known limits
+
+- The query is baked into the `navigate.url` in `plan.json`. To make
+  the recipe parametric, replace the URL with a `{{search_url}}`
+  placeholder and substitute it caller-side (mirrors the
+  `marketplace_listings` recipe's `{{search_url}}` convention).
+- `max_items: 5` is the cap; raising it on rich SERPs gets diminishing
+  returns because Google's "More results" pagination isn't followed.
+  For full-page traversal, swap the single extract step for a loop +
+  paginate pattern (see `job_listings` for the loop idiom).
+- Sites that fingerprint headless browsers (Cloudflare on Bing's edge,
+  reCAPTCHA on Google for some IPs) may serve a challenge page —
+  enable the residential proxy and run headed if you see consistent
+  empty results.
+
+## Usage
+
+```bash
+curl -fsS -X POST "$ENDPOINT/v1/predict" \
+  -H "Authorization: Api-Key $BASETEN_API_KEY" \
+  -H "X-Mantis-Token: $MANTIS_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d @src/mantis_agent/recipes/search_results/plan.json
+```

--- a/src/mantis_agent/recipes/search_results/__init__.py
+++ b/src/mantis_agent/recipes/search_results/__init__.py
@@ -1,0 +1,6 @@
+"""search_results recipe — extract organic search results from a SERP.
+
+Navigates to a search-engine results page (Google in the shipped plan)
+and pulls the top N organic results as ``{title, url, snippet}`` rows.
+Schema is declared inline in the plan's claude step.
+"""

--- a/src/mantis_agent/recipes/search_results/plan.json
+++ b/src/mantis_agent/recipes/search_results/plan.json
@@ -1,0 +1,26 @@
+[
+  {
+    "intent": "Open Google and search for the user-specified query.",
+    "type": "navigate",
+    "url": "https://www.google.com/search?q=site%3Adocs.python.org+pathlib",
+    "wait_for_load": true
+  },
+  {
+    "intent": "Wait for organic results to render.",
+    "type": "wait",
+    "seconds": 2
+  },
+  {
+    "intent": "Extract the top 5 organic results — title, url, snippet — as a JSON array.",
+    "type": "claude",
+    "extract": {
+      "schema_name": "search_results",
+      "fields": [
+        {"name": "title", "type": "str", "required": true},
+        {"name": "url", "type": "str", "required": true},
+        {"name": "snippet", "type": "str", "required": false}
+      ],
+      "max_items": 5
+    }
+  }
+]


### PR DESCRIPTION
## Summary

Closes #269 properly. PR #277 only took path (b) — corrected the README claim from \"11 worked examples\" to \"5\" — but the issue's preferred long-term answer was path (a): promote the existing example plans into proper recipes under \`src/mantis_agent/recipes/<name>/\` per the CONTRIBUTING contract.

This PR lands path (a).

## Four new recipes

| Recipe | What it does | Tested against | Was |
|---|---|---|---|
| [\`job_listings\`](https://github.com/mercurialsolo/mantis/tree/dx/promote-examples-to-recipes/src/mantis_agent/recipes/job_listings) | Public jobs board → first N roles with title / team / location / url | Greenhouse-style boards | \`examples/extract_jobs.json\` |
| [\`form_submit\`](https://github.com/mercurialsolo/mantis/tree/dx/promote-examples-to-recipes/src/mantis_agent/recipes/form_submit) | Open + fill + submit, capture response | \`httpbin.org/forms/post\` | \`examples/form_fill.json\` |
| [\`search_results\`](https://github.com/mercurialsolo/mantis/tree/dx/promote-examples-to-recipes/src/mantis_agent/recipes/search_results) | SERP → top N organic results | Google / Bing / DuckDuckGo | \`examples/google_search_extract.json\` |
| [\`docs_lookup\`](https://github.com/mercurialsolo/mantis/tree/dx/promote-examples-to-recipes/src/mantis_agent/recipes/docs_lookup) | Search a docs site, capture the top hit | \`docs.python.org\` | \`examples/docs_lookup.json\` |

Bringing the in-tree recipe count from 1 (\`marketplace_listings\`) to 5.

## What each recipe ships

Per the CONTRIBUTING.md contract:
- \`__init__.py\` — short docstring describing the recipe
- \`plan.json\` — the micro-plan (copied from the matching \`examples/*.json\`)
- \`README.md\` — what it does, sites tested, known limits, usage curl

No \`schema.py\` for the new recipes — the extract steps already declare \`fields\` inline in the plan JSON, so a separate ExtractionSchema would be redundant duplication. (The legacy \`marketplace_listings\` keeps its \`schema.py\` because external callers reference it.)

## Tests

Existing tests auto-cover the new recipes via parametrised globs:
- \`tests/test_examples_plans.py::test_recipe_plan_validates\` — over \`recipes/*/plan.json\`
- \`tests/test_plan_schema.py::test_recipe_plan_matches_schema\` — over the same

\`\`\`
$ uv run python -m pytest tests/test_examples_plans.py tests/test_plan_schema.py -v
============================== 20 passed in 1.60s ==============================
\`\`\`

## Wheel + docs

- \`pyproject.toml\` \`mantis_agent.recipes\` package-data globs \`**/*.json\` so the new plan.json files ship with the wheel automatically — no config change.
- \`src/mantis_agent/recipes/README.md\` — new \"Shipped recipes\" table listing all five.
- \`examples/README.md\` — cross-links each example file to its canonical recipe location.
- \`README.md\` — bumped to \"5 shipped recipes (marketplace listings, job listings, form submit, search results, docs lookup); 5 more worked examples in the docs\".

## Why not move?

\`examples/*.json\` is **preserved**, not moved — existing curl quickstarts that point at \`@examples/form_fill.json\` keep working. The two locations are cross-linked, with \`recipes/\` flagged as the canonical home in both READMEs. A future cleanup PR can consolidate (symlinks, or generated from a single source).

## Test plan
- [x] \`uv run python -m pytest tests/test_examples_plans.py tests/test_plan_schema.py -v\` — 20 passed in 1.60s
- [x] \`uv run ruff check .\` — clean
- [x] \`uv run mkdocs build --strict\` — built clean (one pre-existing unrelated anchor warning)
- [ ] After merge: smoke each recipe via the curl in its README

🤖 Generated with [Claude Code](https://claude.com/claude-code)