### PR TITLE
docs(cua): explain how to select the Fara backend on Modal vs Baseten

### DIFF
--- a/docs/client/pure-cua.md
+++ b/docs/client/pure-cua.md
@@ -1,9 +1,13 @@
 # Pure CUA mode (`/v1/cua`)
 
-Use this when you want Mantis to be a **thin pass-through for Holo3** —
+Use this when you want Mantis to be a **thin brain pass-through** —
 no plan decomposition, no Claude grounding, no Claude extraction. The
 instruction is handed verbatim to the brain, which drives the headed
 browser inside the deployment via xdotool.
+
+The brain in question is whichever one the pod was started with
+(`MANTIS_MODEL` env — `holo3`, `fara`, `gemma4-cua`, …). Baseten pods
+are single-brain by deployment; see [CUA models](../reference/cua-models.md#selecting-a-backend) for the selection model.
 
 If you've used `/v1/predict`, the mental model is: same auth, same
 tenant caps, same allowlist, same rate limit / concurrency / recording
@@ -21,10 +25,9 @@ plumbing — but the inside of the container is a single
 | You want zero Claude spend per run | You're OK with ~$0.005/click for grounding accuracy |
 
 The tradeoff: without `ClaudeGrounding`, click coordinates come straight
-from Holo3's smart-resize model space (converted to screen pixels in
-`brain_holo3._model_coords_to_screen`). On small targets accuracy drops
-versus the grounded path. That's the whole point of "pure CUA" — you're
-measuring what the brain can do unassisted.
+from the brain's model space (Holo3 / OpenCUA use Qwen smart-resize;
+Fara uses raw screen pixels at its training resolution — see
+[Coordinate spaces](../reference/coordinate-spaces.md)). On small targets accuracy drops versus the grounded path. That's the whole point of "pure CUA" — you're measuring what the brain can do unassisted.
 
 ## Action surface
 

--- a/docs/reference/cua-models.md
+++ b/docs/reference/cua-models.md
@@ -4,6 +4,77 @@ The brain is the vision-action policy that drives the perception-reasoning-actio
 
 All brains implement the same `think(frames, task, action_history, screen_size) -> InferenceResult` contract, so the Hybrid plan-executor + vision-fallback flow (`gym/runner.py`) works identically regardless of which one is wired in. "Passthrough" mode (every step routed straight to the brain) is just `cua_model=<name>` flowing through `_executor_for_model()`.
 
+## Selecting a backend
+
+How you select a backend depends on where Mantis is hosted. The selection model differs:
+
+| Surface | Selection | Notes |
+|---|---|---|
+| Modal `/v1/predict` | Per-request `cua_model` field | One deployment serves every backend; each request spawns the right GPU function. |
+| Modal CLI (`modal run`) | `--model <name>` | Same dispatch as the HTTP API. |
+| Baseten `/v1/predict` and `/v1/cua` | **Per-deployment** via `MANTIS_MODEL` env | Each pod loads one brain at startup. `cua_model` in the request body is **ignored**. To use Fara on Baseten you push `deploy/baseten/fara/` as its own model and hit that deployment's URL. |
+
+Default model is `holo3` on both surfaces — existing callers that don't pass `cua_model` keep getting Holo3.
+
+### Modal — HTTP API
+
+```bash
+curl -X POST https://workspace--mantis-cua-server-api.modal.run/v1/predict \
+  -H "X-Mantis-Token: $MANTIS_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "detached":     true,
+    "micro":        "plans/example/extract_listings.json",
+    "profile_id":   "marketplace-prod",
+    "workflow_id":  "marketplace-listings-v1",
+    "cua_model":    "fara",
+    "max_cost":     2,
+    "max_time_minutes": 20
+  }'
+```
+
+`GET /v1/models` returns the list the dispatcher accepts:
+
+```jsonc
+{ "data": [
+  { "id": "holo3" }, { "id": "fara" }, { "id": "gemma4-cua" },
+  { "id": "evocua-8b" }, { "id": "evocua-32b" },
+  { "id": "opencua-32b" }, { "id": "opencua-72b" }, { "id": "claude" }
+]}
+```
+
+### Modal — CLI
+
+```bash
+uv run modal run --detach deploy/modal/modal_cua_server.py \
+  --micro plans/example/extract_listings.json \
+  --model fara \
+  --max-cost 2 --max-time-minutes 20 \
+  --profile-id marketplace-prod \
+  --workflow-id marketplace-listings-v1
+```
+
+### Baseten — separate deployment per model
+
+```bash
+# Push Fara as its own Baseten model
+uvx truss push deploy/baseten/fara --no-cache --promote \
+  --deployment-name "mantis-fara-$(date -u +%Y%m%d-%H%M)"
+
+# Call its endpoint
+curl -X POST "https://model-<FARA_MODEL_ID>.api.baseten.co/production/v1/predict" \
+  -H "Authorization: Api-Key $BASETEN_API_KEY" \
+  -H "X-Mantis-Token: $TOK" \
+  -H "Content-Type: application/json" \
+  -d '{ "detached": true, "micro": "plans/example/extract_listings.json",
+        "profile_id": "alice", "workflow_id": "v1",
+        "max_cost": 2, "max_time_minutes": 20 }'
+```
+
+Notice the request body has no `cua_model` field — the Fara deployment was started with `MANTIS_MODEL=fara` (see `deploy/baseten/fara/config.yaml`), and that's what determines the brain. Holo3 stays on its own deployment URL.
+
+
+
 | Name | Repo | Base | Serve | GPU | License |
 |---|---|---|---|---|---|
 | `holo3` | `Hcompany/Holo3-35B-A3B` (GGUF: `mradermacher/Holo3-35B-A3B-GGUF`) | Qwen3.5-VL MoE | llama.cpp + Q8_0 GGUF | 1× A100-80GB / H100 / L40S 48GB | Hcompany terms |


### PR DESCRIPTION
## Summary

Follow-up to #396 — fills the "how do I actually call it?" gap. Reviewers/users hitting the new CUA-models reference page got the list of available brains but no concrete worked examples for selecting Fara on each surface.

## What's in here

**`docs/reference/cua-models.md`** — adds a "Selecting a backend" section just under the brain table:

- Selection-model comparison table (Modal HTTP / Modal CLI / Baseten) — calls out the **important asymmetry**: Modal dispatches per-request via `cua_model`, but Baseten is one-brain-per-pod and the field is ignored there.
- Worked `curl` example for Modal `/v1/predict` with `cua_model: "fara"`.
- Worked `modal run --model fara` CLI example.
- Worked Baseten flow: `truss push deploy/baseten/fara` then `curl` against the new deployment's URL.
- Notes default is still `holo3`, so existing callers don't break.

**`docs/client/pure-cua.md`** — small refresh:

- Drops the Holo3-only framing in the intro and the coord-tradeoff blurb; `/v1/cua` uses whichever brain the pod was started with (`MANTIS_MODEL`), not specifically Holo3.
- Links to the new "Selecting a backend" section for the full story.

## Test plan

- [x] mkdocs renders cua-models.md and pure-cua.md without warnings (existing `pytest tests/test_version_and_docs_ui.py` still passes — docs lint is unchanged).
- [ ] Manual: read the new section as a fresh user, confirm the Modal vs Baseten asymmetry is obvious.

🤖 Generated with [Claude Code](https://claude.com/claude-code)