### PR TITLE
fix(recovery): insert normalize-field pre-step on validation-blocked submit (#428 Part A)

### DIFF
--- a/src/mantis_agent/prompts/files/recovery_analysis.txt
+++ b/src/mantis_agent/prompts/files/recovery_analysis.txt
@@ -45,8 +45,27 @@ FAILURE DATA LEGEND (decode the failure string before choosing a mode):
   text the dropdown is actually rendering.
 
 - ``no_state_change`` (or demoted submit) — the click landed but
-  produced no observable page change. Usually a wrong target; try
-  ``edit_step`` with a more specific label.
+  produced no observable page change. Two common shapes — disambiguate
+  using the screenshot:
+  * Wrong target — the click hit a non-action element (label, badge,
+    a div near a button). The form / page would have responded if the
+    click had reached the right pixel. Prefer ``edit_step`` /
+    ``add_hint`` to refine the label or coordinates.
+  * **Form-validation-blocked submit** — the click hit the right
+    submit button but the form has a visible field-level validation
+    error (red text under a field, an ``aria-invalid`` ring, a
+    "value must be ≤ N" / "invalid format" / "required" message
+    near an input). The form's submit handler short-circuits while
+    any field is invalid, so the page never transitions and the
+    runner sees ``no_state_change``. Prefer ``insert_steps`` —
+    splice a small sub-flow that normalizes the offending field
+    (``fill_field`` to a valid value, or ``select_option`` for a
+    bad enum) BEFORE the failed submit. The next attempt at the
+    submit will then succeed because the form is valid.
+    Example: a "Estimated Deal Value" field showing
+    "461927.81" with a red "value must be a whole number" error
+    → ``insert_steps=[{"type": "fill_field", "params": {"label":
+    "Estimated Deal Value", "value": "461928"}}]``.
 
 PLAN CONTEXT (steps already completed successfully):
 __PLAN_CONTEXT__

--- a/tests/test_agentic_recovery.py
+++ b/tests/test_agentic_recovery.py
@@ -133,6 +133,69 @@ def test_prompt_includes_progress_evidence_guidance_for_halt() -> None:
     assert "loop" in rendered.lower() or "didn't" in rendered.lower() or "did not" in rendered.lower()
 
 
+def test_prompt_distinguishes_validation_blocked_submit_for_no_state_change() -> None:
+    """The ``no_state_change`` legend must enumerate the form-validation-
+    blocked-submit shape (red field error → ``insert_steps`` with a
+    normalize-field pre-step), not only the wrong-target shape. This
+    closes the gap surfaced by the staff-crm Update Lead halt
+    (issue #428): the runner kept retrying the submit while a field
+    validation error short-circuited the form handler. The prompt
+    previously only taught Claude the wrong-target shape, so recovery
+    biased toward ``edit_step`` / ``halt`` and never reached
+    ``insert_steps``.
+    """
+    from mantis_agent.prompts import load_prompt
+
+    rendered = load_prompt(
+        "recovery_analysis",
+        intent="x", step_type="submit", params="{}",
+        failure_data="no_state_change", attempts=2, plan_context="",
+    )
+    text = rendered.lower()
+    # Both shapes are explicitly enumerated under no_state_change.
+    assert "form-validation-blocked submit" in text or "validation-blocked submit" in text
+    # The validation case points at insert_steps with a normalize-field example.
+    assert "insert_steps" in rendered
+    assert "fill_field" in rendered
+    # And it explicitly names the validation-error signal Claude should look for.
+    assert "validation" in text
+
+
+def test_validation_blocked_submit_decodes_to_insert_steps() -> None:
+    """End-to-end: a stub Anthropic call that returns ``insert_steps``
+    with a normalize-field pre-step round-trips through
+    :func:`analyse_failure_and_recover` → :class:`RecoveryDecision`.
+    Confirms the schema (and the helper) carry the shape #428's Part A
+    fix needs.
+    """
+    fix_step = {
+        "intent": "Set Estimated Deal Value to a whole-number value",
+        "type": "fill_field",
+        "params": {"label": "Estimated Deal Value", "value": "461928"},
+    }
+    resp = _tool_response({
+        "mode": "insert_steps",
+        "reasoning": "Form shows 'value must be whole number' on Estimated Deal Value.",
+        "inserted_steps": [fix_step],
+    })
+    step = MicroIntent(
+        intent="Click the Update Lead button",
+        type="submit",
+        params={"label": "Update Lead"},
+    )
+    with patch("requests.post", return_value=resp):
+        decision = analyse_failure_and_recover(
+            step=step, failure_data="no_state_change",
+            screenshot=None, plan_context=[], attempts=2,
+            api_key="k",
+        )
+    assert decision is not None
+    assert decision.mode == "insert_steps"
+    assert len(decision.inserted_steps) == 1
+    assert decision.inserted_steps[0]["type"] == "fill_field"
+    assert decision.inserted_steps[0]["params"]["label"] == "Estimated Deal Value"
+
+
 def test_analyse_calls_with_correct_tool_schema() -> None:
     """The ``tool_choice`` must force the ``record_recovery`` tool and
     the input_schema must enumerate the four recovery modes."""


### PR DESCRIPTION
Closes #428 (Part A).

## Summary

- Teach `recovery_analysis.txt` to distinguish the two shapes of `no_state_change`:
  - **Wrong target** — click hit a non-action element (existing guidance preserved)
  - **Form-validation-blocked submit** — click hit the right button but a visible field error short-circuits the form's submit handler. Bias toward `insert_steps` with a `fill_field` / `select_option` pre-step that normalizes the offending field; the re-attempt on the original submit then succeeds.
- The new legend entry includes a worked example using the staff-crm Estimated Deal Value case (`461927.81` → "value must be a whole number" red error → `fill_field` pre-step to `461928`).
- Closes the Part A scope from issue #428. Part B (intent_rewriter ↔ agentic_recovery handoff when the rewriter proposes a semantically-different verb like "First fix X") is flagged as a follow-up.

## Test plan

- [x] New `test_prompt_distinguishes_validation_blocked_submit_for_no_state_change` — asserts the rendered prompt enumerates both shapes and points Claude at `insert_steps` + `fill_field`.
- [x] New `test_validation_blocked_submit_decodes_to_insert_steps` — end-to-end mock of the Anthropic tool_use round-trip with an `insert_steps` payload carrying a `fill_field` pre-step; asserts the decoded `RecoveryDecision` carries the expected shape.
- [x] `uv run pytest tests/test_agentic_recovery.py` — 25 pass (23 prior + 2 new).
- [x] `uv run ruff check tests/test_agentic_recovery.py` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)