### PR TITLE
fix(self-healing): preserve handler-stamped failure_class (critical for #378 + #379)

### DIFF
--- a/src/mantis_agent/gym/run_executor.py
+++ b/src/mantis_agent/gym/run_executor.py
@@ -983,6 +983,18 @@ def _stamp_failure_context(step_result: StepResult, env: Any) -> None:
     failure path must not raise — even if CDP is unreachable or the
     Playwright page is in a half-torn-down state, the StepResult still
     needs to land.
+
+    **Preserves any handler-stamped ``failure_class``.** Step handlers
+    (``Holo3StepHandler`` for ``brain_loop_exhausted``, click handler
+    for ``wrong_target`` / ``no_state_change``, executor demotions for
+    ``no_state_change``) write the canonical class directly on the
+    StepResult. The classifier here is the **fallback** for handlers
+    that haven't been wired yet — it reads ``data`` prose and produces
+    a best-guess. Clobbering an already-stamped class would neuter the
+    self-healing wiring (epic #377): the IntentRewriter / critic key
+    off ``failure_class``, and an "unknown" overwrite means the
+    rewriter never sees the signal the handler took the trouble to
+    surface.
     """
     try:
         url, title = failure_class_mod.read_failure_context(env)
@@ -991,6 +1003,10 @@ def _stamp_failure_context(step_result: StepResult, env: Any) -> None:
         url, title = "", ""
     step_result.final_url = url
     step_result.page_title = title
+    # Honor a handler-stamped class. Only fall through to the
+    # classifier when nothing was stamped.
+    if step_result.failure_class:
+        return
     try:
         step_result.failure_class = failure_class_mod.classify(
             step_result.data or "", title,

--- a/src/mantis_agent/gym/step_handlers/click.py
+++ b/src/mantis_agent/gym/step_handlers/click.py
@@ -715,7 +715,10 @@ class ClaudeGuidedClickHandler:
             data = f"click_no_nav:wrong_target:{verify_reason}"
         elif verify_kind == "no_change":
             failure_class = "no_state_change"
-            data = f"click_no_nav:no_change:{verify_reason}"
+            # ``no_state_change`` substring also lets the classifier
+            # fallback (failure_class.py) map a legacy result.json
+            # to the same class even without the handler stamp.
+            data = f"click_no_nav:no_state_change:{verify_reason}"
         else:
             failure_class = ""
             data = "click_no_nav:detail_page_not_verified"

--- a/tests/test_run_executor.py
+++ b/tests/test_run_executor.py
@@ -385,6 +385,56 @@ def test_handle_failure_continues_when_outcome_is_not_halt():
     assert persist.kwargs["halt_reason"] == "page_exhausted"
 
 
+# ── _stamp_failure_context: preserve handler-stamped class ─────────
+
+
+def test_stamp_failure_context_preserves_handler_stamped_class():
+    """Regression: ``_stamp_failure_context`` runs after every failed
+    step. Handlers (Holo3StepHandler for brain_loop_exhausted, click
+    handler for wrong_target / no_state_change, the demotion path
+    for no_state_change) stamp ``failure_class`` directly with the
+    canonical class. The classifier here is a FALLBACK only — it
+    must NOT clobber an already-stamped class. Otherwise the
+    self-healing wiring (epic #377) is neutered: the rewriter keys
+    off failure_class and the classifier's "unknown" overwrite
+    means the signal is lost."""
+    from mantis_agent.gym.run_executor import _stamp_failure_context
+
+    sr = StepResult(
+        step_index=0, intent="x", success=False,
+        data="click_no_nav:no_change:modal already open",
+        failure_class="no_state_change",  # handler-stamped
+    )
+    _stamp_failure_context(sr, env=MagicMock())
+    assert sr.failure_class == "no_state_change"  # NOT clobbered to "unknown"
+
+
+def test_stamp_failure_context_preserves_brain_loop_exhausted():
+    from mantis_agent.gym.run_executor import _stamp_failure_context
+
+    sr = StepResult(
+        step_index=0, intent="x", success=False,
+        data="",  # Holo3StepHandler doesn't write data on budget burn
+        failure_class="brain_loop_exhausted",
+    )
+    _stamp_failure_context(sr, env=MagicMock())
+    assert sr.failure_class == "brain_loop_exhausted"
+
+
+def test_stamp_failure_context_falls_through_when_no_class_stamped():
+    """When the handler didn't stamp anything, the classifier
+    fallback kicks in over ``data`` + ``page_title``."""
+    from mantis_agent.gym.run_executor import _stamp_failure_context
+
+    sr = StepResult(
+        step_index=0, intent="x", success=False,
+        data="gate:FAIL:Error 403 forbidden",
+    )
+    assert sr.failure_class == ""  # baseline
+    _stamp_failure_context(sr, env=MagicMock())
+    assert sr.failure_class == "cf_challenge"  # classifier fallback
+
+
 # ── Phase B: IntentRewriter wire-in ────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Critical regression in #378 (Phase A) and #379 (Phase B) — \`_stamp_failure_context\` was silently overwriting handler-stamped \`failure_class\` with the classifier's output. Surfaced during the post-merge lu.ma rerun, where step 1's \`data="click_no_nav:no_change:..."\` (stamped with \`failure_class="no_state_change"\` by the click handler) landed in result.json with \`failure_class="unknown"\`.

**Why this is critical**: the IntentRewriter from #379 keys off \`failure_class\` to decide whether to rewrite. \`unknown\` isn't in the trigger set, so the rewriter **never fires**. Phase B is effectively dead until this lands.

## Root cause

\`_stamp_failure_context\` runs after every failed step and always calls \`classify(data, page_title)\`. Handlers that already stamped the canonical class (\`Holo3StepHandler\` for \`brain_loop_exhausted\`, click handler for \`wrong_target\` / \`no_state_change\`, executor demotions for \`no_state_change\`) get silently clobbered. The classifier sees a data string it doesn't recognise (e.g. \`click_no_nav:no_change:...\` doesn't contain the substring \`no_state_change\`) → \`"unknown"\`.

## Fix

- **\`_stamp_failure_context\`**: short-circuits when \`step_result.failure_class\` is already set. The classifier remains the fallback for handlers that haven't been wired to stamp directly — it just doesn't clobber a canonical stamp.
- **\`click.py\`**: canonicalise the \`no_change\` branch's data string from \`click_no_nav:no_change:...\` to \`click_no_nav:no_state_change:...\`. Belt-and-suspenders — even if a future edit accidentally unsets the stamp, the classifier fallback maps the data substring to the right class.

## Test plan

- [x] 3 new regression tests on \`_stamp_failure_context\`: preserves \`no_state_change\` stamp, preserves \`brain_loop_exhausted\` stamp, falls through to classifier when nothing was stamped (preserves existing behavior).
- [x] 117 adjacent tests pass: \`test_run_executor\`, \`test_failure_class\`, \`test_holo3_handler\`, \`test_intent_rewriter\`, \`test_micro_runner_hooks\`, \`test_recovery_hints\`.
- [x] \`ruff check\` clean.
- [ ] **Final gate** (operator): redeploy Modal + rerun lu.ma → expect \`failure_class\` on failed steps to match what the handler stamped, and the IntentRewriter to actually fire on \`wrong_target\` / \`brain_loop_exhausted\` / \`no_state_change\`.

## What this unlocks

This fix is a precondition for ANY signal from #378 / #379 to reach the IntentRewriter. Once it lands, the lu.ma loop should finally exercise the rewriter for the first time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)