### PR TITLE
feat(time-meter): bucketed wall-time accounting on MicroPlanRunner (Phase A of #362)

### DIFF
--- a/docs/operations/metrics.md
+++ b/docs/operations/metrics.md
@@ -16,7 +16,7 @@
 | `mantis_brain_escalation_total` | counter | `tenant_id`, `from_brain`, `to_brain` | One increment per `BrainLadder.think()`. `to_brain` = `primary\|fallback` |
 | `mantis_loop_termination_total` | counter | `tenant_id`, `reason` | One increment per run. reason = `completed\|halted\|cancelled\|paused\|budget_cap\|time_cap` |
 | `mantis_plan_branch_total` | counter | `tenant_id`, `branch`, `outcome` | Special-case dispatch routes: `gate_verify\|claude_only\|navigate_back_close_tab\|click_listings\|click_single_element` × `taken\|skipped\|aborted` |
-| `mantis_step_latency_seconds` | histogram | `tenant_id`, `phase` | phase = `perceive\|think\|act\|settle`. Buckets: 50ms, 100ms, 250ms, 500ms, 1s, 2s, 5s, 10s, 20s, 30s |
+| `mantis_step_latency_seconds` | histogram | `tenant_id`, `phase` | phase = `perceive\|think\|act\|settle\|claude_ground\|claude_extract\|claude_verify\|load\|overhead` (epic [#362](https://github.com/mercurialsolo/mantis/issues/362)). Buckets: 50ms, 100ms, 250ms, 500ms, 1s, 2s, 5s, 10s, 20s, 30s |
 | `mantis_grounding_cache_hits_total` | counter | `tenant_id` | Cache hits on the (frame-region + description) coordinate cache (#117) |
 | `mantis_grounding_cache_misses_total` | counter | `tenant_id` | Cache misses (incl. expirations) |
 | `mantis_grounding_cache_evictions_total` | counter | `tenant_id` | LRU evictions (capacity hit) |

--- a/src/mantis_agent/gym/micro_runner.py
+++ b/src/mantis_agent/gym/micro_runner.py
@@ -205,6 +205,12 @@ class MicroPlanRunner:
             self.cost_meter.cost_config, self.cost_meter.tenant_id
         )
         self.costs, self._run_start = self.cost_meter.costs, self.cost_meter.run_start
+        # Sibling to CostMeter: same lifecycle, surfaces wall-time
+        # accounting per bucket. Phase B (#365) will lift this onto
+        # the result envelope; Phase A wires it only at the executor's
+        # step dispatch so the foundation lands before the surface.
+        from .time_meter import TimeMeter
+        self.time_meter = TimeMeter(tenant_id=tenant_id)
         self.browser_state = BrowserState(self)
         self.checkpoint_manager = CheckpointManager(self)
         from .step_handlers import default_registry

--- a/src/mantis_agent/gym/run_executor.py
+++ b/src/mantis_agent/gym/run_executor.py
@@ -337,12 +337,21 @@ class RunExecutor:
         }
         pre_snapshot = step_snapshot.capture(runner)
         runner._pre_step_snapshot = pre_snapshot
+        meter = getattr(runner, "time_meter", None)
         try:
-            step_result = runner._execute_step(effective_step, state.step_index)
+            if meter is not None:
+                with meter.measure("act", step_idx=state.step_index):
+                    step_result = runner._execute_step(effective_step, state.step_index)
+            else:
+                step_result = runner._execute_step(effective_step, state.step_index)
         finally:
             runner._active_checkpoint_context = None
         if step_result.screenshot_png is None:
-            step_result.screenshot_png = runner._capture_screenshot_bytes()
+            if meter is not None:
+                with meter.measure("perceive", step_idx=state.step_index):
+                    step_result.screenshot_png = runner._capture_screenshot_bytes()
+            else:
+                step_result.screenshot_png = runner._capture_screenshot_bytes()
         if not step_result.success:
             _stamp_failure_context(step_result, runner.env)
         state.results.append(step_result)

--- a/src/mantis_agent/gym/time_meter.py
+++ b/src/mantis_agent/gym/time_meter.py
@@ -1,0 +1,191 @@
+"""Per-run wall-time accounting for MicroPlanRunner — sibling to
+:class:`~.cost_meter.CostMeter`.
+
+Where CostMeter answers "where did the dollars go?", TimeMeter answers
+"where did the wall-time go?". Both are bookkeeping primitives the
+runner mutates in-place; both surface on the run result envelope
+(Phase B / #365) and feed Prometheus.
+
+Buckets are stable strings (the :data:`BUCKETS` constant). They are
+mutually exclusive — a wrapped block of code is credited to exactly
+one bucket. Sum of bucket totals tracks ``elapsed_seconds()`` within a
+few percent; the residual lives in ``overhead`` (computed lazily at
+read time, not stored).
+
+Use the :meth:`measure` context manager at the call site:
+
+>>> meter = TimeMeter(tenant_id="acme")
+>>> with meter.measure("think", step_idx=3):
+...     result = brain.think(frames=[...], task=...)
+>>> meter.totals["think"]
+0.482
+
+The Prometheus histogram ``STEP_LATENCY_SECONDS`` (declared in
+``metrics.py`` but never observed before this module) fires on every
+``measure()`` exit, labelled by ``(tenant_id, phase)``. Skipped when
+``tenant_id`` is empty so local / script runs don't leak a default
+series into the registry.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from typing import Iterator
+
+logger = logging.getLogger(__name__)
+
+
+BUCKETS: tuple[str, ...] = (
+    "perceive",       # env.screenshot() capture, viewport sync
+    "think",          # brain inference (Holo3 / Gemma4 / Claude action emission)
+    "act",            # env.step(action) — keystroke / mouse / scroll / CDP click
+    "settle",         # post-action wait (fixed or adaptive)
+    "claude_ground",  # ClaudeGrounding.refine_click(...) coordinate refinement
+    "claude_extract", # ClaudeExtractor.find_* — extraction calls
+    "claude_verify",  # gate verification, DynamicPlanVerifier checks
+    "load",           # env.reset(url) page-load + Cloudflare wait + proxy CONNECT
+    "overhead",       # residual: runner orchestration, dispatch, Python (computed lazily)
+)
+
+
+def _make_initial_totals() -> dict[str, float]:
+    return {b: 0.0 for b in BUCKETS}
+
+
+def _make_initial_step_record() -> dict[str, float]:
+    return {b: 0.0 for b in BUCKETS}
+
+
+@dataclass
+class TimeMeter:
+    """Owns wall-time counters per bucket + per-step timing records.
+
+    Mirrors :class:`CostMeter`'s pattern: the runner records into
+    ``self.totals`` via the :meth:`measure` context manager, and
+    ``self.per_step[idx]`` keeps a list of per-step bucket breakdowns
+    for the final result envelope (Phase B / #365).
+
+    ``run_start`` uses :func:`time.monotonic` so :meth:`elapsed_seconds`
+    is unaffected by wall-clock jumps (NTP, daylight-saving). Individual
+    measurements also use monotonic time — bucket totals always advance,
+    never go backwards.
+    """
+
+    tenant_id: str = ""
+    totals: dict[str, float] = field(default_factory=_make_initial_totals)
+    per_step: list[dict[str, float]] = field(default_factory=list)
+    run_start: float = field(default_factory=time.monotonic)
+
+    # ── Measurement primitives ──────────────────────────────────────────
+
+    @contextmanager
+    def measure(
+        self, bucket: str, *, step_idx: int | None = None,
+    ) -> Iterator[None]:
+        """Time the wrapped block and credit ``bucket``.
+
+        When ``step_idx`` is provided, the elapsed time is *also*
+        credited to ``self.per_step[step_idx][bucket]``, growing the
+        ``per_step`` list as needed so callers can address future
+        steps before they've been dispatched.
+
+        Unknown buckets raise ``KeyError`` — callers should use a
+        constant from :data:`BUCKETS` to keep the vocabulary closed.
+        """
+        if bucket not in self.totals:
+            raise KeyError(
+                f"unknown TimeMeter bucket: {bucket!r}. "
+                f"Allowed: {sorted(self.totals)}"
+            )
+        t0 = time.monotonic()
+        try:
+            yield
+        finally:
+            elapsed = time.monotonic() - t0
+            self.totals[bucket] += elapsed
+            if step_idx is not None:
+                while len(self.per_step) <= step_idx:
+                    self.per_step.append(_make_initial_step_record())
+                self.per_step[step_idx][bucket] += elapsed
+            self._emit_prometheus(bucket, elapsed)
+
+    def record(
+        self, bucket: str, seconds: float, *, step_idx: int | None = None,
+    ) -> None:
+        """Direct credit without a context manager.
+
+        Useful when the elapsed time is computed elsewhere (e.g., a
+        helper that already times its own work and returns the
+        duration). Same accounting + Prometheus emission as
+        :meth:`measure`.
+        """
+        if bucket not in self.totals:
+            raise KeyError(
+                f"unknown TimeMeter bucket: {bucket!r}. "
+                f"Allowed: {sorted(self.totals)}"
+            )
+        if seconds < 0:
+            return
+        self.totals[bucket] += seconds
+        if step_idx is not None:
+            while len(self.per_step) <= step_idx:
+                self.per_step.append(_make_initial_step_record())
+            self.per_step[step_idx][bucket] += seconds
+        self._emit_prometheus(bucket, seconds)
+
+    # ── Aggregate read accessors ────────────────────────────────────────
+
+    def elapsed_seconds(self) -> float:
+        """Wall-clock since the meter was constructed."""
+        return time.monotonic() - self.run_start
+
+    def breakdown(self) -> dict[str, float]:
+        """Snapshot of totals with ``overhead`` filled in as the residual.
+
+        ``overhead`` is the difference between wall-clock elapsed and the
+        sum of explicitly-measured buckets — captures runner orchestration,
+        dispatch, Python work that isn't wrapped in a :meth:`measure`
+        block. Floored at 0 so overlapping measurements never produce a
+        negative residual.
+        """
+        out = dict(self.totals)
+        residual = self.elapsed_seconds() - sum(
+            v for k, v in self.totals.items() if k != "overhead"
+        )
+        # ``overhead`` may already have explicit contributions; the
+        # residual adds whatever the wall clock says is unaccounted.
+        out["overhead"] = max(0.0, out["overhead"] + residual)
+        return out
+
+    def step_breakdown(self, step_idx: int) -> dict[str, float]:
+        """Per-step bucket record, or an all-zeros dict if the step hasn't
+        been measured yet. Stable for callers that read by index.
+        """
+        if 0 <= step_idx < len(self.per_step):
+            return dict(self.per_step[step_idx])
+        return _make_initial_step_record()
+
+    # ── Prometheus emission ─────────────────────────────────────────────
+
+    def _emit_prometheus(self, bucket: str, seconds: float) -> None:
+        """Observe one measurement into ``STEP_LATENCY_SECONDS``.
+
+        Skipped when ``tenant_id`` is empty so local / script runs
+        don't pollute the registry with a default-label series.
+        Best-effort: a metric emission failure must never break a run.
+        """
+        if not self.tenant_id:
+            return
+        try:
+            from .. import metrics as _metrics
+            _metrics.STEP_LATENCY_SECONDS.labels(
+                tenant_id=self.tenant_id, phase=bucket,
+            ).observe(seconds)
+        except Exception as exc:  # noqa: BLE001 — metrics are observability, never fatal
+            logger.debug("STEP_LATENCY_SECONDS emit failed (bucket=%s): %s", bucket, exc)
+
+
+__all__ = ["BUCKETS", "TimeMeter"]

--- a/src/mantis_agent/metrics.py
+++ b/src/mantis_agent/metrics.py
@@ -207,11 +207,14 @@ PLAN_BRANCH_TOTAL = _counter(
 )
 
 # Per-step latency histogram, labelled by phase. ``phase`` is one of
-# ``perceive | think | act | settle``. Buckets cover the 50ms – 30s
-# window most browser CUA steps land in.
+# the buckets from :mod:`.gym.time_meter` — perceive / think / act /
+# settle / claude_ground / claude_extract / claude_verify / load /
+# overhead (epic #362). Buckets cover the 50ms – 30s window most
+# browser CUA steps land in.
 STEP_LATENCY_SECONDS = _histogram(
     "mantis_step_latency_seconds",
-    "Latency of one step phase (perceive | think | act | settle).",
+    "Latency of one step phase (perceive | think | act | settle | claude_ground "
+    "| claude_extract | claude_verify | load | overhead).",
     ("tenant_id", "phase"),
     buckets=(0.05, 0.1, 0.25, 0.5, 1.0, 2.0, 5.0, 10.0, 20.0, 30.0),
 )

--- a/tests/test_micro_runner_hooks.py
+++ b/tests/test_micro_runner_hooks.py
@@ -132,6 +132,49 @@ def test_step_results_carry_screenshot_bytes_by_default():
         assert s.screenshot_png is not None and s.screenshot_png[:8] == b"\x89PNG\r\n\x1a\n"
 
 
+def test_time_meter_records_act_and_perceive_per_step():
+    """Phase A (epic #362, issue #363): every dispatched step should
+    charge wall time to ``act`` (the wrapped ``_execute_step`` call) and
+    ``perceive`` (the post-step screenshot capture). Both totals + the
+    per-step breakdown must reflect the same measurements."""
+    env = _FakeEnv()
+    r = _runner(env)
+    steps = r.run(_trivial_plan())
+    assert len(steps) == 3
+
+    meter = r.time_meter
+    # Totals carry both buckets.
+    assert meter.totals["act"] > 0.0
+    assert meter.totals["perceive"] > 0.0
+
+    # Per-step breakdown has one entry per dispatched step.
+    assert len(meter.per_step) == 3
+    for i in range(3):
+        bd = meter.per_step[i]
+        # Each step charged BOTH act and perceive (per-step
+        # screenshot capture runs for every step in the dispatch
+        # path).
+        assert bd["act"] > 0.0, f"step {i} did not charge 'act'"
+        assert bd["perceive"] > 0.0, f"step {i} did not charge 'perceive'"
+
+
+def test_time_meter_breakdown_fills_overhead_residual():
+    """``breakdown()`` should account for time not wrapped in any
+    ``measure()`` block as ``overhead`` so the dict sums close to
+    ``elapsed_seconds()``."""
+    env = _FakeEnv()
+    r = _runner(env)
+    r.run(_trivial_plan())
+
+    meter = r.time_meter
+    bd = meter.breakdown()
+    # All buckets present, including overhead.
+    assert set(bd) == set(meter.totals)
+    # Overhead is non-negative — orchestration time the runner spent
+    # outside the wrapped blocks.
+    assert bd["overhead"] >= 0.0
+
+
 def test_keep_screenshots_caps_retained_bytes():
     env = _FakeEnv()
     r = _runner(env, keep_screenshots=1)

--- a/tests/test_time_meter.py
+++ b/tests/test_time_meter.py
@@ -1,0 +1,195 @@
+"""``TimeMeter`` — per-run wall-time bookkeeping (epic #362 Phase A).
+
+Pins the context-manager contract, the per-step accounting, the
+``overhead`` residual semantics, and the Prometheus emission path
+(skipped when ``tenant_id`` is empty)."""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import patch
+
+import pytest
+
+from mantis_agent.gym.time_meter import BUCKETS, TimeMeter
+
+
+# ── BUCKETS vocabulary ──────────────────────────────────────────────────
+
+
+def test_buckets_vocabulary_is_stable() -> None:
+    """A widening of the bucket vocabulary should be deliberate — pinned
+    here so a stealth rename / drop forces a docs + dashboard update."""
+    assert BUCKETS == (
+        "perceive", "think", "act", "settle", "claude_ground",
+        "claude_extract", "claude_verify", "load", "overhead",
+    )
+
+
+# ── measure() primitive ─────────────────────────────────────────────────
+
+
+def test_measure_credits_elapsed_time_to_the_bucket() -> None:
+    meter = TimeMeter()
+    with meter.measure("act"):
+        time.sleep(0.01)
+    assert meter.totals["act"] >= 0.01
+    # Other buckets stay at zero.
+    for b in BUCKETS:
+        if b == "act":
+            continue
+        assert meter.totals[b] == 0.0
+
+
+def test_measure_accumulates_across_calls() -> None:
+    meter = TimeMeter()
+    with meter.measure("think"):
+        time.sleep(0.005)
+    with meter.measure("think"):
+        time.sleep(0.005)
+    assert meter.totals["think"] >= 0.01
+
+
+def test_measure_with_step_idx_records_to_per_step() -> None:
+    meter = TimeMeter()
+    with meter.measure("act", step_idx=2):
+        time.sleep(0.01)
+    # per_step grew to accommodate index 2.
+    assert len(meter.per_step) == 3
+    # Step 0 + step 1 never measured — all-zero records.
+    assert meter.per_step[0]["act"] == 0.0
+    assert meter.per_step[1]["act"] == 0.0
+    # Step 2 carries the measurement.
+    assert meter.per_step[2]["act"] >= 0.01
+
+
+def test_measure_without_step_idx_does_not_touch_per_step() -> None:
+    meter = TimeMeter()
+    with meter.measure("think"):
+        time.sleep(0.001)
+    assert meter.per_step == []
+    assert meter.totals["think"] >= 0.001
+
+
+def test_measure_raises_on_unknown_bucket() -> None:
+    meter = TimeMeter()
+    with pytest.raises(KeyError):
+        with meter.measure("ungoverned_bucket"):
+            pass
+
+
+def test_measure_credits_even_when_block_raises() -> None:
+    """Exceptions don't skip accounting — operators want to see where
+    time went on failed runs too."""
+    meter = TimeMeter()
+    with pytest.raises(RuntimeError):
+        with meter.measure("act"):
+            time.sleep(0.005)
+            raise RuntimeError("synthetic")
+    assert meter.totals["act"] >= 0.005
+
+
+# ── record() direct credit ──────────────────────────────────────────────
+
+
+def test_record_credits_without_context_manager() -> None:
+    meter = TimeMeter()
+    meter.record("settle", 2.5, step_idx=0)
+    assert meter.totals["settle"] == 2.5
+    assert meter.per_step[0]["settle"] == 2.5
+
+
+def test_record_ignores_negative_seconds() -> None:
+    """Defensive: a misbehaving caller shouldn't poison the totals."""
+    meter = TimeMeter()
+    meter.record("settle", -1.0)
+    assert meter.totals["settle"] == 0.0
+
+
+def test_record_raises_on_unknown_bucket() -> None:
+    meter = TimeMeter()
+    with pytest.raises(KeyError):
+        meter.record("nope", 1.0)
+
+
+# ── overhead residual ───────────────────────────────────────────────────
+
+
+def test_breakdown_fills_overhead_with_residual() -> None:
+    """Unmeasured wall time lands in ``overhead`` automatically — so the
+    sum of breakdown values tracks total wall-clock without the caller
+    having to wrap orchestration code."""
+    meter = TimeMeter()
+    with meter.measure("act"):
+        time.sleep(0.01)
+    time.sleep(0.02)  # unaccounted-for orchestration time
+    bd = meter.breakdown()
+    assert bd["act"] >= 0.01
+    # Sum should approximate elapsed (within timing jitter).
+    total = sum(bd.values())
+    assert total == pytest.approx(meter.elapsed_seconds(), rel=0.5)
+    assert bd["overhead"] >= 0.015  # at least the unwrapped sleep
+
+
+def test_breakdown_overhead_floors_at_zero() -> None:
+    """Overlapping measurements (one bucket runs inside another) could
+    push the residual negative; the floor keeps the dict JSON-friendly
+    and avoids surprising consumers."""
+    meter = TimeMeter()
+    # Two measurements that together exceed elapsed wall time.
+    meter.record("act", 100.0)
+    meter.record("think", 50.0)
+    bd = meter.breakdown()
+    assert bd["overhead"] == 0.0
+
+
+def test_step_breakdown_returns_zero_dict_for_unmeasured_step() -> None:
+    meter = TimeMeter()
+    bd = meter.step_breakdown(7)
+    assert set(bd) == set(BUCKETS)
+    assert all(v == 0.0 for v in bd.values())
+
+
+def test_step_breakdown_returns_recorded_values() -> None:
+    meter = TimeMeter()
+    meter.record("act", 1.5, step_idx=0)
+    meter.record("think", 0.75, step_idx=0)
+    bd = meter.step_breakdown(0)
+    assert bd["act"] == 1.5
+    assert bd["think"] == 0.75
+    assert bd["perceive"] == 0.0  # untouched bucket
+
+
+# ── Prometheus emission ─────────────────────────────────────────────────
+
+
+def test_prometheus_emit_skipped_when_tenant_unset() -> None:
+    """Local / script runs (no tenant) must not pollute the registry
+    with a default-label series."""
+    meter = TimeMeter(tenant_id="")
+    with patch("mantis_agent.metrics.STEP_LATENCY_SECONDS") as mock_hist:
+        with meter.measure("act"):
+            time.sleep(0.001)
+    mock_hist.labels.assert_not_called()
+
+
+def test_prometheus_emit_observes_on_tenant_run() -> None:
+    meter = TimeMeter(tenant_id="acme")
+    with patch("mantis_agent.metrics.STEP_LATENCY_SECONDS") as mock_hist:
+        with meter.measure("act"):
+            time.sleep(0.001)
+    mock_hist.labels.assert_called_once_with(tenant_id="acme", phase="act")
+    mock_hist.labels.return_value.observe.assert_called_once()
+    observed = mock_hist.labels.return_value.observe.call_args.args[0]
+    assert observed >= 0.001
+
+
+def test_prometheus_emit_is_best_effort() -> None:
+    """A metric backend error must not crash the run."""
+    meter = TimeMeter(tenant_id="acme")
+    with patch("mantis_agent.metrics.STEP_LATENCY_SECONDS") as mock_hist:
+        mock_hist.labels.side_effect = RuntimeError("registry down")
+        with meter.measure("act"):
+            time.sleep(0.001)
+    # Despite the metric failure, totals still updated.
+    assert meter.totals["act"] >= 0.001


### PR DESCRIPTION
## Summary

Phase A of epic #362 — bucketed wall-time observability on `MicroPlanRunner`. Today Mantis tracks dollars (`CostMeter`) but not seconds: every run reports a single `total_time_s` and operators can't tell whether a 240 s run was bottlenecked by Claude extract, Holo3 inference, Chrome load, or runner overhead. This PR lands the **foundation** that Phase B (#365) surfaces on the result envelope and Phase C (#366) aggregates across runs.

## What ships

- **`src/mantis_agent/gym/time_meter.py`** — `TimeMeter` dataclass sibling to `CostMeter`, with the documented 9-bucket vocabulary (`perceive` / `think` / `act` / `settle` / `claude_ground` / `claude_extract` / `claude_verify` / `load` / `overhead`). Owns `totals` + `per_step` + a `measure()` context manager.
- **`STEP_LATENCY_SECONDS`** — declared in `metrics.py` since #156 but never observed. Now fires on every `measure()` exit, labelled by `(tenant_id, phase)`. Tenant-less local runs skip emission so the registry doesn't accumulate a default-label series.
- **`MicroPlanRunner.time_meter`** — owned per run, lifecycle identical to `cost_meter`.
- **`run_executor._dispatch_step`** wraps the call to `_execute_step` in `measure("act")` and the post-step screenshot capture in `measure("perceive")`. Both attribute to the current `step_idx` so Phase B (#365) can surface per-step breakdowns.
- **`breakdown()`** fills `overhead` as the residual against `elapsed_seconds()` so unwrapped orchestration time is visible without wrapping every dispatch helper.

## What's intentionally deferred (still under #363's umbrella)

Wiring for `think` / `settle` / `claude_ground` / `claude_extract` / `claude_verify` / `load`. Each lives behind a different choke point — `brain.think`, `adaptive_settle.*`, `ClaudeGrounding/Extractor/Verifier`, `navigate` handler — and warrants its own focused PR rather than a single sprawling diff. The framework here is ready: drop a `with meter.measure("...")` block at each site. Filing a follow-up issue for the remaining wiring.

## Why scope it this way

The issue acceptance asks for all 9 wire-ins. I chose to ship the foundation + 2 buckets in one reviewable PR rather than touch every step handler / brain / claude module simultaneously. The TimeMeter API is the contract; each remaining wire-in is mechanical and independently verifiable.

## Public surface changes

- New module: `mantis_agent.gym.time_meter` (`TimeMeter`, `BUCKETS`).
- New attribute: `MicroPlanRunner.time_meter` (additive, no breakage).
- `STEP_LATENCY_SECONDS` widens its `phase` label vocabulary from 4 buckets to 9. Existing dashboards that filter by `phase` will see new buckets appear; the four-bucket queries continue to work.
- Docs (`docs/operations/metrics.md`) updated to reflect the widened vocabulary.

## Test plan

- [x] `pytest tests/test_time_meter.py` — 17 unit tests: context manager, per-step accounting, `overhead` residual, Prom emission incl. best-effort failure handling, bucket-vocabulary stability.
- [x] `pytest tests/test_micro_runner_hooks.py` — two integration tests: fake-plan run charges `act` and `perceive` both in `totals` and `per_step`; `breakdown()` lands a non-negative `overhead`.
- [x] `pytest tests/test_run_executor.py tests/test_microrunner_som_dispatch.py tests/test_context_budget_skip_envelope.py tests/test_nav_halt_skip_envelope.py tests/test_checkpoint_manager.py tests/test_form_intents.py tests/test_brain_mock.py tests/test_micro_runner_seed.py` — 125 passed, no regressions in adjacent surfaces.
- [x] `mkdocs build --strict` clean.
- [x] `ruff check` clean.

Part of epic #362.

🤖 Generated with [Claude Code](https://claude.com/claude-code)