### PR TITLE
fix(ci): serialize sim-env subprocess boots + raise health timeout to 90s

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,7 +146,14 @@ pythonpath = ["."]
 # CPU cores and cuts the full-suite runtime from ~12.5 min to ~6 min on a
 # typical dev laptop. Override with ``pytest -n0`` or ``pytest -p no:xdist``
 # when serial debugging is needed (e.g. running with ``--pdb``).
-addopts = "-n auto"
+#
+# ``--dist loadgroup`` makes xdist honor ``@pytest.mark.xdist_group("X")``:
+# every test with the same group label lands on the same worker, where
+# they execute sequentially. Used by the sim-env subprocess-boot tests
+# (``test_env_up.py`` / ``test_admin_token_isolation.py``) so we don't
+# get 4+ uvicorn boots competing across workers on a contended runner.
+# Tests without an explicit group keep the default load-balancing.
+addopts = "-n auto --dist loadgroup"
 norecursedirs = [
     ".claude",
     "OSWorld",

--- a/src/mantis_agent/sim_envs/local.py
+++ b/src/mantis_agent/sim_envs/local.py
@@ -223,13 +223,17 @@ class LocalBackend:
             extra={"mode": "subprocess", "proc": proc, "port": port},
         )
 
-    def wait_healthy(self, handle: RuntimeHandle, *, timeout_s: float = 60.0) -> None:
+    def wait_healthy(self, handle: RuntimeHandle, *, timeout_s: float = 90.0) -> None:
         """Poll ``/__env__/health`` until 200 or ``timeout_s`` elapses.
 
-        Default 60 s covers contended CI runners where a fresh Python
-        subprocess + FastAPI import + uvicorn bind can drift well past
-        the older 30 s ceiling. The poll loop exits as soon as the env
-        responds 200, so the higher cap costs nothing on the happy path.
+        Default 90 s covers heavily contended CI runners. The previous
+        60 s ceiling (#364) still flaked on different sub-tests of
+        ``test_admin_token_isolation`` and ``test_env_up`` across many
+        PRs, always on the same first-boot path (fresh Python subprocess
+        + FastAPI import + uvicorn bind). The poll loop exits as soon
+        as the env responds 200, so the higher cap costs nothing on the
+        happy path — it only changes whether we surface a noisy
+        TimeoutError on a slow boot.
         """
         deadline = time.time() + timeout_s
         last_err: Exception | None = None

--- a/tests/test_admin_token_isolation.py
+++ b/tests/test_admin_token_isolation.py
@@ -28,13 +28,22 @@ import pytest
 
 from mantis_agent.sim_envs.local import LocalBackend
 
+# Pin sim-env subprocess-boot tests to the same xdist worker so we
+# don't end up spinning up 4+ FastAPI / uvicorn subprocesses across
+# parallel workers — that contention is what made these tests flake
+# repeatedly across PRs even with the 30 s and 60 s wait_healthy
+# budgets. See ``test_env_up.py`` for the matching mark.
+pytestmark = pytest.mark.xdist_group("sim_env_boot")
+
 
 @pytest.fixture
 def stub_env():
     backend = LocalBackend()
     handle = backend.start("stub-test", seed=42)
     try:
-        backend.wait_healthy(handle, timeout_s=30.0)
+        # 90 s — see ``LocalBackend.wait_healthy`` docstring for the
+        # CI-contention rationale. Local runs return in ~1-2 s.
+        backend.wait_healthy(handle, timeout_s=90.0)
         yield handle
     finally:
         backend.stop(handle)

--- a/tests/test_env_up.py
+++ b/tests/test_env_up.py
@@ -26,6 +26,16 @@ import pytest
 
 from mantis_agent.sim_envs.local import LocalBackend, _pick_free_port
 
+# Pin every sim-env subprocess-boot test to the same xdist worker so
+# parallel pytest jobs don't end up spinning up 4+ FastAPI / uvicorn
+# subprocesses concurrently — that contention is what made
+# ``test_admin_token_isolation`` and this file's two-start case flake
+# repeatedly across recent PRs (#355 / #356 / #357 / #364 / #367 /
+# #370 / #371) even with the 30 s and 60 s wait_healthy budgets.
+# Tests within this group still run sequentially on their assigned
+# worker; other workers keep running other tests in parallel.
+pytestmark = pytest.mark.xdist_group("sim_env_boot")
+
 
 def _http_get(url: str, *, timeout: float = 2.0, headers: dict | None = None) -> tuple[int, str]:
     req = Request(url, headers=headers or {})
@@ -50,7 +60,7 @@ def test_local_backend_starts_and_stops_stub_env():
     backend = LocalBackend()
     handle = backend.start("stub-test", seed=7, now="2026-02-01T00:00:00Z")
     try:
-        backend.wait_healthy(handle, timeout_s=30.0)
+        backend.wait_healthy(handle, timeout_s=90.0)
         status, body = _http_get(f"{handle.url}/__env__/health")
         assert status == 200
         payload = json.loads(body)
@@ -74,16 +84,16 @@ def test_local_backend_starts_and_stops_stub_env():
 
 def test_local_backend_two_starts_get_distinct_urls():
     # Two subprocess stubs in parallel under a loaded CI runner can take
-    # noticeably longer than the single-start case. Use the production
-    # default (60 s) — the poll exits as soon as the env responds, so the
+    # noticeably longer than the single-start case. Match the production
+    # default (90 s) — the poll exits as soon as the env responds, so the
     # higher cap costs nothing on the happy path.
     backend = LocalBackend()
     h1 = backend.start("stub-test")
     h2 = backend.start("stub-test")
     try:
         assert h1.url != h2.url
-        backend.wait_healthy(h1, timeout_s=60.0)
-        backend.wait_healthy(h2, timeout_s=60.0)
+        backend.wait_healthy(h1, timeout_s=90.0)
+        backend.wait_healthy(h2, timeout_s=90.0)
     finally:
         backend.stop(h1)
         backend.stop(h2)
@@ -92,7 +102,7 @@ def test_local_backend_two_starts_get_distinct_urls():
 def test_stop_is_idempotent():
     backend = LocalBackend()
     handle = backend.start("stub-test")
-    backend.wait_healthy(handle, timeout_s=30.0)
+    backend.wait_healthy(handle, timeout_s=90.0)
     backend.stop(handle)
     backend.stop(handle)  # second call must not raise
 


### PR DESCRIPTION
## Summary

The pytest-xdist + `LocalBackend` subprocess-stub interaction has now flaked across **seven PRs** (#355 / #356 / #357 / #364 / #367 / #370 / #371). #364 raised the `test_admin_token_isolation` timeout from 10 s to 30 s; #371's run hit the 30 s cap again on a different sub-test of the same suite.

**Root cause** (confirmed locally): with `pytest -n auto` (default, typically 4-8 workers), parallel jobs each fire up a Python subprocess that imports FastAPI + binds uvicorn. Four-plus concurrent boots saturate the runner — on a 16-CPU laptop the two-stub case takes >90 s. **Raising the timeout alone isn't the fix**; the contention is parallel fan-out, not a slow single boot.

## Real fix

- **`pyproject.toml`** — adds `--dist loadgroup` to `addopts`. xdist now honors `@pytest.mark.xdist_group("X")` and routes every test with that label to the same worker, where they run sequentially. Tests without an explicit group keep the default load-balancing, so the bulk of the suite stays parallel.
- **`tests/test_env_up.py`** + **`tests/test_admin_token_isolation.py`** — module-level `pytestmark = pytest.mark.xdist_group("sim_env_boot")`. Every sim-env subprocess-boot test lands on the same worker; no more parallel FastAPI imports competing.
- **`LocalBackend.wait_healthy`** default `60 s → 90 s`, and every test invocation (10/30/60 → 90). **Belt and suspenders**: the loadgroup fix eliminates parallel contention, the 90 s budget covers the remaining single-boot tail.

## Test plan

- [x] **Reproduction**: pre-fix on this branch, `pytest tests/test_env_up.py tests/test_admin_token_isolation.py` under xdist failed at 91.5 s on `test_local_backend_two_starts_get_distinct_urls`. Post-fix: 15 tests pass in **5.16 s**.
- [x] **Full suite** under xdist: `pytest tests/ --ignore=tests/test_e2e_real_browser.py --ignore=tests/test_modal_endpoint.py --ignore=tests/sim_envs` → **2209 passed in 149 s** (was 247 s pre-fix — loadgroup also improves locality).
- [x] `ruff check` clean.
- [x] **Pre-existing flake check**: the `tests/sim_envs/mantis_crm/test_advanced_surfaces.py` collection errors reproduce on `main` without my changes — unrelated.

## Why not just `pytest-rerunfailures`?

Considered. Decided against: the plugin papers over a real signal (runner saturation) and adds a new dep. Serializing on the xdist worker addresses the root cause without hiding future regressions in the sim-env-boot path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)