### PR TITLE
docs: post-mortem playbook for failed plan steps

### DIFF
--- a/docs/client/errors.md
+++ b/docs/client/errors.md
@@ -83,6 +83,62 @@ curl -X POST "$ENDPOINT/v1/predict" \
 
 Every retry of the same `Idempotency-Key` returns the cached `run_id` (24 h TTL). See [Idempotency](../operations/idempotency.md).
 
+## Diagnosing a failed step
+
+When a step fails, `action=result` returns each failed step with structured diagnostics — read these **before** falling back to `action=logs`. The full schema is documented in [`mantis plan run` → `result.json`](../getting-started/cli.md#resultjson-schema); the fields you'll care about per failed step are:
+
+| Field | What it tells you |
+|---|---|
+| `failure_class` | Stable enum (see table below). Branch on this in dashboards / retry policies. |
+| `final_url` | Browser URL at the moment of failure. |
+| `page_title` | Page title at the moment of failure — CF interstitials surface here even when `data` is empty. |
+| `last_action` | The final `Action` dispatched before failure (`{type, params, reasoning}`). |
+| `screenshot_b64` | Base64-encoded PNG of the post-failure viewport. |
+| `data` | Short prose from the handler (`gate:FAIL:Error 403`, `fill_error: not found`, …). |
+
+### `failure_class` → likely cause → first action
+
+| `failure_class` | Likely cause | First action |
+|---|---|---|
+| `cf_challenge` | Cloudflare / anti-bot interstitial didn't clear | Retry with a fresh `profile_id` (rotates the IP / cookies). For repeated failures, ask operator to bump `MANTIS_CF_PREWARM_MAX_SECONDS`. |
+| `http_4xx` | Target returned 401 / 404 / 410 | Check `final_url` — usually a stale URL in the plan or a tenant-scoped page. Not retryable. |
+| `http_5xx` | Target backend returned 5xx | Exponential backoff + retry. Usually transient. |
+| `nav_timeout` | Page load exceeded the navigate budget | Bump `wait_after_load_seconds` on the step, or `MANTIS_NAV_WAIT_SECONDS`. Repeated → check egress / proxy. |
+| `selector_miss` | Click / fill / submit couldn't locate the target | Inspect `screenshot_b64` — the page is often in a different state than the plan expects. Adjust the plan, or add a `wait` step before. |
+| `extractor_error` | Claude extractor failed / returned empty | Schema mismatch with what's visible. Tighten the recipe or relax the schema. |
+| `budget_exceeded` | `max_cost` / `max_time` / per-URL context budget tripped | Raise the cap or shorten the plan. |
+| `unknown` | No rule matched | Pull `action=logs` (below) — the runner traceback usually identifies it. |
+
+### Decoding the failure screenshot
+
+```bash
+# Pull the result, extract the failed step's screenshot to a PNG.
+curl -fsS -X POST "$ENDPOINT/v1/predict" \
+  -H "Authorization: Api-Key $BASETEN_API_KEY" \
+  -H "X-Mantis-Token: $MANTIS_API_TOKEN" \
+  -d "{\"action\":\"result\",\"run_id\":\"$RUN_ID\"}" \
+  | jq -r '.steps[] | select(.success == false) | .screenshot_b64' \
+  | head -1 | base64 -d > failed_step.png
+```
+
+`screenshot_b64` is omitted on success and on steps where capture failed.
+
+### When `failure_class` isn't enough
+
+For `unknown` (or to read the traceback / per-step Holo3 logs), fall through to:
+
+```bash
+curl -fsS -X POST "$ENDPOINT/v1/predict" \
+  -H "Authorization: Api-Key $BASETEN_API_KEY" \
+  -H "X-Mantis-Token: $MANTIS_API_TOKEN" \
+  -d "{\"action\":\"logs\",\"run_id\":\"$RUN_ID\",\"tail\":500}" \
+  | jq -r '.events[]'
+```
+
+`action=logs` returns the runner thread's Python logger tail (state transitions, step handler messages, exception tracebacks). This is the HTTP-API analog of operator-only `modal app logs` — same content, different access path.
+
+If the `events.log` doesn't surface the cause either, ask your operator to pull `modal app logs mantis-plan-runner` for the container-side stdout / stderr. Open a ticket with the `run_id`.
+
 ## Debugging a stuck run
 
 If a `running` status doesn't advance for ≥ 5 min:

--- a/docs/getting-started/cli.md
+++ b/docs/getting-started/cli.md
@@ -237,6 +237,37 @@ The same shape is produced by both `mantis plan run` (local) and
 `mantis plan run-modal` (remote) — post-mortem tools can consume one
 schema regardless of where the browser ran.
 
+#### Diagnosing a failed plan
+
+The post-mortem flow starts in `result.json` and falls through to the
+runner logs only when needed:
+
+1. **Read `failure_class` on each failed step.** The class → likely-cause
+   → first-action table is the canonical reference and lives in
+   [Errors / Diagnosing a failed step](../client/errors.md#diagnosing-a-failed-step).
+   `final_url` + `page_title` + `last_action` give you the rest of the
+   step's state at failure time.
+
+2. **Decode `screenshot_b64`** to see what the agent saw:
+
+   ```bash
+   jq -r '.steps[] | select(.success == false) | .screenshot_b64' \
+       outputs/<run>/result.json \
+     | head -1 | base64 -d > failed_step.png
+   ```
+
+3. **Fall through to logs only for `failure_class=unknown`** (or when
+   you need the Holo3 / Claude prompt context, exception traceback,
+   etc.). Two access paths surface the same Python logger output:
+
+   | Audience | How |
+   |---|---|
+   | HTTP API integrator | `{"action":"logs","run_id":"…","tail":500}` — returns the runner thread's `events.log` tail. See [Errors / When `failure_class` isn't enough](../client/errors.md#when-failure_class-isnt-enough). |
+   | Operator (CLI / direct Modal) | `modal app logs mantis-plan-runner` — full container stdout / stderr (covers cases the per-run `events.log` doesn't, e.g. tinyproxy spawn failures or pre-runner Xvfb crashes). |
+
+   `diagnose_proxy` (operator-only) is the proxy-stack-specific fallback —
+   see [Modal hosting / Diagnostics](../hosting/modal.md).
+
 ### `mantis plan run-modal <path>`
 
 Like `plan run`, but the **browser, decomposer, grounding, and


### PR DESCRIPTION
## Summary

Follow-up to #356. That PR added `failure_class` / `final_url` / `page_title` / `last_action` / `screenshot_b64` to `result.json` for failed steps, but stopped at the schema. This PR adds the **how-to** — a single post-mortem flow that an integrator (HTTP API) or an operator (CLI / Modal) can follow end-to-end without having to stitch docs together.

- **`docs/client/errors.md` — new "Diagnosing a failed step" section.** Holds the canonical `failure_class` → likely cause → first action table, a base64 → PNG decoder snippet for `screenshot_b64`, and the `action=logs` fall-through for `failure_class=unknown`. Calls out explicitly that **`action=logs` is the HTTP-API analog of operator-only `modal app logs`** — same Python logger output, different access path. Closes a gap surfaced post-#356 (HTTP-API consumers can't reach `modal app logs`).
- **`docs/getting-started/cli.md` — short operator-flavored pointer** back to the canonical table, plus a two-row audience matrix (HTTP API: `action=logs` / operator: `modal app logs` + `diagnose_proxy`). Keeps the table single-sourced in errors.md.

## Why now

`mantis` defaults to an end-user / integrator DX lens (per existing convention). Telling integrators "fall back to Modal logs" doesn't work — they don't have Modal CLI access. The `action=logs` endpoint already exists and already streams the same logger output via `DetachedRunLogHandler`; the gap was purely doc-side.

## Test plan

- [x] `uv run mkdocs build --strict` — clean (two pre-existing info notices on unrelated pages).
- [x] Verified the new anchors (`#diagnosing-a-failed-step`, `#when-failure_class-isnt-enough`) actually resolve in the built HTML.
- [x] No code changes — pure docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)