### PR TITLE
feat(gym): tag trajectory steps with executor_backend + RoutingPolicy

### DIFF
--- a/src/mantis_agent/baseten_server/runtime.py
+++ b/src/mantis_agent/baseten_server/runtime.py
@@ -1386,6 +1386,16 @@ class BasetenCUARuntime:
                 "done_rejections_by_reason": dict(
                     getattr(gym_result, "done_rejections_by_reason", None) or {},
                 ),
+                # #295 / #300 ablation signal: per-backend trajectory-step
+                # counts. ``plan`` = :class:`PlanExecutor` deterministic
+                # dispatch, ``som`` = :class:`PageDiscovery` Set-of-Mark
+                # dispatch, ``vision`` = brain-driven raw-coordinate
+                # dispatch. Empty dict on hosts that don't wire a
+                # PlanExecutor or PageDiscovery (the routing falls
+                # straight through to ``vision``).
+                "executor_backend_counts": dict(
+                    getattr(gym_result, "executor_backend_counts", None) or {},
+                ),
             }
             self._attach_recording_metadata(result, recorder, click_log=click_log)
             self._save_result(result, prefix="pure_cua")

--- a/src/mantis_agent/gym/runner.py
+++ b/src/mantis_agent/gym/runner.py
@@ -171,6 +171,117 @@ class TrajectoryStep:
     # surface on ``RunResult.loop_recoveries_by_reason``.
     loop_recovery_reason: str = ""
 
+    # ── #295 / #300 routing backend ─────────────────────────────────────
+    # Which dispatch path produced this trajectory step:
+    #   - "plan"   — :class:`PlanExecutor` executed a structured plan step
+    #                deterministically (no brain inference for the action).
+    #   - "som"    — :class:`PageDiscovery` scanned the DOM and the brain
+    #                picked an element by index; execution was DOM-driven
+    #                (Set-of-Mark routing).
+    #   - "vision" — the brain looked at the screenshot and emitted raw
+    #                coordinates / keystrokes; the env executed those.
+    #   - ""       — backend not classified (host-tool dispatch, paused
+    #                step, etc.).
+    # Aggregate counts surface on ``RunResult.executor_backend_counts``
+    # so a single ``/v1/cua`` run doubles as a routing telemetry point
+    # without dumping the full trajectory (mirrors the predicate /
+    # perceptual / loop-recovery aggregates).
+    executor_backend: str = ""
+
+
+# ── #295 / #300 routing policy ──────────────────────────────────────────
+#
+# Single knob bag controlling how each agent step's action is dispatched.
+# Defaults preserve current behavior: PlanExecutor runs when a
+# :class:`PlanExecutor` is wired and the current plan step is
+# deterministic; PageDiscovery / SoM runs when ``site_config`` opts in
+# OR (#300) when the routing policy explicitly promotes SoM. Vision
+# (brain-driven raw-coordinate dispatch) is always the final fallback.
+#
+# Why a dataclass and not env vars: the routing decision needs to be
+# observable in tests and serializable into the trajectory metadata.
+# Env vars stay supported as overrides in :meth:`RoutingPolicy.from_env`
+# so the ablation harness can A/B without redeploys.
+
+
+@dataclass
+class RoutingPolicy:
+    """Configurable dispatch policy for :class:`GymRunner`.
+
+    The policy is consulted at three boundaries per step:
+
+    1. **PlanExecutor** (``plan_executor_enabled``): a structured plan
+       step (action ∈ {navigate, click, type, key, scroll, wait,
+       verify} with a resolved ``target`` / ``url``) is sent through
+       :class:`PlanExecutor` deterministically. Falls through on
+       :class:`StepResult` ``success=False``.
+    2. **PageDiscovery / SoM** (``som_enabled``): when DOM access is
+       available (Playwright page on the env or CDP-backed evaluate),
+       run :class:`PageDiscovery`, ask the brain to pick ``[N]``,
+       execute via DOM. ``som_for_unstructured_clicks`` extends this
+       to brain-driven CLICK actions outside the plan-step branch
+       (#300).
+    3. **Vision** (always): if neither path produces an action,
+       :class:`Brain.think` returns a raw-coordinate action that the
+       env executes via xdotool / Playwright mouse events.
+
+    The policy never *forces* a path — it only opts a path in. Callers
+    can still wire ``plan_executor=None`` / ``page_discovery=None`` on
+    the runner to suppress a branch entirely.
+    """
+
+    # If True (default), the plan-step branch tries
+    # :class:`PlanExecutor.execute` before falling through to SoM /
+    # vision. Set to False to force vision-only dispatch (useful for
+    # ablating the plan-executor contribution on a benchmark).
+    plan_executor_enabled: bool = True
+
+    # If True (default), the plan-step branch tries
+    # :class:`PageDiscovery._try_discovery_execution` either before the
+    # direct executor (when ``site_config.prefer_som_grounding`` is set)
+    # or after a PlanExecutor failure. ``False`` disables every SoM
+    # branch, including the ``prefer_som_grounding`` short-circuit.
+    som_enabled: bool = True
+
+    # #300: when True, brain-driven CLICK actions that don't go through
+    # the plan-step branch consult :class:`PageDiscovery` if the env
+    # exposes DOM. Default False so the rollout to production is
+    # gated; existing ``site_config.prefer_som_grounding`` plan-step
+    # promotion is unaffected.
+    som_for_unstructured_clicks: bool = False
+
+    @classmethod
+    def from_env(cls) -> RoutingPolicy:
+        """Build a policy from the standard ``MANTIS_ROUTE_*`` env vars.
+
+        Toggles (each accepts ``enabled`` / ``disabled``; case-insensitive):
+
+        * ``MANTIS_ROUTE_PLAN_EXECUTOR`` — gates ``plan_executor_enabled``.
+        * ``MANTIS_ROUTE_SOM`` — gates ``som_enabled``.
+        * ``MANTIS_ROUTE_SOM_CLICKS`` — gates
+          ``som_for_unstructured_clicks`` (#300, default off).
+
+        Anything other than ``disabled`` keeps the dataclass default,
+        so unset / empty env vars never accidentally flip the policy.
+        """
+        def _on(name: str, default: bool) -> bool:
+            v = os.environ.get(name, "").strip().lower()
+            if not v:
+                return default
+            if v == "disabled":
+                return False
+            if v == "enabled":
+                return True
+            return default
+
+        return cls(
+            plan_executor_enabled=_on("MANTIS_ROUTE_PLAN_EXECUTOR", True),
+            som_enabled=_on("MANTIS_ROUTE_SOM", True),
+            som_for_unstructured_clicks=_on(
+                "MANTIS_ROUTE_SOM_CLICKS", False,
+            ),
+        )
+
 
 # Subset of ``gym_result.info`` that round-trips into TrajectoryStep
 # observed_state. Excludes high-cardinality / large-blob fields (raw DOM,
@@ -244,6 +355,15 @@ class RunResult:
     # the policy never fired (toggle off, no soft loops, or no rule
     # matched). Surfaces on /v1/cua.
     loop_recoveries_by_reason: dict[str, int] = field(default_factory=dict)
+    # #295 / #300: per-backend trajectory-step counts. Keys are the
+    # values of :attr:`TrajectoryStep.executor_backend` (``"plan"``,
+    # ``"som"``, ``"vision"``); the empty-string backend is dropped
+    # from the aggregate so consumers can read "how many steps came
+    # from which dispatch path?" without filtering. Empty dict when
+    # no classified backend ever fired (e.g. a paused-only trajectory).
+    # Surfaces on /v1/cua so callers can read the routing mix without
+    # parsing the trajectory.
+    executor_backend_counts: dict[str, int] = field(default_factory=dict)
 
 
 # ── Trajectory serialization for pause snapshots (#285) ────────────────────
@@ -279,6 +399,7 @@ def _trajectory_step_to_dict(step: TrajectoryStep) -> dict[str, Any]:
         "done_rejected_reason": step.done_rejected_reason,
         "action_effect_observed": step.action_effect_observed,
         "loop_recovery_reason": step.loop_recovery_reason,
+        "executor_backend": step.executor_backend,
     }
 
 
@@ -307,6 +428,7 @@ def _trajectory_step_from_dict(payload: dict[str, Any]) -> TrajectoryStep:
         done_rejected_reason=str(payload.get("done_rejected_reason", "")),
         action_effect_observed=payload.get("action_effect_observed"),
         loop_recovery_reason=str(payload.get("loop_recovery_reason", "")),
+        executor_backend=str(payload.get("executor_backend", "")),
     )
 
 
@@ -336,6 +458,7 @@ class GymRunner:
         on_step: Any = None,
         site_config: Any = None,
         cancel_event: Any = None,
+        routing_policy: RoutingPolicy | None = None,
     ):
         self.brain = brain
         self.env = env
@@ -346,6 +469,12 @@ class GymRunner:
         self.hard_loop_window = hard_loop_window
         self.plan_executor = plan_executor
         self.page_discovery = page_discovery
+        # #295 / #300: dispatch policy. Default reads ``MANTIS_ROUTE_*``
+        # env toggles so a deploy can flip the routing mix per request
+        # without restarting; explicit callers (tests, host integrations
+        # that want a fixed policy) pass a :class:`RoutingPolicy`
+        # instance and bypass the env overrides.
+        self.routing_policy = routing_policy or RoutingPolicy.from_env()
         self.on_step = on_step  # Optional: fn(dict) -> None for live viewer
         # #117 step 1: when site_config.prefer_som_grounding is True, the
         # runner tries SoM (page_discovery + brain choice) BEFORE direct
@@ -777,11 +906,15 @@ class GymRunner:
                             thinking=f"SoM-promoted execution: {current_plan_step.action}",
                             reward=0.0, done=False, inference_time=0.0,
                             feedback=feedback,
+                            executor_backend="som",
                         ))
                         last_url = self.env.current_url if hasattr(self.env, 'current_url') else last_url
                         continue
 
-                if self.plan_executor.can_execute(current_plan_step):
+                if (
+                    self.routing_policy.plan_executor_enabled
+                    and self.plan_executor.can_execute(current_plan_step)
+                ):
                     step_result = self.plan_executor.execute(current_plan_step, plan_inputs)
                     print(f"  [executor] result: success={step_result.success} detail={step_result.detail}")
 
@@ -810,6 +943,7 @@ class GymRunner:
                             done=False,
                             inference_time=0.0,
                             feedback=feedback,
+                            executor_backend="plan",
                         ))
 
                         # Check if we completed all plan steps
@@ -823,16 +957,20 @@ class GymRunner:
                                     thinking="All plan steps completed and verified",
                                     reward=1.0, done=True, inference_time=0.0,
                                     feedback=feedback,
+                                    executor_backend="plan",
                                 )
                                 break
 
                         last_url = step_result.url_after or last_url
                         continue
                     else:
-                        # Direct execution failed — try DOM discovery + brain choice
+                        # Direct execution failed (PlanExecutor returned
+                        # success=False — treat that as the documented
+                        # "NotApplicable" fallthrough from issue #295) —
+                        # try DOM discovery + brain choice before vision.
                         print("  [executor] direct failed, trying discovery...")
 
-                        if self.page_discovery:
+                        if self.routing_policy.som_enabled and self.page_discovery:
                             discovery_result = self._try_discovery_execution(
                                 current_plan_step, plan_inputs, step_log, frame_history,
                             )
@@ -857,6 +995,7 @@ class GymRunner:
                                     thinking=f"Discovery execution: {current_plan_step.action}",
                                     reward=0.0, done=False, inference_time=0.0,
                                     feedback=feedback,
+                                    executor_backend="som",
                                 ))
                                 last_url = self.env.current_url if hasattr(self.env, 'current_url') else last_url
                                 continue
@@ -1114,6 +1253,7 @@ class GymRunner:
                             trajectory.append(TrajectoryStep(
                                 step=step_num, action=action, thinking=thinking,
                                 reward=0.0, done=True, inference_time=inference_time,
+                                executor_backend="vision",
                             ))
                             termination_reason = "done"
                             break
@@ -1121,6 +1261,7 @@ class GymRunner:
                         trajectory.append(TrajectoryStep(
                             step=step_num, action=action, thinking=thinking,
                             reward=0.0, done=True, inference_time=inference_time,
+                            executor_backend="vision",
                         ))
                         termination_reason = "done"
                         break
@@ -1586,6 +1727,7 @@ class GymRunner:
                     done_rejected_reason=pending_done_rejected_reason,
                     action_effect_observed=effect_check.effect_observed,
                     loop_recovery_reason=pending_loop_recovery_reason,
+                    executor_backend="vision",
                 ))
                 # One-shot: clear so the next step doesn't inherit it.
                 pending_done_rejected_reason = ""
@@ -1654,6 +1796,16 @@ class GymRunner:
                     loop_recoveries_by_reason.get(t.loop_recovery_reason, 0) + 1
                 )
 
+        # #295 / #300: per-backend trajectory-step counts. Empty-string
+        # backends (tool-call dispatch, pause/resume, etc.) are dropped
+        # so the aggregate reads as a clean routing-mix summary.
+        executor_backend_counts: dict[str, int] = {}
+        for t in trajectory:
+            if t.executor_backend:
+                executor_backend_counts[t.executor_backend] = (
+                    executor_backend_counts.get(t.executor_backend, 0) + 1
+                )
+
         result = RunResult(
             task=task, task_id=task_id, success=success,
             total_reward=total_reward, total_steps=len(trajectory),
@@ -1662,6 +1814,7 @@ class GymRunner:
             done_rejections_by_reason=dict(done_rejections_by_reason),
             perceptual_summary=perceptual_summary,
             loop_recoveries_by_reason=loop_recoveries_by_reason,
+            executor_backend_counts=executor_backend_counts,
         )
 
         # Terminal reward — applied last so episode() can read the full
@@ -1958,10 +2111,26 @@ class GymRunner:
     def _should_prefer_som(self) -> bool:
         """Return True when the site config opts into SoM-first dispatch.
 
-        SoM-first only fires when both ``site_config.prefer_som_grounding``
-        is True AND a ``page_discovery`` instance is available — without
-        DOM access there's no SoM candidate set to choose from.
+        SoM-first only fires when:
+
+        * The routing policy hasn't disabled the SoM branch
+          (:attr:`RoutingPolicy.som_enabled`, default True).
+        * ``site_config.prefer_som_grounding`` is True.
+        * The caller wired ``page_discovery`` on the runner (without
+          DOM access there's no SoM candidate set to choose from).
+
+        The ``page_discovery`` check stays at the call site so existing
+        callers that only set ``site_config.prefer_som_grounding``
+        without wiring discovery don't get an unexpected behavior
+        change.
         """
+        # ``routing_policy`` may be absent on instances built via
+        # ``GymRunner.__new__`` (legacy ``test_som_promotion`` pattern);
+        # treat the missing attr as "default policy" so existing tests
+        # don't need to know about it.
+        policy = getattr(self, "routing_policy", None)
+        if policy is not None and not policy.som_enabled:
+            return False
         cfg = self.site_config
         return bool(cfg is not None and getattr(cfg, "prefer_som_grounding", False))
 

--- a/tests/test_runner_executor_backend.py
+++ b/tests/test_runner_executor_backend.py
@@ -1,0 +1,275 @@
+"""GymRunner routing-backend telemetry (#295 + foundation for #300).
+
+Asserts that every classified trajectory step carries an
+``executor_backend`` tag and that the per-backend aggregate on
+:class:`RunResult.executor_backend_counts` adds up.
+
+The runner exposes three classified backends:
+
+* ``plan``   — :class:`PlanExecutor.execute` ran a structured plan step
+                deterministically.
+* ``som``    — :class:`PageDiscovery` (Set-of-Mark) picked an element
+                and the runner executed via DOM.
+* ``vision`` — brain emitted raw coordinates / keystrokes that the env
+                executed.
+
+Routing decisions are gated by :class:`RoutingPolicy`, which is also
+covered here (env-toggle parsing + default behaviour).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+from PIL import Image
+
+from mantis_agent.actions import Action, ActionType
+from mantis_agent.gym.base import GymEnvironment, GymObservation, GymResult
+from mantis_agent.gym.plans import Plan, PlanStep
+from mantis_agent.gym.runner import (
+    GymRunner,
+    RoutingPolicy,
+    TrajectoryStep,
+    _trajectory_step_from_dict,
+    _trajectory_step_to_dict,
+)
+
+
+# ── Fakes ───────────────────────────────────────────────────────────────
+
+
+@dataclass
+class _BrainResult:
+    action: Action
+    thinking: str = ""
+    predicted_outcome: str = ""
+
+
+class _ScriptedBrain:
+    """Emits a fixed sequence of actions then auto-DONE."""
+
+    def __init__(self, script: list[Action]) -> None:
+        self.script = list(script)
+        self.calls = 0
+
+    def think(
+        self,
+        frames: Any,
+        task: str,
+        action_history: Any = None,
+        screen_size: tuple[int, int] = (100, 100),
+    ) -> _BrainResult:
+        if self.calls >= len(self.script):
+            self.calls += 1
+            return _BrainResult(Action(
+                ActionType.DONE, {"success": True, "summary": "done"},
+            ))
+        action = self.script[self.calls]
+        self.calls += 1
+        return _BrainResult(action)
+
+
+class _NoopEnv(GymEnvironment):
+    """Minimal env that returns the same screenshot every step."""
+
+    def __init__(self) -> None:
+        self._frame = Image.new("RGB", (100, 100), color=(128, 128, 128))
+
+    @property
+    def screen_size(self) -> tuple[int, int]:
+        return (100, 100)
+
+    def reset(self, task: str, **kwargs: Any) -> GymObservation:
+        return GymObservation(screenshot=self._frame)
+
+    def step(self, action: Action) -> GymResult:
+        return GymResult(
+            GymObservation(screenshot=self._frame),
+            reward=0.0, done=False, info={"url": "https://x.test/a", "title": "A"},
+        )
+
+    def close(self) -> None:
+        pass
+
+
+class _FakeStepResult:
+    def __init__(self, success: bool, detail: str = "", url_after: str = "") -> None:
+        self.success = success
+        self.method = "direct"
+        self.detail = detail
+        self.url_after = url_after
+
+
+class _FakePlanExecutor:
+    """Returns success on every can_execute / execute call."""
+
+    def __init__(self, will_succeed: bool = True) -> None:
+        self._will_succeed = will_succeed
+        self.calls = 0
+
+    def can_execute(self, step: PlanStep) -> bool:
+        return True
+
+    def execute(
+        self, step: PlanStep, plan_inputs: dict[str, str],
+    ) -> _FakeStepResult:
+        self.calls += 1
+        return _FakeStepResult(
+            success=self._will_succeed,
+            detail=f"executed {step.action}: {step.target}",
+            url_after="https://x.test/after",
+        )
+
+
+# ── Vision-only run ─────────────────────────────────────────────────────
+
+
+def test_vision_only_run_tags_every_step_as_vision() -> None:
+    """No plan + no executors → every classified step is ``vision``."""
+    brain = _ScriptedBrain([
+        Action(ActionType.CLICK, {"x": 1, "y": 1}),
+        Action(ActionType.WAIT, {"seconds": 0.1}),
+    ])
+    env = _NoopEnv()
+    runner = GymRunner(brain, env, max_steps=4)
+    result = runner.run("vision-only task")
+
+    backends = [s.executor_backend for s in result.trajectory]
+    assert backends, "should produce at least one step"
+    assert all(b == "vision" for b in backends), backends
+    assert result.executor_backend_counts == {"vision": len(backends)}
+
+
+# ── PlanExecutor branch ─────────────────────────────────────────────────
+
+
+def test_plan_executor_success_tags_steps_as_plan() -> None:
+    """Plan + PlanExecutor returning success → executor_backend=plan."""
+    plan = Plan(
+        name="t", description="", url="https://x.test",
+        steps=[
+            PlanStep(action="click", target="Login button"),
+            PlanStep(action="click", target="Continue"),
+        ],
+    )
+    brain = _ScriptedBrain([
+        Action(ActionType.DONE, {"success": True, "summary": "done"}),
+    ])
+    env = _NoopEnv()
+    plan_executor = _FakePlanExecutor(will_succeed=True)
+    runner = GymRunner(
+        brain=brain, env=env, max_steps=5, plan_executor=plan_executor,
+    )
+    result = runner.run("plan-driven task", plan=plan)
+
+    # Both plan steps should execute deterministically.
+    assert plan_executor.calls == 2
+    plan_steps = [s for s in result.trajectory if s.executor_backend == "plan"]
+    assert len(plan_steps) == 2, [s.executor_backend for s in result.trajectory]
+    assert result.executor_backend_counts.get("plan") == 2
+
+
+def test_plan_executor_disabled_falls_through_to_vision() -> None:
+    """``RoutingPolicy.plan_executor_enabled=False`` skips the plan branch.
+
+    The plan exists but the runner ignores PlanExecutor and lets the
+    brain drive every step — every classified step ends up tagged
+    ``vision`` even though a PlanExecutor is wired.
+    """
+    plan = Plan(
+        name="t", description="", url="https://x.test",
+        steps=[PlanStep(action="click", target="Login button")],
+    )
+    brain = _ScriptedBrain([
+        Action(ActionType.CLICK, {"x": 1, "y": 1}),
+        Action(ActionType.DONE, {"success": True, "summary": "done"}),
+    ])
+    plan_executor = _FakePlanExecutor(will_succeed=True)
+    runner = GymRunner(
+        brain=brain, env=_NoopEnv(), max_steps=4,
+        plan_executor=plan_executor,
+        routing_policy=RoutingPolicy(plan_executor_enabled=False),
+    )
+    result = runner.run("plan-driven task", plan=plan)
+
+    # PlanExecutor must not have run.
+    assert plan_executor.calls == 0
+    backends = [s.executor_backend for s in result.trajectory]
+    assert all(b == "vision" for b in backends if b), backends
+    assert "plan" not in result.executor_backend_counts
+
+
+# ── RoutingPolicy.from_env ──────────────────────────────────────────────
+
+
+def test_routing_policy_from_env_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Empty env yields the dataclass defaults."""
+    for v in (
+        "MANTIS_ROUTE_PLAN_EXECUTOR",
+        "MANTIS_ROUTE_SOM",
+        "MANTIS_ROUTE_SOM_CLICKS",
+    ):
+        monkeypatch.delenv(v, raising=False)
+
+    policy = RoutingPolicy.from_env()
+    assert policy.plan_executor_enabled is True
+    assert policy.som_enabled is True
+    assert policy.som_for_unstructured_clicks is False
+
+
+def test_routing_policy_from_env_disabled_flags(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``disabled`` flips each toggle off."""
+    monkeypatch.setenv("MANTIS_ROUTE_PLAN_EXECUTOR", "disabled")
+    monkeypatch.setenv("MANTIS_ROUTE_SOM", "disabled")
+    monkeypatch.setenv("MANTIS_ROUTE_SOM_CLICKS", "enabled")
+
+    policy = RoutingPolicy.from_env()
+    assert policy.plan_executor_enabled is False
+    assert policy.som_enabled is False
+    assert policy.som_for_unstructured_clicks is True
+
+
+def test_routing_policy_from_env_ignores_garbage(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unrecognized values keep the default — fail-closed on typos."""
+    monkeypatch.setenv("MANTIS_ROUTE_PLAN_EXECUTOR", "yes")  # typo for enabled
+    monkeypatch.setenv("MANTIS_ROUTE_SOM", "off")  # typo for disabled
+
+    policy = RoutingPolicy.from_env()
+    assert policy.plan_executor_enabled is True  # default kept
+    assert policy.som_enabled is True  # default kept
+
+
+# ── Trajectory round-trip ───────────────────────────────────────────────
+
+
+def test_trajectory_step_round_trip_carries_executor_backend() -> None:
+    """:func:`_trajectory_step_to_dict` ↔ :func:`_trajectory_step_from_dict`
+    preserve the new field across a pause/resume snapshot."""
+    step = TrajectoryStep(
+        step=1,
+        action=Action(ActionType.CLICK, {"x": 5, "y": 5}),
+        thinking="t", reward=0.0, done=False, inference_time=0.0,
+        executor_backend="plan",
+    )
+    payload = _trajectory_step_to_dict(step)
+    assert payload["executor_backend"] == "plan"
+    restored = _trajectory_step_from_dict(payload)
+    assert restored.executor_backend == "plan"
+
+
+def test_trajectory_step_default_executor_backend_empty() -> None:
+    """Existing pause snapshots (pre-#295) decode without crashing — the
+    missing key resolves to the empty-string default."""
+    payload = {
+        "step": 1,
+        "action": {"action_type": "click", "params": {"x": 0, "y": 0}, "reasoning": ""},
+        "thinking": "", "reward": 0.0, "done": False, "inference_time": 0.0,
+    }
+    restored = _trajectory_step_from_dict(payload)
+    assert restored.executor_backend == ""


### PR DESCRIPTION
## Summary

- Tag every gym trajectory step with ``executor_backend`` (``plan`` | ``som`` | ``vision``) at the existing PlanExecutor / PageDiscovery / brain dispatch sites and aggregate per-backend counts on ``RunResult.executor_backend_counts`` (also surfaced on ``/v1/cua`` next to the existing perceptual / loop-recovery / done-gate aggregates).
- Introduce a ``RoutingPolicy`` dataclass + ``MANTIS_ROUTE_*`` env toggles so the routing mix is a single observable knob (defaults preserve current behaviour). The PlanExecutor branch now gates on ``routing_policy.plan_executor_enabled`` for vision-only ablations even when an executor is wired. Reserves ``som_for_unstructured_clicks`` for the #300 follow-up.
- Covers the issue's acceptance: router lives in ``gym/runner.py``, ``executor_backend`` is on the trajectory, and a single ``/v1/cua`` run now serves as the cost/latency-per-backend data point without re-parsing feedback strings.

Closes #295.

## Test plan

- [x] Added ``tests/test_runner_executor_backend.py`` (vision-only run tags every step as ``vision``; plan-driven run tags ``plan``; ``RoutingPolicy(plan_executor_enabled=False)`` falls through to vision; ``RoutingPolicy.from_env`` env-toggle parsing; ``TrajectoryStep`` pause/resume round-trip preserves the new field).
- [x] Full local pytest sweep (1993 passed).
- [ ] Modal redeploy + staff-crm plan + lu.ma extract-loop verification (next).

🤖 Generated with [Claude Code](https://claude.com/claude-code)