### PR TITLE
feat(click): plan-supplied fallback_url + SoM pointer-event retry

### DIFF
--- a/src/mantis_agent/gym/critic.py
+++ b/src/mantis_agent/gym/critic.py
@@ -172,6 +172,14 @@ class ExecutionCritic:
         if rule_directive is not None:
             return rule_directive
 
+        # Rule-based: plan-supplied fallback_url for stuck clicks.
+        # Deterministic — fires BEFORE the frontier-model capability
+        # so a plan author who knows the structural alternative can
+        # short-circuit the Claude consultation entirely.
+        fallback_directive = self._maybe_use_fallback_url(state, step, step_result)
+        if fallback_directive is not None:
+            return fallback_directive
+
         # Frontier-model: persistent rewrite-triggering failure → ask Claude.
         return self._maybe_frontier_recover_persistent_failure(
             plan, state, step, step_result,
@@ -215,6 +223,71 @@ class ExecutionCritic:
             params={"url": base_url},
         )
 
+
+    # ── Rule-based capability — plan-supplied fallback_url ──────────────
+
+    def _maybe_use_fallback_url(
+        self,
+        state: "RunState",
+        step: MicroIntent,
+        step_result: "StepResult",
+    ) -> Optional[Directive]:
+        """When a click / submit step accumulates 2+ rewrite-triggering
+        failures AND the plan author supplied ``hints.fallback_url``,
+        replace the step with a direct ``navigate`` to that URL.
+
+        Deterministic — no Claude call. Fires BEFORE the frontier
+        capability so a plan that ALREADY names the structural
+        alternative skips the cost + non-determinism of asking Claude.
+
+        Why this is the highest-leverage rule for sites where vision
+        keeps misclicking small targets: the plan author often knows
+        the URL pattern that achieves the same post-state. ``Click
+        Contacted in sidebar`` → ``hints.fallback_url:
+        "/leads?status=Contacted"``. After two demotes the runner
+        navigates directly.
+
+        Trigger:
+
+        * ``step.type`` in ``{"submit", "click"}``
+        * ``step_result.failure_class`` is rewrite-triggering
+          (``no_state_change`` / ``wrong_target`` / ``brain_loop_exhausted``)
+        * ``step.hints.fallback_url`` is non-empty
+        * ``_step_failure_history[step_index]`` has at least 2 entries
+          (so we let the cheap retry path try first)
+        """
+        from . import intent_rewriter
+        step_type = str(getattr(step, "type", "") or "")
+        if step_type not in ("submit", "click"):
+            return None
+        failure_class = str(getattr(step_result, "failure_class", "") or "")
+        if failure_class not in intent_rewriter.REWRITE_TRIGGERING_CLASSES:
+            return None
+        hints = dict(getattr(step, "hints", {}) or {})
+        fallback_url = str(hints.get("fallback_url") or "").strip()
+        if not fallback_url:
+            return None
+        history = (
+            self.runner._step_failure_history.get(int(state.step_index), [])
+            if hasattr(self.runner, "_step_failure_history") else []
+        )
+        if not isinstance(history, list) or len(history) < 2:
+            return None
+        logger.warning(
+            "  [critic] step %d: using plan-supplied fallback_url=%r "
+            "(after %d prior failures of class %s)",
+            state.step_index, fallback_url, len(history), failure_class,
+        )
+        return ReplaceStep(
+            intent=f"Navigate to {fallback_url} (fallback for stuck click)",
+            step_type="navigate",
+            params={"url": fallback_url},
+            reason=(
+                f"plan-supplied fallback_url after {len(history)} prior "
+                f"{failure_class} failures — deterministic rule, no "
+                f"Claude consultation needed"
+            ),
+        )
 
     # ── Frontier-model capability (#435 item 8) ─────────────────────────
 

--- a/src/mantis_agent/gym/step_handlers/form.py
+++ b/src/mantis_agent/gym/step_handlers/form.py
@@ -791,6 +791,41 @@ class ClaudeGuidedFormHandler:
                 )
                 runner.costs["gpu_steps"] += 1
 
+                # #audit batch follow-up: SoM ``el.click()`` returns
+                # ok=True but the page didn't navigate. The synthetic
+                # click event has ``isTrusted=false``; some SPA
+                # frameworks gate on trusted gestures and silently
+                # reject the synthetic chain. Retry once with CDP
+                # ``Input.dispatchMouseEvent`` which produces a
+                # protocol-level click that's indistinguishable from
+                # a real mouse click (isTrusted=true). Only fires
+                # when the SoM path was used (executor_backend ==
+                # "som") and the URL stayed stable — i.e. we're in
+                # the trust-gated case.
+                url_after_click = runner._best_effort_current_url()
+                if (
+                    url_before
+                    and url_after_click == url_before
+                    and ctx.state.get("_executor_backend") == "som"
+                    and hasattr(env, "cdp_click_via_pointer")
+                ):
+                    logger.info(
+                        "  [claude-form] SoM click ok=True but URL stable — "
+                        "retrying via CDP Input.dispatchMouseEvent "
+                        "(real pointer events, isTrusted=true)"
+                    )
+                    try:
+                        ok = env.cdp_click_via_pointer(x, y)
+                    except Exception as exc:  # noqa: BLE001
+                        logger.debug("pointer-retry dispatch raised: %s", exc)
+                        ok = False
+                    if ok:
+                        runner.costs["gpu_seconds"] += runner._adaptive_submit_settle(
+                            url_before=url_before,
+                        )
+                        runner.costs["gpu_steps"] += 1
+                        url_after_click = runner._best_effort_current_url()
+
                 # Enter-key fallback: HTML forms whose JS swallows the click
                 # event still submit on Return in a focused input (the
                 # browser's native form behaviour). When the click + adaptive
@@ -799,7 +834,6 @@ class ClaudeGuidedFormHandler:
                 # the click landed on the right pixel but the button's
                 # onclick handler is conditioned on something we can't see
                 # from the screenshot (CSRF token, validation state).
-                url_after_click = runner._best_effort_current_url()
                 if url_before and url_after_click == url_before:
                     logger.info(
                         "  [claude-form] click did not navigate — trying "

--- a/src/mantis_agent/gym/xdotool_env.py
+++ b/src/mantis_agent/gym/xdotool_env.py
@@ -579,6 +579,68 @@ class XdotoolGymEnv(GymEnvironment):
         # :mod:`reasoning_trace` if/when callers wire it.
         return bool(result.get("ok"))
 
+    def cdp_click_via_pointer(self, x: int, y: int) -> bool:
+        """Dispatch a real-pointer mouse-event chain at SCREEN (x, y)
+        via CDP ``Input.dispatchMouseEvent`` — audit batch follow-up
+        to the ``el.click()`` ok-but-no-state-change case.
+
+        Why this exists: ``cdp_click_at_point`` dispatches a SYNTHETIC
+        click via ``Runtime.evaluate("el.click()")``. The DOM event
+        emitted has ``isTrusted=false``. Some SPA frameworks (most
+        notably React Router under certain navigation guards) gate
+        on ``isTrusted=true`` and silently reject untrusted clicks
+        without raising — exactly the ``ok=True, but page didn't
+        navigate`` pattern that surfaced on staff-crm's sidebar
+        anchors. ``Input.dispatchMouseEvent`` emits events at the
+        protocol layer; they're ``isTrusted=true`` from the page's
+        perspective, indistinguishable from a real OS mouse click.
+
+        Sequence: mouseMoved → mousePressed → mouseReleased at the
+        same viewport coords (chromeH-adjusted from screen coords,
+        same translation ``cdp_click_at_point`` uses).
+
+        Returns ``True`` when all three events dispatched without
+        protocol error. Returns ``False`` on CDP unreachable or any
+        dispatch failure; caller falls back to xdotool / demote.
+        """
+        chrome_h = self._chrome_offset_px()
+        vx = int(x)
+        vy = int(y) - chrome_h
+        for kind in ("mouseMoved", "mousePressed", "mouseReleased"):
+            params: dict[str, Any] = {
+                "type": kind, "x": vx, "y": vy,
+                "button": "left",
+                "buttons": 1 if kind == "mousePressed" else 0,
+            }
+            if kind in ("mousePressed", "mouseReleased"):
+                params["clickCount"] = 1
+            ok, _ = self._cdp_call("Input.dispatchMouseEvent", params)
+            if not ok:
+                logger.debug(
+                    "cdp_click_via_pointer: %s dispatch failed", kind,
+                )
+                return False
+        return True
+
+    def _chrome_offset_px(self) -> int:
+        """JS-eval the chrome offset (``outerHeight - innerHeight``).
+
+        Used by ``cdp_click_via_pointer`` so screen-y → viewport-y for
+        ``Input.dispatchMouseEvent`` matches the translation
+        ``elementFromPoint`` uses in ``cdp_click_at_point``. Returns 0
+        when the eval can't run (no CDP, unusual headless mode).
+        """
+        try:
+            result = self.cdp_evaluate(
+                "Math.max(0, window.outerHeight - window.innerHeight)"
+            )
+        except Exception:  # noqa: BLE001
+            return 0
+        try:
+            return int(result) if result is not None else 0
+        except (TypeError, ValueError):
+            return 0
+
     def _xdotool_type(self, text: str) -> None:
         """Type text via clipboard-paste (preferred) or xdotool fallback.
 

--- a/src/mantis_agent/plan_decomposer.py
+++ b/src/mantis_agent/plan_decomposer.py
@@ -513,7 +513,7 @@ RULES:
   (label/value/dropdown_label/option_label) using the labels the source
   plan provides. The runner trusts `params` over the prose.
 - HINTS — emit `hints` whenever the source plan gives an explicit URL
-  expectation OR a strong spatial cue. Two structured fields are
+  expectation OR a strong spatial cue. Three structured fields are
   recognised by the runner today:
     • `hints.expect_url_contains` — list of substrings the post-click
       URL MUST contain. Emit ONE entry per literal URL clue the source
@@ -539,6 +539,23 @@ RULES:
                  "expect_url_excludes": ["/leads/"]}
       Only emit these for submit / click / navigate steps (URL is
       meaningful). Skip on fill_field / select_option / extract_data.
+    • `hints.fallback_url` — when the click / submit has a STRUCTURAL
+      ALTERNATIVE that the agent can navigate to directly if the
+      click keeps misfiring. The runner's recovery layer will REPLACE
+      the click with a direct navigate after 2+ failures.
+        Source: "click 'Contacted' to filter the leads list ... the
+                 URL should now include status=Contacted"
+        → hints={"expect_url_contains": ["status=Contacted"],
+                 "fallback_url": "/leads?status=Contacted"}
+        Source: "click the lead's Robot Name to open its detail page
+                 (URL ends in /leads/<id>)"
+        → hints={"expect_url_contains": ["/leads/"]}
+        (no fallback_url — the <id> isn't predictable at plan time)
+      Emit fallback_url ONLY when the equivalent URL is PREDICTABLE
+      from the plan text alone — typically filter / view / static-
+      nav clicks where the URL pattern is named in the source. Skip
+      for clicks on dynamic data (lead rows, comment replies, etc.)
+      where the destination URL contains an ID we won't know.
 - The "reverse" field must be a CUA-executable instruction
 - Set section="setup", section="extraction", or section="pagination"
 - Set required=true for all setup/filter/form steps (this is the default)
@@ -692,7 +709,7 @@ class PlanDecomposer:
             domain = m.group(1)
 
         # Check cache — include prompt version in hash to invalidate on schema changes
-        prompt_version = "v26_url_hints"  # Bump this when DECOMPOSE_PROMPT changes
+        prompt_version = "v27_fallback_url"  # Bump this when DECOMPOSE_PROMPT changes
         plan_hash = hashlib.md5(f"{prompt_version}:{plan_text}".encode()).hexdigest()[:8]
         cache_path = (
             cache_path_template.replace("{hash}", plan_hash)

--- a/tests/test_click_dispatch_escalation.py
+++ b/tests/test_click_dispatch_escalation.py
@@ -1,0 +1,304 @@
+"""Audit batch — click-dispatch escalation.
+
+Two CUA-conformant escapes for click failures that previously slid
+into ``halt`` after wasting Claude calls:
+
+1. **Plan-supplied ``hints.fallback_url``** — when a click / submit
+   step accumulates 2+ rewrite-triggering failures, the critic
+   replaces it with a direct ``navigate`` to the URL the plan
+   author named. Deterministic — fires BEFORE the frontier-model
+   capability so plans with known structural alternatives skip
+   the Claude consultation entirely.
+
+2. **SoM ok-but-no-state-change retry via Input.dispatchMouseEvent**
+   — when ``el.click()`` returns ok=True but the URL didn't change
+   AND the SoM path was used, the form handler retries with a
+   real-pointer CDP event chain (``mouseMoved`` → ``mousePressed``
+   → ``mouseReleased``). The protocol-level events are
+   ``isTrusted=true``, so SPA frameworks that gate on trusted
+   gestures accept them.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from mantis_agent.gym.checkpoint import StepResult
+from mantis_agent.gym.critic import (
+    ExecutionCritic,
+    ReplaceStep,
+)
+from mantis_agent.plan_decomposer import MicroIntent, MicroPlan
+
+
+# ── hints.fallback_url — deterministic critic rule ──────────────────
+
+
+def _runner_with_failure_history(step_index: int, n_failures: int):
+    runner = SimpleNamespace(
+        _results_base_url="https://example.com",
+        _healing_events=[],
+        _step_failure_history={
+            step_index: [
+                {"x": i, "y": i, "kind": "no_state_change"}
+                for i in range(n_failures)
+            ]
+        },
+        _recovery_attempts_per_step={},
+        _total_recovery_attempts=0,
+        _recovery_hints={},
+        _critic_frontier_fired_steps=set(),
+        env=None,
+    )
+    return runner
+
+
+def _state(step_index: int):
+    from mantis_agent.gym.checkpoint import RunCheckpoint
+    from mantis_agent.gym.run_executor import RunState
+    return RunState(
+        checkpoint=RunCheckpoint(run_key="t", plan_signature="s", session_name="x"),
+        step_index=step_index,
+    )
+
+
+def test_fallback_url_replaces_step_after_two_failures() -> None:
+    """When a submit step has 2+ rewrite-triggering failures AND
+    ``hints.fallback_url`` is set, the critic emits a ``ReplaceStep``
+    directive with type=navigate and the fallback URL."""
+    runner = _runner_with_failure_history(step_index=6, n_failures=2)
+    critic = ExecutionCritic(runner)
+    plan = MicroPlan(domain="x", steps=[
+        MicroIntent(
+            intent="Click Contacted", type="submit",
+            params={"label": "Contacted"},
+            hints={"fallback_url": "/leads?status=Contacted"},
+        ),
+    ])
+    state = _state(0)  # only one step in the plan; step_index=0 reads steps[0]
+    runner._step_failure_history = {
+        0: [
+            {"x": 1, "y": 1, "kind": "no_state_change"},
+            {"x": 2, "y": 2, "kind": "wrong_target"},
+        ]
+    }
+    result = StepResult(
+        step_index=0, intent="x", success=False,
+        failure_class="no_state_change",
+    )
+    out = critic.observe_step(
+        plan, state, plan.steps[0], result, recovery_continued=True,
+    )
+    assert isinstance(out, ReplaceStep)
+    assert out.step_type == "navigate"
+    assert out.params == {"url": "/leads?status=Contacted"}
+    assert "fallback_url" in out.reason
+
+
+def test_fallback_url_skipped_below_threshold() -> None:
+    """Threshold = 2 prior failures. Only one failure on record →
+    the deterministic rule stays silent; cheap retry path gets a
+    chance first."""
+    runner = _runner_with_failure_history(step_index=0, n_failures=1)
+    critic = ExecutionCritic(runner)
+    plan = MicroPlan(domain="x", steps=[
+        MicroIntent(
+            intent="x", type="submit",
+            hints={"fallback_url": "/leads?status=Contacted"},
+        ),
+    ])
+    result = StepResult(
+        step_index=0, intent="x", success=False,
+        failure_class="no_state_change",
+    )
+    out = critic.observe_step(
+        plan, _state(0), plan.steps[0], result, recovery_continued=True,
+    )
+    assert out is None
+
+
+def test_fallback_url_skipped_without_hint() -> None:
+    """A plan without ``hints.fallback_url`` falls through to the
+    frontier capability (or terminal recovery). The deterministic
+    rule needs the plan author to name the alternative URL — it
+    doesn't invent one."""
+    runner = _runner_with_failure_history(step_index=0, n_failures=3)
+    critic = ExecutionCritic(runner)
+    plan = MicroPlan(domain="x", steps=[
+        MicroIntent(intent="x", type="submit"),  # no hints
+    ])
+    result = StepResult(
+        step_index=0, intent="x", success=False,
+        failure_class="no_state_change",
+    )
+    out = critic.observe_step(
+        plan, _state(0), plan.steps[0], result, recovery_continued=True,
+    )
+    assert out is None  # no fallback emitted; critic may try frontier
+
+
+def test_fallback_url_skipped_for_non_click_step_types() -> None:
+    """The rule is scoped to ``submit`` and ``click`` step types
+    (the ones that have a meaningful structural alternative).
+    ``fill_field`` / ``select_option`` / ``extract_data`` would
+    have to fill / select / read — a navigate doesn't replace
+    those semantics."""
+    runner = _runner_with_failure_history(step_index=0, n_failures=3)
+    critic = ExecutionCritic(runner)
+    plan = MicroPlan(domain="x", steps=[
+        MicroIntent(
+            intent="x", type="fill_field",
+            hints={"fallback_url": "/x"},
+        ),
+    ])
+    result = StepResult(
+        step_index=0, intent="x", success=False,
+        failure_class="no_state_change",
+    )
+    out = critic.observe_step(
+        plan, _state(0), plan.steps[0], result, recovery_continued=True,
+    )
+    assert out is None
+
+
+def test_fallback_url_skipped_for_non_rewrite_failure_class() -> None:
+    """``selector_miss`` / ``unknown`` aren't structural signals; the
+    plan-supplied alternative doesn't apply. Those failures have
+    their own recovery paths."""
+    runner = _runner_with_failure_history(step_index=0, n_failures=3)
+    critic = ExecutionCritic(runner)
+    plan = MicroPlan(domain="x", steps=[
+        MicroIntent(
+            intent="x", type="click",
+            hints={"fallback_url": "/x"},
+        ),
+    ])
+    result = StepResult(
+        step_index=0, intent="x", success=False,
+        failure_class="selector_miss",
+    )
+    out = critic.observe_step(
+        plan, _state(0), plan.steps[0], result, recovery_continued=True,
+    )
+    assert out is None
+
+
+def test_fallback_url_fires_before_frontier_capability(monkeypatch) -> None:
+    """The deterministic rule must run BEFORE the frontier-model
+    capability. Otherwise a plan with a known fallback wastes the
+    cost of a Claude call before the rule fires.
+
+    Verify by: enable frontier, ensure analyse_failure_and_recover
+    is NOT called when fallback_url is set."""
+    monkeypatch.setenv("MANTIS_CRITIC_FRONTIER", "enabled")
+    runner = _runner_with_failure_history(step_index=0, n_failures=3)
+    from mantis_agent import agentic_recovery
+    monkeypatch.setattr(
+        agentic_recovery, "analyse_failure_and_recover",
+        lambda **_: pytest.fail("Claude must not be called when fallback_url is set"),
+    )
+
+    critic = ExecutionCritic(runner)
+    plan = MicroPlan(domain="x", steps=[
+        MicroIntent(
+            intent="x", type="submit",
+            hints={"fallback_url": "/leads?status=Contacted"},
+        ),
+    ])
+    result = StepResult(
+        step_index=0, intent="x", success=False,
+        failure_class="no_state_change",
+    )
+    out = critic.observe_step(
+        plan, _state(0), plan.steps[0], result, recovery_continued=True,
+    )
+    assert isinstance(out, ReplaceStep)
+
+
+# ── cdp_click_via_pointer — Input.dispatchMouseEvent ────────────────
+
+
+def test_cdp_click_via_pointer_dispatches_three_events() -> None:
+    """A real-pointer click dispatches mouseMoved → mousePressed →
+    mouseReleased. Order matters: trust-gated frameworks observe
+    the sequence."""
+    from mantis_agent.gym.xdotool_env import XdotoolGymEnv
+
+    instance = XdotoolGymEnv.__new__(XdotoolGymEnv)
+    instance.cdp_evaluate = lambda _expr: 87  # chrome_h
+    captured: list = []
+    instance._cdp_call = lambda method, params: (  # type: ignore[assignment]
+        captured.append((method, params)) or (True, {})
+    )
+
+    ok = instance.cdp_click_via_pointer(100, 200)
+    assert ok is True
+    assert len(captured) == 3
+    methods = [m for m, _ in captured]
+    assert methods == [
+        "Input.dispatchMouseEvent",
+        "Input.dispatchMouseEvent",
+        "Input.dispatchMouseEvent",
+    ]
+    types = [p.get("type") for _, p in captured]
+    assert types == ["mouseMoved", "mousePressed", "mouseReleased"]
+    # Y is chrome-offset-corrected (screen 200 - 87 = 113).
+    assert all(p.get("y") == 113 for _, p in captured)
+
+
+def test_cdp_click_via_pointer_press_release_carry_click_count() -> None:
+    """``Input.dispatchMouseEvent`` for mousePressed / mouseReleased
+    must include ``clickCount: 1`` — otherwise Chrome treats the
+    event as a move-equivalent and frameworks don't fire onclick."""
+    from mantis_agent.gym.xdotool_env import XdotoolGymEnv
+    instance = XdotoolGymEnv.__new__(XdotoolGymEnv)
+    instance.cdp_evaluate = lambda _expr: 0
+    captured: list = []
+    instance._cdp_call = lambda method, params: (  # type: ignore[assignment]
+        captured.append((method, params)) or (True, {})
+    )
+
+    instance.cdp_click_via_pointer(50, 60)
+    moved, pressed, released = captured
+    assert "clickCount" not in moved[1]
+    assert pressed[1].get("clickCount") == 1
+    assert released[1].get("clickCount") == 1
+    # Pressed carries buttons=1 (left); released carries buttons=0.
+    assert pressed[1].get("buttons") == 1
+    assert released[1].get("buttons") == 0
+
+
+def test_cdp_click_via_pointer_returns_false_when_any_dispatch_fails() -> None:
+    """If any of the three CDP calls fails (network blip, target
+    detached), the helper returns False so the caller falls back
+    to xdotool / Enter-key / demote."""
+    from mantis_agent.gym.xdotool_env import XdotoolGymEnv
+
+    instance = XdotoolGymEnv.__new__(XdotoolGymEnv)
+    instance.cdp_evaluate = lambda _expr: 0
+    call_count = {"n": 0}
+
+    def _fail_on_second(method, params):
+        call_count["n"] += 1
+        return (call_count["n"] != 2, {})  # 2nd call (mousePressed) fails
+
+    instance._cdp_call = _fail_on_second  # type: ignore[assignment]
+    assert instance.cdp_click_via_pointer(10, 20) is False
+
+
+def test_cdp_click_via_pointer_chrome_offset_zero_when_eval_fails() -> None:
+    """``_chrome_offset_px`` is a best-effort JS eval — if it raises,
+    we default to chromeH=0 (the safe degenerate case where the
+    screen-y equals viewport-y, matching headless modes that don't
+    report chrome at all)."""
+    from mantis_agent.gym.xdotool_env import XdotoolGymEnv
+
+    instance = XdotoolGymEnv.__new__(XdotoolGymEnv)
+
+    def _raise(_expr):
+        raise RuntimeError("CDP unreachable")
+
+    instance.cdp_evaluate = _raise  # type: ignore[assignment]
+    assert instance._chrome_offset_px() == 0


### PR DESCRIPTION
## Summary

Final piece of the audit batch — two CUA-conformant escape hatches for clicks that previously slid into ``halt`` after wasting Claude consultations.

### Plan-supplied ``hints.fallback_url``
After 2+ rewrite-triggering failures on a click/submit step that carries ``hints.fallback_url``, the critic emits a ``ReplaceStep`` → ``type=navigate, params.url=fallback_url``. Deterministic — fires BEFORE the frontier-model capability, so a plan that already names the alternative skips Claude entirely.

Decomposer prompt teaches when to emit it: filter/view/static-nav clicks whose target URL is predictable from the plan text. Skips dynamic-ID destinations (lead rows etc.) where the URL contains unknowns.

### SoM ok-but-no-state-change retry
``cdp_click_at_point`` dispatches a synthetic ``el.click()`` event with ``isTrusted=false``. Some SPA frameworks reject those silently — the canonical staff-crm sidebar pattern.

New ``XdotoolGymEnv.cdp_click_via_pointer(x, y)`` dispatches a real-pointer chain (``mouseMoved`` → ``mousePressed`` → ``mouseReleased``) via ``Input.dispatchMouseEvent``. Protocol-level events are ``isTrusted=true``. The form handler retries once with the pointer-event dispatcher when the SoM path returned ok=True but the URL stayed stable.

## CUA conformance
Both stay within the contract: ``fallback_url`` is plan-author data (the alternative URL is named in the source plan); pointer dispatch operates on vision-derived coordinates and only changes the dispatch mechanism, same as the existing ``cdp_click_at_point``.

## Test plan
- [x] 10 new tests pin contract (6 fallback_url + 4 pointer-event)
- [x] 2819 full-suite tests pass
- [x] Ruff clean
- [ ] CI green

Closes the audit batch's last two items. Full audit (items 1–5 + fallback_url + pointer-retry) lands across three PRs:
- #443 — server contract
- #444 — runner plumbing
- this PR — click-dispatch escalation

🤖 Generated with [Claude Code](https://claude.com/claude-code)