### PR TITLE
fix(result-envelope): emit total_time_s on Modal-direct + local CLI result.json

### DIFF
--- a/deploy/modal/modal_plan_runner.py
+++ b/deploy/modal/modal_plan_runner.py
@@ -588,6 +588,11 @@ def run_plan(
         "step_count": len(step_results),
         "successes": successes,
         "failures": failures,
+        # ``total_time_s`` matches ``build_micro_result``'s schema (used
+        # by the HTTP API). ``elapsed_seconds`` is the legacy float form
+        # this path has always returned — kept as an alias so existing
+        # consumers don't break. Both round-trip the same wall-clock.
+        "total_time_s": round(elapsed),
         "elapsed_seconds": round(elapsed, 2),
         "wall_time_breakdown": wall_time_breakdown,
         "final_url": final_url,

--- a/docs/getting-started/cli.md
+++ b/docs/getting-started/cli.md
@@ -204,7 +204,9 @@ raised. Useful as a CI gate against staging endpoints.
   "step_count": 14,
   "successes": 12,
   "failures": 2,
-  "elapsed_seconds": 732.4,
+  "total_time_s": 732,         // integer seconds, matches HTTP API shape
+  "elapsed_seconds": 732.4,    // float alias (legacy; same wall-clock)
+  "wall_time_breakdown": { ... see Wall-time breakdown below ... },
   "final_url": "https://crm.example.test/leads",
   "costs": { "claude_extract": 0.13, "gpu_steps": 47 },
   "steps": [

--- a/src/mantis_agent/cli.py
+++ b/src/mantis_agent/cli.py
@@ -985,6 +985,10 @@ def cmd_plan_run(args: argparse.Namespace) -> int:
         "step_count": len(step_results),
         "successes": successes,
         "failures": failures,
+        # Schema-aligned with build_micro_result (HTTP API path).
+        # elapsed_seconds is the legacy float; total_time_s matches
+        # the HTTP API shape so consumers can use one parser.
+        "total_time_s": round(elapsed),
         "elapsed_seconds": round(elapsed, 2),
         "wall_time_breakdown": wall_time_breakdown,
         "final_url": final_url,


### PR DESCRIPTION
## Summary

Surfaced while verifying epic #362 Phase B end-to-end against staff-crm. Running ``jq .total_time_s outputs/staff-crm-phase-a-verify/result.json`` returned ``null`` — the key was missing.

**Diagnosis:** ``build_micro_result`` (HTTP API path, used by ``mantis-server``) emits ``total_time_s`` per the documented schema. Two sibling result builders — ``modal_plan_runner.run_plan`` (used by ``mantis plan run-modal``) and ``cli.cmd_plan_run`` (local CLI) — historically emitted ``elapsed_seconds`` only. Schema drift between transports.

## Fix

Both direct paths now emit ``total_time_s`` (int seconds, HTTP schema match) **alongside** the existing ``elapsed_seconds`` (float legacy alias). One wall-clock, two keys — back-compat preserved.

## Docs

``docs/getting-started/cli.md`` ``result.json`` schema block updated to show both keys with one-line comments explaining each.

## Test plan

- [x] 126 adjacent tests pass: ``test_cli_plan_run`` / ``test_cli_plan_run_modal`` / ``test_server_utils`` / ``test_time_meter``.
- [x] ``ruff check`` clean.
- [x] ``mkdocs build --strict`` clean.
- [ ] **Final gate** (operator): rerun staff-crm or lu.ma via ``mantis plan run-modal`` and confirm ``jq .total_time_s result.json`` is now an integer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)