### PR TITLE
feat(cua): token-subset matcher for Tab-walk fallbacks (PR-M, reopen)

### DIFF
--- a/src/mantis_agent/gym/step_handlers/form.py
+++ b/src/mantis_agent/gym/step_handlers/form.py
@@ -268,6 +268,31 @@ _TAB_WALK_MAX_TABS = 100
 _TAB_WALK_KEY_DELAY = 0.12  # seconds between Tab keypresses
 
 
+def _label_matches(needle: str, candidate: str) -> bool:
+    """Tab-walk anchor/input label matcher.
+
+    Returns True when ``needle`` should be considered a match for
+    ``candidate``. Lifts a strict exact/substring check (which rejects
+    "Estimated Value" against "Estimated Deal Value:" because the
+    word "Deal" interrupts the substring) into token-subset matching:
+    all whitespace-split tokens of ``needle`` must appear among the
+    tokens of ``candidate``, order-independent.
+
+    Both arguments are expected pre-lowercased and stripped. Empty
+    needle returns False; empty candidate returns False unless needle
+    is also empty (caller-side guard).
+    """
+    if not needle or not candidate:
+        return False
+    if needle == candidate or needle in candidate:
+        return True
+    needle_tokens = {t for t in needle.split() if t}
+    if not needle_tokens:
+        return False
+    cand_tokens = {t.strip(":,.()[]") for t in candidate.split() if t}
+    return needle_tokens.issubset(cand_tokens)
+
+
 def _tab_walk_to_nav_link(
     env: Any,
     target_label: str,
@@ -370,7 +395,7 @@ def _tab_walk_to_nav_link(
         # parent-container click-trap pattern: vision picks coords that
         # resolve to the toolbar `<div>` wrapping the button, not the
         # `<button>` itself. Tab-walk reaches the button via DOM order.
-        if tag in ("A", "BUTTON") and name and (needle == name or needle in name):
+        if tag in ("A", "BUTTON") and name and _label_matches(needle, name):
             logger.warning(
                 "  [claude-form] tab-walk: matched %s at Tab+%d "
                 "(tag=%s name=%r) for target=%r",
@@ -521,7 +546,7 @@ def _tab_walk_to_input(
             str(result.get(k) or "").strip().lower()
             for k in ("labelText", "ariaLabel", "placeholder", "name", "siblingText")
         ]
-        if any(c and (needle == c or needle in c) for c in candidates):
+        if any(_label_matches(needle, c) for c in candidates):
             logger.warning(
                 "  [claude-form] tab-walk-input: matched %s at Tab+%d "
                 "(label=%r aria=%r placeholder=%r name=%r) for target=%r",

--- a/tests/test_form_handler.py
+++ b/tests/test_form_handler.py
@@ -1155,3 +1155,60 @@ def test_tab_walk_input_empty_label_returns_none() -> None:
     assert _tab_walk_to_input(env, "") is None
     assert _tab_walk_to_input(env, "   ") is None
     env.cdp_evaluate.assert_not_called()
+
+
+# ── PR-M: token-subset matcher (lifts strict-substring failure modes) ──
+
+
+def test_label_matches_exact_and_substring() -> None:
+    """Token-subset matcher preserves prior exact / substring semantics."""
+    from mantis_agent.gym.step_handlers.form import _label_matches
+
+    assert _label_matches("contacted", "contacted") is True
+    assert _label_matches("contacted", "contacted (0)") is True
+    assert _label_matches("save", "save changes") is True
+    assert _label_matches("save", "") is False
+    assert _label_matches("", "anything") is False
+
+
+def test_label_matches_token_subset_with_interleaved_word() -> None:
+    """Plan says 'Estimated Value', input shows 'Estimated Deal Value' —
+    word "Deal" interrupts the substring but tokens are a subset. Must match."""
+    from mantis_agent.gym.step_handlers.form import _label_matches
+
+    assert _label_matches("estimated value", "estimated deal value") is True
+    assert _label_matches("estimated value", "estimated deal value:") is True
+    assert _label_matches("phone number", "contact phone number (required)") is True
+
+
+def test_label_matches_rejects_missing_token() -> None:
+    """Token-subset is strict on every token — missing one fails."""
+    from mantis_agent.gym.step_handlers.form import _label_matches
+
+    # "estimated revenue value" has no "revenue" in the candidate.
+    assert _label_matches("estimated revenue value", "estimated value") is False
+    # Login vs Sign In is a semantic mismatch; tokens don't overlap.
+    assert _label_matches("login", "sign in") is False
+
+
+def test_tab_walk_input_matches_via_token_subset(monkeypatch) -> None:
+    """End-to-end: tab-walk-input matches when placeholder has extra word
+    between the plan-label tokens (staff-crm-long step 13 pattern)."""
+    from mantis_agent.gym.step_handlers.form import _tab_walk_to_input
+
+    monkeypatch.setattr("mantis_agent.gym.step_handlers.form.time.sleep", lambda *_: None)
+
+    env = MagicMock()
+    env.cdp_evaluate.side_effect = [
+        True,  # focus reset
+        {
+            "tag": "INPUT", "name": "estimated_deal_value", "placeholder": "Estimated Deal Value",
+            "ariaLabel": "", "siblingText": "", "labelText": "", "value": "4619727.81",
+            "isInputLike": True,
+        },
+    ]
+
+    match = _tab_walk_to_input(env, "Estimated Value", max_tabs=2)
+    assert match is not None
+    assert match["tag"] == "INPUT"
+    assert match["value"] == "4619727.81"


### PR DESCRIPTION
## Summary
Reopen of #457 against `main`. The original PR was based on `feat/tab-walk-input-fill-field` (PR-L's branch). When PR-L (#456) merged to main and its branch got cleaned up, #457 "merged" into its stranded base — so the matcher code never actually reached main.

This PR cherry-picks the single matcher commit onto a fresh branch off `main`.

## What it does
Lifts the strict `needle in candidate` substring check in both Tab-walks (`_tab_walk_to_nav_link` and `_tab_walk_to_input`) into a shared `_label_matches` helper with three modes: exact / substring / token-subset.

## Production evidence (from prior run `fae6743f` before PR-457 stranded)
```
[claude-form] tab-walk-input probe at Tab+71: needle='estimated value' candidates=['', '', '', '', 'estimated deal value ($):']
[13] OK | 2 leads (0 phone) | $0.41 ... | 9m
```
Token-subset accepted `{estimated, value} ⊆ {estimated, deal, value, $}` — the case the matcher was built for. Step 13 cleared on the same retry that the strict substring matcher (pre-PR-M) rejected.

## Test plan
- [x] `pytest tests/test_form_handler.py` — 44/44 pass
- [x] `ruff check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)