### PR TITLE
feat(brain): per-sub-goal action history + outcome-tagged retry attempts

### DIFF
--- a/src/mantis_agent/brain_claude.py
+++ b/src/mantis_agent/brain_claude.py
@@ -200,11 +200,32 @@ class ClaudeBrain:
         task: str,
         action_history: list[Action] | None = None,
         screen_size: tuple[int, int] = (1920, 1080),
+        *,
+        retry_attempts: list[dict] | None = None,
+        per_step_action_history: list[Action] | None = None,
     ) -> InferenceResult:
-        """Run perception-reasoning-action via Claude API with computer_use tool."""
+        """Run perception-reasoning-action via Claude API with computer_use tool.
+
+        ``retry_attempts`` (#435 item 7) — outcome-tagged failure records
+        from ``MicroPlanRunner._step_failure_history[step_index]``. When
+        present, rendered as a ``Recent attempts on this sub-goal:``
+        block. Lets Claude refute coordinates / patterns that already
+        failed without re-deriving the failure mode from prose.
+
+        ``per_step_action_history`` (#435 item 2) — sub-goal-scoped
+        action slice. When provided, overrides the global
+        ``action_history`` for the prompt's ``Recent actions:`` block.
+        The doc's *"Reset between sub-goals. Bounded length: 1–3
+        entries"* guidance — caller (per-step handler) supplies the
+        slice already trimmed.
+        """
         # Update computer_use tool dimensions to match actual screen
         tools = self._build_tools(screen_size)
-        messages = self._build_messages(frames, task, action_history, screen_size)
+        messages = self._build_messages(
+            frames, task, action_history, screen_size,
+            retry_attempts=retry_attempts,
+            per_step_action_history=per_step_action_history,
+        )
 
         payload = {
             "model": self.model,
@@ -291,6 +312,9 @@ class ClaudeBrain:
         task: str,
         action_history: list[Action] | None,
         screen_size: tuple[int, int],
+        *,
+        retry_attempts: list[dict] | None = None,
+        per_step_action_history: list[Action] | None = None,
     ) -> list[dict]:
         """Build Claude API messages with image content.
 
@@ -338,10 +362,28 @@ class ClaudeBrain:
             f"Screen size: {screen_size[0]}x{screen_size[1]} pixels",
         ]
 
-        if action_history:
-            recent = action_history[-10:]
-            history_str = "\n".join(f"  {i+1}. {a}" for i, a in enumerate(recent))
+        # #435 item 2: prefer the sub-goal-scoped action slice when the
+        # caller supplied one. Falls back to the global last-10 slice
+        # when not provided — preserves existing behaviour for callers
+        # that haven't migrated.
+        recent_actions: list[Action] | None = None
+        if per_step_action_history is not None:
+            recent_actions = list(per_step_action_history)
+        elif action_history:
+            recent_actions = action_history[-10:]
+        if recent_actions:
+            history_str = "\n".join(f"  {i+1}. {a}" for i, a in enumerate(recent_actions))
             context_parts.append(f"Recent actions:\n{history_str}")
+
+        # #435 item 7: outcome-tagged retry attempts from the runner's
+        # cross-attempt failure history. Goes AFTER the Recent actions
+        # block so a token budget cap truncates the older, less-specific
+        # action log first.
+        if retry_attempts:
+            from .gym import retry_attempts as _retry
+            block = _retry.render_attempts_block(retry_attempts)
+            if block:
+                context_parts.append(block)
 
         content.append({"type": "text", "text": "\n".join(context_parts)})
 

--- a/src/mantis_agent/brain_fara.py
+++ b/src/mantis_agent/brain_fara.py
@@ -327,9 +327,25 @@ class FaraBrain:
         task: str,
         action_history: list[Action] | None = None,
         screen_size: tuple[int, int] = (1920, 1080),
+        *,
+        retry_attempts: list[dict] | None = None,
+        per_step_action_history: list[Action] | None = None,
     ) -> InferenceResult:
-        """Single perception-reasoning-action cycle."""
-        messages = self._build_messages(frames, task, action_history)
+        """Single perception-reasoning-action cycle.
+
+        ``retry_attempts`` (#435 item 7) and ``per_step_action_history``
+        (#435 item 2) — same contract as ``brain_claude.think``. When
+        the caller (a per-plan-step handler in MicroPlanRunner) supplies
+        them, the prompt carries an outcome-tagged ``Recent attempts``
+        block plus a sub-goal-scoped action slice. Default ``None``
+        preserves the pre-existing global-history behaviour for
+        callers that haven't migrated.
+        """
+        messages = self._build_messages(
+            frames, task, action_history,
+            retry_attempts=retry_attempts,
+            per_step_action_history=per_step_action_history,
+        )
 
         payload: dict = {
             "model": self.model,
@@ -394,6 +410,9 @@ class FaraBrain:
         frames: list[Image.Image],
         task: str,
         action_history: list[Action] | None,
+        *,
+        retry_attempts: list[dict] | None = None,
+        per_step_action_history: list[Action] | None = None,
     ) -> list[dict]:
         """OpenAI-format messages with Fara's input-resolution screenshots."""
         messages: list[dict] = [{"role": "system", "content": SYSTEM_PROMPT}]
@@ -418,9 +437,15 @@ class FaraBrain:
                 " (coordinates are in this space)"
             ),
         ]
-        if action_history:
-            recent = action_history[-5:]
-            history = "\n".join(f"  {i + 1}. {a}" for i, a in enumerate(recent))
+        # #435 item 2: prefer the sub-goal-scoped slice when the caller
+        # supplied one. Otherwise fall back to the global last-5 slice.
+        recent_actions: list[Action] | None = None
+        if per_step_action_history is not None:
+            recent_actions = list(per_step_action_history)
+        elif action_history:
+            recent_actions = action_history[-5:]
+        if recent_actions:
+            history = "\n".join(f"  {i + 1}. {a}" for i, a in enumerate(recent_actions))
             parts.append(f"Recent actions:\n{history}")
         # #435: re-feed the model's own ``pause_and_memorize_fact``
         # entries from earlier turns. The Fara model card calls this
@@ -439,6 +464,17 @@ class FaraBrain:
             if facts:
                 fact_block = "\n".join(f"  - {f}" for f in facts)
                 parts.append(f"Memorized facts (your earlier notes):\n{fact_block}")
+
+        # #435 item 7: outcome-tagged retry attempts from the runner's
+        # cross-attempt failure history. Goes AFTER Recent actions /
+        # Memorized facts so a token budget cap truncates the older,
+        # less-specific action log first.
+        if retry_attempts:
+            from .gym import retry_attempts as _retry
+            block = _retry.render_attempts_block(retry_attempts)
+            if block:
+                parts.append(block)
+
         content.append({"type": "text", "text": "\n".join(parts)})
 
         messages.append({"role": "user", "content": content})

--- a/src/mantis_agent/brain_holo3.py
+++ b/src/mantis_agent/brain_holo3.py
@@ -300,9 +300,22 @@ class Holo3Brain:
         task: str,
         action_history: list[Action] | None = None,
         screen_size: tuple[int, int] = (1920, 1080),
+        *,
+        retry_attempts: list[dict] | None = None,
+        per_step_action_history: list[Action] | None = None,
     ) -> InferenceResult:
-        """Run perception-reasoning-action via Holo3 with tool calling."""
-        messages = self._build_messages(frames, task, action_history, screen_size)
+        """Run perception-reasoning-action via Holo3 with tool calling.
+
+        ``retry_attempts`` (#435 item 7) and ``per_step_action_history``
+        (#435 item 2) — same contract as ``brain_claude.think`` /
+        ``brain_fara.think``. Default ``None`` preserves pre-existing
+        global-history behaviour for callers that haven't migrated.
+        """
+        messages = self._build_messages(
+            frames, task, action_history, screen_size,
+            retry_attempts=retry_attempts,
+            per_step_action_history=per_step_action_history,
+        )
 
         payload: dict = {
             "model": self.model,
@@ -364,6 +377,9 @@ class Holo3Brain:
         task: str,
         action_history: list[Action] | None,
         screen_size: tuple[int, int],
+        *,
+        retry_attempts: list[dict] | None = None,
+        per_step_action_history: list[Action] | None = None,
     ) -> list[dict]:
         """Build OpenAI-format messages with image content."""
         messages = [{"role": "system", "content": SYSTEM_PROMPT}]
@@ -384,10 +400,23 @@ class Holo3Brain:
             f"\nTask: {task}",
             f"Screen size: {screen_size[0]}x{screen_size[1]} pixels",
         ]
-        if action_history:
-            recent = action_history[-5:]  # Keep short — Holo3 context is precious
-            history_str = "\n".join(f"  {i + 1}. {a}" for i, a in enumerate(recent))
+        # #435 item 2: prefer the sub-goal-scoped slice when set.
+        recent_actions: list[Action] | None = None
+        if per_step_action_history is not None:
+            recent_actions = list(per_step_action_history)
+        elif action_history:
+            # Keep short — Holo3 context is precious.
+            recent_actions = action_history[-5:]
+        if recent_actions:
+            history_str = "\n".join(f"  {i + 1}. {a}" for i, a in enumerate(recent_actions))
             context_parts.append(f"Recent actions:\n{history_str}")
+
+        # #435 item 7: outcome-tagged retry attempts.
+        if retry_attempts:
+            from .gym import retry_attempts as _retry
+            block = _retry.render_attempts_block(retry_attempts)
+            if block:
+                context_parts.append(block)
 
         content.append({"type": "text", "text": "\n".join(context_parts)})
         messages.append({"role": "user", "content": content})

--- a/src/mantis_agent/gym/retry_attempts.py
+++ b/src/mantis_agent/gym/retry_attempts.py
@@ -1,0 +1,100 @@
+"""Shared retry-attempt rendering — items 2 + 7 of roadmap #435.
+
+When a plan step fails (no_state_change / wrong_target / brain_loop_
+exhausted), the runner records the failed (x, y) coordinates + label
+into ``MicroPlanRunner._step_failure_history[step_index]``. On retry,
+brain adapters render these structured records in the prompt so the
+model can refute the same coordinates / patterns.
+
+This module centralises:
+
+1. The window cap — how many prior attempts to surface (older entries
+   add noise without signal, and the brain's context is the scarcer
+   resource than runner memory).
+2. The line format — what one attempt looks like in prose:
+   ``clicked (x, y) targeting "<matched>" → <outcome>``.
+3. The block render — full ``Recent attempts on this sub-goal:``
+   block ready to splice into a brain prompt.
+
+Holo3, Claude, and Fara adapters all call ``render_attempts_block``
+so the rendered shape is identical regardless of which brain reads
+the prompt. Without a shared formatter the three adapters drifted
+on outcome verbs / structure / window cap (the original
+``holo3.py``-private helper from #440 item C).
+"""
+
+from __future__ import annotations
+
+# How many prior-failure records to surface to the brain. Older
+# attempts add noise without signal; the brain's prompt is the
+# scarcer resource than runner memory.
+_PRIOR_ATTEMPTS_WINDOW: int = 3
+
+
+# Failure-class → human-readable outcome verb. Keyed on the ``kind``
+# the runner stamps when demoting a step. Unknown classes fall back
+# to ``failed (<kind>)`` so a refactor that adds a new class still
+# renders something legible.
+_OUTCOME_VERBS: dict[str, str] = {
+    "no_state_change": "no observable state change (click registered but page didn't react)",
+    "wrong_target": "wrong target (click changed state but not toward the success criterion)",
+    "brain_loop_exhausted": "brain ran out of moves before reaching the goal",
+    "selector_miss": "the chosen coordinates didn't hit an interactive element",
+}
+
+
+def format_prior_attempt(record: dict) -> str:
+    """One human-readable line per prior failed attempt.
+
+    Format: ``clicked (x, y) targeting "<matched_label>" → <outcome>``.
+
+    The outcome verb is keyed off ``record["kind"]`` (the failure
+    class the runner stamps when demoting). Falls back to a generic
+    ``failed (<kind>)`` when the kind is unknown.
+
+    Defensive on every field — a partial record (e.g. no
+    ``matched_label``) still produces a sensible line rather than
+    a stringified ``None``.
+    """
+    x = record.get("x", "?")
+    y = record.get("y", "?")
+    matched = str(record.get("matched_label") or record.get("label") or "").strip()
+    kind = str(record.get("kind") or "").strip()
+    reason = str(record.get("reason") or "").strip()
+    outcome = _OUTCOME_VERBS.get(kind, f"failed ({kind or 'unknown'})")
+    target_clause = f' targeting "{matched}"' if matched else ""
+    detail = f"; {reason[:120]}" if reason else ""
+    return f"clicked ({x}, {y}){target_clause} → {outcome}{detail}"
+
+
+def render_attempts_block(
+    attempts: list[dict] | None,
+    *,
+    window: int = _PRIOR_ATTEMPTS_WINDOW,
+    header: str = "Recent attempts on this sub-goal (do NOT repeat these coordinates / patterns)",
+) -> str:
+    """Render an outcome-tagged ``Recent attempts...`` block, or ``""``
+    when there's nothing to surface.
+
+    Caller appends the returned block (when non-empty) into the
+    executor prompt. Empty input — None, empty list, all-malformed
+    entries — returns the empty string so the caller's "if it's non-
+    empty, append" splice stays one-line.
+
+    Window cap: only the most-recent ``window`` (default 3) records
+    are rendered. The brain doesn't benefit from seeing every miss
+    in a long retry chain — only the recent pattern.
+    """
+    if not attempts:
+        return ""
+    recent = [r for r in attempts if isinstance(r, dict)][-max(1, int(window)):]
+    if not recent:
+        return ""
+    lines = [f"  {i + 1}. {format_prior_attempt(r)}" for i, r in enumerate(recent)]
+    return f"{header}:\n" + "\n".join(lines)
+
+
+__all__ = [
+    "format_prior_attempt",
+    "render_attempts_block",
+]

--- a/src/mantis_agent/gym/runner.py
+++ b/src/mantis_agent/gym/runner.py
@@ -629,6 +629,7 @@ class GymRunner:
         capture_dir: Any = None,
         pause_input: Any = None,
         pending_form_labels: list[str] | None = None,
+        retry_attempts: list[dict] | None = None,
     ) -> RunResult:
         """Execute a task with plan persistence, feedback, and context.
 
@@ -663,6 +664,12 @@ class GymRunner:
                 inadvertently claims whole-task completion while outer
                 credentials remain pending. Default ``None`` preserves
                 current single-layer behaviour.
+            retry_attempts: Optional structured prior-failure records
+                from the outer ``MicroPlanRunner._step_failure_history``
+                (#435 item 7). When set, threaded into every
+                ``brain.think()`` invocation so the brain sees an
+                outcome-tagged ``Recent attempts on this sub-goal``
+                block. Default ``None`` preserves single-layer behaviour.
         """
         logger.info(f"Starting task: {task!r} (id={task_id})")
         t0 = time.time()
@@ -1060,12 +1067,21 @@ class GymRunner:
                 # The model works from screenshots only
 
                 t_infer = time.time()
-                result = self.brain.think(
-                    frames=recent_frames,
-                    task=effective_task,
-                    action_history=action_history,
-                    screen_size=self.env.screen_size,
-                )
+                think_kwargs: dict[str, Any] = {
+                    "frames": recent_frames,
+                    "task": effective_task,
+                    "action_history": action_history,
+                    "screen_size": self.env.screen_size,
+                }
+                # #435 item 7: only pass ``retry_attempts`` to brains
+                # that opted in. Test stubs / older adapters that
+                # don't accept the kwarg keep working — production
+                # adapters (brain_claude / brain_fara / brain_holo3)
+                # accept it and render the outcome-tagged block in
+                # their prompts.
+                if retry_attempts:
+                    think_kwargs["retry_attempts"] = retry_attempts
+                result = self.brain.think(**think_kwargs)
                 inference_time = time.time() - t_infer
                 # Epic #362: credit brain inference to the ``think``
                 # bucket on the runner's TimeMeter. Reads the current

--- a/src/mantis_agent/gym/step_handlers/holo3.py
+++ b/src/mantis_agent/gym/step_handlers/holo3.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
+from .. import retry_attempts as _retry
 from ..checkpoint import StepResult
 from ..runner import GymRunner
 from ..step_context import StepContext
@@ -52,8 +53,6 @@ logger = logging.getLogger(__name__)
 # (#435 item 7: Claude / Fara prompt builders use the same shape).
 # Re-export the private helpers here for back-compat with existing
 # tests that import them from this module.
-from .. import retry_attempts as _retry
-
 _PRIOR_ATTEMPTS_WINDOW = _retry._PRIOR_ATTEMPTS_WINDOW
 _format_prior_attempt = _retry.format_prior_attempt
 

--- a/src/mantis_agent/gym/step_handlers/holo3.py
+++ b/src/mantis_agent/gym/step_handlers/holo3.py
@@ -48,36 +48,14 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-# Maximum number of prior-failure records to surface to Holo3 — older
-# attempts add noise without adding signal, and Holo3 context is the
-# scarcer resource here than runner memory.
-_PRIOR_ATTEMPTS_WINDOW: int = 3
+# The shared retry-attempts module owns the window cap + line format
+# (#435 item 7: Claude / Fara prompt builders use the same shape).
+# Re-export the private helpers here for back-compat with existing
+# tests that import them from this module.
+from .. import retry_attempts as _retry
 
-
-def _format_prior_attempt(record: dict) -> str:
-    """One human-readable line per prior failed attempt.
-
-    Format: ``clicked (x, y) targeting "<matched_label>" → <outcome>``
-
-    The outcome verb is keyed off ``record.kind`` (the failure class
-    the runner stamps when demoting a step). Falls back to a generic
-    "failed" when the kind is missing.
-    """
-    x = record.get("x", "?")
-    y = record.get("y", "?")
-    matched = str(record.get("matched_label") or record.get("label") or "").strip()
-    kind = str(record.get("kind") or "").strip()
-    reason = str(record.get("reason") or "").strip()
-    outcome_map = {
-        "no_state_change": "no observable state change (click registered but page didn't react)",
-        "wrong_target": "wrong target (click changed state but not toward the success criterion)",
-        "brain_loop_exhausted": "brain ran out of moves before reaching the goal",
-        "selector_miss": "the chosen coordinates didn't hit an interactive element",
-    }
-    outcome = outcome_map.get(kind, f"failed ({kind or 'unknown'})")
-    target_clause = f' targeting "{matched}"' if matched else ""
-    detail = f"; {reason[:120]}" if reason else ""
-    return f"clicked ({x}, {y}){target_clause} → {outcome}{detail}"
+_PRIOR_ATTEMPTS_WINDOW = _retry._PRIOR_ATTEMPTS_WINDOW
+_format_prior_attempt = _retry.format_prior_attempt
 
 
 def _build_scoped_task(step: "MicroIntent", runner: Any, step_index: int) -> str:
@@ -214,10 +192,27 @@ class Holo3StepHandler:
         # plus opaque click(x,y) history; with the new shape the brain
         # sees the same context the outer recovery loop already has.
         task = _build_scoped_task(step, runner, index)
+        # #435 item 7: also thread the structured failure records through
+        # to the inner GymRunner so EVERY brain.think() iteration sees
+        # the outcome-tagged ``Recent attempts on this sub-goal`` block
+        # — not just the first frame off the scoped task string. The
+        # task string still carries it for compat with prompts that
+        # didn't migrate; the kwarg is the structured form that the
+        # brain adapters render via the shared ``retry_attempts``
+        # module.
+        prior_attempts = (
+            runner._step_failure_history.get(index, [])
+            if hasattr(runner, "_step_failure_history") else []
+        )
+        retry_attempts_list = (
+            [r for r in prior_attempts if isinstance(r, dict)]
+            if isinstance(prior_attempts, list) else None
+        )
         result = gym_runner.run(
             task=task,
             task_id=f"step_{index}_{step.type}",
             pending_form_labels=outer_pending_labels,
+            retry_attempts=retry_attempts_list,
         )
 
         success = result.success

--- a/tests/test_brain_retry_attempts_integration.py
+++ b/tests/test_brain_retry_attempts_integration.py
@@ -14,7 +14,6 @@ unit under test; ``think()`` just forwards.
 from __future__ import annotations
 
 import importlib.util
-import sys
 
 import pytest
 from PIL import Image

--- a/tests/test_brain_retry_attempts_integration.py
+++ b/tests/test_brain_retry_attempts_integration.py
@@ -1,0 +1,286 @@
+"""Brain adapter integration with retry_attempts + per_step_action_history.
+
+Roadmap #435 items 2 + 7. All three adapters (Claude, Fara, Holo3) now
+accept structured prior-failure records and a sub-goal-scoped action
+slice as kwargs to ``think()`` / ``_build_messages()``. The rendered
+prompt carries a shared ``Recent attempts on this sub-goal:`` block
+and uses the scoped slice (when set) instead of the global tail.
+
+These tests pin the shape that lands in the request payload — without
+making real API calls. The brain adapter ``_build_messages`` is the
+unit under test; ``think()`` just forwards.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+
+import pytest
+from PIL import Image
+
+from mantis_agent.actions import Action, ActionType
+
+
+def _img() -> Image.Image:
+    return Image.new("RGB", (200, 100), color=(255, 255, 255))
+
+
+@pytest.fixture(scope="module")
+def _has_holo3() -> bool:
+    return importlib.util.find_spec("mantis_agent.brain_holo3") is not None
+
+
+@pytest.fixture(scope="module")
+def _has_claude() -> bool:
+    return importlib.util.find_spec("mantis_agent.brain_claude") is not None
+
+
+@pytest.fixture(scope="module")
+def _has_fara() -> bool:
+    return importlib.util.find_spec("mantis_agent.brain_fara") is not None
+
+
+# ── brain_holo3._build_messages ────────────────────────────────────
+
+
+def test_holo3_build_messages_renders_retry_attempts_block(_has_holo3) -> None:
+    """A non-empty ``retry_attempts`` kwarg lands in the user content
+    as an outcome-tagged ``Recent attempts on this sub-goal:`` block.
+    The shared formatter (``gym.retry_attempts``) renders, the brain
+    adapter just splices."""
+    if not _has_holo3:
+        pytest.skip("brain_holo3 not importable")
+    from mantis_agent.brain_holo3 import Holo3Brain
+
+    brain = Holo3Brain.__new__(Holo3Brain)  # bypass __init__
+    msgs = brain._build_messages(
+        frames=[_img()], task="Click Contacted",
+        action_history=None, screen_size=(1280, 720),
+        retry_attempts=[
+            {"x": 44, "y": 390, "matched_label": "Qualified (1)",
+             "kind": "wrong_target", "reason": "URL missing status=Contacted"},
+            {"x": 47, "y": 376, "matched_label": "Contacted (8)",
+             "kind": "no_state_change", "reason": ""},
+        ],
+    )
+    user_msg = msgs[1]
+    text_blocks = [b["text"] for b in user_msg["content"] if b.get("type") == "text"]
+    joined = "\n".join(text_blocks)
+    assert "Recent attempts on this sub-goal" in joined
+    assert "(44, 390)" in joined
+    assert "Qualified (1)" in joined
+    assert "wrong target" in joined
+    assert "(47, 376)" in joined
+    assert "no observable state change" in joined
+
+
+def test_holo3_build_messages_omits_block_when_no_retry_attempts(_has_holo3) -> None:
+    """No prior failures → no ``Recent attempts`` block. Keeps the
+    prompt tight on a fresh sub-goal where the runner hasn't recorded
+    any failures yet."""
+    if not _has_holo3:
+        pytest.skip("brain_holo3 not importable")
+    from mantis_agent.brain_holo3 import Holo3Brain
+
+    brain = Holo3Brain.__new__(Holo3Brain)
+    msgs = brain._build_messages(
+        frames=[_img()], task="Click X",
+        action_history=None, screen_size=(1280, 720),
+    )
+    user_msg = msgs[1]
+    text_blocks = [b["text"] for b in user_msg["content"] if b.get("type") == "text"]
+    joined = "\n".join(text_blocks)
+    assert "Recent attempts on this sub-goal" not in joined
+
+
+def test_holo3_build_messages_per_step_history_overrides_global(_has_holo3) -> None:
+    """When ``per_step_action_history`` is set, the prompt uses THAT
+    slice for the ``Recent actions:`` block instead of the last-5 of
+    ``action_history``. Caller (the per-step handler) supplies the
+    pre-trimmed slice — runner takes it verbatim."""
+    if not _has_holo3:
+        pytest.skip("brain_holo3 not importable")
+    from mantis_agent.brain_holo3 import Holo3Brain
+
+    brain = Holo3Brain.__new__(Holo3Brain)
+    # 8 global actions — would tail to last-5 by default.
+    global_history = [
+        Action(ActionType.CLICK, {"x": 100 + i, "y": 200, "button": "left"})
+        for i in range(8)
+    ]
+    # Per-step slice carries just one action — distinct (x, y) so we
+    # can tell them apart.
+    per_step = [Action(ActionType.SCROLL, {"direction": "down"})]
+    msgs = brain._build_messages(
+        frames=[_img()], task="Click X",
+        action_history=global_history,
+        screen_size=(1280, 720),
+        per_step_action_history=per_step,
+    )
+    text_blocks = [
+        b["text"] for b in msgs[1]["content"]
+        if b.get("type") == "text"
+    ]
+    joined = "\n".join(text_blocks)
+    # Per-step action lands.
+    assert "scroll" in joined.lower()
+    # Global tail does NOT — no click coords from x=103..107.
+    for x in range(103, 108):
+        assert f"x={x}" not in joined and f"x: {x}" not in joined
+
+
+def test_holo3_build_messages_falls_back_to_global_when_per_step_absent(_has_holo3) -> None:
+    """When the caller doesn't supply a per-step slice, behaviour is
+    exactly the pre-#435 default (last-5 of ``action_history``).
+    Preserves compatibility with non-MicroPlanRunner callers."""
+    if not _has_holo3:
+        pytest.skip("brain_holo3 not importable")
+    from mantis_agent.brain_holo3 import Holo3Brain
+
+    brain = Holo3Brain.__new__(Holo3Brain)
+    history = [
+        Action(ActionType.CLICK, {"x": 100 + i, "y": 200, "button": "left"})
+        for i in range(8)
+    ]
+    msgs = brain._build_messages(
+        frames=[_img()], task="X",
+        action_history=history, screen_size=(1280, 720),
+    )
+    text_blocks = [
+        b["text"] for b in msgs[1]["content"]
+        if b.get("type") == "text"
+    ]
+    joined = "\n".join(text_blocks)
+    assert "Recent actions:" in joined
+    # Last-5: x=103..107 should appear (5 entries).
+    appearance = sum(1 for x in range(103, 108) if str(x) in joined)
+    assert appearance == 5
+
+
+# ── brain_claude._build_messages ───────────────────────────────────
+
+
+def test_claude_build_messages_renders_retry_attempts_block(_has_claude) -> None:
+    if not _has_claude:
+        pytest.skip("brain_claude not importable")
+    from mantis_agent.brain_claude import ClaudeBrain
+
+    brain = ClaudeBrain.__new__(ClaudeBrain)
+    brain._FRAMES_KEEP_AS_IMAGE = 2  # bypass __init__ defaults
+    msgs = brain._build_messages(
+        frames=[_img()], task="Click Contacted",
+        action_history=None, screen_size=(1280, 720),
+        retry_attempts=[
+            {"x": 44, "y": 390, "matched_label": "Qualified (1)",
+             "kind": "wrong_target", "reason": "URL did not navigate"},
+        ],
+    )
+    text_blocks = [
+        b["text"] for b in msgs[0]["content"]
+        if b.get("type") == "text"
+    ]
+    joined = "\n".join(text_blocks)
+    assert "Recent attempts on this sub-goal" in joined
+    assert "Qualified (1)" in joined
+    assert "wrong target" in joined
+
+
+def test_claude_build_messages_omits_block_when_no_retry_attempts(_has_claude) -> None:
+    if not _has_claude:
+        pytest.skip("brain_claude not importable")
+    from mantis_agent.brain_claude import ClaudeBrain
+
+    brain = ClaudeBrain.__new__(ClaudeBrain)
+    brain._FRAMES_KEEP_AS_IMAGE = 2
+    msgs = brain._build_messages(
+        frames=[_img()], task="x",
+        action_history=None, screen_size=(1280, 720),
+    )
+    text_blocks = [
+        b["text"] for b in msgs[0]["content"]
+        if b.get("type") == "text"
+    ]
+    joined = "\n".join(text_blocks)
+    assert "Recent attempts" not in joined
+
+
+def test_claude_per_step_history_overrides_global(_has_claude) -> None:
+    if not _has_claude:
+        pytest.skip("brain_claude not importable")
+    from mantis_agent.brain_claude import ClaudeBrain
+
+    brain = ClaudeBrain.__new__(ClaudeBrain)
+    brain._FRAMES_KEEP_AS_IMAGE = 2
+    global_history = [
+        Action(ActionType.CLICK, {"x": 500 + i, "y": 300, "button": "left"})
+        for i in range(12)
+    ]
+    per_step = [Action(ActionType.KEY_PRESS, {"keys": "Tab"})]
+    msgs = brain._build_messages(
+        frames=[_img()], task="X",
+        action_history=global_history, screen_size=(1280, 720),
+        per_step_action_history=per_step,
+    )
+    text_blocks = [
+        b["text"] for b in msgs[0]["content"]
+        if b.get("type") == "text"
+    ]
+    joined = "\n".join(text_blocks)
+    assert "Tab" in joined
+    # No click x=500+ should leak through.
+    for x in range(505, 512):
+        assert str(x) not in joined
+
+
+# ── brain_fara._build_messages ─────────────────────────────────────
+
+
+def test_fara_build_messages_renders_retry_attempts_block(_has_fara) -> None:
+    if not _has_fara:
+        pytest.skip("brain_fara not importable")
+    from mantis_agent.brain_fara import FaraBrain
+
+    brain = FaraBrain.__new__(FaraBrain)
+    brain.input_size = (1280, 720)
+    msgs = brain._build_messages(
+        frames=[_img()], task="Click Apply",
+        action_history=None,
+        retry_attempts=[
+            {"x": 50, "y": 100, "matched_label": "Search",
+             "kind": "wrong_target", "reason": ""},
+        ],
+    )
+    text_blocks = [
+        b["text"] for b in msgs[1]["content"]
+        if b.get("type") == "text"
+    ]
+    joined = "\n".join(text_blocks)
+    assert "Recent attempts on this sub-goal" in joined
+    assert "Search" in joined
+
+
+def test_fara_per_step_history_overrides_global(_has_fara) -> None:
+    if not _has_fara:
+        pytest.skip("brain_fara not importable")
+    from mantis_agent.brain_fara import FaraBrain
+
+    brain = FaraBrain.__new__(FaraBrain)
+    brain.input_size = (1280, 720)
+    global_history = [
+        Action(ActionType.CLICK, {"x": 999, "y": 999, "button": "left"})
+        for _ in range(6)
+    ]
+    per_step = [Action(ActionType.WAIT, {"seconds": 0.5})]
+    msgs = brain._build_messages(
+        frames=[_img()], task="X",
+        action_history=global_history,
+        per_step_action_history=per_step,
+    )
+    text_blocks = [
+        b["text"] for b in msgs[1]["content"]
+        if b.get("type") == "text"
+    ]
+    joined = "\n".join(text_blocks)
+    assert "wait" in joined.lower()
+    assert "999" not in joined

--- a/tests/test_retry_attempts.py
+++ b/tests/test_retry_attempts.py
@@ -10,8 +10,6 @@ ripples through one place rather than three.
 
 from __future__ import annotations
 
-import pytest
-
 from mantis_agent.gym.retry_attempts import (
     _PRIOR_ATTEMPTS_WINDOW,
     format_prior_attempt,

--- a/tests/test_retry_attempts.py
+++ b/tests/test_retry_attempts.py
@@ -1,0 +1,183 @@
+"""Shared retry-attempt rendering — roadmap #435 items 2 + 7.
+
+The ``mantis_agent.gym.retry_attempts`` module centralises the line
+format + window cap that the three brain adapters use when rendering
+the outcome-tagged ``Recent attempts on this sub-goal`` block.
+
+These tests pin the rendered shape so any future formatting change
+ripples through one place rather than three.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mantis_agent.gym.retry_attempts import (
+    _PRIOR_ATTEMPTS_WINDOW,
+    format_prior_attempt,
+    render_attempts_block,
+)
+
+
+# ── format_prior_attempt — outcome verb map ─────────────────────────
+
+
+def test_format_prior_attempt_known_kinds_get_canonical_verbs() -> None:
+    """Each kind the runner stamps via ``_record_failure_for_retry``
+    maps to a fixed human verb. Pin them — the brain has been seeing
+    these strings since #440 and a phrasing change would alter the
+    model's response patterns."""
+    base = {"x": 10, "y": 20, "label": "X", "matched_label": "X"}
+    out_nsc = format_prior_attempt({**base, "kind": "no_state_change"})
+    assert "no observable state change" in out_nsc
+
+    out_wt = format_prior_attempt({**base, "kind": "wrong_target"})
+    assert "wrong target" in out_wt
+
+    out_ble = format_prior_attempt({**base, "kind": "brain_loop_exhausted"})
+    assert "brain ran out of moves" in out_ble
+
+    out_sm = format_prior_attempt({**base, "kind": "selector_miss"})
+    assert "didn't hit an interactive element" in out_sm
+
+
+def test_format_prior_attempt_unknown_kind_falls_back() -> None:
+    """A failure class we haven't enumerated still renders something
+    legible — generic ``failed (<kind>)`` keeps the line useful and
+    the model can still skip the listed coordinates."""
+    out = format_prior_attempt({
+        "x": 1, "y": 2, "label": "X",
+        "kind": "novel_class_we_added_later",
+    })
+    assert "novel_class_we_added_later" in out
+    assert "failed" in out
+
+
+def test_format_prior_attempt_handles_missing_fields() -> None:
+    """A partial record (no matched_label, no reason) still produces
+    a sensible line rather than crashing or rendering ``None``."""
+    out = format_prior_attempt({"x": 5, "y": 6, "kind": "no_state_change"})
+    assert "(5, 6)" in out
+    assert "no observable state change" in out
+    # No stringified None / Mock / etc in the output.
+    assert "None" not in out
+
+
+def test_format_prior_attempt_includes_matched_label_when_present() -> None:
+    """``matched_label`` (what vision actually targeted) is more
+    informative than ``label`` (what the plan asked for) — prefer it
+    in the rendered line."""
+    out = format_prior_attempt({
+        "x": 10, "y": 20,
+        "label": "Apply",
+        "matched_label": "Apply Filter",
+        "kind": "wrong_target",
+    })
+    assert 'targeting "Apply Filter"' in out
+
+
+def test_format_prior_attempt_falls_back_to_label_when_matched_missing() -> None:
+    """If only ``label`` is set, render that — covers the early-failure
+    case where the runner hasn't recorded what vision actually picked."""
+    out = format_prior_attempt({
+        "x": 10, "y": 20, "label": "Apply", "kind": "no_state_change",
+    })
+    assert 'targeting "Apply"' in out
+
+
+def test_format_prior_attempt_clips_long_reason() -> None:
+    """A 1000-char reason from agentic recovery would blow the prompt
+    if rendered raw — the helper clips to 120 chars."""
+    long_reason = "x" * 500
+    out = format_prior_attempt({
+        "x": 1, "y": 1, "kind": "no_state_change", "reason": long_reason,
+    })
+    # 120 chars + "; " prefix → at most ~125 chars of x's in the line.
+    assert "x" * 121 not in out
+
+
+# ── render_attempts_block — window cap + empty handling ─────────────
+
+
+def test_render_attempts_block_returns_empty_for_none() -> None:
+    """No prior failures → empty string. Caller's ``if block:`` splice
+    stays one-line."""
+    assert render_attempts_block(None) == ""
+    assert render_attempts_block([]) == ""
+
+
+def test_render_attempts_block_returns_empty_when_all_entries_malformed() -> None:
+    """A list of non-dict entries (e.g. a MagicMock auto-attribute
+    leaking in) renders empty rather than crashing."""
+    assert render_attempts_block([None, "string", 42]) == ""  # type: ignore[list-item]
+
+
+def test_render_attempts_block_caps_window() -> None:
+    """Older entries get dropped — only the most-recent ``window``
+    records are surfaced. The brain doesn't benefit from seeing every
+    miss in a long retry chain."""
+    attempts = [
+        {"x": i, "y": i, "kind": "no_state_change"}
+        for i in range(10)
+    ]
+    block = render_attempts_block(attempts, window=3)
+    # Last three (i=7, 8, 9) appear; older ones don't.
+    assert "(7, 7)" in block
+    assert "(8, 8)" in block
+    assert "(9, 9)" in block
+    assert "(0, 0)" not in block
+    assert "(5, 5)" not in block
+
+
+def test_render_attempts_block_default_window_is_three() -> None:
+    """Default window is 3 to keep prompts tight. Verify the constant
+    matches and the rendered shape respects it without an explicit
+    kwarg."""
+    assert _PRIOR_ATTEMPTS_WINDOW == 3
+    attempts = [
+        {"x": i, "y": i, "kind": "no_state_change"}
+        for i in range(5)
+    ]
+    block = render_attempts_block(attempts)
+    assert "(2, 2)" in block  # last 3 = indices 2, 3, 4
+    assert "(3, 3)" in block
+    assert "(4, 4)" in block
+    assert "(0, 0)" not in block
+    assert "(1, 1)" not in block
+
+
+def test_render_attempts_block_includes_header() -> None:
+    """The block leads with the configurable header so the brain
+    knows what to do with the lines that follow. Defaults to a
+    'Recent attempts on this sub-goal' framing."""
+    attempts = [{"x": 1, "y": 1, "kind": "no_state_change"}]
+    block = render_attempts_block(attempts)
+    assert "Recent attempts on this sub-goal" in block
+    assert "do NOT repeat" in block
+
+
+def test_render_attempts_block_indents_each_entry() -> None:
+    """Lines are indented + numbered so the prompt reads naturally
+    when the model glances at it — match the format the Holo3 step
+    handler's scoped task uses elsewhere."""
+    attempts = [
+        {"x": 1, "y": 1, "kind": "no_state_change"},
+        {"x": 2, "y": 2, "kind": "wrong_target"},
+    ]
+    block = render_attempts_block(attempts)
+    assert "  1. " in block
+    assert "  2. " in block
+
+
+def test_render_attempts_block_filters_non_dict_then_caps() -> None:
+    """Non-dict entries are stripped BEFORE the window cap kicks in —
+    so two valid records survive even if the list also has trash."""
+    attempts = [
+        {"x": 1, "y": 1, "kind": "no_state_change"},
+        "garbage",  # type: ignore[list-item]
+        None,
+        {"x": 2, "y": 2, "kind": "wrong_target"},
+    ]
+    block = render_attempts_block(attempts, window=3)
+    assert "(1, 1)" in block
+    assert "(2, 2)" in block


### PR DESCRIPTION
## Summary

Roadmap #435 items 2 + 7 — closes the per-sub-goal scoping and outcome-tagged retry-attempts work that started in #440 (which did the Holo3 path) for the Claude + Fara adapters.

### Item 2 — Per-sub-goal action history reset

Brain adapters (Claude, Fara, Holo3) now accept an optional ``per_step_action_history`` kwarg on ``think()`` / ``_build_messages()``. When the caller (a per-plan-step handler) supplies it, the prompt uses THAT slice for the ``Recent actions:`` block instead of the global ``action_history[-N:]``. Implements the doc's *"Reset between sub-goals. Bounded length: 1–3 entries"* guidance.

### Item 7 — Outcome-tagged retry attempts in every brain prompt

New shared module ``mantis_agent.gym.retry_attempts`` owns the line format + window cap so the three adapters render identical blocks. Holo3StepHandler now threads ``_step_failure_history[step_index]`` through ``GymRunner.run``'s new ``retry_attempts`` kwarg — every ``brain.think()`` iteration in the inner loop sees the outcome-tagged context. Block goes AFTER ``Recent actions:`` / ``Memorized facts:`` so token-budget truncation hits the older, less-specific log first.

## CUA conformance

The new kwargs carry structured runtime metadata (failure records with x/y/label/kind/reason, scoped action slices). Click targets still come from vision grounding on the screenshot — no DOM derivation, consistent with the contract from #440.

## Opt-in at the call site

``GymRunner.run`` only passes ``retry_attempts`` to ``brain.think`` when the kwarg is non-empty (``if retry_attempts: think_kwargs[\"retry_attempts\"] = ...``). Test stubs and older adapters that don't accept the kwarg keep working — only production-path brains pay the cost.

## Test plan
- [x] 2780 local tests pass (full suite, excluding pre-existing test_env_up flake)
- [x] 22 new tests pin shared formatter + brain integration
- [ ] CI green
- [ ] Modal redeploy + staff-crm-long rerun

Closes part of #435 — items 2 + 7 (Holo3 path was done in #440; this completes Claude + Fara).

🤖 Generated with [Claude Code](https://claude.com/claude-code)