### PR TITLE
fix(form): context-aware auto-region inference (no flat (submit,button) default)

### DIFF
--- a/src/mantis_agent/gym/step_handlers/form.py
+++ b/src/mantis_agent/gym/step_handlers/form.py
@@ -170,35 +170,33 @@ _SUBMIT_KIND_INTENT_TEMPLATES: dict[str, str] = {
 _SUBMIT_KIND_DEFAULT = "button"
 
 
-# #435 follow-up: auto-region inference table. When a step's
-# (type, params.kind) lands here AND it has no explicit
-# ``hints.region``, the form handler scopes the screenshot to this
-# named region before grounding. The named regions are defined in
-# ``mantis_agent.form_targeting.region._NAMED_REGIONS``.
+# #435 follow-up: auto-region inference, context-aware. Originally a
+# flat (type, kind) → region table — but the staff-crm-long run
+# revealed that's too coarse: a ``(submit, button)`` step can be
+# either a form-finalize action (Update / Save / Submit, lives in
+# the footer) OR a filter-toolbar action (Apply / Search / Sort,
+# lives at the top). The flat default mapped both to ``"form-footer"``
+# and cropped the toolbar buttons out of frame.
 #
-# Picks come from observed layout patterns on the staff-crm + lu.ma +
-# generic web-app plans:
+# The fix is to peek at preceding plan steps. A submit immediately
+# preceded by ``fill_field`` actions is almost certainly a
+# form-finalize submit; one preceded by ``select_option`` /
+# ``filter`` (with no ``fill_field`` in the recent window) is
+# ambiguous and gets NO default — the plan author / decomposer
+# sets ``hints.region`` explicitly when scoping matters there.
 #
-# * ``submit`` / button — primary-action buttons live in the form's
-#   footer row (the (Cancel, Reset, Save / Update / Submit) row).
-#   The form-footer named region covers the bottom 40% of the
-#   screenshot, which holds both fixed-footer and natural-end-of-form
-#   layouts.
-# * ``submit`` / nav_link — sidebar / top-nav links. Don't auto-crop
-#   (no strong default — could be top or left depending on app).
-# * ``submit`` / row_link — table rows lay across the middle band
-#   in typical list-detail layouts. Use ``"full"`` (no crop) since
-#   the row could be anywhere on a paginated table.
-# * ``select_option`` — dropdown triggers live above the action-
-#   button row, in the form body. Use ``"full"`` because the open
-#   dropdown menu repositions absolutely and we can't anchor to a
-#   form region without breaking it.
-_AUTO_REGION_BY_KIND: dict[tuple[str, str], str] = {
-    ("submit", "button"): "form-footer",
-}
+# The "explicit hint always wins" precedence is enforced at the
+# call site in :meth:`ClaudeGuidedFormHandler.execute`.
+_AUTO_REGION_WINDOW_SIZE: int = 4
 
 
-def _auto_region_for_step(step: Any, params: dict[str, Any]) -> str:
+def _auto_region_for_step(
+    step: Any,
+    params: dict[str, Any],
+    *,
+    plan_steps: list[Any] | None = None,
+    step_index: int | None = None,
+) -> str:
     """Default region hint for a step that didn't set ``hints.region``.
 
     Returns empty string when no auto-default fits — caller treats
@@ -207,10 +205,33 @@ def _auto_region_for_step(step: Any, params: dict[str, Any]) -> str:
     ``hints.region: "full"`` (a no-op named region defined in
     :mod:`..form_targeting.region`); both routes leave the
     screenshot untouched but ``"full"`` is more explicit.
+
+    Context-aware: when ``plan_steps`` and ``step_index`` are both
+    provided, a ``(submit, button)`` step only auto-crops to
+    ``"form-footer"`` if the preceding ``_AUTO_REGION_WINDOW_SIZE``
+    steps include at least one ``fill_field``. That signal
+    distinguishes form-finalize submits (which want the footer
+    crop) from filter-toolbar / list-page submits (which don't).
+
+    When the context is missing (legacy callers, unit tests that
+    build a StepContext directly), the helper returns empty rather
+    than fall back to the old flat default — better to under-crop
+    than mis-crop.
     """
     step_type = str(getattr(step, "type", "") or "")
     kind = str(params.get("kind") or "").lower()
-    return _AUTO_REGION_BY_KIND.get((step_type, kind), "")
+    if (step_type, kind) != ("submit", "button"):
+        return ""
+    if plan_steps is None or step_index is None:
+        return ""
+    window_start = max(0, int(step_index) - _AUTO_REGION_WINDOW_SIZE)
+    recent = plan_steps[window_start:int(step_index)]
+    if any(
+        str(getattr(s, "type", "") or "") == "fill_field"
+        for s in recent
+    ):
+        return "form-footer"
+    return ""
 
 
 def _build_submit_search_intent(label: str, kind: str, fallback: str) -> str:
@@ -267,17 +288,29 @@ class ClaudeGuidedFormHandler:
         # each call — coordinates re-projected by the provider before
         # they reach the runner.
         #
-        # #435 follow-up: auto-region inference. For the canonical
-        # submit-on-button pattern (the staff-crm Update Lead case),
-        # plan authors shouldn't have to add ``hints.region: "bottom"``
-        # by hand — the action-button row almost always lives in the
-        # form footer. When the step's type+kind matches this shape
-        # AND no explicit region is set, default to ``"form-footer"``.
-        # Plan authors who want the unscoped path can opt out with
-        # ``hints.region: "full"`` (the no-op named region).
+        # #435 follow-up: auto-region inference, context-aware. For the
+        # canonical submit-on-button pattern that comes AFTER form
+        # fills (Update Lead, Save, Submit), the action-button row
+        # almost always lives in the form footer. But not all
+        # ``(submit, button)`` steps are footer submits — filter-bar
+        # Apply / Search buttons share the same shape and live at the
+        # top of the page. The helper peeks at preceding plan steps
+        # to disambiguate: a fill_field within the last few steps =
+        # form-finalize submit = footer; otherwise no default.
+        #
+        # Explicit ``hints.region`` always wins (set ``"full"`` for
+        # an explicit no-crop opt-out).
         step_region = (getattr(step, "hints", {}) or {}).get("region")
         if not step_region:
-            step_region = _auto_region_for_step(step, params)
+            ctx_blob = getattr(runner, "_active_checkpoint_context", None) or {}
+            plan_for_ctx = ctx_blob.get("plan")
+            plan_steps_for_ctx = getattr(plan_for_ctx, "steps", None) if plan_for_ctx else None
+            step_index_for_ctx = ctx_blob.get("step_index")
+            step_region = _auto_region_for_step(
+                step, params,
+                plan_steps=plan_steps_for_ctx,
+                step_index=step_index_for_ctx,
+            )
         # Combined settle — form pages frequently finish hydrating after the
         # navigate that brought us here. EPIC #161 cleanup merges the
         # pre-handler 2s sleep that used to live in MicroPlanRunner

--- a/tests/test_form_target_region.py
+++ b/tests/test_form_target_region.py
@@ -193,85 +193,126 @@ def test_claude_provider_no_region_behaves_identically_to_before() -> None:
     assert result["y"] == 400
 
 
-def test_auto_region_inference_for_submit_button() -> None:
-    """#435 follow-up: a ``submit`` step with ``kind: "button"`` and no
-    explicit ``hints.region`` defaults to ``"form-footer"`` — the
-    canonical layout for action-button rows. Removes plan-author
-    burden for the most common pattern.
+def test_auto_region_form_finalize_submit_after_fill_field() -> None:
+    """#435 follow-up: a ``(submit, button)`` step preceded by
+    ``fill_field`` actions is a form-finalize submit (Update / Save /
+    Submit) → auto-crop to ``"form-footer"``. The fill_field signal
+    distinguishes this from filter-toolbar submits (Apply / Search)
+    that share the same (type, kind) shape but live at the top of
+    the page.
     """
     from mantis_agent.gym.step_handlers.form import _auto_region_for_step
     from mantis_agent.plan_decomposer import MicroIntent
 
-    step = MicroIntent(
-        intent="Click Update Lead",
-        type="submit",
-        params={"label": "Update Lead", "kind": "button"},
+    plan_steps = [
+        MicroIntent(intent="Open edit", type="submit"),
+        MicroIntent(intent="Set Status", type="select_option"),
+        MicroIntent(intent="Set notes", type="fill_field"),   # window hit
+        MicroIntent(intent="Click Update Lead", type="submit",
+                    params={"label": "Update Lead", "kind": "button"}),
+    ]
+    region = _auto_region_for_step(
+        plan_steps[3], plan_steps[3].params,
+        plan_steps=plan_steps, step_index=3,
     )
-    region = _auto_region_for_step(step, step.params)
     assert region == "form-footer"
 
 
-def test_auto_region_inference_no_default_for_unmapped_shapes() -> None:
-    """For step shapes that don't have a clear default layout
-    (``submit`` / ``nav_link``, ``submit`` / ``row_link``,
-    ``select_option`` triggers), return empty string — caller falls
-    back to the unscoped path. Avoids cropping out targets that
-    legitimately live outside the form footer.
+def test_auto_region_filter_toolbar_submit_gets_no_default() -> None:
+    """The canonical regression case from staff-crm-long step 8:
+    a ``(submit, button)`` step preceded only by ``select_option``
+    (filter dropdown change) is NOT a form-finalize submit and must
+    NOT default to ``"form-footer"``. The Apply / Search / Sort
+    buttons live in a top toolbar; the prior flat-default cropped
+    them out and the runner couldn't click them.
     """
     from mantis_agent.gym.step_handlers.form import _auto_region_for_step
     from mantis_agent.plan_decomposer import MicroIntent
 
+    plan_steps = [
+        MicroIntent(intent="Go to leads", type="submit"),
+        MicroIntent(intent="Filter status", type="submit"),
+        MicroIntent(intent="Pick Critical", type="select_option"),
+        MicroIntent(intent="Click Apply", type="submit",
+                    params={"label": "Apply", "kind": "button"}),
+    ]
+    region = _auto_region_for_step(
+        plan_steps[3], plan_steps[3].params,
+        plan_steps=plan_steps, step_index=3,
+    )
+    assert region == ""
+
+
+def test_auto_region_inference_no_default_for_unmapped_shapes() -> None:
+    """For step shapes outside ``(submit, button)`` — ``nav_link``,
+    ``row_link``, plain ``link``, missing kind, ``select_option``
+    triggers — return empty string regardless of context. Avoids
+    cropping out targets that legitimately live in non-form regions.
+    """
+    from mantis_agent.gym.step_handlers.form import _auto_region_for_step
+    from mantis_agent.plan_decomposer import MicroIntent
+
+    # Even with a fill_field in recent context, non-button kinds
+    # don't get the footer default.
+    plan_steps = [
+        MicroIntent(intent="Fill", type="fill_field"),
+        MicroIntent(intent="x", type="submit"),
+    ]
     for params in (
         {"kind": "nav_link"},
         {"kind": "row_link"},
         {"kind": "link"},
-        {},  # no kind at all
+        {},
     ):
-        step = MicroIntent(intent="x", type="submit", params=params)
-        assert _auto_region_for_step(step, step.params) == "", (
-            f"unmapped kind {params!r} should return empty string"
-        )
+        plan_steps[1] = MicroIntent(intent="x", type="submit", params=params)
+        assert _auto_region_for_step(
+            plan_steps[1], plan_steps[1].params,
+            plan_steps=plan_steps, step_index=1,
+        ) == "", f"unmapped kind {params!r} should return empty string"
 
 
-def test_auto_region_inference_skips_select_option() -> None:
-    """``select_option`` shouldn't default to any region — the open
-    dropdown menu repositions absolutely and a form-footer crop
-    would hide the option list.
+def test_auto_region_returns_empty_when_context_unavailable() -> None:
+    """Legacy callers / unit tests that build a StepContext directly
+    don't always have plan + step_index handy. Return empty rather
+    than fall back to a flat default — under-cropping is safer than
+    mis-cropping.
     """
     from mantis_agent.gym.step_handlers.form import _auto_region_for_step
     from mantis_agent.plan_decomposer import MicroIntent
 
-    step = MicroIntent(
-        intent="Pick Foo", type="select_option",
-        params={"dropdown_label": "Bar", "option_label": "Foo"},
-    )
+    step = MicroIntent(intent="x", type="submit",
+                       params={"kind": "button", "label": "Update Lead"})
     assert _auto_region_for_step(step, step.params) == ""
 
 
-def test_explicit_region_takes_precedence_over_auto() -> None:
-    """When the plan author sets ``hints.region`` explicitly, the
-    form handler must use that value — auto-inference only fires when
-    the hint is missing. Test the form handler's logic, not just the
-    inference helper.
+def test_auto_region_window_size_limits_lookback() -> None:
+    """The lookback window is bounded (default 4 steps). A fill_field
+    deep in the plan history (e.g. login fields 20 steps earlier)
+    must NOT pull a current submit into footer territory — that
+    would over-broadly footer-crop. The signal is locality.
     """
-    # This is exercised by the form handler's actual control flow
-    # (``step_region = hints.get("region") or _auto_region_for_step(...)``).
-    # The inference helper itself doesn't see ``hints``; the handler's
-    # ``if not step_region`` check is what enforces precedence. Pin
-    # the helper's behaviour: it returns the auto value regardless
-    # of what hints contain, since hints are the caller's
-    # responsibility.
     from mantis_agent.gym.step_handlers.form import _auto_region_for_step
     from mantis_agent.plan_decomposer import MicroIntent
 
-    step = MicroIntent(
-        intent="Click", type="submit",
-        params={"kind": "button"},
-        hints={"region": "top"},  # plan author wants top
+    # Long plan: login fill_fields at index 0-1, then many unrelated
+    # steps, then a submit at index 10.
+    plan_steps: list = []
+    plan_steps.append(MicroIntent(intent="login user", type="fill_field"))
+    plan_steps.append(MicroIntent(intent="login pass", type="fill_field"))
+    for _ in range(8):
+        plan_steps.append(MicroIntent(intent="navigate", type="submit"))
+    submit_step = MicroIntent(
+        intent="Apply filter", type="submit",
+        params={"label": "Apply", "kind": "button"},
     )
-    # Helper still suggests form-footer (it's a pure function of
-    # type/kind); precedence is enforced at the handler.
-    assert _auto_region_for_step(step, step.params) == "form-footer"
+    plan_steps.append(submit_step)
+    region = _auto_region_for_step(
+        submit_step, submit_step.params,
+        plan_steps=plan_steps, step_index=10,
+    )
+    assert region == "", (
+        "old fill_fields outside the window shouldn't apply footer-crop"
+    )
 
 
 def test_claude_provider_explicit_rect_region_reprojects() -> None:


### PR DESCRIPTION
## Summary

- Replaces the flat ``(submit, button) → "form-footer"`` auto-region table with a context-aware helper that peeks at preceding plan steps.
- A submit preceded by ``fill_field`` within a 4-step window is treated as a form-finalize submit (Update / Save / Submit) and gets the footer crop. Anything else (filter-toolbar Apply / Search / Sort) gets no default; under-cropping is safer than mis-cropping.
- Explicit ``hints.region`` always wins (`"full"` for explicit no-crop).
- Form handler reads ``plan + step_index`` from ``runner._active_checkpoint_context`` and passes them to the helper.

## Why

The flat default cropped filter-toolbar Apply / Search buttons out of frame on staff-crm-long step 8 — those buttons share the ``(submit, button)`` shape with form-finalize submits but live at the top of the page. Verified on Modal: step 8 no longer mis-crops, Update Lead path still receives footer crop via the fill_field-in-window signal.

The deeper grounding-accuracy issue on small toolbar buttons remains; follow-up PR adds params/hints preservation through the wire (P0 #1) + DOM-mode tier-0 click on labeled buttons.

## Test plan
- [x] 20 region tests pass locally (``uv run pytest tests/test_form_target_region.py``)
- [x] staff-crm-long verified on Modal — step 8 reaches OK (no mis-crop); plan halts later for an unrelated grounding-accuracy reason
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)