### PR TITLE
feat: surface failure context + classifier on StepResult

### DIFF
--- a/deploy/modal/modal_plan_runner.py
+++ b/deploy/modal/modal_plan_runner.py
@@ -490,6 +490,7 @@ def run_plan(
     from mantis_agent.extraction import ClaudeExtractor
     from mantis_agent.grounding import ClaudeGrounding
     from mantis_agent.gym.micro_runner import MicroPlanRunner
+    from mantis_agent.gym.result_payload import pack_step as _pack_step
     from mantis_agent.gym.xdotool_env import XdotoolGymEnv
     from mantis_agent.plan_decomposer import MicroPlan, PlanDecomposer
     from mantis_agent.site_config import SiteConfig
@@ -585,17 +586,7 @@ def run_plan(
         "elapsed_seconds": round(elapsed, 2),
         "final_url": final_url,
         "costs": dict(getattr(runner, "costs", {})),
-        "steps": [
-            {
-                "index": r.step_index,
-                "intent": r.intent,
-                "success": r.success,
-                "data": getattr(r, "data", ""),
-                "duration": getattr(r, "duration", 0.0),
-                "steps_used": getattr(r, "steps_used", 0),
-            }
-            for r in step_results
-        ],
+        "steps": [_pack_step(r) for r in step_results],
     }
 
 

--- a/docs/getting-started/cli.md
+++ b/docs/getting-started/cli.md
@@ -195,6 +195,48 @@ Key flags:
 Exit code is 0 if every step succeeded, 1 if any failed or the runner
 raised. Useful as a CI gate against staging endpoints.
 
+#### `result.json` schema
+
+```jsonc
+{
+  "plan_signature": "abc12345",
+  "session": "staff-crm",
+  "step_count": 14,
+  "successes": 12,
+  "failures": 2,
+  "elapsed_seconds": 732.4,
+  "final_url": "https://crm.example.test/leads",
+  "costs": { "claude_extract": 0.13, "gpu_steps": 47 },
+  "steps": [
+    { "index": 0, "intent": "Navigate…", "success": true,
+      "data": "", "duration": 3.2, "steps_used": 1 },
+    { "index": 7, "intent": "Fill the search field", "success": false,
+      "data": "fill_error: input not found",
+      "duration": 12.4, "steps_used": 8,
+      "failure_class": "selector_miss",
+      "final_url": "https://crm.example.test/leads",
+      "page_title": "Leads — CRM",
+      "last_action": { "type": "click", "params": {"x": 220, "y": 140},
+                       "reasoning": "click search input" },
+      "screenshot_b64": "<base64 PNG of the post-failure viewport>" }
+  ]
+}
+```
+
+Failed steps additionally carry:
+
+| Field | Meaning |
+|---|---|
+| `failure_class` | One of `cf_challenge` / `http_4xx` / `http_5xx` / `nav_timeout` / `selector_miss` / `extractor_error` / `budget_exceeded` / `unknown`. Branch on this in dashboards instead of regex-ing `data`. |
+| `final_url` | Browser URL at the moment of failure (best-effort; empty on env teardown). |
+| `page_title` | Page title at the moment of failure. CF interstitials surface here even when `data` is empty. |
+| `last_action` | The final `Action` dispatched before the step recorded failure (`{type, params, reasoning}`). Omitted when no action ran. |
+| `screenshot_b64` | Base64-encoded PNG of the post-failure viewport. Omitted on success and when capture failed. |
+
+The same shape is produced by both `mantis plan run` (local) and
+`mantis plan run-modal` (remote) — post-mortem tools can consume one
+schema regardless of where the browser ran.
+
 ### `mantis plan run-modal <path>`
 
 Like `plan run`, but the **browser, decomposer, grounding, and

--- a/src/mantis_agent/cli.py
+++ b/src/mantis_agent/cli.py
@@ -971,6 +971,7 @@ def cmd_plan_run(args: argparse.Namespace) -> int:
     successes = sum(1 for r in step_results if r.success)
     failures = len(step_results) - successes
     final_url = getattr(runner, "_last_known_url", "")
+    from .gym.result_payload import pack_step
     result_payload = {
         "plan_signature": runner.plan_signature,
         "session": session_name,
@@ -982,17 +983,7 @@ def cmd_plan_run(args: argparse.Namespace) -> int:
         "elapsed_seconds": round(elapsed, 2),
         "final_url": final_url,
         "costs": dict(getattr(runner, "costs", {})),
-        "steps": [
-            {
-                "index": r.step_index,
-                "intent": r.intent,
-                "success": r.success,
-                "data": getattr(r, "data", ""),
-                "duration": getattr(r, "duration", 0.0),
-                "steps_used": getattr(r, "steps_used", 0),
-            }
-            for r in step_results
-        ],
+        "steps": [pack_step(r) for r in step_results],
     }
     if grading_dict is not None:
         # Additive — RunReport surface in result.json gains the oracle

--- a/src/mantis_agent/gym/checkpoint.py
+++ b/src/mantis_agent/gym/checkpoint.py
@@ -74,9 +74,21 @@ class StepResult:
     # navigate, etc.). Aggregate counts surface on the run result.
     executor_backend: str = ""
 
+    # Failure diagnostics — populated by the executor on ``success=False``.
+    # ``failure_class`` is one of the keys documented in
+    # :mod:`~.failure_class` (cf_challenge / nav_timeout / http_4xx /
+    # http_5xx / selector_miss / extractor_error / budget_exceeded /
+    # unknown). ``final_url`` and ``page_title`` snapshot the browser at
+    # the moment of failure so post-mortems land in result.json instead
+    # of Modal logs. All three are empty on success.
+    failure_class: str = ""
+    final_url: str = ""
+    page_title: str = ""
+
     _PERSISTED: ClassVar[tuple[str, ...]] = (
         "step_index", "intent", "success", "data", "steps_used", "duration", "reversed",
         "skip", "skip_reason", "executor_backend",
+        "failure_class", "final_url", "page_title",
     )
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/mantis_agent/gym/failure_class.py
+++ b/src/mantis_agent/gym/failure_class.py
@@ -1,0 +1,113 @@
+"""Lightweight failure classifier for StepResults.
+
+When a step fails, MicroPlanRunner records a short prose blob in
+``StepResult.data`` (set by individual step handlers — ``gate:FAIL:...``,
+``fill_error:...``, ``scan_error``, etc.). That string is the only
+post-mortem signal that survives the Modal container teardown. This
+module maps that prose + the page title at failure time into a small
+fixed vocabulary of classes so result.json consumers can branch on
+``failure_class`` instead of regex-ing prose.
+
+Classes (stay small on purpose — anything not matched lands in
+``unknown``):
+
+* ``cf_challenge`` — Cloudflare / anti-bot interstitial. Recognized by
+  HTTP 403 + the canonical CF interstitial titles.
+* ``nav_timeout`` — page-load timeout from Playwright / CDP.
+* ``http_4xx`` / ``http_5xx`` — origin returned an error status.
+* ``selector_miss`` — click / fill / submit couldn't locate the target.
+* ``extractor_error`` — Claude extractor failed or returned empty.
+* ``budget_exceeded`` — cost / time / context budget tripped.
+* ``unknown`` — no rule matched (caller should still surface ``data``).
+
+The classifier is pure-functional and runs in microseconds — it lives
+on the failure path so it can't pull in any heavy imports.
+"""
+
+from __future__ import annotations
+
+
+_CF_TITLE_MARKERS: tuple[str, ...] = (
+    "just a moment",
+    "performing security verification",
+    "checking your browser",
+    "verifying you are human",
+    "verify you are human",
+    "attention required",
+)
+
+
+_DATA_RULES: tuple[tuple[str, tuple[str, ...]], ...] = (
+    # Order matters: more specific rules first.
+    ("cf_challenge", ("error 403", "403 forbidden", "cloudflare", "verify you are human")),
+    ("http_4xx", ("error 404", "404", "error 401", "error 410", "error 4")),
+    ("http_5xx", ("error 5", "502", "503", "504", "internal server error")),
+    ("nav_timeout", ("timeout", "timed out", "navigation timeout")),
+    ("selector_miss", (
+        "fill_error", "submit_error", "click_error", "select_error",
+        "not found", "no element", "element not visible",
+        "filters_not_applied",
+    )),
+    ("extractor_error", ("scan_error", "extract_error", "extractor", "scrape")),
+    ("budget_exceeded", (
+        "budget_exceeded", "max_cost", "max_time", "listing_budget_exceeded",
+    )),
+)
+
+
+def classify(data: str, page_title: str = "") -> str:
+    """Return one of the documented class strings, or ``"unknown"``.
+
+    Both inputs are lowercased and matched against substring rules. An
+    empty ``data`` with a CF title still classifies as ``cf_challenge``
+    so navigate-step halts that didn't write a verbose ``data`` still
+    surface the right diagnosis.
+    """
+    title_lc = (page_title or "").lower()
+    if any(m in title_lc for m in _CF_TITLE_MARKERS):
+        return "cf_challenge"
+
+    data_lc = (data or "").lower()
+    if not data_lc:
+        return "unknown"
+
+    for klass, markers in _DATA_RULES:
+        if any(m in data_lc for m in markers):
+            return klass
+    return "unknown"
+
+
+def read_failure_context(env) -> tuple[str, str]:
+    """Best-effort ``(url, title)`` lookup against any GymEnvironment.
+
+    Tries Playwright's ``page`` first (most common in local CLI runs),
+    then falls back to xdotool's CDP path. Returns empty strings on any
+    failure — the caller stamps whatever it gets onto the StepResult so
+    a missing title is still better than no diagnosis.
+    """
+    url = ""
+    title = ""
+
+    try:
+        url = getattr(env, "current_url", "") or ""
+    except Exception:
+        url = ""
+
+    page = getattr(env, "_page", None) or getattr(env, "page", None)
+    if page is not None and not callable(page):
+        try:
+            title = page.title() or ""
+        except Exception:
+            title = ""
+
+    if not title:
+        cdp_eval = getattr(env, "cdp_evaluate", None)
+        if callable(cdp_eval):
+            try:
+                t = cdp_eval("document.title || ''")
+                if isinstance(t, str):
+                    title = t
+            except Exception:
+                title = ""
+
+    return url, title

--- a/src/mantis_agent/gym/result_payload.py
+++ b/src/mantis_agent/gym/result_payload.py
@@ -1,0 +1,84 @@
+"""Shared StepResult → result.json serialization.
+
+Both ``mantis plan run`` (local) and ``mantis plan run-modal`` (the
+Modal entrypoint) write a ``result.json`` with a ``steps`` array.
+Keeping the packaging in one place ensures the two paths can't drift —
+a failed step looks the same whether the browser ran on the laptop or
+inside Modal.
+
+Successful steps stay slim (index / intent / success / data / duration
+/ steps_used). Failed steps carry the diagnostics added by the
+executor in :func:`~.run_executor._stamp_failure_context`:
+
+* ``failure_class`` — one of the categories from :mod:`~.failure_class`
+* ``final_url`` — browser URL at the moment of failure
+* ``page_title`` — page title at the moment of failure
+* ``last_action`` — the final :class:`~mantis_agent.actions.Action`
+  dispatched before the step recorded failure
+* ``screenshot_b64`` — base64-encoded PNG of the post-failure
+  viewport, when available
+
+The screenshot is only included on failure to keep success payloads
+small — successful step screenshots already get the per-run keep cap
+enforced by :meth:`MicroPlanRunner._enforce_screenshot_cap`.
+"""
+
+from __future__ import annotations
+
+import base64
+from typing import Any
+
+
+def _as_str(value: Any, default: str = "") -> str:
+    """Coerce optional StepResult fields to a JSON-safe string.
+
+    A real ``StepResult`` populates these fields with strings or empties.
+    Some tests / hosts hand the executor a ``MagicMock`` or a near-duck;
+    coerce defensively so the result payload always round-trips through
+    ``json.dumps``.
+    """
+    return value if isinstance(value, str) else default
+
+
+def pack_step(r: Any) -> dict:
+    payload = {
+        "index": r.step_index,
+        "intent": r.intent,
+        "success": bool(r.success),
+        "data": _as_str(getattr(r, "data", "")),
+        "duration": float(getattr(r, "duration", 0.0)),
+        "steps_used": int(getattr(r, "steps_used", 0)),
+    }
+
+    if payload["success"]:
+        return payload
+
+    payload["final_url"] = _as_str(getattr(r, "final_url", ""))
+    payload["page_title"] = _as_str(getattr(r, "page_title", ""))
+
+    # Honor a runner-stamped class if present; otherwise classify here
+    # as a fallback. This keeps the schema self-describing even when
+    # the StepResult bypassed the executor (host integrations, sim-env
+    # halts, legacy resume paths).
+    failure_class = _as_str(getattr(r, "failure_class", ""))
+    if not failure_class:
+        from .failure_class import classify
+        failure_class = classify(payload["data"], payload["page_title"])
+    payload["failure_class"] = failure_class or "unknown"
+
+    from ..actions import Action
+
+    last_action = getattr(r, "last_action", None)
+    if isinstance(last_action, Action):
+        at = last_action.action_type
+        payload["last_action"] = {
+            "type": getattr(at, "value", str(at)),
+            "params": dict(last_action.params or {}),
+            "reasoning": last_action.reasoning or "",
+        }
+
+    screenshot_png = getattr(r, "screenshot_png", None)
+    if isinstance(screenshot_png, (bytes, bytearray)) and screenshot_png:
+        payload["screenshot_b64"] = base64.b64encode(bytes(screenshot_png)).decode("ascii")
+
+    return payload

--- a/src/mantis_agent/gym/run_executor.py
+++ b/src/mantis_agent/gym/run_executor.py
@@ -42,6 +42,7 @@ from typing import TYPE_CHECKING, Any
 
 from ..actions import Action, ActionType
 from ..plan_decomposer import MicroIntent
+from . import failure_class as failure_class_mod
 from . import step_snapshot
 from .checkpoint import RunCheckpoint, StepResult
 
@@ -342,6 +343,8 @@ class RunExecutor:
             runner._active_checkpoint_context = None
         if step_result.screenshot_png is None:
             step_result.screenshot_png = runner._capture_screenshot_bytes()
+        if not step_result.success:
+            _stamp_failure_context(step_result, runner.env)
         state.results.append(step_result)
         runner._enforce_screenshot_cap(state.results)
         runner._invoke_step_callback(step_result)
@@ -778,6 +781,33 @@ class RunExecutor:
             if plan.steps[j].type == step_type:
                 return j
         return None
+
+
+# ── Failure diagnostics ────────────────────────────────────────────────
+
+
+def _stamp_failure_context(step_result: StepResult, env: Any) -> None:
+    """Snapshot URL + page title + failure class onto a failed StepResult.
+
+    Best-effort: every probe is wrapped in ``try/except`` because the
+    failure path must not raise — even if CDP is unreachable or the
+    Playwright page is in a half-torn-down state, the StepResult still
+    needs to land.
+    """
+    try:
+        url, title = failure_class_mod.read_failure_context(env)
+    except Exception as exc:
+        logger.debug("failure context probe raised: %s", exc)
+        url, title = "", ""
+    step_result.final_url = url
+    step_result.page_title = title
+    try:
+        step_result.failure_class = failure_class_mod.classify(
+            step_result.data or "", title,
+        )
+    except Exception as exc:
+        logger.debug("failure classifier raised: %s", exc)
+        step_result.failure_class = "unknown"
 
 
 # ── #156 per-action observability ──────────────────────────────────────

--- a/tests/test_failure_class.py
+++ b/tests/test_failure_class.py
@@ -4,8 +4,6 @@ rely on a stable set of class strings."""
 
 from __future__ import annotations
 
-import pytest
-
 from mantis_agent.gym.failure_class import classify, read_failure_context
 
 

--- a/tests/test_failure_class.py
+++ b/tests/test_failure_class.py
@@ -1,0 +1,163 @@
+"""Failure classifier — pin the documented vocabulary so result.json
+consumers (dashboards, post-mortems, the upcoming retry policy) can
+rely on a stable set of class strings."""
+
+from __future__ import annotations
+
+import pytest
+
+from mantis_agent.gym.failure_class import classify, read_failure_context
+
+
+# ── classify(): data prose + title rules ─────────────────────────────────
+
+
+def test_unknown_when_both_inputs_empty() -> None:
+    assert classify("", "") == "unknown"
+
+
+def test_cf_challenge_from_title_overrides_empty_data() -> None:
+    """Navigate-step halts often record an empty ``data`` but the page
+    title still tells the story."""
+    assert classify("", "Just a moment...") == "cf_challenge"
+    assert classify("", "Verify you are human | example.com") == "cf_challenge"
+
+
+def test_cf_challenge_from_403() -> None:
+    assert classify("gate:FAIL:Error 403 forbidden", "") == "cf_challenge"
+
+
+def test_http_4xx_404() -> None:
+    assert classify("gate:FAIL:Error 404", "") == "http_4xx"
+
+
+def test_http_5xx() -> None:
+    assert classify("gate:FAIL:Error 503", "") == "http_5xx"
+    assert classify("Internal Server Error", "") == "http_5xx"
+
+
+def test_nav_timeout() -> None:
+    assert classify("navigate timeout exceeded 45000ms", "") == "nav_timeout"
+    assert classify("Page.goto timed out", "") == "nav_timeout"
+
+
+def test_selector_miss() -> None:
+    assert classify("fill_error: input not found", "") == "selector_miss"
+    assert classify("submit_error: no element matches", "") == "selector_miss"
+    assert classify("click_error", "") == "selector_miss"
+    assert classify("filters_not_applied", "") == "selector_miss"
+
+
+def test_extractor_error() -> None:
+    assert classify("scan_error", "") == "extractor_error"
+    assert classify("extract_error: empty payload", "") == "extractor_error"
+
+
+def test_budget_exceeded() -> None:
+    assert classify("listing_budget_exceeded:bound=per_url", "") == "budget_exceeded"
+    assert classify("max_cost reached", "") == "budget_exceeded"
+
+
+def test_title_classification_beats_data_classification() -> None:
+    """If the page is a CF interstitial but the handler wrote a
+    selector-miss style ``data`` (because the element wasn't on the CF
+    page), prefer ``cf_challenge`` — that's the root cause."""
+    assert (
+        classify("fill_error: not found", "Just a moment...")
+        == "cf_challenge"
+    )
+
+
+def test_unknown_falls_through_unrelated_data() -> None:
+    assert classify("something_weird_happened", "") == "unknown"
+
+
+# ── read_failure_context(): env duck-typing ──────────────────────────────
+
+
+class _PlaywrightishEnv:
+    """Mimics ``PlaywrightGymEnv``: ``current_url`` property + ``_page``
+    attribute with a callable ``title()``."""
+
+    def __init__(self, url: str, title: str):
+        self._url = url
+        self._page = type("_Page", (), {"title": lambda self_: title})()
+
+    @property
+    def current_url(self) -> str:
+        return self._url
+
+
+class _XdotoolishEnv:
+    """Mimics ``XdotoolGymEnv``: ``current_url`` + ``cdp_evaluate``."""
+
+    def __init__(self, url: str, title: str):
+        self._url = url
+        self._title = title
+
+    @property
+    def current_url(self) -> str:
+        return self._url
+
+    def cdp_evaluate(self, expr: str):
+        if "document.title" in expr:
+            return self._title
+        return None
+
+
+def test_read_context_playwright_path() -> None:
+    env = _PlaywrightishEnv("https://example.com/x", "Example Page")
+    assert read_failure_context(env) == ("https://example.com/x", "Example Page")
+
+
+def test_read_context_xdotool_cdp_path() -> None:
+    env = _XdotoolishEnv("https://cf.example/y", "Just a moment...")
+    assert read_failure_context(env) == ("https://cf.example/y", "Just a moment...")
+
+
+def test_read_context_swallows_exceptions() -> None:
+    """A broken env must never crash the failure path."""
+    class _Broken:
+        @property
+        def current_url(self):
+            raise RuntimeError("env is half-torn-down")
+
+        def cdp_evaluate(self, _expr):
+            raise RuntimeError("CDP unreachable")
+
+    url, title = read_failure_context(_Broken())
+    assert url == ""
+    assert title == ""
+
+
+def test_read_context_returns_empty_strings_when_unsupported() -> None:
+    """A plain object exposes neither attribute → return empties."""
+    url, title = read_failure_context(object())
+    assert url == ""
+    assert title == ""
+
+
+# ── classifier vocabulary stays small ────────────────────────────────────
+
+
+def test_classifier_vocabulary_is_stable() -> None:
+    """Anyone widening the vocabulary should bump this set deliberately —
+    breaks force a docs / dashboard update."""
+    allowed = {
+        "cf_challenge", "http_4xx", "http_5xx", "nav_timeout",
+        "selector_miss", "extractor_error", "budget_exceeded", "unknown",
+    }
+    samples = [
+        ("", ""),
+        ("", "Just a moment..."),
+        ("gate:FAIL:Error 403", ""),
+        ("gate:FAIL:Error 404", ""),
+        ("Error 503", ""),
+        ("navigation timeout", ""),
+        ("fill_error: not found", ""),
+        ("scan_error", ""),
+        ("max_cost exceeded", ""),
+        ("???", ""),
+    ]
+    for data, title in samples:
+        assert classify(data, title) in allowed

--- a/tests/test_result_payload.py
+++ b/tests/test_result_payload.py
@@ -1,0 +1,105 @@
+"""StepResult → result.json packaging — shared between local CLI and
+the Modal entrypoint.
+
+Successful steps stay slim; failed steps carry diagnostics. The
+contract this pins is the failure shape — dashboards and post-mortem
+tools branch on the presence of these fields."""
+
+from __future__ import annotations
+
+import base64
+
+from mantis_agent.actions import Action, ActionType
+from mantis_agent.gym.checkpoint import StepResult
+from mantis_agent.gym.result_payload import pack_step
+
+
+def _success(**overrides) -> StepResult:
+    return StepResult(
+        step_index=overrides.pop("step_index", 0),
+        intent=overrides.pop("intent", "navigate"),
+        success=True,
+        data=overrides.pop("data", ""),
+        duration=overrides.pop("duration", 1.23),
+        steps_used=overrides.pop("steps_used", 1),
+        **overrides,
+    )
+
+
+def _failure(**overrides) -> StepResult:
+    return StepResult(
+        step_index=overrides.pop("step_index", 3),
+        intent=overrides.pop("intent", "fill"),
+        success=False,
+        data=overrides.pop("data", "fill_error: not found"),
+        duration=overrides.pop("duration", 2.5),
+        steps_used=overrides.pop("steps_used", 4),
+        failure_class=overrides.pop("failure_class", "selector_miss"),
+        final_url=overrides.pop("final_url", "https://example.com/form"),
+        page_title=overrides.pop("page_title", "Sign up"),
+        **overrides,
+    )
+
+
+def test_success_payload_stays_slim() -> None:
+    out = pack_step(_success())
+    assert set(out) == {"index", "intent", "success", "data", "duration", "steps_used"}
+    assert out["success"] is True
+
+
+def test_failure_payload_includes_diagnostics() -> None:
+    out = pack_step(_failure())
+    assert out["success"] is False
+    assert out["failure_class"] == "selector_miss"
+    assert out["final_url"] == "https://example.com/form"
+    assert out["page_title"] == "Sign up"
+
+
+def test_failure_payload_fallback_classifies_from_data() -> None:
+    """An old StepResult that never got stamped by the executor should
+    still surface a useful class — pack_step classifies from data +
+    page_title as a fallback so the schema is self-describing."""
+    out = pack_step(_failure(failure_class="", data="gate:FAIL:Error 403"))
+    assert out["failure_class"] == "cf_challenge"
+
+
+def test_failure_payload_unclassifiable_data_lands_in_unknown() -> None:
+    out = pack_step(_failure(failure_class="", data="??", page_title=""))
+    assert out["failure_class"] == "unknown"
+
+
+def test_failure_payload_serializes_last_action() -> None:
+    action = Action(
+        action_type=ActionType.CLICK,
+        params={"x": 100, "y": 200, "button": "left"},
+        reasoning="click the 'Sign up' button",
+    )
+    out = pack_step(_failure(last_action=action))
+    assert out["last_action"]["type"] == ActionType.CLICK.value
+    assert out["last_action"]["params"] == {"x": 100, "y": 200, "button": "left"}
+    assert out["last_action"]["reasoning"] == "click the 'Sign up' button"
+
+
+def test_failure_payload_omits_last_action_when_none() -> None:
+    out = pack_step(_failure(last_action=None))
+    assert "last_action" not in out
+
+
+def test_failure_payload_base64_encodes_screenshot() -> None:
+    png_bytes = b"\x89PNG\r\n\x1a\nfake-png-bytes"
+    out = pack_step(_failure(screenshot_png=png_bytes))
+    assert "screenshot_b64" in out
+    assert base64.b64decode(out["screenshot_b64"]) == png_bytes
+
+
+def test_failure_payload_omits_screenshot_when_absent() -> None:
+    out = pack_step(_failure(screenshot_png=None))
+    assert "screenshot_b64" not in out
+
+
+def test_success_payload_omits_screenshot_even_if_present() -> None:
+    """Successful steps already get capped by
+    ``_enforce_screenshot_cap``; result.json shouldn't carry them."""
+    out = pack_step(_success(screenshot_png=b"big-success-png"))
+    assert "screenshot_b64" not in out
+    assert "failure_class" not in out


### PR DESCRIPTION
## Summary

Follow-up to #355. Today, when a step fails, `result.json` gives you a one-line prose blob (`gate:FAIL:Error 403`, `fill_error: not found`, `scan_error`) and not much else. The post-step screenshot lives in `StepResult.screenshot_png` in memory but is dropped at the Modal-result boundary. URL/title at failure are lost. Root-cause classification means regex-ing the prose by hand. Anyone post-morteming a failed run has to fall back to Modal job logs.

This PR turns the typical post-mortem into "open `result.json`":

- **`StepResult` gains three persisted fields** populated on failure: `failure_class`, `final_url`, `page_title`. `failure_class` is a small fixed vocabulary — `cf_challenge` / `http_4xx` / `http_5xx` / `nav_timeout` / `selector_miss` / `extractor_error` / `budget_exceeded` / `unknown` — so dashboards can branch on a stable enum instead of regex-ing prose. Additive: legacy consumers ignore the new keys.
- **New `mantis_agent.gym.failure_class`** module with the pure-functional classifier and a best-effort env probe (`read_failure_context`) that duck-types both `PlaywrightGymEnv` and `XdotoolGymEnv`.
- **`RunExecutor._dispatch_step` stamps the new fields** on any `StepResult` with `success=False`. Every probe is wrapped in `try/except` so the failure path can't itself raise.
- **New `mantis_agent.gym.result_payload`** module owns the `StepResult` → `result.json` packaging. Successful steps stay slim (6 fields). Failed steps additionally carry `failure_class`, `final_url`, `page_title`, `last_action` (serialized `Action`), and `screenshot_b64` (base64-encoded post-step PNG). `pack_step` also classifies as a fallback so the schema is self-describing even when the runner bypassed `_dispatch_step` (host integrations, halt paths, legacy resume).
- **Both `cmd_plan_run` and `modal_plan_runner.run_plan` now use the shared `pack_step`** — local and Modal `result.json` files now have the same shape.

## Public surface changes

- `result.json` `steps[i]` for **failed** steps gains: `failure_class`, `final_url`, `page_title`, optional `last_action` ({type, params, reasoning}), optional `screenshot_b64`. Successful steps unchanged.
- `StepResult.failure_class` / `final_url` / `page_title` are persisted to `checkpoint.json` (round-trip via `_PERSISTED`). Schema is additive — `StepResult.from_dict` ignores unknown keys.
- Docs (`docs/getting-started/cli.md`) gain a `result.json` schema block + a failure-fields table.

## Test plan

- [x] `pytest tests/test_failure_class.py` — classifier vocabulary (10 patterns + the stability set), title-beats-data ordering, env duck-typing for Playwright + xdotool paths, exception swallow
- [x] `pytest tests/test_result_payload.py` — success/failure schema, `screenshot_b64` round-trips through base64, `last_action` serialization, fallback classification when `failure_class=""`
- [x] `pytest tests/test_run_executor.py tests/test_micro_runner_hooks.py tests/test_micro_runner_seed.py tests/test_modal_cf_prewarm.py tests/test_cli_plan_run.py tests/test_cli_plan_run_modal.py tests/test_checkpoint_manager.py` — 147 passed, no regressions in adjacent surfaces
- [x] Broader sweep: 2131 passed in the wider suite (pre-existing unrelated sim_envs / FastAPI deprecation errors skipped)
- [ ] **Final gate** (operator): `uv run modal deploy deploy/modal/modal_plan_runner.py` then trigger a known-failing plan and confirm `result.json` carries `failure_class` + `screenshot_b64` + `last_action` for the failed step

🤖 Generated with [Claude Code](https://claude.com/claude-code)