### PR TITLE
cua: scrub Staff CRM tokens from generic recovery prompt (#460)

### DIFF
--- a/src/mantis_agent/prompts/files/recovery_analysis.txt
+++ b/src/mantis_agent/prompts/files/recovery_analysis.txt
@@ -64,10 +64,10 @@ FAILURE DATA LEGEND (decode the failure string before choosing a mode):
     (``fill_field`` to a valid value, or ``select_option`` for a
     bad enum) BEFORE the failed submit. The next attempt at the
     submit will then succeed because the form is valid.
-    Example: a "Estimated Deal Value" field showing
-    "461927.81" with a red "value must be a whole number" error
+    Example: an integer-only numeric field showing a decimal value
+    ("461927.81") with a red "value must be a whole number" error
     → ``insert_steps=[{"type": "fill_field", "params": {"label":
-    "Estimated Deal Value", "value": "461928"}}]``.
+    "<the field's rendered label>", "value": "461928"}}]``.
 
 PLAN CONTEXT (steps already completed successfully):
 __PLAN_CONTEXT__
@@ -80,9 +80,10 @@ RECOVERY MODES (pick ONE via the record_recovery tool):
    you can see what the right element is and just need to tell
    the searcher to pick it.
 
-   Example A (label mismatch): the failed step said "Click 'Update
-   Lead'" but the actual button reads "Save" — so hint="The save
-   button is labeled 'Save', not 'Update Lead'."
+   Example A (label mismatch): the failed step asked to click a
+   button by one label but the actual button on screen reads
+   something else — so hint="The primary action button is labeled
+   '<rendered label>', not '<step's params.label>'."
 
    Example B (coord mis-grounding — the ``form_target_not_input``
    case): the failed step asked to fill the "Title" input but the
@@ -124,12 +125,13 @@ RECOVERY MODES (pick ONE via the record_recovery tool):
    - **PROGRESS EVIDENCE** — multiple prior retries (RETRY ATTEMPTS
      >= 2) tried scrolling / clicking but the page state shown in
      the screenshot still looks like the SAME content the earlier
-     attempts saw. If three scrolls down and the "Robot Information"
-     section is still at the top, the form likely has no further
-     content below — the requested target may not exist on this page
-     state. Prefer halt over insert_steps when this signal is
-     present; another scroll is unlikely to reach a section that
-     hasn't moved across multiple attempts.
+     attempts saw. If three scrolls down and the same section
+     heading is still pinned at the top of the viewport, the form
+     likely has no further content below — the requested target
+     may not exist on this page state. Prefer halt over
+     insert_steps when this signal is present; another scroll is
+     unlikely to reach a section that hasn't moved across multiple
+     attempts.
    No plan tweak would help; surface the failure to the operator.
 
 Be conservative on insert_steps: each insertion takes ~30 seconds
@@ -153,11 +155,12 @@ prefer a STRUCTURALLY DIFFERENT recovery:**
   that hints at the desired post-state's URL pattern AND the failed
   step is a click / submit that's supposed to navigate, prefer
   ``edit_step`` with ``type=navigate`` and ``params.url`` pointing
-  at the intended destination. Example: the plan asked to click
-  "Contacted" in a sidebar to filter leads, but the URL pattern
-  ``/leads?status=Contacted`` is reachable directly — propose
-  ``edit_step`` with ``type=navigate, params={"url":
-  "/leads?status=Contacted"}``. This bypasses the click entirely.
+  at the intended destination. Example: the plan asked to click a
+  status / category filter in a sidebar, but the same filter is
+  reachable as a query string on the current list-page URL —
+  propose ``edit_step`` with ``type=navigate, params={"url":
+  "<list-page URL>?<filter-key>=<filter-value>"}``. This bypasses
+  the click entirely.
 * If the visible page contains a search box / typeahead / filter
   input that achieves the same goal as the failed click, prefer
   ``insert_steps`` with a ``fill_field`` + Enter sub-flow.

--- a/tests/test_prompt_hygiene.py
+++ b/tests/test_prompt_hygiene.py
@@ -1,0 +1,88 @@
+"""Guard generic CUA-framework prompts against vertical-specific contamination.
+
+The recipe overlay machinery (``recipes/marketplace_listings/*``,
+``SiteConfig.overlay``) exists to carry vertical concerns; generic prompts
+must stay neutral so the framework handles arbitrary apps. This test
+scans generic prompt surfaces and fails if any token from the denylist
+re-enters.
+
+Coverage grows incrementally with the PR chain that cleans up
+contamination (issues #460-#464). The denylist is the union of all
+tokens we never want in any generic prompt; the parametrized prompt
+list grows per PR as each surface is cleaned:
+
+- PR-1 (#460) — recovery_analysis.txt
+- PR-2 (#461) — plan_decomposer.DECOMPOSE_PROMPT
+- PR-4 (#464) — graph.{learner,probe,enhancer} prompts
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+_RECOVERY_TXT = (
+    Path(__file__).resolve().parents[1]
+    / "src"
+    / "mantis_agent"
+    / "prompts"
+    / "files"
+    / "recovery_analysis.txt"
+)
+
+
+# Tokens cited verbatim in the #460-#464 issue bodies. Narrow on purpose —
+# we want zero false positives on legitimate generic prose ("listing item"
+# in a handler docstring is fine; "BoatTrader" is not).
+VERTICAL_TOKEN_DENYLIST: tuple[str, ...] = (
+    # Staff CRM specifics (issue #460, #461)
+    "Estimated Deal Value",
+    "Robot Information",
+    "Update Lead",
+    "/leads?",
+    "/leads/",
+    # marketplace_listings / BoatTrader specifics (issue #463, #464)
+    "BoatTrader",
+    "MarineMax",
+    "Grady-White",
+    "Bayliner",
+    "Tige Boats",
+    "boat photo",
+    "Private Seller",
+    "by-owner",
+    # generic suspect phrases (issue #463)
+    "dealer signals",
+)
+
+
+def _generic_prompts() -> list[tuple[str, str]]:
+    """Return (label, body) pairs for every generic-framework prompt
+    that the cleanup chain has reached so far.
+
+    Add an entry here in the PR that scrubs that surface:
+    - PR-2 will add ``plan_decomposer.DECOMPOSE_PROMPT``
+    - PR-4 will add the three ``graph.*`` prompts
+    """
+    return [
+        ("prompts/files/recovery_analysis.txt", _RECOVERY_TXT.read_text()),
+    ]
+
+
+@pytest.mark.parametrize(
+    "label,body",
+    _generic_prompts(),
+    ids=[label for label, _ in _generic_prompts()],
+)
+def test_generic_prompt_has_no_vertical_tokens(label: str, body: str) -> None:
+    leaks = [tok for tok in VERTICAL_TOKEN_DENYLIST if tok in body]
+    assert not leaks, (
+        f"Vertical-specific tokens leaked into generic prompt {label!r}: "
+        f"{leaks}. Move the example into the relevant recipe (e.g. "
+        f"recipes/marketplace_listings/) or use neutral placeholders."
+    )
+
+
+def test_recovery_analysis_txt_exists() -> None:
+    # Sanity: catches relocation of the prompt file.
+    assert _RECOVERY_TXT.is_file(), f"recovery_analysis.txt missing at {_RECOVERY_TXT}"


### PR DESCRIPTION
## Summary

- Replaces four Staff CRM-specific examples in `recovery_analysis.txt`
  (Estimated Deal Value, Update Lead, Robot Information,
  /leads?status=Contacted) with neutral placeholders that preserve
  pedagogy without naming any vertical.
- Adds `tests/test_prompt_hygiene.py` — parametrized denylist scan of
  generic-framework prompts. Coverage starts with recovery_analysis.txt
  here; PR-2 (#461) extends to `DECOMPOSE_PROMPT`, PR-4 (#464) extends
  to the three `graph/*` prompts.

This is PR-1 of a 5-PR chain operationalizing the "framework stays
generic; vertical concerns via recipe overlay" rule across issues
#460-#464.

## Test plan

- [x] `pytest tests/test_prompt_hygiene.py tests/test_prompts.py
      tests/test_agentic_recovery.py tests/test_agentic_retry_feedback.py
      tests/test_prompt_versions.py` — 74 pass
- [x] Full local suite (`pytest tests/ --ignore=tests/sim_envs`) —
      2718 pass
- [ ] Modal redeploy with `--no-cache`; rerun staff-crm-long verification
      and confirm recovery still triggers on the same failure classes
      (form-validation insert, label-mismatch hint, hint-loop URL bypass)
      with the neutral copy.

Closes #460