### PR TITLE
fix(ci): raise LocalBackend wait_healthy budgets to absorb runner contention

### DIFF
--- a/src/mantis_agent/sim_envs/local.py
+++ b/src/mantis_agent/sim_envs/local.py
@@ -223,8 +223,14 @@ class LocalBackend:
             extra={"mode": "subprocess", "proc": proc, "port": port},
         )
 
-    def wait_healthy(self, handle: RuntimeHandle, *, timeout_s: float = 30.0) -> None:
-        """Poll ``/__env__/health`` until 200 or ``timeout_s`` elapses."""
+    def wait_healthy(self, handle: RuntimeHandle, *, timeout_s: float = 60.0) -> None:
+        """Poll ``/__env__/health`` until 200 or ``timeout_s`` elapses.
+
+        Default 60 s covers contended CI runners where a fresh Python
+        subprocess + FastAPI import + uvicorn bind can drift well past
+        the older 30 s ceiling. The poll loop exits as soon as the env
+        responds 200, so the higher cap costs nothing on the happy path.
+        """
         deadline = time.time() + timeout_s
         last_err: Exception | None = None
         while time.time() < deadline:

--- a/tests/test_admin_token_isolation.py
+++ b/tests/test_admin_token_isolation.py
@@ -34,7 +34,7 @@ def stub_env():
     backend = LocalBackend()
     handle = backend.start("stub-test", seed=42)
     try:
-        backend.wait_healthy(handle, timeout_s=10.0)
+        backend.wait_healthy(handle, timeout_s=30.0)
         yield handle
     finally:
         backend.stop(handle)

--- a/tests/test_env_up.py
+++ b/tests/test_env_up.py
@@ -50,7 +50,7 @@ def test_local_backend_starts_and_stops_stub_env():
     backend = LocalBackend()
     handle = backend.start("stub-test", seed=7, now="2026-02-01T00:00:00Z")
     try:
-        backend.wait_healthy(handle, timeout_s=10.0)
+        backend.wait_healthy(handle, timeout_s=30.0)
         status, body = _http_get(f"{handle.url}/__env__/health")
         assert status == 200
         payload = json.loads(body)
@@ -74,16 +74,16 @@ def test_local_backend_starts_and_stops_stub_env():
 
 def test_local_backend_two_starts_get_distinct_urls():
     # Two subprocess stubs in parallel under a loaded CI runner can take
-    # noticeably longer than the 10s ceiling used elsewhere — bump to 30s
-    # so the test reflects the same budget the default ``wait_healthy``
-    # uses in production.
+    # noticeably longer than the single-start case. Use the production
+    # default (60 s) — the poll exits as soon as the env responds, so the
+    # higher cap costs nothing on the happy path.
     backend = LocalBackend()
     h1 = backend.start("stub-test")
     h2 = backend.start("stub-test")
     try:
         assert h1.url != h2.url
-        backend.wait_healthy(h1, timeout_s=30.0)
-        backend.wait_healthy(h2, timeout_s=30.0)
+        backend.wait_healthy(h1, timeout_s=60.0)
+        backend.wait_healthy(h2, timeout_s=60.0)
     finally:
         backend.stop(h1)
         backend.stop(h2)
@@ -92,7 +92,7 @@ def test_local_backend_two_starts_get_distinct_urls():
 def test_stop_is_idempotent():
     backend = LocalBackend()
     handle = backend.start("stub-test")
-    backend.wait_healthy(handle, timeout_s=10.0)
+    backend.wait_healthy(handle, timeout_s=30.0)
     backend.stop(handle)
     backend.stop(handle)  # second call must not raise
 


### PR DESCRIPTION
## Summary

Three PRs in a row (#355 / #356 / #357) hit the same flake: pytest fails on a sim-env subprocess that doesn't respond to `/__env__/health` inside the 10 s or 30 s test budget. Each hit was a **different test** (`test_admin_token_isolation`, `test_local_backend_starts_and_stops_stub_env`, `test_local_backend_two_starts_get_distinct_urls`) and a **different Python version** (3.11 / 3.12 alternating), pointing at runner contention rather than any test bug.

Root cause: a fresh Python subprocess + FastAPI import + uvicorn bind on a loaded GitHub Actions runner can drift well past the 10 s ceiling — and even past 30 s for the two-subprocess parallel case. The poll already exits as soon as `/__env__/health` returns 200, so a larger ceiling is **invisible on the happy path** — it only changes whether we surface a noisy `TimeoutError` on a slow boot.

## Changes

- `LocalBackend.wait_healthy` default `30s` → `60s`. Docstring extended to explain why so a future cleanup doesn't shrink it back.
- `test_local_backend_starts_and_stops_stub_env`: 10 s → 30 s
- `test_local_backend_two_starts_get_distinct_urls`: 30 s → 60 s (matches the new production default)
- `test_stop_is_idempotent`: 10 s → 30 s
- `test_admin_token_isolation` fixture: 10 s → 30 s
- `test_health_timeout_raises_clear_error` **stays at 1 s** — that's the negative test verifying `TimeoutError` is raised; a larger cap there would just slow the suite.

## Why not retry / pytest-rerunfailures

A retry plugin papers over the symptom and adds a dependency. The polling already happens inside `wait_healthy`; the question is purely "how long do we wait before giving up?". The cost of a higher cap is zero on the happy path (returns as soon as the env is healthy, typically 1-2 s) and bounded on the sad path (60 s max once, instead of 30 s twice).

## Test plan

- [x] `pytest tests/test_env_up.py tests/test_admin_token_isolation.py -v` — 15 passed in 1.87 s on the happy path. No regression.
- [ ] **CI observation** — the real test is whether the three-PR streak of flakes ends. I'll watch the next few PRs and reopen this if the flake recurs at the new budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)