### PR TITLE
fix(form): feed tag-guard refusals back as recovery hints

### DIFF
--- a/src/mantis_agent/gym/recovery_hints.py
+++ b/src/mantis_agent/gym/recovery_hints.py
@@ -28,6 +28,42 @@ from typing import Any
 _HINT_BLOCK_HEADER = "\n\nRECOVERY HINTS from previous failed attempts:\n"
 
 
+def add_hint(runner: Any, step_index: int, hint: str) -> None:
+    """Append ``hint`` to the recovery-hint list for ``step_index``.
+
+    Producer-side counterpart to :func:`get_hint_block`. Used by code
+    paths that detect a recoverable failure *without* going through the
+    agentic-recovery loop — the canonical case under #411 is the form
+    handler's tag-guard refusing a coord pick whose elementFromPoint is
+    a BUTTON/A/DIV rather than an input. The next attempt's search
+    prompt picks up the hint via :func:`get_hint_block`, so the LLM
+    stops re-picking the same wrong coordinate.
+
+    Defensive on storage state: tests / hosts that hand the runner a
+    ``MagicMock`` already auto-create attributes as Mocks rather than
+    real dicts. Reassigning the attribute when it's not a real dict
+    keeps the helper non-fatal on mocked runners — important because
+    this lives on a hot path inside the form handler.
+
+    Empty / falsy hints are dropped silently — callers can call
+    unconditionally without guarding.
+    """
+    if not hint:
+        return
+    hints_dict = getattr(runner, "_recovery_hints", None)
+    if not isinstance(hints_dict, dict):
+        try:
+            runner._recovery_hints = {}
+        except Exception:  # noqa: BLE001 — frozen test stubs
+            return
+        hints_dict = runner._recovery_hints
+    stored = hints_dict.get(step_index)
+    if not isinstance(stored, list):
+        stored = []
+        hints_dict[step_index] = stored
+    stored.append(str(hint))
+
+
 def get_hint_block(runner: Any, step_index: int) -> str:
     """Return a multi-line hint block to splice into a handler's
     prompt, or ``""`` if no hints are stored for this step.
@@ -71,4 +107,4 @@ def count(runner: Any, step_index: int) -> int:
     return sum(1 for h in stored if h)
 
 
-__all__ = ["get_hint_block", "has_hints", "count"]
+__all__ = ["add_hint", "get_hint_block", "has_hints", "count"]

--- a/src/mantis_agent/gym/step_handlers/form.py
+++ b/src/mantis_agent/gym/step_handlers/form.py
@@ -236,11 +236,28 @@ class ClaudeGuidedFormHandler:
             if isinstance(aliases, str):
                 aliases = [aliases]
             aliases = [str(a).strip() for a in aliases if str(a).strip()]
-            search_intent = (
+            base_intent = (
                 f"Click the input field labelled '{label}' so we can type into it"
                 if label
                 else step.intent
             )
+            # #411: splice any accumulated recovery hints into the
+            # search prompt — same protocol the submit handler uses
+            # (form.py:428). The producer is the tag-guard below: when
+            # a previous attempt's coord-pick landed on a BUTTON/A/DIV
+            # we record where, and the LLM is told to avoid that
+            # rectangle on the next try. Without this, Claude vision
+            # on lu.ma's "Your Info" modal keeps returning the same
+            # (618, 587) coord that overlaps the Register button.
+            from .. import recovery_hints as _hints
+            hint_block = _hints.get_hint_block(runner, index)
+            search_intent = base_intent + hint_block if hint_block else base_intent
+            if hint_block:
+                logger.warning(
+                    "  [claude-form] fill_field '%s' retry — applying %d "
+                    "recovery hint(s) from prior attempts",
+                    label[:30], _hints.count(runner, index),
+                )
             target = target_provider.find_form_target(
                 screenshot,
                 search_intent,
@@ -365,6 +382,28 @@ class ClaudeGuidedFormHandler:
                     "(%d, %d) — elementFromPoint=%s is not "
                     "input-shaped (would dismiss form / mis-submit)",
                     x, y, tag_name,
+                )
+                # #411: feed the exact failure back as a recovery hint
+                # so the next attempt's find_form_target doesn't re-pick
+                # the same wrong coordinate. The Lu.ma "Your Info" modal
+                # is the canonical reproducer: Claude vision keeps
+                # returning the Register button at (618, 587) for the
+                # Title field; without this hint, every retry returns
+                # the same coord and burns the step budget on identical
+                # tag-guard refusals.
+                avoid_label = label or step.intent[:40]
+                _hints.add_hint(
+                    runner, index,
+                    f"Your previous coordinate pick for "
+                    f"'{avoid_label}' was ({x}, {y}), which "
+                    f"document.elementFromPoint resolves to a "
+                    f"<{tag_name}> element (a button or container, "
+                    f"NOT an input). DO NOT return coordinates inside "
+                    f"the box ({max(0, x - 40)}, {max(0, y - 20)}) to "
+                    f"({x + 40}, {y + 20}). The input you want is "
+                    f"almost certainly ABOVE that point — find the "
+                    f"text-input rectangle adjacent to the label and "
+                    f"return its center."
                 )
                 return StepResult(
                     step_index=index, intent=step.intent, success=False,

--- a/tests/test_form_handler.py
+++ b/tests/test_form_handler.py
@@ -316,6 +316,87 @@ def test_fill_field_tag_guard_allows_input_at_click_point(monkeypatch):
     assert result.data == "fill:Email"
 
 
+def test_fill_field_tag_guard_records_recovery_hint(monkeypatch):
+    """#411: when the tag-guard refuses a BUTTON pick, the bad coord +
+    tag must land on ``runner._recovery_hints[index]`` so the *next*
+    attempt's find_form_target prompt tells the LLM not to re-pick
+    the same wrong rectangle. Without this hint, Claude on lu.ma's
+    'Your Info' modal keeps returning (618, 587) for the Title field
+    on every retry and burns the step budget on identical refusals."""
+    monkeypatch.setattr("mantis_agent.gym.step_handlers.form.time.sleep", lambda *_: None)
+
+    runner = _FakeRunner()
+    extractor = MagicMock()
+    extractor.find_form_target.return_value = {"x": 618, "y": 587}
+    env = MagicMock()
+    env.cdp_evaluate = MagicMock(return_value={"tag": "BUTTON", "contentEditable": False})
+    ctx = _ctx(runner, env=env, extractor=extractor)
+
+    step = MicroIntent(
+        intent="Fill title", type="fill_field",
+        params={"label": "What is your title?", "value": "AI Product Tester"},
+    )
+    handler = ClaudeGuidedFormHandler(runner)
+    result = handler.execute(step, ctx)
+
+    assert result.success is False
+    assert result.data == "form_target_not_input:BUTTON"
+    # The hint must be recorded on the runner — keyed by the step
+    # index supplied via ctx.state["index"] (= 5 in _ctx).
+    hints = getattr(runner, "_recovery_hints", {})
+    assert 5 in hints
+    body = "\n".join(hints[5])
+    # Hint mentions the rejected coord, the tag, and gives the LLM
+    # something specific to avoid + something specific to look for.
+    assert "(618, 587)" in body
+    assert "<BUTTON>" in body
+    assert "What is your title?" in body
+    # Bounding rectangle around the rejected coord is in the hint so
+    # the LLM has a concrete region to steer away from.
+    assert "(578, 567)" in body or "(578, 567)" in body  # x-40, y-20
+
+
+def test_fill_field_tag_guard_retry_picks_up_hint(monkeypatch):
+    """End-to-end: a prior tag-guard refusal stored a hint. On the
+    next call to ``execute`` for the same step (= same ctx index),
+    the search prompt passed to find_form_target carries the hint.
+    Locks the consumer side of the hint loop so a future refactor
+    doesn't silently drop the recovery feedback."""
+    monkeypatch.setattr("mantis_agent.gym.step_handlers.form.time.sleep", lambda *_: None)
+    monkeypatch.setattr(
+        "mantis_agent.gym.step_handlers.form.random.uniform",
+        lambda a, b: a,
+    )
+
+    runner = _FakeRunner()
+    # Seed the runner with a hint from a previous failed attempt.
+    runner._recovery_hints = {5: [
+        "Your previous coordinate pick for 'Title' was (618, 587), "
+        "which document.elementFromPoint resolves to a <BUTTON> "
+        "element. DO NOT return coordinates inside the box (578, 567) "
+        "to (658, 607). The input you want is almost certainly ABOVE …"
+    ]}
+    extractor = MagicMock()
+    # Second attempt now finds the *correct* coord above the button.
+    extractor.find_form_target.return_value = {"x": 400, "y": 480}
+    env = MagicMock()
+    env.cdp_evaluate = MagicMock(return_value={"tag": "INPUT", "contentEditable": False})
+    ctx = _ctx(runner, env=env, extractor=extractor)
+
+    step = MicroIntent(
+        intent="Fill title", type="fill_field",
+        params={"label": "Title", "value": "AI Product Tester"},
+    )
+    result = ClaudeGuidedFormHandler(runner).execute(step, ctx)
+
+    assert result.success is True
+    # The hint flowed into find_form_target's search_intent — the
+    # extractor saw the augmented prompt, not the bare label.
+    sent_intent = extractor.find_form_target.call_args.args[1]
+    assert "RECOVERY HINTS" in sent_intent
+    assert "(618, 587)" in sent_intent
+
+
 def test_fill_field_tag_guard_allows_contenteditable_div(monkeypatch):
     """Rich text editors (Quill, ProseMirror, …) render as ``<div
     contenteditable="true">``. The tag-guard must accept them — the

--- a/tests/test_recovery_hints.py
+++ b/tests/test_recovery_hints.py
@@ -89,6 +89,62 @@ def test_count_zero_on_missing_attr() -> None:
     assert recovery_hints.count(SimpleNamespace(), 5) == 0
 
 
+# ── add_hint (producer-side, #411) ────────────────────────────────────────
+
+
+def test_add_hint_creates_dict_on_first_call() -> None:
+    """A runner that didn't have ``_recovery_hints`` before gets a
+    dict autopopulated. The next ``get_hint_block`` call sees the hint."""
+    runner = SimpleNamespace()
+    recovery_hints.add_hint(runner, 3, "avoid (618, 587)")
+    assert recovery_hints.has_hints(runner, 3) is True
+    assert "avoid (618, 587)" in recovery_hints.get_hint_block(runner, 3)
+
+
+def test_add_hint_appends_in_order() -> None:
+    """Multiple add_hint calls preserve insertion order so the model
+    sees the most recent failure last."""
+    runner = SimpleNamespace()
+    recovery_hints.add_hint(runner, 0, "first")
+    recovery_hints.add_hint(runner, 0, "second")
+    recovery_hints.add_hint(runner, 0, "third")
+    block = recovery_hints.get_hint_block(runner, 0)
+    assert block.index("first") < block.index("second") < block.index("third")
+
+
+def test_add_hint_empty_string_is_no_op() -> None:
+    """Empty / falsy hints are dropped silently — callers can call
+    ``add_hint(...)`` unconditionally without guarding for the empty
+    case."""
+    runner = SimpleNamespace()
+    recovery_hints.add_hint(runner, 0, "")
+    recovery_hints.add_hint(runner, 0, None)  # type: ignore[arg-type]
+    assert recovery_hints.has_hints(runner, 0) is False
+
+
+def test_add_hint_replaces_non_dict_state() -> None:
+    """If ``_recovery_hints`` is a MagicMock (test runner stub),
+    add_hint reassigns it to a real dict so subsequent calls work.
+    Without this the hint silently dropped on mocked runners."""
+    runner = MagicMock()
+    runner._recovery_hints = MagicMock()  # not a dict
+    recovery_hints.add_hint(runner, 1, "real hint")
+    # Reassignment happened — _recovery_hints is now a dict.
+    assert isinstance(runner._recovery_hints, dict)
+    assert "real hint" in recovery_hints.get_hint_block(runner, 1)
+
+
+def test_add_hint_replaces_non_list_step_slot() -> None:
+    """Pre-existing dict but the step's slot got some non-list
+    value — coerce to a fresh list rather than crash."""
+    runner = SimpleNamespace(_recovery_hints={0: "stale string"})  # type: ignore[arg-type]
+    recovery_hints.add_hint(runner, 0, "new hint")
+    block = recovery_hints.get_hint_block(runner, 0)
+    assert "new hint" in block
+    # The stale value is gone — only the new hint survives.
+    assert "stale string" not in block
+
+
 # ── Wire-in: Holo3StepHandler splices hints into the inner task ──────────
 
 


### PR DESCRIPTION
## Summary

Closes the retry loop the #404 tag-guard left open. On lu.ma's "Your Info" modal, Claude vision's `find_form_target` consistently returns coordinates that `document.elementFromPoint` resolves to a `<BUTTON>` (the Register submit, immediately below the Title input). The tag-guard correctly refuses the click, but the runner re-attempts the step with a fresh search and Claude returns *the same wrong coordinate* — 9 identical refusals before halting.

This PR feeds the refusal back as a recovery hint so the next attempt's prompt explicitly tells the model:

> Your previous coordinate pick for 'What is your title?' was (618, 587), which document.elementFromPoint resolves to a `<BUTTON>` element (a button or container, NOT an input). DO NOT return coordinates inside the box (578, 567) to (658, 607). The input you want is almost certainly ABOVE that point — find the text-input rectangle adjacent to the label and return its center.

### What changed

- **`recovery_hints.add_hint(runner, index, hint)`** — producer-side helper alongside the existing `get_hint_block` / `has_hints` / `count` consumers. Defensive on MagicMock runners + non-list step slots so it's safe to call from the hot path inside the form handler.
- **`fill_field`'s tag-guard refusal path** — appends a hint specifying rejected coord, resolved tag, and bounding box to avoid. Returns `form_target_not_input:{TAG}` as before so the outer recovery loop still sees a failure.
- **`fill_field`'s search prompt** — splices the accumulated hint block in, same protocol `submit` has used since #224's follow-up. Previously hints were being collected but never consumed by fill_field steps.

### What this fixes (and what it doesn't)

- ✅ Stops the runner from burning 9 identical tag-guard refusals on the same coordinate before halting.
- ✅ Generalises: any form whose layout makes Claude vision keep mis-picking a button gets one shot at a corrected coord from the LLM rather than three blind retries.
- ❌ Doesn't fix the *first* attempt's mis-grounding — that's the underlying #411 issue (Claude vision on tightly-packed forms). Will need separate prompt-engineering work or a Holo3-quality model swap.

The empirical Holo3 cross-check from issue #411 (run `20260515_033625_31a4d5c3`) showed Holo3 grounding lu.ma's "Register" button completely off — failed harder than Claude. Sticking with Claude as default; this PR's hint-feedback is the cheap intermediate win.

### Test plan

- [x] `tests/test_recovery_hints.py` — 5 new tests for `add_hint`: dict autocreate, append order, empty no-op, non-dict reassignment, non-list slot replacement.
- [x] `tests/test_form_handler.py` — 2 new tests for the form-handler loop: tag-guard refusal records a hint with the right content (coord, tag, avoid-box, label); a seeded hint flows into the next `find_form_target` call's search prompt.
- [x] All 108 existing form-handler tests still pass.
- [ ] Modal redeploy + rerun `plans/luma` to confirm fill_field 4 (Title) recovers on retry instead of halting after 9 refusals.

Refs #411 investigation #2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)