### PR TITLE
fix(brain_fara): honour Fara's delete_existing_text + press_enter flags

### DIFF
--- a/src/mantis_agent/brain_fara.py
+++ b/src/mantis_agent/brain_fara.py
@@ -614,8 +614,21 @@ class FaraBrain:
             # Fara emits both verbs depending on training-data variance — the
             # documented action is ``type`` but in practice many turns come
             # through as ``type_text`` (see #405). Treat as aliases.
+            #
+            # Fara also folds two semantics into the same call via flags
+            # rather than emitting separate verbs (#405 follow-up):
+            #   * ``delete_existing_text: true`` — clear field before typing
+            #   * ``press_enter: true``         — Return after typing
+            # Both are forwarded to env executors via TYPE params; xdotool
+            # and playwright envs honour them. URL-shaped text keeps its
+            # own auto-navigate path (which already clears + submits).
             text = str(args.get("text", ""))
-            return Action(ActionType.TYPE, {"text": text})
+            params: dict = {"text": text}
+            if args.get("delete_existing_text") or args.get("clear_first"):
+                params["clear_first"] = True
+            if args.get("press_enter"):
+                params["press_enter"] = True
+            return Action(ActionType.TYPE, params)
 
         if action in ("key", "press_key"):
             keys = args.get("text") or args.get("key") or args.get("keys") or ""

--- a/src/mantis_agent/gym/playwright_env.py
+++ b/src/mantis_agent/gym/playwright_env.py
@@ -818,20 +818,35 @@ class PlaywrightGymEnv(GymEnvironment):
 
             case ActionType.TYPE:
                 text = action.params["text"]
+                # #405 follow-up: Fara folds clear-then-type and submit into
+                # the same ``type`` tool call via boolean flags. Honour the
+                # flags here; URL-shaped text keeps its own auto-navigate
+                # path (goto() already replaces the page).
+                clear_first = bool(action.params.get("clear_first", False))
+                press_enter = bool(action.params.get("press_enter", False))
                 if text.startswith("http://") or text.startswith("https://"):
                     try:
                         self._page.goto(text, wait_until="domcontentloaded", timeout=15000)
                         logger.info(f"Navigated to {text}")
                     except Exception:
                         self._page.keyboard.type(text)
-                elif self._human_speed:
-                    # Type character by character with realistic delays
-                    import random
-                    for char in text:
-                        self._page.keyboard.type(char)
-                        time.sleep(random.uniform(0.03, 0.12))  # 30-120ms per keystroke
                 else:
-                    self._page.keyboard.type(text)
+                    if clear_first:
+                        self._page.keyboard.press("Control+a")
+                        time.sleep(0.05)
+                        self._page.keyboard.press("Delete")
+                        time.sleep(0.05)
+                    if self._human_speed:
+                        # Type character by character with realistic delays
+                        import random
+                        for char in text:
+                            self._page.keyboard.type(char)
+                            time.sleep(random.uniform(0.03, 0.12))  # 30-120ms per keystroke
+                    else:
+                        self._page.keyboard.type(text)
+                    if press_enter:
+                        time.sleep(0.05)
+                        self._page.keyboard.press("Enter")
 
             case ActionType.KEY_PRESS:
                 combo = action.params["keys"]

--- a/src/mantis_agent/gym/xdotool_env.py
+++ b/src/mantis_agent/gym/xdotool_env.py
@@ -952,6 +952,14 @@ class XdotoolGymEnv(GymEnvironment):
                     logger.warning(f"type_text missing text: {action.params}")
                     return
                 text = str(text)
+                # #405 follow-up: Fara emits ``delete_existing_text`` and
+                # ``press_enter`` as flags on the same ``type`` call rather
+                # than as separate verbs. Both are translated to brain-side
+                # TYPE params (``clear_first``, ``press_enter``) and honoured
+                # here by the env. URL-shaped text keeps its own
+                # auto-navigate path (which already does its own clear+Enter).
+                clear_first = bool(action.params.get("clear_first", False))
+                press_enter = bool(action.params.get("press_enter", False))
                 if text.startswith("http://") or text.startswith("https://"):
                     self._xdotool("key", "ctrl+l")
                     time.sleep(0.5)
@@ -961,7 +969,15 @@ class XdotoolGymEnv(GymEnvironment):
                     time.sleep(0.3)
                     self._xdotool("key", "Return")
                 else:
+                    if clear_first:
+                        self._xdotool("key", "ctrl+a")
+                        time.sleep(0.1)
+                        self._xdotool("key", "Delete")
+                        time.sleep(0.1)
                     self._xdotool_type(text)
+                    if press_enter:
+                        time.sleep(0.1)
+                        self._xdotool("key", "Return")
 
             case ActionType.KEY_PRESS:
                 keys = action.params.get("keys") or action.params.get("key") or ""

--- a/tests/test_brain_fara.py
+++ b/tests/test_brain_fara.py
@@ -223,6 +223,75 @@ def test_type_text_alias_maps_to_type_action(brain: FaraBrain) -> None:
     assert action.params == {"text": "alice"}
 
 
+def test_type_with_delete_existing_text_sets_clear_first(brain: FaraBrain) -> None:
+    """Fara folds clear-then-type into one tool call via flag."""
+    action = _parse_tool(
+        brain,
+        _fara_tool_call("type", text="hello", delete_existing_text=True),
+    )
+    assert action.action_type == ActionType.TYPE
+    assert action.params["text"] == "hello"
+    assert action.params["clear_first"] is True
+
+
+def test_type_with_press_enter_sets_press_enter(brain: FaraBrain) -> None:
+    """Fara folds form-submit into the type call via flag."""
+    action = _parse_tool(
+        brain,
+        _fara_tool_call("type", text="hello", press_enter=True),
+    )
+    assert action.action_type == ActionType.TYPE
+    assert action.params["text"] == "hello"
+    assert action.params["press_enter"] is True
+
+
+def test_type_with_both_clear_and_enter_sets_both_flags(brain: FaraBrain) -> None:
+    """The CRM-login shape: clear field, type credential, submit form."""
+    action = _parse_tool(
+        brain,
+        _fara_tool_call(
+            "type", text="hello",
+            delete_existing_text=True, press_enter=True,
+        ),
+    )
+    assert action.params["clear_first"] is True
+    assert action.params["press_enter"] is True
+
+
+def test_type_without_flags_omits_them(brain: FaraBrain) -> None:
+    """Plain type calls should not carry the flags — keeps the action
+    minimal and avoids env executors doing surprise clears."""
+    action = _parse_tool(brain, _fara_tool_call("type", text="hello"))
+    assert "clear_first" not in action.params
+    assert "press_enter" not in action.params
+
+
+def test_type_with_falsy_flags_omits_them(brain: FaraBrain) -> None:
+    """Fara's smoke turn included delete_existing_text=true alongside
+    explicit press_enter=false. The falsy flag should not propagate as
+    a no-op param to keep the action representation tight."""
+    action = _parse_tool(
+        brain,
+        _fara_tool_call(
+            "type", text="hello",
+            delete_existing_text=False, press_enter=False,
+        ),
+    )
+    assert "clear_first" not in action.params
+    assert "press_enter" not in action.params
+
+
+def test_type_clear_first_alias_is_honoured(brain: FaraBrain) -> None:
+    """If a fine-tune emits the param name ``clear_first`` directly,
+    the brain accepts it too — saves a future patch when we observe a
+    different verb-args shape."""
+    action = _parse_tool(
+        brain,
+        _fara_tool_call("type", text="hello", clear_first=True),
+    )
+    assert action.params["clear_first"] is True
+
+
 def test_key_maps_to_key_press(brain: FaraBrain) -> None:
     action = _parse_tool(brain, _fara_tool_call("key", text="Return"))
     assert action.action_type == ActionType.KEY_PRESS

--- a/tests/test_gym_coordinates.py
+++ b/tests/test_gym_coordinates.py
@@ -137,3 +137,62 @@ def test_xdotool_env_current_url_reads_active_tab(monkeypatch):
 
     # First non-internal tab wins; chrome:// URLs are filtered.
     assert env.current_url == "https://crm.example.com/leads/42"
+
+
+# ── TYPE flags: clear_first + press_enter (#405 follow-up) ─────────────────
+
+
+def test_xdotool_type_plain_does_not_clear_or_submit():
+    """Default TYPE behaviour stays minimal — no clear, no Enter — so an
+    incremental field-fill (e.g. autocomplete) isn't accidentally
+    submitted on every keystroke turn."""
+    env = _XdotoolRecorder(viewport=(1280, 720))
+    env.step(Action(ActionType.TYPE, {"text": "hello"}))
+
+    kinds = [c[0] for c in env.calls]
+    assert "type" in kinds
+    assert "key" not in kinds  # no ctrl+a, no Delete, no Return
+
+
+def test_xdotool_type_with_clear_first_emits_ctrl_a_delete():
+    """clear_first=True must wipe the field before typing — matches
+    Fara's ``delete_existing_text: true`` semantics."""
+    env = _XdotoolRecorder(viewport=(1280, 720))
+    env.step(Action(ActionType.TYPE, {"text": "hello", "clear_first": True}))
+
+    # Find the type and the preceding keys
+    type_idx = next(i for i, c in enumerate(env.calls) if c[0] == "type")
+    pre_type = env.calls[:type_idx]
+    pre_keys = [c[1] for c in pre_type if c[0] == "key"]
+    assert "ctrl+a" in pre_keys
+    assert "Delete" in pre_keys
+
+
+def test_xdotool_type_with_press_enter_emits_return_after_text():
+    """press_enter=True must submit after typing — matches Fara's
+    ``press_enter: true`` semantics. The Return must come after the
+    type call, not before."""
+    env = _XdotoolRecorder(viewport=(1280, 720))
+    env.step(Action(ActionType.TYPE, {"text": "hello", "press_enter": True}))
+
+    type_idx = next(i for i, c in enumerate(env.calls) if c[0] == "type")
+    post_type = env.calls[type_idx + 1:]
+    post_keys = [c[1] for c in post_type if c[0] == "key"]
+    assert "Return" in post_keys
+
+
+def test_xdotool_type_clear_first_then_text_then_enter_in_order():
+    """The full CRM-login shape: clear, type, submit — all three in
+    sequence, with type sandwiched between the clear and the Enter."""
+    env = _XdotoolRecorder(viewport=(1280, 720))
+    env.step(Action(ActionType.TYPE, {
+        "text": "secret", "clear_first": True, "press_enter": True,
+    }))
+
+    type_idx = next(i for i, c in enumerate(env.calls) if c[0] == "type")
+    pre_keys = [c[1] for c in env.calls[:type_idx] if c[0] == "key"]
+    post_keys = [c[1] for c in env.calls[type_idx + 1:] if c[0] == "key"]
+
+    assert "ctrl+a" in pre_keys
+    assert "Delete" in pre_keys
+    assert "Return" in post_keys


### PR DESCRIPTION
Follow-up to #405. Live-traced against the production Fara Baseten deploy: Fara folds two semantics into the same \`type\` tool call rather than emitting separate verbs:

\`\`\`json
{
  "action": "type",
  "coordinate": [103, 257],
  "text": "alice",
  "press_enter": false,
  "delete_existing_text": true
}
\`\`\`

Before this fix the brain extracted \`text\` only. **Side-effects**:
- \`delete_existing_text: true\` ignored → stale field content stays mixed with the new value on any pre-populated input.
- \`press_enter: true\` ignored → form not submitted; the model has to retry on the next turn, often tripping the loop detector.

## Fix shape

Forward intent through to env executors via two new \`TYPE\` params (\`clear_first\`, \`press_enter\`). The brain translates Fara's flag names; \`xdotool_env\` and \`playwright_env\` honour the flags:

| Env | \`clear_first\` | \`press_enter\` |
|---|---|---|
| xdotool | \`ctrl+a\` + \`Delete\` **before** the type | \`Return\` **after** the type |
| playwright | \`Control+a\` + \`Delete\` keyboard presses | \`Enter\` |

URL-shaped text keeps its own auto-navigate path (which already clears + submits via the address bar) — flags are inert there.

The brain also accepts \`clear_first\` as a direct param name in case a fine-tune emits that verb shape; falsy flags don't propagate into params to keep the action representation tight.

## Why I chose to extend ActionType.TYPE params instead of decomposing into multiple actions

The brain returns one \`Action\` per \`think()\` call. Splitting clear-type-submit into three turns would be:
- 3× the inference latency for what is conceptually one user-visible operation.
- Brittle if the brain re-evaluates the screen between turns (e.g. the field looks "different enough" after clearing that the model picks a different action than typing).

Keeping it as one Action with intent flags lets the env do the right deterministic key-sequence atomically.

## Test plan

- [x] 6 brain tests (\`tests/test_brain_fara.py\`) covering the flag translation and the falsy-omit contract.
- [x] 4 env tests (\`tests/test_gym_coordinates.py\`) covering the xdotool key-sequence: plain type stays minimal, \`clear_first\` emits \`ctrl+a\`+\`Delete\` **before** the type, \`press_enter\` emits \`Return\` **after**, and the combined CRM-login shape preserves order.
- [x] All 73 \`brain_fara\` + \`gym_coordinates\` + \`docs_client_isolation\` tests pass.
- [ ] Re-run a form-fill plan against the production Fara deployment — expect a single \`type\` turn per field, ending with Return rather than a retry-on-next-turn loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)