### PR TITLE
fix(modal): wire profile_id into Chrome user-data-dir on executors

### DIFF
--- a/deploy/modal/modal_cua_server.py
+++ b/deploy/modal/modal_cua_server.py
@@ -379,6 +379,8 @@ def _run_executor(
     max_retries: int = 2,
     frames_per_inference: int = 5,
     viewer: bool = False,
+    profile_dir: str = "",
+    **_extra,
 ) -> dict:
     """Shared executor logic for all vLLM GPU tiers."""
     from datetime import datetime, timezone
@@ -448,6 +450,7 @@ def _run_executor(
         proxy_state=str(task_suite.get("_proxy_state") or ""),
         proxy_provider=str(task_suite.get("_proxy_provider") or ""),
         proxy_disabled=bool(task_suite.get("_proxy_disabled", False)),
+        profile_dir=profile_dir,
     )
     viewer_ctx, viewer_event_bus, _viewer_url = setup_viewer(viewer)
 
@@ -543,6 +546,11 @@ def _run_holo3_executor(
     # the legacy CLI path which prints the URL to stdout instead.
     api_run_id: str | None = None,
     api_tenant_id: str | None = None,
+    # #341 follow-up: per-tenant, per-profile Chrome user-data-dir.
+    # The /v1/predict handler computes this from ``profile_id`` so
+    # cookies / localStorage / IndexedDB don't leak across runs that
+    # use different profiles on the same warm container.
+    profile_dir: str = "",
     **_extra,
 ) -> dict:
     """Execute tasks using Holo3-35B-A3B via llama.cpp (GGUF on 1x A100).
@@ -639,6 +647,7 @@ def _run_holo3_executor(
         proxy_state=str(task_suite.get("_proxy_state") or ""),
         proxy_provider=str(task_suite.get("_proxy_provider") or ""),
         proxy_disabled=bool(task_suite.get("_proxy_disabled", False)),
+        profile_dir=profile_dir,
     )
     from mantis_agent.extraction import ClaudeExtractor, ExtractionSchema
     schema = None
@@ -1077,6 +1086,8 @@ def _run_gemma4_cua_executor(
     max_steps: int = 30,
     max_retries: int = 2,
     viewer: bool = False,
+    profile_dir: str = "",
+    **_extra,
 ) -> dict:
     """Execute tasks using fine-tuned Gemma4-31B-CUA via llama.cpp."""
     from datetime import datetime, timezone
@@ -1133,6 +1144,7 @@ def _run_gemma4_cua_executor(
         proxy_state=str(task_suite.get("_proxy_state") or ""),
         proxy_provider=str(task_suite.get("_proxy_provider") or ""),
         proxy_disabled=bool(task_suite.get("_proxy_disabled", False)),
+        profile_dir=profile_dir,
     )
     viewer_ctx, viewer_event_bus, _viewer_url = setup_viewer(viewer)
 
@@ -1206,6 +1218,7 @@ def _run_claude_executor(
     claude_model: str = "claude-sonnet-4-20250514",
     thinking_budget: int = 2048,
     viewer: bool = False,
+    profile_dir: str = "",
     **_extra,
 ) -> dict:
     """Execute tasks using Claude CUA via Anthropic API.
@@ -1262,6 +1275,7 @@ def _run_claude_executor(
         proxy_state=str(task_suite.get("_proxy_state") or ""),
         proxy_provider=str(task_suite.get("_proxy_provider") or ""),
         proxy_disabled=bool(task_suite.get("_proxy_disabled", False)),
+        profile_dir=profile_dir,
     )
     viewer_ctx, viewer_event_bus, _viewer_url = setup_viewer(viewer)
 
@@ -1398,6 +1412,23 @@ def _run_dir(tenant_id: str, run_id: str):
     from mantis_agent.server_utils import safe_state_key as _safe
     root = _Path(os.environ.get("MANTIS_DATA_DIR", "/data"))
     return root / "tenants" / _safe(tenant_id) / "runs" / _safe(run_id)
+
+
+def _chrome_profile_dir(tenant_id: str, profile_id: str) -> str:
+    """Per-tenant, per-profile Chrome user-data-dir (#341).
+
+    Without this, every Modal run reused Chrome's default
+    ``/data/chrome-profile`` directory — so cookies, localStorage and
+    IndexedDB from one run leaked into the next regardless of the
+    API-side ``profile_id``. Returns a stringified path the executor
+    forwards to ``setup_env(profile_dir=...)``.
+    """
+    from pathlib import Path as _Path
+    from mantis_agent.server_utils import safe_state_key as _safe
+    root = _Path(os.environ.get("MANTIS_DATA_DIR", "/data"))
+    path = root / "tenants" / _safe(tenant_id) / "chrome-profile" / _safe(profile_id)
+    path.mkdir(parents=True, exist_ok=True)
+    return str(path)
 
 
 def _commit_volume() -> None:
@@ -1600,6 +1631,13 @@ def build_api_app(executor_resolver=None, function_call_lookup=None):
         # is positional; everything else is **kwargs.
         spawn_kwargs: dict = {
             "max_steps": int(payload.get("max_steps", 30)),
+            # Per-tenant, per-profile Chrome user-data-dir (#341).
+            # Until this was added, Modal executors fell back to
+            # XdotoolGymEnv's default ``/data/chrome-profile`` and
+            # every run on the same warm container shared one Chrome
+            # profile — so ``profile_id`` was only honoured by the
+            # API-side lock and not by Chrome itself.
+            "profile_dir": _chrome_profile_dir(tenant.tenant_id, profile_id),
         }
         if model != "claude":
             spawn_kwargs["cua_model"] = model
@@ -1748,6 +1786,7 @@ def build_api_app(executor_resolver=None, function_call_lookup=None):
             executor_fn = resolve_executor(model)
             spawn_kwargs: dict = {
                 "max_steps": int(status.get("max_steps", 30)),
+                "profile_dir": _chrome_profile_dir(tenant.tenant_id, profile_id),
             }
             if model != "claude":
                 spawn_kwargs["cua_model"] = model

--- a/docs/hosting/modal.md
+++ b/docs/hosting/modal.md
@@ -95,6 +95,13 @@ Per-run state for HTTP submissions lives at `/data/tenants/<tenant_id>/runs/<run
 - `viewer.json` — MJPEG tunnel URL when `live_viewer: true` was set; merged into `action=status` responses as `viewer_url` (kept as a side-channel file so the executor never races the API on `status.json`)
 - `events.log` — append-only event stream
 
+Chrome user-data-dirs are kept per tenant + profile at
+`/data/tenants/<tenant_id>/chrome-profile/<profile_id>/`. Cookies,
+localStorage and IndexedDB persist across runs that share a
+`profile_id` (this is what makes `profile_id` "sticky") and are
+fully isolated between different `profile_id`s — including across
+runs that happen to land on the same warm Modal container.
+
 ## Smoke test
 
 ```bash

--- a/tests/test_modal_endpoint.py
+++ b/tests/test_modal_endpoint.py
@@ -121,6 +121,51 @@ def test_predict_returns_run_id(app_with_stub) -> None:
     assert parsed["tasks"] == [{"intent": "x"}]
 
 
+def test_spawn_forwards_per_profile_chrome_user_data_dir(app_with_stub) -> None:
+    """#341 follow-up: the spawn handler must pass a per-profile Chrome
+    user-data-dir to the executor. Without this, every Modal run reused
+    XdotoolGymEnv's default ``/data/chrome-profile`` and cookies leaked
+    across runs that used different ``profile_id``s.
+    """
+    client, executor, _call = app_with_stub
+
+    # Submit two runs with DIFFERENT profile_ids and capture the spawn kwargs
+    # each got. We assert both that the kwarg is present and that the two
+    # runs received DIFFERENT paths — i.e. the dir is actually keyed by
+    # profile_id, not a constant.
+    r1 = client.post(
+        "/v1/predict",
+        headers=_auth_headers(),
+        data=json.dumps({"task_suite": {"tasks": []}, "profile_id": "alice"}),
+    )
+    assert r1.status_code == 200
+    alice_profile_dir = executor.spawn_kwargs.get("profile_dir")
+    assert alice_profile_dir, "spawn must forward a profile_dir"
+    assert "alice" in alice_profile_dir
+    assert "chrome-profile" in alice_profile_dir
+
+    # Release alice's lock first so the second submit isn't a 409.
+    run_id_alice = r1.json()["run_id"]
+    client.post(
+        "/v1/predict",
+        headers=_auth_headers(),
+        data=json.dumps({"action": "cancel", "run_id": run_id_alice}),
+    )
+
+    r2 = client.post(
+        "/v1/predict",
+        headers=_auth_headers(),
+        data=json.dumps({"task_suite": {"tasks": []}, "profile_id": "bob"}),
+    )
+    assert r2.status_code == 200
+    bob_profile_dir = executor.spawn_kwargs.get("profile_dir")
+    assert bob_profile_dir
+    assert "bob" in bob_profile_dir
+    assert bob_profile_dir != alice_profile_dir, (
+        "different profile_ids must resolve to different Chrome user-data-dirs"
+    )
+
+
 def test_predict_rejects_missing_token(app_with_stub) -> None:
     client, _executor, _call = app_with_stub
     r = client.post(


### PR DESCRIPTION
## Summary

- `tenant_chrome_profile()` (Baseten paths helper) defines the per-tenant per-profile Chrome user-data-dir, and `XdotoolGymEnv` reads `profile_dir` for its `--user-data-dir`. The Baseten runtime + legacy `server/run_dispatch.py` wire this through, but Modal's executors never passed `profile_dir` to `setup_env`, so every run on a warm container fell back to the default `/data/chrome-profile` and shared one Chrome state regardless of `profile_id`.
- Confirmed on Modal during the staff-crm investigation: two submissions with fresh random `profile_id`s both landed on the dashboard already authenticated because the first run's cookies / localStorage leaked through.
- This PR adds a `_chrome_profile_dir(tenant_id, profile_id)` helper next to `_run_dir` (mirroring the same `/data/tenants/<tenant>/...` layout the rest of the Modal volume code uses — the `baseten_server` helper resolves a different root and isn't used by Modal). The `/v1/predict` spawn handler computes `profile_dir` and adds it to `spawn_kwargs` for both new submissions and `action=resume` re-spawns. Each executor (`_run_executor`, `_run_holo3_executor`, `_run_gemma4_cua_executor`, `_run_claude_executor`) accepts `profile_dir` and forwards to `setup_env(...)`.
- Closes the half-implemented gap on Modal for [#341](https://github.com/mercurialsolo/mantis/issues/341).

## Test plan

- [x] `uv run pytest tests/test_modal_endpoint.py` — 16 pass (new `test_spawn_forwards_per_profile_chrome_user_data_dir` asserts the kwarg is forwarded AND two profile_ids resolve to different paths).
- [x] `uv run ruff check deploy/modal/modal_cua_server.py tests/test_modal_endpoint.py` — clean.
- [x] `uv run mkdocs build --strict` — clean.
- [x] Modal redeploy + staff-crm submission with a fresh random `profile_id` — login form actually appears now (steps 1-3 OK), executor reaches step 11 organically vs prior halt at step 1. Viewer URL served alongside as expected from PR #422.

🤖 Generated with [Claude Code](https://claude.com/claude-code)