### PR TITLE
fix(brain_fara): accept type_text alias for type + add submit/enter/press_key

### DIFF
--- a/src/mantis_agent/brain_fara.py
+++ b/src/mantis_agent/brain_fara.py
@@ -610,15 +610,29 @@ class FaraBrain:
                 {"x": sx, "y": sy, "button": "left"},
             )
 
-        if action == "type":
+        if action in ("type", "type_text"):
+            # Fara emits both verbs depending on training-data variance — the
+            # documented action is ``type`` but in practice many turns come
+            # through as ``type_text`` (see #405). Treat as aliases.
             text = str(args.get("text", ""))
             return Action(ActionType.TYPE, {"text": text})
 
-        if action == "key":
+        if action in ("key", "press_key"):
             keys = args.get("text") or args.get("key") or args.get("keys") or ""
             if isinstance(keys, list):
                 keys = "+".join(str(k) for k in keys)
             return Action(ActionType.KEY_PRESS, {"keys": str(keys)})
+
+        if action in ("submit", "enter"):
+            # Form submit / Enter — Fara variants emit either verb. Always
+            # map to a Return key press; works on focused inputs and on
+            # selected buttons. If args carry an explicit ``text`` (e.g.
+            # ``submit(text="Return")``), honour it.
+            keys = str(args.get("text") or args.get("key") or "Return")
+            return Action(
+                ActionType.KEY_PRESS, {"keys": keys},
+                reasoning=f"fara {action}",
+            )
 
         if action == "scroll":
             direction = str(

--- a/tests/test_brain_fara.py
+++ b/tests/test_brain_fara.py
@@ -211,10 +211,50 @@ def test_type_maps_to_type_action(brain: FaraBrain) -> None:
     assert action.params == {"text": "hello"}
 
 
+def test_type_text_alias_maps_to_type_action(brain: FaraBrain) -> None:
+    """Fara emits both ``type`` and ``type_text`` in practice (#405).
+
+    Before the alias was added, ``type_text`` fell through to the
+    unknown-action WAIT branch and any form-fill flow halted via the
+    loop detector after ~2 typed fields.
+    """
+    action = _parse_tool(brain, _fara_tool_call("type_text", text="alice"))
+    assert action.action_type == ActionType.TYPE
+    assert action.params == {"text": "alice"}
+
+
 def test_key_maps_to_key_press(brain: FaraBrain) -> None:
     action = _parse_tool(brain, _fara_tool_call("key", text="Return"))
     assert action.action_type == ActionType.KEY_PRESS
     assert action.params == {"keys": "Return"}
+
+
+def test_press_key_alias_maps_to_key_press(brain: FaraBrain) -> None:
+    action = _parse_tool(brain, _fara_tool_call("press_key", text="Tab"))
+    assert action.action_type == ActionType.KEY_PRESS
+    assert action.params == {"keys": "Tab"}
+
+
+def test_submit_action_maps_to_return_key_press(brain: FaraBrain) -> None:
+    """``submit`` is Fara's idiom for form-submit; emit Return."""
+    action = _parse_tool(brain, _fara_tool_call("submit"))
+    assert action.action_type == ActionType.KEY_PRESS
+    assert action.params == {"keys": "Return"}
+    assert "submit" in action.reasoning
+
+
+def test_enter_action_maps_to_return_key_press(brain: FaraBrain) -> None:
+    action = _parse_tool(brain, _fara_tool_call("enter"))
+    assert action.action_type == ActionType.KEY_PRESS
+    assert action.params == {"keys": "Return"}
+
+
+def test_submit_respects_explicit_key_override(brain: FaraBrain) -> None:
+    """A planner adapter that emits ``submit(text="Tab")`` should be
+    honoured rather than blindly forced to Return."""
+    action = _parse_tool(brain, _fara_tool_call("submit", text="Tab"))
+    assert action.action_type == ActionType.KEY_PRESS
+    assert action.params == {"keys": "Tab"}
 
 
 def test_key_list_is_joined(brain: FaraBrain) -> None:


### PR DESCRIPTION
Closes #405.

## Problem

`FaraBrain._action_from_fara` only matched literal `action="type"`. Fara emits both `type` and `type_text` in practice depending on training-data variance, and on a real form-fill plan (reported in #405) `type_text` took over after the first 2-3 keyboard turns. Every `type_text` fell through to the unknown-action WAIT branch, the loop detector tripped, and the run terminated `success=False`.

## Fix

- **Primary**: treat `type` and `type_text` as aliases — both produce `Action(ActionType.TYPE, {"text": <text>})`.
- **Audit-pass** for the other obvious-mapping verbs from #405's "while in there" list:
  - `key` and `press_key` are aliases — both produce `KEY_PRESS`.
  - `submit` and `enter` map to `KEY_PRESS(Return)`, the idiomatic form-submit on both xdotool and playwright envs. Honour an explicit `text` override so `submit(text="Tab")` still works.

Intentionally **skipping** `clear_text` / `clear_and_type` for now — the semantics are ambiguous (select-all + Delete? select-all + type?) and we haven't observed Fara emit either in the wild. Better to wait for a real trace before guessing.

## Test plan

- [x] 5 new tests in `tests/test_brain_fara.py` — including the exact bug from #405 (`type_text` alias).
- [x] All 43 `test_brain_fara` tests pass (38 prior + 5 new).
- [x] `test_docs_client_isolation` still green (test code uses neutral placeholders, not the customer-banned tokens from the issue body).
- [ ] Re-run the CRM form-fill plan against the Fara Baseten deploy at `https://model-w7pr476w.api.baseten.co/production/sync/v1/chat/completions` — expect 0 `unknown action 'type_text'` warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)