### PR TITLE
feat(time-meter): surface wall_time_breakdown on result envelopes (Phase B of #362)

### DIFF
--- a/deploy/modal/modal_plan_runner.py
+++ b/deploy/modal/modal_plan_runner.py
@@ -576,6 +576,11 @@ def run_plan(
     successes = sum(1 for r in step_results if r.success)
     failures = len(step_results) - successes
     final_url = getattr(runner, "_last_known_url", "")
+    time_meter = getattr(runner, "time_meter", None)
+    wall_time_breakdown = (
+        {k: round(v, 3) for k, v in time_meter.breakdown().items()}
+        if time_meter is not None else {}
+    )
 
     return {
         "plan_signature": runner.plan_signature,
@@ -584,9 +589,19 @@ def run_plan(
         "successes": successes,
         "failures": failures,
         "elapsed_seconds": round(elapsed, 2),
+        "wall_time_breakdown": wall_time_breakdown,
         "final_url": final_url,
         "costs": dict(getattr(runner, "costs", {})),
-        "steps": [_pack_step(r) for r in step_results],
+        "steps": [
+            _pack_step(
+                r,
+                time_breakdown=(
+                    time_meter.step_breakdown(r.step_index)
+                    if time_meter is not None else None
+                ),
+            )
+            for r in step_results
+        ],
     }
 
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -138,6 +138,17 @@ Set `action` and `run_id` in the body:
       "gpu":    0.12,
       "claude": 0.12,
       "proxy":  0.18
+    },
+    "wall_time_breakdown": {
+      "perceive":       12.4,
+      "think":          88.1,
+      "act":             6.7,
+      "settle":         32.0,
+      "claude_ground":  18.9,
+      "claude_extract": 71.2,
+      "claude_verify":   4.3,
+      "load":           12.1,
+      "overhead":        1.3
     }
   }
 }
@@ -145,6 +156,36 @@ Set `action` and `run_id` in the body:
 
 `result` returns the full lead list and per-step trace. `logs` returns the
 last `tail` events written by the runner (default 200, max 10000).
+
+### Wall-time breakdown
+
+`summary.wall_time_breakdown` (epic [#362](https://github.com/mercurialsolo/mantis/issues/362)) reports where wall-clock seconds went, alongside the existing `cost_breakdown` for dollars. Both come from the runner — `cost_breakdown` is owned by `CostMeter`, `wall_time_breakdown` by `TimeMeter`.
+
+Each terminal `summary` carries the same nine buckets. `step_details[i].time_breakdown` (same shape, scoped to one step) lets you pinpoint *which* step dominated a bucket — e.g. one extract step consuming 65 s of `claude_extract`.
+
+| Bucket | What lands here |
+|---|---|
+| `perceive` | `env.screenshot()` capture, viewport sync. |
+| `think` | Brain inference — Holo3 / Gemma4 / Claude action emission. |
+| `act` | `env.step(action)` — xdotool keystroke / mouse / scroll, CDP click. |
+| `settle` | Post-action wait (fixed or adaptive); page-render quiescence. |
+| `claude_ground` | `ClaudeGrounding.refine_*` coordinate refinement on grounded steps. |
+| `claude_extract` | `ClaudeExtractor.find_*` extraction calls. |
+| `claude_verify` | Gate verification, `DynamicPlanVerifier` checks. |
+| `load` | `env.reset(url)` page-load + Cloudflare wait + proxy CONNECT. |
+| `overhead` | Residual — runner orchestration, retry loops, dispatch, anything not above. |
+
+Sum of the buckets tracks `total_time_s` within ±5 %; the residual lives in `overhead`. The mantis Python client exposes a typed accessor:
+
+```python
+status = client.status(run_id)
+bd = status.wall_time_breakdown()  # {} on pre-terminal runs
+if bd:
+    largest = max(bd, key=bd.get)
+    print(f"largest bucket: {largest} ({bd[largest]:.1f}s)")
+```
+
+Pre-Phase-B summaries omit the `wall_time_breakdown` key entirely; the accessor returns `{}` so existing client code keeps working.
 
 ### Errors
 

--- a/src/mantis_agent/api_schemas.py
+++ b/src/mantis_agent/api_schemas.py
@@ -344,7 +344,19 @@ class DetachedRunHandle(BaseModel):
 
 
 class RunStatus(BaseModel):
-    """Detached-run status snapshot."""
+    """Detached-run status snapshot.
+
+    ``summary`` carries the result envelope from :func:`build_micro_result`
+    on terminal runs. Notable keys (epic #362 Phase B):
+
+    * ``wall_time_breakdown: {bucket: seconds}`` — aggregate per-bucket
+      wall time. Buckets are the 9-vocabulary from
+      :mod:`~mantis_agent.gym.time_meter` (perceive / think / act /
+      settle / claude_ground / claude_extract / claude_verify / load /
+      overhead). Sum approximates ``total_time_s`` within ±5%.
+    * ``step_details[i].time_breakdown`` — same shape, scoped to one
+      step. Use to find the step that dominates a given bucket.
+    """
 
     model_config = {"extra": "allow"}
 
@@ -364,3 +376,14 @@ class RunStatus(BaseModel):
     prompt: Optional[str] = None
     reason: Optional[str] = None
     pause_state: Optional[dict[str, Any]] = None
+
+    def wall_time_breakdown(self) -> dict[str, float]:
+        """Return the aggregate ``wall_time_breakdown`` dict from
+        ``summary`` if present, else an empty dict. Epic #362 Phase B.
+
+        Convenience accessor so client code doesn't have to defensively
+        index into ``summary`` (which is ``None`` on pre-terminal runs).
+        """
+        summary = self.summary or {}
+        bd = summary.get("wall_time_breakdown") or {}
+        return {str(k): float(v) for k, v in bd.items()} if isinstance(bd, dict) else {}

--- a/src/mantis_agent/cli.py
+++ b/src/mantis_agent/cli.py
@@ -972,6 +972,11 @@ def cmd_plan_run(args: argparse.Namespace) -> int:
     failures = len(step_results) - successes
     final_url = getattr(runner, "_last_known_url", "")
     from .gym.result_payload import pack_step
+    time_meter = getattr(runner, "time_meter", None)
+    wall_time_breakdown = (
+        {k: round(v, 3) for k, v in time_meter.breakdown().items()}
+        if time_meter is not None else {}
+    )
     result_payload = {
         "plan_signature": runner.plan_signature,
         "session": session_name,
@@ -981,9 +986,19 @@ def cmd_plan_run(args: argparse.Namespace) -> int:
         "successes": successes,
         "failures": failures,
         "elapsed_seconds": round(elapsed, 2),
+        "wall_time_breakdown": wall_time_breakdown,
         "final_url": final_url,
         "costs": dict(getattr(runner, "costs", {})),
-        "steps": [pack_step(r) for r in step_results],
+        "steps": [
+            pack_step(
+                r,
+                time_breakdown=(
+                    time_meter.step_breakdown(r.step_index)
+                    if time_meter is not None else None
+                ),
+            )
+            for r in step_results
+        ],
     }
     if grading_dict is not None:
         # Additive — RunReport surface in result.json gains the oracle

--- a/src/mantis_agent/gym/result_payload.py
+++ b/src/mantis_agent/gym/result_payload.py
@@ -40,7 +40,7 @@ def _as_str(value: Any, default: str = "") -> str:
     return value if isinstance(value, str) else default
 
 
-def pack_step(r: Any) -> dict:
+def pack_step(r: Any, *, time_breakdown: dict[str, float] | None = None) -> dict:
     payload = {
         "index": r.step_index,
         "intent": r.intent,
@@ -49,6 +49,13 @@ def pack_step(r: Any) -> dict:
         "duration": float(getattr(r, "duration", 0.0)),
         "steps_used": int(getattr(r, "steps_used", 0)),
     }
+
+    # Epic #362 Phase B: per-step wall-time bucket breakdown. Always
+    # present when provided so consumers can iterate buckets without
+    # branching on key existence; callers that don't have a TimeMeter
+    # (legacy hosts, tests) omit the arg and the key stays out.
+    if time_breakdown is not None:
+        payload["time_breakdown"] = {k: round(v, 3) for k, v in time_breakdown.items()}
 
     if payload["success"]:
         return payload

--- a/src/mantis_agent/server_utils.py
+++ b/src/mantis_agent/server_utils.py
@@ -495,6 +495,21 @@ def build_micro_result(
                 executor_backend_counts.get(backend, 0) + 1
             )
 
+    # Epic #362 Phase B: surface the TimeMeter's bucket breakdown
+    # on the result envelope. ``wall_time_breakdown`` is the aggregate
+    # 9-bucket dict; ``step_details[i].time_breakdown`` is the same
+    # shape scoped to one step. Both are always-present additive
+    # keys — runners without a TimeMeter (pre-Phase-A or test
+    # harnesses) yield all-zero dicts rather than missing keys, so
+    # consumers can branch on bucket presence rather than key
+    # existence.
+    time_meter = getattr(runner, "time_meter", None)
+    if time_meter is not None:
+        wall_time_breakdown = {k: round(v, 3) for k, v in time_meter.breakdown().items()}
+    else:
+        from .gym.time_meter import BUCKETS as _BUCKETS
+        wall_time_breakdown = {b: 0.0 for b in _BUCKETS}
+
     return {
         "run_id": run_id,
         "provider": provider,
@@ -502,6 +517,7 @@ def build_micro_result(
         "model": model_name,
         "mode": "micro_intent",
         "total_time_s": round(elapsed_seconds),
+        "wall_time_breakdown": wall_time_breakdown,
         "steps_executed": len(step_results),
         "viable": len(leads),
         "leads_with_phone": sum(1 for lead in leads if runner._lead_has_phone(lead)),
@@ -524,10 +540,24 @@ def build_micro_result(
                 "steps": r.steps_used,
                 "data": r.data[:300] if r.data else "",
                 "executor_backend": getattr(r, "executor_backend", "") or "",
+                "time_breakdown": _step_time_breakdown(time_meter, r.step_index),
             }
             for r in step_results
         ],
     }
+
+
+def _step_time_breakdown(time_meter: Any, step_index: int) -> dict[str, float]:
+    """Return the per-step bucket dict, rounded for JSON friendliness.
+
+    Falls back to an all-zeros bucket dict when ``time_meter`` is None
+    or the step was never measured — keeps the schema stable across
+    callers that haven't adopted the TimeMeter yet.
+    """
+    if time_meter is None:
+        from .gym.time_meter import BUCKETS as _BUCKETS
+        return {b: 0.0 for b in _BUCKETS}
+    return {k: round(v, 3) for k, v in time_meter.step_breakdown(step_index).items()}
 
 
 # Keys to include in a compact result summary (for detached run status etc.)

--- a/tests/test_result_payload.py
+++ b/tests/test_result_payload.py
@@ -103,3 +103,29 @@ def test_success_payload_omits_screenshot_even_if_present() -> None:
     out = pack_step(_success(screenshot_png=b"big-success-png"))
     assert "screenshot_b64" not in out
     assert "failure_class" not in out
+
+
+# ── Epic #362 Phase B: per-step time_breakdown ──────────────────────────
+
+
+def test_time_breakdown_landed_when_provided() -> None:
+    """Successful step + a TimeMeter breakdown dict → the payload
+    surfaces ``time_breakdown`` rounded to 3dp."""
+    bd = {"act": 1.2345, "think": 2.5}
+    out = pack_step(_success(), time_breakdown=bd)
+    assert out["time_breakdown"] == {"act": 1.234, "think": 2.5}
+
+
+def test_time_breakdown_omitted_when_caller_passes_none() -> None:
+    """Legacy callers that don't have a TimeMeter must not see a
+    ``time_breakdown`` key — keeps pack_step backward-compatible."""
+    out = pack_step(_success())
+    assert "time_breakdown" not in out
+
+
+def test_time_breakdown_present_on_failed_payloads() -> None:
+    bd = {"act": 0.5, "settle": 1.0}
+    out = pack_step(_failure(), time_breakdown=bd)
+    assert out["time_breakdown"] == {"act": 0.5, "settle": 1.0}
+    # Failure diagnostics still land alongside.
+    assert out["failure_class"] == "selector_miss"

--- a/tests/test_run_status_wall_time.py
+++ b/tests/test_run_status_wall_time.py
@@ -1,0 +1,65 @@
+"""``RunStatus.wall_time_breakdown()`` — convenience accessor for the
+epic #362 Phase B surface.
+
+Client code shouldn't have to defensively dereference
+``status.summary["wall_time_breakdown"]`` — the accessor returns
+``{}`` on pre-terminal runs (no summary) or on summaries that pre-date
+Phase B, and a typed dict otherwise.
+"""
+
+from __future__ import annotations
+
+from mantis_agent.api_schemas import RunStatus
+
+
+def test_returns_empty_dict_when_no_summary() -> None:
+    """Pre-terminal runs land here — ``summary`` is ``None`` until the
+    runner writes the result envelope."""
+    status = RunStatus(status="running", run_id="r1")
+    assert status.wall_time_breakdown() == {}
+
+
+def test_returns_empty_dict_when_summary_omits_key() -> None:
+    """Pre-Phase-B summaries (or hosts that skipped the field) yield
+    ``{}`` — caller can branch on truthiness without a KeyError."""
+    status = RunStatus(
+        status="succeeded", run_id="r1",
+        summary={"total_time_s": 30, "steps_executed": 5},
+    )
+    assert status.wall_time_breakdown() == {}
+
+
+def test_returns_typed_dict_when_breakdown_present() -> None:
+    status = RunStatus(
+        status="succeeded", run_id="r1",
+        summary={
+            "total_time_s": 100,
+            "wall_time_breakdown": {
+                "think": 40.5, "act": 5.0, "settle": 14.5, "overhead": 40.0,
+            },
+        },
+    )
+    bd = status.wall_time_breakdown()
+    assert bd == {"think": 40.5, "act": 5.0, "settle": 14.5, "overhead": 40.0}
+    # Values are floats — callers can do arithmetic without coercing.
+    assert all(isinstance(v, float) for v in bd.values())
+
+
+def test_coerces_int_seconds_to_float() -> None:
+    """JSON over the wire may yield int seconds; accessor normalizes."""
+    status = RunStatus(
+        status="succeeded", run_id="r1",
+        summary={"wall_time_breakdown": {"think": 40, "act": 5}},
+    )
+    bd = status.wall_time_breakdown()
+    assert bd == {"think": 40.0, "act": 5.0}
+
+
+def test_handles_non_dict_breakdown_defensively() -> None:
+    """A misshapen summary (string / list under the key) must not
+    raise — the accessor falls back to ``{}``."""
+    status = RunStatus(
+        status="succeeded", run_id="r1",
+        summary={"wall_time_breakdown": "not a dict"},
+    )
+    assert status.wall_time_breakdown() == {}

--- a/tests/test_server_utils.py
+++ b/tests/test_server_utils.py
@@ -324,6 +324,94 @@ def test_build_micro_result_same_output_for_both_providers():
     assert modal_result["dynamic_verification"] == baseten_result["dynamic_verification"]
 
 
+def test_build_micro_result_includes_wall_time_breakdown_when_meter_present():
+    """Epic #362 Phase B: a runner with a populated TimeMeter must
+    surface the aggregate breakdown + per-step breakdown on the
+    result envelope."""
+    from mantis_agent.gym.time_meter import BUCKETS, TimeMeter
+
+    meter = TimeMeter()
+    # Stage known timings: 2s think on step 0, 0.5s act on step 1.
+    meter.record("think", 2.0, step_idx=0)
+    meter.record("act", 0.5, step_idx=1)
+
+    runner = FakeMicroRunner()
+    runner.time_meter = meter
+    steps = [
+        FakeStepResult(0, "Decide what to do", True),
+        FakeStepResult(1, "Click submit", True),
+    ]
+    result = build_micro_result(
+        runner, steps,
+        run_id="run1", provider="modal", session_name="s", model_name="M",
+        elapsed_seconds=3.0,
+    )
+
+    # Aggregate dict carries every bucket from the vocabulary.
+    wt = result["wall_time_breakdown"]
+    assert set(wt) == set(BUCKETS)
+    assert wt["think"] == 2.0
+    assert wt["act"] == 0.5
+    # overhead is the residual against elapsed_seconds — non-negative,
+    # ≤ elapsed.
+    assert wt["overhead"] >= 0.0
+
+    # Per-step breakdowns route to the right step.
+    assert result["step_details"][0]["time_breakdown"]["think"] == 2.0
+    assert result["step_details"][0]["time_breakdown"]["act"] == 0.0
+    assert result["step_details"][1]["time_breakdown"]["act"] == 0.5
+    assert result["step_details"][1]["time_breakdown"]["think"] == 0.0
+
+
+def test_build_micro_result_falls_back_to_zeros_without_time_meter():
+    """Pre-Phase-A runners (or test harnesses) shouldn't break the
+    envelope shape — buckets land as zeros, every key still present."""
+    from mantis_agent.gym.time_meter import BUCKETS
+
+    runner = FakeMicroRunner()
+    # No `time_meter` attribute on this runner.
+    steps = [FakeStepResult(0, "nav", True)]
+    result = build_micro_result(
+        runner, steps,
+        run_id="run1", provider="modal", session_name="s", model_name="M",
+        elapsed_seconds=10.0,
+    )
+    assert "wall_time_breakdown" in result
+    assert set(result["wall_time_breakdown"]) == set(BUCKETS)
+    assert all(v == 0.0 for v in result["wall_time_breakdown"].values())
+    # Per-step zeros too.
+    assert result["step_details"][0]["time_breakdown"]["act"] == 0.0
+
+
+def test_build_micro_result_bucket_sum_approximates_total_time():
+    """Sum of bucket times should track total_time_s within ±5% on a
+    realistic run — captures regressions where overhead drifts wildly."""
+    from mantis_agent.gym.time_meter import TimeMeter
+
+    meter = TimeMeter()
+    # Allocate 100s split across plausible buckets.
+    meter.record("think", 40.0, step_idx=0)
+    meter.record("claude_extract", 30.0, step_idx=0)
+    meter.record("act", 5.0, step_idx=0)
+    meter.record("settle", 15.0, step_idx=0)
+    meter.record("perceive", 8.0, step_idx=0)
+    # ~2s residual lands in overhead via breakdown().
+
+    runner = FakeMicroRunner()
+    runner.time_meter = meter
+    steps = [FakeStepResult(0, "do work", True)]
+    result = build_micro_result(
+        runner, steps,
+        run_id="r", provider="modal", session_name="s", model_name="M",
+        elapsed_seconds=100.0,
+    )
+    bucket_sum = sum(result["wall_time_breakdown"].values())
+    # Both numbers are seconds; total_time_s is round(elapsed).
+    # On a synthetic run with no real wall-clock pressure, the
+    # sum + elapsed agree closely; ±5% gives generous slack.
+    assert abs(bucket_sum - result["total_time_s"]) <= max(0.05 * result["total_time_s"], 1.0)
+
+
 def test_plan_signature_deterministic():
     steps = [{"intent": "click button", "type": "click", "budget": 5}]
     sig1 = plan_signature_from_steps(steps)


### PR DESCRIPTION
## Summary

Phase B of epic #362 — lifts the TimeMeter from #367 onto every `/v1/predict` result envelope so integrators can see where the seconds went without scraping logs. Sibling to the existing `cost_breakdown`: dollars and seconds, side by side.

## What ships

- **`server_utils.py:build_micro_result`** returns:
  - `wall_time_breakdown` — aggregate 9-bucket dict on the top-level summary.
  - `step_details[i].time_breakdown` — same shape, scoped to one step. Use to pinpoint *which* step dominated a bucket.
  - Runners without a TimeMeter (legacy hosts / tests) yield **all-zero** dicts instead of missing keys, so consumers iterate buckets without branching on key existence.
- **`gym/result_payload.py:pack_step`** gains a `time_breakdown` kwarg. Threaded only when the caller has a meter; default behavior unchanged for legacy callers (key omitted, no schema break).
- **`cli.py` (`mantis plan run`) + `deploy/modal/modal_plan_runner.py` (`mantis plan run-modal`)** — both result-build paths thread `runner.time_meter` into `pack_step` and add `wall_time_breakdown` at the top level. Same shape across the three transports (local CLI / Modal direct / `/v1/predict`).
- **`api_schemas.py:RunStatus`** — docstring documents the new key. New `status.wall_time_breakdown()` accessor returns `{}` on pre-terminal or pre-Phase-B summaries and a typed `dict[str, float]` otherwise — client code stays defensive-free.

## Public surface changes

- `summary.wall_time_breakdown` and `summary.step_details[i].time_breakdown` are **additive**. Pre-Phase-B summaries (or hosts that haven't bumped) keep producing the old shape; consumers can branch on truthiness of the new key.
- `RunStatus.wall_time_breakdown()` is a new method, no behavioral change to existing fields.

## Test plan

- [x] `pytest tests/test_server_utils.py` — three new cases: meter populated yields buckets + per-step breakdowns; missing meter falls back to zeros; bucket sum tracks `total_time_s` within ±5 %.
- [x] `pytest tests/test_result_payload.py` — three new cases: `time_breakdown` lands on success + failure payloads, rounded to 3dp; omitted when not provided (back-compat).
- [x] `pytest tests/test_run_status_wall_time.py` (new) — five cases on the client accessor: empty on no-summary / no-key, typed dict on present, int → float coercion, defensive against non-dict values.
- [x] Adjacent surfaces clean: `pytest tests/test_cli_plan_run.py tests/test_cli_plan_run_modal.py tests/test_run_executor.py tests/test_micro_runner_hooks.py tests/test_checkpoint_manager.py` → 114 passed.
- [x] `mkdocs build --strict` clean.
- [x] `ruff check` clean.

## What's next

Phase C (#366) — durable JSONL per-run store + `mantis runs stats` CLI — is unblocked once this lands. The bucket data flowing through `summary.wall_time_breakdown` is the row schema Phase C consumes.

**Useful caveat:** Phase A wired `act` + `perceive` only (see #367 PR notes). With only those two buckets emitting non-zero, the `overhead` residual will dominate the breakdown in real runs until follow-up issues wire the remaining six (`think` / `settle` / `claude_ground` / `claude_extract` / `claude_verify` / `load`). The envelope schema lands here; the breakdown sharpens as the wire-ins come in.

Closes #365. Part of epic #362.

🤖 Generated with [Claude Code](https://claude.com/claude-code)