### PR TITLE
fix(ci): bump sim_envs wait_healthy timeout 90s → 180s

### DIFF
--- a/src/mantis_agent/sim_envs/local.py
+++ b/src/mantis_agent/sim_envs/local.py
@@ -223,17 +223,25 @@ class LocalBackend:
             extra={"mode": "subprocess", "proc": proc, "port": port},
         )
 
-    def wait_healthy(self, handle: RuntimeHandle, *, timeout_s: float = 90.0) -> None:
+    def wait_healthy(self, handle: RuntimeHandle, *, timeout_s: float = 180.0) -> None:
         """Poll ``/__env__/health`` until 200 or ``timeout_s`` elapses.
 
-        Default 90 s covers heavily contended CI runners. The previous
-        60 s ceiling (#364) still flaked on different sub-tests of
-        ``test_admin_token_isolation`` and ``test_env_up`` across many
-        PRs, always on the same first-boot path (fresh Python subprocess
-        + FastAPI import + uvicorn bind). The poll loop exits as soon
-        as the env responds 200, so the higher cap costs nothing on the
-        happy path — it only changes whether we surface a noisy
-        TimeoutError on a slow boot.
+        Default bumped to 180 s after the 90 s ceiling continued flaking
+        across PRs #449 and #453 (this session, 2026-05-17), each time
+        on a different ``test_env_up.py`` sub-test that hit the
+        FastAPI-cold-start race. History:
+
+        - 60 s (#364) — flaked
+        - 90 s (#???) — flaked on PRs #449, #453 in one investigation session
+        - 180 s (current) — covers the slowest CI runners we've observed
+
+        The poll loop exits as soon as the env responds 200, so the
+        higher cap costs nothing on the happy path (healthy boots
+        complete in 1-3 s) — it only changes whether we surface a
+        noisy TimeoutError on a slow boot. The right place to invest
+        further is making the stub env's first-paint faster (lazy
+        FastAPI imports, deferred uvicorn worker bind), not bumping
+        the cap a third time.
         """
         deadline = time.time() + timeout_s
         last_err: Exception | None = None

--- a/tests/test_admin_token_isolation.py
+++ b/tests/test_admin_token_isolation.py
@@ -48,7 +48,7 @@ def stub_env():
     backend = LocalBackend()
     handle = backend.start("stub-test", seed=42)
     try:
-        backend.wait_healthy(handle, timeout_s=90.0)
+        backend.wait_healthy(handle, timeout_s=180.0)
         yield handle
     finally:
         backend.stop(handle)

--- a/tests/test_env_up.py
+++ b/tests/test_env_up.py
@@ -60,7 +60,7 @@ def test_local_backend_starts_and_stops_stub_env():
     backend = LocalBackend()
     handle = backend.start("stub-test", seed=7, now="2026-02-01T00:00:00Z")
     try:
-        backend.wait_healthy(handle, timeout_s=90.0)
+        backend.wait_healthy(handle, timeout_s=180.0)
         status, body = _http_get(f"{handle.url}/__env__/health")
         assert status == 200
         payload = json.loads(body)
@@ -98,7 +98,7 @@ def test_local_backend_two_starts_get_distinct_urls():
     # does synchronously.
     backend = LocalBackend()
     h1 = backend.start("stub-test")
-    backend.wait_healthy(h1, timeout_s=90.0)
+    backend.wait_healthy(h1, timeout_s=180.0)
     h2 = backend.start("stub-test")
     try:
         assert h1.url != h2.url
@@ -110,7 +110,7 @@ def test_local_backend_two_starts_get_distinct_urls():
 def test_stop_is_idempotent():
     backend = LocalBackend()
     handle = backend.start("stub-test")
-    backend.wait_healthy(handle, timeout_s=90.0)
+    backend.wait_healthy(handle, timeout_s=180.0)
     backend.stop(handle)
     backend.stop(handle)  # second call must not raise
 


### PR DESCRIPTION
## Summary

Recurring CI flake on `tests/test_env_up.py::*@sim_env_boot` and `tests/test_admin_token_isolation.py` — the stub FastAPI env's first-boot path (Python subprocess + FastAPI import + uvicorn bind) intermittently takes longer than 90s on heavily contended CI runners.

**Timeline:**
- 60s (#364) → flaked
- **90s (current default before this PR)** → still flaked on PRs **#449** and **#453** in one investigation session, each on a different sub-test (`test_stop_is_idempotent`, `test_local_backend_starts_and_stops_stub_env`)
- **180s (this PR)** → covers the slowest CI runners we've observed

The poll loop exits as soon as the env responds 200, so the higher cap costs nothing on healthy boots (1-3s typical). It only changes whether we surface a TimeoutError on a slow boot.

## Changes

- `sim_envs/local.py:226` — default `timeout_s` 90.0 → 180.0
- `tests/test_env_up.py` (3 call sites) — explicit `timeout_s=90.0` → 180.0
- `tests/test_admin_token_isolation.py` (1 call site) — same

## Future ergonomic improvement (not this PR)

Make the stub env's first-paint faster via lazy FastAPI imports or deferred uvicorn worker bind. Bumping the cap a fourth time isn't the right answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)