### PR TITLE
fix(extractor,form): retry transient Anthropic errors + harden fill_field

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,14 @@ metrics = [
 # Used by the Baseten / EKS / GKE deployments.
 server = [
     "fastapi>=0.100",
+    # Pin starlette below 1.0 — sim_envs/mantis_crm uses the legacy
+    # ``TemplateResponse(name, {"request": request})`` positional
+    # signature that Starlette 1.0 removed (it raises
+    # ``TypeError: unhashable type: 'dict'`` because the context dict
+    # is now interpreted as ``name``). Track the migration to
+    # ``TemplateResponse(request, name)`` separately so this pin can
+    # come off.
+    "starlette<1.0",
     "uvicorn>=0.20",
     "pydantic>=2",
     "requests>=2.28",
@@ -94,6 +102,8 @@ dev = [
     "ruff>=0.4",
     "httpx>=0.24",   # FastAPI TestClient
     "jsonschema>=4.0",  # tests/test_plan_schema.py validates plans against docs/reference/plan.schema.json
+    "python-multipart>=0.0.9",  # FastAPI Form() params — sim_envs/mantis_crm TestClient flows
+    "starlette<1.0",  # see note under [project.optional-dependencies].server
 ]
 # MkDocs site builder + plugins.
 docs = [

--- a/src/mantis_agent/extraction/extractor.py
+++ b/src/mantis_agent/extraction/extractor.py
@@ -31,6 +31,7 @@ import base64
 import json
 import logging
 import os
+import random
 import re
 import time
 from io import BytesIO
@@ -55,6 +56,39 @@ def _credit_claude_time(bucket: str, t0: float) -> None:
         record_to_current(bucket, time.monotonic() - t0)
     except Exception as exc:  # noqa: BLE001 — observability, never fatal
         logger.debug("claude time_meter credit failed: %s", exc)
+
+
+# HTTP status codes treated as transient (worth retrying with backoff).
+# - 429: rate limited
+# - 502/503/504: upstream proxy / gateway hiccups
+# - 529: Anthropic's "Overloaded" code — by far the most common cause
+#   of mid-run halt during peak hours; the failure mode that motivated
+#   adding this loop (issue #403).
+_TRANSIENT_STATUS_CODES: frozenset[int] = frozenset({429, 502, 503, 504, 529})
+
+
+def _retry_delay(attempt: int, retry_after_header: str | None) -> float:
+    """Compute the sleep before the next retry attempt.
+
+    - Honours ``Retry-After`` when it's a numeric seconds value
+      (RFC 7231 §7.1.3 — HTTP-date form not supported; Anthropic
+      uses seconds in practice).
+    - Otherwise exponential backoff with 25% jitter: 1s, 2s, 4s, 8s,
+      capped at 16s. Total worst-case wait across 4 attempts is
+      ~15s + jitter, which clears typical 1–2 minute overload spikes
+      without blowing the per-step budget.
+
+    Standalone function (not a method) so tests can monkeypatch it
+    directly without instantiating ClaudeExtractor.
+    """
+    if retry_after_header:
+        try:
+            return max(0.0, float(retry_after_header))
+        except (TypeError, ValueError):
+            pass
+    base = float(min(16, 2 ** attempt))
+    jitter = random.uniform(0.0, base * 0.25)
+    return base + jitter
 
 
 def _coerce_coord(value: Any) -> int | None:
@@ -356,6 +390,79 @@ class ClaudeExtractor:
             _credit_claude_time(_bucket, t0)
         return ""
 
+    def _post_anthropic_with_retry(
+        self,
+        payload: dict[str, Any],
+        *,
+        timeout: float,
+        max_attempts: int = 4,
+    ):
+        """POST ``payload`` to /v1/messages with retry on transient errors.
+
+        Retries on the status codes in :data:`_TRANSIENT_STATUS_CODES`
+        (429 / 502 / 503 / 504 / 529) and on network exceptions
+        (``requests.Timeout``, ``requests.ConnectionError``). Non-
+        transient HTTP errors (4xx other than 429) return the
+        Response object so the caller can log + parse the body.
+
+        Returns:
+            - The final ``requests.Response`` on success or on a
+              non-transient HTTP error.
+            - The final transient ``requests.Response`` after the
+              retry budget is exhausted (caller logs as a failure).
+            - ``None`` only when every attempt raised a network
+              exception (no Response to return).
+
+        Honours ``Retry-After`` header when present (via
+        :func:`_retry_delay`). Sleeps between attempts via
+        ``time.sleep`` — tests monkeypatch that for speed.
+        """
+        import requests
+
+        url = "https://api.anthropic.com/v1/messages"
+        headers = {
+            "x-api-key": self.api_key,
+            "anthropic-version": "2023-06-01",
+            "content-type": "application/json",
+        }
+        last_response = None
+        for attempt in range(max_attempts):
+            try:
+                resp = requests.post(
+                    url, headers=headers, json=payload, timeout=timeout,
+                )
+            except (requests.Timeout, requests.ConnectionError) as exc:
+                if attempt == max_attempts - 1:
+                    logger.warning(
+                        "ClaudeExtractor network error after %d attempts: %s",
+                        max_attempts, exc,
+                    )
+                    return None
+                delay = _retry_delay(attempt, None)
+                logger.info(
+                    "ClaudeExtractor transient network error (%s) — "
+                    "retry %d/%d in %.1fs",
+                    type(exc).__name__, attempt + 1, max_attempts, delay,
+                )
+                time.sleep(delay)
+                continue
+            if resp.status_code not in _TRANSIENT_STATUS_CODES:
+                return resp
+            last_response = resp
+            if attempt == max_attempts - 1:
+                logger.warning(
+                    "ClaudeExtractor transient HTTP %s after %d attempts; "
+                    "giving up", resp.status_code, max_attempts,
+                )
+                return resp
+            delay = _retry_delay(attempt, resp.headers.get("Retry-After"))
+            logger.info(
+                "ClaudeExtractor transient HTTP %s — retry %d/%d in %.1fs",
+                resp.status_code, attempt + 1, max_attempts, delay,
+            )
+            time.sleep(delay)
+        return last_response
+
     def _call_with_tool_schema(
         self,
         screenshot: Image.Image,
@@ -389,8 +496,6 @@ class ClaudeExtractor:
         extractor call site that wants structured output should use this
         instead of ``_call`` + ``_parse_json``.
         """
-        import requests
-
         if not self.api_key:
             logger.warning("ClaudeExtractor: no API key")
             return None
@@ -399,34 +504,29 @@ class ClaudeExtractor:
         screenshot.save(buf, format="PNG")
         b64 = base64.b64encode(buf.getvalue()).decode()
 
+        payload = {
+            "model": self.model,
+            "max_tokens": max_tokens,
+            "tools": [{
+                "name": tool_name,
+                "description": tool_description,
+                "input_schema": input_schema,
+            }],
+            "tool_choice": {"type": "tool", "name": tool_name},
+            "messages": [{
+                "role": "user",
+                "content": [
+                    {"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": b64}},
+                    {"type": "text", "text": prompt},
+                ],
+            }],
+        }
+
         t0 = time.monotonic()
         try:
-            resp = requests.post(
-                "https://api.anthropic.com/v1/messages",
-                headers={
-                    "x-api-key": self.api_key,
-                    "anthropic-version": "2023-06-01",
-                    "content-type": "application/json",
-                },
-                json={
-                    "model": self.model,
-                    "max_tokens": max_tokens,
-                    "tools": [{
-                        "name": tool_name,
-                        "description": tool_description,
-                        "input_schema": input_schema,
-                    }],
-                    "tool_choice": {"type": "tool", "name": tool_name},
-                    "messages": [{
-                        "role": "user",
-                        "content": [
-                            {"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": b64}},
-                            {"type": "text", "text": prompt},
-                        ],
-                    }],
-                },
-                timeout=30,
-            )
+            resp = self._post_anthropic_with_retry(payload, timeout=30)
+            if resp is None:
+                return None
             if resp.status_code != 200:
                 logger.warning(
                     "ClaudeExtractor tool_use API error %s: %s",
@@ -473,8 +573,6 @@ class ClaudeExtractor:
         Returns the validated input dict, or ``None`` on API / shape
         mismatch — caller treats as fall-through (no answer).
         """
-        import requests
-
         if not self.api_key:
             logger.warning("ClaudeExtractor: no API key")
             return None
@@ -492,28 +590,23 @@ class ClaudeExtractor:
                 "source": {"type": "base64", "media_type": "image/png", "data": b64},
             })
 
+        payload = {
+            "model": self.model,
+            "max_tokens": max_tokens,
+            "tools": [{
+                "name": tool_name,
+                "description": tool_description,
+                "input_schema": input_schema,
+            }],
+            "tool_choice": {"type": "tool", "name": tool_name},
+            "messages": [{"role": "user", "content": content}],
+        }
+
         t0 = time.monotonic()
         try:
-            resp = requests.post(
-                "https://api.anthropic.com/v1/messages",
-                headers={
-                    "x-api-key": self.api_key,
-                    "anthropic-version": "2023-06-01",
-                    "content-type": "application/json",
-                },
-                json={
-                    "model": self.model,
-                    "max_tokens": max_tokens,
-                    "tools": [{
-                        "name": tool_name,
-                        "description": tool_description,
-                        "input_schema": input_schema,
-                    }],
-                    "tool_choice": {"type": "tool", "name": tool_name},
-                    "messages": [{"role": "user", "content": content}],
-                },
-                timeout=45,
-            )
+            resp = self._post_anthropic_with_retry(payload, timeout=45)
+            if resp is None:
+                return None
             if resp.status_code != 200:
                 logger.warning(
                     "ClaudeExtractor multi tool_use API error %s: %s",

--- a/src/mantis_agent/gym/som_dispatch.py
+++ b/src/mantis_agent/gym/som_dispatch.py
@@ -49,6 +49,87 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 
+def probe_element_tag_at(env: Any, x: int, y: int) -> dict | None:
+    """Best-effort: report the tag and contentEditable state of the
+    element at viewport (x, y) via CDP ``Runtime.evaluate``.
+
+    Returns ``None`` when:
+
+    - The env does not expose ``cdp_evaluate`` (Playwright path, tests).
+    - The CDP call fails or throws.
+    - ``document.elementFromPoint`` returns ``null`` (point off-screen).
+
+    On success returns ``{"tag": str, "contentEditable": bool}`` where
+    ``tag`` is the upper-case ``tagName`` of the element and
+    ``contentEditable`` reflects ``el.isContentEditable`` (covers rich
+    text editors that are technically ``<div>`` but accept typed input).
+
+    Used by :class:`~.step_handlers.form.ClaudeGuidedFormHandler` to
+    refuse a ``fill_field`` click when the element at the chosen point
+    is a button / backdrop / modal close-X — clicking those dismisses
+    the form instead of focusing an input (the lu.ma host-question
+    modal failure pattern: Claude returns coordinates near the title
+    label, ``elementFromPoint`` returns the dim overlay above it, the
+    SoM click hits the overlay's outside-to-close handler).
+
+    Tests that don't wire CDP get ``None`` and the caller falls through
+    to legacy behaviour — no breakage on the existing form-handler
+    suite. Real Modal/Baseten envs that DO wire CDP get the guard.
+    """
+    eval_fn = getattr(env, "cdp_evaluate", None)
+    if not callable(eval_fn):
+        return None
+    js = (
+        "(() => {"
+        f"const el = document.elementFromPoint({int(x)}, {int(y)});"
+        "if (!el) return null;"
+        "return {"
+        "tag: (el.tagName || '').toUpperCase(),"
+        "contentEditable: !!el.isContentEditable"
+        "};"
+        "})()"
+    )
+    try:
+        result = eval_fn(js)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("probe_element_tag_at CDP eval raised: %s", exc)
+        return None
+    if not isinstance(result, dict):
+        return None
+    # Normalise shape so callers don't have to defend against missing keys.
+    return {
+        "tag": str(result.get("tag") or "").upper(),
+        "contentEditable": bool(result.get("contentEditable")),
+    }
+
+
+# Tags whose clicked element legitimately receives keyboard input. The
+# allow-list is intentionally narrow: anything outside it (BUTTON, A,
+# DIV-as-backdrop, SVG icons) means the chosen coords are NOT on an
+# input, so a click there dismisses the form rather than focusing it.
+# ``LABEL`` stays in the list because clicking a ``<label for="x">``
+# focuses the bound input — a legitimate fill_field flow.
+INPUT_LIKE_TAGS: frozenset[str] = frozenset({"INPUT", "TEXTAREA", "LABEL"})
+
+
+def is_input_like(tag_info: dict | None) -> bool:
+    """True iff the probed element is something `fill_field` may type into.
+
+    Returns ``True`` when ``tag_info`` is ``None`` (CDP unavailable — we
+    can't refute, so don't block). Returns ``True`` for INPUT / TEXTAREA
+    / LABEL tags, and for any element with ``isContentEditable`` (rich
+    text editors). Everything else returns ``False`` and is the caller's
+    cue to refuse the click and report ``form_target_not_found`` / a
+    typed variant rather than dispatching a misdirected click that
+    would dismiss the form modal.
+    """
+    if tag_info is None:
+        return True
+    if tag_info.get("contentEditable"):
+        return True
+    return tag_info.get("tag", "") in INPUT_LIKE_TAGS
+
+
 def try_som_click(env: Any, x: int, y: int, policy: Any) -> bool:
     """Attempt a SoM-anchored click via CDP.
 
@@ -86,4 +167,9 @@ def try_som_click(env: Any, x: int, y: int, policy: Any) -> bool:
         return False
 
 
-__all__ = ["try_som_click"]
+__all__ = [
+    "try_som_click",
+    "probe_element_tag_at",
+    "is_input_like",
+    "INPUT_LIKE_TAGS",
+]

--- a/src/mantis_agent/gym/step_handlers/form.py
+++ b/src/mantis_agent/gym/step_handlers/form.py
@@ -243,6 +243,60 @@ class ClaudeGuidedFormHandler:
                 target_aliases=aliases,
             )
             runner.costs["claude_extract"] += 1
+            probe_attempts = ["initial"]
+
+            # Scroll-probe before falling back to affordance search —
+            # mirror of the ``submit`` handler's End/Home/Page_Down
+            # sweep (form.py:430). The lu.ma host-question modal is
+            # internally scrollable: after fill_field 1+2 succeed,
+            # the third question is below the visible fold and
+            # find_form_target returns None. Without this probe the
+            # visual-affordance fallback kicks in immediately and is
+            # liable to click the modal's submit button (it's the
+            # most prominent element left on screen), prematurely
+            # submitting a half-filled form. Probing via mouse-wheel
+            # scroll instead of KEY_PRESS Page_Down is intentional:
+            # after the previous fill_field, focus is on its input
+            # and Page_Down would move the cursor inside the input
+            # rather than scroll the page/modal. Mouse wheel events
+            # ignore input focus.
+            def _scroll_probe(direction: str, amount: int, log_tag: str) -> dict | None:
+                try:
+                    env.step(Action(
+                        action_type=ActionType.SCROLL,
+                        params={"direction": direction, "amount": amount},
+                    ))
+                except Exception:
+                    return None
+                time.sleep(0.5)
+                shot = _wait_for_rendered_screenshot(env)
+                t = extractor.find_form_target(
+                    shot,
+                    search_intent,
+                    target_label=label,
+                    target_value=value,
+                    target_aliases=aliases,
+                )
+                runner.costs["claude_extract"] += 1
+                probe_attempts.append(log_tag)
+                logger.info(
+                    "  [claude-form] fill_field '%s' probe %s: %s",
+                    label[:30], log_tag, "found" if t else "not found",
+                )
+                return t
+
+            if target is None:
+                # First jump to top of the form so progressive scrolls
+                # below cover the whole scroll range deterministically.
+                target = _scroll_probe("up", 10, "scroll-top")
+            scroll_steps = 0
+            max_scrolls = 5
+            while target is None and scroll_steps < max_scrolls:
+                target = _scroll_probe(
+                    "down", 3, f"scroll-down-{scroll_steps + 1}/{max_scrolls}",
+                )
+                scroll_steps += 1
+
             if not target:
                 # Visual-affordance fallback before failing — covers
                 # non-English / icon-only inputs whose labels don't
@@ -251,7 +305,8 @@ class ClaudeGuidedFormHandler:
                 # subsequent search's interactions.
                 logger.warning(
                     "  [claude-form] fill_field: label-match exhausted "
-                    "for '%s' — trying visual-affordance fallback", label,
+                    "for '%s' after probes %s — trying visual-affordance "
+                    "fallback", label, probe_attempts,
                 )
                 try:
                     env.step(Action(
@@ -261,12 +316,54 @@ class ClaudeGuidedFormHandler:
                 except Exception:
                     pass
                 shot = _wait_for_rendered_screenshot(env)
-                target = extractor.find_target_by_affordance(shot, search_intent)
+                affordance = extractor.find_target_by_affordance(shot, search_intent)
                 runner.costs["claude_extract"] += 1
+                # Refuse affordance results whose recommended action is
+                # not text-input shaped. A ``fill_field`` step that
+                # falls back to an affordance pass returning
+                # ``action=click`` / ``select`` / ``right_click`` means
+                # Claude could not find any visible input matching the
+                # intent and picked the next-most-prominent element
+                # instead — almost always the modal's submit button.
+                # Clicking it would submit a half-filled form rather
+                # than fill the missing field.
+                if affordance is not None:
+                    aff_action = str(affordance.get("action") or "").lower()
+                    if aff_action and aff_action != "type":
+                        logger.warning(
+                            "  [claude-form] fill_field: affordance "
+                            "returned action=%s for fill intent — "
+                            "refusing to click (would dismiss form / "
+                            "submit partial data)",
+                            aff_action,
+                        )
+                        affordance = None
+                target = affordance
             if not target:
                 logger.warning(f"  [claude-form] fill_field: target '{label}' not found")
                 return StepResult(step_index=index, intent=step.intent, success=False, data="form_target_not_found")
             x, y = target["x"], target["y"]
+            # Tag-guard: refuse a click whose elementFromPoint is not
+            # input-shaped. Without this, a stale or mis-grounded
+            # target whose coordinates fall on the modal backdrop /
+            # close-X / submit button dismisses the form on the
+            # subsequent SoM ``el.click()``. Returns None on envs
+            # without CDP (tests / Playwright path) so legacy
+            # behaviour is preserved where the guard can't run.
+            from ..som_dispatch import is_input_like, probe_element_tag_at
+            tag_info = probe_element_tag_at(env, x, y)
+            if not is_input_like(tag_info):
+                tag_name = (tag_info or {}).get("tag", "?")
+                logger.warning(
+                    "  [claude-form] fill_field: refusing click at "
+                    "(%d, %d) — elementFromPoint=%s is not "
+                    "input-shaped (would dismiss form / mis-submit)",
+                    x, y, tag_name,
+                )
+                return StepResult(
+                    step_index=index, intent=step.intent, success=False,
+                    data=f"form_target_not_input:{tag_name}",
+                )
             type_value = value or target.get("value") or ""
             try:
                 # Click the field, clear any pre-filled value, then type.

--- a/tests/test_extractor_retry.py
+++ b/tests/test_extractor_retry.py
@@ -22,7 +22,6 @@ This module pins:
 
 from __future__ import annotations
 
-from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest

--- a/tests/test_extractor_retry.py
+++ b/tests/test_extractor_retry.py
@@ -1,0 +1,241 @@
+"""Retry-with-backoff coverage for ClaudeExtractor's Anthropic POST helper (#403).
+
+The lu.ma host-question registration plan halted at step 4 because
+Anthropic returned 529 Overloaded on every find_form_target call —
+``ClaudeExtractor._call_with_tool_schema`` previously returned ``None``
+immediately on any non-200, so each scroll-probe + affordance fallback
+inside ``fill_field`` burned its slot on what was a transient API
+hiccup. The step then failed, agentic recovery fired twice more, the
+run halted.
+
+This module pins:
+
+- transient HTTP errors (429 / 502 / 503 / 504 / 529) trigger retry
+  with exponential backoff;
+- ``Retry-After`` header is honoured when the response carries one;
+- non-transient errors (4xx other than 429) return immediately without
+  retry — no point burning the budget on a permanent 400 / 401;
+- network exceptions retry up to the budget then return ``None``;
+- ``time.sleep`` is monkeypatched so the suite stays fast (~10 ms per
+  test) regardless of backoff math.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mantis_agent.extraction.extractor import (
+    _TRANSIENT_STATUS_CODES,
+    ClaudeExtractor,
+    _retry_delay,
+)
+
+
+def _fake_response(status_code: int, headers: dict | None = None) -> MagicMock:
+    """A requests.Response-ish stand-in."""
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.headers = headers or {}
+    resp.text = f"<body status={status_code}>"
+    return resp
+
+
+# ── _retry_delay ────────────────────────────────────────────────────
+
+
+def test_retry_delay_honours_numeric_retry_after() -> None:
+    """Server-supplied Retry-After (seconds) overrides exponential backoff."""
+    assert _retry_delay(0, "3") == 3.0
+    assert _retry_delay(5, "0.5") == 0.5
+    # Empty string is falsy → fall through to backoff path.
+    assert _retry_delay(0, "") >= 1.0
+
+
+def test_retry_delay_ignores_non_numeric_retry_after() -> None:
+    """HTTP-date Retry-After (RFC 7231 §7.1.3) is unsupported; fall back
+    to the backoff path so we still wait something reasonable."""
+    delay = _retry_delay(0, "Mon, 12 Jul 2026 12:00:00 GMT")
+    assert delay >= 1.0  # exp(0) = 1 + jitter
+
+
+def test_retry_delay_exponential_backoff_with_jitter() -> None:
+    """Sequence: 1s, 2s, 4s, 8s (capped at 16s) plus up to 25% jitter."""
+    for attempt, base in enumerate([1, 2, 4, 8]):
+        d = _retry_delay(attempt, None)
+        assert base <= d <= base * 1.25, f"attempt={attempt} got {d}"
+
+
+def test_retry_delay_caps_at_16s() -> None:
+    """Past attempt=4, the base stays at 16s — keep one retry from
+    blowing past a half-minute budget."""
+    d = _retry_delay(10, None)
+    assert 16.0 <= d <= 20.0  # 16 + up to 25%
+
+
+def test_retry_delay_negative_retry_after_clamped_to_zero() -> None:
+    """A negative Retry-After (server bug) must not become a negative
+    sleep — that crashes time.sleep on some platforms."""
+    assert _retry_delay(0, "-5") == 0.0
+
+
+# ── _TRANSIENT_STATUS_CODES sanity ───────────────────────────────────
+
+
+def test_transient_set_includes_529_and_429() -> None:
+    """529 (Anthropic overload) is the canonical retry case — without
+    it we don't survive peak hours. 429 (rate limit) also retryable."""
+    assert 529 in _TRANSIENT_STATUS_CODES
+    assert 429 in _TRANSIENT_STATUS_CODES
+    assert 502 in _TRANSIENT_STATUS_CODES
+    assert 503 in _TRANSIENT_STATUS_CODES
+    assert 504 in _TRANSIENT_STATUS_CODES
+
+
+def test_transient_set_excludes_4xx_client_errors() -> None:
+    """400 / 401 / 403 / 404 are caller bugs, not transient — burning
+    the budget on retries doesn't help."""
+    for code in (400, 401, 403, 404, 422):
+        assert code not in _TRANSIENT_STATUS_CODES
+
+
+# ── _post_anthropic_with_retry ───────────────────────────────────────
+
+
+@pytest.fixture
+def extractor() -> ClaudeExtractor:
+    """Stub extractor with a dummy api_key so the early-return doesn't fire."""
+    return ClaudeExtractor(api_key="test-key")
+
+
+@pytest.fixture(autouse=True)
+def fast_sleep(monkeypatch) -> None:
+    """Don't actually sleep during retry — keeps the suite snappy."""
+    monkeypatch.setattr("mantis_agent.extraction.extractor.time.sleep", lambda *_: None)
+
+
+def test_post_with_retry_returns_200_immediately(extractor: ClaudeExtractor) -> None:
+    """Happy path — first attempt succeeds, no retry, no sleep."""
+    ok = _fake_response(200)
+    with patch("requests.post", return_value=ok) as post:
+        result = extractor._post_anthropic_with_retry({}, timeout=30)
+    assert result is ok
+    assert post.call_count == 1
+
+
+def test_post_with_retry_recovers_from_one_529(extractor: ClaudeExtractor) -> None:
+    """The exact failure that motivated #403: one 529 then 200 — the
+    plan run survives a brief Anthropic overload spike. Before this
+    fix, the 529 propagated to the caller as ``None`` and the
+    fill_field step halted."""
+    responses = [_fake_response(529), _fake_response(200)]
+    with patch("requests.post", side_effect=responses) as post:
+        result = extractor._post_anthropic_with_retry({}, timeout=30)
+    assert result.status_code == 200
+    assert post.call_count == 2
+
+
+def test_post_with_retry_recovers_from_429_with_retry_after(
+    extractor: ClaudeExtractor,
+) -> None:
+    """Rate limit recovery: 429 + Retry-After honoured, then 200."""
+    rate_limited = _fake_response(429, headers={"Retry-After": "2"})
+    ok = _fake_response(200)
+    with patch("requests.post", side_effect=[rate_limited, ok]) as post:
+        result = extractor._post_anthropic_with_retry({}, timeout=30)
+    assert result.status_code == 200
+    assert post.call_count == 2
+
+
+def test_post_with_retry_recovers_from_503(extractor: ClaudeExtractor) -> None:
+    """Gateway hiccup (503) is also transient."""
+    with patch("requests.post", side_effect=[_fake_response(503), _fake_response(200)]):
+        result = extractor._post_anthropic_with_retry({}, timeout=30)
+    assert result.status_code == 200
+
+
+def test_post_with_retry_returns_400_immediately(extractor: ClaudeExtractor) -> None:
+    """400 is a caller bug — no retry, return immediately. Retrying
+    a malformed payload wastes budget AND looks like a transient
+    issue in metrics."""
+    bad = _fake_response(400)
+    with patch("requests.post", return_value=bad) as post:
+        result = extractor._post_anthropic_with_retry({}, timeout=30)
+    assert result is bad
+    assert post.call_count == 1
+
+
+def test_post_with_retry_exhausts_budget_on_persistent_529(
+    extractor: ClaudeExtractor,
+) -> None:
+    """If Anthropic stays down for >15s, we eventually give up — but
+    we return the final Response so the caller can log the status."""
+    persistent = [_fake_response(529) for _ in range(4)]
+    with patch("requests.post", side_effect=persistent) as post:
+        result = extractor._post_anthropic_with_retry({}, timeout=30, max_attempts=4)
+    assert result.status_code == 529
+    assert post.call_count == 4
+
+
+def test_post_with_retry_returns_none_on_repeated_network_errors(
+    extractor: ClaudeExtractor,
+) -> None:
+    """Connection-level failures across the budget yield ``None`` (no
+    Response object to return). Caller treats as the existing
+    not-found path."""
+    import requests
+    with patch(
+        "requests.post",
+        side_effect=requests.ConnectionError("dns lookup failed"),
+    ) as post:
+        result = extractor._post_anthropic_with_retry({}, timeout=30, max_attempts=3)
+    assert result is None
+    assert post.call_count == 3
+
+
+def test_post_with_retry_recovers_from_transient_network_then_200(
+    extractor: ClaudeExtractor,
+) -> None:
+    """One network blip then 200 — the connection-error retry path
+    is symmetric to the transient-HTTP retry path."""
+    import requests
+    ok = _fake_response(200)
+    with patch(
+        "requests.post",
+        side_effect=[requests.Timeout("read timeout"), ok],
+    ) as post:
+        result = extractor._post_anthropic_with_retry({}, timeout=30, max_attempts=3)
+    assert result is ok
+    assert post.call_count == 2
+
+
+def test_call_with_tool_schema_recovers_through_retry(
+    extractor: ClaudeExtractor,
+) -> None:
+    """End-to-end: ``_call_with_tool_schema`` survives a 529 because
+    its underlying POST is now wrapped by the retry helper. This is
+    the contract the lu.ma plan depends on."""
+    from PIL import Image
+    img = Image.new("RGB", (10, 10), color=(255, 255, 255))
+
+    ok = _fake_response(200)
+    ok.json = MagicMock(return_value={
+        "content": [{
+            "type": "tool_use",
+            "name": "test_tool",
+            "input": {"x": 100, "y": 200},
+        }],
+    })
+    responses = [_fake_response(529), ok]
+    with patch("requests.post", side_effect=responses) as post:
+        out = extractor._call_with_tool_schema(
+            img, "find the email field",
+            tool_name="test_tool",
+            tool_description="locate an element",
+            input_schema={"type": "object", "properties": {"x": {"type": "integer"}, "y": {"type": "integer"}}, "required": ["x", "y"]},
+        )
+
+    assert out == {"x": 100, "y": 200}
+    assert post.call_count == 2

--- a/tests/test_form_handler.py
+++ b/tests/test_form_handler.py
@@ -82,7 +82,8 @@ def test_fill_field_target_not_found_returns_form_target_not_found(monkeypatch):
     extractor.find_form_target.return_value = None
     # Vision-affordance fallback also misses → form_target_not_found.
     extractor.find_target_by_affordance.return_value = None
-    ctx = _ctx(runner, extractor=extractor)
+    env = MagicMock()
+    ctx = _ctx(runner, env=env, extractor=extractor)
 
     step = MicroIntent(
         intent="Fill in email", type="fill_field",
@@ -92,8 +93,24 @@ def test_fill_field_target_not_found_returns_form_target_not_found(monkeypatch):
 
     assert result.success is False
     assert result.data == "form_target_not_found"
-    # 1 label-match + 1 visual-affordance fallback = 2 Claude calls.
-    assert runner.costs["claude_extract"] == 2
+    # 1 initial label-match + scroll-top probe + 5 scroll-down sweeps +
+    # 1 visual-affordance fallback = 8 Claude calls. The scroll-probe
+    # path mirrors `submit`'s End/Home/Page_Down sweep so a fill_field
+    # whose target is below the visible fold doesn't go straight to
+    # the affordance fallback (which historically clicked the form's
+    # submit button by mistake on lu.ma-style host-question modals).
+    assert runner.costs["claude_extract"] == 8
+    # Verify the scroll-probe dispatched mouse-wheel SCROLL actions
+    # (not KEY_PRESS) so input focus from a prior fill_field doesn't
+    # absorb the page-scroll keystrokes.
+    scroll_calls = [
+        c for c in env.step.call_args_list
+        if c.args[0].action_type == ActionType.SCROLL
+    ]
+    assert len(scroll_calls) == 6  # 1 scroll-top + 5 scroll-down
+    assert scroll_calls[0].args[0].params == {"direction": "up", "amount": 10}
+    for c in scroll_calls[1:]:
+        assert c.args[0].params == {"direction": "down", "amount": 3}
 
 
 def test_fill_field_success_clicks_triple_clicks_clears_and_types(monkeypatch):
@@ -126,6 +143,203 @@ def test_fill_field_success_clicks_triple_clicks_clears_and_types(monkeypatch):
     assert types[3] == ActionType.KEY_PRESS  # ctrl+a
     assert types[4] == ActionType.KEY_PRESS  # Delete
     assert types[5] == ActionType.TYPE
+
+
+def test_fill_field_scroll_probe_finds_target_after_scroll_down(monkeypatch):
+    """When the labelled input isn't in the initial viewport but
+    becomes visible after a downward scroll, fill_field's scroll-probe
+    locates it and proceeds with the click+type — no affordance
+    fallback fires. Mirrors the lu.ma host-question modal where the
+    third question is below the visible fold."""
+    monkeypatch.setattr("mantis_agent.gym.step_handlers.form.time.sleep", lambda *_: None)
+    monkeypatch.setattr(
+        "mantis_agent.gym.step_handlers.form.random.uniform",
+        lambda a, b: a,
+    )
+
+    runner = _FakeRunner()
+    extractor = MagicMock()
+    # Initial miss; scroll-top miss; first scroll-down hit.
+    extractor.find_form_target.side_effect = [
+        None,  # initial
+        None,  # scroll-top
+        {"x": 600, "y": 480},  # scroll-down-1 hit
+    ]
+    env = MagicMock()
+    ctx = _ctx(runner, env=env, extractor=extractor)
+
+    step = MicroIntent(
+        intent="Fill title", type="fill_field",
+        params={"label": "What is your title?", "value": "AI Product Tester"},
+    )
+    result = ClaudeGuidedFormHandler(runner).execute(step, ctx)
+
+    assert result.success is True
+    assert result.data == "fill:What is your title?"
+    # 3 find_form_target calls (initial + scroll-top + scroll-down-1).
+    # The affordance fallback must NOT fire when scroll-probe succeeds.
+    assert runner.costs["claude_extract"] == 3
+    extractor.find_target_by_affordance.assert_not_called()
+    # Two SCROLL actions dispatched: scroll-top then scroll-down-1.
+    scroll_calls = [
+        c for c in env.step.call_args_list
+        if c.args[0].action_type == ActionType.SCROLL
+    ]
+    assert len(scroll_calls) == 2
+    assert scroll_calls[0].args[0].params == {"direction": "up", "amount": 10}
+    assert scroll_calls[1].args[0].params == {"direction": "down", "amount": 3}
+
+
+def test_fill_field_affordance_refuses_button_action(monkeypatch):
+    """The affordance fallback returning ``action=click`` (button-
+    shaped) is the canonical lu.ma failure: with no visible input,
+    Claude returns the most prominent thing left — the form's submit
+    button. fill_field must refuse and report form_target_not_found
+    rather than dispatch a click that submits a half-filled form."""
+    monkeypatch.setattr("mantis_agent.gym.step_handlers.form.time.sleep", lambda *_: None)
+
+    runner = _FakeRunner()
+    extractor = MagicMock()
+    extractor.find_form_target.return_value = None
+    extractor.find_target_by_affordance.return_value = {
+        "x": 635, "y": 570,
+        "action": "click",
+        "label": "Register",
+        "value": "",
+    }
+    env = MagicMock()
+    ctx = _ctx(runner, env=env, extractor=extractor)
+
+    step = MicroIntent(
+        intent="Fill title", type="fill_field",
+        params={"label": "What is your title?", "value": "AI Product Tester"},
+    )
+    result = ClaudeGuidedFormHandler(runner).execute(step, ctx)
+
+    assert result.success is False
+    assert result.data == "form_target_not_found"
+    # No CLICK action dispatched — the submit button was NOT clicked.
+    click_calls = [
+        c for c in env.step.call_args_list
+        if c.args[0].action_type == ActionType.CLICK
+    ]
+    assert click_calls == []
+
+
+def test_fill_field_affordance_accepts_type_action(monkeypatch):
+    """Counterpart to the refuse test: when the affordance pass
+    returns ``action=type`` (correctly identified as a text input by
+    visual shape rather than label), fill_field proceeds normally."""
+    monkeypatch.setattr("mantis_agent.gym.step_handlers.form.time.sleep", lambda *_: None)
+    monkeypatch.setattr(
+        "mantis_agent.gym.step_handlers.form.random.uniform",
+        lambda a, b: a,
+    )
+
+    runner = _FakeRunner()
+    extractor = MagicMock()
+    extractor.find_form_target.return_value = None
+    extractor.find_target_by_affordance.return_value = {
+        "x": 400, "y": 250,
+        "action": "type",
+        "label": "Le titre",  # non-English label, affordance match
+        "value": "",
+    }
+    env = MagicMock()
+    ctx = _ctx(runner, env=env, extractor=extractor)
+
+    step = MicroIntent(
+        intent="Fill title", type="fill_field",
+        params={"label": "Title", "value": "AI Product Tester"},
+    )
+    result = ClaudeGuidedFormHandler(runner).execute(step, ctx)
+
+    assert result.success is True
+    assert result.data == "fill:Title"
+
+
+def test_fill_field_tag_guard_refuses_button_at_click_point(monkeypatch):
+    """find_form_target returned coords that land on a BUTTON element
+    (most likely cause: stale grounding / a target whose center
+    overlaps the modal submit button). The tag-guard probes the
+    element at (x, y) via CDP and refuses the click rather than
+    dispatching a SoM ``el.click()`` that would submit the form."""
+    monkeypatch.setattr("mantis_agent.gym.step_handlers.form.time.sleep", lambda *_: None)
+
+    runner = _FakeRunner()
+    extractor = MagicMock()
+    extractor.find_form_target.return_value = {"x": 635, "y": 570}
+    env = MagicMock()
+    # Wire CDP eval to simulate "the element at this point is a BUTTON".
+    env.cdp_evaluate = MagicMock(return_value={"tag": "BUTTON", "contentEditable": False})
+    ctx = _ctx(runner, env=env, extractor=extractor)
+
+    step = MicroIntent(
+        intent="Fill title", type="fill_field",
+        params={"label": "Title", "value": "AI Product Tester"},
+    )
+    result = ClaudeGuidedFormHandler(runner).execute(step, ctx)
+
+    assert result.success is False
+    assert result.data == "form_target_not_input:BUTTON"
+    # No CLICK / TYPE dispatched.
+    blocked_types = {ActionType.CLICK, ActionType.TYPE}
+    assert not any(
+        c.args[0].action_type in blocked_types
+        for c in env.step.call_args_list
+    )
+
+
+def test_fill_field_tag_guard_allows_input_at_click_point(monkeypatch):
+    """Counterpart: when the element at (x, y) IS an INPUT, the guard
+    passes through and the click+type sequence proceeds."""
+    monkeypatch.setattr("mantis_agent.gym.step_handlers.form.time.sleep", lambda *_: None)
+    monkeypatch.setattr(
+        "mantis_agent.gym.step_handlers.form.random.uniform",
+        lambda a, b: a,
+    )
+
+    runner = _FakeRunner()
+    extractor = MagicMock()
+    extractor.find_form_target.return_value = {"x": 200, "y": 300}
+    env = MagicMock()
+    env.cdp_evaluate = MagicMock(return_value={"tag": "INPUT", "contentEditable": False})
+    ctx = _ctx(runner, env=env, extractor=extractor)
+
+    step = MicroIntent(
+        intent="Fill email", type="fill_field",
+        params={"label": "Email", "value": "u@e.com"},
+    )
+    result = ClaudeGuidedFormHandler(runner).execute(step, ctx)
+
+    assert result.success is True
+    assert result.data == "fill:Email"
+
+
+def test_fill_field_tag_guard_allows_contenteditable_div(monkeypatch):
+    """Rich text editors (Quill, ProseMirror, …) render as ``<div
+    contenteditable="true">``. The tag-guard must accept them — the
+    INPUT_LIKE_TAGS allow-list alone would reject DIV."""
+    monkeypatch.setattr("mantis_agent.gym.step_handlers.form.time.sleep", lambda *_: None)
+    monkeypatch.setattr(
+        "mantis_agent.gym.step_handlers.form.random.uniform",
+        lambda a, b: a,
+    )
+
+    runner = _FakeRunner()
+    extractor = MagicMock()
+    extractor.find_form_target.return_value = {"x": 200, "y": 300}
+    env = MagicMock()
+    env.cdp_evaluate = MagicMock(return_value={"tag": "DIV", "contentEditable": True})
+    ctx = _ctx(runner, env=env, extractor=extractor)
+
+    step = MicroIntent(
+        intent="Fill bio", type="fill_field",
+        params={"label": "Bio", "value": "hello"},
+    )
+    result = ClaudeGuidedFormHandler(runner).execute(step, ctx)
+
+    assert result.success is True
 
 
 # ── submit ──────────────────────────────────────────────────────────

--- a/tests/test_microrunner_som_dispatch.py
+++ b/tests/test_microrunner_som_dispatch.py
@@ -31,7 +31,12 @@ import pytest
 from mantis_agent.gym._runner_helpers import _stamp_backend
 from mantis_agent.gym.checkpoint import StepResult
 from mantis_agent.gym.runner import RoutingPolicy
-from mantis_agent.gym.som_dispatch import try_som_click
+from mantis_agent.gym.som_dispatch import (
+    INPUT_LIKE_TAGS,
+    is_input_like,
+    probe_element_tag_at,
+    try_som_click,
+)
 
 
 # ── try_som_click ──────────────────────────────────────────────────────
@@ -99,6 +104,93 @@ def test_try_som_click_swallows_exceptions() -> None:
     env = _CdpEnv(raises=True)
     policy = RoutingPolicy(som_for_unstructured_clicks=True)
     assert try_som_click(env, 5, 5, policy) is False
+
+
+# ── probe_element_tag_at / is_input_like ───────────────────────────────
+
+
+class _CdpEvalEnv:
+    """Env exposing only ``cdp_evaluate``."""
+
+    def __init__(self, result: Any = None, raises: bool = False) -> None:
+        self.calls: list[str] = []
+        self._result = result
+        self._raises = raises
+
+    def cdp_evaluate(self, expression: str) -> Any:
+        self.calls.append(expression)
+        if self._raises:
+            raise RuntimeError("boom")
+        return self._result
+
+
+def test_probe_element_tag_at_returns_none_when_env_lacks_cdp() -> None:
+    """No ``cdp_evaluate`` attribute → can't probe; caller falls
+    through to legacy behaviour. Keeps the Playwright path and tests
+    that don't wire CDP from being blocked by the new guard."""
+    env = object()
+    assert probe_element_tag_at(env, 10, 20) is None
+
+
+def test_probe_element_tag_at_returns_none_on_cdp_exception() -> None:
+    """CDP raising must not propagate — guard returns None and the
+    caller proceeds as if CDP weren't available."""
+    env = _CdpEvalEnv(raises=True)
+    assert probe_element_tag_at(env, 10, 20) is None
+
+
+def test_probe_element_tag_at_returns_none_when_no_element_at_point() -> None:
+    """``elementFromPoint`` returns null for off-viewport points →
+    the JS expression returns None; guard surfaces that as None."""
+    env = _CdpEvalEnv(result=None)
+    assert probe_element_tag_at(env, 9999, 9999) is None
+
+
+def test_probe_element_tag_at_normalises_tag_and_contenteditable() -> None:
+    """Tag is upper-cased; contentEditable is coerced to bool. The
+    contract callers depend on: a stable dict shape regardless of
+    what Chrome's CDP returns under the hood."""
+    env = _CdpEvalEnv(result={"tag": "input", "contentEditable": 0})
+    out = probe_element_tag_at(env, 100, 200)
+    assert out == {"tag": "INPUT", "contentEditable": False}
+
+    env2 = _CdpEvalEnv(result={"tag": "div", "contentEditable": 1})
+    out2 = probe_element_tag_at(env2, 100, 200)
+    assert out2 == {"tag": "DIV", "contentEditable": True}
+
+
+def test_is_input_like_allows_unknown_when_cdp_unavailable() -> None:
+    """``None`` tag_info means CDP couldn't probe — don't block on
+    inconclusive evidence. Preserves legacy behaviour where the guard
+    can't run."""
+    assert is_input_like(None) is True
+
+
+def test_is_input_like_accepts_canonical_input_tags() -> None:
+    for tag in INPUT_LIKE_TAGS:
+        assert is_input_like({"tag": tag, "contentEditable": False}) is True
+
+
+def test_is_input_like_accepts_contenteditable_div() -> None:
+    """Rich-text editors (Quill, ProseMirror) are DIVs with
+    ``contentEditable=true`` — they accept typed input legitimately."""
+    assert is_input_like({"tag": "DIV", "contentEditable": True}) is True
+
+
+def test_is_input_like_rejects_button() -> None:
+    """The canonical lu.ma failure: the chosen point overlaps the
+    form's submit button. Refuse so the caller can report
+    ``form_target_not_input`` rather than dismissing the form."""
+    assert is_input_like({"tag": "BUTTON", "contentEditable": False}) is False
+
+
+def test_is_input_like_rejects_anchor_and_div() -> None:
+    """Anchor tags (Lu.ma's 'Sign In' link in the corner of the
+    registration modal) and plain DIVs (modal backdrop / overlay) both
+    fail the allow-list. Anything outside INPUT/TEXTAREA/LABEL/CE goes
+    through the form_target_not_input failure path."""
+    assert is_input_like({"tag": "A", "contentEditable": False}) is False
+    assert is_input_like({"tag": "DIV", "contentEditable": False}) is False
 
 
 # ── _stamp_backend dispatch boundary ───────────────────────────────────


### PR DESCRIPTION
## Summary

Two reliability fixes that together rescue the lu.ma host-question registration plan from the failure mode the user hit on Modal:

1. **`fix(extractor)` — retry transient Anthropic API errors with backoff.** When Anthropic returned 529 Overloaded on the `find_form_target` call inside step 4 (fill Title), the runner used to halt the whole plan. Now each tool-use call retries 429 / 502 / 503 / 504 / 529 with exponential backoff (1s, 2s, 4s, 8s, cap 16s + jitter, honouring `Retry-After`). Total worst-case wait ~15s — covers the typical 1–2 minute overload spikes. Addresses Phase A of #403.

2. **`fix(form)` — harden `fill_field` against premature form dismissal.** Before this work, filling the second of three required fields was silently dismissing the lu.ma registration modal back to the event page. Three composable changes prevent that:
   - Scroll-probe before the affordance fallback (mirror of `submit`'s End/Home/Page_Down sweep, but with mouse-wheel `SCROLL` so a focused input from the previous fill_field doesn't absorb the keystrokes).
   - Affordance fallback refuses `action=click` / `select` / `right_click` results for a fill intent — the canonical lu.ma failure was Claude returning the form's submit button as "the most prominent thing left".
   - CDP `elementFromPoint` tag-guard refuses clicks on anything that isn't `INPUT` / `TEXTAREA` / `LABEL` / `[contenteditable]`. Blocks mis-grounded coords that hit the modal backdrop or close-X.

Plus a small dep hygiene commit (`chore(deps)`) pinning `starlette<1.0` and adding `python-multipart` so the sim_envs/mantis_crm TestClient flows pass — they were erroring on the dev machine because Starlette 1.0 removed a legacy `TemplateResponse` signature. Migration is tracked separately.

## Test plan

- [x] `pytest tests/test_extractor_retry.py` — 16 new tests covering 529/429/503 recovery, Retry-After honouring, 400 immediate-return, backoff math, exhausted budget, network-error retry, end-to-end `_call_with_tool_schema` recovery.
- [x] `pytest tests/test_form_handler.py tests/test_microrunner_som_dispatch.py` — 44 tests; 9 new pinning the scroll-probe / affordance-constraint / tag-guard behaviour.
- [x] `pytest -q --ignore=tests/integration --ignore=tests/e2e` — full unit suite green (2422+ passing on the pre-existing scope; sim_envs now green too with the dep pins).
- [x] Modal redeploy + rerun of `plans/luma` against the deployed `mantis-cua-server` — verified the form fixes prevent the modal-dismiss bug; the 529-retry verification is the next step on this branch after this PR's image is deployed.

Closes #403 Phase A. Phase B (non-Claude VLM provider for `find_form_target` + moving grounding methods out of `extractor.py` + smoke-gate harness) is the next issue, to be filed after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)