### PR TITLE
feat(gym): GymRunner host-tool registration + pause/resume (#285)

### DIFF
--- a/src/mantis_agent/actions.py
+++ b/src/mantis_agent/actions.py
@@ -24,6 +24,12 @@ class ActionType(str, Enum):
     # Launch a binary on the desktop. Closes the symmetry gap with the host integration
     # whose Claude backend uses `bash` to start chromium. See issue #72.
     LAUNCH_APP = "launch_app"
+    # Invoke a host-registered tool (#285). ``params = {"name": str,
+    # "args": dict}``. The runner short-circuits to ``tool_channel.invoke``
+    # instead of dispatching through ``env.step`` — handlers can return a
+    # value (recorded into the trajectory ``feedback`` field) or raise
+    # ``PauseRequested`` to suspend the run for host input.
+    TOOL_CALL = "tool_call"
 
 
 @dataclass

--- a/src/mantis_agent/gym/checkpoint.py
+++ b/src/mantis_agent/gym/checkpoint.py
@@ -173,11 +173,17 @@ PauseRequested = _PauseRequested
 
 @dataclass
 class PauseState:
-    """Serializable snapshot of a paused MicroPlanRunner (#73).
+    """Serializable snapshot of a paused MicroPlanRunner or GymRunner (#73, #285).
 
     Round-trips through JSON so host can store it on
     ``plan.agent_data["host_state"]``. Resume by calling
     ``runner.resume(state, user_input=...)``.
+
+    Most fields are MicroPlanRunner-specific (``step_results``,
+    ``loop_counters``, ``listings_on_page``). GymRunner fills
+    ``trajectory_steps`` + ``task`` + ``task_id`` instead — the other
+    fields stay empty and the runner that wrote the snapshot is the
+    runner that consumes it, so cross-pollution doesn't matter.
     """
     version: int = 1
     run_key: str = ""
@@ -193,6 +199,12 @@ class PauseState:
     listings_on_page: int = 0
     checkpoint_path: str = ""
     timestamp: float = 0.0
+
+    # GymRunner extensions (#285). Empty when the snapshot came from
+    # MicroPlanRunner.
+    trajectory_steps: list[dict[str, Any]] = field(default_factory=list)
+    task: str = ""
+    task_id: str = ""
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)

--- a/src/mantis_agent/gym/runner.py
+++ b/src/mantis_agent/gym/runner.py
@@ -30,7 +30,12 @@ from PIL import Image
 from ..actions import Action, ActionType
 from ..loop_detector import LoopDetector, phash_64
 from .base import GymEnvironment
+# Re-exported so hosts can ``from mantis_agent.gym.runner import
+# PauseRequested, PauseState`` without reaching into the .checkpoint
+# private surface (#285).
+from .checkpoint import PauseRequested, PauseState  # noqa: F401
 from .gallery_trap import detect_gallery_trap, gallery_recovery_actions
+from .tool_channel import ToolChannel
 
 logger = logging.getLogger(__name__)
 
@@ -152,7 +157,13 @@ def _gallery_observed_state(recovery: dict[str, Any] | None) -> dict[str, Any]:
 
 @dataclass
 class RunResult:
-    """Final result of a GymRunner evaluation."""
+    """Final result of a GymRunner evaluation.
+
+    ``paused`` and ``pause_state`` are populated when a registered tool
+    handler raised :class:`PauseRequested` (#285). Host code can call
+    :meth:`GymRunner.resume` with the snapshot once the user has supplied
+    the requested input.
+    """
 
     task: str
     task_id: str
@@ -161,9 +172,67 @@ class RunResult:
     total_steps: int
     total_time: float
     trajectory: list[TrajectoryStep]
-    termination_reason: str  # "done", "max_steps", "loop", "env_done"
+    termination_reason: str  # "done", "max_steps", "loop", "env_done", "paused"
     terminal_reward: float = 0.0
     reward_components: dict[str, float] = field(default_factory=dict)
+    paused: bool = False
+    pause_state: PauseState | None = None
+
+
+# ── Trajectory serialization for pause snapshots (#285) ────────────────────
+
+
+def _trajectory_step_to_dict(step: TrajectoryStep) -> dict[str, Any]:
+    """JSON-friendly snapshot of a TrajectoryStep.
+
+    Custom rather than ``dataclasses.asdict`` because ``Action.action_type``
+    is a ``str``-derived enum that ``asdict`` leaves as an enum instance —
+    not JSON-serializable. Round-tripped by :func:`_trajectory_step_from_dict`.
+    """
+    return {
+        "step": step.step,
+        "action": {
+            "action_type": step.action.action_type.value,
+            "params": dict(step.action.params),
+            "reasoning": step.action.reasoning,
+        },
+        "thinking": step.thinking,
+        "reward": step.reward,
+        "done": step.done,
+        "inference_time": step.inference_time,
+        "feedback": step.feedback,
+        "timestamp": step.timestamp,
+        "reward_components": dict(step.reward_components),
+        "frame_hash": step.frame_hash,
+        "observed_state": dict(step.observed_state),
+        "hypothesized_state": step.hypothesized_state,
+        "predicted_outcome": step.predicted_outcome,
+        "observed_outcome": step.observed_outcome,
+    }
+
+
+def _trajectory_step_from_dict(payload: dict[str, Any]) -> TrajectoryStep:
+    a = payload.get("action") or {}
+    return TrajectoryStep(
+        step=int(payload.get("step", 0)),
+        action=Action(
+            action_type=ActionType(a.get("action_type", "wait")),
+            params=dict(a.get("params") or {}),
+            reasoning=str(a.get("reasoning", "")),
+        ),
+        thinking=str(payload.get("thinking", "")),
+        reward=float(payload.get("reward", 0.0)),
+        done=bool(payload.get("done", False)),
+        inference_time=float(payload.get("inference_time", 0.0)),
+        feedback=str(payload.get("feedback", "")),
+        timestamp=float(payload.get("timestamp", time.time())),
+        reward_components=dict(payload.get("reward_components") or {}),
+        frame_hash=str(payload.get("frame_hash", "")),
+        observed_state=dict(payload.get("observed_state") or {}),
+        hypothesized_state=str(payload.get("hypothesized_state", "")),
+        predicted_outcome=str(payload.get("predicted_outcome", "")),
+        observed_outcome=str(payload.get("observed_outcome", "")),
+    )
 
 
 class GymRunner:
@@ -210,6 +279,79 @@ class GymRunner:
         self.site_config = site_config
         self._loop_detector = LoopDetector()
 
+        # ── Host-tool channel (#285) ────────────────────────────────────
+        # Mirrors MicroPlanRunner's surface so the same host integration
+        # patterns (auth_credentials, user_input, correspondent_message,
+        # …) plug into the perception-action loop. The brain emits a
+        # TOOL_CALL action; the runner short-circuits env.step and calls
+        # tool_channel.invoke. A handler can return a value (fed back as
+        # feedback) or raise PauseRequested to suspend the run.
+        self.tool_channel = ToolChannel()
+        self._pause_input: Any = None
+        # Set by ``resume()``; consumed once on the next ``run()``.
+        self._resume_state: PauseState | None = None
+
+    # ── Host-tool surface (#285) ────────────────────────────────────────
+
+    def register_tool(
+        self,
+        name: str,
+        schema: dict[str, Any],
+        handler: Any,
+    ) -> None:
+        """Register a host-provided tool callable mid-run.
+
+        ``handler`` is ``Callable[[dict[str, Any]], Any]`` — the brain's
+        parsed kwargs come in, the return value (str-rendered, truncated)
+        ends up in the trajectory step's ``feedback`` field. Raise
+        :class:`PauseRequested` from inside the handler to suspend the
+        run; the next :meth:`run` call returns a :class:`RunResult` with
+        ``paused=True`` and a serializable :class:`PauseState`.
+        """
+        self.tool_channel.register(name, schema, handler)
+
+    def list_tools(self) -> list[dict[str, Any]]:
+        """Return registered tools as ``[{"name", "schema"}]`` — typically
+        passed to the brain so it knows what TOOL_CALL names are valid."""
+        return self.tool_channel.list()
+
+    def consume_pause_input(self, default: Any = None) -> Any:
+        """Read-once accessor for the user input supplied via
+        :meth:`resume`. Returns ``default`` when no resume is in flight,
+        and clears the slot after the first read so a subsequent step
+        doesn't see a stale value.
+        """
+        value = self._pause_input
+        self._pause_input = None
+        return default if value is None else value
+
+    def resume(
+        self,
+        pause_state: PauseState | dict[str, Any],
+        *,
+        user_input: Any = None,
+        **run_overrides: Any,
+    ) -> RunResult:
+        """Resume a paused run.
+
+        ``pause_state`` is the snapshot returned in ``RunResult.pause_state``;
+        ``user_input`` is the value the user supplied in response to the
+        handler's prompt. ``run_overrides`` are forwarded to :meth:`run` —
+        ``task`` and ``task_id`` are recovered from the snapshot, anything
+        else (``plan``, ``plan_inputs``, ``reward_fn``, …) must be
+        re-supplied by the caller exactly as it was on the original run.
+        """
+        if isinstance(pause_state, dict):
+            pause_state = PauseState.from_dict(pause_state)
+        self._resume_state = pause_state
+        self._pause_input = user_input
+        kwargs: dict[str, Any] = {
+            "task": pause_state.task,
+            "task_id": pause_state.task_id or "default",
+        }
+        kwargs.update(run_overrides)
+        return self.run(**kwargs)
+
     def _emit(self, event_type: str, **data: Any) -> None:
         """Emit an event to the viewer (if connected). Never crashes the runner."""
         if self.on_step:
@@ -230,6 +372,7 @@ class GymRunner:
         reward_fn: Any = None,
         ground_truth: dict[str, Any] | None = None,
         capture_dir: Any = None,
+        pause_input: Any = None,
     ) -> RunResult:
         """Execute a task with plan persistence, feedback, and context.
 
@@ -257,6 +400,16 @@ class GymRunner:
         logger.info(f"Starting task: {task!r} (id={task_id})")
         t0 = time.time()
 
+        # ── Pause/resume bootstrap (#285) ───────────────────────────────
+        # ``resume()`` stages a snapshot on ``_resume_state`` then
+        # re-enters ``run()``; we consume it once. ``pause_input`` (kwarg
+        # or pre-staged via ``resume()``) is the user reply the next
+        # handler can read with ``consume_pause_input``.
+        resume_state = self._resume_state
+        self._resume_state = None  # consume once
+        if pause_input is not None:
+            self._pause_input = pause_input
+
         # Screenshot capture (opt-in, e.g. rollout collection).
         capture_path = None
         if capture_dir is not None:
@@ -278,6 +431,29 @@ class GymRunner:
         total_reward = 0.0
         plan_inputs = dict(plan_inputs or {})
         done_success: bool | None = None
+
+        # If we're resuming, rehydrate the trajectory + action history so
+        # the brain sees the prior context and the loop continues at the
+        # paused step boundary. The env stays at whatever state the host
+        # left it — we deliberately do NOT replay env.step calls. We skip
+        # env.reset on any resume (even if the prior trajectory was
+        # empty), because resume() promises the host's env state
+        # survives the round-trip.
+        step_offset = 0
+        skip_env_reset = False
+        if resume_state is not None:
+            trajectory = [
+                _trajectory_step_from_dict(d)
+                for d in resume_state.trajectory_steps
+            ]
+            action_history = [t.action for t in trajectory]
+            step_offset = resume_state.step_index
+            skip_env_reset = True
+            total_reward = sum(t.reward for t in trajectory)
+            logger.info(
+                "Resuming from pause at step %d (%d trajectory steps)",
+                step_offset, len(trajectory),
+            )
 
         # Reward state — only populated when reward_fn is provided.
         episode_state: Any = None
@@ -350,28 +526,42 @@ class GymRunner:
         done_rejections: int = 0
         max_done_rejections: int = 2
 
-        # Reset environment
-        reset_kwargs: dict[str, Any] = {"task_id": task_id}
-        if start_url:
-            reset_kwargs["start_url"] = start_url
-        if seed is not None:
-            reset_kwargs["seed"] = seed
+        # Reset environment (skipped on resume — env is owned by the host
+        # across pause/resume and stays at whatever state it was in when
+        # the handler raised PauseRequested).
+        if not skip_env_reset:
+            reset_kwargs: dict[str, Any] = {"task_id": task_id}
+            if start_url:
+                reset_kwargs["start_url"] = start_url
+            if seed is not None:
+                reset_kwargs["seed"] = seed
 
-        obs = self.env.reset(task, **reset_kwargs)
-        self._loop_detector.reset()
-        frame_history.append(obs.screenshot)
-        _save_frame(obs.screenshot, 0)
-        last_url = obs.extras.get("url", "")
-        last_title = obs.extras.get("title", "")
+            obs = self.env.reset(task, **reset_kwargs)
+            self._loop_detector.reset()
+            frame_history.append(obs.screenshot)
+            _save_frame(obs.screenshot, 0)
+            last_url = obs.extras.get("url", "")
+            last_title = obs.extras.get("title", "")
 
-        self._emit(
-            "task_start", task=task, max_steps=self.max_steps,
-            screen_size=list(self.env.screen_size),
-        )
+            self._emit(
+                "task_start", task=task, max_steps=self.max_steps,
+                screen_size=list(self.env.screen_size),
+            )
+        else:
+            # Resume path — capture the current env screen so the brain
+            # has a fresh frame to reason on. _capture is the
+            # env-agnostic helper; if the env doesn't expose it we'll
+            # let the loop's first brain.think run with an empty frame
+            # buffer (rare — production envs ship _capture).
+            cap = self.env._capture() if hasattr(self.env, "_capture") else None
+            if cap is not None:
+                frame_history.append(cap.screenshot)
+                last_url = cap.extras.get("url", "") if hasattr(cap, "extras") else ""
+                last_title = cap.extras.get("title", "") if hasattr(cap, "extras") else ""
 
         termination_reason = "max_steps"
 
-        for step_num in range(1, self.max_steps + 1):
+        for step_num in range(step_offset + 1, self.max_steps + 1):
             logger.info(f"--- Step {step_num}/{self.max_steps} ---")
 
             # ── Hybrid execution: try DOM first, fall back to brain ──
@@ -566,6 +756,85 @@ class GymRunner:
                     agent_plan = self._extract_plan(thinking)
                     if agent_plan:
                         logger.info(f"Plan captured: {agent_plan[:120]}...")
+
+                # ── Host-tool dispatch (#285) ──────────────────────────
+                # Brains opt into host tools by emitting an Action of
+                # type TOOL_CALL with ``params = {"name": str, "args":
+                # dict}``. Short-circuit env.step and route through the
+                # tool channel instead. Handler return value lands in
+                # the trajectory's ``feedback`` field; a raised
+                # ``PauseRequested`` (caught inside
+                # ``ToolChannel.invoke``) is surfaced via
+                # ``self.tool_channel.pending_pause`` — we snapshot and
+                # return a ``RunResult(paused=True, ...)``.
+                if action.action_type == ActionType.TOOL_CALL:
+                    tool_name = str(
+                        action.params.get("name")
+                        or action.params.get("tool")
+                        or "",
+                    )
+                    tool_args = (
+                        action.params.get("args")
+                        or action.params.get("arguments")
+                        or {}
+                    )
+                    success, data = self.tool_channel.invoke(
+                        tool_name, dict(tool_args),
+                    )
+                    pending = self.tool_channel.pending_pause
+                    if pending is not None:
+                        # PauseRequested raised inside the handler. Append
+                        # the paused tool-call step to the trajectory FIRST
+                        # so the snapshot carries it — resume() rehydrates
+                        # the action_history from trajectory_steps, and the
+                        # brain on resume needs to see the prior tool call
+                        # in its context.
+                        self.tool_channel.clear_pause()
+                        trajectory.append(TrajectoryStep(
+                            step=step_num, action=action, thinking=thinking,
+                            reward=0.0, done=False,
+                            inference_time=inference_time,
+                            feedback=f"tool:{tool_name}:pause",
+                        ))
+                        action_history.append(action)
+                        pause_state = PauseState(
+                            session_name=task_id,
+                            step_index=step_num,
+                            pending_tool=tool_name,
+                            pending_arguments=dict(tool_args),
+                            pending_reason=pending.get("reason", "user_input"),
+                            prompt=pending.get("prompt", ""),
+                            trajectory_steps=[
+                                _trajectory_step_to_dict(t) for t in trajectory
+                            ],
+                            task=task,
+                            task_id=task_id,
+                            timestamp=time.time(),
+                        )
+                        return RunResult(
+                            task=task, task_id=task_id, success=False,
+                            total_reward=total_reward,
+                            total_steps=step_num,
+                            total_time=time.time() - t0,
+                            trajectory=trajectory,
+                            termination_reason="paused",
+                            paused=True, pause_state=pause_state,
+                        )
+                    # Normal return path — record + continue. Handler
+                    # errors come back as ``success=False`` with the
+                    # ``tool:<n>:error:…`` data string; we surface them
+                    # via ``feedback`` and keep going (mirrors the
+                    # MicroPlanRunner behaviour of never silently
+                    # swallowing a handler exception).
+                    trajectory.append(TrajectoryStep(
+                        step=step_num, action=action, thinking=thinking,
+                        reward=0.0, done=False,
+                        inference_time=inference_time,
+                        feedback=data,
+                    ))
+                    action_history.append(action)
+                    step_log.append(f"Step {step_num}: {action} → {data}")
+                    continue
 
                 if action.action_type == ActionType.DONE:
                     success = action.params.get("success", False)

--- a/tests/test_gym_runner_tools.py
+++ b/tests/test_gym_runner_tools.py
@@ -1,0 +1,314 @@
+"""Tests for ``GymRunner`` host-tool registration + pause/resume (#285).
+
+Three scenarios pinned (matching the three test cases in the issue):
+
+1. ``register_tool`` + a brain that emits ``TOOL_CALL`` → handler returns
+   a value → loop continues, trajectory carries the tool-call step.
+2. Same setup but the handler raises ``PauseRequested`` → ``run()``
+   returns ``RunResult(paused=True, pause_state=...)`` with the prompt
+   propagated through.
+3. ``resume(pause_state, user_input=...)`` continues the run; the next
+   handler can read the supplied reply via ``consume_pause_input`` exactly
+   once.
+
+The brain and env are stubs — no real perception, no real screenshot
+mutation. The point is the host-tool plumbing, not the agent loop's
+content.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from PIL import Image
+
+from mantis_agent.actions import Action, ActionType
+from mantis_agent.gym.base import GymEnvironment, GymObservation, GymResult
+from mantis_agent.gym.checkpoint import PauseRequested, PauseState
+from mantis_agent.gym.runner import GymRunner, RunResult
+
+
+# ── Stubs ─────────────────────────────────────────────────────────────────
+
+
+def _blank_image(width: int = 32, height: int = 24) -> Image.Image:
+    return Image.new("RGB", (width, height), color="white")
+
+
+class _StubEnv(GymEnvironment):
+    """Minimal env — every step returns a blank frame + reward 0.0."""
+
+    def __init__(self, screen: tuple[int, int] = (320, 200)) -> None:
+        self._screen = screen
+        self.reset_calls = 0
+        self.step_calls = 0
+
+    def reset(self, task: str, **kwargs: Any) -> GymObservation:
+        self.reset_calls += 1
+        return GymObservation(screenshot=_blank_image(*self._screen), extras={})
+
+    def step(self, action: Action) -> GymResult:
+        self.step_calls += 1
+        return GymResult(
+            observation=GymObservation(
+                screenshot=_blank_image(*self._screen), extras={},
+            ),
+            reward=0.0,
+            done=False,
+            info={"url": "", "title": ""},
+        )
+
+    def close(self) -> None:
+        return None
+
+    @property
+    def screen_size(self) -> tuple[int, int]:
+        return self._screen
+
+    def _capture(self) -> GymObservation:
+        """Used by the resume path so the brain has a fresh frame."""
+        return GymObservation(
+            screenshot=_blank_image(*self._screen), extras={},
+        )
+
+
+class _ScriptedBrain:
+    """Brain that emits a scripted sequence of actions.
+
+    Each call to ``think()`` pops the next action off the script. Once
+    empty, returns a ``DONE`` action so the runner terminates cleanly.
+    """
+
+    def __init__(self, actions: list[Action]) -> None:
+        self._actions = list(actions)
+        self.think_calls = 0
+        self.tasks_seen: list[str] = []
+
+    def load(self) -> None:
+        return None
+
+    def think(
+        self,
+        frames: list[Image.Image],
+        task: str,
+        action_history: list[Action] | None = None,
+        screen_size: tuple[int, int] = (1920, 1080),
+    ) -> Any:
+        self.think_calls += 1
+        self.tasks_seen.append(task)
+        if self._actions:
+            action = self._actions.pop(0)
+        else:
+            action = Action(
+                action_type=ActionType.DONE,
+                params={"success": True, "summary": "scripted brain exhausted"},
+            )
+
+        class _Result:
+            pass
+
+        result = _Result()
+        result.action = action
+        result.thinking = ""
+        return result
+
+
+def _tool_call(name: str, args: dict[str, Any] | None = None) -> Action:
+    return Action(
+        action_type=ActionType.TOOL_CALL,
+        params={"name": name, "args": args or {}},
+    )
+
+
+def _runner(actions: list[Action], **kwargs: Any) -> tuple[GymRunner, _StubEnv, _ScriptedBrain]:
+    env = _StubEnv()
+    brain = _ScriptedBrain(actions)
+    runner = GymRunner(brain=brain, env=env, max_steps=10, **kwargs)
+    return runner, env, brain
+
+
+# ── 1. Handler returns value → loop continues ─────────────────────────────
+
+
+def test_tool_call_handler_returns_value_loop_continues() -> None:
+    """A registered handler returning a value records a trajectory step
+    and the loop continues to the next brain.think call."""
+    runner, env, brain = _runner([
+        _tool_call("greet", {"who": "world"}),
+        # Brain falls off the script → returns DONE → run terminates cleanly.
+    ])
+    invocations: list[dict[str, Any]] = []
+
+    def greet(args: dict[str, Any]) -> str:
+        invocations.append(args)
+        return f"hello {args.get('who', '')}".strip()
+
+    runner.register_tool("greet", {"type": "object"}, greet)
+
+    result = runner.run(task="say hi", task_id="t1")
+
+    assert isinstance(result, RunResult)
+    assert result.paused is False
+    assert result.pause_state is None
+    assert invocations == [{"who": "world"}]
+    # Tool-call step is in the trajectory with the handler's return in feedback.
+    tool_steps = [s for s in result.trajectory if s.action.action_type is ActionType.TOOL_CALL]
+    assert len(tool_steps) == 1
+    assert tool_steps[0].feedback == "tool:greet:ok:hello world"
+    # env.step was never called for the tool-call step.
+    assert env.step_calls == 0
+
+
+def test_list_tools_returns_registered_names_and_schemas() -> None:
+    runner, _env, _brain = _runner([])
+    runner.register_tool("a", {"type": "object", "properties": {"x": {}}}, lambda _: "ok")
+    runner.register_tool("b", {}, lambda _: "ok")
+    listed = runner.list_tools()
+    names = {t["name"] for t in listed}
+    assert names == {"a", "b"}
+
+
+def test_unregistered_tool_call_surfaces_error_in_feedback() -> None:
+    """Brain emits TOOL_CALL for a name that wasn't registered — the
+    runner records the step with a `tool:<n>:not_registered:...` feedback
+    string and keeps going (mirrors MicroPlanRunner's non-swallow rule)."""
+    runner, _env, _brain = _runner([_tool_call("missing", {})])
+    result = runner.run(task="t", task_id="t1")
+    tool_steps = [s for s in result.trajectory if s.action.action_type is ActionType.TOOL_CALL]
+    assert len(tool_steps) == 1
+    assert tool_steps[0].feedback.startswith("tool:missing:not_registered")
+
+
+# ── 2. Handler raises PauseRequested → RunResult(paused=True) ─────────────
+
+
+def test_handler_pause_returns_paused_run_result() -> None:
+    runner, _env, _brain = _runner([
+        _tool_call("ask_user", {"why": "need clarification"}),
+    ])
+
+    def ask_user(_args: dict[str, Any]) -> Any:
+        raise PauseRequested(
+            reason="user_input",
+            prompt="What's your email?",
+        )
+
+    runner.register_tool("ask_user", {"type": "object"}, ask_user)
+
+    result = runner.run(task="onboard", task_id="t-onboard")
+
+    assert result.paused is True
+    assert isinstance(result.pause_state, PauseState)
+    assert result.pause_state.pending_tool == "ask_user"
+    assert result.pause_state.pending_reason == "user_input"
+    assert result.pause_state.prompt == "What's your email?"
+    assert result.pause_state.task == "onboard"
+    assert result.pause_state.task_id == "t-onboard"
+    # The paused tool-call step is in both the runtime trajectory AND
+    # the snapshot, so resume can replay.
+    assert len(result.trajectory) >= 1
+    assert result.termination_reason == "paused"
+
+
+def test_pause_state_round_trips_through_dict() -> None:
+    """PauseState must be JSON-serializable so the host can store it on
+    its own state object across processes / restarts."""
+    runner, _env, _brain = _runner([_tool_call("ask", {})])
+    runner.register_tool(
+        "ask", {},
+        lambda _a: (_ for _ in ()).throw(
+            PauseRequested(reason="user_input", prompt="?"),
+        ),
+    )
+    result = runner.run(task="t", task_id="t1")
+    assert result.pause_state is not None
+    payload = result.pause_state.to_dict()
+    # Round-trip via from_dict — exercise the JSON-friendly path.
+    restored = PauseState.from_dict(payload)
+    assert restored.pending_tool == "ask"
+    assert restored.task == "t"
+    assert restored.trajectory_steps == result.pause_state.trajectory_steps
+
+
+# ── 3. resume() continues with consume_pause_input visible to handler ─────
+
+
+def test_resume_makes_user_input_visible_to_consume_pause_input() -> None:
+    """The handler that paused asks again on resume; this time it reads
+    the user reply via ``consume_pause_input`` instead of raising.
+    Read-once: a second call returns the default."""
+    seen_inputs: list[Any] = []
+
+    def ask_user(_args: dict[str, Any]) -> Any:
+        # On first call: raise to pause. On resume: read the input.
+        reply = runner.consume_pause_input(default=None)
+        if reply is None:
+            raise PauseRequested(reason="user_input", prompt="email?")
+        seen_inputs.append(reply)
+        return f"got:{reply}"
+
+    runner, _env, _brain = _runner([
+        # Two TOOL_CALL actions in the script: first pauses, second runs.
+        # On resume the brain re-emits the tool call (host-driven re-prompt).
+        _tool_call("ask_user", {}),
+        _tool_call("ask_user", {}),
+    ])
+    runner.register_tool("ask_user", {}, ask_user)
+
+    first = runner.run(task="onboard", task_id="t-onboard")
+    assert first.paused is True
+    assert first.pause_state is not None
+    assert seen_inputs == []
+
+    second = runner.resume(
+        first.pause_state, user_input="user@example.com",
+    )
+    # Resume completes (brain script falls off → DONE).
+    assert second.paused is False
+    assert seen_inputs == ["user@example.com"]
+    # The combined trajectory carries both the paused tool-call step and
+    # the successful resumed tool-call step.
+    tool_steps = [
+        s for s in second.trajectory
+        if s.action.action_type is ActionType.TOOL_CALL
+    ]
+    assert len(tool_steps) >= 2
+    assert tool_steps[-1].feedback == "tool:ask_user:ok:got:user@example.com"
+
+
+def test_resume_skips_env_reset() -> None:
+    """The env is owned by the host across pause/resume — resume() must
+    NOT call ``env.reset`` again, otherwise the URL / Chrome profile
+    state the host is holding would be wiped."""
+    runner, env, _brain = _runner([
+        _tool_call("ask", {}),
+        _tool_call("ask", {}),
+    ])
+
+    def ask(_a: dict[str, Any]) -> Any:
+        reply = runner.consume_pause_input()
+        if reply is None:
+            raise PauseRequested(reason="user_input", prompt="?")
+        return "ok"
+
+    runner.register_tool("ask", {}, ask)
+
+    runner.run(task="t", task_id="t1")
+    pre_resume_resets = env.reset_calls
+    assert pre_resume_resets == 1  # one for the initial run
+
+    paused = runner.run(task="t", task_id="t1")
+    # Second run() (without going through resume()) reset the env again.
+    assert env.reset_calls == 2
+
+    # Explicit resume path: NO new env.reset.
+    runner.resume(paused.pause_state, user_input="hi")
+    assert env.reset_calls == 2
+
+
+def test_consume_pause_input_is_read_once() -> None:
+    runner, _env, _brain = _runner([])
+    runner._pause_input = "secret"
+    assert runner.consume_pause_input() == "secret"
+    # Second read sees the default.
+    assert runner.consume_pause_input(default="default-value") == "default-value"


### PR DESCRIPTION
## Summary

Closes #285. Mirrors the \`MicroPlanRunner\` surface (\`register_tool\` / \`consume_pause_input\` / \`PauseRequested\` / \`resume\`) on \`GymRunner\` so host integrations can plug \`auth_credentials\` / \`user_input\` / \`correspondent_message\` / similar tools into the perception-action loop. **Unblocks StaffAI-Inc/staffai#641.**

\`\`\`python
runner = GymRunner(brain=..., env=...)
runner.register_tool(\"ask_user\", {\"type\": \"object\"}, handler)

result = runner.run(task=\"onboard the new user\")
if result.paused:
    reply = prompt_user(result.pause_state.prompt)
    result = runner.resume(result.pause_state, user_input=reply)
\`\`\`

## What changed

| File | Change |
|---|---|
| \`actions.py\` | New \`ActionType.TOOL_CALL\` — brain emits \`Action(TOOL_CALL, params={\"name\", \"args\"})\` |
| \`gym/checkpoint.py\` | \`PauseState\` gains \`trajectory_steps\` + \`task\` + \`task_id\` fields for GymRunner snapshots |
| \`gym/runner.py\` | Compose \`ToolChannel\`; add \`register_tool\` / \`list_tools\` / \`consume_pause_input\` / \`resume\`; dispatch \`TOOL_CALL\` in the run loop; \`RunResult\` gains \`paused\` + \`pause_state\`; trajectory round-trip helpers |
| \`tests/test_gym_runner_tools.py\` | 8 tests — stub brain + stub env, fast (~2 s), no live deps |

The \`ToolChannel\` plumbing in \`gym/tool_channel.py\` is unchanged — reused as-is. \`PauseRequested\` / \`PauseState\` exception + dataclass are unchanged in shape; only optional fields added.

## Tests (mirrors the three test cases in the issue)

\`\`\`
$ uv run python -m pytest tests/test_gym_runner_tools.py -v
======================== 8 passed in 2.34s ========================
\`\`\`

Covered:
- Handler returns value → loop continues, trajectory has tool-call step, \`env.step\` not called.
- Unknown tool name → \`feedback=\"tool:<n>:not_registered:...\"\` (no silent swallow).
- Handler raises \`PauseRequested\` → \`RunResult(paused=True, pause_state=...)\` with prompt + args propagated.
- \`PauseState\` round-trips via \`to_dict\` / \`from_dict\` (JSON-safe).
- \`resume(pause_state, user_input=...)\` continues with the handler's \`consume_pause_input()\` returning the reply.
- \`resume()\` does NOT call \`env.reset\` (host owns env state across pause/resume).
- \`consume_pause_input()\` is read-once.

Broader regression check (\`gym_runner_tools\` + \`brain_mock\` + \`plan_schema\` + \`examples_plans\` + \`video_endpoint\`): **47 passed in 2.48s**.

## Test plan
- [x] \`uv run python -m pytest tests/test_gym_runner_tools.py -v\` — 8 passed in 2.34s
- [x] \`uv run ruff check .\` — clean
- [ ] **Modal verification:** This PR adds a new host-tool surface; no shipped Modal plan exercises \`TOOL_CALL\` (staffai owns the consumer side). A pure no-regression smoke (Modal redeploy + lu.ma extract-loop) is recommended before merge — let me know if you want me to run it on this branch.
- [ ] After merge: staffai#641 wires \`_register_host_tools\` and \`_make_user_input_handler\` against the new surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)