### PR TITLE
Port pause/resume through the Modal HTTP endpoint (#347)

### DIFF
--- a/deploy/modal/modal_cua_server.py
+++ b/deploy/modal/modal_cua_server.py
@@ -627,8 +627,9 @@ def _run_holo3_executor(
     # ── Micro-intent mode: run MicroPlanRunner ──
     micro_plan_data = task_suite.get("_micro_plan")
     if micro_plan_data:
-        from mantis_agent.plan_decomposer import MicroPlan, MicroIntent
+        from mantis_agent.gym.checkpoint import PauseRequested, PauseState
         from mantis_agent.gym.micro_runner import MicroPlanRunner
+        from mantis_agent.plan_decomposer import MicroIntent, MicroPlan
 
         micro_plan = MicroPlan(domain=session_name)
         for s in micro_plan_data:
@@ -708,7 +709,48 @@ def _run_holo3_executor(
             max_cost=task_suite.get("_max_cost", 10.0),
             max_time_minutes=task_suite.get("_max_time_minutes", 180),
         )
-        step_results = micro_runner.run(micro_plan, resume=resume_state)
+
+        # #347: default ``request_user_input`` host tool. Brains that emit
+        # ``Action(TOOL_CALL, name="request_user_input")`` get a paused-run
+        # snapshot on the first call, and the staged ``user_input`` on the
+        # second (after action=resume rehydrates).
+        def _request_user_input(args):
+            staged = micro_runner.consume_pause_input(default=None)
+            if staged is None:
+                raise PauseRequested(
+                    reason="user_input",
+                    prompt=str(args.get("prompt", "")),
+                )
+            return staged
+        micro_runner.register_tool(
+            "request_user_input",
+            {
+                "type": "object",
+                "properties": {"prompt": {"type": "string"}},
+                "additionalProperties": False,
+            },
+            _request_user_input,
+        )
+
+        # #347: resume continuation. The Modal API container layers
+        # ``_resume_pause_state`` + ``_resume_user_input`` onto the
+        # task_suite on action=resume; we feed them to runner.resume().
+        resume_blob = task_suite.get("_resume_pause_state")
+        if resume_blob is not None:
+            pause_state_obj = (
+                PauseState.from_dict(resume_blob)
+                if isinstance(resume_blob, dict) else resume_blob
+            )
+            runner_result = micro_runner.resume(
+                pause_state_obj,
+                user_input=task_suite.get("_resume_user_input"),
+                plan=micro_plan,
+            )
+        else:
+            runner_result = micro_runner.run_with_status(
+                micro_plan, resume=resume_state,
+            )
+        step_results = runner_result.steps
 
         # Build standardized result with dynamic verification
         from pathlib import Path as _Path
@@ -746,7 +788,7 @@ def _run_holo3_executor(
                 viewer_ctx.__exit__(None, None, None)
             except Exception:
                 pass
-        return {
+        envelope = {
             "mode": "micro",
             "viable": viable,
             "steps": result["steps_executed"],
@@ -756,7 +798,18 @@ def _run_holo3_executor(
             "checkpoint_path": checkpoint_path,
             "status": result.get("costs", {}).get("status", ""),
             "dynamic_verification_summary": result.get("dynamic_verification_summary"),
+            "run_id": run_id,
         }
+        # #347: surface paused state to the Modal API container. The poll
+        # path detects ``_paused`` on the FunctionCall result and writes
+        # pause_state.json + flips status.json to paused for the next
+        # action=resume round-trip.
+        if runner_result.paused and runner_result.pause_state is not None:
+            envelope["_paused"] = True
+            envelope["pause_state"] = runner_result.pause_state.to_dict()
+            envelope["prompt"] = runner_result.pause_state.prompt
+            envelope["reason"] = runner_result.pause_state.pending_reason
+        return envelope
 
     # ── Learning mode: run LearningRunner instead of normal task loop ──
     learn_mode = task_suite.get("_learn", False)
@@ -1330,6 +1383,42 @@ def _read_result(tenant_id: str, run_id: str) -> dict | None:
         return None
 
 
+def _write_pause_state(tenant_id: str, run_id: str, pause_state: dict) -> None:
+    """Persist the paused-run snapshot for the next action=resume (#347)."""
+    run_dir = _run_dir(tenant_id, run_id)
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / "pause_state.json").write_text(json.dumps(pause_state, indent=2))
+    _commit_volume()
+
+
+def _read_pause_state(tenant_id: str, run_id: str) -> dict | None:
+    path = _run_dir(tenant_id, run_id) / "pause_state.json"
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text())
+    except Exception:
+        return None
+
+
+def _write_task_suite(tenant_id: str, run_id: str, task_file_contents: str) -> None:
+    """Snapshot the raw task_suite string so resume can re-spawn the executor (#347)."""
+    run_dir = _run_dir(tenant_id, run_id)
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / "task_suite.json").write_text(task_file_contents)
+    _commit_volume()
+
+
+def _read_task_suite(tenant_id: str, run_id: str) -> str | None:
+    path = _run_dir(tenant_id, run_id) / "task_suite.json"
+    if not path.exists():
+        return None
+    try:
+        return path.read_text()
+    except Exception:
+        return None
+
+
 def build_api_app(executor_resolver=None, function_call_lookup=None):
     """Construct the FastAPI app exposed by the Modal ASGI endpoint (#342).
 
@@ -1454,8 +1543,12 @@ def build_api_app(executor_resolver=None, function_call_lookup=None):
             "workflow_id": workflow_id,
             "state_key": payload["state_key"],
             "model": model,
+            "max_steps": int(payload.get("max_steps", 30)),
         }
         _write_status(tenant.tenant_id, run_id, status)
+        # #347: snapshot the suite so a later action=resume can re-spawn
+        # the executor with the same plan + identity + caps.
+        _write_task_suite(tenant.tenant_id, run_id, task_file_contents)
 
         run_dir = _run_dir(tenant.tenant_id, run_id)
         return {
@@ -1476,7 +1569,7 @@ def build_api_app(executor_resolver=None, function_call_lookup=None):
         }
 
     def _do_action(payload: dict, tenant: TenantConfig) -> dict:
-        """Handle ``action=status|result|cancel`` against an existing run."""
+        """Handle ``action=status|result|cancel|resume`` against an existing run."""
         run_id = str(payload.get("run_id") or "")
         if not run_id:
             raise HTTPException(400, "action requires run_id")
@@ -1486,9 +1579,9 @@ def build_api_app(executor_resolver=None, function_call_lookup=None):
 
         action = payload["action"]
         if action == "cancel":
-            if status.get("status") in {"queued", "running"}:
+            if status.get("status") in {"queued", "running", "paused"}:
                 call_id = status.get("modal_call_id", "")
-                if call_id:
+                if call_id and status.get("status") != "paused":
                     try:
                         lookup_function_call(call_id).cancel()
                     except Exception:
@@ -1498,6 +1591,79 @@ def build_api_app(executor_resolver=None, function_call_lookup=None):
                 _write_status(tenant.tenant_id, run_id, status)
                 release_profile_lock(tenant, status.get("profile_id", ""))
             return status
+
+        if action == "resume":
+            # #347: rehydrate a paused Modal run. Validate, layer the
+            # caller's user_input + stored pause_state onto the saved
+            # task_suite, re-spawn the executor, update modal_call_id.
+            if status.get("status") != "paused":
+                raise HTTPException(
+                    400,
+                    f"action='resume' requires a paused run; "
+                    f"run_id={run_id!r} is in status={status.get('status')!r}",
+                )
+            user_input = payload.get("user_input")
+            if user_input is None:
+                raise HTTPException(400, "action='resume' requires user_input")
+            pause_state_blob = _read_pause_state(tenant.tenant_id, run_id)
+            if pause_state_blob is None:
+                raise HTTPException(
+                    404, f"pause_state.json missing for run {run_id!r}",
+                )
+            saved_suite = _read_task_suite(tenant.tenant_id, run_id)
+            if saved_suite is None:
+                raise HTTPException(
+                    404, f"task_suite.json missing for run {run_id!r}",
+                )
+            # Re-acquire the profile lock under the same run_id; the
+            # paused state released it, so this is the gate against a
+            # concurrent submission stealing the profile while the human
+            # was fetching the OTP.
+            profile_id = status.get("profile_id", "")
+            if not acquire_profile_lock(tenant, profile_id, run_id):
+                held = read_profile_lock(tenant, profile_id)
+                raise HTTPException(
+                    409,
+                    f"profile_id {profile_id!r} is now busy with run_id={held!r}; "
+                    "cannot resume while another run holds the lock.",
+                )
+            # Layer the resume hints onto the task_suite and re-spawn.
+            try:
+                suite_dict = json.loads(saved_suite)
+            except Exception as exc:
+                release_profile_lock(tenant, profile_id)
+                raise HTTPException(500, f"corrupt task_suite.json: {exc}") from exc
+            suite_dict["_resume_pause_state"] = pause_state_blob
+            suite_dict["_resume_user_input"] = user_input
+            model = status.get("model", "holo3")
+            executor_fn = resolve_executor(model)
+            spawn_kwargs: dict = {
+                "max_steps": int(status.get("max_steps", 30)),
+            }
+            if model != "claude":
+                spawn_kwargs["cua_model"] = model
+            try:
+                call_handle = executor_fn.spawn(
+                    task_file_contents=json.dumps(suite_dict),
+                    **spawn_kwargs,
+                )
+            except Exception as exc:
+                release_profile_lock(tenant, profile_id)
+                raise HTTPException(500, f"executor spawn failed: {exc}") from exc
+            now = datetime.now(timezone.utc).isoformat()
+            status["status"] = "running"
+            status["resumed_at"] = now
+            status["updated_at"] = now
+            status["modal_call_id"] = getattr(call_handle, "object_id", "") or ""
+            # Clear stale pause-surface fields on the resumed status.
+            status["prompt"] = ""
+            status["reason"] = ""
+            _write_status(tenant.tenant_id, run_id, status)
+            return {
+                "run_id": run_id,
+                "status": "running",
+                "resumed_at": now,
+            }
 
         # status / result: check the FunctionCall handle if still running.
         if status.get("status") in {"queued", "running"}:
@@ -1520,11 +1686,37 @@ def build_api_app(executor_resolver=None, function_call_lookup=None):
                     else:
                         status["status"] = "running"
                 else:
-                    status["status"] = "succeeded"
-                    status["updated_at"] = datetime.now(timezone.utc).isoformat()
-                    _write_status(tenant.tenant_id, run_id, status)
-                    _write_result(tenant.tenant_id, run_id, result if isinstance(result, dict) else {"result": result})
-                    release_profile_lock(tenant, status.get("profile_id", ""))
+                    # #347: the executor surfaces ``_paused`` when a host
+                    # tool raised PauseRequested. Persist the snapshot,
+                    # flip status to paused, release the lock so the
+                    # next action=resume can re-acquire under the same
+                    # run_id.
+                    if isinstance(result, dict) and result.get("_paused"):
+                        pause_blob = result.get("pause_state") or {}
+                        _write_pause_state(tenant.tenant_id, run_id, pause_blob)
+                        status["status"] = "paused"
+                        status["paused_at"] = datetime.now(timezone.utc).isoformat()
+                        status["updated_at"] = status["paused_at"]
+                        status["prompt"] = str(result.get("prompt", ""))
+                        status["reason"] = str(result.get("reason", "user_input"))
+                        _write_status(tenant.tenant_id, run_id, status)
+                        release_profile_lock(tenant, status.get("profile_id", ""))
+                    else:
+                        status["status"] = "succeeded"
+                        status["updated_at"] = datetime.now(timezone.utc).isoformat()
+                        _write_status(tenant.tenant_id, run_id, status)
+                        _write_result(
+                            tenant.tenant_id,
+                            run_id,
+                            result if isinstance(result, dict) else {"result": result},
+                        )
+                        release_profile_lock(tenant, status.get("profile_id", ""))
+
+        # action=status on a paused run: inline pause_state for the caller.
+        if action == "status" and status.get("status") == "paused":
+            pause_blob = _read_pause_state(tenant.tenant_id, run_id)
+            if pause_blob is not None:
+                status["pause_state"] = pause_blob
 
         if action == "result":
             if status.get("status") != "succeeded":

--- a/scripts/verify_modal_luma_curl.sh
+++ b/scripts/verify_modal_luma_curl.sh
@@ -39,7 +39,7 @@ fail() { echo "❌ $*" >&2; exit 1; }
 ok()   { echo "✅ $*"; }
 
 # ── 1. health ────────────────────────────────────────────────────
-echo "[1/5] GET ${ENDPOINT}/v1/health"
+echo "[1/8] GET ${ENDPOINT}/v1/health"
 health_status=$(curl -fsSL -o /tmp/mantis_health.json -w '%{http_code}' "${ENDPOINT}/v1/health")
 [[ "${health_status}" == "200" ]] || fail "health returned ${health_status}"
 grep -q '"status":"ok"' /tmp/mantis_health.json || fail "health body missing status:ok"
@@ -65,7 +65,7 @@ SUITE=$(jq -n \
     }')
 
 # ── 2. first submit returns 200 + run_id ────────────────────────
-echo "[2/5] POST /v1/predict — first luma submit"
+echo "[2/8] POST /v1/predict — first luma submit"
 submit_body=$(jq -n \
     --argjson suite "${SUITE}" \
     --arg profile "${PROFILE_ID}" \
@@ -96,7 +96,7 @@ got_workflow=$(jq -r '.payload.workflow_id' "${submit_resp}")
 ok "first submit 200 — run_id=${run_id}, profile_id=${got_profile}"
 
 # ── 3. duplicate profile_id → 409 ───────────────────────────────
-echo "[3/5] POST /v1/predict — duplicate profile_id (expect 409)"
+echo "[3/8] POST /v1/predict — duplicate profile_id (expect 409)"
 dup_resp=$(mktemp)
 dup_status=$(curl -sS -o "${dup_resp}" -w '%{http_code}' \
     -X POST "${ENDPOINT}/v1/predict" "${H_AUTH[@]}" "${H_JSON[@]}" -d "${submit_body}")
@@ -105,7 +105,7 @@ grep -q "${run_id}" "${dup_resp}" || fail "409 detail must surface the held run_
 ok "duplicate 409 — held run_id surfaced in detail"
 
 # ── 4. status poll until terminal-or-paused ─────────────────────
-echo "[4/5] POST /v1/predict — action=status until non-running"
+echo "[4/8] POST /v1/predict — action=status until non-running"
 poll_body=$(jq -n --arg run_id "${run_id}" '{action: "status", run_id: $run_id}')
 deadline=$(( $(date +%s) + 60 ))
 final_status=""
@@ -124,7 +124,7 @@ done
 ok "status reached ${final_status} for run_id=${run_id}"
 
 # ── 5. cancel + re-submit succeeds ──────────────────────────────
-echo "[5/5] cancel + re-submit on same profile_id"
+echo "[5/8] cancel + re-submit on same profile_id"
 cancel_body=$(jq -n --arg run_id "${run_id}" '{action: "cancel", run_id: $run_id}')
 cancel_resp=$(curl -sS -X POST "${ENDPOINT}/v1/predict" \
     "${H_AUTH[@]}" "${H_JSON[@]}" -d "${cancel_body}")
@@ -145,5 +145,43 @@ ok "re-submit 200 — new run_id=${new_run_id} (lock released)"
 curl -sS -X POST "${ENDPOINT}/v1/predict" "${H_AUTH[@]}" "${H_JSON[@]}" \
     -d "$(jq -n --arg run_id "${new_run_id}" '{action: "cancel", run_id: $run_id}')" >/dev/null
 
+# ── 6-8. action=resume validation paths (#347) ──────────────────
+# Full pause/resume E2E requires a brain that emits TOOL_CALL
+# request_user_input. The unit tests cover that with a mocked executor.
+# Here we just verify the HTTP wiring: each invalid resume shape lands
+# on the expected status code.
+
+echo "[6/8] resume validation: missing user_input → expect 400"
+resume_no_input_body=$(jq -n --arg run_id "${new_run_id}" '{action: "resume", run_id: $run_id}')
+resume_no_input_resp=$(mktemp)
+resume_no_input_status=$(curl -sS -o "${resume_no_input_resp}" -w '%{http_code}' \
+    -X POST "${ENDPOINT}/v1/predict" "${H_AUTH[@]}" "${H_JSON[@]}" -d "${resume_no_input_body}")
+[[ "${resume_no_input_status}" == "400" ]] \
+    || fail "missing user_input → expected 400, got ${resume_no_input_status}: $(cat "${resume_no_input_resp}")"
+grep -q "user_input" "${resume_no_input_resp}" \
+    || fail "400 detail must mention user_input: $(cat "${resume_no_input_resp}")"
+ok "missing user_input → 400 with user_input in detail"
+
+echo "[7/8] resume validation: unknown run_id → expect 404"
+resume_unknown_resp=$(mktemp)
+resume_unknown_status=$(curl -sS -o "${resume_unknown_resp}" -w '%{http_code}' \
+    -X POST "${ENDPOINT}/v1/predict" "${H_AUTH[@]}" "${H_JSON[@]}" \
+    -d '{"action": "resume", "run_id": "does-not-exist", "user_input": "x"}')
+[[ "${resume_unknown_status}" == "404" ]] \
+    || fail "unknown run_id → expected 404, got ${resume_unknown_status}: $(cat "${resume_unknown_resp}")"
+ok "unknown run_id → 404"
+
+echo "[8/8] resume validation: non-paused run → expect 400"
+resume_nonpaused_body=$(jq -n --arg run_id "${new_run_id}" \
+    '{action: "resume", run_id: $run_id, user_input: "x"}')
+resume_nonpaused_resp=$(mktemp)
+resume_nonpaused_status=$(curl -sS -o "${resume_nonpaused_resp}" -w '%{http_code}' \
+    -X POST "${ENDPOINT}/v1/predict" "${H_AUTH[@]}" "${H_JSON[@]}" -d "${resume_nonpaused_body}")
+[[ "${resume_nonpaused_status}" == "400" ]] \
+    || fail "non-paused → expected 400, got ${resume_nonpaused_status}: $(cat "${resume_nonpaused_resp}")"
+grep -qi "paused" "${resume_nonpaused_resp}" \
+    || fail "400 detail must explain the non-paused state: $(cat "${resume_nonpaused_resp}")"
+ok "non-paused → 400 with 'paused' in detail"
+
 echo
-echo "🎉 All 5 curl checks passed against ${ENDPOINT}."
+echo "🎉 All 8 curl checks passed against ${ENDPOINT}."

--- a/tests/test_modal_endpoint.py
+++ b/tests/test_modal_endpoint.py
@@ -236,6 +236,183 @@ def test_status_unknown_run_returns_404(app_with_stub) -> None:
     assert r.status_code == 404
 
 
+# ── #347: pause / resume over the Modal endpoint ──────────────────
+
+
+def _paused_envelope(prompt: str = "Enter the 6-digit code") -> dict:
+    """The shape the Holo3 executor returns when PauseRequested fires."""
+    return {
+        "_paused": True,
+        "pause_state": {
+            "version": 1,
+            "run_key": "alice-test",
+            "plan_signature": "fixed-sig-for-tests",
+            "session_name": "modal-pause-test",
+            "step_index": 0,
+            "pending_tool": "request_user_input",
+            "pending_arguments": {"prompt": prompt},
+            "pending_reason": "user_input",
+            "prompt": prompt,
+            "step_results": [],
+            "loop_counters": {},
+            "listings_on_page": 0,
+            "checkpoint_path": "",
+            "timestamp": 1234.5,
+        },
+        "prompt": prompt,
+        "reason": "user_input",
+        "mode": "micro",
+        "viable": 0,
+    }
+
+
+def test_status_returns_paused_with_pause_state(app_with_stub) -> None:
+    """Status poll on a paused executor returns the full pause envelope."""
+    client, _executor, call = app_with_stub
+    call._result = _paused_envelope("Enter the 6-digit code")
+
+    r = client.post(
+        "/v1/predict",
+        headers=_auth_headers(),
+        data=json.dumps({"task_suite": {"tasks": []}, "profile_id": "alice"}),
+    )
+    assert r.status_code == 200, r.text
+    run_id = r.json()["run_id"]
+
+    poll = client.post(
+        "/v1/predict",
+        headers=_auth_headers(),
+        data=json.dumps({"action": "status", "run_id": run_id}),
+    )
+    assert poll.status_code == 200, poll.text
+    body = poll.json()
+    assert body["status"] == "paused"
+    assert body["prompt"] == "Enter the 6-digit code"
+    assert body["reason"] == "user_input"
+    assert body["pause_state"]["pending_tool"] == "request_user_input"
+    assert body["pause_state"]["plan_signature"] == "fixed-sig-for-tests"
+
+
+def test_resume_layers_user_input_into_respawn(app_with_stub) -> None:
+    """action=resume re-spawns the executor with pause_state + user_input baked into the suite."""
+    client, executor, call = app_with_stub
+    call._result = _paused_envelope("Enter the 6-digit code")
+
+    submit = client.post(
+        "/v1/predict",
+        headers=_auth_headers(),
+        data=json.dumps({"task_suite": {"tasks": []}, "profile_id": "alice"}),
+    )
+    run_id = submit.json()["run_id"]
+    # Drive the FunctionCall to terminal-paused.
+    client.post(
+        "/v1/predict",
+        headers=_auth_headers(),
+        data=json.dumps({"action": "status", "run_id": run_id}),
+    )
+
+    # Now flip the stub to return success on the next .get() — the resume
+    # path's fresh .spawn() returns the same stub call (executor reuses
+    # the same _StubFunctionCall instance), so the next status poll lands
+    # on succeeded.
+    call._result = {"viable": 1, "leads": [{"url": "https://example.com/a"}]}
+
+    resume = client.post(
+        "/v1/predict",
+        headers=_auth_headers(),
+        data=json.dumps({"action": "resume", "run_id": run_id, "user_input": "123456"}),
+    )
+    assert resume.status_code == 200, resume.text
+    body = resume.json()
+    assert body["status"] == "running"
+    assert body["run_id"] == run_id
+    assert "resumed_at" in body
+
+    # The fresh spawn must have layered the resume hints onto the suite.
+    spawned_suite = json.loads(executor.spawn_kwargs["task_file_contents"])
+    assert spawned_suite["_resume_user_input"] == "123456"
+    assert spawned_suite["_resume_pause_state"]["pending_tool"] == "request_user_input"
+
+    # Status poll picks up the new succeeded result.
+    final = client.post(
+        "/v1/predict",
+        headers=_auth_headers(),
+        data=json.dumps({"action": "status", "run_id": run_id}),
+    )
+    assert final.json()["status"] == "succeeded"
+
+
+def test_resume_on_non_paused_run_returns_400(app_with_stub) -> None:
+    client, _executor, _call = app_with_stub  # default stub returns success immediately
+    r = client.post(
+        "/v1/predict",
+        headers=_auth_headers(),
+        data=json.dumps({"task_suite": {"tasks": []}, "profile_id": "alice"}),
+    )
+    run_id = r.json()["run_id"]
+    # Drive to succeeded.
+    client.post(
+        "/v1/predict",
+        headers=_auth_headers(),
+        data=json.dumps({"action": "status", "run_id": run_id}),
+    )
+
+    resume = client.post(
+        "/v1/predict",
+        headers=_auth_headers(),
+        data=json.dumps({"action": "resume", "run_id": run_id, "user_input": "x"}),
+    )
+    assert resume.status_code == 400, resume.text
+    assert "paused" in resume.json()["detail"].lower()
+
+
+def test_resume_requires_user_input(app_with_stub) -> None:
+    client, _executor, _call = app_with_stub
+    # Pydantic catches the missing user_input — no real run setup needed.
+    r = client.post(
+        "/v1/predict",
+        headers=_auth_headers(),
+        data=json.dumps({"action": "resume", "run_id": "anything"}),
+    )
+    assert r.status_code == 400, r.text
+    assert "user_input" in r.json()["detail"]
+
+
+def test_paused_run_releases_lock_so_resume_can_reacquire(app_with_stub) -> None:
+    """A paused run releases the profile lock; resume re-acquires it."""
+    client, _executor, call = app_with_stub
+    call._result = _paused_envelope("OTP?")
+    submit = client.post(
+        "/v1/predict",
+        headers=_auth_headers(),
+        data=json.dumps({"task_suite": {"tasks": []}, "profile_id": "alice"}),
+    )
+    run_id = submit.json()["run_id"]
+    client.post(
+        "/v1/predict",
+        headers=_auth_headers(),
+        data=json.dumps({"action": "status", "run_id": run_id}),
+    )
+
+    # While paused, the profile lock is released — a different run_id
+    # under the same profile_id can grab it.
+    call._result = {"viable": 0, "leads": []}
+    new_run = client.post(
+        "/v1/predict",
+        headers=_auth_headers(),
+        data=json.dumps({"task_suite": {"tasks": []}, "profile_id": "alice"}),
+    )
+    assert new_run.status_code == 200, new_run.text
+    # And resuming the PAUSED run can no longer re-acquire the lock now
+    # that a fresh run holds it — caller gets 409.
+    resume = client.post(
+        "/v1/predict",
+        headers=_auth_headers(),
+        data=json.dumps({"action": "resume", "run_id": run_id, "user_input": "123"}),
+    )
+    assert resume.status_code == 409, resume.text
+
+
 def test_succeeded_run_releases_profile_lock(app_with_stub) -> None:
     """Once a run finishes, its profile_id should be free for re-use."""
     client, _executor, _call = app_with_stub


### PR DESCRIPTION
## Summary

Brings #344's pause/resume HTTP surface to the Modal endpoint. #344 wired it for the Baseten ``/v1/predict`` path; the Modal endpoint (added in #342) dispatches via ``.spawn()`` directly to executor functions and didn't pick that up — confirmed during the #344 follow-up verification. This ports the same shape into the Modal path.

Builds on **#345 (Baseten pause/resume)** for the schema additions — branch off `feat/predict-pause-resume-344`. Order of merge: #345 → #347.

## What changed

**Executor** (`_run_holo3_executor` micro branch — the only Modal executor that uses `MicroPlanRunner` directly; the others go through `task_loop`):
- Default `request_user_input` host tool registered on every `MicroPlanRunner` — copy of the same pattern from `BasetenCUARuntime._run_micro`.
- Switched `runner.run(...)` → `runner.run_with_status(...)` so paused state surfaces.
- When the task_suite carries `_resume_pause_state`, calls `runner.resume()` with the layered `user_input`.
- Return envelope tagged with `_paused: True` + `pause_state` + `prompt` + `reason` for the API container to detect.

**API** (`build_api_app`):
- New `_write_pause_state` / `_read_pause_state` / `_write_task_suite` / `_read_task_suite` siblings of the existing `_write_status` / `_write_result`.
- Initial submit snapshots `task_suite.json` to the run dir so resume can re-spawn deterministically.
- Status polling detects `_paused` on `.get()` → writes `pause_state.json` + flips status to `paused` + releases the profile lock.
- New `action=resume` branch: validates paused, reads `pause_state.json` + `task_suite.json`, re-acquires lock under the same `run_id` (409 if a fresh run stole it), layers `_resume_pause_state` + `_resume_user_input` onto the suite, re-spawns, updates `modal_call_id`.
- `action=status` on a paused run inlines `pause_state` so callers don't need a second round-trip.

## Test plan

- [x] `uv run pytest tests/test_modal_endpoint.py tests/test_run_dispatch.py tests/test_server_utils.py tests/test_predict_pause_resume.py -n0` — 115 pass; 5 new endpoint cases:
  - `status` returns paused envelope
  - `resume` layers `_resume_user_input` onto a fresh spawn; subsequent poll → succeeded
  - 400 on resume of a non-paused run
  - 400 on resume missing `user_input`
  - 409 when a fresh run on the same `profile_id` grabbed the lock while paused
- [x] `uv run modal deploy` against `mantis-cua-server`.
- [x] `bash scripts/verify_modal_luma_curl.sh` against the live endpoint — all 8 curl checks pass, including the three new resume-validation paths:
  - `[6/8] missing user_input → 400`
  - `[7/8] unknown run_id → 404`
  - `[8/8] non-paused → 400 with 'paused' in detail`

## Limit (deferred)

True pause→resume→succeed E2E on Modal needs a brain that emits `Action(TOOL_CALL, name="request_user_input")` — that requires running real Holo3 (or a deterministic test brain) and a plan that asks for OTP. **Covered by the unit tests** (mocked executor returns the paused envelope, then succeeded on re-spawn); the live curl smoke confirms the HTTP wire. Once we wire a brain-mock harness into Modal, that's a follow-up.

The other executor paths (Claude / EvoCUA / OpenCUA / Gemma4-CUA) go through `task_loop.run_executor_lifecycle` rather than constructing `MicroPlanRunner` inline, so they don't pick up the pause tool. Extending pause/resume to those is a separate refactor (the task_loop path needs its own pause hook).

Closes #347

🤖 Generated with [Claude Code](https://claude.com/claude-code)