### PR TITLE
fix(server_utils): stop double-truncating the inference-server crash log

### DIFF
--- a/src/mantis_agent/server_utils.py
+++ b/src/mantis_agent/server_utils.py
@@ -774,9 +774,9 @@ def wait_for_openai_server(
             log_text = ""
             log_file = Path(log_path)
             if log_file.exists():
-                log_text = log_file.read_text(errors="ignore")[-3000:]
-            raise RuntimeError(f"{label} crashed during startup:\n{log_text[-1000:]}")
+                log_text = log_file.read_text(errors="ignore")[-20000:]
+            raise RuntimeError(f"{label} crashed during startup:\n{log_text}")
         time.sleep(poll_interval)
 
-    log_text = Path(log_path).read_text(errors="ignore")[-2000:] if Path(log_path).exists() else ""
+    log_text = Path(log_path).read_text(errors="ignore")[-20000:] if Path(log_path).exists() else ""
     raise RuntimeError(f"{label} startup timeout:\n{log_text}")


### PR DESCRIPTION
## Summary

`wait_for_openai_server` reads `/tmp/vllm.log` as `log_text = read_text()[-3000:]` then re-truncates in the error message as `f\"...{log_text[-1000:]}\"`. The 1000-char trailing window cuts off the top of any traceback longer than ~20 lines, so the **actual root-cause line is lost** and we only see the bottom `**kwargs)` / `^^^^^^^^` markers.

Hit this while debugging the Fara Baseten canary (#396 / #398) — the vLLM engine-core init fails with `RuntimeError: Engine core initialization failed. See root cause above` but \"above\" was truncated away before the truss model-logs ever saw it.

This patch:
- Bumps both the crash path and the timeout path to a 20 KB capture (was 1 KB / 2 KB respectively).
- Drops the second redundant `[-1000:]` slice that was the bug.

20 KB is enough to surface the full traceback for a typical vLLM / llama.cpp init failure without flooding the container log.

## Test plan

- [ ] Next Baseten Fara canary push — confirm we see the actual vLLM error (CUDA mismatch / OOM / etc) instead of `, **kwargs)` tails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)