### PR TITLE
Wire PauseRequested / OTP resume through /v1/predict (#344)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -384,9 +384,57 @@ For comparison, equivalent Claude-only CUA flow ~$0.50–$1.50 per listing.
 ## Limits / caveats
 
 - **Detached runs survive replica restart** (state on the data volume) but only on the same Baseten model. Cross-region failover not supported.
-- **Pause/resume for OTP** is not yet wired through `/v1/predict`. It works today in library-embedded integrations because the loop runs in the host's own process — see [Embedding MicroPlanRunner](integrations/embedding-microplanrunner.md).
 - **`/v1/chat/completions`** is unstreamed in v1. Streaming SSE is a Tier 2 follow-up.
 - **Single Anthropic-key per tenant** at request time (re-resolved on every call).
+
+## Pause / resume
+
+> OTP / 2FA / human-in-the-loop confirmation — [#344](https://github.com/mercurialsolo/mantis/issues/344).
+
+When a plan hits an auth wall the agent can't get past on its own — an OTP code, a 2FA push, an explicit "yes, refund this" confirmation — a registered host tool raises [`PauseRequested`](reference/glossary.md). The runner snapshots its state, writes `pause_state.json` to the run dir, and flips the run's status to `paused`. The caller polls status, surfaces the prompt to a human (or fetches the code from a side channel), then resumes with the answer.
+
+A default `request_user_input` host tool is registered on every detached `/v1/predict` run. Brains that emit `Action(TOOL_CALL, name="request_user_input", params={"prompt": "..."})` will pause the run on the first call and receive the caller's `user_input` on the second (after resume).
+
+### Status poll on a paused run
+
+```jsonc
+POST /v1/predict
+{"action": "status", "run_id": "20260513_180527_abc"}
+
+→ {
+  "status":       "paused",
+  "run_id":       "20260513_180527_abc",
+  "prompt":       "Enter the 6-digit code from your authenticator",
+  "reason":       "user_input",
+  "pause_state":  { /* opaque PauseState blob — hand back on resume */ }
+}
+```
+
+`pause_state` is opaque — the server is the only thing that interprets it. Treat it as a token: store it if you want, but you don't need to send it back yourself. The server already has the canonical copy on disk under the run_id; it round-trips automatically on resume.
+
+### Resume
+
+```jsonc
+POST /v1/predict
+{"action": "resume", "run_id": "20260513_180527_abc", "user_input": "123456"}
+
+→ {"status": "running", "run_id": "20260513_180527_abc", "resumed_at": "2026-05-13T18:09:12Z"}
+```
+
+The server rehydrates the stored `PauseState`, calls `runner.resume(state, user_input=...)` against the same `profile_id` / `workflow_id` the original run used, and continues from the paused step. Subsequent `action=status` polls return `running` until the run reaches a terminal status (`succeeded` / `failed` / `cancelled`) — or pauses again, in which case the cycle repeats with a fresh prompt.
+
+### Error cases
+
+| Status | Cause |
+|---|---|
+| `400 action='resume' requires user_input` | Missing the `user_input` field |
+| `400 action='resume' requires a paused run` | Run isn't currently in `paused` status (succeeded, running, cancelled, ...) |
+| `400 plan signature mismatch on resume` | Disk-stored `pause_state.plan_signature` doesn't match the current plan derived from the stored payload — usually means someone edited the on-disk state |
+| `404 unknown run_id` | No `status.json` for that `run_id` on this tenant |
+
+### Library-embedded integrations
+
+If you embed `MicroPlanRunner` / `GymRunner` directly (no HTTP), the same primitives are available in-process via `runner.run_with_status(plan)` returning `RunnerResult(paused=True, pause_state=...)`, plus `runner.resume(state, user_input=..., plan=plan)`. See [Embedding MicroPlanRunner](integrations/embedding-microplanrunner.md) for the canonical walkthrough — the HTTP surface is just a wrapper on top of the same library API.
 
 ## Screencast / video recording
 

--- a/docs/client/runs-and-polling.md
+++ b/docs/client/runs-and-polling.md
@@ -187,6 +187,39 @@ If a run failed mid-way (network hiccup, replica restart, OOM), re-submit with t
 
 The runner picks up from the last checkpoint (extracted leads kept, browser profile + cookies still on the volume). You get a new `run_id` but the same logical workflow continues.
 
+## Paused runs
+
+> OTP / 2FA / human-in-the-loop confirmation — [#344](https://github.com/mercurialsolo/mantis/issues/344).
+
+A run can pause mid-flight — for OTP / 2FA / explicit human confirmation — without failing. The default `request_user_input` host tool is wired into every `/v1/predict` run: if the brain emits `Action(TOOL_CALL, name="request_user_input", params={"prompt": "..."})`, the runner snapshots state and the run's status flips to `paused`.
+
+```python
+from mantis_agent.client import MantisClient
+
+client = MantisClient.from_env()
+handle = client.predict({"micro": "plans/login-flow.json", "profile_id": "alice"})
+
+def on_status(s):
+    if s.status == "paused":
+        code = input(s.prompt + " ")    # surface to the human
+        client.resume(handle.run_id, user_input=code)
+
+# wait_for_completion polls past `paused` (it's NON-terminal); the
+# on_status callback above handles the prompt + calls resume() and
+# the loop continues to terminal succeeded / failed / cancelled.
+final = client.wait_for_completion(handle.run_id, on_status=on_status)
+```
+
+Key points:
+
+* `paused` is **non-terminal**. `wait_for_completion` keeps polling — it only stops on `succeeded` / `failed` / `cancelled` (the `TERMINAL_STATUSES` set is unchanged).
+* `RunStatus.prompt`, `RunStatus.reason`, and `RunStatus.pause_state` are populated when status is `paused`. The pause_state is opaque — the server keeps the canonical copy on disk, so you don't need to send it back yourself.
+* `client.resume(run_id, user_input=...)` is synchronous: it returns `{status: running}` once the worker has been kicked back into the runner. The continuation runs in the background; keep polling status until terminal.
+* The runner can pause more than once on the same run (OTP → confirmation → another OTP). Each pause flips status back to `paused` with a fresh `prompt`; resume the same way.
+* Plan-signature mismatch on resume returns 400 — usually a sign that someone edited the on-disk state, since the plan can't change between submit and resume.
+
+See [API / Pause / resume](../api.md#pause-resume) for the full request/response shapes.
+
 ## See also
 
 - [Recordings](recordings.md) — fetching the screencast

--- a/docs/integrations/embedding-microplanrunner.md
+++ b/docs/integrations/embedding-microplanrunner.md
@@ -164,6 +164,12 @@ the runner catches and turns into a clean pause (next).
 
 ### 4. `PauseRequested` + `runner.resume()` — OTP / 2FA / human-in-the-loop ([#73](https://github.com/mercurialsolo/mantis/issues/73))
 
+> **HTTP callers**: the same surface is now wired through `/v1/predict` —
+> see [API / Pause / resume](../api.md#pause-resume) and
+> [Client / Paused runs](../client/runs-and-polling.md#paused-runs).
+> The default `request_user_input` tool below is registered server-side
+> on every detached run; HTTP callers don't need to register it themselves.
+
 ```python
 def request_user_input(args):
     staged = runner.consume_pause_input(default=None)

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -42,7 +42,7 @@ Errors:
 | 400    | Bad request: missing plan shape, bad JSON, plan too large, missing intent/type |
 | 401    | Missing or invalid `X-Mantis-Token` |
 | 403    | Token valid but lacks `run` scope, OR plan references off-allowlist host |
-| 404    | Unknown `run_id` for `action=status\|result\|logs\|cancel` |
+| 404    | Unknown `run_id` for `action=status\|result\|logs\|cancel\|resume` |
 | 429    | Rate limit (token bucket) or concurrent-run cap exceeded; check `Retry-After` |
 | 500    | Unhandled exception — fetch `action=logs` for the traceback |
 | 502    | Upstream Holo3 / Anthropic API unreachable |
@@ -114,7 +114,23 @@ The `*_path` fields are server-internal — fetch them via the polling actions.
 { "action": "result", "run_id": "..." }
 { "action": "logs",   "run_id": "...", "tail": 200 }
 { "action": "cancel", "run_id": "..." }
+{ "action": "resume", "run_id": "...", "user_input": "123456" }   // #344
 ```
+
+`action=resume` (#344) rehydrates a paused run with the caller's
+``user_input`` (OTP code, 2FA token, confirmation, etc.). Requires the
+run to be in status `paused` and `user_input` to be non-null; returns
+`{status: "running", run_id, resumed_at}`. Subsequent `action=status`
+polls return `running` until terminal. Status table:
+
+| `status`   | Terminal? | Notes |
+|------------|-----------|-------|
+| `queued`   | No   | Worker thread pending |
+| `running`  | No   | Worker thread inside the runner |
+| `paused`   | **No** | A registered tool raised `PauseRequested`; `status.prompt` carries the human-facing question, `status.pause_state` is the opaque snapshot. Resume with `action=resume`. |
+| `succeeded` | Yes | `result.json` available via `action=result` |
+| `failed`   | Yes  | `status.error` populated; `action=logs` for the traceback |
+| `cancelled`| Yes  | Caller invoked `action=cancel` |
 
 `status` returns the current state plus a `summary` block when terminal:
 

--- a/src/mantis_agent/api_schemas.py
+++ b/src/mantis_agent/api_schemas.py
@@ -65,10 +65,17 @@ class PredictRequest(BaseModel):
     micro_path: Optional[str] = None  # alias for micro
     plan_text: Optional[str] = None
 
-    # Action mode (status / result / logs / cancel for an existing run)
-    action: Optional[Literal["status", "result", "logs", "cancel"]] = None
+    # Action mode (status / result / logs / cancel / resume for an existing run).
+    # ``resume`` (#344) requires ``user_input`` and a paused run; the server
+    # rehydrates the stored PauseState and continues the runner from where
+    # the host tool raised PauseRequested.
+    action: Optional[Literal["status", "result", "logs", "cancel", "resume"]] = None
     run_id: Optional[str] = None
     tail: Optional[int] = Field(default=None, ge=1, le=10000)
+    # Caller-supplied value handed to ``runner.consume_pause_input(...)`` on
+    # resume (OTP code, 2FA token, free-text confirmation, etc.). Opaque
+    # to the server. Required on ``action="resume"``; ignored otherwise.
+    user_input: Optional[Any] = None
 
     # Run options
     detached: bool = True
@@ -141,7 +148,9 @@ class PredictRequest(BaseModel):
         if self.action is not None:
             if not self.run_id:
                 raise ValueError(f"action={self.action!r} requires run_id")
-            return self  # poll/cancel modes don't need a plan
+            if self.action == "resume" and self.user_input is None:
+                raise ValueError("action='resume' requires user_input")
+            return self  # poll/cancel/resume modes don't need a plan
 
         # Run mode: at least one plan-shape must be present
         plan_provided = any(
@@ -347,3 +356,11 @@ class RunStatus(BaseModel):
     finished_at: Optional[str] = None
     summary: Optional[dict[str, Any]] = None
     error: Optional[str] = None
+    # #344: paused-run surface. When ``status == "paused"``, ``prompt`` is
+    # the message the registered tool passed to PauseRequested (e.g. "Enter
+    # the 6-digit code"), ``reason`` is the PauseRequested.reason
+    # ("user_input" by default), and ``pause_state`` is an opaque dict
+    # the caller hands back verbatim on ``action="resume"``.
+    prompt: Optional[str] = None
+    reason: Optional[str] = None
+    pause_state: Optional[dict[str, Any]] = None

--- a/src/mantis_agent/baseten_server/runtime.py
+++ b/src/mantis_agent/baseten_server/runtime.py
@@ -272,7 +272,7 @@ class BasetenCUARuntime:
 
     def run(self, payload: dict[str, Any]) -> dict[str, Any]:
         action = str(payload.get("action") or payload.get("op") or "").lower()
-        if action in {"status", "result", "logs"}:
+        if action in {"status", "result", "logs", "resume"}:
             return self._detached_action(action, payload)
         if action == "graph_learn":
             return self._graph_learn(payload)
@@ -370,6 +370,41 @@ class BasetenCUARuntime:
         with (run_dir / "events.log").open("a") as handle:
             handle.write(line + "\n")
 
+    def _save_pause_state(self, run_id: str, pause_state: dict[str, Any]) -> Path:
+        """Persist a paused run's :class:`PauseState` blob (#344)."""
+        run_dir = self._run_path(run_id, create=True)
+        path = run_dir / "pause_state.json"
+        self._write_json_atomic(path, pause_state)
+        return path
+
+    def _read_pause_state(self, run_id: str) -> dict[str, Any]:
+        """Read pause_state.json; returns ``{}`` when absent (#344)."""
+        path = self._run_path(run_id) / "pause_state.json"
+        if not path.exists():
+            return {}
+        try:
+            return json.loads(path.read_text())
+        except Exception:
+            return {}
+
+    def _save_resume_payload(self, run_id: str, payload: dict[str, Any]) -> Path:
+        """Persist the original payload so resume can rebuild the run (#344)."""
+        run_dir = self._run_path(run_id, create=True)
+        path = run_dir / "payload.json"
+        # Skip transient fields that would be wrong to re-apply on resume.
+        keep = {k: v for k, v in payload.items() if not k.startswith("_resume")}
+        self._write_json_atomic(path, keep)
+        return path
+
+    def _read_resume_payload(self, run_id: str) -> dict[str, Any]:
+        path = self._run_path(run_id) / "payload.json"
+        if not path.exists():
+            return {}
+        try:
+            return json.loads(path.read_text())
+        except Exception:
+            return {}
+
     def _start_detached(self, payload: dict[str, Any]) -> dict[str, Any]:
         run_id = _safe_state_key(str(payload.get("run_id") or _new_run_id()))
         if run_id in self.detached_threads and self.detached_threads[run_id].is_alive():
@@ -379,6 +414,11 @@ class BasetenCUARuntime:
         run_payload.pop("detached", None)
         run_payload["_detached_run_id"] = run_id
         run_payload["_detached_started_at"] = _utc_now()
+        # Snapshot the payload so a later action=resume can rebuild the run
+        # (#344). Skipped for resume continuations (the original payload is
+        # already on disk).
+        if not run_payload.get("_resume_pause_state"):
+            self._save_resume_payload(run_id, run_payload)
 
         status = self._write_detached_status(
             run_id,
@@ -424,6 +464,27 @@ class BasetenCUARuntime:
                         result = self._run_micro(task_suite, payload, run_id=run_id)
                     else:
                         result = self._run_tasks(task_suite, payload, run_id=run_id)
+                # #344: paused branch — runner raised PauseRequested through
+                # the default request_user_input tool. Stash the PauseState
+                # snapshot so action=resume can rebuild the runner, and
+                # surface prompt / reason on status.json. The poller hits
+                # this exact shape on the next ``action=status`` round-trip.
+                if result.get("_paused"):
+                    pause_payload = result.pop("pause_state", None) or {}
+                    self._save_pause_state(run_id, pause_payload)
+                    self._save_detached_result(run_id, result)
+                    self._write_detached_status(
+                        run_id,
+                        {
+                            "status": "paused",
+                            "paused_at": _utc_now(),
+                            "prompt": str(result.get("prompt", "")),
+                            "reason": str(result.get("reason", "user_input")),
+                            "summary": self._result_summary(result),
+                        },
+                    )
+                    self._append_detached_event(run_id, "paused")
+                    return
                 self._save_detached_result(run_id, result)
                 self._write_detached_status(
                     run_id,
@@ -475,6 +536,10 @@ class BasetenCUARuntime:
             thread = self.detached_threads.get(run_id)
             if thread and thread.is_alive() and status.get("status") not in {"running", "queued"}:
                 status["in_memory_thread_alive"] = True
+            # #344: inline the PauseState blob so the polling caller has
+            # everything they need to resume without a second round-trip.
+            if status.get("status") == "paused":
+                status["pause_state"] = self._read_pause_state(run_id)
             return status
 
         if action == "result":
@@ -483,6 +548,78 @@ class BasetenCUARuntime:
                 return self._read_json_file(result_path)
             status = self._read_json_file(run_dir / "status.json")
             return {"run_id": run_id, "status": status.get("status", "unknown"), "result_ready": False}
+
+        if action == "resume":
+            # #344: rehydrate a paused detached run.
+            status = self._read_json_file(run_dir / "status.json")
+            if status.get("status") != "paused":
+                raise ValueError(
+                    f"action='resume' requires a paused run; "
+                    f"run_id={run_id!r} is in status={status.get('status')!r}"
+                )
+            user_input = payload.get("user_input")
+            if user_input is None:
+                raise ValueError("action='resume' requires user_input")
+            pause_state = self._read_pause_state(run_id)
+            if not pause_state:
+                raise FileNotFoundError(
+                    f"pause_state.json missing for run {run_id!r}; cannot resume"
+                )
+            original_payload = self._read_resume_payload(run_id)
+            if not original_payload:
+                raise FileNotFoundError(
+                    f"payload.json missing for run {run_id!r}; cannot resume"
+                )
+            existing_thread = self.detached_threads.get(run_id)
+            if existing_thread and existing_thread.is_alive():
+                raise RuntimeError(
+                    f"resume in progress for {run_id!r}; poll status before retrying"
+                )
+            # Synchronous plan-signature guard so a stale pause_state
+            # surfaces as a 400 on this round-trip — not later via
+            # status polling on a doomed worker.
+            stored_sig = str(pause_state.get("plan_signature", ""))
+            current_sig = ""
+            try:
+                rebuilt_suite = self._task_suite_from_payload(dict(original_payload))
+                current_sig = str(rebuilt_suite.get("_plan_signature", ""))
+            except Exception:  # noqa: BLE001 — surface the mismatch, not the rebuild error
+                current_sig = ""
+            if stored_sig and current_sig and stored_sig != current_sig:
+                raise ValueError(
+                    "plan signature mismatch on resume: stored "
+                    f"{stored_sig[:12]!r} ≠ current {current_sig[:12]!r}. "
+                    "The plan referenced by this run_id has changed since it paused."
+                )
+            resume_payload = dict(original_payload)
+            resume_payload["_detached_run_id"] = run_id
+            resume_payload["_resume_pause_state"] = pause_state
+            resume_payload["_resume_user_input"] = user_input
+            now = _utc_now()
+            self._write_detached_status(
+                run_id,
+                {
+                    "status": "running",
+                    "resumed_at": now,
+                    # Wipe stale pause-surface fields so the next status
+                    # poll doesn't keep showing the old prompt.
+                    "prompt": "",
+                    "reason": "",
+                },
+            )
+            self._append_detached_event(run_id, "resuming")
+            thread = threading.Thread(
+                target=self._run_detached_worker,
+                args=(run_id, resume_payload),
+                daemon=True,
+            )
+            self.detached_threads[run_id] = thread
+            thread.start()
+            return {
+                "run_id": run_id,
+                "status": "running",
+                "resumed_at": now,
+            }
 
         tail = int(payload.get("tail", 200))
         events_path = run_dir / "events.log"
@@ -930,6 +1067,7 @@ class BasetenCUARuntime:
     ) -> dict[str, Any]:
         from mantis_agent.extraction import ClaudeExtractor
         from mantis_agent.grounding import ClaudeGrounding
+        from mantis_agent.gym.checkpoint import PauseRequested, PauseState
         from mantis_agent.gym.micro_runner import MicroPlanRunner
         from mantis_agent.plan_decomposer import MicroIntent, MicroPlan
 
@@ -1051,7 +1189,49 @@ class BasetenCUARuntime:
                 extraction_cache=cache,
                 routing_policy=routing_policy,
             )
-            step_results = runner.run(micro_plan, resume=resume_state)
+            # #344: default ``request_user_input`` host tool. Brains that
+            # emit ``Action(TOOL_CALL, name="request_user_input")`` get a
+            # paused-run snapshot on the first call, and the staged
+            # ``user_input`` on the second (after action=resume rehydrates).
+            def _request_user_input(args: dict[str, Any]) -> Any:
+                staged = runner.consume_pause_input(default=None)
+                if staged is None:
+                    raise PauseRequested(
+                        reason="user_input",
+                        prompt=str(args.get("prompt", "")),
+                    )
+                return staged
+            runner.register_tool(
+                "request_user_input",
+                {
+                    "type": "object",
+                    "properties": {"prompt": {"type": "string"}},
+                    "additionalProperties": False,
+                },
+                _request_user_input,
+            )
+
+            # #344: resume continuation. When the caller submits
+            # action=resume, the worker re-enters this method with the
+            # stored PauseState and the caller's user_input layered onto
+            # the payload. ``runner.resume(...)`` replays the recorded
+            # steps and continues from the paused step.
+            resume_blob = payload.get("_resume_pause_state")
+            if resume_blob is not None:
+                pause_state_obj = (
+                    PauseState.from_dict(resume_blob)
+                    if isinstance(resume_blob, dict) else resume_blob
+                )
+                runner_result = runner.resume(
+                    pause_state_obj,
+                    user_input=payload.get("_resume_user_input"),
+                    plan=micro_plan,
+                )
+            else:
+                runner_result = runner.run_with_status(
+                    micro_plan, resume=resume_state,
+                )
+            step_results = runner_result.steps
             if cache is not None:
                 try:
                     cache.save()
@@ -1073,6 +1253,14 @@ class BasetenCUARuntime:
                 resume_state=resume_state,
             )
             self._attach_recording_metadata(result, recorder, click_log=click_log)
+            # #344: surface the paused snapshot so the detached worker can
+            # write status=paused (rather than succeeded) and persist
+            # pause_state.json for the next action=resume.
+            if runner_result.paused and runner_result.pause_state is not None:
+                result["_paused"] = True
+                result["pause_state"] = runner_result.pause_state.to_dict()
+                result["prompt"] = runner_result.pause_state.prompt
+                result["reason"] = runner_result.pause_state.pending_reason
             self._save_result(result, prefix=self.model_kind.replace("-", "_"))
             return result
         finally:

--- a/src/mantis_agent/client/client.py
+++ b/src/mantis_agent/client/client.py
@@ -247,6 +247,24 @@ class MantisClient:
         """
         return self._post_predict({"action": "cancel", "run_id": run_id})
 
+    def resume(self, run_id: str, user_input: Any) -> dict:
+        """``POST /v1/predict {action: resume, run_id, user_input}`` (#344).
+
+        Hands ``user_input`` (OTP code, 2FA token, confirmation, etc.) to
+        a paused run. The server rehydrates the stored ``PauseState``,
+        calls ``runner.resume(state, user_input=...)``, and continues
+        from the paused step. Subsequent :meth:`status` polls return
+        ``running`` until a terminal status (or another pause).
+
+        Raises :class:`MantisError` (400) on plan-signature mismatch, on
+        a run that's not currently paused, or when ``user_input`` is missing.
+        """
+        return self._post_predict({
+            "action": "resume",
+            "run_id": run_id,
+            "user_input": user_input,
+        })
+
     # ── /v1/cua pass-through ────────────────────────────────────────────
 
     def cua_run(
@@ -348,6 +366,13 @@ class MantisClient:
         indicator in a UI without re-implementing the polling loop.
         Raises :class:`MantisTimeoutError` on timeout (the run is *not*
         cancelled — call :meth:`cancel` explicitly if needed).
+
+        ``paused`` is **non-terminal** (#344): if a run pauses for OTP /
+        2FA / human-in-the-loop confirmation, the loop keeps polling
+        until the caller resumes it via :meth:`resume` (or until the
+        run cancels / times out). Inspect ``status.status == "paused"``
+        inside ``on_status`` to detect the pause and surface
+        ``status.prompt`` to the user.
         """
         if poll_interval_s <= 0:
             raise ValueError("poll_interval_s must be > 0")

--- a/tests/test_predict_pause_resume.py
+++ b/tests/test_predict_pause_resume.py
@@ -21,7 +21,6 @@ from __future__ import annotations
 
 import importlib
 import json
-import threading
 import time
 from pathlib import Path
 from typing import Any

--- a/tests/test_predict_pause_resume.py
+++ b/tests/test_predict_pause_resume.py
@@ -1,0 +1,300 @@
+"""End-to-end tests for HTTP pause/resume via /v1/predict (#344).
+
+The library-side pause primitives (`PauseRequested`, `PauseState`,
+`runner.resume`) are already covered by `tests/test_micro_runner_hooks.py`
+and `tests/test_gym_runner_tools.py`. These tests cover the wire shape
+on top of them:
+
+* `action=status` returns `status="paused"` with `prompt` + `reason` +
+  `pause_state` for a paused detached run.
+* `action=resume` rehydrates the stored PauseState, kicks the worker
+  back into the runner, and flips status to `running` → `succeeded`.
+* Negative paths: resume on a non-paused run is 400; missing
+  ``user_input`` is 400; plan-signature mismatch on resume is 400.
+
+We mock at the ``BasetenCUARuntime._run_micro`` boundary — the runner +
+brain + Chrome stack is all covered by upstream library tests, and
+the goal here is the route → runtime → disk → route lifecycle.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("pydantic")
+
+from fastapi.testclient import TestClient
+
+from mantis_agent import tenant_auth as ta_mod
+from mantis_agent.baseten_server.runtime import BasetenCUARuntime
+
+
+@pytest.fixture
+def client(monkeypatch, tmp_path):
+    """Single-tenant TestClient + isolated MANTIS_DATA_DIR."""
+    monkeypatch.setenv("MANTIS_API_TOKEN", "test-token")
+    monkeypatch.setenv("MANTIS_LLAMA_PORT", "18080")
+    monkeypatch.delenv("MANTIS_TENANT_KEYS_PATH", raising=False)
+    monkeypatch.setenv("MANTIS_DATA_DIR", str(tmp_path / "mantis-data"))
+    ta_mod.reset_key_store()
+
+    # ``baseten_server/__init__.py`` exposes ``app`` and ``runtime`` via
+    # PEP-562 lazy attributes; importing ``routes`` materializes both and
+    # forces the singleton ``runtime`` into the lazy cache so the rest of
+    # the test can reach it via ``bs.app`` / ``bs.routes.runtime``.
+    from mantis_agent import baseten_server as bs
+    from mantis_agent.baseten_server import routes as bs_routes
+
+    importlib.reload(bs_routes)
+    importlib.reload(bs)
+
+    # Real ``load()`` boots Holo3 / Gemma4 — out of reach in unit tests.
+    # We're mocking ``_run_micro`` directly, so the brain is never used.
+    bs_routes.runtime.loaded = True
+    monkeypatch.setattr(BasetenCUARuntime, "load", lambda self: None, raising=True)
+
+    return TestClient(bs.app), bs_routes
+
+
+def _auth_headers() -> dict[str, str]:
+    return {"X-Mantis-Token": "test-token", "Content-Type": "application/json"}
+
+
+def _minimal_payload() -> dict[str, Any]:
+    """A payload that bypasses everything — pre-built suite, no decompose."""
+    return {
+        "detached": True,
+        "task_suite": {
+            "session_name": "pause-test",
+            "_micro_plan": [
+                {"intent": "navigate to example.com", "type": "navigate", "budget": 1},
+            ],
+            "_plan_signature": "fixed-sig-for-tests",
+            "_max_cost": 1.0,
+            "_max_time_minutes": 5,
+            "tasks": [],
+        },
+        "max_cost": 1.0,
+        "max_time_minutes": 5,
+        "profile_id": "test-profile",
+        "workflow_id": "test-workflow",
+    }
+
+
+def _stub_run_micro_first_call(self, task_suite, payload, run_id=None):
+    """Replacement for BasetenCUARuntime._run_micro that always pauses."""
+    return {
+        "_paused": True,
+        "pause_state": {
+            "version": 1,
+            "run_key": "test-workflow",
+            "plan_signature": task_suite.get("_plan_signature", ""),
+            "session_name": task_suite.get("session_name", ""),
+            "step_index": 0,
+            "pending_tool": "request_user_input",
+            "pending_arguments": {"prompt": "Enter the 6-digit code"},
+            "pending_reason": "user_input",
+            "prompt": "Enter the 6-digit code",
+            "step_results": [],
+            "loop_counters": {},
+            "listings_on_page": 0,
+            "checkpoint_path": "",
+            "timestamp": time.time(),
+        },
+        "prompt": "Enter the 6-digit code",
+        "reason": "user_input",
+        "leads": [],
+        "run_id": run_id or "stub",
+    }
+
+
+def _stub_run_micro_resume(self, task_suite, payload, run_id=None):
+    """Replacement that succeeds; asserts the resume path carried user_input."""
+    assert payload.get("_resume_user_input") == "123456", (
+        f"expected user_input='123456', got {payload.get('_resume_user_input')!r}"
+    )
+    assert payload.get("_resume_pause_state"), (
+        "expected _resume_pause_state to be layered onto the payload"
+    )
+    return {
+        "viable": 1,
+        "leads": [{"url": "https://example.com/a"}],
+        "run_id": run_id or "stub",
+    }
+
+
+def _wait_for_status(client, run_id: str, *, want: set[str], timeout_s: float = 5.0):
+    """Spin on action=status until status ∈ want (or timeout)."""
+    t0 = time.monotonic()
+    last = None
+    while time.monotonic() - t0 < timeout_s:
+        r = client.post(
+            "/v1/predict",
+            headers=_auth_headers(),
+            json={"action": "status", "run_id": run_id},
+        )
+        assert r.status_code == 200, r.text
+        last = r.json()
+        if last.get("status") in want:
+            return last
+        time.sleep(0.05)
+    pytest.fail(
+        f"status never reached {want} for run_id={run_id}; "
+        f"last={last!r} (waited {timeout_s}s)"
+    )
+
+
+# ── Happy path: pause → status → resume → succeed ─────────────────
+
+
+def test_status_returns_paused_with_pause_state_and_prompt(client, monkeypatch):
+    test_client, bs = client
+    monkeypatch.setattr(
+        BasetenCUARuntime, "_run_micro", _stub_run_micro_first_call, raising=True
+    )
+
+    submit = test_client.post(
+        "/v1/predict", headers=_auth_headers(), json=_minimal_payload(),
+    )
+    assert submit.status_code == 200, submit.text
+    run_id = submit.json()["run_id"]
+
+    status = _wait_for_status(test_client, run_id, want={"paused"})
+    assert status["status"] == "paused"
+    assert status["prompt"] == "Enter the 6-digit code"
+    assert status["reason"] == "user_input"
+    assert status["pause_state"]["pending_tool"] == "request_user_input"
+    assert status["pause_state"]["prompt"] == "Enter the 6-digit code"
+    assert status["pause_state"]["plan_signature"] == "fixed-sig-for-tests"
+
+
+def test_resume_flips_to_running_and_passes_user_input(client, monkeypatch):
+    test_client, bs = client
+
+    # First call: pauses. Second call (after resume): asserts user_input and succeeds.
+    call_count = {"n": 0}
+
+    def _switching_stub(self, task_suite, payload, run_id=None):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            return _stub_run_micro_first_call(self, task_suite, payload, run_id)
+        return _stub_run_micro_resume(self, task_suite, payload, run_id)
+
+    monkeypatch.setattr(
+        BasetenCUARuntime, "_run_micro", _switching_stub, raising=True
+    )
+
+    # Submit + wait for paused.
+    submit = test_client.post(
+        "/v1/predict", headers=_auth_headers(), json=_minimal_payload(),
+    )
+    assert submit.status_code == 200, submit.text
+    run_id = submit.json()["run_id"]
+    _wait_for_status(test_client, run_id, want={"paused"})
+
+    # Resume — synchronous response returns running.
+    resume = test_client.post(
+        "/v1/predict",
+        headers=_auth_headers(),
+        json={"action": "resume", "run_id": run_id, "user_input": "123456"},
+    )
+    assert resume.status_code == 200, resume.text
+    body = resume.json()
+    assert body["status"] == "running"
+    assert body["run_id"] == run_id
+    assert "resumed_at" in body
+
+    # Wait for the resumed worker to finish.
+    final = _wait_for_status(test_client, run_id, want={"succeeded"})
+    assert final["status"] == "succeeded"
+    # Old pause surface is wiped on the resumed status.
+    assert final.get("prompt", "") == ""
+    assert call_count["n"] == 2
+
+
+# ── Negative paths ────────────────────────────────────────────────
+
+
+def test_resume_on_non_paused_run_returns_400(client, monkeypatch):
+    test_client, bs = client
+
+    # Run that succeeds immediately (no pause).
+    def _ok_stub(self, task_suite, payload, run_id=None):
+        return {"viable": 0, "leads": [], "run_id": run_id or "stub"}
+
+    monkeypatch.setattr(BasetenCUARuntime, "_run_micro", _ok_stub, raising=True)
+    submit = test_client.post(
+        "/v1/predict", headers=_auth_headers(), json=_minimal_payload(),
+    )
+    run_id = submit.json()["run_id"]
+    _wait_for_status(test_client, run_id, want={"succeeded"})
+
+    resume = test_client.post(
+        "/v1/predict",
+        headers=_auth_headers(),
+        json={"action": "resume", "run_id": run_id, "user_input": "x"},
+    )
+    assert resume.status_code == 400, resume.text
+    assert "paused" in resume.json()["detail"].lower()
+
+
+def test_resume_requires_user_input(client):
+    test_client, _bs = client
+    # Pydantic catches this at schema level — no need to set up a real run.
+    r = test_client.post(
+        "/v1/predict",
+        headers=_auth_headers(),
+        json={"action": "resume", "run_id": "anything"},
+    )
+    assert r.status_code == 400, r.text
+    assert "user_input" in r.json()["detail"]
+
+
+def test_resume_plan_signature_mismatch_returns_400(client, monkeypatch, tmp_path):
+    test_client, bs = client
+    monkeypatch.setattr(
+        BasetenCUARuntime, "_run_micro", _stub_run_micro_first_call, raising=True
+    )
+
+    submit = test_client.post(
+        "/v1/predict", headers=_auth_headers(), json=_minimal_payload(),
+    )
+    run_id = submit.json()["run_id"]
+    _wait_for_status(test_client, run_id, want={"paused"})
+
+    # Tamper with pause_state.json — change the plan signature so the
+    # synchronous guard in _detached_action("resume", ...) fires.
+    data_root = Path(bs.runtime._run_path(run_id))  # bs is bs_routes here — the singleton lives on it
+    pause_path = data_root / "pause_state.json"
+    blob = json.loads(pause_path.read_text())
+    blob["plan_signature"] = "some-other-signature-from-an-edited-plan"
+    pause_path.write_text(json.dumps(blob))
+
+    resume = test_client.post(
+        "/v1/predict",
+        headers=_auth_headers(),
+        json={"action": "resume", "run_id": run_id, "user_input": "123456"},
+    )
+    assert resume.status_code == 400, resume.text
+    detail = resume.json()["detail"]
+    assert "signature mismatch" in detail.lower()
+
+
+def test_resume_unknown_run_returns_404(client):
+    test_client, _bs = client
+    r = test_client.post(
+        "/v1/predict",
+        headers=_auth_headers(),
+        json={"action": "resume", "run_id": "does-not-exist", "user_input": "x"},
+    )
+    # Reading status.json on a missing run dir raises FileNotFoundError →
+    # the route handler maps that to 404.
+    assert r.status_code == 404, r.text


### PR DESCRIPTION
## Summary

Surfaces the library-side pause/resume primitives (`PauseRequested`, `PauseState`, `runner.resume(...)` — landed in #73 / #285) over the HTTP `/v1/predict` endpoint. Callers hitting an auth wall (OTP / 2FA / "yes, refund this") can now pause cleanly, surface the prompt to a human, and resume — same `run_id`, same `profile_id` / `workflow_id`.

The default `request_user_input` host tool is registered server-side on every detached run. Brains that emit `Action(TOOL_CALL, name="request_user_input", params={"prompt": "..."})` trigger the pause path; brains that don't are unaffected. Three additive route changes:

1. **`action=status` on a paused run** returns `{status: "paused", prompt, reason, pause_state}` — `pause_state` is opaque, the server holds the canonical copy on disk.
2. **`action=resume`** rehydrates the stored `PauseState`, calls `runner.resume(state, user_input=...)`, flips status to `running`. Subsequent status polls continue past the pause until terminal.
3. **`MantisClient.resume(run_id, user_input)`** convenience. `TERMINAL_STATUSES` unchanged — `paused` is non-terminal, `wait_for_completion` keeps polling so callers use `on_status` to detect the pause and call `resume`.

## Test plan

- [x] `uv run pytest tests/test_predict_pause_resume.py tests/test_micro_runner_hooks.py tests/test_client.py tests/test_chat_completions_proxy.py tests/test_server_utils.py -n0` → 137 pass. Six new cases on the HTTP surface:
  - status returns paused + prompt + pause_state with the right plan_signature
  - resume → 200 running → status poll → succeeded; resumed worker sees the layered `user_input`
  - 400 on resume of a non-paused run
  - 400 on resume without `user_input` (Pydantic)
  - 400 on plan-signature mismatch (tampered `pause_state.json`)
  - 404 on unknown `run_id`
- [x] `uv run --extra docs mkdocs build --strict` — clean (no new anchor warnings).

## Files

8 files / +640 / −7.

* `src/mantis_agent/api_schemas.py` — `action` Literal gets `"resume"`; new `user_input` field with validator; `RunStatus` gets optional `prompt` / `reason` / `pause_state`.
* `src/mantis_agent/baseten_server/runtime.py` — default `request_user_input` tool, switched to `run_with_status`, paused branch in worker writes `pause_state.json` + status=paused, `action=resume` rehydrates and re-spawns the worker, synchronous plan-signature guard.
* `src/mantis_agent/client/client.py` — `MantisClient.resume()`; docstring on `wait_for_completion` flagging `paused` as non-terminal.
* `tests/test_predict_pause_resume.py` (new) — six end-to-end cases mocking at the `_run_micro` boundary.
* Docs: `api.md` (struck the caveat, added Pause / resume section with error table), `client/runs-and-polling.md` (Paused runs example with `on_status` + `client.resume`), `integrations/embedding-microplanrunner.md` (HTTP callout), `llms.txt` (action + status tables).

## Out of scope (deferred per the issue)

- Multi-input pauses chained in a single round-trip (callers can chain by polling between resumes — same shape as `runner.resume`).
- Webhook push on pause (poll-based is fine for v1; separate issue).
- Auth-specific abstractions (`request_otp`, `request_password`) — the generic `request_user_input` covers them.

Closes #344