### PR TITLE
docs: add AGENTS.md + CLAUDE.md pointing at auto-memory index

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,87 @@
+# Agent instructions for Mantis
+
+## Read first: compounded learnings from prior sessions
+
+Before debugging the CUA runner, plan execution, deploy pipelines, or
+verification cycles, read the auto-memory index:
+
+```
+~/.claude/projects/-Users-barada-Sandbox-Mason-mantis/memory/MEMORY.md
+```
+
+That index points to ~25+ feedback / project files capturing failure
+modes, triage flows, deploy-cycle caveats, and architectural decisions
+that compounded across multi-day stress-test sessions on the
+staff-crm-long plan and predecessors.
+
+If you're investigating a halt on staff-crm-long or a similar plan,
+start with these two:
+
+- **`project_cua_verification_playbook.md`** — 16-step triage flow:
+  pre-flight checks → submit → app-id resolve → status triage →
+  per-step triage → signature grep → cost economics → stop criteria.
+- **`project_staff_crm_long_pr_jkl_validation.md`** — grep signatures
+  proving each merged CUA fix (PR-G..PR-M) fires as designed in prod
+  logs.
+
+Grep `MEMORY.md` for a one-line description per entry; open the
+linked file for full body. Update memories when you learn something
+new; never write into `MEMORY.md` directly — it's an index, not a
+memory store.
+
+## How verification cycles work
+
+Mantis CUA fixes are validated by:
+1. Local unit tests in `tests/test_form_handler.py` etc. — fast gate.
+2. Modal redeploy + plan rerun against `staffai-test-crm.exe.xyz`
+   (the staff-crm-long stress-test fixture) — real-world gate.
+3. Grep modal logs for the PR-specific signature line. Absence of the
+   signature means the deployed code doesn't have your change (often
+   because of Modal warm-container or new-app-id-per-deploy caveats
+   documented in memory).
+
+Tab-walk fallbacks, native-select fast-path, retry-context, pointer-
+retry, and token-subset matching all live in
+`src/mantis_agent/gym/step_handlers/form.py`. Both Modal and Baseten
+deployments share this code via `src/mantis_agent` (Truss
+`external_package_dirs` for Baseten, `add_local_python_source` for
+Modal).
+
+## Deploy targets
+
+- **Modal**: `modal deploy deploy/modal/modal_cua_server.py`. Each
+  deploy rotates the app id — log fetch must use `modal app logs
+  mantis-cua-server` (by name) or `modal container list` to resolve
+  the active id.
+- **Baseten**: `uvx truss push deploy/baseten/holo3 --no-cache
+  --promote --wait --deployment-name baseten-holo3-workload-<sha>
+  --include-git-info`. Always `--no-cache` after touching
+  `src/mantis_agent` (the package is shipped via
+  `external_package_dirs` and the build hash skips it). Deployment
+  names must be unique per push — append a git SHA.
+
+## Where things live
+
+- `src/mantis_agent/gym/`: CUA execution loop, step handlers, runner.
+- `src/mantis_agent/extraction/`: Claude-based field extraction.
+- `src/mantis_agent/baseten_server/`: FastAPI server for Baseten.
+- `deploy/modal/`: Modal app definitions.
+- `deploy/baseten/`: Truss configs (one per model).
+- `plans/`: micro-plan JSON files (gitignored; per-user).
+- `tests/`: pytest test suite. `pytest -q` runs in parallel via xdist.
+- `docs/`: mkdocs-strict source.
+
+## Conventions
+
+- **CUA-only at runtime**: handlers must be screenshot-grounded.
+  CDP is for *dispatching* vision-derived actions, never for
+  *deriving* them (see `feedback_cua_no_dom_access.md`).
+- **Generic primitives, plan-specific via decomposer**: no
+  vertical-specific (BoatTrader/CRM/etc) heuristics in step
+  handlers. See `feedback_legacy_fallback_smell.md` and
+  `feedback_no_plan_specific_framework.md`.
+- **Tests**: `pytest tests/ -q` (xdist parallel). Some tests are
+  pinned to xdist_groups to avoid subprocess contention.
+- **CI flakes**: same test family flaking twice = root cause, not
+  retry-shrug. Bump timeouts once; if still flaky, ask if the wait is
+  needed at all (`feedback_repeat_flake_root_cause.md`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,8 +33,8 @@ memory store.
 
 Mantis CUA fixes are validated by:
 1. Local unit tests in `tests/test_form_handler.py` etc. — fast gate.
-2. Modal redeploy + plan rerun against `staffai-test-crm.exe.xyz`
-   (the staff-crm-long stress-test fixture) — real-world gate.
+2. Modal redeploy + plan rerun against the staff-crm-long
+   stress-test fixture — real-world gate.
 3. Grep modal logs for the PR-specific signature line. Absence of the
    signature means the deployed code doesn't have your change (often
    because of Modal warm-container or new-app-id-per-deploy caveats

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,63 @@
+# Claude Code instructions for Mantis
+
+This repo's general agent instructions live in **`AGENTS.md`** — read
+that first. Everything in there applies equally to Claude Code.
+
+## Auto-memory pointer (Claude-specific)
+
+Your auto-memory for this project lives at:
+
+```
+~/.claude/projects/-Users-barada-Sandbox-Mason-mantis/memory/
+```
+
+The `MEMORY.md` index there is loaded into context automatically on
+session start, so you'll see the one-line summaries. The individual
+files contain the bodies — open them when a memory's description
+matches what you're investigating. Categories:
+
+- **`feedback_*.md`** — corrections and validated approaches the user
+  has given you across prior sessions. Apply these as standing
+  guidance.
+- **`project_*.md`** — facts about ongoing work, deploy state,
+  experiment series, PR chains. Time-bounded; verify against the
+  current code before recommending from them (memories decay).
+
+Append new memories when you learn something compounding; never
+overwrite existing entries that still apply. See the auto-memory
+guidance in your top-level instructions for the full save protocol.
+
+## Verification cycle scaffolding
+
+When debugging a CUA halt on staff-crm-long or similar, follow the
+playbook in `project_cua_verification_playbook.md`. The compounding
+session log that produced it (PR-G..PR-M) is captured in
+`project_staff_crm_long_pr_jkl_validation.md` and
+`project_staff_crm_long_session_state_2026_05_17.md`.
+
+## Tool-use norms specific to this repo
+
+- Use `Read`/`Edit`/`Write` rather than `cat`/`sed` for files.
+- Prefer `gh` over web fetches for GitHub PR/issue/CI inspection.
+- Modal log fetches must use the app NAME (`modal app logs
+  mantis-cua-server`), not a cached app id — the id rotates per
+  deploy (see `feedback_modal_new_app_id_per_deploy.md`).
+- Baseten redeploys after touching `src/mantis_agent` must use
+  `--no-cache` and a unique `--deployment-name` (see
+  `feedback_baseten_deployment_name_uniqueness.md`).
+- For long-running deploys (`truss push`, `modal deploy` cold start),
+  run in background and let the task-notification wake you when it
+  completes — don't sleep-poll.
+
+## Don't repeat
+
+- Re-running `modal app stop` + `modal deploy` thinking it'll fix a
+  stale-code symptom — the deploy works; check whether you're
+  reading logs from the OLD app id.
+- Submitting a plan as `task_suite: {steps: [...]}` directly — that
+  produces a silent 0/0/0 success because the executor expects
+  `_micro_plan` via `build_micro_suite`. See
+  `feedback_task_suite_shape.md`.
+- Bumping a CI flake timeout for the third time — the third bump is
+  theater. Ask if the wait is needed at all
+  (`feedback_repeat_flake_root_cause.md`).


### PR DESCRIPTION
## Summary
- Add `AGENTS.md` at repo root — canonical agent instructions for any AI coding tool (Claude Code, Cursor, Aider, etc.).
- Add `CLAUDE.md` at repo root — thin Claude-Code-specific wrapper that pulls in `AGENTS.md` and adds Claude-specific norms.
- Both files headline the auto-memory directory (`~/.claude/projects/.../memory/MEMORY.md`) so future sessions can find the compounding learnings without rediscovering the same failure modes.

## Why
Across a 12-hour PR-G..PR-M verification session on the staff-crm-long stress test, 17 memory files were filed capturing failure modes, triage flows, and deploy caveats (Modal app-id rotation, Baseten Truss cache, MicroIntent strict kwargs, repeat-flake escalation, etc.). Without a project-level pointer, future agent sessions don't know the memory exists — they'd rediscover the same wins/losses from scratch. The 12-hour cost includes ~30 min lost to traps that future sessions can now skip via the playbook.

## What's in `AGENTS.md`
- **Read first**: pointer to the memory index + two canonical entries (`project_cua_verification_playbook.md`, `project_staff_crm_long_pr_jkl_validation.md`).
- **Verification cycle**: how local tests, Modal redeploy + plan rerun, and signature-grep fit together.
- **Deploy targets**: Modal app-id rotation rule, Baseten `--no-cache` rule + SHA-stamped deployment names.
- **Repo layout**: where things live (`src/mantis_agent/gym/`, `deploy/modal/`, `deploy/baseten/`, etc.).
- **Conventions**: CUA-only at runtime, generic primitives + plan-specific via decomposer, repeat-flake escalation.

## What's in `CLAUDE.md`
- Defers to `AGENTS.md` for general content.
- Adds Claude-specific bits: memory categories (`feedback_*` vs `project_*`), append-not-overwrite rule, "use Read/Edit/Write not cat/sed", "Modal log fetches by NAME not id", Baseten `--no-cache` reminder.
- Lists "don't repeat" anti-patterns observed during the PR-G..PR-M session.

## Test plan
- [x] No code paths touched; doc-only PR.
- [x] mkdocs-strict will pass — files are at repo root, not under `docs/`.
- [x] Both files render correctly in GitHub's Markdown preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)