### PR TITLE
fix(cua): tighter sidebar regions + final-URL pointer-retry gate

### DIFF
--- a/src/mantis_agent/form_targeting/region.py
+++ b/src/mantis_agent/form_targeting/region.py
@@ -58,6 +58,20 @@ _NAMED_REGIONS: dict[str, tuple[float, float, float, float]] = {
     # lives at the top.
     "form-footer":  (0.0, 0.6, 1.0, 1.0),
     "form-header":  (0.0, 0.0, 1.0, 0.25),
+    # Sidebar-specific aliases. ``"left"`` is a 33% strip that
+    # includes EVERY left-rail item — QUICK LINKS, LEAD VIEWS,
+    # BY PRIORITY, ACTIONS, SYSTEM. On staff-crm-long the brain
+    # learned an "average sidebar position" that pointed at the
+    # wrong section. ``"sidebar-list-mid"`` narrows to the
+    # middle band of the left strip where filter lists typically
+    # live (LEAD VIEWS / Categories / Tags), eliminating
+    # multi-section ambiguity. Use when the plan names a SPECIFIC
+    # sidebar list (``Click Contacted in LEAD VIEWS sidebar`` →
+    # this region; ``Click All Leads in QUICK LINKS sidebar`` →
+    # ``"sidebar-list-top"``).
+    "sidebar-list-top":    (0.0, 0.15, 0.14, 0.40),
+    "sidebar-list-mid":    (0.0, 0.35, 0.14, 0.60),
+    "sidebar-list-bottom": (0.0, 0.55, 0.14, 0.80),
 }
 
 

--- a/src/mantis_agent/gym/step_handlers/form.py
+++ b/src/mantis_agent/gym/step_handlers/form.py
@@ -802,7 +802,35 @@ class ClaudeGuidedFormHandler:
                 # when the SoM path was used (executor_backend ==
                 # "som") and the URL stayed stable — i.e. we're in
                 # the trust-gated case.
+                #
+                # Gate tightening (PR-D follow-up to #445): the gate's
+                # ``url_after_click == url_before`` check used to read
+                # the URL once, immediately after ``_adaptive_submit_settle``.
+                # That race-loses when the synthetic click triggers a
+                # brief navigation that bounces back: the settle returns
+                # early on the intermediate URL, the immediate poll
+                # captures the (different) intermediate, and the gate
+                # doesn't fire. Re-poll after a short stabilization
+                # window and compare the FINAL settled URL — the
+                # bounce-back case now correctly satisfies the gate
+                # and the pointer-retry actually runs.
                 url_after_click = runner._best_effort_current_url()
+                time.sleep(0.8)  # stabilization window
+                final_url = runner._best_effort_current_url()
+                # A blank ``final_url`` means the runner couldn't read
+                # the URL on the second poll — treat as missing info
+                # rather than a navigation. Otherwise a transient
+                # read-fail would mask a genuine no-navigation case
+                # (gate fires on bogus inequality) or hide a genuine
+                # navigation (gate misfires the retry).
+                if final_url and final_url != url_after_click:
+                    logger.warning(
+                        "  [claude-form] post-click URL bounce detected: "
+                        "settle saw %r, final is %r — pointer-retry "
+                        "evaluates against final",
+                        (url_after_click or "")[:80], final_url[:80],
+                    )
+                    url_after_click = final_url
                 if (
                     url_before
                     and url_after_click == url_before
@@ -824,6 +852,8 @@ class ClaudeGuidedFormHandler:
                             url_before=url_before,
                         )
                         runner.costs["gpu_steps"] += 1
+                        # Same final-URL evaluation as the pre-retry guard.
+                        time.sleep(0.8)
                         url_after_click = runner._best_effort_current_url()
 
                 # Enter-key fallback: HTML forms whose JS swallows the click

--- a/tests/test_form_target_region.py
+++ b/tests/test_form_target_region.py
@@ -39,6 +39,39 @@ def test_crop_to_region_top_half_yields_upper_half() -> None:
     assert offset == (0, 0)
 
 
+def test_crop_to_region_sidebar_list_mid_narrows_to_middle_band() -> None:
+    # 14% wide × 25% tall, centred on the middle of the left rail.
+    # On a 1280x800 screenshot:
+    #   left   = 0
+    #   top    = 800 * 0.35 = 280
+    #   right  = 1280 * 0.14 = 179
+    #   bottom = 800 * 0.60 = 480
+    # → cropped size (179, 200), offset (0, 280)
+    cropped, offset = crop_to_region(_img(1280, 800), "sidebar-list-mid")
+    assert cropped.size == (179, 200)
+    assert offset == (0, 280)
+
+
+def test_crop_to_region_sidebar_list_top_is_above_mid() -> None:
+    _, off_top = crop_to_region(_img(1280, 800), "sidebar-list-top")
+    _, off_mid = crop_to_region(_img(1280, 800), "sidebar-list-mid")
+    _, off_bot = crop_to_region(_img(1280, 800), "sidebar-list-bottom")
+    # Strict y-ordering — the three sidebar bands tile the rail.
+    assert off_top[1] < off_mid[1] < off_bot[1]
+    # All start at the screen's left edge.
+    assert off_top[0] == off_mid[0] == off_bot[0] == 0
+
+
+def test_crop_to_region_sidebar_list_is_narrower_than_left() -> None:
+    """The whole point of sidebar-list-* is to be narrower than the
+    33%-wide ``"left"`` region — that's what eliminates the
+    multi-section ambiguity (#447 follow-up).
+    """
+    cropped_sidebar, _ = crop_to_region(_img(1280, 800), "sidebar-list-mid")
+    cropped_left, _ = crop_to_region(_img(1280, 800), "left")
+    assert cropped_sidebar.width < cropped_left.width
+
+
 def test_crop_to_region_unknown_named_region_returns_full_screenshot() -> None:
     """Defensive: a typo in a plan hint must not crash. The caller's
     behaviour should fall back to the unchanged-screenshot path.


### PR DESCRIPTION
## Summary

Two follow-up fixes to address the staff-crm-long step-6 halt that the post-#446 verification run reproduced. Diagnosed via Claude-CUA cross-check (same wrong coords as Holo3 → not a grounding-model floor) and an MCP browser probe (same y-coord hits a different sidebar item across sessions → per-tenant layout drift).

- **Fix A — `sidebar-list-{top,mid,bottom}` named regions.** The previous `"left"` region is a 33%-wide strip covering every left-rail section. The brain learned an "average sidebar position" that pointed at the wrong section once the lead counts changed and items reflowed. New regions are 14% wide × 25% tall and tile the rail vertically — eliminates multi-section ambiguity. Mitigation, not a true fix for drift, but narrows the click choice space dramatically.

- **Fix B — tighten the pointer-retry URL gate.** PR #445 added an `Input.dispatchMouseEvent` retry for trust-gated synthetic clicks, but the gate compared the URL immediately after `_adaptive_submit_settle`. Settle can return early on a transient intermediate URL during a navigation that bounces back, so the immediate poll captured a different value and the gate skipped the retry. Now re-polls after a 0.8s stabilization window and compares the FINAL settled URL. Blank reads on the second poll fall back to the first (defensive against transient runner read-fails).

## Test plan
- [x] `tests/test_form_target_region.py` — added 3 new tests for sidebar-list-* regions (tiling, narrower than `"left"`, exact pixel sizes on 1280×800)
- [x] `tests/test_form_handler.py` and `tests/test_click_dispatch_escalation.py` — no regressions
- [x] Full local suite: 2843 passed
- [x] `uv run ruff check .` — clean
- [ ] Modal redeploy + staff-crm-long rerun — expected: step 6 + step 26 cleanly clear, post-#446 critic-fallback-url path not needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)