### PR TITLE
feat(gym): GymRunner.run accepts cross-layer pending_form_labels (#306 follow-up)

### DIFF
--- a/docs/reference/done-gate.md
+++ b/docs/reference/done-gate.md
@@ -78,6 +78,35 @@ done(success=true) → gate (free, deterministic)
 Both rejection paths share the same `max_done_rejections` budget, so the
 total number of rejection cycles per run is bounded.
 
+## Cross-layer awareness (`pending_form_labels` kwarg)
+
+The done-gate's `pending_form_values` predicate normally reads the inner
+`FormController`'s pending list. When `GymRunner` is invoked from a
+higher-level orchestrator (`MicroPlanRunner` via `Holo3StepHandler` —
+the `/v1/predict` path), the inner runner only sees the sub-step's
+intent and has no visibility into form values that are pending across
+the broader plan.
+
+`GymRunner.run(pending_form_labels: list[str] | None = None)` lets the
+outer caller pass that cross-layer hint:
+
+```python
+gym_runner.run(
+    task=sub_step.intent,
+    task_id=f"step_{i}_{step.type}",
+    pending_form_labels=outer_runner.pending_form_labels,  # e.g. ["password", "captcha"]
+)
+```
+
+When non-`None`, the gate uses the passed list **instead of** the inner
+`FormController`'s derived list. When `None` (default), the inner
+controller's list wins — preserving the single-layer `/v1/cua`
+behaviour.
+
+`Holo3StepHandler` already reads `runner.pending_form_labels` (if the
+attribute exists) and forwards it. `MicroPlanRunner` doesn't track this
+state today; the plumbing point is in place for when it does.
+
 ## Ablation toggle
 
 To disable the gate entirely — useful for measuring whether it's pulling

--- a/src/mantis_agent/gym/runner.py
+++ b/src/mantis_agent/gym/runner.py
@@ -458,6 +458,7 @@ class GymRunner:
         ground_truth: dict[str, Any] | None = None,
         capture_dir: Any = None,
         pause_input: Any = None,
+        pending_form_labels: list[str] | None = None,
     ) -> RunResult:
         """Execute a task with plan persistence, feedback, and context.
 
@@ -481,6 +482,17 @@ class GymRunner:
             capture_dir: Optional Path. If set, each post-step screenshot is
                 written as `<capture_dir>/<NNNN>.png` for offline use (e.g.
                 rollout collection for SFT). The reset frame is `0000.png`.
+            pending_form_labels: Optional cross-layer hint (#306 follow-up).
+                When a higher-level orchestrator (e.g. ``MicroPlanRunner``
+                via ``Holo3StepHandler``) spawns an inner ``GymRunner`` for
+                a sub-step, the outer runner can pass labels of values
+                still pending elsewhere in the plan. The done-acceptance
+                gate uses this list — overriding the inner
+                ``FormController``'s derived pending list — so the gate
+                rejects ``done(success=True)`` on a sub-step that
+                inadvertently claims whole-task completion while outer
+                credentials remain pending. Default ``None`` preserves
+                current single-layer behaviour.
         """
         logger.info(f"Starting task: {task!r} (id={task_id})")
         t0 = time.time()
@@ -996,6 +1008,21 @@ class GymRunner:
                             "MANTIS_DONE_GATE", "enabled",
                         ).lower() != "disabled"
                     ):
+                        # #306 follow-up: when the caller passes
+                        # ``pending_form_labels`` (typically MicroPlanRunner
+                        # via Holo3StepHandler), use that cross-layer
+                        # hint instead of the inner FormController's
+                        # local view. Otherwise fall back to the inner
+                        # controller's pending values.
+                        if pending_form_labels is not None:
+                            gate_pending_labels = [
+                                str(lbl) for lbl in pending_form_labels
+                            ]
+                        else:
+                            gate_pending_labels = [
+                                str(v.get("label") or "")
+                                for v in force_fill_values
+                            ]
                         gate_decision = check_done_acceptance(
                             summary=summary,
                             plan=plan,
@@ -1008,10 +1035,7 @@ class GymRunner:
                                 str(t.observed_state.get("url", "") or "")
                                 for t in trajectory[-5:]
                             ],
-                            pending_form_labels=[
-                                str(v.get("label") or "")
-                                for v in force_fill_values
-                            ],
+                            pending_form_labels=gate_pending_labels,
                         )
 
                     if gate_decision is not None and not gate_decision.accept:

--- a/src/mantis_agent/gym/step_handlers/holo3.py
+++ b/src/mantis_agent/gym/step_handlers/holo3.py
@@ -80,7 +80,19 @@ class Holo3StepHandler:
             on_step=runner.on_step,
         )
 
-        result = gym_runner.run(task=step.intent, task_id=f"step_{index}_{step.type}")
+        # #306 follow-up: when the outer MicroPlanRunner tracks pending
+        # form labels across the whole plan, forward them so the inner
+        # GymRunner's done-gate can reject ``done(success=True)`` on a
+        # sub-step that inadvertently claims whole-task completion
+        # while outer credentials remain pending. MicroPlanRunner
+        # doesn't track this state today; the kwarg gives us a clean
+        # plumbing point for when it does.
+        outer_pending_labels = getattr(runner, "pending_form_labels", None)
+        result = gym_runner.run(
+            task=step.intent,
+            task_id=f"step_{index}_{step.type}",
+            pending_form_labels=outer_pending_labels,
+        )
 
         success = result.success
         runner._update_scroll_state_from_trajectory(result, context=f"holo3_{step.type}")

--- a/tests/test_gym_runner_pending_form_labels_kwarg.py
+++ b/tests/test_gym_runner_pending_form_labels_kwarg.py
@@ -1,0 +1,124 @@
+"""Test for #306 follow-up — GymRunner.run accepts cross-layer
+``pending_form_labels`` kwarg, and the done-gate honours it.
+
+When ``MicroPlanRunner`` spawns an inner ``GymRunner`` via
+``Holo3StepHandler``, the inner runner has its own ``FormController``
+with values extracted from the inner sub-step's intent. The outer
+runner may track values pending across the whole plan that the inner
+can't see. The new kwarg lets the outer pass that state in so the
+inner done-gate rejects ``done(success=True)`` while outer values
+remain unconsumed.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+from PIL import Image
+
+from mantis_agent.actions import Action, ActionType
+from mantis_agent.gym.base import GymEnvironment, GymObservation, GymResult
+from mantis_agent.gym.done_gate import REJECT_PENDING_FORM_VALUES
+from mantis_agent.gym.runner import GymRunner
+
+
+@dataclass
+class _BrainResult:
+    action: Action
+    thinking: str = ""
+    predicted_outcome: str = ""
+
+
+class _DoneBrain:
+    def think(
+        self,
+        frames: Any,
+        task: str,
+        action_history: Any = None,
+        screen_size: tuple[int, int] = (100, 100),
+    ) -> _BrainResult:
+        return _BrainResult(
+            Action(
+                ActionType.DONE,
+                {"success": True, "summary": "all done"},
+            )
+        )
+
+
+class _Env(GymEnvironment):
+    @property
+    def screen_size(self) -> tuple[int, int]:
+        return (100, 100)
+
+    def reset(self, task: str, **kwargs: Any) -> GymObservation:
+        return GymObservation(screenshot=Image.new("RGB", self.screen_size))
+
+    def step(self, action: Action) -> GymResult:
+        return GymResult(self.reset(""), reward=0.0, done=False, info={})
+
+    def close(self) -> None:
+        pass
+
+
+def test_outer_pending_labels_reject_done_at_inner_runner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Inner brain emits done(success=True). Outer caller passed
+    ``pending_form_labels=["password"]`` — the inner done-gate must
+    reject as ``pending_form_values`` even though the inner runner's
+    own FormController is empty."""
+    monkeypatch.delenv("MANTIS_DONE_GATE", raising=False)
+    monkeypatch.delenv("MANTIS_FORM_CONTROLLER", raising=False)
+
+    runner = GymRunner(_DoneBrain(), _Env(), max_steps=3)
+    result = runner.run(
+        "task with no creds in text",
+        pending_form_labels=["password"],
+    )
+
+    # Gate rejects repeatedly until max_done_rejections — what matters
+    # is at least one rejection with the right reason code.
+    assert (
+        result.done_rejections_by_reason.get(REJECT_PENDING_FORM_VALUES, 0) >= 1
+    )
+    rejected_steps = [
+        t for t in result.trajectory if t.done_rejected_reason
+    ]
+    assert len(rejected_steps) >= 1
+    assert rejected_steps[0].done_rejected_reason == REJECT_PENDING_FORM_VALUES
+
+
+def test_default_none_falls_back_to_inner_form_controller(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the kwarg isn't passed, the inner gate sources from the
+    inner FormController as before — backward-compat for /v1/cua."""
+    monkeypatch.delenv("MANTIS_DONE_GATE", raising=False)
+    monkeypatch.delenv("MANTIS_FORM_CONTROLLER", raising=False)
+
+    runner = GymRunner(_DoneBrain(), _Env(), max_steps=3)
+    result = runner.run("task with no creds in text")
+
+    # No outer hint, no inner pending → gate accepts the well-formed
+    # done(success=True, summary="all done").
+    assert REJECT_PENDING_FORM_VALUES not in result.done_rejections_by_reason
+
+
+def test_empty_outer_pending_labels_treated_as_no_hint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An explicit empty list is semantically "outer says nothing pending"
+    and should NOT trigger the rejection — matches the FormController
+    semantic (empty pending list = no rejection)."""
+    monkeypatch.delenv("MANTIS_DONE_GATE", raising=False)
+    monkeypatch.delenv("MANTIS_FORM_CONTROLLER", raising=False)
+
+    runner = GymRunner(_DoneBrain(), _Env(), max_steps=3)
+    result = runner.run(
+        "task",
+        pending_form_labels=[],
+    )
+
+    assert REJECT_PENDING_FORM_VALUES not in result.done_rejections_by_reason


### PR DESCRIPTION
## Summary

Follow-up from PR #306 (done-acceptance gate). I noted there that the gate's `plan_steps_incomplete` / `pending_form_values` predicates only fire on `/v1/cua` because the inner `GymRunner` spawned by `MicroPlanRunner` via `Holo3StepHandler` has no visibility into outer-plan form state.

This PR adds the plumbing:

- `GymRunner.run(pending_form_labels: list[str] | None = None)` — when non-`None`, the done-gate uses this list **instead of** the inner `FormController`'s derived list. When `None` (default), inner controller wins, preserving the single-layer `/v1/cua` behaviour.
- `Holo3StepHandler` reads `runner.pending_form_labels` (if the outer `MicroPlanRunner` exposes it) and forwards it.

`MicroPlanRunner` doesn't track this state today — the plumbing point is in place for when it does. The deliverable here is the **runner-side surface** that future outer-state work can plug into without further code change.

## Why this is the right scope

I considered threading the full outer `Plan` object into the inner `GymRunner` so `plan_steps_incomplete` could fire too. That's architecturally wrong: the inner brain emits `done()` at the end of its **sub-step** (e.g. "click Next"), which is legitimately the last step of its local plan. Rejecting it as "outer plan not complete" would conflate granularity layers.

`pending_form_labels` is different: form values either ARE pending across the whole plan or aren't. A sub-step brain that emits `done(success=True)` while outer-plan credentials remain unconsumed is unambiguously wrong. The cross-layer hint is the minimum correct surface.

## Acceptance against the #306 follow-up note

- [x] Plumbing surface exists for outer state → inner gate
- [x] Default preserves single-layer behaviour (no regression on `/v1/cua`)
- [x] `Holo3StepHandler` forwards the hint when MicroPlanRunner exposes it
- [x] Docs updated (`docs/reference/done-gate.md` gets a Cross-layer awareness section)
- [ ] MicroPlanRunner-side state tracking — separate work, not blocked by this PR

## Local tests

```
$ pytest tests/test_gym_runner_pending_form_labels_kwarg.py
3 passed in 0.07s

$ pytest tests/ --ignore=tests/test_modal_integration.py
1874 passed, 5 skipped
```

`ruff check` clean.

## Test plan

- [x] New `test_gym_runner_pending_form_labels_kwarg.py` (3 tests):
  - Outer hint with pending labels → gate rejects done with `pending_form_values`
  - Default `None` → falls back to inner FormController (current behaviour)
  - Empty list `[]` → semantic "outer says nothing pending", no rejection
- [x] All existing done-gate tests still pass (9/9)
- [x] Full suite: 1874 passed, 5 skipped (up from 1871)
- [x] `ruff check` clean
- [ ] No Modal redeploy needed — pure runner-side surface, no behaviour change unless callers opt in

🤖 Generated with [Claude Code](https://claude.com/claude-code)