### PR TITLE
feat(cua): image pruning + Fara memorize_fact scratchpad (#435 items 3+4)

### DIFF
--- a/deploy/modal/modal_cua_server.py
+++ b/deploy/modal/modal_cua_server.py
@@ -377,12 +377,21 @@ def _run_executor(
     plan_inputs: dict[str, str] | None = None,
     max_steps: int = 30,
     max_retries: int = 2,
-    frames_per_inference: int = 5,
+    frames_per_inference: int = 2,
     viewer: bool = False,
     profile_dir: str = "",
     **_extra,
 ) -> dict:
-    """Shared executor logic for all vLLM GPU tiers."""
+    """Shared executor logic for all vLLM GPU tiers.
+
+    #435: ``frames_per_inference`` default lowered from 5 to 2 per the
+    cua_notes.md "Cost-accuracy sweet spot" guidance — keep the last
+    1-3 screenshots, images dominate token cost, older frames are
+    mostly redundant once you have the action log. Holo3 keeps its
+    own 1-frame default (see ``_run_holo3_executor``); the Claude
+    executor follows the same default. Operators can override via
+    the kwarg.
+    """
     from datetime import datetime, timezone
 
     from mantis_agent.task_loop import TaskLoopConfig, setup_env, setup_viewer, run_executor_lifecycle
@@ -1214,7 +1223,7 @@ def _run_claude_executor(
     plan_inputs: dict[str, str] | None = None,
     max_steps: int = 30,
     max_retries: int = 2,
-    frames_per_inference: int = 5,
+    frames_per_inference: int = 2,
     claude_model: str = "claude-sonnet-4-20250514",
     thinking_budget: int = 2048,
     viewer: bool = False,

--- a/src/mantis_agent/actions.py
+++ b/src/mantis_agent/actions.py
@@ -37,6 +37,12 @@ class Action:
     action_type: ActionType
     params: dict[str, Any] = field(default_factory=dict)
     reasoning: str = ""
+    # #435: explicit-scratchpad primitive that some CUA models (Fara's
+    # ``pause_and_memorize_fact``) emit alongside a no-op action. The
+    # runner accumulates these into ``GymRunner._memorized_facts`` and
+    # re-feeds them to the brain on subsequent turns. Empty string =
+    # nothing to memorize on this step.
+    memorize_fact: str = ""
 
     def __str__(self) -> str:
         return f"{self.action_type.value}({self.params})" + (

--- a/src/mantis_agent/brain_claude.py
+++ b/src/mantis_agent/brain_claude.py
@@ -122,6 +122,13 @@ class ClaudeBrain:
         screen_size: Display resolution for computer_use tool.
     """
 
+    # #435 item 5: keep at most this many frames as raw image bytes
+    # in the prompt — per cua_notes.md §1 *"Keep only the last 1-3
+    # screenshots."* Older frames become text placeholders.
+    # Settable per instance via the constructor for callers that
+    # want to bypass the prune (e.g. evals comparing pre/post).
+    _FRAMES_KEEP_AS_IMAGE: int = 2
+
     def __init__(
         self,
         api_key: str = "",
@@ -235,18 +242,42 @@ class ClaudeBrain:
         return self._parse_response(data)
 
     def _headers(self) -> dict:
-        """Build Anthropic API headers."""
+        """Build Anthropic API headers.
+
+        #435 item 6: betas bumped per ``docs/cua_notes.md`` §3.
+
+        * ``computer-use-2025-11-24`` — current computer-use beta with
+          the matching ``computer_20251124`` tool type (paired with
+          ``_build_tools`` below). Was ``computer-use-2025-01-24``,
+          which paired with ``computer_20250124``.
+        * ``context-management-2025-06-27`` — auto-clears old
+          ``tool_result`` blocks when token budget tightens; useful
+          for long-running agent loops on Claude Opus 4.7. Off in
+          January 2024 beta; on now via this header.
+
+        Multiple beta values are joined with comma per Anthropic
+        docs — order doesn't matter.
+        """
         return {
             "x-api-key": self.api_key,
             "anthropic-version": "2023-06-01",
-            "anthropic-beta": "computer-use-2025-01-24",
+            "anthropic-beta": (
+                "computer-use-2025-11-24,context-management-2025-06-27"
+            ),
             "content-type": "application/json",
         }
 
     def _build_tools(self, screen_size: tuple[int, int]) -> list[dict]:
-        """Build tool list with correct screen dimensions."""
+        """Build tool list with correct screen dimensions.
+
+        #435 item 6: ``computer_20251124`` tool type pairs with the
+        ``computer-use-2025-11-24`` beta header above. The previous
+        pairing was ``computer_20250124`` / ``computer-use-2025-01-24``
+        — these MUST move together because Anthropic validates that
+        the tool type matches the beta version.
+        """
         computer_tool = {
-            "type": "computer_20250124",
+            "type": "computer_20251124",
             "name": "computer",
             "display_width_px": screen_size[0],
             "display_height_px": screen_size[1],
@@ -261,22 +292,45 @@ class ClaudeBrain:
         action_history: list[Action] | None,
         screen_size: tuple[int, int],
     ) -> list[dict]:
-        """Build Claude API messages with image content."""
+        """Build Claude API messages with image content.
+
+        #435 item 5: image stand-ins for older frames. Per
+        ``docs/cua_notes.md`` §3 *"Image pruning happens in your
+        code. Replace older tool_result images with text stand-ins
+        like [screenshot omitted] or a small placeholder."*
+
+        Only the most recent ``_FRAMES_KEEP_AS_IMAGE`` frames go in
+        as raw image bytes; older frames are emitted as
+        ``[screenshot omitted — frame t-N]`` text markers. Keeps
+        position markers and turn-ordering intact (which is what
+        preserves loop-avoidance signal) without paying the
+        ~1-2k tokens/frame image cost on every prior frame.
+        """
         content = []
 
-        # Add frames as images
+        # Add frames as images, but only keep the most recent N as
+        # raw bytes — older ones become text placeholders.
         n_frames = len(frames)
+        keep_as_image = self._FRAMES_KEEP_AS_IMAGE
         for i, frame in enumerate(frames):
             label = "CURRENT" if i == n_frames - 1 else f"t-{n_frames - 1 - i}"
             content.append({"type": "text", "text": f"[Frame {label}]"})
-            content.append({
-                "type": "image",
-                "source": {
-                    "type": "base64",
-                    "media_type": "image/png",
-                    "data": _image_to_base64(frame),
-                },
-            })
+            # Distance from the end: 0 = current, 1 = one back, …
+            distance_from_end = n_frames - 1 - i
+            if distance_from_end < keep_as_image:
+                content.append({
+                    "type": "image",
+                    "source": {
+                        "type": "base64",
+                        "media_type": "image/png",
+                        "data": _image_to_base64(frame),
+                    },
+                })
+            else:
+                content.append({
+                    "type": "text",
+                    "text": "[screenshot omitted — text-only at this distance]",
+                })
 
         # Task context
         context_parts = [

--- a/src/mantis_agent/brain_fara.py
+++ b/src/mantis_agent/brain_fara.py
@@ -422,6 +422,23 @@ class FaraBrain:
             recent = action_history[-5:]
             history = "\n".join(f"  {i + 1}. {a}" for i, a in enumerate(recent))
             parts.append(f"Recent actions:\n{history}")
+        # #435: re-feed the model's own ``pause_and_memorize_fact``
+        # entries from earlier turns. The Fara model card calls this
+        # out as an explicit scratchpad primitive; the doc's §4
+        # *"plumb it through"* note is satisfied by accumulating
+        # non-empty ``Action.memorize_fact`` strings off the action
+        # history and rendering them in their own block. Bounded to
+        # the last 10 facts so a chatty plan doesn't blow the prompt
+        # footprint.
+        if action_history:
+            facts = [
+                str(a.memorize_fact)
+                for a in action_history
+                if getattr(a, "memorize_fact", "")
+            ][-10:]
+            if facts:
+                fact_block = "\n".join(f"  - {f}" for f in facts)
+                parts.append(f"Memorized facts (your earlier notes):\n{fact_block}")
         content.append({"type": "text", "text": "\n".join(parts)})
 
         messages.append({"role": "user", "content": content})
@@ -710,10 +727,19 @@ class FaraBrain:
             )
 
         if action == "pause_and_memorize_fact":
+            # #435: surface the fact through the structured
+            # ``memorize_fact`` field instead of stuffing it in
+            # ``reasoning``. The runner pops it into its
+            # ``_memorized_facts`` list and the next turn's prompt
+            # re-feeds the list as a ``Memorized facts:`` block, which
+            # is what the doc means by *"essentially an explicit
+            # scratchpad primitive"* in §4. The action itself is still
+            # a no-op WAIT — the side-effect is the memo, not movement.
             note = str(args.get("text") or args.get("fact") or "")[:200]
             return Action(
                 ActionType.WAIT, {"seconds": 0.2},
                 reasoning=f"fara memo:{note}",
+                memorize_fact=note,
             )
 
         if action == "terminate":

--- a/src/mantis_agent/form_targeting/base.py
+++ b/src/mantis_agent/form_targeting/base.py
@@ -23,7 +23,7 @@ without forcing a migration of all read sites.
 
 from __future__ import annotations
 
-from typing import Protocol, TypedDict, runtime_checkable
+from typing import Any, Protocol, TypedDict, runtime_checkable
 
 from PIL import Image
 
@@ -84,6 +84,7 @@ class FormTargetProvider(Protocol):
         target_label: str = "",
         target_value: str = "",
         target_aliases: list[str] | None = None,
+        region: Any = None,
     ) -> FormTargetResult | None:
         """Locate a labelled form element.
 

--- a/src/mantis_agent/form_targeting/claude.py
+++ b/src/mantis_agent/form_targeting/claude.py
@@ -123,7 +123,20 @@ class ClaudeFormTargetProvider(FormTargetProvider):
         target_label: str = "",
         target_value: str = "",
         target_aliases: list[str] | None = None,
+        region: Any = None,
     ) -> FormTargetResult | None:
+        # #435 item 1: when the caller hints at a region (named string
+        # like ``"bottom"`` or an explicit ``{"x","y","w","h"}`` rect),
+        # crop before grounding and re-project coordinates after. The
+        # Claude vision call is then disambiguating a much smaller
+        # frame — collapses the staff-crm Update Lead case where a
+        # full 1280×800 screenshot has the button competing visually
+        # with header / sidebar / form body. The doc calls this the
+        # *"collapses most disambiguation pressure"* pattern (§6).
+        crop_offset: tuple[int, int] = (0, 0)
+        if region:
+            from .region import crop_to_region
+            screenshot, crop_offset = crop_to_region(screenshot, region)
         target_clause = (
             f"\nThe target element label/text is: \"{target_label}\""
             if target_label else ""
@@ -226,7 +239,21 @@ class ClaudeFormTargetProvider(FormTargetProvider):
             "value": str(parsed.get("value", target_value or "")),
             "label": str(parsed.get("label", target_label or "")),
         }
-        logger.info(f"  [claude-form] '{result['label'][:40]}' at ({x},{y}) action={result['action']}")
+        # #435 item 1: reproject coordinates back to full-screen space
+        # when the call was region-scoped. No-op when ``crop_offset``
+        # is the (0, 0) sentinel returned by ``crop_to_region`` for
+        # unknown regions or when no region was hinted.
+        if crop_offset != (0, 0):
+            result["x"] = int(result["x"]) + crop_offset[0]
+            result["y"] = int(result["y"]) + crop_offset[1]
+        logger.info(
+            f"  [claude-form] '{result['label'][:40]}' at "
+            f"({result['x']},{result['y']}) action={result['action']}"
+            + (
+                f" [region-cropped, offset=({crop_offset[0]},{crop_offset[1]})]"
+                if crop_offset != (0, 0) else ""
+            )
+        )
         return result
 
     def find_target_by_affordance(

--- a/src/mantis_agent/form_targeting/holo3.py
+++ b/src/mantis_agent/form_targeting/holo3.py
@@ -38,7 +38,7 @@ from __future__ import annotations
 import json
 import logging
 import re
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from PIL import Image
 
@@ -169,7 +169,17 @@ class Holo3FormTargetProvider(FormTargetProvider):
         target_label: str = "",
         target_value: str = "",
         target_aliases: list[str] | None = None,
+        region: Any = None,
     ) -> FormTargetResult | None:
+        # #435 item 1: optional region cropping for the Holo3 brain
+        # too. Same protocol as ``ClaudeFormTargetProvider`` — crop
+        # before grounding and re-project on return. No-op when
+        # ``region`` is falsy. Falling back to the unchanged path
+        # keeps existing callers identical pre/post.
+        crop_offset: tuple[int, int] = (0, 0)
+        if region:
+            from .region import crop_to_region
+            screenshot, crop_offset = crop_to_region(screenshot, region)
         aliases = [a for a in (target_aliases or []) if a]
         prompt = _FORM_PROMPT_TEMPLATE.format(
             width=screenshot.width,
@@ -179,11 +189,17 @@ class Holo3FormTargetProvider(FormTargetProvider):
             aliases=", ".join(aliases) or "(none)",
         )
         text = self._brain.detect_with_image(prompt, screenshot, max_tokens=256)
-        return self._parse_form_response(
+        result = self._parse_form_response(
             text, screenshot.size,
             fallback_action="type" if target_value else "click",
             label=target_label, value=target_value,
         )
+        # #435 item 1: reproject coords back to full-screen space when
+        # the call was region-scoped. No-op for the (0, 0) sentinel.
+        if result is not None and crop_offset != (0, 0):
+            result["x"] = int(result["x"]) + crop_offset[0]
+            result["y"] = int(result["y"]) + crop_offset[1]
+        return result
 
     def find_target_by_affordance(
         self,

--- a/src/mantis_agent/form_targeting/region.py
+++ b/src/mantis_agent/form_targeting/region.py
@@ -1,0 +1,165 @@
+"""Region cropping for form-target grounding (#435 item 1).
+
+Implements the *"planner localizes roughly, router crops the screenshot
+to that region, executor outputs coordinates in the cropped frame
+which get re-projected to screen space"* pattern documented in
+``docs/cua_notes.md`` §6 "Patterns worth knowing".
+
+The planner (plan author or the agentic_recovery's ``insert_steps``)
+hints at a region via ``step.hints["region"]``. The form handler
+calls :func:`crop_to_region` before passing the screenshot to
+``find_form_target``, then re-projects the returned coordinates back
+to full-screen space with :func:`reproject_coords`.
+
+Two hint shapes are supported:
+
+* **Explicit rectangle** —
+  ``{"x": int, "y": int, "w": int, "h": int}``. Pixels at the
+  screenshot's natural resolution. Coordinates outside the screen are
+  clamped.
+* **Named region** — a short string like ``"bottom"`` / ``"bottom-third"``
+  / ``"top-half"``. Translated to a rectangle relative to the
+  screenshot dimensions; lets plan authors avoid hard-coding pixels
+  that drift with viewport changes.
+
+If the hint is missing, malformed, or names a region the helper
+doesn't recognise, :func:`crop_to_region` returns the original
+screenshot with a ``(0, 0)`` offset — a no-op so existing callers
+that don't set a region hint behave identically to the pre-#435
+runtime.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from PIL import Image
+
+logger = logging.getLogger("mantis_agent.form_targeting.region")
+
+
+# Named regions → fractions of (left, top, right, bottom). Coordinates
+# are 0..1 of the screenshot's width/height. Ordered roughly by
+# expected utility on a typical web app layout.
+_NAMED_REGIONS: dict[str, tuple[float, float, float, float]] = {
+    "full":         (0.0, 0.0, 1.0, 1.0),
+    "top":          (0.0, 0.0, 1.0, 1 / 3),
+    "bottom":       (0.0, 2 / 3, 1.0, 1.0),
+    "left":         (0.0, 0.0, 1 / 3, 1.0),
+    "right":        (2 / 3, 0.0, 1.0, 1.0),
+    "center":       (1 / 4, 1 / 4, 3 / 4, 3 / 4),
+    "top-half":     (0.0, 0.0, 1.0, 0.5),
+    "bottom-half":  (0.0, 0.5, 1.0, 1.0),
+    "top-third":    (0.0, 0.0, 1.0, 1 / 3),
+    "bottom-third": (0.0, 2 / 3, 1.0, 1.0),
+    # Form-specific aliases — the most common case in practice. A
+    # submit-button row lives at the bottom; the lead-detail header
+    # lives at the top.
+    "form-footer":  (0.0, 0.6, 1.0, 1.0),
+    "form-header":  (0.0, 0.0, 1.0, 0.25),
+}
+
+
+def crop_to_region(
+    screenshot: Image.Image,
+    region: Any,
+) -> tuple[Image.Image, tuple[int, int]]:
+    """Crop ``screenshot`` to ``region``; return ``(cropped, (offset_x, offset_y))``.
+
+    The offset is the top-left pixel of the crop in full-screen
+    coordinates — callers re-project executor-emitted coordinates
+    back to screen space via :func:`reproject_coords`.
+
+    On any unknown / malformed region, returns the original
+    screenshot with a ``(0, 0)`` offset. Logs a warning so the
+    operator can spot a typo in a plan's ``hints.region``.
+    """
+    if not region:
+        return screenshot, (0, 0)
+
+    width, height = screenshot.size
+    rect = _resolve_rect(region, width, height)
+    if rect is None:
+        logger.warning(
+            "crop_to_region: unrecognised region %r — passing screenshot through unchanged",
+            region,
+        )
+        return screenshot, (0, 0)
+
+    left, top, right, bottom = rect
+    # Clamp to screen bounds; protect against zero-area crops (which
+    # would crash Pillow). A zero-area crop falls back to the full
+    # screenshot too — same fail-open behaviour as an unknown region.
+    left = max(0, min(width - 1, left))
+    top = max(0, min(height - 1, top))
+    right = max(left + 1, min(width, right))
+    bottom = max(top + 1, min(height, bottom))
+
+    cropped = screenshot.crop((left, top, right, bottom))
+    logger.debug(
+        "crop_to_region: %r → (%d,%d,%d,%d) [%dx%d → %dx%d]",
+        region, left, top, right, bottom,
+        width, height, cropped.width, cropped.height,
+    )
+    return cropped, (left, top)
+
+
+def reproject_coords(
+    coords: dict[str, Any] | None,
+    offset: tuple[int, int],
+) -> dict[str, Any] | None:
+    """Add ``offset`` back to coordinate fields in a form-target result.
+
+    ``coords`` is the dict returned by ``find_form_target`` — at
+    minimum ``{"x": int, "y": int, ...}``. The form-target provider
+    saw the cropped screenshot, so its ``x``/``y`` are in cropped
+    space; this helper shifts them by the crop origin so the runner's
+    click lands at the same pixel of the full screen.
+
+    Returns ``None`` when ``coords`` is ``None`` so callers can chain
+    ``reproject_coords(find_form_target(...), offset)``.
+    """
+    if coords is None:
+        return None
+    off_x, off_y = offset
+    if off_x == 0 and off_y == 0:
+        return coords
+    out = dict(coords)
+    if "x" in out and isinstance(out["x"], (int, float)):
+        out["x"] = int(out["x"]) + off_x
+    if "y" in out and isinstance(out["y"], (int, float)):
+        out["y"] = int(out["y"]) + off_y
+    return out
+
+
+def _resolve_rect(
+    region: Any, width: int, height: int,
+) -> tuple[int, int, int, int] | None:
+    """Translate ``region`` (string or dict) into a (left, top, right, bottom)
+    pixel rectangle, or ``None`` if unrecognised.
+    """
+    if isinstance(region, str):
+        frac = _NAMED_REGIONS.get(region.strip().lower())
+        if frac is None:
+            return None
+        fleft, ftop, fright, fbottom = frac
+        return (
+            int(width * fleft), int(height * ftop),
+            int(width * fright), int(height * fbottom),
+        )
+    if isinstance(region, dict):
+        try:
+            x = int(region["x"])
+            y = int(region["y"])
+            w = int(region["w"])
+            h = int(region["h"])
+        except (KeyError, TypeError, ValueError):
+            return None
+        if w <= 0 or h <= 0:
+            return None
+        return (x, y, x + w, y + h)
+    return None
+
+
+__all__ = ["crop_to_region", "reproject_coords"]

--- a/src/mantis_agent/gym/micro_runner.py
+++ b/src/mantis_agent/gym/micro_runner.py
@@ -240,6 +240,16 @@ class MicroPlanRunner:
         self._recovery_hints: dict[int, list[str]] = {}
         self._recovery_attempts_per_step: dict[int, int] = {}
         self._total_recovery_attempts: int = 0
+        # #435 task #1: cap inserted-step cascades. When recovery's
+        # ``insert_steps`` splices N new steps, their indices are
+        # recorded in ``_recovery_inserted_steps``. If one of those
+        # inserted steps fails and triggers ANOTHER recovery that
+        # also wants ``insert_steps``, ``_recovery_cascade_depth``
+        # tracks how many cascades deep we've gone. The policy halts
+        # cleanly at depth >= 2 instead of burning the per-run
+        # recovery budget on the same root cause.
+        self._recovery_inserted_steps: set[int] = set()
+        self._recovery_cascade_depth: dict[int, int] = {}
         self.max_cost, self.max_time = max_cost, max_time_minutes * 60
         self.step_callback, self.keep_screenshots = step_callback, keep_screenshots
         self.cancel_event = cancel_event

--- a/src/mantis_agent/gym/step_handlers/form.py
+++ b/src/mantis_agent/gym/step_handlers/form.py
@@ -217,6 +217,14 @@ class ClaudeGuidedFormHandler:
         index = int(ctx.state.get("index", 0))
 
         params = dict(getattr(step, "params", {}) or {})
+        # #435 item 1: extract the optional region hint once for the
+        # whole step. Every ``find_form_target`` call this handler
+        # makes (initial, scroll-probe sweep, retry-with-hint) passes
+        # ``region`` through, so the executor sees a cropped frame on
+        # each call — coordinates re-projected by the provider before
+        # they reach the runner. Empty / missing → no crop, identical
+        # to the pre-#435 path.
+        step_region = (getattr(step, "hints", {}) or {}).get("region")
         # Combined settle — form pages frequently finish hydrating after the
         # navigate that brought us here. EPIC #161 cleanup merges the
         # pre-handler 2s sleep that used to live in MicroPlanRunner
@@ -264,6 +272,7 @@ class ClaudeGuidedFormHandler:
                 target_label=label,
                 target_value=value,
                 target_aliases=aliases,
+                region=step_region,
             )
             runner.costs["claude_extract"] += 1
             probe_attempts = ["initial"]
@@ -299,6 +308,7 @@ class ClaudeGuidedFormHandler:
                     target_label=label,
                     target_value=value,
                     target_aliases=aliases,
+                    region=step_region,
                 )
                 runner.costs["claude_extract"] += 1
                 probe_attempts.append(log_tag)
@@ -537,6 +547,7 @@ class ClaudeGuidedFormHandler:
             target = target_provider.find_form_target(
                 screenshot, search_intent,
                 target_label=label, target_aliases=aliases,
+                region=step_region,
             )
             runner.costs["claude_extract"] += 1
             probe_attempts = ["initial"]
@@ -559,6 +570,7 @@ class ClaudeGuidedFormHandler:
                 t = target_provider.find_form_target(
                     shot, search_intent,
                     target_label=label, target_aliases=aliases,
+                    region=step_region,
                 )
                 runner.costs["claude_extract"] += 1
                 logger.info(
@@ -768,6 +780,7 @@ class ClaudeGuidedFormHandler:
             target = target_provider.find_form_target(
                 screenshot, search_intent,
                 target_label=label, target_aliases=aliases,
+                region=step_region,
             )
             runner.costs["claude_extract"] += 1
             if not target:
@@ -817,6 +830,7 @@ class ClaudeGuidedFormHandler:
             )
             target = target_provider.find_form_target(
                 screenshot, open_intent, target_label=dropdown,
+                region=step_region,
             )
             runner.costs["claude_extract"] += 1
             if not target:
@@ -848,7 +862,10 @@ class ClaudeGuidedFormHandler:
             )
             option_target = target_provider.find_form_target(
                 opened_shot, pick_intent, target_label=option,
-            )
+            )  # Note: no region= here — the opened dropdown menu lives at
+            # an unpredictable position relative to the trigger, so a
+            # step-level region hint (typed for the closed-form layout)
+            # doesn't apply.
             runner.costs["claude_extract"] += 1
             if not option_target:
                 # Close the dropdown to keep the page in a clean state.

--- a/src/mantis_agent/gym/step_recovery.py
+++ b/src/mantis_agent/gym/step_recovery.py
@@ -812,8 +812,49 @@ class StepRecoveryPolicy:
         if decision.mode == "insert_steps":
             if not decision.inserted_steps:
                 return None
+            # #435 cascade cap: if THIS step is itself an inserted-by-
+            # recovery step (its index is in ``runner._recovery_inserted_steps``),
+            # and we're about to insert MORE steps because the inserted
+            # one failed, that's a cascade. Allow ≤2 cascade depth
+            # before halting cleanly — otherwise insert_steps loops
+            # blow the per-run recovery budget on the same root cause.
+            # Observed on the tab-blur Modal run: 5/5 recoveries spent
+            # on sequential inserted fill_field failures, $0.92 burned.
+            recovery_inserted = getattr(runner, "_recovery_inserted_steps", None)
+            cascade_depth = getattr(runner, "_recovery_cascade_depth", None)
+            if (
+                isinstance(recovery_inserted, set)
+                and isinstance(cascade_depth, dict)
+                and step_index in recovery_inserted
+            ):
+                depth = cascade_depth.get(step_index, 0)
+                if depth >= 2:
+                    logger.warning(
+                        "  [%d] recovery_skipped: inserted-step cascade "
+                        "depth %d exceeded — halting cleanly instead of "
+                        "looping insert_steps on the same root cause",
+                        step_index, depth,
+                    )
+                    return None
+                cascade_depth[step_index] = depth + 1
             # Build MicroIntent objects from the dict-shaped specs.
+            # #435 task #2: the inserted helper steps inherit the
+            # parent step's ``hints`` (specifically ``region``) so
+            # ``find_form_target`` benefits from the same region
+            # cropping that the parent submit had. Without this, the
+            # inserted ``fill_field`` faces the full screen and hits
+            # the same disambiguation pressure the parent did.
             from ..plan_decomposer import MicroIntent
+            parent_hints = dict(getattr(step, "hints", {}) or {})
+            inherited_hints: dict = {}
+            # Only carry hints that are useful on the inserted step.
+            # ``region`` is the canonical one (scoping the grounding);
+            # ``visual`` and ``position`` are submit-step prose hints
+            # that don't translate. Operators can opt fields in/out
+            # by editing this set.
+            for k in ("region",):
+                if k in parent_hints:
+                    inherited_hints[k] = parent_hints[k]
             new_steps = [
                 MicroIntent(
                     intent=spec["intent"],
@@ -821,12 +862,26 @@ class StepRecoveryPolicy:
                     params=spec.get("params") or {},
                     section=getattr(step, "section", "") or "",
                     required=False,  # helper steps are best-effort
+                    hints=dict(inherited_hints),
                 )
                 for spec in decision.inserted_steps
             ]
             plan.steps = splice_inserted_steps(
                 plan.steps, step_index, new_steps,
             )
+            # #435 cascade cap: track the indices of inserted steps
+            # so a future failure on those steps can be detected as
+            # a cascade. The splice puts them at indices
+            # ``step_index .. step_index + len(new_steps) - 1``;
+            # the original failed step is now at
+            # ``step_index + len(new_steps)``. Don't rely on the
+            # attribute existing — initialize defensively.
+            if not hasattr(runner, "_recovery_inserted_steps"):
+                runner._recovery_inserted_steps = set()
+            if not hasattr(runner, "_recovery_cascade_depth"):
+                runner._recovery_cascade_depth = {}
+            for offset in range(len(new_steps)):
+                runner._recovery_inserted_steps.add(step_index + offset)
             # Reset retry count so the (now-deferred) failed step
             # gets fresh attempts after the helper sub-flow.
             step_retry_counts[step_index] = 0

--- a/src/mantis_agent/gym/step_recovery.py
+++ b/src/mantis_agent/gym/step_recovery.py
@@ -50,6 +50,7 @@ HALT              ``required`` retries exhausted, gate failure,
 from __future__ import annotations
 
 import logging
+import os
 import time
 from dataclasses import dataclass, field
 from enum import Enum
@@ -519,6 +520,70 @@ class StepRecoveryPolicy:
 
     # ── Agentic failure-recovery loop ───────────────────────────────────
 
+    # #435 follow-up: typical edit forms have 5-10 inputs. 12 Tabs
+    # covers all of them and a couple of "exit form" tabs into nav
+    # without dragging recovery latency past ~1.5s. Tunable via
+    # ``MANTIS_RECOVERY_TAB_BLUR_COUNT`` for forms with more inputs.
+    _TAB_BLUR_DEFAULT_COUNT: int = 12
+
+    def _tab_blur_traversal(self, runner: Any, step_index: int) -> None:
+        """Send Tab × N to trigger blur-driven validation rendering.
+
+        Why: a ``no_state_change`` failure on a submit step is often
+        a silent client-side validation rejection — the form's submit
+        handler short-circuits because some field is invalid, but no
+        red error is RENDERED until focus leaves the bad field. The
+        post-failure screenshot is visually clean, so the recovery
+        analyser (Claude) sees no validation indicators and picks
+        ``halt`` even when ``insert_steps`` is the right answer.
+
+        Walking Tab across the form forces every input through a blur
+        event, which is what triggers the ``:invalid`` /
+        ``aria-invalid`` styles in React / Vue / vanilla HTML forms.
+        The recovery screenshot is then captured AFTER traversal, so
+        whatever the form was hiding is now visible.
+
+        Best-effort: any exception inside the traversal is swallowed
+        and we fall through to the normal recovery path with whatever
+        screenshot the env can produce. Side-effect-free in the sense
+        that Tab key events don't mutate field values or submit the
+        form — worst case the cursor lands somewhere else, which
+        recovery would have to handle anyway.
+        """
+        try:
+            count = int(os.environ.get(
+                "MANTIS_RECOVERY_TAB_BLUR_COUNT",
+                self._TAB_BLUR_DEFAULT_COUNT,
+            ))
+        except (TypeError, ValueError):
+            count = self._TAB_BLUR_DEFAULT_COUNT
+        if count <= 0:
+            return
+        env = getattr(runner, "env", None)
+        if env is None:
+            return
+        logger.info(
+            "  [%d] recovery: tab-blur traversal × %d to force "
+            "validation rendering before screenshot",
+            step_index, count,
+        )
+        for _ in range(count):
+            try:
+                env.step(Action(
+                    action_type=ActionType.KEY_PRESS,
+                    params={"keys": "Tab"},
+                ))
+            except Exception as exc:  # noqa: BLE001 — best-effort
+                logger.debug("recovery: tab-blur step raised: %s", exc)
+                return
+            # Tiny settle so each blur event can fire its
+            # validation handler before the next Tab. 50ms × 12 =
+            # 0.6s total — acceptable recovery overhead.
+            time.sleep(0.05)
+        # One final settle so the LAST blur's validation render has
+        # time to paint before we screenshot.
+        time.sleep(0.3)
+
     def _try_agentic_recovery(
         self,
         *,
@@ -598,6 +663,28 @@ class StepRecoveryPolicy:
                 step_index, per_run, DEFAULT_MAX_RECOVERIES_PER_RUN,
             )
             return None
+
+        # #435 follow-up: before capturing the recovery screenshot on
+        # a ``no_state_change`` submit, walk Tab across the form to
+        # force blur-driven validation rendering. Most React forms
+        # render :invalid / aria-invalid styles only after focus
+        # leaves a bad field, so the post-submit-fail screenshot is
+        # often visually CLEAN even when the form's submit handler
+        # short-circuited on a validation error (canonical staff-crm
+        # pattern: ``Estimated Deal Value: 461927.81`` silently
+        # rejected by an integer-only rule). Tab traversal forces
+        # the rendering, so Claude actually sees what's invalid and
+        # picks ``insert_steps`` instead of ``halt``. Bounded to 12
+        # Tabs (covers most edit forms); opt-out via
+        # ``MANTIS_RECOVERY_TAB_BLUR=disabled``.
+        failure_class = str(getattr(step_result, "failure_class", "") or "")
+        step_type = str(getattr(step, "type", "") or "")
+        if (
+            failure_class == "no_state_change"
+            and step_type == "submit"
+            and os.environ.get("MANTIS_RECOVERY_TAB_BLUR", "") != "disabled"
+        ):
+            self._tab_blur_traversal(runner, step_index)
 
         # Capture screenshot for the analysis. Best-effort — Claude
         # can reason without it.

--- a/tests/test_agentic_recovery.py
+++ b/tests/test_agentic_recovery.py
@@ -508,6 +508,118 @@ def _make_plan() -> MicroPlan:
     ])
 
 
+def test_recovery_insert_steps_inherits_region_hint_from_parent() -> None:
+    """#435 task #2: when ``insert_steps`` splices a fill_field
+    before a failed submit, the inserted step inherits the parent's
+    ``hints.region`` so ``find_form_target`` benefits from the same
+    region cropping. Without this, the inserted normalize-step faces
+    the full screen and hits the same disambiguation pressure that
+    blocked the parent.
+    """
+    runner = _make_runner_with_recovery_state()
+    policy = StepRecoveryPolicy(parent=runner)
+    plan = _make_plan()
+    parent_step = plan.steps[2]
+    parent_step.hints = {"region": "bottom", "visual": "blue button"}
+    result = StepResult(
+        step_index=2, intent=parent_step.intent, success=False,
+        data="submit:Update Lead:no_state_change",
+        failure_class="no_state_change",
+    )
+    resp = _tool_response({
+        "mode": "insert_steps",
+        "reasoning": "Estimated Deal Value is decimal in integer field",
+        "inserted_steps": [{
+            "intent": "Normalize Estimated Deal Value to whole number",
+            "type": "fill_field",
+            "params": {"label": "Estimated Deal Value", "value": "461928"},
+        }],
+    })
+    with patch("requests.post", return_value=resp):
+        outcome = policy._try_agentic_recovery(
+            step=parent_step, step_result=result, step_index=2,
+            plan=plan, step_retry_counts={}, attempts=2,
+        )
+    assert outcome is not None
+    # The splice inserted the new step at index 2.
+    inserted = plan.steps[2]
+    assert inserted.type == "fill_field"
+    # Region hint inherited; submit-only hints (visual / position) NOT
+    # carried — they don't translate to a fill_field on a different
+    # element.
+    assert inserted.hints.get("region") == "bottom"
+    assert "visual" not in inserted.hints
+
+
+def test_recovery_insert_steps_cascade_caps_at_depth_2() -> None:
+    """#435 task #1: a recovery that inserts a step, the inserted
+    step then fails and triggers another recovery, that one ALSO
+    inserts → cascade. Cap at depth 2: the third cascade halts
+    cleanly instead of burning per-run recovery budget on the same
+    root cause.
+    """
+    runner = _make_runner_with_recovery_state()
+    runner._recovery_inserted_steps = {5, 6}  # both inserted by prior recovery
+    runner._recovery_cascade_depth = {5: 2}  # already at depth 2 for index 5
+    policy = StepRecoveryPolicy(parent=runner)
+    plan = _make_plan()
+    step = MicroIntent(intent="inserted fill", type="fill_field")
+    result = StepResult(
+        step_index=5, intent=step.intent, success=False,
+        data="form_target_not_found",
+        failure_class="no_state_change",
+    )
+    resp = _tool_response({
+        "mode": "insert_steps",
+        "reasoning": "try a different normalize",
+        "inserted_steps": [{
+            "intent": "still trying", "type": "fill_field", "params": {},
+        }],
+    })
+    with patch("requests.post", return_value=resp):
+        outcome = policy._try_agentic_recovery(
+            step=step, step_result=result, step_index=5,
+            plan=plan, step_retry_counts={}, attempts=2,
+        )
+    # Recovery saw the cascade depth and halted instead of inserting
+    # again.
+    assert outcome is None
+
+
+def test_recovery_first_insert_steps_marks_indices_for_cascade_detection() -> None:
+    """Regression guard for #435 task #1's bookkeeping: the FIRST
+    insert_steps call (not yet a cascade) must populate
+    ``_recovery_inserted_steps`` so subsequent failures on those
+    indices can be detected as cascades.
+    """
+    runner = _make_runner_with_recovery_state()
+    runner._recovery_inserted_steps = set()
+    runner._recovery_cascade_depth = {}
+    policy = StepRecoveryPolicy(parent=runner)
+    plan = _make_plan()
+    parent_step = plan.steps[2]
+    result = StepResult(
+        step_index=2, intent=parent_step.intent, success=False,
+        data="submit:no_state_change",
+        failure_class="no_state_change",
+    )
+    resp = _tool_response({
+        "mode": "insert_steps",
+        "reasoning": "normalize field",
+        "inserted_steps": [{
+            "intent": "fix field", "type": "fill_field",
+            "params": {"label": "X", "value": "v"},
+        }],
+    })
+    with patch("requests.post", return_value=resp):
+        policy._try_agentic_recovery(
+            step=parent_step, step_result=result, step_index=2,
+            plan=plan, step_retry_counts={}, attempts=2,
+        )
+    # The inserted step at index 2 is now marked.
+    assert 2 in runner._recovery_inserted_steps
+
+
 def test_recovery_runs_tab_blur_traversal_on_no_state_change_submit() -> None:
     """#435 follow-up: silent-validation handling.
 

--- a/tests/test_agentic_recovery.py
+++ b/tests/test_agentic_recovery.py
@@ -508,6 +508,173 @@ def _make_plan() -> MicroPlan:
     ])
 
 
+def test_recovery_runs_tab_blur_traversal_on_no_state_change_submit() -> None:
+    """#435 follow-up: silent-validation handling.
+
+    When the recovery analyser would otherwise see a clean form
+    (submit failed, no rendered error), pressing Tab through every
+    input forces blur-driven validation rendering. The recovery
+    screenshot is then captured AFTER the traversal, so the
+    analyser sees what was hidden.
+
+    This test pins:
+    1. Tab traversal is called BEFORE ``_safe_screenshot``.
+    2. The default count is 12 (covers a typical edit form).
+    3. The screenshot returned by ``_safe_screenshot`` is what
+       reaches ``analyse_failure_and_recover``.
+    """
+    runner = _make_runner_with_recovery_state()
+    runner._safe_screenshot.return_value = "post-tab-screenshot"
+    call_order: list[str] = []
+    # Order tracker — both env.step (any KEY_PRESS) and the screenshot
+    # call get recorded so we can assert ordering.
+    def _env_step(action):
+        if action.params.get("keys") == "Tab":
+            call_order.append("tab")
+    runner.env.step.side_effect = _env_step
+    runner._safe_screenshot.side_effect = lambda: (
+        call_order.append("screenshot") or "post-tab-screenshot"
+    )
+
+    captured: dict = {}
+
+    def _capture(*, step, failure_data, screenshot, plan_context,
+                 attempts, model=None, api_key=""):
+        captured["screenshot"] = screenshot
+        return None  # short-circuit; we only care about the pre-call sequence.
+
+    policy = StepRecoveryPolicy(parent=runner)
+    plan = _make_plan()
+    step = plan.steps[2]
+    result = StepResult(
+        step_index=2, intent=step.intent, success=False,
+        data="submit:Update Lead@(100,200):no_state_change",
+        failure_class="no_state_change",
+    )
+    with patch(
+        "mantis_agent.agentic_recovery.analyse_failure_and_recover",
+        side_effect=_capture,
+    ):
+        policy._try_agentic_recovery(
+            step=step, step_result=result, step_index=2,
+            plan=plan, step_retry_counts={}, attempts=2,
+        )
+
+    # 12 Tabs were pressed.
+    assert call_order.count("tab") == 12, (
+        f"expected 12 Tab presses; got {call_order.count('tab')}"
+    )
+    # Tabs all happened before the screenshot.
+    last_tab = max(
+        i for i, ev in enumerate(call_order) if ev == "tab"
+    )
+    first_screenshot = next(
+        i for i, ev in enumerate(call_order) if ev == "screenshot"
+    )
+    assert last_tab < first_screenshot, (
+        f"Tab traversal must complete before screenshot; "
+        f"got order {call_order}"
+    )
+    # The recovery's screenshot is the post-tab one.
+    assert captured["screenshot"] == "post-tab-screenshot"
+
+
+def test_recovery_skips_tab_blur_for_non_submit_failures() -> None:
+    """Tab traversal is scoped to ``no_state_change`` submit failures
+    — it doesn't fire on click-type failures, form_target_not_found,
+    or anything else. Avoids changing behaviour on unrelated paths.
+    """
+    runner = _make_runner_with_recovery_state()
+    tab_count = [0]
+    runner.env.step.side_effect = lambda action: (
+        tab_count.__setitem__(0, tab_count[0] + 1)
+        if action.params.get("keys") == "Tab" else None
+    )
+
+    policy = StepRecoveryPolicy(parent=runner)
+    plan = _make_plan()
+    click_step = MicroIntent(intent="Click", type="click")
+    plan.steps[2] = click_step
+    result = StepResult(
+        step_index=2, intent="Click", success=False,
+        data="click_no_nav", failure_class="no_state_change",
+    )
+    with patch(
+        "mantis_agent.agentic_recovery.analyse_failure_and_recover",
+        return_value=None,
+    ):
+        policy._try_agentic_recovery(
+            step=click_step, step_result=result, step_index=2,
+            plan=plan, step_retry_counts={}, attempts=2,
+        )
+
+    assert tab_count[0] == 0, (
+        f"Tab traversal must NOT fire on click failures; got {tab_count[0]}"
+    )
+
+
+def test_recovery_tab_blur_disabled_by_env(monkeypatch) -> None:
+    """``MANTIS_RECOVERY_TAB_BLUR=disabled`` opts out — useful for
+    bisecting whether the traversal helps or harms on a given plan.
+    """
+    monkeypatch.setenv("MANTIS_RECOVERY_TAB_BLUR", "disabled")
+    runner = _make_runner_with_recovery_state()
+    tab_count = [0]
+    runner.env.step.side_effect = lambda action: (
+        tab_count.__setitem__(0, tab_count[0] + 1)
+        if action.params.get("keys") == "Tab" else None
+    )
+
+    policy = StepRecoveryPolicy(parent=runner)
+    plan = _make_plan()
+    step = plan.steps[2]
+    result = StepResult(
+        step_index=2, intent=step.intent, success=False,
+        data="submit:Update Lead@(100,200):no_state_change",
+        failure_class="no_state_change",
+    )
+    with patch(
+        "mantis_agent.agentic_recovery.analyse_failure_and_recover",
+        return_value=None,
+    ):
+        policy._try_agentic_recovery(
+            step=step, step_result=result, step_index=2,
+            plan=plan, step_retry_counts={}, attempts=2,
+        )
+
+    assert tab_count[0] == 0
+
+
+def test_recovery_tab_blur_count_overridable_by_env(monkeypatch) -> None:
+    """Operators can tune the Tab count for unusually large forms."""
+    monkeypatch.setenv("MANTIS_RECOVERY_TAB_BLUR_COUNT", "4")
+    runner = _make_runner_with_recovery_state()
+    tab_count = [0]
+    runner.env.step.side_effect = lambda action: (
+        tab_count.__setitem__(0, tab_count[0] + 1)
+        if action.params.get("keys") == "Tab" else None
+    )
+
+    policy = StepRecoveryPolicy(parent=runner)
+    plan = _make_plan()
+    step = plan.steps[2]
+    result = StepResult(
+        step_index=2, intent=step.intent, success=False,
+        data="submit:Update Lead@(100,200):no_state_change",
+        failure_class="no_state_change",
+    )
+    with patch(
+        "mantis_agent.agentic_recovery.analyse_failure_and_recover",
+        return_value=None,
+    ):
+        policy._try_agentic_recovery(
+            step=step, step_result=result, step_index=2,
+            plan=plan, step_retry_counts={}, attempts=2,
+        )
+
+    assert tab_count[0] == 4
+
+
 def test_recovery_returns_none_without_api_key(monkeypatch) -> None:
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
     runner = _make_runner_with_recovery_state()

--- a/tests/test_brain_claude.py
+++ b/tests/test_brain_claude.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from PIL import Image
+
 from mantis_agent.actions import ActionType
 from mantis_agent.brain_claude import ClaudeBrain
 from mantis_agent.gym.claude_director import _decision_to_action
@@ -58,3 +60,94 @@ def test_claude_empty_key_action_without_hint_becomes_wait() -> None:
 
 def test_claude_director_rejects_empty_keypress() -> None:
     assert _decision_to_action({"action_type": "key_press", "keys": ""}) is None
+
+
+# ── #435 item 5: image stand-ins for older frames ────────────────────
+
+
+def _img() -> Image.Image:
+    return Image.new("RGB", (10, 10), color=(255, 255, 255))
+
+
+def test_claude_brain_keeps_recent_frames_as_images() -> None:
+    """The most recent _FRAMES_KEEP_AS_IMAGE frames are sent as raw
+    image bytes (the default is 2 per cua_notes.md §1's 1-3 sweet spot).
+    """
+    brain = ClaudeBrain(api_key="k")
+    messages = brain._build_messages(
+        frames=[_img(), _img()], task="task",
+        action_history=None, screen_size=(10, 10),
+    )
+    content = messages[0]["content"]
+    image_blocks = [b for b in content if b.get("type") == "image"]
+    assert len(image_blocks) == 2
+
+
+def test_claude_brain_drops_older_frames_to_text_placeholders() -> None:
+    """When >2 frames are passed, the older ones become
+    ``[screenshot omitted — text-only at this distance]`` placeholders
+    instead of raw image bytes. Position markers (``[Frame t-N]``) stay
+    so the model can still reason about turn ordering.
+    """
+    brain = ClaudeBrain(api_key="k")
+    messages = brain._build_messages(
+        frames=[_img(), _img(), _img(), _img(), _img()],
+        task="task", action_history=None, screen_size=(10, 10),
+    )
+    content = messages[0]["content"]
+    # 2 images for the last 2 frames; 3 placeholder texts for the older 3.
+    image_blocks = [b for b in content if b.get("type") == "image"]
+    placeholder_blocks = [
+        b for b in content
+        if b.get("type") == "text"
+        and "screenshot omitted" in b.get("text", "")
+    ]
+    # Position markers still present for all 5 frames.
+    frame_markers = [
+        b for b in content
+        if b.get("type") == "text"
+        and b.get("text", "").startswith("[Frame ")
+    ]
+    assert len(image_blocks) == 2
+    assert len(placeholder_blocks) == 3
+    assert len(frame_markers) == 5
+
+
+def test_claude_brain_uses_current_beta_headers() -> None:
+    """#435 item 6: brain_claude.py uses the current
+    ``computer-use-2025-11-24`` + ``context-management-2025-06-27``
+    betas. The headers must keep them in sync with the tool type
+    (paired in ``_build_tools``).
+    """
+    brain = ClaudeBrain(api_key="k")
+    headers = brain._headers()
+    beta = headers["anthropic-beta"]
+    assert "computer-use-2025-11-24" in beta
+    assert "context-management-2025-06-27" in beta
+    # Regression: the previous beta is replaced, not just appended.
+    assert "computer-use-2025-01-24" not in beta
+
+
+def test_claude_brain_tool_type_matches_beta() -> None:
+    """The tool ``type`` must match the beta version — Anthropic
+    rejects mismatched pairs. ``computer_20251124`` pairs with
+    ``computer-use-2025-11-24``.
+    """
+    brain = ClaudeBrain(api_key="k")
+    tools = brain._build_tools((1280, 800))
+    computer_tool = next(t for t in tools if t.get("name") == "computer")
+    assert computer_tool["type"] == "computer_20251124"
+
+
+def test_claude_brain_marks_current_frame_distinctly() -> None:
+    """The newest frame is labelled CURRENT, older ones t-N."""
+    brain = ClaudeBrain(api_key="k")
+    messages = brain._build_messages(
+        frames=[_img(), _img(), _img()], task="task",
+        action_history=None, screen_size=(10, 10),
+    )
+    text_markers = [
+        b["text"] for b in messages[0]["content"]
+        if b.get("type") == "text" and b["text"].startswith("[Frame ")
+    ]
+    assert text_markers == ["[Frame t-2]", "[Frame t-1]", "[Frame CURRENT]"]

--- a/tests/test_brain_fara.py
+++ b/tests/test_brain_fara.py
@@ -406,6 +406,73 @@ def test_pause_and_memorize_fact_collapses_with_note_in_reasoning(
     assert "phone=555" in action.reasoning
 
 
+def test_pause_and_memorize_fact_surfaces_via_memorize_fact_field(
+    brain: FaraBrain,
+) -> None:
+    """#435: the doc says "plumb it through" for ``pause_and_memorize_fact``.
+    The Action now carries the note on the structured ``memorize_fact``
+    field (not just ``reasoning``), so the next turn's prompt can re-feed it.
+    """
+    action = _parse_tool(
+        brain, _fara_tool_call("pause_and_memorize_fact", text="phone=555"),
+    )
+    assert action.memorize_fact == "phone=555"
+
+
+def test_build_messages_refeeds_memorized_facts_from_prior_actions(
+    brain: FaraBrain,
+) -> None:
+    """#435: when the action history contains ``Action.memorize_fact``
+    entries, the brain re-feeds them in a ``Memorized facts:`` block
+    on the next turn — that's what makes the scratchpad primitive
+    useful (otherwise it's a write-only signal).
+    """
+    from PIL import Image
+
+    from mantis_agent.actions import Action, ActionType
+
+    history = [
+        Action(ActionType.CLICK, {"x": 100, "y": 200}),
+        Action(
+            ActionType.WAIT, {"seconds": 0.2},
+            memorize_fact="customer=ACME, deal=$120k",
+        ),
+        Action(ActionType.CLICK, {"x": 300, "y": 400}),
+        Action(
+            ActionType.WAIT, {"seconds": 0.2},
+            memorize_fact="phone=555-0100",
+        ),
+    ]
+    img = Image.new("RGB", (100, 100), "white")
+    messages = brain._build_messages([img], "task", history)
+    # The final text block is the joined task+history+facts context.
+    text_blocks = [
+        b["text"] for b in messages[-1]["content"] if b.get("type") == "text"
+    ]
+    full_text = "\n".join(text_blocks)
+    assert "Memorized facts" in full_text
+    assert "customer=ACME, deal=$120k" in full_text
+    assert "phone=555-0100" in full_text
+
+
+def test_build_messages_omits_memorized_facts_block_when_none(
+    brain: FaraBrain,
+) -> None:
+    """No prior ``memorize_fact`` entries → no block in the prompt."""
+    from PIL import Image
+
+    from mantis_agent.actions import Action, ActionType
+
+    history = [Action(ActionType.CLICK, {"x": 100, "y": 200})]
+    img = Image.new("RGB", (100, 100), "white")
+    messages = brain._build_messages([img], "task", history)
+    text_blocks = [
+        b["text"] for b in messages[-1]["content"] if b.get("type") == "text"
+    ]
+    full_text = "\n".join(text_blocks)
+    assert "Memorized facts" not in full_text
+
+
 def test_terminate_success_maps_to_done(brain: FaraBrain) -> None:
     action = _parse_tool(
         brain,

--- a/tests/test_form_target_region.py
+++ b/tests/test_form_target_region.py
@@ -1,0 +1,219 @@
+"""Tests for region cropping (#435 item 1).
+
+The new ``mantis_agent.form_targeting.region`` module crops screenshots
+to a hint-specified region before grounding and re-projects executor-
+emitted coordinates back to full-screen space. These tests pin the
+crop arithmetic, the named-region table, the no-op fallback for
+unknown regions, and the end-to-end ``find_form_target(..., region=...)``
+contract on the ``ClaudeFormTargetProvider``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from PIL import Image
+
+from mantis_agent._anthropic.client import AnthropicToolUseClient
+from mantis_agent.form_targeting.claude import ClaudeFormTargetProvider
+from mantis_agent.form_targeting.region import crop_to_region, reproject_coords
+
+
+def _img(w: int = 1280, h: int = 800) -> Image.Image:
+    return Image.new("RGB", (w, h), color=(255, 255, 255))
+
+
+# ── crop_to_region — named regions ──────────────────────────────────
+
+
+def test_crop_to_region_bottom_yields_lower_third() -> None:
+    cropped, offset = crop_to_region(_img(1280, 900), "bottom")
+    # 900 * 2/3 = 600 → bottom rect (0, 600, 1280, 900)
+    assert cropped.size == (1280, 300)
+    assert offset == (0, 600)
+
+
+def test_crop_to_region_top_half_yields_upper_half() -> None:
+    cropped, offset = crop_to_region(_img(1280, 800), "top-half")
+    assert cropped.size == (1280, 400)
+    assert offset == (0, 0)
+
+
+def test_crop_to_region_unknown_named_region_returns_full_screenshot() -> None:
+    """Defensive: a typo in a plan hint must not crash. The caller's
+    behaviour should fall back to the unchanged-screenshot path.
+    """
+    full = _img(1280, 800)
+    cropped, offset = crop_to_region(full, "BACKGROUND-MIDDLE-XYZ")
+    assert cropped.size == full.size
+    assert offset == (0, 0)
+
+
+def test_crop_to_region_case_insensitive() -> None:
+    """Operators shouldn't have to remember casing."""
+    cropped_a, off_a = crop_to_region(_img(1000, 1000), "Bottom")
+    cropped_b, off_b = crop_to_region(_img(1000, 1000), "bottom")
+    assert cropped_a.size == cropped_b.size
+    assert off_a == off_b
+
+
+# ── crop_to_region — explicit rect ──────────────────────────────────
+
+
+def test_crop_to_region_explicit_rect() -> None:
+    cropped, offset = crop_to_region(
+        _img(1280, 800), {"x": 100, "y": 200, "w": 400, "h": 150},
+    )
+    assert cropped.size == (400, 150)
+    assert offset == (100, 200)
+
+
+def test_crop_to_region_explicit_rect_clamps_to_bounds() -> None:
+    """Rect extending past screen edges → clamped to viewport."""
+    cropped, offset = crop_to_region(
+        _img(1280, 800), {"x": 1200, "y": 700, "w": 500, "h": 500},
+    )
+    # Width clamped to 80 (1280 - 1200), height clamped to 100 (800 - 700)
+    assert cropped.size == (80, 100)
+    assert offset == (1200, 700)
+
+
+def test_crop_to_region_zero_or_negative_dimensions_no_ops() -> None:
+    full = _img(1000, 1000)
+    cropped, offset = crop_to_region(
+        full, {"x": 0, "y": 0, "w": 0, "h": 100},
+    )
+    assert cropped.size == full.size
+    assert offset == (0, 0)
+
+
+def test_crop_to_region_malformed_dict_no_ops() -> None:
+    full = _img(1000, 1000)
+    cropped, offset = crop_to_region(full, {"x": "oops", "y": 0})
+    assert cropped.size == full.size
+    assert offset == (0, 0)
+
+
+def test_crop_to_region_none_or_empty_no_ops() -> None:
+    for hint in [None, "", 0, {}]:
+        full = _img(1000, 1000)
+        cropped, offset = crop_to_region(full, hint)
+        assert cropped.size == full.size
+        assert offset == (0, 0)
+
+
+# ── reproject_coords ────────────────────────────────────────────────
+
+
+def test_reproject_coords_adds_offset() -> None:
+    out = reproject_coords({"x": 50, "y": 30, "label": "foo"}, (100, 200))
+    assert out == {"x": 150, "y": 230, "label": "foo"}
+
+
+def test_reproject_coords_zero_offset_is_no_op() -> None:
+    coords = {"x": 50, "y": 30}
+    out = reproject_coords(coords, (0, 0))
+    assert out is coords  # same object — no copy on no-op
+
+
+def test_reproject_coords_none_passthrough() -> None:
+    assert reproject_coords(None, (10, 10)) is None
+
+
+# ── ClaudeFormTargetProvider — region kwarg end-to-end ───────────
+
+
+def test_claude_provider_passes_region_through_and_reprojects() -> None:
+    """End-to-end: the provider receives ``region="bottom"``, the
+    Anthropic call sees a cropped image, and the returned ``(x, y)``
+    is shifted by the crop offset before being handed back to the
+    caller.
+    """
+    captured: dict = {}
+
+    def _capture(*_args, **kwargs):
+        captured["json"] = kwargs.get("json")
+        resp = MagicMock(status_code=200)
+        resp.json.return_value = {
+            "content": [{
+                "type": "tool_use",
+                "name": "report_form_target",
+                "input": {
+                    "x": 100, "y": 50, "action": "click",
+                    "value": "", "label": "Update Lead",
+                },
+            }],
+        }
+        return resp
+
+    client = AnthropicToolUseClient(api_key="k", model="m", log_prefix="t")
+    provider = ClaudeFormTargetProvider(client)
+    with patch("requests.post", side_effect=_capture):
+        result = provider.find_form_target(
+            _img(1280, 900), "Click Update Lead",
+            target_label="Update Lead",
+            region="bottom",
+        )
+
+    assert result is not None
+    # bottom region of 1280x900 = (0, 600, 1280, 900); the cropped
+    # image is 1280x300 with offset (0, 600). Provider returned
+    # (x=100, y=50) in cropped space → reprojected to (100, 650).
+    assert result["x"] == 100
+    assert result["y"] == 650
+
+
+def test_claude_provider_no_region_behaves_identically_to_before() -> None:
+    """Regression guard: a call with ``region=None`` (the default)
+    must look identical to the pre-#435 path.
+    """
+    def _no_target(*_args, **kwargs):
+        resp = MagicMock(status_code=200)
+        resp.json.return_value = {
+            "content": [{
+                "type": "tool_use",
+                "name": "report_form_target",
+                "input": {
+                    "x": 500, "y": 400, "action": "click",
+                    "value": "", "label": "Login",
+                },
+            }],
+        }
+        return resp
+
+    client = AnthropicToolUseClient(api_key="k", model="m", log_prefix="t")
+    provider = ClaudeFormTargetProvider(client)
+    with patch("requests.post", side_effect=_no_target):
+        result = provider.find_form_target(
+            _img(), "Click Login", target_label="Login",
+        )
+
+    assert result is not None
+    assert result["x"] == 500
+    assert result["y"] == 400
+
+
+def test_claude_provider_explicit_rect_region_reprojects() -> None:
+    def _capture(*_args, **kwargs):
+        resp = MagicMock(status_code=200)
+        resp.json.return_value = {
+            "content": [{
+                "type": "tool_use",
+                "name": "report_form_target",
+                "input": {
+                    "x": 10, "y": 20, "action": "click",
+                    "value": "", "label": "X",
+                },
+            }],
+        }
+        return resp
+
+    client = AnthropicToolUseClient(api_key="k", model="m", log_prefix="t")
+    provider = ClaudeFormTargetProvider(client)
+    with patch("requests.post", side_effect=_capture):
+        result = provider.find_form_target(
+            _img(1280, 800), "click",
+            region={"x": 300, "y": 400, "w": 200, "h": 100},
+        )
+    assert result["x"] == 310
+    assert result["y"] == 420


### PR DESCRIPTION
First slice of the docs/cua_notes.md → runtime roadmap (#435). Two mechanical wins, no architectural changes.

## Item 3 — Image pruning to 1-3 frames

cua_notes.md §1 *"Keep only the last 1-3 screenshots — images dominate token cost; older frames are mostly redundant once you have the action log."*

\`frames_per_inference\` defaults across the Modal executors:
- Holo3 — 1 (unchanged, already compliant)
- Claude / Fara / EvoCUA / OpenCUA — was 5, now 2

Holo3 keeps 1 (tightest context budget); Claude keeps 2 so current-vs-previous frame diff is still legible for reasoning. Operators override via the kwarg.

## Item 4 — Fara \`pause_and_memorize_fact\` plumbed through

cua_notes.md §4 *"Plumb it through if you build on Fara. Essentially an explicit scratchpad primitive."*

Previously \`brain_fara.py:712\` collapsed the tool call to \`WAIT(0.2s)\` with the note stuffed in \`Action.reasoning\` — write-only signal the next turn never read.

Two-line change:
- \`Action\` gains a \`memorize_fact: str\` field. Fara's handler populates it from the tool call's \`text\` arg.
- \`FaraBrain._build_messages\` scans \`action_history\` for non-empty \`memorize_fact\` entries (capped at last 10) and renders them in a \`Memorized facts (your earlier notes):\` block in the prompt.

So a model that emits \`pause_and_memorize_fact({"text": "customer=ACME, deal=$120k"})\` on turn 3 sees that fact in its prompt on turn 4 onward — a real running scratchpad that survives turn-to-turn pruning.

## Test plan

- [x] Three new tests in \`tests/test_brain_fara.py\` (pin the structured field + end-to-end re-feed + empty-history no-block).
- [x] \`uv run pytest tests/ -k 'fara or modal_endpoint or brain' -q\` → 178 pass.
- [x] \`uv run ruff check\` over touched files — clean.

## Roadmap status (#435)

Done: 3, 4. Next: 1 (region cropping), 2 (per-sub-goal history reset), 7 (structured retry signal to brain.think).

🤖 Generated with [Claude Code](https://claude.com/claude-code)