### PR TITLE
fix(modal): wire live_viewer URL through /v1/predict spawn path

### DIFF
--- a/deploy/modal/modal_cua_server.py
+++ b/deploy/modal/modal_cua_server.py
@@ -536,6 +536,13 @@ def _run_holo3_executor(
     frames_per_inference: int = 1,
     viewer: bool = False,
     sub_plan: bool = True,
+    # #416: when set, the executor surfaces the live-viewer URL into
+    # the API-side ``status.json`` so a polling client gets a hot-
+    # link mid-run. Both values come from ``Function.spawn``'s
+    # kwargs at the /v1/predict handler; ``viewer`` flag alone is
+    # the legacy CLI path which prints the URL to stdout instead.
+    api_run_id: str | None = None,
+    api_tenant_id: str | None = None,
     **_extra,
 ) -> dict:
     """Execute tasks using Holo3-35B-A3B via llama.cpp (GGUF on 1x A100).
@@ -641,7 +648,38 @@ def _run_holo3_executor(
         objective = ObjectiveSpec.from_dict(objective_data)
         schema = ExtractionSchema.from_objective(objective)
     extractor = ClaudeExtractor(schema=schema)
-    viewer_ctx, viewer_event_bus, _viewer_url = setup_viewer(viewer)
+    # #416 follow-up: the live-viewer's screen-capture thread reads
+    # ``os.environ["DISPLAY"]`` (via mss) but ``setup_env`` doesn't
+    # propagate that into the executor process's environ — the env
+    # only stashes it on its own ``self._env`` for subprocess use.
+    # Bring up Xvfb explicitly and set the process-wide DISPLAY so
+    # the capture thread can attach. Skip when viewer isn't requested
+    # — Chrome's launch path (inside ``env.reset()``) handles its own
+    # subprocess env.
+    if viewer:
+        try:
+            display = env.ensure_display_ready()
+            if display:
+                os.environ["DISPLAY"] = display
+        except Exception as exc:  # noqa: BLE001 — best-effort
+            print(f"  WARNING: ensure_display_ready before viewer failed: {exc}")
+    viewer_ctx, viewer_event_bus, viewer_url = setup_viewer(viewer)
+    # #416: surface the tunnel URL into the API-side status.json so a
+    # caller polling ``action=status`` gets a hot-link to the live
+    # screen. Only fires when the /v1/predict handler forwarded the
+    # API's run_id + tenant_id alongside ``viewer=True``. The legacy
+    # CLI path (no api_run_id) keeps the old behaviour — URL is
+    # printed to stdout by ``modal_viewer`` and we don't touch
+    # status.json.
+    if viewer_url and api_run_id and api_tenant_id:
+        try:
+            existing = _read_status(api_tenant_id, api_run_id) or {}
+            existing["viewer_url"] = viewer_url
+            existing["updated_at"] = datetime.now(timezone.utc).isoformat()
+            _write_status(api_tenant_id, api_run_id, existing)
+            print(f"  live-viewer URL written to status.json: {viewer_url}")
+        except Exception as exc:  # noqa: BLE001 — viewer is best-effort
+            print(f"  WARNING: failed to surface live-viewer URL into status.json: {exc}")
 
     # ── Micro-intent mode: run MicroPlanRunner ──
     micro_plan_data = task_suite.get("_micro_plan")
@@ -1542,6 +1580,15 @@ def build_api_app(executor_resolver=None, function_call_lookup=None):
         }
         if model != "claude":
             spawn_kwargs["cua_model"] = model
+        # #416: forward the live-viewer flag into the executor so it
+        # can call setup_viewer + write the tunnel URL into the API-
+        # side status.json. The executor needs the API's run_id +
+        # tenant_id to know which status file to update (the
+        # executor's internal run_id differs).
+        if payload.get("live_viewer"):
+            spawn_kwargs["viewer"] = True
+            spawn_kwargs["api_run_id"] = run_id
+            spawn_kwargs["api_tenant_id"] = tenant.tenant_id
         try:
             call_handle = executor_fn.spawn(
                 task_file_contents=task_file_contents,
@@ -1593,6 +1640,21 @@ def build_api_app(executor_resolver=None, function_call_lookup=None):
         run_id = str(payload.get("run_id") or "")
         if not run_id:
             raise HTTPException(400, "action requires run_id")
+        # #416 follow-up: Modal Volume reads are cached per container.
+        # When an executor commits a status update from a different
+        # container (e.g. the live-viewer URL written from inside
+        # ``_run_holo3_executor``), the API container's mount keeps
+        # serving the old file content until ``vol.reload()`` invalidates
+        # the cache. Without this reload, ``status.json`` from the
+        # caller's perspective stays frozen at the initial ``queued``
+        # state for the whole run — and the executor-side
+        # ``viewer_url`` never surfaces. Best-effort: a reload failure
+        # is non-fatal; the caller just sees the stale view, same as
+        # before this fix.
+        try:
+            vol.reload()
+        except Exception as exc:  # noqa: BLE001 — volume reload is best-effort
+            print(f"  WARNING: vol.reload() failed in _do_action: {exc}")
         status = _read_status(tenant.tenant_id, run_id)
         if status is None:
             raise HTTPException(404, f"unknown run_id: {run_id}")


### PR DESCRIPTION
## Summary

PR #417 surfaced the live-viewer URL via `BasetenCUARuntime._maybe_start_live_viewer`, but Modal's `/v1/predict` route doesn't go through `BasetenCUARuntime` — it calls `executor_fn.spawn` against the Modal Function directly. So setting `live_viewer=True` on a Modal `/v1/predict` request had **no effect**: the executor never received the flag and `status.json` never got a `viewer_url` written to it.

This PR threads `live_viewer` through the Modal spawn path with three targeted changes, all in `deploy/modal/modal_cua_server.py`:

1. **`/v1/predict` handler** forwards `live_viewer` into `spawn_kwargs` as `viewer=True`, along with the API's `run_id` + `tenant_id` so the executor knows which status file to update (the executor's internal run_id differs from the API-side one).

2. **`_run_holo3_executor`** accepts `api_run_id` + `api_tenant_id`, brings up Xvfb via `env.ensure_display_ready` and sets `os.environ["DISPLAY"]` **before** `setup_viewer` so the MJPEG capture thread (mss) can attach to the display. Then writes `viewer_url` into the API-side `status.json` if both API ids were forwarded. Without the explicit DISPLAY setup, the capture thread logged `[viewer] capture error: Cannot connect to display` on every frame and the URL served a blank stream.

3. **`_do_action`** calls `vol.reload()` before `_read_status`. Modal Volume reads are cached per-container; the executor writes `status.json` from a different container than the API serves polls from, so without an explicit reload the API container kept returning the stale `queued` view for the whole run — and the executor-side `viewer_url` never surfaced.

## Test plan

- [x] Modal redeploy + lu.ma plan rerun with `live_viewer: true` in `/v1/predict` body
- [x] `action=status` poll returns `viewer_url` mid-run (no longer frozen at `queued`)
- [x] No `[viewer] capture error: Cannot connect to display` in executor logs
- [x] Opening the returned MJPEG URL renders live frames

## Closes

Closes #416

🤖 Generated with [Claude Code](https://claude.com/claude-code)