### PR TITLE
feat(gym): adaptive click_tol_px by screen DPI + element class (closes #296)

### DIFF
--- a/docs/reference/adaptive-click-tol.md
+++ b/docs/reference/adaptive-click-tol.md
@@ -1,0 +1,85 @@
+# Adaptive click tolerance
+
+`LoopDetector` flags coordinate-drift loops by comparing successive
+click coordinates against a fixed `click_tol_px = 8`. That single
+constant is wrong on two ends of the viewport spectrum:
+
+- **4K (3840 × 2160)**: an 8 px tolerance is one third of one
+  percent of the diagonal; legitimate retries on the same UI target
+  routinely drift by 15–20 px and get flagged as loops.
+- **Phone-class (1080p portrait)**: 8 px is roughly correct, but
+  could be tighter on dense layouts where 8 px straddles two adjacent
+  controls.
+
+Element semantics also matter: a `Submit` button covers ~150 × 50 px
+and tolerates wider drift; a navigation link is one word wide and
+needs tighter detection so a click drifting onto the next link
+doesn't read as the same target.
+
+Tracking issue: [#296](https://github.com/mercurialsolo/mantis/issues/296).
+
+## Surfaces
+
+| Symbol | Returns |
+|---|---|
+| `compute_click_tol_px(viewport, *, floor=8)` | `int` — drift tolerance baseline scaled as `max(floor, 0.4 % × diagonal)`. |
+| `LoopDetector._effective_click_tol(action)` | `int` — `click_tol_px × class_multiplier` when the action's reasoning text classifies the target. |
+| `MANTIS_ADAPTIVE_CLICK_TOL` env var | `enabled` (default) / `disabled`. When off, `compute_click_tol_px` returns `floor` and `_effective_click_tol` returns the raw attribute. |
+
+`GymRunner.__init__` calls `compute_click_tol_px(env.screen_size)` once
+and passes the result as `LoopDetector(click_tol_px=…)`. Env access is
+guarded — a misconfigured env that raises on `screen_size` falls back
+to the floor.
+
+## Scaling table
+
+| Viewport | Diagonal | Tolerance |
+|---|---|---|
+| 1280 × 800 (default Mantis) | 1430 px | 8 px (floor) |
+| 1366 × 768 (laptop) | 1567 px | 8 px (floor) |
+| 1920 × 1080 (FHD desktop) | 2202 px | 9 px |
+| 2560 × 1440 (QHD) | 2937 px | 12 px |
+| 3840 × 2160 (4K) | 4404 px | 18 px |
+| 7680 × 4320 (8K) | 8810 px | 35 px |
+
+## Element-class multipliers
+
+Reasoning-text keywords on the first sample of a drift window scale
+the effective tolerance:
+
+| Keyword (substring) | Multiplier | Rationale |
+|---|---|---|
+| `submit button` / `button` / `submit` | 1.5× | Large hit areas, brain re-clicks the centroid. |
+| `dropdown` / `select` / `menu item` | 0.75× | Adjacent options must be distinguished. |
+| `link` / `anchor` | 0.5× | Text targets — small drift = different word. |
+| `listing` / `card` / `input field` / `form field` / `text field` | 1.0× | Default — no widening or tightening. |
+| (no match) | 1.0× | Falls back to base `click_tol_px`. |
+
+The keyword tuple is checked in order; earlier entries win on a tie.
+Multi-word phrases (`submit button`) are listed before their substrings
+(`button`) so future divergence in multipliers stays correct.
+
+## Ablation
+
+| Var | Default | Effect when set |
+|---|---|---|
+| `MANTIS_ADAPTIVE_CLICK_TOL` | `enabled` | `disabled` reverts both the screen-DPI baseline and the per-class multiplier — `LoopDetector` runs with the legacy hardcoded `click_tol_px`. |
+
+`/v1/cua` accepts `adaptive_click_tol: true|false` in the request
+payload to flip the toggle for that single request via the runtime's
+per-request override surface.
+
+```bash
+.venv/bin/python scripts/ablate_v1_cua.py \
+  --toggle adaptive_click_tol \
+  --instruction "Extract events from lu.ma SF and paginate" \
+  --start-url https://lu.ma/sf \
+  --pairs 3
+```
+
+## Follow-ups
+
+- `GroundingResult` has no `element_class` field today; the per-class
+  multiplier reads keywords out of the action's free-form reasoning.
+  When grounding gets a structured class hint, swap the substring
+  match for the structured value.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -15,4 +15,5 @@
 | [Perceptual diff verifier](perceptual-diff.md) | Detects silent failures on high-risk actions by comparing pre/post frame hashes |
 | [Loop recovery policy](loop-recovery.md) | Forces action-class transitions (Tab / Return / Type) when the brain loops on a no-effect class |
 | [Adaptive loop windows](adaptive-loop-windows.md) | Per-call adjustment of the soft/hard loop-detection windows by recent action diversity + state progress |
+| [Adaptive click tolerance](adaptive-click-tol.md) | Drift-loop tolerance scaled by screen DPI and per-action element class (button / link / dropdown) |
 | [Ablation harness](ablation-harness.md) | Single-deploy paired ON/OFF A/B against `/v1/cua`; required for quality-touching PRs |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -143,6 +143,7 @@ nav:
       - Perceptual diff verifier: reference/perceptual-diff.md
       - Loop recovery policy: reference/loop-recovery.md
       - Adaptive loop windows: reference/adaptive-loop-windows.md
+      - Adaptive click tolerance: reference/adaptive-click-tol.md
       - Ablation harness: reference/ablation-harness.md
   - Appendix:
       - appendix/index.md

--- a/scripts/ablate_v1_cua.py
+++ b/scripts/ablate_v1_cua.py
@@ -28,6 +28,7 @@ Available toggles (per-request override surface added to /v1/cua):
     perceptual_verify (#293)   loop_recovery (#302)   done_gate (#303)
     predicate_verify (#291)    adaptive_settle (#294)  form_controller (#301)
     reuse_session (#311)       speculation (#118)     loop_adaptive (#298)
+    adaptive_click_tol (#296)
 """
 
 from __future__ import annotations

--- a/src/mantis_agent/baseten_server/runtime.py
+++ b/src/mantis_agent/baseten_server/runtime.py
@@ -1174,6 +1174,8 @@ class BasetenCUARuntime:
             "form_controller": "MANTIS_FORM_CONTROLLER",
             # #298: adaptive loop-detector windows (default on).
             "loop_adaptive": "MANTIS_LOOP_ADAPTIVE",
+            # #296: screen-DPI / element-class drift tolerance (default on).
+            "adaptive_click_tol": "MANTIS_ADAPTIVE_CLICK_TOL",
         }
         _toggle_overrides: dict[str, str] = {}
         _toggle_restore: dict[str, str | None] = {}

--- a/src/mantis_agent/gym/runner.py
+++ b/src/mantis_agent/gym/runner.py
@@ -31,6 +31,7 @@ from ..actions import Action, ActionType
 from ..loop_detector import (
     LoopDetector,
     adaptive_loop_enabled as _loop_adaptive_enabled,
+    compute_click_tol_px,
     phash_64,
 )
 from ._runner_helpers import is_cancelled
@@ -352,7 +353,15 @@ class GymRunner:
         # SoM-friendly sites. Default None → flag is False → behaviour
         # unchanged.
         self.site_config = site_config
-        self._loop_detector = LoopDetector()
+        # #296: scale drift tolerance by env screen diagonal so 4K isn't
+        # too tight and phone-class viewports keep the legacy 8 px floor.
+        # ``MANTIS_ADAPTIVE_CLICK_TOL=disabled`` short-circuits to the
+        # floor so the ablation harness can A/B without redeploys.
+        try:
+            tol = compute_click_tol_px(env.screen_size)
+        except Exception:
+            tol = 8
+        self._loop_detector = LoopDetector(click_tol_px=tol)
 
         # ── Cooperative cancellation (#288) ─────────────────────────────
         # Mirrors MicroPlanRunner.__init__'s `cancel_event` semantics

--- a/src/mantis_agent/loop_detector.py
+++ b/src/mantis_agent/loop_detector.py
@@ -21,10 +21,18 @@ thresholds by recent action diversity + observed state progress, so
 pagination doesn't trigger spurious soft nudges and clear traps fire
 sooner. Enabled by default; ``MANTIS_LOOP_ADAPTIVE=disabled`` falls
 back to fixed windows for ablation.
+
+#296: ``compute_click_tol_px`` derives the drift tolerance from screen
+diagonal so a fixed 8 px isn't too tight on 4K or too loose on a phone.
+``LoopDetector._effective_click_tol`` applies a per-action class
+multiplier (button 1.5×, link 0.5×, …) when the action's reasoning
+text classifies the target. ``MANTIS_ADAPTIVE_CLICK_TOL=disabled``
+forces the hardcoded ``click_tol_px`` for ablation.
 """
 
 from __future__ import annotations
 
+import math
 import os
 from dataclasses import dataclass, field
 from io import BytesIO
@@ -43,6 +51,28 @@ _SCROLL_LIKE_ACTIONS: frozenset[ActionType] = frozenset(
 )
 _SCROLL_LIKE_KEYS: frozenset[str] = frozenset(
     {"page_down", "pagedown", "page_up", "pageup", "down", "up", "j", "k"}
+)
+
+# #296: per-class drift-tolerance multipliers applied when the action's
+# reasoning text classifies the target. Buttons cluster widely (large
+# hit areas; brain often re-clicks the centroid), links cluster tightly
+# (text targets — even small drift means a different word).
+_CLASS_TOL_MULTIPLIERS: tuple[tuple[str, float], ...] = (
+    # Order matters: longer / more specific keywords first so the
+    # ambiguous "submit" doesn't match before "submit button".
+    ("submit button", 1.5),
+    ("button", 1.5),
+    ("submit", 1.5),
+    ("dropdown", 0.75),
+    ("select", 0.75),
+    ("menu item", 0.75),
+    ("link", 0.5),
+    ("anchor", 0.5),
+    ("listing", 1.0),
+    ("card", 1.0),
+    ("input field", 1.0),
+    ("form field", 1.0),
+    ("text field", 1.0),
 )
 
 
@@ -104,6 +134,9 @@ class LoopDetector:
 
         Applies to CLICK / DOUBLE_CLICK / DRAG. Other action types fall back to
         byte-equality (handled by :meth:`is_repeat_loop`).
+
+        #296: tolerance is :meth:`_effective_click_tol` of the first sample's
+        reasoning — a button gets 1.5×, a link gets 0.5×.
         """
         recent = self._tail(window)
         if recent is None:
@@ -118,15 +151,16 @@ class LoopDetector:
         first_xy = (first.params.get("x"), first.params.get("y"))
         if first_xy[0] is None or first_xy[1] is None:
             return False
+        tol = self._effective_click_tol(first)
         for s in recent[1:]:
             if s.action.action_type != first.action_type:
                 return False
             x, y = s.action.params.get("x"), s.action.params.get("y")
             if x is None or y is None:
                 return False
-            if abs(x - first_xy[0]) > self.click_tol_px:
+            if abs(x - first_xy[0]) > tol:
                 return False
-            if abs(y - first_xy[1]) > self.click_tol_px:
+            if abs(y - first_xy[1]) > tol:
                 return False
         return True
 
@@ -260,6 +294,23 @@ class LoopDetector:
             return False
         return self.is_any_loop(effective)
 
+    def _effective_click_tol(self, action: Action) -> int:
+        """#296: per-action drift tolerance.
+
+        Defaults to :attr:`click_tol_px`. Scaled by class multiplier when
+        the action's reasoning text classifies the target (button → 1.5×,
+        link → 0.5×, …) AND ``MANTIS_ADAPTIVE_CLICK_TOL`` is on (default).
+        Falls back to the raw attribute when the toggle is off so the
+        ablation harness can A/B without redeploys.
+        """
+        if not adaptive_click_tol_enabled():
+            return self.click_tol_px
+        reasoning = (action.reasoning or "").lower()
+        for keyword, multiplier in _CLASS_TOL_MULTIPLIERS:
+            if keyword in reasoning:
+                return max(1, int(round(self.click_tol_px * multiplier)))
+        return self.click_tol_px
+
     @staticmethod
     def _action_signature(action: Action) -> tuple:
         """Stable signature used by :meth:`pattern_diversity`.
@@ -378,3 +429,43 @@ def adaptive_loop_enabled() -> bool:
     """
     raw = os.environ.get("MANTIS_LOOP_ADAPTIVE", "enabled").strip().lower()
     return raw not in {"disabled", "0", "false", "off", "no"}
+
+
+def adaptive_click_tol_enabled() -> bool:
+    """#296: gate for screen-DPI / element-class drift tolerance.
+
+    Default-on. ``MANTIS_ADAPTIVE_CLICK_TOL=disabled`` (or ``0`` /
+    ``false``) forces the hardcoded ``LoopDetector.click_tol_px`` for
+    A/B comparison without redeploys.
+    """
+    raw = os.environ.get("MANTIS_ADAPTIVE_CLICK_TOL", "enabled").strip().lower()
+    return raw not in {"disabled", "0", "false", "off", "no"}
+
+
+def compute_click_tol_px(viewport: tuple[int, int], *, floor: int = 8) -> int:
+    """#296: drift tolerance baseline scaled by screen diagonal.
+
+    The legacy ``click_tol_px = 8`` is too tight on 4K (legitimate
+    micro-retries flagged as drift loops) and approximately right on
+    1080p. Scale ``0.4 %`` of the diagonal so 4K gets ~18 px and 8K
+    gets ~37 px, with a ``floor`` so phone-class viewports keep the
+    legacy value:
+
+    | Viewport            | Diagonal | Tolerance |
+    |---------------------|----------|-----------|
+    | 1280 × 800 (default)| 1430 px  | 8 px (floor) |
+    | 1366 × 768 (laptop) | 1567 px  | 8 px (floor) |
+    | 1920 × 1080 (FHD)   | 2202 px  | 9 px |
+    | 2560 × 1440 (QHD)   | 2937 px  | 12 px |
+    | 3840 × 2160 (4K)    | 4404 px  | 18 px |
+
+    The harness toggles tolerance via ``MANTIS_ADAPTIVE_CLICK_TOL``;
+    when off, callers should pass the legacy ``8`` constructor default.
+    """
+    if not adaptive_click_tol_enabled():
+        return floor
+    w, h = viewport
+    if w <= 0 or h <= 0:
+        return floor
+    diag = math.sqrt(w * w + h * h)
+    return max(floor, int(round(0.004 * diag)))

--- a/tests/test_loop_detector_click_tol.py
+++ b/tests/test_loop_detector_click_tol.py
@@ -1,0 +1,256 @@
+"""Tests for #296 — adaptive ``click_tol_px`` by screen DPI + element class.
+
+The fixed ``click_tol_px = 8`` in ``LoopDetector`` is wrong on 4K (too
+tight — legitimate retries near the same target get flagged as drift
+loops) and on phone-class viewports (too loose — small drifts go
+unflagged). Element semantics also matter: a "Submit" button covers
+~150 × 50 px so 1.5× tolerance is fine; a navigation link is one word
+wide so 0.5× catches drift onto the next link.
+
+Coverage:
+- ``compute_click_tol_px`` scaling table on common viewports.
+- Element-class multipliers via reasoning text (``button``, ``link``,
+  ``dropdown``, …).
+- ``MANTIS_ADAPTIVE_CLICK_TOL=disabled`` falls back to the floor.
+- ``GymRunner`` wires the env's ``screen_size`` into the detector.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mantis_agent.actions import Action, ActionType
+from mantis_agent.loop_detector import (
+    LoopDetector,
+    adaptive_click_tol_enabled,
+    compute_click_tol_px,
+)
+
+
+# ── compute_click_tol_px ─────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "viewport, expected",
+    [
+        ((1280, 800), 8),    # default Mantis viewport — floor
+        ((1366, 768), 8),    # laptop — floor
+        ((1920, 1080), 9),   # FHD desktop
+        ((2560, 1440), 12),  # QHD
+        ((3840, 2160), 18),  # 4K
+        ((7680, 4320), 35),  # 8K
+    ],
+)
+def test_compute_click_tol_scales_with_diagonal(
+    viewport: tuple[int, int],
+    expected: int,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("MANTIS_ADAPTIVE_CLICK_TOL", raising=False)
+    assert compute_click_tol_px(viewport) == expected
+
+
+def test_compute_click_tol_zero_dimensions_returns_floor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Defensive: a zeroed viewport (env not yet initialized) doesn't crash."""
+    monkeypatch.delenv("MANTIS_ADAPTIVE_CLICK_TOL", raising=False)
+    assert compute_click_tol_px((0, 0)) == 8
+    assert compute_click_tol_px((1920, 0)) == 8
+
+
+def test_compute_click_tol_disabled_returns_floor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MANTIS_ADAPTIVE_CLICK_TOL", "disabled")
+    assert compute_click_tol_px((3840, 2160)) == 8
+
+
+def test_compute_click_tol_custom_floor(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("MANTIS_ADAPTIVE_CLICK_TOL", raising=False)
+    assert compute_click_tol_px((1280, 800), floor=12) == 12
+    assert compute_click_tol_px((3840, 2160), floor=12) == 18
+
+
+# ── element-class multipliers ────────────────────────────────────────
+
+
+def _click(x: int, y: int, reasoning: str = "") -> Action:
+    return Action(ActionType.CLICK, {"x": x, "y": y}, reasoning=reasoning)
+
+
+def test_button_multiplier_widens_drift_tolerance(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two clicks 11 px apart on a Submit button (1.5× → ~12 px tol)
+    are NOT a drift loop; without the multiplier they would be."""
+    monkeypatch.delenv("MANTIS_ADAPTIVE_CLICK_TOL", raising=False)
+    d = LoopDetector(click_tol_px=8)  # base 8, button 1.5× → 12
+    for _ in range(3):
+        d.record(_click(100, 100, reasoning="Click the Submit button"))
+        d.record(_click(111, 109, reasoning="Click the Submit button"))
+    assert d.is_drift_loop(window=5) is True
+    # Now try 13 px apart — outside the 12 px button tolerance.
+    d2 = LoopDetector(click_tol_px=8)
+    for _ in range(3):
+        d2.record(_click(100, 100, reasoning="Click the Submit button"))
+        d2.record(_click(113, 109, reasoning="Click the Submit button"))
+    assert d2.is_drift_loop(window=5) is False
+
+
+def test_link_multiplier_tightens_drift_tolerance(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two clicks 5 px apart on a link (0.5× → 4 px tol) ARE a drift
+    loop only if within the tightened tolerance."""
+    monkeypatch.delenv("MANTIS_ADAPTIVE_CLICK_TOL", raising=False)
+    d = LoopDetector(click_tol_px=8)
+    # 5 px drift > 4 px link tolerance → NOT a drift loop
+    for _ in range(3):
+        d.record(_click(100, 100, reasoning="Click the link to next page"))
+        d.record(_click(105, 100, reasoning="Click the link to next page"))
+    assert d.is_drift_loop(window=5) is False
+    # 3 px drift ≤ 4 px link tolerance → drift loop
+    d2 = LoopDetector(click_tol_px=8)
+    for _ in range(3):
+        d2.record(_click(100, 100, reasoning="Click the link to next page"))
+        d2.record(_click(103, 100, reasoning="Click the link to next page"))
+    assert d2.is_drift_loop(window=5) is True
+
+
+def test_no_classification_uses_base_tolerance(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Reasoning without a class keyword falls back to ``click_tol_px``."""
+    monkeypatch.delenv("MANTIS_ADAPTIVE_CLICK_TOL", raising=False)
+    d = LoopDetector(click_tol_px=8)
+    for _ in range(3):
+        d.record(_click(100, 100, reasoning="click somewhere"))
+        d.record(_click(107, 107, reasoning="click somewhere"))
+    assert d.is_drift_loop(window=5) is True
+    d2 = LoopDetector(click_tol_px=8)
+    for _ in range(3):
+        d2.record(_click(100, 100, reasoning="click somewhere"))
+        d2.record(_click(109, 109, reasoning="click somewhere"))
+    assert d2.is_drift_loop(window=5) is False
+
+
+def test_class_multiplier_disabled_falls_back_to_base(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the toggle is off, button text doesn't widen tolerance."""
+    monkeypatch.setenv("MANTIS_ADAPTIVE_CLICK_TOL", "disabled")
+    d = LoopDetector(click_tol_px=8)
+    # 10 px drift would fit a 12 px button tolerance, but toggle is off.
+    for _ in range(3):
+        d.record(_click(100, 100, reasoning="Click the Submit button"))
+        d.record(_click(110, 100, reasoning="Click the Submit button"))
+    # 10 > 8 → not a drift loop with raw 8 px tolerance.
+    assert d.is_drift_loop(window=5) is False
+
+
+def test_compound_keyword_matched_before_substring(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The keyword tuple is ordered so multi-word phrases match first.
+    ``submit button`` and the bare ``button`` both map to 1.5× today,
+    but the ordering protects against future divergence (different
+    multipliers for ``submit button`` vs generic ``button``).
+    """
+    monkeypatch.delenv("MANTIS_ADAPTIVE_CLICK_TOL", raising=False)
+    d = LoopDetector(click_tol_px=8)
+    # Both "submit button" and bare "button" → 1.5× → 12 px tolerance.
+    for _ in range(3):
+        d.record(_click(100, 100, reasoning="Click the submit button"))
+        d.record(_click(111, 100, reasoning="Click the submit button"))
+    assert d.is_drift_loop(window=5) is True
+
+
+# ── env-var toggle ───────────────────────────────────────────────────
+
+
+def test_adaptive_click_tol_default_on(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("MANTIS_ADAPTIVE_CLICK_TOL", raising=False)
+    assert adaptive_click_tol_enabled() is True
+
+
+@pytest.mark.parametrize(
+    "value", ["disabled", "0", "false", "FALSE", "off", "no"]
+)
+def test_adaptive_click_tol_disabled_when_off(
+    value: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("MANTIS_ADAPTIVE_CLICK_TOL", value)
+    assert adaptive_click_tol_enabled() is False
+
+
+# ── GymRunner wiring ─────────────────────────────────────────────────
+
+
+def test_gym_runner_uses_env_screen_size_for_tolerance(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``GymRunner`` should construct its detector with a tolerance
+    derived from ``env.screen_size``, not the hardcoded 8."""
+    monkeypatch.delenv("MANTIS_ADAPTIVE_CLICK_TOL", raising=False)
+
+    from mantis_agent.gym.base import GymEnvironment, GymObservation, GymResult
+    from mantis_agent.gym.runner import GymRunner
+    from PIL import Image
+
+    class _Env(GymEnvironment):
+        @property
+        def screen_size(self) -> tuple[int, int]:
+            return (3840, 2160)  # 4K
+
+        def reset(self, task: str, **kw):
+            return GymObservation(screenshot=Image.new("RGB", (3840, 2160)))
+
+        def step(self, action):
+            return GymResult(self.reset(""), 0.0, False, {})
+
+        def close(self) -> None:
+            pass
+
+    class _Brain:
+        def think(self, frames, task, action_history=None, screen_size=(3840, 2160)):
+            class R:
+                action = Action(ActionType.DONE, {"success": True})
+                thinking = ""
+                predicted_outcome = ""
+            return R()
+
+    runner = GymRunner(_Brain(), _Env(), max_steps=1)
+    assert runner._loop_detector.click_tol_px == 18  # 4K diagonal scale
+
+
+def test_gym_runner_handles_env_without_screen_size_attribute() -> None:
+    """Defensive: an env that raises on ``screen_size`` falls back to 8."""
+    from mantis_agent.gym.base import GymEnvironment, GymObservation, GymResult
+    from mantis_agent.gym.runner import GymRunner
+    from PIL import Image
+
+    class _BadEnv(GymEnvironment):
+        @property
+        def screen_size(self):
+            raise RuntimeError("not initialized yet")
+
+        def reset(self, task: str, **kw):
+            return GymObservation(screenshot=Image.new("RGB", (100, 100)))
+
+        def step(self, action):
+            return GymResult(self.reset(""), 0.0, False, {})
+
+        def close(self) -> None:
+            pass
+
+    class _Brain:
+        def think(self, frames, task, action_history=None, screen_size=(100, 100)):
+            class R:
+                action = Action(ActionType.DONE, {"success": True})
+                thinking = ""
+                predicted_outcome = ""
+            return R()
+
+    runner = GymRunner(_Brain(), _BadEnv(), max_steps=1)
+    assert runner._loop_detector.click_tol_px == 8


### PR DESCRIPTION
## Summary

- Closes #296 — hardcoded ``LoopDetector.click_tol_px = 8`` is too tight on 4K (legitimate retries at 15-20 px get flagged as drift loops) and doesn't account for element semantics.
- ``compute_click_tol_px(viewport, *, floor=8)`` returns ``max(floor, 0.4 % × diagonal)``: 1080p → 9 px, QHD → 12 px, 4K → 18 px, 8K → 35 px. ``GymRunner.__init__`` calls it with ``env.screen_size``.
- ``LoopDetector._effective_click_tol`` scales the base by a per-class multiplier when the action's reasoning text classifies the target — buttons get 1.5×, links get 0.5×, dropdowns get 0.75×.
- ``MANTIS_ADAPTIVE_CLICK_TOL`` env-toggle (default on) + per-request ``adaptive_click_tol`` override on ``/v1/cua`` for A/B without redeploys.
- Reasoning-text heuristic is a soft proxy until ``GroundingResult`` gets a structured ``element_class`` field — documented as a follow-up.

## Scaling table

| Viewport | Diagonal | Tolerance |
|---|---|---|
| 1280 × 800 (default) | 1430 px | 8 px (floor) |
| 1366 × 768 (laptop) | 1567 px | 8 px (floor) |
| 1920 × 1080 (FHD) | 2202 px | 9 px |
| 2560 × 1440 (QHD) | 2937 px | 12 px |
| 3840 × 2160 (4K) | 4404 px | 18 px |

## Test plan

- [x] `tests/test_loop_detector_click_tol.py` covers the scaling table, button widening, link tightening, env-toggle parsing, ``GymRunner`` wiring, defensive fallback for envs without ``screen_size``.
- [x] Existing loop-detector / runner suites: 284 passed.
- [x] Full pytest: 2003 passed locally (23 net new).
- [x] ruff clean.
- [ ] Modal redeploy + ablation pair (MANTIS_ADAPTIVE_CLICK_TOL=enabled vs disabled) on lu.ma extract-loop after merge, per the verify-via-redeploy memory.

## Ablation

Run after merge against the warm Modal container:
```bash
.venv/bin/python scripts/ablate_v1_cua.py \\
  --toggle adaptive_click_tol \\
  --instruction "Extract events from lu.ma SF and paginate" \\
  --start-url https://lu.ma/sf \\
  --pairs 3
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)