### PR TITLE
feat(runs-log): durable JSONL per-run store + mantis runs stats CLI (Phase C of #362)

### DIFF
--- a/docs/operations/wall-time-aggregation.md
+++ b/docs/operations/wall-time-aggregation.md
@@ -1,0 +1,108 @@
+# Wall-time aggregation
+
+`summary.wall_time_breakdown` (epic [#362](https://github.com/mercurialsolo/mantis/issues/362)) reports where each run's seconds went. This page describes the **durable per-run log** the runtime writes on terminal status and the `mantis runs stats` CLI that aggregates p50/p95/p99 across runs.
+
+The triad it replaces:
+
+- Prometheus is for **live alerting** — cardinality kills it for per-workflow historical analysis.
+- `result.json` is per-run — useful for one post-mortem, not for comparing across a week's worth of runs.
+- The JSONL log + `mantis runs stats` answers "across the last 100 runs of workflow X, what's the p95 latency per bucket, and which bucket regressed since last month."
+
+## Where the log lives
+
+```
+$MANTIS_DATA_DIR/runs_log/<YYYY-MM>.jsonl
+```
+
+Sharded by month so a single file stays bounded over time and old months can be archived independently. Defaults to `/workspace/mantis-data/runs_log/...` on Baseten, `/data/mantis-runs/runs_log/...` on Modal.
+
+The runtime appends **one line per terminal run** (succeeded / failed). Paused runs are not logged — they'll land on the next terminal transition after `action=resume`.
+
+## Row schema
+
+Each line is a JSON object with stable keys. Permissive — extra keys are allowed so future fields don't break readers.
+
+```jsonc
+{
+  "schema_version": 1,
+  "run_id":            "20260513_180527_abc12345",
+  "tenant_id":         "default",
+  "profile_id":        "default__alice-prod",
+  "workflow_id":       "default__marketplace-listings-v1",
+  "plan_signature":    "a1b2c3d4e5f6",
+  "model":             "Hcompany/Holo3-35B-A3B",
+  "status":            "succeeded",          // succeeded | failed
+  "created_at":        "2026-05-13T18:05:27Z",
+  "finished_at":       "2026-05-13T18:09:34Z",
+  "total_time_s":      247,
+  "wall_time_breakdown": { ...9-bucket dict from Phase B... },
+  "cost_breakdown":     { ...same shape as summary.cost_breakdown... },
+  "steps_executed":    12,
+  "viable":             3,
+  "error":              null
+}
+```
+
+## Append semantics
+
+- **Atomic** between concurrent writers on one pod — files opened in append mode get POSIX `O_APPEND` guarantees for small writes, and a JSONL line easily fits under `PIPE_BUF` (4096 B+ on every modern OS). The writer issues one `write()` per row + `fsync` for durability.
+- **Best-effort** — bookkeeping failures (full disk, EIO, …) are logged and swallowed. The runtime never breaks a finishing run because the log couldn't be written.
+- **No external dependency** — pure stdlib. DuckDB / Postgres can replace the query side later when row counts demand it; the writer doesn't need to change.
+
+## Querying with `mantis runs stats`
+
+```
+mantis runs stats <workflow_id> [--last 100] [--bucket NAME ...] [--since 7d] [--status STATUS] [--json]
+```
+
+Default rendering — bucket × percentile table, ordered by `p50` descending so the worst offender lands first:
+
+```
+$ mantis runs stats default__marketplace-listings-v1
+
+Across last 100 succeeded runs of default__marketplace-listings-v1:
+
+bucket                  p50        p95        p99
+──────────────────────────────────────────────────
+think                  92.0s     145.0s     201.0s
+claude_extract         67.0s     128.0s     156.0s
+settle                 28.0s      44.0s      55.0s
+claude_ground          18.0s      31.0s      42.0s
+perceive               11.0s      18.0s      22.0s
+load                   10.0s      19.0s      28.0s
+act                     6.0s       9.0s      12.0s
+claude_verify           4.0s       7.0s       9.0s
+overhead                2.0s       4.0s       5.0s
+──────────────────────────────────────────────────
+total_time_s          238.0s     383.0s     478.0s
+```
+
+### Flags
+
+| Flag | Default | Purpose |
+|---|---|---|
+| `--last N` | `100` | Newest-first cap on rows considered. Truncation is deterministic — most recent terminal runs first. |
+| `--bucket NAME` | — (all) | Restrict to a subset of wall-time buckets. Repeat to select multiple (`--bucket think --bucket claude_extract`). `total_time_s` is always included as the headline aggregate. |
+| `--since 7d` / `24h` / `30m` | — (no bound) | Time-window filter: drops rows whose `finished_at` is older than `now - duration`. Combine with `--last` for a sliding window. |
+| `--status STATUS` | `succeeded` | Filter by terminal status. Pass `--status ''` to include every terminal status (useful for failure-mode analysis). |
+| `--json` | off | Emit a JSON object instead of the table. Field shape: `{workflow_id, run_count, percentiles: {bucket: {p50, p95, p99}}}`. |
+
+### Percentile method
+
+Linear interpolation between the closest ranks — matches numpy's default `linear` method. `p50` of 2 values is their midpoint; `p50` of an odd-length set is the middle element.
+
+## When to use what
+
+- **Live alerting** → Prometheus + Grafana over [`mantis_step_latency_seconds`](metrics.md). Real-time, low cardinality, no per-workflow drill-down.
+- **One run's post-mortem** → `summary.wall_time_breakdown` + `summary.step_details[i].time_breakdown` on the `/v1/predict` `action=result` response. See [HTTP API / Wall-time breakdown](../api.md#wall-time-breakdown).
+- **Cross-run analytics** → `mantis runs stats` over the JSONL log. Workflow-grouped, percentile-based, retained as long as you keep the files.
+
+## When the JSONL outgrows Python
+
+The current query path streams the JSONL with pure Python. It comfortably handles ~100k rows per month. If you need cross-month aggregation over millions of rows, swap the query path for DuckDB or a Postgres copy — the JSONL row schema is stable, so the read-side migration is a one-pass ETL. The writer never needs to change.
+
+## See also
+
+- [HTTP API / Wall-time breakdown](../api.md#wall-time-breakdown) — single-run schema.
+- [Metrics](metrics.md) — Prometheus surface.
+- [Cost model](cost.md) — the existing dollar twin of this seconds-side surface.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -118,6 +118,7 @@ nav:
       - URL allowlist: operations/allowlist.md
       - Metrics: operations/metrics.md
       - Cost model: operations/cost.md
+      - Wall-time aggregation: operations/wall-time-aggregation.md
       - Continual fine-tuning: operations/continual-finetuning.md
       - Model promotion: operations/model-promotion.md
       - Independent grounding: operations/independent-grounding.md

--- a/src/mantis_agent/baseten_server/runtime.py
+++ b/src/mantis_agent/baseten_server/runtime.py
@@ -486,30 +486,75 @@ class BasetenCUARuntime:
                     self._append_detached_event(run_id, "paused")
                     return
                 self._save_detached_result(run_id, result)
+                finished_at = _utc_now()
                 self._write_detached_status(
                     run_id,
                     {
                         "status": "succeeded",
-                        "finished_at": _utc_now(),
+                        "finished_at": finished_at,
                         "summary": self._result_summary(result),
                     },
                 )
                 self._append_detached_event(run_id, "succeeded")
+                self._append_runs_log(
+                    run_id, payload, result,
+                    status="succeeded", finished_at=finished_at,
+                )
         except Exception as exc:
             logger.exception("detached run %s failed", run_id)
+            finished_at = _utc_now()
             self._write_detached_status(
                 run_id,
                 {
                     "status": "failed",
-                    "finished_at": _utc_now(),
+                    "finished_at": finished_at,
                     "error": str(exc),
                     "traceback": traceback.format_exc()[-4000:],
                 },
             )
             self._append_detached_event(run_id, f"failed: {exc}")
+            self._append_runs_log(
+                run_id, payload, result=None,
+                status="failed", finished_at=finished_at, error=str(exc),
+            )
         finally:
             agent_logger.removeHandler(handler)
             handler.close()
+
+    def _append_runs_log(
+        self,
+        run_id: str,
+        payload: dict[str, Any],
+        result: dict[str, Any] | None,
+        *,
+        status: str,
+        finished_at: str,
+        error: str | None = None,
+    ) -> None:
+        """Append a JSONL row to ``$MANTIS_DATA_DIR/runs_log/<YYYY-MM>.jsonl``
+        on terminal status (epic #362 Phase C). Best-effort — bookkeeping
+        I/O must never break a finishing run.
+        """
+        try:
+            from ..runs_log import append_run, row_from_result
+
+            tenant_id = os.environ.get("MANTIS_TENANT_ID", "default")
+            row = row_from_result(
+                run_id=run_id,
+                tenant_id=tenant_id,
+                profile_id=str(payload.get("profile_id") or ""),
+                workflow_id=str(payload.get("workflow_id") or ""),
+                plan_signature=str((result or {}).get("plan_signature") or ""),
+                model=str((result or {}).get("model") or ""),
+                status=status,
+                created_at=str(payload.get("_created_at") or ""),
+                finished_at=finished_at,
+                result=result,
+                error=error,
+            )
+            append_run(row)
+        except Exception as exc:  # noqa: BLE001 — observability, never fatal
+            logger.debug("runs_log: append failed for %s: %s", run_id, exc)
 
     def _save_detached_result(self, run_id: str, result: dict[str, Any]) -> None:
         run_dir = self._run_path(run_id, create=True)

--- a/src/mantis_agent/cli.py
+++ b/src/mantis_agent/cli.py
@@ -1016,6 +1016,103 @@ def cmd_plan_run(args: argparse.Namespace) -> int:
     return EXIT_OK if failures == 0 else EXIT_ERROR
 
 
+def cmd_runs_stats(args: argparse.Namespace) -> int:
+    """``mantis runs stats <workflow_id>`` — render p50/p95/p99 per
+    wall-time bucket across the last N completed runs of a workflow.
+
+    Reads the durable JSONL log written by the runtime on terminal
+    status (epic #362 Phase C). Pure local query — no network, no
+    server roundtrip. Renders a fixed-width table by default; pass
+    ``--json`` to feed downstream tooling.
+    """
+    from .runs_log import stats
+
+    since = _parse_since(args.since) if args.since else None
+    if args.since and since is None:
+        print(
+            f"error: --since {args.since!r} must look like '7d' / '24h' / '30m'",
+            file=sys.stderr,
+        )
+        return EXIT_ERROR
+
+    result = stats(
+        args.workflow_id,
+        last_n=int(args.last),
+        since=since,
+        buckets=list(args.bucket) if args.bucket else None,
+        status_filter=args.status,
+    )
+
+    if args.json:
+        payload = {
+            "workflow_id": result.workflow_id,
+            "run_count": result.run_count,
+            "percentiles": {
+                k: {"p50": p50, "p95": p95, "p99": p99}
+                for k, (p50, p95, p99) in result.percentiles.items()
+            },
+        }
+        print(json.dumps(payload, indent=2))
+        return EXIT_OK
+
+    if result.run_count == 0:
+        print(
+            f"No runs matched workflow_id={args.workflow_id!r} "
+            f"(status_filter={args.status!r}, last_n={args.last})."
+        )
+        return EXIT_OK
+
+    # Render the fixed-width table: bucket | p50 | p95 | p99.
+    header = (
+        f"\nAcross last {result.run_count} {args.status or 'terminal'} "
+        f"runs of {args.workflow_id}:\n"
+    )
+    print(header)
+    # Order buckets by p50 descending so the worst offender lands first.
+    rows = sorted(
+        ((k, v) for k, v in result.percentiles.items() if k != "total_time_s"),
+        key=lambda kv: kv[1][0],
+        reverse=True,
+    )
+    total = result.percentiles.get("total_time_s")
+    print(f"{'bucket':<16} {'p50':>10} {'p95':>10} {'p99':>10}")
+    print("─" * 50)
+    for k, (p50, p95, p99) in rows:
+        print(f"{k:<16} {p50:>9.1f}s {p95:>9.1f}s {p99:>9.1f}s")
+    print("─" * 50)
+    if total is not None:
+        p50, p95, p99 = total
+        print(f"{'total_time_s':<16} {p50:>9.1f}s {p95:>9.1f}s {p99:>9.1f}s")
+    return EXIT_OK
+
+
+def _parse_since(value: str):
+    """Parse a duration like '7d' / '24h' / '30m' into a ``timedelta``.
+
+    Returns ``None`` for unparseable inputs so the caller can surface a
+    friendly error message.
+    """
+    from datetime import timedelta
+
+    value = (value or "").strip().lower()
+    if not value or len(value) < 2:
+        return None
+    suffix = value[-1]
+    try:
+        n = int(value[:-1])
+    except ValueError:
+        return None
+    if n < 0:
+        return None
+    if suffix == "d":
+        return timedelta(days=n)
+    if suffix == "h":
+        return timedelta(hours=n)
+    if suffix == "m":
+        return timedelta(minutes=n)
+    return None
+
+
 def cmd_plan_run_modal(args: argparse.Namespace) -> int:
     """``mantis plan run-modal <plan>`` — execute a plan inside Modal.
 
@@ -1789,6 +1886,51 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Emit the labelled trace as JSON",
     )
     review.set_defaults(func=cmd_trace_review)
+
+    # ── runs: cross-run aggregation over the JSONL log (epic #362 C) ──
+    runs = sub.add_parser(
+        "runs",
+        help="Cross-run aggregation over the durable JSONL log written "
+             "on terminal status by the mantis-server runtime.",
+    )
+    runs_sub = runs.add_subparsers(dest="runs_command", required=True)
+
+    runs_stats = runs_sub.add_parser(
+        "stats",
+        help="Aggregate p50/p95/p99 per wall-time bucket across the "
+             "last N runs of a workflow.",
+    )
+    runs_stats.add_argument(
+        "workflow_id",
+        help="Workflow ID to aggregate over (matches summary.workflow_id "
+             "and the JSONL row's workflow_id field).",
+    )
+    runs_stats.add_argument(
+        "--last", type=int, default=100,
+        help="Newest-first cap on rows considered (default: 100).",
+    )
+    runs_stats.add_argument(
+        "--bucket", action="append", default=None,
+        metavar="NAME",
+        help="Restrict to one or more wall-time buckets (e.g. think, "
+             "claude_extract). Repeat to select multiple. Default: all.",
+    )
+    runs_stats.add_argument(
+        "--since",
+        default=None,
+        help="Restrict to rows finished within the last DURATION "
+             "(formats: '7d', '24h', '30m'). Default: no time bound.",
+    )
+    runs_stats.add_argument(
+        "--status", default="succeeded",
+        help="Filter rows by status (default: succeeded). Pass '' to "
+             "include every terminal status.",
+    )
+    runs_stats.add_argument(
+        "--json", action="store_true",
+        help="Emit results as JSON instead of a table.",
+    )
+    runs_stats.set_defaults(func=cmd_runs_stats)
 
     return parser
 

--- a/src/mantis_agent/runs_log/__init__.py
+++ b/src/mantis_agent/runs_log/__init__.py
@@ -1,0 +1,35 @@
+"""Durable per-run JSONL log + cross-run aggregation (epic #362 Phase C).
+
+Writes one structured row per terminal run to::
+
+    $MANTIS_DATA_DIR/runs_log/<YYYY-MM>.jsonl
+
+Append-only, sharded by month so a single file never grows unbounded
+and old months can be archived independently. Atomic append via
+``open('a') + fsync`` — concurrent writers on one pod are serialized
+by the OS append guarantee for files opened with ``O_APPEND``.
+
+Public surface:
+
+* :func:`writer.append_run` — append one row from a terminal result.
+* :func:`query.stats` — load rows and compute p50/p95/p99 per bucket
+  for a given workflow.
+
+The schema lives in :data:`writer.SCHEMA_VERSION` + the helper
+:func:`writer.row_from_result`. Permissive (extra keys allowed) so
+future fields don't break readers.
+"""
+
+from __future__ import annotations
+
+from .query import RunStats, stats
+from .writer import RUNS_LOG_SUBDIR, SCHEMA_VERSION, append_run, row_from_result
+
+__all__ = [
+    "RUNS_LOG_SUBDIR",
+    "RunStats",
+    "SCHEMA_VERSION",
+    "append_run",
+    "row_from_result",
+    "stats",
+]

--- a/src/mantis_agent/runs_log/query.py
+++ b/src/mantis_agent/runs_log/query.py
@@ -1,0 +1,191 @@
+"""Pure-Python aggregation over the JSONL run-log (epic #362 Phase C).
+
+Streams rows from ``$MANTIS_DATA_DIR/runs_log/*.jsonl``, filters by
+workflow / status / time window, and computes p50/p95/p99 per
+wall-time bucket. No DuckDB dependency — fast enough up to ~100k
+rows. The DuckDB-backed query path is reserved for follow-up if /
+when row counts demand it.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Iterable, Iterator
+
+from .writer import RUNS_LOG_SUBDIR, _data_dir
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class RunStats:
+    """Aggregated stats for a workflow across N runs.
+
+    ``percentiles`` is keyed by bucket (``perceive`` / ``think`` / etc.
+    plus ``total_time_s``) and each value is ``(p50, p95, p99)``.
+    ``run_count`` reflects the rows that passed all filters.
+    """
+
+    workflow_id: str
+    run_count: int
+    percentiles: dict[str, tuple[float, float, float]] = field(default_factory=dict)
+
+
+def _iter_jsonl(paths: Iterable[Path], *, reverse: bool = False) -> Iterator[dict]:
+    """Yield parsed rows from a set of JSONL shards. Malformed lines
+    are logged and skipped — one bad line shouldn't poison a query.
+
+    When ``reverse=True``, each shard's lines are yielded
+    newest-line-first (load + reverse the line list); combined with
+    a newest-shard-first iteration this gives a global newest-first
+    walk that ``last_n`` can truncate cheaply.
+    """
+    for path in paths:
+        try:
+            with open(path, encoding="utf-8") as fh:
+                lines = list(enumerate(fh, start=1))
+        except FileNotFoundError:
+            continue
+        if reverse:
+            lines = list(reversed(lines))
+        for lineno, raw in lines:
+            raw = raw.strip()
+            if not raw:
+                continue
+            try:
+                yield json.loads(raw)
+            except json.JSONDecodeError as exc:
+                logger.warning(
+                    "runs_log: skip malformed line %s:%d: %s",
+                    path, lineno, exc,
+                )
+
+
+def _shard_paths(data_dir: Path | None = None) -> list[Path]:
+    base = (data_dir if data_dir is not None else _data_dir()) / RUNS_LOG_SUBDIR
+    if not base.exists():
+        return []
+    return sorted(base.glob("*.jsonl"))
+
+
+def _percentile(samples: list[float], q: float) -> float:
+    """``q`` is a fraction in [0, 1]. Linear interpolation between
+    closest ranks — matches numpy's default 'linear' method."""
+    if not samples:
+        return 0.0
+    s = sorted(samples)
+    if len(s) == 1:
+        return float(s[0])
+    idx = q * (len(s) - 1)
+    lo = int(idx)
+    hi = min(lo + 1, len(s) - 1)
+    frac = idx - lo
+    return float(s[lo] + (s[hi] - s[lo]) * frac)
+
+
+def stats(
+    workflow_id: str,
+    *,
+    last_n: int = 100,
+    since: timedelta | None = None,
+    buckets: list[str] | None = None,
+    status_filter: str = "succeeded",
+    data_dir: Path | None = None,
+    _now: datetime | None = None,
+) -> RunStats:
+    """Return p50/p95/p99 per bucket for the last ``last_n`` runs of
+    ``workflow_id``.
+
+    Filtering:
+
+    * ``status_filter`` — defaults to ``"succeeded"`` so cost/time
+      stats reflect only completed runs. Pass ``""`` to include every
+      terminal status (useful for failure-mode analysis).
+    * ``since`` — if set, drops rows whose ``finished_at`` is older
+      than ``now - since``. Combine with ``last_n`` for a sliding
+      window.
+    * ``buckets`` — restrict to a subset of wall-time buckets. Default
+      is all buckets present in the rows + the ``total_time_s`` sum.
+
+    Rows are read newest-shard-first so ``last_n`` is the most-recent
+    runs, not a random tail.
+    """
+    cutoff = None
+    if since is not None:
+        now = _now or datetime.now(timezone.utc)
+        cutoff = now - since
+
+    # Walk shards newest-first AND lines within each shard newest-first
+    # so ``last_n`` truly truncates the most recent runs.
+    paths = list(reversed(_shard_paths(data_dir=data_dir)))
+    matched: list[dict] = []
+    for row in _iter_jsonl(paths, reverse=True):
+        if row.get("workflow_id") != workflow_id:
+            continue
+        if status_filter and row.get("status") != status_filter:
+            continue
+        if cutoff is not None:
+            finished = _parse_iso(row.get("finished_at"))
+            if finished is None or finished < cutoff:
+                continue
+        matched.append(row)
+        if len(matched) >= last_n:
+            break
+
+    if not matched:
+        return RunStats(workflow_id=workflow_id, run_count=0)
+
+    # Collect samples per bucket.
+    bucket_samples: dict[str, list[float]] = {}
+    totals: list[float] = []
+    for row in matched:
+        bd = row.get("wall_time_breakdown") or {}
+        for k, v in bd.items():
+            try:
+                bucket_samples.setdefault(k, []).append(float(v))
+            except (TypeError, ValueError):
+                continue
+        try:
+            totals.append(float(row.get("total_time_s") or 0))
+        except (TypeError, ValueError):
+            continue
+
+    if buckets:
+        bucket_samples = {k: v for k, v in bucket_samples.items() if k in buckets}
+
+    out: dict[str, tuple[float, float, float]] = {}
+    for k, samples in bucket_samples.items():
+        out[k] = (
+            _percentile(samples, 0.50),
+            _percentile(samples, 0.95),
+            _percentile(samples, 0.99),
+        )
+    out["total_time_s"] = (
+        _percentile(totals, 0.50),
+        _percentile(totals, 0.95),
+        _percentile(totals, 0.99),
+    )
+
+    return RunStats(
+        workflow_id=workflow_id,
+        run_count=len(matched),
+        percentiles=out,
+    )
+
+
+def _parse_iso(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        # Tolerate both ``...Z`` and ``...+00:00`` shapes.
+        v = value.replace("Z", "+00:00") if value.endswith("Z") else value
+        return datetime.fromisoformat(v)
+    except (ValueError, TypeError):
+        return None
+
+
+__all__ = ["RunStats", "stats"]

--- a/src/mantis_agent/runs_log/writer.py
+++ b/src/mantis_agent/runs_log/writer.py
@@ -1,0 +1,131 @@
+"""Per-run JSONL writer — epic #362 Phase C.
+
+One line per terminal run, atomic append, sharded by month. Pure
+stdlib — no DuckDB dependency at write time (query side is also pure
+Python; DuckDB can replace it later if row counts grow past comfort).
+
+Atomicity: files opened with ``O_APPEND`` (Python's ``"a"`` mode) give
+POSIX guarantees that ``write()`` of <= PIPE_BUF bytes is atomic
+between concurrent writers on the same FS. A single JSONL line easily
+fits under PIPE_BUF (4096+ on every modern OS); we write line +
+newline in one call. ``fsync`` after each write makes durability
+explicit so a crashing pod doesn't lose the last-completed runs.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+SCHEMA_VERSION = 1
+RUNS_LOG_SUBDIR = "runs_log"
+
+
+def _data_dir() -> Path:
+    """Resolve the on-disk root from ``MANTIS_DATA_DIR``.
+
+    Falls back to the same default as the rest of the server
+    (``/workspace/mantis-data``) so the log lands alongside the
+    existing per-tenant data.
+    """
+    return Path(os.environ.get("MANTIS_DATA_DIR", "/workspace/mantis-data"))
+
+
+def _shard_path(now: datetime | None = None, data_dir: Path | None = None) -> Path:
+    """Return the JSONL path for the current month: ``<dir>/runs_log/YYYY-MM.jsonl``."""
+    now = now or datetime.now(timezone.utc)
+    base = data_dir if data_dir is not None else _data_dir()
+    return base / RUNS_LOG_SUBDIR / f"{now.strftime('%Y-%m')}.jsonl"
+
+
+def row_from_result(
+    *,
+    run_id: str,
+    tenant_id: str = "",
+    profile_id: str = "",
+    workflow_id: str = "",
+    plan_signature: str = "",
+    model: str = "",
+    status: str,
+    created_at: str = "",
+    finished_at: str = "",
+    result: dict[str, Any] | None = None,
+    error: str | None = None,
+) -> dict[str, Any]:
+    """Project the runtime's result envelope + status metadata into a
+    schema-stable row.
+
+    ``result`` is the dict returned by :func:`build_micro_result`
+    (Phase B). When ``None`` (failed-before-result paths), the row
+    still lands with ``total_time_s=0`` and empty breakdowns so
+    aggregations can count failures correctly.
+    """
+    result = result or {}
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "run_id": run_id,
+        "tenant_id": tenant_id,
+        "profile_id": profile_id,
+        "workflow_id": workflow_id,
+        "plan_signature": plan_signature,
+        "model": model,
+        "status": status,
+        "created_at": created_at,
+        "finished_at": finished_at or _utc_now_iso(),
+        "total_time_s": int(result.get("total_time_s", 0) or 0),
+        "wall_time_breakdown": dict(result.get("wall_time_breakdown") or {}),
+        "cost_breakdown": dict(result.get("cost_breakdown") or {}),
+        "steps_executed": int(result.get("steps_executed", 0) or 0),
+        "viable": int(result.get("viable", 0) or 0),
+        "error": error,
+    }
+
+
+def append_run(
+    row: dict[str, Any],
+    *,
+    now: datetime | None = None,
+    data_dir: Path | None = None,
+) -> Path:
+    """Append one JSONL row to this month's shard. Returns the path
+    written to. Best-effort: a write failure is logged and re-raised
+    only to the caller — never break the parent run on observability
+    I/O.
+
+    The caller is expected to have already validated the row shape via
+    :func:`row_from_result`; arbitrary dicts will still serialize, but
+    cross-run aggregation assumes the canonical keys.
+    """
+    path = _shard_path(now=now, data_dir=data_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    line = json.dumps(row, ensure_ascii=False, default=str) + "\n"
+    # Single ``write`` of a small line is atomic w.r.t. concurrent
+    # appenders on POSIX (PIPE_BUF >= 4096 on Linux/macOS). ``fsync``
+    # makes the write durable past a pod crash.
+    with open(path, "a", encoding="utf-8") as fh:
+        fh.write(line)
+        fh.flush()
+        try:
+            os.fsync(fh.fileno())
+        except OSError as exc:  # noqa: BLE001 — some FSes (tmpfs) can't fsync
+            logger.debug("runs_log: fsync failed (path=%s): %s", path, exc)
+    return path
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+__all__ = [
+    "RUNS_LOG_SUBDIR",
+    "SCHEMA_VERSION",
+    "append_run",
+    "row_from_result",
+]

--- a/tests/test_cli_runs_stats.py
+++ b/tests/test_cli_runs_stats.py
@@ -1,0 +1,157 @@
+"""``mantis runs stats <workflow_id>`` CLI surface (epic #362 Phase C).
+
+Pins the argument parsing, the table / JSON rendering, and the
+``--since`` duration parser. End-to-end uses a tmp data dir seeded
+with fake rows so no actual server is required.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import timedelta
+from pathlib import Path
+
+import pytest
+
+from mantis_agent.cli import EXIT_OK, _parse_since, main
+from mantis_agent.runs_log import append_run, row_from_result
+
+
+# ── _parse_since duration parser ────────────────────────────────────────
+
+
+def test_parse_since_days() -> None:
+    assert _parse_since("7d") == timedelta(days=7)
+
+
+def test_parse_since_hours() -> None:
+    assert _parse_since("24h") == timedelta(hours=24)
+
+
+def test_parse_since_minutes() -> None:
+    assert _parse_since("30m") == timedelta(minutes=30)
+
+
+def test_parse_since_rejects_unknown_suffix() -> None:
+    assert _parse_since("7w") is None
+
+
+def test_parse_since_rejects_non_numeric() -> None:
+    assert _parse_since("xd") is None
+
+
+def test_parse_since_rejects_negative() -> None:
+    assert _parse_since("-1d") is None
+
+
+def test_parse_since_empty_or_short() -> None:
+    assert _parse_since("") is None
+    assert _parse_since("d") is None
+
+
+# ── stats CLI end-to-end ────────────────────────────────────────────────
+
+
+def _seed(tmp_path: Path, samples: list[dict], workflow_id: str = "w1") -> None:
+    for i, sample in enumerate(samples):
+        row = row_from_result(
+            run_id=f"r{i}", workflow_id=workflow_id, status="succeeded",
+            finished_at=f"2026-05-13T18:{i:02d}:00Z",
+            result={
+                "total_time_s": sum(sample.values()),
+                "wall_time_breakdown": sample,
+            },
+        )
+        append_run(row, data_dir=tmp_path)
+
+
+def test_stats_no_runs_returns_ok(tmp_path: Path, monkeypatch, capsys) -> None:
+    """Empty store should not crash — return OK with a friendly note."""
+    monkeypatch.setenv("MANTIS_DATA_DIR", str(tmp_path))
+    code = main(["runs", "stats", "w1"])
+    assert code == EXIT_OK
+    out = capsys.readouterr().out
+    assert "No runs matched" in out
+    assert "w1" in out
+
+
+def test_stats_table_render_orders_buckets_by_p50(
+    tmp_path: Path, monkeypatch, capsys,
+) -> None:
+    monkeypatch.setenv("MANTIS_DATA_DIR", str(tmp_path))
+    _seed(tmp_path, [
+        {"think": 40, "act": 5, "settle": 15},
+        {"think": 50, "act": 6, "settle": 16},
+    ])
+    code = main(["runs", "stats", "w1"])
+    assert code == EXIT_OK
+    out = capsys.readouterr().out
+    # Header should mention the matched count + workflow.
+    assert "Across last 2" in out
+    assert "w1" in out
+    # think (largest p50) lands before settle which lands before act.
+    think_idx = out.find("think")
+    settle_idx = out.find("settle")
+    act_idx = out.find("act")
+    assert 0 < think_idx < settle_idx < act_idx
+    # total_time_s is always last.
+    assert "total_time_s" in out
+    assert out.find("total_time_s") > act_idx
+
+
+def test_stats_json_output(tmp_path: Path, monkeypatch, capsys) -> None:
+    monkeypatch.setenv("MANTIS_DATA_DIR", str(tmp_path))
+    _seed(tmp_path, [
+        {"think": 10}, {"think": 20}, {"think": 30},
+    ])
+    code = main(["runs", "stats", "w1", "--json"])
+    assert code == EXIT_OK
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["workflow_id"] == "w1"
+    assert payload["run_count"] == 3
+    assert payload["percentiles"]["think"]["p50"] == 20.0
+    assert "total_time_s" in payload["percentiles"]
+
+
+def test_stats_bucket_filter_restricts_table(
+    tmp_path: Path, monkeypatch, capsys,
+) -> None:
+    monkeypatch.setenv("MANTIS_DATA_DIR", str(tmp_path))
+    _seed(tmp_path, [
+        {"think": 10, "act": 1, "settle": 5},
+        {"think": 20, "act": 2, "settle": 6},
+    ])
+    code = main(["runs", "stats", "w1", "--bucket", "think"])
+    assert code == EXIT_OK
+    out = capsys.readouterr().out
+    assert "think" in out
+    # act / settle filtered out of the breakdown rows.
+    # (we just check they don't appear as a row prefix)
+    for line in out.splitlines():
+        if line.lstrip().startswith(("act ", "settle ")):
+            pytest.fail(f"unexpected bucket row: {line!r}")
+
+
+def test_stats_last_n_caps_input(tmp_path: Path, monkeypatch, capsys) -> None:
+    monkeypatch.setenv("MANTIS_DATA_DIR", str(tmp_path))
+    _seed(tmp_path, [
+        {"think": 100}, {"think": 200}, {"think": 300},
+        {"think": 1}, {"think": 2},
+    ])
+    code = main(["runs", "stats", "w1", "--last", "2", "--json"])
+    assert code == EXIT_OK
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["run_count"] == 2
+    # Most recent two are [1, 2] → p50 = 1.5
+    assert payload["percentiles"]["think"]["p50"] == 1.5
+
+
+def test_stats_invalid_since_returns_error(
+    tmp_path: Path, monkeypatch, capsys,
+) -> None:
+    monkeypatch.setenv("MANTIS_DATA_DIR", str(tmp_path))
+    code = main(["runs", "stats", "w1", "--since", "garbage"])
+    assert code != EXIT_OK
+    err = capsys.readouterr().err
+    assert "--since" in err
+    assert "7d" in err or "24h" in err

--- a/tests/test_runs_log.py
+++ b/tests/test_runs_log.py
@@ -1,0 +1,285 @@
+"""Durable JSONL runs-log (epic #362 Phase C).
+
+Pins the writer's atomic-append semantics, the row schema, and the
+percentile aggregation that the ``mantis runs stats`` CLI consumes.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from mantis_agent.runs_log import (
+    RUNS_LOG_SUBDIR,
+    SCHEMA_VERSION,
+    append_run,
+    row_from_result,
+    stats,
+)
+
+
+# ── row_from_result projection ──────────────────────────────────────────
+
+
+def test_row_from_result_lifts_breakdowns_from_result_envelope() -> None:
+    result = {
+        "total_time_s": 247,
+        "wall_time_breakdown": {"think": 88.1, "act": 6.7, "overhead": 1.3},
+        "cost_breakdown": {"gpu": 0.12, "claude": 0.30},
+        "steps_executed": 17,
+        "viable": 3,
+        "plan_signature": "abc123",
+        "model": "Hcompany/Holo3-35B-A3B",
+    }
+    row = row_from_result(
+        run_id="r1", tenant_id="t1", profile_id="p1", workflow_id="w1",
+        status="succeeded", finished_at="2026-05-13T18:00:00Z",
+        result=result,
+    )
+    assert row["schema_version"] == SCHEMA_VERSION
+    assert row["run_id"] == "r1"
+    assert row["workflow_id"] == "w1"
+    assert row["status"] == "succeeded"
+    assert row["wall_time_breakdown"] == {
+        "think": 88.1, "act": 6.7, "overhead": 1.3,
+    }
+    assert row["cost_breakdown"] == {"gpu": 0.12, "claude": 0.30}
+    assert row["total_time_s"] == 247
+    assert row["steps_executed"] == 17
+
+
+def test_row_from_result_handles_missing_result() -> None:
+    """Failed-before-build paths still produce a valid row so failures
+    don't disappear from the log."""
+    row = row_from_result(
+        run_id="r1", workflow_id="w1", status="failed",
+        finished_at="2026-05-13T18:00:00Z",
+        result=None, error="page_blocked",
+    )
+    assert row["status"] == "failed"
+    assert row["error"] == "page_blocked"
+    assert row["total_time_s"] == 0
+    assert row["wall_time_breakdown"] == {}
+    assert row["cost_breakdown"] == {}
+
+
+# ── append_run atomic-append + schema round-trip ────────────────────────
+
+
+def test_append_run_creates_shard_and_writes_jsonl(tmp_path: Path) -> None:
+    row = row_from_result(
+        run_id="r1", workflow_id="w1", status="succeeded",
+        finished_at="2026-05-13T18:00:00Z",
+        result={"total_time_s": 100},
+    )
+    path = append_run(row, data_dir=tmp_path)
+    assert path.exists()
+    assert path.parent.name == RUNS_LOG_SUBDIR
+
+    lines = path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    parsed = json.loads(lines[0])
+    assert parsed["run_id"] == "r1"
+    assert parsed["workflow_id"] == "w1"
+    assert parsed["total_time_s"] == 100
+
+
+def test_append_run_appends_to_existing_shard(tmp_path: Path) -> None:
+    for run_id in ("r1", "r2", "r3"):
+        append_run(
+            row_from_result(
+                run_id=run_id, workflow_id="w1", status="succeeded",
+                finished_at="2026-05-13T18:00:00Z",
+                result={"total_time_s": 100},
+            ),
+            data_dir=tmp_path,
+        )
+    paths = list((tmp_path / RUNS_LOG_SUBDIR).glob("*.jsonl"))
+    assert len(paths) == 1
+    lines = paths[0].read_text(encoding="utf-8").splitlines()
+    assert [json.loads(line)["run_id"] for line in lines] == ["r1", "r2", "r3"]
+
+
+def test_append_run_shards_by_month(tmp_path: Path) -> None:
+    """Two runs in different months must land in different shards so a
+    single file stays bounded over time."""
+    apr = datetime(2026, 4, 30, tzinfo=timezone.utc)
+    may = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    row = row_from_result(
+        run_id="r1", workflow_id="w1", status="succeeded",
+        finished_at="...", result={},
+    )
+    p_apr = append_run(row, now=apr, data_dir=tmp_path)
+    p_may = append_run(row, now=may, data_dir=tmp_path)
+    assert p_apr != p_may
+    assert "2026-04.jsonl" in str(p_apr)
+    assert "2026-05.jsonl" in str(p_may)
+
+
+def test_append_run_is_safe_under_concurrent_writers(tmp_path: Path) -> None:
+    """20 threads appending in parallel — every line must land intact.
+
+    Tests POSIX O_APPEND atomicity (Python's ``"a"`` mode opens with
+    O_APPEND) which guarantees small ``write()`` calls don't interleave.
+    A regression that buffers across writes or seeks before appending
+    would fail this with truncated or mixed-up lines.
+    """
+    def worker(i: int) -> None:
+        for j in range(5):
+            append_run(
+                row_from_result(
+                    run_id=f"t{i}-r{j}", workflow_id="w1",
+                    status="succeeded", finished_at="x",
+                    result={"total_time_s": 10},
+                ),
+                data_dir=tmp_path,
+            )
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(20)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    paths = list((tmp_path / RUNS_LOG_SUBDIR).glob("*.jsonl"))
+    assert len(paths) == 1
+    lines = paths[0].read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 100
+    # All lines parse — no truncation / mid-line interleaving.
+    parsed = [json.loads(line) for line in lines]
+    run_ids = sorted(p["run_id"] for p in parsed)
+    expected = sorted(f"t{i}-r{j}" for i in range(20) for j in range(5))
+    assert run_ids == expected
+
+
+# ── stats() aggregation ─────────────────────────────────────────────────
+
+
+def _seed_runs(
+    tmp_path: Path, workflow_id: str, samples: list[dict],
+    status: str = "succeeded",
+) -> None:
+    """Append a batch of fake-row samples. Each sample is a dict of
+    bucket → seconds; total_time_s is summed automatically."""
+    for i, sample in enumerate(samples):
+        result = {
+            "total_time_s": sum(sample.values()),
+            "wall_time_breakdown": sample,
+        }
+        row = row_from_result(
+            run_id=f"r{i}", workflow_id=workflow_id, status=status,
+            finished_at=f"2026-05-13T18:{i:02d}:00Z",
+            result=result,
+        )
+        append_run(row, data_dir=tmp_path)
+
+
+def test_stats_returns_zero_run_count_when_log_missing(tmp_path: Path) -> None:
+    result = stats("w1", data_dir=tmp_path)
+    assert result.run_count == 0
+    assert result.percentiles == {}
+
+
+def test_stats_filters_by_workflow_id(tmp_path: Path) -> None:
+    _seed_runs(tmp_path, "w1", [{"think": 10}, {"think": 20}])
+    _seed_runs(tmp_path, "w2", [{"think": 999}])
+    result = stats("w1", data_dir=tmp_path)
+    assert result.run_count == 2
+    # p50 of [10, 20] = 15 (linear interpolation).
+    assert result.percentiles["think"][0] == 15.0
+
+
+def test_stats_computes_percentiles_per_bucket(tmp_path: Path) -> None:
+    _seed_runs(tmp_path, "w1", [
+        {"think": 10, "act": 1},
+        {"think": 20, "act": 2},
+        {"think": 30, "act": 3},
+        {"think": 40, "act": 4},
+        {"think": 50, "act": 5},
+    ])
+    result = stats("w1", data_dir=tmp_path)
+    assert result.run_count == 5
+    # think samples: 10,20,30,40,50 → p50=30, p95≈48, p99≈49.6
+    p50, p95, p99 = result.percentiles["think"]
+    assert p50 == 30.0
+    assert 47.5 <= p95 <= 49.0
+    assert 49.0 <= p99 <= 50.0
+    assert result.percentiles["total_time_s"][0] == 33.0  # p50 of 11..55
+
+
+def test_stats_respects_last_n_cap_newest_first(tmp_path: Path) -> None:
+    """Older runs beyond last_n must be ignored — last_n=2 over five
+    runs should aggregate only the last two appended."""
+    _seed_runs(tmp_path, "w1", [
+        {"think": 100}, {"think": 200}, {"think": 300},
+        {"think": 1}, {"think": 2},  # most recent
+    ])
+    result = stats("w1", last_n=2, data_dir=tmp_path)
+    assert result.run_count == 2
+    # p50 of [1, 2] = 1.5
+    assert result.percentiles["think"][0] == 1.5
+
+
+def test_stats_status_filter_default_excludes_failures(tmp_path: Path) -> None:
+    _seed_runs(tmp_path, "w1", [{"think": 10}])
+    _seed_runs(tmp_path, "w1", [{"think": 999}], status="failed")
+    result = stats("w1", data_dir=tmp_path)
+    assert result.run_count == 1
+    assert result.percentiles["think"][0] == 10.0
+
+
+def test_stats_status_filter_empty_includes_all_terminals(tmp_path: Path) -> None:
+    _seed_runs(tmp_path, "w1", [{"think": 10}])
+    _seed_runs(tmp_path, "w1", [{"think": 50}], status="failed")
+    result = stats("w1", status_filter="", data_dir=tmp_path)
+    assert result.run_count == 2
+
+
+def test_stats_since_drops_old_rows(tmp_path: Path) -> None:
+    now = datetime(2026, 5, 13, 18, 0, 0, tzinfo=timezone.utc)
+    # Manually write rows with explicit finished_at so we can test the
+    # cutoff. One an hour ago, one a week ago.
+    for run_id, hours in (("recent", 1), ("ancient", 168)):
+        row = row_from_result(
+            run_id=run_id, workflow_id="w1", status="succeeded",
+            finished_at=(now - timedelta(hours=hours)).strftime(
+                "%Y-%m-%dT%H:%M:%SZ"
+            ),
+            result={"total_time_s": 100, "wall_time_breakdown": {"think": 10}},
+        )
+        append_run(row, data_dir=tmp_path, now=now)
+    # since=24h → only the recent row should land.
+    result = stats(
+        "w1", since=timedelta(hours=24), data_dir=tmp_path, _now=now,
+    )
+    assert result.run_count == 1
+
+
+def test_stats_buckets_filter_restricts_output(tmp_path: Path) -> None:
+    _seed_runs(tmp_path, "w1", [
+        {"think": 10, "act": 1, "settle": 5},
+        {"think": 20, "act": 2, "settle": 6},
+    ])
+    result = stats("w1", buckets=["think"], data_dir=tmp_path)
+    assert "think" in result.percentiles
+    assert "act" not in result.percentiles
+    assert "settle" not in result.percentiles
+    # total_time_s is always included as the headline aggregate.
+    assert "total_time_s" in result.percentiles
+
+
+def test_stats_skips_malformed_lines(tmp_path: Path) -> None:
+    """A truncated line from a crashed write must not poison the query."""
+    # Seed one valid run.
+    _seed_runs(tmp_path, "w1", [{"think": 10}])
+    # Append a malformed line.
+    path = (tmp_path / RUNS_LOG_SUBDIR).glob("*.jsonl").__next__()
+    with open(path, "a") as fh:
+        fh.write("{not valid json\n")
+    # Seed another valid run.
+    _seed_runs(tmp_path, "w1", [{"think": 20}])
+
+    result = stats("w1", data_dir=tmp_path)
+    assert result.run_count == 2


### PR DESCRIPTION
## Summary

Phase C of epic #362 — durable per-run JSONL log + `mantis runs stats` CLI. Closes #366.

Today every run carries its own `wall_time_breakdown` (Phase B / #368), but nothing rolls those up across runs. Plan authors can't tell "is my workflow faster or slower than last month?"; operators can't answer "across the last 100 runs of workflow X, what's the p95 latency per bucket, and which bucket regressed?". Prometheus is the wrong tool — per-workflow cardinality explodes and retention is too short.

This PR lands the cheapest durable answer: **append-only JSONL, one line per terminal run, queried in pure Python by a new CLI.**

## What ships

- **`src/mantis_agent/runs_log/`** — writer + query module.
  - `writer.row_from_result` projects a Phase-B result envelope + identity tuple into a schema-stable row (`schema_version`, `run_id`, `tenant_id`, `profile_id`, `workflow_id`, `plan_signature`, `model`, `status`, `created_at`, `finished_at`, `total_time_s`, `wall_time_breakdown`, `cost_breakdown`, `steps_executed`, `viable`, `error`).
  - `writer.append_run` writes one JSON line + `fsync` to `$MANTIS_DATA_DIR/runs_log/<YYYY-MM>.jsonl`. **Sharded by month**, **atomic between concurrent writers** (POSIX `O_APPEND` for sub-`PIPE_BUF` writes).
  - `query.stats` streams rows newest-first, filters by workflow / status / time window, returns `p50/p95/p99` per bucket plus the `total_time_s` aggregate. **Pure Python** — no DuckDB dependency. Schema is stable, so swapping the read side for DuckDB later is a one-pass migration.

- **`baseten_server/runtime.py`** — `_append_runs_log` hooks the writer on both terminal branches (succeeded + failed). **Best-effort** — a write failure logs at DEBUG and is swallowed; bookkeeping I/O must never break a finishing run.

- **`cli.py`** — new `mantis runs stats <workflow_id>` subcommand with `--last`, `--bucket`, `--since`, `--status`, `--json` flags. Renders a bucket × percentile table **sorted by p50 descending** so the worst offender lands first; `--json` for downstream tooling.

Example output:
```
$ mantis runs stats default__marketplace-listings-v1

Across last 100 succeeded runs of default__marketplace-listings-v1:

bucket                  p50        p95        p99
──────────────────────────────────────────────────
think                  92.0s     145.0s     201.0s
claude_extract         67.0s     128.0s     156.0s
settle                 28.0s      44.0s      55.0s
...
──────────────────────────────────────────────────
total_time_s          238.0s     383.0s     478.0s
```

## Why pure Python over DuckDB

The issue suggested DuckDB; I shipped pure-Python streaming for the MVP. Rationale:
1. **Comfortable up to ~100k rows per month** — covers most operators for months.
2. **Zero new dependency** in the core install.
3. **The schema is stable** — swapping the read side for DuckDB / Postgres later is a one-pass ETL, not a breaking change. The writer never has to change.

The CLI docs explicitly call out the DuckDB-migration escape hatch for when row counts demand it.

## Test plan

- [x] `pytest tests/test_runs_log.py` — 15 cases: row projection, atomic append, monthly sharding, **concurrent writers** (20 threads × 5 appends, every line lands intact), percentile correctness, workflow / status / since / last_n / bucket filters, malformed-line resilience.
- [x] `pytest tests/test_cli_runs_stats.py` — 13 cases: `--since` duration parser (d/h/m + rejection paths), empty-store render, table-vs-JSON output, bucket ordering by p50, `--last` truncation, error surface on bad `--since`.
- [x] Adjacent surfaces clean: `pytest tests/test_cli_plan_run.py tests/test_cli_plan_run_modal.py tests/test_server_utils.py tests/test_run_executor.py tests/test_microrunner_som_dispatch.py tests/test_checkpoint_manager.py` → 142 passed.
- [x] `mkdocs build --strict` clean.
- [x] `ruff check` clean.

## Wire-ins remaining (out of scope, separate epic-#362 follow-ups)

- `think` bucket — needs `GymRunner` threading. The breakdown CLI will keep working; that column will just sharpen once wire-in lands.
- `claude_ground` / `claude_extract` / `claude_verify` — need the relevant classes to read the dispatch context.

Closes #366. Part of epic #362.

🤖 Generated with [Claude Code](https://claude.com/claude-code)