### PR TITLE
feat(cua): token-subset matcher for Tab-walk fallbacks (PR-M)

### DIFF
--- a/src/mantis_agent/gym/step_handlers/form.py
+++ b/src/mantis_agent/gym/step_handlers/form.py
@@ -546,6 +546,11 @@ def _tab_walk_to_input(
             str(result.get(k) or "").strip().lower()
             for k in ("labelText", "ariaLabel", "placeholder", "name", "siblingText")
         ]
+        if tag in ("INPUT", "TEXTAREA"):
+            logger.warning(
+                "  [claude-form] tab-walk-input probe at Tab+%d: needle=%r candidates=%r",
+                i, needle, candidates,
+            )
         if any(_label_matches(needle, c) for c in candidates):
             logger.warning(
                 "  [claude-form] tab-walk-input: matched %s at Tab+%d "

--- a/src/mantis_agent/gym/step_handlers/form.py
+++ b/src/mantis_agent/gym/step_handlers/form.py
@@ -546,11 +546,6 @@ def _tab_walk_to_input(
             str(result.get(k) or "").strip().lower()
             for k in ("labelText", "ariaLabel", "placeholder", "name", "siblingText")
         ]
-        if tag in ("INPUT", "TEXTAREA"):
-            logger.warning(
-                "  [claude-form] tab-walk-input probe at Tab+%d: needle=%r candidates=%r",
-                i, needle, candidates,
-            )
         if any(_label_matches(needle, c) for c in candidates):
             logger.warning(
                 "  [claude-form] tab-walk-input: matched %s at Tab+%d "

--- a/src/mantis_agent/gym/step_handlers/form.py
+++ b/src/mantis_agent/gym/step_handlers/form.py
@@ -268,6 +268,31 @@ _TAB_WALK_MAX_TABS = 100
 _TAB_WALK_KEY_DELAY = 0.12  # seconds between Tab keypresses
 
 
+def _label_matches(needle: str, candidate: str) -> bool:
+    """Tab-walk anchor/input label matcher.
+
+    Returns True when ``needle`` should be considered a match for
+    ``candidate``. Lifts a strict exact/substring check (which rejects
+    "Estimated Value" against "Estimated Deal Value:" because the
+    word "Deal" interrupts the substring) into token-subset matching:
+    all whitespace-split tokens of ``needle`` must appear among the
+    tokens of ``candidate``, order-independent.
+
+    Both arguments are expected pre-lowercased and stripped. Empty
+    needle returns False; empty candidate returns False unless needle
+    is also empty (caller-side guard).
+    """
+    if not needle or not candidate:
+        return False
+    if needle == candidate or needle in candidate:
+        return True
+    needle_tokens = {t for t in needle.split() if t}
+    if not needle_tokens:
+        return False
+    cand_tokens = {t.strip(":,.()[]") for t in candidate.split() if t}
+    return needle_tokens.issubset(cand_tokens)
+
+
 def _tab_walk_to_nav_link(
     env: Any,
     target_label: str,
@@ -370,7 +395,7 @@ def _tab_walk_to_nav_link(
         # parent-container click-trap pattern: vision picks coords that
         # resolve to the toolbar `<div>` wrapping the button, not the
         # `<button>` itself. Tab-walk reaches the button via DOM order.
-        if tag in ("A", "BUTTON") and name and (needle == name or needle in name):
+        if tag in ("A", "BUTTON") and name and _label_matches(needle, name):
             logger.warning(
                 "  [claude-form] tab-walk: matched %s at Tab+%d "
                 "(tag=%s name=%r) for target=%r",
@@ -521,7 +546,7 @@ def _tab_walk_to_input(
             str(result.get(k) or "").strip().lower()
             for k in ("labelText", "ariaLabel", "placeholder", "name", "siblingText")
         ]
-        if any(c and (needle == c or needle in c) for c in candidates):
+        if any(_label_matches(needle, c) for c in candidates):
             logger.warning(
                 "  [claude-form] tab-walk-input: matched %s at Tab+%d "
                 "(label=%r aria=%r placeholder=%r name=%r) for target=%r",

--- a/tests/test_form_handler.py
+++ b/tests/test_form_handler.py
@@ -1155,3 +1155,60 @@ def test_tab_walk_input_empty_label_returns_none() -> None:
     assert _tab_walk_to_input(env, "") is None
     assert _tab_walk_to_input(env, "   ") is None
     env.cdp_evaluate.assert_not_called()
+
+
+# ── PR-M: token-subset matcher (lifts strict-substring failure modes) ──
+
+
+def test_label_matches_exact_and_substring() -> None:
+    """Token-subset matcher preserves prior exact / substring semantics."""
+    from mantis_agent.gym.step_handlers.form import _label_matches
+
+    assert _label_matches("contacted", "contacted") is True
+    assert _label_matches("contacted", "contacted (0)") is True
+    assert _label_matches("save", "save changes") is True
+    assert _label_matches("save", "") is False
+    assert _label_matches("", "anything") is False
+
+
+def test_label_matches_token_subset_with_interleaved_word() -> None:
+    """Plan says 'Estimated Value', input shows 'Estimated Deal Value' —
+    word "Deal" interrupts the substring but tokens are a subset. Must match."""
+    from mantis_agent.gym.step_handlers.form import _label_matches
+
+    assert _label_matches("estimated value", "estimated deal value") is True
+    assert _label_matches("estimated value", "estimated deal value:") is True
+    assert _label_matches("phone number", "contact phone number (required)") is True
+
+
+def test_label_matches_rejects_missing_token() -> None:
+    """Token-subset is strict on every token — missing one fails."""
+    from mantis_agent.gym.step_handlers.form import _label_matches
+
+    # "estimated revenue value" has no "revenue" in the candidate.
+    assert _label_matches("estimated revenue value", "estimated value") is False
+    # Login vs Sign In is a semantic mismatch; tokens don't overlap.
+    assert _label_matches("login", "sign in") is False
+
+
+def test_tab_walk_input_matches_via_token_subset(monkeypatch) -> None:
+    """End-to-end: tab-walk-input matches when placeholder has extra word
+    between the plan-label tokens (staff-crm-long step 13 pattern)."""
+    from mantis_agent.gym.step_handlers.form import _tab_walk_to_input
+
+    monkeypatch.setattr("mantis_agent.gym.step_handlers.form.time.sleep", lambda *_: None)
+
+    env = MagicMock()
+    env.cdp_evaluate.side_effect = [
+        True,  # focus reset
+        {
+            "tag": "INPUT", "name": "estimated_deal_value", "placeholder": "Estimated Deal Value",
+            "ariaLabel": "", "siblingText": "", "labelText": "", "value": "4619727.81",
+            "isInputLike": True,
+        },
+    ]
+
+    match = _tab_walk_to_input(env, "Estimated Value", max_tabs=2)
+    assert match is not None
+    assert match["tag"] == "INPUT"
+    assert match["value"] == "4619727.81"


### PR DESCRIPTION
## Summary
- Lift Tab-walk anchor and Tab-walk-input matchers into a shared `_label_matches` helper.
- Adds token-subset matching as a fallback when exact + substring don't match.
- Unblocks the case where the plan label is a strict-token-subset of the rendered input's name (e.g. plan: `Estimated Value`, input placeholder: `Estimated Deal Value`).

## Production evidence
From `staff-crm-long` run `832f9e91` step 13 (run with PR-J + PR-K + PR-L stacked):
```
fill_field: tag-guard refused click at (863, 608) — elementFromPoint=TD is not input-shaped — trying Tab-walk DOM-input fallback
tab-walk-input: no input matched 'Estimated Value' after 100 Tabs — visited: ... INPUT(Estimated Deal Value) ...
```
The right input was visited, but the plan label `Estimated Value` failed substring match against `Estimated Deal Value` because the word "Deal" interrupts the substring. Token-subset (`{"estimated", "value"} ⊆ {"estimated", "deal", "value"}`) clears it.

## Scope
- `_label_matches` helper: exact / substring / token-subset (order-independent).
- Wired into `_tab_walk_to_nav_link` (PR-J/E) AND `_tab_walk_to_input` (PR-L).
- 4 new unit tests pinning each matching mode + the end-to-end Tab-walk-input case.

## Not in scope (intentional)
- Semantic-mismatch cases ("Login" vs "Sign In") — those need plan-author aliases, not a more permissive matcher.

## Stack
- Based on `feat/tab-walk-input-fill-field` (PR-L #456). Merge after #456.

## Test plan
- [x] `pytest tests/test_form_handler.py` — 44/44 pass
- [x] `ruff check` — clean
- [ ] Modal redeploy + staff-crm-long rerun — confirm step 13 clears via token-subset match

🤖 Generated with [Claude Code](https://claude.com/claude-code)