### PR TITLE
feat(api): per-request route_som_clicks override on /v1/cua + /v1/predict

### DIFF
--- a/deploy/modal/modal_mantis_server.py
+++ b/deploy/modal/modal_mantis_server.py
@@ -124,6 +124,12 @@ image = (
         "openai", "requests", "pillow", "mss", "huggingface-hub",
         "fastapi>=0.100", "uvicorn>=0.20", "pydantic>=2",
         "prometheus-client>=0.20",
+        # ``websocket-client`` is what :meth:`XdotoolGymEnv._cdp_call`
+        # imports to talk to Chrome DevTools Protocol. Without it the
+        # SoM-anchored CDP click path (#300) silently no-ops and every
+        # click falls through to xdotool — defeats the whole purpose
+        # of #300 / #327 on Modal.
+        "websocket-client>=1.6",
     )
     .run_commands(
         # Pin to the same llama.cpp SHA the Baseten Truss uses (b8948).

--- a/src/mantis_agent/api_schemas.py
+++ b/src/mantis_agent/api_schemas.py
@@ -114,6 +114,14 @@ class PredictRequest(BaseModel):
     video_format: Literal["mp4", "webm", "gif"] = "mp4"
     video_fps: int = Field(default=5, ge=1, le=30)
 
+    # #300 follow-up: per-request override for
+    # :attr:`RoutingPolicy.som_for_unstructured_clicks`. ``None`` defers
+    # to the deployment env (``MANTIS_ROUTE_SOM_CLICKS``). ``True`` /
+    # ``False`` forces the toggle on / off for this run, mirroring the
+    # ablation pattern documented in ``scripts/ablate_v1_cua.py`` (the
+    # ``perceptual_verify`` / ``loop_recovery`` / ``done_gate`` toggles).
+    route_som_clicks: Optional[bool] = None
+
     @model_validator(mode="after")
     def _clamp_caps_and_validate_action(self) -> "PredictRequest":
         # Hard caps — caller cannot exceed
@@ -189,6 +197,15 @@ class PureCUARequest(BaseModel):
     record_video: bool = False
     video_format: Literal["mp4", "webm", "gif"] = "mp4"
     video_fps: int = Field(default=5, ge=1, le=30)
+
+    # #300 follow-up: per-request override for
+    # :attr:`RoutingPolicy.som_for_unstructured_clicks`. ``None``
+    # defers to the deployment env (``MANTIS_ROUTE_SOM_CLICKS``).
+    # ``True`` / ``False`` forces the toggle on / off for this run,
+    # mirroring the per-request ablation pattern used for
+    # ``perceptual_verify`` / ``loop_recovery`` / ``done_gate`` so the
+    # ablation harness can A/B without redeploying.
+    route_som_clicks: Optional[bool] = None
 
     @model_validator(mode="after")
     def _clamp_caps(self) -> "PureCUARequest":

--- a/src/mantis_agent/baseten_server/runtime.py
+++ b/src/mantis_agent/baseten_server/runtime.py
@@ -1014,6 +1014,22 @@ class BasetenCUARuntime:
             # previously-seen URLs (~$0.04/item per cache hit).
             cache = self._build_extraction_cache(task_suite, payload)
 
+            # #300 follow-up: per-request RoutingPolicy override.
+            # ``payload["route_som_clicks"]`` flips SoM-anchored
+            # CDP clicks on / off for the run; ``None`` defers to
+            # ``MANTIS_ROUTE_SOM_CLICKS``. Same override shape as
+            # /v1/cua so the ablation harness threads identically
+            # through both endpoints.
+            from ..gym.runner import RoutingPolicy
+            routing_policy = RoutingPolicy.from_env()
+            som_override = payload.get("route_som_clicks")
+            if som_override is not None:
+                routing_policy = RoutingPolicy(
+                    plan_executor_enabled=routing_policy.plan_executor_enabled,
+                    som_enabled=routing_policy.som_enabled,
+                    som_for_unstructured_clicks=bool(som_override),
+                )
+
             runner = MicroPlanRunner(
                 brain=self.brain,
                 env=env,
@@ -1027,6 +1043,7 @@ class BasetenCUARuntime:
                 max_cost=task_suite.get("_max_cost", 10.0),
                 max_time_minutes=task_suite.get("_max_time_minutes", 180),
                 extraction_cache=cache,
+                routing_policy=routing_policy,
             )
             step_results = runner.run(micro_plan, resume=resume_state)
             if cache is not None:
@@ -1298,6 +1315,18 @@ class BasetenCUARuntime:
             if hasattr(env, "cdp_evaluate"):
                 from ..gym.page_discovery import PageDiscovery
                 page_discovery = PageDiscovery(env=env)
+            # #300 follow-up: per-request RoutingPolicy override. The
+            # request can flip ``route_som_clicks`` on / off; ``None``
+            # defers to ``MANTIS_ROUTE_SOM_CLICKS``.
+            from ..gym.runner import RoutingPolicy
+            routing_policy = RoutingPolicy.from_env()
+            override = payload.get("route_som_clicks")
+            if override is not None:
+                routing_policy = RoutingPolicy(
+                    plan_executor_enabled=routing_policy.plan_executor_enabled,
+                    som_enabled=routing_policy.som_enabled,
+                    som_for_unstructured_clicks=bool(override),
+                )
             runner = GymRunner(
                 brain=brain_for_run,
                 env=env,
@@ -1305,6 +1334,7 @@ class BasetenCUARuntime:
                 frames_per_inference=frames,
                 grounding=None,  # pure CUA: no Claude grounding
                 page_discovery=page_discovery,
+                routing_policy=routing_policy,
             )
             gym_result = runner.run(
                 task=instruction,

--- a/tests/test_route_som_clicks_override.py
+++ b/tests/test_route_som_clicks_override.py
@@ -1,0 +1,136 @@
+"""Per-request ``route_som_clicks`` override for both /v1/cua and /v1/predict.
+
+The default is the environment toggle ``MANTIS_ROUTE_SOM_CLICKS``;
+callers can pin SoM on / off per request without redeploying, matching
+the ablation pattern documented in :mod:`scripts.ablate_v1_cua`. This
+module covers:
+
+1. The Pydantic request schemas (``PureCUARequest``, ``PredictRequest``)
+   accept ``route_som_clicks`` and forward it through ``model_dump``.
+2. The runtime override resolution: env default → ``True`` when request
+   says ``True`` → ``False`` when request says ``False`` → env value
+   when request says ``None``.
+
+The runtime-side resolution is the same inline ``RoutingPolicy`` builder
+used in both ``run_pure_cua`` (/v1/cua) and ``_run_micro`` (/v1/predict),
+so the test exercises the policy-build helper directly to avoid spinning
+up a full FastAPI test client / GymRunner.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mantis_agent.api_schemas import PredictRequest, PureCUARequest
+from mantis_agent.gym.runner import RoutingPolicy
+
+
+# ── Request schema accepts route_som_clicks ────────────────────────────
+
+
+def test_pure_cua_request_accepts_route_som_clicks() -> None:
+    req = PureCUARequest.model_validate({
+        "instruction": "do something",
+        "route_som_clicks": True,
+    })
+    assert req.route_som_clicks is True
+    payload = req.model_dump(exclude_none=True)
+    assert payload.get("route_som_clicks") is True
+
+
+def test_pure_cua_request_route_som_clicks_defaults_none() -> None:
+    """Unset → omitted from model_dump(exclude_none=True), so the runtime
+    sees ``payload.get("route_som_clicks") is None`` and falls back to
+    the env toggle."""
+    req = PureCUARequest.model_validate({"instruction": "x"})
+    assert req.route_som_clicks is None
+    assert "route_som_clicks" not in req.model_dump(exclude_none=True)
+
+
+def test_predict_request_accepts_route_som_clicks() -> None:
+    req = PredictRequest.model_validate({
+        "task_suite": {"_micro_plan": [{"intent": "x", "type": "navigate"}]},
+        "route_som_clicks": False,
+    })
+    assert req.route_som_clicks is False
+    payload = req.model_dump(exclude_none=True)
+    assert payload.get("route_som_clicks") is False
+
+
+def test_predict_request_route_som_clicks_omitted_when_none() -> None:
+    req = PredictRequest.model_validate({
+        "task_suite": {"_micro_plan": [{"intent": "x", "type": "navigate"}]},
+    })
+    assert req.route_som_clicks is None
+    assert "route_som_clicks" not in req.model_dump(exclude_none=True)
+
+
+# ── Runtime override resolution ────────────────────────────────────────
+
+
+def _resolve_policy(payload: dict, monkeypatch: pytest.MonkeyPatch) -> RoutingPolicy:
+    """Mirror the inline override resolution in ``runtime.run_pure_cua`` /
+    ``_run_micro``. Kept as a tiny helper so a regression in the override
+    semantics surfaces here rather than at endpoint level."""
+    policy = RoutingPolicy.from_env()
+    override = payload.get("route_som_clicks")
+    if override is not None:
+        policy = RoutingPolicy(
+            plan_executor_enabled=policy.plan_executor_enabled,
+            som_enabled=policy.som_enabled,
+            som_for_unstructured_clicks=bool(override),
+        )
+    return policy
+
+
+def test_resolve_policy_request_true_overrides_env_off(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Env says off (default); request flips on."""
+    monkeypatch.delenv("MANTIS_ROUTE_SOM_CLICKS", raising=False)
+    policy = _resolve_policy({"route_som_clicks": True}, monkeypatch)
+    assert policy.som_for_unstructured_clicks is True
+
+
+def test_resolve_policy_request_false_overrides_env_on(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Env says on; request flips off."""
+    monkeypatch.setenv("MANTIS_ROUTE_SOM_CLICKS", "enabled")
+    policy = _resolve_policy({"route_som_clicks": False}, monkeypatch)
+    assert policy.som_for_unstructured_clicks is False
+
+
+def test_resolve_policy_request_none_defers_to_env_on(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Request says None (or field absent); env wins."""
+    monkeypatch.setenv("MANTIS_ROUTE_SOM_CLICKS", "enabled")
+    policy = _resolve_policy({}, monkeypatch)
+    assert policy.som_for_unstructured_clicks is True
+
+
+def test_resolve_policy_request_none_defers_to_env_default_off(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unset env + missing request field → dataclass default ``False``."""
+    monkeypatch.delenv("MANTIS_ROUTE_SOM_CLICKS", raising=False)
+    policy = _resolve_policy({}, monkeypatch)
+    assert policy.som_for_unstructured_clicks is False
+
+
+def test_resolve_policy_preserves_other_policy_fields(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Override only flips ``som_for_unstructured_clicks`` — the other
+    policy fields (``plan_executor_enabled`` / ``som_enabled``) stay
+    whatever the env-default produced. Catches a regression where a
+    naive ``RoutingPolicy(som_for_unstructured_clicks=...)`` rebuild
+    would silently reset the others to dataclass defaults."""
+    monkeypatch.setenv("MANTIS_ROUTE_PLAN_EXECUTOR", "disabled")
+    monkeypatch.setenv("MANTIS_ROUTE_SOM", "disabled")
+    monkeypatch.delenv("MANTIS_ROUTE_SOM_CLICKS", raising=False)
+    policy = _resolve_policy({"route_som_clicks": True}, monkeypatch)
+    assert policy.som_for_unstructured_clicks is True
+    assert policy.plan_executor_enabled is False
+    assert policy.som_enabled is False


### PR DESCRIPTION
## Summary

Add an ``Optional[bool] route_som_clicks`` request field on both ``PureCUARequest`` (/v1/cua) and ``PredictRequest`` (/v1/predict). The runtime resolves the final ``RoutingPolicy`` as ``env-default → request override (when non-None)``, only flipping ``som_for_unstructured_clicks`` and preserving the other policy fields. Mirrors the per-request toggle pattern from ``scripts/ablate_v1_cua.py`` (``perceptual_verify`` / ``loop_recovery`` / ``done_gate``) so a single Modal deploy can serve both arms of a paired SoM ablation without a redeploy between runs.

Why now: after #325 / #326 / #327 wired SoM-anchored CDP clicks on both runners, the toggle was deploy-time only — defeats the per-PR ablation discipline. With this PR, a follow-up to the ablation harness can add SoM as a toggle and PRs that touch the click path can ship a Mantis-canary ablation report inline.

## Test plan

- [x] ``tests/test_route_som_clicks_override.py`` — schema acceptance (PureCUA + Predict), ``model_dump(exclude_none=True)`` semantics, runtime resolver matrix (request True over env off / request False over env on / request None defers to env / preserves ``plan_executor_enabled`` + ``som_enabled``).
- [x] Full pytest sweep — 2023 passed.
- [ ] Modal redeploy + paired lu.ma run (one with ``route_som_clicks=false`` baseline, one with ``true``) showing ``executor_backend_counts`` flipping from all-``vision`` to mixed ``som`` / ``vision``.

🤖 Generated with [Claude Code](https://claude.com/claude-code)