### PR TITLE
Split state_key into profile_id + workflow_id (#341); Modal HTTP detached-run endpoint (#342)

### DIFF
--- a/deploy/modal/modal_cua_server.py
+++ b/deploy/modal/modal_cua_server.py
@@ -1171,6 +1171,406 @@ def run_claude_cua(task_file_contents: str, claude_model: str = "claude-sonnet-4
     return _run_claude_executor(task_file_contents, claude_model=claude_model, **kwargs)
 
 
+# ═══════════════════════════════════════════════════════════════════
+# D) HTTP API (#342) — concurrent multi-plan submission via ASGI
+# ═══════════════════════════════════════════════════════════════════
+
+# Lightweight image — no Chrome, no CUDA, no vLLM. Just FastAPI +
+# pydantic + the mantis_agent package. The ASGI container only validates,
+# locks, and dispatches; all heavy work happens in the executor functions
+# above via .spawn().
+api_image = (
+    modal.Image.debian_slim(python_version="3.11")
+    .pip_install(
+        "fastapi>=0.110",
+        "uvicorn[standard]>=0.27",
+        "pydantic>=2.0",
+        "requests",
+        "anthropic",
+    )
+    .add_local_python_source("mantis_agent")
+)
+
+
+def _executor_for_model(model: str):
+    """Map ``cua_model`` → the appropriate ``@app.function`` executor."""
+    table = {
+        "evocua-8b": run_cua_1gpu,
+        "evocua-32b": run_cua_2gpu,
+        "opencua-32b": run_cua_4gpu,
+        "opencua-72b": run_cua_8gpu,
+        "holo3": run_holo3,
+        "gemma4-cua": run_gemma4_cua,
+        "claude": run_claude_cua,
+    }
+    return table.get(model, run_holo3)
+
+
+def _build_suite_from_payload(payload: dict) -> str:
+    """Build the ``task_file_contents`` string the executors expect.
+
+    Supports three pre-decomposed shapes for Phase 1 of #342:
+
+    * ``task_suite`` dict — used verbatim.
+    * ``task_file_contents`` string — used verbatim.
+    * ``micro`` ending in ``.json`` — loaded, packed via
+      :func:`build_micro_suite` with the resolved identity (#341).
+
+    ``plan_text`` and ``.txt`` ``micro`` paths require Claude
+    decomposition and are explicitly out of scope for Phase 1 — see
+    issue #342 Phase 2.
+    """
+    if payload.get("task_suite"):
+        return json.dumps(payload["task_suite"])
+    if payload.get("task_file_contents"):
+        return payload["task_file_contents"]
+
+    micro = payload.get("micro") or payload.get("micro_path") or ""
+    if not micro or not micro.endswith(".json"):
+        raise ValueError(
+            "Modal HTTP endpoint v1 requires task_suite, task_file_contents, "
+            "or a .json micro path. Free-text decomposition is Phase 2 (#342)."
+        )
+
+    from pathlib import Path as _Path
+    from mantis_agent.plan_decomposer import MicroPlan, PlanDecomposer
+
+    path = _Path(micro)
+    if not path.is_absolute():
+        repo_root = _Path(os.environ.get("MANTIS_REPO_ROOT", "/workspace/cua-agent"))
+        path = repo_root / path
+    if not path.exists():
+        raise FileNotFoundError(f"micro plan not found: {path}")
+
+    raw_steps = json.loads(path.read_text())
+    micro_plan = MicroPlan(domain=path.stem)
+    for step in raw_steps:
+        micro_plan.steps.append(PlanDecomposer._build_intent(step))
+
+    steps_dicts = micro_plan_steps_to_dicts(micro_plan.steps)
+    suite = build_micro_suite(
+        steps_dicts,
+        micro_plan.domain,
+        max_cost=float(payload.get("max_cost", 10.0)),
+        max_time_minutes=int(payload.get("max_time_minutes", 180)),
+        resume_state=bool(payload.get("resume_state", False)),
+        state_key=str(payload.get("state_key") or ""),
+        profile_id=str(payload.get("profile_id") or ""),
+        workflow_id=str(payload.get("workflow_id") or ""),
+        proxy_city=str(payload.get("proxy_city") or ""),
+        proxy_state=str(payload.get("proxy_state") or ""),
+        proxy_disabled=bool(payload.get("proxy_disabled", False)),
+    )
+    return json.dumps(suite)
+
+
+def _run_dir(tenant_id: str, run_id: str):
+    from pathlib import Path as _Path
+    from mantis_agent.server_utils import safe_state_key as _safe
+    root = _Path(os.environ.get("MANTIS_DATA_DIR", "/data"))
+    return root / "tenants" / _safe(tenant_id) / "runs" / _safe(run_id)
+
+
+def _commit_volume() -> None:
+    """Best-effort ``vol.commit()`` — no-op when the Modal volume isn't mounted (tests)."""
+    try:
+        vol.commit()
+    except Exception:
+        pass
+
+
+def _write_status(tenant_id: str, run_id: str, status: dict) -> None:
+    run_dir = _run_dir(tenant_id, run_id)
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / "status.json").write_text(json.dumps(status, indent=2))
+    _commit_volume()
+
+
+def _read_status(tenant_id: str, run_id: str) -> dict | None:
+    path = _run_dir(tenant_id, run_id) / "status.json"
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text())
+    except Exception:
+        return None
+
+
+def _write_result(tenant_id: str, run_id: str, result: dict) -> None:
+    run_dir = _run_dir(tenant_id, run_id)
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / "result.json").write_text(json.dumps(result, indent=2))
+    _commit_volume()
+
+
+def _read_result(tenant_id: str, run_id: str) -> dict | None:
+    path = _run_dir(tenant_id, run_id) / "result.json"
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text())
+    except Exception:
+        return None
+
+
+def build_api_app(executor_resolver=None, function_call_lookup=None):
+    """Construct the FastAPI app exposed by the Modal ASGI endpoint (#342).
+
+    Factored into a plain function (not wrapped by ``@modal.asgi_app()``)
+    so unit tests can drive it through ``fastapi.testclient.TestClient``
+    without going through Modal's runtime.
+
+    * ``executor_resolver(model) -> executor_fn`` — overrides the
+      built-in ``_executor_for_model`` map. Tests pass a stub that
+      returns a fake ``.spawn(...)`` handle.
+    * ``function_call_lookup(call_id) -> FunctionCall`` — overrides
+      ``modal.FunctionCall.from_id``. Tests pass a stub that returns
+      a fake ``.get(timeout=...) / .cancel()`` interface so polling
+      doesn't need a live Modal runtime.
+    """
+    from datetime import datetime, timezone
+
+    from fastapi import Depends, FastAPI, HTTPException, Request
+
+    from mantis_agent.baseten_server.middleware import require_run_scope
+    from mantis_agent.server.run_dispatch import (
+        DispatchError,
+        acquire_profile_lock,
+        prepare_predict_payload,
+        read_profile_lock,
+        release_profile_lock,
+    )
+    from mantis_agent.server_utils import new_run_id as _mint_run_id
+    from mantis_agent.tenant_auth import TenantConfig
+
+    resolve_executor = executor_resolver or _executor_for_model
+    lookup_function_call = function_call_lookup or modal.FunctionCall.from_id
+
+    fastapi_app = FastAPI(
+        title="Mantis CUA (Modal)",
+        version="0.1",
+        description="Concurrent multi-plan submission via @modal.asgi_app — #342",
+    )
+
+    @fastapi_app.get("/v1/health")
+    def health() -> dict:
+        return {"status": "ok", "service": "mantis-cua-modal-api"}
+
+    @fastapi_app.get("/v1/models")
+    def models() -> dict:
+        return {
+            "object": "list",
+            "data": [
+                {"id": name, "object": "model", "owned_by": "mantis"}
+                for name in (
+                    "evocua-8b", "evocua-32b", "opencua-32b", "opencua-72b",
+                    "holo3", "gemma4-cua", "claude",
+                )
+            ],
+        }
+
+    @fastapi_app.post("/v1/predict")
+    async def predict(
+        request: Request,
+        tenant: TenantConfig = Depends(require_run_scope),
+    ) -> dict:
+        try:
+            raw = await request.json()
+        except Exception:
+            raise HTTPException(400, "request body must be JSON")
+        try:
+            payload = prepare_predict_payload(raw, tenant)
+        except DispatchError as exc:
+            raise HTTPException(exc.status_code, exc.detail) from exc
+
+        # Action mode: poll/cancel an existing run.
+        if payload.get("action"):
+            return _do_action(payload, tenant)
+
+        # Run mode: build suite, lock the profile, spawn the executor.
+        try:
+            task_file_contents = _build_suite_from_payload(payload)
+        except (ValueError, FileNotFoundError) as exc:
+            raise HTTPException(400, str(exc)) from exc
+
+        profile_id = payload["profile_id"]
+        workflow_id = payload["workflow_id"]
+        run_id = _mint_run_id()
+
+        # 409 if another run is using this profile (Chrome lock).
+        if not acquire_profile_lock(tenant, profile_id, run_id):
+            existing = read_profile_lock(tenant, profile_id)
+            raise HTTPException(
+                409,
+                f"profile_id {profile_id!r} is busy; held by run_id={existing!r}. "
+                "Use a different profile_id or wait for the existing run to finish.",
+            )
+
+        model = payload.get("cua_model") or payload.get("model") or "holo3"
+        executor_fn = resolve_executor(model)
+
+        # Forward only what the executors accept. `task_file_contents`
+        # is positional; everything else is **kwargs.
+        spawn_kwargs: dict = {
+            "max_steps": int(payload.get("max_steps", 30)),
+        }
+        if model != "claude":
+            spawn_kwargs["cua_model"] = model
+        try:
+            call_handle = executor_fn.spawn(
+                task_file_contents=task_file_contents,
+                **spawn_kwargs,
+            )
+        except Exception as exc:
+            release_profile_lock(tenant, profile_id)
+            raise HTTPException(500, f"executor spawn failed: {exc}") from exc
+
+        now = datetime.now(timezone.utc).isoformat()
+        status = {
+            "run_id": run_id,
+            "status": "queued",
+            "created_at": now,
+            "updated_at": now,
+            "modal_call_id": getattr(call_handle, "object_id", "") or "",
+            "tenant_id": tenant.tenant_id,
+            "profile_id": profile_id,
+            "workflow_id": workflow_id,
+            "state_key": payload["state_key"],
+            "model": model,
+        }
+        _write_status(tenant.tenant_id, run_id, status)
+
+        run_dir = _run_dir(tenant.tenant_id, run_id)
+        return {
+            "status": "queued",
+            "mode": "detached",
+            "run_id": run_id,
+            "created_at": now,
+            "updated_at": now,
+            "model": model,
+            "payload": {
+                "profile_id": profile_id,
+                "workflow_id": workflow_id,
+            },
+            "status_path": str(run_dir / "status.json"),
+            "result_path": str(run_dir / "result.json"),
+            "csv_path": str(run_dir / "leads.csv"),
+            "events_path": str(run_dir / "events.log"),
+        }
+
+    def _do_action(payload: dict, tenant: TenantConfig) -> dict:
+        """Handle ``action=status|result|cancel`` against an existing run."""
+        run_id = str(payload.get("run_id") or "")
+        if not run_id:
+            raise HTTPException(400, "action requires run_id")
+        status = _read_status(tenant.tenant_id, run_id)
+        if status is None:
+            raise HTTPException(404, f"unknown run_id: {run_id}")
+
+        action = payload["action"]
+        if action == "cancel":
+            if status.get("status") in {"queued", "running"}:
+                call_id = status.get("modal_call_id", "")
+                if call_id:
+                    try:
+                        lookup_function_call(call_id).cancel()
+                    except Exception:
+                        pass
+                status["status"] = "cancelled"
+                status["updated_at"] = datetime.now(timezone.utc).isoformat()
+                _write_status(tenant.tenant_id, run_id, status)
+                release_profile_lock(tenant, status.get("profile_id", ""))
+            return status
+
+        # status / result: check the FunctionCall handle if still running.
+        if status.get("status") in {"queued", "running"}:
+            call_id = status.get("modal_call_id", "")
+            if call_id:
+                try:
+                    result = lookup_function_call(call_id).get(timeout=0.1)
+                except modal.exception.OutputExpiredError:
+                    status["status"] = "expired"
+                except Exception as exc:
+                    # TimeoutError from .get(timeout=0.1) means still running.
+                    msg = str(type(exc).__name__).lower()
+                    if "timeout" not in msg:
+                        # Real error — mark failed, release the lock.
+                        status["status"] = "failed"
+                        status["error"] = f"{type(exc).__name__}: {exc}"
+                        status["updated_at"] = datetime.now(timezone.utc).isoformat()
+                        _write_status(tenant.tenant_id, run_id, status)
+                        release_profile_lock(tenant, status.get("profile_id", ""))
+                    else:
+                        status["status"] = "running"
+                else:
+                    status["status"] = "succeeded"
+                    status["updated_at"] = datetime.now(timezone.utc).isoformat()
+                    _write_status(tenant.tenant_id, run_id, status)
+                    _write_result(tenant.tenant_id, run_id, result if isinstance(result, dict) else {"result": result})
+                    release_profile_lock(tenant, status.get("profile_id", ""))
+
+        if action == "result":
+            if status.get("status") != "succeeded":
+                return {**status, "result": None}
+            result = _read_result(tenant.tenant_id, run_id)
+            return {**status, "result": result}
+        return status
+
+    @fastapi_app.get("/v1/runs/{run_id}/status")
+    def get_status(
+        run_id: str,
+        tenant: TenantConfig = Depends(require_run_scope),
+    ) -> dict:
+        return _do_action({"action": "status", "run_id": run_id}, tenant)
+
+    @fastapi_app.get("/v1/runs/{run_id}/result")
+    def get_result(
+        run_id: str,
+        tenant: TenantConfig = Depends(require_run_scope),
+    ) -> dict:
+        return _do_action({"action": "result", "run_id": run_id}, tenant)
+
+    @fastapi_app.post("/v1/runs/{run_id}/cancel")
+    def cancel_run(
+        run_id: str,
+        tenant: TenantConfig = Depends(require_run_scope),
+    ) -> dict:
+        return _do_action({"action": "cancel", "run_id": run_id}, tenant)
+
+    return fastapi_app
+
+
+@app.function(
+    image=api_image,
+    volumes={"/data": vol},
+    secrets=[modal.Secret.from_dotenv()],
+    timeout=300,
+    memory=2048,
+    cpu=2,
+    scaledown_window=600,
+)
+@modal.concurrent(max_inputs=64)
+@modal.asgi_app()
+def api():
+    """Mantis CUA HTTP API on Modal (#342).
+
+    Mirrors the Baseten ``/v1/predict`` shape: caller submits a plan with
+    ``detached: true`` (default), gets back ``{run_id, status, ...}``,
+    polls via ``action=status|result|cancel`` with the same ``run_id``.
+
+    Concurrency: ``@modal.concurrent(max_inputs=64)`` lets one ASGI
+    container service many concurrent submissions; each spawned
+    executor opens its own dedicated container (1 input per container,
+    matching the pre-existing executor decorators).
+
+    Per-profile lock: two concurrent runs against the same
+    ``profile_id`` get a 409 with the conflicting ``run_id`` — Chrome
+    cannot share a user-data-dir between processes (#341 motivation,
+    #342 enforcement).
+    """
+    return build_api_app()
+
+
 @app.function(
     gpu="A100-80GB",
     image=planner_base_image.run_commands(

--- a/deploy/modal/modal_cua_server.py
+++ b/deploy/modal/modal_cua_server.py
@@ -667,13 +667,16 @@ def _run_holo3_executor(
 
         resume_state = bool(task_suite.get("_resume_state", False))
         state_key = task_suite.get("_state_key", "")
+        profile_id = task_suite.get("_profile_id", state_key)
+        workflow_id = task_suite.get("_workflow_id", state_key)
         checkpoint_path = task_suite.get("_checkpoint_path") or f"/data/checkpoints/micro_{session_name}_{run_id}.json"
         plan_signature = task_suite.get("_plan_signature", "")
 
         print(f"\n  === MICRO-INTENT MODE ({len(micro_plan.steps)} steps) ===")
         print(micro_plan.summary())
-        if state_key:
-            print(f"  State key:  {state_key}")
+        if profile_id or workflow_id:
+            print(f"  Profile:    {profile_id}")
+            print(f"  Workflow:   {workflow_id}")
             print(f"  Resume:     {'on' if resume_state else 'off'}")
             print(f"  Checkpoint: {checkpoint_path}")
 
@@ -682,7 +685,7 @@ def _run_holo3_executor(
             grounding=grounding, extractor=extractor,
             on_step=viewer_event_bus.emit if viewer_event_bus else None,
             checkpoint_path=checkpoint_path,
-            run_key=state_key or session_name,
+            run_key=workflow_id or session_name,
             session_name=session_name,
             plan_signature=plan_signature,
             resume_state=resume_state,
@@ -703,6 +706,8 @@ def _run_holo3_executor(
             model_name="Holo3-35B-A3B (micro)",
             elapsed_seconds=time.time() - t0,
             state_key=state_key,
+            profile_id=profile_id,
+            workflow_id=workflow_id,
             checkpoint_path=checkpoint_path,
             plan_signature=plan_signature,
             resume_state=resume_state,
@@ -731,6 +736,8 @@ def _run_holo3_executor(
             "viable": viable,
             "steps": result["steps_executed"],
             "state_key": state_key,
+            "profile_id": profile_id,
+            "workflow_id": workflow_id,
             "checkpoint_path": checkpoint_path,
             "status": result.get("costs", {}).get("status", ""),
             "dynamic_verification_summary": result.get("dynamic_verification_summary"),
@@ -1340,6 +1347,8 @@ def main(
     max_time_minutes: int = 180,
     resume_state: bool = False,
     state_key: str = "",
+    profile_id: str = "",
+    workflow_id: str = "",
     graph_learn: bool = False,
     graph_learn_only: bool = False,
     proxy_provider: str = "oxylabs",
@@ -1365,7 +1374,8 @@ def main(
     Learning: --learn --learn-samples 5   (build site playbook from N samples)
     Verification: --verify   (enable step verification during execution)
     Micro: --micro plan.txt   (decompose → micro-intents → execute with checkpoint/reverse)
-    Resume: --resume-state --state-key my-run   (reuse externalized micro state across sessions)
+    Resume: --resume-state --workflow-id my-run   (reuse externalized micro state across sessions)
+            --profile-id alice-prod  (Chrome user-data-dir identity, sticky across plan revisions, #341)
     Graph: --graph-learn   (probe + graph + compile + execute) --graph-learn-only (no execution)
     Proxy: --proxy-provider privateproxy|oxylabs|iproyal --proxy-city miami --proxy-state florida
     """
@@ -1527,12 +1537,14 @@ def main(
             max_time_minutes=max_time_minutes,
             resume_state=resume_state,
             state_key=state_key,
+            profile_id=profile_id,
+            workflow_id=workflow_id,
             objective=objective_dict,
         )
-        resolved_state_key = task_suite["_state_key"]
 
-        print(f"  State:   {resolved_state_key}")
-        print(f"  Resume:  {'on' if resume_state else 'off'}")
+        print(f"  Profile:  {task_suite['_profile_id']}")
+        print(f"  Workflow: {task_suite['_workflow_id']}")
+        print(f"  Resume:   {'on' if resume_state else 'off'}")
 
         task_file_contents = json.dumps(task_suite)
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -75,8 +75,10 @@ Plus the run options:
 | Field | Default | Description |
 |---|---|---|
 | `detached` | `true` | Return a `run_id` immediately and continue work in the background. Set `false` to block until done (only useful for short plans — 5–10s). |
-| `state_key` | `""` | Caller-chosen identifier; the server prefixes it with `tenant_id` so callers can't collide. Reuse the same key across runs to share checkpoint state and Chrome profile (cookies, sessions). |
-| `resume_state` | `false` | Reconstruct browser state from the latest checkpoint at `state_key` before starting. |
+| `profile_id` | `"default"` | (#341) Chrome user-data-dir identity. Server prefixes with `tenant_id`. Sticky across plan revisions — same id ⇒ same cookies / logged-in sessions. |
+| `workflow_id` | `plan_signature[:12]` | (#341) Checkpoint identity. Server prefixes with `tenant_id`. Rotate when the plan definition changes; pair with `resume_state` to pick up where the last run with this id stopped. |
+| `state_key` | `""` | Legacy single-field identity. When set alone, the server routes it to both `profile_id` and `workflow_id` (back-compat). Prefer the split fields above in new code; see [#341](https://github.com/mercurialsolo/mantis/issues/341). |
+| `resume_state` | `false` | Reconstruct browser state from the latest checkpoint at `workflow_id` before starting. |
 | `max_cost` | `25.0` | Cap in USD; clamped against the tenant cap. |
 | `max_time_minutes` | `60` | Wall-clock cap; clamped against the tenant cap. |
 | `proxy_city`, `proxy_state` | unset | Optional IPRoyal geo overrides. Subject to allowlist. |
@@ -218,7 +220,8 @@ RESP=$(curl -fsS -X POST "$ENDPOINT/v1/predict" \
   -d '{
     "detached": true,
     "plan_text": "Extract the first 3 listings from <your URL>: year, make, model, price, phone, url.",
-    "state_key": "smoke-test",
+    "profile_id":  "smoke",
+    "workflow_id": "smoke-test-v1",
     "resume_state": false,
     "max_cost": 2,
     "max_time_minutes": 20
@@ -373,8 +376,8 @@ For comparison, equivalent Claude-only CUA flow ~$0.50–$1.50 per listing.
 |---|---|
 | Tenant token confidentiality | Stored in Baseten secrets; constant-time compare on validation; never echoed in logs |
 | Per-tenant Anthropic key | Resolved from the tenant's `anthropic_secret_name` — keys are not shared across tenants |
-| Per-tenant browser profile | Mounted at `/workspace/mantis-data/tenants/<tenant_id>/chrome-profile/<state_key>/` — cookies cannot bleed across tenants |
-| Per-tenant run state | Same volume layout — `state_key` is server-prefixed so callers cannot read another tenant's checkpoint |
+| Per-tenant browser profile | Mounted at `/workspace/mantis-data/tenants/<tenant_id>/chrome-profile/<profile_id>/` — cookies cannot bleed across tenants |
+| Per-tenant run state | Same volume layout — `profile_id` / `workflow_id` / legacy `state_key` are all server-prefixed so callers cannot read another tenant's checkpoint |
 | Plan injection (e.g., `loop_count: 999_999`) | Server-side hard caps clamp the values; oversized plans are rejected with `400` |
 | Upstream credential leak | `/v1/chat/completions` strips `X-Mantis-Token`, `Authorization`, `Cookie` before forwarding to in-pod llama.cpp |
 
@@ -452,7 +455,8 @@ RESP=$(curl -fsS -X POST "$ENDPOINT/v1/predict" \
   -d '{
     "detached": true,
     "micro": "plans/example/extract_listings.json",
-    "state_key": "demo-recording",
+    "profile_id":  "demo-recording",
+    "workflow_id": "demo-recording-v1",
     "max_cost": 2,
     "max_time_minutes": 20,
     "record_video": true,

--- a/docs/client/errors.md
+++ b/docs/client/errors.md
@@ -14,6 +14,7 @@ What every status code means and how to handle it.
 | **403** allowlist | Plan references a host not in tenant's `allowed_domains` | No — fix the plan or ask operator to add the domain |
 | **404** run | `action=status\|result\|logs` referenced a `run_id` your tenant doesn't own | No — wrong `run_id` or wrong tenant |
 | **404** video | No recording for the run (recording disabled or ffmpeg failed) | No |
+| **409** profile-busy | (#342, Modal HTTP endpoint only) Another run is currently holding the requested `profile_id`'s Chrome user-data-dir lock. The `detail` includes the held `run_id` so you can poll it. | Yes — wait for the held run to finish, or submit with a different `profile_id` |
 | **429** rate | Tenant exceeded `rate_limit_per_minute` | Yes — honor `Retry-After` header |
 | **429** concurrent | Tenant at `max_concurrent_runs` | Yes — honor `Retry-After` |
 | **500** | Unhandled exception | Sometimes — check `{"action":"logs", ...}` for the traceback before retrying |
@@ -51,7 +52,7 @@ A run can return `200 OK` and still have `status: failed`:
 | `timeout` | `max_time_minutes` hit | Same |
 | `gate_failed` | A `gate: true` step's verify clause was false | The site didn't reach the expected state — different filters / start URL |
 | `extract_failed` | Claude couldn't parse the screenshot into the expected schema | Schema mismatch with what's actually visible — adjust the plan |
-| `navigation_blocked` | Cloudflare 403 or sustained 5xx from the target | Wait + retry; or try with a fresh `state_key` |
+| `navigation_blocked` | Cloudflare 403 or sustained 5xx from the target | Wait + retry; or try with a fresh `profile_id` (different cookies / IP rotation) |
 
 These are partial successes — the `summary` block reflects whatever was completed (e.g., 2 of 3 listings extracted before the cap hit).
 
@@ -61,7 +62,7 @@ These are partial successes — the `summary` block reflects whatever was comple
 |---|---|
 | 4xx (except 429) | Don't retry — fix the request |
 | 429 | Honor `Retry-After`; capped exponential backoff after that |
-| 500 | Inspect `{"action":"logs"}` first; retry with a fresh `state_key` if it looks transient |
+| 500 | Inspect `{"action":"logs"}` first; retry with a fresh `workflow_id` (and a fresh `profile_id` if the failure looks tied to a corrupted Chrome session) if it looks transient |
 | 502 | Exponential backoff (5 s → 30 s → 2 min); the upstream Holo3 / Anthropic might be down |
 | 503 (auth) | Don't retry — operator action needed |
 

--- a/docs/client/index.md
+++ b/docs/client/index.md
@@ -28,7 +28,8 @@ client = MantisClient.from_env()
 result = client.run_to_completion(
     PredictRequest(
         micro="plans/example/extract_listings.json",
-        state_key="marketplace-prod",
+        profile_id="marketplace-prod",
+        workflow_id="marketplace-listings-v1",
         max_cost=2,
         max_time_minutes=20,
         record_video=True,
@@ -49,7 +50,8 @@ For longer runs where you want to surface progress to a UI:
 ```python
 handle = client.predict(PredictRequest(
     micro="plans/example/extract_listings.json",
-    state_key="marketplace-prod",
+    profile_id="marketplace-prod",
+    workflow_id="marketplace-listings-v1",
     record_video=True,
 ))
 

--- a/docs/client/plans.md
+++ b/docs/client/plans.md
@@ -10,8 +10,10 @@ Once you have an authenticated session, every plan submission lands on `POST /v1
   "micro":       "plans/example/...json",            // OR
   "plan_text":   "Plain English description",        //
 
-  "state_key":         "stable-workflow-id",         // namespaced server-side
-  "resume_state":      false,                        // continue from last checkpoint
+  "profile_id":        "alice-prod",                 // (#341) Chrome user-data-dir; sticky across plan revisions
+  "workflow_id":       "marketplace-listings-v3",    // (#341) checkpoint id; rotate when the plan changes
+  // "state_key": "legacy-single-field",            // pre-#341 callers; routes to BOTH on the server for back-compat
+  "resume_state":      false,                        // continue from last checkpoint at workflow_id
   "max_cost":          2.0,                          // clamped to tenant cap
   "max_time_minutes":  20,
   "proxy_city":        "Miami",                      // optional IPRoyal geo override
@@ -49,7 +51,8 @@ Have a stable workflow you'll run many times?
       -d '{
         "detached": true,
         "micro": "plans/example/extract_listings.json",
-        "state_key": "marketplace-prod",
+        "profile_id": "marketplace-prod",
+        "workflow_id": "marketplace-listings-v1",
         "max_cost": 2,
         "max_time_minutes": 20
       }'
@@ -65,7 +68,8 @@ Have a stable workflow you'll run many times?
       -d '{
         "detached": true,
         "plan_text": "Go to a marketplace listings site, filter to private sellers above $35,000 in Florida, extract listing details for the first 3 listings.",
-        "state_key": "ad-hoc-1",
+        "profile_id": "ad-hoc",
+        "workflow_id": "ad-hoc-marketplace-1",
         "max_cost": 2
       }'
     ```
@@ -81,7 +85,8 @@ Have a stable workflow you'll run many times?
     {
       "detached": true,
       "task_suite": $(cat tasks/crm/crm_tasks.json),
-      "state_key": "crm-$(date +%s)",
+      "profile_id": "crm-prod",
+      "workflow_id": "crm-$(date +%s)",
       "max_cost": 5,
       "max_time_minutes": 30
     }
@@ -99,7 +104,8 @@ Have a stable workflow you'll run many times?
       -d '{
         "detached": true,
         "task_file": "tasks/crm/crm_tasks.json",
-        "state_key": "crm-prod"
+        "profile_id": "crm-prod",
+        "workflow_id": "crm-tasks-v1"
       }'
     ```
 

--- a/docs/client/pure-cua.md
+++ b/docs/client/pure-cua.md
@@ -71,7 +71,9 @@ curl -X POST "$ENDPOINT/v1/cua" \
 | `frames_per_inference` | `1` | Screenshots fed to the brain per step. Holo3 wants 1 |
 | `settle_time` | `2.0` | Seconds to wait after each action before re-screenshotting |
 | `detached` | `false` | Queue as background; return `run_id` to poll via `/v1/predict` actions |
-| `state_key` | unset | Reuses the Chrome profile + tenant dir tied to this key |
+| `profile_id` | `"default"` | (#341) Chrome user-data-dir identity; sticky across plan revisions |
+| `workflow_id` | `plan_signature[:12]` | (#341) Checkpoint identity; rotate when the plan changes |
+| `state_key` | unset | Legacy single-field identity. When set alone, routes to both `profile_id` and `workflow_id` (back-compat) |
 | `max_cost` | `25.0` | USD cap (mostly informational — pure CUA spends nothing on Claude) |
 | `max_time_minutes` | `60` | Wall-clock cap; clamped against tenant cap |
 | `proxy_city` / `proxy_state` | unset | Geo override (allowlist-gated) |
@@ -141,7 +143,9 @@ Useful flags:
 | `--start-url` | Initial URL for the browser |
 | `--max-steps` | Cap on the CUA loop |
 | `--settle-time` | Seconds to wait after each action |
-| `--state-key` | Namespace Chrome profile + checkpoint dir |
+| `--profile-id` | (#341) Chrome user-data-dir identity (sticky across plan revisions) |
+| `--workflow-id` | (#341) Checkpoint identity (rotate on plan change; pair with `--resume-state`) |
+| `--state-key` | Legacy single-field; routes to both `--profile-id` and `--workflow-id` |
 | `--detached` | Queue as background; print `run_id` and exit |
 | `--proxy-disabled` | Skip the residential proxy |
 | `--record-video` | Capture screencast |

--- a/docs/client/runs-and-polling.md
+++ b/docs/client/runs-and-polling.md
@@ -172,13 +172,14 @@ Cancels are cooperative — the runner finishes the current step's checkpoint wr
 
 ## Resuming
 
-If a run failed mid-way (network hiccup, replica restart, OOM), re-submit with the **same `state_key`** and `resume_state: true`:
+If a run failed mid-way (network hiccup, replica restart, OOM), re-submit with the **same `workflow_id`** and `resume_state: true`. Keep the same `profile_id` too so the resumed run reuses the logged-in Chrome session from the failed attempt (#341):
 
 ```jsonc
 {
   "detached": true,
   "micro": "plans/example/...json",
-  "state_key": "marketplace-prod",    // ← same key as the failed run
+  "profile_id":  "marketplace-prod",       // ← same profile (cookies / sessions)
+  "workflow_id": "marketplace-listings-v1", // ← same workflow (checkpoint to resume from)
   "resume_state": true,
   "max_cost": 2
 }

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -72,26 +72,32 @@ Useful per-step modifiers:
 
 Mantis is multi-tenant from Tier 1. A *tenant* is just a record in the operator's keys file mapping an `X-Mantis-Token` to:
 
-- `tenant_id` — the namespace prefix used in `state_key` and on the data volume
+- `tenant_id` — the namespace prefix used in `profile_id` / `workflow_id` / legacy `state_key` and on the data volume
 - `scopes` — which actions this token can do (`run`, `status`, `result`, `logs`)
 - `max_concurrent_runs`, `max_cost_per_run`, `max_time_minutes_per_run`, `rate_limit_per_minute` — caps the server enforces in addition to the global hard caps
 - `anthropic_secret_name` — which Anthropic key this tenant's runs use (each tenant can bring its own billing)
 - `allowed_domains` — wildcards matched against `navigate` URLs in submitted plans
 - `webhook_url`, `webhook_secret_name` — optional run-completion callback
 
-Plans submitted by tenant A cannot read tenant B's checkpoints, profiles, or recordings — `state_key` is server-prefixed with the tenant id and the data volume is namespaced.
+Plans submitted by tenant A cannot read tenant B's checkpoints, profiles, or recordings — `profile_id` / `workflow_id` (and legacy `state_key`) are all server-prefixed with the tenant id and the data volume is namespaced.
 
-## state_key — the resume primitive
+## `profile_id` + `workflow_id` — the resume primitives (#341)
 
-`state_key` is the most important per-run field after the plan itself. It controls:
+The two most important per-run fields after the plan itself. They were one field — `state_key` — until [#341](https://github.com/mercurialsolo/mantis/issues/341) split them because they have opposite rotation lifetimes.
 
-| | Behavior |
-|---|---|
-| Browser profile | A Chrome profile dir at `tenants/<tenant_id>/chrome-profile/<state_key>/` is created or reused. Cookies + sessions persist across runs with the same key. |
-| Checkpoint resume | The runner saves progress to `tenants/<tenant_id>/checkpoints/<state_key>.json`. Pass `resume_state: true` to pick up where the last run left off. |
-| Idempotency | (Not the same as `Idempotency-Key` header) — `state_key` is the *workflow* identity, the header is the *request* identity. |
+| | Field | Behavior |
+|---|---|---|
+| Browser profile | `profile_id` | A Chrome user-data-dir at `tenants/<tenant_id>/chrome-profile/<profile_id>/` is created or reused. Cookies + logged-in sessions persist across runs. **Sticky** — keep this stable so you don't have to log back in every time the plan changes. |
+| Checkpoint | `workflow_id` | The runner saves progress to `tenants/<tenant_id>/checkpoints/<workflow_id>.json`. Pass `resume_state: true` to pick up where the last run with this id left off. **Rotate** when the plan definition changes meaningfully — resuming step `N/12` of an old plan against a new layout is incoherent. |
+| Idempotency | (not these) | The `Idempotency-Key` header is the *request* identity (24h dedup); `workflow_id` is the *workflow* identity. |
 
-Pick `state_key` to match the conceptual workflow: `marketplace-miami-listings-v1`, `crm-prod`, `customer-12345-onboarding`. Reuse the same key across runs of the same workflow; pick a new key when the workflow definition changes.
+Pick `profile_id` to match the *account or persona* — e.g. `alice-prod`, `customer-12345`. Pick `workflow_id` to match the *plan revision* — e.g. `marketplace-miami-listings-v3`, the default is `plan_signature[:12]`.
+
+Same account running 5 different workflows in parallel? Pass one `profile_id` and five distinct `workflow_id`s. (Note: Chrome serializes those runs because two processes cannot share a user-data-dir at the same time — distinct `profile_id`s are required for true parallelism. See [#342](https://github.com/mercurialsolo/mantis/issues/342) for the Modal HTTP endpoint that surfaces this as a 409 instead of silent corruption.)
+
+### Legacy `state_key`
+
+The single-field `state_key` still works — when set alone, the server routes it to both `profile_id` and `workflow_id` for back-compat. New code should set the two fields independently. The result envelope echoes all three fields so callers can grep either.
 
 ## The cost meter
 

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -10,7 +10,7 @@ Caller                /v1/predict                 MicroPlanRunner
                                                   ┌─ BrainHolo3   (Holo3 GPU inference)
 plan, tenant ──HTTP──► validate, clamp ──────────►├─ ClaudeGrounding (refine clicks)
                        caps, namespace             ├─ ClaudeExtractor (read structured data)
-                       state_key                   ├─ DynamicPlanVerifier
+                       profile_id, workflow_id     ├─ DynamicPlanVerifier
                                                    └─ XdotoolGymEnv (Xvfb + Chrome)
                                                           │
                                                           ▼

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -4,7 +4,7 @@ Three reading paths depending on what you want to do:
 
 - :material-rocket-launch: **[Quickstart](quickstart.md)** — five minutes from zero to a real listings extraction by curling the live Baseten endpoint.
 - :material-target: **[Use cases](use-cases.md)** — what Mantis is good at: read flows (listings, jobs, real-estate, products, news), write flows (CRM edit, refunds, contact upsert), social posting, multi-step authenticated workflows, desktop apps.
-- :material-school: **[Concepts](concepts.md)** — what `MicroPlanRunner`, `BrainHolo3`, `ClaudeExtractor`, sections, gates, and `state_key` actually mean. Read this once before writing your own plans.
+- :material-school: **[Concepts](concepts.md)** — what `MicroPlanRunner`, `BrainHolo3`, `ClaudeExtractor`, sections, gates, and `profile_id` / `workflow_id` actually mean. Read this once before writing your own plans.
 - :material-format-list-bulleted: **[Plan formats](plan-formats.md)** — when to use a plain-text plan, a micro-plan JSON, or a task suite.
 - :material-console: **[CLI](cli.md)** — `mantis plan validate <path>` and the rest of the plan-authoring command surface.
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -33,7 +33,8 @@ RESP=$(curl -fsS -X POST "$ENDPOINT/v1/predict" \
   -d '{
     "detached": true,
     "micro": "plans/example/extract_listings.json",
-    "state_key": "first-quickstart",
+    "profile_id": "first-quickstart",
+    "workflow_id": "first-quickstart-v1",
     "max_cost": 2,
     "max_time_minutes": 20,
     "record_video": true
@@ -147,7 +148,7 @@ You ran one orchestrated extraction against a live website, used both Holo3 (che
 
 ## Next steps
 
-- Read the [Concepts](concepts.md) page so you understand `state_key`, `max_cost`, gates, and sections before designing your own plan.
+- Read the [Concepts](concepts.md) page so you understand `profile_id` / `workflow_id`, `max_cost`, gates, and sections before designing your own plan.
 - Browse the [Plan formats](plan-formats.md) to pick the right shape for your workflow.
 - Want to host your own instance? Go to [Hosting](../hosting/index.md).
 - Building an integration? Start with [Client](../client/index.md) → [Authentication](../client/auth.md).

--- a/docs/hosting/aws.md
+++ b/docs/hosting/aws.md
@@ -84,7 +84,7 @@ The detailed runbook is in [`deploy/aws/README.md`](https://github.com/mercurial
    curl -fsS -X POST "https://$HOST/v1/predict" \
      -H "X-Mantis-Token: $TOK" \
      -H "Content-Type: application/json" \
-     -d '{"detached": true, "micro": "plans/example/extract_listings.json", "state_key": "smoke", "max_cost": 2}'
+     -d '{"detached": true, "micro": "plans/example/extract_listings.json", "profile_id": "smoke", "workflow_id": "smoke-v1", "max_cost": 2}'
    ```
 
 ## Operational notes

--- a/docs/hosting/baseten.md
+++ b/docs/hosting/baseten.md
@@ -73,7 +73,8 @@ curl -fsS -X POST "$ENDPOINT/v1/predict" \
   -d '{
     "detached": true,
     "micro": "plans/example/extract_listings.json",
-    "state_key": "smoke-test",
+    "profile_id":  "smoke",
+    "workflow_id": "smoke-test-v1",
     "max_cost": 2,
     "max_time_minutes": 20
   }'

--- a/docs/hosting/gke.md
+++ b/docs/hosting/gke.md
@@ -90,7 +90,7 @@ The detailed runbook is in [`deploy/gke/README.md`](https://github.com/mercurial
    TOK=$(gcloud secrets versions access latest --secret=mantis-prod-mantis_api_token)
    curl -fsS -X POST "https://$HOST/v1/predict" \
      -H "X-Mantis-Token: $TOK" \
-     -d '{"detached": true, "micro": "plans/example/extract_listings.json", "state_key": "smoke"}'
+     -d '{"detached": true, "micro": "plans/example/extract_listings.json", "profile_id": "smoke", "workflow_id": "smoke-v1"}'
    ```
 
 ## Operational notes

--- a/docs/hosting/index.md
+++ b/docs/hosting/index.md
@@ -42,7 +42,8 @@ RESP=$(curl -fsS -X POST "$ENDPOINT/v1/predict" \
   -d '{
     "detached": true,
     "micro": "plans/example/extract_listings.json",
-    "state_key": "deploy-smoke",
+    "profile_id":  "deploy-smoke",
+    "workflow_id": "deploy-smoke-v1",
     "max_cost": 2,
     "max_time_minutes": 20
   }')

--- a/docs/hosting/local.md
+++ b/docs/hosting/local.md
@@ -68,7 +68,8 @@ curl -fsS -X POST http://localhost:8000/v1/predict \
   -d '{
     "detached": true,
     "micro": "plans/example/extract_listings.json",
-    "state_key": "local-smoke",
+    "profile_id":  "local-smoke",
+    "workflow_id": "local-smoke-v1",
     "max_cost": 2,
     "max_time_minutes": 20
   }'

--- a/docs/integrations/generic-cua.md
+++ b/docs/integrations/generic-cua.md
@@ -59,7 +59,8 @@ curl -fsS -X POST "$MANTIS_ENDPOINT/v1/predict" \
   -d '{
     "detached": true,
     "plan_text": "Go to https://news.ycombinator.com/ and extract the title, points, and comment count of the top 5 stories",
-    "state_key": "hn-top5",
+    "profile_id":  "hn-anon",
+    "workflow_id": "hn-top5",
     "max_cost": 1,
     "max_time_minutes": 10
   }'
@@ -95,7 +96,8 @@ curl -fsS -X POST "$MANTIS_ENDPOINT/v1/predict" \
   -d @- <<'JSON'
 {
   "detached": true,
-  "state_key": "greenhouse-ml-sf-prod",
+  "profile_id":  "greenhouse-anon",
+  "workflow_id": "greenhouse-ml-sf-prod",
   "max_cost": 4,
   "max_time_minutes": 30,
   "extraction_schema": {
@@ -161,7 +163,8 @@ ship a `site_config` block alongside the plan:
 ```jsonc
 {
   "detached": true,
-  "state_key": "redfin-sf-condos-v1",
+  "profile_id":  "redfin-anon",
+  "workflow_id": "redfin-sf-condos-v1",
   "site_config": {
     "domain": "redfin.com",
     "detail_page_pattern": "/CA/[\\w-]+/.*?/home/\\d+",
@@ -261,7 +264,8 @@ names. CSV and recording are downloadable via dedicated endpoints — see
 - **CAPTCHA / hCaptcha.** Holo3 cannot solve these. Residential proxy
   + Cloudflare auto-pass usually works; hard challenges don't.
 - **Plans >200 steps in one submission.** Server hard cap. Chunk into
-  multiple runs sharing the same `state_key` to use checkpoint resume.
+  multiple runs sharing the same `workflow_id` (and the same `profile_id`
+  if you also want to share the Chrome session) to use checkpoint resume.
 
 For these, [Library embedding](embedding-microplanrunner.md) gives you
 escape hatches via `register_tool` (host-provided tools the model can

--- a/docs/integrations/recipes.md
+++ b/docs/integrations/recipes.md
@@ -29,7 +29,8 @@ curl -fsS -X POST "$MANTIS_ENDPOINT/v1/predict" \
   -d @- <<'JSON'
 {
   "detached": true,
-  "state_key": "greenhouse-openai-eng-sf",
+  "profile_id":  "greenhouse-prod",
+  "workflow_id": "greenhouse-openai-eng-sf",
   "max_cost": 4,
   "max_time_minutes": 30,
   "extraction_schema": {
@@ -87,7 +88,8 @@ curl -fsS -X POST "$MANTIS_ENDPOINT/v1/predict" \
   -d @- <<'JSON'
 {
   "detached": true,
-  "state_key": "amazon-mech-keyboards",
+  "profile_id":  "amazon-anon",
+  "workflow_id": "amazon-mech-keyboards",
   "max_cost": 3,
   "max_time_minutes": 25,
   "extraction_schema": {
@@ -154,7 +156,8 @@ curl -fsS -X POST "$MANTIS_ENDPOINT/v1/predict" \
   -d @- <<'JSON'
 {
   "detached": true,
-  "state_key": "techcrunch-ai-recent",
+  "profile_id":  "techcrunch-anon",
+  "workflow_id": "techcrunch-ai-recent",
   "max_cost": 2,
   "max_time_minutes": 20,
   "extraction_schema": {
@@ -209,7 +212,8 @@ curl -fsS -X POST "$MANTIS_ENDPOINT/v1/predict" \
   -d @- <<'JSON'
 {
   "detached": true,
-  "state_key": "zillow-sf-condos-1m-2m",
+  "profile_id":  "zillow-anon",
+  "workflow_id": "zillow-sf-condos-1m-2m",
   "max_cost": 5,
   "max_time_minutes": 35,
   "extraction_schema": {
@@ -282,7 +286,8 @@ curl -fsS -X POST "$MANTIS_ENDPOINT/v1/predict" \
   -d @- <<'JSON'
 {
   "detached": true,
-  "state_key": "crm-edit-lead-industry",
+  "profile_id":  "crm-prod-sdr-alice",
+  "workflow_id": "crm-edit-lead-industry",
   "max_cost": 2,
   "max_time_minutes": 15,
   "micro": [
@@ -357,7 +362,8 @@ curl -fsS -X POST "$MANTIS_ENDPOINT/v1/predict" \
   -d '{
     "detached": true,
     "plan_text": "1. Go to https://crm.example.com\n2. Log in with user ID alice password <password>\n3. Go to the Leads Page\n4. Select the first lead with the \"Qualified\" status\n5. Go to the Edit Lead page for this lead\n6. Update the Industry Vertical to \"Space Exploration\"\n7. Click \"Update Lead\"",
-    "state_key": "crm-edit-lead-text",
+    "profile_id":  "crm-prod-sdr-alice",
+    "workflow_id": "crm-edit-lead-text",
     "max_cost": 2,
     "max_time_minutes": 15
   }'
@@ -395,7 +401,8 @@ curl -fsS -X POST "$MANTIS_ENDPOINT/v1/predict" \
   -d @- <<'JSON'
 {
   "detached": true,
-  "state_key": "linkedin-post-weekly",
+  "profile_id":  "linkedin-acct-sales-team",
+  "workflow_id": "linkedin-post-weekly",
   "max_cost": 2,
   "max_time_minutes": 15,
   "micro": [
@@ -458,7 +465,8 @@ curl -fsS -X POST "$MANTIS_ENDPOINT/v1/predict" \
   -d @- <<'JSON'
 {
   "detached": true,
-  "state_key": "reddit-post-r-mysub",
+  "profile_id":  "reddit-acct-mod",
+  "workflow_id": "reddit-post-r-mysub",
   "max_cost": 1.5,
   "max_time_minutes": 12,
   "micro": [
@@ -518,7 +526,8 @@ curl -fsS -X POST "$MANTIS_ENDPOINT/v1/predict" \
   -d @- <<'JSON'
 {
   "detached": true,
-  "state_key": "instagram-post-feed",
+  "profile_id":  "instagram-acct-brand",
+  "workflow_id": "instagram-post-feed",
   "max_cost": 2.5,
   "max_time_minutes": 18,
   "micro": [
@@ -591,7 +600,8 @@ curl -fsS -X POST "$MANTIS_ENDPOINT/v1/predict" \
   -d @- <<'JSON'
 {
   "detached": true,
-  "state_key": "admin-fetch-user-by-email",
+  "profile_id":  "admin-prod-ops",
+  "workflow_id": "admin-fetch-user-by-email",
   "max_cost": 1.5,
   "max_time_minutes": 10,
   "extraction_schema": {
@@ -668,7 +678,8 @@ curl -fsS -X POST "$MANTIS_ENDPOINT/v1/predict" \
   -d @- <<'JSON'
 {
   "detached": true,
-  "state_key": "crm-upsert-contact-bob",
+  "profile_id":  "crm-prod-sdr-alice",
+  "workflow_id": "crm-upsert-contact-bob",
   "max_cost": 2,
   "max_time_minutes": 15,
   "micro": [
@@ -737,7 +748,8 @@ curl -fsS -X POST "$MANTIS_ENDPOINT/v1/predict" \
   -d @- <<'JSON'
 {
   "detached": true,
-  "state_key": "refund-order-ord-91234",
+  "profile_id":  "shopify-admin-prod",
+  "workflow_id": "refund-order-ord-91234",
   "max_cost": 2,
   "max_time_minutes": 15,
   "micro": [
@@ -814,14 +826,15 @@ Rough calibration (Holo3 / Claude / IPRoyal proxy on the Baseten H100):
 | 3-5 | 5-8 | 6-10 min | $0.50-$1.00 |
 | 10 | 15 | 15-20 min | $1.50-$2.50 |
 | 20 | 30 | 30-40 min | $3-$5 |
-| 50+ | Chunk via state_key resume | n/a | n/a |
+| 50+ | Chunk via `workflow_id` + `resume_state` | n/a | n/a |
 
 Bump `loop_count` higher than your target (1.5×) — it absorbs failures on
 spam-skipped listings and dead detail pages. Hard caps:
 `MANTIS_MAX_LOOP_ITERATIONS=50`, `MANTIS_MAX_STEPS_PER_PLAN=200`.
 
 For >50 items, split into multiple `/v1/predict` runs sharing the same
-`state_key` and pass `resume_state: true` — the runner picks up at the
+`workflow_id` (and the same `profile_id` if you want to reuse the Chrome
+session) and pass `resume_state: true` — the runner picks up at the
 last checkpoint.
 
 ---

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -71,8 +71,10 @@ Plus run options (all optional):
 | Field             | Default | Effect                                                                       |
 |-------------------|---------|------------------------------------------------------------------------------|
 | `detached`        | `true`  | Return `run_id` immediately; work continues in the background                 |
-| `state_key`       | `""`    | Caller-chosen ID; server prefixes with tenant. Reuse to share Chrome profile + checkpoint. **Not safe for concurrent runs — see §4b** |
-| `resume_state`    | `false` | Reconstruct browser state from latest checkpoint at `state_key` before start  |
+| `profile_id`      | `"default"` | (#341) Chrome user-data-dir identity. Server prefixes with `tenant_id`. Sticky across plan revisions — same id ⇒ same cookies / logged-in sessions. **Two concurrent runs against the same `profile_id` collide (Chrome cannot share a user-data-dir); the Modal HTTP endpoint surfaces this as 409 — see #342.** |
+| `workflow_id`     | `plan_signature[:12]` | (#341) Checkpoint identity. Server prefixes with `tenant_id`. Rotate when the plan definition changes; pair with `resume_state` to pick up where the last run with this id stopped. Distinct `workflow_id`s under the same `profile_id` still serialize via the Chrome lock. |
+| `state_key`       | `""`    | Legacy single-field identity. When set alone, server routes to both `profile_id` and `workflow_id` (Phase 1 back-compat). Prefer the split fields in new code. |
+| `resume_state`    | `false` | Reconstruct browser state from latest checkpoint at `workflow_id` before start |
 | `max_cost`        | `25.0`  | USD cap; clamped against tenant cap                                           |
 | `max_time_minutes`| `60`    | Wall-clock cap; clamped against tenant cap                                    |
 | `proxy_disabled`  | `false` | Bypass the upstream residential proxy. Use for sites that don't bot-detect    |
@@ -85,7 +87,7 @@ Plus run options (all optional):
 | `cache_read`      | `false` | Skip the deep-extract Claude call (~$0.04/item) when the current URL is already cached fresh |
 | `cache_write`     | `false` | Persist every viable extraction so future runs (or loop iterations) hit the cache |
 | `cache_ttl_seconds` | `86400` | Entries older than this are treated as misses; 0 = never stale; max 30 days |
-| `cache_key`       | unset   | Cache namespace; defaults to `state_key`. Use one key per logical job to share extracted state |
+| `cache_key`       | unset   | Cache namespace; defaults to `workflow_id` (legacy `state_key`). Use one key per logical job to share extracted state |
 
 Detached response:
 
@@ -436,7 +438,7 @@ Two opt-in flags on `POST /v1/predict`:
   "cache_read":  true,      // skip the deep-extract Claude call on cache hit
   "cache_write": true,      // record every viable extraction to the cache file
   "cache_ttl_seconds": 86400,   // entries older than this are misses (default 1 day)
-  "cache_key":   "luma_events"  // namespace; defaults to state_key
+  "cache_key":   "luma_events"  // namespace; defaults to workflow_id (legacy state_key)
 }
 ```
 
@@ -472,42 +474,56 @@ cache even with the same key string.
 
 ---
 
-## 4b. `state_key` concurrency — one key per logical session
+## 4b. `profile_id` concurrency — one profile per logical session (#341, #342)
 
-**Two parallel runs with the same `state_key` will collide.** The
-state_key is the unit of *shared session state* across runs — it
-identifies a Chrome profile + checkpoint + (by default) extraction
-cache pool. Concurrent runs sharing it step on three things:
+**Two parallel runs with the same `profile_id` will collide.** The
+`profile_id` is the unit of *shared browser session* across runs — it
+identifies the Chrome user-data-dir (cookies / logged-in sessions).
+Concurrent runs sharing it step on the Chrome user-data-dir lock; the
+Modal HTTP endpoint surfaces this as a 409 with the held `run_id` (see
+#342). Without that gate, the second launch either fails outright or
+silently corrupts cookies / session tokens.
 
-1. **Chrome profile dir** — `<data_root>/tenants/<tenant>/chrome-profile/<state_key>/`.
-   Chrome holds an exclusive file lock per profile; the second
-   concurrent launch either fails or boots in a fallback mode that
-   silently corrupts cookies / session tokens.
-2. **Checkpoint file** — `<data_root>/tenants/<tenant>/checkpoints/<state_key>.json`.
-   Both runs persist incrementally; last-write-wins → a parallel
-   run can stomp the first's progress mid-step.
-3. **Extraction cache** — when `cache_key` defaults to `state_key`,
+`workflow_id` is the *checkpoint* identity (separate field since #341).
+Two concurrent runs with different `workflow_id`s under the same
+`profile_id` still serialize via the Chrome lock — that's a Chrome
+limitation, not a Mantis policy. Distinct `profile_id`s parallelize
+cleanly.
+
+Three artifacts are keyed:
+
+1. **Chrome user-data-dir** — `<data_root>/tenants/<tenant>/chrome-profile/<profile_id>/`.
+   Sticky across plan revisions. Chrome holds an exclusive file lock per
+   directory; the lockfile at `tenants/<tenant>/locks/<profile_id>.lock`
+   (#342) lets the Modal endpoint surface a 409 before Chrome even
+   launches.
+2. **Checkpoint file** — `<data_root>/tenants/<tenant>/checkpoints/<workflow_id>.json`.
+   Rotate `workflow_id` when the plan definition changes; pair with
+   `resume_state: true` to resume mid-flight.
+3. **Extraction cache** — when `cache_key` defaults to `workflow_id`,
    parallel writers can interleave puts and lose entries. Pull
    `cache_key` out to share cache across parallel runs (see below).
 
-### Pick the right `state_key` shape for your use case
+### Pick the right identity shape for your use case
 
-| Use case | state_key shape |
-|---|---|
-| Per-end-user session (their own Chrome profile, cookies, login) | `user:<user_id>` |
-| Per-workflow type, multi-tenant, no shared cookies | `workflow:<workflow_id>` |
-| Stateless one-shot extraction with no resume | omit / unique per call (e.g. UUID) |
-| Idempotent retry of a failed run | reuse the same `state_key` to resume from checkpoint |
+| Use case | `profile_id` | `workflow_id` |
+|---|---|---|
+| Per-end-user session (their own cookies / login) | `user:<user_id>` | `<plan_signature[:12]>` (default) |
+| Per-account, many plan revisions | stable account id | rotate per plan version |
+| Stateless one-shot extraction with no resume | `"default"` / unique UUID | unique UUID |
+| Idempotent retry of a failed run | reuse the same `profile_id` (keep cookies) | reuse the same `workflow_id` + `resume_state: true` |
+| Pre-#341 legacy callers | (omit) — pass `state_key` and the server routes it to both | (omit) |
 
 ### Pattern for parallel calls that should share extraction state but not browser state
 
-Generate a unique `state_key` per call (so Chrome profiles + checkpoints
-are isolated), but pin `cache_key` to a shared pool:
+Generate a unique `profile_id` per call (so Chrome profiles are isolated
+and parallelize), but pin `cache_key` to a shared pool:
 
 ```jsonc
 {
-  "state_key":  "user-42:job-abc-123",   // unique per parallel call
-  "cache_key":  "user-42",               // shared cache pool
+  "profile_id":  "user-42-job-abc",     // unique per parallel call — Chrome lock identity
+  "workflow_id": "user-42-job-abc",     // typically the same; rotate independently if the plan changes
+  "cache_key":   "user-42",             // shared cache pool across all of user-42's runs
   "cache_read":  true,
   "cache_write": true
 }
@@ -518,6 +534,9 @@ cache file (which is internally append-friendly per URL) without
 fighting over Chrome locks or checkpoints. The cache lookup is keyed by
 URL, so cache-hit short-circuits work even when the parallel runs
 extract overlapping listings.
+
+(Pre-#341 callers used a single `state_key` here; the server still
+routes a lone `state_key` to both `profile_id` and `workflow_id`.)
 
 ### What if I need both?
 
@@ -627,12 +646,15 @@ override.
    runs.** Sequential detached submissions don't stack against
    `max_concurrent_runs` — they each return `queued` quickly and release
    the slot. The cap protects against parallel callers.
-6. **Parallel runs MUST use unique `state_key`s.** Two concurrent
-   runs sharing a `state_key` collide on the Chrome profile lock,
-   the checkpoint file, and (by default) the extraction cache.
-   See §4b for the pattern: unique `state_key` per call + shared
+6. **Parallel runs MUST use unique `profile_id`s** (#341, #342). Two
+   concurrent runs sharing a `profile_id` collide on the Chrome
+   user-data-dir lock; the Modal HTTP endpoint returns 409 with the
+   held `run_id`. Distinct `workflow_id`s under one `profile_id` still
+   serialize via Chrome — only `profile_id` decouples parallelism.
+   See §4b for the pattern: unique `profile_id` per call + shared
    `cache_key` lets parallel runs share extraction-cache hits while
-   keeping browser state isolated.
+   keeping browser state isolated. Legacy `state_key` works as a
+   single-field shim (routes to both).
 7. **Cold-start on Modal/Baseten is ~50–90s.** First request after idle
    pays Chrome + Xvfb + llama-server boot. Subsequent calls within the
    scaledown window are ~instant.
@@ -745,7 +767,9 @@ curl -X POST "$ENDPOINT/v1/cua" \
 | `frames_per_inference` | `1` | Screenshots per step (Holo3 wants 1) |
 | `settle_time` | `2.0` | Seconds to wait after each action |
 | `detached` | `false` | Queue as background; return `run_id` to poll via `/v1/predict` actions |
-| `state_key` | unset | Reuses Chrome profile + tenant dir tied to this key |
+| `profile_id` | `"default"` | (#341) Chrome user-data-dir identity; sticky across plan revisions |
+| `workflow_id` | (auto) | (#341) Checkpoint identity; rotate when the plan changes |
+| `state_key` | unset | Legacy single-field; routes to both `profile_id` and `workflow_id` (back-compat) |
 | `max_cost` / `max_time_minutes` | tenant caps | Same clamping as `/v1/predict` |
 | `proxy_city` / `proxy_state` / `proxy_disabled` | unset / unset / `false` | Same proxy controls as `/v1/predict` |
 | `record_video` / `video_format` / `video_fps` | `false` / `mp4` / `5` | Same screencast controls as `/v1/predict` |

--- a/docs/operations/index.md
+++ b/docs/operations/index.md
@@ -28,7 +28,7 @@ Without `MANTIS_TENANT_KEYS_PATH` set, the server runs in single-tenant mode usi
 
 1. **Hot reload.** The keys file has a 5 s read cache. Update the file → 5 s later the new keys work / old keys are rejected. No pod restart.
 2. **Per-replica state.** Rate limits + concurrency are in-process per replica. With N replicas, the effective per-tenant cap is roughly N × the configured cap. For strict cluster-wide limits, run a single replica or swap to a Redis-backed limiter (planned Tier 2.5).
-3. **Per-tenant data isolation.** `state_key` is server-prefixed with `tenant_id`. Browser profiles and run state live under `$MANTIS_DATA_DIR/tenants/<tenant_id>/`. Tenants cannot read each other's checkpoints, profiles, or recordings.
+3. **Per-tenant data isolation.** `profile_id` / `workflow_id` / legacy `state_key` are all server-prefixed with `tenant_id` (#341). Browser profiles and run state live under `$MANTIS_DATA_DIR/tenants/<tenant_id>/`. Tenants cannot read each other's checkpoints, profiles, or recordings.
 4. **Hard caps come from env vars.** `MANTIS_MAX_STEPS_PER_PLAN`, `MANTIS_MAX_LOOP_ITERATIONS`, `MANTIS_MAX_RUNTIME_MINUTES`, `MANTIS_MAX_COST_USD` cap **above** every tenant cap. Tighten globally by lowering these.
 
 ## See also

--- a/docs/operations/tenant-keys.md
+++ b/docs/operations/tenant-keys.md
@@ -47,7 +47,7 @@ Every field except `tenant_id` is optional and falls back to the `DEFAULT_TENANT
 
 | Field | Default | Purpose |
 |---|---|---|
-| `tenant_id` | (required) | Identifier used as the prefix for `state_key`, browser profile dir, run dir, log lines, and metric labels. Pick something stable and human-readable. |
+| `tenant_id` | (required) | Identifier used as the prefix for `profile_id` / `workflow_id` / legacy `state_key`, browser profile dir, run dir, log lines, and metric labels. Pick something stable and human-readable. |
 | `scopes` | `["run", "status", "result", "logs"]` | Which actions this token can perform. Use `["status", "result"]` for read-only consumers. |
 | `max_concurrent_runs` | 5 | Per-tenant concurrency gauge. 6th in-flight run returns 429. |
 | `max_cost_per_run` | 25.0 | Per-tenant cost cap (clamps each request's `max_cost`). |

--- a/docs/operations/tenant-keys.md
+++ b/docs/operations/tenant-keys.md
@@ -256,7 +256,7 @@ The runtime never logs tokens, only `tenant_id`. Every request emits:
   "ts": "2026-04-28T02:14:32Z",
   "level": "INFO",
   "logger": "mantis_agent.baseten_server",
-  "msg": "predict tenant=tenant_a scope=run state_key=… detached=true action=run",
+  "msg": "predict tenant=tenant_a scope=run profile_id=… workflow_id=… detached=true action=run",
   "tenant_id": "tenant_a"
 }
 ```

--- a/docs/reference/chrome-session-reuse.md
+++ b/docs/reference/chrome-session-reuse.md
@@ -27,8 +27,10 @@ Tracking issue: [#311](https://github.com/mercurialsolo/mantis/issues/311).
   configs don't share a browser.
 
 Cross-tenant isolation is preserved because the profile_dir is
-tenant-scoped (`tenants/<tenant_id>/chrome-profile/<safe_state_key>`)
-and tenant requests will mismatch on the first key component.
+tenant-scoped (`tenants/<tenant_id>/chrome-profile/<safe_profile_id>`,
+keyed by `profile_id` since #341 — fallback to legacy `state_key` when
+`profile_id` is not set) and tenant requests will mismatch on the first
+key component.
 
 ## Lifecycle
 

--- a/docs/reference/env-vars.md
+++ b/docs/reference/env-vars.md
@@ -28,7 +28,7 @@ These are global hard caps; tenant config can be tighter, never looser.
 | `MANTIS_REPO_ROOT` | `/workspace/cua-agent` | Where `task_file` / `micro` paths are resolved from. |
 | `MANTIS_DEBUG_DIR` | `<MANTIS_DATA_DIR>/screenshots/claude_debug` | Where Claude extraction prompt + screenshot debug bundles land. |
 | `MANTIS_IDEMPOTENCY_DIR` | `<MANTIS_DATA_DIR>/idempotency` | Sidecar files for idempotency cache. |
-| `MANTIS_CHROME_PROFILE_DIR` | set per-request by handler | Chrome profile dir used by the Xvfb env. The handler overrides this per tenant + state_key. |
+| `MANTIS_CHROME_PROFILE_DIR` | set per-request by handler | Chrome profile dir used by the Xvfb env. The handler overrides this per tenant + `profile_id` (#341; falls back to legacy `state_key` when `profile_id` isn't set). |
 
 ## Inference
 
@@ -110,7 +110,7 @@ See [operations/cost.md](../operations/cost.md) for the full rate-tuning workflo
 The handler sets these on every `/v1/predict` so downstream code (the runtime, the JSON log formatter) can read them via `os.environ`. **Don't rely on them being set at deployment time.**
 
 - `MANTIS_TENANT_ID` — current request's tenant id
-- `MANTIS_CHROME_PROFILE_DIR` — per-tenant per-state_key Chrome profile dir for this run
+- `MANTIS_CHROME_PROFILE_DIR` — per-tenant per-`profile_id` Chrome user-data-dir for this run (#341)
 
 ## See also
 

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -18,7 +18,9 @@ Quick definitions for project-specific terms. For deeper explanations, follow th
 | **Polished video** | The composed walkthrough (title card → captioned run with action overlays → outro card) produced when `record_video: true`. |
 | **Raw recording** | The unprocessed Xvfb screencast. Available via `?raw=1` on the video endpoint. |
 | **`run_id`** | Server-generated identifier for a detached run. Format: `<YYYYMMDD>_<HHMMSS>_<random_hex>`. |
-| **`state_key`** | Caller-chosen identifier for a workflow. Server prefixes it with `tenant_id` to isolate. Controls browser-profile reuse and checkpoint resume. |
+| **`profile_id`** | (#341) Caller-chosen Chrome user-data-dir identity. Server prefixes with `tenant_id` to isolate. Sticky across plan revisions — same id ⇒ same cookies / logged-in sessions. Defaults to `"default"` (one profile per tenant). |
+| **`workflow_id`** | (#341) Caller-chosen checkpoint identity. Server prefixes with `tenant_id` to isolate. Rotate when the plan definition changes; pair with `resume_state: true` to pick up where the last run with this id stopped. Defaults to `plan_signature[:12]`. |
+| **`state_key`** | Legacy single-field identity. When set alone, the server routes it to both `profile_id` and `workflow_id` for back-compat. Prefer the split fields in new code; see [#341](https://github.com/mercurialsolo/mantis/issues/341). |
 | **Step** | One element of a micro-plan. Has `intent`, `type`, optional `section`, `gate`, `verify`, `loop_target`, etc. |
 | **Task suite** | Multi-task plan format (`{tasks: [...]}`). Each task has its own `verify` predicate. |
 | **Tenant** | A unit of isolation. Each tenant has its own token, scopes, caps, browser profile dir, run dir, and optionally its own Anthropic key. |

--- a/scripts/baseten_workload.py
+++ b/scripts/baseten_workload.py
@@ -117,6 +117,10 @@ def command_run(args: argparse.Namespace) -> int:
         "max_cost": args.max_cost,
         "max_time_minutes": args.max_time_minutes,
     }
+    if args.profile_id:
+        payload["profile_id"] = args.profile_id
+    if args.workflow_id:
+        payload["workflow_id"] = args.workflow_id
     if args.proxy_city:
         payload["proxy_city"] = args.proxy_city
     if args.proxy_state:
@@ -191,6 +195,8 @@ def build_parser() -> argparse.ArgumentParser:
     run.add_argument("--attach", action="store_true", help="block until Baseten returns a result")
     run.add_argument("--micro", default=DEFAULT_MICRO)
     run.add_argument("--state-key", default="boattrader-miami-private-v1")
+    run.add_argument("--profile-id", default="", help="Chrome user-data-dir identity (#341)")
+    run.add_argument("--workflow-id", default="", help="Checkpoint identity (#341)")
     run.add_argument("--resume-state", action="store_true")
     run.add_argument("--max-cost", type=float, default=10.0)
     run.add_argument("--max-time-minutes", type=int, default=180)

--- a/scripts/bench_text_plan.py
+++ b/scripts/bench_text_plan.py
@@ -39,6 +39,8 @@ def build_payload(args: argparse.Namespace) -> dict[str, Any]:
     payload: dict[str, Any] = {
         "detached": not args.attach,
         "state_key": args.state_key,
+        "profile_id": args.profile_id,
+        "workflow_id": args.workflow_id,
         "resume_state": False,
         "max_cost": args.max_cost,
         "max_time_minutes": args.max_time_minutes,
@@ -77,6 +79,8 @@ def main() -> int:
     parser.add_argument("--start-url", default="about:blank")
     parser.add_argument("--session-name", default="text_plan_bench")
     parser.add_argument("--state-key", default="text-plan-bench-1")
+    parser.add_argument("--profile-id", default="", help="Chrome user-data-dir identity (#341)")
+    parser.add_argument("--workflow-id", default="", help="Checkpoint identity (#341)")
     parser.add_argument("--max-steps", type=int, default=500)
     parser.add_argument("--max-cost", type=float, default=50.0)
     parser.add_argument("--max-time-minutes", type=int, default=200)

--- a/scripts/verify_modal_endpoint.py
+++ b/scripts/verify_modal_endpoint.py
@@ -1,0 +1,188 @@
+"""End-to-end verification for the Modal HTTP endpoint (#342).
+
+Submits the luma + staff-crm plans against the deployed `/v1/predict`,
+verifies parallel dispatch on distinct ``profile_id``s, and that a
+same-``profile_id`` collision returns 409. Polls one run to confirm
+the action=status path works.
+
+Usage:
+    uv run python scripts/verify_modal_endpoint.py \
+        --endpoint https://getmason--mantis-cua-server-api.modal.run \
+        --token "$MANTIS_API_TOKEN"
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import requests
+
+# Bring the in-repo helpers onto sys.path.
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from mantis_agent.plan_decomposer import MicroPlan, PlanDecomposer  # noqa: E402
+from mantis_agent.server_utils import (  # noqa: E402
+    build_micro_suite,
+    micro_plan_steps_to_dicts,
+)
+
+
+def load_plan_as_suite(plan_path: Path, profile_id: str, workflow_id: str) -> dict[str, Any]:
+    raw = json.loads(plan_path.read_text())
+    steps = raw["steps"] if isinstance(raw, dict) else raw
+    plan = MicroPlan(domain=plan_path.stem)
+    for step in steps:
+        plan.steps.append(PlanDecomposer._build_intent(step))
+    return build_micro_suite(
+        micro_plan_steps_to_dicts(plan.steps),
+        plan.domain,
+        profile_id=profile_id,
+        workflow_id=workflow_id,
+    )
+
+
+def post(url: str, token: str, body: dict[str, Any]) -> tuple[int, dict[str, Any]]:
+    r = requests.post(
+        url,
+        headers={"X-Mantis-Token": token, "Content-Type": "application/json"},
+        data=json.dumps(body),
+        timeout=60,
+    )
+    try:
+        return r.status_code, r.json()
+    except Exception:
+        return r.status_code, {"raw": r.text}
+
+
+def submit(endpoint: str, token: str, suite: dict, model: str = "holo3") -> tuple[int, dict]:
+    return post(
+        f"{endpoint.rstrip('/')}/v1/predict",
+        token,
+        {
+            "task_suite": suite,
+            "profile_id": suite["_profile_id"],
+            "workflow_id": suite["_workflow_id"],
+            "cua_model": model,
+            "max_steps": 4,  # smoke — just exercise the dispatch path, not the full run
+            "max_cost": 1.0,
+            "max_time_minutes": 5,
+            "detached": True,
+        },
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--endpoint",
+        default="https://getmason--mantis-cua-server-api.modal.run",
+    )
+    parser.add_argument("--token", default=os.environ.get("MANTIS_API_TOKEN", ""))
+    parser.add_argument("--model", default="claude")
+    args = parser.parse_args()
+
+    if not args.token:
+        print("ERROR: --token or MANTIS_API_TOKEN required", file=sys.stderr)
+        return 2
+
+    print(f"endpoint: {args.endpoint}")
+    print(f"model:    {args.model}")
+    print()
+
+    # ── 1. Health check ────────────────────────────────────────────
+    r = requests.get(f"{args.endpoint}/v1/health", timeout=30)
+    print(f"[health] HTTP {r.status_code}: {r.text}")
+    assert r.status_code == 200
+
+    # ── 2. Submit luma + staff-crm in parallel with DISTINCT profile_ids ─
+    luma_suite = load_plan_as_suite(
+        REPO_ROOT / "plans" / "luma-extract.json",
+        profile_id="verify-luma",
+        workflow_id="verify-luma-v1",
+    )
+    crm_suite = load_plan_as_suite(
+        REPO_ROOT / "plans" / "staff-crm.json",
+        profile_id="verify-staffcrm",
+        workflow_id="verify-staffcrm-v1",
+    )
+
+    print("[submit] luma → profile_id=verify-luma")
+    luma_status, luma_resp = submit(args.endpoint, args.token, luma_suite, args.model)
+    print(f"  HTTP {luma_status}: run_id={luma_resp.get('run_id')!r}")
+    print(f"  payload.profile_id={luma_resp.get('payload', {}).get('profile_id')}")
+    print(f"  payload.workflow_id={luma_resp.get('payload', {}).get('workflow_id')}")
+
+    print("[submit] staff-crm → profile_id=verify-staffcrm")
+    crm_status, crm_resp = submit(args.endpoint, args.token, crm_suite, args.model)
+    print(f"  HTTP {crm_status}: run_id={crm_resp.get('run_id')!r}")
+    print(f"  payload.profile_id={crm_resp.get('payload', {}).get('profile_id')}")
+    print(f"  payload.workflow_id={crm_resp.get('payload', {}).get('workflow_id')}")
+
+    assert luma_status == 200, f"luma submit failed: {luma_resp}"
+    assert crm_status == 200, f"crm submit failed: {crm_resp}"
+    assert luma_resp["run_id"] != crm_resp["run_id"], "run_ids must be distinct"
+    # Identity round-trip — server prefixes with tenant_id__.
+    assert luma_resp["payload"]["profile_id"].endswith("__verify-luma")
+    assert crm_resp["payload"]["profile_id"].endswith("__verify-staffcrm")
+
+    # ── 3. Same-profile_id submission should return 409 ───────────
+    print("[submit] duplicate luma profile_id → expect 409")
+    dup_status, dup_resp = submit(args.endpoint, args.token, luma_suite, args.model)
+    print(f"  HTTP {dup_status}: detail={dup_resp.get('detail', dup_resp)!r}")
+    assert dup_status == 409, f"expected 409, got {dup_status}: {dup_resp}"
+    held = luma_resp["run_id"]
+    assert held in dup_resp.get("detail", ""), (
+        f"409 detail should surface the held run_id={held}; got {dup_resp}"
+    )
+
+    # ── 4. Status poll on luma ─────────────────────────────────────
+    print("[status] action=status on luma run")
+    s_status, s_resp = post(
+        f"{args.endpoint}/v1/predict",
+        args.token,
+        {"action": "status", "run_id": luma_resp["run_id"]},
+    )
+    print(f"  HTTP {s_status}: status={s_resp.get('status')!r}, modal_call_id={s_resp.get('modal_call_id', '')[:20]}...")
+    assert s_status == 200
+    assert s_resp["status"] in {"queued", "running", "succeeded", "failed", "cancelled"}
+    assert s_resp["profile_id"] == luma_resp["payload"]["profile_id"]
+    assert s_resp["workflow_id"] == luma_resp["payload"]["workflow_id"]
+
+    # ── 5. Cancel both so the lock releases for the next run ──────
+    for run_id in (luma_resp["run_id"], crm_resp["run_id"]):
+        c_status, c_resp = post(
+            f"{args.endpoint}/v1/predict",
+            args.token,
+            {"action": "cancel", "run_id": run_id},
+        )
+        print(f"[cancel] {run_id}: HTTP {c_status}, status={c_resp.get('status')!r}")
+
+    # ── 6. After cancel, same profile_id should accept a new run ──
+    print("[submit] luma profile_id after cancel → expect 200 (lock released)")
+    time.sleep(1)  # belt-and-braces — the cancel→release is synchronous but volume commit takes a beat
+    re_status, re_resp = submit(args.endpoint, args.token, luma_suite, args.model)
+    print(f"  HTTP {re_status}: run_id={re_resp.get('run_id', re_resp)!r}")
+    assert re_status == 200, f"post-cancel submit failed: {re_resp}"
+    assert re_resp["run_id"] != luma_resp["run_id"]
+
+    # Tidy up.
+    post(
+        f"{args.endpoint}/v1/predict",
+        args.token,
+        {"action": "cancel", "run_id": re_resp["run_id"]},
+    )
+
+    print()
+    print("✅ All verifications passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/mantis_agent/api_schemas.py
+++ b/src/mantis_agent/api_schemas.py
@@ -72,7 +72,15 @@ class PredictRequest(BaseModel):
 
     # Run options
     detached: bool = True
+    # Identity (#341).
+    # ``state_key`` is the legacy single field; when set alone the server
+    # routes it to both ``profile_id`` and ``workflow_id`` for back-compat.
+    # New callers should set ``profile_id`` (Chrome user-data-dir identity,
+    # sticky across plan revisions) and ``workflow_id`` (checkpoint identity,
+    # rotated when the plan definition changes) independently.
     state_key: Optional[str] = None
+    profile_id: Optional[str] = None
+    workflow_id: Optional[str] = None
     resume_state: bool = False
     max_cost: float = Field(default=MAX_COST_USD, gt=0)
     max_time_minutes: int = Field(default=MAX_RUNTIME_MINUTES, gt=0)
@@ -182,9 +190,12 @@ class PureCUARequest(BaseModel):
     frames_per_inference: int = Field(default=1, ge=1, le=8)
 
     # Run options (mirrors PredictRequest shape so tenant caps clamp the
-    # same way).
+    # same way). ``state_key`` / ``profile_id`` / ``workflow_id`` semantics
+    # match PredictRequest (#341).
     detached: bool = False
     state_key: Optional[str] = None
+    profile_id: Optional[str] = None
+    workflow_id: Optional[str] = None
     max_cost: float = Field(default=MAX_COST_USD, gt=0)
     max_time_minutes: int = Field(default=MAX_RUNTIME_MINUTES, gt=0)
 

--- a/src/mantis_agent/baseten_server/__init__.py
+++ b/src/mantis_agent/baseten_server/__init__.py
@@ -10,11 +10,24 @@ PR #107):
 External callers — both the deployed Baseten Truss config and the test
 suite — import via ``from mantis_agent.baseten_server import app``.
 That import path is preserved.
+
+Imports are deferred via ``__getattr__`` so that lightweight consumers
+that only need :mod:`baseten_server.middleware` or
+:mod:`baseten_server.paths` (e.g. the Modal HTTP endpoint added in
+#342) don't pay the cost of importing the full GPU / Chrome runtime
+chain.
 """
 
 from __future__ import annotations
 
-from .routes import app, runtime
-from .runtime import BasetenCUARuntime
-
 __all__ = ["app", "runtime", "BasetenCUARuntime"]
+
+
+def __getattr__(name: str):  # PEP 562
+    if name in {"app", "runtime"}:
+        from .routes import app, runtime
+        return {"app": app, "runtime": runtime}[name]
+    if name == "BasetenCUARuntime":
+        from .runtime import BasetenCUARuntime
+        return BasetenCUARuntime
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/mantis_agent/baseten_server/paths.py
+++ b/src/mantis_agent/baseten_server/paths.py
@@ -32,27 +32,54 @@ def tenant_root(tenant: TenantConfig) -> Path:
 
       /workspace/mantis-data/tenants/<tenant_id>/
         ├── runs/<run_id>/{status,result,leads,events}
-        ├── checkpoints/<state_key>.json
-        ├── chrome-profile/<state_key>/
+        ├── checkpoints/<workflow_id>.json
+        ├── chrome-profile/<profile_id>/
+        ├── locks/<profile_id>          (#342)
         └── screenshots/<run_id>/
     """
     root = data_root() / "tenants" / safe_state_key(tenant.tenant_id)
-    for child in ("runs", "checkpoints", "chrome-profile", "screenshots"):
+    for child in ("runs", "checkpoints", "chrome-profile", "screenshots", "locks"):
         (root / child).mkdir(parents=True, exist_ok=True)
     return root
 
 
 def tenant_state_key(tenant: TenantConfig, caller_state_key: str | None) -> str:
-    """Server-namespaced state key. Caller's value is sanitized + prefixed."""
+    """Server-namespaced state key. Caller's value is sanitized + prefixed.
+
+    Legacy single-field identity (#341). New code should call
+    :func:`tenant_profile_id` and :func:`tenant_workflow_id` instead.
+    """
     base = safe_state_key(caller_state_key or "default")
     return f"{safe_state_key(tenant.tenant_id)}__{base}"
 
 
-def tenant_chrome_profile(tenant: TenantConfig, state_key: str) -> Path:
-    """Per-tenant, per-state-key Chrome profile dir."""
-    profile = tenant_root(tenant) / "chrome-profile" / safe_state_key(state_key)
+def tenant_profile_id(tenant: TenantConfig, caller_profile_id: str | None) -> str:
+    """Server-namespaced profile id (Chrome user-data-dir identity, #341)."""
+    base = safe_state_key(caller_profile_id or "default")
+    return f"{safe_state_key(tenant.tenant_id)}__{base}"
+
+
+def tenant_workflow_id(tenant: TenantConfig, caller_workflow_id: str | None) -> str:
+    """Server-namespaced workflow id (checkpoint identity, #341)."""
+    base = safe_state_key(caller_workflow_id or "default")
+    return f"{safe_state_key(tenant.tenant_id)}__{base}"
+
+
+def tenant_chrome_profile(tenant: TenantConfig, profile_id: str) -> Path:
+    """Per-tenant, per-profile Chrome user-data-dir (#341)."""
+    profile = tenant_root(tenant) / "chrome-profile" / safe_state_key(profile_id)
     profile.mkdir(parents=True, exist_ok=True)
     return profile
+
+
+def tenant_lock_path(tenant: TenantConfig, profile_id: str) -> Path:
+    """Per-tenant, per-profile lockfile (#342).
+
+    A non-empty file at this path means a run is currently using the
+    profile. The lock holder writes its ``run_id`` into the file so a
+    concurrent submitter can return a 409 with the conflicting run.
+    """
+    return tenant_root(tenant) / "locks" / f"{safe_state_key(profile_id)}.lock"
 
 
 def repo_root() -> Path:

--- a/src/mantis_agent/baseten_server/routes.py
+++ b/src/mantis_agent/baseten_server/routes.py
@@ -83,8 +83,10 @@ from .paths import (
     new_run_id,
     repo_root,
     tenant_chrome_profile,
+    tenant_profile_id,
     tenant_root,
     tenant_state_key,
+    tenant_workflow_id,
 )
 from .runtime import BasetenCUARuntime
 
@@ -190,6 +192,8 @@ _load_secret_environment = load_secret_environment
 _data_root = data_root
 _tenant_root = tenant_root
 _tenant_state_key = tenant_state_key
+_tenant_profile_id = tenant_profile_id
+_tenant_workflow_id = tenant_workflow_id
 _tenant_chrome_profile = tenant_chrome_profile
 _repo_root = repo_root
 _new_run_id = new_run_id
@@ -446,11 +450,25 @@ async def _handle_predict(
         int(payload.get("max_time_minutes", MAX_RUNTIME_MINUTES)),
         tenant.max_time_minutes_per_run,
     )
-    payload["state_key"] = _tenant_state_key(tenant, payload.get("state_key"))
+    # Identity resolution (#341): legacy ``state_key`` routes to both; new
+    # callers can pass ``profile_id`` / ``workflow_id`` independently.
+    caller_state_key = payload.get("state_key")
+    caller_profile_id = payload.get("profile_id")
+    caller_workflow_id = payload.get("workflow_id")
+    if caller_profile_id or caller_workflow_id:
+        payload["profile_id"] = _tenant_profile_id(tenant, caller_profile_id)
+        payload["workflow_id"] = _tenant_workflow_id(tenant, caller_workflow_id)
+    else:
+        legacy = _tenant_state_key(tenant, caller_state_key)
+        payload["profile_id"] = legacy
+        payload["workflow_id"] = legacy
+    # Downstream callers still read ``state_key``; keep it set to the
+    # workflow identity so checkpoint paths and cache keys stay stable.
+    payload["state_key"] = payload["workflow_id"]
 
     os.environ["ANTHROPIC_API_KEY"] = _resolve_anthropic_key(tenant)
     os.environ["MANTIS_TENANT_ID"] = tenant.tenant_id
-    profile_dir = _tenant_chrome_profile(tenant, payload["state_key"])
+    profile_dir = _tenant_chrome_profile(tenant, payload["profile_id"])
     os.environ["MANTIS_CHROME_PROFILE_DIR"] = str(profile_dir)
 
     is_run_mode = req.action is None
@@ -544,9 +562,10 @@ async def _handle_predict(
         payload["_tenant_id"] = tenant.tenant_id
 
     logger.info(
-        "predict tenant=%s scope=run state_key=%s detached=%s action=%s",
+        "predict tenant=%s scope=run profile_id=%s workflow_id=%s detached=%s action=%s",
         tenant.tenant_id,
-        payload["state_key"],
+        payload["profile_id"],
+        payload["workflow_id"],
         payload.get("detached", True),
         req.action or "run",
     )
@@ -672,11 +691,25 @@ async def cua_v1(
         int(payload.get("max_time_minutes", MAX_RUNTIME_MINUTES)),
         tenant.max_time_minutes_per_run,
     )
-    payload["state_key"] = _tenant_state_key(tenant, payload.get("state_key"))
+    # Identity resolution (#341): legacy ``state_key`` routes to both; new
+    # callers can pass ``profile_id`` / ``workflow_id`` independently.
+    caller_state_key = payload.get("state_key")
+    caller_profile_id = payload.get("profile_id")
+    caller_workflow_id = payload.get("workflow_id")
+    if caller_profile_id or caller_workflow_id:
+        payload["profile_id"] = _tenant_profile_id(tenant, caller_profile_id)
+        payload["workflow_id"] = _tenant_workflow_id(tenant, caller_workflow_id)
+    else:
+        legacy = _tenant_state_key(tenant, caller_state_key)
+        payload["profile_id"] = legacy
+        payload["workflow_id"] = legacy
+    # Downstream callers still read ``state_key``; keep it set to the
+    # workflow identity so checkpoint paths and cache keys stay stable.
+    payload["state_key"] = payload["workflow_id"]
 
     os.environ["ANTHROPIC_API_KEY"] = _resolve_anthropic_key(tenant)
     os.environ["MANTIS_TENANT_ID"] = tenant.tenant_id
-    profile_dir = _tenant_chrome_profile(tenant, payload["state_key"])
+    profile_dir = _tenant_chrome_profile(tenant, payload["profile_id"])
     os.environ["MANTIS_CHROME_PROFILE_DIR"] = str(profile_dir)
 
     # URL allowlist: enforce on start_url + any URL embedded in the
@@ -736,9 +769,10 @@ async def cua_v1(
     )
 
     logger.info(
-        "cua tenant=%s state_key=%s detached=%s start_url=%s",
+        "cua tenant=%s profile_id=%s workflow_id=%s detached=%s start_url=%s",
         tenant.tenant_id,
-        payload["state_key"],
+        payload["profile_id"],
+        payload["workflow_id"],
         payload.get("detached", False),
         payload.get("start_url", ""),
     )

--- a/src/mantis_agent/baseten_server/runtime.py
+++ b/src/mantis_agent/baseten_server/runtime.py
@@ -566,6 +566,8 @@ class BasetenCUARuntime:
             max_time_minutes=int(payload.get("max_time_minutes", 180)),
             resume_state=bool(payload.get("resume_state", False)),
             state_key=str(payload.get("state_key") or ""),
+            profile_id=str(payload.get("profile_id") or ""),
+            workflow_id=str(payload.get("workflow_id") or ""),
             checkpoint_dir=str(data_root / "checkpoints"),
             proxy_city=str(payload.get("proxy_city") or os.environ.get("MANTIS_PROXY_CITY", "")),
             proxy_state=str(payload.get("proxy_state") or os.environ.get("MANTIS_PROXY_STATE", "")),
@@ -654,6 +656,8 @@ class BasetenCUARuntime:
             max_time_minutes=int(payload.get("max_time_minutes", 180)),
             resume_state=bool(payload.get("resume_state", False)),
             state_key=str(payload.get("state_key") or ""),
+            profile_id=str(payload.get("profile_id") or ""),
+            workflow_id=str(payload.get("workflow_id") or ""),
             checkpoint_dir=str(data_root / "checkpoints"),
             proxy_city=str(payload.get("proxy_city") or os.environ.get("MANTIS_PROXY_CITY", "")),
             proxy_state=str(payload.get("proxy_state") or os.environ.get("MANTIS_PROXY_STATE", "")),
@@ -1030,13 +1034,15 @@ class BasetenCUARuntime:
                     som_for_unstructured_clicks=bool(som_override),
                 )
 
+            workflow_id = task_suite.get("_workflow_id") or task_suite.get("_state_key", "")
+            profile_id = task_suite.get("_profile_id") or task_suite.get("_state_key", "")
             runner = MicroPlanRunner(
                 brain=self.brain,
                 env=env,
                 grounding=grounding,
                 extractor=extractor,
                 checkpoint_path=checkpoint_path,
-                run_key=task_suite.get("_state_key", session_name),
+                run_key=workflow_id or session_name,
                 session_name=session_name,
                 plan_signature=task_suite.get("_plan_signature", ""),
                 resume_state=resume_state,
@@ -1060,6 +1066,8 @@ class BasetenCUARuntime:
                 model_name=self.model_kind,
                 elapsed_seconds=time.time() - t0,
                 state_key=task_suite.get("_state_key", ""),
+                profile_id=profile_id,
+                workflow_id=workflow_id,
                 checkpoint_path=checkpoint_path,
                 plan_signature=task_suite.get("_plan_signature", ""),
                 resume_state=resume_state,

--- a/src/mantis_agent/cli.py
+++ b/src/mantis_agent/cli.py
@@ -1228,6 +1228,10 @@ def cmd_cua_run(args: argparse.Namespace) -> int:
     }
     if args.state_key:
         body["state_key"] = args.state_key
+    if args.profile_id:
+        body["profile_id"] = args.profile_id
+    if args.workflow_id:
+        body["workflow_id"] = args.workflow_id
     if args.proxy_city:
         body["proxy_city"] = args.proxy_city
     if args.proxy_state:
@@ -1674,8 +1678,22 @@ def _build_parser() -> argparse.ArgumentParser:
     cua_run.add_argument(
         "--state-key",
         default=None,
-        help="Optional state key to namespace the Chrome profile / "
-             "checkpoint dir on the deployment.",
+        help="Legacy single-field identity (#341). When set alone, the "
+             "server routes it to both --profile-id and --workflow-id. "
+             "Prefer the split flags below for new code.",
+    )
+    cua_run.add_argument(
+        "--profile-id",
+        default=None,
+        help="Chrome user-data-dir identity (#341). Sticky across plan "
+             "revisions — same id => same cookies / logged-in sessions.",
+    )
+    cua_run.add_argument(
+        "--workflow-id",
+        default=None,
+        help="Checkpoint identity (#341). Rotate when the plan definition "
+             "changes; pair with --resume-state to pick up where the last "
+             "run with this id left off.",
     )
     cua_run.add_argument(
         "--detached",

--- a/src/mantis_agent/server/__init__.py
+++ b/src/mantis_agent/server/__init__.py
@@ -1,0 +1,7 @@
+"""Shared HTTP-server utilities used by both Baseten and Modal deployments.
+
+The Baseten deployment (``baseten_server/``) is the canonical
+implementation; the Modal deployment (``deploy/modal/modal_cua_server.py``,
+ASGI endpoint added in #342) reuses the framework-agnostic pieces here
+so the two surfaces don't drift.
+"""

--- a/src/mantis_agent/server/run_dispatch.py
+++ b/src/mantis_agent/server/run_dispatch.py
@@ -1,0 +1,240 @@
+"""Framework-agnostic predict-payload prep + per-profile lock helpers (#342).
+
+The Baseten ASGI app and the Modal ASGI app both need the same pre-spawn
+work: validate the JSON, clamp the per-tenant caps, resolve
+``profile_id`` / ``workflow_id`` / legacy ``state_key`` (#341), enforce
+the tenant URL allowlist, and write a tenant-scoped lockfile so two
+concurrent submissions for the same ``profile_id`` get a 409 instead of
+silently corrupting Chrome's user-data-dir.
+
+This module raises :class:`DispatchError` instead of ``HTTPException``
+so it stays usable from contexts that don't depend on FastAPI.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from ..api_schemas import (
+    MAX_COST_USD,
+    MAX_RUNTIME_MINUTES,
+    PredictRequest,
+    PureCUARequest,
+    assert_hosts_allowed,
+    extract_navigate_hosts,
+)
+from ..baseten_server.paths import (
+    tenant_chrome_profile,
+    tenant_lock_path,
+    tenant_profile_id,
+    tenant_state_key,
+    tenant_workflow_id,
+)
+from ..baseten_server.middleware import resolve_anthropic_key
+from ..tenant_auth import TenantConfig
+
+
+class DispatchError(Exception):
+    """Validation / authorization failure surfaced from the prep step.
+
+    ``status_code`` maps to HTTP cleanly; FastAPI shells re-raise as
+    ``HTTPException(status_code, detail)``.
+    """
+
+    def __init__(self, status_code: int, detail: str, *, run_id: str = "") -> None:
+        super().__init__(detail)
+        self.status_code = status_code
+        self.detail = detail
+        self.run_id = run_id
+
+
+def _resolve_identity(payload: dict[str, Any], tenant: TenantConfig) -> None:
+    """In-place: set ``profile_id``, ``workflow_id``, ``state_key`` (#341)."""
+    caller_state_key = payload.get("state_key")
+    caller_profile_id = payload.get("profile_id")
+    caller_workflow_id = payload.get("workflow_id")
+    if caller_profile_id or caller_workflow_id:
+        payload["profile_id"] = tenant_profile_id(tenant, caller_profile_id)
+        payload["workflow_id"] = tenant_workflow_id(tenant, caller_workflow_id)
+    else:
+        legacy = tenant_state_key(tenant, caller_state_key)
+        payload["profile_id"] = legacy
+        payload["workflow_id"] = legacy
+    payload["state_key"] = payload["workflow_id"]
+
+
+def _check_allowlist(plan_obj: Any, tenant: TenantConfig) -> None:
+    if not tenant.allowed_domains:
+        return
+    hosts = extract_navigate_hosts(plan_obj)
+    try:
+        assert_hosts_allowed(hosts, tenant.is_domain_allowed)
+    except PermissionError as exc:
+        raise DispatchError(403, str(exc)) from exc
+
+
+def prepare_predict_payload(raw: dict[str, Any], tenant: TenantConfig) -> dict[str, Any]:
+    """Validate + normalize a ``/v1/predict`` request body.
+
+    Returns the prepared payload dict with caps clamped, identity
+    resolved + tenant-prefixed, and chrome-profile env vars set. The
+    returned dict carries ``profile_id``, ``workflow_id`` and (legacy)
+    ``state_key`` so downstream code that reads any of the three keeps
+    working.
+
+    Raises :class:`DispatchError` on validation, allowlist, or
+    permission failures.
+    """
+    if not isinstance(raw, dict):
+        raise DispatchError(400, "request body must be a JSON object")
+
+    try:
+        req = PredictRequest.model_validate(raw)
+    except Exception as exc:
+        raise DispatchError(400, f"invalid request: {exc}") from exc
+
+    payload = req.model_dump(exclude_none=True)
+    payload["max_cost"] = min(
+        float(payload.get("max_cost", MAX_COST_USD)),
+        tenant.max_cost_per_run,
+    )
+    payload["max_time_minutes"] = min(
+        int(payload.get("max_time_minutes", MAX_RUNTIME_MINUTES)),
+        tenant.max_time_minutes_per_run,
+    )
+    _resolve_identity(payload, tenant)
+
+    os.environ["ANTHROPIC_API_KEY"] = resolve_anthropic_key(tenant)
+    os.environ["MANTIS_TENANT_ID"] = tenant.tenant_id
+    profile_dir = tenant_chrome_profile(tenant, payload["profile_id"])
+    os.environ["MANTIS_CHROME_PROFILE_DIR"] = str(profile_dir)
+
+    # Tier-2 URL allowlist — enforce on whatever pre-built plan shape
+    # the caller submitted. ``micro`` / ``plan_text`` decomposition
+    # happens downstream and is gated separately.
+    if req.action is None:
+        plan_obj: Any = None
+        if req.task_suite is not None:
+            plan_obj = req.task_suite
+        elif req.task_file_contents:
+            try:
+                plan_obj = json.loads(req.task_file_contents)
+            except json.JSONDecodeError:
+                plan_obj = None
+        if plan_obj is not None:
+            _check_allowlist(plan_obj, tenant)
+
+    return payload
+
+
+def prepare_cua_payload(raw: dict[str, Any], tenant: TenantConfig) -> dict[str, Any]:
+    """Validate + normalize a ``/v1/cua`` request body.
+
+    Same shape as :func:`prepare_predict_payload`, but routed through
+    :class:`PureCUARequest`. The allowlist gate checks the ``start_url``
+    plus any URL embedded in ``instruction``.
+    """
+    if not isinstance(raw, dict):
+        raise DispatchError(400, "request body must be a JSON object")
+
+    try:
+        req = PureCUARequest.model_validate(raw)
+    except Exception as exc:
+        raise DispatchError(400, f"invalid request: {exc}") from exc
+
+    payload = req.model_dump(exclude_none=True)
+    payload["max_cost"] = min(
+        float(payload.get("max_cost", MAX_COST_USD)),
+        tenant.max_cost_per_run,
+    )
+    payload["max_time_minutes"] = min(
+        int(payload.get("max_time_minutes", MAX_RUNTIME_MINUTES)),
+        tenant.max_time_minutes_per_run,
+    )
+    _resolve_identity(payload, tenant)
+
+    os.environ["ANTHROPIC_API_KEY"] = resolve_anthropic_key(tenant)
+    os.environ["MANTIS_TENANT_ID"] = tenant.tenant_id
+    profile_dir = tenant_chrome_profile(tenant, payload["profile_id"])
+    os.environ["MANTIS_CHROME_PROFILE_DIR"] = str(profile_dir)
+
+    plan_obj = {
+        "base_url": payload.get("start_url", ""),
+        "tasks": [{"intent": payload["instruction"]}],
+    }
+    _check_allowlist(plan_obj, tenant)
+
+    return payload
+
+
+# ── Profile lock (#342) ───────────────────────────────────────────
+
+
+def acquire_profile_lock(
+    tenant: TenantConfig,
+    profile_id: str,
+    run_id: str,
+    *,
+    stale_after_seconds: int = 4 * 3600,
+) -> bool:
+    """Attempt to acquire the per-tenant per-profile lock.
+
+    Returns ``True`` on success. Returns ``False`` if the lock is held
+    by a still-fresh run (caller should surface a 409 and include the
+    held ``run_id`` from :func:`read_profile_lock`).
+
+    Stale locks (older than ``stale_after_seconds``, default 4h) are
+    treated as released and overwritten — covers the case where an
+    executor crashed without writing terminal status.
+    """
+    path = tenant_lock_path(tenant, profile_id)
+    if path.exists():
+        try:
+            age = (
+                datetime.now(timezone.utc).timestamp() - path.stat().st_mtime
+            )
+        except OSError:
+            age = 0.0
+        if age < stale_after_seconds:
+            try:
+                held = path.read_text(encoding="utf-8").strip().splitlines()[0]
+            except OSError:
+                held = ""
+            if held and held != run_id:
+                return False
+    _write_lock(path, run_id)
+    return True
+
+
+def read_profile_lock(tenant: TenantConfig, profile_id: str) -> str:
+    """Return the ``run_id`` currently holding the lock, or empty string."""
+    path = tenant_lock_path(tenant, profile_id)
+    if not path.exists():
+        return ""
+    try:
+        return path.read_text(encoding="utf-8").strip().splitlines()[0]
+    except OSError:
+        return ""
+
+
+def release_profile_lock(tenant: TenantConfig, profile_id: str) -> None:
+    """Idempotent — missing file is treated as success."""
+    path = tenant_lock_path(tenant, profile_id)
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        pass
+    except OSError:
+        # Best-effort. A failed unlink turns into a stale-lock
+        # next-acquire path, not a correctness bug.
+        pass
+
+
+def _write_lock(path: Path, run_id: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    now = datetime.now(timezone.utc).isoformat()
+    path.write_text(f"{run_id}\n{now}\n", encoding="utf-8")

--- a/src/mantis_agent/server_utils.py
+++ b/src/mantis_agent/server_utils.py
@@ -338,9 +338,50 @@ def plan_signature_from_steps(steps: list[dict[str, Any]]) -> str:
 
 
 def safe_state_key(raw: str) -> str:
-    """Sanitize a string into a safe filesystem/state key."""
+    """Sanitize a string into a safe filesystem/state key.
+
+    Despite the legacy name, this is now used for ``profile_id``,
+    ``workflow_id``, ``tenant_id``, and any other identifier that lands on
+    disk. Kept as ``safe_state_key`` for back-compat with all existing
+    callers; new code can call it whatever fits semantically.
+    """
     cleaned = re.sub(r"[^A-Za-z0-9_.-]+", "_", raw).strip("._")
     return cleaned or "micro_state"
+
+
+def resolve_ids(
+    *,
+    state_key: str = "",
+    profile_id: str = "",
+    workflow_id: str = "",
+    plan_signature: str = "",
+) -> tuple[str, str]:
+    """Resolve caller inputs into ``(profile_id, workflow_id)`` (#341).
+
+    Behavior matrix:
+
+    * Caller set ``profile_id`` / ``workflow_id`` → use them (new shape).
+      Missing ``workflow_id`` defaults to ``plan_signature[:12]``;
+      missing ``profile_id`` defaults to ``"default"``.
+    * Caller set only legacy ``state_key`` → route to both (Phase 1
+      back-compat; preserves today's "one key controls profile + checkpoint"
+      behavior). Eventually deprecated; see issue #341.
+    * Neither set → ``profile_id="default"``, ``workflow_id=plan_signature[:12]``.
+
+    Outputs are sanitized via :func:`safe_state_key`.
+    """
+    if profile_id or workflow_id:
+        wf_default = plan_signature[:12] if plan_signature else "default"
+        wid = safe_state_key(workflow_id or wf_default)
+        pid = safe_state_key(profile_id or "default")
+        return pid, wid
+
+    if state_key:
+        sk = safe_state_key(state_key)
+        return sk, sk
+
+    wf_default = plan_signature[:12] if plan_signature else "default"
+    return safe_state_key("default"), safe_state_key(wf_default)
 
 
 # ── Time and ID utilities ─────────────────────────────────────────
@@ -415,6 +456,8 @@ def build_micro_result(
     model_name: str,
     elapsed_seconds: float,
     state_key: str = "",
+    profile_id: str = "",
+    workflow_id: str = "",
     checkpoint_path: str = "",
     plan_signature: str = "",
     resume_state: bool = False,
@@ -462,7 +505,9 @@ def build_micro_result(
         "steps_executed": len(step_results),
         "viable": len(leads),
         "leads_with_phone": sum(1 for lead in leads if runner._lead_has_phone(lead)),
-        "state_key": state_key,
+        "state_key": state_key or workflow_id,
+        "profile_id": profile_id or state_key,
+        "workflow_id": workflow_id or state_key,
         "checkpoint_path": checkpoint_path,
         "plan_signature": plan_signature,
         "resume_state": resume_state,
@@ -603,6 +648,8 @@ def build_micro_suite(
     max_time_minutes: int = 180,
     resume_state: bool = False,
     state_key: str = "",
+    profile_id: str = "",
+    workflow_id: str = "",
     checkpoint_dir: str = "/data/checkpoints",
     proxy_city: str = "",
     proxy_state: str = "",
@@ -614,12 +661,32 @@ def build_micro_suite(
     Used by both Modal main() and Baseten _micro_suite_from_path().
     When ``objective`` is provided, it's embedded so downstream code
     (e.g. ClaudeExtractor) can build an ExtractionSchema from it.
+
+    Identity resolution (#341):
+
+    * ``profile_id`` keys the Chrome user-data-dir.
+    * ``workflow_id`` keys the runner checkpoint file.
+    * ``state_key`` is the legacy single-field input; when set alone it
+      routes to both (Phase 1 back-compat).
+
+    The returned suite carries ``_profile_id`` + ``_workflow_id`` for new
+    consumers, plus ``_state_key`` (= ``workflow_id``) for downstream
+    code that hasn't migrated yet.
     """
     signature = plan_signature_from_steps(micro_plan_steps)
     safe_domain = domain.replace(".", "_")
-    default_key = f"micro_{safe_domain}_{signature[:12]}"
-    resolved_key = safe_state_key(state_key or default_key)
-    checkpoint_path = f"{checkpoint_dir}/{resolved_key}.json"
+    default_wf = f"micro_{safe_domain}_{signature[:12]}"
+
+    if not (profile_id or workflow_id or state_key):
+        workflow_id = default_wf
+
+    resolved_profile, resolved_workflow = resolve_ids(
+        state_key=state_key,
+        profile_id=profile_id,
+        workflow_id=workflow_id,
+        plan_signature=signature,
+    )
+    checkpoint_path = f"{checkpoint_dir}/{resolved_workflow}.json"
 
     suite: dict[str, Any] = {
         "session_name": f"micro_{safe_domain}",
@@ -627,7 +694,9 @@ def build_micro_suite(
         "_max_cost": max_cost,
         "_max_time_minutes": max_time_minutes,
         "_resume_state": resume_state,
-        "_state_key": resolved_key,
+        "_profile_id": resolved_profile,
+        "_workflow_id": resolved_workflow,
+        "_state_key": resolved_workflow,
         "_checkpoint_path": checkpoint_path,
         "_plan_signature": signature,
         "_proxy_city": proxy_city,

--- a/tests/test_modal_endpoint.py
+++ b/tests/test_modal_endpoint.py
@@ -1,0 +1,254 @@
+"""Tests for the Modal HTTP endpoint (#342).
+
+Drives the FastAPI app through ``TestClient`` with a mocked executor
+spawner, so we exercise the full request lifecycle (validate → lock →
+spawn → return run_id) without going through Modal's runtime.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from mantis_agent import tenant_auth as ta_mod
+
+
+# Modal app modules under deploy/modal/ aren't on sys.path by default.
+_DEPLOY_MODAL = Path(__file__).resolve().parent.parent / "deploy" / "modal"
+if str(_DEPLOY_MODAL) not in sys.path:
+    sys.path.insert(0, str(_DEPLOY_MODAL))
+
+
+class _StubFunctionCall:
+    """Stand-in for ``modal.Function.spawn(...)`` and ``FunctionCall``."""
+
+    def __init__(self, result: Any = None, raise_on_get: Exception | None = None) -> None:
+        self.object_id = "fc-stub-123"
+        self._result = result
+        self._raise = raise_on_get
+
+    def get(self, timeout: float = 0.1) -> Any:
+        if self._raise is not None:
+            raise self._raise
+        return self._result
+
+    def cancel(self) -> None:
+        return None
+
+
+class _StubExecutor:
+    """Stand-in for an @app.function() executor."""
+
+    def __init__(self, call: _StubFunctionCall) -> None:
+        self.call = call
+        self.spawn_kwargs: dict[str, Any] = {}
+
+    def spawn(self, *, task_file_contents: str, **kwargs) -> _StubFunctionCall:
+        self.spawn_kwargs = {"task_file_contents": task_file_contents, **kwargs}
+        return self.call
+
+
+@pytest.fixture
+def app_with_stub(monkeypatch, tmp_path):
+    """FastAPI app wired with a stub executor + isolated data dir."""
+    monkeypatch.setenv("MANTIS_API_TOKEN", "test-token")
+    monkeypatch.setenv("MANTIS_DATA_DIR", str(tmp_path / "mantis-data"))
+    monkeypatch.delenv("MANTIS_TENANT_KEYS_PATH", raising=False)
+    ta_mod.reset_key_store()
+
+    import modal_cua_server as mcs  # type: ignore[import-not-found]
+    importlib.reload(mcs)
+
+    stub_call = _StubFunctionCall(result={"viable": 3, "status": "succeeded"})
+    stub_executor = _StubExecutor(stub_call)
+
+    app = mcs.build_api_app(
+        executor_resolver=lambda model: stub_executor,
+        function_call_lookup=lambda call_id: stub_call,
+    )
+    return TestClient(app), stub_executor, stub_call
+
+
+def _auth_headers() -> dict[str, str]:
+    return {"X-Mantis-Token": "test-token", "Content-Type": "application/json"}
+
+
+# ── Happy path ──────────────────────────────────────────────────────
+
+
+def test_health_ok(app_with_stub) -> None:
+    client, _exec, _call = app_with_stub
+    r = client.get("/v1/health")
+    assert r.status_code == 200
+    assert r.json()["status"] == "ok"
+
+
+def test_predict_returns_run_id(app_with_stub) -> None:
+    client, executor, _call = app_with_stub
+    r = client.post(
+        "/v1/predict",
+        headers=_auth_headers(),
+        data=json.dumps({
+            "task_suite": {"tasks": [{"intent": "x"}]},
+            "profile_id": "alice",
+            "workflow_id": "plan_v1",
+        }),
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["status"] == "queued"
+    assert body["mode"] == "detached"
+    assert body["run_id"]
+    # Identity round-trips through the response envelope.
+    assert body["payload"]["profile_id"].endswith("__alice")
+    assert body["payload"]["workflow_id"].endswith("__plan_v1")
+    # Stub executor was actually spawned with the JSON-encoded suite.
+    assert "task_file_contents" in executor.spawn_kwargs
+    parsed = json.loads(executor.spawn_kwargs["task_file_contents"])
+    assert parsed["tasks"] == [{"intent": "x"}]
+
+
+def test_predict_rejects_missing_token(app_with_stub) -> None:
+    client, _executor, _call = app_with_stub
+    r = client.post(
+        "/v1/predict",
+        headers={"Content-Type": "application/json"},
+        data=json.dumps({"task_suite": {"tasks": []}}),
+    )
+    assert r.status_code == 401
+
+
+# ── Profile-lock 409 (#342 core motivation) ─────────────────────────
+
+
+def test_concurrent_same_profile_returns_409(app_with_stub) -> None:
+    client, _executor, _call = app_with_stub
+    # First submission acquires the lock.
+    r1 = client.post(
+        "/v1/predict",
+        headers=_auth_headers(),
+        data=json.dumps({
+            "task_suite": {"tasks": []},
+            "profile_id": "alice",
+            "workflow_id": "plan_v1",
+        }),
+    )
+    assert r1.status_code == 200, r1.text
+    held_run_id = r1.json()["run_id"]
+
+    # Second submission with the same profile_id hits the lock → 409.
+    r2 = client.post(
+        "/v1/predict",
+        headers=_auth_headers(),
+        data=json.dumps({
+            "task_suite": {"tasks": []},
+            "profile_id": "alice",  # same profile
+            "workflow_id": "plan_v2",  # different workflow doesn't matter — Chrome locks at the profile level
+        }),
+    )
+    assert r2.status_code == 409
+    # The 409 surfaces the conflicting run_id so the caller can poll it.
+    assert held_run_id in r2.text
+
+
+def test_different_profiles_run_in_parallel(app_with_stub) -> None:
+    """Distinct profile_ids must not serialize each other."""
+    client, _executor, _call = app_with_stub
+    r1 = client.post(
+        "/v1/predict",
+        headers=_auth_headers(),
+        data=json.dumps({"task_suite": {"tasks": []}, "profile_id": "alice"}),
+    )
+    r2 = client.post(
+        "/v1/predict",
+        headers=_auth_headers(),
+        data=json.dumps({"task_suite": {"tasks": []}, "profile_id": "bob"}),
+    )
+    assert r1.status_code == 200, r1.text
+    assert r2.status_code == 200, r2.text
+    assert r1.json()["run_id"] != r2.json()["run_id"]
+
+
+# ── Status / result polling ────────────────────────────────────────
+
+
+def test_status_action_returns_succeeded_after_get(app_with_stub) -> None:
+    client, _executor, _call = app_with_stub
+    r = client.post(
+        "/v1/predict",
+        headers=_auth_headers(),
+        data=json.dumps({"task_suite": {"tasks": []}, "profile_id": "alice"}),
+    )
+    run_id = r.json()["run_id"]
+
+    # Poll via action=status — stub .get() returns the result immediately.
+    poll = client.post(
+        "/v1/predict",
+        headers=_auth_headers(),
+        data=json.dumps({"action": "status", "run_id": run_id}),
+    )
+    assert poll.status_code == 200, poll.text
+    body = poll.json()
+    assert body["status"] == "succeeded"
+    assert body["run_id"] == run_id
+
+
+def test_result_action_returns_executor_result(app_with_stub) -> None:
+    client, _executor, call = app_with_stub
+    call._result = {"viable": 42, "leads": ["alice"]}
+    r = client.post(
+        "/v1/predict",
+        headers=_auth_headers(),
+        data=json.dumps({"task_suite": {"tasks": []}, "profile_id": "alice"}),
+    )
+    run_id = r.json()["run_id"]
+    poll = client.post(
+        "/v1/predict",
+        headers=_auth_headers(),
+        data=json.dumps({"action": "result", "run_id": run_id}),
+    )
+    assert poll.status_code == 200, poll.text
+    body = poll.json()
+    assert body["status"] == "succeeded"
+    assert body["result"] == {"viable": 42, "leads": ["alice"]}
+
+
+def test_status_unknown_run_returns_404(app_with_stub) -> None:
+    client, _executor, _call = app_with_stub
+    r = client.post(
+        "/v1/predict",
+        headers=_auth_headers(),
+        data=json.dumps({"action": "status", "run_id": "does-not-exist"}),
+    )
+    assert r.status_code == 404
+
+
+def test_succeeded_run_releases_profile_lock(app_with_stub) -> None:
+    """Once a run finishes, its profile_id should be free for re-use."""
+    client, _executor, _call = app_with_stub
+    r1 = client.post(
+        "/v1/predict",
+        headers=_auth_headers(),
+        data=json.dumps({"task_suite": {"tasks": []}, "profile_id": "alice"}),
+    )
+    run_id_1 = r1.json()["run_id"]
+    # Poll to terminal — stub returns immediately, lock released.
+    client.post(
+        "/v1/predict",
+        headers=_auth_headers(),
+        data=json.dumps({"action": "status", "run_id": run_id_1}),
+    )
+    # Same profile_id can now start a new run.
+    r2 = client.post(
+        "/v1/predict",
+        headers=_auth_headers(),
+        data=json.dumps({"task_suite": {"tasks": []}, "profile_id": "alice"}),
+    )
+    assert r2.status_code == 200, r2.text
+    assert r2.json()["run_id"] != run_id_1

--- a/tests/test_modal_endpoint.py
+++ b/tests/test_modal_endpoint.py
@@ -14,6 +14,13 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+
+# ``deploy/modal/modal_cua_server.py`` imports the ``modal`` SDK at module
+# scope. It's a deploy-time dependency, not a test dependency, so CI
+# environments often don't have it installed. Skip cleanly rather than
+# blowing up at collection.
+pytest.importorskip("modal")
+
 from fastapi.testclient import TestClient
 
 from mantis_agent import tenant_auth as ta_mod

--- a/tests/test_run_dispatch.py
+++ b/tests/test_run_dispatch.py
@@ -1,0 +1,216 @@
+"""Tests for the framework-agnostic dispatch helpers (#342).
+
+The Modal HTTP endpoint and (eventually) the Baseten ASGI app both
+prepare payloads through these helpers, so the dispatch logic stays
+consistent across deployments. Tests use ``DEFAULT_TENANT`` to skip
+the keyfile setup; allowlist and cap-clamp paths are exercised
+explicitly.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from mantis_agent.server.run_dispatch import (
+    DispatchError,
+    acquire_profile_lock,
+    prepare_cua_payload,
+    prepare_predict_payload,
+    read_profile_lock,
+    release_profile_lock,
+)
+from mantis_agent.tenant_auth import DEFAULT_TENANT, TenantConfig
+
+
+@pytest.fixture(autouse=True)
+def _isolate_data_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Each test gets its own MANTIS_DATA_DIR so file writes don't collide."""
+    monkeypatch.setenv("MANTIS_DATA_DIR", str(tmp_path))
+    yield
+
+
+# ── Identity resolution (#341 wired into the dispatcher) ───────────
+
+
+def test_prepare_predict_payload_routes_legacy_state_key_to_both() -> None:
+    out = prepare_predict_payload(
+        {"task_suite": {"tasks": []}, "state_key": "abc"},
+        DEFAULT_TENANT,
+    )
+    assert out["profile_id"] == out["workflow_id"]
+    assert out["profile_id"].endswith("__abc")
+    # state_key tracks workflow_id for downstream consumers.
+    assert out["state_key"] == out["workflow_id"]
+
+
+def test_prepare_predict_payload_new_fields_decouple() -> None:
+    out = prepare_predict_payload(
+        {
+            "task_suite": {"tasks": []},
+            "profile_id": "alice",
+            "workflow_id": "plan_v3",
+        },
+        DEFAULT_TENANT,
+    )
+    assert out["profile_id"].endswith("__alice")
+    assert out["workflow_id"].endswith("__plan_v3")
+    assert out["profile_id"] != out["workflow_id"]
+
+
+def test_prepare_predict_payload_clamps_caps_to_tenant() -> None:
+    tenant = TenantConfig(
+        tenant_id="capped",
+        max_cost_per_run=5.0,
+        max_time_minutes_per_run=10,
+    )
+    out = prepare_predict_payload(
+        {"task_suite": {"tasks": []}, "max_cost": 100.0, "max_time_minutes": 999},
+        tenant,
+    )
+    assert out["max_cost"] == 5.0
+    assert out["max_time_minutes"] == 10
+
+
+def test_prepare_predict_payload_rejects_non_dict() -> None:
+    with pytest.raises(DispatchError) as exc_info:
+        prepare_predict_payload([], DEFAULT_TENANT)  # type: ignore[arg-type]
+    assert exc_info.value.status_code == 400
+
+
+def test_prepare_predict_payload_rejects_invalid_schema() -> None:
+    # No plan-shape field provided — PredictRequest validator rejects.
+    with pytest.raises(DispatchError) as exc_info:
+        prepare_predict_payload({}, DEFAULT_TENANT)
+    assert exc_info.value.status_code == 400
+
+
+# ── Allowlist gate ─────────────────────────────────────────────────
+
+
+def test_prepare_predict_payload_enforces_allowlist() -> None:
+    tenant = TenantConfig(
+        tenant_id="t1",
+        allowed_domains=("example.com",),
+    )
+    bad = {
+        "task_suite": {
+            "base_url": "https://disallowed.io/x",
+            "tasks": [{"intent": "x", "start_url": "https://disallowed.io/x"}],
+        }
+    }
+    with pytest.raises(DispatchError) as exc_info:
+        prepare_predict_payload(bad, tenant)
+    assert exc_info.value.status_code == 403
+
+
+def test_prepare_predict_payload_allows_listed_domain() -> None:
+    tenant = TenantConfig(
+        tenant_id="t1",
+        allowed_domains=("example.com",),
+    )
+    ok = {
+        "task_suite": {
+            "base_url": "https://example.com/x",
+            "tasks": [{"intent": "x", "start_url": "https://example.com/x"}],
+        }
+    }
+    out = prepare_predict_payload(ok, tenant)
+    assert out["task_suite"]["base_url"] == "https://example.com/x"
+
+
+# ── Pure CUA flavor mirrors predict prep ───────────────────────────
+
+
+def test_prepare_cua_payload_resolves_identity() -> None:
+    out = prepare_cua_payload(
+        {
+            "instruction": "click foo",
+            "start_url": "https://example.com",
+            "profile_id": "alice",
+            "workflow_id": "wf_v1",
+        },
+        DEFAULT_TENANT,
+    )
+    assert out["profile_id"].endswith("__alice")
+    assert out["workflow_id"].endswith("__wf_v1")
+
+
+def test_prepare_cua_payload_enforces_allowlist_on_start_url() -> None:
+    tenant = TenantConfig(
+        tenant_id="t1",
+        allowed_domains=("example.com",),
+    )
+    with pytest.raises(DispatchError) as exc_info:
+        prepare_cua_payload(
+            {"instruction": "x", "start_url": "https://blocked.io"},
+            tenant,
+        )
+    assert exc_info.value.status_code == 403
+
+
+# ── Profile lock — concurrent-submission 409 (#342) ────────────────
+
+
+def test_acquire_profile_lock_first_caller_wins() -> None:
+    tenant = TenantConfig(tenant_id="t1")
+    assert acquire_profile_lock(tenant, "alice", "run-1") is True
+    assert read_profile_lock(tenant, "alice") == "run-1"
+
+
+def test_acquire_profile_lock_second_caller_rejected() -> None:
+    tenant = TenantConfig(tenant_id="t1")
+    assert acquire_profile_lock(tenant, "alice", "run-1") is True
+    assert acquire_profile_lock(tenant, "alice", "run-2") is False
+    # The held run_id is exactly what the 409 surfaces.
+    assert read_profile_lock(tenant, "alice") == "run-1"
+
+
+def test_release_profile_lock_lets_next_run_proceed() -> None:
+    tenant = TenantConfig(tenant_id="t1")
+    assert acquire_profile_lock(tenant, "alice", "run-1") is True
+    release_profile_lock(tenant, "alice")
+    assert read_profile_lock(tenant, "alice") == ""
+    assert acquire_profile_lock(tenant, "alice", "run-2") is True
+
+
+def test_release_profile_lock_idempotent_on_missing_file() -> None:
+    tenant = TenantConfig(tenant_id="t1")
+    # No exception when the lock doesn't exist.
+    release_profile_lock(tenant, "never-locked")
+
+
+def test_acquire_profile_lock_stale_lock_is_overwritten(tmp_path, monkeypatch):
+    """4h+ old lock files are treated as released — covers the crashed-executor case."""
+    tenant = TenantConfig(tenant_id="t1")
+    assert acquire_profile_lock(tenant, "alice", "run-1") is True
+
+    # Backdate the lockfile to simulate a crash 5h ago.
+    from mantis_agent.baseten_server.paths import tenant_lock_path
+    lock_path = tenant_lock_path(tenant, "alice")
+    old = lock_path.stat().st_mtime - 5 * 3600
+    os.utime(lock_path, (old, old))
+
+    # A fresh acquire on a stale lock succeeds.
+    assert acquire_profile_lock(tenant, "alice", "run-2") is True
+    assert read_profile_lock(tenant, "alice") == "run-2"
+
+
+def test_profile_locks_are_independent_across_profiles() -> None:
+    """Two distinct profile_ids are not serialized by each other's lock."""
+    tenant = TenantConfig(tenant_id="t1")
+    assert acquire_profile_lock(tenant, "alice", "run-1") is True
+    # Different profile — should succeed.
+    assert acquire_profile_lock(tenant, "bob", "run-2") is True
+    assert read_profile_lock(tenant, "alice") == "run-1"
+    assert read_profile_lock(tenant, "bob") == "run-2"
+
+
+def test_profile_locks_are_independent_across_tenants() -> None:
+    t1 = TenantConfig(tenant_id="t1")
+    t2 = TenantConfig(tenant_id="t2")
+    assert acquire_profile_lock(t1, "alice", "run-1") is True
+    # Different tenant, same profile name — must not collide.
+    assert acquire_profile_lock(t2, "alice", "run-2") is True

--- a/tests/test_server_utils.py
+++ b/tests/test_server_utils.py
@@ -18,6 +18,7 @@ from mantis_agent.server_utils import (
     micro_plan_steps_to_dicts,
     parse_lead_row,
     plan_signature_from_steps,
+    resolve_ids,
     result_summary,
     safe_state_key,
     save_result_json,
@@ -258,6 +259,8 @@ def test_build_micro_result_includes_dynamic_verification():
         model_name="Holo3-35B-A3B",
         elapsed_seconds=120.5,
         state_key="test_key",
+        profile_id="alice",
+        workflow_id="plan_v3",
         checkpoint_path="/data/checkpoints/test.json",
         plan_signature="abc123",
         resume_state=False,
@@ -273,6 +276,9 @@ def test_build_micro_result_includes_dynamic_verification():
     assert result["viable"] == 2
     assert result["leads_with_phone"] == 1
     assert result["state_key"] == "test_key"
+    # #341: split identities echoed in the envelope.
+    assert result["profile_id"] == "alice"
+    assert result["workflow_id"] == "plan_v3"
 
     # THE CRITICAL CHECK: dynamic_verification must be present
     assert "dynamic_verification" in result
@@ -339,9 +345,86 @@ def test_build_micro_suite_structure():
     assert suite["session_name"] == "micro_example_com"
     assert suite["_max_cost"] == 3.0
     assert suite["_state_key"] == "my_key"
+    # Phase 1 back-compat (#341): legacy state_key routes to both identities.
+    assert suite["_profile_id"] == "my_key"
+    assert suite["_workflow_id"] == "my_key"
     assert suite["_micro_plan"] == steps
     assert suite["tasks"] == []
     assert suite["_checkpoint_path"].endswith("my_key.json")
+
+
+# ── #341: profile_id / workflow_id split ─────────────────────────────
+
+
+def test_resolve_ids_legacy_state_key_routes_to_both():
+    pid, wid = resolve_ids(state_key="abc", plan_signature="deadbeef")
+    assert pid == "abc"
+    assert wid == "abc"
+
+
+def test_resolve_ids_new_fields_win_over_state_key():
+    pid, wid = resolve_ids(
+        state_key="legacy", profile_id="alice", workflow_id="plan_v3"
+    )
+    assert pid == "alice"
+    assert wid == "plan_v3"
+
+
+def test_resolve_ids_workflow_defaults_to_signature_prefix():
+    pid, wid = resolve_ids(profile_id="alice", plan_signature="deadbeef1234567890")
+    assert pid == "alice"
+    assert wid == "deadbeef1234"  # first 12 hex chars
+
+
+def test_resolve_ids_profile_defaults_to_default():
+    pid, wid = resolve_ids(workflow_id="plan_v1", plan_signature="abc")
+    assert pid == "default"
+    assert wid == "plan_v1"
+
+
+def test_resolve_ids_no_input_uses_defaults():
+    pid, wid = resolve_ids(plan_signature="cafe000000000000")
+    assert pid == "default"
+    assert wid == "cafe00000000"
+
+
+def test_resolve_ids_sanitizes():
+    pid, wid = resolve_ids(profile_id="alice@prod!", workflow_id="plan v2")
+    assert pid == "alice_prod"
+    assert wid == "plan_v2"
+
+
+def test_build_micro_suite_split_identities():
+    steps = [{"intent": "nav", "type": "navigate"}]
+    suite = build_micro_suite(
+        steps,
+        "example.com",
+        profile_id="alice",
+        workflow_id="plan_v3",
+    )
+    assert suite["_profile_id"] == "alice"
+    assert suite["_workflow_id"] == "plan_v3"
+    # state_key tracks workflow_id for downstream back-compat readers.
+    assert suite["_state_key"] == "plan_v3"
+    # Checkpoint path uses workflow_id, NOT profile_id.
+    assert suite["_checkpoint_path"].endswith("plan_v3.json")
+
+
+def test_profile_id_preserved_across_workflow_rotation():
+    """Regression guard for the core motivation of #341.
+
+    Rotating workflow_id (because the plan definition changed) must not
+    invalidate the Chrome profile. The two suites below share a profile
+    but use different checkpoints — exactly what coupling under one
+    state_key prevented.
+    """
+    steps_v1 = [{"intent": "nav", "type": "navigate"}]
+    steps_v2 = [{"intent": "nav", "type": "navigate"}, {"intent": "click", "type": "click"}]
+    suite_v1 = build_micro_suite(steps_v1, "example.com", profile_id="alice", workflow_id="v1")
+    suite_v2 = build_micro_suite(steps_v2, "example.com", profile_id="alice", workflow_id="v2")
+    assert suite_v1["_profile_id"] == suite_v2["_profile_id"] == "alice"
+    assert suite_v1["_workflow_id"] != suite_v2["_workflow_id"]
+    assert suite_v1["_checkpoint_path"] != suite_v2["_checkpoint_path"]
 
 
 def test_micro_plan_steps_to_dicts():


### PR DESCRIPTION
## Summary

Two related changes landed together because #342 builds on the identity model from #341.

* **#341 — `state_key` split**: the legacy single field conflated two identities with opposite rotation lifetimes (Chrome user-data-dir vs runner checkpoint). Splits into `profile_id` (sticky — same id ⇒ same logged-in cookies across plan revisions) and `workflow_id` (rotated on plan change; pair with `resume_state: true`). Phase 1 is fully back-compat: when callers set only `state_key`, the server routes it to both. `MicroIntentRequest` / `PureCUARequest` accept the new fields; the result envelope echoes all three.
* **#342 — Modal HTTP endpoint**: lightweight `@modal.asgi_app()` (`api_image` — no Chrome / CUDA / vLLM) at `https://getmason--mantis-cua-server-api.modal.run`. Mirrors the Baseten `/v1/predict` shape. Each `.spawn()` opens a fresh GPU/xdotool container, so concurrent multi-plan submissions parallelize at the Modal layer with no driver-process bottleneck. Per-profile lockfile gives 409 on a busy `profile_id` instead of silent Chrome user-data-dir corruption — the issue's core motivation, and the practical reason #341 had to land first.

Shared dispatch helpers live in `src/mantis_agent/server/run_dispatch.py` (`prepare_predict_payload`, `prepare_cua_payload`, profile-lock primitives) and raise framework-agnostic `DispatchError(status_code, detail)` so Baseten can adopt them later without depending on FastAPI types.

## Files

20 files / +1649 / -49.

* `src/mantis_agent/server_utils.py` — `resolve_ids()` + `build_micro_suite` / `build_micro_result` take both fields
* `src/mantis_agent/baseten_server/paths.py` — `tenant_profile_id` / `tenant_workflow_id` / `tenant_lock_path`
* `src/mantis_agent/baseten_server/routes.py`, `runtime.py` — `_handle_predict` and `cua_v1` key the Chrome profile by `profile_id`
* `src/mantis_agent/baseten_server/__init__.py` — PEP-562 `__getattr__` so the lightweight Modal API image doesn't transitively pull PIL/gym/xdotool
* `src/mantis_agent/server/run_dispatch.py` — new shared module
* `deploy/modal/modal_cua_server.py` — `build_api_app()` + `@app.function(@modal.asgi_app())` `api()` + `_executor_for_model` dispatch map + run_dir/status/result helpers
* `scripts/verify_modal_endpoint.py` — live e2e harness
* CLI / scripts / docs (glossary, concepts, tenant-keys, chrome-session-reuse) and 25 new tests

## Test plan

- [x] `uv run pytest tests/test_server_utils.py tests/test_run_dispatch.py tests/test_modal_endpoint.py tests/test_client.py tests/test_tenant_auth.py tests/test_chat_completions_proxy.py -n0` — 111 pass.
- [x] `uv run modal deploy deploy/modal/modal_cua_server.py` — deployed app `mantis-cua-server`, web function `api` at `https://getmason--mantis-cua-server-api.modal.run`.
- [x] `uv run python scripts/verify_modal_endpoint.py` against the live endpoint passed all six checks:
  - `/v1/health` → 200 in <500ms
  - luma + staff-crm submitted with distinct `profile_id`s → both 200 with distinct `run_id`s (parallel dispatch confirmed)
  - identity round-trips through the response envelope, tenant-prefixed (`default__verify-luma`)
  - duplicate `profile_id` submission → 409 with the held `run_id` surfaced in the detail
  - `action=status` poll → terminal state writeback works (got `'failed'` on the smoke executor, which itself proves spawn → `FunctionCall.from_id` → lock-release round-trip)
  - post-cancel re-submit on the same `profile_id` → 200 (lock-release path works)

## Out of scope for Phase 1 (tracked under #342 Phase 2)

* Free-text `plan_text` / `.txt` `micro` decomposition (currently the endpoint requires `task_suite` / `task_file_contents` / `.json` micro)
* Idempotency-Key cache port from `baseten_server/routes.py`
* Webhook delivery on terminal status
* `GET /v1/runs/{id}/video` streaming

## Migration

No breaking changes. Callers passing only `state_key` continue to work — the server routes it to both `profile_id` and `workflow_id`. New code should set the two independently.

Closes #341
Closes #342

🤖 Generated with [Claude Code](https://claude.com/claude-code)