### PR TITLE
fix(baseten/fara): pin vllm < 0.12 + disable DeepGEMM warmup

### DIFF
--- a/deploy/baseten/fara/config.yaml
+++ b/deploy/baseten/fara/config.yaml
@@ -8,9 +8,9 @@ build_commands:
   - curl -fsSL https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /usr/share/keyrings/google-chrome.gpg
   - echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/google-chrome.gpg] http://dl.google.com/linux/chrome/deb/ stable main' > /etc/apt/sources.list.d/google-chrome.list
   - apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y google-chrome-stable
-  - pip install --no-cache-dir openai requests pillow mss huggingface-hub fastapi uvicorn pydantic websocket-client "vllm>=0.12.0" "transformers>=4.53.3"
+  - pip install --no-cache-dir openai requests pillow mss huggingface-hub fastapi uvicorn pydantic websocket-client "vllm>=0.10.0,<0.12.0" "transformers>=4.53.3"
 docker_server:
-  start_command: bash -lc "PYTHONPATH=/packages MANTIS_MODEL=fara MANTIS_LLAMA_PORT=18080 MANTIS_FARA_MODEL_DIR=/models/fara MANTIS_DATA_DIR=/workspace/mantis-data MANTIS_REPO_ROOT=/packages MANTIS_MAX_RUNTIME_MINUTES=240 MANTIS_MAX_COST_USD=75 MANTIS_MAX_STEPS_PER_PLAN=500 MANTIS_CONTEXT_SIZE=32768 uvicorn mantis_agent.baseten_server:app --host 0.0.0.0 --port 8000 --timeout-keep-alive 300"
+  start_command: bash -lc "PYTHONPATH=/packages MANTIS_MODEL=fara MANTIS_LLAMA_PORT=18080 MANTIS_FARA_MODEL_DIR=/models/fara MANTIS_DATA_DIR=/workspace/mantis-data MANTIS_REPO_ROOT=/packages MANTIS_MAX_RUNTIME_MINUTES=240 MANTIS_MAX_COST_USD=75 MANTIS_MAX_STEPS_PER_PLAN=500 MANTIS_CONTEXT_SIZE=32768 VLLM_USE_DEEP_GEMM=0 uvicorn mantis_agent.baseten_server:app --host 0.0.0.0 --port 8000 --timeout-keep-alive 300"
   server_port: 8000
   predict_endpoint: /predict
   readiness_endpoint: /health


### PR DESCRIPTION
## Summary

The 3rd Fara canary failed at vLLM engine-core init with:

```
RuntimeError: DeepGEMM backend is not available or outdated.
Please install or update the \`deep_gemm\` to a newer version
to enable FP8 kernels.
```

**Root cause**: vLLM 0.20.2 (what pip resolves from \`vllm>=0.12.0\`) has an eager \`kernel_warmup\` → \`deep_gemm_warmup\` path that calls \`get_mk_alignment_for_contiguous_layout()\` **unconditionally**, even for bf16 models like Fara that have zero FP8 layers. DeepGEMM is **not pip-installable** (it's a CUDA source-build from deepseek-ai), so the check explodes before the engine can finish init.

Everything else was healthy in the canary — weights pull (17 GB in 6 s), model load (15.6 GiB on GPU in 2.3 s), torch.compile (18 s), KV cache (50.5 GiB available). Fara was ready to serve; vLLM killed itself on a warmup that shouldn't apply.

## Fix

- Pin \`vllm>=0.10.0,<0.12.0\` — Fara's HF card recommends \`>= 0.10.0\`; the 0.11.x line has Qwen2.5-VL support but predates the eager DeepGEMM warmup that 0.20.x introduced.
- Add \`VLLM_USE_DEEP_GEMM=0\` to the start_command env as belt-and-suspenders (some 0.11.x patch releases also gate on this var).

## Test plan

- [ ] Re-push the Fara canary; expect vLLM to bind 18080 and \`/health\` to flip to 200, deployment status to \`ACTIVE\`.
- [ ] Wrong-token / right-token smoke test against the canary URL to validate \`MANTIS_API_TOKEN\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)