### PR TITLE
fix(self-healing): click-demotion uses env.current_url instead of handler-mutated runner state (closes #381)

### DIFF
--- a/src/mantis_agent/gym/run_executor.py
+++ b/src/mantis_agent/gym/run_executor.py
@@ -355,6 +355,14 @@ class RunExecutor:
         }
         pre_snapshot = step_snapshot.capture(runner)
         runner._pre_step_snapshot = pre_snapshot
+        # Epic #377 follow-up (#381): read the browser's URL directly
+        # from the env BEFORE the step executes. The snapshot's ``url``
+        # field reads ``runner._last_known_url``, which the click
+        # handler can self-mutate on its SPA-aware verify path —
+        # making the snapshot diff a misleading proxy for "did the
+        # world actually change?". The pre-URL stash here is the
+        # ground truth the click-demotion path consults instead.
+        runner._pre_step_env_url = _read_env_url(runner.env)
         meter = getattr(runner, "time_meter", None)
         # Publish the dispatch context for the duration of this step.
         # Deep helpers (adaptive_settle, navigate handler, env.step /
@@ -493,16 +501,22 @@ class RunExecutor:
         """Demote click / navigate_back success → fail when no observable
         change. Self-healing primitive — epic #377 Phase A.
 
-        Generic by design: the trigger is the snapshot delta (URL,
-        page, scroll, focus, viewport, extraction), not a step
-        type / plan / domain pattern. Any step type whose action is
-        expected to change one of those dimensions can be added to
-        :attr:`_CLICK_DEMOTE_STEP_TYPES`. The submit case has its own
-        method because it needs an SPA-aware visual escape hatch
-        (same-URL form submits replace the form with a dashboard);
-        that complication doesn't apply here — a click that doesn't
-        change URL / scroll / page genuinely didn't accomplish anything
-        the runner can act on.
+        **URL-first signal** (#381): reads ``env.current_url`` directly
+        for the pre-snapshot URL and the current URL. ``runner._last_known_url``
+        is unreliable because the click handler's SPA-aware verify path
+        writes it optimistically even when the browser's URL didn't
+        change. ``env.current_url`` (CDP / Playwright) is the actual
+        browser state — the handler can't lie about it without genuinely
+        navigating.
+
+        Falls through to the original snapshot-diff signal when the
+        env doesn't expose ``current_url`` (legacy adapters / test
+        stubs) so the primitive doesn't lose coverage where the
+        ground-truth URL isn't available.
+
+        Generic by design: triggers on ``step.type`` membership in
+        :attr:`_CLICK_DEMOTE_STEP_TYPES` (currently ``click`` /
+        ``navigate_back``). No plan, URL, or domain content reads in.
 
         After demoting, records the failure into the per-step retry
         history (so the next attempt can avoid the same target) and
@@ -519,19 +533,64 @@ class RunExecutor:
             return
         if effective_step.type not in self._CLICK_DEMOTE_STEP_TYPES:
             return
-        try:
-            post_snapshot = step_snapshot.capture(runner)
-            delta = step_snapshot.diff(pre_snapshot, post_snapshot)
-        except Exception as exc:  # noqa: BLE001 — never break runs
-            logger.debug("post-click diff capture failed: %s", exc)
-            return
-        if delta is None or delta.has_changes:
-            return
-        logger.warning(
-            "  [%d] %s reported success but no observable state "
-            "change — demoting to failure (will retry)",
-            state.step_index, effective_step.type,
-        )
+
+        pre_url = getattr(runner, "_pre_step_env_url", None)
+        post_url = _read_env_url(runner.env)
+
+        # Prefer the direct URL signal when we have both ends (#381).
+        # The handler can't self-mutate ``env.current_url``, so URL-
+        # unchanged here is a strong signal the click didn't actually
+        # accomplish anything.
+        if isinstance(pre_url, str) and isinstance(post_url, str) and pre_url and post_url:
+            if pre_url == post_url:
+                # URL is unchanged — but a true SPA-modal click would
+                # also have no URL change. Disambiguate via the
+                # runner-state snapshot's NON-handler-mutated fields:
+                # ``focused_input_signature``, ``viewport_stage``,
+                # ``current_page``. Excludes ``scroll_signature`` and
+                # ``last_extracted_url`` since those are exactly what
+                # the click handler optimistically mutates.
+                try:
+                    post_snapshot = step_snapshot.capture(runner)
+                    non_handler_changed = (
+                        pre_snapshot.viewport_stage != post_snapshot.viewport_stage
+                        or pre_snapshot.current_page != post_snapshot.current_page
+                        or pre_snapshot.focused_input_signature
+                            != post_snapshot.focused_input_signature
+                    )
+                except Exception as exc:  # noqa: BLE001 — never break runs
+                    logger.debug("post-click snapshot capture failed: %s", exc)
+                    non_handler_changed = False
+                if non_handler_changed:
+                    return
+                # URL same + nothing-the-handler-shouldn't-have-touched
+                # changed → demote.
+                logger.warning(
+                    "  [%d] %s reported success but URL stayed at %s "
+                    "and no non-handler state changed — demoting "
+                    "(handler self-mutation isn't real navigation)",
+                    state.step_index, effective_step.type, post_url[:80],
+                )
+                # Fall through to the demotion stamping below.
+            else:
+                # URL changed → real navigation. Don't demote.
+                return
+        else:
+            # Direct URL signal unavailable (legacy adapter / test
+            # stub). Fall back to the original snapshot-diff check.
+            try:
+                post_snapshot = step_snapshot.capture(runner)
+                delta = step_snapshot.diff(pre_snapshot, post_snapshot)
+            except Exception as exc:  # noqa: BLE001 — never break runs
+                logger.debug("post-click diff capture failed: %s", exc)
+                return
+            if delta is None or delta.has_changes:
+                return
+            logger.warning(
+                "  [%d] %s reported success but no observable state "
+                "change — demoting to failure (will retry)",
+                state.step_index, effective_step.type,
+            )
         step_result.success = False
         step_result.data = (step_result.data or "") + ":no_state_change"
         step_result.failure_class = "no_state_change"
@@ -974,6 +1033,31 @@ class RunExecutor:
 
 
 # ── Failure diagnostics ────────────────────────────────────────────────
+
+
+def _read_env_url(env: Any) -> str:
+    """Best-effort read of the browser's actual URL from the env.
+
+    Both ``XdotoolGymEnv`` and ``PlaywrightGymEnv`` expose ``current_url``
+    as a property. The xdotool path reads CDP's ``/json/list``; the
+    Playwright path reads ``self._page.url``. Both return ``""`` on
+    any failure (CDP unreachable, page not initialised).
+
+    Returns ``""`` when the env doesn't expose the attribute, the read
+    raises, or the returned value isn't a string. Lets callers
+    distinguish "ground-truth URL unavailable" (fall through to
+    snapshot-based logic) from "URL is known to be X" (use it).
+
+    Used by the click-demotion path (#381) because ``runner._last_known_url``
+    can be self-mutated by the click handler's SPA-aware verify and
+    isn't a reliable proxy for "did the browser actually navigate?".
+    """
+    try:
+        value = getattr(env, "current_url", None)
+    except Exception as exc:  # noqa: BLE001 — never break runs
+        logger.debug("env.current_url access raised: %s", exc)
+        return ""
+    return value if isinstance(value, str) else ""
 
 
 def _stamp_failure_context(step_result: StepResult, env: Any) -> None:

--- a/tests/test_run_executor.py
+++ b/tests/test_run_executor.py
@@ -736,6 +736,105 @@ def test_click_demote_skipped_for_form_step_types():
         )
 
 
+def test_click_demote_uses_env_url_when_available(monkeypatch):
+    """Issue #381: when the env exposes ``current_url`` directly, the
+    demotion uses the browser's ground-truth URL (not
+    ``runner._last_known_url`` which the handler can self-mutate).
+
+    Pre-URL was /discover, post-URL still /discover → demote even if
+    the snapshot delta shows handler-touched state changes (scroll,
+    listings count). The lu.ma cluster A symptom this fixes."""
+    from mantis_agent.gym import step_snapshot as _snap
+
+    runner = _runner_stub()
+    runner.env = MagicMock(current_url="https://luma.com/discover")
+    runner._pre_step_env_url = "https://luma.com/discover"
+    state = _state()
+    state.results.append(StepResult(step_index=0, intent="x", success=True, data="ok"))
+
+    pre_snapshot = MagicMock(
+        viewport_stage=0, current_page=1, focused_input_signature="empty",
+    )
+    post_snapshot = MagicMock(
+        viewport_stage=0, current_page=1, focused_input_signature="empty",
+    )
+    monkeypatch.setattr(_snap, "capture", lambda r: post_snapshot)
+
+    eff_step = MicroIntent(intent="x", type="click")
+    RunExecutor(runner)._maybe_demote_click_no_change(state, eff_step, pre_snapshot)
+
+    assert state.results[0].success is False
+    assert state.results[0].failure_class == "no_state_change"
+
+
+def test_click_demote_skipped_when_env_url_actually_changed(monkeypatch):
+    """Real navigation → don't demote, regardless of what
+    ``runner._last_known_url`` says."""
+    from mantis_agent.gym import step_snapshot as _snap
+
+    runner = _runner_stub()
+    runner.env = MagicMock(current_url="https://luma.com/event/abc")
+    runner._pre_step_env_url = "https://luma.com/discover"
+    state = _state()
+    state.results.append(StepResult(step_index=0, intent="x", success=True))
+
+    monkeypatch.setattr(_snap, "capture", lambda r: MagicMock())
+
+    eff_step = MicroIntent(intent="x", type="click")
+    RunExecutor(runner)._maybe_demote_click_no_change(state, eff_step, MagicMock())
+
+    assert state.results[0].success is True
+
+
+def test_click_demote_keeps_success_when_non_handler_state_changed(monkeypatch):
+    """SPA-modal escape hatch: URL didn't change BUT a non-handler-
+    touched snapshot field did (e.g. focused_input_signature). Treat
+    as a legitimate intra-page action and keep success."""
+    from mantis_agent.gym import step_snapshot as _snap
+
+    runner = _runner_stub()
+    runner.env = MagicMock(current_url="https://luma.com/discover")
+    runner._pre_step_env_url = "https://luma.com/discover"
+    state = _state()
+    state.results.append(StepResult(step_index=0, intent="x", success=True))
+
+    pre_snapshot = MagicMock(
+        viewport_stage=0, current_page=1, focused_input_signature="empty",
+    )
+    post_snapshot = MagicMock(
+        viewport_stage=0, current_page=1,
+        focused_input_signature="search_input_focused",  # non-handler change
+    )
+    monkeypatch.setattr(_snap, "capture", lambda r: post_snapshot)
+
+    eff_step = MicroIntent(intent="x", type="click")
+    RunExecutor(runner)._maybe_demote_click_no_change(state, eff_step, pre_snapshot)
+
+    assert state.results[0].success is True  # NOT demoted
+
+
+def test_click_demote_falls_back_to_snapshot_when_env_url_unavailable(monkeypatch):
+    """Legacy adapters / test stubs that don't expose
+    ``env.current_url`` fall back to the original snapshot-diff
+    behavior — primitive doesn't lose coverage."""
+    from mantis_agent.gym import step_snapshot as _snap
+
+    runner = _runner_stub()
+    runner.env = MagicMock(spec=[])  # NO current_url
+    runner._pre_step_env_url = ""
+    state = _state()
+    state.results.append(StepResult(step_index=0, intent="x", success=True))
+
+    monkeypatch.setattr(_snap, "capture", lambda r: MagicMock())
+    monkeypatch.setattr(_snap, "diff", lambda a, b: MagicMock(has_changes=False))
+
+    eff_step = MicroIntent(intent="x", type="click")
+    RunExecutor(runner)._maybe_demote_click_no_change(state, eff_step, MagicMock())
+
+    assert state.results[0].success is False
+    assert state.results[0].failure_class == "no_state_change"
+
+
 def test_click_demote_respects_skip_envelope():
     """A step with ``skip=True`` (recipe rejection / advance signal)
     must NOT be demoted — skip is an intentional halt path, not a


### PR DESCRIPTION
## Summary

Closes #381. The Phase A click-demotion from #378 was being bypassed on lu.ma because the click handler self-mutates \`runner._last_known_url\` / \`_set_scroll_state\` / \`_listings_on_page\` on its SPA-aware visual-verifier-accepted branch. The runner-state snapshot reads those fields back, sees changes, and \`has_changes\` returns True — demotion skips even though the actual browser URL is unchanged.

The fix: read the URL directly from \`env.current_url\` (both \`XdotoolGymEnv\` and \`PlaywrightGymEnv\` expose it). That's ground truth — the handler can't lie about it without genuinely navigating.

## Why this matters

Without this fix, the lu.ma cluster A symptom (click handler reports success despite no real navigation) leaks past A.1, cascade-fails steps 3–5, and Phase B's IntentRewriter from #379 never sees the \`no_state_change\` / \`wrong_target\` signal it needs to fire. This is the unblocker for the full self-healing chain to exercise on lu.ma for the first time.

## Generic primitive

Every check keys off framework-level attributes — \`env.current_url\` (in the GymEnvironment ABC), \`viewport_stage\` / \`current_page\` / \`focused_input_signature\` (snapshot fields the click handler is NOT allowed to write). Zero plan / URL / domain content in the diff.

## Logic

- **\`_dispatch_step\`** stashes \`runner._pre_step_env_url\` from \`env.current_url\` BEFORE the step executes.
- **\`_maybe_demote_click_no_change\`** picks its signal:
  - Pre + post env URLs both non-empty strings →
    - URL changed → real navigation, don't demote.
    - URL unchanged + a non-handler-touched snapshot field changed (viewport / page / focused input) → SPA-modal escape hatch, keep success.
    - URL unchanged + nothing non-handler changed → demote.
  - Env doesn't expose \`current_url\` (legacy adapter / test stub) → fall back to original snapshot-diff (no coverage loss).
- **\`_read_env_url\`** is the shared probe helper. Returns \`""\` on any failure (CDP unreachable / not initialised / not a string).

## Test plan

- [x] 4 new cases on \`_maybe_demote_click_no_change\`: env URL unchanged → demote (the lu.ma cluster A scenario); env URL actually changed → don't demote; env URL unchanged but non-handler field changed → keep success; legacy env without \`current_url\` falls back to snapshot-diff.
- [x] 225 adjacent tests pass (run_executor, failure_class, holo3_handler, intent_rewriter, micro_runner_hooks, microrunner_som_dispatch, checkpoint_manager, nav_halt, context_budget, form_intents, server_utils, cli_plan_run, cli_plan_run_modal, recovery_hints, time_meter).
- [x] \`ruff check\` clean.
- [ ] **Final gate** (operator): redeploy Modal + rerun \`plans/luma-extract.json\` → expect step 1 iter 1 to demote on URL-unchanged signal, retry via the rewriter, and the cluster A cascade through steps 3–5 to be replaced by a clean fail-fast or recovered path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)