### PR TITLE
fix(gym): bound SCROLL.amount so top-click guard doesn't hang ~40s (closes #320)

### DIFF
--- a/src/mantis_agent/gym/runner.py
+++ b/src/mantis_agent/gym/runner.py
@@ -2136,9 +2136,13 @@ class GymRunner:
         if abs(prev_x - x) > 80 or abs(prev_y - y) > 40:
             return None
 
+        # #320: amount is wheel notches (each notch is one xdotool subprocess
+        # ~100 ms), not pixels. The original ``350`` was a pixel-unit value
+        # that hung the env for ~40 s on every substitution. 5 notches reveals
+        # roughly half a viewport on Chrome's default scroll step.
         return Action(
             ActionType.SCROLL,
-            {"direction": "down", "amount": 350},
+            {"direction": "down", "amount": 5},
             reasoning=(
                 "top-click guard: repeated top/header click during forward "
                 "action; scroll to reveal the in-page control"

--- a/src/mantis_agent/gym/xdotool_env.py
+++ b/src/mantis_agent/gym/xdotool_env.py
@@ -37,6 +37,12 @@ from .base import GymEnvironment, GymObservation, GymResult
 
 logger = logging.getLogger(__name__)
 
+# #320: cap on SCROLL.amount expressed in wheel notches. Each notch costs
+# one xdotool subprocess fork (~100 ms), so an unbounded loop on
+# ``amount=350`` (a caller meant pixels) hangs the runner for ~40 s. 40 is
+# already used as the upper bound in ``browser_state._wheel_summary``.
+_MAX_SCROLL_NOTCHES = 40
+
 
 def scale_brain_to_display(
     x_brain: int | float,
@@ -685,7 +691,12 @@ class XdotoolGymEnv(GymEnvironment):
 
             case ActionType.SCROLL:
                 direction = action.params.get("direction", "down")
-                amount = action.params.get("amount", 3)
+                amount = int(action.params.get("amount", 3) or 0)
+                # #320: SCROLL.amount is "wheel notches", not pixels.
+                # Each notch is one xdotool subprocess (~100 ms). Bound the
+                # iteration count so a caller passing a pixel value (e.g. 350)
+                # can't lock the runner for ~40 s.
+                amount = max(0, min(amount, _MAX_SCROLL_NOTCHES))
                 x = action.params.get("x", self._viewport[0] // 2)
                 y = action.params.get("y", self._viewport[1] // 2)
                 x, y = self._clamp(x, y)

--- a/tests/test_runner_force_fill.py
+++ b/tests/test_runner_force_fill.py
@@ -202,7 +202,9 @@ def test_repeated_top_click_redirects_forward_task_to_scroll() -> None:
 
     assert redirected is not None
     assert redirected.action_type == ActionType.SCROLL
-    assert redirected.params == {"direction": "down", "amount": 350}
+    # #320: amount is wheel notches, not pixels. The pre-#320 value of 350
+    # hung the env for ~40 s. Cap to a viewport-half scroll (5 notches).
+    assert redirected.params == {"direction": "down", "amount": 5}
 
 
 def test_repeated_top_click_guard_ignores_non_forward_tasks() -> None:

--- a/tests/test_xdotool_env_scroll_cap.py
+++ b/tests/test_xdotool_env_scroll_cap.py
@@ -1,0 +1,88 @@
+"""Regression tests for #320 — SCROLL.amount must be capped.
+
+The pre-#320 bug: ``GymRunner._maybe_redirect_repeated_top_click``
+substituted ``scroll(direction='down', amount=350)`` (intent: 350 px,
+contract: wheel notches). ``XdotoolGymEnv._execute_action`` looped that
+many times calling ``self._xdotool("click", "5")`` — each subprocess
+fork ~100 ms — so the substituted action hung the runner for ~40 s
+before producing the next observation.
+
+Two safety nets, both tested here:
+
+1. The substituted amount itself is now ``5``, not ``350``.
+2. The env caps SCROLL.amount at ``_MAX_SCROLL_NOTCHES`` so any future
+   caller that passes a pixel-unit value is bounded to ~4 s instead of
+   minutes.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mantis_agent.actions import Action, ActionType
+from mantis_agent.gym.xdotool_env import XdotoolGymEnv, _MAX_SCROLL_NOTCHES
+
+
+@pytest.fixture
+def env_with_recorder(monkeypatch: pytest.MonkeyPatch) -> tuple[XdotoolGymEnv, list[tuple[str, ...]]]:
+    """Build an env that records every ``_xdotool`` call instead of forking."""
+    env = XdotoolGymEnv.__new__(XdotoolGymEnv)
+    env._viewport = (1280, 800)
+    env._human_speed = False
+    env._env = {}
+
+    calls: list[tuple[str, ...]] = []
+
+    def _record(self: XdotoolGymEnv, *args: str) -> None:
+        calls.append(args)
+
+    monkeypatch.setattr(XdotoolGymEnv, "_xdotool", _record)
+    return env, calls
+
+
+def test_scroll_clamped_to_max_notches(env_with_recorder) -> None:
+    """A pixel-unit caller (amount=350) must not produce 350 subprocesses."""
+    env, calls = env_with_recorder
+    env._execute_action(
+        Action(ActionType.SCROLL, {"direction": "down", "amount": 350})
+    )
+    # mousemove + (capped) clicks
+    click_calls = [c for c in calls if c and c[0] == "click"]
+    assert len(click_calls) == _MAX_SCROLL_NOTCHES
+    assert all(c[1] == "5" for c in click_calls)
+
+
+def test_scroll_within_cap_passes_through(env_with_recorder) -> None:
+    """A reasonable caller (amount=5) must still execute exactly 5 notches."""
+    env, calls = env_with_recorder
+    env._execute_action(
+        Action(ActionType.SCROLL, {"direction": "down", "amount": 5})
+    )
+    click_calls = [c for c in calls if c and c[0] == "click"]
+    assert len(click_calls) == 5
+
+
+def test_scroll_up_uses_button_4(env_with_recorder) -> None:
+    env, calls = env_with_recorder
+    env._execute_action(
+        Action(ActionType.SCROLL, {"direction": "up", "amount": 3})
+    )
+    click_calls = [c for c in calls if c and c[0] == "click"]
+    assert len(click_calls) == 3
+    assert all(c[1] == "4" for c in click_calls)
+
+
+def test_scroll_negative_amount_is_zero(env_with_recorder) -> None:
+    """Defensive: a negative or None amount shouldn't loop or raise."""
+    env, calls = env_with_recorder
+    env._execute_action(
+        Action(ActionType.SCROLL, {"direction": "down", "amount": -10})
+    )
+    click_calls = [c for c in calls if c and c[0] == "click"]
+    assert len(click_calls) == 0
+
+
+def test_max_scroll_notches_constant_is_sane() -> None:
+    """If someone bumps the cap above ~50, revisit whether the iteration
+    cost is still acceptable (~100 ms per notch)."""
+    assert 1 < _MAX_SCROLL_NOTCHES <= 50


### PR DESCRIPTION
## Summary

- Fixes #320 — top-click guard substituted ``scroll(direction='down', amount=350)``; the env's SCROLL contract is wheel-notches (1 notch = 1 ``xdotool click 5`` subprocess fork ~100 ms), not pixels, so 350 → ~40 s of serial subprocesses before the next observation.
- Substitution amount changed to ``5`` (about half a viewport at Chrome's default scroll step).
- Defense-in-depth: ``XdotoolGymEnv._execute_action`` now clamps SCROLL.amount to ``_MAX_SCROLL_NOTCHES = 40`` (matches the existing cap in ``browser_state._wheel_summary``), so any future caller that confuses pixels for notches is bounded to ~4 s instead of minutes.

## Evidence the bug is real

From the #293 retroactive ablation Modal logs:

```
22:03:02.649 — Action: click({'x': 0, 'y': 0, 'button': 'left'}) (1.57s)
22:03:02.649 — top-click guard: substituting click({'x':0,'y':0}) → scroll({'direction':'down','amount':350})
22:03:43.035 — Feedback: no visible change   ← 40 s after substitution
```

Three consecutive 40-second hangs explained ~115 s of a single run vs ~19 s on the paired control arm.

## Test plan

- [x] New `tests/test_xdotool_env_scroll_cap.py` recorder shim asserts:
  - ``amount=350`` produces exactly ``_MAX_SCROLL_NOTCHES`` ``click`` subprocesses (not 350).
  - ``amount=5`` and ``amount=3`` pass through unchanged (regression for every other caller).
  - Negative amount produces 0 clicks (no raise, no loop).
  - ``_MAX_SCROLL_NOTCHES`` constant stays in a sane range.
- [x] Existing ``test_repeated_top_click_redirects_forward_task_to_scroll`` updated to assert the new substituted amount.
- [x] Full pytest: 1951 passed locally.
- [x] ruff clean.
- [ ] Modal redeploy + lu.ma extract-loop rerun to confirm hangs are gone in production (will run after merge per the verify-via-redeploy memory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)