### PR TITLE
docs(baseten): document the /production/sync/<path> URL contract

### DIFF
--- a/docs/hosting/baseten.md
+++ b/docs/hosting/baseten.md
@@ -72,10 +72,21 @@ done
 
 ## 4. Test the live endpoint
 
+The Baseten gateway exposes two route families against every truss-server deployment:
+
+| URL | What it serves |
+|---|---|
+| `https://model-${MODEL_ID}.api.baseten.co/production/predict` | The configured `predict_endpoint` (default `/predict`) — the orchestrated run/status/resume entry point |
+| `https://model-${MODEL_ID}.api.baseten.co/production/sync/<any-path>` | Pass-through to arbitrary FastAPI routes in the container — `/v1/chat/completions`, `/v1/models`, `/v1/health`, `/v1/cua` |
+
+For a canary (non-promoted) deployment, swap `production` for `deployment/<DEPLOY_ID>` in either form.
+
+Quick orchestrated-mode smoke:
+
 ```bash
 ENDPOINT="https://model-${MODEL_ID}.api.baseten.co/production"
 
-curl -fsS -X POST "$ENDPOINT/v1/predict" \
+curl -fsS -X POST "$ENDPOINT/predict" \
   -H "Authorization: Api-Key $BASETEN_API_KEY" \
   -H "X-Mantis-Token: $TOK" \
   -H "Content-Type: application/json" \
@@ -90,6 +101,20 @@ curl -fsS -X POST "$ENDPOINT/v1/predict" \
 ```
 
 Expected: a `queued` response with a `run_id`. Then poll with `{"action":"status","run_id":"..."}` until terminal, then `{"action":"result","run_id":"..."}` for the leads.
+
+Raw-inference smoke (the StaffAI-shaped path — model returns OpenAI-format tool calls; the caller runs its own CUA loop):
+
+```bash
+curl -fsS -X POST "$ENDPOINT/sync/v1/chat/completions" \
+  -H "Authorization: Api-Key $BASETEN_API_KEY" \
+  -H "X-Mantis-Token: $TOK" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "model",
+    "messages": [{"role": "user", "content": "Say hi."}],
+    "max_tokens": 32
+  }'
+```
 
 ## Auth model
 

--- a/docs/hosting/baseten.md
+++ b/docs/hosting/baseten.md
@@ -102,7 +102,7 @@ curl -fsS -X POST "$ENDPOINT/predict" \
 
 Expected: a `queued` response with a `run_id`. Then poll with `{"action":"status","run_id":"..."}` until terminal, then `{"action":"result","run_id":"..."}` for the leads.
 
-Raw-inference smoke (the StaffAI-shaped path — model returns OpenAI-format tool calls; the caller runs its own CUA loop):
+Raw-inference smoke (remote-brain shape — model returns OpenAI-format tool calls; the caller runs its own CUA loop against its own browser):
 
 ```bash
 curl -fsS -X POST "$ENDPOINT/sync/v1/chat/completions" \

--- a/docs/reference/cua-models.md
+++ b/docs/reference/cua-models.md
@@ -12,7 +12,7 @@ How you select a backend depends on where Mantis is hosted. The selection model 
 |---|---|---|
 | Modal `/v1/predict` | Per-request `cua_model` field | One deployment serves every backend; each request spawns the right GPU function. |
 | Modal CLI (`modal run`) | `--model <name>` | Same dispatch as the HTTP API. |
-| Baseten `/v1/predict` and `/v1/cua` | **Per-deployment** via `MANTIS_MODEL` env | Each pod loads one brain at startup. `cua_model` in the request body is **ignored**. To use Fara on Baseten you push `deploy/baseten/fara/` as its own model and hit that deployment's URL. |
+| Baseten `/production/predict` and `/production/sync/v1/cua` | **Per-deployment** via `MANTIS_MODEL` env | Each pod loads one brain at startup. `cua_model` in the request body is **ignored**. To use Fara on Baseten you push `deploy/baseten/fara/` as its own model and hit that deployment's URL. See [the URL contract below](#baseten-url-contract) for `/production/predict` vs `/production/sync/<path>`. |
 
 Default model is `holo3` on both surfaces — existing callers that don't pass `cua_model` keep getting Holo3.
 
@@ -61,8 +61,8 @@ uv run modal run --detach deploy/modal/modal_cua_server.py \
 uvx truss push deploy/baseten/fara --no-cache --promote \
   --deployment-name "mantis-fara-$(date -u +%Y%m%d-%H%M)"
 
-# Call its endpoint
-curl -X POST "https://model-<FARA_MODEL_ID>.api.baseten.co/production/v1/predict" \
+# Call the orchestrated /predict route
+curl -X POST "https://model-<FARA_MODEL_ID>.api.baseten.co/production/predict" \
   -H "Authorization: Api-Key $BASETEN_API_KEY" \
   -H "X-Mantis-Token: $TOK" \
   -H "Content-Type: application/json" \
@@ -72,6 +72,36 @@ curl -X POST "https://model-<FARA_MODEL_ID>.api.baseten.co/production/v1/predict
 ```
 
 Notice the request body has no `cua_model` field — the Fara deployment was started with `MANTIS_MODEL=fara` (see `deploy/baseten/fara/config.yaml`), and that's what determines the brain. Holo3 stays on its own deployment URL.
+
+#### Baseten URL contract
+
+The Baseten gateway forwards **two** route families to every truss-server deployment:
+
+| Public URL | Container path | What it serves |
+|---|---|---|
+| `/production/predict` | `predict_endpoint:` from `config.yaml` (default `/predict`) | Mantis orchestrated run / status / resume — the high-level entry point. |
+| `/production/sync/<any-path>` | `<any-path>` on the in-pod FastAPI / nginx (port `server_port`) | Pass-through for arbitrary FastAPI routes — `/v1/chat/completions`, `/v1/models`, `/v1/health`, `/v1/cua`. |
+
+For a non-promoted (canary) deployment, swap `production` for `deployment/<DEPLOYMENT_ID>` in either form.
+
+This is how StaffAI-style integrations point a remote `FaraBrain` at the Baseten deployment:
+
+```python
+endpoint = "https://model-<FARA_MODEL_ID>.api.baseten.co/production/sync"
+
+brain = FaraBrain(
+    base_url=f"{endpoint}/v1",                 # → /v1/chat/completions
+    extra_headers={
+        "Authorization": f"Api-Key {BASETEN_API_KEY}",
+        "X-Mantis-Token": MANTIS_API_TOKEN,
+    },
+    screen_size=(1280, 800),
+)
+```
+
+The brain only hits `/v1/chat/completions` (single-step inference). The CUA loop (screenshot → think → action → step) runs in the caller's container against the caller's `XdotoolGymEnv` — the Mantis Baseten pod is a thin model server in that mode.
+
+Use `/production/predict` instead when you want Mantis itself to run the CUA loop on its own headed Chrome inside Xvfb (the orchestrated path).
 
 
 

--- a/docs/reference/cua-models.md
+++ b/docs/reference/cua-models.md
@@ -84,7 +84,7 @@ The Baseten gateway forwards **two** route families to every truss-server deploy
 
 For a non-promoted (canary) deployment, swap `production` for `deployment/<DEPLOYMENT_ID>` in either form.
 
-This is how StaffAI-style integrations point a remote `FaraBrain` at the Baseten deployment:
+This is how a remote-brain integration (caller runs the CUA loop locally, hits Mantis only for per-step inference) points a `FaraBrain` at the Baseten deployment:
 
 ```python
 endpoint = "https://model-<FARA_MODEL_ID>.api.baseten.co/production/sync"


### PR DESCRIPTION
## Summary

The cua-models reference and baseten hosting docs both pointed users at \`https://model-<id>.api.baseten.co/production/v1/predict\`, which **404s** — the Baseten gateway does not forward arbitrary container paths under \`/production/<path>\`.

It forwards **two** route families:

| Public URL | Container path | What it serves |
|---|---|---|
| \`/production/predict\` | \`predict_endpoint:\` from \`config.yaml\` (default \`/predict\`) | Mantis orchestrated run / status / resume |
| \`/production/sync/<any-path>\` | \`<any-path>\` on the in-pod FastAPI on \`server_port\` | Pass-through to arbitrary routes — \`/v1/chat/completions\`, \`/v1/models\`, \`/v1/health\`, \`/v1/cua\` |

This is wired by the truss-server catch-all (\`proxy.conf.jinja:84\`'s \`location /\` block) plus the outer Baseten gateway's routing rules. Verified against the live Fara deployment (\`w7pr476w\` / \`q95rvp0\`) — every URL pattern in this PR returns the expected response.

## Why this matters

StaffAI-style integrations point a remote \`FaraBrain\` at the Mantis Baseten deployment and the brain posts to \`{endpoint}/v1/chat/completions\` only. Without this doc fix, callers either:
- Try \`{endpoint}/v1/predict\` and get a 404 from the gateway, or
- Get told to use \`{endpoint}/v1/cua\` (also 404 from the gateway).

The right endpoint is \`{endpoint}/production/sync/v1/chat/completions\`. The PR documents that explicitly along with the StaffAI-shaped \`FaraBrain\` setup snippet.

## Changes

- \`docs/reference/cua-models.md\` — fix the broken Baseten \`curl\` example to use \`/production/predict\`; add a "Baseten URL contract" subsection documenting both route families, the canary form \`/deployment/<id>/...\`, and the StaffAI-shaped \`FaraBrain\` config.
- \`docs/hosting/baseten.md\` — replace the broken \`$ENDPOINT/v1/predict\` smoke with the correct \`$ENDPOINT/predict\` (orchestrated) and add a second \`$ENDPOINT/sync/v1/chat/completions\` smoke for the raw-inference path.

\`docs/api.md\` already documents the contract correctly (lines 255-257) and stays as-is.

## Test plan

- [x] \`pytest tests/test_version_and_docs_ui.py\` passes (9/9).
- [x] Hand-verified URLs against live deployment \`w7pr476w\` / \`q95rvp0\`:
  - \`POST /production/predict\` → 200 (orchestrated Mantis API)
  - \`POST /production/sync/v1/chat/completions\` → 200 with \`tool_calls\` (StaffAI path)
  - \`GET  /production/sync/v1/models\` → 200
  - \`GET  /production/sync/v1/health\` → 200
  - \`POST /production/v1/predict\` → 404 (the previously-documented URL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)