### PR TITLE
fix(cdp): translate screen y → viewport y before elementFromPoint

### DIFF
--- a/src/mantis_agent/gym/som_dispatch.py
+++ b/src/mantis_agent/gym/som_dispatch.py
@@ -50,8 +50,8 @@ logger = logging.getLogger(__name__)
 
 
 def probe_element_tag_at(env: Any, x: int, y: int) -> dict | None:
-    """Best-effort: report the tag and contentEditable state of the
-    element at viewport (x, y) via CDP ``Runtime.evaluate``.
+    """Best-effort: report the tag + contentEditable of the element at
+    SCREEN (x, y) — the same coordinates xdotool would click.
 
     Returns ``None`` when:
 
@@ -67,10 +67,19 @@ def probe_element_tag_at(env: Any, x: int, y: int) -> dict | None:
     Used by :class:`~.step_handlers.form.ClaudeGuidedFormHandler` to
     refuse a ``fill_field`` click when the element at the chosen point
     is a button / backdrop / modal close-X — clicking those dismisses
-    the form instead of focusing an input (the lu.ma host-question
-    modal failure pattern: Claude returns coordinates near the title
-    label, ``elementFromPoint`` returns the dim overlay above it, the
-    SoM click hits the overlay's outside-to-close handler).
+    the form instead of focusing an input.
+
+    Coordinate system note (#413): caller passes screen-space (x, y) —
+    the same numbers xdotool will receive. But ``document.element
+    FromPoint`` takes CSS-viewport coords (origin = top-left of the
+    page area, BELOW the browser's tabs + URL bar). Without the
+    chrome-offset subtraction below, a tag-guard call for a Title
+    input visually at screen-y=588 would resolve to whatever element
+    sits at viewport-y=588 instead — which on Lu.ma's modal is the
+    Register button ~85 px below the input. The runner then refused
+    correct clicks as ``form_target_not_input:BUTTON``. Fix: subtract
+    ``window.outerHeight - window.innerHeight`` so screen-y is
+    translated into viewport-y before the elementFromPoint call.
 
     Tests that don't wire CDP get ``None`` and the caller falls through
     to legacy behaviour — no breakage on the existing form-handler
@@ -81,7 +90,17 @@ def probe_element_tag_at(env: Any, x: int, y: int) -> dict | None:
         return None
     js = (
         "(() => {"
-        f"const el = document.elementFromPoint({int(x)}, {int(y)});"
+        # screen-y → viewport-y by subtracting the chrome offset.
+        # ``outerHeight - innerHeight`` is the canonical browser
+        # measurement that covers tabs + URL bar (+ OS window
+        # decorations when present). On Xvfb without a WM this is
+        # just Chrome's tabs+URL bar (~85 px); on a desktop it
+        # additionally includes the OS title bar. ``Math.max(0, …)``
+        # guards against headless modes that report 0 chrome.
+        "const chromeH = Math.max(0, window.outerHeight - window.innerHeight);"
+        f"const vx = {int(x)};"
+        f"const vy = {int(y)} - chromeH;"
+        "const el = document.elementFromPoint(vx, vy);"
         "if (!el) return null;"
         "return {"
         "tag: (el.tagName || '').toUpperCase(),"

--- a/src/mantis_agent/gym/xdotool_env.py
+++ b/src/mantis_agent/gym/xdotool_env.py
@@ -479,7 +479,7 @@ class XdotoolGymEnv(GymEnvironment):
         return (payload.get("result") or {}).get("value")
 
     def cdp_click_at_point(self, x: int, y: int) -> bool:
-        """SoM-anchored click: find the element at (x, y) and call
+        """SoM-anchored click: find the element at SCREEN (x, y) and call
         ``el.click()`` via Runtime.evaluate.
 
         Why this isn't just xdotool: xdotool sends X-level mouse events
@@ -496,13 +496,26 @@ class XdotoolGymEnv(GymEnvironment):
         click was dispatched successfully. Returns ``False`` if CDP is
         unreachable, no element exists at the point, or the JS threw.
         Caller is expected to fall back to xdotool on ``False``.
+
+        Coordinate system note (#413): caller passes screen-space
+        (x, y) — the same numbers xdotool would click. But
+        ``document.elementFromPoint`` uses CSS-viewport coords (origin
+        = top-left of the page area, BELOW the browser tabs + URL
+        bar). Subtract ``window.outerHeight - window.innerHeight``
+        so the screen-y is translated into viewport-y before the
+        elementFromPoint call. Without this, the SoM ``el.click()``
+        fires on whatever element sits ~85 px below the visual click
+        target — the symptom that motivated the tag-guard fix in #413.
         """
         # Use a self-executing function so the eval result is a clean
         # boolean. ``elementFromPoint`` returns ``null`` for points
         # outside the viewport — that surfaces as ``False`` here.
         js = (
             "(() => {"
-            f"const el = document.elementFromPoint({int(x)}, {int(y)});"
+            "const chromeH = Math.max(0, window.outerHeight - window.innerHeight);"
+            f"const vx = {int(x)};"
+            f"const vy = {int(y)} - chromeH;"
+            "const el = document.elementFromPoint(vx, vy);"
             "if (!el) return false;"
             "try { el.click(); return true; }"
             "catch (e) { return false; }"

--- a/tests/test_microrunner_som_dispatch.py
+++ b/tests/test_microrunner_som_dispatch.py
@@ -159,6 +159,51 @@ def test_probe_element_tag_at_normalises_tag_and_contenteditable() -> None:
     assert out2 == {"tag": "DIV", "contentEditable": True}
 
 
+def test_probe_element_tag_at_subtracts_chrome_offset_in_js(monkeypatch) -> None:
+    """#413: caller passes screen coordinates (matching what xdotool
+    will click), but ``document.elementFromPoint`` uses CSS-viewport
+    coordinates. The JS expression sent through CDP must subtract the
+    chrome offset (``outerHeight - innerHeight``) so the tag-guard
+    reads the same element xdotool will hit.
+
+    Lock the JS shape literally — a future refactor that drops the
+    offset would silently bring back the lu.ma tag-guard false-
+    positive (#413 reproducer)."""
+    env = _CdpEvalEnv(result={"tag": "INPUT", "contentEditable": False})
+    probe_element_tag_at(env, 618, 588)
+    assert len(env.calls) == 1
+    js = env.calls[0]
+    # Both the chrome-offset computation and the elementFromPoint
+    # call with the corrected viewport y must be in the script.
+    assert "window.outerHeight - window.innerHeight" in js
+    assert "document.elementFromPoint" in js
+    # Y is subtracted by chromeH (the variable name we used in
+    # the JS); literal subtraction would also be acceptable but
+    # using the variable keeps the math overflow-safe.
+    assert "- chromeH" in js
+
+
+def test_cdp_click_at_point_subtracts_chrome_offset_in_js() -> None:
+    """#413 sibling: the SoM ``el.click()`` dispatcher in
+    ``xdotool_env.cdp_click_at_point`` shares the same screen-vs-
+    viewport bug. Today SoM defaults to off so the bug hasn't bitten
+    production traffic, but enabling SoM with the old JS would have
+    clicked the wrong element (typically the button 85 px below the
+    intended target). Pin the offset in the JS literally."""
+    from mantis_agent.gym.xdotool_env import XdotoolGymEnv
+    instance = XdotoolGymEnv.__new__(XdotoolGymEnv)
+
+    captured: list[str] = []
+    instance.cdp_evaluate = lambda expr: captured.append(expr) or True  # type: ignore[assignment]
+    instance.cdp_click_at_point(618, 588)
+
+    assert len(captured) == 1
+    js = captured[0]
+    assert "window.outerHeight - window.innerHeight" in js
+    assert "document.elementFromPoint" in js
+    assert "- chromeH" in js
+
+
 def test_is_input_like_allows_unknown_when_cdp_unavailable() -> None:
     """``None`` tag_info means CDP couldn't probe — don't block on
     inconclusive evidence. Preserves legacy behaviour where the guard


### PR DESCRIPTION
## Summary

`probe_element_tag_at` (the #404 tag-guard) and `cdp_click_at_point` (SoM dispatch) both pass screen-space coordinates to `document.elementFromPoint`, which expects CSS-viewport coordinates. On Xvfb the offset between the two spaces is ~85 px (Chrome tabs + URL bar). Every tag-guard probe was reading the DOM ~85 px lower than where xdotool's click would actually land — causing false-positive `form_target_not_input:BUTTON` refusals when the actual click would have been correct.

## Reproducer with ground truth

Pulled `/data/screenshots/claude_debug/claude_form.png` from run `20260515_050308_ea9463ea`:

- Claude returned `{"x": 618, "y": 588, "action": "type", "label": "Title input field"}`.
- The screenshot confirms `(618, 588)` is the centre of the empty Title input.
- The Register button sits at screen-y ≈ 657 → viewport-y ≈ 572–615.
- The tag-guard's `elementFromPoint(618, 588)` was checking viewport-y=588 — inside the button's bounds — and refused the click.
- xdotool clicking screen-y=588 would have correctly hit the input. The recovery hint added in #412 was telling the model to *avoid coordinates that were correct*.

## Fix

```js
const chromeH = Math.max(0, window.outerHeight - window.innerHeight);
const el = document.elementFromPoint(x, y - chromeH);
```

`outerHeight - innerHeight` is the canonical browser measurement of the chrome offset (tabs + URL bar + OS title bar when present). `Math.max(0, ...)` keeps it safe in headless modes that report 0 chrome. Applied to both helpers; both have regression tests that pin the JS shape literally.

## Why Company / LinkedIn fills succeeded before this fix

Two wrongs → one right. For Company at screen-y≈410, the tag-guard called `elementFromPoint(x, 410)` checking viewport-y=410 — which corresponds to a *different* INPUT (the LinkedIn field's region in viewport space). INPUT tag → guard allowed. Then xdotool clicked screen-y=410, which landed on Company. Tag-guard was checking the wrong element entirely but happened to see INPUT, and the actual click was correct.

For Title at screen-y=588, the offset put the tag-guard inside the Register button → refused. Different luck of the layout.

## Why SoM-clicks weren't visibly broken

`routing_policy.som_for_unstructured_clicks` defaults to off — production traffic falls through to xdotool. Enabling SoM with the old JS would have made every form-fill click the *wrong* element. Fixing it here unblocks the SoM rollout path too.

## Test plan

- [x] `tests/test_microrunner_som_dispatch.py`: 2 new regression tests pin the JS literally — `outerHeight - innerHeight` and `- chromeH` must both appear in the JS sent through CDP. 25 tests total in that file, all green.
- [x] Existing form-handler tests (79 across `test_microrunner_som_dispatch.py` + `test_form_handler.py` + `test_form_intents.py`) still pass — the fix doesn't change the *contract* the tag-guard exposes, only the coordinate space it reads.
- [ ] Modal redeploy + `plans/luma` rerun: confirm step 4 (Title fill) is no longer refused on `form_target_not_input`. Whether the run reaches step 6 still depends on #411 (the underlying grounding-quality work) but this fix should at least stop the tag-guard from blocking correct clicks.

Closes #413.

🤖 Generated with [Claude Code](https://claude.com/claude-code)