### PR TITLE
feat: auto-region inference for submit buttons + step-recovery docs

### DIFF
--- a/docs/operations/form-target-providers.md
+++ b/docs/operations/form-target-providers.md
@@ -47,13 +47,24 @@ forms. Before changing the default away from `claude`:
 4. Flip the default only when Holo3 is within 5% success-rate parity
    and >30% faster or cheaper.
 
-| Plan | Provider | Runs | Success rate | Mean $ / step | Mean s / step |
-|------|----------|-----:|-------------:|--------------:|--------------:|
-| `plans/luma` | claude | 0/5 | — | — | — |
-| `plans/luma` | holo3 | 0/5 | — | — | — |
+| Plan | Provider model | Runs | Success rate | Mean grounding calls / run | Mean $ / run |
+|------|----------------|-----:|-------------:|---------------------------:|-------------:|
+| `plans/staff-crm` | Opus (default) | 4 | 2/4 (1 complete on best, 1 complete after recovery, 2 halts on form-validation) | 36 (good) / 75-90 (bad) | $0.21 (good) / $0.54-0.65 (bad) |
+| `plans/staff-crm` | Haiku (override) | 1 | 0/1 | 93 | $0.65 |
 
-(Table left empty intentionally — the gate is a follow-up after #406
-lands. Replace with real numbers before any default change.)
+The Haiku-on-grounding A/B (#434) ran a side-by-side comparison of
+the same plan with the same code. Haiku's per-call price is ~25%
+of Opus, but its lower accuracy increased the grounding-call count
+~24% (75 → 93 calls on the canonical staff-crm halt). The retry
+amplification more than ate the per-call savings — total cost was
+*higher* on Haiku. The default reverted to "match the extractor's
+main model" with `form_target_model` kept as an opt-in kwarg for
+future experiments.
+
+Recovery interventions that landed on top of this (#435 region
+cropping + tab-blur + cascade cap) brought the staff-crm happy
+path down to $0.19 / 14 grounding calls — these matter much more
+for cost than the per-call model price.
 
 ## Wiring summary
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -15,6 +15,7 @@
 | [Speculative inference](speculative-inference.md) | Overlaps `brain.think()` with the post-action settle to remove the serial inference cost |
 | [Perceptual diff verifier](perceptual-diff.md) | Detects silent failures on high-risk actions by comparing pre/post frame hashes |
 | [Loop recovery policy](loop-recovery.md) | Forces action-class transitions (Tab / Return / Type) when the brain loops on a no-effect class |
+| [Step recovery](step-recovery.md) | Multi-layer recovery chain when a required step exhausts retries: handler escalation → intent_rewriter (Opus) → agentic_recovery (Haiku/Opus, four modes) |
 | [Adaptive loop windows](adaptive-loop-windows.md) | Per-call adjustment of the soft/hard loop-detection windows by recent action diversity + state progress |
 | [Adaptive click tolerance](adaptive-click-tol.md) | Drift-loop tolerance scaled by screen DPI and per-action element class (button / link / dropdown) |
 | [Ablation harness](ablation-harness.md) | Single-deploy paired ON/OFF A/B against `/v1/cua`; required for quality-touching PRs |

--- a/docs/reference/step-recovery.md
+++ b/docs/reference/step-recovery.md
@@ -1,0 +1,125 @@
+# Step recovery
+
+When a required step fails after its retry budget is exhausted, Mantis runs a multi-layer recovery chain before halting. This page documents the layers, the gates that bound them, and the env vars that tune them.
+
+The recovery surface sits inside `MicroPlanRunner` — it doesn't apply to legacy `GymRunner.run()` (OSWorld-style benchmarks, `cua_model=claude` direct path). Plan-driven runs (`/v1/predict` with `micro: …`, `task_suite: {_micro_plan: …}`, or `plan_text: …`) all flow through this chain.
+
+## Layers, in firing order
+
+```
+step fails (required:true, retry budget = max_retries=2 exhausted)
+   │
+   ├─ Layer 1: per-step handler escalation
+   │   (form → Holo3StepHandler when ≥2 no_state_change demotes)
+   │
+   ├─ Layer 2: intent_rewriter (Opus, same-step rewrite)
+   │   gated on failure_class ∈ {brain_loop_exhausted, wrong_target,
+   │   no_state_change}; budget 1 rewrite per step
+   │
+   └─ Layer 3: agentic_recovery (Haiku → Opus on validation-blocked
+       submits) — picks one of:
+           add_hint | edit_step | insert_steps | halt
+       budget: 2 per step, 5 per run
+       on no_state_change submit: tab-blur traversal before screenshot
+       on insert_steps: inherits parent's hints.region, cascade-depth
+       capped at ≤2
+```
+
+Each layer is independent; failure at one layer falls through to the next. The chain ends in either a `RecoveryOutcome(halt=False, …)` (run continues, possibly at a different step) or `RecoveryOutcome(halt=True, …)` (legacy HALT path).
+
+## Layer 1 — Handler escalation
+
+When a step type has multiple handlers registered, the form handler's submit / fill_field path tracks `_step_failure_history` per index. After 2 same-kind failures (canonical: `no_state_change` demotes), `_maybe_set_handler_override` flips the per-step override:
+
+```
+runner._step_handler_override[index] = "holo3"
+```
+
+The next dispatch routes through `Holo3StepHandler`, which spawns a fresh `GymRunner` with the Holo3 brain (`step_handlers/holo3.py`). The brain receives the augmented intent prose including a `CONTEXT: previous attempts clicked on …` block built from `_step_failure_history`. Budget bumps to `max(step.budget, 25)` for the brain-grounded loop.
+
+This layer fires before `intent_rewriter` and `agentic_recovery` get a turn. Many staff-crm halts get unblocked here without ever reaching layers 2 or 3.
+
+## Layer 2 — `intent_rewriter` (epic #377 Phase B)
+
+Module: `src/mantis_agent/gym/intent_rewriter.py`. Model: `claude-opus-4-7`.
+
+Fires from `RunExecutor._maybe_rewrite_intent_for_retry` after `_handle_failure` decides retry (not halt). Asks Opus to propose a more mechanical / specific intent for the next retry. Returns either:
+
+- A new intent string → stashed in `runner._step_intent_overrides[step_index]`, next retry uses it
+- `KEEP` → no rewrite; retry uses the original intent
+
+**Pre-step filter** (issue #428 Part B): pre-step-shaped rewrites like `"First fix the invalid X field"` or `"Before clicking, set Y"` are recognized via `_looks_like_pre_step_rewrite` and dropped to `None`. Those describe a different verb that should be a Layer-3 `insert_steps`, not a same-step rewrite. The rewriter prompt also forbids them upstream so they don't reach the filter in the common case.
+
+**Triggering classes**: `REWRITE_TRIGGERING_CLASSES = {brain_loop_exhausted, wrong_target, no_state_change}`. Anything else short-circuits at `should_attempt_rewrite()`.
+
+**Budget**: `max_attempts=1` per step (`_step_rewrite_attempts[step_index]`). One rewrite per step per run. The first rewrite either lands (next retry takes the new intent) or no-changes (retry uses original); a second call short-circuits with `[N] rewriter_skipped: per-step budget exhausted`.
+
+**Env**: `ANTHROPIC_API_KEY` required. No opt-out env var today; the budget cap is the throttle.
+
+## Layer 3 — `agentic_recovery` (issue #224)
+
+Module: `src/mantis_agent/agentic_recovery.py` (the Claude call) + `step_recovery.StepRecoveryPolicy._try_agentic_recovery` (the runner integration). Default model: `claude-haiku-4-5-20251001`. **Upgraded to `claude-opus-4-7` for `no_state_change` failures on `submit` steps** (issue #432) — Haiku's vision frequently misses red field-validation indicators, which is the canonical "silent submit rejection" pattern.
+
+Fires after layers 1 and 2 have given up — i.e., the per-step retry budget is exhausted and the step is still failing. Returns a `RecoveryDecision` with one of four modes:
+
+| Mode | What it does | When to use (per the prompt) |
+|---|---|---|
+| `add_hint` | Append a clarifying instruction to the next retry's search prompt | Right element visible, just need to tell the searcher to pick it |
+| `edit_step` | Mutate `step.intent` / `step.type` / `step.params` in place | Labels in params are wrong, or step type genuinely needs to change |
+| `insert_steps` | Splice helper sub-flow before the failed step | Precondition missing — modal blocking, section collapsed, scroll needed, field value invalid |
+| `halt` | Surface the failure to the operator | Target genuinely missing, anti-bot block, page state contradicts step premise |
+
+**Tab-blur traversal**: when `failure_class == "no_state_change"` AND `step.type == "submit"`, the policy walks `Tab × 12` through the form *before* capturing the screenshot. Most React forms render `:invalid` / `aria-invalid` styles only after focus leaves a bad field — the post-submit-fail screenshot is visually clean even when the submit handler short-circuited on a validation error. Tab traversal forces the rendering so Claude can see what to insert a normalize step for. Disable via `MANTIS_RECOVERY_TAB_BLUR=disabled`; count via `MANTIS_RECOVERY_TAB_BLUR_COUNT` (default 12).
+
+**Region hint inheritance**: when `insert_steps` splices new steps before the failed one, the new steps inherit the parent step's `hints.region` so `find_form_target` runs with the same scoping the parent had. The submit-only hints (`visual`, `position`) aren't carried — they don't translate to the inserted step.
+
+**Cascade cap**: if an inserted step itself fails and triggers another `_try_agentic_recovery` that wants `insert_steps`, the runner halts cleanly at cascade depth ≥ 2 instead of looping `insert_steps` on the same root cause (which would burn the per-run recovery budget on cascading no-effect retries — observed pattern: $0.92 / 32-step halt before the cap was added).
+
+**Budgets**: `DEFAULT_MAX_RECOVERIES_PER_STEP = 2`, `DEFAULT_MAX_RECOVERIES_PER_RUN = 5`. Both are hard caps in `agentic_recovery.py`. The per-step counter sits on `runner._recovery_attempts_per_step`; per-run on `runner._total_recovery_attempts`. Cascade tracking on `runner._recovery_inserted_steps` (set) + `runner._recovery_cascade_depth` (dict).
+
+## Failure-class taxonomy
+
+`StepResult.failure_class` is the discriminator across the chain. Common values:
+
+| `failure_class` | Set by | Meaning |
+|---|---|---|
+| `""` (empty) | default | Generic failure, no specific diagnosis |
+| `no_state_change` | `_maybe_demote_form_no_change` / `_maybe_demote_click_no_change` | Action reported success but the page didn't transition |
+| `brain_loop_exhausted` | `Holo3StepHandler` | Inner GymRunner hit `max_steps` or the loop detector tripped |
+| `wrong_target` | various click handlers | Click landed on a non-action element (status badge, label) |
+| `selector_miss` | form `right_click` handler | `find_form_target` returned None on a structured-label call |
+
+The rewriter only triggers on the first three; the recovery analyser sees all of them.
+
+## Visibility
+
+Issue #431 normalized every silent-skip path in the chain to log at WARNING. Grep markers:
+
+| Marker | What it means |
+|---|---|
+| `[N] rewriter_skipped: …` | Rewriter call site exited without producing a rewrite |
+| `[N] rewriter_no_change: Claude returned no actionable rewrite` | Rewriter ran, Claude returned KEEP / empty / identical |
+| `[rewriter] step N intent rewritten from … → …` | Rewriter applied a new intent |
+| `[N] recovery_skipped: per-step budget exhausted` | Layer 3 hit per-step cap |
+| `[N] recovery_skipped: per-run budget exhausted` | Layer 3 hit per-run cap |
+| `[N] recovery_skipped: inserted-step cascade depth N exceeded` | Layer 3 cascade cap fired |
+| `[N] recovery: tab-blur traversal × 12 …` | Layer 3 ran the blur-driven validation render before screenshot |
+| `[N] agentic recovery: mode=… — …` | Layer 3 applied a decision |
+| `agentic_recovery_skipped: 200 OK but no record_recovery tool_use block` | Anthropic returned text-only instead of the forced tool |
+
+Each of these surfaces enough state to debug from Modal logs alone — issue #433's diagnosis chain depended on every one of them firing reliably.
+
+## Env knobs
+
+| Env var | Default | Effect |
+|---|---|---|
+| `MANTIS_RECOVERY_TAB_BLUR` | (unset) | Set to `"disabled"` to skip Tab traversal before the recovery screenshot. Useful for bisecting whether the traversal helps or harms a specific plan. |
+| `MANTIS_RECOVERY_TAB_BLUR_COUNT` | `12` | Override the Tab count for forms with more inputs. Each Tab is ~50ms; 12 → ~0.6s overhead per recovery call. |
+| `ANTHROPIC_API_KEY` | (unset) | Required for layers 2 and 3. If missing, both fall through to the legacy retry-then-halt path with a WARNING log. |
+
+## What's NOT here (open follow-ups)
+
+* **Runtime sub-goal decomposition by the frontier model** (epic #435 item 8). Today the planner is plan-time only; mid-run replanning lives in `agentic_recovery.insert_steps` which only fires on failure. A continuous planner that observes step outcomes and emits directives mid-run would be a different layer.
+* **CDP-readonly probe** (option 3 in #432). Inspect `input.validity` / `aria-invalid` directly via DOM injection instead of relying on Claude vision. Deterministic, but breaks the zero-fingerprint architecture invariant — opt-in flag at minimum.
+
+See [`docs/cua_notes.md`](../cua_notes.md) for the design rationale behind the planner-executor split and the "history mostly text, not images" pattern that frames how this chain is built.

--- a/docs/reference/step-recovery.md
+++ b/docs/reference/step-recovery.md
@@ -122,4 +122,4 @@ Each of these surfaces enough state to debug from Modal logs alone — issue #43
 * **Runtime sub-goal decomposition by the frontier model** (epic #435 item 8). Today the planner is plan-time only; mid-run replanning lives in `agentic_recovery.insert_steps` which only fires on failure. A continuous planner that observes step outcomes and emits directives mid-run would be a different layer.
 * **CDP-readonly probe** (option 3 in #432). Inspect `input.validity` / `aria-invalid` directly via DOM injection instead of relying on Claude vision. Deterministic, but breaks the zero-fingerprint architecture invariant — opt-in flag at minimum.
 
-See [`docs/cua_notes.md`](../cua_notes.md) for the design rationale behind the planner-executor split and the "history mostly text, not images" pattern that frames how this chain is built.
+The design rationale behind the planner-executor split and the "history mostly text, not images" pattern that frames how this chain is built lives in internal CUA agent design notes (epic #435 roadmap).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -144,6 +144,7 @@ nav:
       - Speculative inference: reference/speculative-inference.md
       - Perceptual diff verifier: reference/perceptual-diff.md
       - Loop recovery policy: reference/loop-recovery.md
+      - Step recovery: reference/step-recovery.md
       - Adaptive loop windows: reference/adaptive-loop-windows.md
       - Adaptive click tolerance: reference/adaptive-click-tol.md
       - Ablation harness: reference/ablation-harness.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -151,3 +151,4 @@ nav:
   - Appendix:
       - appendix/index.md
       - Learnings: learnings.md
+      - CUA agent design notes: cua_notes.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -151,4 +151,3 @@ nav:
   - Appendix:
       - appendix/index.md
       - Learnings: learnings.md
-      - CUA agent design notes: cua_notes.md

--- a/src/mantis_agent/gym/step_handlers/form.py
+++ b/src/mantis_agent/gym/step_handlers/form.py
@@ -170,6 +170,49 @@ _SUBMIT_KIND_INTENT_TEMPLATES: dict[str, str] = {
 _SUBMIT_KIND_DEFAULT = "button"
 
 
+# #435 follow-up: auto-region inference table. When a step's
+# (type, params.kind) lands here AND it has no explicit
+# ``hints.region``, the form handler scopes the screenshot to this
+# named region before grounding. The named regions are defined in
+# ``mantis_agent.form_targeting.region._NAMED_REGIONS``.
+#
+# Picks come from observed layout patterns on the staff-crm + lu.ma +
+# generic web-app plans:
+#
+# * ``submit`` / button — primary-action buttons live in the form's
+#   footer row (the (Cancel, Reset, Save / Update / Submit) row).
+#   The form-footer named region covers the bottom 40% of the
+#   screenshot, which holds both fixed-footer and natural-end-of-form
+#   layouts.
+# * ``submit`` / nav_link — sidebar / top-nav links. Don't auto-crop
+#   (no strong default — could be top or left depending on app).
+# * ``submit`` / row_link — table rows lay across the middle band
+#   in typical list-detail layouts. Use ``"full"`` (no crop) since
+#   the row could be anywhere on a paginated table.
+# * ``select_option`` — dropdown triggers live above the action-
+#   button row, in the form body. Use ``"full"`` because the open
+#   dropdown menu repositions absolutely and we can't anchor to a
+#   form region without breaking it.
+_AUTO_REGION_BY_KIND: dict[tuple[str, str], str] = {
+    ("submit", "button"): "form-footer",
+}
+
+
+def _auto_region_for_step(step: Any, params: dict[str, Any]) -> str:
+    """Default region hint for a step that didn't set ``hints.region``.
+
+    Returns empty string when no auto-default fits — caller treats
+    that as "no crop, same as pre-#435 behaviour". Operators who
+    want to force the unscoped path can set
+    ``hints.region: "full"`` (a no-op named region defined in
+    :mod:`..form_targeting.region`); both routes leave the
+    screenshot untouched but ``"full"`` is more explicit.
+    """
+    step_type = str(getattr(step, "type", "") or "")
+    kind = str(params.get("kind") or "").lower()
+    return _AUTO_REGION_BY_KIND.get((step_type, kind), "")
+
+
 def _build_submit_search_intent(label: str, kind: str, fallback: str) -> str:
     """Construct the find_form_target prompt for a submit step.
 
@@ -222,9 +265,19 @@ class ClaudeGuidedFormHandler:
         # makes (initial, scroll-probe sweep, retry-with-hint) passes
         # ``region`` through, so the executor sees a cropped frame on
         # each call — coordinates re-projected by the provider before
-        # they reach the runner. Empty / missing → no crop, identical
-        # to the pre-#435 path.
+        # they reach the runner.
+        #
+        # #435 follow-up: auto-region inference. For the canonical
+        # submit-on-button pattern (the staff-crm Update Lead case),
+        # plan authors shouldn't have to add ``hints.region: "bottom"``
+        # by hand — the action-button row almost always lives in the
+        # form footer. When the step's type+kind matches this shape
+        # AND no explicit region is set, default to ``"form-footer"``.
+        # Plan authors who want the unscoped path can opt out with
+        # ``hints.region: "full"`` (the no-op named region).
         step_region = (getattr(step, "hints", {}) or {}).get("region")
+        if not step_region:
+            step_region = _auto_region_for_step(step, params)
         # Combined settle — form pages frequently finish hydrating after the
         # navigate that brought us here. EPIC #161 cleanup merges the
         # pre-handler 2s sleep that used to live in MicroPlanRunner

--- a/tests/test_form_target_region.py
+++ b/tests/test_form_target_region.py
@@ -193,6 +193,87 @@ def test_claude_provider_no_region_behaves_identically_to_before() -> None:
     assert result["y"] == 400
 
 
+def test_auto_region_inference_for_submit_button() -> None:
+    """#435 follow-up: a ``submit`` step with ``kind: "button"`` and no
+    explicit ``hints.region`` defaults to ``"form-footer"`` — the
+    canonical layout for action-button rows. Removes plan-author
+    burden for the most common pattern.
+    """
+    from mantis_agent.gym.step_handlers.form import _auto_region_for_step
+    from mantis_agent.plan_decomposer import MicroIntent
+
+    step = MicroIntent(
+        intent="Click Update Lead",
+        type="submit",
+        params={"label": "Update Lead", "kind": "button"},
+    )
+    region = _auto_region_for_step(step, step.params)
+    assert region == "form-footer"
+
+
+def test_auto_region_inference_no_default_for_unmapped_shapes() -> None:
+    """For step shapes that don't have a clear default layout
+    (``submit`` / ``nav_link``, ``submit`` / ``row_link``,
+    ``select_option`` triggers), return empty string — caller falls
+    back to the unscoped path. Avoids cropping out targets that
+    legitimately live outside the form footer.
+    """
+    from mantis_agent.gym.step_handlers.form import _auto_region_for_step
+    from mantis_agent.plan_decomposer import MicroIntent
+
+    for params in (
+        {"kind": "nav_link"},
+        {"kind": "row_link"},
+        {"kind": "link"},
+        {},  # no kind at all
+    ):
+        step = MicroIntent(intent="x", type="submit", params=params)
+        assert _auto_region_for_step(step, step.params) == "", (
+            f"unmapped kind {params!r} should return empty string"
+        )
+
+
+def test_auto_region_inference_skips_select_option() -> None:
+    """``select_option`` shouldn't default to any region — the open
+    dropdown menu repositions absolutely and a form-footer crop
+    would hide the option list.
+    """
+    from mantis_agent.gym.step_handlers.form import _auto_region_for_step
+    from mantis_agent.plan_decomposer import MicroIntent
+
+    step = MicroIntent(
+        intent="Pick Foo", type="select_option",
+        params={"dropdown_label": "Bar", "option_label": "Foo"},
+    )
+    assert _auto_region_for_step(step, step.params) == ""
+
+
+def test_explicit_region_takes_precedence_over_auto() -> None:
+    """When the plan author sets ``hints.region`` explicitly, the
+    form handler must use that value — auto-inference only fires when
+    the hint is missing. Test the form handler's logic, not just the
+    inference helper.
+    """
+    # This is exercised by the form handler's actual control flow
+    # (``step_region = hints.get("region") or _auto_region_for_step(...)``).
+    # The inference helper itself doesn't see ``hints``; the handler's
+    # ``if not step_region`` check is what enforces precedence. Pin
+    # the helper's behaviour: it returns the auto value regardless
+    # of what hints contain, since hints are the caller's
+    # responsibility.
+    from mantis_agent.gym.step_handlers.form import _auto_region_for_step
+    from mantis_agent.plan_decomposer import MicroIntent
+
+    step = MicroIntent(
+        intent="Click", type="submit",
+        params={"kind": "button"},
+        hints={"region": "top"},  # plan author wants top
+    )
+    # Helper still suggests form-footer (it's a pure function of
+    # type/kind); precedence is enforced at the handler.
+    assert _auto_region_for_step(step, step.params) == "form-footer"
+
+
 def test_claude_provider_explicit_rect_region_reprojects() -> None:
     def _capture(*_args, **kwargs):
         resp = MagicMock(status_code=200)


### PR DESCRIPTION
Follow-up to #436 — pins down the wins from the docs/cua_notes.md roadmap (#435) by automating the most common region-cropping case and documenting the recovery chain we just shipped.

## Auto-region inference (code)

PR #436 added the \`hints.region\` mechanism. Plan authors had to set it by hand on each submit step. This adds an inference table that defaults \`(submit, button)\` → \`"form-footer"\` so the staff-crm Update Lead case (and every other action-button submit) gets region scoping with zero plan changes.

\`_AUTO_REGION_BY_KIND\` covers only one mapping today (\`("submit", "button")\`); other kinds return empty so the unscoped path runs. Plan authors override by setting \`hints.region\` explicitly (any value, including \`"full"\` as an explicit no-crop opt-out).

## Docs — recovery reference + form-target smoke-gate fill-in

New \`docs/reference/step-recovery.md\` covers the three-layer chain: handler escalation → intent_rewriter (Opus) → agentic_recovery (Haiku/Opus, four modes). Documents the tab-blur traversal, cascade cap, budget gates, visibility grep markers, env knobs, and the failure_class taxonomy. Closes the documentation gap I found when reading docs after the #426-#434 work landed — \`loop-recovery.md\` covers action-level only.

Filled in \`docs/operations/form-target-providers.md\`'s previously-empty smoke-gate table with the Haiku-vs-Opus data from #434.

Added a nav entry in \`mkdocs.yml\`.

## Test plan

- [x] 4 new tests in \`tests/test_form_target_region.py\` (auto-region helper).
- [x] \`uv run pytest tests/ -k 'form_target or fara or claude or recovery or rewriter' -q\` → 325 pass.
- [x] \`uv run ruff check\` — clean.
- [x] \`uv run mkdocs build --strict\` — clean (only pre-existing INFO notices).
- [ ] Modal redeploy + staff-crm rerun WITHOUT \`hints.region\` on the plan should match the cleanest run we've seen ($0.19 / 14 steps / completed) since auto-region picks up where the explicit hint left off.

## Roadmap status (#435)

Done in PR #436: items 1-6 + cascade cap + region inheritance + tab-blur. Done in this PR: auto-region inference (emergent, not on original roadmap) + recovery docs.

Remaining on #435: item #8 (runtime sub-goal decomposition by frontier model) and #9 (runner-driven scratchpad) — both larger architectural pieces tracked for separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)