### PR TITLE
feat(envs): sim-env harness — runtime backends, grading, CLI wiring

### DIFF
--- a/benchmarks/sim_envs.py
+++ b/benchmarks/sim_envs.py
@@ -28,7 +28,6 @@ from __future__ import annotations
 import argparse
 import concurrent.futures
 import json
-import os
 import subprocess
 import sys
 import time

--- a/benchmarks/sim_envs.py
+++ b/benchmarks/sim_envs.py
@@ -1,0 +1,227 @@
+"""benchmarks/sim_envs.py — batch oracle-graded eval across all plans in an env.
+
+Walks ``plans/<env>/*.json`` and runs each plan against a freshly booted
+env instance. Collects ``oracle.json`` results into a single summary
+table so we can see per-task pass/fail at a glance and compare an
+agent's progress over time on the same seed.
+
+Usage::
+
+    python -m benchmarks.sim_envs --env mantis-crm --runtime local \\
+        --endpoint https://workspace--app-fn.modal.run/v1 \\
+        --output-dir outputs/bench-crm-$(date +%s)
+
+Parallelism: ``--max-workers N`` runs up to N plans concurrently. Each
+worker boots its own env instance — there's no shared container in v1
+(see #336 §"Isolation model"). The local backend hands out a free port
+per worker; the Modal backend picks a fresh run suffix per worker so
+deployed app names don't collide.
+
+This is deliberately a thin shell over ``mantis plan run --env``: every
+plan goes through the same CLI codepath, gets the same grading hook,
+writes the same artifact layout. The batch runner only handles the
+orchestration around N plans + the summary table.
+"""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+
+def _find_plans(env_name: str, plans_dir: Path) -> list[Path]:
+    """Discover ``plans/<env>/*.json`` for the env (sorted, deterministic)."""
+    target = plans_dir / env_name
+    if not target.exists():
+        return []
+    return sorted(p for p in target.glob("*.json") if p.is_file())
+
+
+def _run_one(
+    plan_path: Path,
+    *,
+    env_name: str,
+    runtime: str,
+    output_dir: Path,
+    endpoint: str | None,
+    seed: int,
+    extra_args: list[str],
+) -> dict[str, Any]:
+    """Invoke ``mantis plan run`` for one plan; return a summary dict.
+
+    Subprocess so each plan gets its own clean Python process (env vars,
+    network state, modal session). The CLI writes ``oracle.json`` next
+    to ``result.json``; we read both back into the summary.
+    """
+    plan_output = output_dir / plan_path.stem
+    cmd = [
+        sys.executable, "-m", "mantis_agent.main", "plan", "run",
+        str(plan_path),
+        "--env", env_name,
+        "--runtime", runtime,
+        "--seed", str(seed),
+        "--output-dir", str(plan_output),
+    ]
+    if endpoint:
+        cmd += ["--endpoint", endpoint]
+    cmd += extra_args
+
+    t0 = time.time()
+    proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    elapsed = time.time() - t0
+
+    oracle_path = plan_output / "oracle.json"
+    result_path = plan_output / "result.json"
+
+    grading: dict[str, Any] = {}
+    if oracle_path.exists():
+        try:
+            grading = json.loads(oracle_path.read_text())
+        except json.JSONDecodeError:
+            grading = {"error": "oracle.json not valid JSON"}
+
+    result_summary: dict[str, Any] = {}
+    if result_path.exists():
+        try:
+            payload = json.loads(result_path.read_text())
+            result_summary = {
+                "successes": payload.get("successes"),
+                "failures": payload.get("failures"),
+                "step_count": payload.get("step_count"),
+            }
+        except json.JSONDecodeError:
+            result_summary = {"error": "result.json not valid JSON"}
+
+    return {
+        "plan": plan_path.name,
+        "task_id": grading.get("task_id", plan_path.stem),
+        "passed": grading.get("passed"),
+        "score": grading.get("score"),
+        "exit_code": proc.returncode,
+        "elapsed_seconds": round(elapsed, 2),
+        "result": result_summary,
+        "oracle_error": grading.get("error"),
+        "stderr_tail": proc.stderr.strip().splitlines()[-5:] if proc.returncode != 0 else [],
+    }
+
+
+def _print_summary(rows: list[dict[str, Any]]) -> None:
+    if not rows:
+        print("\nNo plans run.")
+        return
+    passed = sum(1 for r in rows if r.get("passed") is True)
+    print()
+    print("=" * 72)
+    print(f"sim_envs batch summary — {passed}/{len(rows)} plans passed oracle")
+    print("=" * 72)
+    print(f"  {'plan':35s} {'task_id':24s} {'passed':7s} {'score':>6s} {'t(s)':>6s}")
+    print(f"  {'-' * 35} {'-' * 24} {'-' * 7} {'-' * 6} {'-' * 6}")
+    for r in rows:
+        passed_str = "—" if r.get("passed") is None else ("✓" if r["passed"] else "✗")
+        score_str = "—" if r.get("score") is None else f"{r['score']:.2f}"
+        print(
+            f"  {r['plan'][:35]:35s} {str(r.get('task_id', ''))[:24]:24s} "
+            f"{passed_str:7s} {score_str:>6s} {r.get('elapsed_seconds', 0):>6.1f}"
+        )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Batch sim-env eval (#336)")
+    parser.add_argument("--env", required=True, help="Env name, e.g. 'stub' or 'mantis-crm'")
+    parser.add_argument("--runtime", choices=("local", "modal", "e2b"), default="local")
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--endpoint", default=None,
+                        help="Brain endpoint (passed through to `mantis plan run`)")
+    parser.add_argument("--plans-dir", default="plans",
+                        help="Root of the plan tree (default: plans)")
+    parser.add_argument("--output-dir", default=None,
+                        help="Where to write per-plan dirs + bench_summary.json")
+    parser.add_argument("--max-workers", type=int, default=1,
+                        help="Parallel plan runs (default: 1)")
+    parser.add_argument("--plan-arg", action="append", default=None,
+                        metavar="ARG",
+                        help="Extra arg passed through verbatim to `mantis plan run`. "
+                             "Repeat for multiple. Example: --plan-arg --no-headless "
+                             "--plan-arg --header --plan-arg X-Foo=bar.")
+    args = parser.parse_args(argv)
+
+    plans_dir = Path(args.plans_dir)
+    plans = _find_plans(args.env, plans_dir)
+    if not plans:
+        print(f"error: no plans found under {plans_dir}/{args.env}/", file=sys.stderr)
+        return 1
+
+    output_dir = Path(args.output_dir or f"outputs/bench-{args.env}-{int(time.time())}")
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    extra_args = list(args.plan_arg or [])
+
+    print(f"sim_envs: env={args.env}  runtime={args.runtime}  plans={len(plans)}  "
+          f"workers={args.max_workers}  output={output_dir}")
+
+    rows: list[dict[str, Any]] = []
+    if args.max_workers <= 1:
+        for plan_path in plans:
+            print(f"\n  running {plan_path.name}…")
+            rows.append(_run_one(
+                plan_path, env_name=args.env, runtime=args.runtime,
+                output_dir=output_dir, endpoint=args.endpoint, seed=args.seed,
+                extra_args=extra_args,
+            ))
+    else:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=args.max_workers) as pool:
+            futures = {
+                pool.submit(
+                    _run_one, plan, env_name=args.env, runtime=args.runtime,
+                    output_dir=output_dir, endpoint=args.endpoint, seed=args.seed,
+                    extra_args=extra_args,
+                ): plan
+                for plan in plans
+            }
+            for fut in concurrent.futures.as_completed(futures):
+                plan = futures[fut]
+                try:
+                    rows.append(fut.result())
+                    print(f"  done   {plan.name}")
+                except Exception as exc:  # noqa: BLE001
+                    rows.append({
+                        "plan": plan.name,
+                        "task_id": plan.stem,
+                        "passed": None,
+                        "exit_code": -1,
+                        "elapsed_seconds": 0.0,
+                        "oracle_error": f"worker raised: {exc!r}",
+                    })
+
+    # Stable order in the summary file regardless of completion order.
+    rows.sort(key=lambda r: r["plan"])
+    summary_path = output_dir / "bench_summary.json"
+    summary_payload = {
+        "env": args.env,
+        "runtime": args.runtime,
+        "seed": args.seed,
+        "endpoint": args.endpoint,
+        "plan_count": len(rows),
+        "passed_count": sum(1 for r in rows if r.get("passed") is True),
+        "rows": rows,
+    }
+    summary_path.write_text(json.dumps(summary_payload, indent=2) + "\n",
+                            encoding="utf-8")
+    _print_summary(rows)
+    print(f"\nsummary: {summary_path}")
+
+    # Exit non-zero if any plan didn't pass — useful in CI.
+    if summary_payload["passed_count"] < len(rows):
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/deploy/sim_envs/__init__.py
+++ b/deploy/sim_envs/__init__.py
@@ -1,0 +1,7 @@
+"""Modal apps for simulated environments (#331).
+
+One file per env. The stub env (``modal_stub.py``) lives here as the
+reference implementation that proves the Modal harness path end-to-end.
+Real envs land their own file under the same directory in their child
+PRs (#332+).
+"""

--- a/deploy/sim_envs/modal_stub.py
+++ b/deploy/sim_envs/modal_stub.py
@@ -1,0 +1,189 @@
+"""Modal stub env — deploys the in-package stub as a Modal app.
+
+This is the reference deploy for #336. Real envs land their own file in
+this directory; they all follow the same shape:
+
+1. Define a Modal image carrying the env's runtime + dependencies.
+2. Mount a Modal Secret holding ``ENV_ADMIN_TOKEN``.
+3. Expose an ASGI route that serves both the agent UI (``/``) and the
+   harness surface (``/__env__/*``).
+
+For the stub the ASGI app is built on top of stdlib ``http.server``
+wrapped to look like an ASGI callable, so no extra dependency lands in
+the image.
+
+## Deploy
+
+    uv run modal deploy deploy/sim_envs/modal_stub.py
+
+That gives you a Modal app named ``mantis-sim-env-stub`` whose ``web``
+function is reachable from the local CLI:
+
+    uv run mantis plan run plans/_stub_env/T01_stub_passthrough.json \\
+        --env stub --runtime modal --endpoint <BRAIN_URL>
+
+## Required Modal Secret
+
+Mount a Modal Secret named ``mantis-sim-env-stub-secrets`` containing
+``ENV_ADMIN_TOKEN=<a-random-token>``. The same value must be exported
+locally as ``MANTIS_STUB_ENV_ADMIN_TOKEN`` so the local CLI can sign
+admin calls against the deployed stub.
+"""
+
+from __future__ import annotations
+
+import os
+
+import modal
+
+APP_NAME = "mantis-sim-env-stub"
+
+app = modal.App(APP_NAME)
+
+stub_image = (
+    modal.Image.debian_slim(python_version="3.11")
+    # The stub uses only stdlib; we pull the mantis_agent package in so
+    # the deploy file can reach the handler factory.
+    .pip_install("pillow>=10.0")
+    .add_local_python_source("mantis_agent")
+)
+
+secret = modal.Secret.from_name(
+    "mantis-sim-env-stub-secrets",
+    required_keys=["ENV_ADMIN_TOKEN"],
+)
+
+
+def _build_asgi_app():
+    """Build an ASGI app that wraps the stdlib stub handler.
+
+    The mantis stub uses ``http.server`` for the slim install path. To
+    host it on Modal we need an ASGI surface. Rather than re-implement
+    routing in two places we wrap the stub via a tiny ASGI ↔ WSGI bridge
+    using the stdlib + ``a2wsgi`` equivalent — but only stdlib is
+    available in the slim image, so the bridge is hand-rolled here.
+    """
+    # Modal's ``asgi_app`` decorator expects a callable conforming to
+    # the ASGI spec. We use Starlette's ASGI primitives indirectly via
+    # a minimal manual implementation: parse the HTTP request, dispatch
+    # to a per-request stdlib handler, return the response.
+    #
+    # In practice we just delegate to a Starlette app to avoid the
+    # 200-line stdlib dance. Starlette ships with Modal's slim image
+    # via uvicorn (which depends on it), so this is free.
+    from starlette.applications import Starlette
+    from starlette.requests import Request
+    from starlette.responses import HTMLResponse, JSONResponse, Response
+    from starlette.routing import Route
+
+    from mantis_agent.sim_envs.stub_app import AGENT_LANDING_HTML, _EnvState
+
+    admin_token = os.environ.get("ENV_ADMIN_TOKEN", "")
+    if not admin_token:
+        raise RuntimeError(
+            "ENV_ADMIN_TOKEN not set — the Modal stub requires the "
+            "mantis-sim-env-stub-secrets secret to be mounted."
+        )
+
+    seed = int(os.environ.get("SEED") or 42)
+    now = os.environ.get("FAKE_NOW") or "2026-01-15T09:00:00Z"
+    state = _EnvState(seed=seed, now=now, admin_token=admin_token)
+
+    def _require_admin(request: Request) -> Response | None:
+        if request.headers.get("x-env-admin", "") != state.admin_token:
+            return JSONResponse({"error": "admin token required"}, status_code=401)
+        return None
+
+    async def health(_request: Request) -> Response:
+        return JSONResponse({
+            "ok": True,
+            "seed": state.seed,
+            "now": state.now,
+            "boot_time": state.boot_time,
+        })
+
+    async def reset(request: Request) -> Response:
+        err = _require_admin(request)
+        if err is not None:
+            return err
+        state.reset()
+        return JSONResponse({"ok": True})
+
+    async def seed_route(request: Request) -> Response:
+        err = _require_admin(request)
+        if err is not None:
+            return err
+        body = await request.json() if await request.body() else {}
+        new_seed = int(body.get("seed", state.seed))
+        state.seed = new_seed
+        state.emit("seed_changed", {"seed": new_seed})
+        return JSONResponse({"ok": True, "seed": new_seed})
+
+    async def clock_route(request: Request) -> Response:
+        err = _require_admin(request)
+        if err is not None:
+            return err
+        body = await request.json() if await request.body() else {}
+        new_now = str(body.get("now") or state.now)
+        state.now = new_now
+        state.emit("clock_changed", {"now": new_now})
+        return JSONResponse({"ok": True, "now": new_now})
+
+    async def oracle(request: Request) -> Response:
+        err = _require_admin(request)
+        if err is not None:
+            return err
+        task_id = (request.query_params.get("task_id") or "").strip()
+        state.emit("oracle_query", {"task_id": task_id})
+        return JSONResponse({
+            "passed": True,
+            "score": 1.0,
+            "task_id": task_id,
+            "reasons": ["stub env: every task passes"],
+            "diff": {},
+        })
+
+    async def state_dump(request: Request) -> Response:
+        err = _require_admin(request)
+        if err is not None:
+            return err
+        return JSONResponse({
+            "seed": state.seed,
+            "now": state.now,
+            "touched": state.touched,
+            "event_count": len(state.events),
+        })
+
+    async def events_route(request: Request) -> Response:
+        err = _require_admin(request)
+        if err is not None:
+            return err
+        since = float(request.query_params.get("since") or 0)
+        filtered = [e for e in state.events if e["ts"] >= since]
+        return JSONResponse({"events": filtered})
+
+    async def landing(_request: Request) -> Response:
+        return HTMLResponse(AGENT_LANDING_HTML)
+
+    return Starlette(routes=[
+        Route("/__env__/health", health, methods=["GET"]),
+        Route("/__env__/reset", reset, methods=["POST"]),
+        Route("/__env__/seed", seed_route, methods=["POST"]),
+        Route("/__env__/clock", clock_route, methods=["POST"]),
+        Route("/__env__/oracle", oracle, methods=["GET"]),
+        Route("/__env__/state", state_dump, methods=["GET"]),
+        Route("/__env__/events", events_route, methods=["GET"]),
+        Route("/{rest:path}", landing, methods=["GET"]),
+    ])
+
+
+@app.function(
+    image=stub_image,
+    secrets=[secret],
+    min_containers=0,
+    max_containers=4,
+    timeout=300,
+)
+@modal.asgi_app()
+def web():
+    return _build_asgi_app()

--- a/docs/envs/HARNESS.md
+++ b/docs/envs/HARNESS.md
@@ -1,0 +1,123 @@
+# Sim-env harness — wiring plans to simulated environments
+
+Status: v1 (#336 — landed by this PR)
+Reference contract: [SPEC.md](SPEC.md) §"Shared harness contract"
+
+The harness is the integration layer between `mantis plan run` and the
+per-env containers that ship under #332+. It lets one plan JSON run
+against a local Docker env or a Modal-hosted env with no plan edits —
+the agent's view is always "navigate to a URL".
+
+## Quick start
+
+Boot the stub env locally, run a smoke plan against it, and read the
+oracle verdict:
+
+```bash
+# Optional: get a handle file you can keep across shells.
+uv run python scripts/env_up.py start --env stub
+
+# One-shot plan-run-against-env (handles start/stop for you):
+uv run mantis plan run examples/sim_envs/stub_T01_passthrough.json \
+    --env stub --runtime local \
+    --endpoint <BRAIN_URL> \
+    --output-dir outputs/harness-smoke
+cat outputs/harness-smoke/oracle.json
+```
+
+## What `--env <name>` actually does
+
+When `--env` is set, the CLI does five things on top of the normal run:
+
+1. **Boot** — picks a runtime backend (`local`, `modal`, or the
+   reserved `e2b`), calls `backend.start(<env>, seed=…, now=…)`,
+   waits for `/__env__/health` to return `{"ok": true}`. Health-poll
+   timeouts surface a clear `TimeoutError` rather than hanging.
+2. **Template** — substitutes `{{ENV_URL}}` in the plan JSON for the
+   env's base URL. Every string-shaped field is touched (intents,
+   `params.url`, nested params).
+3. **Run** — hands the templated plan to `MicroPlanRunner` as usual.
+   The runner doesn't know it's running against a sim env.
+4. **Grade** — after the runner exits, calls
+   `GET /__env__/oracle?task_id=<id>` with the admin token. The
+   verdict lands as `oracle.json` next to `result.json`; `result.json`
+   gets an additive `grading` block.
+5. **Tear down** — calls `backend.stop(handle)` in a `finally`. Pass
+   `--keep` to leave the env running for debugging.
+
+`task_id` comes from a top-level `"task_id"` field in the plan JSON.
+Plans without one fall back to the plan filename's stem.
+
+## Two route surfaces, one container
+
+Every env exposes:
+
+| Surface | Path | Audience | Auth |
+| --- | --- | --- | --- |
+| Web UI | `:PORT/` | Agent | Pre-seeded session cookie (single user) |
+| Harness | `:PORT/__env__/*` | Harness only | `X-Env-Admin: <token>` |
+
+The admin token is generated per run by the harness and passed to the
+container as an env var (`ENV_ADMIN_TOKEN`). The agent's browser
+context never sees it. `/__env__/health` is intentionally open so
+health checks can run un-authenticated; everything else 401s without
+the header.
+
+See `tests/test_admin_token_isolation.py` for the contract assertions.
+
+## Runtimes
+
+| Runtime | Cold start | Use it when | Default for |
+| --- | --- | --- | --- |
+| `local`  | n/a       | Laptop dev, debugging | Local CLI |
+| `modal`  | 5–15 s    | CI / benchmark runs   | Modal-resident CLI |
+| `e2b`    | reserved  | High-volume batch (#336 §"Hosting") | — |
+
+`--runtime` default is `local` unless `MODAL_TASK_ID` /
+`MODAL_FUNCTION_NAME` is set in the environment, in which case it's
+`modal`. Override explicitly when needed.
+
+The `local` backend falls back to a Python subprocess running the
+in-package stub env when no Docker image is registered for the env
+name. Real envs land an entry in
+`mantis_agent.sim_envs.local._image_for_env` (or override via
+`MANTIS_SIM_ENV_IMAGE_<NAME>`).
+
+## Adding a real env
+
+Each env PR (#332+) lands four things on top of this harness:
+
+1. A Dockerfile + container image registered in `_image_for_env`.
+2. A `deploy/sim_envs/<env>.py` exporting a `modal.App` named
+   `mantis-sim-env-<env>`.
+3. A `SiteConfig.default_<env>()` classmethod.
+4. ≥5 plans under `plans/<env>/` with explicit `task_id` fields.
+
+Nothing in the harness needs to change for those PRs.
+
+## Batch eval
+
+```bash
+uv run python -m benchmarks.sim_envs --env mantis-crm --runtime modal \
+    --endpoint <BRAIN_URL> --max-workers 4
+```
+
+Runs every plan in `plans/<env>/` against a fresh env instance per
+plan, writes per-plan dirs + `bench_summary.json`, prints a one-line
+oracle pass/fail table. Exit code 0 iff every plan passed the oracle.
+
+## Modal deploy of the stub
+
+```bash
+# One-time: create the secret holding the admin token.
+modal secret create mantis-sim-env-stub-secrets \
+    ENV_ADMIN_TOKEN=$(python -c 'import secrets; print(secrets.token_urlsafe(32))')
+
+# Deploy the stub app.
+uv run modal deploy deploy/sim_envs/modal_stub.py
+
+# Use it.
+export MANTIS_STUB_ENV_ADMIN_TOKEN=<the-value-you-just-generated>
+uv run mantis plan run examples/sim_envs/stub_T01_passthrough.json \
+    --env stub --runtime modal --endpoint <BRAIN_URL>
+```

--- a/examples/sim_envs/stub_T01_passthrough.json
+++ b/examples/sim_envs/stub_T01_passthrough.json
@@ -1,0 +1,33 @@
+{
+  "task_id": "T01_stub_passthrough",
+  "source_plan": "Stub-env smoke test for #336 harness.\nNavigate to the stub env landing page and confirm it loaded.",
+  "domain": "stub",
+  "steps": [
+    {
+      "type": "navigate",
+      "intent": "Open the stub env landing page at {{ENV_URL}}/",
+      "section": "setup",
+      "required": true,
+      "gate": false,
+      "claude_only": false,
+      "loop_target": -1,
+      "loop_count": 0,
+      "verify": "",
+      "params": {"url": "{{ENV_URL}}/"},
+      "hints": {}
+    },
+    {
+      "type": "extract_data",
+      "intent": "Confirm the page shows the 'mantis stub env' heading",
+      "section": "verify",
+      "required": false,
+      "gate": false,
+      "claude_only": true,
+      "loop_target": -1,
+      "loop_count": 0,
+      "verify": "",
+      "params": {},
+      "hints": {}
+    }
+  ]
+}

--- a/scripts/env_up.py
+++ b/scripts/env_up.py
@@ -1,0 +1,184 @@
+"""env_up.py — local lifecycle wrapper for simulated envs.
+
+Usage::
+
+    python scripts/env_up.py start --env stub --seed 42
+    # → prints JSON: {"url": "http://127.0.0.1:NNNN", "admin_token": "...", "handle_file": "..."}
+
+    python scripts/env_up.py stop --handle <path-to-handle-file>
+
+This is the thin CLI on top of :class:`LocalBackend`. ``start`` writes
+the handle (env name, url, token, backend-specific state) to a JSON file
+so a separate ``stop`` invocation in another shell can find it. The
+default handle file lives under ``$TMPDIR/mantis-env-<env>-<pid>.json``
+unless ``--handle`` overrides.
+
+Most callers don't reach for this directly — ``mantis plan run --env
+... --runtime local`` does start/stop in the same process. ``env_up.py``
+is for the cases where you want to keep the env hot across multiple
+manual invocations (debugging a flaky plan, poking the UI by hand).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+# Add ``src/`` to path so the script works both installed and from a
+# fresh checkout without ``pip install -e .``.
+_REPO_SRC = Path(__file__).resolve().parents[1] / "src"
+if _REPO_SRC.exists() and str(_REPO_SRC) not in sys.path:
+    sys.path.insert(0, str(_REPO_SRC))
+
+from mantis_agent.sim_envs.local import LocalBackend  # noqa: E402
+from mantis_agent.sim_envs.runtime import RuntimeHandle  # noqa: E402
+
+
+def _default_handle_path(env_name: str) -> Path:
+    return Path(tempfile.gettempdir()) / f"mantis-env-{env_name}-{os.getpid()}.json"
+
+
+def _serialize_handle(handle: RuntimeHandle) -> dict[str, Any]:
+    """Persistable view of the handle.
+
+    The local backend's ``extra.proc`` is a ``Popen`` — not JSON-serialisable.
+    We drop it from the on-disk view; ``stop`` reconstructs enough state
+    from the container id / port to terminate the process group by PID
+    (subprocess mode stores the pid; docker mode stores the container id).
+    """
+    extra = dict(handle.extra)
+    proc = extra.pop("proc", None)
+    if proc is not None and hasattr(proc, "pid"):
+        extra["pid"] = proc.pid
+    return {
+        "env_name": handle.env_name,
+        "url": handle.url,
+        "admin_token": handle.admin_token,
+        "backend": handle.backend,
+        "started_at": handle.started_at,
+        "extra": extra,
+    }
+
+
+def _stop_from_serialized(payload: dict[str, Any]) -> None:
+    """Stop an env using only the JSON view of its handle.
+
+    Subprocess: kill by PID. Docker: ``docker stop`` by container id.
+    We avoid round-tripping through ``LocalBackend.stop`` because the
+    Popen object is gone — we'd just re-implement the same two branches
+    with a slightly different shape.
+    """
+    extra = payload.get("extra", {}) or {}
+    mode = extra.get("mode")
+
+    if mode == "docker":
+        from mantis_agent.sim_envs.local import _docker_stop  # noqa: PLC0415
+
+        _docker_stop(extra.get("container_id", ""))
+        return
+
+    if mode == "subprocess":
+        pid = int(extra.get("pid") or 0)
+        if pid > 0:
+            try:
+                os.kill(pid, 15)  # SIGTERM
+            except ProcessLookupError:
+                pass
+        return
+
+    print(f"warning: unknown mode {mode!r} — nothing to stop", file=sys.stderr)
+
+
+# ── subcommands ─────────────────────────────────────────────────────────
+
+
+def cmd_start(args: argparse.Namespace) -> int:
+    backend = LocalBackend()
+    handle = backend.start(args.env, seed=args.seed, now=args.now)
+    try:
+        backend.wait_healthy(handle, timeout_s=args.timeout)
+    except TimeoutError as exc:
+        backend.stop(handle)
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    handle_path = Path(args.handle) if args.handle else _default_handle_path(args.env)
+    handle_path.write_text(json.dumps(_serialize_handle(handle), indent=2) + "\n")
+
+    out = {
+        "env": args.env,
+        "url": handle.url,
+        "admin_token": handle.admin_token,
+        "handle_file": str(handle_path),
+        "mode": handle.extra.get("mode"),
+    }
+    print(json.dumps(out, indent=2))
+    return 0
+
+
+def cmd_stop(args: argparse.Namespace) -> int:
+    handle_path = Path(args.handle)
+    if not handle_path.exists():
+        print(f"error: handle file not found: {handle_path}", file=sys.stderr)
+        return 1
+    payload = json.loads(handle_path.read_text())
+    _stop_from_serialized(payload)
+    handle_path.unlink(missing_ok=True)
+    print(json.dumps({"stopped": payload.get("env_name", "?")}))
+    return 0
+
+
+def cmd_health(args: argparse.Namespace) -> int:
+    """``env_up.py health --handle <path>`` — one-shot health check.
+
+    Mostly a convenience for shell scripts driving env_up in a Makefile
+    or CI step.
+    """
+    import urllib.request
+
+    handle_path = Path(args.handle)
+    payload = json.loads(handle_path.read_text())
+    url = payload.get("url", "").rstrip("/")
+    with urllib.request.urlopen(f"{url}/__env__/health", timeout=5.0) as resp:  # noqa: S310
+        print(resp.read().decode("utf-8"))
+    return 0
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description="mantis sim env local lifecycle")
+    sub = p.add_subparsers(dest="command", required=True)
+
+    start = sub.add_parser("start", help="Boot an env and write a handle file")
+    start.add_argument("--env", required=True, help="Env name, e.g. 'stub', 'mantis-crm'")
+    start.add_argument("--seed", type=int, default=42)
+    start.add_argument("--now", default="2026-01-15T09:00:00Z")
+    start.add_argument("--timeout", type=float, default=30.0,
+                       help="Health-wait timeout in seconds (default: 30)")
+    start.add_argument("--handle", default=None,
+                       help="Where to write the handle JSON (default: a tmp path)")
+    start.set_defaults(func=cmd_start)
+
+    stop = sub.add_parser("stop", help="Stop an env using a handle file from `start`")
+    stop.add_argument("--handle", required=True)
+    stop.set_defaults(func=cmd_stop)
+
+    health = sub.add_parser("health", help="Hit /__env__/health on a running env")
+    health.add_argument("--handle", required=True)
+    health.set_defaults(func=cmd_health)
+
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    return int(args.func(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/mantis_agent/cli.py
+++ b/src/mantis_agent/cli.py
@@ -595,6 +595,11 @@ def cmd_plan_run(args: argparse.Namespace) -> int:
 
     from .plan_decomposer import MicroPlan, PlanDecomposer
 
+    # Raw payload retained so the env-harness path can read top-level
+    # ``task_id`` metadata that ``MicroPlan.to_dict()`` strips on
+    # round-trip. ``None`` when the plan came from a text source.
+    raw_plan_payload: dict[str, Any] | None = None
+
     if _looks_like_text_plan(plan_path):
         plan_text = plan_path.read_text(encoding="utf-8")
         if not plan_text.strip():
@@ -631,10 +636,53 @@ def cmd_plan_run(args: argparse.Namespace) -> int:
         except Exception as exc:  # noqa: BLE001
             print(f"error: cannot parse plan from {plan_path}: {exc}", file=sys.stderr)
             return EXIT_ERROR
+        raw_plan_payload = payload if isinstance(payload, dict) else None
 
     if not plan.steps:
         print("error: plan has no steps", file=sys.stderr)
         return EXIT_ERROR
+
+    # ── env harness (#336) ─────────────────────────────────────────────
+    # When ``--env <name>`` is set, boot a simulated env, template
+    # ``{{ENV_URL}}`` into the plan, and prepare grading at end of run.
+    # Skipping when ``--env`` is absent keeps the existing path bit-
+    # identical for every plan that targets a live URL.
+    env_session = None
+    env_task_id = ""
+    if args.env:
+        from .sim_envs.cli_integration import EnvSession, detect_default_runtime
+        from .sim_envs.templating import substitute_env_url
+
+        runtime = args.runtime or detect_default_runtime()
+        try:
+            env_session = EnvSession(
+                args.env,
+                runtime=runtime,
+                seed=int(args.seed),
+                now=args.now,
+                keep=bool(args.keep),
+            ).__enter__()
+        except Exception as exc:  # noqa: BLE001 — surface boot errors
+            print(f"error: env boot failed ({args.env}/{runtime}): {exc}", file=sys.stderr)
+            return EXIT_ERROR
+
+        env_url = env_session.url
+        # Substitute on the plan dict (covers params.url and intent body),
+        # then re-build the MicroPlan from the substituted payload.
+        plan_dict = plan.to_dict()
+        plan_dict = substitute_env_url(plan_dict, env_url)
+        plan = MicroPlan.from_dict(plan_dict)
+
+        # Pull task_id off the raw JSON payload (text plans land none).
+        env_task_id = ""
+        if raw_plan_payload is not None:
+            env_task_id = str(raw_plan_payload.get("task_id", "")).strip()
+        if not env_task_id:
+            env_task_id = plan_path.stem  # fall back to filename
+        print(
+            f"  env:     {args.env}  (runtime={runtime}, url={env_url}, "
+            f"task_id={env_task_id})"
+        )
 
     # Output dir.
     output_dir = Path(args.output_dir or f"outputs/run-{int(_time.time())}")
@@ -854,12 +902,57 @@ def cmd_plan_run(args: argparse.Namespace) -> int:
         return EXIT_ERROR
 
     t0 = _time.time()
+    runner_exc: BaseException | None = None
+    step_results: list[Any] = []
     try:
-        step_results = runner.run(plan, resume=bool(args.resume))
-    except Exception as exc:  # noqa: BLE001
-        print(f"error: runner raised: {exc}", file=sys.stderr)
+        try:
+            step_results = runner.run(plan, resume=bool(args.resume))
+        except Exception as exc:  # noqa: BLE001
+            runner_exc = exc
+            print(f"error: runner raised: {exc}", file=sys.stderr)
+    finally:
+        elapsed = _time.time() - t0
+
+        # ── grading + env teardown (#336) ──────────────────────────────
+        grading_dict: dict[str, Any] | None = None
+        if env_session is not None:
+            from .gym.grading import grade_run
+            try:
+                grading = grade_run(
+                    env_session.url,
+                    env_session.admin_token,
+                    env_task_id,
+                )
+                grading_dict = grading.to_dict()
+                (output_dir / "oracle.json").write_text(
+                    json.dumps(grading_dict, indent=2) + "\n", encoding="utf-8",
+                )
+                print(
+                    f"  oracle:  passed={grading.passed} score={grading.score} "
+                    f"task_id={env_task_id}  → {output_dir / 'oracle.json'}"
+                )
+            except Exception as exc:  # noqa: BLE001 — never crash teardown
+                print(f"  oracle:  call failed: {exc}", file=sys.stderr)
+
+            # Merge env-side events into the agent trace (additive).
+            try:
+                from .sim_envs.trace_merge import merge_env_events
+
+                merge_env_events(
+                    output_dir, env_session.backend, env_session.handle,
+                    since=t0,
+                )
+            except Exception as exc:  # noqa: BLE001
+                print(f"  trace-merge: failed: {exc}", file=sys.stderr)
+
+            # Tear down (unless --keep). EnvSession.__exit__ is idempotent.
+            try:
+                env_session.__exit__(None, None, None)
+            except Exception:  # noqa: BLE001
+                pass
+
+    if runner_exc is not None:
         return EXIT_ERROR
-    elapsed = _time.time() - t0
 
     # Result summary — write the structured payload then print a
     # human-readable rollup.
@@ -889,6 +982,10 @@ def cmd_plan_run(args: argparse.Namespace) -> int:
             for r in step_results
         ],
     }
+    if grading_dict is not None:
+        # Additive — RunReport surface in result.json gains the oracle
+        # verdict. Consumers that don't know about ``grading`` ignore it.
+        result_payload["grading"] = grading_dict
     (output_dir / "result.json").write_text(
         json.dumps(result_payload, indent=2) + "\n", encoding="utf-8",
     )
@@ -1376,6 +1473,42 @@ def _build_parser() -> argparse.ArgumentParser:
         "--resume",
         action="store_true",
         help="Resume from checkpoint at --output-dir/checkpoint.json if present.",
+    )
+    # ── env harness (#336) ────────────────────────────────────────────
+    run.add_argument(
+        "--env",
+        default=None,
+        help="Simulated env to boot for this run (e.g. 'stub', 'mantis-crm'). "
+             "When set, the harness boots the env via --runtime, templates "
+             "{{ENV_URL}} into the plan, calls grade_run after, and writes "
+             "oracle.json + env_events.jsonl into --output-dir.",
+    )
+    run.add_argument(
+        "--seed",
+        type=int,
+        default=42,
+        help="Deterministic env seed passed via SEED= (default: 42). "
+             "Only consulted when --env is set.",
+    )
+    run.add_argument(
+        "--now",
+        default="2026-01-15T09:00:00Z",
+        help="Frozen wall-clock for the env via FAKE_NOW= (default: "
+             "2026-01-15T09:00:00Z). Only consulted when --env is set.",
+    )
+    run.add_argument(
+        "--runtime",
+        choices=("local", "modal", "e2b"),
+        default=None,
+        help="Where to boot the env: local (Docker / subprocess stub), modal "
+             "(one app per env), or e2b (reserved, not implemented in v1). "
+             "Defaults to modal when running on Modal, local otherwise.",
+    )
+    run.add_argument(
+        "--keep",
+        action="store_true",
+        help="Leave the env running after the plan finishes (for debugging). "
+             "Default: env is torn down on exit.",
     )
     run.set_defaults(func=cmd_plan_run)
 

--- a/src/mantis_agent/gym/grading.py
+++ b/src/mantis_agent/gym/grading.py
@@ -1,0 +1,111 @@
+"""``grade_run`` — call the env's oracle, parse the response, return a result.
+
+After ``MicroPlanRunner`` finishes a plan, the harness calls
+:func:`grade_run` to get a server-side ground-truth verdict on whether
+the agent accomplished the task. Oracle endpoint contract (see
+``docs/envs/SPEC.md`` §"Oracle interface"):
+
+* ``GET /__env__/oracle?task_id=<id>`` with header ``X-Env-Admin: <token>``
+* Returns JSON: ``{"passed": bool, "score": float, "reasons": [...], "diff": {...}}``
+
+Result type :class:`GradingResult` is a thin dataclass so it round-trips
+through JSON cleanly. The CLI writes it to ``<output_dir>/oracle.json``
+next to ``trace.jsonl`` (additive — nothing breaks if it isn't there).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import asdict, dataclass, field
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote
+from urllib.request import Request, urlopen
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class GradingResult:
+    """Oracle verdict for one plan run.
+
+    ``error`` is populated when the oracle call itself failed (network,
+    401, non-JSON body, etc.); callers can distinguish "plan failed
+    according to oracle" (``passed=False, error=None``) from "we never
+    got an oracle verdict" (``error=<reason>``). Both write through to
+    ``oracle.json`` so the failure mode is captured in the run record.
+    """
+
+    task_id: str
+    passed: bool = False
+    score: float = 0.0
+    reasons: list[str] = field(default_factory=list)
+    diff: dict[str, Any] = field(default_factory=dict)
+    error: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def grade_run(
+    env_url: str,
+    admin_token: str,
+    task_id: str,
+    *,
+    timeout_s: float = 30.0,
+) -> GradingResult:
+    """Hit ``GET <env_url>/__env__/oracle?task_id=<task_id>`` with the admin token.
+
+    Returns a :class:`GradingResult`. Never raises — oracle / network
+    failures populate ``error`` so the run record always reflects what
+    happened. This is the right shape for benchmarks: a flaky network
+    should not lose the rest of the run record.
+    """
+    if not env_url:
+        return GradingResult(
+            task_id=task_id,
+            error="env_url is empty — no oracle to call",
+        )
+    if not task_id:
+        return GradingResult(
+            task_id="",
+            error="task_id is empty — plans must declare a task_id under --env",
+        )
+
+    base = env_url.rstrip("/")
+    url = f"{base}/__env__/oracle?task_id={quote(task_id)}"
+    req = Request(url, headers={"X-Env-Admin": admin_token})
+    try:
+        with urlopen(req, timeout=timeout_s) as resp:  # noqa: S310 — env URL only
+            body = resp.read().decode("utf-8")
+            payload = json.loads(body)
+    except HTTPError as exc:
+        return GradingResult(
+            task_id=task_id,
+            error=f"oracle returned HTTP {exc.code}: {exc.reason}",
+        )
+    except (URLError, ConnectionError, OSError, TimeoutError) as exc:
+        return GradingResult(
+            task_id=task_id,
+            error=f"oracle network error: {exc!r}",
+        )
+    except json.JSONDecodeError as exc:
+        return GradingResult(
+            task_id=task_id,
+            error=f"oracle returned non-JSON body: {exc!r}",
+        )
+
+    if not isinstance(payload, dict):
+        return GradingResult(
+            task_id=task_id,
+            error=f"oracle returned non-dict payload: {type(payload).__name__}",
+        )
+
+    return GradingResult(
+        task_id=task_id,
+        passed=bool(payload.get("passed", False)),
+        score=float(payload.get("score", 0.0)),
+        reasons=list(payload.get("reasons", []) or []),
+        diff=dict(payload.get("diff", {}) or {}),
+    )

--- a/src/mantis_agent/sim_envs/__init__.py
+++ b/src/mantis_agent/sim_envs/__init__.py
@@ -1,0 +1,41 @@
+"""Simulated environments (#331 / harness #336).
+
+This package contains the *integration layer* that lets `mantis plan run`
+talk to a self-hosted, deterministic web env — the same contract whether
+the env runs locally (Docker / subprocess) or on Modal.
+
+Public surface:
+
+- :class:`RuntimeBackend` — start/health/url/events/stop protocol every
+  backend implements.
+- :class:`RuntimeHandle` — opaque handle returned by ``start`` and
+  threaded back into ``stop`` / ``fetch_events``.
+- :func:`get_backend` — resolves a backend by name (``local`` / ``modal``
+  / ``e2b``). ``e2b`` raises ``NotImplementedError``; the slot is
+  reserved so a future PR can land it without touching plans / CLI.
+- :func:`substitute_env_url` — templates ``{{ENV_URL}}`` into a plan
+  payload before the runner sees it.
+
+Env images are not in this package. They live under ``deploy/sim_envs/``
+(Modal apps) and the per-env Dockerfiles. This package only contains the
+glue that boots them and reaches them over HTTP.
+
+Adding a new backend is a one-file change: implement ``RuntimeBackend``,
+register it in ``registry.py``. Nothing in ``MicroPlanRunner``,
+``SiteConfig``, the planner, or the executor needs to change.
+"""
+
+from __future__ import annotations
+
+from .registry import get_backend, list_backends
+from .runtime import RuntimeBackend, RuntimeHandle
+from .templating import ENV_URL_PLACEHOLDER, substitute_env_url
+
+__all__ = [
+    "ENV_URL_PLACEHOLDER",
+    "RuntimeBackend",
+    "RuntimeHandle",
+    "get_backend",
+    "list_backends",
+    "substitute_env_url",
+]

--- a/src/mantis_agent/sim_envs/cli_integration.py
+++ b/src/mantis_agent/sim_envs/cli_integration.py
@@ -1,0 +1,137 @@
+"""CLI integration glue — boots, grades, and tears down a sim env around a plan run.
+
+Pulled out of :mod:`mantis_agent.cli` so the main CLI module stays
+readable. Public surface:
+
+* :class:`EnvSession` — context-manager wrapping ``backend.start`` +
+  ``backend.wait_healthy`` and ``backend.stop`` (skip on ``keep=True``).
+* :func:`detect_default_runtime` — picks ``modal`` when running on
+  Modal, ``local`` otherwise. Caller can override with ``--runtime``.
+
+Why a session class and not a free function: the cleanup happens on
+multiple exit paths (success, runner exception, env health failure
+mid-run). A context manager makes the cleanup contract explicit and the
+caller's life simpler.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from contextlib import AbstractContextManager
+from typing import Any
+
+from .registry import get_backend
+from .runtime import RuntimeBackend, RuntimeHandle
+
+logger = logging.getLogger(__name__)
+
+
+def detect_default_runtime() -> str:
+    """Pick a sensible default for ``--runtime`` based on the environment.
+
+    Heuristic: if the process is already running on Modal (``MODAL_TASK_ID``
+    or ``MODAL_FUNCTION_NAME`` set) we default to ``modal``. Otherwise
+    ``local``. The CLI's explicit ``--runtime`` flag always wins; this
+    is only consulted when the user didn't pass it.
+    """
+    if os.environ.get("MODAL_TASK_ID") or os.environ.get("MODAL_FUNCTION_NAME"):
+        return "modal"
+    return "local"
+
+
+class EnvSession(AbstractContextManager["EnvSession"]):
+    """Context manager that owns an env's lifecycle for one plan run.
+
+    Usage::
+
+        with EnvSession("stub", runtime="local", seed=42) as session:
+            url = session.url
+            plan = template(plan, url)
+            runner.run(plan)
+            grading = grade_run(url, session.admin_token, task_id)
+
+    Mantras:
+
+    * ``__exit__`` calls ``backend.stop`` unless ``keep=True``.
+    * ``backend.stop`` is idempotent; ``__exit__`` is safe to call twice.
+    * If ``start`` succeeds but ``wait_healthy`` fails, we tear down
+      before re-raising so we don't leak a half-booted container.
+    """
+
+    def __init__(
+        self,
+        env_name: str,
+        *,
+        runtime: str,
+        seed: int = 42,
+        now: str = "2026-01-15T09:00:00Z",
+        keep: bool = False,
+        health_timeout_s: float | None = None,
+    ) -> None:
+        self.env_name = env_name
+        self.runtime = runtime
+        self.seed = seed
+        self.now = now
+        self.keep = keep
+        self.health_timeout_s = health_timeout_s
+        self._backend: RuntimeBackend | None = None
+        self._handle: RuntimeHandle | None = None
+
+    @property
+    def url(self) -> str:
+        if self._handle is None:
+            raise RuntimeError("EnvSession.url accessed before __enter__")
+        return self._handle.url
+
+    @property
+    def admin_token(self) -> str:
+        if self._handle is None:
+            raise RuntimeError("EnvSession.admin_token accessed before __enter__")
+        return self._handle.admin_token
+
+    @property
+    def handle(self) -> RuntimeHandle:
+        if self._handle is None:
+            raise RuntimeError("EnvSession.handle accessed before __enter__")
+        return self._handle
+
+    @property
+    def backend(self) -> RuntimeBackend:
+        if self._backend is None:
+            raise RuntimeError("EnvSession.backend accessed before __enter__")
+        return self._backend
+
+    def __enter__(self) -> "EnvSession":
+        backend = get_backend(self.runtime)
+        self._backend = backend
+        handle = backend.start(self.env_name, seed=self.seed, now=self.now)
+        self._handle = handle
+        try:
+            if self.health_timeout_s is not None:
+                backend.wait_healthy(handle, timeout_s=self.health_timeout_s)
+            else:
+                backend.wait_healthy(handle)
+        except Exception:
+            # Half-booted env — tear down before propagating so we don't
+            # leak a hanging container / subprocess. ``stop`` is idempotent.
+            try:
+                backend.stop(handle)
+            except Exception:  # noqa: BLE001 — best-effort cleanup
+                logger.exception("env stop failed during health-wait error")
+            raise
+        return self
+
+    def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+        if self.keep:
+            logger.info(
+                "EnvSession.keep=True — env %s left running at %s",
+                self.env_name, self.url if self._handle else "?",
+            )
+            return
+        if self._backend is None or self._handle is None:
+            return
+        try:
+            self._backend.stop(self._handle)
+        except Exception:  # noqa: BLE001 — exit must not raise
+            logger.exception("env stop failed in EnvSession.__exit__")

--- a/src/mantis_agent/sim_envs/e2b.py
+++ b/src/mantis_agent/sim_envs/e2b.py
@@ -1,0 +1,54 @@
+"""E2B runtime backend — reserved stub for the high-throughput batch path.
+
+E2B Firecracker microVMs offer ~200ms cold starts versus Modal's 5-15s,
+which only matters at thousands-of-plans-per-day batch volume (see #336
+§Hosting). At v1 we are nowhere near that volume, so this file exists
+solely to reserve the ``--runtime e2b`` flag so a future PR can wire
+the real backend without touching CLI, plans, or env images.
+
+Calling :meth:`E2BBackend.start` raises ``NotImplementedError`` with a
+message pointing at the relevant issue. Tests assert on the specific
+exception so we catch silent regressions if someone adds a half-baked
+implementation here.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .runtime import RuntimeHandle
+
+
+class E2BBackend:
+    name = "e2b"
+
+    def start(
+        self,
+        env_name: str,
+        *,
+        seed: int = 42,
+        now: str = "2026-01-15T09:00:00Z",
+        admin_token: str | None = None,
+    ) -> RuntimeHandle:
+        raise NotImplementedError(
+            "E2B backend not implemented in v1. See #336 §Hosting — the flag "
+            "is reserved so the backend can be added without touching plans "
+            "or CLI. Use --runtime local for dev and --runtime modal for CI."
+        )
+
+    def wait_healthy(self, handle: RuntimeHandle, *, timeout_s: float = 30.0) -> None:
+        raise NotImplementedError("E2B backend not implemented in v1.")
+
+    def get_url(self, handle: RuntimeHandle) -> str:
+        raise NotImplementedError("E2B backend not implemented in v1.")
+
+    def fetch_events(
+        self,
+        handle: RuntimeHandle,
+        *,
+        since: float | None = None,
+    ) -> list[dict[str, Any]]:
+        raise NotImplementedError("E2B backend not implemented in v1.")
+
+    def stop(self, handle: RuntimeHandle) -> None:
+        raise NotImplementedError("E2B backend not implemented in v1.")

--- a/src/mantis_agent/sim_envs/local.py
+++ b/src/mantis_agent/sim_envs/local.py
@@ -1,0 +1,281 @@
+"""Local runtime backend — boots a sim env on the developer's laptop.
+
+Two boot modes, picked automatically:
+
+1. **Docker** (preferred for real envs): if the env name resolves to a
+   container image (registered in :func:`_image_for_env` or via the
+   ``MANTIS_SIM_ENV_IMAGE_<NAME>`` env var) and ``docker`` is on PATH,
+   we ``docker run`` the image with ``--network none``, port-published
+   to a free local port, and the env vars (``SEED``, ``FAKE_NOW``,
+   ``ENV_ADMIN_TOKEN``) populated.
+
+2. **Subprocess** (used by the stub env + tests): if no image is
+   registered, we boot ``python -m mantis_agent.sim_envs.stub_app`` as
+   a subprocess. This keeps tests fast and lets the harness be
+   exercised end-to-end without requiring a docker daemon.
+
+Both modes return the same :class:`RuntimeHandle`; the caller (CLI,
+benchmark, env_up.py) never has to know which mode was used.
+
+Picking a free port: we ask the kernel for one (`socket.bind(("", 0))`)
+then close the socket. There's a tiny race between close and the child
+process binding; the health-wait loop retries health for 30s so a lost
+race is recovered transparently. We do not try to reserve the port via
+``SO_REUSEADDR`` magic — that buys little and adds complexity.
+
+What this backend deliberately does NOT do:
+
+* Manage a pool / cache of warm envs (v1.5 territory).
+* Multi-tenant scoping inside one container (v1.5 — see #336).
+* Talk to a remote docker host. ``DOCKER_HOST`` works because we shell
+  out, but cross-machine docker is not something we test.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import secrets
+import shutil
+import socket
+import subprocess
+import sys
+import time
+from typing import Any
+from urllib.error import URLError
+from urllib.request import Request, urlopen
+
+from .runtime import RuntimeHandle
+
+logger = logging.getLogger(__name__)
+
+
+# ── image registry ─────────────────────────────────────────────────────
+
+
+def _image_for_env(env_name: str) -> str | None:
+    """Resolve an env name to a Docker image tag.
+
+    Real envs land their own entry here in their per-env PRs. The
+    canonical pattern is ``mantis/sim-env-<env>:latest`` extending the
+    ``mantis/sim-env-base:latest`` shared base image (see #336 §9).
+
+    The env var override ``MANTIS_SIM_ENV_IMAGE_<NAME>`` (uppercased,
+    hyphens → underscores) lets a dev point at a freshly-built image
+    without editing this table.
+
+    Returns ``None`` for envs without a registered image — the local
+    backend then falls back to the subprocess stub mode.
+    """
+    override_key = f"MANTIS_SIM_ENV_IMAGE_{env_name.upper().replace('-', '_')}"
+    override = os.environ.get(override_key, "").strip()
+    if override:
+        return override
+    # No real images registered yet — child env PRs (#332+) populate this.
+    return None
+
+
+# ── port allocation ────────────────────────────────────────────────────
+
+
+def _pick_free_port() -> int:
+    """Ask the kernel for a free TCP port on localhost."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+# ── http health poll ───────────────────────────────────────────────────
+
+
+def _http_get_json(url: str, *, timeout: float = 1.0, headers: dict[str, str] | None = None) -> Any:
+    req = Request(url, headers=headers or {})
+    with urlopen(req, timeout=timeout) as resp:  # noqa: S310 — local-only health check
+        return json.loads(resp.read().decode("utf-8"))
+
+
+# ── docker mode ────────────────────────────────────────────────────────
+
+
+def _docker_start(
+    image: str,
+    *,
+    port: int,
+    admin_token: str,
+    seed: int,
+    now: str,
+) -> str:
+    """``docker run`` the image; return the container id."""
+    cmd = [
+        "docker", "run", "-d",
+        "--rm",
+        "--network", "none",  # no outbound egress, see #336 §"Open questions"
+        "-p", f"127.0.0.1:{port}:8080",
+        "-e", f"SEED={seed}",
+        "-e", f"FAKE_NOW={now}",
+        "-e", f"ENV_ADMIN_TOKEN={admin_token}",
+        "-e", "PORT=8080",
+        image,
+    ]
+    logger.info("local backend: docker run %s", image)
+    proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"docker run failed (image={image}): {proc.stderr.strip() or proc.stdout.strip()}"
+        )
+    container_id = proc.stdout.strip()
+    if not container_id:
+        raise RuntimeError("docker run returned empty container id")
+    return container_id
+
+
+def _docker_stop(container_id: str) -> None:
+    if not container_id:
+        return
+    # ``docker stop`` is idempotent enough — if the container is already
+    # gone we silently ignore. ``--rm`` on start auto-removes on stop.
+    subprocess.run(
+        ["docker", "stop", container_id],
+        capture_output=True, text=True, check=False,
+    )
+
+
+# ── subprocess (stub) mode ─────────────────────────────────────────────
+
+
+def _stub_subprocess_start(
+    *,
+    port: int,
+    admin_token: str,
+    seed: int,
+    now: str,
+) -> subprocess.Popen[bytes]:
+    """Launch the stub env as a Python subprocess."""
+    cmd = [
+        sys.executable, "-m", "mantis_agent.sim_envs.stub_app",
+        "--host", "127.0.0.1",
+        "--port", str(port),
+        "--admin-token", admin_token,
+        "--seed", str(seed),
+        "--now", now,
+    ]
+    env = dict(os.environ)
+    env["ENV_ADMIN_TOKEN"] = admin_token
+    logger.info("local backend: subprocess stub on port %d", port)
+    return subprocess.Popen(
+        cmd,
+        env=env,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+
+# ── backend ────────────────────────────────────────────────────────────
+
+
+class LocalBackend:
+    """Local-only :class:`RuntimeBackend` — Docker preferred, stub fallback."""
+
+    name = "local"
+
+    def start(
+        self,
+        env_name: str,
+        *,
+        seed: int = 42,
+        now: str = "2026-01-15T09:00:00Z",
+        admin_token: str | None = None,
+    ) -> RuntimeHandle:
+        token = admin_token or secrets.token_urlsafe(32)
+        port = _pick_free_port()
+        url = f"http://127.0.0.1:{port}"
+
+        image = _image_for_env(env_name)
+        if image and shutil.which("docker"):
+            container_id = _docker_start(
+                image, port=port, admin_token=token, seed=seed, now=now,
+            )
+            return RuntimeHandle(
+                env_name=env_name,
+                url=url,
+                admin_token=token,
+                backend=self.name,
+                started_at=time.time(),
+                extra={"mode": "docker", "container_id": container_id, "port": port},
+            )
+
+        # No image / no docker → subprocess stub mode. This is the path
+        # the harness acceptance tests exercise; real envs land an image
+        # in `_image_for_env` and switch to the docker branch.
+        proc = _stub_subprocess_start(port=port, admin_token=token, seed=seed, now=now)
+        return RuntimeHandle(
+            env_name=env_name,
+            url=url,
+            admin_token=token,
+            backend=self.name,
+            started_at=time.time(),
+            extra={"mode": "subprocess", "proc": proc, "port": port},
+        )
+
+    def wait_healthy(self, handle: RuntimeHandle, *, timeout_s: float = 30.0) -> None:
+        """Poll ``/__env__/health`` until 200 or ``timeout_s`` elapses."""
+        deadline = time.time() + timeout_s
+        last_err: Exception | None = None
+        while time.time() < deadline:
+            try:
+                payload = _http_get_json(f"{handle.url}/__env__/health", timeout=1.0)
+                if isinstance(payload, dict) and payload.get("ok") is True:
+                    return
+                last_err = RuntimeError(f"health endpoint returned: {payload!r}")
+            except (URLError, ConnectionError, OSError, json.JSONDecodeError) as exc:
+                last_err = exc
+            time.sleep(0.25)
+        raise TimeoutError(
+            f"env {handle.env_name!r} did not become healthy in {timeout_s:.0f}s "
+            f"(last error: {last_err!r})"
+        )
+
+    def get_url(self, handle: RuntimeHandle) -> str:
+        return handle.url
+
+    def fetch_events(
+        self,
+        handle: RuntimeHandle,
+        *,
+        since: float | None = None,
+    ) -> list[dict[str, Any]]:
+        since_ts = since if since is not None else handle.started_at
+        try:
+            payload = _http_get_json(
+                f"{handle.url}/__env__/events?since={since_ts}",
+                timeout=5.0,
+                headers={"X-Env-Admin": handle.admin_token},
+            )
+        except (URLError, ConnectionError, OSError, json.JSONDecodeError):
+            return []
+        if isinstance(payload, dict):
+            events = payload.get("events", [])
+            if isinstance(events, list):
+                return events
+        return []
+
+    def stop(self, handle: RuntimeHandle) -> None:
+        mode = handle.extra.get("mode")
+        if mode == "docker":
+            _docker_stop(handle.extra.get("container_id", ""))
+            return
+        if mode == "subprocess":
+            proc: subprocess.Popen[bytes] | None = handle.extra.get("proc")
+            if proc is None:
+                return
+            if proc.poll() is None:
+                proc.terminate()
+                try:
+                    proc.wait(timeout=5.0)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+                    proc.wait(timeout=2.0)
+            return
+        # Unknown mode — nothing to do, but don't crash. ``stop`` is idempotent.
+        logger.debug("local backend: unknown mode %r — stop is no-op", mode)

--- a/src/mantis_agent/sim_envs/modal_backend.py
+++ b/src/mantis_agent/sim_envs/modal_backend.py
@@ -1,0 +1,209 @@
+"""Modal runtime backend — deploys one ``modal.App`` per env, per run.
+
+V1 strategy: per-run app suffix. Each ``start()`` call deploys (or looks
+up + redeploys) ``mantis-sim-env-<env>-<run_id>``, hits its
+``/__env__/health`` until it returns 200, and hands the resulting URL
+back to the caller. ``stop()`` ``modal app stop``s it.
+
+The Modal app definitions live under ``deploy/sim_envs/``. The stub env
+is ``deploy/sim_envs/modal_stub.py``; per-env PRs land their own
+``deploy/sim_envs/<env>.py`` exporting an ASGI route under
+``mantis-sim-env-<env>``.
+
+Why per-run app instead of per-run scope inside one long-lived app:
+
+* Per-run app is *clean teardown*: failure during a benchmark cannot
+  leak state between plans.
+* The cost is ~5-15s cold start. Acceptable at v1 benchmark volume
+  (dozens of plans/day).
+* When batch volume justifies it, swap to per-run-scope inside a hot
+  app — same backend interface, different ``start`` body. See #336
+  §"Open questions".
+
+Modal SDK is imported lazily: callers that never select ``--runtime
+modal`` should not pay the import cost (and the slim install does not
+ship ``modal`` at all).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import secrets
+import time
+from typing import Any
+from urllib.error import URLError
+from urllib.request import Request, urlopen
+
+from .runtime import RuntimeHandle
+
+logger = logging.getLogger(__name__)
+
+
+APP_NAME_PREFIX = "mantis-sim-env"
+
+
+def _modal_app_name(env_name: str, run_suffix: str) -> str:
+    return f"{APP_NAME_PREFIX}-{env_name}-{run_suffix}"
+
+
+def _http_get_json(
+    url: str,
+    *,
+    timeout: float = 5.0,
+    headers: dict[str, str] | None = None,
+) -> Any:
+    req = Request(url, headers=headers or {})
+    with urlopen(req, timeout=timeout) as resp:  # noqa: S310 — Modal URL only
+        return json.loads(resp.read().decode("utf-8"))
+
+
+class ModalBackend:
+    """:class:`RuntimeBackend` that ships envs as Modal apps.
+
+    The backend is intentionally thin — Modal's app definition (the
+    container image, the ASGI mount, the secret bindings) lives in the
+    per-env file under ``deploy/sim_envs/``. This class only knows how
+    to look one up, deploy it, wait for it to come live, and tear it
+    down.
+    """
+
+    name = "modal"
+
+    def __init__(self, *, workspace: str | None = None) -> None:
+        # Workspace lives on the handle; passing it explicitly lets the
+        # CI runner override the inferred workspace name when the same
+        # image is deployed under a non-default user.
+        self.workspace = workspace or os.environ.get("MODAL_WORKSPACE") or ""
+
+    # ── helpers ─────────────────────────────────────────────────────
+
+    def _resolve_modal(self) -> Any:
+        try:
+            import modal  # type: ignore[import-not-found]
+        except ImportError as exc:  # pragma: no cover — exercised in tests via mocking
+            raise RuntimeError(
+                "modal SDK not installed. `pip install modal` or use the [hud] extras."
+            ) from exc
+        return modal
+
+    # ── RuntimeBackend protocol ─────────────────────────────────────
+
+    def start(
+        self,
+        env_name: str,
+        *,
+        seed: int = 42,
+        now: str = "2026-01-15T09:00:00Z",
+        admin_token: str | None = None,
+    ) -> RuntimeHandle:
+        modal = self._resolve_modal()
+        token = admin_token or secrets.token_urlsafe(32)
+        run_suffix = secrets.token_hex(4)
+        app_name = _modal_app_name(env_name, run_suffix)
+
+        # The per-env deploy file is expected to expose a function /
+        # ASGI app under ``<APP_NAME_PREFIX>-<env_name>`` that we then
+        # re-deploy under the run-suffixed name. The mechanism for
+        # "deploy a copy with a per-run name" is intentionally left to
+        # the deploy file (it knows the image + secrets); we just look
+        # up the function by the run-suffixed name and read its URL.
+        #
+        # Until per-env deploy files land (#332+), the canonical
+        # already-deployed entry is the stub at ``mantis-sim-env-stub``
+        # which we read directly (no per-run app — the stub is shared).
+        if env_name == "stub":
+            try:
+                fn = modal.Function.from_name("mantis-sim-env-stub", "web")
+                url = fn.get_web_url()
+            except Exception as exc:  # noqa: BLE001 — modal raises varied exceptions
+                raise RuntimeError(
+                    "Modal stub env not deployed. Run "
+                    "`modal deploy deploy/sim_envs/modal_stub.py` first."
+                ) from exc
+            # The stub trusts a fixed admin token from its Modal Secret;
+            # bridge that into the handle so admin calls work.
+            stub_token = os.environ.get("MANTIS_STUB_ENV_ADMIN_TOKEN") or token
+            return RuntimeHandle(
+                env_name=env_name,
+                url=url,
+                admin_token=stub_token,
+                backend=self.name,
+                started_at=time.time(),
+                extra={"app_name": "mantis-sim-env-stub", "run_suffix": run_suffix},
+            )
+
+        # Per-env apps: each env PR lands its own deploy file. We look
+        # for ``<app_name>``'s ``web`` function. If absent we surface a
+        # clear error that points at the missing deploy.
+        try:
+            fn = modal.Function.from_name(app_name, "web")
+            url = fn.get_web_url()
+        except Exception as exc:  # noqa: BLE001
+            raise RuntimeError(
+                f"Modal app {app_name!r} not found. Per-env deploy files "
+                f"land in deploy/sim_envs/<env>.py. For development you "
+                f"can override the env image with MANTIS_SIM_ENV_IMAGE_<NAME> "
+                f"and use --runtime local instead."
+            ) from exc
+
+        return RuntimeHandle(
+            env_name=env_name,
+            url=url,
+            admin_token=token,
+            backend=self.name,
+            started_at=time.time(),
+            extra={"app_name": app_name, "run_suffix": run_suffix},
+        )
+
+    def wait_healthy(self, handle: RuntimeHandle, *, timeout_s: float = 60.0) -> None:
+        # Modal cold start is 5-15s; bump the default timeout vs local.
+        deadline = time.time() + timeout_s
+        last_err: Exception | None = None
+        while time.time() < deadline:
+            try:
+                payload = _http_get_json(f"{handle.url}/__env__/health", timeout=5.0)
+                if isinstance(payload, dict) and payload.get("ok") is True:
+                    return
+                last_err = RuntimeError(f"health endpoint returned: {payload!r}")
+            except (URLError, ConnectionError, OSError, json.JSONDecodeError) as exc:
+                last_err = exc
+            time.sleep(1.0)
+        raise TimeoutError(
+            f"modal env {handle.env_name!r} did not become healthy in "
+            f"{timeout_s:.0f}s (last error: {last_err!r})"
+        )
+
+    def get_url(self, handle: RuntimeHandle) -> str:
+        return handle.url
+
+    def fetch_events(
+        self,
+        handle: RuntimeHandle,
+        *,
+        since: float | None = None,
+    ) -> list[dict[str, Any]]:
+        since_ts = since if since is not None else handle.started_at
+        try:
+            payload = _http_get_json(
+                f"{handle.url}/__env__/events?since={since_ts}",
+                timeout=15.0,
+                headers={"X-Env-Admin": handle.admin_token},
+            )
+        except (URLError, ConnectionError, OSError, json.JSONDecodeError):
+            return []
+        if isinstance(payload, dict):
+            events = payload.get("events", [])
+            if isinstance(events, list):
+                return events
+        return []
+
+    def stop(self, handle: RuntimeHandle) -> None:
+        # The stub is shared / long-lived; never stop it.
+        if handle.env_name == "stub":
+            return
+        # Per-env apps are long-lived in v1 (no per-run app yet — see
+        # module docstring). Nothing to tear down here. When v1.5 lands
+        # per-run apps, this is where the ``modal app stop`` call goes.
+        return

--- a/src/mantis_agent/sim_envs/registry.py
+++ b/src/mantis_agent/sim_envs/registry.py
@@ -1,0 +1,43 @@
+"""Backend registry — resolve ``--runtime <name>`` to a :class:`RuntimeBackend`.
+
+Trivial map keyed on the canonical name. Splitting this out of
+``__init__.py`` keeps the import cost down: the local backend pulls in
+``subprocess`` + ``socket``, the modal backend lazy-imports the Modal
+SDK, e2b is a stub. A direct ``from .local import LocalBackend`` in
+``__init__.py`` would load all three on every import; the registry
+imports only the one the caller asked for.
+"""
+
+from __future__ import annotations
+
+from .runtime import RuntimeBackend
+
+
+def get_backend(name: str) -> RuntimeBackend:
+    """Return the backend registered under ``name``.
+
+    ``ValueError`` for an unknown name — the CLI's ``--runtime`` flag
+    uses ``argparse`` ``choices=`` to short-circuit invalid values, so
+    this is the belt-and-braces check for direct callers.
+    """
+    if name == "local":
+        from .local import LocalBackend
+
+        return LocalBackend()
+    if name == "modal":
+        from .modal_backend import ModalBackend
+
+        return ModalBackend()
+    if name == "e2b":
+        from .e2b import E2BBackend
+
+        return E2BBackend()
+    raise ValueError(
+        f"unknown runtime backend: {name!r}. "
+        f"Pick one of: {', '.join(list_backends())}."
+    )
+
+
+def list_backends() -> list[str]:
+    """Names accepted by :func:`get_backend`."""
+    return ["local", "modal", "e2b"]

--- a/src/mantis_agent/sim_envs/runtime.py
+++ b/src/mantis_agent/sim_envs/runtime.py
@@ -1,0 +1,99 @@
+"""RuntimeBackend protocol — pluggable hosting for simulated envs.
+
+Every backend implements the same five operations:
+
+* ``start(env_name, seed, now, admin_token)`` — boot a fresh env instance
+  with the supplied seed + frozen clock, return a :class:`RuntimeHandle`
+  the caller threads back into the other operations.
+* ``wait_healthy(handle, timeout_s)`` — block until ``/__env__/health``
+  returns 200 or raise :class:`TimeoutError`.
+* ``get_url(handle)`` — agent-facing base URL, e.g.
+  ``http://localhost:8001`` for the local backend, ``https://<id>-myenv-fn.modal.run``
+  for the Modal backend.
+* ``fetch_events(handle, since)`` — pull the env's ``events.jsonl`` (or
+  whatever equivalent the backend exposes) since the supplied wall-clock
+  timestamp. Returns a list of dicts; merging into the agent trace is
+  the caller's job (see :mod:`mantis_agent.gym.trace_exporter`).
+* ``stop(handle)`` — tear down the instance. Idempotent: calling twice
+  with the same handle should not raise.
+
+The protocol is intentionally narrow. Anything beyond these five ops
+(grading, URL templating, plan dispatch, batch runs) is backend-agnostic
+and lives in higher layers.
+
+The handle is a plain dataclass rather than an opaque ID because some
+backends (Modal) need to remember sub-objects (the deployed app handle,
+the per-run suffix, etc.) for ``stop`` and ``fetch_events``. Storing
+them on the handle keeps the call sites clean and the backend stateless
+between calls.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Protocol, runtime_checkable
+
+
+@dataclass
+class RuntimeHandle:
+    """Opaque-ish handle returned by ``RuntimeBackend.start``.
+
+    Most fields are populated by the backend and only meaningful to
+    that backend. ``url`` and ``admin_token`` are the two callers always
+    consume — everything else is bookkeeping.
+    """
+
+    env_name: str
+    url: str
+    admin_token: str
+    backend: str
+
+    # Backend-specific state. The local backend stuffs a process /
+    # container id; the Modal backend stuffs the per-run app name and
+    # function handle. Treat as private to the backend that produced it.
+    extra: dict[str, Any] = field(default_factory=dict)
+
+    # Unix epoch seconds — the moment ``start`` completed. ``fetch_events``
+    # uses this as the default ``since`` when the caller doesn't pass one.
+    started_at: float = 0.0
+
+
+@runtime_checkable
+class RuntimeBackend(Protocol):
+    """The five-method contract every hosting backend implements.
+
+    Implementations live in:
+
+    * :mod:`mantis_agent.sim_envs.local` — Docker (or stub subprocess)
+    * :mod:`mantis_agent.sim_envs.modal_backend` — one ``modal.App`` per env
+    * :mod:`mantis_agent.sim_envs.e2b` — stub raising NotImplementedError
+    """
+
+    name: str
+
+    def start(
+        self,
+        env_name: str,
+        *,
+        seed: int = 42,
+        now: str = "2026-01-15T09:00:00Z",
+        admin_token: str | None = None,
+    ) -> RuntimeHandle:
+        ...
+
+    def wait_healthy(self, handle: RuntimeHandle, *, timeout_s: float = 30.0) -> None:
+        ...
+
+    def get_url(self, handle: RuntimeHandle) -> str:
+        ...
+
+    def fetch_events(
+        self,
+        handle: RuntimeHandle,
+        *,
+        since: float | None = None,
+    ) -> list[dict[str, Any]]:
+        ...
+
+    def stop(self, handle: RuntimeHandle) -> None:
+        ...

--- a/src/mantis_agent/sim_envs/stub_app.py
+++ b/src/mantis_agent/sim_envs/stub_app.py
@@ -1,0 +1,284 @@
+"""Minimal stub env — proves the harness contract end-to-end without a real env.
+
+Implements just enough of the ``/__env__/*`` surface to (a) satisfy the
+acceptance criteria of #336 and (b) let the integration layer be tested
+without standing up a 50k-row CRM. Uses the stdlib ``http.server`` so the
+slim install (just Pillow) can boot the stub — no FastAPI dependency.
+
+Endpoints (mirror docs/envs/SPEC.md §"Shared harness contract"):
+
+* ``GET  /``             — bare HTML "stub env" page (the agent sees this)
+* ``GET  /__env__/health``  — ``{"ok": true, "seed": <int>, "now": <iso>}``
+* ``POST /__env__/reset``   — resets in-memory state; idempotent
+* ``POST /__env__/seed``    — re-seed with body ``{"seed": int}``
+* ``POST /__env__/clock``   — re-set clock with body ``{"now": iso8601}``
+* ``GET  /__env__/oracle``  — query param ``task_id``; returns canned grade
+* ``GET  /__env__/state``   — full in-memory state JSON
+* ``GET  /__env__/events``  — newline-delimited events emitted since boot
+
+Admin-token middleware:
+  Every ``/__env__/*`` route except ``/__env__/health`` requires the
+  ``X-Env-Admin`` header to match ``ENV_ADMIN_TOKEN``. Missing or wrong
+  token returns 401 with body ``{"error": "admin token required"}``.
+  ``/__env__/health`` is intentionally open so health-poll loops don't
+  need the token plumbed in — health is non-sensitive.
+
+The stub returns ``passed=true`` for any ``task_id`` so the integration
+layer has a non-trivial oracle response to assert against. Real envs
+land their own oracle logic; the stub only exists to prove plumbing.
+
+Run standalone for local testing::
+
+    python -m mantis_agent.sim_envs.stub_app --port 8001 \\
+        --admin-token devtoken --seed 42
+
+Or import the handler factory for in-process tests:
+
+    from mantis_agent.sim_envs.stub_app import build_handler
+    handler = build_handler(admin_token="t", seed=42, now="2026-01-15T09:00:00Z")
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Any
+from urllib.parse import parse_qs, urlparse
+
+logger = logging.getLogger(__name__)
+
+# Path of the agent-facing landing page. Anything under this prefix is
+# the SPA. ``/__env__/*`` is the harness surface and never returned to
+# the agent's browser context (the admin-token check enforces this).
+AGENT_LANDING_HTML = (
+    "<!doctype html><html><head><title>mantis stub env</title></head>"
+    "<body><h1>mantis stub env</h1><p>This is a stub. See "
+    "<code>docs/envs/SPEC.md</code> for the real contract.</p></body></html>"
+)
+
+
+class _EnvState:
+    """In-memory state for the stub. Real envs replace this with a DB."""
+
+    def __init__(self, seed: int, now: str, admin_token: str) -> None:
+        self.seed = seed
+        self.now = now
+        self.admin_token = admin_token
+        self.boot_time = time.time()
+        # Each entry: {"ts": float, "event": str, "data": dict}
+        self.events: list[dict[str, Any]] = []
+        # Touched flag so tests can verify reset cleared state.
+        self.touched = False
+        self._lock = threading.Lock()
+
+    def emit(self, event: str, data: dict[str, Any] | None = None) -> None:
+        with self._lock:
+            self.events.append({
+                "ts": time.time(),
+                "event": event,
+                "data": data or {},
+            })
+
+    def reset(self) -> None:
+        with self._lock:
+            self.events.clear()
+            self.touched = False
+            self.boot_time = time.time()
+
+
+def build_handler(
+    *,
+    admin_token: str,
+    seed: int = 42,
+    now: str = "2026-01-15T09:00:00Z",
+) -> type[BaseHTTPRequestHandler]:
+    """Build a request handler class closed over a fresh :class:`_EnvState`.
+
+    Returned as a class because :class:`HTTPServer` instantiates one
+    handler per request — the state has to live on a closure, not on
+    ``self``.
+    """
+
+    state = _EnvState(seed=seed, now=now, admin_token=admin_token)
+
+    class StubHandler(BaseHTTPRequestHandler):
+        # http.server logs to stderr by default; quiet it down so test
+        # output stays readable. Operators wanting verbose logs can set
+        # MANTIS_STUB_ENV_VERBOSE=1.
+        def log_message(self, format: str, *args: Any) -> None:  # noqa: A002
+            if os.environ.get("MANTIS_STUB_ENV_VERBOSE"):
+                super().log_message(format, *args)
+
+        # ── helpers ─────────────────────────────────────────────────
+        def _json(self, status: int, payload: dict[str, Any]) -> None:
+            body = json.dumps(payload).encode("utf-8")
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def _html(self, status: int, body_str: str) -> None:
+            body = body_str.encode("utf-8")
+            self.send_response(status)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def _read_json_body(self) -> dict[str, Any]:
+            length = int(self.headers.get("Content-Length") or "0")
+            if length <= 0:
+                return {}
+            raw = self.rfile.read(length)
+            try:
+                return json.loads(raw.decode("utf-8"))
+            except json.JSONDecodeError:
+                return {}
+
+        def _require_admin(self) -> bool:
+            token = self.headers.get("X-Env-Admin", "")
+            if token == state.admin_token:
+                return True
+            self._json(401, {"error": "admin token required"})
+            return False
+
+        # ── routing ─────────────────────────────────────────────────
+        def do_GET(self) -> None:  # noqa: N802 — http.server contract
+            parsed = urlparse(self.path)
+            path = parsed.path
+
+            # Health is open by design — health checks can't authenticate.
+            if path == "/__env__/health":
+                self._json(200, {
+                    "ok": True,
+                    "seed": state.seed,
+                    "now": state.now,
+                    "boot_time": state.boot_time,
+                })
+                return
+
+            if path.startswith("/__env__/"):
+                if not self._require_admin():
+                    return
+
+            if path == "/__env__/state":
+                self._json(200, {
+                    "seed": state.seed,
+                    "now": state.now,
+                    "touched": state.touched,
+                    "event_count": len(state.events),
+                })
+                return
+
+            if path == "/__env__/events":
+                qs = parse_qs(parsed.query)
+                since = float(qs.get("since", ["0"])[0])
+                filtered = [e for e in state.events if e["ts"] >= since]
+                self._json(200, {"events": filtered})
+                return
+
+            if path == "/__env__/oracle":
+                qs = parse_qs(parsed.query)
+                task_id = (qs.get("task_id", [""])[0] or "").strip()
+                state.emit("oracle_query", {"task_id": task_id})
+                # Stub: every task passes. Real envs encode per-task
+                # ground-truth assertions over the DB.
+                self._json(200, {
+                    "passed": True,
+                    "score": 1.0,
+                    "task_id": task_id,
+                    "reasons": ["stub env: every task passes"],
+                    "diff": {},
+                })
+                return
+
+            # Agent-facing surface: anything else returns the landing page.
+            self._html(200, AGENT_LANDING_HTML)
+
+        def do_POST(self) -> None:  # noqa: N802
+            parsed = urlparse(self.path)
+            path = parsed.path
+
+            if path.startswith("/__env__/"):
+                if not self._require_admin():
+                    return
+
+            if path == "/__env__/reset":
+                state.reset()
+                self._json(200, {"ok": True})
+                return
+
+            if path == "/__env__/seed":
+                body = self._read_json_body()
+                new_seed = int(body.get("seed", state.seed))
+                state.seed = new_seed
+                state.emit("seed_changed", {"seed": new_seed})
+                self._json(200, {"ok": True, "seed": new_seed})
+                return
+
+            if path == "/__env__/clock":
+                body = self._read_json_body()
+                new_now = str(body.get("now") or state.now)
+                state.now = new_now
+                state.emit("clock_changed", {"now": new_now})
+                self._json(200, {"ok": True, "now": new_now})
+                return
+
+            self._json(404, {"error": f"no route for POST {path}"})
+
+    return StubHandler
+
+
+def serve(host: str, port: int, *, admin_token: str, seed: int, now: str) -> HTTPServer:
+    """Boot a stub-env HTTP server bound to ``host:port`` and return it.
+
+    The server runs in its own thread so the caller (tests, env_up.py)
+    can do other work while it serves. Call :meth:`HTTPServer.shutdown`
+    to stop cleanly.
+    """
+    handler_cls = build_handler(admin_token=admin_token, seed=seed, now=now)
+    server = HTTPServer((host, port), handler_cls)
+    thread = threading.Thread(target=server.serve_forever, daemon=True, name=f"stub-env-{port}")
+    thread.start()
+    logger.info("stub env serving at http://%s:%d", host, port)
+    return server
+
+
+def main() -> None:
+    """CLI entrypoint: ``python -m mantis_agent.sim_envs.stub_app ...``."""
+    parser = argparse.ArgumentParser(description="mantis stub simulated env")
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=8001)
+    parser.add_argument("--admin-token", default=None,
+                        help="Admin token for /__env__/*. Default: ENV_ADMIN_TOKEN env var.")
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--now", default="2026-01-15T09:00:00Z")
+    args = parser.parse_args()
+
+    admin_token = args.admin_token or os.environ.get("ENV_ADMIN_TOKEN")
+    if not admin_token:
+        raise SystemExit("error: --admin-token or ENV_ADMIN_TOKEN must be set")
+
+    server = serve(
+        host=args.host,
+        port=args.port,
+        admin_token=admin_token,
+        seed=args.seed,
+        now=args.now,
+    )
+    try:
+        # Block forever — Ctrl-C exits.
+        while True:
+            time.sleep(3600)
+    except KeyboardInterrupt:
+        server.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/mantis_agent/sim_envs/templating.py
+++ b/src/mantis_agent/sim_envs/templating.py
@@ -1,0 +1,46 @@
+"""Plan URL templating — substitute ``{{ENV_URL}}`` with the live env URL.
+
+Plans under ``plans/<env>/`` carry a placeholder in the first navigate
+step rather than a hardcoded ``http://localhost:8001`` so the same plan
+JSON works against a local Docker env, a Modal env, or (one day) an
+e2b env with no edits.
+
+The substitution is a pure string replace inside the plan payload right
+before the runner sees it. We touch every string-shaped field on every
+step (intent + params values) — placeholders that show up in plain
+intents like ``"Navigate to {{ENV_URL}}/contacts"`` work the same way as
+the canonical ``params.url`` slot.
+
+Out of scope: more elaborate templating (Jinja, dotted lookups). Plans
+should stay declarative JSON; if a future env needs N variables we
+extend the placeholder set, not the templating engine.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+ENV_URL_PLACEHOLDER = "{{ENV_URL}}"
+
+
+def _replace_in(value: Any, env_url: str) -> Any:
+    """Recursively replace ``ENV_URL_PLACEHOLDER`` in strings inside a JSON-shaped value."""
+    if isinstance(value, str):
+        if ENV_URL_PLACEHOLDER in value:
+            return value.replace(ENV_URL_PLACEHOLDER, env_url)
+        return value
+    if isinstance(value, list):
+        return [_replace_in(item, env_url) for item in value]
+    if isinstance(value, dict):
+        return {k: _replace_in(v, env_url) for k, v in value.items()}
+    return value
+
+
+def substitute_env_url(plan_payload: dict[str, Any], env_url: str) -> dict[str, Any]:
+    """Return a copy of ``plan_payload`` with ``{{ENV_URL}}`` swapped for ``env_url``.
+
+    Trailing slash on ``env_url`` is stripped — plans usually template
+    ``{{ENV_URL}}/some/path`` so we don't want a double slash.
+    """
+    base = env_url.rstrip("/")
+    return _replace_in(plan_payload, base)

--- a/src/mantis_agent/sim_envs/trace_merge.py
+++ b/src/mantis_agent/sim_envs/trace_merge.py
@@ -1,0 +1,89 @@
+"""Merge env-side events into the agent trace post-run.
+
+After a plan finishes, the harness calls
+:meth:`RuntimeBackend.fetch_events` to pull the env's structured event
+log (timestamped HTTP requests + state mutations), then merges that
+list into the run's output directory as ``env_events.jsonl`` plus a
+unified ``merged_trace.jsonl`` that interleaves agent steps with env
+events by timestamp.
+
+The merge is opportunistic and additive:
+
+* If the env returns zero events (or the fetch errors out), we still
+  finish — the agent's own trace is untouched.
+* If an agent trace file isn't present (single-run CLI invocation
+  that bypasses ``TraceExporter``), we write only ``env_events.jsonl``.
+* Output schema stays JSONL so downstream tools can read it line by
+  line without buffering the whole file.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+from .runtime import RuntimeBackend, RuntimeHandle
+
+logger = logging.getLogger(__name__)
+
+
+def merge_env_events(
+    output_dir: Path,
+    backend: RuntimeBackend,
+    handle: RuntimeHandle,
+    *,
+    since: float | None = None,
+) -> int:
+    """Pull events from the env, write JSONL files, return event count.
+
+    Returns the number of events fetched (zero if the env had none or
+    the call errored). Caller can use the count for logging.
+    """
+    events = backend.fetch_events(handle, since=since)
+    if not events:
+        return 0
+
+    out_path = output_dir / "env_events.jsonl"
+    with out_path.open("w", encoding="utf-8") as fh:
+        for evt in events:
+            fh.write(json.dumps(evt) + "\n")
+
+    # Best-effort interleave with the agent trace. The CLI writes
+    # ``trace.jsonl`` only when the trace exporter is enabled
+    # (MANTIS_TRACE_EXPORT_DIR); without it the merge is just the env
+    # events.
+    trace_jsonl = output_dir / "trace.jsonl"
+    if trace_jsonl.exists():
+        try:
+            merged = _interleave(trace_jsonl, events)
+        except Exception:  # noqa: BLE001
+            logger.exception("trace merge: interleave failed; env_events.jsonl is authoritative")
+            return len(events)
+        (output_dir / "merged_trace.jsonl").write_text(
+            "\n".join(json.dumps(item) for item in merged) + "\n",
+            encoding="utf-8",
+        )
+
+    return len(events)
+
+
+def _interleave(trace_jsonl: Path, env_events: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Sort agent steps and env events by timestamp into one stream."""
+    items: list[tuple[float, dict[str, Any]]] = []
+    for line in trace_jsonl.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        ts = float(obj.get("ts") or obj.get("started_at") or 0.0)
+        items.append((ts, {"source": "agent", **obj}))
+    for evt in env_events:
+        ts = float(evt.get("ts") or 0.0)
+        items.append((ts, {"source": "env", **evt}))
+    items.sort(key=lambda pair: pair[0])
+    return [obj for _, obj in items]

--- a/tests/test_admin_token_isolation.py
+++ b/tests/test_admin_token_isolation.py
@@ -1,0 +1,122 @@
+"""Admin-token isolation tests for the stub env.
+
+The harness contract (#336): the admin token used to call ``/__env__/*``
+endpoints MUST NOT be reachable from the agent's browser context. The
+agent navigates to ``/`` (a normal SPA), the harness signs admin calls
+out-of-band, and the two surfaces share no auth material.
+
+Tested invariants:
+
+* ``/__env__/oracle`` returns 401 without ``X-Env-Admin``.
+* ``/__env__/oracle`` returns 401 with the WRONG ``X-Env-Admin``.
+* ``/__env__/reset`` / ``/__env__/seed`` / ``/__env__/clock`` /
+  ``/__env__/state`` / ``/__env__/events`` all gate on the token.
+* ``/__env__/health`` is intentionally OPEN (health checks can't
+  authenticate). This is a contract assertion — surface in case anyone
+  adds gating here later by accident.
+* Agent-facing GET ``/`` doesn't echo the admin token anywhere in its
+  body — sanity check on the response we'd render in a real env.
+"""
+
+from __future__ import annotations
+
+import json
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+
+import pytest
+
+from mantis_agent.sim_envs.local import LocalBackend
+
+
+@pytest.fixture
+def stub_env():
+    backend = LocalBackend()
+    handle = backend.start("stub-test", seed=42)
+    try:
+        backend.wait_healthy(handle, timeout_s=10.0)
+        yield handle
+    finally:
+        backend.stop(handle)
+
+
+def _get(url: str, *, headers: dict | None = None) -> tuple[int, str]:
+    req = Request(url, headers=headers or {})
+    try:
+        with urlopen(req, timeout=2.0) as resp:  # noqa: S310
+            return resp.status, resp.read().decode("utf-8")
+    except HTTPError as exc:
+        return exc.code, exc.read().decode("utf-8")
+
+
+def _post(url: str, *, headers: dict | None = None, body: dict | None = None) -> tuple[int, str]:
+    data = json.dumps(body or {}).encode("utf-8")
+    req = Request(
+        url, data=data, method="POST",
+        headers={"Content-Type": "application/json", **(headers or {})},
+    )
+    try:
+        with urlopen(req, timeout=2.0) as resp:  # noqa: S310
+            return resp.status, resp.read().decode("utf-8")
+    except HTTPError as exc:
+        return exc.code, exc.read().decode("utf-8")
+
+
+@pytest.mark.parametrize("path", [
+    "/__env__/oracle?task_id=T01",
+    "/__env__/state",
+    "/__env__/events",
+])
+def test_admin_endpoints_require_token_get(stub_env, path):
+    """GET /__env__/* without the token returns 401."""
+    status, body = _get(f"{stub_env.url}{path}")
+    assert status == 401
+    assert "admin token" in body.lower()
+
+
+@pytest.mark.parametrize("path", [
+    "/__env__/reset",
+    "/__env__/seed",
+    "/__env__/clock",
+])
+def test_admin_endpoints_require_token_post(stub_env, path):
+    """POST /__env__/* without the token returns 401."""
+    status, body = _post(f"{stub_env.url}{path}")
+    assert status == 401
+    assert "admin token" in body.lower()
+
+
+def test_wrong_token_still_401(stub_env):
+    status, _ = _get(
+        f"{stub_env.url}/__env__/oracle?task_id=T",
+        headers={"X-Env-Admin": "GUESSED_VALUE"},
+    )
+    assert status == 401
+
+
+def test_health_is_open(stub_env):
+    """Health endpoint MUST work without a token (health checks can't auth)."""
+    status, body = _get(f"{stub_env.url}/__env__/health")
+    assert status == 200
+    assert json.loads(body)["ok"] is True
+
+
+def test_correct_token_unlocks_oracle(stub_env):
+    status, body = _get(
+        f"{stub_env.url}/__env__/oracle?task_id=T01",
+        headers={"X-Env-Admin": stub_env.admin_token},
+    )
+    assert status == 200
+    payload = json.loads(body)
+    assert payload["task_id"] == "T01"
+    assert payload["passed"] is True
+
+
+def test_agent_landing_page_does_not_leak_admin_token(stub_env):
+    """The agent's view of the SPA must not contain the admin token."""
+    status, body = _get(stub_env.url + "/")
+    assert status == 200
+    # The admin token is high-entropy random — assert it's absent in the
+    # HTML we render to the agent.
+    assert stub_env.admin_token not in body
+    assert "stub env" in body.lower()

--- a/tests/test_env_up.py
+++ b/tests/test_env_up.py
@@ -1,0 +1,111 @@
+"""Tests for the local backend lifecycle (subprocess stub mode).
+
+These tests do NOT require Docker — they exercise the subprocess fallback
+that the local backend uses when no Docker image is registered for an
+env name. The stub env is a Python subprocess serving the harness
+contract on a free local port.
+
+Coverage:
+
+* ``start`` + ``wait_healthy`` boots the stub and lands ``/__env__/health``.
+* ``get_url`` returns the bound URL.
+* ``stop`` terminates the subprocess.
+* Two concurrent starts get different ports (port-conflict regression).
+* Health timeout surfaces a clear ``TimeoutError`` instead of hanging.
+"""
+
+from __future__ import annotations
+
+import json
+import socket
+import time
+from urllib.error import URLError
+from urllib.request import Request, urlopen
+
+import pytest
+
+from mantis_agent.sim_envs.local import LocalBackend, _pick_free_port
+
+
+def _http_get(url: str, *, timeout: float = 2.0, headers: dict | None = None) -> tuple[int, str]:
+    req = Request(url, headers=headers or {})
+    try:
+        with urlopen(req, timeout=timeout) as resp:  # noqa: S310
+            return resp.status, resp.read().decode("utf-8")
+    except URLError as exc:
+        # urlopen raises HTTPError (a URLError subclass) on non-2xx.
+        code = getattr(exc, "code", None)
+        if code is not None:
+            return code, getattr(exc, "reason", "") or ""
+        raise
+
+
+def test_pick_free_port_returns_unique_ports():
+    p1 = _pick_free_port()
+    p2 = _pick_free_port()
+    assert p1 != p2 or p1 > 0  # at minimum, port is valid
+
+
+def test_local_backend_starts_and_stops_stub_env():
+    backend = LocalBackend()
+    handle = backend.start("stub-test", seed=7, now="2026-02-01T00:00:00Z")
+    try:
+        backend.wait_healthy(handle, timeout_s=10.0)
+        status, body = _http_get(f"{handle.url}/__env__/health")
+        assert status == 200
+        payload = json.loads(body)
+        assert payload["ok"] is True
+        assert payload["seed"] == 7
+        assert payload["now"] == "2026-02-01T00:00:00Z"
+        assert backend.get_url(handle).startswith("http://127.0.0.1:")
+    finally:
+        backend.stop(handle)
+
+    # After stop the port should be free again (eventually). Polling
+    # briefly to avoid platform-specific TIME_WAIT noise.
+    deadline = time.time() + 3.0
+    while time.time() < deadline:
+        try:
+            _http_get(f"{handle.url}/__env__/health", timeout=0.5)
+        except Exception:  # noqa: BLE001 — expected
+            break
+        time.sleep(0.1)
+
+
+def test_local_backend_two_starts_get_distinct_urls():
+    backend = LocalBackend()
+    h1 = backend.start("stub-test")
+    h2 = backend.start("stub-test")
+    try:
+        assert h1.url != h2.url
+        backend.wait_healthy(h1, timeout_s=10.0)
+        backend.wait_healthy(h2, timeout_s=10.0)
+    finally:
+        backend.stop(h1)
+        backend.stop(h2)
+
+
+def test_stop_is_idempotent():
+    backend = LocalBackend()
+    handle = backend.start("stub-test")
+    backend.wait_healthy(handle, timeout_s=10.0)
+    backend.stop(handle)
+    backend.stop(handle)  # second call must not raise
+
+
+def test_health_timeout_raises_clear_error():
+    """A handle pointed at nothing should time out cleanly."""
+    backend = LocalBackend()
+    from mantis_agent.sim_envs.runtime import RuntimeHandle
+
+    # Bind+release a port — guaranteed nothing listening on it.
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        dead_port = s.getsockname()[1]
+
+    handle = RuntimeHandle(
+        env_name="dead", url=f"http://127.0.0.1:{dead_port}",
+        admin_token="x", backend="local", extra={"mode": "subprocess"},
+    )
+    with pytest.raises(TimeoutError):
+        backend.wait_healthy(handle, timeout_s=1.0)

--- a/tests/test_grading.py
+++ b/tests/test_grading.py
@@ -1,0 +1,146 @@
+"""Tests for ``grade_run`` — the oracle-call wrapper.
+
+Stand up a one-off HTTP server with a configurable oracle response and
+assert that :func:`grade_run` parses it correctly. Failure modes covered:
+
+* Passing / failing oracle responses round-trip into :class:`GradingResult`.
+* 401 from a wrong admin token surfaces as ``error`` (not a raise).
+* Network failure (closed port) surfaces as ``error`` (not a raise).
+* Non-JSON body surfaces as ``error``.
+* Missing ``task_id`` short-circuits with a clear ``error``.
+"""
+
+from __future__ import annotations
+
+import json
+import socket
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+from mantis_agent.gym.grading import GradingResult, grade_run
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+class _OracleHandler(BaseHTTPRequestHandler):
+    response: dict = {"passed": True, "score": 1.0, "reasons": ["ok"], "diff": {}}
+    admin_token = "trusted"
+
+    def log_message(self, fmt, *args):  # noqa: ANN001, A002
+        return  # silence test log
+
+    def do_GET(self):  # noqa: N802
+        parsed = urlparse(self.path)
+        if parsed.path != "/__env__/oracle":
+            self.send_response(404)
+            self.end_headers()
+            return
+        if self.headers.get("X-Env-Admin") != self.admin_token:
+            self.send_response(401)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(b'{"error":"admin"}')
+            return
+        qs = parse_qs(parsed.query)
+        task_id = qs.get("task_id", [""])[0]
+        body = dict(self.response)
+        body["task_id"] = task_id
+        raw = json.dumps(body).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(raw)))
+        self.end_headers()
+        self.wfile.write(raw)
+
+
+@pytest.fixture
+def oracle_server():
+    port = _free_port()
+    server = HTTPServer(("127.0.0.1", port), _OracleHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{port}", _OracleHandler.admin_token
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_oracle_pass(oracle_server):
+    url, token = oracle_server
+    result = grade_run(url, token, "T01_demo")
+    assert isinstance(result, GradingResult)
+    assert result.passed is True
+    assert result.score == 1.0
+    assert result.task_id == "T01_demo"
+    assert result.error is None
+    assert "ok" in result.reasons
+
+
+def test_oracle_fail(oracle_server):
+    url, token = oracle_server
+    _OracleHandler.response = {
+        "passed": False, "score": 0.0,
+        "reasons": ["wrong contact tagged"], "diff": {"unexpected": 1},
+    }
+    try:
+        result = grade_run(url, token, "T02_demo")
+        assert result.passed is False
+        assert "wrong contact tagged" in result.reasons
+        assert result.diff == {"unexpected": 1}
+        assert result.error is None
+    finally:
+        _OracleHandler.response = {
+            "passed": True, "score": 1.0, "reasons": ["ok"], "diff": {},
+        }
+
+
+def test_wrong_admin_token_yields_error_not_raise(oracle_server):
+    url, _ = oracle_server
+    result = grade_run(url, "WRONG_TOKEN", "T03_demo")
+    assert result.passed is False
+    assert result.error is not None
+    assert "401" in result.error
+
+
+def test_connection_failure_yields_error_not_raise():
+    """Use a port that's definitely closed to provoke a connection refused."""
+    port = _free_port()  # bind+release so OS knows nothing is listening
+    result = grade_run(f"http://127.0.0.1:{port}", "any", "T04")
+    assert result.passed is False
+    assert result.error is not None
+
+
+def test_grading_result_round_trips_to_dict():
+    gr = GradingResult(
+        task_id="T05", passed=True, score=0.42,
+        reasons=["a", "b"], diff={"k": 1},
+    )
+    d = gr.to_dict()
+    assert d["task_id"] == "T05"
+    assert d["passed"] is True
+    assert d["score"] == 0.42
+    assert d["reasons"] == ["a", "b"]
+    assert d["diff"] == {"k": 1}
+    assert d["error"] is None
+
+
+def test_empty_task_id_short_circuits():
+    result = grade_run("http://does-not-matter", "tok", "")
+    assert result.passed is False
+    assert result.error is not None
+    assert "task_id" in result.error.lower()
+
+
+def test_empty_url_short_circuits():
+    result = grade_run("", "tok", "T07")
+    assert result.passed is False
+    assert result.error is not None
+    assert "env_url" in result.error.lower()

--- a/tests/test_plan_url_templating.py
+++ b/tests/test_plan_url_templating.py
@@ -1,0 +1,90 @@
+"""Tests for plan URL templating — ``{{ENV_URL}}`` substitution.
+
+The harness substitutes ``{{ENV_URL}}`` for the booted env's base URL
+on every string-shaped field in the plan JSON. These tests assert:
+
+* String fields under ``params.url`` get substituted.
+* Free-text intents (e.g. ``"Navigate to {{ENV_URL}}/foo"``) also get
+  substituted — common when authors write plans by hand.
+* Non-string values are untouched.
+* Trailing slashes on ``env_url`` are normalised so we don't end up with
+  ``http://host//path``.
+"""
+
+from __future__ import annotations
+
+from mantis_agent.sim_envs.templating import (
+    ENV_URL_PLACEHOLDER,
+    substitute_env_url,
+)
+
+
+def test_substitutes_params_url():
+    plan = {
+        "steps": [
+            {
+                "type": "navigate",
+                "params": {"url": f"{ENV_URL_PLACEHOLDER}/contacts"},
+                "intent": "Open contacts",
+            }
+        ],
+    }
+    out = substitute_env_url(plan, "http://127.0.0.1:8001")
+    assert out["steps"][0]["params"]["url"] == "http://127.0.0.1:8001/contacts"
+
+
+def test_substitutes_intent_string():
+    plan = {
+        "steps": [
+            {
+                "type": "navigate",
+                "intent": f"Open {ENV_URL_PLACEHOLDER}/deals",
+                "params": {},
+            }
+        ],
+    }
+    out = substitute_env_url(plan, "http://example/")
+    assert out["steps"][0]["intent"] == "Open http://example/deals"
+
+
+def test_normalises_trailing_slash():
+    plan = {"steps": [{"params": {"url": f"{ENV_URL_PLACEHOLDER}/x"}}]}
+    out = substitute_env_url(plan, "http://h:1234///")
+    assert out["steps"][0]["params"]["url"] == "http://h:1234/x"
+
+
+def test_leaves_non_string_fields_untouched():
+    plan = {
+        "steps": [
+            {
+                "type": "loop",
+                "loop_count": 5,
+                "params": {"flags": [True, False, 1]},
+            }
+        ],
+    }
+    out = substitute_env_url(plan, "http://x")
+    assert out["steps"][0]["loop_count"] == 5
+    assert out["steps"][0]["params"]["flags"] == [True, False, 1]
+
+
+def test_no_placeholder_is_passthrough():
+    plan = {"steps": [{"params": {"url": "http://live.example/page"}}]}
+    out = substitute_env_url(plan, "http://anything")
+    assert out["steps"][0]["params"]["url"] == "http://live.example/page"
+
+
+def test_nested_dict_in_params():
+    plan = {
+        "steps": [
+            {
+                "params": {
+                    "nested": {
+                        "deeper": {"url": f"{ENV_URL_PLACEHOLDER}/q"},
+                    },
+                },
+            }
+        ],
+    }
+    out = substitute_env_url(plan, "http://e")
+    assert out["steps"][0]["params"]["nested"]["deeper"]["url"] == "http://e/q"

--- a/tests/test_runtime_modal.py
+++ b/tests/test_runtime_modal.py
@@ -1,0 +1,110 @@
+"""Tests for the Modal runtime backend.
+
+We mock the ``modal`` SDK so the suite runs without a Modal account.
+Two paths covered:
+
+* ``stub`` env name short-circuits to the long-lived ``mantis-sim-env-stub``
+  app (no per-run deploy).
+* Other env names look up ``mantis-sim-env-<env>-<suffix>`` and fail
+  clearly when the function isn't deployed.
+
+We also test the e2b backend stub raises ``NotImplementedError`` with a
+clear message (so a half-finished landing of #336.5 is caught).
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from unittest import mock
+
+import pytest
+
+from mantis_agent.sim_envs.e2b import E2BBackend
+from mantis_agent.sim_envs.registry import get_backend, list_backends
+
+
+def _install_fake_modal(get_web_url: str = "https://fake-modal.run") -> types.ModuleType:
+    """Build a minimal fake ``modal`` module and register it in sys.modules."""
+    fake = types.ModuleType("modal")
+
+    class FakeFunction:
+        @classmethod
+        def from_name(cls, app_name: str, fn_name: str):
+            f = cls()
+            f.app_name = app_name
+            f.fn_name = fn_name
+            return f
+
+        def get_web_url(self) -> str:
+            return get_web_url
+
+    fake.Function = FakeFunction
+    sys.modules["modal"] = fake
+    return fake
+
+
+def test_list_backends_returns_three():
+    assert list_backends() == ["local", "modal", "e2b"]
+
+
+def test_get_backend_unknown_raises():
+    with pytest.raises(ValueError):
+        get_backend("nonexistent")
+
+
+def test_e2b_backend_start_raises_not_implemented():
+    backend = E2BBackend()
+    with pytest.raises(NotImplementedError) as ei:
+        backend.start("stub")
+    assert "v1" in str(ei.value)
+
+
+def test_modal_backend_stub_env_uses_shared_app(monkeypatch):
+    _install_fake_modal("https://fake-stub.modal.run")
+    from mantis_agent.sim_envs.modal_backend import ModalBackend
+
+    backend = ModalBackend()
+    handle = backend.start("stub", admin_token="t1")
+    assert handle.url == "https://fake-stub.modal.run"
+    assert handle.extra["app_name"] == "mantis-sim-env-stub"
+    assert handle.backend == "modal"
+    # No-op stop on the shared stub app.
+    backend.stop(handle)
+
+
+def test_modal_backend_missing_env_raises_clear_error(monkeypatch):
+    fake = _install_fake_modal()
+
+    class _Boom:
+        @classmethod
+        def from_name(cls, *_a, **_kw):
+            raise RuntimeError("function not found")
+
+    fake.Function = _Boom
+
+    from mantis_agent.sim_envs.modal_backend import ModalBackend
+
+    backend = ModalBackend()
+    with pytest.raises(RuntimeError) as ei:
+        backend.start("mantis-crm")
+    msg = str(ei.value)
+    # The clear error mentions deploy path + suggests --runtime local fallback
+    assert "deploy/sim_envs" in msg
+    assert "--runtime local" in msg
+
+
+def test_modal_backend_missing_sdk(monkeypatch):
+    """No ``modal`` module on path → start() raises a friendly error."""
+    monkeypatch.delitem(sys.modules, "modal", raising=False)
+    # ``import modal`` inside the backend should hit ImportError.
+    with mock.patch.dict(
+        sys.modules,
+        {"modal": None},  # type: ignore[dict-item]
+    ):
+        from mantis_agent.sim_envs.modal_backend import ModalBackend
+
+        backend = ModalBackend()
+        with pytest.raises(RuntimeError) as ei:
+            backend.start("stub")
+        assert "modal SDK not installed" in str(ei.value)


### PR DESCRIPTION
## Summary

Lands the integration layer for the simulated environments epic (#331) — the wiring that makes per-env containers usable from \`mantis plan run\`. Real envs land in #332+ on top of this.

- **\`RuntimeBackend\` protocol** with three impls: \`local\` (Docker / subprocess stub), \`modal\` (one app per env), \`e2b\` (reserved — \`NotImplementedError\` with a clear message; flag exists so the backend lands without touching CLI / plans / envs).
- **Stub env** under \`mantis_agent/sim_envs/stub_app.py\` — stdlib \`http.server\`, no FastAPI in the slim install. Serves \`/__env__/{health, reset, seed, clock, oracle, state, events}\` with \`X-Env-Admin\` middleware (health is intentionally open).
- **\`grade_run\`** in \`mantis_agent/gym/grading.py\` — hits \`GET /__env__/oracle?task_id=…\`, parses verdict into a \`GradingResult\` dataclass; never raises, surfaces network/auth failures as \`error\`.
- **CLI** — \`mantis plan run … --env <name> [--seed N] [--now ISO] [--runtime local|modal|e2b] [--keep]\`. When \`--env\` is absent the existing path is bit-identical.
- **\`{{ENV_URL}}\` templating** — substituted into the plan dict pre-run; covers \`params.url\` and free-text intents.
- **\`env_up.py\`** local lifecycle CLI (\`start\` / \`stop\` / \`health\`) for keeping a hot env across shells.
- **\`benchmarks/sim_envs.py\`** — batch oracle-graded eval across \`plans/<env>/*.json\`, parallel via \`--max-workers\`, exits non-zero if any plan didn't pass.
- **\`deploy/sim_envs/modal_stub.py\`** — \`mantis-sim-env-stub\` Modal app for the cloud-agent path.
- **Docs** — \`docs/envs/HARNESS.md\` ships with the code (per repo discipline).
- **\`RunReport\`-shaped \`result.json\`** gains an optional \`grading\` block; \`oracle.json\` + \`env_events.jsonl\` land next to \`trace.jsonl\`. All additive.

## Acceptance criteria (#336)

- [x] \`env_up start/stop\` against the stub env
- [x] \`mantis plan run --env stub --runtime local\` runs end-to-end with grading output
- [x] \`mantis plan run --env stub --runtime modal\` path wired (Modal stub deploy file shipped)
- [x] \`--runtime e2b\` raises a clear not-implemented error
- [x] \`RunReport.grading\` populates and round-trips
- [x] \`benchmarks/sim_envs.py\` runs N plans without port conflicts (local) / app-name conflicts (modal — per-run suffix)
- [x] Admin-token isolation: agent landing page does not contain the token; \`/__env__/*\` returns 401 without header
- [x] Tests landed: \`test_env_up\`, \`test_runtime_modal\`, \`test_grading\`, \`test_admin_token_isolation\`, \`test_plan_url_templating\` (34 new tests)

## Backwards compatibility

Strictly additive. No existing test broken — verified:

- 129/129 in the affected test suites (34 new + 95 existing CLI / plan / runner / examples / reporter).
- 2043/2043 in the full repo suite pre-doc-touchups (one pre-existing collection error from a missing \`jsonschema\` dep unrelated to this PR).

The existing \`cmd_plan_run\` flow is bit-identical when \`--env\` is absent — the env wiring is gated behind \`if args.env:\` at every touch point.

## Test plan

- [x] Run new test suites locally (\`tests/test_{env_up,grading,admin_token_isolation,plan_url_templating,runtime_modal}.py\`)
- [x] Verify CLI surface unchanged when \`--env\` absent (\`tests/test_cli_plan_run*.py\`)
- [x] End-to-end smoke: \`mantis plan run examples/sim_envs/stub_T01_passthrough.json --env stub --runtime local\` — env boots, plan navigates to env URL, oracle returns \`passed=true\`, \`oracle.json\` + \`grading\` written, env torn down
- [ ] Modal stub deploy + cross-host smoke: \`uv run modal deploy deploy/sim_envs/modal_stub.py\` then run with \`--runtime modal\` (deferred — needs Modal workspace access)
- [ ] \`benchmarks/sim_envs.py\` in CI against a hosted brain (will be exercised by the per-env PRs)

## Sequencing

Prerequisite for #332 (mantis-crm), #333 (mantis-helpdesk), #334 (mantis-shop), #335 (mantis-docs). Each of those PRs lands an entry in \`mantis_agent.sim_envs.local._image_for_env\`, a \`deploy/sim_envs/<env>.py\`, a \`SiteConfig.default_<env>()\`, and ≥5 plans under \`plans/<env>/\` — nothing in this harness needs to change.

Closes #336

🤖 Generated with [Claude Code](https://claude.com/claude-code)