### PR TITLE
fix(baseten): point vllm startup probe at /tmp/vllm.log + raise timeout

### DIFF
--- a/src/mantis_agent/baseten_server/runtime.py
+++ b/src/mantis_agent/baseten_server/runtime.py
@@ -287,7 +287,11 @@ class BasetenCUARuntime:
             self._llama_log_fh.close()
             self._llama_log_fh = None
             raise
-        _wait_for_openai_server(self.port, self.llama_proc, "vllm")
+        _wait_for_openai_server(
+            self.port, self.llama_proc, "vllm",
+            log_path="/tmp/vllm.log",
+            timeout_seconds=int(os.environ.get("MANTIS_VLLM_TIMEOUT_S", "900")),
+        )
 
     def _load_fara(self) -> Any:
         """Load Microsoft Fara-7B via vLLM and return a ``FaraBrain``.


### PR DESCRIPTION
## Summary

First Fara canary on Baseten (`mantis-fara-cua-workload`, deployment `w5dxovp`) failed with an empty `vllm crashed during startup:` message because `_start_vllm` writes stdout/stderr to `/tmp/vllm.log` but called `wait_for_openai_server` with its default `log_path="/tmp/llama.log"` — the crash-report code read from the wrong (empty) file and we lost the real vLLM error.

This patch:
- Passes `log_path="/tmp/vllm.log"` so the next failure surfaces the actual stack.
- Bumps the startup timeout from the helper default (360s) to 900s via `MANTIS_VLLM_TIMEOUT_S`. First-time vLLM init on H100 (CUDA kernel compile + 14 GB weight load + KV cache allocation) routinely takes 6-10 min on a cold image; the old 6-min cap was tight.

## Test plan

- [ ] Push the Fara canary again — expect a real error message in the truss model-logs output rather than "vllm crashed during startup: " with empty body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)