### PR TITLE
feat(gym): adaptive loop-detector windows by action diversity + state progress (closes #298)

### DIFF
--- a/docs/reference/adaptive-loop-windows.md
+++ b/docs/reference/adaptive-loop-windows.md
@@ -1,0 +1,67 @@
+# Adaptive loop-detector windows
+
+`LoopDetector` flags three loop shapes — byte-equal repeats,
+coordinate-drift, and frozen-state. The runner responds with a
+soft-nudge at three repeats and a hard-terminate at eight. Those
+fixed thresholds work for the median case but hurt two patterns:
+
+- **Pagination / drilldown.** The brain emits five identical
+  `click("Next")` actions; the page advances each time. The legacy
+  `is_repeat_loop` fires (identical params) even though the run is
+  making progress.
+- **Stuck loops with micro-changing pixels.** A captcha or animated
+  spinner re-renders enough to defeat `is_state_loop`'s frame-hash
+  check, and the brain takes seven dead steps before the hard window
+  trips.
+
+This module adapts the comparison window per call by recent **action
+diversity** + observed **state progress**.
+
+Tracking issue: [#298](https://github.com/mercurialsolo/mantis/issues/298).
+
+## Surfaces
+
+| Method | Returns |
+|---|---|
+| `LoopDetector.pattern_diversity(window)` | `float` in `[0, 1]` — unique action signatures / window. Click-like actions bucket coords by ~`click_tol_px` so micro-drift collapses to one signature. |
+| `LoopDetector.state_progressed(window)` | `bool` — public mirror of the URL/frame-hash check already used by `is_repeat_loop`. |
+| `LoopDetector.adaptive_window(base, max_extension=2, floor=2)` | `int` — `base` widened on diverse / progressing windows, tightened on low-diversity / frozen-state windows. Floor and max-extension clamps applied. |
+| `LoopDetector.is_any_loop_adaptive(base, max_extension=2)` | `bool` — `is_any_loop` over the adaptive window with a pagination guard (state moved AND not a state-loop → don't fire). |
+
+`GymRunner._is_loop` is the single internal hook the runner consults
+for every soft-nudge / hard-terminate / loop-recovery / claude-director
+gate. It dispatches to `is_any_loop_adaptive` by default and falls
+back to the legacy `is_any_loop` when `MANTIS_LOOP_ADAPTIVE=disabled`.
+
+## Threshold logic
+
+For the default `soft=3` / `hard=8` runner windows:
+
+| Pattern in last `base` samples | Effective window | Rationale |
+|---|---|---|
+| Diversity ≥ 0.6 (varied action types/coords) | `base + 2` | Productive exploration — defer the nudge. |
+| State progressed (URL or frame moved) | `base + 2` | Pagination / drilldown — defer. |
+| Diversity ≤ 0.25 AND state frozen | `max(floor, base − 1)` | Clear stuck signature — terminate sooner. |
+| Buffer < `base` samples | `base` (unchanged) | Not enough history to judge. |
+| Otherwise | `base` (unchanged) | No clear signal. |
+
+The pagination guard inside `is_any_loop_adaptive` provides the second
+half of the fix: even after extension, identical-click pagination
+would still trip `is_repeat_loop`. The guard short-circuits to `False`
+when state moved across the (effective) window AND `is_state_loop`
+would not fire.
+
+## Ablation toggle
+
+| Var | Default | Effect when set |
+|---|---|---|
+| `MANTIS_LOOP_ADAPTIVE` | `enabled` | `disabled` falls back to `is_any_loop(base)` everywhere — legacy fixed windows. |
+
+`/v1/cua` accepts `loop_adaptive: true|false` in the request payload
+to flip the toggle for that single request (the runtime patches
+`os.environ` under a `try/finally` since `/v1/cua` is serialized per
+container). Pairs with the existing per-request override surface
+established for `perceptual_verify`, `loop_recovery`, `done_gate`.
+
+Use `scripts/ablate_v1_cua.py --toggle loop_adaptive` to run a paired
+A/B against a warm container.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -14,4 +14,5 @@
 | [Speculative inference](speculative-inference.md) | Overlaps `brain.think()` with the post-action settle to remove the serial inference cost |
 | [Perceptual diff verifier](perceptual-diff.md) | Detects silent failures on high-risk actions by comparing pre/post frame hashes |
 | [Loop recovery policy](loop-recovery.md) | Forces action-class transitions (Tab / Return / Type) when the brain loops on a no-effect class |
+| [Adaptive loop windows](adaptive-loop-windows.md) | Per-call adjustment of the soft/hard loop-detection windows by recent action diversity + state progress |
 | [Ablation harness](ablation-harness.md) | Single-deploy paired ON/OFF A/B against `/v1/cua`; required for quality-touching PRs |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -142,6 +142,7 @@ nav:
       - Speculative inference: reference/speculative-inference.md
       - Perceptual diff verifier: reference/perceptual-diff.md
       - Loop recovery policy: reference/loop-recovery.md
+      - Adaptive loop windows: reference/adaptive-loop-windows.md
       - Ablation harness: reference/ablation-harness.md
   - Appendix:
       - appendix/index.md

--- a/scripts/ablate_v1_cua.py
+++ b/scripts/ablate_v1_cua.py
@@ -27,7 +27,7 @@ Discipline (per project memory):
 Available toggles (per-request override surface added to /v1/cua):
     perceptual_verify (#293)   loop_recovery (#302)   done_gate (#303)
     predicate_verify (#291)    adaptive_settle (#294)  form_controller (#301)
-    reuse_session (#311)       speculation (#118)
+    reuse_session (#311)       speculation (#118)     loop_adaptive (#298)
 """
 
 from __future__ import annotations

--- a/src/mantis_agent/baseten_server/runtime.py
+++ b/src/mantis_agent/baseten_server/runtime.py
@@ -1172,6 +1172,8 @@ class BasetenCUARuntime:
             "predicate_verify": "MANTIS_PREDICATE_VERIFY",
             "adaptive_settle": "MANTIS_ADAPTIVE_SETTLE",
             "form_controller": "MANTIS_FORM_CONTROLLER",
+            # #298: adaptive loop-detector windows (default on).
+            "loop_adaptive": "MANTIS_LOOP_ADAPTIVE",
         }
         _toggle_overrides: dict[str, str] = {}
         _toggle_restore: dict[str, str | None] = {}

--- a/src/mantis_agent/gym/runner.py
+++ b/src/mantis_agent/gym/runner.py
@@ -28,7 +28,11 @@ from typing import Any, Protocol
 from PIL import Image
 
 from ..actions import Action, ActionType
-from ..loop_detector import LoopDetector, phash_64
+from ..loop_detector import (
+    LoopDetector,
+    adaptive_loop_enabled as _loop_adaptive_enabled,
+    phash_64,
+)
 from ._runner_helpers import is_cancelled
 from .base import GymEnvironment
 from .done_gate import DoneAcceptanceDecision, check_done_acceptance
@@ -1225,7 +1229,7 @@ class GymRunner:
                     not substituted_action
                     and director_enabled
                     and step_num - last_director_step >= director_cooldown_steps
-                    and self._loop_detector.is_any_loop(self.soft_loop_window)
+                    and self._is_loop(self.soft_loop_window)
                 ):
                     from . import claude_director
                     # Reconstruct what's been filled so the director doesn't
@@ -1289,7 +1293,7 @@ class GymRunner:
                 pending_loop_recovery_reason: str = ""
                 if (
                     not substituted_action
-                    and self._loop_detector.is_any_loop(self.soft_loop_window)
+                    and self._is_loop(self.soft_loop_window)
                 ):
                     recent_frame_hashes_for_recovery = [
                         t.frame_hash for t in trajectory[-self.soft_loop_window:]
@@ -1588,7 +1592,7 @@ class GymRunner:
                     termination_reason = "env_done"
                     break
 
-                if self._loop_detector.is_any_loop(self.hard_loop_window):
+                if self._is_loop(self.hard_loop_window):
                     logger.warning("Hard action loop detected — stopping")
                     termination_reason = "loop"
                     break
@@ -1876,7 +1880,7 @@ class GymRunner:
 
             # Soft loop nudge — fires on byte-equal repeats, coordinate-drift
             # clicks, or diverse-actions-on-frozen-state.
-            if self._loop_detector.is_any_loop(self.soft_loop_window):
+            if self._is_loop(self.soft_loop_window):
                 nudge = self._build_nudge(action_history, last_focused_input)
                 parts.append(nudge)
                 # #123: re-inject curriculum techniques scoped to whatever
@@ -2081,6 +2085,19 @@ class GymRunner:
     def _is_valid_force_fill_click(x: int, y: int) -> bool:
         """Reject sentinel/browser-chrome clicks before typing plan values."""
         return x >= 10 and y >= 80
+
+    def _is_loop(self, base_window: int) -> bool:
+        """Loop check honoring the #298 ``MANTIS_LOOP_ADAPTIVE`` toggle.
+
+        When the toggle is on (default) the comparison window is expanded
+        on diverse / state-progressing histories and tightened on stuck
+        signatures via :meth:`LoopDetector.is_any_loop_adaptive`. When
+        off, falls through to the legacy fixed-window check so the
+        ablation harness gets a clean A/B.
+        """
+        if _loop_adaptive_enabled():
+            return self._loop_detector.is_any_loop_adaptive(base_window)
+        return self._loop_detector.is_any_loop(base_window)
 
     @staticmethod
     def _maybe_redirect_repeated_top_click(

--- a/src/mantis_agent/loop_detector.py
+++ b/src/mantis_agent/loop_detector.py
@@ -15,10 +15,17 @@ loop when the visible content changes between presses.
 This module gives both runners one helper with all three signals:
 ``is_repeat_loop``, ``is_drift_loop``, ``is_state_loop``. Each takes the
 same ``window`` so callers can keep their existing soft/hard thresholds.
+
+#298: ``adaptive_window`` / ``is_any_loop_adaptive`` adjust those
+thresholds by recent action diversity + observed state progress, so
+pagination doesn't trigger spurious soft nudges and clear traps fire
+sooner. Enabled by default; ``MANTIS_LOOP_ADAPTIVE=disabled`` falls
+back to fixed windows for ablation.
 """
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass, field
 from io import BytesIO
 from typing import TYPE_CHECKING
@@ -154,6 +161,139 @@ class LoopDetector:
             or self.is_state_loop(window)
         )
 
+    # ── #298: adaptive thresholds ──────────────────────────────────────
+
+    def pattern_diversity(self, window: int) -> float:
+        """Ratio of unique action signatures to window size, in ``[0, 1]``.
+
+        ``1.0`` means every recent action was distinct; ``0.0`` is empty
+        history. Click / double-click coordinates are bucketed by
+        :attr:`click_tol_px` so micro-drift on the same UI target counts
+        as one signature (matches :meth:`is_drift_loop` semantics).
+
+        Returns ``0.0`` when the buffer is shorter than ``window`` so the
+        signal is conservative on cold starts.
+        """
+        if window < 2 or len(self._samples) < window:
+            return 0.0
+        recent = self._samples[-window:]
+        sigs = {self._action_signature(s.action) for s in recent}
+        return len(sigs) / window
+
+    def state_progressed(self, window: int) -> bool:
+        """True when URL or frame hash moved across the last ``window`` samples.
+
+        Public-surface mirror of the internal ``_state_changed`` guard
+        already used by :meth:`is_repeat_loop`. Returns ``False`` when the
+        buffer is too short to draw a conclusion.
+        """
+        if window < 2 or len(self._samples) < window:
+            return False
+        return self._state_changed(self._samples[-window:])
+
+    def adaptive_window(
+        self,
+        base_window: int,
+        *,
+        max_extension: int = 2,
+        floor: int = 2,
+    ) -> int:
+        """Adjust ``base_window`` by recent action diversity + state progress.
+
+        The fixed default windows (soft=3, hard=8 in :class:`GymRunner`)
+        are correct for the median case but produce two failure modes:
+
+        - **Spurious nudges on pagination**: the brain clicks the "Next"
+          button five times, the page advances each time. ``is_repeat_loop``
+          fires (identical click params) even though the run is making
+          progress. The fix is to *extend* the window when state is
+          progressing or actions are varied — diversity alone isn't
+          enough because pagination has zero diversity.
+        - **Late termination on real traps**: a modal/captcha keeps the
+          page locked while the brain emits five identical clicks. The
+          state-loop signal already catches this at the hard window;
+          the soft window can fire earlier (recovery / nudge) when
+          diversity is low *and* state is frozen.
+
+        The returned window is clamped to ``[floor, base + max_extension]``.
+        """
+        if base_window <= floor:
+            return base_window
+        # Need at least ``base_window`` samples to draw any conclusion;
+        # short-buffer reads from ``pattern_diversity`` / ``state_progressed``
+        # both return zero/False which would otherwise tip the tightening
+        # branch. Keep the legacy fixed window until history catches up.
+        if len(self._samples) < base_window:
+            return base_window
+        diversity = self.pattern_diversity(base_window)
+        progressed = self.state_progressed(base_window)
+        # Extend when work looks productive (varied actions OR moving page).
+        if diversity >= 0.6 or progressed:
+            return base_window + max_extension
+        # Tighten when we have a clear stuck signature (no state, no variety).
+        if diversity <= 0.25 and not progressed:
+            shrink = max(1, max_extension // 2)
+            return max(floor, base_window - shrink)
+        return base_window
+
+    def is_any_loop_adaptive(
+        self,
+        base_window: int,
+        *,
+        max_extension: int = 2,
+    ) -> bool:
+        """Adaptive variant of :meth:`is_any_loop` (#298).
+
+        - Computes the effective window via :meth:`adaptive_window`.
+        - Adds a pagination guard: if observed state moved across the
+          window AND the run isn't a state-loop (frozen state with
+          diverse actions, which the legacy :meth:`is_state_loop` catches),
+          the run is making progress — don't fire even on identical
+          repeated actions. This is the case the legacy ``is_repeat_loop``
+          gets wrong on drilldown / "Next" pagination, where every
+          ``click("Next")`` is byte-equal but the URL/frame moves.
+        """
+        effective = self.adaptive_window(
+            base_window, max_extension=max_extension
+        )
+        if self.state_progressed(effective) and not self.is_state_loop(effective):
+            return False
+        return self.is_any_loop(effective)
+
+    @staticmethod
+    def _action_signature(action: Action) -> tuple:
+        """Stable signature used by :meth:`pattern_diversity`.
+
+        Click-like actions bucket coordinates so micro-drift collapses to
+        one signature (same UI target). Other action types use their
+        primary discriminating parameter.
+        """
+        atype = action.action_type
+        params = action.params or {}
+        if atype in (ActionType.CLICK, ActionType.DOUBLE_CLICK):
+            x = params.get("x")
+            y = params.get("y")
+            if isinstance(x, (int, float)) and isinstance(y, (int, float)):
+                # Bucket to ``click_tol_px``-ish granularity; 8 px matches
+                # the default ``click_tol_px`` so signatures track drift.
+                return (atype, int(x) // 8, int(y) // 8)
+            return (atype,)
+        if atype == ActionType.DRAG:
+            return (
+                atype,
+                int((params.get("end_x") or 0)) // 8,
+                int((params.get("end_y") or 0)) // 8,
+            )
+        if atype == ActionType.KEY_PRESS:
+            keys = str(params.get("keys") or params.get("key") or "").lower()
+            return (atype, keys)
+        if atype == ActionType.TYPE:
+            text = str(params.get("text") or params.get("content") or "")
+            return (atype, text[:32])
+        if atype == ActionType.SCROLL:
+            return (atype, str(params.get("direction") or "down"))
+        return (atype,)
+
     # ── Internals ────────────────────────────────────────────────────────
 
     def _tail(self, window: int) -> list[_Sample] | None:
@@ -225,3 +365,16 @@ def encode_png_hash(img: "Image.Image") -> str:
     buf = BytesIO()
     img.save(buf, format="PNG")
     return hashlib.sha1(buf.getvalue()).hexdigest()[:16]
+
+
+def adaptive_loop_enabled() -> bool:
+    """#298: gate for adaptive loop windows.
+
+    Default-on. ``MANTIS_LOOP_ADAPTIVE=disabled`` (or ``0`` / ``false``)
+    forces fixed-window behaviour so the ablation harness can run an
+    A/B without redeploys. Read once per call site so the per-request
+    env-var override in ``BasetenCUARuntime._run_pure_cua`` flips
+    behaviour mid-container.
+    """
+    raw = os.environ.get("MANTIS_LOOP_ADAPTIVE", "enabled").strip().lower()
+    return raw not in {"disabled", "0", "false", "off", "no"}

--- a/tests/test_loop_detector_adaptive.py
+++ b/tests/test_loop_detector_adaptive.py
@@ -1,0 +1,227 @@
+"""Tests for #298 — adaptive loop-detector windows.
+
+The fixed default windows (soft=3, hard=8) miss two classes of work:
+
+- **Pagination / drilldown**: same-coordinate clicks at "Next" advance
+  the page; the runner used to soft-nudge spuriously. Adaptive expansion
+  defers the nudge when state moved across the window.
+- **Stuck loops on micro-changing pages**: brain emits identical clicks
+  on a captcha that re-renders pixels but doesn't really change state.
+  Adaptive shrinking trips earlier on the low-diversity / no-state
+  signature.
+
+The toggle ``MANTIS_LOOP_ADAPTIVE=disabled`` falls back to fixed-window
+``is_any_loop`` so the ablation harness can run an A/B without redeploys.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mantis_agent.actions import Action, ActionType
+from mantis_agent.loop_detector import LoopDetector, adaptive_loop_enabled
+
+
+def _click(x: int, y: int) -> Action:
+    return Action(ActionType.CLICK, {"x": x, "y": y})
+
+
+def _key(keys: str) -> Action:
+    return Action(ActionType.KEY_PRESS, {"keys": keys})
+
+
+def _scroll(direction: str = "down") -> Action:
+    return Action(ActionType.SCROLL, {"direction": direction, "amount": 3})
+
+
+# ── pattern_diversity ───────────────────────────────────────────────
+
+
+def test_pattern_diversity_all_same_action_is_low() -> None:
+    d = LoopDetector()
+    for _ in range(5):
+        d.record(_click(100, 100))
+    # 5 identical bucketed clicks → 1 unique signature / 5 = 0.2
+    assert d.pattern_diversity(window=5) == pytest.approx(1 / 5)
+
+
+def test_pattern_diversity_all_different_is_one() -> None:
+    d = LoopDetector()
+    actions = [
+        _click(50, 50),
+        _click(200, 200),
+        _key("Tab"),
+        _scroll("down"),
+        Action(ActionType.TYPE, {"text": "hello"}),
+    ]
+    for a in actions:
+        d.record(a)
+    assert d.pattern_diversity(window=5) == 1.0
+
+
+def test_pattern_diversity_buckets_drift_clicks_low() -> None:
+    """Drift clicks within ~8 px collapse to a small number of bucket
+    signatures (boundary-crossing means it's not always 1, but it's
+    always low — the metric is approximate, not exact)."""
+    d = LoopDetector()
+    coords = [(487, 312), (489, 310), (491, 308), (488, 311), (490, 309)]
+    for x, y in coords:
+        d.record(_click(x, y))
+    diversity = d.pattern_diversity(window=5)
+    # ≤ 0.5: drift always lands in a small subset of buckets even when it
+    # straddles boundaries. Compare against 5 distinct widely-separated
+    # clicks (diversity == 1.0) to confirm drift collapses.
+    assert diversity <= 0.5
+
+
+def test_pattern_diversity_short_buffer_is_zero() -> None:
+    d = LoopDetector()
+    d.record(_click(1, 1))
+    assert d.pattern_diversity(window=5) == 0.0
+
+
+# ── state_progressed ─────────────────────────────────────────────────
+
+
+def test_state_progressed_on_url_change() -> None:
+    d = LoopDetector()
+    for i in range(5):
+        d.record(_click(1, 1), url=f"https://x.test/p{i}")
+    assert d.state_progressed(window=5) is True
+
+
+def test_state_progressed_on_frozen_state() -> None:
+    d = LoopDetector()
+    for _ in range(5):
+        d.record(_click(1, 1), url="https://x.test/p")
+    assert d.state_progressed(window=5) is False
+
+
+# ── adaptive_window ──────────────────────────────────────────────────
+
+
+def test_adaptive_window_extends_on_progressing_state() -> None:
+    """Pagination case: identical click coords, but URL advances → extend."""
+    d = LoopDetector()
+    for i in range(3):
+        d.record(_click(800, 600), url=f"https://x.test/page-{i}")
+    # base soft=3, max_extension=2 → effective window 5.
+    assert d.adaptive_window(base_window=3) == 5
+
+
+def test_adaptive_window_extends_on_high_diversity() -> None:
+    d = LoopDetector()
+    for a in [_click(1, 1), _key("Tab"), _scroll(), _click(50, 50), _key("Return")]:
+        d.record(a)
+    # diversity 1.0 ≥ 0.6 → extend.
+    assert d.adaptive_window(base_window=3) == 5
+
+
+def test_adaptive_window_tightens_on_low_diversity_frozen_state() -> None:
+    """Captcha-trap case: identical clicks, no state movement → tighten."""
+    d = LoopDetector()
+    for _ in range(8):
+        d.record(_click(100, 100), url="https://x.test/stuck")
+    # diversity ≤ 0.25 AND not progressed → shrink hard window 8 → 7.
+    assert d.adaptive_window(base_window=8) == 7
+
+
+def test_adaptive_window_floor_respected() -> None:
+    """Tightening must not drive the window below ``floor``."""
+    d = LoopDetector()
+    for _ in range(3):
+        d.record(_click(1, 1), url="https://x.test/")
+    # base 3, floor default 2 → tighten by 1 → 2 (floor).
+    assert d.adaptive_window(base_window=3, max_extension=2) >= 2
+
+
+def test_adaptive_window_unchanged_on_moderate_diversity() -> None:
+    """No clear signal in either direction → don't move the window."""
+    d = LoopDetector()
+    actions = [_click(1, 1), _click(100, 100), _click(1, 1)]
+    for a in actions:
+        d.record(a, url="https://x.test/")
+    # 2/3 diversity = 0.66 → triggers extension. Use a more moderate case.
+    d2 = LoopDetector()
+    moderate = [_click(1, 1), _click(1, 1), _click(50, 50)]  # 2/3 = 0.66
+    for a in moderate:
+        d2.record(a, url="https://x.test/")
+    # Even 2/3 ≈ 0.66 ≥ 0.6 triggers extend; tweak threshold by recording
+    # 3/4 unique-actions across a 4-window:
+    d3 = LoopDetector()
+    for a in [_click(1, 1), _click(1, 1), _click(50, 50), _click(100, 100)]:
+        d3.record(a, url="https://x.test/")
+    # 3 uniques / 4 = 0.75 → extend. Build a moderate diversity 0.5 window:
+    d4 = LoopDetector()
+    for a in [_click(1, 1), _click(1, 1), _click(50, 50), _click(50, 50)]:
+        d4.record(a, url="https://x.test/")
+    # diversity 2/4 = 0.5 < 0.6, > 0.25, not progressed → window unchanged.
+    assert d4.adaptive_window(base_window=4) == 4
+
+
+# ── is_any_loop_adaptive end-to-end ──────────────────────────────────
+
+
+def test_pagination_does_not_fire_adaptive_loop() -> None:
+    """Five identical "Next" clicks with state advancing → not a loop."""
+    d = LoopDetector()
+    for i in range(5):
+        d.record(_click(800, 600), url=f"https://x.test/page-{i}")
+    # Non-adaptive: extends soft=3 → effective 5; state-loop fails (URLs vary)
+    # repeat-loop fires on identical clicks but adaptive widens past soft.
+    # Use the soft window to confirm:
+    assert d.is_any_loop(window=3) is True  # legacy: false positive
+    assert d.is_any_loop_adaptive(base_window=3) is False  # fixed by #298
+
+
+def test_real_repeat_still_fires_adaptive() -> None:
+    """Five identical clicks on a frozen page → still a loop."""
+    d = LoopDetector()
+    for _ in range(5):
+        d.record(_click(800, 600), url="https://x.test/p")
+    assert d.is_any_loop_adaptive(base_window=3) is True
+
+
+def test_diverse_actions_on_progressing_state_no_loop() -> None:
+    d = LoopDetector()
+    actions = [_click(1, 1), _key("Tab"), _scroll(), _key("Return"), _click(50, 50)]
+    for i, a in enumerate(actions):
+        d.record(a, url=f"https://x.test/p{i}")
+    assert d.is_any_loop_adaptive(base_window=3) is False
+
+
+def test_diverse_actions_on_frozen_state_still_loop() -> None:
+    """State-loop signal must keep firing under adaptive widening."""
+    d = LoopDetector()
+    actions = [_click(1, 1), _key("Tab"), _scroll(), _key("Return"), _click(50, 50)]
+    for a in actions:
+        d.record(a, url="https://x.test/stuck")
+        d._samples[-1].frame_hash = "deadbeefdeadbeef"
+    # State-loop fires regardless of window size since URLs are all equal.
+    assert d.is_any_loop_adaptive(base_window=3) is True
+
+
+# ── env-var toggle ───────────────────────────────────────────────────
+
+
+def test_adaptive_loop_enabled_default_on(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("MANTIS_LOOP_ADAPTIVE", raising=False)
+    assert adaptive_loop_enabled() is True
+
+
+@pytest.mark.parametrize(
+    "value", ["disabled", "0", "false", "FALSE", "off", "no", " disabled "]
+)
+def test_adaptive_loop_disabled_when_off(
+    value: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("MANTIS_LOOP_ADAPTIVE", value)
+    assert adaptive_loop_enabled() is False
+
+
+@pytest.mark.parametrize("value", ["enabled", "1", "true", "on", "yes", ""])
+def test_adaptive_loop_enabled_for_truthy_values(
+    value: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("MANTIS_LOOP_ADAPTIVE", value)
+    assert adaptive_loop_enabled() is True


### PR DESCRIPTION
## Summary

- Closes #298 — fixed soft=3/hard=8 windows produce two failure modes:
  1. **Pagination / drilldown**: identical ``click("Next")`` advances the page; ``is_repeat_loop`` fires spuriously.
  2. **Stuck loops with micro-changing pixels**: captcha re-renders defeat ``is_state_loop``'s frame-hash equality check; the hard window trips one step too late.
- Adds ``LoopDetector.pattern_diversity / state_progressed / adaptive_window / is_any_loop_adaptive``. Effective window expands on diverse / progressing histories, tightens on low-diversity / frozen-state histories, with a pagination guard that short-circuits identical-click pagination even after expansion.
- Wired into ``GymRunner`` via a single ``_is_loop`` helper at four call sites (claude-director, loop-recovery, hard-terminate, soft-nudge).
- ``MANTIS_LOOP_ADAPTIVE`` env-toggle (default on) + per-request ``loop_adaptive`` override on ``/v1/cua`` for A/B without redeploys.

## Threshold logic

For default ``soft=3`` / ``hard=8``:

| Pattern in last `base` samples | Effective window |
|---|---|
| Diversity ≥ 0.6 (varied actions/coords) | `base + 2` |
| State progressed (URL or frame moved) | `base + 2` |
| Diversity ≤ 0.25 AND state frozen | `max(2, base − 1)` |
| Buffer < `base` samples | `base` (unchanged) |
| Otherwise | `base` (unchanged) |

The pagination guard inside ``is_any_loop_adaptive`` adds: state moved AND not a state-loop → return ``False`` regardless of repeat / drift signals.

## Test plan

- [x] `tests/test_loop_detector_adaptive.py` covers diversity / state progress / window adjustment / pagination guard / env-var toggle parsing (29 new tests).
- [x] Existing ``test_gym_runner_loop_recovery`` regression: static env with fixed frame_hash exposed an early bug where short-buffer zero-diversity reads tripped the tightening branch — fixed by the ``len(self._samples) < base_window`` guard.
- [x] Full pytest: 1980 passed locally (29 net new).
- [x] ruff clean.
- [ ] Modal redeploy + ablation pair (MANTIS_LOOP_ADAPTIVE=enabled vs disabled) on lu.ma extract-loop after merge, per the verify-via-redeploy memory.

## Ablation

Run after merge against the warm Modal container:
```bash
.venv/bin/python scripts/ablate_v1_cua.py \\
  --toggle loop_adaptive \\
  --instruction "Extract all events from lu.ma SF, paginate at the bottom" \\
  --start-url https://lu.ma/sf \\
  --pairs 3
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)