### PR TITLE
fix(audit): Modal envelope terminal_status + critic trace events + fallback_url caveat

### DIFF
--- a/deploy/modal/modal_cua_server.py
+++ b/deploy/modal/modal_cua_server.py
@@ -892,6 +892,14 @@ def _run_holo3_executor(
             "status": result.get("costs", {}).get("status", ""),
             "dynamic_verification_summary": result.get("dynamic_verification_summary"),
             "run_id": run_id,
+            # #audit item 4 follow-up: the Modal entry was dropping
+            # ``terminal_status`` + ``halt_reason`` from the envelope
+            # so the API container couldn't read them off the result.
+            # Re-export both so ``_do_action`` can map the wire
+            # ``status`` honestly instead of stamping "succeeded" on
+            # every non-exception result.
+            "terminal_status": result.get("terminal_status", ""),
+            "halt_reason": result.get("halt_reason", ""),
         }
         # #347: surface paused state to the Modal API container. The poll
         # path detects ``_paused`` on the FunctionCall result and writes
@@ -1918,8 +1926,41 @@ def build_api_app(executor_resolver=None, function_call_lookup=None):
                         _write_status(tenant.tenant_id, run_id, status)
                         release_profile_lock(tenant, status.get("profile_id", ""))
                     else:
-                        status["status"] = "succeeded"
+                        # #audit item 4 follow-up: read the honest
+                        # terminal_status off the envelope (the Modal
+                        # entry surfaces it explicitly now). Map the
+                        # internal value to the wire status with the
+                        # same rules as ``baseten_server/runtime.py``
+                        # (which already had this fix):
+                        #   completed              → succeeded (back-compat)
+                        #   completed_with_failures → completed_with_failures
+                        #   halted / budget_exceeded / time_exceeded → halted
+                        #   anything else / missing  → succeeded (defensive)
+                        rt_status = ""
+                        halt_reason = ""
+                        if isinstance(result, dict):
+                            rt_status = str(result.get("terminal_status") or "")
+                            halt_reason = str(result.get("halt_reason") or "")
+                        if rt_status == "completed":
+                            wire_status = "succeeded"
+                        elif rt_status == "completed_with_failures":
+                            wire_status = "completed_with_failures"
+                        elif rt_status in (
+                            "halted", "budget_exceeded", "time_exceeded",
+                        ):
+                            wire_status = "halted"
+                        else:
+                            wire_status = "succeeded"
+                        status["status"] = wire_status
                         status["updated_at"] = datetime.now(timezone.utc).isoformat()
+                        # Surface the finer detail under explicit keys
+                        # alongside the back-compat wire status so
+                        # callers that want to distinguish budget vs
+                        # time vs step-halt can branch on them.
+                        if rt_status:
+                            status["terminal_status"] = rt_status
+                        if halt_reason:
+                            status["halt_reason"] = halt_reason
                         _write_status(tenant.tenant_id, run_id, status)
                         _write_result(
                             tenant.tenant_id,

--- a/src/mantis_agent/gym/critic.py
+++ b/src/mantis_agent/gym/critic.py
@@ -212,6 +212,14 @@ class ExecutionCritic:
             # propose an alternative. Fall through to whatever the
             # recovery policy decided.
             return None
+        # Reasoning-trace event so viewer overlays see the
+        # deterministic recovery alongside the frontier-critic events.
+        from . import reasoning_trace as _trace
+        _trace.record(
+            self.runner, layer="critic-navigate-back-recovery", kind="fire",
+            summary=f"inserting direct navigate to {base_url[:80]}",
+            base_url=base_url[:200],
+        )
         return InsertStep(
             intent=f"Navigate to {base_url}",
             step_type="navigate",
@@ -277,6 +285,21 @@ class ExecutionCritic:
             "  [critic] step %d: using plan-supplied fallback_url=%r "
             "(after %d prior failures of class %s)",
             state.step_index, fallback_url, len(history), failure_class,
+        )
+        # Reasoning-trace event so viewer overlays see the
+        # deterministic replacement alongside the frontier-critic
+        # events the Claude-based capability emits.
+        from . import reasoning_trace as _trace
+        _trace.record(
+            self.runner, layer="critic-fallback-url", kind="fire",
+            summary=(
+                f"replaced step with navigate to {fallback_url[:80]} "
+                f"(after {len(history)} {failure_class} failures)"
+            ),
+            step_index=int(state.step_index),
+            failure_class=failure_class,
+            failure_count=len(history),
+            fallback_url=fallback_url[:200],
         )
         return ReplaceStep(
             intent=f"Navigate to {fallback_url} (fallback for stuck click)",

--- a/src/mantis_agent/plan_decomposer.py
+++ b/src/mantis_agent/plan_decomposer.py
@@ -556,6 +556,21 @@ RULES:
       nav clicks where the URL pattern is named in the source. Skip
       for clicks on dynamic data (lead rows, comment replies, etc.)
       where the destination URL contains an ID we won't know.
+
+      CAVEAT — fallback_url assumes the site is URL-DRIVEN: that
+      navigating directly to the URL produces the same observable
+      state as clicking the original element. Many SPA admin
+      consoles (CRMs, ticket systems, dashboards) accept the URL
+      visually but strip the query string and apply default state,
+      so direct navigation does NOT match the click's intended
+      effect — the click handler maintains in-app state that the
+      route doesn't. When you can see from the source plan that
+      the site routes only via clicks (e.g. "the URL bar updates
+      after you click but typing the same URL in the address bar
+      loads the default view"), DO NOT emit fallback_url; let the
+      frontier critic propose a different recovery instead. Default
+      to emitting fallback_url unless the source explicitly warns
+      about URL-stripping or SPA-only state.
 - The "reverse" field must be a CUA-executable instruction
 - Set section="setup", section="extraction", or section="pagination"
 - Set required=true for all setup/filter/form steps (this is the default)
@@ -709,7 +724,7 @@ class PlanDecomposer:
             domain = m.group(1)
 
         # Check cache — include prompt version in hash to invalidate on schema changes
-        prompt_version = "v27_fallback_url"  # Bump this when DECOMPOSE_PROMPT changes
+        prompt_version = "v28_fallback_url_url_driven"  # Bump this when DECOMPOSE_PROMPT changes
         plan_hash = hashlib.md5(f"{prompt_version}:{plan_text}".encode()).hexdigest()[:8]
         cache_path = (
             cache_path_template.replace("{hash}", plan_hash)

--- a/tests/test_click_dispatch_escalation.py
+++ b/tests/test_click_dispatch_escalation.py
@@ -185,6 +185,73 @@ def test_fallback_url_skipped_for_non_rewrite_failure_class() -> None:
     assert out is None
 
 
+def test_fallback_url_emits_reasoning_trace_event() -> None:
+    """When the deterministic fallback_url rule fires, a structured
+    event lands on ``runner._healing_events`` so the viewer overlay
+    can render it on the timeline alongside the Claude-based critic
+    events. Without this, the rule was invisible to the trace
+    endpoint (count=0 events even when the rule fired)."""
+    runner = _runner_with_failure_history(step_index=0, n_failures=2)
+    runner._reasoning_jsonl_path = None  # don't write to disk; in-memory only
+    critic = ExecutionCritic(runner)
+    plan = MicroPlan(domain="x", steps=[
+        MicroIntent(
+            intent="Click Contacted", type="submit",
+            hints={"fallback_url": "https://x.example/leads?status=Contacted"},
+        ),
+    ])
+    result = StepResult(
+        step_index=0, intent="x", success=False,
+        failure_class="no_state_change",
+    )
+    out = critic.observe_step(
+        plan, _state(0), plan.steps[0], result, recovery_continued=True,
+    )
+    assert isinstance(out, ReplaceStep)
+    # A reasoning event landed.
+    events = [
+        e for e in runner._healing_events
+        if isinstance(e, dict) and e.get("layer") == "critic-fallback-url"
+    ]
+    assert len(events) == 1
+    event = events[0]
+    assert event["kind"] == "fire"
+    assert event["category"] == "reasoning"
+    assert "leads?status=Contacted" in event["summary"]
+    assert event["detail"]["failure_class"] == "no_state_change"
+    assert event["detail"]["failure_count"] == 2
+
+
+def test_navigate_back_recovery_emits_reasoning_trace_event() -> None:
+    """Same trace plumbing for the older navigate_back rule. Without
+    this the deterministic recovery slipped through the viewer's
+    timeline."""
+    runner = SimpleNamespace(
+        _results_base_url="https://example.com/discover",
+        _healing_events=[],
+    )
+    critic = ExecutionCritic(runner)
+    plan = MicroPlan(domain="x", steps=[
+        MicroIntent(intent="back", type="navigate_back"),
+    ])
+    result = StepResult(
+        step_index=0, intent="back", success=False,
+        failure_class="brain_loop_exhausted",
+    )
+    out = critic.observe_step(
+        plan, _state(0), plan.steps[0], result, recovery_continued=True,
+    )
+    assert out is not None  # InsertStep emitted
+    events = [
+        e for e in runner._healing_events
+        if isinstance(e, dict)
+        and e.get("layer") == "critic-navigate-back-recovery"
+    ]
+    assert len(events) == 1
+    assert events[0]["kind"] == "fire"
+    assert "discover" in events[0]["summary"]
+
+
 def test_fallback_url_fires_before_frontier_capability(monkeypatch) -> None:
     """The deterministic rule must run BEFORE the frontier-model
     capability. Otherwise a plan with a known fallback wastes the


### PR DESCRIPTION
## Summary

Three follow-up gaps surfaced by the full-stack verification run on staff-crm-long after the audit batch (#443/#444/#445) landed.

### Gap 1 — Modal envelope dropped terminal_status
The audit named ``baseten_server/runtime.py:614`` for the "blanket succeeded" bug. #443 fixed that file — but the **Modal deploy path is different code with the same bug**. Verified post-merge: the verification run halted at step 6, but ``action=status`` returned ``"status": "succeeded", "terminal_status": null``.

Root cause: ``modal_cua_server.py:884`` builds a slim envelope that drops ``terminal_status`` + ``halt_reason`` before returning. The API-side ``_do_action`` then stamps blanket ``"succeeded"``.

Fix: add the fields to the envelope + port the runtime.py status-mapping rules to the Modal API writer. Modal + Baseten now report identical honest terminal-state shapes.

### Gap 2 — Deterministic critic rules invisible in reasoning trace
#442's reasoning-trace endpoint instruments the frontier-Claude path. The two deterministic rules (``_maybe_recover_navigate_back``, ``_maybe_use_fallback_url``) emit log lines but no structured events — viewers saw ``count: 0`` even when a rule had fired. Verified: run eb70281f's fallback_url rule fired (visible in logs) but trace endpoint returned 0 events.

Fix: both rule-based capabilities now ``reasoning_trace.record(...)`` when they emit a directive. New layers: ``critic-fallback-url``, ``critic-navigate-back-recovery``.

### Gap 3 — fallback_url assumes URL-driven SPA
Verification revealed staff-crm strips the query string on direct navigation: ``/leads?status=Contacted`` redirects to ``/leads?sort_by=created_at`` because the filter is set only via the click handler's in-app state, not by the route. ``fallback_url`` proposed a valid-looking alternative that didn't actually achieve the click's intended state.

Fix: decomposer prompt's HINTS section documents the URL-driven prerequisite. Bumps v27 → v28.

## Test plan
- [x] 2 new tests pin reasoning-trace events for the rule-based capabilities (37 critic tests pass)
- [x] 2840 full-suite tests pass
- [x] Ruff clean
- [ ] CI green
- [ ] Modal redeploy + verify ``action=status`` returns ``status: "halted", terminal_status: ...``

Closes the verification gaps from the staff-crm-long full-stack run. The full audit (items 1–5 + fallback_url + Input.dispatchMouseEvent + these follow-ups) is now end-to-end consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)