### PR TITLE
feat(critic): ReplaceStep directive + frontier-model observer (#435 item 8)

### DIFF
--- a/deploy/modal/modal_cua_server.py
+++ b/deploy/modal/modal_cua_server.py
@@ -786,6 +786,23 @@ def _run_holo3_executor(
             max_time_minutes=task_suite.get("_max_time_minutes", 180),
         )
 
+        # Reasoning-trace stream → ``<run_dir>/reasoning.jsonl``. The
+        # API container's ``action=reasoning_trace`` reads this file
+        # so a viewer overlay can render a structured timeline of
+        # critic decisions / Claude recovery results / etc.
+        # alongside the live MJPEG feed. Only configured when the
+        # API forwarded the run identity (CLI path uses neither).
+        if api_run_id and api_tenant_id:
+            try:
+                from mantis_agent.gym import reasoning_trace as _rt
+                _rt.configure_disk_stream(
+                    micro_runner,
+                    _run_dir(api_tenant_id, api_run_id) / "reasoning.jsonl",
+                )
+                print(f"  reasoning trace → {api_run_id}/reasoning.jsonl")
+            except Exception as exc:  # noqa: BLE001
+                print(f"  WARNING: reasoning-trace stream init failed: {exc}")
+
         # #347: default ``request_user_input`` host tool. Brains that emit
         # ``Action(TOOL_CALL, name="request_user_input")`` get a paused-run
         # snapshot on the first call, and the staged ``user_input`` on the
@@ -1734,6 +1751,24 @@ def build_api_app(executor_resolver=None, function_call_lookup=None):
             status["viewer_url"] = viewer_url
 
         action = payload["action"]
+
+        # action=reasoning_trace — return the structured event stream
+        # the runner writes to ``<run_dir>/reasoning.jsonl`` during
+        # execution. Used by viewer overlays to render the runner's
+        # decision timeline (critic gates, Claude recovery results,
+        # ReplaceStep / InsertStep directives) beside the MJPEG feed.
+        # Cheap, file-backed read — no compute.
+        if action == "reasoning_trace":
+            from mantis_agent.gym import reasoning_trace as _rt
+            since_ts = str(payload.get("since") or "") or None
+            jsonl_path = _run_dir(tenant.tenant_id, run_id) / "reasoning.jsonl"
+            events = _rt.read_jsonl(jsonl_path, since_ts=since_ts)
+            return {
+                **status,
+                "events": events,
+                "count": len(events),
+            }
+
         if action == "cancel":
             if status.get("status") in {"queued", "running", "paused"}:
                 call_id = status.get("modal_call_id", "")

--- a/deploy/modal/modal_cua_server.py
+++ b/deploy/modal/modal_cua_server.py
@@ -1758,11 +1758,35 @@ def build_api_app(executor_resolver=None, function_call_lookup=None):
         # decision timeline (critic gates, Claude recovery results,
         # ReplaceStep / InsertStep directives) beside the MJPEG feed.
         # Cheap, file-backed read — no compute.
+        #
+        # Inlined rather than importing ``mantis_agent.gym.reasoning_trace``
+        # because the API container's tiny image (fastapi + pydantic +
+        # requests) doesn't have PIL — and importing ``mantis_agent.gym``
+        # transitively pulls in PlaywrightGymEnv → PIL. The JSONL read
+        # is trivial; duplicating those ~12 lines here keeps the import
+        # chain clean.
         if action == "reasoning_trace":
-            from mantis_agent.gym import reasoning_trace as _rt
             since_ts = str(payload.get("since") or "") or None
             jsonl_path = _run_dir(tenant.tenant_id, run_id) / "reasoning.jsonl"
-            events = _rt.read_jsonl(jsonl_path, since_ts=since_ts)
+            events: list[dict] = []
+            if jsonl_path.exists():
+                try:
+                    with jsonl_path.open("r", encoding="utf-8") as f:
+                        for line in f:
+                            line = line.strip()
+                            if not line:
+                                continue
+                            try:
+                                ev = json.loads(line)
+                            except (json.JSONDecodeError, ValueError):
+                                continue
+                            if not isinstance(ev, dict):
+                                continue
+                            if since_ts and ev.get("ts", "") <= since_ts:
+                                continue
+                            events.append(ev)
+                except OSError:
+                    pass
             return {
                 **status,
                 "events": events,

--- a/src/mantis_agent/agentic_recovery.py
+++ b/src/mantis_agent/agentic_recovery.py
@@ -191,6 +191,7 @@ def analyse_failure_and_recover(
     attempts: int,
     api_key: str = "",
     model: str = "claude-haiku-4-5-20251001",
+    prior_hints: list[str] | None = None,
 ) -> RecoveryDecision | None:
     """Ask Claude to analyse a step failure and pick a recovery mode.
 
@@ -243,6 +244,7 @@ def analyse_failure_and_recover(
         attempts=attempts,
         api_key=api_key,
         model=model,
+        prior_hints=prior_hints or [],
     )
     if parsed is None:
         return None
@@ -259,11 +261,20 @@ def _call_recovery_tool(
     attempts: int,
     api_key: str,
     model: str,
+    prior_hints: list[str] | None = None,
 ) -> dict | None:
     """Tool_use call. Returns the validated input dict or ``None``."""
     import requests
 
     from .prompts import load_prompt
+
+    hints = [h for h in (prior_hints or []) if str(h).strip()]
+    if hints:
+        hints_block = "PRIOR HINTS TEXT:\n" + "\n".join(
+            f"  - {str(h)[:200]}" for h in hints[-3:]
+        )
+    else:
+        hints_block = ""
 
     prompt = load_prompt(
         "recovery_analysis",
@@ -273,6 +284,8 @@ def _call_recovery_tool(
         failure_data=failure_data[:300],
         attempts=attempts,
         plan_context=_format_plan_context(plan_context),
+        prior_hint_count=len(hints),
+        prior_hints_block=hints_block,
     )
 
     content: list[dict[str, Any]] = [{"type": "text", "text": prompt}]

--- a/src/mantis_agent/api_schemas.py
+++ b/src/mantis_agent/api_schemas.py
@@ -65,17 +65,28 @@ class PredictRequest(BaseModel):
     micro_path: Optional[str] = None  # alias for micro
     plan_text: Optional[str] = None
 
-    # Action mode (status / result / logs / cancel / resume for an existing run).
-    # ``resume`` (#344) requires ``user_input`` and a paused run; the server
-    # rehydrates the stored PauseState and continues the runner from where
-    # the host tool raised PauseRequested.
-    action: Optional[Literal["status", "result", "logs", "cancel", "resume"]] = None
+    # Action mode (status / result / logs / cancel / resume / reasoning_trace
+    # for an existing run). ``resume`` (#344) requires ``user_input`` and a
+    # paused run; the server rehydrates the stored PauseState and continues
+    # the runner from where the host tool raised PauseRequested.
+    # ``reasoning_trace`` returns the structured event stream the runner
+    # writes to ``<run_dir>/reasoning.jsonl`` — critic gate decisions,
+    # Claude recovery results, ReplaceStep / InsertStep directives. Used
+    # by viewer overlays to render a timeline beside the MJPEG live feed.
+    # Supports a ``since`` ISO-8601 cursor for incremental polling.
+    action: Optional[Literal[
+        "status", "result", "logs", "cancel", "resume", "reasoning_trace",
+    ]] = None
     run_id: Optional[str] = None
     tail: Optional[int] = Field(default=None, ge=1, le=10000)
     # Caller-supplied value handed to ``runner.consume_pause_input(...)`` on
     # resume (OTP code, 2FA token, free-text confirmation, etc.). Opaque
     # to the server. Required on ``action="resume"``; ignored otherwise.
     user_input: Optional[Any] = None
+    # Caller-supplied ISO-8601 cursor for ``action=reasoning_trace`` —
+    # return only events strictly more recent than ``since``. Empty
+    # / missing returns the full stream.
+    since: Optional[str] = None
 
     # Run options
     detached: bool = True

--- a/src/mantis_agent/gym/critic.py
+++ b/src/mantis_agent/gym/critic.py
@@ -26,8 +26,9 @@ Zero plan / URL / domain content reads in.
 from __future__ import annotations
 
 import logging
+import os
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 from ..plan_decomposer import MicroIntent
 
@@ -37,6 +38,25 @@ if TYPE_CHECKING:
     from .run_executor import RunState
 
 logger = logging.getLogger(__name__)
+
+
+# How many ``wrong_target`` failures on the same step before the
+# frontier-model capability fires. Set to 2 so the first failure
+# still goes through the existing recovery loop (cheap rewriter,
+# label-match retries) — only the persistent miss escalates to a
+# Claude call.
+_FRONTIER_WRONG_TARGET_THRESHOLD: int = 2
+
+
+def _frontier_enabled() -> bool:
+    """``MANTIS_CRITIC_FRONTIER=enabled`` flips the opt-in.
+
+    Default off so deployments that don't want the extra Claude
+    spend behave exactly as before. The lone existing rule
+    (``navigate_back`` + ``brain_loop_exhausted``) keeps working
+    regardless of this gate.
+    """
+    return os.environ.get("MANTIS_CRITIC_FRONTIER", "").strip().lower() == "enabled"
 
 
 @dataclass(frozen=True)
@@ -51,6 +71,34 @@ class InsertStep:
     step_type: str
     reason: str
     params: dict[str, Any] | None = None
+
+
+@dataclass(frozen=True)
+class ReplaceStep:
+    """Critic directive: replace the step at the current
+    ``state.step_index`` IN PLACE — does NOT shift subsequent steps.
+    The new step occupies the same plan slot and runs on the next
+    loop iteration.
+
+    Used when the frontier-model observer (#435 item 8) decides the
+    current step's structure is wrong rather than its execution — a
+    sidebar-link click cascade should become a direct ``navigate``
+    to the filtered URL, for example. The runner records the
+    replacement as a healing event and resets the per-step retry
+    history so the new step starts with a clean slate.
+    """
+
+    intent: str
+    step_type: str
+    reason: str
+    params: dict[str, Any] | None = None
+    hints: dict[str, Any] | None = None
+
+
+# Union of every directive type ``observe_step`` may return — used
+# in apply_directive's dispatch and for type hints on the public
+# surface.
+Directive = Union[InsertStep, ReplaceStep]
 
 
 class ExecutionCritic:
@@ -84,25 +132,42 @@ class ExecutionCritic:
         step_result: "StepResult",
         *,
         recovery_continued: bool,
-    ) -> Optional[InsertStep]:
+    ) -> Optional[Directive]:
         """Called after every step dispatch + recovery handling.
 
         ``recovery_continued`` is True when the recovery policy
         decided retry/advance (i.e. ``_handle_failure`` returned
         True), False on halt. The critic only emits directives when
-        the run is continuing — there's no point inserting a step
+        the run is continuing — there's no point mutating the plan
         ahead of a halted run.
 
-        Returns an :class:`InsertStep` directive or ``None``. The
-        runner consumes the directive and mutates ``plan.steps``;
-        the critic's job is the decision, not the mutation.
+        Returns one of:
+
+        * :class:`InsertStep` — splice a NEW step at the current
+          index (existing capability: navigate_back + brain loop).
+        * :class:`ReplaceStep` — replace the step in place (new in
+          #435 item 8: frontier-model observer on persistent
+          ``wrong_target`` failures).
+        * ``None`` — let the recovery policy continue as-is.
+
+        Capabilities are checked cheapest-first. Rule-based
+        capabilities run unconditionally; the frontier-model
+        capability is opt-in via ``MANTIS_CRITIC_FRONTIER``.
         """
         if not recovery_continued:
             return None
         if step_result.success:
             return None
 
-        return self._maybe_recover_navigate_back(step, step_result)
+        # Rule-based: navigate_back loop exhaustion → direct nav.
+        rule_directive = self._maybe_recover_navigate_back(step, step_result)
+        if rule_directive is not None:
+            return rule_directive
+
+        # Frontier-model: persistent wrong_target → ask Claude.
+        return self._maybe_frontier_recover_wrong_target(
+            plan, state, step, step_result,
+        )
 
     # ── Capabilities ────────────────────────────────────────────────────
 
@@ -143,24 +208,246 @@ class ExecutionCritic:
         )
 
 
+    # ── Frontier-model capability (#435 item 8) ─────────────────────────
+
+    def _maybe_frontier_recover_wrong_target(
+        self,
+        plan: Any,
+        state: "RunState",
+        step: MicroIntent,
+        step_result: "StepResult",
+    ) -> Optional[Directive]:
+        """Ask the frontier model (Claude via :mod:`agentic_recovery`)
+        for a mid-run plan change when a ``wrong_target`` failure
+        pattern persists.
+
+        Trigger conditions (all generic — no plan / URL / domain
+        content reads in):
+
+        * ``MANTIS_CRITIC_FRONTIER=enabled`` (opt-in).
+        * ``step_result.failure_class == "wrong_target"``.
+        * At least :data:`_FRONTIER_WRONG_TARGET_THRESHOLD`
+          ``wrong_target`` records in ``_step_failure_history[step_index]``
+          (skip the first miss — that's still in the cheap retry zone).
+        * The frontier model hasn't already been consulted for this
+          step (tracked on ``runner._critic_frontier_fired_steps``).
+        * The shared recovery budget (per-step + per-run, from
+          :mod:`agentic_recovery`) isn't exhausted.
+
+        Mode mapping:
+
+        * ``add_hint`` — append to ``_recovery_hints[step_index]`` and
+          return ``None`` (no directive — the next retry's prompt
+          carries the hint and we don't disturb the plan).
+        * ``edit_step`` — :class:`ReplaceStep` with the model's
+          ``intent`` / ``type`` / ``params``. Missing fields preserve
+          the original step's values.
+        * ``insert_steps`` — first inserted step becomes an
+          :class:`InsertStep` directive (MVP simplification — multi-
+          step inserts come from the terminal-failure path that
+          already supports splicing).
+        * ``halt`` — return ``None`` so the recovery loop's terminal
+          path handles it.
+
+        On any fallback (no API key, API error, decision schema
+        violation, exception) the method returns ``None`` and the
+        existing recovery flow continues unchanged.
+        """
+        if not _frontier_enabled():
+            return None
+        failure_class = str(getattr(step_result, "failure_class", "") or "")
+        if failure_class != "wrong_target":
+            return None
+
+        runner = self.runner
+        step_index = int(state.step_index)
+        history = (
+            runner._step_failure_history.get(step_index, [])
+            if hasattr(runner, "_step_failure_history") else []
+        )
+        wrong_target_count = sum(
+            1 for r in history
+            if isinstance(r, dict) and r.get("kind") == "wrong_target"
+        )
+        if wrong_target_count < _FRONTIER_WRONG_TARGET_THRESHOLD:
+            return None
+
+        # Already consulted Claude for this step? Don't double-spend.
+        fired = getattr(runner, "_critic_frontier_fired_steps", None)
+        if not isinstance(fired, set):
+            fired = set()
+            runner._critic_frontier_fired_steps = fired
+        if step_index in fired:
+            return None
+
+        # Reuse the existing recovery budget pool so the critic's
+        # frontier call and step_recovery's terminal call share one
+        # pot — keeps the total Claude spend bounded by the same
+        # per-step / per-run caps.
+        per_step_dict = getattr(runner, "_recovery_attempts_per_step", None)
+        total_attempts = getattr(runner, "_total_recovery_attempts", None)
+        if not isinstance(per_step_dict, dict) or not isinstance(total_attempts, int):
+            logger.debug(
+                "  [critic-frontier] runner missing budget trackers — skip"
+            )
+            return None
+        try:
+            from ..agentic_recovery import (
+                DEFAULT_MAX_RECOVERIES_PER_RUN,
+                DEFAULT_MAX_RECOVERIES_PER_STEP,
+            )
+        except Exception as exc:  # noqa: BLE001 — never break runs
+            logger.debug("  [critic-frontier] agentic_recovery import failed: %s", exc)
+            return None
+        if per_step_dict.get(step_index, 0) >= DEFAULT_MAX_RECOVERIES_PER_STEP:
+            return None
+        if total_attempts >= DEFAULT_MAX_RECOVERIES_PER_RUN:
+            return None
+
+        # Capture the post-failure screenshot for Claude's analysis.
+        # Same shape ``step_recovery._try_agentic_recovery`` uses.
+        env = getattr(runner, "env", None)
+        screenshot = None
+        if env is not None and hasattr(env, "screenshot"):
+            try:
+                screenshot = env.screenshot()
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("  [critic-frontier] env.screenshot failed: %s", exc)
+
+        plan_context = [
+            f"step {i}: type={s.type}, intent={s.intent[:60]}"
+            for i, s in enumerate(getattr(plan, "steps", []) or [])
+        ]
+        failure_data = (
+            f"failure_class={failure_class}; "
+            f"prior_wrong_target={wrong_target_count}; "
+            f"data={(step_result.data or '')[:160]}"
+        )
+
+        try:
+            from ..agentic_recovery import analyse_failure_and_recover
+            decision = analyse_failure_and_recover(
+                step=step,
+                failure_data=failure_data,
+                screenshot=screenshot,
+                plan_context=plan_context,
+                attempts=wrong_target_count,
+            )
+        except Exception as exc:  # noqa: BLE001 — never break runs
+            logger.warning("  [critic-frontier] Claude call raised: %s", exc)
+            return None
+
+        # Mark fired BEFORE applying — even if Claude returned halt /
+        # invalid, we don't want to retry the consultation on the same
+        # step (the policy budget exists for that).
+        fired.add(step_index)
+        # Increment the shared budget counters so the terminal path
+        # sees this consultation count.
+        per_step_dict[step_index] = per_step_dict.get(step_index, 0) + 1
+        runner._total_recovery_attempts = total_attempts + 1
+
+        if decision is None:
+            logger.info(
+                "  [critic-frontier] step %d: Claude returned no decision "
+                "(API/key/parse fallback) — recovery continues unchanged",
+                step_index,
+            )
+            return None
+        if decision.mode == "halt":
+            return None
+        if decision.mode == "add_hint" and decision.hint:
+            from . import recovery_hints
+            recovery_hints.add_hint(runner, step_index, decision.hint)
+            logger.warning(
+                "  [critic-frontier] step %d: add_hint — %s",
+                step_index, decision.hint[:120],
+            )
+            return None
+        if decision.mode == "edit_step":
+            edited = decision.edited_step or {}
+            new_intent = (edited.get("intent") or step.intent or "").strip()
+            new_type = (edited.get("type") or step.type or "").strip()
+            new_params = dict(edited.get("params") or step.params or {})
+            if not new_intent or not new_type:
+                return None
+            logger.warning(
+                "  [critic-frontier] step %d: edit_step → ReplaceStep "
+                "(type=%s, intent=%s)",
+                step_index, new_type, new_intent[:80],
+            )
+            return ReplaceStep(
+                intent=new_intent,
+                step_type=new_type,
+                params=new_params,
+                hints=dict(getattr(step, "hints", {}) or {}),
+                reason=(
+                    f"frontier critic replaced step on persistent "
+                    f"wrong_target ({wrong_target_count} prior): "
+                    f"{decision.reasoning[:120]}"
+                ),
+            )
+        if decision.mode == "insert_steps":
+            steps = decision.inserted_steps or []
+            if not steps:
+                return None
+            first = steps[0]
+            intent = str(first.get("intent") or "").strip()
+            step_type = str(first.get("type") or "").strip()
+            if not intent or not step_type:
+                return None
+            logger.warning(
+                "  [critic-frontier] step %d: insert_steps[0] → InsertStep "
+                "(type=%s, intent=%s)",
+                step_index, step_type, intent[:80],
+            )
+            return InsertStep(
+                intent=intent,
+                step_type=step_type,
+                params=dict(first.get("params") or {}),
+                reason=(
+                    f"frontier critic insert on persistent wrong_target "
+                    f"({wrong_target_count} prior): "
+                    f"{decision.reasoning[:120]}"
+                ),
+            )
+        return None
+
+
 def apply_directive(
     runner: "MicroPlanRunner",
     plan: Any,
     state: "RunState",
-    directive: InsertStep,
+    directive: Directive,
 ) -> None:
-    """Mutate ``plan.steps`` per a critic-emitted ``InsertStep``.
+    """Mutate ``plan.steps`` per a critic-emitted directive.
 
-    Splices the inserted step at ``state.step_index`` so it runs on
-    the next loop iteration. Records the action as a healing event
-    on the runner for audit.
+    Dispatches on directive type:
+
+    * :class:`InsertStep` — splice a new step at ``state.step_index``
+      so it runs on the next loop iteration.
+    * :class:`ReplaceStep` — replace the step at ``state.step_index``
+      in place (no shift). Resets ``_step_failure_history`` for the
+      slot so the new step doesn't inherit the old one's retry
+      pressure.
 
     Stays separate from :class:`ExecutionCritic` so the critic stays
     pure (returns directives, doesn't mutate state) — the runner
     owns plan mutation.
     """
-    if not isinstance(directive, InsertStep):
+    if isinstance(directive, InsertStep):
+        _apply_insert_step(runner, plan, state, directive)
         return
+    if isinstance(directive, ReplaceStep):
+        _apply_replace_step(runner, plan, state, directive)
+        return
+
+
+def _apply_insert_step(
+    runner: "MicroPlanRunner",
+    plan: Any,
+    state: "RunState",
+    directive: InsertStep,
+) -> None:
     new_step = MicroIntent(
         intent=directive.intent,
         type=directive.step_type,
@@ -186,4 +473,65 @@ def apply_directive(
     )
 
 
-__all__ = ["ExecutionCritic", "InsertStep", "apply_directive"]
+def _apply_replace_step(
+    runner: "MicroPlanRunner",
+    plan: Any,
+    state: "RunState",
+    directive: ReplaceStep,
+) -> None:
+    idx = int(state.step_index)
+    if idx < 0 or idx >= len(plan.steps):
+        return
+    original = plan.steps[idx]
+    original_type = str(getattr(original, "type", "") or "")
+    new_step = MicroIntent(
+        intent=directive.intent,
+        type=directive.step_type,
+        params=dict(directive.params or {}),
+        hints=dict(directive.hints or {}),
+        budget=int(getattr(original, "budget", 3) or 3),
+        required=bool(getattr(original, "required", False)),
+        section=str(getattr(original, "section", "") or ""),
+        gate=bool(getattr(original, "gate", False)),
+    )
+    plan.steps[idx] = new_step
+
+    # Reset the per-step retry history so the replacement runs with a
+    # clean slate. Inheriting the original step's failure pattern
+    # would defeat the point of replacing the step.
+    if hasattr(runner, "_step_failure_history"):
+        try:
+            runner._step_failure_history.pop(idx, None)
+        except Exception:  # noqa: BLE001
+            pass
+    # Same for the recovery hint accumulator — the new step likely
+    # has a different label / shape and the old hints don't apply.
+    if hasattr(runner, "_recovery_hints"):
+        try:
+            runner._recovery_hints.pop(idx, None)
+        except Exception:  # noqa: BLE001
+            pass
+
+    from . import healing_events
+    healing_events.record_replace_step(
+        runner,
+        step_index=idx,
+        original_type=original_type,
+        new_intent=directive.intent,
+        new_type=directive.step_type,
+        reason=directive.reason,
+    )
+    logger.warning(
+        "  [critic] replacing step %d in place: %s → %s (%s)",
+        idx, original_type or "?",
+        directive.step_type, directive.reason[:120],
+    )
+
+
+__all__ = [
+    "ExecutionCritic",
+    "InsertStep",
+    "ReplaceStep",
+    "Directive",
+    "apply_directive",
+]

--- a/src/mantis_agent/gym/critic.py
+++ b/src/mantis_agent/gym/critic.py
@@ -40,12 +40,20 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-# How many ``wrong_target`` failures on the same step before the
+# How many rewrite-triggering failures on the same step before the
 # frontier-model capability fires. Set to 2 so the first failure
 # still goes through the existing recovery loop (cheap rewriter,
 # label-match retries) — only the persistent miss escalates to a
 # Claude call.
-_FRONTIER_WRONG_TARGET_THRESHOLD: int = 2
+#
+# The gate covers any class in :data:`intent_rewriter.REWRITE_TRIGGERING_CLASSES`
+# (``wrong_target`` / ``no_state_change`` / ``brain_loop_exhausted``).
+# The original wrong_target-only gate left the canonical staff-crm
+# sidebar cascade unreachable: clicks LAND on real ``<a>`` elements
+# (so the snapshot-diff demote stamps ``no_state_change``, not
+# ``wrong_target``) yet the page doesn't navigate — exactly the
+# pattern the frontier critic exists to break.
+_FRONTIER_PERSISTENT_FAILURE_THRESHOLD: int = 2
 
 
 def _frontier_enabled() -> bool:
@@ -164,8 +172,8 @@ class ExecutionCritic:
         if rule_directive is not None:
             return rule_directive
 
-        # Frontier-model: persistent wrong_target → ask Claude.
-        return self._maybe_frontier_recover_wrong_target(
+        # Frontier-model: persistent rewrite-triggering failure → ask Claude.
+        return self._maybe_frontier_recover_persistent_failure(
             plan, state, step, step_result,
         )
 
@@ -210,7 +218,7 @@ class ExecutionCritic:
 
     # ── Frontier-model capability (#435 item 8) ─────────────────────────
 
-    def _maybe_frontier_recover_wrong_target(
+    def _maybe_frontier_recover_persistent_failure(
         self,
         plan: Any,
         state: "RunState",
@@ -218,21 +226,32 @@ class ExecutionCritic:
         step_result: "StepResult",
     ) -> Optional[Directive]:
         """Ask the frontier model (Claude via :mod:`agentic_recovery`)
-        for a mid-run plan change when a ``wrong_target`` failure
-        pattern persists.
+        for a mid-run plan change when a rewrite-triggering failure
+        pattern persists on the same step.
 
         Trigger conditions (all generic — no plan / URL / domain
         content reads in):
 
         * ``MANTIS_CRITIC_FRONTIER=enabled`` (opt-in).
-        * ``step_result.failure_class == "wrong_target"``.
-        * At least :data:`_FRONTIER_WRONG_TARGET_THRESHOLD`
-          ``wrong_target`` records in ``_step_failure_history[step_index]``
+        * ``step_result.failure_class`` is in
+          :data:`intent_rewriter.REWRITE_TRIGGERING_CLASSES`
+          (``wrong_target`` / ``no_state_change`` /
+          ``brain_loop_exhausted``).
+        * At least :data:`_FRONTIER_PERSISTENT_FAILURE_THRESHOLD`
+          rewrite-triggering records in ``_step_failure_history[step_index]``
           (skip the first miss — that's still in the cheap retry zone).
         * The frontier model hasn't already been consulted for this
           step (tracked on ``runner._critic_frontier_fired_steps``).
         * The shared recovery budget (per-step + per-run, from
           :mod:`agentic_recovery`) isn't exhausted.
+
+        The gate covers all three rewrite-triggering classes (not
+        just ``wrong_target``) because the staff-crm sidebar cascade
+        produces ``no_state_change`` failures even when SoM clicks
+        resolve to real ``<a>`` elements — the page doesn't navigate
+        so snapshot-diff fires first and stamps no_state_change
+        before the URL postcondition can stamp wrong_target. A
+        wrong_target-only gate would never trigger on that pattern.
 
         Mode mapping:
 
@@ -255,8 +274,9 @@ class ExecutionCritic:
         """
         if not _frontier_enabled():
             return None
+        from . import intent_rewriter
         failure_class = str(getattr(step_result, "failure_class", "") or "")
-        if failure_class != "wrong_target":
+        if failure_class not in intent_rewriter.REWRITE_TRIGGERING_CLASSES:
             return None
 
         runner = self.runner
@@ -265,11 +285,12 @@ class ExecutionCritic:
             runner._step_failure_history.get(step_index, [])
             if hasattr(runner, "_step_failure_history") else []
         )
-        wrong_target_count = sum(
+        failure_count = sum(
             1 for r in history
-            if isinstance(r, dict) and r.get("kind") == "wrong_target"
+            if isinstance(r, dict)
+            and str(r.get("kind") or "") in intent_rewriter.REWRITE_TRIGGERING_CLASSES
         )
-        if wrong_target_count < _FRONTIER_WRONG_TARGET_THRESHOLD:
+        if failure_count < _FRONTIER_PERSISTENT_FAILURE_THRESHOLD:
             return None
 
         # Already consulted Claude for this step? Don't double-spend.
@@ -320,7 +341,7 @@ class ExecutionCritic:
         ]
         failure_data = (
             f"failure_class={failure_class}; "
-            f"prior_wrong_target={wrong_target_count}; "
+            f"prior_failures={failure_count}; "
             f"data={(step_result.data or '')[:160]}"
         )
 
@@ -331,7 +352,7 @@ class ExecutionCritic:
                 failure_data=failure_data,
                 screenshot=screenshot,
                 plan_context=plan_context,
-                attempts=wrong_target_count,
+                attempts=failure_count,
             )
         except Exception as exc:  # noqa: BLE001 — never break runs
             logger.warning("  [critic-frontier] Claude call raised: %s", exc)
@@ -382,7 +403,7 @@ class ExecutionCritic:
                 hints=dict(getattr(step, "hints", {}) or {}),
                 reason=(
                     f"frontier critic replaced step on persistent "
-                    f"wrong_target ({wrong_target_count} prior): "
+                    f"{failure_class} ({failure_count} prior): "
                     f"{decision.reasoning[:120]}"
                 ),
             )
@@ -405,8 +426,8 @@ class ExecutionCritic:
                 step_type=step_type,
                 params=dict(first.get("params") or {}),
                 reason=(
-                    f"frontier critic insert on persistent wrong_target "
-                    f"({wrong_target_count} prior): "
+                    f"frontier critic insert on persistent "
+                    f"{failure_class} ({failure_count} prior): "
                     f"{decision.reasoning[:120]}"
                 ),
             )

--- a/src/mantis_agent/gym/critic.py
+++ b/src/mantis_agent/gym/critic.py
@@ -276,11 +276,21 @@ class ExecutionCritic:
             return None
         from . import intent_rewriter
         failure_class = str(getattr(step_result, "failure_class", "") or "")
-        if failure_class not in intent_rewriter.REWRITE_TRIGGERING_CLASSES:
-            return None
-
         runner = self.runner
         step_index = int(state.step_index)
+
+        # Diagnostic: surface every gate decision at WARNING so the
+        # trace shows which guard closed the door. This makes the
+        # "critic never fired" failure mode visible from Modal logs
+        # alone (Modal suppresses INFO+DEBUG).
+        if failure_class not in intent_rewriter.REWRITE_TRIGGERING_CLASSES:
+            logger.warning(
+                "  [critic-frontier] step %d: skipped — failure_class=%r "
+                "not in REWRITE_TRIGGERING_CLASSES",
+                step_index, failure_class,
+            )
+            return None
+
         history = (
             runner._step_failure_history.get(step_index, [])
             if hasattr(runner, "_step_failure_history") else []
@@ -291,6 +301,11 @@ class ExecutionCritic:
             and str(r.get("kind") or "") in intent_rewriter.REWRITE_TRIGGERING_CLASSES
         )
         if failure_count < _FRONTIER_PERSISTENT_FAILURE_THRESHOLD:
+            logger.warning(
+                "  [critic-frontier] step %d: skipped — failure_count=%d "
+                "below threshold %d",
+                step_index, failure_count, _FRONTIER_PERSISTENT_FAILURE_THRESHOLD,
+            )
             return None
 
         # Already consulted Claude for this step? Don't double-spend.
@@ -299,6 +314,10 @@ class ExecutionCritic:
             fired = set()
             runner._critic_frontier_fired_steps = fired
         if step_index in fired:
+            logger.warning(
+                "  [critic-frontier] step %d: skipped — already fired this step",
+                step_index,
+            )
             return None
 
         # Reuse the existing recovery budget pool so the critic's
@@ -308,8 +327,10 @@ class ExecutionCritic:
         per_step_dict = getattr(runner, "_recovery_attempts_per_step", None)
         total_attempts = getattr(runner, "_total_recovery_attempts", None)
         if not isinstance(per_step_dict, dict) or not isinstance(total_attempts, int):
-            logger.debug(
-                "  [critic-frontier] runner missing budget trackers — skip"
+            logger.warning(
+                "  [critic-frontier] step %d: skipped — runner missing budget "
+                "trackers (per_step=%s, total=%s)",
+                step_index, type(per_step_dict).__name__, type(total_attempts).__name__,
             )
             return None
         try:
@@ -318,12 +339,32 @@ class ExecutionCritic:
                 DEFAULT_MAX_RECOVERIES_PER_STEP,
             )
         except Exception as exc:  # noqa: BLE001 — never break runs
-            logger.debug("  [critic-frontier] agentic_recovery import failed: %s", exc)
+            logger.warning(
+                "  [critic-frontier] step %d: skipped — agentic_recovery "
+                "import failed: %s", step_index, exc,
+            )
             return None
         if per_step_dict.get(step_index, 0) >= DEFAULT_MAX_RECOVERIES_PER_STEP:
+            logger.warning(
+                "  [critic-frontier] step %d: skipped — per-step budget "
+                "exhausted (%d/%d) before critic could fire",
+                step_index, per_step_dict.get(step_index, 0),
+                DEFAULT_MAX_RECOVERIES_PER_STEP,
+            )
             return None
         if total_attempts >= DEFAULT_MAX_RECOVERIES_PER_RUN:
+            logger.warning(
+                "  [critic-frontier] step %d: skipped — per-run budget "
+                "exhausted (%d/%d)",
+                step_index, total_attempts, DEFAULT_MAX_RECOVERIES_PER_RUN,
+            )
             return None
+        # All gates passed — Claude call below logs result.
+        logger.warning(
+            "  [critic-frontier] step %d: gate passed (failure_class=%s, "
+            "failures=%d) — calling analyse_failure_and_recover",
+            step_index, failure_class, failure_count,
+        )
 
         # Capture the post-failure screenshot for Claude's analysis.
         # Same shape ``step_recovery._try_agentic_recovery`` uses.

--- a/src/mantis_agent/gym/critic.py
+++ b/src/mantis_agent/gym/critic.py
@@ -365,6 +365,13 @@ class ExecutionCritic:
             "failures=%d) — calling analyse_failure_and_recover",
             step_index, failure_class, failure_count,
         )
+        from . import reasoning_trace as _trace
+        _trace.record(
+            runner, layer="critic-frontier", kind="fire",
+            summary=f"gate passed on {failure_class} (×{failure_count})",
+            step_index=step_index,
+            failure_class=failure_class, failure_count=failure_count,
+        )
 
         # Capture the post-failure screenshot for Claude's analysis.
         # Same shape ``step_recovery._try_agentic_recovery`` uses.
@@ -426,6 +433,11 @@ class ExecutionCritic:
                 "for the terminal path",
                 step_index,
             )
+            _trace.record(
+                runner, layer="critic-frontier", kind="result",
+                summary="Claude returned no decision (API fallback)",
+                step_index=step_index, decision_mode="none",
+            )
             return None
 
         # Real decision received — count this as a recovery consultation
@@ -439,6 +451,12 @@ class ExecutionCritic:
                 "tweak helps (%s)",
                 step_index, decision.reasoning[:120],
             )
+            _trace.record(
+                runner, layer="critic-frontier", kind="result",
+                summary=f"halt: {decision.reasoning[:120]}",
+                step_index=step_index, decision_mode="halt",
+                reasoning=decision.reasoning[:300],
+            )
             return None
         if decision.mode == "add_hint" and decision.hint:
             from . import recovery_hints
@@ -446,6 +464,13 @@ class ExecutionCritic:
             logger.warning(
                 "  [critic-frontier] step %d: add_hint — %s",
                 step_index, decision.hint[:120],
+            )
+            _trace.record(
+                runner, layer="critic-frontier", kind="result",
+                summary=f"add_hint: {decision.hint[:120]}",
+                step_index=step_index, decision_mode="add_hint",
+                hint=decision.hint[:300],
+                reasoning=decision.reasoning[:300],
             )
             return None
         if decision.mode == "edit_step":
@@ -459,6 +484,13 @@ class ExecutionCritic:
                 "  [critic-frontier] step %d: edit_step → ReplaceStep "
                 "(type=%s, intent=%s)",
                 step_index, new_type, new_intent[:80],
+            )
+            _trace.record(
+                runner, layer="critic-frontier", kind="result",
+                summary=f"edit_step → ReplaceStep (type={new_type})",
+                step_index=step_index, decision_mode="edit_step",
+                new_intent=new_intent[:200], new_type=new_type,
+                reasoning=decision.reasoning[:300],
             )
             return ReplaceStep(
                 intent=new_intent,
@@ -484,6 +516,13 @@ class ExecutionCritic:
                 "  [critic-frontier] step %d: insert_steps[0] → InsertStep "
                 "(type=%s, intent=%s)",
                 step_index, step_type, intent[:80],
+            )
+            _trace.record(
+                runner, layer="critic-frontier", kind="result",
+                summary=f"insert_steps[0] → InsertStep (type={step_type})",
+                step_index=step_index, decision_mode="insert_steps",
+                inserted_intent=intent[:200], inserted_type=step_type,
+                reasoning=decision.reasoning[:300],
             )
             return InsertStep(
                 intent=intent,

--- a/src/mantis_agent/gym/critic.py
+++ b/src/mantis_agent/gym/critic.py
@@ -403,19 +403,31 @@ class ExecutionCritic:
         # invalid, we don't want to retry the consultation on the same
         # step (the policy budget exists for that).
         fired.add(step_index)
-        # Increment the shared budget counters so the terminal path
-        # sees this consultation count.
-        per_step_dict[step_index] = per_step_dict.get(step_index, 0) + 1
-        runner._total_recovery_attempts = total_attempts + 1
 
         if decision is None:
-            logger.info(
+            # Claude call failed (no key / API error / parse fallback).
+            # Don't burn the shared recovery budget — the terminal
+            # path may yet succeed on its own call. Mark fired so we
+            # don't retry, but keep budget intact for downstream.
+            logger.warning(
                 "  [critic-frontier] step %d: Claude returned no decision "
-                "(API/key/parse fallback) — recovery continues unchanged",
+                "(API/key/parse fallback) — leaving recovery budget intact "
+                "for the terminal path",
                 step_index,
             )
             return None
+
+        # Real decision received — count this as a recovery consultation
+        # against the shared per-step / per-run budget so the terminal
+        # path doesn't double-spend.
+        per_step_dict[step_index] = per_step_dict.get(step_index, 0) + 1
+        runner._total_recovery_attempts = total_attempts + 1
         if decision.mode == "halt":
+            logger.warning(
+                "  [critic-frontier] step %d: halt — Claude says no plan "
+                "tweak helps (%s)",
+                step_index, decision.reasoning[:120],
+            )
             return None
         if decision.mode == "add_hint" and decision.hint:
             from . import recovery_hints

--- a/src/mantis_agent/gym/critic.py
+++ b/src/mantis_agent/gym/critic.py
@@ -386,6 +386,16 @@ class ExecutionCritic:
             f"data={(step_result.data or '')[:160]}"
         )
 
+        # H8: surface accumulated hints so Claude sees when add_hint
+        # loops are already burning attempts. The runner stores hints
+        # in ``_recovery_hints[step_index]``; the prompt's HINT-LOOP
+        # DETECTION section reads from PRIOR HINTS TEXT directly.
+        prior_hints: list[str] = []
+        hint_map = getattr(runner, "_recovery_hints", None)
+        if isinstance(hint_map, dict):
+            stored = hint_map.get(step_index, [])
+            if isinstance(stored, list):
+                prior_hints = [str(h) for h in stored if str(h).strip()]
         try:
             from ..agentic_recovery import analyse_failure_and_recover
             decision = analyse_failure_and_recover(
@@ -394,6 +404,7 @@ class ExecutionCritic:
                 screenshot=screenshot,
                 plan_context=plan_context,
                 attempts=failure_count,
+                prior_hints=prior_hints,
             )
         except Exception as exc:  # noqa: BLE001 — never break runs
             logger.warning("  [critic-frontier] Claude call raised: %s", exc)

--- a/src/mantis_agent/gym/healing_events.py
+++ b/src/mantis_agent/gym/healing_events.py
@@ -139,6 +139,39 @@ def record_insert_step(
     })
 
 
+def record_replace_step(
+    runner: Any,
+    *,
+    step_index: int,
+    original_type: str,
+    new_intent: str,
+    new_type: str,
+    reason: str,
+    source: str = "critic",
+) -> None:
+    """The critic (typically a frontier-model observer) replaced the
+    step at ``step_index`` in place — same plan slot, different
+    action. Distinct from ``insert_step`` (which splices a NEW step)
+    and from the ``rewrite`` event (which only edits the intent
+    prose, keeping the same step type / params).
+
+    Common trigger: a ``wrong_target`` failure cascade where vision
+    keeps clicking adjacent items. The frontier model proposes a
+    structurally different action (e.g. direct navigate instead of
+    sidebar link click) that bypasses the grounding miss.
+    """
+    _append(runner, {
+        "kind": "replace_step",
+        "step_index": int(step_index),
+        "source": str(source),
+        "original_type": str(original_type),
+        "new_intent": str(new_intent)[:200],
+        "new_type": str(new_type),
+        "reason": str(reason)[:200],
+        "at": _now_iso(),
+    })
+
+
 def snapshot(runner: Any) -> list[dict[str, Any]]:
     """Plain list copy for the result envelope. Empty list when no
     events recorded (preserves ``json.dumps`` compatibility)."""

--- a/src/mantis_agent/gym/reasoning_trace.py
+++ b/src/mantis_agent/gym/reasoning_trace.py
@@ -1,0 +1,177 @@
+"""Structured reasoning trace — every decision the runner makes,
+streamed to disk so a viewer / debugger can scrub through them
+alongside the MJPEG live feed.
+
+Existing observability:
+
+* :mod:`healing_events` — records plan mutations (rewrite, demote,
+  handler_escalation, insert_step, replace_step). Append-only on
+  ``runner._healing_events``. Surfaced at run-end via
+  ``build_micro_result``.
+* Modal log lines (``[critic-frontier]`` / ``[som-click]`` / etc.)
+  — visible via ``modal app logs`` but require grep + correlate to
+  reconstruct the timeline.
+
+What's missing — and what this module adds — is a STRUCTURED LIVE
+stream of the same decisions the log lines already make visible.
+The runner appends to ``runner._reasoning_events`` and flushes
+periodically to ``<run_dir>/reasoning.jsonl``; the API container
+serves the file via ``action=reasoning_trace``. A future viewer
+overlay polls the endpoint and renders a timeline beside the
+MJPEG feed (separate PR).
+
+Event shape (consistent across types)::
+
+    {
+        "ts": "2026-05-16T19:46:51Z",
+        "step_index": 6,
+        "layer": "critic-frontier" | "agentic-recovery"
+                 | "som-click" | "gate-decision" | …,
+        "kind": "fire" | "skip" | "decision" | "result",
+        "summary": "edit_step → ReplaceStep",
+        "detail": {...},
+    }
+
+The same ``runner._healing_events`` list backs both streams —
+``record(...)`` here is a shim that appends to that list with a
+``kind="reasoning"`` flag, so the existing ``healing_events.snapshot``
+keeps working without changes.
+
+Why no separate list: viewers and result envelopes want a single
+ordered timeline. Splitting into two lists would force consumers
+to merge-sort on every read; one list keeps the order natural.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def record(
+    runner: Any,
+    *,
+    layer: str,
+    kind: str,
+    summary: str,
+    step_index: int | None = None,
+    **detail: Any,
+) -> None:
+    """Append a reasoning event to the runner's event list.
+
+    Defensive on every access — tests that hand the runner a
+    ``MagicMock`` auto-create ``_healing_events`` as a Mock, not a
+    list. A non-list silently drops the event so production never
+    crashes on the trace path.
+
+    The event is also written to the runner's reasoning_jsonl_path
+    when the runner exposes one — the runtime sets this attribute
+    so events stream to disk during the run.
+    """
+    log = getattr(runner, "_healing_events", None)
+    if not isinstance(log, list):
+        return
+    event = {
+        "ts": _now_iso(),
+        "layer": str(layer),
+        "kind": str(kind),
+        "summary": str(summary)[:300],
+        "step_index": int(step_index) if step_index is not None else -1,
+        "detail": _sanitize_detail(detail),
+    }
+    # Tag as reasoning so ``healing_events.snapshot`` consumers can
+    # filter if they only want the plan-mutation subset.
+    event["category"] = "reasoning"
+    log.append(event)
+
+    # Stream to disk when the runner has a configured path. Errors
+    # never propagate — the trace is observability; a broken FS
+    # mustn't break the run.
+    path = getattr(runner, "_reasoning_jsonl_path", None)
+    if path:
+        try:
+            with Path(path).open("a", encoding="utf-8") as f:
+                f.write(json.dumps(event) + "\n")
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("reasoning_trace flush failed: %s", exc)
+
+
+def _sanitize_detail(detail: dict[str, Any]) -> dict[str, Any]:
+    """JSON-serializable copy of the detail dict. Drops keys whose
+    values can't be safely stringified."""
+    out: dict[str, Any] = {}
+    for key, val in detail.items():
+        try:
+            json.dumps(val)
+            out[str(key)] = val
+        except (TypeError, ValueError):
+            try:
+                out[str(key)] = str(val)[:200]
+            except Exception:  # noqa: BLE001
+                continue
+    return out
+
+
+def configure_disk_stream(runner: Any, jsonl_path: str | Path) -> None:
+    """Tell the runner to mirror reasoning events to ``jsonl_path``
+    in append mode. The runtime calls this at run start so the
+    HTTP ``action=reasoning_trace`` endpoint sees fresh events
+    DURING the run (not only after termination).
+
+    Idempotent — calling twice with the same path just re-stamps
+    the attribute. Calling with a different path swaps the
+    destination for events emitted AFTER the call.
+    """
+    path = Path(jsonl_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    runner._reasoning_jsonl_path = str(path)
+
+
+def read_jsonl(path: str | Path, *, since_ts: str | None = None) -> list[dict]:
+    """Read events from a JSONL file with optional ``since_ts``
+    cursor. Returns events whose ``ts`` is strictly greater than
+    ``since_ts`` — lexicographic compare on the ISO-8601 timestamp,
+    which is order-preserving for UTC.
+
+    Malformed lines are skipped silently — a partially-written
+    final line (the runner crashed mid-flush) doesn't break the
+    reader.
+    """
+    p = Path(path)
+    if not p.exists():
+        return []
+    events: list[dict] = []
+    try:
+        with p.open("r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    event = json.loads(line)
+                except (json.JSONDecodeError, ValueError):
+                    continue
+                if not isinstance(event, dict):
+                    continue
+                if since_ts and event.get("ts", "") <= since_ts:
+                    continue
+                events.append(event)
+    except OSError as exc:
+        logger.debug("reasoning_trace read failed: %s", exc)
+    return events
+
+
+__all__ = [
+    "record",
+    "configure_disk_stream",
+    "read_jsonl",
+]

--- a/src/mantis_agent/gym/step_recovery.py
+++ b/src/mantis_agent/gym/step_recovery.py
@@ -721,6 +721,15 @@ class StepRecoveryPolicy:
             and getattr(step, "type", "") == "submit"
             else "claude-haiku-4-5-20251001"
         )
+        # H8: pass the accumulated hints on this step so Claude can
+        # detect the "same hint twice, still failing" pattern and bias
+        # toward structural recovery instead of yet another add_hint.
+        prior_hints = []
+        hint_map = getattr(runner, "_recovery_hints", None)
+        if isinstance(hint_map, dict):
+            stored = hint_map.get(step_index, [])
+            if isinstance(stored, list):
+                prior_hints = [str(h) for h in stored if str(h).strip()]
         decision = analyse_failure_and_recover(
             step=step,
             failure_data=str(getattr(step_result, "data", "") or ""),
@@ -728,6 +737,7 @@ class StepRecoveryPolicy:
             plan_context=plan_context,
             attempts=attempts,
             model=recovery_model,
+            prior_hints=prior_hints,
         )
         if decision is None:
             # #431: even though analyse_failure_and_recover already logs

--- a/src/mantis_agent/gym/xdotool_env.py
+++ b/src/mantis_agent/gym/xdotool_env.py
@@ -570,6 +570,13 @@ class XdotoolGymEnv(GymEnvironment):
             result.get("els_tag"), result.get("els_text"),
             same_element, result.get("ok"),
         )
+        # Also emit into the structured reasoning trace when a runner
+        # back-reference is available. The env doesn't carry a direct
+        # runner ref by design; callers that want to attribute SoM
+        # clicks to a specific runner pass the runner via the public
+        # ``record_som_click`` helper below. We skip the trace here
+        # because we have no runner — see ``record_som_click`` in
+        # :mod:`reasoning_trace` if/when callers wire it.
         return bool(result.get("ok"))
 
     def _xdotool_type(self, text: str) -> None:

--- a/src/mantis_agent/prompts/__init__.py
+++ b/src/mantis_agent/prompts/__init__.py
@@ -60,6 +60,14 @@ _PROMPT_NAMES: tuple[str, ...] = (
 # empty string by default; a domain harness can pass a populated block).
 _PROMPT_PLACEHOLDER_DEFAULTS: dict[str, dict[str, str]] = {
     "holo3_system": {"examples_block": ""},
+    # H8 — recovery_analysis surfaces a hint-loop signal. Defaults
+    # keep the prompt valid when the caller doesn't supply the
+    # hint context (legacy callers / unit tests that don't track
+    # per-step hint counts).
+    "recovery_analysis": {
+        "prior_hint_count": "0",
+        "prior_hints_block": "",
+    },
 }
 
 

--- a/src/mantis_agent/prompts/files/recovery_analysis.txt
+++ b/src/mantis_agent/prompts/files/recovery_analysis.txt
@@ -14,6 +14,8 @@ params: __PARAMS__
 
 FAILURE DATA: __FAILURE_DATA__
 RETRY ATTEMPTS: __ATTEMPTS__
+PRIOR HINTS ON THIS STEP: __PRIOR_HINT_COUNT__
+__PRIOR_HINTS_BLOCK__
 
 FAILURE DATA LEGEND (decode the failure string before choosing a mode):
 
@@ -135,6 +137,33 @@ and consumes per-run recovery budget. If you've seen evidence that
 the same approach already failed (RETRY ATTEMPTS shows the runner
 already tried), prefer halt or edit_step over inserting MORE steps
 of the same kind.
+
+**HINT-LOOP DETECTION (read PRIOR HINTS ON THIS STEP first):**
+If ``PRIOR HINT COUNT >= 2`` and the step is STILL failing, the
+previous hint(s) didn't unstick the brain. Continuing to emit more
+``add_hint`` here is a near-guaranteed waste — every hint Claude
+has already given says the SAME thing about WHERE to click, and
+the grounder keeps missing in the same way. The bug is below the
+prompt layer (vision pixel-accuracy, event-trust, layout drift).
+
+**When you see ``PRIOR HINT COUNT >= 2``, AVOID ``add_hint`` and
+prefer a STRUCTURALLY DIFFERENT recovery:**
+
+* If the visible page contains a URL bar / address bar / breadcrumb
+  that hints at the desired post-state's URL pattern AND the failed
+  step is a click / submit that's supposed to navigate, prefer
+  ``edit_step`` with ``type=navigate`` and ``params.url`` pointing
+  at the intended destination. Example: the plan asked to click
+  "Contacted" in a sidebar to filter leads, but the URL pattern
+  ``/leads?status=Contacted`` is reachable directly — propose
+  ``edit_step`` with ``type=navigate, params={"url":
+  "/leads?status=Contacted"}``. This bypasses the click entirely.
+* If the visible page contains a search box / typeahead / filter
+  input that achieves the same goal as the failed click, prefer
+  ``insert_steps`` with a ``fill_field`` + Enter sub-flow.
+* If you genuinely can't find a structurally different path, return
+  ``halt`` rather than ``add_hint``. Surfacing the failure honestly
+  is better than burning more retries on the same dead end.
 
 Decision priority when multiple modes plausibly fit:
 - FAILURE_DATA starts with ``form_target_not_input:`` → strongly

--- a/tests/test_agentic_recovery.py
+++ b/tests/test_agentic_recovery.py
@@ -170,6 +170,132 @@ def test_prompt_includes_progress_evidence_guidance_for_halt() -> None:
     assert "loop" in rendered.lower() or "didn't" in rendered.lower() or "did not" in rendered.lower()
 
 
+# ── H8: hint-loop detection in the recovery prompt ──────────────
+
+
+def test_prompt_renders_prior_hint_count_when_supplied() -> None:
+    """The prompt should surface ``PRIOR HINTS ON THIS STEP: N``
+    when callers pass ``prior_hints`` so Claude can detect the
+    "same hint twice, still failing" pattern and switch off
+    ``add_hint``."""
+    from mantis_agent.prompts import load_prompt
+
+    rendered = load_prompt(
+        "recovery_analysis",
+        intent="x", step_type="submit", params="{}",
+        failure_data="no_state_change", attempts=3, plan_context="",
+        prior_hint_count=2,
+        prior_hints_block=(
+            "PRIOR HINTS TEXT:\n"
+            "  - Click the Contacted text in the LEAD VIEWS sidebar\n"
+            "  - The Contacted link is the text 'Contacted' itself"
+        ),
+    )
+    assert "PRIOR HINTS ON THIS STEP: 2" in rendered
+    assert "Click the Contacted text" in rendered
+    # The HINT-LOOP DETECTION language must be present.
+    assert "HINT-LOOP DETECTION" in rendered
+    assert "AVOID ``add_hint``" in rendered
+
+
+def test_prompt_renders_zero_hint_count_by_default() -> None:
+    """Callers that don't supply ``prior_hints`` get a clean prompt —
+    PRIOR HINT COUNT defaults to 0 and the prior-hints-block is
+    empty so nothing leaks into the rendered text. Keeps legacy
+    callers unaffected."""
+    from mantis_agent.prompts import load_prompt
+
+    rendered = load_prompt(
+        "recovery_analysis",
+        intent="x", step_type="submit", params="{}",
+        failure_data="x", attempts=1, plan_context="",
+    )
+    assert "PRIOR HINTS ON THIS STEP: 0" in rendered
+    # No prior-hints text block leaked through.
+    assert "PRIOR HINTS TEXT:" not in rendered
+    # The HINT-LOOP DETECTION guidance is STILL in the prompt —
+    # Claude sees it but it triggers on count >= 2 not 0.
+    assert "HINT-LOOP DETECTION" in rendered
+
+
+def test_analyse_threads_prior_hints_into_prompt() -> None:
+    """End-to-end: ``analyse_failure_and_recover`` accepts a
+    ``prior_hints`` kwarg, formats it into a PRIOR HINTS TEXT block,
+    and the rendered prompt carries the hint text Claude can read."""
+    captured_prompt: dict = {}
+
+    def _capture(*_args, **kwargs):
+        payload = kwargs.get("json") or {}
+        msgs = payload.get("messages", [])
+        if msgs and isinstance(msgs[0].get("content"), list):
+            for block in msgs[0]["content"]:
+                if block.get("type") == "text":
+                    captured_prompt["text"] = block.get("text", "")
+                    break
+        resp = MagicMock(status_code=200)
+        resp.json.return_value = {
+            "content": [{
+                "type": "tool_use", "name": "record_recovery",
+                "input": {"mode": "halt", "reasoning": "test"},
+            }],
+        }
+        return resp
+
+    from mantis_agent.agentic_recovery import analyse_failure_and_recover
+    step = MicroIntent(intent="Click Contacted", type="submit",
+                       params={"label": "Contacted"})
+    with patch("requests.post", side_effect=_capture):
+        analyse_failure_and_recover(
+            step=step,
+            failure_data="no_state_change",
+            screenshot=None,
+            plan_context=[],
+            attempts=2,
+            api_key="k",
+            prior_hints=[
+                "Click the Contacted text in the LEAD VIEWS sidebar",
+                "Target the link text not the count number",
+            ],
+        )
+
+    text = captured_prompt.get("text", "")
+    assert "PRIOR HINTS ON THIS STEP: 2" in text, text[:500]
+    assert "Click the Contacted text" in text
+    assert "Target the link text" in text
+
+
+def test_analyse_with_no_prior_hints_renders_zero() -> None:
+    """No prior_hints kwarg → renders ``PRIOR HINTS ON THIS STEP: 0``
+    and no PRIOR HINTS TEXT block."""
+    captured: dict = {}
+
+    def _capture(*_args, **kwargs):
+        payload = kwargs.get("json") or {}
+        msgs = payload.get("messages", [])
+        for block in msgs[0]["content"]:
+            if block.get("type") == "text":
+                captured["text"] = block.get("text", "")
+        resp = MagicMock(status_code=200)
+        resp.json.return_value = {
+            "content": [{
+                "type": "tool_use", "name": "record_recovery",
+                "input": {"mode": "halt", "reasoning": "test"},
+            }],
+        }
+        return resp
+
+    from mantis_agent.agentic_recovery import analyse_failure_and_recover
+    step = MicroIntent(intent="x", type="submit", params={})
+    with patch("requests.post", side_effect=_capture):
+        analyse_failure_and_recover(
+            step=step, failure_data="x", screenshot=None,
+            plan_context=[], attempts=1, api_key="k",
+        )
+    text = captured.get("text", "")
+    assert "PRIOR HINTS ON THIS STEP: 0" in text
+    assert "PRIOR HINTS TEXT:" not in text
+
+
 def test_call_recovery_tool_logs_warning_on_missing_tool_use_block(caplog) -> None:
     """When the Anthropic 200 OK response has no ``record_recovery``
     tool_use block, the silent ``return None`` used to leave operators
@@ -212,7 +338,7 @@ def test_no_state_change_submit_uses_opus_model() -> None:
     captured: dict = {}
 
     def _capture(*, step, failure_data, screenshot, plan_context,
-                 attempts, model=None, api_key=""):
+                 attempts, model=None, api_key="", prior_hints=None):
         captured["model"] = model
         return None  # short-circuit; we only care about the model arg.
 
@@ -651,7 +777,7 @@ def test_recovery_runs_tab_blur_traversal_on_no_state_change_submit() -> None:
     captured: dict = {}
 
     def _capture(*, step, failure_data, screenshot, plan_context,
-                 attempts, model=None, api_key=""):
+                 attempts, model=None, api_key="", prior_hints=None):
         captured["screenshot"] = screenshot
         return None  # short-circuit; we only care about the pre-call sequence.
 

--- a/tests/test_execution_critic.py
+++ b/tests/test_execution_critic.py
@@ -10,10 +10,13 @@ from __future__ import annotations
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+import pytest
+
 from mantis_agent.gym.checkpoint import StepResult
 from mantis_agent.gym.critic import (
     ExecutionCritic,
     InsertStep,
+    ReplaceStep,
     apply_directive,
 )
 from mantis_agent.plan_decomposer import MicroIntent, MicroPlan
@@ -257,3 +260,432 @@ def test_critic_fires_inside_executor_after_navigate_back_failure(monkeypatch):
     # And the healing log records it.
     kinds = [e["kind"] for e in runner._healing_events]
     assert "insert_step" in kinds
+
+
+# ── ReplaceStep mutation + healing event (item 8) ─────────────────────
+
+
+def _runner_with_frontier_state(*, results_base_url: str = ""):
+    """Minimal runner with the shared-recovery-budget trackers that
+    the frontier capability reads. Mirrors the real
+    ``MicroPlanRunner`` attributes without pulling the heavy class."""
+    return SimpleNamespace(
+        _results_base_url=results_base_url,
+        _healing_events=[],
+        _step_failure_history={},
+        _recovery_attempts_per_step={},
+        _total_recovery_attempts=0,
+        _recovery_hints={},
+        _critic_frontier_fired_steps=set(),
+        env=None,
+    )
+
+
+def test_apply_replace_step_swaps_step_in_place() -> None:
+    """ReplaceStep replaces the step at ``state.step_index`` without
+    shifting subsequent steps. Length stays the same, the new step
+    occupies the same slot, neighbours are untouched."""
+    runner = _runner_with_frontier_state()
+    plan = MicroPlan(domain="t")
+    plan.steps.append(MicroIntent(intent="step-0", type="navigate"))
+    plan.steps.append(MicroIntent(intent="orig", type="submit",
+                                   params={"label": "Contacted"},
+                                   required=True, budget=4))
+    plan.steps.append(MicroIntent(intent="step-2", type="extract_data"))
+    state = _state(step_index=1)
+
+    apply_directive(runner, plan, state, ReplaceStep(
+        intent="Navigate to /leads?status=Contacted",
+        step_type="navigate",
+        params={"url": "/leads?status=Contacted"},
+        reason="vision miss cascade — direct nav bypasses sidebar click",
+    ))
+
+    assert len(plan.steps) == 3
+    replaced = plan.steps[1]
+    assert replaced.type == "navigate"
+    assert replaced.intent == "Navigate to /leads?status=Contacted"
+    assert replaced.params == {"url": "/leads?status=Contacted"}
+    # Neighbours untouched.
+    assert plan.steps[0].intent == "step-0"
+    assert plan.steps[2].intent == "step-2"
+    # The original step's required + budget are inherited (critic
+    # changes the action, not the plan-author's gate settings).
+    assert replaced.required is True
+    assert replaced.budget == 4
+
+
+def test_apply_replace_step_records_healing_event() -> None:
+    runner = _runner_with_frontier_state()
+    plan = MicroPlan(domain="t")
+    plan.steps.append(MicroIntent(intent="orig", type="submit"))
+    state = _state(step_index=0)
+
+    apply_directive(runner, plan, state, ReplaceStep(
+        intent="Navigate to /x", step_type="navigate",
+        params={"url": "/x"}, reason="r",
+    ))
+    assert len(runner._healing_events) == 1
+    ev = runner._healing_events[0]
+    assert ev["kind"] == "replace_step"
+    assert ev["original_type"] == "submit"
+    assert ev["new_type"] == "navigate"
+    assert ev["source"] == "critic"
+
+
+def test_apply_replace_step_resets_step_failure_history() -> None:
+    """The replaced step gets a clean slate — the old step's retry
+    pressure (which led the critic to intervene) doesn't carry to
+    the new step. Otherwise the new step would inherit the rewrite-
+    triggering failure_class and the agentic recovery loop would
+    immediately fire again."""
+    runner = _runner_with_frontier_state()
+    runner._step_failure_history[5] = [
+        {"x": 1, "y": 1, "kind": "wrong_target"},
+        {"x": 2, "y": 2, "kind": "wrong_target"},
+    ]
+    runner._recovery_hints[5] = ["old hint"]
+    plan = MicroPlan(domain="t")
+    for _ in range(6):
+        plan.steps.append(MicroIntent(intent="x", type="submit"))
+    state = _state(step_index=5)
+
+    apply_directive(runner, plan, state, ReplaceStep(
+        intent="Navigate", step_type="navigate", reason="r",
+    ))
+    assert 5 not in runner._step_failure_history
+    assert 5 not in runner._recovery_hints
+
+
+def test_apply_replace_step_out_of_range_is_no_op() -> None:
+    runner = _runner_with_frontier_state()
+    plan = MicroPlan(domain="t")
+    plan.steps.append(MicroIntent(intent="x", type="submit"))
+    state = _state(step_index=99)  # past the end
+
+    apply_directive(runner, plan, state, ReplaceStep(
+        intent="X", step_type="navigate", reason="r",
+    ))
+    assert len(plan.steps) == 1
+    assert plan.steps[0].intent == "x"
+    assert runner._healing_events == []
+
+
+# ── Frontier capability — env var gate + threshold + budget ──────────
+
+
+def test_frontier_disabled_by_default(monkeypatch) -> None:
+    """``MANTIS_CRITIC_FRONTIER`` unset → frontier capability is a
+    no-op even with the threshold met. Preserves the existing cost
+    profile for deployments that haven't opted in."""
+    monkeypatch.delenv("MANTIS_CRITIC_FRONTIER", raising=False)
+    runner = _runner_with_frontier_state()
+    runner._step_failure_history[0] = [
+        {"x": 1, "y": 1, "kind": "wrong_target"},
+        {"x": 2, "y": 2, "kind": "wrong_target"},
+    ]
+    critic = ExecutionCritic(runner)
+    plan = MicroPlan(domain="t")
+    plan.steps.append(MicroIntent(intent="x", type="submit"))
+    state = _state()
+    result = StepResult(
+        step_index=0, intent="x", success=False,
+        failure_class="wrong_target",
+    )
+    out = critic.observe_step(
+        plan, state, plan.steps[0], result, recovery_continued=True,
+    )
+    assert out is None
+
+
+def test_frontier_skipped_below_wrong_target_threshold(monkeypatch) -> None:
+    """Threshold = 2 wrong_target failures. After only one prior
+    failure the critic stays quiet — the cheap retry / rewriter path
+    deserves a chance first."""
+    monkeypatch.setenv("MANTIS_CRITIC_FRONTIER", "enabled")
+    runner = _runner_with_frontier_state()
+    runner._step_failure_history[0] = [
+        {"x": 1, "y": 1, "kind": "wrong_target"},
+    ]
+    critic = ExecutionCritic(runner)
+    plan = MicroPlan(domain="t")
+    plan.steps.append(MicroIntent(intent="x", type="submit"))
+    state = _state()
+    result = StepResult(
+        step_index=0, intent="x", success=False,
+        failure_class="wrong_target",
+    )
+    out = critic.observe_step(
+        plan, state, plan.steps[0], result, recovery_continued=True,
+    )
+    assert out is None
+
+
+def test_frontier_fires_on_persistent_wrong_target(monkeypatch) -> None:
+    """At ≥2 wrong_target failures, env-enabled + budget-available,
+    the critic invokes ``analyse_failure_and_recover`` and maps the
+    decision to a directive."""
+    monkeypatch.setenv("MANTIS_CRITIC_FRONTIER", "enabled")
+    runner = _runner_with_frontier_state()
+    runner._step_failure_history[0] = [
+        {"x": 1, "y": 1, "kind": "wrong_target"},
+        {"x": 2, "y": 2, "kind": "wrong_target"},
+    ]
+
+    # Stub the Claude call.
+    from mantis_agent import agentic_recovery
+    from mantis_agent.agentic_recovery import RecoveryDecision
+
+    captured: list = []
+
+    def _fake_analyse(**kwargs):
+        captured.append(kwargs)
+        return RecoveryDecision(
+            mode="edit_step",
+            reasoning="vision miss cascade; direct navigate bypasses",
+            edited_step={
+                "intent": "Navigate to /leads?status=Contacted",
+                "type": "navigate",
+                "params": {"url": "/leads?status=Contacted"},
+            },
+        )
+
+    monkeypatch.setattr(agentic_recovery, "analyse_failure_and_recover", _fake_analyse)
+    # Also patch the import-as-needed inside critic.py — the critic
+    # imports lazily so we stub the underlying function rather than
+    # the import path.
+
+    critic = ExecutionCritic(runner)
+    plan = MicroPlan(domain="t")
+    plan.steps.append(MicroIntent(
+        intent="Click Contacted in sidebar", type="submit",
+        params={"label": "Contacted"},
+    ))
+    state = _state()
+    result = StepResult(
+        step_index=0, intent="Click Contacted", success=False,
+        failure_class="wrong_target",
+    )
+    out = critic.observe_step(
+        plan, state, plan.steps[0], result, recovery_continued=True,
+    )
+    assert isinstance(out, ReplaceStep)
+    assert out.step_type == "navigate"
+    assert out.params == {"url": "/leads?status=Contacted"}
+    # Budget counters incremented.
+    assert runner._recovery_attempts_per_step[0] == 1
+    assert runner._total_recovery_attempts == 1
+    # Step is marked as consulted so a second observe_step on the
+    # same step is a no-op.
+    assert 0 in runner._critic_frontier_fired_steps
+    # Claude got called once.
+    assert len(captured) == 1
+
+
+def test_frontier_skipped_if_already_fired_on_step(monkeypatch) -> None:
+    """The frontier consultation happens at most once per step —
+    even if the next step also reports wrong_target, we don't re-
+    call Claude on the same slot."""
+    monkeypatch.setenv("MANTIS_CRITIC_FRONTIER", "enabled")
+    runner = _runner_with_frontier_state()
+    runner._step_failure_history[0] = [
+        {"x": 1, "y": 1, "kind": "wrong_target"},
+        {"x": 2, "y": 2, "kind": "wrong_target"},
+    ]
+    runner._critic_frontier_fired_steps.add(0)
+
+    from mantis_agent import agentic_recovery
+    monkeypatch.setattr(
+        agentic_recovery, "analyse_failure_and_recover",
+        lambda **_: pytest.fail("Claude must not be called"),
+    )
+
+    critic = ExecutionCritic(runner)
+    plan = MicroPlan(domain="t")
+    plan.steps.append(MicroIntent(intent="x", type="submit"))
+    state = _state()
+    result = StepResult(
+        step_index=0, intent="x", success=False,
+        failure_class="wrong_target",
+    )
+    out = critic.observe_step(
+        plan, state, plan.steps[0], result, recovery_continued=True,
+    )
+    assert out is None
+
+
+def test_frontier_skipped_when_per_step_budget_exhausted(monkeypatch) -> None:
+    monkeypatch.setenv("MANTIS_CRITIC_FRONTIER", "enabled")
+    runner = _runner_with_frontier_state()
+    runner._step_failure_history[0] = [
+        {"x": 1, "y": 1, "kind": "wrong_target"},
+        {"x": 2, "y": 2, "kind": "wrong_target"},
+    ]
+    # Existing terminal-failure recovery already burned the per-step
+    # budget — the critic must not double-spend.
+    from mantis_agent.agentic_recovery import DEFAULT_MAX_RECOVERIES_PER_STEP
+    runner._recovery_attempts_per_step[0] = DEFAULT_MAX_RECOVERIES_PER_STEP
+
+    from mantis_agent import agentic_recovery
+    monkeypatch.setattr(
+        agentic_recovery, "analyse_failure_and_recover",
+        lambda **_: pytest.fail("Claude must not be called"),
+    )
+
+    critic = ExecutionCritic(runner)
+    plan = MicroPlan(domain="t")
+    plan.steps.append(MicroIntent(intent="x", type="submit"))
+    state = _state()
+    result = StepResult(
+        step_index=0, intent="x", success=False,
+        failure_class="wrong_target",
+    )
+    out = critic.observe_step(
+        plan, state, plan.steps[0], result, recovery_continued=True,
+    )
+    assert out is None
+
+
+def test_frontier_maps_add_hint_decision_to_recovery_hint(monkeypatch) -> None:
+    """add_hint mode doesn't return a directive — it writes to the
+    runner's recovery_hints map so the next retry's prompt picks it
+    up. The critic STILL marks the step as consulted so we don't
+    redo Claude work."""
+    monkeypatch.setenv("MANTIS_CRITIC_FRONTIER", "enabled")
+    runner = _runner_with_frontier_state()
+    runner._step_failure_history[0] = [
+        {"x": 1, "y": 1, "kind": "wrong_target"},
+        {"x": 2, "y": 2, "kind": "wrong_target"},
+    ]
+
+    from mantis_agent import agentic_recovery
+    from mantis_agent.agentic_recovery import RecoveryDecision
+    monkeypatch.setattr(
+        agentic_recovery, "analyse_failure_and_recover",
+        lambda **_: RecoveryDecision(
+            mode="add_hint",
+            reasoning="text",
+            hint="The Contacted link is the second item in the LEAD VIEWS sidebar.",
+        ),
+    )
+
+    critic = ExecutionCritic(runner)
+    plan = MicroPlan(domain="t")
+    plan.steps.append(MicroIntent(intent="x", type="submit"))
+    state = _state()
+    result = StepResult(
+        step_index=0, intent="x", success=False,
+        failure_class="wrong_target",
+    )
+    out = critic.observe_step(
+        plan, state, plan.steps[0], result, recovery_continued=True,
+    )
+    assert out is None
+    assert runner._recovery_hints[0] == [
+        "The Contacted link is the second item in the LEAD VIEWS sidebar."
+    ]
+    assert 0 in runner._critic_frontier_fired_steps
+
+
+def test_frontier_maps_halt_decision_to_no_directive(monkeypatch) -> None:
+    """halt mode → no directive. The existing terminal-failure path
+    handles the actual halt (this critic capability is mid-run; it
+    doesn't short-circuit the recovery policy)."""
+    monkeypatch.setenv("MANTIS_CRITIC_FRONTIER", "enabled")
+    runner = _runner_with_frontier_state()
+    runner._step_failure_history[0] = [
+        {"x": 1, "y": 1, "kind": "wrong_target"},
+        {"x": 2, "y": 2, "kind": "wrong_target"},
+    ]
+
+    from mantis_agent import agentic_recovery
+    from mantis_agent.agentic_recovery import RecoveryDecision
+    monkeypatch.setattr(
+        agentic_recovery, "analyse_failure_and_recover",
+        lambda **_: RecoveryDecision(mode="halt", reasoning="anti-bot block"),
+    )
+
+    critic = ExecutionCritic(runner)
+    plan = MicroPlan(domain="t")
+    plan.steps.append(MicroIntent(intent="x", type="submit"))
+    state = _state()
+    result = StepResult(
+        step_index=0, intent="x", success=False,
+        failure_class="wrong_target",
+    )
+    out = critic.observe_step(
+        plan, state, plan.steps[0], result, recovery_continued=True,
+    )
+    assert out is None
+
+
+def test_frontier_does_not_fire_on_non_wrong_target_failure(monkeypatch) -> None:
+    """no_state_change / brain_loop_exhausted route through other
+    capabilities — the wrong_target-specific frontier doesn't pre-
+    empt them."""
+    monkeypatch.setenv("MANTIS_CRITIC_FRONTIER", "enabled")
+    runner = _runner_with_frontier_state()
+    runner._step_failure_history[0] = [
+        {"x": 1, "y": 1, "kind": "no_state_change"},
+        {"x": 2, "y": 2, "kind": "no_state_change"},
+    ]
+
+    from mantis_agent import agentic_recovery
+    monkeypatch.setattr(
+        agentic_recovery, "analyse_failure_and_recover",
+        lambda **_: pytest.fail("Claude must not be called"),
+    )
+
+    critic = ExecutionCritic(runner)
+    plan = MicroPlan(domain="t")
+    plan.steps.append(MicroIntent(intent="x", type="submit"))
+    state = _state()
+    result = StepResult(
+        step_index=0, intent="x", success=False,
+        failure_class="no_state_change",
+    )
+    out = critic.observe_step(
+        plan, state, plan.steps[0], result, recovery_continued=True,
+    )
+    assert out is None
+
+
+def test_frontier_maps_insert_steps_to_insert_directive(monkeypatch) -> None:
+    """insert_steps mode emits the FIRST inserted step as an
+    InsertStep directive. Multi-step inserts come from the terminal
+    path's full splice — this MVP keeps the critic surface clean."""
+    monkeypatch.setenv("MANTIS_CRITIC_FRONTIER", "enabled")
+    runner = _runner_with_frontier_state()
+    runner._step_failure_history[0] = [
+        {"x": 1, "y": 1, "kind": "wrong_target"},
+        {"x": 2, "y": 2, "kind": "wrong_target"},
+    ]
+
+    from mantis_agent import agentic_recovery
+    from mantis_agent.agentic_recovery import RecoveryDecision
+    monkeypatch.setattr(
+        agentic_recovery, "analyse_failure_and_recover",
+        lambda **_: RecoveryDecision(
+            mode="insert_steps",
+            reasoning="dismiss the modal first, then retry the original step",
+            inserted_steps=[
+                {"intent": "Press Escape to dismiss modal", "type": "key_press",
+                 "params": {"keys": "Escape"}},
+            ],
+        ),
+    )
+
+    critic = ExecutionCritic(runner)
+    plan = MicroPlan(domain="t")
+    plan.steps.append(MicroIntent(intent="x", type="submit"))
+    state = _state()
+    result = StepResult(
+        step_index=0, intent="x", success=False,
+        failure_class="wrong_target",
+    )
+    out = critic.observe_step(
+        plan, state, plan.steps[0], result, recovery_continued=True,
+    )
+    assert isinstance(out, InsertStep)
+    assert out.step_type == "key_press"
+    assert "Escape" in out.intent

--- a/tests/test_execution_critic.py
+++ b/tests/test_execution_critic.py
@@ -398,10 +398,10 @@ def test_frontier_disabled_by_default(monkeypatch) -> None:
     assert out is None
 
 
-def test_frontier_skipped_below_wrong_target_threshold(monkeypatch) -> None:
-    """Threshold = 2 wrong_target failures. After only one prior
-    failure the critic stays quiet — the cheap retry / rewriter path
-    deserves a chance first."""
+def test_frontier_skipped_below_persistent_failure_threshold(monkeypatch) -> None:
+    """Threshold = 2 rewrite-triggering failures. After only one
+    prior failure the critic stays quiet — the cheap retry /
+    rewriter path deserves a chance first."""
     monkeypatch.setenv("MANTIS_CRITIC_FRONTIER", "enabled")
     runner = _runner_with_frontier_state()
     runner._step_failure_history[0] = [
@@ -619,15 +619,113 @@ def test_frontier_maps_halt_decision_to_no_directive(monkeypatch) -> None:
     assert out is None
 
 
-def test_frontier_does_not_fire_on_non_wrong_target_failure(monkeypatch) -> None:
-    """no_state_change / brain_loop_exhausted route through other
-    capabilities — the wrong_target-specific frontier doesn't pre-
-    empt them."""
+def test_frontier_fires_on_persistent_no_state_change(monkeypatch) -> None:
+    """H6: extended gate also fires on ``no_state_change``. This is
+    the canonical staff-crm sidebar pattern — SoM clicks resolve to
+    real ``<a>`` elements (``el.click()`` returns ok=True) but the
+    page doesn't navigate, so snapshot-diff stamps no_state_change
+    before the URL postcondition can stamp wrong_target. A
+    wrong_target-only gate (the original frontier critic) was a
+    no-op on this pattern; the broader rewrite-triggering gate
+    catches it.
+    """
     monkeypatch.setenv("MANTIS_CRITIC_FRONTIER", "enabled")
     runner = _runner_with_frontier_state()
     runner._step_failure_history[0] = [
-        {"x": 1, "y": 1, "kind": "no_state_change"},
-        {"x": 2, "y": 2, "kind": "no_state_change"},
+        {"x": 1, "y": 1, "kind": "no_state_change",
+         "matched_label": "Qualified (1)"},
+        {"x": 2, "y": 2, "kind": "no_state_change",
+         "matched_label": "Proposal (37)"},
+    ]
+
+    from mantis_agent import agentic_recovery
+    from mantis_agent.agentic_recovery import RecoveryDecision
+    captured: list = []
+
+    def _fake_analyse(**kwargs):
+        captured.append(kwargs)
+        return RecoveryDecision(
+            mode="edit_step",
+            reasoning="brain consistently misses the sidebar link; direct navigate bypasses",
+            edited_step={
+                "intent": "Navigate to /leads?status=Contacted",
+                "type": "navigate",
+                "params": {"url": "/leads?status=Contacted"},
+            },
+        )
+
+    monkeypatch.setattr(agentic_recovery, "analyse_failure_and_recover", _fake_analyse)
+
+    critic = ExecutionCritic(runner)
+    plan = MicroPlan(domain="t")
+    plan.steps.append(MicroIntent(
+        intent="Click Contacted in sidebar", type="submit",
+        params={"label": "Contacted"},
+    ))
+    state = _state()
+    result = StepResult(
+        step_index=0, intent="x", success=False,
+        failure_class="no_state_change",
+    )
+    out = critic.observe_step(
+        plan, state, plan.steps[0], result, recovery_continued=True,
+    )
+    assert isinstance(out, ReplaceStep)
+    assert out.step_type == "navigate"
+    assert len(captured) == 1
+    # Reason string carries the actual failure class (no_state_change),
+    # not the obsolete "wrong_target" hardcode.
+    assert "no_state_change" in out.reason
+
+
+def test_frontier_fires_on_persistent_brain_loop_exhausted(monkeypatch) -> None:
+    """The third rewrite-triggering class also opens the gate.
+    Holo3 burning its budget without progress is a structural
+    signal the plan needs help."""
+    monkeypatch.setenv("MANTIS_CRITIC_FRONTIER", "enabled")
+    runner = _runner_with_frontier_state()
+    runner._step_failure_history[0] = [
+        {"x": 1, "y": 1, "kind": "brain_loop_exhausted"},
+        {"x": 2, "y": 2, "kind": "brain_loop_exhausted"},
+    ]
+
+    from mantis_agent import agentic_recovery
+    from mantis_agent.agentic_recovery import RecoveryDecision
+    monkeypatch.setattr(
+        agentic_recovery, "analyse_failure_and_recover",
+        lambda **_: RecoveryDecision(
+            mode="halt", reasoning="anti-bot",
+        ),
+    )
+
+    critic = ExecutionCritic(runner)
+    plan = MicroPlan(domain="t")
+    plan.steps.append(MicroIntent(intent="x", type="click"))
+    state = _state()
+    result = StepResult(
+        step_index=0, intent="x", success=False,
+        failure_class="brain_loop_exhausted",
+    )
+    # Gate opens; Claude returns halt → no directive. But the
+    # ``fired`` flag IS set so a second observation on this step
+    # doesn't re-spend.
+    out = critic.observe_step(
+        plan, state, plan.steps[0], result, recovery_continued=True,
+    )
+    assert out is None
+    assert 0 in runner._critic_frontier_fired_steps
+
+
+def test_frontier_does_not_fire_on_unknown_failure_class(monkeypatch) -> None:
+    """A failure class outside ``REWRITE_TRIGGERING_CLASSES``
+    (e.g. ``selector_miss``, ``unknown``) doesn't open the gate.
+    Those have their own recovery paths and aren't structural
+    signals the plan needs help."""
+    monkeypatch.setenv("MANTIS_CRITIC_FRONTIER", "enabled")
+    runner = _runner_with_frontier_state()
+    runner._step_failure_history[0] = [
+        {"x": 1, "y": 1, "kind": "selector_miss"},
+        {"x": 2, "y": 2, "kind": "selector_miss"},
     ]
 
     from mantis_agent import agentic_recovery
@@ -642,7 +740,7 @@ def test_frontier_does_not_fire_on_non_wrong_target_failure(monkeypatch) -> None
     state = _state()
     result = StepResult(
         step_index=0, intent="x", success=False,
-        failure_class="no_state_change",
+        failure_class="selector_miss",
     )
     out = critic.observe_step(
         plan, state, plan.steps[0], result, recovery_continued=True,

--- a/tests/test_reasoning_trace.py
+++ b/tests/test_reasoning_trace.py
@@ -1,0 +1,183 @@
+"""Reasoning-trace module — structured runner decision stream.
+
+Backs the ``action=reasoning_trace`` HTTP endpoint that viewer
+overlays poll to render a timeline beside the MJPEG live feed.
+The module reuses ``runner._healing_events`` for the in-memory
+list so existing healing-event consumers keep working, and
+mirrors events to a JSONL file when the runtime configures one.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+from mantis_agent.gym import reasoning_trace
+
+
+def _runner() -> SimpleNamespace:
+    return SimpleNamespace(_healing_events=[])
+
+
+# ── record ─────────────────────────────────────────────────────────
+
+
+def test_record_appends_event_with_required_fields() -> None:
+    """Every event carries ``ts``, ``layer``, ``kind``, ``summary``,
+    ``step_index``, ``detail``, and ``category=reasoning``. The
+    last lets healing-event consumers filter the timeline by source
+    without rebuilding the list."""
+    runner = _runner()
+    reasoning_trace.record(
+        runner, layer="critic-frontier", kind="fire",
+        summary="gate passed on wrong_target", step_index=6,
+        failure_count=2, failure_class="wrong_target",
+    )
+    assert len(runner._healing_events) == 1
+    ev = runner._healing_events[0]
+    assert ev["layer"] == "critic-frontier"
+    assert ev["kind"] == "fire"
+    assert ev["summary"] == "gate passed on wrong_target"
+    assert ev["step_index"] == 6
+    assert ev["category"] == "reasoning"
+    assert ev["detail"]["failure_count"] == 2
+    assert ev["detail"]["failure_class"] == "wrong_target"
+    # ISO-8601 with TZ — sortable lexicographically across events.
+    assert "T" in ev["ts"]
+    assert ev["ts"].endswith(("+00:00", "Z"))
+
+
+def test_record_silently_drops_when_runner_lacks_events_list() -> None:
+    """A MagicMock runner auto-creates ``_healing_events`` as a Mock,
+    not a list. The trace path must not crash production runs on
+    weird runner shapes — silently drop the event."""
+    runner = SimpleNamespace(_healing_events=None)  # not a list
+    reasoning_trace.record(
+        runner, layer="x", kind="y", summary="z",
+    )
+    # No crash; the non-list stays non-list.
+    assert runner._healing_events is None
+
+
+def test_record_clips_long_summary() -> None:
+    """Summary is bounded to 300 chars so a sloppy caller (e.g.
+    dumping a 5KB Claude response into ``summary``) doesn't bloat
+    the timeline."""
+    runner = _runner()
+    reasoning_trace.record(
+        runner, layer="x", kind="y", summary="x" * 500,
+    )
+    assert len(runner._healing_events[0]["summary"]) == 300
+
+
+def test_record_drops_non_jsonable_detail_values() -> None:
+    """Detail dict values that don't survive ``json.dumps`` (sockets,
+    Mocks, lambdas) get stringified — never raised. Preserves the
+    event even when one field is unhealthy."""
+    runner = _runner()
+    reasoning_trace.record(
+        runner, layer="x", kind="y", summary="z",
+        good=123, weird=lambda: None,
+    )
+    ev = runner._healing_events[0]
+    assert ev["detail"]["good"] == 123
+    # Weird key survives, value coerced to a string.
+    assert "weird" in ev["detail"]
+
+
+# ── disk stream ────────────────────────────────────────────────────
+
+
+def test_configure_disk_stream_creates_parent_directory(tmp_path) -> None:
+    """The configured path's parent is created on demand — keeps
+    callers from having to mkdir for every nested run_dir."""
+    runner = _runner()
+    target = tmp_path / "tenants" / "x" / "runs" / "abc" / "reasoning.jsonl"
+    reasoning_trace.configure_disk_stream(runner, target)
+    assert target.parent.is_dir()
+    assert runner._reasoning_jsonl_path == str(target)
+
+
+def test_record_writes_to_configured_jsonl_path(tmp_path) -> None:
+    """After ``configure_disk_stream``, every ``record`` call also
+    appends a single JSONL line to the file. Live-tailable during
+    a run."""
+    runner = _runner()
+    target = tmp_path / "reasoning.jsonl"
+    reasoning_trace.configure_disk_stream(runner, target)
+    reasoning_trace.record(
+        runner, layer="critic-frontier", kind="fire",
+        summary="gate passed", step_index=6,
+    )
+    reasoning_trace.record(
+        runner, layer="critic-frontier", kind="result",
+        summary="add_hint: click contacted text", step_index=6,
+    )
+    lines = [
+        json.loads(line)
+        for line in target.read_text().splitlines() if line.strip()
+    ]
+    assert len(lines) == 2
+    assert lines[0]["summary"] == "gate passed"
+    assert lines[1]["summary"] == "add_hint: click contacted text"
+
+
+def test_record_does_not_crash_on_unwritable_path(tmp_path) -> None:
+    """A misconfigured path (parent doesn't exist, permissions denied,
+    disk full) must not propagate the OSError — observability isn't
+    worth crashing the run for. Event still lands in the in-memory
+    list."""
+    runner = _runner()
+    # configure_disk_stream is normally what creates the parent; here
+    # we bypass it to simulate a stale path that disappeared.
+    runner._reasoning_jsonl_path = "/this/path/does/not/exist/x.jsonl"
+    reasoning_trace.record(
+        runner, layer="x", kind="y", summary="z",
+    )
+    # Event still in memory.
+    assert len(runner._healing_events) == 1
+
+
+# ── read_jsonl ─────────────────────────────────────────────────────
+
+
+def test_read_jsonl_returns_empty_on_missing_file(tmp_path) -> None:
+    """The endpoint hits ``read_jsonl`` before the runner has fired
+    any events — must return ``[]`` cleanly rather than raise."""
+    assert reasoning_trace.read_jsonl(tmp_path / "nope.jsonl") == []
+
+
+def test_read_jsonl_filters_by_since_ts(tmp_path) -> None:
+    """The endpoint supports incremental polling — ``since_ts`` filters
+    to events strictly more recent than the cursor. Lexicographic
+    compare on ISO-8601 UTC timestamps is order-preserving."""
+    runner = _runner()
+    target = tmp_path / "reasoning.jsonl"
+    reasoning_trace.configure_disk_stream(runner, target)
+    reasoning_trace.record(runner, layer="x", kind="y", summary="first")
+    first_ts = runner._healing_events[-1]["ts"]
+    reasoning_trace.record(runner, layer="x", kind="y", summary="second")
+    reasoning_trace.record(runner, layer="x", kind="y", summary="third")
+
+    out = reasoning_trace.read_jsonl(target, since_ts=first_ts)
+    summaries = [e["summary"] for e in out]
+    assert "first" not in summaries
+    assert summaries == ["second", "third"]
+
+
+def test_read_jsonl_skips_malformed_lines(tmp_path) -> None:
+    """A partially-written final line (the runner crashed mid-flush)
+    or an operator hand-editing the file with a stray text line must
+    not break the reader. Skip malformed lines silently and return
+    the rest."""
+    target = tmp_path / "reasoning.jsonl"
+    target.write_text(
+        '{"ts": "2026-05-16T19:00:00+00:00", "summary": "valid"}\n'
+        'this is not json\n'
+        '{"ts": "2026-05-16T19:01:00+00:00", "summary": "after garbage"}\n'
+        '{"partial-line": "no-close-brace"\n'
+    )
+    out = reasoning_trace.read_jsonl(target)
+    assert len(out) == 2
+    assert out[0]["summary"] == "valid"
+    assert out[1]["summary"] == "after garbage"


### PR DESCRIPTION
## Summary

Roadmap #435 item 8 (slice B per chat). Adds the missing **continuous PlannerObserver** capability — a Claude-backed critic that fires mid-run on persistent ``wrong_target`` failures BEFORE retries exhaust.

### What's new

1. **``ReplaceStep`` directive** — swaps the step at ``state.step_index`` IN PLACE (no shift of subsequent steps). New step inherits ``required`` / ``budget`` / ``section`` / ``gate`` from the original; ``_step_failure_history[idx]`` + ``_recovery_hints[idx]`` reset to clean slate.

2. **Frontier observer capability in ``ExecutionCritic``** — fires when:
   - ``MANTIS_CRITIC_FRONTIER=enabled`` (opt-in)
   - ``failure_class == "wrong_target"``
   - ≥2 prior wrong_target records on the step
   - Not already fired for this step
   - Shared recovery budget available

3. **Reuses ``agentic_recovery.analyse_failure_and_recover``** — no new Claude integration. Maps the four ``RecoveryDecision`` modes (``add_hint`` / ``edit_step`` / ``insert_steps`` / ``halt``) to critic directives (``ReplaceStep`` / ``InsertStep`` / hint write / no-op).

### Why mid-run

The existing terminal-failure recovery fires AFTER retries + handler escalation exhaust. The staff-crm sidebar pattern — vision misclicking adjacent items — wastes 5+ retries before that path runs. The critic surface catches the pattern at retry #2 while budget is still available to apply a structural fix (e.g. ``ReplaceStep`` to a direct navigate that bypasses the grounding miss).

### Budget discipline

The critic increments the SAME counters (``_recovery_attempts_per_step`` + ``_total_recovery_attempts``) the terminal path reads — one pool. Total Claude spend bounded by the existing per-step (2) + per-run (5) caps.

### CUA conformance

Frontier observer reads the screenshot via Claude's vision and proposes a STRUCTURAL plan change. Click targets in the replacement step still come from vision grounding at dispatch — no DOM derivation.

## Test plan
- [x] 23 critic tests pass (10 existing + 13 new) — directive mutation, healing events, failure-history reset, frontier gating, mode mapping, budget exhaustion
- [x] 2793 full-suite tests pass
- [x] Ruff clean
- [ ] CI green
- [ ] Modal redeploy + staff-crm-long rerun with ``MANTIS_CRITIC_FRONTIER=enabled``

Closes part of #435 — item 8 (slice B: mid-run frontier critic). Outstanding from item 8: continuous observation of SUCCESS steps (URL-drift detection); separate slice when picked up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)