### PR TITLE
feat(gym): SoM-anchored click default for unstructured CLICK actions

### DIFF
--- a/src/mantis_agent/baseten_server/runtime.py
+++ b/src/mantis_agent/baseten_server/runtime.py
@@ -1287,12 +1287,24 @@ class BasetenCUARuntime:
             logger.info("brain: per-request override → synchronous (inner)")
 
         try:
+            # #300: attach :class:`PageDiscovery` whenever the env
+            # exposes the CDP DOM shim (``cdp_evaluate``). The SoM
+            # branch in :meth:`GymRunner.run` only fires when both a
+            # plan-step / site-config opts in AND the runner has a
+            # discovery instance, so attaching it unconditionally is
+            # a no-op on legacy callers but unlocks the plan-step
+            # SoM path on production xdotool.
+            page_discovery: Any = None
+            if hasattr(env, "cdp_evaluate"):
+                from ..gym.page_discovery import PageDiscovery
+                page_discovery = PageDiscovery(env=env)
             runner = GymRunner(
                 brain=brain_for_run,
                 env=env,
                 max_steps=max_steps,
                 frames_per_inference=frames,
                 grounding=None,  # pure CUA: no Claude grounding
+                page_discovery=page_discovery,
             )
             gym_result = runner.run(
                 task=instruction,

--- a/src/mantis_agent/baseten_server/runtime.py
+++ b/src/mantis_agent/baseten_server/runtime.py
@@ -1386,6 +1386,16 @@ class BasetenCUARuntime:
                 "done_rejections_by_reason": dict(
                     getattr(gym_result, "done_rejections_by_reason", None) or {},
                 ),
+                # #295 / #300 ablation signal: per-backend trajectory-step
+                # counts. ``plan`` = :class:`PlanExecutor` deterministic
+                # dispatch, ``som`` = :class:`PageDiscovery` Set-of-Mark
+                # dispatch, ``vision`` = brain-driven raw-coordinate
+                # dispatch. Empty dict on hosts that don't wire a
+                # PlanExecutor or PageDiscovery (the routing falls
+                # straight through to ``vision``).
+                "executor_backend_counts": dict(
+                    getattr(gym_result, "executor_backend_counts", None) or {},
+                ),
             }
             self._attach_recording_metadata(result, recorder, click_log=click_log)
             self._save_result(result, prefix="pure_cua")

--- a/src/mantis_agent/gym/page_discovery.py
+++ b/src/mantis_agent/gym/page_discovery.py
@@ -131,8 +131,22 @@ class PageElement:
 class PageDiscovery:
     """Discover interactive elements on a page and let the brain choose.
 
+    Two backends are supported:
+
+    1. **Playwright** — pass a Playwright ``Page`` (or an env that
+       exposes one via a ``.page`` attribute). Discovery and click
+       execution use Playwright's native API.
+    2. **CDP** (#300) — pass an env that implements
+       ``cdp_evaluate(expression)`` (e.g.
+       :class:`XdotoolGymEnv`). Discovery and click execution use
+       Chrome DevTools Protocol ``Runtime.evaluate``, so the
+       production xdotool path gets DOM access without spinning up a
+       separate Playwright session.
+
     Args:
         page: Playwright Page object (or env with .page property).
+        env: Env exposing ``.page`` (Playwright) and/or
+            ``cdp_evaluate`` / ``cdp_click_at_point`` (CDP).
         max_elements: Maximum elements to include in the brain prompt.
     """
 
@@ -150,15 +164,38 @@ class PageDiscovery:
             return self._env.page
         return None
 
+    @property
+    def _cdp_capable(self) -> bool:
+        """True iff the env exposes the CDP DOM evaluation shim (#300)."""
+        return self._env is not None and hasattr(self._env, "cdp_evaluate")
+
+    def _evaluate_js(self, expression: str):
+        """Run a JS expression against the active page.
+
+        Prefers Playwright (returns parsed value directly); falls back
+        to CDP ``Runtime.evaluate`` via the env's ``cdp_evaluate`` shim
+        when no Playwright page is wired. Returns ``None`` when neither
+        backend is available.
+        """
+        page = self._page
+        if page is not None:
+            return page.evaluate(expression)
+        if self._cdp_capable:
+            return self._env.cdp_evaluate(expression)
+        return None
+
     def discover(self) -> list[PageElement]:
         """Scan the current page and return all interactive elements."""
-        if self._page is None:
+        if self._page is None and not self._cdp_capable:
             return []
 
         try:
-            raw_elements = self._page.evaluate(DISCOVER_ELEMENTS_JS)
+            raw_elements = self._evaluate_js(DISCOVER_ELEMENTS_JS)
         except Exception as e:
             logger.warning(f"Element discovery failed: {e}")
+            return []
+
+        if not raw_elements:
             return []
 
         elements = []
@@ -247,42 +284,79 @@ If no element matches, reply: NONE"""
         return None
 
     def click_element(self, index: int) -> bool:
-        """Click an element by its discovery index using Playwright."""
+        """Click an element by its discovery index.
+
+        Uses Playwright ``page.mouse.click`` when a Playwright page is
+        wired; otherwise falls back to a CDP-backed click via the env's
+        ``cdp_click_at_point`` shim (#300). Returns ``False`` if neither
+        backend can dispatch.
+        """
         el = self.get_element_by_index(index)
-        if not el or not self._page:
+        if not el:
             return False
 
-        try:
-            # Use bbox center for clicking (most reliable)
-            cx = el.bbox.get("x", 0) + el.bbox.get("w", 0) // 2
-            cy = el.bbox.get("y", 0) + el.bbox.get("h", 0) // 2
-            self._page.mouse.click(cx, cy)
-            return True
-        except Exception as e:
-            logger.warning(f"Click element [{index}] failed: {e}")
-            return False
+        cx = el.bbox.get("x", 0) + el.bbox.get("w", 0) // 2
+        cy = el.bbox.get("y", 0) + el.bbox.get("h", 0) // 2
+
+        page = self._page
+        if page is not None:
+            try:
+                page.mouse.click(cx, cy)
+                return True
+            except Exception as e:
+                logger.warning(f"Click element [{index}] failed: {e}")
+                return False
+        if self._cdp_capable and hasattr(self._env, "cdp_click_at_point"):
+            try:
+                return bool(self._env.cdp_click_at_point(cx, cy))
+            except Exception as e:
+                logger.warning(f"CDP click element [{index}] failed: {e}")
+                return False
+        return False
 
     def type_into_element(self, index: int, text: str) -> bool:
-        """Click an element and type text into it."""
+        """Click an element and type text into it.
+
+        Playwright backend: focuses via ``mouse.click`` + ``keyboard.type``.
+        CDP backend: ``cdp_click_at_point`` to focus, then defers typing
+        to whatever the env exposes (xdotool's _xdotool_type path on
+        :class:`XdotoolGymEnv`). Returns ``False`` when no backend can
+        carry both steps.
+        """
         el = self.get_element_by_index(index)
-        if not el or not self._page:
+        if not el:
             return False
 
-        try:
-            cx = el.bbox.get("x", 0) + el.bbox.get("w", 0) // 2
-            cy = el.bbox.get("y", 0) + el.bbox.get("h", 0) // 2
-            self._page.mouse.click(cx, cy)
+        cx = el.bbox.get("x", 0) + el.bbox.get("w", 0) // 2
+        cy = el.bbox.get("y", 0) + el.bbox.get("h", 0) // 2
 
-            import time
-            time.sleep(0.3)
-
-            # Clear existing value and type new one
-            self._page.keyboard.press("Control+a")
-            self._page.keyboard.type(text)
-            return True
-        except Exception as e:
-            logger.warning(f"Type into element [{index}] failed: {e}")
+        page = self._page
+        if page is not None:
+            try:
+                page.mouse.click(cx, cy)
+                import time
+                time.sleep(0.3)
+                page.keyboard.press("Control+a")
+                page.keyboard.type(text)
+                return True
+            except Exception as e:
+                logger.warning(f"Type into element [{index}] failed: {e}")
+                return False
+        if self._cdp_capable and hasattr(self._env, "cdp_click_at_point"):
+            try:
+                if not self._env.cdp_click_at_point(cx, cy):
+                    return False
+            except Exception as e:
+                logger.warning(f"CDP focus element [{index}] failed: {e}")
+                return False
+            cdp_type = getattr(self._env, "_cdp_insert_text", None)
+            if callable(cdp_type):
+                try:
+                    return bool(cdp_type(text))
+                except Exception as e:
+                    logger.warning(f"CDP type element [{index}] failed: {e}")
             return False
+        return False
 
     def select_option(self, index: int, value: str) -> bool:
         """Select an option in a dropdown element."""

--- a/src/mantis_agent/gym/runner.py
+++ b/src/mantis_agent/gym/runner.py
@@ -171,6 +171,117 @@ class TrajectoryStep:
     # surface on ``RunResult.loop_recoveries_by_reason``.
     loop_recovery_reason: str = ""
 
+    # ── #295 / #300 routing backend ─────────────────────────────────────
+    # Which dispatch path produced this trajectory step:
+    #   - "plan"   — :class:`PlanExecutor` executed a structured plan step
+    #                deterministically (no brain inference for the action).
+    #   - "som"    — :class:`PageDiscovery` scanned the DOM and the brain
+    #                picked an element by index; execution was DOM-driven
+    #                (Set-of-Mark routing).
+    #   - "vision" — the brain looked at the screenshot and emitted raw
+    #                coordinates / keystrokes; the env executed those.
+    #   - ""       — backend not classified (host-tool dispatch, paused
+    #                step, etc.).
+    # Aggregate counts surface on ``RunResult.executor_backend_counts``
+    # so a single ``/v1/cua`` run doubles as a routing telemetry point
+    # without dumping the full trajectory (mirrors the predicate /
+    # perceptual / loop-recovery aggregates).
+    executor_backend: str = ""
+
+
+# ── #295 / #300 routing policy ──────────────────────────────────────────
+#
+# Single knob bag controlling how each agent step's action is dispatched.
+# Defaults preserve current behavior: PlanExecutor runs when a
+# :class:`PlanExecutor` is wired and the current plan step is
+# deterministic; PageDiscovery / SoM runs when ``site_config`` opts in
+# OR (#300) when the routing policy explicitly promotes SoM. Vision
+# (brain-driven raw-coordinate dispatch) is always the final fallback.
+#
+# Why a dataclass and not env vars: the routing decision needs to be
+# observable in tests and serializable into the trajectory metadata.
+# Env vars stay supported as overrides in :meth:`RoutingPolicy.from_env`
+# so the ablation harness can A/B without redeploys.
+
+
+@dataclass
+class RoutingPolicy:
+    """Configurable dispatch policy for :class:`GymRunner`.
+
+    The policy is consulted at three boundaries per step:
+
+    1. **PlanExecutor** (``plan_executor_enabled``): a structured plan
+       step (action ∈ {navigate, click, type, key, scroll, wait,
+       verify} with a resolved ``target`` / ``url``) is sent through
+       :class:`PlanExecutor` deterministically. Falls through on
+       :class:`StepResult` ``success=False``.
+    2. **PageDiscovery / SoM** (``som_enabled``): when DOM access is
+       available (Playwright page on the env or CDP-backed evaluate),
+       run :class:`PageDiscovery`, ask the brain to pick ``[N]``,
+       execute via DOM. ``som_for_unstructured_clicks`` extends this
+       to brain-driven CLICK actions outside the plan-step branch
+       (#300).
+    3. **Vision** (always): if neither path produces an action,
+       :class:`Brain.think` returns a raw-coordinate action that the
+       env executes via xdotool / Playwright mouse events.
+
+    The policy never *forces* a path — it only opts a path in. Callers
+    can still wire ``plan_executor=None`` / ``page_discovery=None`` on
+    the runner to suppress a branch entirely.
+    """
+
+    # If True (default), the plan-step branch tries
+    # :class:`PlanExecutor.execute` before falling through to SoM /
+    # vision. Set to False to force vision-only dispatch (useful for
+    # ablating the plan-executor contribution on a benchmark).
+    plan_executor_enabled: bool = True
+
+    # If True (default), the plan-step branch tries
+    # :class:`PageDiscovery._try_discovery_execution` either before the
+    # direct executor (when ``site_config.prefer_som_grounding`` is set)
+    # or after a PlanExecutor failure. ``False`` disables every SoM
+    # branch, including the ``prefer_som_grounding`` short-circuit.
+    som_enabled: bool = True
+
+    # #300: when True, brain-driven CLICK actions that don't go through
+    # the plan-step branch consult :class:`PageDiscovery` if the env
+    # exposes DOM. Default False so the rollout to production is
+    # gated; existing ``site_config.prefer_som_grounding`` plan-step
+    # promotion is unaffected.
+    som_for_unstructured_clicks: bool = False
+
+    @classmethod
+    def from_env(cls) -> RoutingPolicy:
+        """Build a policy from the standard ``MANTIS_ROUTE_*`` env vars.
+
+        Toggles (each accepts ``enabled`` / ``disabled``; case-insensitive):
+
+        * ``MANTIS_ROUTE_PLAN_EXECUTOR`` — gates ``plan_executor_enabled``.
+        * ``MANTIS_ROUTE_SOM`` — gates ``som_enabled``.
+        * ``MANTIS_ROUTE_SOM_CLICKS`` — gates
+          ``som_for_unstructured_clicks`` (#300, default off).
+
+        Anything other than ``disabled`` keeps the dataclass default,
+        so unset / empty env vars never accidentally flip the policy.
+        """
+        def _on(name: str, default: bool) -> bool:
+            v = os.environ.get(name, "").strip().lower()
+            if not v:
+                return default
+            if v == "disabled":
+                return False
+            if v == "enabled":
+                return True
+            return default
+
+        return cls(
+            plan_executor_enabled=_on("MANTIS_ROUTE_PLAN_EXECUTOR", True),
+            som_enabled=_on("MANTIS_ROUTE_SOM", True),
+            som_for_unstructured_clicks=_on(
+                "MANTIS_ROUTE_SOM_CLICKS", False,
+            ),
+        )
+
 
 # Subset of ``gym_result.info`` that round-trips into TrajectoryStep
 # observed_state. Excludes high-cardinality / large-blob fields (raw DOM,
@@ -244,6 +355,15 @@ class RunResult:
     # the policy never fired (toggle off, no soft loops, or no rule
     # matched). Surfaces on /v1/cua.
     loop_recoveries_by_reason: dict[str, int] = field(default_factory=dict)
+    # #295 / #300: per-backend trajectory-step counts. Keys are the
+    # values of :attr:`TrajectoryStep.executor_backend` (``"plan"``,
+    # ``"som"``, ``"vision"``); the empty-string backend is dropped
+    # from the aggregate so consumers can read "how many steps came
+    # from which dispatch path?" without filtering. Empty dict when
+    # no classified backend ever fired (e.g. a paused-only trajectory).
+    # Surfaces on /v1/cua so callers can read the routing mix without
+    # parsing the trajectory.
+    executor_backend_counts: dict[str, int] = field(default_factory=dict)
 
 
 # ── Trajectory serialization for pause snapshots (#285) ────────────────────
@@ -279,6 +399,7 @@ def _trajectory_step_to_dict(step: TrajectoryStep) -> dict[str, Any]:
         "done_rejected_reason": step.done_rejected_reason,
         "action_effect_observed": step.action_effect_observed,
         "loop_recovery_reason": step.loop_recovery_reason,
+        "executor_backend": step.executor_backend,
     }
 
 
@@ -307,6 +428,7 @@ def _trajectory_step_from_dict(payload: dict[str, Any]) -> TrajectoryStep:
         done_rejected_reason=str(payload.get("done_rejected_reason", "")),
         action_effect_observed=payload.get("action_effect_observed"),
         loop_recovery_reason=str(payload.get("loop_recovery_reason", "")),
+        executor_backend=str(payload.get("executor_backend", "")),
     )
 
 
@@ -336,6 +458,7 @@ class GymRunner:
         on_step: Any = None,
         site_config: Any = None,
         cancel_event: Any = None,
+        routing_policy: RoutingPolicy | None = None,
     ):
         self.brain = brain
         self.env = env
@@ -346,6 +469,12 @@ class GymRunner:
         self.hard_loop_window = hard_loop_window
         self.plan_executor = plan_executor
         self.page_discovery = page_discovery
+        # #295 / #300: dispatch policy. Default reads ``MANTIS_ROUTE_*``
+        # env toggles so a deploy can flip the routing mix per request
+        # without restarting; explicit callers (tests, host integrations
+        # that want a fixed policy) pass a :class:`RoutingPolicy`
+        # instance and bypass the env overrides.
+        self.routing_policy = routing_policy or RoutingPolicy.from_env()
         self.on_step = on_step  # Optional: fn(dict) -> None for live viewer
         # #117 step 1: when site_config.prefer_som_grounding is True, the
         # runner tries SoM (page_discovery + brain choice) BEFORE direct
@@ -777,11 +906,15 @@ class GymRunner:
                             thinking=f"SoM-promoted execution: {current_plan_step.action}",
                             reward=0.0, done=False, inference_time=0.0,
                             feedback=feedback,
+                            executor_backend="som",
                         ))
                         last_url = self.env.current_url if hasattr(self.env, 'current_url') else last_url
                         continue
 
-                if self.plan_executor.can_execute(current_plan_step):
+                if (
+                    self.routing_policy.plan_executor_enabled
+                    and self.plan_executor.can_execute(current_plan_step)
+                ):
                     step_result = self.plan_executor.execute(current_plan_step, plan_inputs)
                     print(f"  [executor] result: success={step_result.success} detail={step_result.detail}")
 
@@ -810,6 +943,7 @@ class GymRunner:
                             done=False,
                             inference_time=0.0,
                             feedback=feedback,
+                            executor_backend="plan",
                         ))
 
                         # Check if we completed all plan steps
@@ -823,16 +957,20 @@ class GymRunner:
                                     thinking="All plan steps completed and verified",
                                     reward=1.0, done=True, inference_time=0.0,
                                     feedback=feedback,
+                                    executor_backend="plan",
                                 )
                                 break
 
                         last_url = step_result.url_after or last_url
                         continue
                     else:
-                        # Direct execution failed — try DOM discovery + brain choice
+                        # Direct execution failed (PlanExecutor returned
+                        # success=False — treat that as the documented
+                        # "NotApplicable" fallthrough from issue #295) —
+                        # try DOM discovery + brain choice before vision.
                         print("  [executor] direct failed, trying discovery...")
 
-                        if self.page_discovery:
+                        if self.routing_policy.som_enabled and self.page_discovery:
                             discovery_result = self._try_discovery_execution(
                                 current_plan_step, plan_inputs, step_log, frame_history,
                             )
@@ -857,6 +995,7 @@ class GymRunner:
                                     thinking=f"Discovery execution: {current_plan_step.action}",
                                     reward=0.0, done=False, inference_time=0.0,
                                     feedback=feedback,
+                                    executor_backend="som",
                                 ))
                                 last_url = self.env.current_url if hasattr(self.env, 'current_url') else last_url
                                 continue
@@ -1114,6 +1253,7 @@ class GymRunner:
                             trajectory.append(TrajectoryStep(
                                 step=step_num, action=action, thinking=thinking,
                                 reward=0.0, done=True, inference_time=inference_time,
+                                executor_backend="vision",
                             ))
                             termination_reason = "done"
                             break
@@ -1121,6 +1261,7 @@ class GymRunner:
                         trajectory.append(TrajectoryStep(
                             step=step_num, action=action, thinking=thinking,
                             reward=0.0, done=True, inference_time=inference_time,
+                            executor_backend="vision",
                         ))
                         termination_reason = "done"
                         break
@@ -1586,6 +1727,7 @@ class GymRunner:
                     done_rejected_reason=pending_done_rejected_reason,
                     action_effect_observed=effect_check.effect_observed,
                     loop_recovery_reason=pending_loop_recovery_reason,
+                    executor_backend="vision",
                 ))
                 # One-shot: clear so the next step doesn't inherit it.
                 pending_done_rejected_reason = ""
@@ -1654,6 +1796,16 @@ class GymRunner:
                     loop_recoveries_by_reason.get(t.loop_recovery_reason, 0) + 1
                 )
 
+        # #295 / #300: per-backend trajectory-step counts. Empty-string
+        # backends (tool-call dispatch, pause/resume, etc.) are dropped
+        # so the aggregate reads as a clean routing-mix summary.
+        executor_backend_counts: dict[str, int] = {}
+        for t in trajectory:
+            if t.executor_backend:
+                executor_backend_counts[t.executor_backend] = (
+                    executor_backend_counts.get(t.executor_backend, 0) + 1
+                )
+
         result = RunResult(
             task=task, task_id=task_id, success=success,
             total_reward=total_reward, total_steps=len(trajectory),
@@ -1662,6 +1814,7 @@ class GymRunner:
             done_rejections_by_reason=dict(done_rejections_by_reason),
             perceptual_summary=perceptual_summary,
             loop_recoveries_by_reason=loop_recoveries_by_reason,
+            executor_backend_counts=executor_backend_counts,
         )
 
         # Terminal reward — applied last so episode() can read the full
@@ -1958,10 +2111,26 @@ class GymRunner:
     def _should_prefer_som(self) -> bool:
         """Return True when the site config opts into SoM-first dispatch.
 
-        SoM-first only fires when both ``site_config.prefer_som_grounding``
-        is True AND a ``page_discovery`` instance is available — without
-        DOM access there's no SoM candidate set to choose from.
+        SoM-first only fires when:
+
+        * The routing policy hasn't disabled the SoM branch
+          (:attr:`RoutingPolicy.som_enabled`, default True).
+        * ``site_config.prefer_som_grounding`` is True.
+        * The caller wired ``page_discovery`` on the runner (without
+          DOM access there's no SoM candidate set to choose from).
+
+        The ``page_discovery`` check stays at the call site so existing
+        callers that only set ``site_config.prefer_som_grounding``
+        without wiring discovery don't get an unexpected behavior
+        change.
         """
+        # ``routing_policy`` may be absent on instances built via
+        # ``GymRunner.__new__`` (legacy ``test_som_promotion`` pattern);
+        # treat the missing attr as "default policy" so existing tests
+        # don't need to know about it.
+        policy = getattr(self, "routing_policy", None)
+        if policy is not None and not policy.som_enabled:
+            return False
         cfg = self.site_config
         return bool(cfg is not None and getattr(cfg, "prefer_som_grounding", False))
 

--- a/src/mantis_agent/gym/runner.py
+++ b/src/mantis_agent/gym/runner.py
@@ -1561,6 +1561,58 @@ class GymRunner:
                     )
                     gym_result = self.env.step(pre_action)
                     action_history.append(pre_action)
+
+                # #300: SoM-anchored click. When the policy promotes SoM
+                # for unstructured clicks AND the env exposes a CDP
+                # ``cdp_click_at_point`` method, hand the click off to
+                # ``document.elementFromPoint(x,y).click()`` instead of
+                # the xdotool mouse pipeline. Fixes the #88 row-click
+                # failure (xdotool's synthetic ``mousedown`` doesn't
+                # route to React's onClick on some SPAs) without
+                # changing the brain's emitted coordinates.
+                #
+                # Only fires on a plain CLICK that wasn't already
+                # substituted by force-fill / force-submit / loop-recovery
+                # — those carry their own execution semantics.
+                #
+                # On success, the original CLICK is swapped for a brief
+                # WAIT so :meth:`env.step` still runs the settle / capture
+                # loop but doesn't *also* fire the xdotool click. On
+                # failure (no DOM element at (x,y), CDP unreachable, JS
+                # threw) the original action falls through untouched.
+                pending_executor_backend: str = "vision"
+                if (
+                    not substituted_action
+                    and action.action_type == ActionType.CLICK
+                    and getattr(self.routing_policy, "som_for_unstructured_clicks", False)
+                    and hasattr(self.env, "cdp_click_at_point")
+                ):
+                    raw_x = action.params.get("x")
+                    raw_y = action.params.get("y")
+                    if raw_x is not None and raw_y is not None:
+                        try:
+                            cdp_ok = bool(self.env.cdp_click_at_point(
+                                int(raw_x), int(raw_y),
+                            ))
+                        except Exception as exc:
+                            logger.warning("SoM CDP click raised: %s", exc)
+                            cdp_ok = False
+                        if cdp_ok:
+                            logger.info(
+                                "SoM: dispatched CDP click at (%s,%s); "
+                                "swapping xdotool click for no-op wait",
+                                raw_x, raw_y,
+                            )
+                            pending_executor_backend = "som"
+                            action = Action(
+                                ActionType.WAIT,
+                                {"seconds": 0.0},
+                                reasoning=(
+                                    f"SoM: CDP-dispatched click at "
+                                    f"({raw_x},{raw_y})"
+                                ),
+                            )
+
                 gym_result = self.env.step(action)
                 action_history.append(action)
                 for post_action in post_actions:
@@ -1727,7 +1779,7 @@ class GymRunner:
                     done_rejected_reason=pending_done_rejected_reason,
                     action_effect_observed=effect_check.effect_observed,
                     loop_recovery_reason=pending_loop_recovery_reason,
-                    executor_backend="vision",
+                    executor_backend=pending_executor_backend,
                 ))
                 # One-shot: clear so the next step doesn't inherit it.
                 pending_done_rejected_reason = ""

--- a/src/mantis_agent/gym/xdotool_env.py
+++ b/src/mantis_agent/gym/xdotool_env.py
@@ -287,6 +287,84 @@ class XdotoolGymEnv(GymEnvironment):
             env=self._env, capture_output=True, timeout=5,
         )
 
+    def _cdp_call(
+        self, method: str, params: dict[str, Any] | None = None,
+        *, timeout: float = 3.0,
+    ) -> tuple[bool, Any]:
+        """One-shot CDP request against the active page.
+
+        Resolves the active page's WebSocket debugger URL via the
+        ``/json/list`` REST endpoint, opens a synchronous WebSocket
+        connection, sends a single ``{id, method, params}`` request, and
+        polls for the matching response.
+
+        Returns ``(ok, payload)`` where ``payload`` is the parsed
+        ``result`` dict on success and an empty dict on failure. Caller
+        sites decide how to interpret a missing key — :meth:`cdp_evaluate`
+        unwraps ``result.value``, :meth:`cdp_click_at_point` only cares
+        about ``ok``.
+
+        Failure paths (CDP unreachable, no eligible page, ws import
+        missing, timeout) all return ``(False, {})`` so callers fall
+        back to the legacy xdotool path. Errors are logged at WARNING
+        level so a flaky CDP doesn't silently mute the entire SoM
+        routing path.
+        """
+        try:
+            import json as _json
+            import urllib.request
+            try:
+                import websocket  # websocket-client package
+            except ImportError:
+                return False, {}
+            with urllib.request.urlopen(
+                f"http://127.0.0.1:{self._cdp_port}/json/list",
+                timeout=2,
+            ) as resp:
+                tabs = _json.loads(resp.read().decode())
+            ws_url: str | None = None
+            for tab in tabs:
+                if tab.get("type") != "page":
+                    continue
+                url = str(tab.get("url") or "")
+                if not url or url.startswith("chrome://") or url.startswith("about:"):
+                    continue
+                ws_url = tab.get("webSocketDebuggerUrl")
+                if ws_url:
+                    break
+            if not ws_url:
+                return False, {}
+            ws = websocket.create_connection(ws_url, timeout=timeout)
+            try:
+                req_id = int(time.time() * 1000) % 1_000_000
+                ws.send(_json.dumps({
+                    "id": req_id,
+                    "method": method,
+                    "params": params or {},
+                }))
+                ws.settimeout(timeout)
+                for _ in range(16):
+                    raw = ws.recv()
+                    if not raw:
+                        continue
+                    decoded = _json.loads(raw)
+                    if decoded.get("id") != req_id:
+                        # Drop background CDP events while waiting for
+                        # our response id (eg lifecycle, frame nav).
+                        continue
+                    if decoded.get("error"):
+                        return False, decoded.get("error") or {}
+                    return True, decoded.get("result") or {}
+                return False, {}
+            finally:
+                try:
+                    ws.close()
+                except Exception:
+                    pass
+        except Exception as exc:
+            logger.warning("CDP %s failed: %s", method, exc)
+            return False, {}
+
     def _cdp_insert_text(self, text: str) -> bool:
         """Type text via Chrome DevTools Protocol's Input.insertText.
 
@@ -301,58 +379,66 @@ class XdotoolGymEnv(GymEnvironment):
         (run 020-031, b3b4364 commit history). Click/scroll/screenshot
         stay xdotool; only the type-text execution moves to CDP.
         """
-        try:
-            import json as _json
-            import urllib.request
-            try:
-                import websocket  # websocket-client package
-            except ImportError:
-                return False
-            with urllib.request.urlopen(
-                f"http://127.0.0.1:{self._cdp_port}/json/list",
-                timeout=2,
-            ) as resp:
-                tabs = _json.loads(resp.read().decode())
-            ws_url = None
-            for tab in tabs:
-                if tab.get("type") != "page":
-                    continue
-                url = str(tab.get("url") or "")
-                if not url or url.startswith("chrome://") or url.startswith("about:"):
-                    continue
-                ws_url = tab.get("webSocketDebuggerUrl")
-                if ws_url:
-                    break
-            if not ws_url:
-                return False
-            ws = websocket.create_connection(ws_url, timeout=3)
-            try:
-                req_id = int(time.time() * 1000) % 1_000_000
-                ws.send(_json.dumps({
-                    "id": req_id,
-                    "method": "Input.insertText",
-                    "params": {"text": text},
-                }))
-                ws.settimeout(3)
-                for _ in range(8):
-                    raw = ws.recv()
-                    if not raw:
-                        continue
-                    resp = _json.loads(raw)
-                    if resp.get("id") != req_id:
-                        continue
-                    if resp.get("error"):
-                        return False
-                    return True
-                return False
-            finally:
-                try:
-                    ws.close()
-                except Exception:
-                    pass
-        except Exception as exc:
-            logger.warning("CDP insertText failed: %s", exc)
-            return False
+        ok, _ = self._cdp_call("Input.insertText", {"text": text})
+        return ok
+
+    def cdp_evaluate(self, expression: str) -> Any:
+        """Run a JS expression via CDP ``Runtime.evaluate``.
+
+        Returns the unwrapped ``result.value`` (any JSON-serializable
+        type), or ``None`` on any failure (CDP unreachable, JS threw,
+        result not serializable). Used by :class:`PageDiscovery` to
+        scan the DOM and by :meth:`cdp_click_at_point` to dispatch a
+        synthetic click on the topmost element at a screen point —
+        both are #300 routing primitives that need to work in the
+        production xdotool path where there's no Playwright ``page``.
+        """
+        ok, payload = self._cdp_call(
+            "Runtime.evaluate",
+            {
+                "expression": expression,
+                "returnByValue": True,
+                "awaitPromise": False,
+            },
+        )
+        if not ok:
+            return None
+        # ``Runtime.evaluate`` returns ``{result: {type, value}}``;
+        # ``value`` is missing for ``undefined`` results — treat that
+        # as None too rather than KeyError-ing on the caller.
+        return (payload.get("result") or {}).get("value")
+
+    def cdp_click_at_point(self, x: int, y: int) -> bool:
+        """SoM-anchored click: find the element at (x, y) and call
+        ``el.click()`` via Runtime.evaluate.
+
+        Why this isn't just xdotool: xdotool sends X-level mouse events
+        that Chrome maps to synthetic ``mousedown`` / ``mouseup`` /
+        ``click`` DOM events. On SPA rows whose handler is bound via
+        ``onPointerDown`` (or whose ``mousedown`` calls
+        ``stopPropagation``) the actual click handler never fires — the
+        well-known #88 row-click failure. Dispatching ``el.click()``
+        directly invokes the element's click listeners *and* the
+        framework's synthetic event chain (React onClick, etc.), so the
+        click reaches the handler.
+
+        Returns ``True`` iff an element was found at (x, y) and the JS
+        click was dispatched successfully. Returns ``False`` if CDP is
+        unreachable, no element exists at the point, or the JS threw.
+        Caller is expected to fall back to xdotool on ``False``.
+        """
+        # Use a self-executing function so the eval result is a clean
+        # boolean. ``elementFromPoint`` returns ``null`` for points
+        # outside the viewport — that surfaces as ``False`` here.
+        js = (
+            "(() => {"
+            f"const el = document.elementFromPoint({int(x)}, {int(y)});"
+            "if (!el) return false;"
+            "try { el.click(); return true; }"
+            "catch (e) { return false; }"
+            "})()"
+        )
+        return bool(self.cdp_evaluate(js))
 
     def _xdotool_type(self, text: str) -> None:
         """Type text via clipboard-paste (preferred) or xdotool fallback.

--- a/tests/test_routing_som_unstructured_clicks.py
+++ b/tests/test_routing_som_unstructured_clicks.py
@@ -1,0 +1,257 @@
+"""SoM-anchored click dispatch for unstructured CLICK actions (#300).
+
+When ``RoutingPolicy.som_for_unstructured_clicks`` is on AND the env
+exposes :meth:`XdotoolGymEnv.cdp_click_at_point` (or equivalent), the
+runner hands a brain-emitted CLICK off to a CDP-dispatched
+``el.click()`` instead of the legacy xdotool mouse pipeline. The
+substituted trajectory step is tagged ``executor_backend=som``.
+
+This pins:
+
+* Policy gating: ``som_for_unstructured_clicks=False`` keeps current
+  behaviour (every CLICK goes through xdotool and tags ``vision``).
+* Capability gating: an env without ``cdp_click_at_point`` falls
+  through to xdotool even with the policy on.
+* Successful dispatch swaps the CLICK for a no-op WAIT so :meth:`env.step`
+  doesn't double-click, and the trajectory carries ``som``.
+* CDP failure (returns False) preserves the original CLICK and the
+  trajectory tags ``vision``.
+
+Plus :class:`PageDiscovery`'s CDP backend (its plan-step
+``_try_discovery_execution`` consumer is exercised by the existing
+``_try_discovery_execution`` integration; here we cover the
+PageDiscovery internals end-to-end via a fake CDP env).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from PIL import Image
+
+from mantis_agent.actions import Action, ActionType
+from mantis_agent.gym.base import GymEnvironment, GymObservation, GymResult
+from mantis_agent.gym.page_discovery import PageDiscovery
+from mantis_agent.gym.runner import GymRunner, RoutingPolicy
+
+
+# ── Fakes ───────────────────────────────────────────────────────────────
+
+
+@dataclass
+class _BrainResult:
+    action: Action
+    thinking: str = ""
+    predicted_outcome: str = ""
+
+
+class _ScriptedBrain:
+    def __init__(self, script: list[Action]) -> None:
+        self.script = list(script)
+        self.calls = 0
+
+    def think(
+        self, frames: Any, task: str, action_history: Any = None,
+        screen_size: tuple[int, int] = (100, 100),
+    ) -> _BrainResult:
+        if self.calls >= len(self.script):
+            self.calls += 1
+            return _BrainResult(Action(
+                ActionType.DONE, {"success": True, "summary": "done"},
+            ))
+        action = self.script[self.calls]
+        self.calls += 1
+        return _BrainResult(action)
+
+
+class _CdpEnv(GymEnvironment):
+    """Env that exposes a stub ``cdp_click_at_point`` and counts xdotool steps."""
+
+    def __init__(self, cdp_returns: list[bool] | None = None) -> None:
+        self._frame = Image.new("RGB", (100, 100), color=(200, 200, 200))
+        self.xdotool_clicks: list[tuple[int, int]] = []
+        self.cdp_clicks: list[tuple[int, int]] = []
+        self._cdp_returns = list(cdp_returns or [])
+
+    @property
+    def screen_size(self) -> tuple[int, int]:
+        return (100, 100)
+
+    def reset(self, task: str, **kwargs: Any) -> GymObservation:
+        return GymObservation(screenshot=self._frame)
+
+    def step(self, action: Action) -> GymResult:
+        # Only record xdotool clicks the env would have executed. A
+        # WAIT means the runner already SoM-dispatched via CDP and
+        # asked the env to no-op.
+        if action.action_type == ActionType.CLICK:
+            self.xdotool_clicks.append((
+                int(action.params.get("x", 0)),
+                int(action.params.get("y", 0)),
+            ))
+        return GymResult(
+            GymObservation(screenshot=self._frame),
+            reward=0.0, done=False, info={"url": "https://x.test/a", "title": "A"},
+        )
+
+    def close(self) -> None:
+        pass
+
+    def cdp_click_at_point(self, x: int, y: int) -> bool:
+        self.cdp_clicks.append((x, y))
+        if self._cdp_returns:
+            return self._cdp_returns.pop(0)
+        return True
+
+
+class _NoCdpEnv(_CdpEnv):
+    """Env without the CDP shim — covers capability gating."""
+
+    cdp_click_at_point = None  # type: ignore[assignment]
+
+
+# ── Runner integration ─────────────────────────────────────────────────
+
+
+def test_som_dispatch_swaps_click_when_policy_on_and_cdp_succeeds() -> None:
+    """Policy on + CDP available + CDP returns True ⇒ trajectory tagged
+    ``som`` and xdotool sees no CLICK."""
+    brain = _ScriptedBrain([Action(ActionType.CLICK, {"x": 42, "y": 7})])
+    env = _CdpEnv(cdp_returns=[True])
+    runner = GymRunner(
+        brain=brain, env=env, max_steps=3,
+        routing_policy=RoutingPolicy(som_for_unstructured_clicks=True),
+    )
+    result = runner.run("som task")
+
+    assert env.cdp_clicks == [(42, 7)]
+    assert env.xdotool_clicks == [], "env should not see an xdotool click"
+    backends = [
+        s.executor_backend for s in result.trajectory if s.executor_backend
+    ]
+    assert "som" in backends, backends
+    assert result.executor_backend_counts.get("som", 0) == 1
+
+
+def test_som_dispatch_falls_back_to_vision_when_cdp_fails() -> None:
+    """CDP returns False ⇒ original CLICK reaches the env via xdotool
+    and trajectory carries ``vision``."""
+    brain = _ScriptedBrain([Action(ActionType.CLICK, {"x": 10, "y": 11})])
+    env = _CdpEnv(cdp_returns=[False])
+    runner = GymRunner(
+        brain=brain, env=env, max_steps=3,
+        routing_policy=RoutingPolicy(som_for_unstructured_clicks=True),
+    )
+    result = runner.run("som-miss task")
+
+    assert env.cdp_clicks == [(10, 11)]
+    assert env.xdotool_clicks == [(10, 11)], "env should see the xdotool fallback click"
+    backends = [
+        s.executor_backend for s in result.trajectory if s.executor_backend
+    ]
+    assert "som" not in backends
+    assert "vision" in backends
+
+
+def test_som_dispatch_disabled_by_default() -> None:
+    """Default policy (``som_for_unstructured_clicks=False``) keeps the
+    legacy xdotool path even when CDP is available."""
+    brain = _ScriptedBrain([Action(ActionType.CLICK, {"x": 50, "y": 60})])
+    env = _CdpEnv()
+    runner = GymRunner(brain=brain, env=env, max_steps=3)
+    result = runner.run("legacy task")
+
+    assert env.cdp_clicks == [], "CDP must not fire when policy is off"
+    assert env.xdotool_clicks == [(50, 60)]
+    assert all(
+        s.executor_backend in ("", "vision")
+        for s in result.trajectory
+    ), [s.executor_backend for s in result.trajectory]
+
+
+def test_som_dispatch_skips_when_env_lacks_cdp() -> None:
+    """An env that doesn't expose ``cdp_click_at_point`` falls through
+    to xdotool even with the policy on — capability gating."""
+    brain = _ScriptedBrain([Action(ActionType.CLICK, {"x": 5, "y": 6})])
+    env = _NoCdpEnv()
+    runner = GymRunner(
+        brain=brain, env=env, max_steps=3,
+        routing_policy=RoutingPolicy(som_for_unstructured_clicks=True),
+    )
+    result = runner.run("no-cdp task")
+
+    assert env.xdotool_clicks == [(5, 6)]
+    backends = [
+        s.executor_backend for s in result.trajectory if s.executor_backend
+    ]
+    assert "som" not in backends
+
+
+# ── PageDiscovery CDP backend ──────────────────────────────────────────
+
+
+class _CdpDiscoveryEnv:
+    """Minimal env exposing :meth:`cdp_evaluate` + :meth:`cdp_click_at_point`
+    for the PageDiscovery CDP backend tests. Not a full GymEnvironment —
+    only the shims PageDiscovery needs."""
+
+    def __init__(self, elements: list[dict]) -> None:
+        self._elements = elements
+        self.evaluate_calls: list[str] = []
+        self.cdp_clicks: list[tuple[int, int]] = []
+
+    def cdp_evaluate(self, expression: str):
+        self.evaluate_calls.append(expression)
+        # The discovery JS expects a list of element dicts; everything
+        # else returns None.
+        if "querySelectorAll" in expression:
+            return list(self._elements)
+        return None
+
+    def cdp_click_at_point(self, x: int, y: int) -> bool:
+        self.cdp_clicks.append((x, y))
+        return True
+
+
+def test_page_discovery_cdp_backend_discovers_elements() -> None:
+    """PageDiscovery without a Playwright page should drive discovery
+    through the env's ``cdp_evaluate`` shim."""
+    env = _CdpDiscoveryEnv(elements=[
+        {"tag": "button", "text": "Login", "type": "submit", "role": "",
+         "name": "submit", "id": "login-btn", "placeholder": "",
+         "ariaLabel": "", "value": "", "href": "",
+         "bbox": {"x": 10, "y": 20, "w": 80, "h": 30}},
+        {"tag": "a", "text": "Forgot password", "type": "", "role": "",
+         "name": "", "id": "", "placeholder": "", "ariaLabel": "",
+         "value": "", "href": "/forgot",
+         "bbox": {"x": 10, "y": 60, "w": 120, "h": 20}},
+    ])
+
+    discovery = PageDiscovery(env=env)
+    elements = discovery.discover()
+
+    assert env.evaluate_calls, "PageDiscovery should have called cdp_evaluate"
+    assert len(elements) == 2
+    assert elements[0].text == "Login"
+    assert elements[1].href == "/forgot"
+
+
+def test_page_discovery_cdp_backend_click_uses_cdp_click_at_point() -> None:
+    """``click_element`` on the CDP backend dispatches via
+    :meth:`cdp_click_at_point` using the bbox center."""
+    env = _CdpDiscoveryEnv(elements=[
+        {"tag": "button", "text": "Save", "bbox": {"x": 100, "y": 200, "w": 40, "h": 20}},
+    ])
+    discovery = PageDiscovery(env=env)
+    discovery.discover()
+    assert discovery.click_element(0) is True
+    # bbox center: (100 + 40//2, 200 + 20//2) = (120, 210)
+    assert env.cdp_clicks == [(120, 210)]
+
+
+def test_page_discovery_returns_empty_when_no_backend() -> None:
+    """No Playwright page, no CDP shim ⇒ discover() returns an empty list
+    (existing behaviour preserved)."""
+    discovery = PageDiscovery()  # neither page nor env wired
+    assert discovery.discover() == []

--- a/tests/test_runner_executor_backend.py
+++ b/tests/test_runner_executor_backend.py
@@ -1,0 +1,275 @@
+"""GymRunner routing-backend telemetry (#295 + foundation for #300).
+
+Asserts that every classified trajectory step carries an
+``executor_backend`` tag and that the per-backend aggregate on
+:class:`RunResult.executor_backend_counts` adds up.
+
+The runner exposes three classified backends:
+
+* ``plan``   — :class:`PlanExecutor.execute` ran a structured plan step
+                deterministically.
+* ``som``    — :class:`PageDiscovery` (Set-of-Mark) picked an element
+                and the runner executed via DOM.
+* ``vision`` — brain emitted raw coordinates / keystrokes that the env
+                executed.
+
+Routing decisions are gated by :class:`RoutingPolicy`, which is also
+covered here (env-toggle parsing + default behaviour).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+from PIL import Image
+
+from mantis_agent.actions import Action, ActionType
+from mantis_agent.gym.base import GymEnvironment, GymObservation, GymResult
+from mantis_agent.gym.plans import Plan, PlanStep
+from mantis_agent.gym.runner import (
+    GymRunner,
+    RoutingPolicy,
+    TrajectoryStep,
+    _trajectory_step_from_dict,
+    _trajectory_step_to_dict,
+)
+
+
+# ── Fakes ───────────────────────────────────────────────────────────────
+
+
+@dataclass
+class _BrainResult:
+    action: Action
+    thinking: str = ""
+    predicted_outcome: str = ""
+
+
+class _ScriptedBrain:
+    """Emits a fixed sequence of actions then auto-DONE."""
+
+    def __init__(self, script: list[Action]) -> None:
+        self.script = list(script)
+        self.calls = 0
+
+    def think(
+        self,
+        frames: Any,
+        task: str,
+        action_history: Any = None,
+        screen_size: tuple[int, int] = (100, 100),
+    ) -> _BrainResult:
+        if self.calls >= len(self.script):
+            self.calls += 1
+            return _BrainResult(Action(
+                ActionType.DONE, {"success": True, "summary": "done"},
+            ))
+        action = self.script[self.calls]
+        self.calls += 1
+        return _BrainResult(action)
+
+
+class _NoopEnv(GymEnvironment):
+    """Minimal env that returns the same screenshot every step."""
+
+    def __init__(self) -> None:
+        self._frame = Image.new("RGB", (100, 100), color=(128, 128, 128))
+
+    @property
+    def screen_size(self) -> tuple[int, int]:
+        return (100, 100)
+
+    def reset(self, task: str, **kwargs: Any) -> GymObservation:
+        return GymObservation(screenshot=self._frame)
+
+    def step(self, action: Action) -> GymResult:
+        return GymResult(
+            GymObservation(screenshot=self._frame),
+            reward=0.0, done=False, info={"url": "https://x.test/a", "title": "A"},
+        )
+
+    def close(self) -> None:
+        pass
+
+
+class _FakeStepResult:
+    def __init__(self, success: bool, detail: str = "", url_after: str = "") -> None:
+        self.success = success
+        self.method = "direct"
+        self.detail = detail
+        self.url_after = url_after
+
+
+class _FakePlanExecutor:
+    """Returns success on every can_execute / execute call."""
+
+    def __init__(self, will_succeed: bool = True) -> None:
+        self._will_succeed = will_succeed
+        self.calls = 0
+
+    def can_execute(self, step: PlanStep) -> bool:
+        return True
+
+    def execute(
+        self, step: PlanStep, plan_inputs: dict[str, str],
+    ) -> _FakeStepResult:
+        self.calls += 1
+        return _FakeStepResult(
+            success=self._will_succeed,
+            detail=f"executed {step.action}: {step.target}",
+            url_after="https://x.test/after",
+        )
+
+
+# ── Vision-only run ─────────────────────────────────────────────────────
+
+
+def test_vision_only_run_tags_every_step_as_vision() -> None:
+    """No plan + no executors → every classified step is ``vision``."""
+    brain = _ScriptedBrain([
+        Action(ActionType.CLICK, {"x": 1, "y": 1}),
+        Action(ActionType.WAIT, {"seconds": 0.1}),
+    ])
+    env = _NoopEnv()
+    runner = GymRunner(brain, env, max_steps=4)
+    result = runner.run("vision-only task")
+
+    backends = [s.executor_backend for s in result.trajectory]
+    assert backends, "should produce at least one step"
+    assert all(b == "vision" for b in backends), backends
+    assert result.executor_backend_counts == {"vision": len(backends)}
+
+
+# ── PlanExecutor branch ─────────────────────────────────────────────────
+
+
+def test_plan_executor_success_tags_steps_as_plan() -> None:
+    """Plan + PlanExecutor returning success → executor_backend=plan."""
+    plan = Plan(
+        name="t", description="", url="https://x.test",
+        steps=[
+            PlanStep(action="click", target="Login button"),
+            PlanStep(action="click", target="Continue"),
+        ],
+    )
+    brain = _ScriptedBrain([
+        Action(ActionType.DONE, {"success": True, "summary": "done"}),
+    ])
+    env = _NoopEnv()
+    plan_executor = _FakePlanExecutor(will_succeed=True)
+    runner = GymRunner(
+        brain=brain, env=env, max_steps=5, plan_executor=plan_executor,
+    )
+    result = runner.run("plan-driven task", plan=plan)
+
+    # Both plan steps should execute deterministically.
+    assert plan_executor.calls == 2
+    plan_steps = [s for s in result.trajectory if s.executor_backend == "plan"]
+    assert len(plan_steps) == 2, [s.executor_backend for s in result.trajectory]
+    assert result.executor_backend_counts.get("plan") == 2
+
+
+def test_plan_executor_disabled_falls_through_to_vision() -> None:
+    """``RoutingPolicy.plan_executor_enabled=False`` skips the plan branch.
+
+    The plan exists but the runner ignores PlanExecutor and lets the
+    brain drive every step — every classified step ends up tagged
+    ``vision`` even though a PlanExecutor is wired.
+    """
+    plan = Plan(
+        name="t", description="", url="https://x.test",
+        steps=[PlanStep(action="click", target="Login button")],
+    )
+    brain = _ScriptedBrain([
+        Action(ActionType.CLICK, {"x": 1, "y": 1}),
+        Action(ActionType.DONE, {"success": True, "summary": "done"}),
+    ])
+    plan_executor = _FakePlanExecutor(will_succeed=True)
+    runner = GymRunner(
+        brain=brain, env=_NoopEnv(), max_steps=4,
+        plan_executor=plan_executor,
+        routing_policy=RoutingPolicy(plan_executor_enabled=False),
+    )
+    result = runner.run("plan-driven task", plan=plan)
+
+    # PlanExecutor must not have run.
+    assert plan_executor.calls == 0
+    backends = [s.executor_backend for s in result.trajectory]
+    assert all(b == "vision" for b in backends if b), backends
+    assert "plan" not in result.executor_backend_counts
+
+
+# ── RoutingPolicy.from_env ──────────────────────────────────────────────
+
+
+def test_routing_policy_from_env_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Empty env yields the dataclass defaults."""
+    for v in (
+        "MANTIS_ROUTE_PLAN_EXECUTOR",
+        "MANTIS_ROUTE_SOM",
+        "MANTIS_ROUTE_SOM_CLICKS",
+    ):
+        monkeypatch.delenv(v, raising=False)
+
+    policy = RoutingPolicy.from_env()
+    assert policy.plan_executor_enabled is True
+    assert policy.som_enabled is True
+    assert policy.som_for_unstructured_clicks is False
+
+
+def test_routing_policy_from_env_disabled_flags(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``disabled`` flips each toggle off."""
+    monkeypatch.setenv("MANTIS_ROUTE_PLAN_EXECUTOR", "disabled")
+    monkeypatch.setenv("MANTIS_ROUTE_SOM", "disabled")
+    monkeypatch.setenv("MANTIS_ROUTE_SOM_CLICKS", "enabled")
+
+    policy = RoutingPolicy.from_env()
+    assert policy.plan_executor_enabled is False
+    assert policy.som_enabled is False
+    assert policy.som_for_unstructured_clicks is True
+
+
+def test_routing_policy_from_env_ignores_garbage(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unrecognized values keep the default — fail-closed on typos."""
+    monkeypatch.setenv("MANTIS_ROUTE_PLAN_EXECUTOR", "yes")  # typo for enabled
+    monkeypatch.setenv("MANTIS_ROUTE_SOM", "off")  # typo for disabled
+
+    policy = RoutingPolicy.from_env()
+    assert policy.plan_executor_enabled is True  # default kept
+    assert policy.som_enabled is True  # default kept
+
+
+# ── Trajectory round-trip ───────────────────────────────────────────────
+
+
+def test_trajectory_step_round_trip_carries_executor_backend() -> None:
+    """:func:`_trajectory_step_to_dict` ↔ :func:`_trajectory_step_from_dict`
+    preserve the new field across a pause/resume snapshot."""
+    step = TrajectoryStep(
+        step=1,
+        action=Action(ActionType.CLICK, {"x": 5, "y": 5}),
+        thinking="t", reward=0.0, done=False, inference_time=0.0,
+        executor_backend="plan",
+    )
+    payload = _trajectory_step_to_dict(step)
+    assert payload["executor_backend"] == "plan"
+    restored = _trajectory_step_from_dict(payload)
+    assert restored.executor_backend == "plan"
+
+
+def test_trajectory_step_default_executor_backend_empty() -> None:
+    """Existing pause snapshots (pre-#295) decode without crashing — the
+    missing key resolves to the empty-string default."""
+    payload = {
+        "step": 1,
+        "action": {"action_type": "click", "params": {"x": 0, "y": 0}, "reasoning": ""},
+        "thinking": "", "reward": 0.0, "done": False, "inference_time": 0.0,
+    }
+    restored = _trajectory_step_from_dict(payload)
+    assert restored.executor_backend == ""


### PR DESCRIPTION
## Summary

- Add a SoM-anchored click default that the CUA runner can use for unstructured CLICK actions. ``XdotoolGymEnv`` gains ``cdp_evaluate`` / ``cdp_click_at_point`` (CDP ``Runtime.evaluate`` over a shared ``_cdp_call`` helper; ``_cdp_insert_text`` migrates onto the helper). ``cdp_click_at_point`` calls ``document.elementFromPoint(x, y).click()`` so SPA frameworks see a real synthetic click — fixes the #88 row-click failure where xdotool's ``mousedown`` chain doesn't reach React onClick handlers.
- ``RoutingPolicy.som_for_unstructured_clicks`` (default off; env toggle ``MANTIS_ROUTE_SOM_CLICKS=enabled``) gates the rollout. When on and the env exposes CDP, the runner swaps the brain's CLICK for a no-op WAIT after a successful CDP dispatch and tags the trajectory step ``executor_backend=som`` (the #295 routing tag).
- ``PageDiscovery`` grows a CDP backend that mirrors the Playwright path; ``discover`` / ``click_element`` / ``type_into_element`` all work via ``cdp_evaluate`` / ``cdp_click_at_point`` (+ ``_cdp_insert_text`` for typing). Satisfies the issue's acceptance that PageDiscovery works on both Playwright and the production xdotool/CDP path. ``run_pure_cua`` auto-attaches a ``PageDiscovery(env=env)`` when the env exposes ``cdp_evaluate``.
- Force-fill / force-submit / loop-recovery substitutions short-circuit the SoM path; on a CDP failure the original CLICK falls through to xdotool and the trajectory tags ``vision`` — production behaviour is unchanged unless the policy is explicitly flipped.

Closes #300. Builds on #325 (#295 routing telemetry) — review that first.

## Test plan

- [x] Added ``tests/test_routing_som_unstructured_clicks.py``: policy-on + CDP success swaps to SoM (xdotool sees no click); CDP failure falls back to xdotool / vision; policy-off keeps legacy; env without ``cdp_click_at_point`` falls through; PageDiscovery CDP backend discovers + clicks; PageDiscovery with no backend returns empty.
- [x] Full local pytest sweep (2000 passed).
- [ ] Modal redeploy + staff-crm plan + lu.ma extract-loop verification (next).

🤖 Generated with [Claude Code](https://claude.com/claude-code)