### PR TITLE
feat: deterministic plan runs (seed) + adaptive CF prewarm

### DIFF
--- a/deploy/modal/modal_plan_runner.py
+++ b/deploy/modal/modal_plan_runner.py
@@ -385,6 +385,67 @@ def _ensure_tinyproxy_running(session: str = "mantis") -> str | None:
     return None
 
 
+def _wait_for_cf_challenge_clear(
+    env,
+    *,
+    max_seconds: float | None = None,
+    poll_interval: float = 1.0,
+    min_seconds: float = 2.0,
+) -> float:
+    """Poll until the Cloudflare interstitial is gone, capped at
+    ``max_seconds`` (default 45s, override via
+    ``MANTIS_CF_PREWARM_MAX_SECONDS``).
+
+    Returns seconds actually waited. Uses ``env.cdp_evaluate`` to read
+    ``document.title`` + a slice of ``document.body.innerText`` and
+    look for known CF/anti-bot markers. ``None`` from CDP means the
+    page isn't queryable yet — treated as "keep polling", never as
+    "cleared". An always-on ``min_seconds`` floor gives the browser a
+    beat to start rendering before we declare success on an empty
+    page.
+    """
+    if max_seconds is None:
+        try:
+            max_seconds = float(
+                os.environ.get("MANTIS_CF_PREWARM_MAX_SECONDS", "45")
+            )
+        except ValueError:
+            max_seconds = 45.0
+
+    js = (
+        "(() => {"
+        "const t = (document.title || '').toLowerCase();"
+        "const body = (document.body && document.body.innerText || '')"
+        ".slice(0, 4000).toLowerCase();"
+        "const blob = t + ' ' + body;"
+        "const markers = ["
+        "  'just a moment',"
+        "  'performing security verification',"
+        "  'checking your browser',"
+        "  'verifying you are human',"
+        "  'verify you are human',"
+        "  'enable javascript and cookies to continue'"
+        "];"
+        "return markers.some(m => blob.includes(m));"
+        "})()"
+    )
+
+    start = time.monotonic()
+    deadline = start + max_seconds
+    if min_seconds > 0:
+        time.sleep(min(min_seconds, max_seconds))
+
+    while time.monotonic() < deadline:
+        try:
+            challenge_present = env.cdp_evaluate(js)
+        except Exception:
+            challenge_present = None
+        if challenge_present is False:
+            return time.monotonic() - start
+        time.sleep(poll_interval)
+    return time.monotonic() - start
+
+
 # ── The function ─────────────────────────────────────────────────────
 
 
@@ -409,6 +470,7 @@ def run_plan(
     use_proxy: bool = False,
     proxy_session: str = "mantis",
     session_name: str = "mantis_run",
+    seed: int | None = 42,
 ) -> dict:
     """Run :class:`MicroPlanRunner` end-to-end inside this container.
 
@@ -482,13 +544,15 @@ def run_plan(
     site_config = SiteConfig(detail_page_pattern=detail_page_pattern or "")
 
     # 5. Pre-warm env at start_url before runner.run, mirroring the
-    # local CLI's prewarm contract from PR #218. Then sleep 15s to
-    # let any Cloudflare JS challenge resolve before the first
-    # verifier hits the page — without this delay, CF-protected
-    # sites show "Performing security verification" on the first
-    # screenshot and the gate step rejects with ``gate:FAIL:Error 403``.
+    # local CLI's prewarm contract from PR #218. Then poll the page
+    # until any Cloudflare JS challenge resolves — replaces the old
+    # hardcoded 15s sleep, which was insufficient when CF takes
+    # 20-30s on residential proxies and wasteful when it clears in
+    # 2-3s. Without this, CF-protected sites show "Performing
+    # security verification" on the first screenshot and the gate
+    # step rejects with ``gate:FAIL:Error 403``.
     env.reset(task="modal_plan_run", start_url=start_url)
-    time.sleep(15)
+    _wait_for_cf_challenge_clear(env)
 
     # 6. Construct + run runner.
     runner = MicroPlanRunner(
@@ -501,6 +565,7 @@ def run_plan(
         session_name=session_name,
         max_cost=max_cost_usd,
         max_time_minutes=max_time_minutes,
+        seed=seed,
     )
     t0 = time.time()
     step_results = runner.run(plan, resume=False)

--- a/docs/getting-started/cli.md
+++ b/docs/getting-started/cli.md
@@ -190,6 +190,7 @@ Key flags:
 | `--max-time-minutes` | `30` | Wall-clock cap. |
 | `--output-dir` | `outputs/run-<unix>` | Where to write `plan.json` + `result.json` + `checkpoint.json`. |
 | `--resume` | off | Resume from a previous checkpoint at `<output-dir>/checkpoint.json`. |
+| `--seed` | `42` | Deterministic seed for the runner. Seeds Python's `random` module so per-action `human_speed` delays (`random.uniform`/`random.randint` in `playwright_env` + `xdotool_env` + step handlers) are reproducible across reruns of the same plan. Also passed via `SEED=` to the sim-env when `--env` is set. |
 
 Exit code is 0 if every step succeeded, 1 if any failed or the runner
 raised. Useful as a CI gate against staging endpoints.
@@ -232,6 +233,7 @@ Same flags as `plan run` minus `--platform` / `--browser` / `--headless`
 | `--use-proxy` | off | Route the Modal-side browser through the configured upstream proxy (auth held by an in-container `tinyproxy`). |
 | `--proxy-session` | `mantis` | Session ID for sticky-IP behavior on providers that support it. |
 | `--start-url` | required for text plans | Text plans are decomposed inside Modal so the CLI can't introspect navigate steps; pass it explicitly. JSON plans infer it from the first navigate step. |
+| `--seed` | `42` | Deterministic seed forwarded to `MicroPlanRunner` inside Modal. Reseeds the global RNG so `human_speed` action delays are reproducible across reruns of the same plan. |
 
 Prerequisites:
 

--- a/src/mantis_agent/cli.py
+++ b/src/mantis_agent/cli.py
@@ -887,6 +887,7 @@ def cmd_plan_run(args: argparse.Namespace) -> int:
         session_name=session_name,
         max_cost=float(args.max_cost),
         max_time_minutes=int(args.max_time_minutes),
+        seed=int(args.seed),
     )
 
     print(
@@ -1137,6 +1138,7 @@ def cmd_plan_run_modal(args: argparse.Namespace) -> int:
             use_proxy=bool(args.use_proxy),
             proxy_session=args.proxy_session,
             session_name=session_name,
+            seed=int(args.seed),
         )
     except Exception as exc:  # noqa: BLE001 — modal invocation errors
         print(f"error: Modal run_plan raised: {exc}", file=sys.stderr)
@@ -1502,8 +1504,10 @@ def _build_parser() -> argparse.ArgumentParser:
         "--seed",
         type=int,
         default=42,
-        help="Deterministic env seed passed via SEED= (default: 42). "
-             "Only consulted when --env is set.",
+        help="Deterministic seed for the runner (default: 42). Seeds "
+             "Python's random module so human_speed action delays are "
+             "reproducible across reruns of the same plan. Also passed "
+             "via SEED= to the sim-env when --env is set.",
     )
     run.add_argument(
         "--now",
@@ -1609,6 +1613,14 @@ def _build_parser() -> argparse.ArgumentParser:
         default=None,
         help="Where to write plan.json / plan.txt + result.json. "
              "Defaults to outputs/run-modal-<unix-timestamp>.",
+    )
+    run_modal.add_argument(
+        "--seed",
+        type=int,
+        default=42,
+        help="Deterministic seed for the runner (default: 42). Forwarded "
+             "to MicroPlanRunner inside Modal so human_speed delays are "
+             "reproducible across reruns of the same plan.",
     )
     run_modal.set_defaults(func=cmd_plan_run_modal)
 

--- a/src/mantis_agent/gym/micro_runner.py
+++ b/src/mantis_agent/gym/micro_runner.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import functools
 import logging
+import random
 import time  # noqa: F401 — re-exported for tests that monkeypatch micro_runner.time.sleep
 from typing import TYPE_CHECKING, Any
 
@@ -82,7 +83,16 @@ class MicroPlanRunner:
         context_budget: Any = None,  # ContextBudget | None — typed in body to avoid import cycle
         seen_url_predicate: Any = None,  # Callable[[str], bool] | None
         routing_policy: Any = None,  # RoutingPolicy | None — typed in body to avoid import cycle
+        seed: int | None = None,
     ):
+        # Seed the global RNG so per-action human_speed delays
+        # (random.uniform / random.randint in playwright_env.py +
+        # xdotool_env.py + step_handlers/*) are reproducible across
+        # runs of the same plan. ``None`` preserves the previous
+        # non-deterministic behavior.
+        if seed is not None:
+            random.seed(seed)
+        self.seed = seed
         self.brain, self.env, self.grounding, self.extractor = (
             brain, env, grounding, extractor
         )

--- a/tests/test_cli_plan_run_modal.py
+++ b/tests/test_cli_plan_run_modal.py
@@ -301,6 +301,37 @@ def test_run_modal_uses_explicit_start_url_over_plan(
     assert kwargs["start_url"] == "https://other.example.test/dashboard"
 
 
+def test_run_modal_defaults_seed_to_42(
+    tmp_path: Path, modal_stub,
+) -> None:
+    plan_path = _write_json_plan(tmp_path / "plan.json")
+    code = main([
+        "plan", "run-modal", str(plan_path),
+        "--endpoint", "https://example/v1",
+        "--output-dir", str(tmp_path / "out"),
+    ])
+    assert code == EXIT_OK
+
+    kwargs = modal_stub["run_plan"].remote.call_args.kwargs
+    assert kwargs["seed"] == 42
+
+
+def test_run_modal_threads_explicit_seed(
+    tmp_path: Path, modal_stub,
+) -> None:
+    plan_path = _write_json_plan(tmp_path / "plan.json")
+    code = main([
+        "plan", "run-modal", str(plan_path),
+        "--endpoint", "https://example/v1",
+        "--seed", "1337",
+        "--output-dir", str(tmp_path / "out"),
+    ])
+    assert code == EXIT_OK
+
+    kwargs = modal_stub["run_plan"].remote.call_args.kwargs
+    assert kwargs["seed"] == 1337
+
+
 def test_run_modal_uses_custom_app_name(
     tmp_path: Path, modal_stub,
 ) -> None:

--- a/tests/test_micro_runner_seed.py
+++ b/tests/test_micro_runner_seed.py
@@ -1,0 +1,71 @@
+"""``MicroPlanRunner(seed=...)`` reseeds the global ``random`` module so
+``human_speed`` per-action delays (random.uniform / random.randint calls
+in playwright_env, xdotool_env, step_handlers/*) are reproducible across
+runs of the same plan.
+
+The wiring is one line in the constructor; the contract is that *every*
+``random`` consumer downstream observes the same draw sequence when two
+runners are built with the same seed.
+"""
+
+from __future__ import annotations
+
+import random
+
+from mantis_agent.gym.micro_runner import MicroPlanRunner
+
+
+def _build(seed):
+    return MicroPlanRunner(
+        brain=None,
+        env=None,
+        grounding=None,
+        extractor=None,
+        run_key="seed-test",
+        session_name="seed-test",
+        max_cost=999.0,
+        max_time_minutes=999,
+        seed=seed,
+    )
+
+
+def test_seed_makes_random_reproducible() -> None:
+    _build(seed=42)
+    draws_first = [random.random() for _ in range(8)]
+
+    _build(seed=42)
+    draws_second = [random.random() for _ in range(8)]
+
+    assert draws_first == draws_second
+
+
+def test_different_seeds_yield_different_draws() -> None:
+    _build(seed=42)
+    a = [random.random() for _ in range(8)]
+
+    _build(seed=1337)
+    b = [random.random() for _ in range(8)]
+
+    assert a != b
+
+
+def test_seed_none_does_not_touch_global_rng() -> None:
+    """``seed=None`` preserves the previous non-deterministic behavior:
+    two consecutive ``seed=None`` runners must NOT collapse to the same
+    draws (state continues from wherever the process left it)."""
+    random.seed(0)
+    _ = random.random()  # advance state past a known starting point
+
+    _build(seed=None)
+    a = random.random()
+
+    _build(seed=None)
+    b = random.random()
+
+    assert a != b
+    assert isinstance(_build(seed=None).seed, type(None))
+
+
+def test_seed_attribute_exposed() -> None:
+    runner = _build(seed=7)
+    assert runner.seed == 7

--- a/tests/test_modal_cf_prewarm.py
+++ b/tests/test_modal_cf_prewarm.py
@@ -1,0 +1,150 @@
+"""``_wait_for_cf_challenge_clear`` polls until the Cloudflare interstitial
+clears, replacing the old hardcoded 15s sleep in ``run_plan``.
+
+Loaded by path because ``deploy/modal/modal_plan_runner.py`` isn't a
+package and imports ``modal`` at top level. We skip when ``modal`` is
+not installed (same pattern as ``test_oxylabs_username_format.py``).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import time
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip(
+    "modal",
+    reason="modal package not installed; deploy module can't be loaded",
+)
+
+
+def _load_module():
+    path = Path(__file__).parent.parent / "deploy" / "modal" / "modal_plan_runner.py"
+    spec = importlib.util.spec_from_file_location("_test_modal_plan_runner_cf", path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["_test_modal_plan_runner_cf"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _env_with_cdp_sequence(values):
+    """Build a fake env whose cdp_evaluate yields ``values`` in order.
+
+    Once the sequence is exhausted, the last value repeats forever.
+    """
+    iterator = iter(values)
+    last = [values[-1]] if values else [False]
+
+    def _eval(_expr):
+        try:
+            v = next(iterator)
+        except StopIteration:
+            v = last[0]
+        last[0] = v
+        return v
+
+    env = MagicMock()
+    env.cdp_evaluate.side_effect = _eval
+    return env
+
+
+def test_returns_quickly_when_no_cf_marker(monkeypatch) -> None:
+    """CF marker absent on the first poll → returns after at most
+    ``min_seconds`` of floor + one poll."""
+    mod = _load_module()
+    env = _env_with_cdp_sequence([False])
+
+    start = time.monotonic()
+    elapsed = mod._wait_for_cf_challenge_clear(
+        env, max_seconds=10.0, poll_interval=0.05, min_seconds=0.01,
+    )
+    wall = time.monotonic() - start
+
+    assert elapsed <= 1.0
+    assert wall <= 1.0
+    env.cdp_evaluate.assert_called()
+
+
+def test_caps_at_max_seconds_when_challenge_never_clears(monkeypatch) -> None:
+    """CF marker stays present → poll loop is bounded by ``max_seconds``,
+    not by an infinite wait."""
+    mod = _load_module()
+    env = _env_with_cdp_sequence([True])
+
+    start = time.monotonic()
+    elapsed = mod._wait_for_cf_challenge_clear(
+        env, max_seconds=0.5, poll_interval=0.05, min_seconds=0.0,
+    )
+    wall = time.monotonic() - start
+
+    assert 0.4 <= elapsed <= 1.2
+    assert wall <= 1.5
+
+
+def test_returns_when_challenge_clears_mid_poll() -> None:
+    """CF marker present on first 3 polls, then clears → return shortly
+    after the clear, well before ``max_seconds``."""
+    mod = _load_module()
+    env = _env_with_cdp_sequence([True, True, True, False])
+
+    elapsed = mod._wait_for_cf_challenge_clear(
+        env, max_seconds=5.0, poll_interval=0.05, min_seconds=0.0,
+    )
+
+    assert elapsed < 1.0
+    assert env.cdp_evaluate.call_count >= 4
+
+
+def test_treats_none_as_keep_polling() -> None:
+    """``cdp_evaluate`` returning ``None`` (CDP unreachable, JS threw,
+    page not ready) must NOT be interpreted as "challenge cleared" —
+    keep polling until a real ``False`` or the cap."""
+    mod = _load_module()
+    env = _env_with_cdp_sequence([None, None, False])
+
+    elapsed = mod._wait_for_cf_challenge_clear(
+        env, max_seconds=5.0, poll_interval=0.05, min_seconds=0.0,
+    )
+
+    assert elapsed < 1.0
+    assert env.cdp_evaluate.call_count >= 3
+
+
+def test_env_override_for_max_seconds(monkeypatch) -> None:
+    """``MANTIS_CF_PREWARM_MAX_SECONDS`` overrides the 45s default."""
+    mod = _load_module()
+    monkeypatch.setenv("MANTIS_CF_PREWARM_MAX_SECONDS", "0.3")
+    env = _env_with_cdp_sequence([True])
+
+    elapsed = mod._wait_for_cf_challenge_clear(
+        env, poll_interval=0.05, min_seconds=0.0,
+    )
+
+    assert elapsed <= 1.0
+
+
+def test_exception_from_cdp_treated_as_unknown() -> None:
+    """``cdp_evaluate`` raising must not crash the poll — treat as
+    "not cleared" and keep going."""
+    mod = _load_module()
+    env = MagicMock()
+    calls = {"n": 0}
+
+    def _eval(_expr):
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise RuntimeError("CDP unreachable")
+        return False
+
+    env.cdp_evaluate.side_effect = _eval
+
+    elapsed = mod._wait_for_cf_challenge_clear(
+        env, max_seconds=5.0, poll_interval=0.05, min_seconds=0.0,
+    )
+
+    assert elapsed < 1.0
+    assert calls["n"] >= 3


### PR DESCRIPTION
## Summary

Plan reruns on Modal were failing ~1/4 of the time. This PR tightens the two biggest non-determinism sources surfaced by a code survey of `MicroPlanRunner` + the Modal entrypoint:

- **Seed the global RNG at runner init.** Per-action `human_speed` delays in `playwright_env` / `xdotool_env` / `step_handlers/*` use unseeded `random.uniform` / `random.randint`. Same plan → different wall-clock per step → cascading into navigate timeouts on slow pages. `MicroPlanRunner` now accepts `seed: int | None`; both `mantis plan run` and `mantis plan run-modal` expose `--seed` (default `42`). Default behavior is now deterministic.
- **Replace the 15s CF prewarm sleep with a poll.** `modal_plan_runner.run_plan` previously slept a hardcoded 15s after `env.reset` so Cloudflare's JS challenge could resolve. CF on residential proxies takes 20-30s, so the first gate step hit `"Performing security verification"` and rejected with `gate:FAIL:Error 403`. The new `_wait_for_cf_challenge_clear` polls `document.title` + body `innerText` via `env.cdp_evaluate` for CF interstitial markers, capped at 45s (override via `MANTIS_CF_PREWARM_MAX_SECONDS`). `None` from CDP is treated as keep-polling, never as cleared.

## Why

Same investigation produced a longer punch list (Cloudflare variability, proxy stickiness, retry jitter, warm-container state). These two are the highest-leverage and smallest enough to ship in one PR. Failure-identification improvements (failed-step screenshot + last action + URL/title surfacing, `failure_class` classifier) will follow in a separate PR.

## Public surface changes

- `mantis plan run-modal` gains `--seed INT` (default `42`).
- `mantis plan run`'s existing `--seed` flag now also seeds the runner's RNG, not only the sim-env when `--env` is set. Default is unchanged (`42`).
- New env var: `MANTIS_CF_PREWARM_MAX_SECONDS` (default `45`) — emergency override for the CF poll cap.
- Docs (`docs/getting-started/cli.md`) updated for both flag tables.

## Test plan

- [x] `pytest tests/test_micro_runner_seed.py` — seed reproducibility, `seed=None` back-compat, exposed `runner.seed` attr
- [x] `pytest tests/test_modal_cf_prewarm.py` — quick-return, max-cap, mid-poll clear, `None`-as-keep-polling, env override, exception swallow
- [x] `pytest tests/test_cli_plan_run_modal.py` — `--seed` threads through `.remote()` kwargs (default + explicit)
- [x] `pytest tests/test_run_executor.py tests/test_micro_runner_hooks.py tests/test_microrunner_som_dispatch.py tests/test_context_budget_skip_envelope.py tests/test_nav_halt_skip_envelope.py tests/test_checkpoint_manager.py tests/test_form_intents.py tests/test_brain_mock.py` — 141 passed, no regressions in adjacent runner surfaces
- [ ] **Final gate** (operator): `uv run modal deploy deploy/modal/modal_plan_runner.py` then rerun a known-flaky plan ≥ 4 times to verify the 1/4 failure rate drops

🤖 Generated with [Claude Code](https://claude.com/claude-code)