### PR TITLE
feat(cua): extract pointer-retry into click-dispatch primitive

### DIFF
--- a/src/mantis_agent/gym/pointer_retry.py
+++ b/src/mantis_agent/gym/pointer_retry.py
@@ -1,0 +1,157 @@
+"""Click-dispatch trust-gate-bypass primitive.
+
+Originally lived inside :class:`~.step_handlers.form.ClaudeGuidedFormHandler`
+as PR #447 Fix B (`submit`-only). Extracted to a reusable helper so the
+generic click handler and any future step handler can apply the same
+post-dispatch URL gate.
+
+The pattern: when a synthetic CDP ``el.click()`` returns ``ok=True``
+but the page doesn't navigate, the click event likely had
+``isTrusted=false`` and the SPA's framework rejected it silently. Retry
+once with CDP ``Input.dispatchMouseEvent`` which produces a
+protocol-level click that's indistinguishable from a real mouse click
+(``isTrusted=true``).
+
+Gate tightening (PR #447 follow-up): the URL check compares the FINAL
+settled URL — re-polled after a stabilization window — not the
+immediately-polled URL. The latter race-loses when the synthetic click
+triggers a brief navigation that bounces back: settle returns early on
+the intermediate URL, the immediate poll captures the (different)
+intermediate, and the gate doesn't fire. The stabilization window
+makes the gate read the true post-click steady-state URL.
+
+Surfaced as a generic primitive in PR-G (run ``74add5d8``, 2026-05-17):
+staff-crm-long step 8 (`type: click` row-link) halted with the same
+trust-gated pattern as step 6 (`type: submit` sidebar anchor). The
+form handler's inline Fix B logic was the right tool but lived in the
+wrong handler.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from .micro_runner import MicroPlanRunner
+
+logger = logging.getLogger(__name__)
+
+
+_STABILIZATION_WINDOW_SECONDS = 0.8
+
+
+def pointer_retry_if_unchanged(
+    env: Any,
+    runner: "MicroPlanRunner",
+    x: int,
+    y: int,
+    *,
+    url_before: str,
+    executor_backend: str,
+    log_prefix: str = "[click]",
+) -> str:
+    """After a click + initial settle, re-poll URL and retry via
+    ``Input.dispatchMouseEvent`` if the URL hasn't changed.
+
+    Returns the final ``url_after_click`` — either the post-retry URL
+    (if retry fired and changed things) or the post-stabilization URL
+    (if retry was skipped or didn't change anything). Callers should
+    update their step-result logic with this value rather than reading
+    URL again themselves.
+
+    The retry only fires when ALL of these hold:
+
+    1. ``url_before`` is non-empty (otherwise we have no baseline)
+    2. The FINAL settled URL equals ``url_before`` (click didn't navigate)
+    3. ``executor_backend == "som"`` (the SoM path was used; trust-gated
+       is the canonical SoM-path symptom; xdotool's already-real clicks
+       don't need this retry)
+    4. ``env`` exposes ``cdp_click_via_pointer`` (capability check)
+
+    Any of these conditions failing → return the stabilization-window
+    URL unchanged. Errors during retry dispatch (CDP unreachable,
+    method missing, page closed) are caught and logged at DEBUG; the
+    caller's existing fallback path (Enter key, scroll-and-rescan, etc.)
+    handles the leftover failure.
+    """
+    url_after_click = _safe_url_read(runner)
+    time.sleep(_STABILIZATION_WINDOW_SECONDS)
+    final_url = _safe_url_read(runner)
+
+    # A blank final_url means the runner couldn't read URL on the
+    # second poll — treat as missing info rather than a navigation.
+    # Otherwise a transient read-fail would mask a genuine no-navigation
+    # case (gate fires on bogus inequality) or hide a genuine
+    # navigation (gate misfires the retry).
+    if final_url and final_url != url_after_click:
+        logger.warning(
+            "  %s post-click URL bounce detected: settle saw %r, "
+            "final is %r — pointer-retry evaluates against final",
+            log_prefix,
+            (url_after_click or "")[:80],
+            final_url[:80],
+        )
+        url_after_click = final_url
+
+    if not (
+        url_before
+        and url_after_click == url_before
+        and executor_backend == "som"
+        and hasattr(env, "cdp_click_via_pointer")
+    ):
+        return url_after_click
+
+    logger.info(
+        "  %s SoM click ok=True but URL stable — retrying via CDP "
+        "Input.dispatchMouseEvent (real pointer events, isTrusted=true)",
+        log_prefix,
+    )
+    try:
+        ok = env.cdp_click_via_pointer(x, y)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("pointer-retry dispatch raised: %s", exc)
+        ok = False
+    if not ok:
+        return url_after_click
+
+    # Re-settle and re-read; preserve the original cost-accounting
+    # pattern (one extra settle billed, one extra gpu_step billed).
+    settle_seconds = _safe_adaptive_settle(runner, url_before=url_before)
+    runner.costs["gpu_seconds"] += settle_seconds
+    runner.costs["gpu_steps"] += 1
+    time.sleep(_STABILIZATION_WINDOW_SECONDS)
+    return _safe_url_read(runner)
+
+
+def _safe_url_read(runner: "MicroPlanRunner") -> str:
+    """Read current URL via ``_best_effort_current_url`` if available,
+    falling back to ``""`` on any error.
+    """
+    reader = getattr(runner, "_best_effort_current_url", None)
+    if not callable(reader):
+        return ""
+    try:
+        return str(reader() or "")
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def _safe_adaptive_settle(runner: "MicroPlanRunner", *, url_before: str) -> float:
+    """Call ``_adaptive_submit_settle`` if available; return 0.0 otherwise.
+
+    Both ``MicroPlanRunner`` and ``GymRunner`` (legacy) expose this
+    method; tests with FakeRunners may stub it. Defensive default
+    avoids attribute errors in unusual harness configurations.
+    """
+    settle = getattr(runner, "_adaptive_submit_settle", None)
+    if not callable(settle):
+        return 0.0
+    try:
+        return float(settle(url_before=url_before) or 0.0)
+    except Exception:  # noqa: BLE001
+        return 0.0
+
+
+__all__ = ["pointer_retry_if_unchanged"]

--- a/src/mantis_agent/gym/pointer_retry.py
+++ b/src/mantis_agent/gym/pointer_retry.py
@@ -103,7 +103,7 @@ def pointer_retry_if_unchanged(
     ):
         return url_after_click
 
-    logger.info(
+    logger.warning(
         "  %s SoM click ok=True but URL stable — retrying via CDP "
         "Input.dispatchMouseEvent (real pointer events, isTrusted=true)",
         log_prefix,

--- a/src/mantis_agent/gym/step_handlers/click.py
+++ b/src/mantis_agent/gym/step_handlers/click.py
@@ -315,6 +315,15 @@ class ClaudeGuidedClickHandler:
         except Exception:
             pre_click_screenshot = None
 
+        # Capture pre-click URL so the post-click trust-gate retry has
+        # a baseline to compare against. ``_best_effort_current_url``
+        # returns "" on any error so the retry's gate fails closed.
+        url_before_click: str = ""
+        try:
+            url_before_click = str(getattr(runner, "_best_effort_current_url", lambda: "")() or "")
+        except Exception:
+            url_before_click = ""
+
         # Click — #300: try SoM-anchored CDP dispatch first when the
         # routing policy promotes it AND the env exposes the CDP click
         # shim. Falls through to legacy xdotool on policy-off /
@@ -346,6 +355,23 @@ class ClaudeGuidedClickHandler:
             return StepResult(step_index=index, intent=step.intent, success=False)
         # Stash so the rest of execute() can tag the eventual StepResult.
         ctx.state["_executor_backend"] = primary_click_backend
+
+        # PR-G: SoM ``el.click()`` returns ok=True but the page didn't
+        # navigate. The synthetic click event has ``isTrusted=false`` and
+        # some SPA frameworks gate on trusted gestures and silently
+        # reject the synthetic chain — surfaced on staff-crm-long step
+        # 8 (row Robot-Name link, run ``74add5d8``). Retry once with CDP
+        # ``Input.dispatchMouseEvent`` (isTrusted=true, indistinguishable
+        # from a real click). Same primitive PR #447 Fix B added to the
+        # submit handler; extracted to ``pointer_retry`` so both handlers
+        # share the gate logic and stabilization-window semantics.
+        from ..pointer_retry import pointer_retry_if_unchanged
+        pointer_retry_if_unchanged(
+            env, runner, x, y,
+            url_before=url_before_click,
+            executor_backend=primary_click_backend,
+            log_prefix="[claude-click]",
+        )
 
         # Verify: are we on a detail page? Retry once (page may still load)
         # Prefer CDP over screenshot URL extraction — issue #89 §1.

--- a/src/mantis_agent/gym/step_handlers/form.py
+++ b/src/mantis_agent/gym/step_handlers/form.py
@@ -935,69 +935,18 @@ class ClaudeGuidedFormHandler:
                 runner.costs["gpu_steps"] += 1
 
                 # #audit batch follow-up: SoM ``el.click()`` returns
-                # ok=True but the page didn't navigate. The synthetic
-                # click event has ``isTrusted=false``; some SPA
-                # frameworks gate on trusted gestures and silently
-                # reject the synthetic chain. Retry once with CDP
-                # ``Input.dispatchMouseEvent`` which produces a
-                # protocol-level click that's indistinguishable from
-                # a real mouse click (isTrusted=true). Only fires
-                # when the SoM path was used (executor_backend ==
-                # "som") and the URL stayed stable — i.e. we're in
-                # the trust-gated case.
-                #
-                # Gate tightening (PR-D follow-up to #445): the gate's
-                # ``url_after_click == url_before`` check used to read
-                # the URL once, immediately after ``_adaptive_submit_settle``.
-                # That race-loses when the synthetic click triggers a
-                # brief navigation that bounces back: the settle returns
-                # early on the intermediate URL, the immediate poll
-                # captures the (different) intermediate, and the gate
-                # doesn't fire. Re-poll after a short stabilization
-                # window and compare the FINAL settled URL — the
-                # bounce-back case now correctly satisfies the gate
-                # and the pointer-retry actually runs.
-                url_after_click = runner._best_effort_current_url()
-                time.sleep(0.8)  # stabilization window
-                final_url = runner._best_effort_current_url()
-                # A blank ``final_url`` means the runner couldn't read
-                # the URL on the second poll — treat as missing info
-                # rather than a navigation. Otherwise a transient
-                # read-fail would mask a genuine no-navigation case
-                # (gate fires on bogus inequality) or hide a genuine
-                # navigation (gate misfires the retry).
-                if final_url and final_url != url_after_click:
-                    logger.warning(
-                        "  [claude-form] post-click URL bounce detected: "
-                        "settle saw %r, final is %r — pointer-retry "
-                        "evaluates against final",
-                        (url_after_click or "")[:80], final_url[:80],
-                    )
-                    url_after_click = final_url
-                if (
-                    url_before
-                    and url_after_click == url_before
-                    and ctx.state.get("_executor_backend") == "som"
-                    and hasattr(env, "cdp_click_via_pointer")
-                ):
-                    logger.info(
-                        "  [claude-form] SoM click ok=True but URL stable — "
-                        "retrying via CDP Input.dispatchMouseEvent "
-                        "(real pointer events, isTrusted=true)"
-                    )
-                    try:
-                        ok = env.cdp_click_via_pointer(x, y)
-                    except Exception as exc:  # noqa: BLE001
-                        logger.debug("pointer-retry dispatch raised: %s", exc)
-                        ok = False
-                    if ok:
-                        runner.costs["gpu_seconds"] += runner._adaptive_submit_settle(
-                            url_before=url_before,
-                        )
-                        runner.costs["gpu_steps"] += 1
-                        # Same final-URL evaluation as the pre-retry guard.
-                        time.sleep(0.8)
-                        url_after_click = runner._best_effort_current_url()
+                # ok=True but the page didn't navigate. Trust-gate-
+                # bypass logic extracted to ``pointer_retry`` (PR-G
+                # follow-up) so the click handler can call the same
+                # primitive. See that module's docstring for the full
+                # rationale, gate conditions, and bounce-detection.
+                from ..pointer_retry import pointer_retry_if_unchanged
+                url_after_click = pointer_retry_if_unchanged(
+                    env, runner, x, y,
+                    url_before=url_before,
+                    executor_backend=str(ctx.state.get("_executor_backend") or ""),
+                    log_prefix="[claude-form]",
+                )
 
                 # Enter-key fallback: HTML forms whose JS swallows the click
                 # event still submit on Return in a focused input (the

--- a/tests/test_pointer_retry.py
+++ b/tests/test_pointer_retry.py
@@ -1,0 +1,263 @@
+"""Unit tests for ``mantis_agent.gym.pointer_retry``.
+
+The helper extracted from ``ClaudeGuidedFormHandler`` (PR #447 Fix B)
+so the click handler and any future handler can share the trust-gate-
+bypass logic.
+
+The gate conditions are well-defined: ``url_before`` non-empty + final
+URL equals ``url_before`` + executor was SoM + env exposes
+``cdp_click_via_pointer``. Each test pins one or more of these
+conditions so a future regression in the gate logic is caught
+immediately.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from mantis_agent.gym.pointer_retry import pointer_retry_if_unchanged
+
+
+class _FakeRunner:
+    """Minimal runner stub: URL history + cost dict + settle stub."""
+
+    def __init__(self, urls: list[str]) -> None:
+        self._urls = list(urls)
+        self.costs: dict[str, float] = {"gpu_seconds": 0, "gpu_steps": 0}
+        self.settle_calls: list[str] = []
+
+    def _best_effort_current_url(self) -> str:
+        return self._urls.pop(0) if self._urls else ""
+
+    def _adaptive_submit_settle(self, *, url_before: str) -> float:
+        self.settle_calls.append(url_before)
+        return 0.5
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Skip the stabilization-window sleeps in tests."""
+    monkeypatch.setattr("mantis_agent.gym.pointer_retry.time.sleep", lambda *_: None)
+
+
+def test_pointer_retry_fires_when_som_click_did_not_navigate() -> None:
+    """Canonical case: SoM click + URL unchanged → retry via real-pointer."""
+    runner = _FakeRunner(urls=[
+        "https://app.example/leads",  # url_after_click (immediate poll)
+        "https://app.example/leads",  # final_url (after stabilization)
+        "https://app.example/leads/42",  # post-retry URL
+    ])
+    env = MagicMock()
+    env.cdp_click_via_pointer.return_value = True
+
+    result = pointer_retry_if_unchanged(
+        env, runner, 100, 200,
+        url_before="https://app.example/leads",
+        executor_backend="som",
+        log_prefix="[test]",
+    )
+
+    env.cdp_click_via_pointer.assert_called_once_with(100, 200)
+    assert result == "https://app.example/leads/42"
+    # Cost-accounting: one extra settle + one extra gpu_step billed
+    assert runner.costs["gpu_steps"] == 1
+    assert runner.costs["gpu_seconds"] == 0.5
+    assert runner.settle_calls == ["https://app.example/leads"]
+
+
+def test_pointer_retry_skipped_when_url_changed_after_click() -> None:
+    """If the URL DID change, the click actually navigated → no retry."""
+    runner = _FakeRunner(urls=[
+        "https://app.example/leads/42",  # immediate poll: URL changed
+        "https://app.example/leads/42",  # final URL: still changed
+    ])
+    env = MagicMock()
+
+    result = pointer_retry_if_unchanged(
+        env, runner, 100, 200,
+        url_before="https://app.example/leads",
+        executor_backend="som",
+        log_prefix="[test]",
+    )
+
+    env.cdp_click_via_pointer.assert_not_called()
+    assert result == "https://app.example/leads/42"
+    # No extra settle billed when retry doesn't fire
+    assert runner.costs["gpu_steps"] == 0
+
+
+def test_pointer_retry_skipped_when_executor_was_vision() -> None:
+    """xdotool / vision-path clicks are already real events; no retry needed."""
+    runner = _FakeRunner(urls=[
+        "https://app.example/leads",
+        "https://app.example/leads",
+    ])
+    env = MagicMock()
+
+    result = pointer_retry_if_unchanged(
+        env, runner, 100, 200,
+        url_before="https://app.example/leads",
+        executor_backend="vision",  # ← not SoM
+        log_prefix="[test]",
+    )
+
+    env.cdp_click_via_pointer.assert_not_called()
+    assert result == "https://app.example/leads"
+
+
+def test_pointer_retry_skipped_when_url_before_empty() -> None:
+    """No baseline URL → can't decide if click navigated → no retry."""
+    runner = _FakeRunner(urls=["", ""])
+    env = MagicMock()
+
+    result = pointer_retry_if_unchanged(
+        env, runner, 100, 200,
+        url_before="",
+        executor_backend="som",
+        log_prefix="[test]",
+    )
+
+    env.cdp_click_via_pointer.assert_not_called()
+    # Empty url_before is preserved through the function
+    assert result == ""
+
+
+def test_pointer_retry_skipped_when_env_lacks_cdp_click_via_pointer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If env doesn't expose the real-pointer method, gate fails closed."""
+    runner = _FakeRunner(urls=[
+        "https://app.example/leads",
+        "https://app.example/leads",
+    ])
+    env = MagicMock(spec=[])  # no methods auto-created
+
+    result = pointer_retry_if_unchanged(
+        env, runner, 100, 200,
+        url_before="https://app.example/leads",
+        executor_backend="som",
+        log_prefix="[test]",
+    )
+
+    # No exception raised; returns final URL
+    assert result == "https://app.example/leads"
+
+
+def test_pointer_retry_handles_url_bounce_between_polls() -> None:
+    """If the immediate post-click URL is transient (page mid-navigation),
+    re-read after the stabilization window — the gate evaluates against
+    the FINAL URL, not the transient one.
+    """
+    runner = _FakeRunner(urls=[
+        "https://app.example/leads?status=Contacted",  # transient
+        "https://app.example/leads",  # final (bounced back to base)
+        "https://app.example/leads",  # post-retry settle
+    ])
+    env = MagicMock()
+    env.cdp_click_via_pointer.return_value = True
+
+    result = pointer_retry_if_unchanged(
+        env, runner, 100, 200,
+        url_before="https://app.example/leads",
+        executor_backend="som",
+        log_prefix="[test]",
+    )
+
+    # Bounce detected → retry SHOULD have fired (final URL == url_before)
+    env.cdp_click_via_pointer.assert_called_once()
+    assert result == "https://app.example/leads"
+
+
+def test_pointer_retry_blank_final_url_keeps_immediate_read() -> None:
+    """If the second URL poll returns blank (transient read failure),
+    don't treat blank as a navigation. Keep the first poll's value.
+    """
+    runner = _FakeRunner(urls=[
+        "https://app.example/leads",  # immediate poll
+        "",                            # second poll: blank (failure)
+        "https://app.example/leads",  # post-retry settle
+    ])
+    env = MagicMock()
+    env.cdp_click_via_pointer.return_value = True
+
+    result = pointer_retry_if_unchanged(
+        env, runner, 100, 200,
+        url_before="https://app.example/leads",
+        executor_backend="som",
+        log_prefix="[test]",
+    )
+
+    # Retry SHOULD still fire because url_after_click == url_before
+    # (blank was discarded, keeping the immediate read of "leads")
+    env.cdp_click_via_pointer.assert_called_once()
+    assert result == "https://app.example/leads"
+
+
+def test_pointer_retry_cdp_dispatch_failure_returns_pre_retry_url() -> None:
+    """If cdp_click_via_pointer returns False or raises, no settle is
+    billed and the returned URL is the pre-retry stabilized URL.
+    """
+    runner = _FakeRunner(urls=[
+        "https://app.example/leads",
+        "https://app.example/leads",
+    ])
+    env = MagicMock()
+    env.cdp_click_via_pointer.return_value = False  # dispatch declined
+
+    result = pointer_retry_if_unchanged(
+        env, runner, 100, 200,
+        url_before="https://app.example/leads",
+        executor_backend="som",
+        log_prefix="[test]",
+    )
+
+    env.cdp_click_via_pointer.assert_called_once()
+    # No extra cost billed (dispatch failed)
+    assert runner.costs["gpu_steps"] == 0
+    # Returned URL is the pre-retry stabilized URL
+    assert result == "https://app.example/leads"
+
+
+def test_pointer_retry_cdp_dispatch_exception_does_not_propagate() -> None:
+    """An exception in cdp_click_via_pointer is caught and logged at debug;
+    function returns gracefully with the pre-retry URL.
+    """
+    runner = _FakeRunner(urls=[
+        "https://app.example/leads",
+        "https://app.example/leads",
+    ])
+    env = MagicMock()
+    env.cdp_click_via_pointer.side_effect = RuntimeError("CDP unreachable")
+
+    result = pointer_retry_if_unchanged(
+        env, runner, 100, 200,
+        url_before="https://app.example/leads",
+        executor_backend="som",
+        log_prefix="[test]",
+    )
+
+    assert result == "https://app.example/leads"
+    assert runner.costs["gpu_steps"] == 0
+
+
+def test_pointer_retry_runner_without_url_reader_returns_blank() -> None:
+    """A runner stub that doesn't expose ``_best_effort_current_url``
+    is treated as having no URL info; gate fails closed.
+    """
+    runner = MagicMock(spec=["costs"])  # no URL reader
+    runner.costs = {"gpu_seconds": 0, "gpu_steps": 0}
+    env = MagicMock()
+
+    result = pointer_retry_if_unchanged(
+        env, runner, 100, 200,
+        url_before="https://app.example/leads",
+        executor_backend="som",
+        log_prefix="[test]",
+    )
+
+    # url_after_click was "" (no reader); url_before was "/leads"
+    # → gate fails (mismatch) → no retry
+    env.cdp_click_via_pointer.assert_not_called()
+    assert result == ""


### PR DESCRIPTION
## Summary

PR #447 Fix B (final-URL pointer-retry gate after a no-state-change SoM click) lived inside `ClaudeGuidedFormHandler` — `submit` steps only. Step 8 of staff-crm-long (`type: click` on a row's Robot-Name link) halts with the same trust-gated symptom but goes through the generic click handler, which doesn't have Fix B. Surfaced in PR-F's verification run `74add5d8` (2026-05-17):

```
[8] click reported success but URL stayed at .../leads?status=Contacted&...
    and no non-handler state changed — demoting
```

## Change

- New module `mantis_agent.gym.pointer_retry` exposing `pointer_retry_if_unchanged(env, runner, x, y, *, url_before, executor_backend, log_prefix)`. Same semantics as the original inline Fix B: stabilization-window re-poll, URL-bounce detection, gate on (url_before set, final URL unchanged, `executor_backend == "som"`, env has `cdp_click_via_pointer`). On retry success, bills one extra settle + one gpu_step to match the form-handler accounting.
- Refactor `form.py`'s inline Fix B (75 lines) to call the helper. No behavior change; existing tests (`test_form_handler.py` 31 tests) still pass.
- Wire helper into `click.py` after the primary SoM click + backend assignment, before the existing detail-page verify loop. The helper's stabilization window is independent of the verify loop's `adaptive_settle.settle_after_action`; the verify loop runs ONCE on the post-retry state.

## Tests

- `tests/test_pointer_retry.py` — 10 new unit tests covering: canonical retry, URL changed (skip), vision backend (skip), empty url_before, missing CDP method, URL bounce-between-polls, blank final URL, CDP dispatch False, CDP dispatch exception, runner missing URL reader
- `tests/test_form_handler.py` — 31 existing tests pass after refactor (regression guard)
- `tests/test_click_handler.py` + related — 64 existing click tests pass after click.py wiring
- Full suite: **2866 pass** (2856 + 10 new)
- `uv run ruff check .` — clean

## What it should unblock

After PR-F (#449) shipped the CDP `Page.navigate` fix, staff-crm-long's halt moved from step 5 → step 8 — first time the plan got past filter setup. Step 8 is `type: click` on a row's `<a>Robot-Name</a>` link, hits the same trust-gated synthetic-click pattern Fix B was designed for. This PR wires that fix into the click path so step 8 should clear too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)