### PR TITLE
fix(baseten): per-tenant per-profile Chrome user-data-dir (PR #426 parity)

### DIFF
--- a/src/mantis_agent/baseten_server/runtime.py
+++ b/src/mantis_agent/baseten_server/runtime.py
@@ -94,12 +94,19 @@ _build_proxy_config = build_proxy_config
 # A fresh ``/v1/cua`` request pays ~10 s for Xvfb + Chrome launch + first
 # navigation before the brain runs. Cache keyed on
 # ``(profile_dir, proxy_server)`` so successive requests with the same
-# tenant + same proxy reuse the live browser process. ``reset(start_url=...)``
-# inside the cached env handles the in-tab navigation in <500 ms.
+# tenant + same profile + same proxy reuse the live browser process.
+# ``reset(start_url=...)`` inside the cached env handles the in-tab
+# navigation in <500 ms.
 #
-# Cross-tenant isolation is preserved because the profile_dir is
-# tenant-scoped (``data_root / "chrome-profile" / <tenant_id>__<key>``)
-# and tenant requests will mismatch on the first key component.
+# Cross-tenant AND cross-profile isolation is preserved by
+# :func:`_chrome_profile_dir_for_suite`, which derives the path from
+# ``task_suite["_profile_id"]`` — a value already namespaced as
+# ``<tenant_id>__<caller_profile_id>`` by
+# :func:`server_utils.build_micro_suite`. Different profile_ids land
+# on different cache keys (and on disk in different user-data-dirs)
+# so cookies / localStorage don't leak across them. Earlier code passed
+# a flat ``data_root / "chrome-profile"`` here — the cache key was the
+# same string across tenants, and the on-disk profile was shared too.
 #
 # Set ``MANTIS_CHROME_REUSE=disabled`` to fall back to the per-request
 # launch path (the legacy behaviour). Callers can also opt out per request
@@ -110,6 +117,36 @@ _chrome_env_cache_lock = threading.Lock()
 
 def _chrome_reuse_enabled() -> bool:
     return os.environ.get("MANTIS_CHROME_REUSE", "enabled").lower() != "disabled"
+
+
+def _chrome_profile_dir_for_suite(task_suite: dict[str, Any]) -> str:
+    """Per-tenant, per-profile Chrome user-data-dir for a Baseten request.
+
+    Mirrors the same isolation guarantee the Modal path got in PR #426.
+    The earlier Baseten code passed ``data_root / "chrome-profile"`` — a
+    flat path shared across every request — which the surrounding
+    comment claimed was tenant-scoped but wasn't. Cookies / localStorage /
+    IndexedDB leaked across tenants AND across ``profile_id``s on the
+    same container.
+
+    ``task_suite["_profile_id"]`` is already server-prefixed (the
+    ``<tenant_id>__<caller_profile_id>`` shape produced by
+    :func:`server_utils.build_micro_suite`), so a single path
+    segment gives us both isolations at once. Falling back to
+    ``"default"`` keeps legacy / unscoped callers working, just with
+    them sharing one default profile rather than the previous "everyone
+    shares one chrome-profile" behaviour.
+
+    The session-reuse cache (``_chrome_env_cache``) keys on this same
+    path, so two requests with different ``profile_id``s no longer
+    accidentally share a cached Chrome instance.
+    """
+    profile_id = (
+        task_suite.get("_profile_id")
+        or task_suite.get("_state_key")
+        or "default"
+    )
+    return str(_data_root() / "chrome-profile" / _safe_state_key(str(profile_id)))
 
 
 def _shutdown_chrome_env_cache() -> None:
@@ -958,7 +995,7 @@ class BasetenCUARuntime:
             proxy_state=str(task_suite.get("_proxy_state") or ""),
             proxy_disabled=bool(task_suite.get("_proxy_disabled", False)),
             browser=os.environ.get("MANTIS_BROWSER", "google-chrome"),
-            profile_dir=str(data_root / "chrome-profile"),
+            profile_dir=_chrome_profile_dir_for_suite(task_suite),
             save_screenshots_dir=str(data_root / "screenshots"),
             reuse_session=reuse_session,
         )
@@ -1653,8 +1690,7 @@ class BasetenCUARuntime:
         else:
             reuse_session_for_request = bool(reuse_session_payload)
 
-        data_root_path = _data_root()
-        cache_profile_dir = str(data_root_path / "chrome-profile")
+        cache_profile_dir = _chrome_profile_dir_for_suite(task_suite)
         # _make_env reads proxy_server via setup_env → build_proxy_config;
         # the cache key needs to include it so two requests with different
         # proxy configs don't share a browser. Recreate the proxy URL here

--- a/tests/test_baseten_chrome_profile.py
+++ b/tests/test_baseten_chrome_profile.py
@@ -1,0 +1,108 @@
+"""Tests for the Baseten per-tenant per-profile Chrome user-data-dir
+isolation (parity with PR #426 on Modal).
+
+The Baseten runtime previously passed ``data_root / "chrome-profile"``
+as the profile_dir — a flat path shared across every request, despite
+a surrounding comment that claimed tenant scoping. These tests pin the
+new behaviour: ``_chrome_profile_dir_for_suite`` derives a per-profile
+sub-path so cookies / localStorage / IndexedDB are isolated across
+tenants and across ``profile_id``s on the same container.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+# The baseten_server.runtime module imports the Anthropic / mss /
+# torch surface lazily, but the top-level import already pulls
+# transitively-heavy modules. Skip the whole file when those aren't
+# available so CI environments without the full extra-set can still
+# collect the rest of the test suite.
+pytest.importorskip("mantis_agent.baseten_server.runtime")
+from mantis_agent.baseten_server.runtime import _chrome_profile_dir_for_suite
+
+
+@pytest.fixture(autouse=True)
+def _isolated_data_root(tmp_path, monkeypatch):
+    monkeypatch.setenv("MANTIS_DATA_DIR", str(tmp_path / "mantis-data"))
+
+
+def test_per_profile_path_when_profile_id_present() -> None:
+    """The most common shape: ``_profile_id`` is set by
+    ``build_micro_suite`` to ``<tenant_id>__<caller_profile_id>``. The
+    returned path embeds that segment under ``chrome-profile/``.
+    """
+    suite = {"_profile_id": "default__alice"}
+    path = _chrome_profile_dir_for_suite(suite)
+    assert path.endswith("/chrome-profile/default__alice")
+
+
+def test_different_profiles_yield_different_paths() -> None:
+    """The CORE isolation guarantee — two distinct ``profile_id``s
+    on the same tenant + container must resolve to DIFFERENT paths.
+    Without this, Chrome reuses the cached user-data-dir across runs
+    and cookies / localStorage leak.
+    """
+    alice = _chrome_profile_dir_for_suite({"_profile_id": "default__alice"})
+    bob = _chrome_profile_dir_for_suite({"_profile_id": "default__bob"})
+    assert alice != bob
+
+
+def test_different_tenants_yield_different_paths() -> None:
+    """Cross-tenant isolation. ``build_micro_suite`` prefixes
+    profile_id with tenant_id, so two tenants with the same caller-
+    side profile_id ("default") still end up on distinct paths.
+    """
+    tenant_a = _chrome_profile_dir_for_suite({"_profile_id": "acme__default"})
+    tenant_b = _chrome_profile_dir_for_suite({"_profile_id": "globex__default"})
+    assert tenant_a != tenant_b
+
+
+def test_falls_back_to_state_key_when_profile_id_missing() -> None:
+    """Legacy callers that only set ``_state_key`` (pre-#341) still
+    get a per-key dir rather than landing in the shared default.
+    """
+    suite = {"_state_key": "legacy-tenant__some-key"}
+    path = _chrome_profile_dir_for_suite(suite)
+    assert path.endswith("/chrome-profile/legacy-tenant__some-key")
+
+
+def test_falls_back_to_default_when_neither_id_present() -> None:
+    """No-id payloads end up under a ``default`` segment instead of
+    sharing the previous ``data_root / "chrome-profile"`` flat path.
+    The shared-default still represents a leak surface between
+    unscoped callers, but it's strictly better than the pre-fix
+    state (every caller shared one profile).
+    """
+    suite = {}
+    path = _chrome_profile_dir_for_suite(suite)
+    assert path.endswith("/chrome-profile/default")
+
+
+def test_path_lives_under_data_root() -> None:
+    """The path roots at ``MANTIS_DATA_DIR / "chrome-profile" / …``
+    so the on-disk layout matches the doc's claim and is reachable
+    by the session-reuse cache lookups.
+    """
+    expected_root = os.environ["MANTIS_DATA_DIR"]
+    path = _chrome_profile_dir_for_suite({"_profile_id": "x__y"})
+    assert path.startswith(expected_root + "/chrome-profile/")
+
+
+def test_profile_id_sanitization_via_safe_state_key() -> None:
+    """``safe_state_key`` is applied to the profile_id before it
+    becomes a path segment, so a caller-supplied id with unsafe
+    characters can't escape the chrome-profile directory.
+    """
+    # Caller-supplied ids that ``build_micro_suite`` should have
+    # already sanitised — but we apply the helper defensively here
+    # too. The final path segment must not contain a slash (which
+    # would allow path-traversal); ``safe_state_key`` collapses
+    # slashes into underscores. The ``..`` characters themselves
+    # can survive in the middle of a filename — they're harmless
+    # when there's no slash to start a traversal from.
+    path = _chrome_profile_dir_for_suite({"_profile_id": "default__alice/../etc"})
+    final_segment = path.rsplit("/chrome-profile/", 1)[-1]
+    assert "/" not in final_segment


### PR DESCRIPTION
PR #426 fixed this exact bug on Modal — Baseten has the same flat ``data_root / "chrome-profile"`` path despite an in-tree comment claiming tenant scoping. Cookies / localStorage / IndexedDB leak across tenants AND across ``profile_id``s on the same container.

## Fix

Single helper ``_chrome_profile_dir_for_suite(task_suite)`` derives ``data_root / "chrome-profile" / safe_state_key(profile_id)`` from ``task_suite["_profile_id"]`` (already namespaced as ``<tenant_id>__<caller_profile_id>`` by ``build_micro_suite``). Routed through both call sites:

- ``_make_env`` (line 961) — initial Chrome launch on first request
- Session-reuse cache key (line 1657) — successive requests no longer collide on a cached Chrome with a different profile

Falls back to ``_state_key`` (pre-#341 callers) then ``"default"`` so unscoped callers stay working — just sharing one default profile rather than sharing every other tenant's data.

Also rewrote the stale comment at lines 94-107 to describe what the code actually does (cross-profile isolation, not just cross-tenant).

## Test plan

- [x] 7 new tests in ``tests/test_baseten_chrome_profile.py`` cover the helper's shape (per-profile path, different profile_ids → different paths, cross-tenant via embedded prefix, fallbacks, sanitization).
- [x] ``uv run pytest tests/ -k 'baseten' -q`` → 19 pass.
- [x] ``uv run ruff check`` over touched files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)