### PR TITLE
feat(server): contract hardening — raw-long-plan guard + terminal_status + validate_micro_steps

### DIFF
--- a/src/mantis_agent/baseten_server/runtime.py
+++ b/src/mantis_agent/baseten_server/runtime.py
@@ -613,18 +613,48 @@ class BasetenCUARuntime:
                     return
                 self._save_detached_result(run_id, result)
                 finished_at = _utc_now()
-                self._write_detached_status(
-                    run_id,
-                    {
-                        "status": "succeeded",
-                        "finished_at": finished_at,
-                        "summary": self._result_summary(result),
-                    },
-                )
-                self._append_detached_event(run_id, "succeeded")
+                # #audit item 4: read the honest terminal_status from
+                # the runner's result envelope and use it as the
+                # canonical detached-status. The legacy practice of
+                # writing "succeeded" on any non-exception result hid
+                # halts (REQUIRED step failures, budget/time caps) as
+                # successful runs.
+                #
+                # Wire-level status mapping for callers that consume
+                # action=status:
+                #   completed              → succeeded (back-compat)
+                #   completed_with_failures → completed_with_failures
+                #   halted / budget_exceeded / time_exceeded → halted
+                #     (with status_detail carrying the specific reason)
+                #   anything else → succeeded (defensive — old plans
+                #     don't surface terminal_status)
+                rt_status = ""
+                halt_reason = ""
+                if isinstance(result, dict):
+                    rt_status = str(result.get("terminal_status") or "")
+                    halt_reason = str(result.get("halt_reason") or "")
+                if rt_status == "completed":
+                    wire_status = "succeeded"
+                elif rt_status == "completed_with_failures":
+                    wire_status = "completed_with_failures"
+                elif rt_status in ("halted", "budget_exceeded", "time_exceeded"):
+                    wire_status = "halted"
+                else:
+                    wire_status = "succeeded"
+                status_blob: dict[str, Any] = {
+                    "status": wire_status,
+                    "finished_at": finished_at,
+                    "summary": self._result_summary(result),
+                }
+                if rt_status:
+                    status_blob["terminal_status"] = rt_status
+                if halt_reason:
+                    status_blob["halt_reason"] = halt_reason
+                self._write_detached_status(run_id, status_blob)
+                self._append_detached_event(run_id, wire_status)
                 self._append_runs_log(
                     run_id, payload, result,
-                    status="succeeded", finished_at=finished_at,
+                    status=wire_status, finished_at=finished_at,
                 )
         except Exception as exc:
             logger.exception("detached run %s failed", run_id)
@@ -838,8 +868,35 @@ class BasetenCUARuntime:
                 return self._raw_text_suite(resolved.read_text(), payload)
         return self._micro_suite_from_path(str(micro_path), payload)
 
+    # #audit item 1: long raw plans are brittle — the executor maps
+    # them to a single Holo3 task and the brain has no scaffolding to
+    # decompose internally. The threshold below is the budget the
+    # /v1/predict surface enforces unless the caller explicitly opts
+    # in via ``payload.allow_raw_long_plan = True``. Word count
+    # rather than char count because line breaks / whitespace in the
+    # source text dominate at small scale.
+    _RAW_LONG_PLAN_WORD_LIMIT: int = 80
+
     def _raw_text_suite(self, plan_text: str, payload: dict[str, Any]) -> dict[str, Any]:
-        """Wrap raw free-text in a single-task task_suite without decomposition."""
+        """Wrap raw free-text in a single-task task_suite without decomposition.
+
+        Long plans should always decompose — the executor's done-gate
+        and recovery loop assume single-goal tasks. Raw long plans
+        either oscillate or terminate prematurely. Callers that
+        genuinely want to feed a long text directly (benchmark
+        scaffolding, ablation harness) opt in via
+        ``payload.allow_raw_long_plan = True``.
+        """
+        words = len((plan_text or "").split())
+        allow_long = bool(payload.get("allow_raw_long_plan", False))
+        if words > self._RAW_LONG_PLAN_WORD_LIMIT and not allow_long:
+            raise ValueError(
+                f"raw plan_text has {words} words; server cap for "
+                f"decompose=False is {self._RAW_LONG_PLAN_WORD_LIMIT}. "
+                f"Either drop decompose=False (the decomposer handles "
+                f"long plans), or pass allow_raw_long_plan=true if you "
+                f"intend the brain to run the full text as a single task."
+            )
         return {
             "session_name": str(payload.get("session_name") or "plan_text_raw"),
             "base_url": str(payload.get("base_url") or ""),
@@ -866,6 +923,13 @@ class BasetenCUARuntime:
         )
 
         steps_dicts = micro_plan_steps_to_dicts(micro_plan.steps)
+        # #audit item 5: validate the parsed plan against MAX_STEPS /
+        # MAX_LOOP_ITERATIONS / required-field rules BEFORE handing it
+        # to build_micro_suite. Catches obvious problems (a 1000-step
+        # plan from a runaway decomposer, missing intent/type on a
+        # step) before the run consumes any Modal time.
+        from mantis_agent.api_schemas import validate_micro_steps
+        steps_dicts = validate_micro_steps(steps_dicts)
         data_root = _data_root()
         return build_micro_suite(
             steps_dicts,
@@ -956,6 +1020,11 @@ class BasetenCUARuntime:
                 logger.warning("Baseten: no fallback plan found, using minimal navigate-only plan")
 
         steps_dicts = micro_plan_steps_to_dicts(micro_plan.steps)
+        # #audit item 5: same validation gate as the from-text path —
+        # catches malformed JSON plans (missing required fields, step
+        # count over the cap) before the run starts.
+        from mantis_agent.api_schemas import validate_micro_steps
+        steps_dicts = validate_micro_steps(steps_dicts)
         data_root = _data_root()
         suite = build_micro_suite(
             steps_dicts,

--- a/src/mantis_agent/gym/micro_runner.py
+++ b/src/mantis_agent/gym/micro_runner.py
@@ -185,6 +185,10 @@ class MicroPlanRunner:
         self._opened_detail_in_new_tab = False
         self._active_checkpoint_context = None
         self._pre_step_snapshot, self._final_status = None, "running"
+        # #audit item 4: halt_reason last set by ``_persist`` — read by
+        # ``build_micro_result`` to surface honest terminal status
+        # (``budget_cap`` / ``time_cap`` / ``step_halt`` …).
+        self._final_halt_reason: str = ""
         # Stash for the SPA-aware submit demotion check. The form
         # handler's submit branch sets this just before clicking the
         # submit button; ``run_executor._maybe_demote_form_no_change``

--- a/src/mantis_agent/gym/run_executor.py
+++ b/src/mantis_agent/gym/run_executor.py
@@ -1244,6 +1244,12 @@ class RunExecutor:
         halt_reason: str = "",
     ) -> None:
         runner = self.parent
+        # #audit item 4: surface halt_reason on the runner so
+        # ``build_micro_result`` can include it in the result envelope
+        # (the detached-status writer needs it to distinguish
+        # ``budget_cap`` / ``time_cap`` / generic ``halted``).
+        if halt_reason:
+            runner._final_halt_reason = halt_reason
         runner._persist_checkpoint(
             checkpoint=state.checkpoint,
             plan=plan,

--- a/src/mantis_agent/server_utils.py
+++ b/src/mantis_agent/server_utils.py
@@ -474,6 +474,30 @@ def build_micro_result(
     leads = list(unique_leads.values())
     costs = getattr(runner, "_final_costs", {})
     status = costs.get("status") or getattr(runner, "_final_status", "unknown")
+    # #audit item 4: top-level ``terminal_status`` + ``halt_reason``
+    # so the detached-status writer can map honestly rather than
+    # writing blanket "succeeded" on any non-exception return.
+    # Mapping rules:
+    #   ``completed`` + any step.success=False → completed_with_failures
+    #   ``completed`` + all success            → completed
+    #   ``halted``   + halt_reason=budget_cap  → budget_exceeded
+    #   ``halted``   + halt_reason=time_cap    → time_exceeded
+    #   ``halted``   + anything else           → halted
+    #   ``cancelled`` / ``paused``             → preserved as-is
+    runner_status = str(getattr(runner, "_final_status", "") or "")
+    halt_reason = str(getattr(runner, "_final_halt_reason", "") or "")
+    if runner_status == "completed":
+        any_failed = any(not r.success for r in step_results)
+        terminal_status = "completed_with_failures" if any_failed else "completed"
+    elif runner_status == "halted":
+        if halt_reason == "budget_cap":
+            terminal_status = "budget_exceeded"
+        elif halt_reason == "time_cap":
+            terminal_status = "time_exceeded"
+        else:
+            terminal_status = "halted"
+    else:
+        terminal_status = runner_status or "unknown"
 
     dynamic_verification = runner.dynamic_verification_report(status=status)
     dynamic_verification_summary = {
@@ -523,6 +547,11 @@ def build_micro_result(
         "session_name": session_name,
         "model": model_name,
         "mode": "micro_intent",
+        # #audit item 4: honest terminal-state surface for the detached
+        # status writer. Replaces the prior practice of stamping
+        # "succeeded" on any non-exception result.
+        "terminal_status": terminal_status,
+        "halt_reason": halt_reason,
         "total_time_s": round(elapsed_seconds),
         "wall_time_breakdown": wall_time_breakdown,
         "steps_executed": len(step_results),

--- a/tests/test_server_contract_hardening.py
+++ b/tests/test_server_contract_hardening.py
@@ -1,0 +1,223 @@
+"""Audit batch — server contract hardening.
+
+Three independent guards on the /v1/predict surface:
+
+* **Raw-long-plan guard** — long ``plan_text`` with ``decompose=False``
+  used to silently route into a single-task suite. The brain has no
+  scaffolding to decompose internally, so long raw plans oscillate
+  or terminate prematurely. The guard rejects the request unless
+  the caller explicitly opts in via ``allow_raw_long_plan=True``.
+
+* **Honest terminal_status** — ``build_micro_result`` now emits a
+  top-level ``terminal_status`` derived from ``runner._final_status``
+  and ``runner._final_halt_reason``. The detached-status writer
+  reads it instead of stamping ``"succeeded"`` on any non-exception
+  result. A REQUIRED step that halted now surfaces as ``halted`` /
+  ``budget_exceeded`` / ``time_exceeded``, not as a success.
+
+* **Wire validate_micro_steps()** — the validator runs after
+  decomposition / file-load and BEFORE ``build_micro_suite``. A
+  1000-step plan from a runaway decomposer or a JSON file missing
+  ``intent`` / ``type`` fields now fails fast instead of consuming
+  Modal time.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mantis_agent.baseten_server.runtime import BasetenCUARuntime
+
+
+# ── Raw-long-plan guard ────────────────────────────────────────────
+
+
+def _runtime() -> BasetenCUARuntime:
+    return BasetenCUARuntime.__new__(BasetenCUARuntime)  # bypass __init__
+
+
+def test_raw_text_suite_accepts_short_plan() -> None:
+    """Short plan_text continues to work — the guard only kicks in
+    on plans that genuinely exceed the executor's single-goal
+    assumption."""
+    rt = _runtime()
+    suite = rt._raw_text_suite("Click the Login button.", {"start_url": "https://x"})
+    assert suite["tasks"][0]["intent"] == "Click the Login button."
+
+
+def test_raw_text_suite_rejects_long_plan_without_opt_in() -> None:
+    """A 100-word plan_text with decompose=False must error — the
+    server cap is 80 words. The error message tells the caller how
+    to either decompose (drop decompose=False) or override
+    (allow_raw_long_plan=true)."""
+    rt = _runtime()
+    long_text = " ".join(["word"] * 100)
+    with pytest.raises(ValueError, match=r"100 words.*server cap.*80"):
+        rt._raw_text_suite(long_text, {})
+
+
+def test_raw_text_suite_accepts_long_plan_with_opt_in() -> None:
+    """Benchmark scaffolding / ablation harnesses that intentionally
+    want the brain to run a long text as a single task can opt in
+    via ``allow_raw_long_plan=True``. The guard then steps aside."""
+    rt = _runtime()
+    long_text = " ".join(["word"] * 200)
+    suite = rt._raw_text_suite(long_text, {"allow_raw_long_plan": True})
+    assert long_text in suite["tasks"][0]["intent"]
+
+
+def test_raw_text_suite_error_message_names_the_two_escape_hatches() -> None:
+    """The error message must tell the caller BOTH paths forward —
+    decompose (the recommended default) and allow_raw_long_plan
+    (the expert escape hatch). Without that, callers have to read
+    server source to recover."""
+    rt = _runtime()
+    long_text = " ".join(["word"] * 100)
+    with pytest.raises(ValueError) as excinfo:
+        rt._raw_text_suite(long_text, {})
+    msg = str(excinfo.value).lower()
+    assert "decompose" in msg
+    assert "allow_raw_long_plan" in msg
+
+
+# ── Honest terminal_status in build_micro_result ───────────────────
+
+
+def test_terminal_status_completed_when_runner_completed_all_success() -> None:
+    """``runner._final_status == "completed"`` + every step result
+    success → terminal_status = "completed". The happy path; same
+    semantics as the prior "succeeded" stamp."""
+    from mantis_agent.gym.checkpoint import StepResult
+    from mantis_agent.server_utils import build_micro_result
+
+    runner = _build_minimal_runner(final_status="completed")
+    step_results = [
+        StepResult(step_index=0, intent="x", success=True),
+        StepResult(step_index=1, intent="y", success=True),
+    ]
+    result = build_micro_result(
+        runner=runner, run_id="r1", provider="modal",
+        session_name="s", model_name="m", elapsed_seconds=10.0,
+        step_results=step_results, state_key="", profile_id="",
+        workflow_id="", checkpoint_path="", plan_signature="",
+        resume_state=False,
+    )
+    assert result["terminal_status"] == "completed"
+
+
+def test_terminal_status_completed_with_failures_when_some_steps_failed() -> None:
+    """``runner._final_status == "completed"`` BUT some step.success
+    is False → terminal_status = "completed_with_failures". This is
+    the case for non-required steps that failed; the runner kept
+    going but the run isn't a clean success."""
+    from mantis_agent.gym.checkpoint import StepResult
+    from mantis_agent.server_utils import build_micro_result
+
+    runner = _build_minimal_runner(final_status="completed")
+    step_results = [
+        StepResult(step_index=0, intent="x", success=True),
+        StepResult(step_index=1, intent="y", success=False),
+        StepResult(step_index=2, intent="z", success=True),
+    ]
+    result = build_micro_result(
+        runner=runner, run_id="r1", provider="modal",
+        session_name="s", model_name="m", elapsed_seconds=10.0,
+        step_results=step_results, state_key="", profile_id="",
+        workflow_id="", checkpoint_path="", plan_signature="",
+        resume_state=False,
+    )
+    assert result["terminal_status"] == "completed_with_failures"
+
+
+def test_terminal_status_budget_exceeded_when_halted_on_budget_cap() -> None:
+    """halt_reason=budget_cap maps to terminal_status=budget_exceeded.
+    Distinct from generic halt so dashboards / alerts can branch."""
+    from mantis_agent.server_utils import build_micro_result
+
+    runner = _build_minimal_runner(final_status="halted", halt_reason="budget_cap")
+    result = build_micro_result(
+        runner=runner, run_id="r1", provider="modal",
+        session_name="s", model_name="m", elapsed_seconds=10.0,
+        step_results=[], state_key="", profile_id="",
+        workflow_id="", checkpoint_path="", plan_signature="",
+        resume_state=False,
+    )
+    assert result["terminal_status"] == "budget_exceeded"
+    assert result["halt_reason"] == "budget_cap"
+
+
+def test_terminal_status_time_exceeded_when_halted_on_time_cap() -> None:
+    from mantis_agent.server_utils import build_micro_result
+
+    runner = _build_minimal_runner(final_status="halted", halt_reason="time_cap")
+    result = build_micro_result(
+        runner=runner, run_id="r1", provider="modal",
+        session_name="s", model_name="m", elapsed_seconds=10.0,
+        step_results=[], state_key="", profile_id="",
+        workflow_id="", checkpoint_path="", plan_signature="",
+        resume_state=False,
+    )
+    assert result["terminal_status"] == "time_exceeded"
+
+
+def test_terminal_status_halted_when_halt_reason_is_step_halt() -> None:
+    """Generic halt (a REQUIRED step exhausted retries) → terminal_status
+    = "halted". Distinct from budget/time so consumers can prioritize."""
+    from mantis_agent.server_utils import build_micro_result
+
+    runner = _build_minimal_runner(final_status="halted", halt_reason="step_halt")
+    result = build_micro_result(
+        runner=runner, run_id="r1", provider="modal",
+        session_name="s", model_name="m", elapsed_seconds=10.0,
+        step_results=[], state_key="", profile_id="",
+        workflow_id="", checkpoint_path="", plan_signature="",
+        resume_state=False,
+    )
+    assert result["terminal_status"] == "halted"
+
+
+# ── validate_micro_steps wiring (smoke) ────────────────────────────
+
+
+def test_validate_micro_steps_is_invoked_in_micro_suite_from_path(tmp_path) -> None:
+    """``_micro_suite_from_path`` runs the validator on the loaded
+    JSON plan. A plan missing required fields raises ValueError
+    BEFORE the run starts — catches malformed plans cheaply."""
+    import json
+
+    bad_plan = tmp_path / "bad.json"
+    bad_plan.write_text(json.dumps([{"type": "navigate"}]))  # missing intent
+
+    rt = _runtime()
+    with pytest.raises(ValueError, match=r"missing required field 'intent'"):
+        rt._micro_suite_from_path(str(bad_plan), {})
+
+
+# ── Helpers ────────────────────────────────────────────────────────
+
+
+def _build_minimal_runner(
+    *,
+    final_status: str = "completed",
+    halt_reason: str = "",
+):
+    """Minimal MicroPlanRunner-shaped object for build_micro_result.
+
+    The function reads many attributes; we wire only the ones it
+    actually consumes for the terminal_status path."""
+    from unittest.mock import MagicMock
+
+    runner = MagicMock()
+    runner._final_status = final_status
+    runner._final_halt_reason = halt_reason
+    runner._final_costs = {}
+    runner._successful_lead_data = lambda _: []
+    runner._lead_key = lambda x: id(x)
+    runner._lead_has_phone = lambda x: False
+    runner.dynamic_verification_report = lambda **kw: {
+        "status": kw.get("status", final_status),
+        "verdict": "ok",
+        "totals": {}, "checks": [],
+    }
+    runner.time_meter = None
+    return runner


### PR DESCRIPTION
## Summary

Audit items 1, 4, 5 from the post-#442 review. Three independent guards on the /v1/predict surface, each closing a way the runtime could silently mis-execute a request.

### #1 — Raw-long-plan guard
``_raw_text_suite`` rejects plans > 80 words when ``decompose=False`` unless the caller explicitly opts in via ``allow_raw_long_plan=True``. The executor's done-gate + recovery loop assume single-goal tasks; raw long plans oscillate or terminate prematurely. Error message names both escape hatches (drop ``decompose=False`` OR set ``allow_raw_long_plan=True``).

### #4 — Honest terminal_status
``build_micro_result`` now emits ``terminal_status`` derived from ``runner._final_status`` + ``runner._final_halt_reason``. The detached-status writer reads it instead of stamping ``"succeeded"`` on every non-exception result. Mapping:
- ``completed`` + all success → ``completed`` → wire ``succeeded``
- ``completed`` + any failure → ``completed_with_failures``
- ``halted`` + ``halt_reason=budget_cap`` → ``budget_exceeded``
- ``halted`` + ``halt_reason=time_cap`` → ``time_exceeded``
- ``halted`` + other → ``halted``

Wire-side ``status`` stays back-compat. Status.json also carries ``terminal_status`` + ``halt_reason`` as extra fields for callers that want the finer distinction.

### #5 — Wire validate_micro_steps()
The validator (MAX_STEPS_PER_PLAN, MAX_LOOP_ITERATIONS, required-field presence) existed but was never called. Now invoked in both ``_micro_suite_from_text`` and ``_micro_suite_from_path`` after decomposition / load and before ``build_micro_suite``. Catches runaway plans + malformed JSON before they consume Modal time.

## Test plan
- [x] 10 new tests pin contract: short/long plan, escape hatches, terminal_status mapping (5 cases), validator wiring
- [x] 2819 full-suite tests pass
- [x] Ruff clean
- [ ] CI green

Closes audit items 1 + 4 + 5. Items 2 (``pending_form_labels``) + 3 (scroll-delta) tracked separately in PR-B; click-dispatch escalation in PR-C.

🤖 Generated with [Claude Code](https://claude.com/claude-code)