### PR TITLE
fix(recorder): bring up Xvfb before ffmpeg fires — kill the recurring 'Cannot open display :99' error

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -620,6 +620,12 @@ For long recordings or tight bandwidth, prefer `mp4` at 5 fps. The `gif` path us
 ### Operational caveats
 
 - The container image must have `ffmpeg` installed. Both `docker/server.Dockerfile` and `deploy/baseten/holo3/config.yaml` ship it; if you're rolling your own image, add `ffmpeg` to the apt deps. Without ffmpeg, `record_video: true` is a soft-fail — the run completes normally, and the response carries `video.error: "ffmpeg-not-installed"`.
+- `video.error` envelopes you may see (soft-fail in every case — the run itself never fails because recording couldn't start):
+  - `ffmpeg-not-installed` — ffmpeg isn't on PATH inside the container.
+  - `x-display-not-ready:<display>` — the Xvfb display ffmpeg targets wasn't up when the recorder fired. The runtime now calls `env.ensure_display_ready()` before spawning the recorder, so this error only appears when a custom image hasn't installed `xvfb` / `xdpyinfo` or when a third-party caller spawns `ScreenRecorder` directly outside the standard runtime. Fix: install `xvfb` + `xdpyinfo` (apt: `xvfb x11-utils`) in your image.
+  - `ffmpeg-startup-failed:<stderr>` — ffmpeg exited within ~300 ms of spawn. The trailing stderr blob is the actionable part; common cause was historically `Cannot open display :99, error 1` (fixed by the display-ready probe above).
+  - `empty-output` — ffmpeg started and stopped cleanly but wrote a zero-byte file. Usually means the run completed before any frames captured.
+  - `spawn-failed:<oserror>` — the Popen itself raised (e.g., process budget exhausted).
 - Recordings live at `$MANTIS_DATA_DIR/tenants/<tenant_id>/runs/<run_id>/recording.<fmt>` so tenants cannot read each other's files. The download endpoint uses the authenticated tenant's dir; even if you guess another tenant's `run_id`, the file lookup is scoped.
 - `video_fps` is clamped to `[1, 30]`. Higher fps doesn't help much (UI rarely changes faster than 5–10 fps) and bloats the file.
 - Each second of recording is ~50 KB at 5 fps mp4. Multiply by your target run duration + tenant count to size the EFS / Filestore.

--- a/src/mantis_agent/baseten_server/runtime.py
+++ b/src/mantis_agent/baseten_server/runtime.py
@@ -875,7 +875,7 @@ class BasetenCUARuntime:
         )
 
     def _maybe_record(
-        self, payload: dict[str, Any], run_id: str
+        self, payload: dict[str, Any], run_id: str, env: Any = None,
     ) -> tuple[Any, Any]:
         """Spawn a ScreenRecorder if payload.record_video is set.
 
@@ -883,11 +883,33 @@ class BasetenCUARuntime:
         with a ``ClickRecordingEnv`` to capture click coordinates that
         feed the polished video's ripple animations. Either may be None
         when recording is disabled.
+
+        When ``env`` is provided and exposes ``ensure_display_ready``,
+        the X display is brought up *before* ffmpeg fires. Without this
+        the recorder races ``env.reset()``'s lazy Xvfb spawn and ffmpeg
+        fails with ``Cannot open display :99`` — the recurring error
+        integrators were reporting on /v1/predict runs with
+        ``record_video=true``.
         """
         if not payload.get("record_video"):
             return (None, None)
         from mantis_agent.presentation import ClickEventLog
         from mantis_agent.recorder import ScreenRecorder
+
+        # Bring up Xvfb before ffmpeg attaches — fixes the startup race
+        # where ``_make_env`` returns an env whose ``reset()`` hasn't
+        # run yet, so the X display ffmpeg targets doesn't exist.
+        # ``ensure_display_ready`` is idempotent: a no-op on warm
+        # containers where Xvfb is already alive.
+        display: str | None = None
+        if env is not None and hasattr(env, "ensure_display_ready"):
+            try:
+                display = env.ensure_display_ready()
+            except Exception as exc:  # noqa: BLE001 — best-effort
+                logger.warning(
+                    "ensure_display_ready failed before recorder spawn: %s",
+                    exc,
+                )
 
         tenant_id = safe_state_key(
             os.environ.get("MANTIS_TENANT_ID", DEFAULT_TENANT.tenant_id)
@@ -896,11 +918,14 @@ class BasetenCUARuntime:
         runs_dir.mkdir(parents=True, exist_ok=True)
         fmt = str(payload.get("video_format", "mp4"))
         output = runs_dir / f"recording.{fmt}"
-        rec = ScreenRecorder(
-            output=output,
-            fps=int(payload.get("video_fps", 5)),
-            fmt=fmt,  # type: ignore[arg-type]
-        )
+        rec_kwargs: dict[str, Any] = {
+            "output": output,
+            "fps": int(payload.get("video_fps", 5)),
+            "fmt": fmt,
+        }
+        if display:
+            rec_kwargs["display"] = display
+        rec = ScreenRecorder(**rec_kwargs)  # type: ignore[arg-type]
         click_log = ClickEventLog()
         if not rec.start():
             logger.warning(
@@ -1134,7 +1159,7 @@ class BasetenCUARuntime:
             run_id,
             settle_time=4.0 if self.model_kind == "holo3" else 2.0,
         )
-        recorder, click_log = self._maybe_record(payload, run_id)
+        recorder, click_log = self._maybe_record(payload, run_id, env=env)
         if click_log is not None:
             from mantis_agent.presentation import ClickRecordingEnv
             env = ClickRecordingEnv(env, click_log)
@@ -1344,7 +1369,7 @@ class BasetenCUARuntime:
             run_id,
             settle_time=4.0 if self.model_kind == "holo3" else 2.0,
         )
-        recorder, click_log = self._maybe_record(payload, run_id)
+        recorder, click_log = self._maybe_record(payload, run_id, env=env)
         if click_log is not None:
             from mantis_agent.presentation import ClickRecordingEnv
             env = ClickRecordingEnv(env, click_log)
@@ -1521,7 +1546,7 @@ class BasetenCUARuntime:
                 reuse_session=False,
             )
 
-        recorder, click_log = self._maybe_record(payload, run_id)
+        recorder, click_log = self._maybe_record(payload, run_id, env=env)
         if click_log is not None:
             from mantis_agent.presentation import ClickRecordingEnv
             env = ClickRecordingEnv(env, click_log)

--- a/src/mantis_agent/gym/xdotool_env.py
+++ b/src/mantis_agent/gym/xdotool_env.py
@@ -128,6 +128,64 @@ class XdotoolGymEnv(GymEnvironment):
 
     # ── Xvfb + Browser ──────────��───────────────────────────────────
 
+    def ensure_display_ready(self, *, timeout: float = 5.0) -> str:
+        """Bring up the X display and return its name (e.g. ``":99"``).
+
+        Idempotent: if Xvfb is already alive on the configured display
+        (either because a sibling process started it or because a prior
+        call wired it up), returns the display name immediately without
+        spawning a duplicate Xvfb. Used by callers that need the X
+        display *before* ``reset()`` runs — canonical case is
+        :class:`mantis_agent.recorder.ScreenRecorder`, which spawns
+        ``ffmpeg -f x11grab`` against the display before the agent loop
+        opens a browser. Without this hook the recorder would race
+        ``reset()``'s lazy Xvfb spawn and ffmpeg would fail with
+        ``Cannot open display :99`` (the recurring integrator error).
+
+        The browser is NOT launched — that stays in ``reset()``. This
+        method only guarantees the display + the ``DISPLAY`` env var.
+        """
+        # Determine the canonical display name (without spawning).
+        # ``:99`` matches ``_start_xvfb``'s default — staying in sync
+        # so the probe + spawn agree on the same target.
+        display = self._display or ":99"
+        if not self._xdpyinfo_alive(display):
+            # Display not up yet — let ``_start_xvfb`` boot it. The
+            # method already short-circuits when ``self._display`` was
+            # passed in at construction time, so this is safe even if
+            # the caller wired up a custom display.
+            display = self._start_xvfb()
+        # Propagate the display name onto self._env so subprocesses we
+        # spawn (Chrome, xdotool, ffmpeg-via-recorder) all agree on the
+        # same target. ``reset()`` does the same wire-up before starting
+        # the browser; doing it here too is safe and idempotent.
+        if not self._env:
+            self._env = {**os.environ, "DISPLAY": display}
+        else:
+            self._env["DISPLAY"] = display
+        # Bounded wait so a slow Xvfb boot doesn't leave the caller
+        # racing the same problem. ``xdpyinfo`` is the cheapest probe
+        # that confirms the X server is accepting connections.
+        deadline = time.time() + max(0.0, timeout)
+        while time.time() < deadline:
+            if self._xdpyinfo_alive(display):
+                return display
+            time.sleep(0.15)
+        # Don't raise — the recorder caller treats "no display" as a
+        # benign failure (record_video=False semantics on this run).
+        return display
+
+    @staticmethod
+    def _xdpyinfo_alive(display: str) -> bool:
+        try:
+            proc = subprocess.run(
+                ["xdpyinfo", "-display", display],
+                capture_output=True, timeout=3,
+            )
+            return proc.returncode == 0
+        except Exception:  # noqa: BLE001 — best-effort liveness probe
+            return False
+
     def _start_xvfb(self) -> str:
         """Start Xvfb virtual display if not already running."""
         if self._display:

--- a/src/mantis_agent/recorder.py
+++ b/src/mantis_agent/recorder.py
@@ -54,6 +54,33 @@ def ffmpeg_available() -> bool:
     return shutil.which("ffmpeg") is not None
 
 
+def x_display_alive(display: str, *, timeout_s: float = 3.0) -> bool:
+    """Best-effort probe: is the X server on ``display`` accepting
+    connections? Uses ``xdpyinfo`` (already required by the Modal
+    image — same probe ``_ensure_xvfb_running`` uses) and returns
+    False if the binary is missing so we don't false-fail on hosts
+    that lack it.
+
+    Used by :meth:`ScreenRecorder.start` to surface a precise error
+    when ffmpeg would otherwise die with the cryptic ``Cannot open
+    display :99`` line — common when callers spawn the recorder
+    before bringing up Xvfb (issue: recurring integrator error on
+    /v1/predict with ``record_video=true``).
+    """
+    if not shutil.which("xdpyinfo"):
+        # Can't probe → don't block; let ffmpeg surface its own error.
+        return True
+    try:
+        proc = subprocess.run(
+            ["xdpyinfo", "-display", display],
+            capture_output=True,
+            timeout=timeout_s,
+        )
+        return proc.returncode == 0
+    except Exception:  # noqa: BLE001 — best-effort liveness probe
+        return False
+
+
 def _build_ffmpeg_cmd(
     display: str,
     output: Path,
@@ -158,6 +185,26 @@ class ScreenRecorder:
             self.result = RecorderResult(
                 output_path=None, duration_seconds=0.0, bytes_written=0,
                 error="ffmpeg-not-installed",
+            )
+            return False
+        # Probe the X server before spawning ffmpeg. Without this check
+        # ffmpeg dies with the cryptic line ``Cannot open display :99,
+        # error 1`` — common when the recorder is spawned before
+        # Xvfb is up (the runtime's ``_make_env`` no longer starts
+        # Xvfb eagerly; ``env.reset()`` does, but the recorder fires
+        # before ``reset()``). The runtime now calls
+        # ``env.ensure_display_ready()`` before constructing this
+        # recorder, but third-party callers (CLI embedders, tests)
+        # might not — this probe gives them a precise error envelope
+        # instead of a stderr blob.
+        if not x_display_alive(self._display):
+            logger.warning(
+                "recorder: X display %s is not alive — refusing to spawn ffmpeg",
+                self._display,
+            )
+            self.result = RecorderResult(
+                output_path=None, duration_seconds=0.0, bytes_written=0,
+                error=f"x-display-not-ready:{self._display}",
             )
             return False
         self._output.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_recorder.py
+++ b/tests/test_recorder.py
@@ -19,7 +19,23 @@ from mantis_agent.recorder import (
     _build_ffmpeg_cmd,
     content_type_for,
     ffmpeg_available,
+    x_display_alive,
 )
+
+
+# The existing happy-path / lifecycle tests in this file pre-date the
+# X-display probe ``ScreenRecorder.start`` now does before spawning
+# ffmpeg. On Modal images (and most linux dev boxes) ``xdpyinfo`` IS on
+# PATH and the probe would correctly report "no display" — which would
+# fail the lifecycle tests for reasons unrelated to what they pin. Stub
+# the probe to "alive" by default so those tests keep covering ffmpeg
+# lifecycle; the new probe-failure path is exercised explicitly below
+# (the inner ``with patch(...)`` overrides this fixture for the
+# probe-failure case).
+@pytest.fixture(autouse=True)
+def _stub_x_display_alive():
+    with patch("mantis_agent.recorder.x_display_alive", return_value=True):
+        yield
 
 
 # ── Command construction ────────────────────────────────────────────────────
@@ -209,3 +225,67 @@ def test_recorder_context_manager(tmp_path: Path):
 def test_ffmpeg_available_real(monkeypatch):
     # Without monkeypatch, just verifies the helper returns a bool.
     assert isinstance(ffmpeg_available(), bool)
+
+
+# ── X-display probe (the new layer for the integrator error) ────────────────
+
+
+def test_x_display_alive_returns_true_when_xdpyinfo_missing():
+    """On hosts without ``xdpyinfo`` (most CI runners), the probe must
+    return True so we don't false-fail recorder.start()."""
+    with patch("mantis_agent.recorder.shutil.which", return_value=None):
+        assert x_display_alive(":99") is True
+
+
+def test_x_display_alive_returns_true_when_probe_succeeds(tmp_path: Path):
+    """``xdpyinfo`` exits 0 → display is alive."""
+    fake_proc = MagicMock()
+    fake_proc.returncode = 0
+    with patch("mantis_agent.recorder.shutil.which", return_value="/usr/bin/xdpyinfo"), \
+         patch("mantis_agent.recorder.subprocess.run", return_value=fake_proc):
+        assert x_display_alive(":99") is True
+
+
+def test_x_display_alive_returns_false_when_probe_fails():
+    """``xdpyinfo`` exits non-zero → display is not alive."""
+    fake_proc = MagicMock()
+    fake_proc.returncode = 1
+    with patch("mantis_agent.recorder.shutil.which", return_value="/usr/bin/xdpyinfo"), \
+         patch("mantis_agent.recorder.subprocess.run", return_value=fake_proc):
+        assert x_display_alive(":99") is False
+
+
+def test_x_display_alive_returns_false_on_exception():
+    """``xdpyinfo`` raises (timeout, missing display, …) → False."""
+    with patch("mantis_agent.recorder.shutil.which", return_value="/usr/bin/xdpyinfo"), \
+         patch(
+             "mantis_agent.recorder.subprocess.run",
+             side_effect=__import__("subprocess").TimeoutExpired("xdpyinfo", 3),
+         ):
+        assert x_display_alive(":99") is False
+
+
+def test_recorder_refuses_to_spawn_when_display_not_ready(tmp_path: Path):
+    """When the X display isn't alive, ``start()`` must fail with a
+    precise ``x-display-not-ready:<display>`` envelope BEFORE
+    spawning ffmpeg. This is the actionable replacement for the
+    cryptic ``Cannot open display :99, error 1`` integrators saw.
+
+    Patches the module-level ``x_display_alive`` to False (overriding
+    the autouse fixture). The subprocess.Popen patch is asserted
+    *not* to be called — proving we short-circuit before ffmpeg fires.
+    """
+    out = tmp_path / "vid.mp4"
+    popen_mock = MagicMock()
+    with patch("mantis_agent.recorder.ffmpeg_available", return_value=True), \
+         patch("mantis_agent.recorder.x_display_alive", return_value=False), \
+         patch("mantis_agent.recorder.subprocess.Popen", popen_mock):
+        rec = ScreenRecorder(out, display=":99")
+        ok = rec.start()
+
+    assert ok is False
+    assert rec.result is not None
+    assert rec.result.error == "x-display-not-ready::99"
+    assert not rec.result.succeeded
+    # Most important assertion: ffmpeg never got spawned.
+    popen_mock.assert_not_called()

--- a/tests/test_recorder_xvfb_race.py
+++ b/tests/test_recorder_xvfb_race.py
@@ -1,0 +1,223 @@
+"""Recorder vs Xvfb startup race — recurring integrator error.
+
+Pins the fix for the recurring ``ffmpeg-startup-failed:[x11grab ...]
+Cannot open display :99, error 1.`` error users were seeing on
+``/v1/predict`` runs with ``record_video=true``.
+
+Root cause: the baseten runtime constructs an ``XdotoolGymEnv`` (which
+lazy-starts Xvfb inside ``reset()``) and then spawns the screen recorder
+*before* ``reset()`` runs. ffmpeg's ``-f x11grab -i :99`` attaches to a
+display that doesn't exist yet → cryptic failure surfaces in
+``result.json``'s ``video.error`` field.
+
+Two layers of defense pinned here:
+
+1. ``XdotoolGymEnv.ensure_display_ready()`` — idempotent hook the
+   runtime can call to bring Xvfb up before ffmpeg fires. Skips the
+   ``_start_xvfb`` Popen when the display is already alive.
+2. Recorder probe in ``ScreenRecorder.start()`` — exits with a
+   precise ``x-display-not-ready:<display>`` error if the display
+   still isn't reachable, so third-party callers / tests get an
+   actionable envelope (covered in ``test_recorder.py``).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from mantis_agent.gym.xdotool_env import XdotoolGymEnv
+
+
+# ── env.ensure_display_ready — fast-path when Xvfb is already up ────────
+
+
+def test_ensure_display_ready_fast_path_when_alive(monkeypatch):
+    """When xdpyinfo reports the display is alive, ``ensure_display_ready``
+    must NOT spawn another Xvfb (would Popen-collide on :99 and waste a
+    process). It should just wire ``self._env["DISPLAY"]`` and return."""
+    env = XdotoolGymEnv.__new__(XdotoolGymEnv)
+    env._display = None
+    env._env = {}
+    env._xvfb_proc = None
+    env._viewport = (1280, 720)
+
+    # The probe says display is alive — no need to start Xvfb.
+    monkeypatch.setattr(
+        XdotoolGymEnv, "_xdpyinfo_alive", staticmethod(lambda d: True),
+    )
+    start_xvfb_calls: list[str] = []
+    monkeypatch.setattr(
+        XdotoolGymEnv,
+        "_start_xvfb",
+        lambda self: start_xvfb_calls.append("called") or ":99",
+    )
+
+    display = env.ensure_display_ready(timeout=0.5)
+
+    assert display == ":99"
+    assert start_xvfb_calls == []  # spawn skipped — idempotency holds
+    assert env._env["DISPLAY"] == ":99"
+
+
+def test_ensure_display_ready_spawns_xvfb_when_dead(monkeypatch):
+    """When the display is dead, ``_start_xvfb`` is invoked exactly once
+    and the result is propagated onto ``self._env["DISPLAY"]``."""
+    env = XdotoolGymEnv.__new__(XdotoolGymEnv)
+    env._display = None
+    env._env = {"OTHER": "val"}
+    env._xvfb_proc = None
+    env._viewport = (1280, 720)
+
+    # First probe: not alive. Subsequent probes (during the bounded
+    # wait after spawn): alive — simulates Xvfb coming up.
+    probe_calls = {"n": 0}
+
+    def _probe(_d):
+        probe_calls["n"] += 1
+        return probe_calls["n"] > 1
+
+    monkeypatch.setattr(
+        XdotoolGymEnv, "_xdpyinfo_alive", staticmethod(_probe),
+    )
+    spawned = []
+    monkeypatch.setattr(
+        XdotoolGymEnv,
+        "_start_xvfb",
+        lambda self: spawned.append("called") or ":99",
+    )
+
+    display = env.ensure_display_ready(timeout=2.0)
+    assert display == ":99"
+    assert spawned == ["called"]
+    # Preserves prior env, adds DISPLAY.
+    assert env._env["OTHER"] == "val"
+    assert env._env["DISPLAY"] == ":99"
+
+
+def test_ensure_display_ready_returns_even_on_persistent_failure(monkeypatch):
+    """When Xvfb never comes up, ``ensure_display_ready`` must NOT
+    raise — the recorder treats that as a benign failure (run continues
+    without recording). Raising would crash the run."""
+    env = XdotoolGymEnv.__new__(XdotoolGymEnv)
+    env._display = None
+    env._env = {}
+    env._xvfb_proc = None
+    env._viewport = (1280, 720)
+
+    monkeypatch.setattr(
+        XdotoolGymEnv, "_xdpyinfo_alive", staticmethod(lambda d: False),
+    )
+    monkeypatch.setattr(
+        XdotoolGymEnv,
+        "_start_xvfb",
+        lambda self: ":99",
+    )
+
+    # Tiny timeout so the test finishes fast — the contract is "don't
+    # raise", not "wait forever".
+    display = env.ensure_display_ready(timeout=0.3)
+    assert display == ":99"  # we still return a value the caller can use
+
+
+# ── runtime._maybe_record passes env in and calls ensure_display_ready ──
+
+
+def test_maybe_record_calls_ensure_display_ready_before_spawning_ffmpeg(tmp_path):
+    """The runtime hook ``_maybe_record`` must invoke
+    ``env.ensure_display_ready()`` before spawning the recorder so
+    Xvfb is alive by the time ffmpeg attaches. Pins the wiring
+    introduced for the integrator-reported ffmpeg-startup race.
+    """
+    # Use a real BasetenRuntime so we exercise the actual code path.
+    from mantis_agent.baseten_server.runtime import BasetenCUARuntime
+
+    # Build a minimal env stub that records the order of calls.
+    order: list[str] = []
+    env_stub = MagicMock()
+
+    def _ensure_display() -> str:
+        order.append("ensure_display_ready")
+        return ":99"
+
+    env_stub.ensure_display_ready.side_effect = _ensure_display
+
+    # Stub ScreenRecorder so start() succeeds without ffmpeg.
+    fake_rec = MagicMock()
+    fake_rec._started_at = 1234567890.0
+    fake_rec._fmt = "mp4"
+    fake_rec.result = None
+
+    def _rec_start() -> bool:
+        order.append("recorder.start")
+        return True
+
+    fake_rec.start.side_effect = _rec_start
+
+    rt = BasetenCUARuntime.__new__(BasetenCUARuntime)
+    # Minimal payload — record_video=True triggers the path under test.
+    payload = {"record_video": True, "video_format": "mp4", "video_fps": 5}
+
+    with patch(
+        "mantis_agent.recorder.ScreenRecorder",
+        return_value=fake_rec,
+    ), patch.dict(
+        "os.environ",
+        {"MANTIS_TENANT_ID": "default", "MANTIS_DATA_DIR": str(tmp_path)},
+    ):
+        recorder, click_log = rt._maybe_record(
+            payload, run_id="test_run_xvfb_race", env=env_stub,
+        )
+
+    assert recorder is fake_rec
+    assert click_log is not None
+    # Critical: ensure_display_ready happens BEFORE recorder.start.
+    assert order == ["ensure_display_ready", "recorder.start"], (
+        f"expected ensure_display_ready→recorder.start, got {order!r}"
+    )
+
+
+def test_maybe_record_tolerates_env_without_ensure_display_ready(tmp_path):
+    """Legacy / test envs that don't implement ``ensure_display_ready``
+    must not crash ``_maybe_record`` — the wiring is best-effort. Also
+    used by callers that supply ``env=None``."""
+    from mantis_agent.baseten_server.runtime import BasetenCUARuntime
+
+    fake_rec = MagicMock()
+    fake_rec._started_at = 1234567890.0
+    fake_rec._fmt = "mp4"
+    fake_rec.start.return_value = True
+    fake_rec.result = None
+
+    rt = BasetenCUARuntime.__new__(BasetenCUARuntime)
+    payload = {"record_video": True, "video_format": "mp4", "video_fps": 5}
+
+    # env=None — most defensive callsite.
+    with patch(
+        "mantis_agent.recorder.ScreenRecorder",
+        return_value=fake_rec,
+    ), patch.dict(
+        "os.environ",
+        {"MANTIS_TENANT_ID": "default", "MANTIS_DATA_DIR": str(tmp_path)},
+    ):
+        recorder, click_log = rt._maybe_record(
+            payload, run_id="test_run_no_env", env=None,
+        )
+
+    assert recorder is fake_rec  # still ran, didn't crash
+
+
+def test_maybe_record_skipped_when_record_video_false(tmp_path):
+    """Sanity: when ``record_video`` isn't set, no display probe / no
+    recorder spawn happens. Pin the existing short-circuit so the
+    new wiring doesn't accidentally fire on plain runs."""
+    from mantis_agent.baseten_server.runtime import BasetenCUARuntime
+
+    env_stub = MagicMock()
+    rt = BasetenCUARuntime.__new__(BasetenCUARuntime)
+
+    recorder, click_log = rt._maybe_record(
+        {}, run_id="no_video", env=env_stub,
+    )
+    assert recorder is None
+    assert click_log is None
+    env_stub.ensure_display_ready.assert_not_called()


### PR DESCRIPTION
## Summary

Closes the recurring integrator error on ``/v1/predict`` runs with ``record_video=true``:

```jsonc
"video": {
  "path": null,
  "format": "mp4",
  "duration_seconds": 0,
  "bytes": 0,
  "error": "ffmpeg-startup-failed:[x11grab ...] Cannot open display :99, error 1."
}
```

### Root cause

The baseten / mantis-server runtime calls ``_make_env`` (which constructs an ``XdotoolGymEnv``) and then ``_maybe_record`` (which spawns ``ScreenRecorder.start()`` → ``ffmpeg -f x11grab -i :99``). But ``XdotoolGymEnv`` lazy-starts Xvfb inside ``reset()`` — and ``reset()`` doesn't run until the agent loop begins, *after* ``_maybe_record``. ffmpeg attaches to a display that doesn't exist yet → cryptic failure surfaces in ``result.json``.

The Modal plan-runner doesn't hit this because it calls ``_ensure_xvfb_running()`` at the top of ``run_plan``. The mantis-server / baseten path doesn't have an equivalent.

### Fix — two layers of defense

1. **``XdotoolGymEnv.ensure_display_ready()``** — idempotent hook the runtime can call to bring Xvfb up *before* ffmpeg fires. Probes ``xdpyinfo`` first so warm-container reuse doesn't Popen a duplicate Xvfb on ``:99``. Wires ``self._env["DISPLAY"]`` so subsequent ``reset()`` + Chrome launch reuse the same display. Bounded wait (~5 s); doesn't raise on persistent failure so the recorder caller can degrade to "record_video=False" semantics on the run.

2. **``ScreenRecorder.start()``** — defense-in-depth probe via the new ``x_display_alive()`` helper. Third-party callers that spawn the recorder outside the baseten runtime (CLI embedders, tests) now get a precise ``x-display-not-ready:<display>`` envelope instead of an opaque ffmpeg stderr blob. No-op when ``xdpyinfo`` isn't on PATH (most CI runners) — refuses to false-fail.

The runtime's ``_maybe_record`` now takes the env and calls ``ensure_display_ready()`` before spawning the recorder. The three call-sites under ``predict_*`` are updated.

### Docs

``docs/api.md`` recording section gains a per-error-envelope breakdown so integrators can recognise + fix each soft-fail mode (``ffmpeg-not-installed``, ``x-display-not-ready``, ``ffmpeg-startup-failed``, ``empty-output``, ``spawn-failed``).

## Test plan

- [x] `pytest tests/test_recorder.py` — 12 passing, plus 5 new tests for the ``x_display_alive`` probe + the ``x-display-not-ready`` envelope (autouse fixture stubs the probe so existing lifecycle tests keep passing)
- [x] `pytest tests/test_recorder_xvfb_race.py` — 6 new tests pinning the ordering: ``ensure_display_ready`` fast-paths when alive, spawns Xvfb when dead, returns gracefully on persistent failure; ``_maybe_record`` calls ``ensure_display_ready`` before ``recorder.start``, tolerates ``env=None``, short-circuits when ``record_video`` isn't set
- [x] Full suite minus the pre-existing sim-envs/mantis_crm python-multipart blocker — **2423 passing**, 4 skipped
- [x] `ruff check` clean on all touched files
- [x] `mkdocs build --strict` clean
- [ ] Modal redeploy + lu.ma rerun with ``record_video=true`` — confirms end-to-end on a real Chromium under Xvfb that the ``video.error`` field is no longer populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)