### PR TITLE
feat(time-meter): wire load + settle buckets via dispatch context (epic #362)

### DIFF
--- a/src/mantis_agent/gym/adaptive_settle.py
+++ b/src/mantis_agent/gym/adaptive_settle.py
@@ -138,14 +138,19 @@ def settle_after_action(
     if not is_enabled() or max_seconds <= 0:
         if max_seconds > 0:
             time.sleep(max_seconds)
-        return max_seconds if max_seconds > 0 else 0.0
+        elapsed = max_seconds if max_seconds > 0 else 0.0
+        _credit_settle(elapsed)
+        return elapsed
     capture = getattr(env, "_screenshot", None) or getattr(env, "screenshot", None)
     if not callable(capture):
         time.sleep(max_seconds)
+        _credit_settle(max_seconds)
         return max_seconds
-    return wait_until_stable(
+    elapsed = wait_until_stable(
         capture, max_seconds=max_seconds, poll_interval=poll_interval,
     )
+    _credit_settle(elapsed)
+    return elapsed
 
 
 def wait_for_networkidle(
@@ -165,7 +170,9 @@ def wait_for_networkidle(
     start = time.monotonic()
     if page is None:
         time.sleep(max_seconds)
-        return time.monotonic() - start
+        elapsed = time.monotonic() - start
+        _credit_settle(elapsed)
+        return elapsed
     try:
         page.wait_for_load_state(
             "networkidle", timeout=int(max_seconds * 1000),
@@ -175,4 +182,20 @@ def wait_for_networkidle(
         remaining = max_seconds - (time.monotonic() - start)
         if remaining > 0:
             time.sleep(remaining)
-    return time.monotonic() - start
+    elapsed = time.monotonic() - start
+    _credit_settle(elapsed)
+    return elapsed
+
+
+def _credit_settle(elapsed: float) -> None:
+    """Best-effort: credit the ``settle`` bucket on the runner's
+    TimeMeter (epic #362). No-op when no dispatch context is published
+    or the import fails — bookkeeping must not break the runtime.
+    """
+    if elapsed <= 0:
+        return
+    try:
+        from . import time_meter as _tm
+        _tm.record_to_current("settle", elapsed)
+    except Exception as exc:  # noqa: BLE001 — observability, never fatal
+        logger.debug("adaptive-settle: time_meter credit failed: %s", exc)

--- a/src/mantis_agent/gym/run_executor.py
+++ b/src/mantis_agent/gym/run_executor.py
@@ -338,12 +338,23 @@ class RunExecutor:
         pre_snapshot = step_snapshot.capture(runner)
         runner._pre_step_snapshot = pre_snapshot
         meter = getattr(runner, "time_meter", None)
+        # Publish the dispatch context so deep helpers (adaptive_settle,
+        # navigate, the inner GymRunner used by Holo3StepHandler, ...)
+        # can record into the same TimeMeter without being passed it as
+        # a kwarg. Outer ``measure("act", ...)`` is the coarse dispatch
+        # bucket; sub-bucket records (``settle``, ``load``, ...) made
+        # via :func:`time_meter.record_to_current` from inside the
+        # dispatch land on the same per-step slot. Buckets can overlap
+        # — ``breakdown()`` floors the ``overhead`` residual at zero so
+        # consumers see useful per-bucket totals either way.
+        from . import time_meter as _tm
         try:
-            if meter is not None:
-                with meter.measure("act", step_idx=state.step_index):
+            with _tm.publish_dispatch(meter, state.step_index):
+                if meter is not None:
+                    with meter.measure("act", step_idx=state.step_index):
+                        step_result = runner._execute_step(effective_step, state.step_index)
+                else:
                     step_result = runner._execute_step(effective_step, state.step_index)
-            else:
-                step_result = runner._execute_step(effective_step, state.step_index)
         finally:
             runner._active_checkpoint_context = None
         if step_result.screenshot_png is None:

--- a/src/mantis_agent/gym/step_handlers/navigate.py
+++ b/src/mantis_agent/gym/step_handlers/navigate.py
@@ -104,7 +104,19 @@ class NavigateHandler:
         runner = self.parent
 
         try:
-            env.reset(task="navigate", start_url=url)
+            # Epic #362: time the page-load (network + Cloudflare + first
+            # paint) under the ``load`` bucket. ``settle_after_action``
+            # below records its own ``settle`` time via the dispatch
+            # context — separated here so a slow proxy / CF stall is
+            # distinguishable from a slow JS framework warming up.
+            import time as _time_mod
+            _load_t0 = _time_mod.monotonic()
+            try:
+                env.reset(task="navigate", start_url=url)
+            finally:
+                _load_elapsed = _time_mod.monotonic() - _load_t0
+                from .. import time_meter as _tm
+                _tm.record_to_current("load", _load_elapsed)
             # Wait for Cloudflare challenge to auto-solve + page render.
             # #294: cap at the configured budget (default 18s); exit early
             # when the frame hash stabilises — most sites finish first

--- a/src/mantis_agent/gym/time_meter.py
+++ b/src/mantis_agent/gym/time_meter.py
@@ -29,6 +29,7 @@ series into the registry.
 
 from __future__ import annotations
 
+import contextvars
 import logging
 import time
 from contextlib import contextmanager
@@ -188,4 +189,67 @@ class TimeMeter:
             logger.debug("STEP_LATENCY_SECONDS emit failed (bucket=%s): %s", bucket, exc)
 
 
-__all__ = ["BUCKETS", "TimeMeter"]
+# ── Dispatch context (contextvars) ──────────────────────────────────────
+
+
+# Published by the executor for the duration of a step dispatch so deep
+# helpers (adaptive_settle, brain wrappers, Claude callers) can record
+# into the runner's TimeMeter without having to be passed it as an
+# argument. The contract is (meter, step_idx) — both required so the
+# helper can route to the right per-step bucket.
+#
+# PEP 567 contextvars make this scope-correct for asyncio + threaded
+# callers (each task / thread sees its own publication; reset() rolls
+# back deterministically on context exit). The previous PR threaded
+# the meter through call-site arguments; this is the equivalent
+# without touching every adaptive_settle.* invocation.
+_CURRENT_DISPATCH: contextvars.ContextVar[
+    "tuple[TimeMeter, int | None] | None"
+] = contextvars.ContextVar("mantis_time_meter_dispatch", default=None)
+
+
+def current_dispatch() -> "tuple[TimeMeter, int | None] | None":
+    """Return ``(meter, step_idx)`` if a runner has published a dispatch
+    context, else ``None``. Helpers that opportunistically time
+    themselves should bail out cleanly when this returns ``None``.
+    """
+    return _CURRENT_DISPATCH.get()
+
+
+@contextmanager
+def publish_dispatch(
+    meter: "TimeMeter | None", step_idx: int | None,
+) -> Iterator[None]:
+    """Publish ``(meter, step_idx)`` for the wrapped block.
+
+    ``meter=None`` clears the context — useful in tests that exercise
+    helpers in isolation. Always resets on exit, including on
+    exceptions, so a crashed dispatch can't leak context into the
+    next one.
+    """
+    token = _CURRENT_DISPATCH.set((meter, step_idx) if meter is not None else None)
+    try:
+        yield
+    finally:
+        _CURRENT_DISPATCH.reset(token)
+
+
+def record_to_current(bucket: str, seconds: float) -> None:
+    """Credit ``seconds`` to ``bucket`` on the currently-published meter.
+
+    No-op when no dispatch context is published (e.g., script runs,
+    standalone helper tests). Helpers call this instead of demanding
+    the meter as an arg — keeps their public signature free of
+    bookkeeping plumbing.
+    """
+    pub = _CURRENT_DISPATCH.get()
+    if pub is None:
+        return
+    meter, step_idx = pub
+    meter.record(bucket, seconds, step_idx=step_idx)
+
+
+__all__ = [
+    "BUCKETS", "TimeMeter",
+    "current_dispatch", "publish_dispatch", "record_to_current",
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,11 @@ _SETTLE_TEST_FILES: frozenset[str] = frozenset({
     "test_adaptive_settle.py",
     "test_adaptive_content_settle.py",
     "test_adaptive_settle_end_to_end_budget.py",
+    # Epic #362: TimeMeter tests need the real adaptive_settle to verify
+    # the dispatch-context credit path. None of the existing TimeMeter
+    # cases trigger a real wait (they call adaptive_settle directly
+    # with tiny budgets), so the suite stays fast.
+    "test_time_meter.py",
 })
 
 

--- a/tests/test_micro_runner_hooks.py
+++ b/tests/test_micro_runner_hooks.py
@@ -158,6 +158,28 @@ def test_time_meter_records_act_and_perceive_per_step():
         assert bd["perceive"] > 0.0, f"step {i} did not charge 'perceive'"
 
 
+def test_time_meter_records_load_via_navigate_handler():
+    """Phase A wire-ins (epic #362): the navigate step handler wraps
+    ``env.reset`` in the ``load`` bucket — credited via the dispatch
+    context published by the executor.
+
+    ``settle`` is intentionally NOT asserted here: the broad test suite
+    stubs ``adaptive_settle.*`` to instant-return via the autouse
+    fixture in ``conftest.py`` for speed. The settle → dispatch credit
+    path is verified directly in ``test_time_meter.py``."""
+    env = _FakeEnv()
+    r = _runner(env)
+    r.run(_trivial_plan())
+
+    meter = r.time_meter
+    assert meter.totals["load"] > 0.0, (
+        "navigate handler should record env.reset time to the load bucket"
+    )
+    # The dispatch publisher routes deep-helper records to the active
+    # step_idx — verify per-step rather than just the aggregate.
+    assert any(rec["load"] > 0.0 for rec in meter.per_step)
+
+
 def test_time_meter_breakdown_fills_overhead_residual():
     """``breakdown()`` should account for time not wrapped in any
     ``measure()`` block as ``overhead`` so the dict sums close to

--- a/tests/test_time_meter.py
+++ b/tests/test_time_meter.py
@@ -11,7 +11,13 @@ from unittest.mock import patch
 
 import pytest
 
-from mantis_agent.gym.time_meter import BUCKETS, TimeMeter
+from mantis_agent.gym.time_meter import (
+    BUCKETS,
+    TimeMeter,
+    current_dispatch,
+    publish_dispatch,
+    record_to_current,
+)
 
 
 # ── BUCKETS vocabulary ──────────────────────────────────────────────────
@@ -193,3 +199,104 @@ def test_prometheus_emit_is_best_effort() -> None:
             time.sleep(0.001)
     # Despite the metric failure, totals still updated.
     assert meter.totals["act"] >= 0.001
+
+
+# ── Dispatch context (contextvars) ──────────────────────────────────────
+
+
+def test_current_dispatch_is_none_by_default() -> None:
+    assert current_dispatch() is None
+
+
+def test_publish_dispatch_routes_record_to_current_meter() -> None:
+    """Deep helpers call ``record_to_current(bucket, seconds)``; the
+    contextvar-published meter receives the credit on the right step."""
+    meter = TimeMeter()
+    with publish_dispatch(meter, step_idx=2):
+        record_to_current("settle", 1.5)
+        record_to_current("load", 0.5)
+    assert meter.totals["settle"] == 1.5
+    assert meter.totals["load"] == 0.5
+    assert meter.per_step[2]["settle"] == 1.5
+    assert meter.per_step[2]["load"] == 0.5
+
+
+def test_publish_dispatch_resets_on_exit() -> None:
+    """Context must clear after the ``with`` block — no leakage into
+    later helpers running outside any step."""
+    meter = TimeMeter()
+    with publish_dispatch(meter, step_idx=0):
+        assert current_dispatch() == (meter, 0)
+    assert current_dispatch() is None
+
+
+def test_publish_dispatch_resets_on_exception() -> None:
+    """A crashing step must NOT leave the contextvar pointing at a
+    stale meter — the next runner would silently inherit it."""
+    meter = TimeMeter()
+    with pytest.raises(RuntimeError):
+        with publish_dispatch(meter, step_idx=0):
+            raise RuntimeError("synthetic")
+    assert current_dispatch() is None
+
+
+def test_record_to_current_is_noop_outside_dispatch() -> None:
+    """Helpers invoked outside any dispatch (script mode, tests) must
+    not raise — they silently skip recording."""
+    # No exception, no state change.
+    record_to_current("settle", 2.0)
+
+
+def test_publish_dispatch_with_none_meter_clears_context() -> None:
+    """Tests sometimes want to verify a helper bails out cleanly when
+    no meter is published — ``publish_dispatch(None, ...)`` makes that
+    inline-testable."""
+    real_meter = TimeMeter()
+    with publish_dispatch(real_meter, 0):
+        with publish_dispatch(None, 0):
+            record_to_current("settle", 1.0)
+        # Outer context restored after inner exits.
+        assert current_dispatch() == (real_meter, 0)
+    # The recording inside the inner block (None meter) should have
+    # been a no-op.
+    assert real_meter.totals["settle"] == 0.0
+
+
+# ── adaptive_settle integration ─────────────────────────────────────────
+
+
+def test_adaptive_settle_credits_settle_bucket_via_dispatch() -> None:
+    """The real ``settle_after_action`` should record its elapsed wait
+    into the ``settle`` bucket on whichever meter the executor has
+    published — zero call-site changes in step handlers."""
+    from PIL import Image
+
+    from mantis_agent.gym import adaptive_settle
+
+    class _Env:
+        def screenshot(self) -> Image.Image:
+            return Image.new("RGB", (32, 32), "white")
+
+    meter = TimeMeter()
+    with publish_dispatch(meter, step_idx=4):
+        elapsed = adaptive_settle.settle_after_action(_Env(), max_seconds=0.5)
+
+    assert elapsed > 0.0
+    assert meter.totals["settle"] == pytest.approx(elapsed, rel=0.01)
+    assert meter.per_step[4]["settle"] == pytest.approx(elapsed, rel=0.01)
+
+
+def test_adaptive_settle_is_silent_outside_dispatch() -> None:
+    """Without a published dispatch, ``settle_after_action`` still
+    works — it just doesn't credit any meter."""
+    from PIL import Image
+
+    from mantis_agent.gym import adaptive_settle
+
+    class _Env:
+        def screenshot(self) -> Image.Image:
+            return Image.new("RGB", (32, 32), "white")
+
+    # No publish_dispatch wrapping → record_to_current is a no-op.
+    elapsed = adaptive_settle.settle_after_action(_Env(), max_seconds=0.3)
+    assert elapsed > 0.0  # The wait still happened, just unrecorded.


### PR DESCRIPTION
## Summary

Follow-up to #367 (Phase A) and #368 (Phase B). With only `act` + `perceive` wired, real-world breakdowns were dominated by `overhead`. This PR wires two more buckets — **`load`** and **`settle`** — using a contextvars-based dispatch publisher that lets deep helpers credit time without being threaded the meter as an argument.

## Design

- **`time_meter`** gains `publish_dispatch(meter, step_idx)` (a contextmanager that sets a PEP-567 contextvar) and `record_to_current(bucket, seconds)` (helpers read the contextvar and credit the active step's meter, or no-op when none is published). Scope-correct for asyncio + threaded callers; resets on exception so a crashed dispatch can't leak context.
- **`run_executor._dispatch_step`** wraps the existing `measure("act")` block in `publish_dispatch(meter, state.step_index)` so every helper invoked during the step sees the same meter + step idx.
- **`adaptive_settle.settle_after_action` / `wait_for_networkidle`** call `record_to_current("settle", elapsed)` at the end. **Zero call-site changes** across the 13 step-handler invocations that use these helpers.
- **`navigate.py`** wraps the `env.reset(...)` call with an explicit `record_to_current("load", elapsed)` so a slow proxy / CF stall is distinguishable from a slow JS framework warming up.

## Honest note on overlap

`act` (outer dispatch-level) currently **double-counts** `settle` and `load` because the sub-buckets fire from inside `_execute_step`. `breakdown()` already floors the `overhead` residual at 0 so the dict stays useful — operators see `settle=8s` clearly even when `act=30s` includes that 8s. A follow-up will narrow `act` to `env.step` calls specifically; the right place is the same PR that introduces a `runner.timed_step` choke point.

## Wire-ins remaining (filed as follow-ups under epic #362)

- **`think`** — needs `GymRunner` threading or contextvar reads inside `brain.think` wrappers. The Holo3StepHandler spins up a fresh `GymRunner` whose internals are where most "think" time lives.
- **`claude_ground` / `claude_extract` / `claude_verify`** — need `ClaudeGrounding` / `ClaudeExtractor` / `DynamicPlanVerifier` to read the dispatch context, same pattern as `adaptive_settle` here.

## Test plan

- [x] `pytest tests/test_time_meter.py` — six new cases on the contextvars surface (default-None state, publish/restore, reset-on-exception, no-op outside dispatch, nested None-meter sentinel) + two integration cases verifying real `adaptive_settle` credits the published meter. Adds `test_time_meter.py` to conftest's `_SETTLE_TEST_FILES` so it opts out of the test-suite-wide `adaptive_settle` stub (none of the cases trigger a real wait, suite stays fast).
- [x] `pytest tests/test_micro_runner_hooks.py` — rewrites the fake-plan integration test to verify `load` lands per step (settle assertion moved to `test_time_meter.py` since the broad suite stubs `adaptive_settle`).
- [x] `pytest tests/test_run_executor.py tests/test_microrunner_som_dispatch.py tests/test_context_budget_skip_envelope.py tests/test_nav_halt_skip_envelope.py tests/test_checkpoint_manager.py tests/test_form_intents.py tests/test_brain_mock.py tests/test_cli_plan_run.py tests/test_cli_plan_run_modal.py tests/test_server_utils.py tests/test_adaptive_settle.py` — 231 passed, no regressions.
- [x] `mkdocs build --strict` clean.
- [x] `ruff check` clean.

Part of epic #362.

🤖 Generated with [Claude Code](https://claude.com/claude-code)