### PR TITLE
feat(predict): expose live MJPEG viewer URL for detached runs

### DIFF
--- a/deploy/modal/modal_cua_server.py
+++ b/deploy/modal/modal_cua_server.py
@@ -449,7 +449,7 @@ def _run_executor(
         proxy_provider=str(task_suite.get("_proxy_provider") or ""),
         proxy_disabled=bool(task_suite.get("_proxy_disabled", False)),
     )
-    viewer_ctx, viewer_event_bus = setup_viewer(viewer)
+    viewer_ctx, viewer_event_bus, _viewer_url = setup_viewer(viewer)
 
     # ── Delegate to shared lifecycle ──
     config = TaskLoopConfig(
@@ -641,7 +641,7 @@ def _run_holo3_executor(
         objective = ObjectiveSpec.from_dict(objective_data)
         schema = ExtractionSchema.from_objective(objective)
     extractor = ClaudeExtractor(schema=schema)
-    viewer_ctx, viewer_event_bus = setup_viewer(viewer)
+    viewer_ctx, viewer_event_bus, _viewer_url = setup_viewer(viewer)
 
     # ── Micro-intent mode: run MicroPlanRunner ──
     micro_plan_data = task_suite.get("_micro_plan")
@@ -1095,7 +1095,7 @@ def _run_gemma4_cua_executor(
         proxy_provider=str(task_suite.get("_proxy_provider") or ""),
         proxy_disabled=bool(task_suite.get("_proxy_disabled", False)),
     )
-    viewer_ctx, viewer_event_bus = setup_viewer(viewer)
+    viewer_ctx, viewer_event_bus, _viewer_url = setup_viewer(viewer)
 
     # ── Delegate to shared lifecycle ──
     config = TaskLoopConfig(
@@ -1224,7 +1224,7 @@ def _run_claude_executor(
         proxy_provider=str(task_suite.get("_proxy_provider") or ""),
         proxy_disabled=bool(task_suite.get("_proxy_disabled", False)),
     )
-    viewer_ctx, viewer_event_bus = setup_viewer(viewer)
+    viewer_ctx, viewer_event_bus, _viewer_url = setup_viewer(viewer)
 
     # ── Delegate to shared lifecycle ──
     config = TaskLoopConfig(

--- a/src/mantis_agent/api_schemas.py
+++ b/src/mantis_agent/api_schemas.py
@@ -129,6 +129,15 @@ class PredictRequest(BaseModel):
     video_format: Literal["mp4", "webm", "gif"] = "mp4"
     video_fps: int = Field(default=5, ge=1, le=30)
 
+    # #416: opt in to the existing MJPEG viewer for the detached run.
+    # When True, the runtime starts ``viewer_modal._start_background``
+    # alongside ``_make_env`` and surfaces the modal.forward tunnel
+    # URL (with auth token) into ``status.json`` so a caller polling
+    # ``action=status`` gets a hot-link to the live screen. The
+    # viewer stops automatically on run termination. Distinct from
+    # ``record_video`` (post-run MP4); both can be set independently.
+    live_viewer: bool = False
+
     # #300 follow-up: per-request override for
     # :attr:`RoutingPolicy.som_for_unstructured_clicks`. ``None`` defers
     # to the deployment env (``MANTIS_ROUTE_SOM_CLICKS``). ``True`` /
@@ -217,6 +226,15 @@ class PureCUARequest(BaseModel):
     record_video: bool = False
     video_format: Literal["mp4", "webm", "gif"] = "mp4"
     video_fps: int = Field(default=5, ge=1, le=30)
+
+    # #416: opt in to the existing MJPEG viewer for the detached run.
+    # When True, the runtime starts ``viewer_modal._start_background``
+    # alongside ``_make_env`` and surfaces the modal.forward tunnel
+    # URL (with auth token) into ``status.json`` so a caller polling
+    # ``action=status`` gets a hot-link to the live screen. The
+    # viewer stops automatically on run termination. Distinct from
+    # ``record_video`` (post-run MP4); both can be set independently.
+    live_viewer: bool = False
 
     # #300 follow-up: per-request override for
     # :attr:`RoutingPolicy.som_for_unstructured_clicks`. ``None``

--- a/src/mantis_agent/baseten_server/runtime.py
+++ b/src/mantis_agent/baseten_server/runtime.py
@@ -963,6 +963,66 @@ class BasetenCUARuntime:
             reuse_session=reuse_session,
         )
 
+    def _maybe_start_live_viewer(
+        self, payload: dict[str, Any], run_id: str, env: Any = None,
+    ) -> Any:
+        """Start the MJPEG live viewer if ``payload.live_viewer`` is set (#416).
+
+        Mirrors the structure of :meth:`_maybe_record`: a no-op when the
+        feature isn't requested, an idempotent ``ensure_display_ready``
+        call before the capture thread starts so it doesn't race the
+        env's lazy Xvfb spawn, and a defensive try/except so a viewer
+        failure never breaks the run.
+
+        Returns the viewer context object (from
+        :func:`task_loop.setup_viewer`) so the caller can call
+        ``viewer_ctx.__exit__(None, None, None)`` in its ``finally``.
+        ``None`` when the feature is off / setup failed — the caller
+        should treat that as the no-viewer case.
+
+        Surfaces the tunnel URL by merging ``{"viewer_url": url}`` into
+        ``status.json`` via :meth:`_write_detached_status`. Callers
+        polling ``action=status`` see the URL on the next round-trip
+        after this method has been called.
+        """
+        if not payload.get("live_viewer"):
+            return None
+        if env is not None and hasattr(env, "ensure_display_ready"):
+            try:
+                env.ensure_display_ready()
+            except Exception as exc:  # noqa: BLE001 — viewer is best-effort
+                logger.warning(
+                    "ensure_display_ready failed before live-viewer start: %s",
+                    exc,
+                )
+        try:
+            from ..task_loop import setup_viewer
+            viewer_ctx, _event_bus, viewer_url = setup_viewer(True)
+        except Exception as exc:  # noqa: BLE001 — never fatal
+            logger.warning("live-viewer setup failed: %s", exc)
+            return None
+        if viewer_ctx is None:
+            return None
+        if viewer_url:
+            self._write_detached_status(run_id, {"viewer_url": viewer_url})
+            logger.info("live viewer ready for run %s at %s", run_id, viewer_url)
+        return viewer_ctx
+
+    def _stop_live_viewer(self, viewer_ctx: Any) -> None:
+        """Idempotent cleanup for :meth:`_maybe_start_live_viewer`.
+
+        Wrapped because ``viewer_ctx.__exit__`` can raise (the FastAPI
+        server's shutdown can race the capture thread), and we don't
+        want a viewer-cleanup error to mask whatever failed during the
+        run itself.
+        """
+        if viewer_ctx is None:
+            return
+        try:
+            viewer_ctx.__exit__(None, None, None)
+        except Exception as exc:  # noqa: BLE001 — cleanup, never fatal
+            logger.warning("live-viewer cleanup raised: %s", exc)
+
     def _maybe_record(
         self, payload: dict[str, Any], run_id: str, env: Any = None,
     ) -> tuple[Any, Any]:
@@ -1252,6 +1312,10 @@ class BasetenCUARuntime:
         if click_log is not None:
             from mantis_agent.presentation import ClickRecordingEnv
             env = ClickRecordingEnv(env, click_log)
+        # #416: start live MJPEG viewer alongside the recorder when
+        # the caller requested it. URL surfaces into status.json so
+        # the polling client can hot-link it.
+        viewer_ctx = self._maybe_start_live_viewer(payload, run_id, env=env)
 
         try:
             micro_plan = MicroPlan(domain=session_name)
@@ -1432,6 +1496,9 @@ class BasetenCUARuntime:
                     recorder.stop()
                 except Exception:
                     logger.exception("recorder stop in finally failed")
+            # #416: stop the live viewer before env close so the FastAPI
+            # capture thread can shut down cleanly while Xvfb is still up.
+            self._stop_live_viewer(viewer_ctx)
             env.close()
             if proxy_proc:
                 proxy_proc.terminate()
@@ -1462,6 +1529,9 @@ class BasetenCUARuntime:
         if click_log is not None:
             from mantis_agent.presentation import ClickRecordingEnv
             env = ClickRecordingEnv(env, click_log)
+        # #416: live MJPEG viewer alongside the recorder; same lifetime
+        # contract as in :meth:`_run_micro`.
+        viewer_ctx = self._maybe_start_live_viewer(payload, run_id, env=env)
         grounding = ClaudeGrounding(cache=self.grounding_cache)
 
         try:
@@ -1493,6 +1563,8 @@ class BasetenCUARuntime:
                     recorder.stop()
                 except Exception:
                     logger.exception("recorder stop in finally failed")
+            # #416: stop live viewer (no-op if it wasn't started).
+            self._stop_live_viewer(viewer_ctx)
 
     def run_pure_cua(self, payload: dict[str, Any]) -> dict[str, Any]:
         """Entrypoint for ``POST /v1/cua``.

--- a/src/mantis_agent/task_loop.py
+++ b/src/mantis_agent/task_loop.py
@@ -158,22 +158,29 @@ def setup_env(
     return env, proxy_proc
 
 
-def setup_viewer(enabled: bool) -> tuple[Any, Any]:
+def setup_viewer(enabled: bool) -> tuple[Any, Any, str | None]:
     """Set up the Modal viewer if enabled.
 
-    Returns (viewer_ctx, viewer_event_bus). Both None if disabled or failed.
+    Returns ``(viewer_ctx, viewer_event_bus, viewer_url)``. All three
+    are ``None`` when ``enabled`` is False or setup fails.
+
+    The third element (``viewer_url``) was added under #416 so the
+    detached ``/v1/predict`` worker can surface the live tunnel URL
+    via ``status.json``. Existing CLI callers — which previously
+    discarded the URL — should destructure all three values and can
+    ignore the third if they don't need it.
     """
     if not enabled:
-        return None, None
+        return None, None, None
     try:
         from .viewer_modal import modal_viewer
 
         viewer_ctx = modal_viewer()
-        viewer_event_bus, _viewer_url = viewer_ctx.__enter__()
-        return viewer_ctx, viewer_event_bus
+        viewer_event_bus, viewer_url = viewer_ctx.__enter__()
+        return viewer_ctx, viewer_event_bus, viewer_url
     except Exception as e:
         print(f"  Viewer failed to start: {e}")
-        return None, None
+        return None, None, None
 
 
 # ── Internal helpers ──────────────────────────────────────────────

--- a/tests/test_baseten_live_viewer.py
+++ b/tests/test_baseten_live_viewer.py
@@ -1,0 +1,193 @@
+"""Coverage for the live-viewer wiring on the detached /v1/predict path (#416).
+
+The viewer surface itself (``viewer_modal._start_background`` /
+``modal.forward`` tunnel) is exercised separately. These tests pin the
+*opt-in plumbing*:
+
+- ``PredictRequest.live_viewer`` defaults to ``False`` and accepts ``True``.
+- ``task_loop.setup_viewer`` returns the new 3-tuple shape
+  ``(ctx, event_bus, url)`` — ``None`` for each when disabled.
+- ``BasetenCUARuntime._maybe_start_live_viewer`` is a no-op when the
+  flag is absent, calls ``ensure_display_ready`` + ``setup_viewer`` +
+  ``_write_detached_status({"viewer_url": …})`` when present, and
+  swallows any exception so a viewer failure can never break the run.
+- ``_stop_live_viewer`` is idempotent and swallows exceptions.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from mantis_agent.api_schemas import PredictRequest
+
+
+# ── Schema ───────────────────────────────────────────────────────────
+
+
+def test_predict_request_defaults_live_viewer_to_false() -> None:
+    req = PredictRequest.model_validate({"plan_text": "x"})
+    assert req.live_viewer is False
+
+
+def test_predict_request_accepts_live_viewer_true() -> None:
+    req = PredictRequest.model_validate({"plan_text": "x", "live_viewer": True})
+    assert req.live_viewer is True
+
+
+# ── setup_viewer 3-tuple shape ───────────────────────────────────────
+
+
+def test_setup_viewer_disabled_returns_three_nones() -> None:
+    """Existing CLI callers were destructuring 2 values; #416 expands
+    to 3. Locks the disabled-path shape so any caller that still
+    destructures only 2 will fail loudly during import."""
+    from mantis_agent.task_loop import setup_viewer
+    ctx, bus, url = setup_viewer(False)
+    assert ctx is None and bus is None and url is None
+
+
+# ── _maybe_start_live_viewer ─────────────────────────────────────────
+
+
+def _make_runtime() -> MagicMock:
+    """Stand-in for BasetenCUARuntime that owns enough surface for
+    _maybe_start_live_viewer / _stop_live_viewer to function in
+    isolation. Only the methods the helpers actually call are wired."""
+    from mantis_agent.baseten_server.runtime import BasetenCUARuntime
+    runtime = MagicMock(spec=BasetenCUARuntime)
+    runtime._write_detached_status = MagicMock()
+    # Bind the real methods to the mock so they execute against our stubs.
+    runtime._maybe_start_live_viewer = BasetenCUARuntime._maybe_start_live_viewer.__get__(
+        runtime, BasetenCUARuntime,
+    )
+    runtime._stop_live_viewer = BasetenCUARuntime._stop_live_viewer.__get__(
+        runtime, BasetenCUARuntime,
+    )
+    return runtime
+
+
+def test_maybe_start_live_viewer_returns_none_when_flag_off() -> None:
+    """No flag → no viewer, no status write. The fast path."""
+    runtime = _make_runtime()
+    out = runtime._maybe_start_live_viewer({"live_viewer": False}, "run-1", env=MagicMock())
+    assert out is None
+    runtime._write_detached_status.assert_not_called()
+
+
+def test_maybe_start_live_viewer_missing_key_is_off() -> None:
+    """``payload.get('live_viewer')`` returning falsy → no-op."""
+    runtime = _make_runtime()
+    out = runtime._maybe_start_live_viewer({}, "run-1", env=MagicMock())
+    assert out is None
+    runtime._write_detached_status.assert_not_called()
+
+
+def test_maybe_start_live_viewer_starts_and_writes_url(monkeypatch) -> None:
+    """Happy path: flag on → ensure_display_ready called, setup_viewer
+    invoked, URL merged into status.json, viewer_ctx returned."""
+    runtime = _make_runtime()
+
+    fake_ctx = MagicMock(name="viewer_ctx")
+    fake_url = "https://tunnel.modal.run/?token=abc"
+
+    def fake_setup_viewer(enabled: bool):
+        assert enabled is True
+        return fake_ctx, MagicMock(name="event_bus"), fake_url
+
+    monkeypatch.setattr(
+        "mantis_agent.task_loop.setup_viewer", fake_setup_viewer,
+    )
+
+    env = MagicMock()
+    env.ensure_display_ready = MagicMock(return_value=":99")
+
+    out = runtime._maybe_start_live_viewer(
+        {"live_viewer": True}, "run-42", env=env,
+    )
+
+    assert out is fake_ctx
+    env.ensure_display_ready.assert_called_once()
+    # The URL must be merged into status.json — runtime callers
+    # depend on this so action=status surfaces the link.
+    runtime._write_detached_status.assert_called_once_with(
+        "run-42", {"viewer_url": fake_url},
+    )
+
+
+def test_maybe_start_live_viewer_swallows_setup_exception(monkeypatch) -> None:
+    """A failure in setup_viewer must never break the run. Return None
+    and skip the status write — caller treats as no-viewer."""
+    runtime = _make_runtime()
+
+    def boom(_enabled: bool):
+        raise RuntimeError("modal.forward unavailable")
+
+    monkeypatch.setattr("mantis_agent.task_loop.setup_viewer", boom)
+    out = runtime._maybe_start_live_viewer(
+        {"live_viewer": True}, "run-X", env=MagicMock(),
+    )
+    assert out is None
+    runtime._write_detached_status.assert_not_called()
+
+
+def test_maybe_start_live_viewer_handles_setup_returning_none(monkeypatch) -> None:
+    """If setup_viewer returns (None, None, None) (its disabled path),
+    treat as no-viewer — don't write a null URL to status."""
+    runtime = _make_runtime()
+    monkeypatch.setattr(
+        "mantis_agent.task_loop.setup_viewer",
+        lambda enabled: (None, None, None),
+    )
+    out = runtime._maybe_start_live_viewer(
+        {"live_viewer": True}, "run-Y", env=MagicMock(),
+    )
+    assert out is None
+    runtime._write_detached_status.assert_not_called()
+
+
+def test_maybe_start_live_viewer_tolerates_env_without_ensure_display() -> None:
+    """``env.ensure_display_ready`` is best-effort. Envs that don't
+    expose it (Playwright path, tests) must not break the helper."""
+    runtime = _make_runtime()
+    env_no_display = MagicMock(spec=[])  # no ensure_display_ready
+
+    def fake_setup_viewer(enabled: bool):
+        return MagicMock(), MagicMock(), "https://x"
+
+    import mantis_agent.task_loop as tl_module
+    original = tl_module.setup_viewer
+    tl_module.setup_viewer = fake_setup_viewer  # type: ignore[assignment]
+    try:
+        out = runtime._maybe_start_live_viewer(
+            {"live_viewer": True}, "run-Z", env=env_no_display,
+        )
+    finally:
+        tl_module.setup_viewer = original  # type: ignore[assignment]
+    assert out is not None
+    runtime._write_detached_status.assert_called_once()
+
+
+# ── _stop_live_viewer ────────────────────────────────────────────────
+
+
+def test_stop_live_viewer_no_op_on_none() -> None:
+    runtime = _make_runtime()
+    runtime._stop_live_viewer(None)  # must not raise
+
+
+def test_stop_live_viewer_invokes_exit_with_no_exception_info() -> None:
+    runtime = _make_runtime()
+    ctx = MagicMock()
+    runtime._stop_live_viewer(ctx)
+    ctx.__exit__.assert_called_once_with(None, None, None)
+
+
+def test_stop_live_viewer_swallows_exit_exception() -> None:
+    """Viewer cleanup failures must not mask whatever happened during
+    the run — the FastAPI capture thread occasionally races shutdown
+    and raises on __exit__. Log + swallow."""
+    runtime = _make_runtime()
+    ctx = MagicMock()
+    ctx.__exit__.side_effect = RuntimeError("capture thread already gone")
+    runtime._stop_live_viewer(ctx)  # must not raise
+    ctx.__exit__.assert_called_once()


### PR DESCRIPTION
## Summary

Today the live MJPEG viewer (`viewer_modal.py`) is fully built but gated behind a `viewer: bool = False` flag the detached `/v1/predict` path doesn't expose. Callers using the canonical Modal HTTP API can only see the recorded MP4 after the run completes — useless when a run is 14 min long and you want to debug mid-flight (run `20260515_052506_0143df24` was the motivating case).

This PR adds `live_viewer: bool` to the PredictRequest. When set, the detached worker starts the existing MJPEG server + `modal.forward` tunnel alongside the run, and surfaces the auth URL via `status.json` so a polling client gets a hot-link to the live screen.

## Plumbing

| File | Change |
|------|--------|
| `api_schemas.py` | New `PredictRequest.live_viewer: bool = False` (and on `PureCUARequest` for parity) |
| `task_loop.py` | `setup_viewer(enabled)` returns `(ctx, event_bus, url)` instead of `(ctx, event_bus)` |
| `modal_cua_server.py` | 4 callers updated to destructure 3 values (they ignore the URL today) |
| `baseten_server/runtime.py` | `_maybe_start_live_viewer` + `_stop_live_viewer` helpers; wired alongside `_maybe_record` in `_run_micro` + `_run_tasks` |

`_maybe_start_live_viewer` is structurally identical to `_maybe_record`: opt-in via payload, `env.ensure_display_ready` before capture starts (the same Xvfb race the recorder already guards against), idempotent cleanup, defensive try/except so a viewer failure never breaks the run.

URL flow:

```
PredictRequest{live_viewer:true} → _run_micro / _run_tasks
                                  → _maybe_start_live_viewer
                                  → setup_viewer(True)
                                  → modal.forward + token
                                  → _write_detached_status({"viewer_url": url})
                                  → status.json merges field
client poll action=status         ← sees viewer_url in response
```

## Test plan

- [x] **12 new tests** in `test_baseten_live_viewer.py` covering: schema defaults + accept, `setup_viewer` 3-tuple, `_maybe_start_live_viewer` (no-flag / happy path / exception swallow / null-tuple / env-without-ensure-display), `_stop_live_viewer` (None / __exit__ / exception swallow).
- [x] Existing suites that touch the changed code (`test_route_som_clicks_override.py`, `test_tenant_auth.py`, `test_run_dispatch.py`, `test_recorder_xvfb_race.py`, `test_client.py`, `test_predict_pause_resume.py`): 82 pass, no regressions.
- [ ] Full suite running locally in background.
- [ ] Manual Modal verification: submit a `plans/luma` run with `live_viewer: true`, poll `status`, hit the URL in a browser, watch the live screen.

## Out of scope (Phase 2 / follow-up)

- Docs entry under `docs/operations/` — will land separately once a real run validates the wire-up end-to-end in production.
- Multi-run dashboard / persistent viewer URL — current model is one URL per run, valid until the run terminates.
- WS / binary protocol — MJPEG at 3 fps is enough for the debugging use case.

Closes #416 Phase 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)