### PR TITLE
feat(sim-envs): mock auth surface (login + Google OAuth)

### DIFF
--- a/deploy/sim_envs/mantis_crm/app/auth.py
+++ b/deploy/sim_envs/mantis_crm/app/auth.py
@@ -1,0 +1,164 @@
+"""Mock auth surface — email-password + Google-style OAuth (#387).
+
+Mirrors ``mantis_shop/app/auth.py``. CRM users in this env are all
+*agents* (no "buyer" role), so no ``effective_customer_id`` indirection
+— the session user IS the actor on every mutation.
+
+Two extra columns are added to the existing ``users`` table:
+``password_hash`` + ``oauth_subject``. Existing CRM seed users get a
+default password so any of them can be impersonated for tests.
+
+``ENV_REQUIRE_AUTH=1`` flips the gate on every non-``/`` route except
+``/login``, ``/logout``, ``/oauth/*``, ``/__env__/*``, ``/static/*``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import os
+import secrets
+import time
+from typing import Any
+
+from fastapi import Request, Response
+from fastapi.responses import RedirectResponse
+
+from . import db
+
+SESSION_COOKIE = "mantis_session"
+SESSION_TTL_DEFAULT_S = 60 * 60
+LOGIN_PATH = "/login"
+OAUTH_AUTHORIZE_PATH = "/oauth/authorize"
+OAUTH_CALLBACK_PATH = "/oauth/callback"
+
+_OAUTH_CODE_TTL_S = 60
+_OAUTH_CODES: dict[str, dict[str, Any]] = {}
+
+
+def session_secret() -> str:
+    return os.environ.get("ENV_SESSION_SECRET", "dev-only-do-not-use-in-prod")
+
+
+def session_ttl_s() -> int:
+    raw = os.environ.get("ENV_SESSION_TTL_S")
+    try:
+        return int(raw) if raw else SESSION_TTL_DEFAULT_S
+    except ValueError:
+        return SESSION_TTL_DEFAULT_S
+
+
+def auth_required() -> bool:
+    return os.environ.get("ENV_REQUIRE_AUTH", "0").lower() in {"1", "true", "yes"}
+
+
+def hash_password(plain: str) -> str:
+    return hashlib.sha256(plain.encode("utf-8")).hexdigest()
+
+
+def verify_password(plain: str, stored: str) -> bool:
+    if not stored:
+        return False
+    return hmac.compare_digest(hash_password(plain), stored)
+
+
+def mint_session(user_id: str, *, now: float | None = None) -> str:
+    issued = int(now if now is not None else time.time())
+    payload = f"{user_id}|{issued}"
+    sig = hmac.new(
+        session_secret().encode("utf-8"),
+        payload.encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+    return f"{payload}|{sig}"
+
+
+def verify_session(cookie_val: str, *, now: float | None = None) -> str | None:
+    if not cookie_val:
+        return None
+    parts = cookie_val.split("|")
+    if len(parts) != 3:
+        return None
+    user_id, issued_at_s, sig = parts
+    try:
+        issued_at = int(issued_at_s)
+    except ValueError:
+        return None
+    payload = f"{user_id}|{issued_at}"
+    expected = hmac.new(
+        session_secret().encode("utf-8"),
+        payload.encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+    if not hmac.compare_digest(sig, expected):
+        return None
+    now_ts = now if now is not None else time.time()
+    if now_ts - issued_at > session_ttl_s():
+        return None
+    return user_id
+
+
+def set_session_cookie(response: Response, user_id: str) -> None:
+    response.set_cookie(
+        SESSION_COOKIE,
+        mint_session(user_id),
+        httponly=True,
+        samesite="lax",
+        max_age=session_ttl_s(),
+        path="/",
+    )
+
+
+def clear_session_cookie(response: Response) -> None:
+    response.delete_cookie(SESSION_COOKIE, path="/")
+
+
+def lookup_user_by_id(user_id: str) -> dict[str, Any] | None:
+    conn = db.connect()
+    row = conn.execute(
+        "SELECT id, email, name, role, oauth_subject FROM users WHERE id = ?",
+        (user_id,),
+    ).fetchone()
+    return dict(row) if row else None
+
+
+def lookup_user_by_email(email: str) -> dict[str, Any] | None:
+    conn = db.connect()
+    row = conn.execute(
+        "SELECT id, email, name, password_hash, role, oauth_subject "
+        "FROM users WHERE LOWER(email) = ?",
+        (email.strip().lower(),),
+    ).fetchone()
+    return dict(row) if row else None
+
+
+def current_user(request: Request) -> dict[str, Any] | None:
+    raw = request.cookies.get(SESSION_COOKIE)
+    user_id = verify_session(raw or "")
+    if user_id is None:
+        return None
+    return lookup_user_by_id(user_id)
+
+
+def issue_oauth_code(*, user_id: str, redirect_uri: str, state: str) -> str:
+    code = secrets.token_urlsafe(16)
+    _OAUTH_CODES[code] = {
+        "user_id": user_id,
+        "redirect_uri": redirect_uri,
+        "state": state,
+        "expires_at": time.time() + _OAUTH_CODE_TTL_S,
+    }
+    return code
+
+
+def consume_oauth_code(code: str) -> dict[str, Any] | None:
+    entry = _OAUTH_CODES.pop(code, None)
+    if entry is None:
+        return None
+    if time.time() > entry["expires_at"]:
+        return None
+    return entry
+
+
+def clear_oauth_codes() -> None:
+    _OAUTH_CODES.clear()

--- a/deploy/sim_envs/mantis_crm/app/auth.py
+++ b/deploy/sim_envs/mantis_crm/app/auth.py
@@ -22,7 +22,6 @@ import time
 from typing import Any
 
 from fastapi import Request, Response
-from fastapi.responses import RedirectResponse
 
 from . import db
 

--- a/deploy/sim_envs/mantis_crm/app/db.py
+++ b/deploy/sim_envs/mantis_crm/app/db.py
@@ -50,8 +50,13 @@ CREATE TABLE IF NOT EXISTS users (
     id              TEXT PRIMARY KEY,
     name            TEXT NOT NULL,
     email           TEXT NOT NULL,
-    is_active       INTEGER NOT NULL DEFAULT 1
+    is_active       INTEGER NOT NULL DEFAULT 1,
+    -- Mock auth surface (#387). Plain sha256 hex — sim env, not prod.
+    password_hash   TEXT,
+    role            TEXT NOT NULL DEFAULT 'agent',  -- 'agent' | 'admin'
+    oauth_subject   TEXT
 );
+CREATE INDEX IF NOT EXISTS idx_users_email ON users(email);
 
 CREATE TABLE IF NOT EXISTS companies (
     id              TEXT PRIMARY KEY,

--- a/deploy/sim_envs/mantis_crm/app/main.py
+++ b/deploy/sim_envs/mantis_crm/app/main.py
@@ -22,11 +22,11 @@ from pathlib import Path
 from typing import Any
 
 from fastapi import FastAPI, Request, Response
-from fastapi.responses import HTMLResponse, JSONResponse
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
-from . import db, seed
+from . import auth, db, seed
 
 APP_DIR = Path(__file__).parent
 ADMIN_TOKEN_ENV = "ENV_ADMIN_TOKEN"
@@ -81,6 +81,28 @@ def create_app() -> FastAPI:
     app.state.templates = templates
     app.state.admin_token = _admin_token()
 
+    # Resolve the session user once per request + gate everything except
+    # ``/``, ``/login``, ``/logout``, ``/oauth/*``, ``/__env__/*``,
+    # ``/static/*`` when ``ENV_REQUIRE_AUTH=1``. See #387.
+    @app.middleware("http")
+    async def _auth_gate(request: Request, call_next):  # noqa: ANN202
+        try:
+            request.state.current_user = auth.current_user(request)
+        except Exception:  # noqa: BLE001 — never block request on auth lookup
+            request.state.current_user = None
+
+        if auth.auth_required():
+            path = request.url.path
+            open_prefixes = (
+                "/login", "/logout", "/oauth/", "/__env__/", "/static/",
+            )
+            if path != "/" and not path.startswith(open_prefixes):
+                if request.state.current_user is None:
+                    return RedirectResponse(
+                        f"/login?next={path}", status_code=303,
+                    )
+        return await call_next(request)
+
     # Seed the DB at startup. If you mount a persistent volume, seed
     # only runs on first boot; otherwise it runs every container start.
     @app.on_event("startup")
@@ -101,6 +123,7 @@ def create_app() -> FastAPI:
     )
 
     # Router registration is split by surface for readability.
+    from .routes import auth as auth_router
     from .routes import companies as companies_router
     from .routes import contacts as contacts_router
     from .routes import deals as deals_router
@@ -113,6 +136,7 @@ def create_app() -> FastAPI:
     from .routes import templates as templates_router
 
     app.include_router(env_admin_router.router)
+    app.include_router(auth_router.router)
     app.include_router(contacts_router.router)
     app.include_router(companies_router.router)
     app.include_router(deals_router.router)

--- a/deploy/sim_envs/mantis_crm/app/oracles/__init__.py
+++ b/deploy/sim_envs/mantis_crm/app/oracles/__init__.py
@@ -34,6 +34,7 @@ from . import (
     t03_at_risk_deals,
     t04_add_meeting_note,
     t05_pipeline_review,
+    t06_login_then_tag_reengage,
 )
 
 GraderFn = Callable[..., dict[str, Any]]
@@ -45,6 +46,7 @@ GRADERS: dict[str, GraderFn] = {
     "T03_at_risk_deals": t03_at_risk_deals.grade,
     "T04_add_meeting_note": t04_add_meeting_note.grade,
     "T05_pipeline_review": t05_pipeline_review.grade,
+    "T06_login_then_tag_reengage": t06_login_then_tag_reengage.grade,
 }
 
 

--- a/deploy/sim_envs/mantis_crm/app/oracles/t06_login_then_tag_reengage.py
+++ b/deploy/sim_envs/mantis_crm/app/oracles/t06_login_then_tag_reengage.py
@@ -1,0 +1,80 @@
+"""T06_login_then_tag_reengage — adds the auth gate on top of T01.
+
+Pass conditions
+---------------
+
+1. ``mutations`` contains a ``login_succeeded`` row with target_id
+   ``user_00001`` (the seeded demo agent) *before* the first mutation
+   T01 grades on. Mutation ids auto-increment, so id-ordering proves
+   "logged in first".
+2. The login row's payload was minted via the real flow
+   (``via='password'`` or ``via='oauth'``). Harness ``login_as``
+   shortcuts don't write this row, so they fail the gate.
+3. All of T01_tag_reengage's existing pass conditions still hold.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Any
+
+from . import t01_tag_reengage
+
+EXPECTED_USER_ID = "user_00001"
+VALID_LOGIN_VIA = {"password", "oauth"}
+
+
+def grade(conn: sqlite3.Connection, *, now: str, seed_val: int) -> dict[str, Any]:
+    reasons: list[str] = []
+
+    login_row = conn.execute(
+        "SELECT id, occurred_at, payload_json FROM mutations "
+        "WHERE operation = 'login_succeeded' AND target_id = ? "
+        "ORDER BY id ASC LIMIT 1",
+        (EXPECTED_USER_ID,),
+    ).fetchone()
+    login_mut_id = None
+    if login_row is None:
+        reasons.append(
+            f"no login_succeeded mutation for {EXPECTED_USER_ID}; "
+            "agent must navigate /login (password) or /oauth/authorize first"
+        )
+    else:
+        login_mut_id = login_row["id"]
+        raw = login_row["payload_json"] or ""
+        if not any(f'"via": "{v}"' in raw or f'"via":"{v}"' in raw
+                   for v in VALID_LOGIN_VIA):
+            reasons.append(
+                "login_succeeded mutation missing valid `via` "
+                f"(expected one of {sorted(VALID_LOGIN_VIA)})"
+            )
+
+    # Check at least one tag mutation came AFTER login.
+    if login_mut_id is not None:
+        post = conn.execute(
+            "SELECT COUNT(*) FROM mutations "
+            "WHERE operation IN ('contact_tag_added', 'contact_tagged') "
+            "AND id > ?",
+            (login_mut_id,),
+        ).fetchone()[0]
+        if post == 0:
+            reasons.append(
+                "no contact tag mutations recorded after login_succeeded"
+            )
+
+    inner = t01_tag_reengage.grade(conn, now=now, seed_val=seed_val)
+    if not inner["passed"]:
+        reasons.extend(f"[T01] {r}" for r in inner["reasons"])
+
+    passed = not reasons
+    return {
+        "passed": passed,
+        "score": 1.0 if passed else 0.0,
+        "reasons": reasons or [
+            f"logged in as {EXPECTED_USER_ID} then completed T01_tag_reengage"
+        ],
+        "diff": {
+            "login_mutation_id": login_mut_id,
+            **inner.get("diff", {}),
+        },
+    }

--- a/deploy/sim_envs/mantis_crm/app/routes/auth.py
+++ b/deploy/sim_envs/mantis_crm/app/routes/auth.py
@@ -1,0 +1,206 @@
+"""Mock auth routes — ``/login``, ``/logout``, OAuth-mock pair (#387).
+
+Mirrors ``mantis_shop/app/routes/auth.py``. Audit goes into the CRM's
+``mutations`` table via ``db.log_mutation`` (shop uses ``audit_log`` +
+``log_audit`` — same shape, different table name per env design).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Form, Request
+from fastapi.responses import HTMLResponse, RedirectResponse, Response
+
+from .. import auth, db, main as app_main
+
+router = APIRouter()
+
+OAUTH_CLIENT_ID = "mantis-crm"
+OAUTH_DEFAULT_REDIRECT = "/oauth/callback"
+
+
+def _audit(operation: str, target_id: str, payload: dict[str, Any]) -> None:
+    conn = db.connect()
+    db.log_mutation(
+        conn,
+        occurred_at=app_main.now_value(),
+        operation=operation,
+        target_type="user",
+        target_id=target_id,
+        payload=payload,
+    )
+    conn.commit()
+    app_main.emit(f"mutation.{operation}", {"target_id": target_id, **payload})
+
+
+@router.get("/login", response_class=HTMLResponse)
+async def login_get(request: Request) -> HTMLResponse:
+    return app_main.app.state.templates.TemplateResponse(
+        "login.html",
+        {
+            "request": request,
+            "next": request.query_params.get("next") or "/",
+            "error": request.query_params.get("error") or "",
+            "current_user": auth.current_user(request),
+        },
+    )
+
+
+@router.post("/login")
+async def login_post(
+    request: Request,
+    email: str = Form(""),
+    password: str = Form(""),
+    next: str = Form("/"),
+) -> Response:
+    user = auth.lookup_user_by_email(email)
+    if user is None or not auth.verify_password(password, user["password_hash"]):
+        _audit(
+            "login_failed",
+            target_id="anon",
+            payload={"email": email.strip().lower(), "via": "password"},
+        )
+        return RedirectResponse(
+            f"/login?error=Invalid+email+or+password&next={next}",
+            status_code=303,
+        )
+
+    resp = RedirectResponse(next or "/", status_code=303)
+    auth.set_session_cookie(resp, user["id"])
+    _audit(
+        "login_succeeded",
+        target_id=user["id"],
+        payload={"email": user["email"], "role": user["role"], "via": "password"},
+    )
+    return resp
+
+
+@router.post("/logout")
+async def logout_post(request: Request) -> Response:
+    user = auth.current_user(request)
+    resp = RedirectResponse("/login", status_code=303)
+    auth.clear_session_cookie(resp)
+    if user is not None:
+        _audit("logout", target_id=user["id"], payload={"email": user["email"]})
+    return resp
+
+
+@router.get("/oauth/authorize", response_class=HTMLResponse)
+async def oauth_authorize_get(request: Request) -> HTMLResponse:
+    client_id = request.query_params.get("client_id", "")
+    redirect_uri = request.query_params.get("redirect_uri", OAUTH_DEFAULT_REDIRECT)
+    state = request.query_params.get("state", "")
+    error = ""
+    if client_id and client_id != OAUTH_CLIENT_ID:
+        error = f"unknown client_id: {client_id}"
+    return app_main.app.state.templates.TemplateResponse(
+        "oauth_authorize.html",
+        {
+            "request": request,
+            "client_id": client_id or OAUTH_CLIENT_ID,
+            "redirect_uri": redirect_uri,
+            "state": state,
+            "error": error,
+            "accounts": [
+                {"sub": "google-oauth2|crm-demo-001",
+                 "label": "demo@mantis.example"},
+                {"sub": "google-oauth2|crm-admin-001",
+                 "label": "admin@mantis.example"},
+            ],
+        },
+    )
+
+
+@router.post("/oauth/consent", response_class=HTMLResponse)
+async def oauth_consent_get(
+    request: Request,
+    oauth_subject: str = Form(""),
+    redirect_uri: str = Form(OAUTH_DEFAULT_REDIRECT),
+    state: str = Form(""),
+) -> Response:
+    """Step 2 of the OAuth mock — consent screen for the picked account."""
+    conn = db.connect()
+    row = conn.execute(
+        "SELECT id, email, oauth_subject FROM users WHERE oauth_subject = ?",
+        (oauth_subject,),
+    ).fetchone()
+    if row is None:
+        return RedirectResponse(
+            f"/oauth/authorize?error=unknown+account&state={state}",
+            status_code=303,
+        )
+    return app_main.app.state.templates.TemplateResponse(
+        "oauth_consent.html",
+        {
+            "request": request,
+            "user": dict(row),
+            "client_id": OAUTH_CLIENT_ID,
+            "redirect_uri": redirect_uri,
+            "state": state,
+        },
+    )
+
+
+@router.post("/oauth/consent/grant", response_class=HTMLResponse)
+async def oauth_consent_grant(
+    request: Request,
+    oauth_subject: str = Form(""),
+    redirect_uri: str = Form(OAUTH_DEFAULT_REDIRECT),
+    state: str = Form(""),
+) -> Response:
+    """Step 3 — mint a single-use code and render the redirect interstitial."""
+    conn = db.connect()
+    row = conn.execute(
+        "SELECT id FROM users WHERE oauth_subject = ?", (oauth_subject,),
+    ).fetchone()
+    if row is None:
+        return RedirectResponse(
+            f"/oauth/authorize?error=unknown+account&state={state}",
+            status_code=303,
+        )
+    code = auth.issue_oauth_code(
+        user_id=row["id"], redirect_uri=redirect_uri, state=state,
+    )
+    _audit(
+        "oauth_consent",
+        target_id=row["id"],
+        payload={"oauth_subject": oauth_subject, "client_id": OAUTH_CLIENT_ID},
+    )
+    sep = "&" if "?" in redirect_uri else "?"
+    target = f"{redirect_uri}{sep}code={code}&state={state}"
+    return app_main.app.state.templates.TemplateResponse(
+        "oauth_redirect.html",
+        {
+            "request": request,
+            "target": target,
+            "client_id": OAUTH_CLIENT_ID,
+        },
+    )
+
+
+@router.get("/oauth/callback")
+async def oauth_callback(request: Request) -> Response:
+    code = request.query_params.get("code", "")
+    if not code:
+        return RedirectResponse(
+            "/login?error=missing+oauth+code", status_code=303,
+        )
+    entry = auth.consume_oauth_code(code)
+    if entry is None:
+        return RedirectResponse(
+            "/login?error=oauth+code+expired+or+used", status_code=303,
+        )
+    user = auth.lookup_user_by_id(entry["user_id"])
+    if user is None:
+        return RedirectResponse(
+            "/login?error=oauth+user+not+found", status_code=303,
+        )
+    resp = RedirectResponse("/", status_code=303)
+    auth.set_session_cookie(resp, user["id"])
+    _audit(
+        "login_succeeded",
+        target_id=user["id"],
+        payload={"email": user["email"], "role": user["role"], "via": "oauth"},
+    )
+    return resp

--- a/deploy/sim_envs/mantis_crm/app/seed.py
+++ b/deploy/sim_envs/mantis_crm/app/seed.py
@@ -154,6 +154,16 @@ def _parse_iso(value: str) -> datetime:
 
 
 def _seed_users(cur: sqlite3.Cursor, rng: random.Random) -> None:
+    """Seed CRM users with mock-auth fields (#387).
+
+    user_00001 doubles as the canonical "demo agent" with password
+    ``hunter2``; user_00002 doubles as the admin with password
+    ``admin123``. Other users have NULL password_hash → they exist in
+    the data but can't sign in (mirrors real-world deactivated /
+    SAML-only accounts).
+    """
+    from . import auth  # local import — avoids circular at module load
+
     rows: list[tuple[Any, ...]] = []
     for i in range(1, N_USERS + 1):
         first = rng.choice(_FIRST_NAMES)
@@ -161,9 +171,27 @@ def _seed_users(cur: sqlite3.Cursor, rng: random.Random) -> None:
         name = f"{first} {last}"
         email = f"{first.lower()}.{last.lower()}@mantis-crm.test"
         is_active = 0 if i == N_USERS else 1  # one deactivated user, per spec
-        rows.append((_id("user", i), name, email, is_active))
+        if i == 1:
+            password_hash = auth.hash_password("hunter2")
+            email = "demo@mantis.example"
+            role = "agent"
+            oauth_subject = "google-oauth2|crm-demo-001"
+        elif i == 2:
+            password_hash = auth.hash_password("admin123")
+            email = "admin@mantis.example"
+            role = "admin"
+            oauth_subject = "google-oauth2|crm-admin-001"
+        else:
+            password_hash = None
+            role = "agent"
+            oauth_subject = None
+        rows.append((
+            _id("user", i), name, email, is_active,
+            password_hash, role, oauth_subject,
+        ))
     cur.executemany(
-        "INSERT INTO users (id, name, email, is_active) VALUES (?, ?, ?, ?)",
+        "INSERT INTO users (id, name, email, is_active, password_hash, "
+        "role, oauth_subject) VALUES (?, ?, ?, ?, ?, ?, ?)",
         rows,
     )
 

--- a/deploy/sim_envs/mantis_crm/app/static/app.css
+++ b/deploy/sim_envs/mantis_crm/app/static/app.css
@@ -402,3 +402,59 @@ pre { background: #f8fafc; padding: 10px; border-radius: 6px;
   padding: 14px; white-space: pre-wrap; font-family: ui-monospace, Menlo, monospace;
   font-size: 12px; line-height: 1.6;
 }
+  align-items: start;
+}
+
+pre { background: #f8fafc; padding: 10px; border-radius: 6px;
+      border: 1px solid var(--border); overflow-x: auto; font-size: 12px; }
+code { font-size: 11px; font-family: ui-monospace, Menlo, monospace; color: var(--slate); }
+
+/* ── auth (login + OAuth consent) ─────────────────────────────────── */
+.login-card {
+  max-width: 380px; margin: 32px auto;
+  background: var(--bg-panel); border: 1px solid var(--border);
+  border-radius: 10px; padding: 28px; box-shadow: var(--shadow-md);
+}
+.login-card h1 { margin: 0 0 14px; font-size: 20px; }
+.login-card .muted { color: var(--text-muted); margin-top: -8px; }
+.login-card .error {
+  background: var(--red-soft); color: var(--red);
+  padding: 8px 10px; border-radius: 6px; margin-bottom: 12px; font-size: 12px;
+}
+.login-card .notice {
+  background: var(--accent-soft); color: var(--accent);
+  padding: 8px 10px; border-radius: 6px; margin-bottom: 12px; font-size: 12px;
+}
+.login-form { display: flex; flex-direction: column; gap: 12px; }
+.login-form label { display: flex; flex-direction: column; gap: 4px;
+                    font-size: 12px; color: var(--text-muted); }
+.login-form input {
+  padding: 8px 10px; border: 1px solid var(--border-strong);
+  border-radius: 6px; font-size: 13px;
+}
+.login-form button {
+  background: var(--accent); color: white; border: 0;
+  padding: 10px; border-radius: 6px; font-weight: 600; cursor: pointer;
+}
+.login-form button:hover { background: var(--accent-hover); }
+.oauth-divider {
+  text-align: center; color: var(--text-faint); font-size: 11px;
+  margin: 16px 0; text-transform: uppercase; letter-spacing: 0.1em;
+}
+.btn-oauth {
+  display: block; text-align: center; padding: 10px;
+  border: 1px solid var(--border-strong); border-radius: 6px;
+  color: var(--text); text-decoration: none; font-weight: 500;
+}
+.btn-oauth:hover { background: var(--bg-hover); }
+.oauth-account {
+  display: block; padding: 10px; border: 1px solid var(--border);
+  border-radius: 6px; margin: 6px 0; cursor: pointer;
+}
+.oauth-account input { margin-right: 8px; }
+.login-hint { margin-top: 18px; font-size: 11px; color: var(--text-muted); }
+.login-hint code { background: var(--bg-hover); padding: 1px 4px; border-radius: 3px; }
+.link-button {
+  background: none; border: 0; color: var(--link); cursor: pointer;
+  font: inherit; padding: 0; text-decoration: underline;
+}

--- a/deploy/sim_envs/mantis_crm/app/static/oauth.css
+++ b/deploy/sim_envs/mantis_crm/app/static/oauth.css
@@ -1,0 +1,190 @@
+/* OAuth "IdP" surface (#387).
+ *
+ * Loaded ONLY by /oauth/authorize and /oauth/consent — deliberately
+ * does not pull in app.css so the page visually feels like a different
+ * origin (Google's accounts.google.com surface). No app sidebar / app
+ * topbar; centered card on a plain white background.
+ */
+:root {
+  --idp-bg: #fff;
+  --idp-text: #202124;
+  --idp-text-muted: #5f6368;
+  --idp-border: #dadce0;
+  --idp-blue: #1a73e8;
+  --idp-blue-hover: #1765c8;
+  --idp-row-hover: #f1f3f4;
+  --idp-shadow: 0 1px 3px rgba(60, 64, 67, 0.15);
+}
+
+* { box-sizing: border-box; }
+html, body {
+  margin: 0; padding: 0; height: 100%;
+  background: var(--idp-bg);
+  color: var(--idp-text);
+  font: 14px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+        "Helvetica Neue", Arial, sans-serif;
+}
+
+.idp-shell {
+  display: flex; flex-direction: column;
+  min-height: 100vh;
+  max-width: 100%;
+}
+
+/* Top "Google" wordmark, mimics the accounts.google.com chrome. */
+.idp-topbar {
+  display: flex; justify-content: space-between; align-items: center;
+  padding: 16px 24px;
+}
+.g-logo {
+  font-family: "Product Sans", Roboto, Arial, sans-serif;
+  font-size: 22px; font-weight: 500; letter-spacing: 0.5px;
+}
+.g-blue { color: #4285f4; }
+.g-red { color: #ea4335; }
+.g-yellow { color: #fbbc05; }
+.g-green { color: #34a853; }
+.idp-help, .idp-account-chip {
+  color: var(--idp-text-muted); font-size: 13px;
+  text-decoration: none;
+}
+.idp-account-chip {
+  display: inline-flex; align-items: center; gap: 8px;
+  border: 1px solid var(--idp-border); padding: 4px 12px; border-radius: 99px;
+}
+
+/* The auth card — narrow, centered, soft shadow. */
+.idp-card {
+  margin: 16px auto 24px;
+  width: min(450px, 92vw);
+  background: #fff;
+  border: 1px solid var(--idp-border);
+  border-radius: 8px;
+  padding: 40px 40px 32px;
+  box-shadow: var(--idp-shadow);
+}
+.idp-card h1 {
+  font-size: 24px; font-weight: 400; letter-spacing: -0.2px;
+  margin: 0 0 8px;
+}
+.idp-sub {
+  margin: 0 0 24px; color: var(--idp-text);
+}
+.idp-app {
+  font-weight: 500;
+}
+.idp-error {
+  background: #fce8e6; color: #c5221f;
+  padding: 10px 12px; border-radius: 6px; margin-bottom: 16px;
+  font-size: 13px;
+}
+
+/* Account picker. */
+.idp-account-list {
+  list-style: none; padding: 0; margin: 0 -16px 16px;
+}
+.idp-account-list li { border-top: 1px solid var(--idp-border); }
+.idp-account-list li:last-child { border-bottom: 1px solid var(--idp-border); }
+.idp-account-row {
+  width: 100%; background: none; border: 0; cursor: pointer;
+  display: flex; align-items: center; gap: 14px;
+  padding: 14px 16px; text-align: left; font: inherit; color: inherit;
+}
+.idp-account-row:hover { background: var(--idp-row-hover); }
+.idp-account-row.idp-other { color: var(--idp-text-muted); cursor: default; }
+.idp-account-row.idp-other:hover { background: none; }
+.idp-avatar {
+  width: 32px; height: 32px; border-radius: 99px;
+  background: #1a73e8; color: white;
+  display: inline-flex; align-items: center; justify-content: center;
+  font-weight: 500; font-size: 13px;
+}
+.idp-avatar-sm { width: 24px; height: 24px; font-size: 12px; }
+.idp-avatar-placeholder {
+  background: #f1f3f4; color: var(--idp-text-muted);
+  border: 1px dashed var(--idp-border);
+}
+.idp-account-meta {
+  display: flex; flex-direction: column; line-height: 1.3;
+  flex: 1; min-width: 0;
+}
+.idp-account-name { font-size: 14px; }
+.idp-account-email { font-size: 12px; color: var(--idp-text-muted); }
+.idp-chevron { color: var(--idp-text-muted); font-size: 18px; }
+
+/* Consent screen. */
+.idp-account-line {
+  display: inline-flex; align-items: center; gap: 8px;
+  background: var(--idp-row-hover);
+  padding: 6px 12px; border-radius: 99px;
+  margin: 0 0 24px; font-size: 13px;
+}
+.idp-permits { margin: 24px 0 8px; font-weight: 500; }
+.idp-scope-list {
+  list-style: none; padding: 0; margin: 0 0 24px;
+}
+.idp-scope-list li {
+  display: flex; align-items: center; gap: 12px;
+  padding: 12px 0;
+  border-top: 1px solid var(--idp-border);
+}
+.idp-scope-list li:last-child { border-bottom: 1px solid var(--idp-border); }
+.idp-scope-ico {
+  width: 28px; height: 28px; border-radius: 99px;
+  display: inline-flex; align-items: center; justify-content: center;
+  background: var(--idp-row-hover); color: var(--idp-text-muted);
+  font-size: 14px; font-weight: 500;
+}
+
+.idp-fineprint {
+  font-size: 11px; color: var(--idp-text-muted);
+  line-height: 1.6;
+}
+.idp-fineprint a { color: var(--idp-blue); text-decoration: none; }
+.idp-fineprint a:hover { text-decoration: underline; }
+
+.idp-actions {
+  display: flex; justify-content: flex-end; gap: 8px;
+  margin-top: 24px;
+}
+.idp-btn {
+  border: 0; cursor: pointer; font: inherit; font-weight: 500;
+  padding: 10px 22px; border-radius: 4px;
+  font-size: 14px;
+}
+.idp-btn-primary {
+  background: var(--idp-blue); color: white;
+}
+.idp-btn-primary:hover { background: var(--idp-blue-hover); }
+.idp-btn-secondary {
+  background: transparent; color: var(--idp-blue);
+}
+.idp-btn-secondary:hover { background: rgba(26, 115, 232, 0.04); }
+
+.idp-footer {
+  display: flex; justify-content: space-between; align-items: center;
+  padding: 14px 32px; border-top: 1px solid var(--idp-border);
+  font-size: 12px; color: var(--idp-text-muted);
+}
+.idp-footer select {
+  border: 0; background: none; color: var(--idp-text-muted);
+  font: inherit;
+}
+.idp-footer-links { display: flex; gap: 24px; }
+.idp-footer-links a { color: var(--idp-text-muted); text-decoration: none; }
+.idp-footer-links a:hover { color: var(--idp-text); }
+
+/* "Redirecting back to mantis-shop..." page between consent and callback,
+ * to make the redirect feel real (vs. the instant 303 the agent never
+ * "sees"). Auto-redirects after a beat via meta refresh.
+ */
+.idp-redirect-card {
+  margin: 80px auto; width: min(420px, 92vw); text-align: center;
+}
+.idp-redirect-card .idp-spinner {
+  display: inline-block; width: 36px; height: 36px;
+  border: 3px solid var(--idp-border); border-top-color: var(--idp-blue);
+  border-radius: 99px; animation: idp-spin 0.8s linear infinite;
+  margin-bottom: 16px;
+}
+@keyframes idp-spin { to { transform: rotate(360deg); } }

--- a/deploy/sim_envs/mantis_crm/app/templates/base.html
+++ b/deploy/sim_envs/mantis_crm/app/templates/base.html
@@ -31,7 +31,18 @@
       <form class="search-form" action="/search" method="get">
         <input type="text" name="q" placeholder="Search contacts, companies, deals…" value="{{ request.query_params.get('q') or '' }}" data-testid="topbar-search"/>
       </form>
-      <div class="user-chip"><span class="avatar">YS</span> You · Sales</div>
+      <div class="user-chip" data-testid="user-chip">
+        {% set _u = request.state.current_user if request.state and request.state.current_user else None %}
+        {% if _u %}
+          <span class="avatar">{{ _u.email[0]|upper }}</span> {{ _u.email }}
+          <form method="post" action="/logout" style="display:inline; margin-left:8px;">
+            <button type="submit" class="link-button" data-testid="topbar-logout">Sign out</button>
+          </form>
+        {% else %}
+          <span class="avatar">?</span>
+          <a href="/login" data-testid="topbar-login">Sign in</a>
+        {% endif %}
+      </div>
     </header>
     <main class="workspace">
       {% block content %}{% endblock %}

--- a/deploy/sim_envs/mantis_crm/app/templates/login.html
+++ b/deploy/sim_envs/mantis_crm/app/templates/login.html
@@ -1,0 +1,49 @@
+{% extends "base.html" %}
+{% block title %}Sign in — mantis-crm{% endblock %}
+{% block content %}
+<div class="login-card" data-testid="login-card">
+  <h1>Sign in to mantis-crm</h1>
+
+  {% if error %}
+    <div class="error" data-testid="login-error">{{ error }}</div>
+  {% endif %}
+
+  {% if current_user %}
+    <div class="notice" data-testid="already-logged-in">
+      You're already signed in as <strong>{{ current_user.email }}</strong>.
+      <form method="post" action="/logout" style="display:inline">
+        <button type="submit" data-testid="logout-btn">Sign out</button>
+      </form>
+    </div>
+  {% endif %}
+
+  <form method="post" action="/login" class="login-form" data-testid="login-form">
+    <input type="hidden" name="next" value="{{ next }}"/>
+    <label>Email
+      <input type="email" name="email" required autocomplete="email"
+             placeholder="demo@mantis.example" data-testid="login-email"/>
+    </label>
+    <label>Password
+      <input type="password" name="password" required autocomplete="current-password"
+             data-testid="login-password"/>
+    </label>
+    <button type="submit" data-testid="login-submit">Sign in</button>
+  </form>
+
+  <div class="oauth-divider">or</div>
+
+  <a class="btn-oauth"
+     href="/oauth/authorize?client_id=mantis-crm&redirect_uri=/oauth/callback&state=login"
+     data-testid="login-oauth">
+    Continue with Google
+  </a>
+
+  <details class="login-hint">
+    <summary>Demo credentials</summary>
+    <ul>
+      <li><code>demo@mantis.example</code> / <code>hunter2</code> — agent (links to user_00001)</li>
+      <li><code>admin@mantis.example</code> / <code>admin123</code> — admin</li>
+    </ul>
+  </details>
+</div>
+{% endblock %}

--- a/deploy/sim_envs/mantis_crm/app/templates/oauth_authorize.html
+++ b/deploy/sim_envs/mantis_crm/app/templates/oauth_authorize.html
@@ -1,0 +1,74 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Sign in - Google Accounts</title>
+  <link rel="stylesheet" href="/static/oauth.css" />
+</head>
+<body class="idp">
+<div class="idp-shell" data-testid="oauth-idp-shell">
+  <header class="idp-topbar">
+    <div class="g-logo">
+      <span class="g-blue">G</span><span class="g-red">o</span><span class="g-yellow">o</span><span class="g-blue">g</span><span class="g-green">l</span><span class="g-red">e</span>
+    </div>
+    <a class="idp-help" href="#">Help</a>
+  </header>
+
+  <main class="idp-card" data-testid="oauth-account-picker">
+    <h1>Choose an account</h1>
+    <p class="idp-sub">to continue to <span class="idp-app">{{ client_id }}</span></p>
+
+    {% if error %}
+      <div class="idp-error" data-testid="oauth-error">{{ error }}</div>
+    {% endif %}
+
+    {% if not error %}
+      <ul class="idp-account-list">
+        {% for account in accounts %}
+          <li>
+            <form method="post" action="/oauth/consent" data-testid="oauth-account-form-{{ loop.index }}">
+              <input type="hidden" name="oauth_subject" value="{{ account.sub }}"/>
+              <input type="hidden" name="redirect_uri" value="{{ redirect_uri }}"/>
+              <input type="hidden" name="state" value="{{ state }}"/>
+              <button class="idp-account-row" type="submit"
+                      data-testid="oauth-account-{{ loop.index }}">
+                <span class="idp-avatar" aria-hidden="true">{{ account.label[0]|upper }}</span>
+                <span class="idp-account-meta">
+                  <span class="idp-account-name">{{ account.label.split('@')[0]|capitalize }}</span>
+                  <span class="idp-account-email">{{ account.label }}</span>
+                </span>
+                <span class="idp-chevron" aria-hidden="true">›</span>
+              </button>
+            </form>
+          </li>
+        {% endfor %}
+        <li>
+          <button class="idp-account-row idp-other" type="button" disabled
+                  data-testid="oauth-use-another">
+            <span class="idp-avatar idp-avatar-placeholder">+</span>
+            <span class="idp-account-meta">
+              <span class="idp-account-name">Use another account</span>
+            </span>
+          </button>
+        </li>
+      </ul>
+    {% endif %}
+
+    <p class="idp-fineprint">
+      Before using this app, you can review {{ client_id }}'s
+      <a href="#">privacy policy</a> and <a href="#">terms of service</a>.
+    </p>
+  </main>
+
+  <footer class="idp-footer">
+    <select disabled><option>English (United States)</option></select>
+    <div class="idp-footer-links">
+      <a href="#">Help</a>
+      <a href="#">Privacy</a>
+      <a href="#">Terms</a>
+    </div>
+  </footer>
+</div>
+</body>
+</html>

--- a/deploy/sim_envs/mantis_crm/app/templates/oauth_consent.html
+++ b/deploy/sim_envs/mantis_crm/app/templates/oauth_consent.html
@@ -1,0 +1,73 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Sign in - Google Accounts</title>
+  <link rel="stylesheet" href="/static/oauth.css" />
+</head>
+<body class="idp">
+<div class="idp-shell" data-testid="oauth-consent-shell">
+  <header class="idp-topbar">
+    <div class="g-logo">
+      <span class="g-blue">G</span><span class="g-red">o</span><span class="g-yellow">o</span><span class="g-blue">g</span><span class="g-green">l</span><span class="g-red">e</span>
+    </div>
+    <div class="idp-account-chip">
+      <span class="idp-avatar idp-avatar-sm">{{ user.email[0]|upper }}</span>
+      <span>{{ user.email }}</span>
+    </div>
+  </header>
+
+  <main class="idp-card" data-testid="oauth-consent-card">
+    <h1>{{ client_id }} wants to access your Google Account</h1>
+    <div class="idp-account-line">
+      <span class="idp-avatar idp-avatar-sm">{{ user.email[0]|upper }}</span>
+      <span>{{ user.email }}</span>
+    </div>
+
+    <p class="idp-sub idp-permits">This will allow {{ client_id }} to:</p>
+    <ul class="idp-scope-list">
+      <li>
+        <span class="idp-scope-ico">@</span>
+        <span>See your primary Google Account email address</span>
+      </li>
+      <li>
+        <span class="idp-scope-ico">i</span>
+        <span>See your personal info, including any personal info you've made publicly available</span>
+      </li>
+    </ul>
+
+    <p class="idp-fineprint">
+      Make sure you trust {{ client_id }}. You may be sharing sensitive info with this site or app.
+      You can always see or remove access in your <a href="#">Google Account</a>.
+    </p>
+
+    <div class="idp-actions">
+      <form method="get" action="/oauth/authorize" style="display:inline">
+        <input type="hidden" name="client_id" value="{{ client_id }}"/>
+        <input type="hidden" name="redirect_uri" value="{{ redirect_uri }}"/>
+        <input type="hidden" name="state" value="{{ state }}"/>
+        <button type="submit" class="idp-btn idp-btn-secondary"
+                data-testid="oauth-cancel">Cancel</button>
+      </form>
+      <form method="post" action="/oauth/consent/grant" style="display:inline">
+        <input type="hidden" name="oauth_subject" value="{{ user.oauth_subject }}"/>
+        <input type="hidden" name="redirect_uri" value="{{ redirect_uri }}"/>
+        <input type="hidden" name="state" value="{{ state }}"/>
+        <button type="submit" class="idp-btn idp-btn-primary"
+                data-testid="oauth-allow">Allow</button>
+      </form>
+    </div>
+  </main>
+
+  <footer class="idp-footer">
+    <select disabled><option>English (United States)</option></select>
+    <div class="idp-footer-links">
+      <a href="#">Help</a>
+      <a href="#">Privacy</a>
+      <a href="#">Terms</a>
+    </div>
+  </footer>
+</div>
+</body>
+</html>

--- a/deploy/sim_envs/mantis_crm/app/templates/oauth_redirect.html
+++ b/deploy/sim_envs/mantis_crm/app/templates/oauth_redirect.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Redirecting…</title>
+  <link rel="stylesheet" href="/static/oauth.css" />
+  <meta http-equiv="refresh" content="1;url={{ target }}" />
+</head>
+<body class="idp">
+<div class="idp-shell" data-testid="oauth-redirect-shell">
+  <header class="idp-topbar">
+    <div class="g-logo">
+      <span class="g-blue">G</span><span class="g-red">o</span><span class="g-yellow">o</span><span class="g-blue">g</span><span class="g-green">l</span><span class="g-red">e</span>
+    </div>
+  </header>
+  <main class="idp-card idp-redirect-card" data-testid="oauth-redirect-card">
+    <div class="idp-spinner" aria-hidden="true"></div>
+    <h1 style="font-size:18px">Redirecting back to {{ client_id }}…</h1>
+    <p class="idp-fineprint" style="margin-top:12px">
+      If you're not redirected automatically,
+      <a href="{{ target }}" data-testid="oauth-redirect-link">click here</a>.
+    </p>
+  </main>
+</div>
+</body>
+</html>

--- a/deploy/sim_envs/mantis_helpdesk/app/auth.py
+++ b/deploy/sim_envs/mantis_helpdesk/app/auth.py
@@ -1,0 +1,164 @@
+"""Mock auth surface — email-password + Google-style OAuth (#387).
+
+Mirrors ``mantis_shop/app/auth.py``. CRM users in this env are all
+*agents* (no "buyer" role), so no ``effective_customer_id`` indirection
+— the session user IS the actor on every mutation.
+
+Two extra columns are added to the existing ``users`` table:
+``password_hash`` + ``oauth_subject``. Existing CRM seed users get a
+default password so any of them can be impersonated for tests.
+
+``ENV_REQUIRE_AUTH=1`` flips the gate on every non-``/`` route except
+``/login``, ``/logout``, ``/oauth/*``, ``/__env__/*``, ``/static/*``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import os
+import secrets
+import time
+from typing import Any
+
+from fastapi import Request, Response
+from fastapi.responses import RedirectResponse
+
+from . import db
+
+SESSION_COOKIE = "mantis_session"
+SESSION_TTL_DEFAULT_S = 60 * 60
+LOGIN_PATH = "/login"
+OAUTH_AUTHORIZE_PATH = "/oauth/authorize"
+OAUTH_CALLBACK_PATH = "/oauth/callback"
+
+_OAUTH_CODE_TTL_S = 60
+_OAUTH_CODES: dict[str, dict[str, Any]] = {}
+
+
+def session_secret() -> str:
+    return os.environ.get("ENV_SESSION_SECRET", "dev-only-do-not-use-in-prod")
+
+
+def session_ttl_s() -> int:
+    raw = os.environ.get("ENV_SESSION_TTL_S")
+    try:
+        return int(raw) if raw else SESSION_TTL_DEFAULT_S
+    except ValueError:
+        return SESSION_TTL_DEFAULT_S
+
+
+def auth_required() -> bool:
+    return os.environ.get("ENV_REQUIRE_AUTH", "0").lower() in {"1", "true", "yes"}
+
+
+def hash_password(plain: str) -> str:
+    return hashlib.sha256(plain.encode("utf-8")).hexdigest()
+
+
+def verify_password(plain: str, stored: str) -> bool:
+    if not stored:
+        return False
+    return hmac.compare_digest(hash_password(plain), stored)
+
+
+def mint_session(user_id: str, *, now: float | None = None) -> str:
+    issued = int(now if now is not None else time.time())
+    payload = f"{user_id}|{issued}"
+    sig = hmac.new(
+        session_secret().encode("utf-8"),
+        payload.encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+    return f"{payload}|{sig}"
+
+
+def verify_session(cookie_val: str, *, now: float | None = None) -> str | None:
+    if not cookie_val:
+        return None
+    parts = cookie_val.split("|")
+    if len(parts) != 3:
+        return None
+    user_id, issued_at_s, sig = parts
+    try:
+        issued_at = int(issued_at_s)
+    except ValueError:
+        return None
+    payload = f"{user_id}|{issued_at}"
+    expected = hmac.new(
+        session_secret().encode("utf-8"),
+        payload.encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+    if not hmac.compare_digest(sig, expected):
+        return None
+    now_ts = now if now is not None else time.time()
+    if now_ts - issued_at > session_ttl_s():
+        return None
+    return user_id
+
+
+def set_session_cookie(response: Response, user_id: str) -> None:
+    response.set_cookie(
+        SESSION_COOKIE,
+        mint_session(user_id),
+        httponly=True,
+        samesite="lax",
+        max_age=session_ttl_s(),
+        path="/",
+    )
+
+
+def clear_session_cookie(response: Response) -> None:
+    response.delete_cookie(SESSION_COOKIE, path="/")
+
+
+def lookup_user_by_id(user_id: str) -> dict[str, Any] | None:
+    conn = db.connect()
+    row = conn.execute(
+        "SELECT id, email, name, role, oauth_subject FROM users WHERE id = ?",
+        (user_id,),
+    ).fetchone()
+    return dict(row) if row else None
+
+
+def lookup_user_by_email(email: str) -> dict[str, Any] | None:
+    conn = db.connect()
+    row = conn.execute(
+        "SELECT id, email, name, password_hash, role, oauth_subject "
+        "FROM users WHERE LOWER(email) = ?",
+        (email.strip().lower(),),
+    ).fetchone()
+    return dict(row) if row else None
+
+
+def current_user(request: Request) -> dict[str, Any] | None:
+    raw = request.cookies.get(SESSION_COOKIE)
+    user_id = verify_session(raw or "")
+    if user_id is None:
+        return None
+    return lookup_user_by_id(user_id)
+
+
+def issue_oauth_code(*, user_id: str, redirect_uri: str, state: str) -> str:
+    code = secrets.token_urlsafe(16)
+    _OAUTH_CODES[code] = {
+        "user_id": user_id,
+        "redirect_uri": redirect_uri,
+        "state": state,
+        "expires_at": time.time() + _OAUTH_CODE_TTL_S,
+    }
+    return code
+
+
+def consume_oauth_code(code: str) -> dict[str, Any] | None:
+    entry = _OAUTH_CODES.pop(code, None)
+    if entry is None:
+        return None
+    if time.time() > entry["expires_at"]:
+        return None
+    return entry
+
+
+def clear_oauth_codes() -> None:
+    _OAUTH_CODES.clear()

--- a/deploy/sim_envs/mantis_helpdesk/app/auth.py
+++ b/deploy/sim_envs/mantis_helpdesk/app/auth.py
@@ -22,7 +22,6 @@ import time
 from typing import Any
 
 from fastapi import Request, Response
-from fastapi.responses import RedirectResponse
 
 from . import db
 

--- a/deploy/sim_envs/mantis_helpdesk/app/db.py
+++ b/deploy/sim_envs/mantis_helpdesk/app/db.py
@@ -40,10 +40,15 @@ CREATE TABLE IF NOT EXISTS users (
     id              TEXT PRIMARY KEY,
     name            TEXT NOT NULL,
     email           TEXT NOT NULL,
-    role            TEXT NOT NULL DEFAULT 'requester',  -- requester | agent
+    role            TEXT NOT NULL DEFAULT 'requester',  -- requester | agent | admin
     group_id        TEXT,                                -- agents only
     locale          TEXT NOT NULL DEFAULT 'en',
-    is_active       INTEGER NOT NULL DEFAULT 1
+    is_active       INTEGER NOT NULL DEFAULT 1,
+    -- Mock auth surface (#387). Plain sha256 hex — sim env, not prod.
+    -- Only agents + admins have a password_hash; requesters are external
+    -- and never sign in to this env.
+    password_hash   TEXT,
+    oauth_subject   TEXT
 );
 CREATE INDEX IF NOT EXISTS idx_users_role ON users(role);
 CREATE INDEX IF NOT EXISTS idx_users_group ON users(group_id);

--- a/deploy/sim_envs/mantis_helpdesk/app/main.py
+++ b/deploy/sim_envs/mantis_helpdesk/app/main.py
@@ -18,11 +18,11 @@ from pathlib import Path
 from typing import Any
 
 from fastapi import FastAPI, Request, Response
-from fastapi.responses import HTMLResponse, JSONResponse
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
-from . import db, seed
+from . import auth, db, seed
 
 APP_DIR = Path(__file__).parent
 ADMIN_TOKEN_ENV = "ENV_ADMIN_TOKEN"
@@ -72,6 +72,26 @@ def create_app() -> FastAPI:
     app.state.templates = templates
     app.state.admin_token = _admin_token()
 
+    # See #387. Mirrors mantis_crm's gate.
+    @app.middleware("http")
+    async def _auth_gate(request: Request, call_next):  # noqa: ANN202
+        try:
+            request.state.current_user = auth.current_user(request)
+        except Exception:  # noqa: BLE001
+            request.state.current_user = None
+
+        if auth.auth_required():
+            path = request.url.path
+            open_prefixes = (
+                "/login", "/logout", "/oauth/", "/__env__/", "/static/",
+            )
+            if path != "/" and not path.startswith(open_prefixes):
+                if request.state.current_user is None:
+                    return RedirectResponse(
+                        f"/login?next={path}", status_code=303,
+                    )
+        return await call_next(request)
+
     @app.on_event("startup")
     def _bootstrap() -> None:
         conn = db.connect()
@@ -86,6 +106,7 @@ def create_app() -> FastAPI:
         name="static",
     )
 
+    from .routes import auth as auth_router
     from .routes import env_admin as env_admin_router
     from .routes import macros as macros_router
     from .routes import reports as reports_router
@@ -94,6 +115,7 @@ def create_app() -> FastAPI:
     from .routes import triggers_ui as triggers_router
 
     app.include_router(env_admin_router.router)
+    app.include_router(auth_router.router)
     app.include_router(tickets_router.router)
     app.include_router(macros_router.router)
     app.include_router(triggers_router.router)

--- a/deploy/sim_envs/mantis_helpdesk/app/oracles/__init__.py
+++ b/deploy/sim_envs/mantis_helpdesk/app/oracles/__init__.py
@@ -23,6 +23,7 @@ from . import (
     t03_merge_outage_dupes,
     t04_sla_rescue,
     t05_redact_and_reply,
+    t06_login_then_triage_inbox,
 )
 
 GraderFn = Callable[..., dict[str, Any]]
@@ -34,6 +35,7 @@ GRADERS: dict[str, GraderFn] = {
     "T03_merge_outage_dupes": t03_merge_outage_dupes.grade,
     "T04_sla_rescue": t04_sla_rescue.grade,
     "T05_redact_and_reply": t05_redact_and_reply.grade,
+    "T06_login_then_triage_inbox": t06_login_then_triage_inbox.grade,
 }
 
 

--- a/deploy/sim_envs/mantis_helpdesk/app/oracles/t06_login_then_triage_inbox.py
+++ b/deploy/sim_envs/mantis_helpdesk/app/oracles/t06_login_then_triage_inbox.py
@@ -1,0 +1,79 @@
+"""T06_login_then_triage_inbox — adds the auth gate on top of T01.
+
+Pass conditions
+---------------
+
+1. ``mutations`` has a ``login_succeeded`` row with target_id
+   ``agent_001`` (the seeded demo agent — note helpdesk uses 3-digit
+   padding for agents, unlike CRM's 5-digit) *before* the first ticket
+   mutation T01 grades on.
+2. Login row's payload was minted via the real flow
+   (``via='password'`` or ``via='oauth'``); harness shortcuts don't
+   write that row.
+3. All of T01_triage_inbox's existing pass conditions still hold.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Any
+
+from . import t01_triage_inbox
+
+EXPECTED_USER_ID = "agent_001"
+VALID_LOGIN_VIA = {"password", "oauth"}
+
+
+def grade(conn: sqlite3.Connection, *, now: str, seed_val: int) -> dict[str, Any]:
+    reasons: list[str] = []
+
+    login_row = conn.execute(
+        "SELECT id, occurred_at, payload_json FROM mutations "
+        "WHERE operation = 'login_succeeded' AND target_id = ? "
+        "ORDER BY id ASC LIMIT 1",
+        (EXPECTED_USER_ID,),
+    ).fetchone()
+    login_mut_id = None
+    if login_row is None:
+        reasons.append(
+            f"no login_succeeded mutation for {EXPECTED_USER_ID}; "
+            "agent must navigate /login (password) or /oauth/authorize first"
+        )
+    else:
+        login_mut_id = login_row["id"]
+        raw = login_row["payload_json"] or ""
+        if not any(f'"via": "{v}"' in raw or f'"via":"{v}"' in raw
+                   for v in VALID_LOGIN_VIA):
+            reasons.append(
+                "login_succeeded mutation missing valid `via` "
+                f"(expected one of {sorted(VALID_LOGIN_VIA)})"
+            )
+
+    # At least one ticket mutation must come after login.
+    if login_mut_id is not None:
+        post = conn.execute(
+            "SELECT COUNT(*) FROM mutations "
+            "WHERE target_type = 'ticket' AND id > ?",
+            (login_mut_id,),
+        ).fetchone()[0]
+        if post == 0:
+            reasons.append(
+                "no ticket mutations recorded after login_succeeded"
+            )
+
+    inner = t01_triage_inbox.grade(conn, now=now, seed_val=seed_val)
+    if not inner["passed"]:
+        reasons.extend(f"[T01] {r}" for r in inner["reasons"])
+
+    passed = not reasons
+    return {
+        "passed": passed,
+        "score": 1.0 if passed else 0.0,
+        "reasons": reasons or [
+            f"logged in as {EXPECTED_USER_ID} then completed T01_triage_inbox"
+        ],
+        "diff": {
+            "login_mutation_id": login_mut_id,
+            **inner.get("diff", {}),
+        },
+    }

--- a/deploy/sim_envs/mantis_helpdesk/app/routes/auth.py
+++ b/deploy/sim_envs/mantis_helpdesk/app/routes/auth.py
@@ -1,0 +1,206 @@
+"""Mock auth routes — ``/login``, ``/logout``, OAuth-mock pair (#387).
+
+Mirrors ``mantis_shop/app/routes/auth.py``. Audit goes into the CRM's
+``mutations`` table via ``db.log_mutation`` (shop uses ``audit_log`` +
+``log_audit`` — same shape, different table name per env design).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Form, Request
+from fastapi.responses import HTMLResponse, RedirectResponse, Response
+
+from .. import auth, db, main as app_main
+
+router = APIRouter()
+
+OAUTH_CLIENT_ID = "mantis-helpdesk"
+OAUTH_DEFAULT_REDIRECT = "/oauth/callback"
+
+
+def _audit(operation: str, target_id: str, payload: dict[str, Any]) -> None:
+    conn = db.connect()
+    db.log_mutation(
+        conn,
+        occurred_at=app_main.now_value(),
+        operation=operation,
+        target_type="user",
+        target_id=target_id,
+        payload=payload,
+    )
+    conn.commit()
+    app_main.emit(f"mutation.{operation}", {"target_id": target_id, **payload})
+
+
+@router.get("/login", response_class=HTMLResponse)
+async def login_get(request: Request) -> HTMLResponse:
+    return app_main.app.state.templates.TemplateResponse(
+        "login.html",
+        {
+            "request": request,
+            "next": request.query_params.get("next") or "/",
+            "error": request.query_params.get("error") or "",
+            "current_user": auth.current_user(request),
+        },
+    )
+
+
+@router.post("/login")
+async def login_post(
+    request: Request,
+    email: str = Form(""),
+    password: str = Form(""),
+    next: str = Form("/"),
+) -> Response:
+    user = auth.lookup_user_by_email(email)
+    if user is None or not auth.verify_password(password, user["password_hash"]):
+        _audit(
+            "login_failed",
+            target_id="anon",
+            payload={"email": email.strip().lower(), "via": "password"},
+        )
+        return RedirectResponse(
+            f"/login?error=Invalid+email+or+password&next={next}",
+            status_code=303,
+        )
+
+    resp = RedirectResponse(next or "/", status_code=303)
+    auth.set_session_cookie(resp, user["id"])
+    _audit(
+        "login_succeeded",
+        target_id=user["id"],
+        payload={"email": user["email"], "role": user["role"], "via": "password"},
+    )
+    return resp
+
+
+@router.post("/logout")
+async def logout_post(request: Request) -> Response:
+    user = auth.current_user(request)
+    resp = RedirectResponse("/login", status_code=303)
+    auth.clear_session_cookie(resp)
+    if user is not None:
+        _audit("logout", target_id=user["id"], payload={"email": user["email"]})
+    return resp
+
+
+@router.get("/oauth/authorize", response_class=HTMLResponse)
+async def oauth_authorize_get(request: Request) -> HTMLResponse:
+    client_id = request.query_params.get("client_id", "")
+    redirect_uri = request.query_params.get("redirect_uri", OAUTH_DEFAULT_REDIRECT)
+    state = request.query_params.get("state", "")
+    error = ""
+    if client_id and client_id != OAUTH_CLIENT_ID:
+        error = f"unknown client_id: {client_id}"
+    return app_main.app.state.templates.TemplateResponse(
+        "oauth_authorize.html",
+        {
+            "request": request,
+            "client_id": client_id or OAUTH_CLIENT_ID,
+            "redirect_uri": redirect_uri,
+            "state": state,
+            "error": error,
+            "accounts": [
+                {"sub": "google-oauth2|helpdesk-demo-001",
+                 "label": "demo@mantis.example"},
+                {"sub": "google-oauth2|helpdesk-admin-001",
+                 "label": "admin@mantis.example"},
+            ],
+        },
+    )
+
+
+@router.post("/oauth/consent", response_class=HTMLResponse)
+async def oauth_consent_get(
+    request: Request,
+    oauth_subject: str = Form(""),
+    redirect_uri: str = Form(OAUTH_DEFAULT_REDIRECT),
+    state: str = Form(""),
+) -> Response:
+    """Step 2 of the OAuth mock — consent screen for the picked account."""
+    conn = db.connect()
+    row = conn.execute(
+        "SELECT id, email, oauth_subject FROM users WHERE oauth_subject = ?",
+        (oauth_subject,),
+    ).fetchone()
+    if row is None:
+        return RedirectResponse(
+            f"/oauth/authorize?error=unknown+account&state={state}",
+            status_code=303,
+        )
+    return app_main.app.state.templates.TemplateResponse(
+        "oauth_consent.html",
+        {
+            "request": request,
+            "user": dict(row),
+            "client_id": OAUTH_CLIENT_ID,
+            "redirect_uri": redirect_uri,
+            "state": state,
+        },
+    )
+
+
+@router.post("/oauth/consent/grant", response_class=HTMLResponse)
+async def oauth_consent_grant(
+    request: Request,
+    oauth_subject: str = Form(""),
+    redirect_uri: str = Form(OAUTH_DEFAULT_REDIRECT),
+    state: str = Form(""),
+) -> Response:
+    """Step 3 — mint a single-use code and render the redirect interstitial."""
+    conn = db.connect()
+    row = conn.execute(
+        "SELECT id FROM users WHERE oauth_subject = ?", (oauth_subject,),
+    ).fetchone()
+    if row is None:
+        return RedirectResponse(
+            f"/oauth/authorize?error=unknown+account&state={state}",
+            status_code=303,
+        )
+    code = auth.issue_oauth_code(
+        user_id=row["id"], redirect_uri=redirect_uri, state=state,
+    )
+    _audit(
+        "oauth_consent",
+        target_id=row["id"],
+        payload={"oauth_subject": oauth_subject, "client_id": OAUTH_CLIENT_ID},
+    )
+    sep = "&" if "?" in redirect_uri else "?"
+    target = f"{redirect_uri}{sep}code={code}&state={state}"
+    return app_main.app.state.templates.TemplateResponse(
+        "oauth_redirect.html",
+        {
+            "request": request,
+            "target": target,
+            "client_id": OAUTH_CLIENT_ID,
+        },
+    )
+
+
+@router.get("/oauth/callback")
+async def oauth_callback(request: Request) -> Response:
+    code = request.query_params.get("code", "")
+    if not code:
+        return RedirectResponse(
+            "/login?error=missing+oauth+code", status_code=303,
+        )
+    entry = auth.consume_oauth_code(code)
+    if entry is None:
+        return RedirectResponse(
+            "/login?error=oauth+code+expired+or+used", status_code=303,
+        )
+    user = auth.lookup_user_by_id(entry["user_id"])
+    if user is None:
+        return RedirectResponse(
+            "/login?error=oauth+user+not+found", status_code=303,
+        )
+    resp = RedirectResponse("/", status_code=303)
+    auth.set_session_cookie(resp, user["id"])
+    _audit(
+        "login_succeeded",
+        target_id=user["id"],
+        payload={"email": user["email"], "role": user["role"], "via": "oauth"},
+    )
+    return resp

--- a/deploy/sim_envs/mantis_helpdesk/app/seed.py
+++ b/deploy/sim_envs/mantis_helpdesk/app/seed.py
@@ -178,6 +178,15 @@ def _requester_id(idx: int) -> str:
 
 
 def _seed_users(cur: sqlite3.Cursor, rng: random.Random) -> None:
+    """Seed agents + requesters with mock-auth fields (#387).
+
+    agent_00001 → ``demo@mantis.example`` / ``hunter2`` / role=agent
+    agent_00002 → ``admin@mantis.example`` / ``admin123`` / role=admin
+    All other agents have NULL password_hash (can be queried but not
+    impersonated). Requesters never sign in.
+    """
+    from . import auth  # local import — avoids circular at module load
+
     rows: list[tuple[Any, ...]] = []
     # Agents — distribute across groups round-robin.
     group_ids = [g[0] for g in _GROUPS]
@@ -187,7 +196,22 @@ def _seed_users(cur: sqlite3.Cursor, rng: random.Random) -> None:
         name = f"{first} {last}"
         email = f"{first.lower()}.{last.lower()}@mantis-helpdesk.test"
         group_id = group_ids[(i - 1) % len(group_ids)]
-        rows.append((_agent_id(i), name, email, "agent", group_id, "en", 1))
+        role = "agent"
+        password_hash = None
+        oauth_subject = None
+        if i == 1:
+            email = "demo@mantis.example"
+            password_hash = auth.hash_password("hunter2")
+            oauth_subject = "google-oauth2|helpdesk-demo-001"
+        elif i == 2:
+            email = "admin@mantis.example"
+            password_hash = auth.hash_password("admin123")
+            role = "admin"
+            oauth_subject = "google-oauth2|helpdesk-admin-001"
+        rows.append((
+            _agent_id(i), name, email, role, group_id, "en", 1,
+            password_hash, oauth_subject,
+        ))
 
     # Requesters — pseudo-uniform locale distribution (mostly en).
     for i in range(1, N_REQUESTERS + 1):
@@ -205,11 +229,15 @@ def _seed_users(cur: sqlite3.Cursor, rng: random.Random) -> None:
             locale = "fr"
         else:
             locale = "de"
-        rows.append((_requester_id(i), name, email, "requester", None, locale, 1))
+        rows.append((
+            _requester_id(i), name, email, "requester", None, locale, 1,
+            None, None,
+        ))
 
     cur.executemany(
-        "INSERT INTO users (id, name, email, role, group_id, locale, is_active) "
-        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        "INSERT INTO users (id, name, email, role, group_id, locale, "
+        "is_active, password_hash, oauth_subject) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
         rows,
     )
 

--- a/deploy/sim_envs/mantis_helpdesk/app/static/app.css
+++ b/deploy/sim_envs/mantis_helpdesk/app/static/app.css
@@ -305,3 +305,59 @@ pre { background: #f8fafc; padding: 10px; border-radius: 6px;
   padding: 14px; white-space: pre-wrap; font-family: ui-monospace, Menlo, monospace;
   font-size: 12px; line-height: 1.6;
 }
+  align-items: start;
+}
+
+pre { background: #f8fafc; padding: 10px; border-radius: 6px;
+      border: 1px solid var(--border); overflow-x: auto; font-size: 12px; }
+code { font-size: 11px; font-family: ui-monospace, Menlo, monospace; color: var(--slate); }
+
+/* ── auth (login + OAuth consent) ─────────────────────────────────── */
+.login-card {
+  max-width: 380px; margin: 32px auto;
+  background: var(--bg-panel); border: 1px solid var(--border);
+  border-radius: 10px; padding: 28px; box-shadow: var(--shadow-md);
+}
+.login-card h1 { margin: 0 0 14px; font-size: 20px; }
+.login-card .muted { color: var(--text-muted); margin-top: -8px; }
+.login-card .error {
+  background: var(--red-soft); color: var(--red);
+  padding: 8px 10px; border-radius: 6px; margin-bottom: 12px; font-size: 12px;
+}
+.login-card .notice {
+  background: var(--accent-soft); color: var(--accent);
+  padding: 8px 10px; border-radius: 6px; margin-bottom: 12px; font-size: 12px;
+}
+.login-form { display: flex; flex-direction: column; gap: 12px; }
+.login-form label { display: flex; flex-direction: column; gap: 4px;
+                    font-size: 12px; color: var(--text-muted); }
+.login-form input {
+  padding: 8px 10px; border: 1px solid var(--border-strong);
+  border-radius: 6px; font-size: 13px;
+}
+.login-form button {
+  background: var(--accent); color: white; border: 0;
+  padding: 10px; border-radius: 6px; font-weight: 600; cursor: pointer;
+}
+.login-form button:hover { background: var(--accent-hover); }
+.oauth-divider {
+  text-align: center; color: var(--text-faint); font-size: 11px;
+  margin: 16px 0; text-transform: uppercase; letter-spacing: 0.1em;
+}
+.btn-oauth {
+  display: block; text-align: center; padding: 10px;
+  border: 1px solid var(--border-strong); border-radius: 6px;
+  color: var(--text); text-decoration: none; font-weight: 500;
+}
+.btn-oauth:hover { background: var(--bg-hover); }
+.oauth-account {
+  display: block; padding: 10px; border: 1px solid var(--border);
+  border-radius: 6px; margin: 6px 0; cursor: pointer;
+}
+.oauth-account input { margin-right: 8px; }
+.login-hint { margin-top: 18px; font-size: 11px; color: var(--text-muted); }
+.login-hint code { background: var(--bg-hover); padding: 1px 4px; border-radius: 3px; }
+.link-button {
+  background: none; border: 0; color: var(--link); cursor: pointer;
+  font: inherit; padding: 0; text-decoration: underline;
+}

--- a/deploy/sim_envs/mantis_helpdesk/app/static/oauth.css
+++ b/deploy/sim_envs/mantis_helpdesk/app/static/oauth.css
@@ -1,0 +1,190 @@
+/* OAuth "IdP" surface (#387).
+ *
+ * Loaded ONLY by /oauth/authorize and /oauth/consent — deliberately
+ * does not pull in app.css so the page visually feels like a different
+ * origin (Google's accounts.google.com surface). No app sidebar / app
+ * topbar; centered card on a plain white background.
+ */
+:root {
+  --idp-bg: #fff;
+  --idp-text: #202124;
+  --idp-text-muted: #5f6368;
+  --idp-border: #dadce0;
+  --idp-blue: #1a73e8;
+  --idp-blue-hover: #1765c8;
+  --idp-row-hover: #f1f3f4;
+  --idp-shadow: 0 1px 3px rgba(60, 64, 67, 0.15);
+}
+
+* { box-sizing: border-box; }
+html, body {
+  margin: 0; padding: 0; height: 100%;
+  background: var(--idp-bg);
+  color: var(--idp-text);
+  font: 14px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+        "Helvetica Neue", Arial, sans-serif;
+}
+
+.idp-shell {
+  display: flex; flex-direction: column;
+  min-height: 100vh;
+  max-width: 100%;
+}
+
+/* Top "Google" wordmark, mimics the accounts.google.com chrome. */
+.idp-topbar {
+  display: flex; justify-content: space-between; align-items: center;
+  padding: 16px 24px;
+}
+.g-logo {
+  font-family: "Product Sans", Roboto, Arial, sans-serif;
+  font-size: 22px; font-weight: 500; letter-spacing: 0.5px;
+}
+.g-blue { color: #4285f4; }
+.g-red { color: #ea4335; }
+.g-yellow { color: #fbbc05; }
+.g-green { color: #34a853; }
+.idp-help, .idp-account-chip {
+  color: var(--idp-text-muted); font-size: 13px;
+  text-decoration: none;
+}
+.idp-account-chip {
+  display: inline-flex; align-items: center; gap: 8px;
+  border: 1px solid var(--idp-border); padding: 4px 12px; border-radius: 99px;
+}
+
+/* The auth card — narrow, centered, soft shadow. */
+.idp-card {
+  margin: 16px auto 24px;
+  width: min(450px, 92vw);
+  background: #fff;
+  border: 1px solid var(--idp-border);
+  border-radius: 8px;
+  padding: 40px 40px 32px;
+  box-shadow: var(--idp-shadow);
+}
+.idp-card h1 {
+  font-size: 24px; font-weight: 400; letter-spacing: -0.2px;
+  margin: 0 0 8px;
+}
+.idp-sub {
+  margin: 0 0 24px; color: var(--idp-text);
+}
+.idp-app {
+  font-weight: 500;
+}
+.idp-error {
+  background: #fce8e6; color: #c5221f;
+  padding: 10px 12px; border-radius: 6px; margin-bottom: 16px;
+  font-size: 13px;
+}
+
+/* Account picker. */
+.idp-account-list {
+  list-style: none; padding: 0; margin: 0 -16px 16px;
+}
+.idp-account-list li { border-top: 1px solid var(--idp-border); }
+.idp-account-list li:last-child { border-bottom: 1px solid var(--idp-border); }
+.idp-account-row {
+  width: 100%; background: none; border: 0; cursor: pointer;
+  display: flex; align-items: center; gap: 14px;
+  padding: 14px 16px; text-align: left; font: inherit; color: inherit;
+}
+.idp-account-row:hover { background: var(--idp-row-hover); }
+.idp-account-row.idp-other { color: var(--idp-text-muted); cursor: default; }
+.idp-account-row.idp-other:hover { background: none; }
+.idp-avatar {
+  width: 32px; height: 32px; border-radius: 99px;
+  background: #1a73e8; color: white;
+  display: inline-flex; align-items: center; justify-content: center;
+  font-weight: 500; font-size: 13px;
+}
+.idp-avatar-sm { width: 24px; height: 24px; font-size: 12px; }
+.idp-avatar-placeholder {
+  background: #f1f3f4; color: var(--idp-text-muted);
+  border: 1px dashed var(--idp-border);
+}
+.idp-account-meta {
+  display: flex; flex-direction: column; line-height: 1.3;
+  flex: 1; min-width: 0;
+}
+.idp-account-name { font-size: 14px; }
+.idp-account-email { font-size: 12px; color: var(--idp-text-muted); }
+.idp-chevron { color: var(--idp-text-muted); font-size: 18px; }
+
+/* Consent screen. */
+.idp-account-line {
+  display: inline-flex; align-items: center; gap: 8px;
+  background: var(--idp-row-hover);
+  padding: 6px 12px; border-radius: 99px;
+  margin: 0 0 24px; font-size: 13px;
+}
+.idp-permits { margin: 24px 0 8px; font-weight: 500; }
+.idp-scope-list {
+  list-style: none; padding: 0; margin: 0 0 24px;
+}
+.idp-scope-list li {
+  display: flex; align-items: center; gap: 12px;
+  padding: 12px 0;
+  border-top: 1px solid var(--idp-border);
+}
+.idp-scope-list li:last-child { border-bottom: 1px solid var(--idp-border); }
+.idp-scope-ico {
+  width: 28px; height: 28px; border-radius: 99px;
+  display: inline-flex; align-items: center; justify-content: center;
+  background: var(--idp-row-hover); color: var(--idp-text-muted);
+  font-size: 14px; font-weight: 500;
+}
+
+.idp-fineprint {
+  font-size: 11px; color: var(--idp-text-muted);
+  line-height: 1.6;
+}
+.idp-fineprint a { color: var(--idp-blue); text-decoration: none; }
+.idp-fineprint a:hover { text-decoration: underline; }
+
+.idp-actions {
+  display: flex; justify-content: flex-end; gap: 8px;
+  margin-top: 24px;
+}
+.idp-btn {
+  border: 0; cursor: pointer; font: inherit; font-weight: 500;
+  padding: 10px 22px; border-radius: 4px;
+  font-size: 14px;
+}
+.idp-btn-primary {
+  background: var(--idp-blue); color: white;
+}
+.idp-btn-primary:hover { background: var(--idp-blue-hover); }
+.idp-btn-secondary {
+  background: transparent; color: var(--idp-blue);
+}
+.idp-btn-secondary:hover { background: rgba(26, 115, 232, 0.04); }
+
+.idp-footer {
+  display: flex; justify-content: space-between; align-items: center;
+  padding: 14px 32px; border-top: 1px solid var(--idp-border);
+  font-size: 12px; color: var(--idp-text-muted);
+}
+.idp-footer select {
+  border: 0; background: none; color: var(--idp-text-muted);
+  font: inherit;
+}
+.idp-footer-links { display: flex; gap: 24px; }
+.idp-footer-links a { color: var(--idp-text-muted); text-decoration: none; }
+.idp-footer-links a:hover { color: var(--idp-text); }
+
+/* "Redirecting back to mantis-shop..." page between consent and callback,
+ * to make the redirect feel real (vs. the instant 303 the agent never
+ * "sees"). Auto-redirects after a beat via meta refresh.
+ */
+.idp-redirect-card {
+  margin: 80px auto; width: min(420px, 92vw); text-align: center;
+}
+.idp-redirect-card .idp-spinner {
+  display: inline-block; width: 36px; height: 36px;
+  border: 3px solid var(--idp-border); border-top-color: var(--idp-blue);
+  border-radius: 99px; animation: idp-spin 0.8s linear infinite;
+  margin-bottom: 16px;
+}
+@keyframes idp-spin { to { transform: rotate(360deg); } }

--- a/deploy/sim_envs/mantis_helpdesk/app/templates/base.html
+++ b/deploy/sim_envs/mantis_helpdesk/app/templates/base.html
@@ -29,7 +29,18 @@
       <form class="search-form" action="/search" method="get">
         <input type="text" name="q" placeholder="Search tickets, requesters…" value="{{ request.query_params.get('q') or '' }}" data-testid="topbar-search"/>
       </form>
-      <div class="user-chip"><span class="avatar">YS</span> You · Agent</div>
+      <div class="user-chip" data-testid="user-chip">
+        {% set _u = request.state.current_user if request.state and request.state.current_user else None %}
+        {% if _u %}
+          <span class="avatar">{{ _u.email[0]|upper }}</span> {{ _u.email }}
+          <form method="post" action="/logout" style="display:inline; margin-left:8px;">
+            <button type="submit" class="link-button" data-testid="topbar-logout">Sign out</button>
+          </form>
+        {% else %}
+          <span class="avatar">?</span>
+          <a href="/login" data-testid="topbar-login">Sign in</a>
+        {% endif %}
+      </div>
     </header>
     <main class="workspace">
       {% block content %}{% endblock %}

--- a/deploy/sim_envs/mantis_helpdesk/app/templates/login.html
+++ b/deploy/sim_envs/mantis_helpdesk/app/templates/login.html
@@ -1,0 +1,49 @@
+{% extends "base.html" %}
+{% block title %}Sign in — mantis-helpdesk{% endblock %}
+{% block content %}
+<div class="login-card" data-testid="login-card">
+  <h1>Sign in to mantis-helpdesk</h1>
+
+  {% if error %}
+    <div class="error" data-testid="login-error">{{ error }}</div>
+  {% endif %}
+
+  {% if current_user %}
+    <div class="notice" data-testid="already-logged-in">
+      You're already signed in as <strong>{{ current_user.email }}</strong>.
+      <form method="post" action="/logout" style="display:inline">
+        <button type="submit" data-testid="logout-btn">Sign out</button>
+      </form>
+    </div>
+  {% endif %}
+
+  <form method="post" action="/login" class="login-form" data-testid="login-form">
+    <input type="hidden" name="next" value="{{ next }}"/>
+    <label>Email
+      <input type="email" name="email" required autocomplete="email"
+             placeholder="demo@mantis.example" data-testid="login-email"/>
+    </label>
+    <label>Password
+      <input type="password" name="password" required autocomplete="current-password"
+             data-testid="login-password"/>
+    </label>
+    <button type="submit" data-testid="login-submit">Sign in</button>
+  </form>
+
+  <div class="oauth-divider">or</div>
+
+  <a class="btn-oauth"
+     href="/oauth/authorize?client_id=mantis-helpdesk&redirect_uri=/oauth/callback&state=login"
+     data-testid="login-oauth">
+    Continue with Google
+  </a>
+
+  <details class="login-hint">
+    <summary>Demo credentials</summary>
+    <ul>
+      <li><code>demo@mantis.example</code> / <code>hunter2</code> — agent (links to agent_00001)</li>
+      <li><code>admin@mantis.example</code> / <code>admin123</code> — admin</li>
+    </ul>
+  </details>
+</div>
+{% endblock %}

--- a/deploy/sim_envs/mantis_helpdesk/app/templates/oauth_authorize.html
+++ b/deploy/sim_envs/mantis_helpdesk/app/templates/oauth_authorize.html
@@ -1,0 +1,74 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Sign in - Google Accounts</title>
+  <link rel="stylesheet" href="/static/oauth.css" />
+</head>
+<body class="idp">
+<div class="idp-shell" data-testid="oauth-idp-shell">
+  <header class="idp-topbar">
+    <div class="g-logo">
+      <span class="g-blue">G</span><span class="g-red">o</span><span class="g-yellow">o</span><span class="g-blue">g</span><span class="g-green">l</span><span class="g-red">e</span>
+    </div>
+    <a class="idp-help" href="#">Help</a>
+  </header>
+
+  <main class="idp-card" data-testid="oauth-account-picker">
+    <h1>Choose an account</h1>
+    <p class="idp-sub">to continue to <span class="idp-app">{{ client_id }}</span></p>
+
+    {% if error %}
+      <div class="idp-error" data-testid="oauth-error">{{ error }}</div>
+    {% endif %}
+
+    {% if not error %}
+      <ul class="idp-account-list">
+        {% for account in accounts %}
+          <li>
+            <form method="post" action="/oauth/consent" data-testid="oauth-account-form-{{ loop.index }}">
+              <input type="hidden" name="oauth_subject" value="{{ account.sub }}"/>
+              <input type="hidden" name="redirect_uri" value="{{ redirect_uri }}"/>
+              <input type="hidden" name="state" value="{{ state }}"/>
+              <button class="idp-account-row" type="submit"
+                      data-testid="oauth-account-{{ loop.index }}">
+                <span class="idp-avatar" aria-hidden="true">{{ account.label[0]|upper }}</span>
+                <span class="idp-account-meta">
+                  <span class="idp-account-name">{{ account.label.split('@')[0]|capitalize }}</span>
+                  <span class="idp-account-email">{{ account.label }}</span>
+                </span>
+                <span class="idp-chevron" aria-hidden="true">›</span>
+              </button>
+            </form>
+          </li>
+        {% endfor %}
+        <li>
+          <button class="idp-account-row idp-other" type="button" disabled
+                  data-testid="oauth-use-another">
+            <span class="idp-avatar idp-avatar-placeholder">+</span>
+            <span class="idp-account-meta">
+              <span class="idp-account-name">Use another account</span>
+            </span>
+          </button>
+        </li>
+      </ul>
+    {% endif %}
+
+    <p class="idp-fineprint">
+      Before using this app, you can review {{ client_id }}'s
+      <a href="#">privacy policy</a> and <a href="#">terms of service</a>.
+    </p>
+  </main>
+
+  <footer class="idp-footer">
+    <select disabled><option>English (United States)</option></select>
+    <div class="idp-footer-links">
+      <a href="#">Help</a>
+      <a href="#">Privacy</a>
+      <a href="#">Terms</a>
+    </div>
+  </footer>
+</div>
+</body>
+</html>

--- a/deploy/sim_envs/mantis_helpdesk/app/templates/oauth_consent.html
+++ b/deploy/sim_envs/mantis_helpdesk/app/templates/oauth_consent.html
@@ -1,0 +1,73 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Sign in - Google Accounts</title>
+  <link rel="stylesheet" href="/static/oauth.css" />
+</head>
+<body class="idp">
+<div class="idp-shell" data-testid="oauth-consent-shell">
+  <header class="idp-topbar">
+    <div class="g-logo">
+      <span class="g-blue">G</span><span class="g-red">o</span><span class="g-yellow">o</span><span class="g-blue">g</span><span class="g-green">l</span><span class="g-red">e</span>
+    </div>
+    <div class="idp-account-chip">
+      <span class="idp-avatar idp-avatar-sm">{{ user.email[0]|upper }}</span>
+      <span>{{ user.email }}</span>
+    </div>
+  </header>
+
+  <main class="idp-card" data-testid="oauth-consent-card">
+    <h1>{{ client_id }} wants to access your Google Account</h1>
+    <div class="idp-account-line">
+      <span class="idp-avatar idp-avatar-sm">{{ user.email[0]|upper }}</span>
+      <span>{{ user.email }}</span>
+    </div>
+
+    <p class="idp-sub idp-permits">This will allow {{ client_id }} to:</p>
+    <ul class="idp-scope-list">
+      <li>
+        <span class="idp-scope-ico">@</span>
+        <span>See your primary Google Account email address</span>
+      </li>
+      <li>
+        <span class="idp-scope-ico">i</span>
+        <span>See your personal info, including any personal info you've made publicly available</span>
+      </li>
+    </ul>
+
+    <p class="idp-fineprint">
+      Make sure you trust {{ client_id }}. You may be sharing sensitive info with this site or app.
+      You can always see or remove access in your <a href="#">Google Account</a>.
+    </p>
+
+    <div class="idp-actions">
+      <form method="get" action="/oauth/authorize" style="display:inline">
+        <input type="hidden" name="client_id" value="{{ client_id }}"/>
+        <input type="hidden" name="redirect_uri" value="{{ redirect_uri }}"/>
+        <input type="hidden" name="state" value="{{ state }}"/>
+        <button type="submit" class="idp-btn idp-btn-secondary"
+                data-testid="oauth-cancel">Cancel</button>
+      </form>
+      <form method="post" action="/oauth/consent/grant" style="display:inline">
+        <input type="hidden" name="oauth_subject" value="{{ user.oauth_subject }}"/>
+        <input type="hidden" name="redirect_uri" value="{{ redirect_uri }}"/>
+        <input type="hidden" name="state" value="{{ state }}"/>
+        <button type="submit" class="idp-btn idp-btn-primary"
+                data-testid="oauth-allow">Allow</button>
+      </form>
+    </div>
+  </main>
+
+  <footer class="idp-footer">
+    <select disabled><option>English (United States)</option></select>
+    <div class="idp-footer-links">
+      <a href="#">Help</a>
+      <a href="#">Privacy</a>
+      <a href="#">Terms</a>
+    </div>
+  </footer>
+</div>
+</body>
+</html>

--- a/deploy/sim_envs/mantis_helpdesk/app/templates/oauth_redirect.html
+++ b/deploy/sim_envs/mantis_helpdesk/app/templates/oauth_redirect.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Redirecting…</title>
+  <link rel="stylesheet" href="/static/oauth.css" />
+  <meta http-equiv="refresh" content="1;url={{ target }}" />
+</head>
+<body class="idp">
+<div class="idp-shell" data-testid="oauth-redirect-shell">
+  <header class="idp-topbar">
+    <div class="g-logo">
+      <span class="g-blue">G</span><span class="g-red">o</span><span class="g-yellow">o</span><span class="g-blue">g</span><span class="g-green">l</span><span class="g-red">e</span>
+    </div>
+  </header>
+  <main class="idp-card idp-redirect-card" data-testid="oauth-redirect-card">
+    <div class="idp-spinner" aria-hidden="true"></div>
+    <h1 style="font-size:18px">Redirecting back to {{ client_id }}…</h1>
+    <p class="idp-fineprint" style="margin-top:12px">
+      If you're not redirected automatically,
+      <a href="{{ target }}" data-testid="oauth-redirect-link">click here</a>.
+    </p>
+  </main>
+</div>
+</body>
+</html>

--- a/deploy/sim_envs/mantis_shop/app/auth.py
+++ b/deploy/sim_envs/mantis_shop/app/auth.py
@@ -1,0 +1,237 @@
+"""Mock auth surface — email-password + Google-style OAuth.
+
+Per issue #387: real B2B SaaS starts with a login screen and a chunk of
+production agent failures happen *at the login step*. This module gives
+the sim env that surface without dragging in a real IdP.
+
+Shape
+-----
+
+* ``users`` table holds canonical creds. Password is plain sha256 hex
+  (no bcrypt — these are sim envs, not prod).
+* Session = signed cookie ``user_id|issued_at|hmac_sha256``. HMAC key
+  is ``ENV_SESSION_SECRET`` (defaulted for dev; harness should override
+  per run so signatures don't leak across resets).
+* ``ENV_REQUIRE_AUTH=1`` flips the gate on ``/admin/*`` and
+  ``/checkout/*``. Default ``0`` keeps the existing T01–T05 oracle
+  contract — they grade DB state and don't care about the audit row.
+* The new ``T06_login_then_buy_jacket`` oracle reads
+  ``audit_log.operation='login_succeeded'`` and only passes if the
+  agent went through the real flow (cookie-mint via
+  ``/__env__/login_as`` does NOT write that row).
+
+OAuth mock
+----------
+
+Same env is both IdP and relying party. ``/oauth/authorize`` renders a
+Google-style consent page ("Continue as demo@mantis.example"); POST
+mints a one-time code, ``/oauth/callback`` exchanges it for a session.
+No real crypto — shape only.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import os
+import secrets
+import time
+from typing import Any
+
+from fastapi import Request, Response
+from fastapi.responses import RedirectResponse
+
+from . import db
+
+SESSION_COOKIE = "mantis_session"
+SESSION_TTL_DEFAULT_S = 60 * 60  # 1h
+LOGIN_PATH = "/login"
+OAUTH_AUTHORIZE_PATH = "/oauth/authorize"
+OAUTH_CALLBACK_PATH = "/oauth/callback"
+
+# OAuth code TTL — short, like Google's.
+_OAUTH_CODE_TTL_S = 60
+_OAUTH_CODES: dict[str, dict[str, Any]] = {}
+
+
+# ── env knobs ─────────────────────────────────────────────────────────
+
+
+def session_secret() -> str:
+    return os.environ.get("ENV_SESSION_SECRET", "dev-only-do-not-use-in-prod")
+
+
+def session_ttl_s() -> int:
+    raw = os.environ.get("ENV_SESSION_TTL_S")
+    try:
+        return int(raw) if raw else SESSION_TTL_DEFAULT_S
+    except ValueError:
+        return SESSION_TTL_DEFAULT_S
+
+
+def auth_required() -> bool:
+    return os.environ.get("ENV_REQUIRE_AUTH", "0").lower() in {"1", "true", "yes"}
+
+
+# ── password ──────────────────────────────────────────────────────────
+
+
+def hash_password(plain: str) -> str:
+    return hashlib.sha256(plain.encode("utf-8")).hexdigest()
+
+
+def verify_password(plain: str, stored: str) -> bool:
+    return hmac.compare_digest(hash_password(plain), stored)
+
+
+# ── session cookie ────────────────────────────────────────────────────
+
+
+def mint_session(user_id: str, *, now: float | None = None) -> str:
+    issued = int(now if now is not None else time.time())
+    payload = f"{user_id}|{issued}"
+    sig = hmac.new(
+        session_secret().encode("utf-8"),
+        payload.encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+    return f"{payload}|{sig}"
+
+
+def verify_session(cookie_val: str, *, now: float | None = None) -> str | None:
+    if not cookie_val:
+        return None
+    parts = cookie_val.split("|")
+    if len(parts) != 3:
+        return None
+    user_id, issued_at_s, sig = parts
+    try:
+        issued_at = int(issued_at_s)
+    except ValueError:
+        return None
+    payload = f"{user_id}|{issued_at}"
+    expected = hmac.new(
+        session_secret().encode("utf-8"),
+        payload.encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+    if not hmac.compare_digest(sig, expected):
+        return None
+    now_ts = now if now is not None else time.time()
+    if now_ts - issued_at > session_ttl_s():
+        return None
+    return user_id
+
+
+def set_session_cookie(response: Response, user_id: str) -> None:
+    response.set_cookie(
+        SESSION_COOKIE,
+        mint_session(user_id),
+        httponly=True,
+        samesite="lax",
+        max_age=session_ttl_s(),
+        path="/",
+    )
+
+
+def clear_session_cookie(response: Response) -> None:
+    response.delete_cookie(SESSION_COOKIE, path="/")
+
+
+# ── user lookup ───────────────────────────────────────────────────────
+
+
+def lookup_user_by_id(user_id: str) -> dict[str, Any] | None:
+    conn = db.connect()
+    row = conn.execute(
+        "SELECT id, email, role, customer_id, oauth_subject FROM users WHERE id = ?",
+        (user_id,),
+    ).fetchone()
+    return dict(row) if row else None
+
+
+def lookup_user_by_email(email: str) -> dict[str, Any] | None:
+    conn = db.connect()
+    row = conn.execute(
+        "SELECT id, email, password_hash, role, customer_id, oauth_subject "
+        "FROM users WHERE email = ?",
+        (email.strip().lower(),),
+    ).fetchone()
+    return dict(row) if row else None
+
+
+def current_user(request: Request) -> dict[str, Any] | None:
+    raw = request.cookies.get(SESSION_COOKIE)
+    user_id = verify_session(raw or "")
+    if user_id is None:
+        return None
+    return lookup_user_by_id(user_id)
+
+
+# ── gating ────────────────────────────────────────────────────────────
+
+
+def require_user(
+    request: Request, *, roles: list[str] | None = None
+) -> Response | None:
+    """Return a redirect-to-login if the request is gated but unauthed.
+
+    Returns ``None`` if auth is disabled, or if the user is present
+    *and* matches one of ``roles`` (when given). Callers do::
+
+        if redirect := require_user(request, roles=["admin"]):
+            return redirect
+    """
+    if not auth_required():
+        return None
+    user = current_user(request)
+    next_path = request.url.path
+    if user is None:
+        return RedirectResponse(
+            f"{LOGIN_PATH}?next={next_path}", status_code=303
+        )
+    if roles and user.get("role") not in roles:
+        return RedirectResponse(LOGIN_PATH, status_code=303)
+    return None
+
+
+def effective_customer_id(request: Request) -> str:
+    """Resolve the acting customer for checkout flows.
+
+    When auth is required: pull from the session. When disabled
+    (legacy behaviour): fall back to the seeded canonical customer so
+    T01–T05 oracles keep grading against the same shape.
+    """
+    user = current_user(request)
+    if user and user.get("customer_id"):
+        return str(user["customer_id"])
+    return "customer_00001"
+
+
+# ── OAuth mock store ──────────────────────────────────────────────────
+
+
+def issue_oauth_code(*, user_id: str, redirect_uri: str, state: str) -> str:
+    """Mint a one-time code bound to (user, redirect_uri). Expires in 60s."""
+    code = secrets.token_urlsafe(16)
+    _OAUTH_CODES[code] = {
+        "user_id": user_id,
+        "redirect_uri": redirect_uri,
+        "state": state,
+        "expires_at": time.time() + _OAUTH_CODE_TTL_S,
+    }
+    return code
+
+
+def consume_oauth_code(code: str) -> dict[str, Any] | None:
+    """Atomic consume — code is single-use."""
+    entry = _OAUTH_CODES.pop(code, None)
+    if entry is None:
+        return None
+    if time.time() > entry["expires_at"]:
+        return None
+    return entry
+
+
+def clear_oauth_codes() -> None:
+    _OAUTH_CODES.clear()

--- a/deploy/sim_envs/mantis_shop/app/db.py
+++ b/deploy/sim_envs/mantis_shop/app/db.py
@@ -218,6 +218,23 @@ CREATE TABLE IF NOT EXISTS saved_view_members (
     PRIMARY KEY (view_id, order_id)
 );
 
+CREATE TABLE IF NOT EXISTS users (
+    -- Mock auth surface (#387). Plain sha256 password hash — sim env,
+    -- not prod. ``customer_id`` links a buyer-role user to their
+    -- existing customer row so checkout/order rows attribute correctly.
+    -- ``oauth_subject`` is the IdP-side stable id (Google-style
+    -- ``google-oauth2|<sub>``) used by the OAuth mock flow.
+    id              TEXT PRIMARY KEY,
+    email           TEXT NOT NULL UNIQUE,
+    password_hash   TEXT NOT NULL,
+    role            TEXT NOT NULL,        -- 'admin' | 'customer'
+    customer_id     TEXT REFERENCES customers(id),
+    oauth_subject   TEXT,
+    created_at      TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_users_email ON users(email);
+CREATE INDEX IF NOT EXISTS idx_users_oauth_subject ON users(oauth_subject);
+
 CREATE TABLE IF NOT EXISTS audit_log (
     -- Append-only mutation record. The oracle reads this + the DB
     -- snapshot to grade runs. Mirrors mantis-crm's ``mutations`` table.

--- a/deploy/sim_envs/mantis_shop/app/main.py
+++ b/deploy/sim_envs/mantis_shop/app/main.py
@@ -14,11 +14,11 @@ from pathlib import Path
 from typing import Any
 
 from fastapi import FastAPI, Request, Response
-from fastapi.responses import HTMLResponse, JSONResponse
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
-from . import db, seed
+from . import auth, db, seed
 
 APP_DIR = Path(__file__).parent
 ADMIN_TOKEN_ENV = "ENV_ADMIN_TOKEN"
@@ -68,6 +68,40 @@ def create_app() -> FastAPI:
     app.state.templates = templates
     app.state.admin_token = _admin_token()
 
+    # Resolve the session user once per request + gate protected paths
+    # when ``ENV_REQUIRE_AUTH=1``.
+    #
+    # ``request.state.current_user`` is exposed to every template
+    # (``base.html`` reads it for the topbar). When auth is required
+    # we 303 → ``/login`` for unauthed admin/checkout traffic. Admin
+    # paths additionally require ``role='admin'``.
+    @app.middleware("http")
+    async def _auth_gate(request: Request, call_next):  # noqa: ANN202
+        try:
+            request.state.current_user = auth.current_user(request)
+        except Exception:  # noqa: BLE001 — never block request on auth lookup
+            request.state.current_user = None
+
+        if auth.auth_required():
+            path = request.url.path
+            open_prefixes = (
+                "/login", "/logout", "/oauth/", "/__env__/",
+                "/static/", "/cart", "/catalog", "/products/",
+            )
+            if path == "/" or path.startswith(open_prefixes):
+                pass
+            elif path.startswith(("/admin/", "/checkout/", "/orders/")):
+                user = request.state.current_user
+                if user is None:
+                    return RedirectResponse(
+                        f"/login?next={path}", status_code=303,
+                    )
+                if path.startswith("/admin/") and user.get("role") != "admin":
+                    return RedirectResponse(
+                        "/login?error=admin+access+required", status_code=303,
+                    )
+        return await call_next(request)
+
     # Bootstrap the DB. Mirrors mantis-crm: re-seed only when empty so
     # dev iteration under uvicorn --reload preserves state.
     @app.on_event("startup")
@@ -88,12 +122,14 @@ def create_app() -> FastAPI:
     from .routes import admin_coupons as admin_coupons_router
     from .routes import admin_orders as admin_orders_router
     from .routes import admin_products as admin_products_router
+    from .routes import auth as auth_router
     from .routes import cart as cart_router
     from .routes import checkout as checkout_router
     from .routes import env_admin as env_admin_router
     from .routes import storefront as storefront_router
 
     app.include_router(env_admin_router.router)
+    app.include_router(auth_router.router)
     app.include_router(storefront_router.router)
     app.include_router(cart_router.router)
     app.include_router(checkout_router.router)

--- a/deploy/sim_envs/mantis_shop/app/oracles/__init__.py
+++ b/deploy/sim_envs/mantis_shop/app/oracles/__init__.py
@@ -15,6 +15,7 @@ from . import (
     t03_create_coupon,
     t04_export_bogo_orders,
     t05_inventory_adjust,
+    t06_login_then_buy_jacket,
 )
 
 GraderFn = Callable[..., dict[str, Any]]
@@ -26,6 +27,7 @@ GRADERS: dict[str, GraderFn] = {
     "T03_create_coupon": t03_create_coupon.grade,
     "T04_export_bogo_orders": t04_export_bogo_orders.grade,
     "T05_inventory_adjust": t05_inventory_adjust.grade,
+    "T06_login_then_buy_jacket": t06_login_then_buy_jacket.grade,
 }
 
 

--- a/deploy/sim_envs/mantis_shop/app/oracles/t06_login_then_buy_jacket.py
+++ b/deploy/sim_envs/mantis_shop/app/oracles/t06_login_then_buy_jacket.py
@@ -1,0 +1,88 @@
+"""T06_login_then_buy_jacket — adds the auth gate on top of T01.
+
+Pass conditions
+---------------
+
+1. ``audit_log`` contains a ``login_succeeded`` row with target_id
+   ``user_demo`` *before* the ``order_placed`` row. (Audit ids
+   auto-increment, so id-ordering is the proof of "logged in first".)
+2. The login row's payload was minted via the real flow — either
+   ``via='password'`` or ``via='oauth'``. Synthetic seeds / harness
+   bypasses don't write this row, so they fail the gate.
+3. All of T01's existing pass conditions still hold (order shape +
+   coupon + inventory + no collateral inventory mutations).
+
+This is the gradable surface for issue #387: it asserts the agent
+actually navigated the login screen, not that the harness pre-authed
+a cookie.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Any
+
+from . import t01_buy_jacket
+
+EXPECTED_USER_ID = "user_demo"
+VALID_LOGIN_VIA = {"password", "oauth"}
+
+
+def grade(conn: sqlite3.Connection, *, now: str, seed_val: int) -> dict[str, Any]:
+    reasons: list[str] = []
+
+    # 1+2: login row exists and is from a real flow.
+    login_row = conn.execute(
+        "SELECT id, occurred_at, payload_json FROM audit_log "
+        "WHERE operation = 'login_succeeded' AND target_id = ? "
+        "ORDER BY id ASC LIMIT 1",
+        (EXPECTED_USER_ID,),
+    ).fetchone()
+    login_audit_id = None
+    if login_row is None:
+        reasons.append(
+            f"no login_succeeded audit row for {EXPECTED_USER_ID}; "
+            "agent must navigate /login (password) or /oauth/authorize first"
+        )
+    else:
+        login_audit_id = login_row["id"]
+        # payload_json is a json string; we don't need to deserialize to
+        # check a simple substring on ``via=``.
+        raw = login_row["payload_json"] or ""
+        if not any(f'"via": "{v}"' in raw or f'"via":"{v}"' in raw
+                   for v in VALID_LOGIN_VIA):
+            reasons.append(
+                "login_succeeded audit row missing valid `via` "
+                f"(expected one of {sorted(VALID_LOGIN_VIA)})"
+            )
+
+    # 1 (cont): login precedes order_placed.
+    order_row = conn.execute(
+        "SELECT id FROM audit_log "
+        "WHERE operation = 'order_placed' ORDER BY id ASC LIMIT 1"
+    ).fetchone()
+    if login_audit_id is not None and order_row is not None:
+        if order_row["id"] <= login_audit_id:
+            reasons.append(
+                "order_placed audit id precedes login_succeeded — "
+                "the order must be placed *after* logging in"
+            )
+
+    # 3: T01 still grades the order shape.
+    inner = t01_buy_jacket.grade(conn, now=now, seed_val=seed_val)
+    if not inner["passed"]:
+        reasons.extend(f"[T01] {r}" for r in inner["reasons"])
+
+    passed = not reasons
+    return {
+        "passed": passed,
+        "score": 1.0 if passed else 0.0,
+        "reasons": reasons or [
+            f"logged in as {EXPECTED_USER_ID} then placed {inner['diff'].get('order_id')}"
+        ],
+        "diff": {
+            "login_audit_id": login_audit_id,
+            "order_audit_id": order_row["id"] if order_row else None,
+            **inner.get("diff", {}),
+        },
+    }

--- a/deploy/sim_envs/mantis_shop/app/routes/auth.py
+++ b/deploy/sim_envs/mantis_shop/app/routes/auth.py
@@ -1,0 +1,255 @@
+"""Mock auth routes — ``/login``, ``/logout``, OAuth-mock pair (#387).
+
+The five surfaces (all server-rendered HTML, no JS-only validation, to
+match the rest of the env):
+
+* ``GET  /login``                — render the login form. Honours
+  ``?next=`` to bounce the user back where they were headed.
+* ``POST /login``                — verify creds, set session cookie,
+  audit ``login_succeeded`` (or ``login_failed``), redirect.
+* ``POST /logout``               — clear cookie, audit ``logout``,
+  redirect to ``/login``.
+* ``GET  /oauth/authorize``      — Google-style consent screen. POSTs
+  to itself to grant the code.
+* ``GET  /oauth/callback``       — exchanges the code for a session.
+
+The OAuth flow is single-issuer: the env is both the IdP and the
+relying party. ``client_id=mantis-shop`` is the only registered client.
+That's enough to give an agent the *shape* of "click sign-in →
+consent → land back logged in" without dragging in a real OAuth lib.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Form, Request
+from fastapi.responses import HTMLResponse, RedirectResponse, Response
+
+from .. import auth, db, main as app_main
+
+router = APIRouter()
+
+OAUTH_CLIENT_ID = "mantis-shop"
+OAUTH_DEFAULT_REDIRECT = "/oauth/callback"
+
+
+# ── audit helper ──────────────────────────────────────────────────────
+
+
+def _audit(operation: str, target_id: str, payload: dict[str, Any]) -> None:
+    conn = db.connect()
+    db.log_audit(
+        conn,
+        occurred_at=app_main.now_value(),
+        operation=operation,
+        target_type="user",
+        target_id=target_id,
+        payload=payload,
+    )
+    conn.commit()
+    app_main.emit(f"mutation.{operation}", {"target_id": target_id, **payload})
+
+
+# ── /login ────────────────────────────────────────────────────────────
+
+
+@router.get("/login", response_class=HTMLResponse)
+async def login_get(request: Request) -> HTMLResponse:
+    return app_main.app.state.templates.TemplateResponse(
+        "login.html",
+        {
+            "request": request,
+            "next": request.query_params.get("next") or "/",
+            "error": request.query_params.get("error") or "",
+            "current_user": auth.current_user(request),
+        },
+    )
+
+
+@router.post("/login")
+async def login_post(
+    request: Request,
+    email: str = Form(""),
+    password: str = Form(""),
+    next: str = Form("/"),
+) -> Response:
+    user = auth.lookup_user_by_email(email)
+    if user is None or not auth.verify_password(password, user["password_hash"]):
+        _audit(
+            "login_failed",
+            target_id="anon",
+            payload={"email": email.strip().lower(), "via": "password"},
+        )
+        return RedirectResponse(
+            f"/login?error=Invalid+email+or+password&next={next}",
+            status_code=303,
+        )
+
+    resp = RedirectResponse(next or "/", status_code=303)
+    auth.set_session_cookie(resp, user["id"])
+    _audit(
+        "login_succeeded",
+        target_id=user["id"],
+        payload={"email": user["email"], "role": user["role"], "via": "password"},
+    )
+    return resp
+
+
+# ── /logout ───────────────────────────────────────────────────────────
+
+
+@router.post("/logout")
+async def logout_post(request: Request) -> Response:
+    user = auth.current_user(request)
+    resp = RedirectResponse("/login", status_code=303)
+    auth.clear_session_cookie(resp)
+    if user is not None:
+        _audit("logout", target_id=user["id"], payload={"email": user["email"]})
+    return resp
+
+
+# ── /oauth/authorize ─────────────────────────────────────────────────
+
+
+@router.get("/oauth/authorize", response_class=HTMLResponse)
+async def oauth_authorize_get(request: Request) -> HTMLResponse:
+    client_id = request.query_params.get("client_id", "")
+    redirect_uri = request.query_params.get("redirect_uri", OAUTH_DEFAULT_REDIRECT)
+    state = request.query_params.get("state", "")
+    error = ""
+    if client_id and client_id != OAUTH_CLIENT_ID:
+        error = f"unknown client_id: {client_id}"
+    return app_main.app.state.templates.TemplateResponse(
+        "oauth_authorize.html",
+        {
+            "request": request,
+            "client_id": client_id or OAUTH_CLIENT_ID,
+            "redirect_uri": redirect_uri,
+            "state": state,
+            "error": error,
+            # Two known IdP subjects so the consent screen offers a
+            # realistic "choose-an-account" UI.
+            "accounts": [
+                {"sub": "google-oauth2|demo-001",
+                 "label": "demo@mantis.example"},
+                {"sub": "google-oauth2|admin-001",
+                 "label": "admin@mantis.example"},
+            ],
+        },
+    )
+
+
+@router.post("/oauth/consent", response_class=HTMLResponse)
+async def oauth_consent_get(
+    request: Request,
+    oauth_subject: str = Form(""),
+    redirect_uri: str = Form(OAUTH_DEFAULT_REDIRECT),
+    state: str = Form(""),
+) -> Response:
+    """Render the consent screen for the picked account.
+
+    Real Google OAuth is two screens — account picker, then a separate
+    consent screen listing scopes and showing the chosen account. This
+    matches that shape so an agent has to actually navigate both pages
+    before the code is issued.
+    """
+    user = auth.lookup_user_by_oauth_subject(oauth_subject) \
+        if hasattr(auth, "lookup_user_by_oauth_subject") else None
+    if user is None:
+        # Fallback to a direct DB lookup so we don't have to add an extra
+        # helper to ``auth.py``.
+        conn = db.connect()
+        row = conn.execute(
+            "SELECT id, email, oauth_subject FROM users WHERE oauth_subject = ?",
+            (oauth_subject,),
+        ).fetchone()
+        user = dict(row) if row else None
+    if user is None:
+        return RedirectResponse(
+            f"/oauth/authorize?error=unknown+account&state={state}",
+            status_code=303,
+        )
+    return app_main.app.state.templates.TemplateResponse(
+        "oauth_consent.html",
+        {
+            "request": request,
+            "user": user,
+            "client_id": OAUTH_CLIENT_ID,
+            "redirect_uri": redirect_uri,
+            "state": state,
+        },
+    )
+
+
+@router.post("/oauth/consent/grant", response_class=HTMLResponse)
+async def oauth_consent_grant(
+    request: Request,
+    oauth_subject: str = Form(""),
+    redirect_uri: str = Form(OAUTH_DEFAULT_REDIRECT),
+    state: str = Form(""),
+) -> Response:
+    """User clicked 'Allow' — mint a single-use code + render the
+    'Redirecting back to {client_id}…' interstitial.
+
+    The interstitial auto-redirects via ``<meta http-equiv=refresh>``
+    so the agent sees the realistic two-hop shape (consent → IdP
+    redirect page → app callback) rather than an instant 303.
+    """
+    conn = db.connect()
+    row = conn.execute(
+        "SELECT id FROM users WHERE oauth_subject = ?", (oauth_subject,),
+    ).fetchone()
+    if row is None:
+        return RedirectResponse(
+            f"/oauth/authorize?error=unknown+account&state={state}",
+            status_code=303,
+        )
+    code = auth.issue_oauth_code(
+        user_id=row["id"], redirect_uri=redirect_uri, state=state,
+    )
+    _audit(
+        "oauth_consent",
+        target_id=row["id"],
+        payload={"oauth_subject": oauth_subject, "client_id": OAUTH_CLIENT_ID},
+    )
+    sep = "&" if "?" in redirect_uri else "?"
+    target = f"{redirect_uri}{sep}code={code}&state={state}"
+    return app_main.app.state.templates.TemplateResponse(
+        "oauth_redirect.html",
+        {
+            "request": request,
+            "target": target,
+            "client_id": OAUTH_CLIENT_ID,
+        },
+    )
+
+
+# ── /oauth/callback ──────────────────────────────────────────────────
+
+
+@router.get("/oauth/callback")
+async def oauth_callback(request: Request) -> Response:
+    code = request.query_params.get("code", "")
+    if not code:
+        return RedirectResponse(
+            "/login?error=missing+oauth+code", status_code=303,
+        )
+    entry = auth.consume_oauth_code(code)
+    if entry is None:
+        return RedirectResponse(
+            "/login?error=oauth+code+expired+or+used", status_code=303,
+        )
+    user = auth.lookup_user_by_id(entry["user_id"])
+    if user is None:
+        return RedirectResponse(
+            "/login?error=oauth+user+not+found", status_code=303,
+        )
+    resp = RedirectResponse("/", status_code=303)
+    auth.set_session_cookie(resp, user["id"])
+    _audit(
+        "login_succeeded",
+        target_id=user["id"],
+        payload={"email": user["email"], "role": user["role"], "via": "oauth"},
+    )
+    return resp

--- a/deploy/sim_envs/mantis_shop/app/routes/checkout.py
+++ b/deploy/sim_envs/mantis_shop/app/routes/checkout.py
@@ -17,7 +17,7 @@ import time
 from fastapi import APIRouter, Form, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
 
-from .. import db, main as app_main
+from .. import auth, db, main as app_main
 from .cart import (
     _coupon_active,
     _coupon_row,
@@ -44,14 +44,16 @@ async def address_get(request: Request) -> HTMLResponse:
     conn = db.connect()
     cart = _get_or_create_cart(conn, sid)
 
-    # Show saved addresses for customer_00001 (canonical test customer)
-    # because we're auto-logged-in as them. Real shop would resolve
-    # customer from the session; we keep it simple.
+    # Resolve acting customer from session (#387). When auth is
+    # disabled, ``effective_customer_id`` falls back to
+    # ``customer_00001`` so T01–T05 oracles keep grading against the
+    # same shape.
+    acting_customer_id = auth.effective_customer_id(request)
     saved = [
         dict(r) for r in conn.execute(
             "SELECT * FROM customer_addresses WHERE customer_id = ? "
             "ORDER BY is_default DESC, id ASC",
-            ("customer_00001",),
+            (acting_customer_id,),
         ).fetchall()
     ]
     error = request.query_params.get("error") or ""
@@ -115,14 +117,15 @@ async def address_post(
                 f"/checkout/address?error=Invalid%20ZIP%20code:%20{zip.strip()}",
                 sid,
             )
-        # Persist as a new address on customer_00001 so checkout has a row.
+        # Persist as a new address on the acting customer.
+        acting_customer_id = auth.effective_customer_id(request)
         new_id = f"addr_adhoc_{int(time.time() * 1000)}"
         with db.transaction() as txn:
             txn.execute(
                 "INSERT INTO customer_addresses "
                 "(id, customer_id, line1, city, region, zip, is_default) "
                 "VALUES (?, ?, ?, ?, ?, ?, 0)",
-                (new_id, "customer_00001", line1.strip(), city.strip(),
+                (new_id, acting_customer_id, line1.strip(), city.strip(),
                  region.strip().upper(), zip.strip()),
             )
         chosen_addr_id = new_id
@@ -225,7 +228,7 @@ async def payment_get(request: Request) -> HTMLResponse:
     payment_methods = [
         dict(r) for r in conn.execute(
             "SELECT * FROM customer_payment_methods WHERE customer_id = ?",
-            ("customer_00001",),
+            (auth.effective_customer_id(request),),
         ).fetchall()
     ]
     resp = app_main.app.state.templates.TemplateResponse(
@@ -398,13 +401,14 @@ async def place_order(request: Request) -> RedirectResponse:
     number = f"#{next_num}"
     placed_at = app_main.now_value()
 
+    acting_customer_id = auth.effective_customer_id(request)
     with db.transaction() as txn:
         txn.execute(
             "INSERT INTO orders (id, number, customer_id, shipping_address_id, "
             "payment_method_id, status, subtotal, discount_total, "
             "shipping_total, total, coupon_codes, notify_customer, placed_at) "
             "VALUES (?, ?, ?, ?, ?, 'paid', ?, ?, ?, ?, ?, 0, ?)",
-            (order_id, number, "customer_00001",
+            (order_id, number, acting_customer_id,
              cart["shipping_address_id"], cart["payment_method_id"],
              totals["subtotal"], totals["discount"],
              round(shipping_total, 2), round(total_with_method, 2),
@@ -439,7 +443,7 @@ async def place_order(request: Request) -> RedirectResponse:
             )
         _log_audit(txn, operation="order_placed", target_type="order",
                    target_id=order_id,
-                   payload={"customer_id": "customer_00001",
+                   payload={"customer_id": acting_customer_id,
                             "total": round(total_with_method, 2),
                             "coupon_codes": coupon_codes,
                             "session_id": sid,

--- a/deploy/sim_envs/mantis_shop/app/routes/env_admin.py
+++ b/deploy/sim_envs/mantis_shop/app/routes/env_admin.py
@@ -108,6 +108,7 @@ async def state(request: Request) -> JSONResponse:
         "now": app_main.now_value(),
         "counts": {
             "customers": count("customers"),
+            "users": count("users"),
             "products": count("products"),
             "variants": count("variants"),
             "collections": count("collections"),

--- a/deploy/sim_envs/mantis_shop/app/seed.py
+++ b/deploy/sim_envs/mantis_shop/app/seed.py
@@ -164,6 +164,7 @@ def seed(conn: sqlite3.Connection, *, seed_val: int,
         "collection_members", "collections",
         "variant_region_locks", "inventory", "variants", "products",
         "customer_payment_methods", "customer_addresses", "customers",
+        "users",
     ):
         cur.execute(f"DELETE FROM {table}")
 
@@ -173,8 +174,51 @@ def seed(conn: sqlite3.Connection, *, seed_val: int,
     _seed_coupons(cur, rng, now_dt)
     _seed_orders(cur, rng, now_dt)
     _seed_saved_views(cur)
+    _seed_users(cur, fake_now=fake_now)
 
     conn.commit()
+
+
+# ── users (mock auth — #387) ──────────────────────────────────────────
+
+
+def _seed_users(cur: sqlite3.Cursor, *, fake_now: str) -> None:
+    """Two canonical creds.
+
+    * ``user_demo`` — buyer-role; links to ``customer_00001`` so T01
+      "buy a jacket as the logged-in customer" attributes correctly.
+    * ``user_admin`` — admin-role; gates ``/admin/*`` when
+      ``ENV_REQUIRE_AUTH=1``.
+
+    Both have an ``oauth_subject`` so the Google-style mock flow can
+    resolve them by IdP subject id too.
+    """
+    from . import auth  # local import — avoids circular at module load
+
+    cur.executemany(
+        "INSERT INTO users (id, email, password_hash, role, customer_id, "
+        "oauth_subject, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        [
+            (
+                "user_demo",
+                "demo@mantis.example",
+                auth.hash_password("hunter2"),
+                "customer",
+                "customer_00001",
+                "google-oauth2|demo-001",
+                fake_now,
+            ),
+            (
+                "user_admin",
+                "admin@mantis.example",
+                auth.hash_password("admin123"),
+                "admin",
+                None,
+                "google-oauth2|admin-001",
+                fake_now,
+            ),
+        ],
+    )
 
 
 # ── customers + addresses + payment methods ───────────────────────────

--- a/deploy/sim_envs/mantis_shop/app/static/app.css
+++ b/deploy/sim_envs/mantis_shop/app/static/app.css
@@ -386,3 +386,53 @@ dl.kv dd { margin: 0; font-size: 13px; }
 pre { background: #f8fafc; padding: 10px; border-radius: 6px;
       border: 1px solid var(--border); overflow-x: auto; font-size: 12px; }
 code { font-size: 11px; font-family: ui-monospace, Menlo, monospace; color: var(--slate); }
+
+/* ── auth (login + OAuth consent) ─────────────────────────────────── */
+.login-card {
+  max-width: 380px; margin: 32px auto;
+  background: var(--bg-panel); border: 1px solid var(--border);
+  border-radius: 10px; padding: 28px; box-shadow: var(--shadow-md);
+}
+.login-card h1 { margin: 0 0 14px; font-size: 20px; }
+.login-card .muted { color: var(--text-muted); margin-top: -8px; }
+.login-card .error {
+  background: var(--red-soft); color: var(--red);
+  padding: 8px 10px; border-radius: 6px; margin-bottom: 12px; font-size: 12px;
+}
+.login-card .notice {
+  background: var(--accent-soft); color: var(--accent);
+  padding: 8px 10px; border-radius: 6px; margin-bottom: 12px; font-size: 12px;
+}
+.login-form { display: flex; flex-direction: column; gap: 12px; }
+.login-form label { display: flex; flex-direction: column; gap: 4px;
+                    font-size: 12px; color: var(--text-muted); }
+.login-form input {
+  padding: 8px 10px; border: 1px solid var(--border-strong);
+  border-radius: 6px; font-size: 13px;
+}
+.login-form button {
+  background: var(--accent); color: white; border: 0;
+  padding: 10px; border-radius: 6px; font-weight: 600; cursor: pointer;
+}
+.login-form button:hover { background: var(--accent-hover); }
+.oauth-divider {
+  text-align: center; color: var(--text-faint); font-size: 11px;
+  margin: 16px 0; text-transform: uppercase; letter-spacing: 0.1em;
+}
+.btn-oauth {
+  display: block; text-align: center; padding: 10px;
+  border: 1px solid var(--border-strong); border-radius: 6px;
+  color: var(--text); text-decoration: none; font-weight: 500;
+}
+.btn-oauth:hover { background: var(--bg-hover); }
+.oauth-account {
+  display: block; padding: 10px; border: 1px solid var(--border);
+  border-radius: 6px; margin: 6px 0; cursor: pointer;
+}
+.oauth-account input { margin-right: 8px; }
+.login-hint { margin-top: 18px; font-size: 11px; color: var(--text-muted); }
+.login-hint code { background: var(--bg-hover); padding: 1px 4px; border-radius: 3px; }
+.link-button {
+  background: none; border: 0; color: var(--link); cursor: pointer;
+  font: inherit; padding: 0; text-decoration: underline;
+}

--- a/deploy/sim_envs/mantis_shop/app/static/oauth.css
+++ b/deploy/sim_envs/mantis_shop/app/static/oauth.css
@@ -1,0 +1,190 @@
+/* OAuth "IdP" surface (#387).
+ *
+ * Loaded ONLY by /oauth/authorize and /oauth/consent — deliberately
+ * does not pull in app.css so the page visually feels like a different
+ * origin (Google's accounts.google.com surface). No app sidebar / app
+ * topbar; centered card on a plain white background.
+ */
+:root {
+  --idp-bg: #fff;
+  --idp-text: #202124;
+  --idp-text-muted: #5f6368;
+  --idp-border: #dadce0;
+  --idp-blue: #1a73e8;
+  --idp-blue-hover: #1765c8;
+  --idp-row-hover: #f1f3f4;
+  --idp-shadow: 0 1px 3px rgba(60, 64, 67, 0.15);
+}
+
+* { box-sizing: border-box; }
+html, body {
+  margin: 0; padding: 0; height: 100%;
+  background: var(--idp-bg);
+  color: var(--idp-text);
+  font: 14px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+        "Helvetica Neue", Arial, sans-serif;
+}
+
+.idp-shell {
+  display: flex; flex-direction: column;
+  min-height: 100vh;
+  max-width: 100%;
+}
+
+/* Top "Google" wordmark, mimics the accounts.google.com chrome. */
+.idp-topbar {
+  display: flex; justify-content: space-between; align-items: center;
+  padding: 16px 24px;
+}
+.g-logo {
+  font-family: "Product Sans", Roboto, Arial, sans-serif;
+  font-size: 22px; font-weight: 500; letter-spacing: 0.5px;
+}
+.g-blue { color: #4285f4; }
+.g-red { color: #ea4335; }
+.g-yellow { color: #fbbc05; }
+.g-green { color: #34a853; }
+.idp-help, .idp-account-chip {
+  color: var(--idp-text-muted); font-size: 13px;
+  text-decoration: none;
+}
+.idp-account-chip {
+  display: inline-flex; align-items: center; gap: 8px;
+  border: 1px solid var(--idp-border); padding: 4px 12px; border-radius: 99px;
+}
+
+/* The auth card — narrow, centered, soft shadow. */
+.idp-card {
+  margin: 16px auto 24px;
+  width: min(450px, 92vw);
+  background: #fff;
+  border: 1px solid var(--idp-border);
+  border-radius: 8px;
+  padding: 40px 40px 32px;
+  box-shadow: var(--idp-shadow);
+}
+.idp-card h1 {
+  font-size: 24px; font-weight: 400; letter-spacing: -0.2px;
+  margin: 0 0 8px;
+}
+.idp-sub {
+  margin: 0 0 24px; color: var(--idp-text);
+}
+.idp-app {
+  font-weight: 500;
+}
+.idp-error {
+  background: #fce8e6; color: #c5221f;
+  padding: 10px 12px; border-radius: 6px; margin-bottom: 16px;
+  font-size: 13px;
+}
+
+/* Account picker. */
+.idp-account-list {
+  list-style: none; padding: 0; margin: 0 -16px 16px;
+}
+.idp-account-list li { border-top: 1px solid var(--idp-border); }
+.idp-account-list li:last-child { border-bottom: 1px solid var(--idp-border); }
+.idp-account-row {
+  width: 100%; background: none; border: 0; cursor: pointer;
+  display: flex; align-items: center; gap: 14px;
+  padding: 14px 16px; text-align: left; font: inherit; color: inherit;
+}
+.idp-account-row:hover { background: var(--idp-row-hover); }
+.idp-account-row.idp-other { color: var(--idp-text-muted); cursor: default; }
+.idp-account-row.idp-other:hover { background: none; }
+.idp-avatar {
+  width: 32px; height: 32px; border-radius: 99px;
+  background: #1a73e8; color: white;
+  display: inline-flex; align-items: center; justify-content: center;
+  font-weight: 500; font-size: 13px;
+}
+.idp-avatar-sm { width: 24px; height: 24px; font-size: 12px; }
+.idp-avatar-placeholder {
+  background: #f1f3f4; color: var(--idp-text-muted);
+  border: 1px dashed var(--idp-border);
+}
+.idp-account-meta {
+  display: flex; flex-direction: column; line-height: 1.3;
+  flex: 1; min-width: 0;
+}
+.idp-account-name { font-size: 14px; }
+.idp-account-email { font-size: 12px; color: var(--idp-text-muted); }
+.idp-chevron { color: var(--idp-text-muted); font-size: 18px; }
+
+/* Consent screen. */
+.idp-account-line {
+  display: inline-flex; align-items: center; gap: 8px;
+  background: var(--idp-row-hover);
+  padding: 6px 12px; border-radius: 99px;
+  margin: 0 0 24px; font-size: 13px;
+}
+.idp-permits { margin: 24px 0 8px; font-weight: 500; }
+.idp-scope-list {
+  list-style: none; padding: 0; margin: 0 0 24px;
+}
+.idp-scope-list li {
+  display: flex; align-items: center; gap: 12px;
+  padding: 12px 0;
+  border-top: 1px solid var(--idp-border);
+}
+.idp-scope-list li:last-child { border-bottom: 1px solid var(--idp-border); }
+.idp-scope-ico {
+  width: 28px; height: 28px; border-radius: 99px;
+  display: inline-flex; align-items: center; justify-content: center;
+  background: var(--idp-row-hover); color: var(--idp-text-muted);
+  font-size: 14px; font-weight: 500;
+}
+
+.idp-fineprint {
+  font-size: 11px; color: var(--idp-text-muted);
+  line-height: 1.6;
+}
+.idp-fineprint a { color: var(--idp-blue); text-decoration: none; }
+.idp-fineprint a:hover { text-decoration: underline; }
+
+.idp-actions {
+  display: flex; justify-content: flex-end; gap: 8px;
+  margin-top: 24px;
+}
+.idp-btn {
+  border: 0; cursor: pointer; font: inherit; font-weight: 500;
+  padding: 10px 22px; border-radius: 4px;
+  font-size: 14px;
+}
+.idp-btn-primary {
+  background: var(--idp-blue); color: white;
+}
+.idp-btn-primary:hover { background: var(--idp-blue-hover); }
+.idp-btn-secondary {
+  background: transparent; color: var(--idp-blue);
+}
+.idp-btn-secondary:hover { background: rgba(26, 115, 232, 0.04); }
+
+.idp-footer {
+  display: flex; justify-content: space-between; align-items: center;
+  padding: 14px 32px; border-top: 1px solid var(--idp-border);
+  font-size: 12px; color: var(--idp-text-muted);
+}
+.idp-footer select {
+  border: 0; background: none; color: var(--idp-text-muted);
+  font: inherit;
+}
+.idp-footer-links { display: flex; gap: 24px; }
+.idp-footer-links a { color: var(--idp-text-muted); text-decoration: none; }
+.idp-footer-links a:hover { color: var(--idp-text); }
+
+/* "Redirecting back to mantis-shop..." page between consent and callback,
+ * to make the redirect feel real (vs. the instant 303 the agent never
+ * "sees"). Auto-redirects after a beat via meta refresh.
+ */
+.idp-redirect-card {
+  margin: 80px auto; width: min(420px, 92vw); text-align: center;
+}
+.idp-redirect-card .idp-spinner {
+  display: inline-block; width: 36px; height: 36px;
+  border: 3px solid var(--idp-border); border-top-color: var(--idp-blue);
+  border-radius: 99px; animation: idp-spin 0.8s linear infinite;
+  margin-bottom: 16px;
+}
+@keyframes idp-spin { to { transform: rotate(360deg); } }

--- a/deploy/sim_envs/mantis_shop/app/templates/base.html
+++ b/deploy/sim_envs/mantis_shop/app/templates/base.html
@@ -28,7 +28,18 @@
       <form class="search-form" action="/catalog" method="get">
         <input type="text" name="q" placeholder="Search products…" value="{{ request.query_params.get('q') or '' }}" data-testid="topbar-search"/>
       </form>
-      <div class="user-chip"><span class="avatar">TC</span> Test Customer</div>
+      <div class="user-chip" data-testid="user-chip">
+        {% set _u = request.state.current_user if request.state and request.state.current_user else None %}
+        {% if _u %}
+          <span class="avatar">{{ _u.email[0]|upper }}</span> {{ _u.email }}
+          <form method="post" action="/logout" style="display:inline; margin-left:8px;">
+            <button type="submit" class="link-button" data-testid="topbar-logout">Sign out</button>
+          </form>
+        {% else %}
+          <span class="avatar">?</span>
+          <a href="/login" data-testid="topbar-login">Sign in</a>
+        {% endif %}
+      </div>
     </header>
     <main class="workspace">
       {% block content %}{% endblock %}

--- a/deploy/sim_envs/mantis_shop/app/templates/login.html
+++ b/deploy/sim_envs/mantis_shop/app/templates/login.html
@@ -1,0 +1,49 @@
+{% extends "base.html" %}
+{% block title %}Sign in — mantis-shop{% endblock %}
+{% block content %}
+<div class="login-card" data-testid="login-card">
+  <h1>Sign in to mantis-shop</h1>
+
+  {% if error %}
+    <div class="error" data-testid="login-error">{{ error }}</div>
+  {% endif %}
+
+  {% if current_user %}
+    <div class="notice" data-testid="already-logged-in">
+      You're already signed in as <strong>{{ current_user.email }}</strong>.
+      <form method="post" action="/logout" style="display:inline">
+        <button type="submit" data-testid="logout-btn">Sign out</button>
+      </form>
+    </div>
+  {% endif %}
+
+  <form method="post" action="/login" class="login-form" data-testid="login-form">
+    <input type="hidden" name="next" value="{{ next }}"/>
+    <label>Email
+      <input type="email" name="email" required autocomplete="email"
+             placeholder="demo@mantis.example" data-testid="login-email"/>
+    </label>
+    <label>Password
+      <input type="password" name="password" required autocomplete="current-password"
+             data-testid="login-password"/>
+    </label>
+    <button type="submit" data-testid="login-submit">Sign in</button>
+  </form>
+
+  <div class="oauth-divider">or</div>
+
+  <a class="btn-oauth"
+     href="/oauth/authorize?client_id=mantis-shop&redirect_uri=/oauth/callback&state=login"
+     data-testid="login-oauth">
+    Continue with Google
+  </a>
+
+  <details class="login-hint">
+    <summary>Demo credentials</summary>
+    <ul>
+      <li><code>demo@mantis.example</code> / <code>hunter2</code> — buyer (links to customer_00001)</li>
+      <li><code>admin@mantis.example</code> / <code>admin123</code> — admin</li>
+    </ul>
+  </details>
+</div>
+{% endblock %}

--- a/deploy/sim_envs/mantis_shop/app/templates/oauth_authorize.html
+++ b/deploy/sim_envs/mantis_shop/app/templates/oauth_authorize.html
@@ -1,0 +1,74 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Sign in - Google Accounts</title>
+  <link rel="stylesheet" href="/static/oauth.css" />
+</head>
+<body class="idp">
+<div class="idp-shell" data-testid="oauth-idp-shell">
+  <header class="idp-topbar">
+    <div class="g-logo">
+      <span class="g-blue">G</span><span class="g-red">o</span><span class="g-yellow">o</span><span class="g-blue">g</span><span class="g-green">l</span><span class="g-red">e</span>
+    </div>
+    <a class="idp-help" href="#">Help</a>
+  </header>
+
+  <main class="idp-card" data-testid="oauth-account-picker">
+    <h1>Choose an account</h1>
+    <p class="idp-sub">to continue to <span class="idp-app">{{ client_id }}</span></p>
+
+    {% if error %}
+      <div class="idp-error" data-testid="oauth-error">{{ error }}</div>
+    {% endif %}
+
+    {% if not error %}
+      <ul class="idp-account-list">
+        {% for account in accounts %}
+          <li>
+            <form method="post" action="/oauth/consent" data-testid="oauth-account-form-{{ loop.index }}">
+              <input type="hidden" name="oauth_subject" value="{{ account.sub }}"/>
+              <input type="hidden" name="redirect_uri" value="{{ redirect_uri }}"/>
+              <input type="hidden" name="state" value="{{ state }}"/>
+              <button class="idp-account-row" type="submit"
+                      data-testid="oauth-account-{{ loop.index }}">
+                <span class="idp-avatar" aria-hidden="true">{{ account.label[0]|upper }}</span>
+                <span class="idp-account-meta">
+                  <span class="idp-account-name">{{ account.label.split('@')[0]|capitalize }}</span>
+                  <span class="idp-account-email">{{ account.label }}</span>
+                </span>
+                <span class="idp-chevron" aria-hidden="true">›</span>
+              </button>
+            </form>
+          </li>
+        {% endfor %}
+        <li>
+          <button class="idp-account-row idp-other" type="button" disabled
+                  data-testid="oauth-use-another">
+            <span class="idp-avatar idp-avatar-placeholder">+</span>
+            <span class="idp-account-meta">
+              <span class="idp-account-name">Use another account</span>
+            </span>
+          </button>
+        </li>
+      </ul>
+    {% endif %}
+
+    <p class="idp-fineprint">
+      Before using this app, you can review {{ client_id }}'s
+      <a href="#">privacy policy</a> and <a href="#">terms of service</a>.
+    </p>
+  </main>
+
+  <footer class="idp-footer">
+    <select disabled><option>English (United States)</option></select>
+    <div class="idp-footer-links">
+      <a href="#">Help</a>
+      <a href="#">Privacy</a>
+      <a href="#">Terms</a>
+    </div>
+  </footer>
+</div>
+</body>
+</html>

--- a/deploy/sim_envs/mantis_shop/app/templates/oauth_consent.html
+++ b/deploy/sim_envs/mantis_shop/app/templates/oauth_consent.html
@@ -1,0 +1,73 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Sign in - Google Accounts</title>
+  <link rel="stylesheet" href="/static/oauth.css" />
+</head>
+<body class="idp">
+<div class="idp-shell" data-testid="oauth-consent-shell">
+  <header class="idp-topbar">
+    <div class="g-logo">
+      <span class="g-blue">G</span><span class="g-red">o</span><span class="g-yellow">o</span><span class="g-blue">g</span><span class="g-green">l</span><span class="g-red">e</span>
+    </div>
+    <div class="idp-account-chip">
+      <span class="idp-avatar idp-avatar-sm">{{ user.email[0]|upper }}</span>
+      <span>{{ user.email }}</span>
+    </div>
+  </header>
+
+  <main class="idp-card" data-testid="oauth-consent-card">
+    <h1>{{ client_id }} wants to access your Google Account</h1>
+    <div class="idp-account-line">
+      <span class="idp-avatar idp-avatar-sm">{{ user.email[0]|upper }}</span>
+      <span>{{ user.email }}</span>
+    </div>
+
+    <p class="idp-sub idp-permits">This will allow {{ client_id }} to:</p>
+    <ul class="idp-scope-list">
+      <li>
+        <span class="idp-scope-ico">@</span>
+        <span>See your primary Google Account email address</span>
+      </li>
+      <li>
+        <span class="idp-scope-ico">i</span>
+        <span>See your personal info, including any personal info you've made publicly available</span>
+      </li>
+    </ul>
+
+    <p class="idp-fineprint">
+      Make sure you trust {{ client_id }}. You may be sharing sensitive info with this site or app.
+      You can always see or remove access in your <a href="#">Google Account</a>.
+    </p>
+
+    <div class="idp-actions">
+      <form method="get" action="/oauth/authorize" style="display:inline">
+        <input type="hidden" name="client_id" value="{{ client_id }}"/>
+        <input type="hidden" name="redirect_uri" value="{{ redirect_uri }}"/>
+        <input type="hidden" name="state" value="{{ state }}"/>
+        <button type="submit" class="idp-btn idp-btn-secondary"
+                data-testid="oauth-cancel">Cancel</button>
+      </form>
+      <form method="post" action="/oauth/consent/grant" style="display:inline">
+        <input type="hidden" name="oauth_subject" value="{{ user.oauth_subject }}"/>
+        <input type="hidden" name="redirect_uri" value="{{ redirect_uri }}"/>
+        <input type="hidden" name="state" value="{{ state }}"/>
+        <button type="submit" class="idp-btn idp-btn-primary"
+                data-testid="oauth-allow">Allow</button>
+      </form>
+    </div>
+  </main>
+
+  <footer class="idp-footer">
+    <select disabled><option>English (United States)</option></select>
+    <div class="idp-footer-links">
+      <a href="#">Help</a>
+      <a href="#">Privacy</a>
+      <a href="#">Terms</a>
+    </div>
+  </footer>
+</div>
+</body>
+</html>

--- a/deploy/sim_envs/mantis_shop/app/templates/oauth_redirect.html
+++ b/deploy/sim_envs/mantis_shop/app/templates/oauth_redirect.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Redirecting…</title>
+  <link rel="stylesheet" href="/static/oauth.css" />
+  <meta http-equiv="refresh" content="1;url={{ target }}" />
+</head>
+<body class="idp">
+<div class="idp-shell" data-testid="oauth-redirect-shell">
+  <header class="idp-topbar">
+    <div class="g-logo">
+      <span class="g-blue">G</span><span class="g-red">o</span><span class="g-yellow">o</span><span class="g-blue">g</span><span class="g-green">l</span><span class="g-red">e</span>
+    </div>
+  </header>
+  <main class="idp-card idp-redirect-card" data-testid="oauth-redirect-card">
+    <div class="idp-spinner" aria-hidden="true"></div>
+    <h1 style="font-size:18px">Redirecting back to {{ client_id }}…</h1>
+    <p class="idp-fineprint" style="margin-top:12px">
+      If you're not redirected automatically,
+      <a href="{{ target }}" data-testid="oauth-redirect-link">click here</a>.
+    </p>
+  </main>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Closes #387.
- Adds a real-shape auth surface to all three sim envs (`mantis_shop`, `mantis_crm`, `mantis_helpdesk`) so agent tasks can be graded on the *login step* — the one that fails most often in production.
- Two-step Google-style OAuth mock (account picker → consent with scopes → "Redirecting back to ${app}…" interstitial → callback), in a standalone IdP-feeling surface (no app shell, Google wordmark + Help/Privacy/Terms footer).
- New `T06_login_then_*` oracle per env that asserts a real `login_succeeded` row precedes the inner T01 mutations. Existing T01–T05 oracles still grade unchanged.
- Opt-in via `ENV_REQUIRE_AUTH=1`. Default off → 87 existing `tests/sim_envs/` cases still pass.

## What ships per env

| | shop | crm | helpdesk |
|---|---|---|---|
| `app/auth.py` (sha256 hash, HMAC session, OAuth code store) | ✅ | ✅ | ✅ |
| `app/routes/auth.py` (login + logout + 3-step OAuth) | ✅ | ✅ | ✅ |
| `templates/login.html` + `oauth_{authorize,consent,redirect}.html` | ✅ | ✅ | ✅ |
| `static/oauth.css` (IdP-only styles) | ✅ | ✅ | ✅ |
| Middleware gate in `main.py` | ✅ | ✅ | ✅ |
| `users` table (new) keyed to `customers` | ✅ | — | — |
| Hardcoded acting-user replaced with `current_user` | ✅ (4 spots in checkout.py) | — | — |
| `password_hash` + `oauth_subject` added to existing `users` table | — | ✅ | ✅ |
| New `T06` oracle | `T06_login_then_buy_jacket` | `T06_login_then_tag_reengage` | `T06_login_then_triage_inbox` |

## Canonical creds (all 3 envs)

- `demo@mantis.example` / `hunter2` (role=customer for shop / agent for crm/helpdesk)
- `admin@mantis.example` / `admin123` (role=admin)

OAuth subjects: `google-oauth2|{env}-demo-001` and `google-oauth2|{env}-admin-001`.

## Audit shape

The audit log (`audit_log` in shop, `mutations` in crm/helpdesk) gains four new operation types:

- `login_succeeded` (payload: `email`, `role`, `via=password|oauth`)
- `login_failed` (payload: `email`, `via`)
- `logout` (payload: `email`)
- `oauth_consent` (payload: `oauth_subject`, `client_id`)

T06 oracles assert (a) the login row exists for the expected user, (b) `via ∈ {password, oauth}`, (c) login id precedes the inner T01 mutations. A future `/__env__/login_as` harness shortcut would *not* write the login row, so it fails the gate cleanly.

## Test plan

- [x] **`uv run pytest tests/sim_envs/`** — 87 passed (4 skipped). No regressions vs main.
- [x] **Docker rebuild all three images**, run with `ENV_REQUIRE_AUTH=1`, exercise via curl + Chrome MCP. Anonymous `/admin/orders` 303s to `/login?next=...`; password login mints cookie; admin role gate rejects non-admins.
- [x] **OAuth roundtrip** (Chrome MCP screenshots): `/oauth/authorize` shows Google-branded account picker with no app shell → click account → consent screen "`mantis-shop` wants to access your Google Account" with scope list + Cancel/Allow → click Allow → "Redirecting back to mantis-shop…" interstitial with spinner → meta-refresh to `/oauth/callback?code=…` → session cookie set, lands on `/` with email in topbar.
- [x] **T06 oracle**:
  - Reset DB → query T06 → fails on "no login_succeeded audit row" (negative case).
  - Login as demo via password → run full T01 buy-jacket via curl (cart/add + apply-coupon + 4-step checkout + place_order) → T06 returns `passed=true, score=1.0` with `login_audit_id=10 < order_audit_id=16`, `discount_total=$13.35`, inventory decremented `25 → 24`.
  - T01_buy_jacket still passes against the same DB state (backwards-compat).
- [ ] **Final gate (operator)**: deploy Modal + re-run a real agent plan that wants to grade on the new T06 surface.

## Why opt-in (not always-on)

Existing T01–T05 are graded on DB state, not the auth surface. Always-on auth would have forced a rewrite of the per-task oracles + the harness's bootstrap. The `ENV_REQUIRE_AUTH` toggle is the same shape as `SEED` / `FAKE_NOW` / `ENV_ADMIN_TOKEN` — a per-task env knob the harness sets. T06 grades with it on; T01 keeps grading with it off.

## Follow-ups (out of scope here)

- Real Google OAuth (we mock shape, not protocol). 
- `/__env__/login_as` admin helper for harness pre-auth on tasks that don't grade the login step.
- MFA / passkey / "session expired mid-task" simulation.
- Multi-tenant data partitioning per session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)