### PR TITLE
feat(time-meter): wire remaining buckets + narrow act precision (closes #363)

### DIFF
--- a/src/mantis_agent/extraction/extractor.py
+++ b/src/mantis_agent/extraction/extractor.py
@@ -45,6 +45,18 @@ from .spam import contains_dealer_text, parse_bool, seller_looks_like_dealer
 logger = logging.getLogger(__name__)
 
 
+def _credit_claude_time(bucket: str, t0: float) -> None:
+    """Credit elapsed Claude API time to the runner's TimeMeter
+    (epic #362). Best-effort — bookkeeping I/O must never break a
+    Claude call. Internal-only — invoked from ``_call*`` wrappers.
+    """
+    try:
+        from ..gym.time_meter import record_to_current
+        record_to_current(bucket, time.monotonic() - t0)
+    except Exception as exc:  # noqa: BLE001 — observability, never fatal
+        logger.debug("claude time_meter credit failed: %s", exc)
+
+
 def _coerce_coord(value: Any) -> int | None:
     """Best-effort int coercion for click coordinates returned by Claude.
 
@@ -287,7 +299,14 @@ class ClaudeExtractor:
                 continue
         return os.path.join("/tmp", f"{stem}_{int(time.time())}{suffix}")
 
-    def _call(self, screenshot: Image.Image, prompt: str, max_tokens: int = 500) -> str:
+    def _call(
+        self,
+        screenshot: Image.Image,
+        prompt: str,
+        max_tokens: int = 500,
+        *,
+        _bucket: str = "claude_extract",
+    ) -> str:
         """Call Claude API with screenshot + prompt."""
         import requests
 
@@ -299,6 +318,7 @@ class ClaudeExtractor:
         screenshot.save(buf, format="PNG")
         b64 = base64.b64encode(buf.getvalue()).decode()
 
+        t0 = time.monotonic()
         try:
             resp = requests.post(
                 "https://api.anthropic.com/v1/messages",
@@ -332,6 +352,8 @@ class ClaudeExtractor:
                     return block["text"].strip()
         except Exception as e:
             logger.warning(f"ClaudeExtractor failed: {e}")
+        finally:
+            _credit_claude_time(_bucket, t0)
         return ""
 
     def _call_with_tool_schema(
@@ -343,6 +365,7 @@ class ClaudeExtractor:
         tool_description: str,
         input_schema: dict[str, Any],
         max_tokens: int = 500,
+        _bucket: str = "claude_extract",
     ) -> dict | None:
         """Call Claude API and force the response into a JSON-Schema-validated tool_use.
 
@@ -376,6 +399,7 @@ class ClaudeExtractor:
         screenshot.save(buf, format="PNG")
         b64 = base64.b64encode(buf.getvalue()).decode()
 
+        t0 = time.monotonic()
         try:
             resp = requests.post(
                 "https://api.anthropic.com/v1/messages",
@@ -421,6 +445,8 @@ class ClaudeExtractor:
             )
         except Exception as e:
             logger.warning(f"ClaudeExtractor tool_use failed: {e}")
+        finally:
+            _credit_claude_time(_bucket, t0)
         return None
 
     def _call_with_tool_schema_multi(
@@ -433,6 +459,7 @@ class ClaudeExtractor:
         input_schema: dict[str, Any],
         labels: list[str] | None = None,
         max_tokens: int = 500,
+        _bucket: str = "claude_extract",
     ) -> dict | None:
         """Multi-screenshot variant of :meth:`_call_with_tool_schema`.
 
@@ -465,6 +492,7 @@ class ClaudeExtractor:
                 "source": {"type": "base64", "media_type": "image/png", "data": b64},
             })
 
+        t0 = time.monotonic()
         try:
             resp = requests.post(
                 "https://api.anthropic.com/v1/messages",
@@ -504,6 +532,8 @@ class ClaudeExtractor:
             )
         except Exception as e:
             logger.warning(f"ClaudeExtractor multi tool_use failed: {e}")
+        finally:
+            _credit_claude_time(_bucket, t0)
         return None
 
     def _call_many(
@@ -512,6 +542,8 @@ class ClaudeExtractor:
         prompt: str,
         labels: list[str] | None = None,
         max_tokens: int = 350,
+        *,
+        _bucket: str = "claude_extract",
     ) -> str:
         """Call Claude API with multiple screenshots and one prompt."""
         import requests
@@ -537,6 +569,7 @@ class ClaudeExtractor:
                 },
             })
 
+        t0 = time.monotonic()
         try:
             resp = requests.post(
                 "https://api.anthropic.com/v1/messages",
@@ -567,6 +600,8 @@ class ClaudeExtractor:
                     return block["text"].strip()
         except Exception as e:
             logger.warning(f"ClaudeExtractor multi failed: {e}")
+        finally:
+            _credit_claude_time(_bucket, t0)
         return ""
 
     @staticmethod
@@ -937,6 +972,7 @@ class ClaudeExtractor:
                 "required": ["navigated", "kind", "reason"],
             },
             labels=["BEFORE click", "AFTER click"],
+            _bucket="claude_verify",
         )
 
     def verify_gate(self, screenshot: Image.Image, expected: str) -> tuple[bool, str]:
@@ -976,6 +1012,7 @@ class ClaudeExtractor:
                 },
                 "required": ["passed", "reason"],
             },
+            _bucket="claude_verify",
         )
 
         if not parsed:

--- a/src/mantis_agent/grounding.py
+++ b/src/mantis_agent/grounding.py
@@ -181,13 +181,25 @@ Nothing else."""
         # fallback every time and pollute the cache).
         # #181: ``force_compute=True`` bypasses the cache so high-risk
         # clicks never inherit a stale coordinate.
-        if not force_compute and self.cache is not None and description and self.api_key:
-            return self.cache.lookup_or_compute(
-                screenshot, description,
-                lambda: self._ground_remote(screenshot, description, initial_x, initial_y),
-                initial_x=initial_x, initial_y=initial_y,
-            )
-        return self._ground_remote(screenshot, description, initial_x, initial_y)
+        # Epic #362: time the whole call (cache hit or API miss) under
+        # the ``claude_ground`` bucket. Cache hits are near-zero but
+        # still credited so per-step breakdowns sum cleanly.
+        import time as _time_mod
+        t0 = _time_mod.monotonic()
+        try:
+            if not force_compute and self.cache is not None and description and self.api_key:
+                return self.cache.lookup_or_compute(
+                    screenshot, description,
+                    lambda: self._ground_remote(screenshot, description, initial_x, initial_y),
+                    initial_x=initial_x, initial_y=initial_y,
+                )
+            return self._ground_remote(screenshot, description, initial_x, initial_y)
+        finally:
+            try:
+                from .gym.time_meter import record_to_current
+                record_to_current("claude_ground", _time_mod.monotonic() - t0)
+            except Exception as exc:  # noqa: BLE001 — observability, never fatal
+                logger.debug("claude_ground time_meter credit failed: %s", exc)
 
     def _ground_remote(self, screenshot, description, initial_x=None, initial_y=None):
         import base64

--- a/src/mantis_agent/gym/playwright_env.py
+++ b/src/mantis_agent/gym/playwright_env.py
@@ -217,7 +217,17 @@ class PlaywrightGymEnv(GymEnvironment):
             elif action.action_type == ActionType.SCROLL:
                 time.sleep(random.uniform(0.2, 0.6))  # Reading pace
 
-        self._execute_action(action)
+        # Epic #362: credit the actual action dispatch to ``act`` —
+        # exclusively the time inside _execute_action.
+        _act_t0 = time.monotonic()
+        try:
+            self._execute_action(action)
+        finally:
+            try:
+                from .time_meter import record_to_current
+                record_to_current("act", time.monotonic() - _act_t0)
+            except Exception:
+                pass
 
         # Post-action settle time (longer for human speed)
         if action.action_type not in (ActionType.WAIT, ActionType.DONE):
@@ -288,8 +298,17 @@ class PlaywrightGymEnv(GymEnvironment):
                 "PlaywrightGymEnv: screenshot() called before reset(). "
                 "Call env.reset(task=..., start_url=...) first."
             )
-        png_bytes = self._page.screenshot(type="png")
-        return Image.open(io.BytesIO(png_bytes))
+        # Epic #362: credit screenshot capture to ``perceive``.
+        _t0 = time.monotonic()
+        try:
+            png_bytes = self._page.screenshot(type="png")
+            return Image.open(io.BytesIO(png_bytes))
+        finally:
+            try:
+                from .time_meter import record_to_current
+                record_to_current("perceive", time.monotonic() - _t0)
+            except Exception:
+                pass
 
     @property
     def page(self):
@@ -465,6 +484,10 @@ class PlaywrightGymEnv(GymEnvironment):
         If annotate_som=True, overlays numbered red labels on all interactive
         elements (Set-of-Mark), and includes the element list in extras.
         """
+        # Epic #362: credit ``perceive`` for the screenshot. SoM
+        # annotation work below also lands here intentionally — it's
+        # frame-derived perception, not part of any other bucket.
+        _t0 = time.monotonic()
         png_bytes = self._page.screenshot(type="png")
 
         elements = []
@@ -476,6 +499,11 @@ class PlaywrightGymEnv(GymEnvironment):
                 element_text = self._format_element_list(elements)
 
         screenshot = Image.open(io.BytesIO(png_bytes))
+        try:
+            from .time_meter import record_to_current
+            record_to_current("perceive", time.monotonic() - _t0)
+        except Exception:
+            pass
 
         return GymObservation(
             screenshot=screenshot,

--- a/src/mantis_agent/gym/run_executor.py
+++ b/src/mantis_agent/gym/run_executor.py
@@ -338,30 +338,24 @@ class RunExecutor:
         pre_snapshot = step_snapshot.capture(runner)
         runner._pre_step_snapshot = pre_snapshot
         meter = getattr(runner, "time_meter", None)
-        # Publish the dispatch context so deep helpers (adaptive_settle,
-        # navigate, the inner GymRunner used by Holo3StepHandler, ...)
-        # can record into the same TimeMeter without being passed it as
-        # a kwarg. Outer ``measure("act", ...)`` is the coarse dispatch
-        # bucket; sub-bucket records (``settle``, ``load``, ...) made
-        # via :func:`time_meter.record_to_current` from inside the
-        # dispatch land on the same per-step slot. Buckets can overlap
-        # — ``breakdown()`` floors the ``overhead`` residual at zero so
-        # consumers see useful per-bucket totals either way.
+        # Publish the dispatch context for the duration of this step.
+        # Deep helpers (adaptive_settle, navigate handler, env.step /
+        # env.screenshot inside the GymRunner, ClaudeExtractor /
+        # ClaudeGrounding) read this context and credit their own
+        # buckets — no outer ``measure`` is needed. Time spent in
+        # runner orchestration outside any helper falls into
+        # ``overhead`` automatically via :meth:`TimeMeter.breakdown`.
         from . import time_meter as _tm
         try:
             with _tm.publish_dispatch(meter, state.step_index):
-                if meter is not None:
-                    with meter.measure("act", step_idx=state.step_index):
-                        step_result = runner._execute_step(effective_step, state.step_index)
-                else:
-                    step_result = runner._execute_step(effective_step, state.step_index)
+                step_result = runner._execute_step(effective_step, state.step_index)
         finally:
             runner._active_checkpoint_context = None
         if step_result.screenshot_png is None:
-            if meter is not None:
-                with meter.measure("perceive", step_idx=state.step_index):
-                    step_result.screenshot_png = runner._capture_screenshot_bytes()
-            else:
+            # The screenshot helper itself credits ``perceive`` via the
+            # env-level wrapper; we still publish the dispatch context
+            # so the credit routes to this step.
+            with _tm.publish_dispatch(meter, state.step_index):
                 step_result.screenshot_png = runner._capture_screenshot_bytes()
         if not step_result.success:
             _stamp_failure_context(step_result, runner.env)

--- a/src/mantis_agent/gym/runner.py
+++ b/src/mantis_agent/gym/runner.py
@@ -1039,6 +1039,16 @@ class GymRunner:
                     screen_size=self.env.screen_size,
                 )
                 inference_time = time.time() - t_infer
+                # Epic #362: credit brain inference to the ``think``
+                # bucket on the runner's TimeMeter. Reads the current
+                # dispatch context — no-op when GymRunner is invoked
+                # outside a MicroPlanRunner step (legacy /v1/cua path
+                # publishes nothing; that's fine).
+                try:
+                    from .time_meter import record_to_current
+                    record_to_current("think", inference_time)
+                except Exception:
+                    pass
 
                 action = result.action
                 thinking = getattr(result, "thinking", "")
@@ -2246,6 +2256,9 @@ class GymRunner:
         print(f"  [discovery] {len(elements)} elements found, asking brain...")
 
         recent_frames = frame_history[-self.frames_per_inference:]
+        # Epic #362: time brain.think under the ``think`` bucket; no-op
+        # when no dispatch context is published.
+        _think_t0 = time.time()
         try:
             result = self.brain.think(
                 frames=recent_frames,
@@ -2256,6 +2269,12 @@ class GymRunner:
         except Exception as e:
             print(f"  [discovery] brain error: {e}")
             return None
+        finally:
+            try:
+                from .time_meter import record_to_current
+                record_to_current("think", time.time() - _think_t0)
+            except Exception:
+                pass
 
         # Parse the brain's response — it might be in thinking or in action params
         response_text = getattr(result, "thinking", "") or ""

--- a/src/mantis_agent/gym/xdotool_env.py
+++ b/src/mantis_agent/gym/xdotool_env.py
@@ -254,7 +254,16 @@ class XdotoolGymEnv(GymEnvironment):
 
     def screenshot(self) -> Image.Image:
         """Public: capture current screenshot as PIL Image."""
-        return self._screenshot()
+        # Epic #362: credit screenshot capture to ``perceive``.
+        _t0 = time.monotonic()
+        try:
+            return self._screenshot()
+        finally:
+            try:
+                from .time_meter import record_to_current
+                record_to_current("perceive", time.monotonic() - _t0)
+            except Exception:
+                pass
 
     def _screenshot(self) -> Image.Image:
         """Capture screenshot via mss (fast) or scrot (fallback)."""
@@ -581,7 +590,18 @@ class XdotoolGymEnv(GymEnvironment):
             elif action.action_type == ActionType.TYPE:
                 time.sleep(random.uniform(0.5, 1.5))
 
-        self._execute_action(action)
+        # Epic #362: credit the actual action dispatch to ``act`` —
+        # exclusively the time inside _execute_action, not the
+        # human-speed pre-sleep above (which lands in ``overhead``).
+        _act_t0 = time.monotonic()
+        try:
+            self._execute_action(action)
+        finally:
+            try:
+                from .time_meter import record_to_current
+                record_to_current("act", time.monotonic() - _act_t0)
+            except Exception:
+                pass
 
         # Post-action settle (#294).
         #
@@ -693,14 +713,24 @@ class XdotoolGymEnv(GymEnvironment):
 
         If save_screenshots is set, saves each screenshot for replay testing.
         """
+        # Epic #362: credit screenshot capture to ``perceive``. Uses
+        # ``_screenshot`` directly so adaptive_settle's internal frame
+        # polling (which also calls ``_screenshot``) stays in the
+        # ``settle`` bucket — no double-counting.
+        _t0 = time.monotonic()
         screenshot = self._screenshot()
-
-        if self._save_screenshots:
-            from .replay_env import save_screenshot
-            save_screenshot(screenshot, self._save_screenshots, self._step_counter)
-            self._step_counter += 1
-
-        return GymObservation(screenshot=screenshot, extras={})
+        try:
+            if self._save_screenshots:
+                from .replay_env import save_screenshot
+                save_screenshot(screenshot, self._save_screenshots, self._step_counter)
+                self._step_counter += 1
+            return GymObservation(screenshot=screenshot, extras={})
+        finally:
+            try:
+                from .time_meter import record_to_current
+                record_to_current("perceive", time.monotonic() - _t0)
+            except Exception:
+                pass
 
     @staticmethod
     def _to_int(val) -> int:

--- a/tests/test_admin_token_isolation.py
+++ b/tests/test_admin_token_isolation.py
@@ -36,13 +36,18 @@ from mantis_agent.sim_envs.local import LocalBackend
 pytestmark = pytest.mark.xdist_group("sim_env_boot")
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def stub_env():
+    # Module-scoped: one subprocess boot for the whole file instead of
+    # one per parametrize (~12 boots on this file). Every test here
+    # checks auth gating (401/403 outcomes) and never mutates env
+    # state, so sharing a single stub between cases is safe — and on
+    # CI runners with 2 vCPUs, avoiding 10+ serial FastAPI imports
+    # is the difference between green and flaky. 90 s budget kept as
+    # belt-and-suspenders; the local happy path returns in ~1-2 s.
     backend = LocalBackend()
     handle = backend.start("stub-test", seed=42)
     try:
-        # 90 s — see ``LocalBackend.wait_healthy`` docstring for the
-        # CI-contention rationale. Local runs return in ~1-2 s.
         backend.wait_healthy(handle, timeout_s=90.0)
         yield handle
     finally:

--- a/tests/test_env_up.py
+++ b/tests/test_env_up.py
@@ -83,17 +83,22 @@ def test_local_backend_starts_and_stops_stub_env():
 
 
 def test_local_backend_two_starts_get_distinct_urls():
-    # Two subprocess stubs in parallel under a loaded CI runner can take
-    # noticeably longer than the single-start case. Match the production
-    # default (90 s) — the poll exits as soon as the env responds, so the
-    # higher cap costs nothing on the happy path.
+    # The test contract is "two concurrent backends get different
+    # ports". Earlier versions started both subprocesses before
+    # waiting on either, which on a 2-vCPU GitHub runner meant two
+    # FastAPI / uvicorn imports racing for the box at once —
+    # observed timing out even at 90 s. Sequence the boots: start +
+    # wait h1, then start + wait h2. h2 is still up while we run
+    # the assertion (h1.stop hasn't fired), so the "two backends
+    # coexist with distinct URLs" invariant is preserved without
+    # the parallel-boot pressure.
     backend = LocalBackend()
     h1 = backend.start("stub-test")
+    backend.wait_healthy(h1, timeout_s=90.0)
     h2 = backend.start("stub-test")
+    backend.wait_healthy(h2, timeout_s=90.0)
     try:
         assert h1.url != h2.url
-        backend.wait_healthy(h1, timeout_s=90.0)
-        backend.wait_healthy(h2, timeout_s=90.0)
     finally:
         backend.stop(h1)
         backend.stop(h2)

--- a/tests/test_micro_runner_hooks.py
+++ b/tests/test_micro_runner_hooks.py
@@ -132,32 +132,6 @@ def test_step_results_carry_screenshot_bytes_by_default():
         assert s.screenshot_png is not None and s.screenshot_png[:8] == b"\x89PNG\r\n\x1a\n"
 
 
-def test_time_meter_records_act_and_perceive_per_step():
-    """Phase A (epic #362, issue #363): every dispatched step should
-    charge wall time to ``act`` (the wrapped ``_execute_step`` call) and
-    ``perceive`` (the post-step screenshot capture). Both totals + the
-    per-step breakdown must reflect the same measurements."""
-    env = _FakeEnv()
-    r = _runner(env)
-    steps = r.run(_trivial_plan())
-    assert len(steps) == 3
-
-    meter = r.time_meter
-    # Totals carry both buckets.
-    assert meter.totals["act"] > 0.0
-    assert meter.totals["perceive"] > 0.0
-
-    # Per-step breakdown has one entry per dispatched step.
-    assert len(meter.per_step) == 3
-    for i in range(3):
-        bd = meter.per_step[i]
-        # Each step charged BOTH act and perceive (per-step
-        # screenshot capture runs for every step in the dispatch
-        # path).
-        assert bd["act"] > 0.0, f"step {i} did not charge 'act'"
-        assert bd["perceive"] > 0.0, f"step {i} did not charge 'perceive'"
-
-
 def test_time_meter_records_load_via_navigate_handler():
     """Phase A wire-ins (epic #362): the navigate step handler wraps
     ``env.reset`` in the ``load`` bucket — credited via the dispatch

--- a/tests/test_time_meter.py
+++ b/tests/test_time_meter.py
@@ -300,3 +300,189 @@ def test_adaptive_settle_is_silent_outside_dispatch() -> None:
     # No publish_dispatch wrapping → record_to_current is a no-op.
     elapsed = adaptive_settle.settle_after_action(_Env(), max_seconds=0.3)
     assert elapsed > 0.0  # The wait still happened, just unrecorded.
+
+
+# ── XdotoolGymEnv / PlaywrightGymEnv credit ``act`` + ``perceive`` ──────
+
+
+def test_xdotool_env_step_credits_act_via_dispatch() -> None:
+    """``XdotoolGymEnv.step`` wraps ``_execute_action`` in ``act``;
+    deeper helpers credit themselves. Verified end-to-end by patching
+    ``_execute_action`` + ``_capture`` to instant returns and watching
+    the totals."""
+    from unittest.mock import patch
+
+    from mantis_agent.actions import Action, ActionType
+    from mantis_agent.gym.xdotool_env import XdotoolGymEnv
+
+    env = object.__new__(XdotoolGymEnv)
+    env._human_speed = False
+    env._settle_time = 0.0
+    env._screenshot = lambda: None  # type: ignore[attr-defined]
+    env._capture = lambda: object()  # type: ignore[attr-defined]
+    env._execute_action = lambda _a: time.sleep(0.01)  # type: ignore[attr-defined]
+
+    meter = TimeMeter()
+    with publish_dispatch(meter, step_idx=0):
+        # Patch adaptive_settle to a no-op so this test only measures
+        # _execute_action time on the ``act`` bucket.
+        with patch(
+            "mantis_agent.gym.xdotool_env.adaptive_settle.is_enabled",
+            return_value=False,
+        ):
+            env.step(Action(action_type=ActionType.CLICK, params={"x": 1, "y": 1}))
+    assert meter.totals["act"] >= 0.01
+    assert meter.per_step[0]["act"] >= 0.01
+
+
+def test_xdotool_env_screenshot_credits_perceive_via_dispatch() -> None:
+    """``XdotoolGymEnv.screenshot()`` credits ``perceive`` —
+    ``_screenshot()`` (the private path used by adaptive_settle's frame
+    polling) deliberately does NOT, to avoid double-counting settle."""
+    from PIL import Image
+
+    from mantis_agent.gym.xdotool_env import XdotoolGymEnv
+
+    env = object.__new__(XdotoolGymEnv)
+    img = Image.new("RGB", (8, 8), "white")
+    env._screenshot = lambda: img  # type: ignore[attr-defined]
+
+    meter = TimeMeter()
+    with publish_dispatch(meter, step_idx=0):
+        env.screenshot()
+    assert meter.totals["perceive"] > 0.0
+    assert meter.per_step[0]["perceive"] > 0.0
+
+
+def test_xdotool_env_private_screenshot_does_not_credit_perceive() -> None:
+    """Regression guard: adaptive_settle uses ``_screenshot`` directly
+    inside its settle wait; that path must NOT credit ``perceive`` (it
+    already credits ``settle`` once at the loop's end). Otherwise the
+    two buckets compound for every settle call."""
+    from PIL import Image
+
+    from mantis_agent.gym.xdotool_env import XdotoolGymEnv
+
+    env = object.__new__(XdotoolGymEnv)
+    img = Image.new("RGB", (8, 8), "white")
+
+    # Override _screenshot to skip the OS calls but keep the method on
+    # the instance for the test.
+    def _take():
+        return img
+
+    env._screenshot = _take  # type: ignore[attr-defined]
+
+    meter = TimeMeter()
+    with publish_dispatch(meter, step_idx=0):
+        # Call ``_screenshot`` directly — must not credit any bucket.
+        env._screenshot()
+    assert meter.totals["perceive"] == 0.0
+
+
+# ── ClaudeExtractor / ClaudeGrounding credit Claude buckets ────────────
+
+
+def test_claude_extractor_call_credits_claude_extract_by_default() -> None:
+    """``ClaudeExtractor._call`` records elapsed time to
+    ``claude_extract`` via the dispatch context. Mocks out requests so
+    no actual HTTP happens — only the timer matters."""
+    from unittest.mock import MagicMock, patch
+
+    from PIL import Image
+
+    from mantis_agent.extraction import ClaudeExtractor
+
+    extractor = ClaudeExtractor(api_key="x")
+    img = Image.new("RGB", (8, 8), "white")
+
+    fake_resp = MagicMock()
+    fake_resp.status_code = 200
+    fake_resp.json.return_value = {"content": [{"type": "text", "text": "ok"}]}
+
+    def _post(*_a, **_kw):
+        time.sleep(0.01)
+        return fake_resp
+
+    meter = TimeMeter()
+    with publish_dispatch(meter, step_idx=0):
+        with patch("requests.post", _post):
+            extractor._call(img, "prompt")
+    assert meter.totals["claude_extract"] >= 0.01
+    assert meter.per_step[0]["claude_extract"] >= 0.01
+
+
+def test_claude_extractor_verify_calls_credit_claude_verify() -> None:
+    """``ClaudeExtractor.verify_gate`` routes through ``_call_with_tool_schema``
+    with ``_bucket="claude_verify"``, so the elapsed time lands in the
+    verify bucket rather than ``claude_extract``."""
+    from unittest.mock import MagicMock, patch
+
+    from PIL import Image
+
+    from mantis_agent.extraction import ClaudeExtractor
+
+    extractor = ClaudeExtractor(api_key="x")
+    img = Image.new("RGB", (8, 8), "white")
+
+    fake_resp = MagicMock()
+    fake_resp.status_code = 200
+    fake_resp.json.return_value = {
+        "content": [
+            {"type": "tool_use", "name": "report_gate_verification",
+             "input": {"passed": True, "reason": "ok"}},
+        ],
+    }
+
+    def _post(*_a, **_kw):
+        time.sleep(0.01)
+        return fake_resp
+
+    meter = TimeMeter()
+    with publish_dispatch(meter, step_idx=0):
+        with patch("requests.post", _post):
+            extractor.verify_gate(img, "filters visible")
+    assert meter.totals["claude_verify"] >= 0.01
+    assert meter.totals["claude_extract"] == 0.0
+
+
+def test_claude_grounding_credits_claude_ground() -> None:
+    """``ClaudeGrounding.ground`` wraps both cache hits and API calls in
+    ``claude_ground``."""
+    from unittest.mock import MagicMock, patch
+
+    from PIL import Image
+
+    from mantis_agent.grounding import ClaudeGrounding
+
+    grounding = ClaudeGrounding(api_key="x")
+    img = Image.new("RGB", (32, 32), "white")
+
+    fake_resp = MagicMock()
+    fake_resp.status_code = 200
+    fake_resp.json.return_value = {"content": [{"type": "text", "text": "10 12"}]}
+
+    def _post(*_a, **_kw):
+        time.sleep(0.01)
+        return fake_resp
+
+    meter = TimeMeter()
+    with publish_dispatch(meter, step_idx=0):
+        with patch("requests.post", _post):
+            grounding.ground(img, "click sign in", initial_x=5, initial_y=5)
+    assert meter.totals["claude_ground"] >= 0.01
+
+
+# ── think bucket ────────────────────────────────────────────────────────
+
+
+def test_record_to_current_credits_think_bucket() -> None:
+    """``GymRunner`` calls ``record_to_current("think", elapsed)``
+    around every ``brain.think`` call. This unit test exercises the
+    contract directly — the integration is verified via the wire-in
+    in ``gym/runner.py``."""
+    meter = TimeMeter()
+    with publish_dispatch(meter, step_idx=2):
+        record_to_current("think", 1.25)
+    assert meter.totals["think"] == 1.25
+    assert meter.per_step[2]["think"] == 1.25


### PR DESCRIPTION
## Summary

Finishes Phase A of epic #362 — every bucket in the 9-vocabulary now has a credit path. Also fixes the **`act` double-counting caveat** that was carried forward as a known imprecision in #369.

## What ships

- **`think`** (`gym/runner.py`): `brain.think()` calls in `GymRunner` credit `think` via `record_to_current`. Catches both the main action-loop call (`runner.py:1035`) and the discovery brain call (`runner.py:2260`).

- **`claude_extract` / `claude_verify`** (`extraction/extractor.py`): `ClaudeExtractor`'s four `_call*` methods (the actual Anthropic API callers) accept a `_bucket` kwarg defaulting to `"claude_extract"`. `verify_gate` + `verify_post_click_navigation` pass `_bucket="claude_verify"` so verify time lands in the right bucket. Centralised at the HTTP-call layer so all 10+ public methods (`extract*`, `find_*`) credit correctly without per-method decoration.

- **`claude_ground`** (`grounding.py`): `ClaudeGrounding.ground()` wraps the cache-or-API path. Cache hits credit a near-zero `claude_ground` contribution; API calls credit the real elapsed time.

- **`act` precision** (`gym/xdotool_env.py`, `gym/playwright_env.py`): both envs now credit `act` **only inside `_execute_action`** — the human-speed pre-sleep lands in `overhead`, the post-action settle credits `settle`, the post-action `_capture` credits `perceive`. Replaces the old outer `measure("act")` on `_execute_step` which double-counted `settle` / `load` / `claude` inside.

- **`perceive` precision** (same files): `env.screenshot()` (public) and `_capture()` credit `perceive`. `env._screenshot()` (private, used by `adaptive_settle` frame polling) deliberately does **NOT** credit, so the settle loop's internal screenshots stay in the `settle` bucket with no double-count. Regression test included.

- **`run_executor._dispatch_step`**: removes the outer `measure("act")` and `measure("perceive")` wraps. Keeps `publish_dispatch` around the `_execute_step` call so deep helpers route credit to the right step.

## Tests

- **`test_time_meter.py`**: 7 new cases covering env-level `act`/`perceive` wiring (including the regression guard that `_screenshot` does NOT credit `perceive`), the `claude_extract` default + `claude_verify` override paths, and `claude_ground` via cache miss.
- **`test_micro_runner_hooks.py`**: removes the old "act + perceive per step via fake plan" assertion. The fake env doesn't go through `XdotoolGymEnv`/`PlaywrightGymEnv` so those buckets stay 0 — that test was checking the old outer-wrap design. New unit tests in `test_time_meter.py` cover env-level wiring directly. The `load`-bucket integration test stays as the runner-flow proof.
- 241 adjacent tests pass: `test_run_executor / test_microrunner_som_dispatch / test_context_budget_skip_envelope / test_nav_halt_skip_envelope / test_checkpoint_manager / test_form_intents / test_brain_mock / test_cli_plan_run / test_cli_plan_run_modal / test_server_utils / test_adaptive_settle / test_micro_runner_seed / test_modal_cf_prewarm`.
- `mkdocs build --strict` clean; `ruff check` clean.

## Bucket map (final)

| Bucket | Wire-in | PR |
|---|---|---|
| `perceive` | `XdotoolGymEnv.screenshot` + `_capture`; `PlaywrightGymEnv.screenshot` + `_capture` | this |
| `think` | `GymRunner.brain.think()` call sites | this |
| `act` | `XdotoolGymEnv` + `PlaywrightGymEnv` `_execute_action` | this (narrowed from #367 outer wrap) |
| `settle` | `adaptive_settle.settle_after_action` + `wait_for_networkidle` | #369 |
| `claude_ground` | `ClaudeGrounding.ground` | this |
| `claude_extract` | `ClaudeExtractor._call*` (default bucket) | this |
| `claude_verify` | `ClaudeExtractor.verify_gate` + `verify_post_click_navigation` (`_bucket` override) | this |
| `load` | `navigate.py` `env.reset` wrap | #369 |
| `overhead` | Residual via `TimeMeter.breakdown()` | #367 |

Closes #363. Part of epic #362.

🤖 Generated with [Claude Code](https://claude.com/claude-code)