### PR TITLE
feat(browser-checkpoint): form input on PauseState (#360, epic #358 Phase B)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -462,7 +462,7 @@ POST /v1/predict
 | Pending tool call (`pending_tool` + `pending_arguments` + `prompt`) | ✓ — the resumed runner re-invokes the tool with `user_input` set | The mechanism that lets a paused tool finish its `call_tool` round-trip. |
 | **URL + scroll + viewport** (`browser_state`, [epic #358](https://github.com/mercurialsolo/mantis/issues/358) Phase A) | ✓ — agent re-lands on the exact pixel | CDP-captured (`location.href`, `window.scrollX/Y`, `window.innerWidth/Height`) just before pause raises. Empty when the env doesn't expose CDP (legacy adapters). |
 | Cookies / localStorage / IndexedDB | ✓ — but via the `profile_id` Chrome user-data-dir, not `pause_state` | Persists across runs on its own; `profile_id` is the identity that scopes the dir. |
-| Unsubmitted form input | ✗ — half-filled forms reset on resume | [Phase B (#360)](https://github.com/mercurialsolo/mantis/issues/360). |
+| **Unsubmitted form input** (`browser_state.form_state`, [Phase B (#360)](https://github.com/mercurialsolo/mantis/issues/360)) | ✓ — half-filled inputs / selects / checkboxes / radios / contenteditable repopulate on resume | Keyed by stable selector (`data-*` > `id` > short CSS path). Passwords masked: the selector is kept so the caller knows *which* field to re-prompt, but the value is dropped before serialization (opt in via `MANTIS_PAUSE_CAPTURE_PASSWORDS=1` for test/debug only). Missing selectors on the resumed page are silently skipped. |
 | In-memory JS state (React/Redux store, in-flight network) | ✗ — fresh page load | Container-level snapshots would be the right answer; out of scope. |
 
 ### Resume

--- a/src/mantis_agent/gym/checkpoint.py
+++ b/src/mantis_agent/gym/checkpoint.py
@@ -192,14 +192,39 @@ class _PauseRequested(Exception):
 PauseRequested = _PauseRequested
 
 
+@dataclass(frozen=True)
+class FormFieldValue:
+    """One captured form field — text input, select, checkbox, radio,
+    or contenteditable — keyed by a stable selector in
+    :attr:`BrowserState.form_state` (epic #358 Phase B).
+
+    Password fields are captured as ``masked=True`` with an empty
+    ``value``: the selector survives so the resume path knows
+    *which* field needs re-prompting, but the secret never lands in
+    the JSON. Opt out of masking via ``MANTIS_PAUSE_CAPTURE_PASSWORDS=1``
+    (test / debug only).
+    """
+
+    kind: str        # "text" | "select" | "checkbox" | "radio" | "contenteditable"
+    value: str = ""  # for text/select/contenteditable; "true"/"false" for checkbox/radio
+    masked: bool = False
+
+
 @dataclass
 class BrowserState:
-    """Browser-runtime snapshot captured at pause time (epic #358 Phase A).
+    """Browser-runtime snapshot captured at pause time (epic #358).
 
-    URL + scroll + viewport — the smallest unit of "where in the page
-    was the agent?" that lets a resumed run restore visual context
-    instead of starting from page-top. Captured via CDP just before
-    :class:`PauseRequested` raises; replayed during ``runner.resume``.
+    Phase A: URL + scroll + viewport — the smallest unit of "where
+    in the page was the agent?" that lets a resumed run restore
+    visual context instead of starting from page-top. Captured via
+    CDP just before :class:`PauseRequested` raises; replayed during
+    ``runner.resume``.
+
+    Phase B: ``form_state`` — unsubmitted form input (text inputs,
+    selects, checkboxes, radios, contenteditable elements) keyed by
+    a stable selector. Half-filled forms paused for OTP / 2FA /
+    manual review come back populated. Password fields are captured
+    as ``masked=True`` with empty values (caller re-prompts).
 
     Defaults to all-zero / empty so a snapshot from a runner that
     hasn't initialised the browser (or an env adapter that doesn't
@@ -213,6 +238,7 @@ class BrowserState:
     viewport_w: int = 0
     viewport_h: int = 0
     captured_at: float = 0.0
+    form_state: dict[str, FormFieldValue] = field(default_factory=dict)
 
 
 @dataclass
@@ -270,9 +296,20 @@ class PauseState:
         bs_raw = filtered.get("browser_state")
         if isinstance(bs_raw, dict):
             bs_allowed = {f.name for f in fields(BrowserState)}
-            filtered["browser_state"] = BrowserState(
-                **{k: v for k, v in bs_raw.items() if k in bs_allowed}
-            )
+            bs_kwargs = {k: v for k, v in bs_raw.items() if k in bs_allowed}
+            # Phase B: ``form_state`` is dict[selector, FormFieldValue].
+            # asdict turned each value into a dict; reverse here.
+            form_raw = bs_kwargs.get("form_state")
+            if isinstance(form_raw, dict):
+                ffv_allowed = {f.name for f in fields(FormFieldValue)}
+                bs_kwargs["form_state"] = {
+                    str(sel): FormFieldValue(
+                        **{k: v for k, v in entry.items() if k in ffv_allowed}
+                    )
+                    for sel, entry in form_raw.items()
+                    if isinstance(entry, dict)
+                }
+            filtered["browser_state"] = BrowserState(**bs_kwargs)
         elif bs_raw is None:
             filtered.pop("browser_state", None)
         return cls(**filtered)
@@ -303,5 +340,6 @@ __all__ = [
     "PauseRequested",
     "PauseState",
     "BrowserState",
+    "FormFieldValue",
     "RunnerResult",
 ]

--- a/src/mantis_agent/gym/form_capture_js.py
+++ b/src/mantis_agent/gym/form_capture_js.py
@@ -1,0 +1,147 @@
+"""JS payloads for form-field capture + replay (epic #358 Phase B).
+
+Lives in its own module so xdotool / Playwright env adapters share
+one implementation. The two-half pattern — single JS expression on
+capture, single JS expression on replay — keeps the env adapters
+thin (one ``cdp_evaluate`` or ``page.evaluate`` call each).
+
+Capture skips passwords by default (records the field key, masks
+the value, sets ``masked=true``) so secrets never land in
+``PauseState`` JSON. ``MANTIS_PAUSE_CAPTURE_PASSWORDS=1`` opts in
+for test / debug only.
+
+Replay is best-effort: selectors that no longer match (the DOM
+shifted between pause and resume) are silently skipped — never
+fail a resume because the page changed shape.
+"""
+
+from __future__ import annotations
+
+import os
+
+
+def capture_js() -> str:
+    """Return a JS expression that evaluates to a list of captured
+    form fields, each ``{selector, kind, value, masked}``.
+
+    The expression is wrapped in an IIFE so the env's eval call
+    receives a clean value. Selectors prefer ``data-*`` > ``id``
+    > shortest ascending CSS path — keeps the snapshot robust
+    against minor DOM churn between pause and resume.
+    """
+    capture_passwords = (
+        os.environ.get("MANTIS_PAUSE_CAPTURE_PASSWORDS", "").lower()
+        in ("1", "true", "yes")
+    )
+    capture_pw_literal = "true" if capture_passwords else "false"
+    return (
+        "(() => {"
+        # ── stable-selector heuristic ────────────────────────────
+        "const stableSelector = (el) => {"
+        "  for (const attr of el.attributes || []) {"
+        "    if (attr.name.startsWith('data-') && attr.value) {"
+        "      return `[${attr.name}=${JSON.stringify(attr.value)}]`;"
+        "    }"
+        "  }"
+        "  if (el.id) return `#${CSS.escape(el.id)}`;"
+        # Ascending path fallback — name + nth-of-type up to 4 levels.
+        "  const parts = [];"
+        "  let cur = el;"
+        "  for (let depth = 0; depth < 4 && cur && cur !== document.body; depth++) {"
+        "    let s = cur.tagName.toLowerCase();"
+        "    if (cur.classList && cur.classList.length) {"
+        "      s += '.' + [...cur.classList].slice(0, 2).map(c => CSS.escape(c)).join('.');"
+        "    }"
+        "    const parent = cur.parentElement;"
+        "    if (parent) {"
+        "      const sameTag = [...parent.children].filter(c => c.tagName === cur.tagName);"
+        "      if (sameTag.length > 1) {"
+        "        s += `:nth-of-type(${sameTag.indexOf(cur) + 1})`;"
+        "      }"
+        "    }"
+        "    parts.unshift(s);"
+        "    cur = parent;"
+        "  }"
+        "  return parts.join(' > ');"
+        "};"
+        # ── field classification + value extraction ─────────────
+        "const classify = (el) => {"
+        "  const tag = el.tagName.toLowerCase();"
+        "  if (tag === 'select') return 'select';"
+        "  if (tag === 'textarea') return 'text';"
+        "  if (el.isContentEditable) return 'contenteditable';"
+        "  const type = (el.type || 'text').toLowerCase();"
+        "  if (type === 'checkbox') return 'checkbox';"
+        "  if (type === 'radio') return 'radio';"
+        "  return 'text';"
+        "};"
+        "const extractValue = (el, kind) => {"
+        "  if (kind === 'checkbox' || kind === 'radio') return el.checked ? 'true' : 'false';"
+        "  if (kind === 'contenteditable') return el.textContent || '';"
+        "  return el.value || '';"
+        "};"
+        # ── walk + filter ────────────────────────────────────────
+        f"const capturePasswords = {capture_pw_literal};"
+        "const sel = "
+        "  \"input:not([type='hidden']), select, textarea, [contenteditable='true']\";"
+        "const out = [];"
+        "for (const el of document.querySelectorAll(sel)) {"
+        "  const type = (el.type || '').toLowerCase();"
+        "  const isPassword = type === 'password';"
+        "  const kind = classify(el);"
+        "  const selector = stableSelector(el);"
+        "  if (!selector) continue;"
+        "  if (isPassword && !capturePasswords) {"
+        "    out.push({selector, kind: 'text', value: '', masked: true});"
+        "  } else {"
+        "    out.push({selector, kind, value: extractValue(el, kind), masked: false});"
+        "  }"
+        "}"
+        "return out;"
+        "})()"
+    )
+
+
+def replay_js(serialized_entries: str) -> str:
+    """Return a JS expression that walks the captured entries (a
+    pre-stringified JSON array) and re-applies each one. Missing
+    selectors silently skipped; ``masked`` entries skipped (the
+    caller re-prompts).
+
+    Returns an object ``{applied, skipped, missing}`` for the caller
+    to log how the replay went.
+    """
+    return (
+        "(() => {"
+        f"const entries = {serialized_entries};"
+        "let applied = 0, skipped = 0, missing = 0;"
+        "for (const entry of entries) {"
+        "  if (entry.masked) { skipped++; continue; }"
+        "  let el;"
+        "  try { el = document.querySelector(entry.selector); }"
+        "  catch (e) { el = null; }"
+        "  if (!el) { missing++; continue; }"
+        "  try {"
+        "    if (entry.kind === 'text') {"
+        "      el.value = entry.value;"
+        "      el.dispatchEvent(new Event('input', {bubbles: true}));"
+        "      el.dispatchEvent(new Event('change', {bubbles: true}));"
+        "    } else if (entry.kind === 'contenteditable') {"
+        "      el.textContent = entry.value;"
+        "      el.dispatchEvent(new Event('input', {bubbles: true}));"
+        "    } else if (entry.kind === 'checkbox' || entry.kind === 'radio') {"
+        "      el.checked = entry.value === 'true';"
+        "      el.dispatchEvent(new Event('change', {bubbles: true}));"
+        "    } else if (entry.kind === 'select') {"
+        "      el.value = entry.value;"
+        "      el.dispatchEvent(new Event('change', {bubbles: true}));"
+        "    }"
+        "    applied++;"
+        "  } catch (e) { skipped++; }"
+        "}"
+        "return {applied, skipped, missing};"
+        "})()"
+    )
+
+
+__all__ = ["capture_js", "replay_js"]

--- a/src/mantis_agent/gym/playwright_env.py
+++ b/src/mantis_agent/gym/playwright_env.py
@@ -29,7 +29,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from .checkpoint import BrowserState
+    from .checkpoint import BrowserState, FormFieldValue
 
 from PIL import Image
 
@@ -326,16 +326,18 @@ class PlaywrightGymEnv(GymEnvironment):
         return ""
 
     def capture_browser_state(self) -> "BrowserState":
-        """Snapshot URL + scroll + viewport for pause/resume (epic #358
-        Phase A). Mirrors :meth:`XdotoolGymEnv.capture_browser_state`
-        — same return shape, Playwright path uses ``page.evaluate``.
+        """Snapshot URL + scroll + viewport + form-field values for
+        pause/resume (epic #358 Phase A + B). Mirrors
+        :meth:`XdotoolGymEnv.capture_browser_state` — same return
+        shape, Playwright path uses ``page.evaluate``.
 
         Returns an all-empty :class:`BrowserState` on any failure
         (no page, page mid-navigation, JS exception). The caller
         branches on ``bool(state.url)`` to decide whether to apply
         a restore.
         """
-        from .checkpoint import BrowserState
+        from . import form_capture_js
+        from .checkpoint import BrowserState, FormFieldValue
         if self._page is None:
             return BrowserState(captured_at=time.time())
         try:
@@ -353,6 +355,29 @@ class PlaywrightGymEnv(GymEnvironment):
             return BrowserState(captured_at=time.time())
         if not isinstance(result, dict):
             return BrowserState(captured_at=time.time())
+        form_state: dict[str, FormFieldValue] = {}
+        try:
+            entries = self._page.evaluate(form_capture_js.capture_js())
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("form_state capture: page.evaluate raised: %s", exc)
+            entries = None
+        if isinstance(entries, list):
+            for entry in entries:
+                if not isinstance(entry, dict):
+                    continue
+                selector = entry.get("selector")
+                if not isinstance(selector, str) or not selector:
+                    continue
+                kind = entry.get("kind", "text")
+                if not isinstance(kind, str) or not kind:
+                    kind = "text"
+                value = entry.get("value", "")
+                if not isinstance(value, str):
+                    value = str(value)
+                masked = bool(entry.get("masked", False))
+                form_state[selector] = FormFieldValue(
+                    kind=kind, value=value, masked=masked,
+                )
         return BrowserState(
             url=str(result.get("url", "") or ""),
             scroll_x=int(result.get("scroll_x", 0) or 0),
@@ -360,11 +385,13 @@ class PlaywrightGymEnv(GymEnvironment):
             viewport_w=int(result.get("viewport_w", 0) or 0),
             viewport_h=int(result.get("viewport_h", 0) or 0),
             captured_at=time.time(),
+            form_state=form_state,
         )
 
     def restore_browser_state(self, state: "BrowserState") -> None:
         """Replay the captured browser state — navigate to ``url``,
-        scroll to (x, y). No-op when ``state.url`` is empty.
+        scroll to (x, y), re-apply captured form-field values
+        (epic #358 Phase B). No-op when ``state.url`` is empty.
 
         Called from ``runner.resume``; best-effort throughout.
         """
@@ -383,6 +410,45 @@ class PlaywrightGymEnv(GymEnvironment):
                 )
             except Exception as exc:  # noqa: BLE001
                 logger.debug("restore_browser_state: scroll restore failed: %s", exc)
+        if state.form_state and self._page is not None:
+            try:
+                self._replay_form_state(state.form_state)
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("restore_browser_state: form_state replay failed: %s", exc)
+
+    def _replay_form_state(self, form_state: dict) -> None:
+        """Re-apply captured form values via a single ``page.evaluate``.
+        Mirrors :meth:`XdotoolGymEnv._replay_form_state`. Best-effort:
+        masked entries are skipped (caller re-prompts), missing
+        selectors are silently dropped.
+        """
+        from . import form_capture_js
+        if not form_state or self._page is None:
+            return
+        entries = [
+            {
+                "selector": selector,
+                "kind": ffv.kind,
+                "value": ffv.value,
+                "masked": ffv.masked,
+            }
+            for selector, ffv in form_state.items()
+        ]
+        if not entries:
+            return
+        serialized = json.dumps(entries)
+        try:
+            outcome = self._page.evaluate(form_capture_js.replay_js(serialized))
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("_replay_form_state: page.evaluate raised: %s", exc)
+            return
+        if isinstance(outcome, dict):
+            logger.info(
+                "form_state replay: applied=%s skipped=%s missing=%s",
+                outcome.get("applied", 0),
+                outcome.get("skipped", 0),
+                outcome.get("missing", 0),
+            )
 
     # ── Session persistence ──────────────────────────────────────────────
 

--- a/src/mantis_agent/gym/xdotool_env.py
+++ b/src/mantis_agent/gym/xdotool_env.py
@@ -701,16 +701,18 @@ class XdotoolGymEnv(GymEnvironment):
         return ""
 
     def capture_browser_state(self) -> "BrowserState":
-        """Snapshot URL + scroll + viewport for pause/resume (epic #358
-        Phase A). Single CDP ``Runtime.evaluate`` call reads everything
-        in one round-trip.
+        """Snapshot URL + scroll + viewport + form input for
+        pause/resume (epic #358 Phase A + B). Two CDP
+        ``Runtime.evaluate`` calls: one for the URL/scroll/viewport
+        primitives, one for the form-field walk.
 
         Returns an all-empty :class:`BrowserState` on any failure (CDP
         unreachable, page mid-navigation, JS exception). The caller
         branches on ``bool(state.url)`` to decide whether to apply a
         restore — empty url means "no browser state to restore".
         """
-        from .checkpoint import BrowserState
+        from . import form_capture_js
+        from .checkpoint import BrowserState, FormFieldValue
         result = self.cdp_evaluate(
             "({"
             "url: (location && location.href) || '',"
@@ -722,6 +724,27 @@ class XdotoolGymEnv(GymEnvironment):
         )
         if not isinstance(result, dict):
             return BrowserState(captured_at=time.time())
+        # Phase B: form-field walk. Separate eval call so a JS error
+        # in form_capture_js doesn't drop the URL/scroll capture too.
+        form_state: dict[str, FormFieldValue] = {}
+        try:
+            entries = self.cdp_evaluate(form_capture_js.capture_js())
+        except Exception as exc:  # noqa: BLE001 — observability
+            logger.debug("form_state capture: cdp_evaluate raised: %s", exc)
+            entries = None
+        if isinstance(entries, list):
+            for entry in entries:
+                if not isinstance(entry, dict):
+                    continue
+                selector = entry.get("selector")
+                kind = entry.get("kind")
+                if not isinstance(selector, str) or not isinstance(kind, str):
+                    continue
+                form_state[selector] = FormFieldValue(
+                    kind=kind,
+                    value=str(entry.get("value", "") or ""),
+                    masked=bool(entry.get("masked", False)),
+                )
         return BrowserState(
             url=str(result.get("url", "") or ""),
             scroll_x=int(result.get("scroll_x", 0) or 0),
@@ -729,6 +752,7 @@ class XdotoolGymEnv(GymEnvironment):
             viewport_w=int(result.get("viewport_w", 0) or 0),
             viewport_h=int(result.get("viewport_h", 0) or 0),
             captured_at=time.time(),
+            form_state=form_state,
         )
 
     def restore_browser_state(self, state: "BrowserState") -> None:
@@ -755,6 +779,43 @@ class XdotoolGymEnv(GymEnvironment):
                 )
             except Exception as exc:  # noqa: BLE001
                 logger.debug("restore_browser_state: scroll restore failed: %s", exc)
+        # Phase B: replay captured form fields after URL + scroll
+        # restoration. Selectors that don't resolve on the resumed
+        # page (DOM shifted) are silently skipped by the JS shim
+        # itself — never fail a resume because the page changed.
+        if state.form_state:
+            try:
+                self._replay_form_state(state.form_state)
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("restore_browser_state: form_state replay failed: %s", exc)
+
+    def _replay_form_state(self, form_state: dict) -> None:
+        """Re-apply captured form fields via a single CDP eval.
+
+        Skips ``masked`` entries (passwords) — the caller is expected
+        to re-prompt the user. Logs the JS shim's per-call outcome
+        ``{applied, skipped, missing}`` for audit.
+        """
+        from . import form_capture_js
+        entries = [
+            {
+                "selector": selector,
+                "kind": ffv.kind,
+                "value": ffv.value,
+                "masked": ffv.masked,
+            }
+            for selector, ffv in form_state.items()
+        ]
+        if not entries:
+            return
+        serialized = json.dumps(entries)
+        outcome = self.cdp_evaluate(form_capture_js.replay_js(serialized))
+        if isinstance(outcome, dict):
+            logger.info(
+                "form_state replay: applied=%s skipped=%s missing=%s",
+                outcome.get("applied"), outcome.get("skipped"),
+                outcome.get("missing"),
+            )
 
     def has_session(self, name: str) -> bool:
         return self._browser_proc is not None and self._browser_proc.poll() is None

--- a/tests/test_browser_state_checkpoint.py
+++ b/tests/test_browser_state_checkpoint.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import json
 from unittest.mock import MagicMock
 
-from mantis_agent.gym.checkpoint import BrowserState, PauseState
+from mantis_agent.gym.checkpoint import BrowserState, FormFieldValue, PauseState
 
 
 # ── BrowserState defaults + JSON round-trip ─────────────────────────────
@@ -89,28 +89,32 @@ def test_xdotool_capture_browser_state_via_cdp_evaluate() -> None:
     from mantis_agent.gym.xdotool_env import XdotoolGymEnv
 
     env = object.__new__(XdotoolGymEnv)
-    env.cdp_evaluate = MagicMock(return_value={
-        "url": "https://example.com/page",
-        "scroll_x": 0,
-        "scroll_y": 1800,
-        "viewport_w": 1280,
-        "viewport_h": 720,
-    })
+    env.cdp_evaluate = MagicMock(side_effect=[
+        {  # URL/scroll/viewport eval
+            "url": "https://example.com/page",
+            "scroll_x": 0,
+            "scroll_y": 1800,
+            "viewport_w": 1280,
+            "viewport_h": 720,
+        },
+        [],  # form-field eval (empty page)
+    ])
     bs = env.capture_browser_state()
     assert bs.url == "https://example.com/page"
     assert bs.scroll_y == 1800
     assert bs.viewport_w == 1280
-    # The CDP call happened.
-    env.cdp_evaluate.assert_called_once()
-    expr = env.cdp_evaluate.call_args.args[0]
-    assert "location.href" in expr
-    assert "window.scrollX" in expr
+    # Two CDP calls: primitives + form-state walk.
+    assert env.cdp_evaluate.call_count == 2
+    first_expr = env.cdp_evaluate.call_args_list[0].args[0]
+    assert "location.href" in first_expr
+    assert "window.scrollX" in first_expr
 
 
 def test_xdotool_capture_handles_cdp_failure() -> None:
-    """CDP unreachable / page mid-navigation returns None from
-    cdp_evaluate — capture must yield an empty BrowserState, not
-    crash."""
+    """CDP unreachable / page mid-navigation returns None from the
+    URL eval — capture must yield an empty BrowserState, not crash.
+    The form-state eval is skipped entirely (no point capturing
+    fields when we don't even know the URL)."""
     from mantis_agent.gym.xdotool_env import XdotoolGymEnv
 
     env = object.__new__(XdotoolGymEnv)
@@ -202,3 +206,241 @@ def test_capture_helper_returns_env_result_when_callable() -> None:
     expected = BrowserState(url="https://x", scroll_y=42)
     runner.env.capture_browser_state.return_value = expected
     assert _capture_browser_state_safe(runner) is expected
+
+
+# ── Phase B: form-field capture / replay ────────────────────────────────
+
+
+def test_form_field_value_defaults() -> None:
+    ffv = FormFieldValue(kind="text")
+    assert ffv.kind == "text"
+    assert ffv.value == ""
+    assert ffv.masked is False
+
+
+def test_form_capture_js_masks_passwords_by_default(monkeypatch) -> None:
+    """The capture JS expression is built from env state; default
+    must produce a literal ``capturePasswords = false`` so secrets
+    never leave the page even before they reach Python."""
+    monkeypatch.delenv("MANTIS_PAUSE_CAPTURE_PASSWORDS", raising=False)
+    from mantis_agent.gym import form_capture_js
+
+    js = form_capture_js.capture_js()
+    assert "capturePasswords = false" in js
+
+
+def test_form_capture_js_opts_in_with_env_flag(monkeypatch) -> None:
+    monkeypatch.setenv("MANTIS_PAUSE_CAPTURE_PASSWORDS", "1")
+    from mantis_agent.gym import form_capture_js
+
+    js = form_capture_js.capture_js()
+    assert "capturePasswords = true" in js
+
+
+def test_replay_js_embeds_serialized_entries() -> None:
+    from mantis_agent.gym import form_capture_js
+
+    payload = json.dumps([
+        {"selector": "#email", "kind": "text",
+         "value": "a@b.com", "masked": False},
+    ])
+    js = form_capture_js.replay_js(payload)
+    assert "#email" in js
+    assert "applied" in js  # returns {applied, skipped, missing}
+
+
+def test_pause_state_json_round_trip_with_form_state() -> None:
+    """form_state survives the JSON round-trip: dict values come
+    back as FormFieldValue instances, not raw dicts. Passwords
+    stay masked."""
+    bs = BrowserState(
+        url="https://example.com/checkout",
+        form_state={
+            "#email": FormFieldValue(kind="text", value="a@b.com"),
+            "#country": FormFieldValue(kind="select", value="US"),
+            "#tos": FormFieldValue(kind="checkbox", value="true"),
+            "#password": FormFieldValue(kind="text", value="", masked=True),
+        },
+    )
+    ps = PauseState(browser_state=bs)
+    payload = json.dumps(ps.to_dict())
+    rehydrated = PauseState.from_dict(json.loads(payload))
+    fs = rehydrated.browser_state.form_state
+    assert isinstance(fs["#email"], FormFieldValue)
+    assert fs["#email"].value == "a@b.com"
+    assert fs["#country"].kind == "select"
+    assert fs["#tos"].value == "true"
+    assert fs["#password"].masked is True
+    assert fs["#password"].value == ""
+
+
+def test_xdotool_capture_returns_form_state() -> None:
+    """The form-state capture call returns a list of dicts; the env
+    converts that to a dict[selector, FormFieldValue]."""
+    from mantis_agent.gym.xdotool_env import XdotoolGymEnv
+
+    env = object.__new__(XdotoolGymEnv)
+    env.cdp_evaluate = MagicMock(side_effect=[
+        {  # URL/scroll/viewport eval
+            "url": "https://example.com/form", "scroll_x": 0,
+            "scroll_y": 0, "viewport_w": 1280, "viewport_h": 720,
+        },
+        [  # form-field eval
+            {"selector": "#email", "kind": "text",
+             "value": "a@b.com", "masked": False},
+            {"selector": "#tos", "kind": "checkbox",
+             "value": "true", "masked": False},
+        ],
+    ])
+    bs = env.capture_browser_state()
+    assert bs.url == "https://example.com/form"
+    assert "#email" in bs.form_state
+    assert bs.form_state["#email"].value == "a@b.com"
+    assert bs.form_state["#tos"].kind == "checkbox"
+    assert env.cdp_evaluate.call_count == 2
+
+
+def test_xdotool_capture_handles_form_capture_failure() -> None:
+    """If the form-state eval raises, URL/scroll capture should
+    still succeed — form_state lands empty, the rest is intact."""
+    from mantis_agent.gym.xdotool_env import XdotoolGymEnv
+
+    env = object.__new__(XdotoolGymEnv)
+    env.cdp_evaluate = MagicMock(side_effect=[
+        {"url": "https://example.com/form", "scroll_x": 0,
+         "scroll_y": 0, "viewport_w": 1280, "viewport_h": 720},
+        RuntimeError("CDP dropped mid-eval"),
+    ])
+    bs = env.capture_browser_state()
+    assert bs.url == "https://example.com/form"  # URL part survived
+    assert bs.form_state == {}
+
+
+def test_xdotool_capture_drops_malformed_entries() -> None:
+    """Entries without a string selector / kind get skipped, the
+    valid ones still flow through."""
+    from mantis_agent.gym.xdotool_env import XdotoolGymEnv
+
+    env = object.__new__(XdotoolGymEnv)
+    env.cdp_evaluate = MagicMock(side_effect=[
+        {"url": "https://example.com/form", "scroll_x": 0,
+         "scroll_y": 0, "viewport_w": 1280, "viewport_h": 720},
+        [
+            {"selector": "#good", "kind": "text", "value": "x"},
+            {"selector": None, "kind": "text", "value": "y"},
+            {"selector": "#bad-kind", "kind": None, "value": "z"},
+            "not-a-dict",
+        ],
+    ])
+    bs = env.capture_browser_state()
+    assert list(bs.form_state.keys()) == ["#good"]
+
+
+def test_xdotool_restore_replays_form_state() -> None:
+    """When state.form_state is non-empty, restore_browser_state
+    should call _replay_form_state after the URL + scroll steps."""
+    from mantis_agent.gym.xdotool_env import XdotoolGymEnv
+
+    env = object.__new__(XdotoolGymEnv)
+    env.reset = MagicMock()
+    env.cdp_evaluate = MagicMock(return_value={
+        "applied": 1, "skipped": 0, "missing": 0,
+    })
+    state = BrowserState(
+        url="https://example.com/form",
+        scroll_x=0, scroll_y=0,
+        form_state={"#email": FormFieldValue(kind="text", value="a@b.com")},
+    )
+    env.restore_browser_state(state)
+
+    env.reset.assert_called_once()
+    # scroll skipped (both zero) — single eval for form replay.
+    env.cdp_evaluate.assert_called_once()
+    js = env.cdp_evaluate.call_args.args[0]
+    assert "#email" in js
+    assert "a@b.com" in js
+
+
+def test_playwright_capture_returns_form_state() -> None:
+    """Same shape as the xdotool test but exercised through
+    PlaywrightGymEnv — page.evaluate is the seam, two evals per
+    capture (URL + form fields)."""
+    from mantis_agent.gym.playwright_env import PlaywrightGymEnv
+
+    env = object.__new__(PlaywrightGymEnv)
+    env._page = MagicMock()
+    env._page.evaluate = MagicMock(side_effect=[
+        {"url": "https://example.com/form", "scroll_x": 0,
+         "scroll_y": 100, "viewport_w": 1280, "viewport_h": 720},
+        [
+            {"selector": "#email", "kind": "text",
+             "value": "x@y.com", "masked": False},
+        ],
+    ])
+    bs = env.capture_browser_state()
+    assert bs.url == "https://example.com/form"
+    assert bs.form_state["#email"].value == "x@y.com"
+    assert env._page.evaluate.call_count == 2
+
+
+def test_playwright_capture_handles_form_capture_failure() -> None:
+    """Form-state eval failure on Playwright path: URL/scroll
+    survives, form_state lands empty."""
+    from mantis_agent.gym.playwright_env import PlaywrightGymEnv
+
+    env = object.__new__(PlaywrightGymEnv)
+    env._page = MagicMock()
+    env._page.evaluate = MagicMock(side_effect=[
+        {"url": "https://example.com/form", "scroll_x": 0,
+         "scroll_y": 0, "viewport_w": 1280, "viewport_h": 720},
+        RuntimeError("page closed mid-eval"),
+    ])
+    bs = env.capture_browser_state()
+    assert bs.url == "https://example.com/form"
+    assert bs.form_state == {}
+
+
+def test_playwright_restore_replays_form_state() -> None:
+    """restore_browser_state on Playwright env hits page.evaluate
+    with the replay JS once the URL+scroll path is done."""
+    from mantis_agent.gym.playwright_env import PlaywrightGymEnv
+
+    env = object.__new__(PlaywrightGymEnv)
+    env._page = MagicMock()
+    env._page.evaluate = MagicMock(return_value={
+        "applied": 1, "skipped": 0, "missing": 0,
+    })
+    env.reset = MagicMock(side_effect=lambda **_: None)
+
+    state = BrowserState(
+        url="https://example.com/form",
+        scroll_x=0, scroll_y=0,
+        form_state={"#email": FormFieldValue(kind="text", value="a@b.com")},
+    )
+    env.restore_browser_state(state)
+
+    env.reset.assert_called_once()
+    # Single eval for the form replay (scroll skipped, both zero).
+    env._page.evaluate.assert_called_once()
+    js = env._page.evaluate.call_args.args[0]
+    assert "#email" in js
+    assert "a@b.com" in js
+
+
+def test_xdotool_replay_skips_when_form_state_empty() -> None:
+    """An empty form_state on a state with a real url must skip
+    the replay eval entirely (no wasted CDP round-trip)."""
+    from mantis_agent.gym.xdotool_env import XdotoolGymEnv
+
+    env = object.__new__(XdotoolGymEnv)
+    env.reset = MagicMock()
+    env.cdp_evaluate = MagicMock()
+
+    env.restore_browser_state(BrowserState(
+        url="https://example.com/page",
+        scroll_x=0, scroll_y=0,
+        form_state={},
+    ))
+
+    env.reset.assert_called_once()
+    env.cdp_evaluate.assert_not_called()  # no scroll, no form replay


### PR DESCRIPTION
## Summary

- Half-filled forms paused for OTP / 2FA / manual review now come back populated on resume. Captures text inputs, selects, checkboxes, radios, and contenteditable elements keyed by stable selectors (`data-*` > `id` > short CSS path).
- Password fields are masked: the selector is preserved so callers know *which* field to re-prompt, but the value is dropped before serialization. Opt in with `MANTIS_PAUSE_CAPTURE_PASSWORDS=1` (test / debug only).
- Replay is best-effort — selectors that no longer match the resumed DOM are silently skipped. Never fail a resume because the page shifted shape.
- Shared JS payloads live in `gym/form_capture_js.py` so the xdotool + Playwright env adapters use one implementation.

Closes #360.

### Phase A → B

Phase A ([#386](https://github.com/mercurialsolo/mantis/pull/386)) restored URL + scroll + viewport. Phase B adds the in-page input state on top of the same `BrowserState` dataclass — one extra `cdp_evaluate` / `page.evaluate` call per capture, one per replay.

### What's captured at pause time

The docs table in `docs/api.md` is updated to flip the "Unsubmitted form input" row from ✗ to ✓.

## Test plan

- [x] `pytest tests/test_browser_state_checkpoint.py` — 26 passing (Phase A round-trip + xdotool path + Phase B form capture/replay across both xdotool and Playwright envs)
- [x] `pytest tests/test_micro_runner_hooks.py tests/test_checkpoint_*.py tests/test_predict_pause_resume.py` — 74 passing
- [x] Full suite (excluding the pre-existing sim-envs/mantis_crm python-multipart blocker) — 2402 passed
- [x] `ruff check` clean on all touched files
- [x] `mkdocs build --strict` — docs render cleanly
- [ ] Modal redeploy + lu.ma plan rerun to verify form replay works end-to-end against a real Chromium

🤖 Generated with [Claude Code](https://claude.com/claude-code)