### PR TITLE
fix(fara): enable vLLM auto tool-choice + hermes parser

### DIFF
--- a/deploy/modal/modal_cua_server.py
+++ b/deploy/modal/modal_cua_server.py
@@ -405,7 +405,14 @@ def _run_executor(
         print(f"{cua_config['name']} cached at {model_dir}")
 
     tp = cua_config["tp"]
-    vllm_proc = _start_vllm(model_dir, port=8000, tp=tp)
+    # Fara emits OpenAI-format tool calls (computer_use). vLLM 0.11+ requires
+    # both flags to honour ``tool_choice="auto"``; without them every request
+    # 400s and the brain falls back to WAITs. ``hermes`` is the Qwen-family
+    # parser shipped in vLLM and matches Fara's Qwen2.5-VL base.
+    vllm_extra: list[str] = []
+    if cua_model == "fara":
+        vllm_extra = ["--enable-auto-tool-choice", "--tool-call-parser", "hermes"]
+    vllm_proc = _start_vllm(model_dir, port=8000, tp=tp, extra_args=vllm_extra)
 
     # ── Brain (model-dependent) ──
     task_suite = json.loads(task_file_contents)

--- a/src/mantis_agent/baseten_server/runtime.py
+++ b/src/mantis_agent/baseten_server/runtime.py
@@ -309,7 +309,21 @@ class BasetenCUARuntime:
         model_ref: str | Path = model_dir if model_dir.exists() else (
             os.environ.get("MANTIS_FARA_REPO", "microsoft/Fara-7B")
         )
-        self._start_vllm(Path(str(model_ref)), extra_args=[])
+        # vLLM 0.11+ requires both flags to honour ``tool_choice="auto"``.
+        # Without them, every FaraBrain.think() request 400s with
+        # `"auto" tool choice requires --enable-auto-tool-choice and
+        # --tool-call-parser to be set`. ``hermes`` is the Qwen-family
+        # parser that matches Fara's Qwen2.5-VL base and OpenAI-format
+        # tool_calls. Override via MANTIS_FARA_TOOL_PARSER for fine-tunes
+        # that emit a different schema.
+        tool_parser = os.environ.get("MANTIS_FARA_TOOL_PARSER", "hermes")
+        self._start_vllm(
+            Path(str(model_ref)),
+            extra_args=[
+                "--enable-auto-tool-choice",
+                "--tool-call-parser", tool_parser,
+            ],
+        )
 
         brain = FaraBrain(
             base_url=f"http://127.0.0.1:{self.port}/v1",


### PR DESCRIPTION
## Summary

The 4th Fara Baseten canary went \`ACTIVE\` but every per-step inference returned 400 from vLLM:

\`\`\`
"auto" tool choice requires --enable-auto-tool-choice and --tool-call-parser to be set
\`\`\`

\`FaraBrain.think()\` sends \`tool_choice=\"auto\"\` with the \`computer_use\` tool schema (matching Microsoft's HF guidance). **vLLM 0.11+ refuses to honour that without two server-side flags.** Result: 400 on every call → brain falls back to \`WAIT\` → runner never gets a real action → claude-director loop-recovery kicks in to substitute scrolls. Effectively dead.

## Why this is the StaffAI-relevant fix, not just \`/predict\`-side

StaffAI's \`mantis-fara-7b\` backend uses \`make_instrumented_brain(brain_cls=FaraBrain, base_url=…/v1)\` and \`FaraBrain\` hits \`/v1/chat/completions\` inside the in-pod vLLM **the same way** the Mantis-orchestrated \`/predict\` path does. Both share the brain code and the vLLM 400. Fixing the vLLM startup flags fixes both consumers in one place — the "deploy-config fix" path discussed in the prior review.

## Fix

Pass \`--enable-auto-tool-choice\` + \`--tool-call-parser hermes\` to vLLM at startup, but **only for \`cua_model=\"fara\"\`**:

- \`deploy/modal/modal_cua_server.py\` — \`_run_executor\` chooses \`vllm_extra\` upfront by \`cua_model\`, passes through \`_start_vllm\`.
- \`src/mantis_agent/baseten_server/runtime.py\` — \`_load_fara\` passes the same two flags. Operators can override the parser via \`MANTIS_FARA_TOOL_PARSER\` for fine-tunes that emit a non-Hermes schema.

\`hermes\` is the Qwen-family parser shipped in vLLM and matches Fara's Qwen2.5-VL base + OpenAI-format \`tool_calls\` emission. Holo3 (llama.cpp), OpenCUA/EvoCUA (their own training format) aren't affected by this path, so they stay untouched.

## Test plan

- [ ] Push a 5th Fara Baseten canary; expect \`/predict\` smoke task to actually do inference instead of WAIT-looping on 400s.
- [ ] Verify the deployment log shows zero \`Fara 400: "auto" tool choice requires…\` warnings during a real task run.
- [ ] StaffAI side: re-run the integration that was seeing the parsing fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)