### PR TITLE
feat(gym): structured predicate evaluation per step (closes #291)

### DIFF
--- a/docs/reference/env-vars.md
+++ b/docs/reference/env-vars.md
@@ -84,6 +84,12 @@ See [operations/cost.md](../operations/cost.md) for the full rate-tuning workflo
 | `LOG_LEVEL` | `INFO` | Standard Python logging level |
 | `MANTIS_LOG_FORMAT` | `json` | `json` (default) emits one-line JSON per record with `tenant_id` enrichment; `plain` reverts to ad-hoc format |
 
+## Runner / verification
+
+| Var | Default | Effect |
+|---|---|---|
+| `MANTIS_PREDICATE_VERIFY` | `enabled` | Per-step world-model verification (#291). When the brain emits a structured prediction (`{"expected": [...]}` or `Predicted: ...`), the runner parses, evaluates, and writes per-predicate booleans into the trajectory plus a `world_model_error` reward component. Set to `disabled` to ablate — `predicted_outcome` is still recorded for distillation, but no evaluation runs. See [Predicate grammar](predicates.md). |
+
 ## API documentation surface
 
 | Var | Default | Effect |

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -6,3 +6,4 @@
 | [Architecture](../architecture.md) | Internal architecture: brains, runner, env, gym, verification |
 | [Environment variables](env-vars.md) | Server-side env knobs (caps, paths, log format, model routing) |
 | [Glossary](glossary.md) | Quick definitions of project-specific terms |
+| [Predicate grammar](predicates.md) | World-model verification predicates emitted by brains and evaluated by the runner |

--- a/docs/reference/predicates.md
+++ b/docs/reference/predicates.md
@@ -1,0 +1,136 @@
+# Predicate grammar (world-model verification)
+
+Brains may emit a structured prediction of what they expect to observe **after**
+their action lands. The runner parses the prediction, evaluates each predicate
+against the post-action observation, writes per-predicate booleans into the
+trajectory, and derives a `world_model_error` reward contribution.
+
+This closes the world-model loop: the schema (`TrajectoryStep.predicted_outcome`,
+`observed_outcome`, `reward_components`), exporter, labeller, and reward weights
+were already in place; predicates make the signal structured rather than
+free-form.
+
+Tracking issue: [#291](https://github.com/mercurialsolo/mantis/issues/291).
+
+## Surface forms
+
+A brain emits one of two forms in its response. The runner accepts both.
+
+**Structured JSON (preferred):**
+
+```text
+{"expected": ["url_contains:/checkout", "title_changed", "field_focused:email"]}
+```
+
+**Back-compat free-form line (the original Holo3 surface, #120):**
+
+```text
+Predicted: url_contains:/checkout, title_changed, field_focused:email
+```
+
+Free-form prose tokens that don't match a known predicate kind are silently
+dropped, so the brain can mix natural-language reasoning with predicate tokens
+without breaking the parser.
+
+If the brain genuinely doesn't know what will happen, it should **omit the line
+entirely**. Guessing is worse than silence — it inflates measured error and
+poisons the reward signal.
+
+## Grammar
+
+Each predicate is a `kind[:arg]` token. Recognised kinds:
+
+| Kind | Arg | Meaning |
+|---|---|---|
+| `url_contains` | `<substr>` | observed URL contains substr |
+| `url_equals` | `<full url>` | observed URL equals the URL exactly |
+| `url_changed` | — | URL differs from previous step |
+| `url_unchanged` | — | URL identical to previous step |
+| `title_contains` | `<substr>` | page title contains substr |
+| `title_changed` | — | title differs from previous step |
+| `field_focused` | optional `<name>` | a field is focused (and contains the name in its id/name/label/selector/placeholder when given) |
+| `field_unfocused` | — | no field is focused |
+| `frame_changed` | — | post-action frame hash differs from previous |
+| `frame_stable` | — | post-action frame hash identical to previous |
+
+Best-effort kinds — recognised by the grammar so trajectories round-trip them,
+but evaluators currently return `None` ("not measured") on every adapter:
+
+| Kind | Arg | Status |
+|---|---|---|
+| `element_appears` | `<text or selector>` | Returns `None` until a DOM/OCR bridge lands |
+| `element_disappears` | `<text or selector>` | Same |
+| `modal_opens` | — | Same |
+| `modal_closes` | — | Same |
+
+A predicate evaluating to `None` is **excluded from the accuracy denominator** —
+the world-model metric stays meaningful across adapter capability levels.
+
+## Evaluation signals
+
+Predicates are evaluated against the post-action observation:
+
+- `url`, `title` — from `gym_result.info` (Playwright/CDP-backed envs)
+- `focused_input` — from `gym_result.info` (DOM-introspecting envs)
+- `frame_hash` — perceptual hash of the post-action screenshot, compared
+  against the previous step's hash for `frame_changed` / `frame_stable`
+
+The previous step's URL/title/frame_hash come from `last_url`, `last_title`,
+and the last entry in `trajectory`.
+
+## Reward contribution
+
+When at least one predicate is evaluable, the runner adds a per-step
+`world_model_error` component to `TrajectoryStep.reward_components`:
+
+```text
+world_model_error = -0.05 * (wrong_predicates / evaluated_predicates)
+```
+
+The 0.05 weight matches the existing `PlanAdherenceReward.world_model_weight`
+(see `rewards/plan_adherence.py`). All-correct predictions contribute `0.0`;
+all-wrong contribute `-0.05`. Steps with no parseable or no evaluable
+predicates contribute nothing.
+
+The structured per-step component coexists with the existing episode-level
+Jaccard `world_model_accuracy` from `rewards/components.world_model_accuracy_reward` —
+they measure different things (per-predicate exact match vs. token overlap
+of free-form prose) and both stay in `reward_components` for downstream
+consumers.
+
+## Trajectory shape
+
+Each `TrajectoryStep` carries the parsed-and-evaluated results:
+
+```python
+step.predicted_outcome       # raw string the brain emitted
+step.predicate_results       # list[{"predicate": str, "result": bool|None, "reason": str}]
+step.reward_components       # may include "world_model_error"
+```
+
+The full list round-trips through `_trajectory_step_to_dict` (pause snapshots,
+trace exports, training data).
+
+## Ablation toggle
+
+To disable predicate evaluation entirely — useful when measuring whether the
+verification step itself is pulling its weight (per [#261](https://github.com/mercurialsolo/mantis/issues/261)):
+
+```bash
+MANTIS_PREDICATE_VERIFY=disabled
+```
+
+When disabled the runner still records `predicted_outcome` (so the raw model
+output is preserved for distillation and offline analysis), but skips parsing
+and evaluation, and emits no `world_model_error` component.
+
+## Brain support
+
+| Brain | Emits structured `expected` | Emits `Predicted:` |
+|---|---|---|
+| Claude (`brain_claude.py`) | Yes (system prompt updated) | — |
+| OpenCUA (`brain_opencua.py`) | Yes (system prompt updated) | — |
+| Holo3 (`brain_holo3.py`) | — | Yes (since #120) |
+
+All three flow through `extract_predicted_outcome` in `gym/predicates.py` and
+the same runner evaluation path.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -134,6 +134,7 @@ nav:
       - Environment variables: reference/env-vars.md
       - Glossary: reference/glossary.md
       - Coordinate spaces: reference/coordinate-spaces.md
+      - Predicate grammar: reference/predicates.md
   - Appendix:
       - appendix/index.md
       - Learnings: learnings.md

--- a/src/mantis_agent/baseten_server/runtime.py
+++ b/src/mantis_agent/baseten_server/runtime.py
@@ -1115,6 +1115,20 @@ class BasetenCUARuntime:
             )
             elapsed = time.time() - t0
             trajectory = list(getattr(gym_result, "trajectory", []) or [])
+            # #291 ablation signal: how many predicates the brain emitted,
+            # how many were evaluable (env exposed the signal), and how many
+            # the brain got right. Lets a /v1/cua run double as an ablation
+            # data point without dumping the full trajectory.
+            predicate_total = 0
+            predicate_evaluated = 0
+            predicate_correct = 0
+            for tstep in trajectory:
+                for r in getattr(tstep, "predicate_results", None) or []:
+                    predicate_total += 1
+                    if r.get("result") is not None:
+                        predicate_evaluated += 1
+                        if r.get("result") is True:
+                            predicate_correct += 1
             result: dict[str, Any] = {
                 "run_id": run_id,
                 "mode": "pure_cua",
@@ -1129,6 +1143,15 @@ class BasetenCUARuntime:
                 "duration_s": round(elapsed),
                 "elapsed_seconds": elapsed,
                 "trajectory_len": len(trajectory),
+                "predicate_summary": {
+                    "total": predicate_total,
+                    "evaluated": predicate_evaluated,
+                    "correct": predicate_correct,
+                    "accuracy": (
+                        predicate_correct / predicate_evaluated
+                        if predicate_evaluated else None
+                    ),
+                },
             }
             self._attach_recording_metadata(result, recorder, click_log=click_log)
             self._save_result(result, prefix="pure_cua")

--- a/src/mantis_agent/brain_claude.py
+++ b/src/mantis_agent/brain_claude.py
@@ -104,6 +104,11 @@ class InferenceResult:
     raw_output: str
     thinking: str = ""
     tokens_used: int = 0
+    # #291: brain's structured prediction of post-action signals — either a
+    # ``{"expected": [...]}`` JSON block or a back-compat ``Predicted: ...``
+    # line. Empty when the model didn't emit one. Parsed downstream by
+    # :func:`mantis_agent.gym.predicates.parse_predicates`.
+    predicted_outcome: str = ""
 
 
 class ClaudeBrain:
@@ -374,11 +379,19 @@ class ClaudeBrain:
         tokens_used = data.get("usage", {})
         total_tokens = tokens_used.get("input_tokens", 0) + tokens_used.get("output_tokens", 0)
 
+        # #291: capture the brain's structured prediction (JSON ``expected``
+        # block or ``Predicted: ...`` line) for the runner to evaluate against
+        # the post-action observation. Search across thinking + assistant text
+        # — Claude tends to emit the JSON inside the assistant text block.
+        from .gym.predicates import extract_predicted_outcome
+        predicted = extract_predicted_outcome(text) or extract_predicted_outcome(thinking)
+
         return InferenceResult(
             action=action,
             raw_output=raw_output,
             thinking=full_thinking,
             tokens_used=total_tokens,
+            predicted_outcome=predicted,
         )
 
     @staticmethod

--- a/src/mantis_agent/brain_opencua.py
+++ b/src/mantis_agent/brain_opencua.py
@@ -84,6 +84,11 @@ class InferenceResult:
     raw_output: str
     thinking: str = ""
     tokens_used: int = 0
+    # #291: brain's structured prediction of post-action signals — either a
+    # ``{"expected": [...]}`` JSON block or a back-compat ``Predicted: ...``
+    # line. Empty when the model didn't emit one. Parsed downstream by
+    # :func:`mantis_agent.gym.predicates.parse_predicates`.
+    predicted_outcome: str = ""
 
 
 class OpenCUABrain:
@@ -282,11 +287,19 @@ class OpenCUABrain:
         if action is None:
             action = Action(ActionType.WAIT, {"seconds": 1.0}, reasoning=f"Could not parse: {text[:100]}")
 
+        # #291: capture the brain's structured prediction (JSON ``expected``
+        # block or ``Predicted: ...`` line). Search the raw text — OpenCUA
+        # has no separate thinking channel, so the prediction lives wherever
+        # the model emitted it.
+        from .gym.predicates import extract_predicted_outcome
+        predicted = extract_predicted_outcome(text)
+
         return InferenceResult(
             action=action,
             raw_output=raw_output,
             thinking=thinking,
             tokens_used=data.get("usage", {}).get("total_tokens", 0),
+            predicted_outcome=predicted,
         )
 
     @staticmethod

--- a/src/mantis_agent/gym/predicates.py
+++ b/src/mantis_agent/gym/predicates.py
@@ -1,0 +1,355 @@
+"""Predicate grammar + evaluators for #291.
+
+Brains emit structured predictions either as a JSON block:
+
+    {"expected": ["url_contains:/checkout", "title_changed", "field_focused:email"]}
+
+or as a back-compat ``Predicted: <prose>`` line (the #120 Holo3 surface).
+The runner parses the predictions, evaluates each predicate against the
+post-action observation, writes per-predicate booleans into the trajectory
+step, and derives a ``world_model_error`` reward contribution (fraction
+wrong of evaluated predicates).
+
+Predicate grammar — deterministic, observable from gym signals today
+(``gym_result.info`` plus a perceptual frame hash):
+
+  url_contains:<substr>       observed URL contains substr
+  url_equals:<url>            observed URL == url exactly
+  url_changed                 URL differs from previous step
+  url_unchanged               URL identical to previous step
+  title_contains:<substr>     page title contains substr
+  title_changed               title differs from previous step
+  field_focused[:<name>]      a field is focused (and matches name if given)
+  field_unfocused             no field is focused
+  frame_changed               frame hash differs from previous step
+  frame_stable                frame hash identical to previous step
+
+Best-effort kinds — recognised by the grammar so the brain can emit them
+and trajectories round-trip the predictions, but evaluators return ``None``
+("not measured") on any adapter that doesn't expose the DOM/OCR signal:
+
+  element_appears:<text>
+  element_disappears:<text>
+  modal_opens
+  modal_closes
+
+A predicate evaluating to ``None`` is excluded from the accuracy
+denominator — it didn't fail, it just wasn't measurable. That keeps the
+``world_model_error`` metric stable across adapter capability levels.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class Predicate:
+    """One parsed prediction token, e.g. ``url_contains:/checkout``."""
+
+    kind: str
+    arg: str | None = None
+    raw: str = ""
+
+    def __str__(self) -> str:
+        if self.raw:
+            return self.raw
+        if self.arg is not None:
+            return f"{self.kind}:{self.arg}"
+        return self.kind
+
+
+@dataclass
+class PredicateResult:
+    """Outcome of evaluating one predicate. ``result is None`` => unevaluable."""
+
+    predicate: str
+    result: bool | None
+    reason: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "predicate": self.predicate,
+            "result": self.result,
+            "reason": self.reason,
+        }
+
+
+@dataclass
+class ObservationContext:
+    """Signals the runner hands to predicate evaluators after each step."""
+
+    url: str = ""
+    title: str = ""
+    focused_input: dict | None = None
+    frame_hash: str = ""
+    prev_url: str = ""
+    prev_title: str = ""
+    prev_frame_hash: str = ""
+
+
+# Recognised predicate kinds — anything else is dropped during parsing so
+# free-form prose ("clicking the link") doesn't pollute the predicate stream.
+_KNOWN_KINDS: frozenset[str] = frozenset({
+    "url_contains", "url_equals", "url_changed", "url_unchanged",
+    "title_contains", "title_changed",
+    "field_focused", "field_unfocused",
+    "frame_changed", "frame_stable",
+    # Best-effort kinds — evaluators return None when no DOM/OCR signal is
+    # available. Listed so trajectories round-trip them and adopting envs
+    # can light them up later without a grammar change.
+    "element_appears", "element_disappears",
+    "modal_opens", "modal_closes",
+})
+
+
+# ``{"expected": [...]}`` may live inside a markdown fence; the regex
+# tolerates the fence prefix and matches the first such object.
+_JSON_BLOCK_RE = re.compile(
+    r'\{[^{}]*"expected"\s*:\s*\[[^\]]*\][^{}]*\}',
+    re.DOTALL,
+)
+
+_PREDICTED_LINE_RE = re.compile(
+    r"^\s*Predicted\s*:\s*(.+?)\s*$",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+_FREEFORM_DELIMS_RE = re.compile(r"[,;]+")
+
+
+# Cap to keep trajectories bounded — matches brain_holo3's 240-char cap on
+# the back-compat free-form line, but lifted to 500 to fit a small JSON
+# block of ~5 predicates.
+_PREDICTED_OUTCOME_MAX_CHARS: int = 500
+
+
+def extract_predicted_outcome(text: str) -> str:
+    """Pull a brain's predicted-outcome string out of its raw response.
+
+    Looks for, in order:
+    1. A ``{"expected": [...]}`` JSON block (the #291 structured contract).
+    2. A trailing ``Predicted: <prose>`` line (the #120 Holo3 surface).
+
+    Returns ``""`` when neither form is present so trajectories from brains
+    that don't emit predictions stay clean (no spurious empty predicates).
+
+    The result is the literal text the brain emitted (capped at
+    :data:`_PREDICTED_OUTCOME_MAX_CHARS`) — :func:`parse_predicates` does
+    the actual grammar work downstream. Keeping the raw form lets traces
+    round-trip what the model actually said for distillation.
+    """
+    if not text:
+        return ""
+    m = _JSON_BLOCK_RE.search(text)
+    if m:
+        return m.group(0)[:_PREDICTED_OUTCOME_MAX_CHARS]
+    pm = _PREDICTED_LINE_RE.search(text)
+    if pm:
+        line = pm.group(1).strip().strip('"').strip("'").strip()
+        return line[:_PREDICTED_OUTCOME_MAX_CHARS]
+    return ""
+
+
+def _coerce_predicate(token: str) -> Predicate | None:
+    """Turn ``'url_contains:/checkout'`` into a :class:`Predicate`.
+
+    Returns ``None`` when the token's kind isn't in :data:`_KNOWN_KINDS` —
+    that's what lets ``parse_predicates`` accept free-form prose alongside
+    structured tokens (everything that isn't a real predicate is dropped).
+    """
+    token = token.strip().strip('"').strip("'").rstrip(".")
+    if not token:
+        return None
+    if ":" in token:
+        kind, _, arg = token.partition(":")
+        kind = kind.strip().lower()
+        arg = arg.strip()
+        if kind in _KNOWN_KINDS:
+            raw = f"{kind}:{arg}" if arg else kind
+            return Predicate(kind=kind, arg=arg or None, raw=raw)
+        return None
+    kind = token.strip().lower()
+    if kind in _KNOWN_KINDS:
+        return Predicate(kind=kind, arg=None, raw=kind)
+    return None
+
+
+def parse_predicates(text: str) -> list[Predicate]:
+    """Extract a predicate list from a brain's ``predicted_outcome`` string.
+
+    Two surface forms are supported:
+
+    1. **Structured JSON** — the #291 contract::
+
+           {"expected": ["url_contains:/checkout", "title_changed"]}
+
+    2. **Back-compat free-form** — the #120 Holo3 surface::
+
+           Predicted: clicking will navigate to /checkout, title changes.
+
+       Free-form prose is split on commas/semicolons and each token is
+       matched against the grammar. Tokens that don't match a known kind
+       are silently dropped, which lets brains adopt structured emissions
+       incrementally without breaking existing prompts.
+
+    Returns ``[]`` when nothing parses — the caller treats that as
+    "no prediction this step" (no reward contribution).
+    """
+    if not text:
+        return []
+    out: list[Predicate] = []
+
+    m = _JSON_BLOCK_RE.search(text)
+    if m:
+        try:
+            obj = json.loads(m.group(0))
+            for tok in obj.get("expected", []) or []:
+                p = _coerce_predicate(str(tok))
+                if p is not None:
+                    out.append(p)
+        except (json.JSONDecodeError, TypeError, AttributeError):
+            pass
+        if out:
+            return out
+
+    pm = _PREDICTED_LINE_RE.search(text)
+    if pm:
+        line = pm.group(1)
+        for tok in _FREEFORM_DELIMS_RE.split(line):
+            p = _coerce_predicate(tok)
+            if p is not None:
+                out.append(p)
+
+    return out
+
+
+def _focus_matches(focused: dict | None, name: str) -> bool:
+    """``focused_input`` matches ``name`` if any identifying field contains
+    the substring (case-insensitive).
+
+    Mantis adapters populate ``focused_input`` with varying keys depending on
+    available DOM access (id, name, label, selector, placeholder); checking
+    each one keeps the predicate robust across env capability levels.
+    """
+    if not focused or not isinstance(focused, dict):
+        return False
+    needle = name.lower().lstrip("#.")
+    for k in ("name", "id", "label", "selector", "placeholder"):
+        v = focused.get(k)
+        if v and needle in str(v).lower():
+            return True
+    return False
+
+
+def evaluate_predicate(p: Predicate, ctx: ObservationContext) -> PredicateResult:
+    """Evaluate one predicate against the post-action observation.
+
+    Returns ``result=None`` when the env didn't expose the signal needed
+    (e.g. ``element_appears`` on a screenshot-only adapter, or
+    ``url_changed`` when the env doesn't surface URLs at all).
+    """
+    raw = p.raw or str(p)
+    kind = p.kind
+    arg = p.arg
+
+    if kind == "url_contains":
+        if not arg:
+            return PredicateResult(raw, False, "url_contains requires arg")
+        if not ctx.url:
+            return PredicateResult(raw, None, "no url in observation")
+        return PredicateResult(raw, arg in ctx.url, ctx.url)
+
+    if kind == "url_equals":
+        if not arg:
+            return PredicateResult(raw, False, "url_equals requires arg")
+        if not ctx.url:
+            return PredicateResult(raw, None, "no url in observation")
+        return PredicateResult(raw, ctx.url == arg, ctx.url)
+
+    if kind == "url_changed":
+        if not ctx.url and not ctx.prev_url:
+            return PredicateResult(raw, None, "no url before/after")
+        return PredicateResult(
+            raw, ctx.url != ctx.prev_url, f"{ctx.prev_url} -> {ctx.url}",
+        )
+
+    if kind == "url_unchanged":
+        if not ctx.url and not ctx.prev_url:
+            return PredicateResult(raw, None, "no url before/after")
+        return PredicateResult(
+            raw, ctx.url == ctx.prev_url, f"{ctx.prev_url} -> {ctx.url}",
+        )
+
+    if kind == "title_contains":
+        if not arg:
+            return PredicateResult(raw, False, "title_contains requires arg")
+        if not ctx.title:
+            return PredicateResult(raw, None, "no title in observation")
+        return PredicateResult(raw, arg in ctx.title, ctx.title)
+
+    if kind == "title_changed":
+        if not ctx.title and not ctx.prev_title:
+            return PredicateResult(raw, None, "no title before/after")
+        return PredicateResult(
+            raw, ctx.title != ctx.prev_title, f"{ctx.prev_title} -> {ctx.title}",
+        )
+
+    if kind == "field_focused":
+        if ctx.focused_input is None:
+            return PredicateResult(raw, False, "no focused field")
+        if arg:
+            return PredicateResult(
+                raw, _focus_matches(ctx.focused_input, arg), str(ctx.focused_input),
+            )
+        return PredicateResult(raw, True, str(ctx.focused_input))
+
+    if kind == "field_unfocused":
+        return PredicateResult(raw, ctx.focused_input is None, str(ctx.focused_input))
+
+    if kind == "frame_changed":
+        if not ctx.frame_hash or not ctx.prev_frame_hash:
+            return PredicateResult(raw, None, "no frame hash before/after")
+        return PredicateResult(
+            raw,
+            ctx.frame_hash != ctx.prev_frame_hash,
+            f"{ctx.prev_frame_hash} -> {ctx.frame_hash}",
+        )
+
+    if kind == "frame_stable":
+        if not ctx.frame_hash or not ctx.prev_frame_hash:
+            return PredicateResult(raw, None, "no frame hash before/after")
+        return PredicateResult(
+            raw,
+            ctx.frame_hash == ctx.prev_frame_hash,
+            f"{ctx.prev_frame_hash} -> {ctx.frame_hash}",
+        )
+
+    if kind in {"element_appears", "element_disappears", "modal_opens", "modal_closes"}:
+        # No DOM/OCR bridge in observed_state today — skip rather than fail.
+        return PredicateResult(raw, None, "no DOM/OCR signal")
+
+    return PredicateResult(raw, None, f"unknown predicate kind: {kind}")
+
+
+def evaluate_all(
+    predicates: list[Predicate], ctx: ObservationContext,
+) -> list[PredicateResult]:
+    return [evaluate_predicate(p, ctx) for p in predicates]
+
+
+def world_model_error(results: list[PredicateResult]) -> float | None:
+    """Fraction of evaluated predicates the brain got wrong, in ``[0.0, 1.0]``.
+
+    Returns ``None`` when no predicates were evaluable — the caller should
+    skip the reward contribution for that step (don't conflate "no signal"
+    with "perfect prediction"). Lower is better.
+    """
+    evaluated = [r for r in results if r.result is not None]
+    if not evaluated:
+        return None
+    wrong = sum(1 for r in evaluated if not r.result)
+    return wrong / len(evaluated)

--- a/src/mantis_agent/gym/runner.py
+++ b/src/mantis_agent/gym/runner.py
@@ -31,6 +31,12 @@ from ..actions import Action, ActionType
 from ..loop_detector import LoopDetector, phash_64
 from ._runner_helpers import is_cancelled
 from .base import GymEnvironment
+from .predicates import (
+    ObservationContext,
+    evaluate_all,
+    parse_predicates,
+    world_model_error,
+)
 # Re-exported so hosts can ``from mantis_agent.gym.runner import
 # PauseRequested, PauseState`` without reaching into the .checkpoint
 # private surface (#285).
@@ -118,6 +124,19 @@ class TrajectoryStep:
     # url/title changes. The reward function compares this to predicted_outcome
     # to compute world-model error.
     observed_outcome: str = ""
+
+    # ── #291 structured predicate evaluation ────────────────────────────
+    # Per-predicate evaluation results derived from ``predicted_outcome``
+    # against the post-action observation. Each entry is
+    # ``{"predicate": str, "result": bool|None, "reason": str}`` where
+    # ``result is None`` means "couldn't measure" (the env didn't expose
+    # the signal). Empty list when the brain emitted no parseable
+    # predicates or when MANTIS_PREDICATE_VERIFY is disabled.
+    #
+    # Aggregate world-model error (fraction of evaluated predicates the
+    # brain got wrong) lands in ``reward_components["world_model_error"]``
+    # — see GymRunner.run for the wire-up.
+    predicate_results: list[dict] = field(default_factory=list)
 
 
 # Subset of ``gym_result.info`` that round-trips into TrajectoryStep
@@ -209,6 +228,7 @@ def _trajectory_step_to_dict(step: TrajectoryStep) -> dict[str, Any]:
         "hypothesized_state": step.hypothesized_state,
         "predicted_outcome": step.predicted_outcome,
         "observed_outcome": step.observed_outcome,
+        "predicate_results": list(step.predicate_results),
     }
 
 
@@ -233,6 +253,7 @@ def _trajectory_step_from_dict(payload: dict[str, Any]) -> TrajectoryStep:
         hypothesized_state=str(payload.get("hypothesized_state", "")),
         predicted_outcome=str(payload.get("predicted_outcome", "")),
         observed_outcome=str(payload.get("observed_outcome", "")),
+        predicate_results=list(payload.get("predicate_results") or []),
     )
 
 
@@ -1258,6 +1279,10 @@ class GymRunner:
                 elif action.action_type not in (ActionType.CLICK, ActionType.DOUBLE_CLICK):
                     last_focused_input = None
 
+                # Capture pre-action url/title for predicate evaluation BEFORE
+                # advancing them — `url_changed` etc. compare new vs. previous.
+                prev_url_for_predicates = last_url
+                prev_title_for_predicates = last_title
                 last_url = gym_result.info.get("url", last_url)
                 last_title = gym_result.info.get("title", last_title)
 
@@ -1268,18 +1293,55 @@ class GymRunner:
                 # the brain's predicted_outcome to what actually happened.
                 # frame_hash uses the same dHash as the loop detector so two
                 # trajectories at the same logical state hash equal.
+                step_frame_hash = phash_64(gym_result.observation.screenshot)
+                step_observed_state = {
+                    **_observed_state(gym_result.info),
+                    **_gallery_observed_state(gallery_recovery),
+                }
+
+                # #291 structured predicate evaluation. Default ON; set
+                # MANTIS_PREDICATE_VERIFY=disabled to ablate. Skipped when
+                # the brain emitted no predicted_outcome.
+                step_predicate_results: list[dict] = []
+                if (
+                    predicted_outcome
+                    and os.environ.get(
+                        "MANTIS_PREDICATE_VERIFY", "enabled",
+                    ).lower() != "disabled"
+                ):
+                    parsed = parse_predicates(predicted_outcome)
+                    if parsed:
+                        ctx = ObservationContext(
+                            url=str(gym_result.info.get("url", "") or ""),
+                            title=str(gym_result.info.get("title", "") or ""),
+                            focused_input=focused_input
+                                if isinstance(focused_input, dict) else None,
+                            frame_hash=step_frame_hash,
+                            prev_url=str(prev_url_for_predicates or ""),
+                            prev_title=str(prev_title_for_predicates or ""),
+                            prev_frame_hash=trajectory[-1].frame_hash
+                                if trajectory else "",
+                        )
+                        results = evaluate_all(parsed, ctx)
+                        step_predicate_results = [r.to_dict() for r in results]
+                        wm_err = world_model_error(results)
+                        if wm_err is not None:
+                            # Emit as a negative reward contribution so a
+                            # high-error step lowers total reward. Magnitude
+                            # is small (matches the existing
+                            # world_model_weight=0.05 in PlanAdherenceReward).
+                            step_components["world_model_error"] = -wm_err * 0.05
+
                 trajectory.append(TrajectoryStep(
                     step=step_num, action=action, thinking=thinking,
                     reward=step_reward, done=gym_result.done,
                     inference_time=inference_time, feedback=feedback,
                     reward_components=step_components,
-                    frame_hash=phash_64(gym_result.observation.screenshot),
-                    observed_state={
-                        **_observed_state(gym_result.info),
-                        **_gallery_observed_state(gallery_recovery),
-                    },
+                    frame_hash=step_frame_hash,
+                    observed_state=step_observed_state,
                     observed_outcome=feedback,
                     predicted_outcome=predicted_outcome,
+                    predicate_results=step_predicate_results,
                 ))
 
                 logger.info(f"Feedback: {feedback}")

--- a/src/mantis_agent/prompts/files/claude_system.txt
+++ b/src/mantis_agent/prompts/files/claude_system.txt
@@ -31,3 +31,16 @@ Your job:
 # Waiting
 - If a page is loading or animating, call wait() to observe the result.
 - After submitting a form, call wait(seconds=2) before checking the result.
+
+# Predicted outcome (optional — improves world-model signal)
+After your action, you MAY emit a one-line JSON object declaring what observable signals you expect after the action lands:
+
+  {"expected": ["url_contains:/checkout", "title_changed", "field_focused:email"]}
+
+Predicate grammar:
+  url_contains:<substr>     url_equals:<url>     url_changed     url_unchanged
+  title_contains:<substr>   title_changed
+  field_focused[:<name>]    field_unfocused
+  frame_changed             frame_stable
+
+Only include predicates you're confident about — omit the line entirely if you don't know. The system uses these to measure your world-model accuracy; guessing is worse than silence.

--- a/src/mantis_agent/prompts/files/holo3_system.txt
+++ b/src/mantis_agent/prompts/files/holo3_system.txt
@@ -3,7 +3,7 @@ You are a computer use agent. You observe screenshots and perform actions to com
 RESPONSE FORMAT — Every response must follow this structure:
 1. One brief sentence of reasoning (what you see and plan to do)
 2. One action call
-3. One line starting with "Predicted:" describing what you expect to happen after the action — one short sentence about the visible delta (URL change, modal opens, field focuses, page loads, etc.). Skip this only for done().
+3. One line starting with "Predicted:" describing what you expect to happen after the action. Prefer comma-separated predicate tokens from this grammar (the system uses them to score your world model): url_contains:<substr>, url_equals:<url>, url_changed, url_unchanged, title_contains:<substr>, title_changed, field_focused[:<name>], field_unfocused, frame_changed, frame_stable. Free-form prose still works as a fallback. Skip this only for done().
 
 ACTIONS — use exactly one per response:
 click(x=<int>, y=<int>)
@@ -17,7 +17,7 @@ done(success=false, summary="<reason>")
 FORMAT EXAMPLE (shape only — adapt the reasoning, action, and prediction to the real screen):
 I see the target element. I'll click it to advance.
 click(x=640, y=320)
-Predicted: the page navigates to the target's detail view and the URL changes.
+Predicted: url_changed, title_changed
 
 DONE-SUMMARY EXAMPLE (shape only — substitute the fields the plan asks for):
 I executed every step in the plan and captured the requested fields.

--- a/src/mantis_agent/prompts/files/opencua_system.txt
+++ b/src/mantis_agent/prompts/files/opencua_system.txt
@@ -28,3 +28,16 @@ Data extraction:
 - Read prices, years, makes, models from page titles and content
 - Read the current URL from the browser address bar
 - When reporting results, include EVERY piece of extracted data
+
+Predicted outcome (optional):
+After your action, you MAY emit a one-line JSON object declaring observable signals you expect after the action lands:
+
+  {"expected": ["url_contains:/checkout", "title_changed", "field_focused:email"]}
+
+Predicate grammar:
+  url_contains:<substr>     url_equals:<url>     url_changed     url_unchanged
+  title_contains:<substr>   title_changed
+  field_focused[:<name>]    field_unfocused
+  frame_changed             frame_stable
+
+Only include predicates you're confident about — omit the line entirely if you don't know. The system measures your world-model accuracy; guessing is worse than silence.

--- a/tests/test_brain_predicted_outcome.py
+++ b/tests/test_brain_predicted_outcome.py
@@ -1,0 +1,171 @@
+"""Tests for #291 — brain_claude and brain_opencua emit predicted_outcome.
+
+Mirrors the existing test_holo3_predicted_outcome.py shape so the three
+brains (Holo3, Claude, OpenCUA) all have the same coverage contract.
+"""
+
+from __future__ import annotations
+
+from mantis_agent.actions import Action, ActionType
+from mantis_agent.brain_claude import InferenceResult as ClaudeIR
+from mantis_agent.brain_opencua import InferenceResult as OpenCUAIR
+
+
+# ── InferenceResult schema ──────────────────────────────────────────────
+
+
+def test_claude_inference_result_defaults_predicted_outcome_empty() -> None:
+    r = ClaudeIR(action=Action(ActionType.CLICK, {"x": 1, "y": 1}), raw_output="")
+    assert r.predicted_outcome == ""
+
+
+def test_claude_inference_result_carries_predicted_outcome() -> None:
+    r = ClaudeIR(
+        action=Action(ActionType.CLICK, {"x": 1, "y": 1}),
+        raw_output="",
+        predicted_outcome='{"expected": ["url_changed"]}',
+    )
+    assert r.predicted_outcome == '{"expected": ["url_changed"]}'
+
+
+def test_opencua_inference_result_defaults_predicted_outcome_empty() -> None:
+    r = OpenCUAIR(action=Action(ActionType.CLICK, {"x": 1, "y": 1}), raw_output="")
+    assert r.predicted_outcome == ""
+
+
+def test_opencua_inference_result_carries_predicted_outcome() -> None:
+    r = OpenCUAIR(
+        action=Action(ActionType.CLICK, {"x": 1, "y": 1}),
+        raw_output="",
+        predicted_outcome="Predicted: url_changed",
+    )
+    assert r.predicted_outcome == "Predicted: url_changed"
+
+
+# ── System prompts mention the predicate contract ──────────────────────
+
+
+def test_claude_system_prompt_documents_predicate_grammar() -> None:
+    from mantis_agent.prompts import load_prompt
+    p = load_prompt("claude_system")
+    assert '"expected"' in p
+    assert "url_contains" in p
+    assert "url_changed" in p
+    assert "field_focused" in p
+    # Stay-silent rule prevents hallucinated predictions.
+    assert "omit" in p.lower() or "skip" in p.lower()
+
+
+def test_opencua_system_prompt_documents_predicate_grammar() -> None:
+    from mantis_agent.prompts import load_prompt
+    p = load_prompt("opencua_system")
+    assert '"expected"' in p
+    assert "url_contains" in p
+    assert "field_focused" in p
+    assert "omit" in p.lower() or "skip" in p.lower()
+
+
+# ── extract_predicted_outcome shared helper ─────────────────────────────
+
+
+def test_extract_predicted_outcome_prefers_json_block() -> None:
+    from mantis_agent.gym.predicates import extract_predicted_outcome
+    text = (
+        "Clicking the button.\n"
+        '{"expected": ["url_contains:/checkout"]}\n'
+        "Predicted: page navigates"
+    )
+    out = extract_predicted_outcome(text)
+    assert out.startswith('{"expected"')
+    assert "url_contains" in out
+
+
+def test_extract_predicted_outcome_falls_back_to_predicted_line() -> None:
+    from mantis_agent.gym.predicates import extract_predicted_outcome
+    text = "click(x=1, y=1)\nPredicted: url_changed, title_changed"
+    out = extract_predicted_outcome(text)
+    assert out == "url_changed, title_changed"
+
+
+def test_extract_predicted_outcome_returns_empty_on_no_signal() -> None:
+    from mantis_agent.gym.predicates import extract_predicted_outcome
+    assert extract_predicted_outcome("just thinking") == ""
+    assert extract_predicted_outcome("") == ""
+
+
+def test_extract_predicted_outcome_caps_long_input() -> None:
+    from mantis_agent.gym.predicates import (
+        _PREDICTED_OUTCOME_MAX_CHARS,
+        extract_predicted_outcome,
+    )
+    text = "Predicted: " + "x" * 5000
+    assert len(extract_predicted_outcome(text)) <= _PREDICTED_OUTCOME_MAX_CHARS
+
+
+# ── Claude _parse_response captures predicted_outcome ──────────────────
+
+
+def test_claude_parse_response_captures_json_block() -> None:
+    from mantis_agent.brain_claude import ClaudeBrain
+    brain = ClaudeBrain(api_key="dummy")
+    data = {
+        "content": [
+            {"type": "text", "text": (
+                'I see the checkout link. {"expected": ["url_contains:/checkout"]}'
+            )},
+            {"type": "tool_use", "name": "computer", "input": {
+                "action": "left_click", "coordinate": [100, 200],
+            }},
+        ],
+        "usage": {"input_tokens": 10, "output_tokens": 5},
+    }
+    result = brain._parse_response(data)
+    assert "url_contains" in result.predicted_outcome
+
+
+def test_claude_parse_response_no_prediction_yields_empty() -> None:
+    from mantis_agent.brain_claude import ClaudeBrain
+    brain = ClaudeBrain(api_key="dummy")
+    data = {
+        "content": [
+            {"type": "text", "text": "I'll click."},
+            {"type": "tool_use", "name": "computer", "input": {
+                "action": "left_click", "coordinate": [1, 2],
+            }},
+        ],
+        "usage": {"input_tokens": 1, "output_tokens": 1},
+    }
+    result = brain._parse_response(data)
+    assert result.predicted_outcome == ""
+
+
+# ── OpenCUA _parse_response captures predicted_outcome ─────────────────
+
+
+def test_opencua_parse_response_captures_predicted_line() -> None:
+    from mantis_agent.brain_opencua import OpenCUABrain
+    brain = OpenCUABrain(base_url="http://localhost:8000/v1")
+    data = {
+        "choices": [{"message": {"content": (
+            "I'll click.\n"
+            "pyautogui.click(100, 200)\n"
+            "Predicted: url_changed"
+        )}}],
+        "usage": {"total_tokens": 0},
+    }
+    result = brain._parse_response(data, screen_size=(1280, 720))
+    assert result.predicted_outcome == "url_changed"
+
+
+def test_opencua_parse_response_captures_json_block() -> None:
+    from mantis_agent.brain_opencua import OpenCUABrain
+    brain = OpenCUABrain(base_url="http://localhost:8000/v1")
+    data = {
+        "choices": [{"message": {"content": (
+            'I will click. pyautogui.click(100, 200) {"expected": ["url_changed"]}'
+        )}}],
+        "usage": {"total_tokens": 0},
+    }
+    result = brain._parse_response(data, screen_size=(1280, 720))
+    assert "url_changed" in result.predicted_outcome
+    assert '"expected"' in result.predicted_outcome

--- a/tests/test_gym_runner_predicates.py
+++ b/tests/test_gym_runner_predicates.py
@@ -1,0 +1,210 @@
+"""GymRunner integration for #291 — predicates evaluated per step.
+
+Drives the runner with a fake brain that emits a structured ``expected``
+JSON block, then asserts the trajectory carries per-predicate booleans
+plus a ``world_model_error`` reward component.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+from PIL import Image
+
+from mantis_agent.actions import Action, ActionType
+from mantis_agent.gym.base import GymEnvironment, GymObservation, GymResult
+from mantis_agent.gym.runner import GymRunner
+
+
+@dataclass
+class _BrainResult:
+    action: Action
+    thinking: str = ""
+    predicted_outcome: str = ""
+
+
+class _ScriptedBrain:
+    """Emits a fixed sequence of (action, predicted_outcome) tuples."""
+
+    def __init__(self, script: list[tuple[Action, str]]) -> None:
+        self.script = list(script)
+        self.calls = 0
+
+    def think(
+        self,
+        frames: Any,
+        task: str,
+        action_history: Any = None,
+        screen_size: tuple[int, int] = (100, 100),
+    ) -> _BrainResult:
+        if self.calls >= len(self.script):
+            action = Action(ActionType.DONE, {"success": True, "summary": "done"})
+            self.calls += 1
+            return _BrainResult(action)
+        action, pred = self.script[self.calls]
+        self.calls += 1
+        return _BrainResult(action, predicted_outcome=pred)
+
+
+class _ScriptedEnv(GymEnvironment):
+    """Plays back a fixed sequence of (url, title) post-step observations."""
+
+    def __init__(self, observations: list[tuple[str, str]]) -> None:
+        self.observations = list(observations)
+        self.calls = 0
+        # Two distinct images so frame_hash differs on transition.
+        self._white = Image.new("RGB", (100, 100), color=(255, 255, 255))
+        self._black = Image.new("RGB", (100, 100), color=(0, 0, 0))
+
+    @property
+    def screen_size(self) -> tuple[int, int]:
+        return (100, 100)
+
+    def reset(self, task: str, **kwargs: Any) -> GymObservation:
+        self.calls = 0
+        return GymObservation(screenshot=self._white)
+
+    def step(self, action: Action) -> GymResult:
+        if self.calls >= len(self.observations):
+            url, title = self.observations[-1] if self.observations else ("", "")
+        else:
+            url, title = self.observations[self.calls]
+        self.calls += 1
+        # Alternate frame so frame_changed predicates evaluate True.
+        screenshot = self._black if self.calls % 2 == 1 else self._white
+        return GymResult(
+            GymObservation(screenshot=screenshot),
+            reward=0.0,
+            done=False,
+            info={"url": url, "title": title},
+        )
+
+    def close(self) -> None:
+        pass
+
+
+def _click() -> Action:
+    return Action(ActionType.CLICK, {"x": 1, "y": 1})
+
+
+def test_runner_evaluates_predicates_and_emits_world_model_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Brain predicts url_changed; env confirms — error component should be 0."""
+    monkeypatch.delenv("MANTIS_PREDICATE_VERIFY", raising=False)
+
+    brain = _ScriptedBrain([
+        (_click(), '{"expected": ["url_changed", "title_changed"]}'),
+    ])
+    env = _ScriptedEnv([("https://x.test/b", "Page B")])
+
+    result = GymRunner(brain, env, max_steps=2).run("task")
+
+    # First step is the click; second is the auto-DONE the scripted brain emits.
+    step = result.trajectory[0]
+    assert step.predicate_results, "predicate_results should be populated"
+    kinds = [r["predicate"] for r in step.predicate_results]
+    assert "url_changed" in kinds
+    assert "title_changed" in kinds
+    # Both predicates were True (URL/title changed from "" to a non-empty value).
+    assert all(r["result"] is True for r in step.predicate_results)
+    # All-correct => world_model_error contribution == 0 (no penalty).
+    assert step.reward_components.get("world_model_error", 0.0) == 0.0
+
+
+def test_runner_penalizes_wrong_predictions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("MANTIS_PREDICATE_VERIFY", raising=False)
+
+    brain = _ScriptedBrain([
+        # Brain predicts URL will contain '/checkout', but env stays on /home.
+        (_click(), '{"expected": ["url_contains:/checkout"]}'),
+    ])
+    env = _ScriptedEnv([("https://x.test/home", "Home")])
+
+    result = GymRunner(brain, env, max_steps=2).run("task")
+    step = result.trajectory[0]
+    assert step.predicate_results[0]["result"] is False
+    # All-wrong => error == 1.0, weighted by 0.05.
+    assert step.reward_components["world_model_error"] == pytest.approx(-0.05)
+
+
+def test_runner_skips_when_brain_emits_no_prediction(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("MANTIS_PREDICATE_VERIFY", raising=False)
+
+    brain = _ScriptedBrain([(_click(), "")])  # no prediction
+    env = _ScriptedEnv([("https://x.test/a", "A")])
+
+    result = GymRunner(brain, env, max_steps=2).run("task")
+    step = result.trajectory[0]
+    assert step.predicate_results == []
+    assert "world_model_error" not in step.reward_components
+
+
+def test_runner_disabled_via_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
+    """MANTIS_PREDICATE_VERIFY=disabled is the ablation toggle."""
+    monkeypatch.setenv("MANTIS_PREDICATE_VERIFY", "disabled")
+
+    brain = _ScriptedBrain([
+        (_click(), '{"expected": ["url_changed"]}'),
+    ])
+    env = _ScriptedEnv([("https://x.test/b", "B")])
+
+    result = GymRunner(brain, env, max_steps=2).run("task")
+    step = result.trajectory[0]
+    # Predicates parsed but not evaluated — no per-step results, no reward
+    # contribution. predicted_outcome is still recorded for distillation.
+    assert step.predicate_results == []
+    assert "world_model_error" not in step.reward_components
+    assert step.predicted_outcome == '{"expected": ["url_changed"]}'
+
+
+def test_runner_unevaluable_predicate_skipped_from_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A best-effort predicate (no DOM) returns None and is excluded
+    from the world_model_error denominator."""
+    monkeypatch.delenv("MANTIS_PREDICATE_VERIFY", raising=False)
+
+    brain = _ScriptedBrain([
+        (_click(),
+         '{"expected": ["url_changed", "modal_opens"]}'),
+    ])
+    env = _ScriptedEnv([("https://x.test/b", "B")])
+
+    result = GymRunner(brain, env, max_steps=2).run("task")
+    step = result.trajectory[0]
+    results_by_kind = {r["predicate"]: r["result"] for r in step.predicate_results}
+    assert results_by_kind["url_changed"] is True
+    assert results_by_kind["modal_opens"] is None
+    # Only url_changed contributes — it was correct, so error == 0.
+    assert step.reward_components.get("world_model_error", 0.0) == 0.0
+
+
+def test_trajectory_step_to_dict_round_trips_predicate_results() -> None:
+    from mantis_agent.gym.runner import (
+        TrajectoryStep,
+        _trajectory_step_from_dict,
+        _trajectory_step_to_dict,
+    )
+
+    original = TrajectoryStep(
+        step=1,
+        action=Action(ActionType.CLICK, {"x": 1, "y": 1}),
+        thinking="",
+        reward=0.0,
+        done=False,
+        inference_time=0.0,
+        predicate_results=[
+            {"predicate": "url_changed", "result": True, "reason": "/a -> /b"},
+            {"predicate": "modal_opens", "result": None, "reason": "no DOM"},
+        ],
+    )
+    payload = _trajectory_step_to_dict(original)
+    rehydrated = _trajectory_step_from_dict(payload)
+    assert rehydrated.predicate_results == original.predicate_results

--- a/tests/test_predicates.py
+++ b/tests/test_predicates.py
@@ -1,0 +1,306 @@
+"""Tests for #291 predicate grammar + evaluators (gym/predicates.py).
+
+Covers parsing both surface forms (structured JSON, free-form Predicted:),
+evaluator semantics including the "unevaluable" case (result=None), and the
+world_model_error aggregate.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mantis_agent.gym.predicates import (
+    ObservationContext,
+    Predicate,
+    PredicateResult,
+    evaluate_all,
+    evaluate_predicate,
+    parse_predicates,
+    world_model_error,
+)
+
+
+# ── parse_predicates: structured JSON surface ──────────────────────────
+
+
+def test_parse_structured_json_block() -> None:
+    text = '{"expected": ["url_contains:/checkout", "title_changed"]}'
+    out = parse_predicates(text)
+    assert [p.kind for p in out] == ["url_contains", "title_changed"]
+    assert out[0].arg == "/checkout"
+    assert out[1].arg is None
+
+
+def test_parse_json_inside_prose() -> None:
+    text = (
+        "I'll click checkout. "
+        '{"expected": ["url_contains:/checkout"]} '
+        "Then proceed."
+    )
+    out = parse_predicates(text)
+    assert len(out) == 1
+    assert out[0].kind == "url_contains"
+    assert out[0].arg == "/checkout"
+
+
+def test_parse_json_drops_unknown_kinds_silently() -> None:
+    text = '{"expected": ["url_contains:/x", "lol_unknown:foo", "frame_changed"]}'
+    out = parse_predicates(text)
+    assert [p.kind for p in out] == ["url_contains", "frame_changed"]
+
+
+def test_parse_json_handles_empty_expected_list() -> None:
+    assert parse_predicates('{"expected": []}') == []
+
+
+def test_parse_json_falls_through_to_freeform_on_invalid_json() -> None:
+    # Malformed JSON shouldn't crash; falls through to Predicted: parser.
+    text = '{"expected": [malformed} \nPredicted: url_changed'
+    out = parse_predicates(text)
+    assert len(out) == 1
+    assert out[0].kind == "url_changed"
+
+
+# ── parse_predicates: free-form Predicted: surface ─────────────────────
+
+
+def test_parse_freeform_predicted_line() -> None:
+    text = "click(x=1, y=1)\nPredicted: url_contains:/detail, title_changed"
+    out = parse_predicates(text)
+    assert [p.kind for p in out] == ["url_contains", "title_changed"]
+
+
+def test_parse_freeform_drops_prose_tokens() -> None:
+    # Prose like "the page navigates" doesn't match any kind — dropped.
+    text = "Predicted: the page navigates, title_changed, lol_unknown:foo"
+    out = parse_predicates(text)
+    assert [p.kind for p in out] == ["title_changed"]
+
+
+def test_parse_returns_empty_on_no_signal() -> None:
+    assert parse_predicates("") == []
+    assert parse_predicates("just some thinking text") == []
+    assert parse_predicates("Predicted: ") == []
+
+
+def test_parse_strips_quotes_from_tokens() -> None:
+    text = '{"expected": ["url_contains:/x"]}'
+    out = parse_predicates(text)
+    assert out[0].arg == "/x"
+
+
+# ── evaluate_predicate: url predicates ─────────────────────────────────
+
+
+def test_url_contains_true() -> None:
+    p = Predicate("url_contains", "/checkout", "url_contains:/checkout")
+    ctx = ObservationContext(url="https://shop.test/checkout?step=1")
+    r = evaluate_predicate(p, ctx)
+    assert r.result is True
+
+
+def test_url_contains_false() -> None:
+    p = Predicate("url_contains", "/checkout", "url_contains:/checkout")
+    ctx = ObservationContext(url="https://shop.test/cart")
+    r = evaluate_predicate(p, ctx)
+    assert r.result is False
+
+
+def test_url_contains_unevaluable_when_no_url() -> None:
+    p = Predicate("url_contains", "/checkout", "url_contains:/checkout")
+    r = evaluate_predicate(p, ObservationContext())
+    assert r.result is None
+
+
+def test_url_changed_true() -> None:
+    p = Predicate("url_changed", None, "url_changed")
+    ctx = ObservationContext(url="https://x.test/b", prev_url="https://x.test/a")
+    assert evaluate_predicate(p, ctx).result is True
+
+
+def test_url_changed_false() -> None:
+    p = Predicate("url_changed", None, "url_changed")
+    ctx = ObservationContext(url="https://x.test/a", prev_url="https://x.test/a")
+    assert evaluate_predicate(p, ctx).result is False
+
+
+def test_url_unchanged_true() -> None:
+    p = Predicate("url_unchanged", None, "url_unchanged")
+    ctx = ObservationContext(url="https://x.test/a", prev_url="https://x.test/a")
+    assert evaluate_predicate(p, ctx).result is True
+
+
+def test_url_equals_exact_match() -> None:
+    p = Predicate("url_equals", "https://x.test/a", "url_equals:https://x.test/a")
+    ctx = ObservationContext(url="https://x.test/a")
+    assert evaluate_predicate(p, ctx).result is True
+    ctx2 = ObservationContext(url="https://x.test/a?q=1")
+    assert evaluate_predicate(p, ctx2).result is False
+
+
+# ── evaluate_predicate: title predicates ───────────────────────────────
+
+
+def test_title_contains() -> None:
+    p = Predicate("title_contains", "Checkout", "title_contains:Checkout")
+    ctx = ObservationContext(title="Checkout — Shop")
+    assert evaluate_predicate(p, ctx).result is True
+    ctx2 = ObservationContext(title="Cart — Shop")
+    assert evaluate_predicate(p, ctx2).result is False
+
+
+def test_title_changed() -> None:
+    p = Predicate("title_changed", None, "title_changed")
+    ctx = ObservationContext(title="B", prev_title="A")
+    assert evaluate_predicate(p, ctx).result is True
+    ctx2 = ObservationContext(title="A", prev_title="A")
+    assert evaluate_predicate(p, ctx2).result is False
+
+
+# ── evaluate_predicate: focus predicates ───────────────────────────────
+
+
+def test_field_focused_any_true() -> None:
+    p = Predicate("field_focused", None, "field_focused")
+    ctx = ObservationContext(focused_input={"name": "email"})
+    assert evaluate_predicate(p, ctx).result is True
+
+
+def test_field_focused_any_false() -> None:
+    p = Predicate("field_focused", None, "field_focused")
+    ctx = ObservationContext(focused_input=None)
+    assert evaluate_predicate(p, ctx).result is False
+
+
+def test_field_focused_named_match_by_name() -> None:
+    p = Predicate("field_focused", "email", "field_focused:email")
+    ctx = ObservationContext(focused_input={"name": "email"})
+    assert evaluate_predicate(p, ctx).result is True
+
+
+def test_field_focused_named_match_by_id() -> None:
+    p = Predicate("field_focused", "#login-email", "field_focused:#login-email")
+    ctx = ObservationContext(focused_input={"id": "login-email"})
+    assert evaluate_predicate(p, ctx).result is True
+
+
+def test_field_focused_named_no_match() -> None:
+    p = Predicate("field_focused", "password", "field_focused:password")
+    ctx = ObservationContext(focused_input={"name": "email"})
+    assert evaluate_predicate(p, ctx).result is False
+
+
+def test_field_unfocused() -> None:
+    p = Predicate("field_unfocused", None, "field_unfocused")
+    assert evaluate_predicate(p, ObservationContext()).result is True
+    ctx = ObservationContext(focused_input={"name": "x"})
+    assert evaluate_predicate(p, ctx).result is False
+
+
+# ── evaluate_predicate: frame predicates ───────────────────────────────
+
+
+def test_frame_changed_true() -> None:
+    p = Predicate("frame_changed", None, "frame_changed")
+    ctx = ObservationContext(frame_hash="aaaa", prev_frame_hash="bbbb")
+    assert evaluate_predicate(p, ctx).result is True
+
+
+def test_frame_changed_false() -> None:
+    p = Predicate("frame_changed", None, "frame_changed")
+    ctx = ObservationContext(frame_hash="aaaa", prev_frame_hash="aaaa")
+    assert evaluate_predicate(p, ctx).result is False
+
+
+def test_frame_changed_unevaluable_at_first_step() -> None:
+    p = Predicate("frame_changed", None, "frame_changed")
+    ctx = ObservationContext(frame_hash="aaaa", prev_frame_hash="")
+    assert evaluate_predicate(p, ctx).result is None
+
+
+def test_frame_stable_true() -> None:
+    p = Predicate("frame_stable", None, "frame_stable")
+    ctx = ObservationContext(frame_hash="aaaa", prev_frame_hash="aaaa")
+    assert evaluate_predicate(p, ctx).result is True
+
+
+# ── evaluate_predicate: best-effort kinds return None ──────────────────
+
+
+@pytest.mark.parametrize(
+    "kind,arg",
+    [
+        ("element_appears", "Submit"),
+        ("element_disappears", "#login"),
+        ("modal_opens", None),
+        ("modal_closes", None),
+    ],
+)
+def test_dom_predicates_return_none_today(kind: str, arg: str | None) -> None:
+    raw = f"{kind}:{arg}" if arg else kind
+    p = Predicate(kind, arg, raw)
+    r = evaluate_predicate(p, ObservationContext(url="https://x.test"))
+    assert r.result is None
+    assert "no DOM/OCR signal" in r.reason
+
+
+# ── world_model_error aggregate ────────────────────────────────────────
+
+
+def test_world_model_error_zero_when_all_correct() -> None:
+    results = [
+        PredicateResult("url_changed", True),
+        PredicateResult("title_changed", True),
+    ]
+    assert world_model_error(results) == 0.0
+
+
+def test_world_model_error_one_when_all_wrong() -> None:
+    results = [
+        PredicateResult("url_changed", False),
+        PredicateResult("title_changed", False),
+    ]
+    assert world_model_error(results) == 1.0
+
+
+def test_world_model_error_excludes_unevaluable() -> None:
+    # 1 right, 1 wrong, 1 unevaluable => error = 1/2 (None excluded).
+    results = [
+        PredicateResult("url_changed", True),
+        PredicateResult("title_changed", False),
+        PredicateResult("modal_opens", None),
+    ]
+    assert world_model_error(results) == 0.5
+
+
+def test_world_model_error_none_when_nothing_evaluable() -> None:
+    results = [
+        PredicateResult("modal_opens", None),
+        PredicateResult("element_appears:x", None),
+    ]
+    assert world_model_error(results) is None
+
+
+def test_world_model_error_empty_input() -> None:
+    assert world_model_error([]) is None
+
+
+# ── evaluate_all integration ───────────────────────────────────────────
+
+
+def test_evaluate_all_round_trips_predicate_strings() -> None:
+    preds = parse_predicates(
+        '{"expected": ["url_changed", "field_focused:email", "frame_changed"]}',
+    )
+    ctx = ObservationContext(
+        url="https://x.test/b",
+        prev_url="https://x.test/a",
+        focused_input={"name": "email"},
+        frame_hash="cccc",
+        prev_frame_hash="bbbb",
+    )
+    results = evaluate_all(preds, ctx)
+    assert [r.predicate for r in results] == [
+        "url_changed", "field_focused:email", "frame_changed",
+    ]
+    assert all(r.result is True for r in results)


### PR DESCRIPTION
## Summary

- Closes #291.
- Brains can emit a structured `{"expected": [...]}` JSON block (or back-compat `Predicted: ...` line); the runner parses, evaluates each predicate against the post-action observation, writes per-predicate booleans into `TrajectoryStep.predicate_results`, and adds a `world_model_error` reward component.
- New module `gym/predicates.py` (grammar + evaluators), system-prompt updates for Claude and OpenCUA, runner integration, docs at `docs/reference/predicates.md`, env-var toggle `MANTIS_PREDICATE_VERIFY=disabled` for ablation.
- `/v1/cua` response now includes `predicate_summary` (`{total, evaluated, correct, accuracy}`) so each run doubles as an ablation data point.
- Holo3 prompt updated additively to suggest grammar tokens (the existing free-form `Predicted:` surface still parses).

## Predicate grammar

```
url_contains:<substr>     url_equals:<url>     url_changed     url_unchanged
title_contains:<substr>   title_changed
field_focused[:<name>]    field_unfocused
frame_changed             frame_stable
```

Best-effort kinds (recognised; return `None` until DOM/OCR bridge lands): `element_appears`, `element_disappears`, `modal_opens`, `modal_closes`.

## Acceptance against the issue

- [x] Predicate grammar documented in `docs/reference/predicates.md`
- [x] `brain_claude.py` and `brain_opencua.py` emit structured predictions (system prompts updated; `InferenceResult.predicted_outcome` + `_parse_response` capture)
- [x] `gym/runner.py` evaluates predicates and writes per-step booleans into `TrajectoryStep.predicate_results`
- [x] Aggregate accuracy surfaced in trajectory artifact via `predicate_summary` on the API response
- [x] Per-step `world_model_error` contribution wired into `reward_components` (weight 0.05, matches existing `world_model_weight`)

## Local tests

- 38 predicate grammar / evaluator tests (`tests/test_predicates.py`)
- 13 brain-parse + system-prompt tests (`tests/test_brain_predicted_outcome.py`)
- 6 runner integration tests including the `MANTIS_PREDICATE_VERIFY=disabled` ablation toggle (`tests/test_gym_runner_predicates.py`)
- All pre-existing trajectory schema / Holo3 / runner / brain tests continue to pass (no contract break)

```
$ pytest tests/test_predicates.py tests/test_brain_predicted_outcome.py \
    tests/test_gym_runner_predicates.py tests/test_holo3_predicted_outcome.py \
    tests/test_gym_runner_done_success.py tests/test_trajectory_schema.py \
    tests/test_trace_exporter.py tests/test_trace_labeller.py \
    tests/test_brain_claude.py tests/test_brain_mock.py tests/test_gym_runner_tools.py
150 passed in 0.88s
```

`ruff check` clean. Full pytest suite passes (run with `-x` exit 0).

## Modal ablation runs

Deployed to `getmason--mantis-server-api.modal.run` and ran three `/v1/cua` plans against `https://lu.ma/discover` with predicates **on** (default).

| Run | Steps | Duration | `predicate_summary` |
|---|---|---|---|
| 1 | 1 | 15s | not surfaced (pre-runtime-update pod) |
| 2 | 4 | 34s | `{total: 0, evaluated: 0, correct: 0, accuracy: null}` |
| 3 | 5 | 95s | `{total: 0, evaluated: 0, correct: 0, accuracy: null}` |

**What this verifies**: deploy succeeded, the new field appears in the response, and the new code path runs without breaking the `/v1/cua` flow.

**What this does NOT yet verify**: end-to-end signal from the production brain. Holo3-35B-A3B Q8 on llama.cpp does not reliably emit the trailing `Predicted:` line in production despite the prompt change — it skipped the line on every step across all three runs. This is a model-side issue (instruction-following at Q8), not a wiring issue. Brains that explicitly emit structured predictions (Claude, OpenCUA — both updated here) will populate `predicate_summary` once they're routed through the same `/v1/cua` path or a sibling endpoint.

The local 6-test runner integration suite (`tests/test_gym_runner_predicates.py`) drives a scripted brain through the full pipeline and asserts:
- Correct prediction → `world_model_error == 0.0`
- Wrong prediction → `world_model_error == -0.05`
- No prediction → no component emitted, no `predicate_results`
- Best-effort predicates (`modal_opens`) → `result=None`, excluded from accuracy
- `MANTIS_PREDICATE_VERIFY=disabled` → results stay empty (ablation toggle)
- Trajectory dict round-trips `predicate_results`

## Test plan

- [x] `pytest tests/test_predicates.py tests/test_brain_predicted_outcome.py tests/test_gym_runner_predicates.py` (57 tests pass)
- [x] `ruff check` on changed files passes
- [x] Full test suite passes (`pytest -x` exits 0)
- [x] Modal redeploy successful, `predicate_summary` appears in `/v1/cua` response
- [ ] Follow-up: route Claude/OpenCUA brains through a Modal endpoint and re-run ablation to capture non-zero `predicate_summary` (separate PR — Holo3 is the only brain on `/v1/cua` today)

🤖 Generated with [Claude Code](https://claude.com/claude-code)