### PR TITLE
feat(plan): right_click step type — context-menu primitive across all three layers (#373)

### DIFF
--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -53,6 +53,10 @@ Each step in a micro-plan is a JSON object with a `type` and an `intent`:
 | `paginate` | URL-based or grounded click on the Next button |
 | `loop` | Jumps back to step `loop_target` up to `loop_count` times |
 | `filter` | Claude finds the filter checkbox and clicks it |
+| `fill_field` | Claude finds the labelled input (`params.label`), clears it, types `params.value` |
+| `submit` | Claude finds the labelled button / nav-link / row-link (`params.label` + `params.kind`) and left-clicks it |
+| `select_option` | Opens a labelled dropdown then picks the named option (`params.dropdown_label` + `params.option_label`) |
+| `right_click` | Claude finds the labelled element (`params.label`) and right-clicks to open the native context menu — use for "Open Link in New Tab" / "Copy Link" / app-defined context menus on table rows or grid cells ([#373](https://github.com/mercurialsolo/mantis/issues/373)) |
 
 Useful per-step modifiers:
 

--- a/docs/reference/plan.schema.json
+++ b/docs/reference/plan.schema.json
@@ -39,6 +39,7 @@
             "fill_field",
             "submit",
             "select_option",
+            "right_click",
             "paginate",
             "filter",
             "done",
@@ -155,7 +156,7 @@
         },
         "params": {
           "type": "object",
-          "description": "Structured payload for form-shaped step types: fill_field {label, value, aliases?}, submit {label, aliases?}, select_option {dropdown_label, option_label}, navigate {wait_after_load_seconds?}."
+          "description": "Structured payload for form-shaped step types: fill_field {label, value, aliases?}, submit {label, aliases?}, select_option {dropdown_label, option_label}, right_click {label, aliases?}, navigate {wait_after_load_seconds?}."
         },
         "hints": {
           "type": "object",

--- a/src/mantis_agent/extraction/extractor.py
+++ b/src/mantis_agent/extraction/extractor.py
@@ -1414,7 +1414,7 @@ class ClaudeExtractor:
                     "y": {"type": "integer", "description": "Center Y in pixels"},
                     "action": {
                         "type": "string",
-                        "enum": ["click", "type", "select", "not_found"],
+                        "enum": ["click", "right_click", "type", "select", "not_found"],
                     },
                     "value": {"type": "string"},
                     "label": {"type": "string"},
@@ -1554,7 +1554,7 @@ class ClaudeExtractor:
                     "y": {"type": "integer", "description": "Center Y in pixels"},
                     "action": {
                         "type": "string",
-                        "enum": ["click", "type", "select", "not_found"],
+                        "enum": ["click", "right_click", "type", "select", "not_found"],
                     },
                     "value": {"type": "string"},
                     "label": {"type": "string"},
@@ -1821,14 +1821,17 @@ class ClaudeExtractor:
                     },
                     "action": {
                         "type": "string",
-                        "enum": ["click", "type", "select", "not_found"],
+                        "enum": ["click", "right_click", "type", "select", "not_found"],
                         "description": (
                             "What the runner should do at this element. "
                             "``click`` for buttons / links / row "
-                            "containers; ``type`` for text inputs the "
-                            "runner should fill; ``select`` for an "
-                            "option already visible in an open "
-                            "dropdown menu (click first if the "
+                            "containers; ``right_click`` only when the "
+                            "task explicitly needs the browser's native "
+                            "context menu on the element (e.g. \"Open "
+                            "Link in New Tab\", \"Copy Link\"); ``type`` "
+                            "for text inputs the runner should fill; "
+                            "``select`` for an option already visible in "
+                            "an open dropdown menu (click first if the "
                             "dropdown is closed). ``not_found`` if "
                             "the page has nothing matching the intent."
                         ),

--- a/src/mantis_agent/gym/step_handlers/__init__.py
+++ b/src/mantis_agent/gym/step_handlers/__init__.py
@@ -64,7 +64,10 @@ def default_registry(runner: "MicroPlanRunner") -> HandlerRegistry:
     ``register_for_types``:
 
     - ``ClaudeGuidedFormHandler`` → ``fill_field`` / ``submit`` /
-      ``select_option`` (form-shaped dispatch)
+      ``select_option`` / ``right_click`` (form-shaped dispatch —
+      one labelled target per call to ``find_form_target``; the
+      handler picks the button=right path for ``right_click`` and
+      a left-click for the other three)
     - ``ClaudeStepHandler`` → ``extract_url`` / ``extract_data``
       (Claude-only steps)
     - ``Holo3StepHandler`` → ``scroll`` / ``navigate_back`` (the only
@@ -89,7 +92,7 @@ def default_registry(runner: "MicroPlanRunner") -> HandlerRegistry:
     reg.register(ClaudeGuidedFilterHandler(runner))
     reg.register_for_types(
         ClaudeGuidedFormHandler(runner),
-        ("fill_field", "submit", "select_option"),
+        ("fill_field", "submit", "select_option", "right_click"),
     )
     reg.register_for_types(
         ClaudeStepHandler(runner),

--- a/src/mantis_agent/gym/step_handlers/form.py
+++ b/src/mantis_agent/gym/step_handlers/form.py
@@ -604,6 +604,67 @@ class ClaudeGuidedFormHandler:
                 logger.warning(f"  [claude-form] submit failed: {e}")
                 return StepResult(step_index=index, intent=step.intent, success=False, data=f"submit_error:{e}")
 
+        if step.type == "right_click":
+            # #373: open the browser's native context menu on a single
+            # labelled element. Uses find_form_target (Claude vision)
+            # to locate the target by label, then dispatches a
+            # button=right click. No URL-change verification — a
+            # right-click that succeeds opens a menu, it does not
+            # navigate. SoM dispatch is left-click-only (``el.click()``
+            # synthesises a left-button event chain), so this path
+            # goes straight through xdotool / Playwright button=3.
+            label = str(params.get("label") or "").strip()
+            aliases = params.get("aliases") or []
+            if isinstance(aliases, str):
+                aliases = [aliases]
+            aliases = [str(a).strip() for a in aliases if str(a).strip()]
+            search_intent = (
+                f"Find the '{label}' element so we can right-click on it "
+                f"to open its native context menu"
+                if label else step.intent
+            )
+            target = extractor.find_form_target(
+                screenshot, search_intent,
+                target_label=label, target_aliases=aliases,
+            )
+            runner.costs["claude_extract"] += 1
+            if not target:
+                logger.warning(
+                    f"  [claude-form] right_click: target '{label}' not found"
+                )
+                return StepResult(
+                    step_index=index, intent=step.intent, success=False,
+                    data="form_target_not_found",
+                    failure_class="selector_miss",
+                )
+            x, y = int(target["x"]), int(target["y"])
+            try:
+                time.sleep(random.uniform(0.2, 0.5))
+                env.step(Action(
+                    action_type=ActionType.CLICK,
+                    params={"x": x, "y": y, "button": "right"},
+                ))
+                ctx.state["_executor_backend"] = "vision"
+                runner.costs["gpu_steps"] += 1
+                # Brief settle to let the context menu render — caller
+                # typically follows with a ``submit`` step keyed on a
+                # menu item ("Open Link in New Tab", "Copy Link", …).
+                time.sleep(0.6)
+                logger.info(
+                    f"  [claude-form] right_click '{label[:40]}' at ({x}, {y})"
+                )
+                return StepResult(
+                    step_index=index, intent=step.intent, success=True,
+                    steps_used=1, duration=1.0,
+                    data=f"right_click:{label[:40]}@({x},{y})",
+                )
+            except Exception as e:  # noqa: BLE001
+                logger.warning(f"  [claude-form] right_click failed: {e}")
+                return StepResult(
+                    step_index=index, intent=step.intent, success=False,
+                    data=f"right_click_error:{e}",
+                )
+
         if step.type == "select_option":
             dropdown = str(params.get("dropdown_label") or params.get("label") or "").strip()
             option = str(params.get("option_label") or params.get("value") or "").strip()

--- a/src/mantis_agent/plan_decomposer.py
+++ b/src/mantis_agent/plan_decomposer.py
@@ -120,7 +120,7 @@ def _extract_json_payload(text: str) -> Any:
 class MicroIntent:
     """A single atomic instruction for the CUA executor."""
     intent: str             # 1 sentence for Holo3: "Click the blue title text below the photo"
-    type: str               # click, scroll, navigate, extract_url, extract_data, filter, paginate, loop, navigate_back, fill_field, submit, select_option
+    type: str               # click, scroll, navigate, extract_url, extract_data, filter, paginate, loop, navigate_back, fill_field, submit, select_option, right_click
     verify: str = ""        # Expected outcome: "URL contains boattrader.com/boat/"
     budget: int = 5         # Max Holo3 steps
     reverse: str = ""       # How to undo: "Press Alt+Left"
@@ -135,6 +135,7 @@ class MicroIntent:
     #   fill_field    : {"label": str, "value": str, "aliases"?: list[str]}
     #   submit        : {"label": str, "aliases"?: list[str]}
     #   select_option : {"dropdown_label": str, "option_label": str}
+    #   right_click   : {"label": str, "aliases"?: list[str]}  # opens native context menu
     #   navigate      : {"wait_after_load_seconds"?: int}
     # ``aliases`` (#89 §2) lets a plan list synonyms for a primary submit
     # button whose copy varies across products (e.g. "Update Lead" /
@@ -456,6 +457,18 @@ VERB → STEP-TYPE MAPPING (FORM FLOWS):
        → click (this IS a listings click — many similar items on one page,
        runner picks the next un-extracted one). DO NOT use click for nav
        links, buttons, or any single-element clickable.
+   "right-click on Y", "open the context menu on Y",
+   "press the right mouse button on Y", "secondary-click Y"
+       → right_click with params={"label": "Y"}.
+       Use ONLY when the workflow needs the browser's native context
+       menu on a specific labelled target — typically "Open Link in
+       New Tab", "Copy Link", "Inspect Element", or app-defined
+       context menus on table rows / grid cells. The runner finds the
+       element via find_form_target then dispatches a right mouse
+       button click at its center. Do NOT use right_click as a generic
+       "click harder" — a plain click step is correct unless the
+       source explicitly calls for a right-click verb or a context
+       menu is the only way to reach the next action.
 
 When the source text says "Click the {field-name} field and enter {value}", emit
 a SINGLE fill_field step (label={field-name}, value={value}) — NOT a click step.
@@ -652,7 +665,7 @@ class PlanDecomposer:
             domain = m.group(1)
 
         # Check cache — include prompt version in hash to invalidate on schema changes
-        prompt_version = "v24_verification_gate"  # Bump this when DECOMPOSE_PROMPT changes
+        prompt_version = "v25_right_click"  # Bump this when DECOMPOSE_PROMPT changes
         plan_hash = hashlib.md5(f"{prompt_version}:{plan_text}".encode()).hexdigest()[:8]
         cache_path = (
             cache_path_template.replace("{hash}", plan_hash)
@@ -779,6 +792,15 @@ class PlanDecomposer:
     # Always claude-grounded; no listings find_all. See issue #80.
     FORM_STEP_TYPES = ("fill_field", "submit", "select_option")
 
+    # ``right_click`` (#373) shares the FormHandler dispatch shape —
+    # find_form_target finds one labelled element, the handler then
+    # dispatches an ``Action(CLICK, button="right")`` — but the
+    # FORM_STEP_TYPES defaults (section=setup, required=True) are
+    # wrong for right-click, which is typically an extraction-flow
+    # primitive (open a context menu mid-extract). The build path
+    # below treats it as its own group with extraction-friendly
+    # defaults.
+
     # Verification-language triggers (issue #244). When an
     # ``extract_data`` step's intent contains any of these substrings
     # (case-insensitive) and the source dict didn't set ``gate``
@@ -824,7 +846,7 @@ class PlanDecomposer:
                 section = "setup"
             elif step_type in ("paginate",):
                 section = "pagination"
-            elif step_type in ("click", "scroll", "extract_url", "extract_data", "navigate_back"):
+            elif step_type in ("click", "scroll", "extract_url", "extract_data", "navigate_back", "right_click"):
                 section = "extraction"
             elif step_type in PlanDecomposer.FORM_STEP_TYPES:
                 # Form steps default to "setup" — login + form-fill happens before extraction.

--- a/src/mantis_agent/prompts/files/find_form_target.txt
+++ b/src/mantis_agent/prompts/files/find_form_target.txt
@@ -36,12 +36,17 @@ scroll, or surface a planning error.
 
 Determine the interaction:
 - "click" for buttons, links, checkbox/radio/toggle, or to OPEN a dropdown.
+- "right_click" for opening a native context menu on the element (e.g. the
+  task explicitly asks to right-click, or the workflow needs the browser's
+  context menu — "Open Link in New Tab", "Copy Link", "Inspect"). Only pick
+  this when the task verb is right-click or when no other interaction can
+  reach the goal.
 - "type" for text inputs (the runner will click the field, clear, then type).
 - "select" for picking an option from a dropdown that is already open
   (if the dropdown is closed, return action=click on the dropdown control first).
 
 Return the CENTER coordinates of the target element. Output ONLY valid JSON:
-{"x": N, "y": N, "action": "click|type|select",
+{"x": N, "y": N, "action": "click|right_click|type|select",
  "value": "text to type or option to select or empty",
  "label": "what element you found"}
 If the target is not visible anywhere on the page:

--- a/tests/test_decomposer_literal_values.py
+++ b/tests/test_decomposer_literal_values.py
@@ -129,10 +129,11 @@ def test_prompt_version_was_bumped() -> None:
     from mantis_agent.plan_decomposer import PlanDecomposer
 
     src = inspect.getsource(PlanDecomposer.decompose_text)
-    # Current version (route verification extract_data through gate).
-    assert "v24_verification_gate" in src
     # Superseded versions must NOT appear — would mean someone
-    # accidentally restored a stale cache key.
+    # accidentally restored a stale cache key. Each historical
+    # version gets its own no-reappearance guard so a future bump
+    # only needs to add one new line, not edit a "current" pin.
+    assert "v24_verification_gate" not in src
     assert "v23_skip_runtime_hints" not in src
     assert "v22_row_link" not in src
     assert "v21_submit_kind" not in src

--- a/tests/test_decomposer_verification_gate.py
+++ b/tests/test_decomposer_verification_gate.py
@@ -100,12 +100,15 @@ def test_prompt_calls_out_recipe_schema_rejection_failure_mode() -> None:
 
 def test_cache_version_bumped() -> None:
     """A prompt change requires a cache-version bump so previously-
-    decomposed plans get re-decomposed under the new rule."""
+    decomposed plans get re-decomposed under the new rule. The
+    durable assertion is "the superseded version must not reappear"
+    — pinning a specific current version forces a churn-edit on
+    every legitimate downstream bump (e.g. #373's v25_right_click)."""
     src = inspect.getsource(PlanDecomposer.decompose_text)
-    # The new version MUST differ from the previous one and reference
-    # this fix (issue #244 / verification gate).
     assert "v23_skip_runtime_hints" not in src
-    assert "v24" in src
+    # The verification-gate bump itself was v24; it must not silently
+    # reappear and resurrect pre-#373 cached plans.
+    assert "v24_verification_gate" not in src
 
 
 # ── Runtime safety net (PlanDecomposer._build_intent) ────────────

--- a/tests/test_extractor_tool_use_migration.py
+++ b/tests/test_extractor_tool_use_migration.py
@@ -121,7 +121,10 @@ def test_find_filter_target_schema_includes_full_action_enum() -> None:
 
     schema = tool.call_args.kwargs["input_schema"]
     enum = schema["properties"]["action"]["enum"]
-    assert set(enum) == {"click", "type", "select", "not_found"}
+    # ``right_click`` (#373) joined the enum so Claude can adaptively
+    # suggest a context-menu open when a filter chip is right-click-
+    # only (rare but observed on a few SaaS filter pickers).
+    assert set(enum) == {"click", "right_click", "type", "select", "not_found"}
     assert set(schema["required"]) == {"x", "y", "action", "value", "label"}
 
 

--- a/tests/test_form_handler.py
+++ b/tests/test_form_handler.py
@@ -382,3 +382,106 @@ def test_unknown_step_type_returns_failure(monkeypatch):
 def test_step_type_property():
     handler = ClaudeGuidedFormHandler(_FakeRunner())
     assert handler.step_type == "submit"
+
+
+# ── right_click (#373) ──────────────────────────────────────────────
+
+
+def test_right_click_dispatches_button_right_at_target(monkeypatch):
+    """right_click finds the labelled target via find_form_target,
+    then dispatches a single CLICK Action with ``button="right"``
+    at the target's center — no SoM dispatch, no URL-change check."""
+    monkeypatch.setattr("mantis_agent.gym.step_handlers.form.time.sleep", lambda *_: None)
+    monkeypatch.setattr(
+        "mantis_agent.gym.step_handlers.form.random.uniform",
+        lambda a, b: a,
+    )
+
+    runner = _FakeRunner()
+    extractor = MagicMock()
+    extractor.find_form_target.return_value = {"x": 320, "y": 480}
+    env = MagicMock()
+    ctx = _ctx(runner, env=env, extractor=extractor)
+
+    step = MicroIntent(
+        intent="Right-click on Open Link in New Tab",
+        type="right_click",
+        params={"label": "Listing card #2"},
+    )
+    result = ClaudeGuidedFormHandler(runner).execute(step, ctx)
+
+    assert result.success is True
+    assert result.data == "right_click:Listing card #2@(320,480)"
+    # Single env.step call: the right-mouse-button click.
+    click_calls = [
+        c for c in env.step.call_args_list
+        if c.args[0].action_type == ActionType.CLICK
+    ]
+    assert len(click_calls) == 1
+    params = click_calls[0].args[0].params
+    assert params == {"x": 320, "y": 480, "button": "right"}
+    # One find_form_target call billed; no Holo3 grounding.
+    assert runner.costs["claude_extract"] == 1
+    assert runner.costs["gpu_steps"] == 1
+
+
+def test_right_click_target_not_found_returns_form_target_not_found(monkeypatch):
+    """When find_form_target misses, right_click returns the same
+    ``form_target_not_found`` envelope as the other form variants
+    so the executor / recovery path can react uniformly."""
+    monkeypatch.setattr("mantis_agent.gym.step_handlers.form.time.sleep", lambda *_: None)
+
+    runner = _FakeRunner()
+    extractor = MagicMock()
+    extractor.find_form_target.return_value = None
+    env = MagicMock()
+    ctx = _ctx(runner, env=env, extractor=extractor)
+
+    step = MicroIntent(
+        intent="Right-click on Save",
+        type="right_click",
+        params={"label": "Save"},
+    )
+    result = ClaudeGuidedFormHandler(runner).execute(step, ctx)
+
+    assert result.success is False
+    assert result.data == "form_target_not_found"
+    # ``selector_miss`` lets the recovery / rewrite path see the
+    # specific failure mode (same vocabulary as failure_class.py).
+    assert result.failure_class == "selector_miss"
+    # No click was dispatched.
+    click_calls = [
+        c for c in env.step.call_args_list
+        if c.args[0].action_type == ActionType.CLICK
+    ]
+    assert click_calls == []
+
+
+def test_right_click_uses_intent_string_when_no_label(monkeypatch):
+    """right_click without ``params.label`` falls back to the step
+    intent verbatim (same shape as the other form variants)."""
+    monkeypatch.setattr("mantis_agent.gym.step_handlers.form.time.sleep", lambda *_: None)
+    monkeypatch.setattr(
+        "mantis_agent.gym.step_handlers.form.random.uniform",
+        lambda a, b: a,
+    )
+
+    runner = _FakeRunner()
+    extractor = MagicMock()
+    extractor.find_form_target.return_value = {"x": 50, "y": 60}
+    env = MagicMock()
+    ctx = _ctx(runner, env=env, extractor=extractor)
+
+    step = MicroIntent(
+        intent="Right-click on the first table row to open its menu",
+        type="right_click",
+        params={},
+    )
+    result = ClaudeGuidedFormHandler(runner).execute(step, ctx)
+
+    assert result.success is True
+    # find_form_target invoked with the raw intent (no label-templated
+    # framing). Inspect the search_intent positional argument.
+    call_args = extractor.find_form_target.call_args
+    search_intent = call_args.args[1]
+    assert "first table row" in search_intent

--- a/tests/test_handler_registry_default.py
+++ b/tests/test_handler_registry_default.py
@@ -39,7 +39,7 @@ def test_registry_covers_every_step_type_phase2_lifted():
     reg = _registry()
     expected = {
         "navigate", "click", "paginate", "filter",
-        "fill_field", "submit", "select_option",
+        "fill_field", "submit", "select_option", "right_click",
         "extract_url", "extract_data",
         "scroll", "navigate_back",
     }

--- a/tests/test_right_click_step_type.py
+++ b/tests/test_right_click_step_type.py
@@ -1,0 +1,153 @@
+"""``right_click`` step type — three-layer pin (#373).
+
+The original gap stacked across three layers, all in one PR:
+
+1. ``MicroIntent.type`` accepts ``right_click`` and ``_build_intent``
+   gives it extraction-friendly defaults (section=extraction, not
+   required, no Holo3 grounding).
+2. ``ClaudeExtractor.find_form_target`` / ``find_filter_target`` /
+   ``find_target_by_affordance`` accept ``"right_click"`` in the
+   ``action`` enum so Claude can suggest the verb adaptively even
+   on a plain ``click`` step.
+3. The :class:`~mantis_agent.gym.step_handlers.form.ClaudeGuidedFormHandler`
+   is wired to handle ``right_click`` and dispatches an
+   ``Action(CLICK, button="right")`` at the resolved target. The
+   handler-level dispatch + ``form_target_not_found`` envelope are
+   pinned in ``tests/test_form_handler.py``; this file holds the
+   cross-layer pins that the issue called out.
+
+These tests are deliberately schema- / config-level. The runtime
+behaviour is exercised in ``test_form_handler.py``.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+from mantis_agent.gym.step_handlers import default_registry
+from mantis_agent.gym.step_handlers.form import ClaudeGuidedFormHandler
+from mantis_agent.plan_decomposer import DECOMPOSE_PROMPT, PlanDecomposer
+
+
+# ── Layer 1: MicroIntent / decomposer ──────────────────────────────────
+
+
+def test_micro_intent_docstring_lists_right_click() -> None:
+    """The :class:`MicroIntent` ``type`` field docstring is the
+    canonical enum surface — newcomers reading the class learn the
+    allowed values from there. ``right_click`` MUST appear so any
+    plan author can find it without spelunking the dispatch code."""
+    from mantis_agent import plan_decomposer
+
+    src = inspect.getsource(plan_decomposer)
+    # The comment on the ``type`` field lists every allowed step
+    # type — grep for the canonical right-click token.
+    assert "right_click" in src
+
+
+def test_build_intent_routes_right_click_to_extraction_section() -> None:
+    """A ``right_click`` step with no explicit ``section`` must
+    default to ``"extraction"`` — right-clicks open context menus
+    mid-flow, not during setup. Required must stay False (a missed
+    context menu shouldn't be fatal). Grounding must stay False
+    (find_form_target is Claude-only, not Holo3)."""
+    intent = PlanDecomposer._build_intent({
+        "intent": "Right-click on Save to open hidden options",
+        "type": "right_click",
+        "params": {"label": "Save"},
+    })
+    assert intent.type == "right_click"
+    assert intent.section == "extraction"
+    assert intent.required is False
+    assert intent.grounding is False
+    # claude_only stays False — find_form_target is Claude-only but
+    # the runner doesn't flag it via claude_only (that gate is for
+    # extract_url / extract_data which have no executor action).
+    assert intent.claude_only is False
+    # ``params`` is preserved verbatim — the handler reads label/
+    # aliases from there.
+    assert intent.params == {"label": "Save"}
+
+
+def test_build_intent_respects_explicit_overrides_on_right_click() -> None:
+    """Plan author can override the defaults — e.g. a setup-flow
+    right-click on a SSO popup, or a critical right-click that must
+    succeed (required=True) for the rest of the plan to be coherent."""
+    intent = PlanDecomposer._build_intent({
+        "intent": "Right-click on SSO context icon",
+        "type": "right_click",
+        "section": "setup",
+        "required": True,
+        "params": {"label": "SSO"},
+    })
+    assert intent.section == "setup"
+    assert intent.required is True
+
+
+def test_decomposer_prompt_documents_right_click_verb_mapping() -> None:
+    """``DECOMPOSE_PROMPT`` must teach Claude when to emit
+    ``right_click`` vs ``click``. Without an explicit verb mapping
+    the decomposer would always pick ``click`` and the new primitive
+    would be unreachable from text plans."""
+    text = DECOMPOSE_PROMPT
+    assert "right_click" in text
+    # The verb-mapping section should describe the context-menu
+    # semantics so Claude doesn't mis-route a plain "click" verb.
+    assert "context menu" in text.lower()
+
+
+# ── Layer 2: extractor schema ──────────────────────────────────────────
+
+
+def test_find_form_target_schema_includes_right_click() -> None:
+    """``find_form_target``'s tool schema must list ``right_click``
+    so Claude can return the verb when the page genuinely needs the
+    native context menu — adaptive routing on plain ``click`` steps."""
+    src = inspect.getsource(
+        __import__("mantis_agent.extraction.extractor", fromlist=["*"])
+    )
+    # The action-enum line MUST list right_click. There are three
+    # copies of the same enum (find_filter_target, find_form_target,
+    # find_target_by_affordance); pin that every occurrence carries
+    # right_click — otherwise the gap re-opens on a partial fix.
+    enum_count = src.count('"click", "right_click", "type", "select", "not_found"')
+    assert enum_count == 3, (
+        f"expected 3 schema copies to include right_click, found {enum_count}"
+    )
+
+
+def test_find_form_target_prompt_documents_right_click() -> None:
+    """The prompt file teaches Claude when to pick right_click vs
+    click on a form-shaped page. Without this, the schema enum
+    accepts the verb but the model would never emit it."""
+    from importlib.resources import files
+
+    prompt = files("mantis_agent.prompts.files").joinpath(
+        "find_form_target.txt"
+    ).read_text(encoding="utf-8")
+    assert "right_click" in prompt
+    assert "context menu" in prompt.lower()
+
+
+# ── Layer 3: handler registry wiring ───────────────────────────────────
+
+
+def test_right_click_is_registered_to_form_handler() -> None:
+    """``default_registry`` MUST bind ``right_click`` to the form
+    handler so the runner's fall-through dispatch (``registry.get
+    (step.type)``) picks it up. Without this, every right_click
+    step would crash through to ``_execute_holo3_step`` which has
+    no understanding of the verb."""
+    from unittest.mock import MagicMock
+
+    runner = MagicMock()
+    reg = default_registry(runner)
+    handler = reg.get("right_click")
+    assert handler is not None
+    assert isinstance(handler, ClaudeGuidedFormHandler)
+    # The form handler is also bound to the existing three form types
+    # — make sure right_click didn't accidentally replace one.
+    for legacy_type in ("fill_field", "submit", "select_option"):
+        assert isinstance(
+            reg.get(legacy_type), ClaudeGuidedFormHandler
+        ), f"existing binding for {legacy_type!r} regressed"


### PR DESCRIPTION
## Summary

Closes [#373](https://github.com/mercurialsolo/mantis/issues/373) — reopens it on the mantis side. The original close picked staffai's ``enable_computer_use_tools=True`` flip as the fast fix, but that pushes right-click *out of mantis*: any plan / runner / handler that doesn't go through the hybrid backend (pure Holo3-micro, MicroPlanRunner direct embed, future non-staffai consumers) is still blind to the verb. This PR closes the gap inside mantis so any caller can express right-click in a plan.

The original gap stacked across three layers; this PR fixes all three in one commit:

1. **MicroIntent / PlanDecomposer** — `right_click` is now a first-class step type. `_build_intent` gives it extraction-friendly defaults (section=extraction, not required, no Holo3 grounding) and `DECOMPOSE_PROMPT` teaches Claude the verb mapping (cache key bumped to ``v25_right_click``).
2. **find_form_target / find_filter_target / find_target_by_affordance schemas** — all three action enums now accept ``"right_click"`` so Claude can adaptively suggest the verb on a plain ``click`` step when the page genuinely needs the native context menu. Prompt file teaches when to pick it.
3. **ClaudeGuidedFormHandler** — new ``right_click`` branch finds the labelled target via ``find_form_target`` then dispatches ``Action(CLICK, button="right")``. No SoM dispatch (left-click semantic only). No URL-change verification (context menus don't navigate). Best-effort settle (~0.6s) so a follow-up ``submit`` on a menu item ("Open Link in New Tab", "Copy Link", …) lands cleanly.

The handler-registry binding is extended so the runner's fall-through dispatch picks up the new type without any router edits.

## Why ship the mantis-side fix despite the original close

The "other places too" lens: any execution path that doesn't go through the hybrid backend never gets the staffai ``computer_tool`` fallback. With this PR, the right-click verb is available to **every** consumer — pure MicroPlanRunner embeds, Holo3-micro Modal HTTP path, future agent SDK wrappers — not just staffai/hybrid runs.

## Test plan

- [x] `pytest tests/test_form_handler.py` — 15 passing, including 3 new right_click tests (button=right at target, ``form_target_not_found`` envelope, intent-fallback when no label)
- [x] `pytest tests/test_right_click_step_type.py` — 7 new cross-layer pins (MicroIntent docstring, ``_build_intent`` defaults, decomposer prompt vocab, schema enum count across all three find_* tools, prompt file vocab, registry binding non-regression)
- [x] Full suite minus the pre-existing sim-envs/mantis_crm python-multipart blocker — **2412 passing**, 4 skipped
- [x] `ruff check` clean on all touched files
- [x] `mkdocs build --strict` clean (only pre-existing INFOs on unrelated pages)
- [x] Updated three pre-existing tests that pinned superseded surface: cache-version pin (now no-reappearance pattern), filter-target enum count, registry coverage set
- [ ] Modal redeploy + lu.ma rerun (the new code is dormant on the lu.ma plan since it has no right_click steps; a synthetic plan that exercises a `right_click` step on a known context-menu target would be the canonical E2E)

🤖 Generated with [Claude Code](https://claude.com/claude-code)