### PR TITLE
cua: split generic loop runner from marketplace listings (#463)

### DIFF
--- a/deploy/modal/modal_web_tasks_opencua.py
+++ b/deploy/modal/modal_web_tasks_opencua.py
@@ -358,6 +358,18 @@ def run_opencua_tasks(
                     status = "VIABLE" if iter_result.success else "SKIP"
                     print(f"  [{iter_num}] {status} — {viable_so_far}/{total_so_far} viable ({elapsed:.0f}s)")
 
+                # Recipe-injected loop overrides (issue #463). When the
+                # plan declares a recipe, spread its loop_overrides into
+                # LoopConfig so vertical-specific dealer signals, brand
+                # domains, entity keywords, and gallery-trap copy flow
+                # in without contaminating the generic runner. Empty
+                # dict when no recipe is selected.
+                loop_overrides: dict = {}
+                recipe_name = task_config.get("recipe")
+                if recipe_name:
+                    from mantis_agent import recipes
+                    loop_overrides = recipes.load_loop_overrides(recipe_name)
+
                 loop_cfg = LoopConfig(
                     iteration_intent=intent,
                     pagination_intent=task_config["loop"].get("pagination_intent",
@@ -365,6 +377,7 @@ def run_opencua_tasks(
                     max_iterations=task_config["loop"].get("max_iterations", 50),
                     max_pages=task_config["loop"].get("max_pages", 10),
                     max_steps_per_iteration=max_steps,
+                    **loop_overrides,
                 )
                 wf_runner = WorkflowRunner(brain=brain, env=env, loop_config=loop_cfg,
                                            on_iteration=on_loop_iteration)

--- a/src/mantis_agent/gym/listings_scanner.py
+++ b/src/mantis_agent/gym/listings_scanner.py
@@ -99,21 +99,27 @@ class ListingsScanner:
         self.viewport_stage = 0
 
     @staticmethod
-    def scroll_directive_for(listings_count: int) -> str | None:
+    def scroll_directive_for(listings_count: int, entity_name: str = "listing") -> str | None:
         """Return the click-intent hint when ``listings_count > 0``.
 
         Stateless because the executor tracks the "attempted on this
         page" counter separately from ``listings_attempted`` (the
         executor's count survives DUPLICATE skips; the scanner's
-        counter advances on successful clicks). Same wording as the
-        pre-Phase-4 inline directive so plan-decomposer caches and
-        downstream prompts stay byte-identical.
+        counter advances on successful clicks).
+
+        ``entity_name`` defaults to ``"listing"`` so callers that
+        don't supply it get the pre-#463 string byte-identical
+        (plan-decomposer caches and downstream prompts stay valid).
+        Recipes / generic loop callers can pass ``"item"`` / ``"row"``
+        / etc. to avoid forcing a marketplace-listings mental model on
+        non-marketplace flows.
         """
         if listings_count <= 0:
             return None
+        plural = entity_name + "s"
         return (
-            f"Scroll down past the first {listings_count} listings. "
-            f"Then click the next listing title text below a photo."
+            f"Scroll down past the first {listings_count} {plural}. "
+            f"Then click the next {entity_name} title text below a photo."
         )
 
     def advance_attempted(self) -> None:

--- a/src/mantis_agent/gym/workflow_runner.py
+++ b/src/mantis_agent/gym/workflow_runner.py
@@ -93,23 +93,6 @@ def _extract_url_from_text(text: str, domain: str = "") -> str | None:
     return None
 
 
-# Legacy BoatTrader-specific URL extractor (kept as backup/reference)
-def _extract_boattrader_url(text: str) -> str | None:
-    """Extract a BoatTrader listing URL from text (legacy)."""
-    match = _re_module.search(
-        r"(?:https?://)?(?:www\.)?boattrader\.com/boats?/[\w\-]+(?:/[\w\-]*)*/?",
-        text,
-    )
-    if match:
-        url = match.group()
-        url = _re_module.sub(r"^https?://(?:www\.)?", "", url)
-        if url.rstrip("/") in ("boattrader.com/boats", "boattrader.com/boat"):
-            return None
-        slug = _re_module.search(r"/boats?/([\w\-]+)", url)
-        if slug and len(slug.group(1)) > 5:
-            return url
-    return None
-
 ORDINALS = {
     1: "first", 2: "second", 3: "third", 4: "fourth", 5: "fifth",
     6: "sixth", 7: "seventh", 8: "eighth", 9: "ninth", 10: "tenth",
@@ -132,7 +115,15 @@ PAGE_EXHAUSTED_SIGNALS = [
 
 @dataclass
 class LoopConfig:
-    """Configuration for a dynamic loop."""
+    """Configuration for a dynamic loop.
+
+    The first block of fields is loop-shape — required for every loop.
+    The second block is recipe-injected behavior the runner used to
+    hardcode for marketplace_listings (see issue #463). Defaults are
+    empty so the generic loop runner stays neutral when no recipe is
+    selected; the marketplace_listings recipe supplies them via
+    ``recipes.load_loop_overrides("marketplace_listings")``.
+    """
     iteration_intent: str       # Template with {ORDINAL}, {N} placeholders
     pagination_intent: str = "Scroll to the bottom and click the Next page button or '>' arrow. If there is no next page, call terminate('failure') with 'no more pages'."
     max_iterations: int = 50    # Safety cap
@@ -140,6 +131,14 @@ class LoopConfig:
     max_steps_per_iteration: int = 60
     max_retries_per_iteration: int = 2
     max_steps_pagination: int = 20
+
+    # Recipe-injected loop behavior. All optional; empty defaults keep
+    # the generic loop runner free of vertical assumptions.
+    entity_name: str = "item"                          # "listing" / "lead" / "row"
+    spam_signals: tuple[str, ...] = ()                 # dealer/sponsored skip tokens
+    offsite_brand_domains: tuple[str, ...] = ()        # vertical-specific external sites
+    entity_keywords: tuple[str, ...] = ()              # viability-check fallback
+    gallery_trap_hint: str = ""                        # parameterized recovery copy
 
 
 class FailureCategory:
@@ -157,23 +156,20 @@ class FailureCategory:
     UNKNOWN = "unknown"
 
 
-# Default spam/dealer signals for failure classification (BoatTrader defaults kept as backup)
-DEFAULT_DEALER_SIGNALS = [
-    "more from this dealer", "view dealer website", "dealer listing",
-    "visit seller website", "more boats from this dealer",
-]
-
-
-def _classify_failure(data: str, result=None, spam_signals: list[str] | None = None) -> tuple[str, str]:
+def _classify_failure(data: str, result=None, spam_signals: list[str] | tuple[str, ...] | None = None) -> tuple[str, str]:
     """Classify a failed iteration into category + reason.
 
     Returns (category, reason) tuple for structured logging.
+
+    ``spam_signals`` is supplied by ``LoopConfig.spam_signals`` (which a
+    recipe like ``marketplace_listings`` populates). When no recipe is
+    active and no signals are passed, the dealer/spam-listing class is
+    simply unreachable — there are no built-in vertical assumptions.
     """
     text = (data or "").lower()
 
     # Spam/dealer listing detection (highest priority — wrong listing type entirely)
-    signals = spam_signals or DEFAULT_DEALER_SIGNALS
-    if any(sig in text for sig in signals):
+    if spam_signals and any(sig in text for sig in spam_signals):
         return FailureCategory.DEALER_LISTING, "Clicked spam/dealer listing instead of target entity"
 
     if "popup" in text or "modal" in text or "contact seller" in text or "request info" in text:
@@ -594,10 +590,14 @@ class WorkflowRunner:
                 _listing_url = _extract_url_from_text(extracted)
                 viable = self._validate_viable(extracted, listing_url=_listing_url)
 
-            # Classify failure for structured logging
+            # Classify failure for structured logging. spam_signals come
+            # from the active recipe (LoopConfig.spam_signals); empty when
+            # no recipe is active and the dealer-listing class is unreachable.
             fail_cat, fail_reason = "", ""
             if not viable:
-                fail_cat, fail_reason = _classify_failure(extracted, result)
+                fail_cat, fail_reason = _classify_failure(
+                    extracted, result, spam_signals=self.config.spam_signals or None
+                )
 
             iter_result = IterationResult(
                 iteration=global_iteration,
@@ -1096,14 +1096,16 @@ class WorkflowRunner:
                     count += 1
         return count
 
-    @staticmethod
-    def _distill_learning(result, iter_result, viable: bool) -> str:
+    def _distill_learning(self, result, iter_result, viable: bool) -> str:
         """Analyze the trajectory and distill actionable learnings.
 
         Examines the full trajectory to detect failure patterns:
-        - Off-site navigation (Facebook, Instagram, external dealer sites)
+        - Off-site navigation (social media is universal; vertical-specific
+          brand domains come from ``LoopConfig.offsite_brand_domains``)
         - Backtracking loops (repeated Alt+Left)
-        - Image gallery traps
+        - Image gallery traps (recovery copy from
+          ``LoopConfig.gallery_trap_hint`` when supplied, generic
+          otherwise)
         - Wrong clicks (ads, social icons, menus)
         - Cookie/popup blocking
         - Successful patterns to reinforce
@@ -1130,16 +1132,14 @@ class WorkflowRunner:
                     f"ONLY click result card titles, not social icons or footer links."
                 )
 
-        # External brand/dealer sites — static method, so no `self` to pull from.
-        external_sites = [
-            "hanover yachts", "tige boats", "cobalt boats", "bayliner.com",
-            "sea ray.com", "boston whaler.com", "grady-white.com",
-        ]
-        for site in external_sites:
+        # External vertical-specific brand sites — supplied by the active
+        # recipe via LoopConfig.offsite_brand_domains; empty when no recipe.
+        entity = self.config.entity_name or "item"
+        for site in self.config.offsite_brand_domains:
             if site in all_thinking or site in data:
                 return (
                     f"You navigated to an external website ({site}). "
-                    f"Only click listings within the search results page. "
+                    f"Only click {entity}s within the search results page. "
                     f"If you end up on a different site, press Alt+Left immediately to go back."
                 )
 
@@ -1153,16 +1153,17 @@ class WorkflowRunner:
                 "not menu items, ads, social icons, or navigation links."
             )
 
-        # ── Image gallery trap ──
+        # ── Image gallery trap — vertical-specific recipe wins if set,
+        # otherwise emit a neutral fallback that names the active entity.
         if "image viewer" in all_thinking or "lightbox" in all_thinking or "1 of" in all_thinking or "gallery" in all_thinking:
+            if self.config.gallery_trap_hint:
+                return self.config.gallery_trap_hint.format(entity_name=entity)
             return (
-                "You clicked the PHOTO and got trapped in an image gallery. "
-                "Press Escape then Alt+Left to go back. "
-                "NEXT TIME: do NOT click the boat photo. Instead click one of these:\n"
-                "  - The boat NAME TEXT (e.g. '2022 Grady-White Freedom 235')\n"
-                "  - The PRICE text (e.g. '$145,000')\n"
-                "  - A 'View Details', 'See Details', or 'Contact Seller' link\n"
-                "These open the detail page WITHOUT the gallery trap."
+                f"You clicked the PHOTO and got trapped in an image gallery. "
+                f"Press Escape then Alt+Left to go back. "
+                f"NEXT TIME: do NOT click the {entity}'s photo. Instead click "
+                f"the {entity}'s TITLE TEXT or a 'View Details' / 'See Details' "
+                f"link. These open the detail page without the gallery trap."
             )
 
         # ── 404 / Page Not Found / external site ──
@@ -1366,12 +1367,10 @@ class WorkflowRunner:
         data = str(data)
         text = data.lower()
 
-        # Reject dealer listings (not private sellers — no phone numbers)
-        dealer_signals = [
-            "more from this dealer", "view dealer website",
-            "more boats from this dealer", "visit seller website",
-        ]
-        if any(sig in text for sig in dealer_signals):
+        # Reject dealer/spam listings supplied by the active recipe.
+        # ``spam_signals`` is empty when no recipe is selected; the
+        # generic loop runner imposes no vertical assumptions.
+        if self.config.spam_signals and any(sig in text for sig in self.config.spam_signals):
             return False
 
         # Reject error/blocked pages
@@ -1406,18 +1405,11 @@ class WorkflowRunner:
         has_year = bool(re.search(r'(?:19|20)\d{2}', data))
         has_price = bool(re.search(r'\$[\d,]+', data))
         has_entity_info = False
-        # Use extractor schema keywords if available, else default boat keywords
-        entity_keywords = getattr(self, '_entity_keywords', None)
-        if entity_keywords is None:
-            # Default: BoatTrader keywords (kept as backup for backward compat)
-            entity_keywords = [
-                "make", "model", "hull", "engine", "console", "cabin",
-                "grady", "boston whaler", "sea hunt", "tracker", "yamaha",
-                "mercury", "suzuki", "honda", "evinrude", "intrepid",
-                "azimut", "sea ray", "sundeck", "walkaround", "sportfish",
-                "bayliner", "chaparral", "everglades", "cigarette", "century",
-                "cobia", "nor-tech", "may-craft", "key west", "robalo",
-            ]
+        # Entity keywords come from (in order): the extractor's schema,
+        # the active recipe (LoopConfig.entity_keywords), or none. When
+        # both are empty the keyword check is skipped and viability
+        # falls back to year/price only.
+        entity_keywords = getattr(self, '_entity_keywords', None) or self.config.entity_keywords
         for kw in entity_keywords:
             if kw in text:
                 has_entity_info = True

--- a/src/mantis_agent/recipes/__init__.py
+++ b/src/mantis_agent/recipes/__init__.py
@@ -77,3 +77,34 @@ def load_site_config(name: str) -> "SiteConfig | None":
         # Some other intermediate import error — surface it.
         raise
     return getattr(mod, "SITE_CONFIG", None)
+
+
+def load_loop_overrides(name: str) -> dict[str, object]:
+    """Resolve ``mantis_agent.recipes.<name>.loop_overrides.LOOP_OVERRIDES``.
+
+    Same shape contract as :func:`load_site_config`: missing
+    ``loop_overrides.py`` returns an empty dict (recipe ships no loop
+    customizations), missing recipe directory raises. The empty-dict
+    path lets the caller spread the result into a ``LoopConfig`` without
+    branching on whether the recipe ships loop overrides::
+
+        overrides = recipes.load_loop_overrides(recipe_name)
+        loop_cfg = LoopConfig(iteration_intent=..., **overrides)
+
+    Keys must match ``gym.workflow_runner.LoopConfig`` field names. See
+    :mod:`mantis_agent.recipes.marketplace_listings.loop_overrides` for
+    the reference shape (issue #463).
+    """
+    try:
+        mod = importlib.import_module(f"{__name__}.{name}.loop_overrides")
+    except ModuleNotFoundError as exc:
+        missing = getattr(exc, "name", "") or ""
+        if missing.endswith(f".{name}"):
+            raise
+        if missing == f"{__name__}.{name}.loop_overrides":
+            return {}
+        raise
+    overrides = getattr(mod, "LOOP_OVERRIDES", None)
+    if overrides is None:
+        return {}
+    return dict(overrides)

--- a/src/mantis_agent/recipes/marketplace_listings/loop_overrides.py
+++ b/src/mantis_agent/recipes/marketplace_listings/loop_overrides.py
@@ -1,0 +1,82 @@
+"""Loop-runner overrides for the marketplace_listings recipe.
+
+Per issue #463 these constants were previously hardcoded inside
+``gym/workflow_runner.py`` and ``gym/listings_scanner.py``, biasing the
+generic loop runner toward BoatTrader-shaped flows. They now live with
+the recipe so the generic runner stays neutral and only sees marketplace
+heuristics when a plan explicitly opts in via the ``marketplace_listings``
+recipe.
+
+Each constant maps 1:1 to a field on ``gym.workflow_runner.LoopConfig``.
+``recipes.load_loop_overrides("marketplace_listings")`` returns the
+mapping below; callers (e.g. ``deploy/modal/modal_web_tasks_opencua.py``)
+spread it into their ``LoopConfig`` constructor when the active recipe
+is marketplace_listings.
+"""
+
+from __future__ import annotations
+
+from ._data import DEALER_TEXT_INDICATORS
+
+# Vertical entity name. Drives prompt copy that refers to "the X" / "the
+# next X title". ``listings_scanner.scroll_directive_for`` falls back to
+# "listing" if no override is provided, so this preserves the pre-#463
+# wording byte-identically.
+ENTITY_NAME = "listing"
+
+# Failure-classification spam tokens. Superset of the pre-#463
+# ``DEFAULT_DEALER_SIGNALS`` list that lived in workflow_runner — the
+# recipe already maintained a richer ``DEALER_TEXT_INDICATORS`` set, so
+# the loop runner now reuses that single source of truth.
+SPAM_SIGNALS: tuple[str, ...] = DEALER_TEXT_INDICATORS
+
+# External brand sites the agent should never follow off the marketplace.
+# These are extracted from the pre-#463 ``external_sites`` list in
+# ``WorkflowRunner._distill_learning``. Adding a new boat-brand domain
+# here automatically gets picked up the next time loop overrides are
+# loaded; no core change is needed.
+OFFSITE_BRAND_DOMAINS: tuple[str, ...] = (
+    "hanover yachts",
+    "tige boats",
+    "cobalt boats",
+    "bayliner.com",
+    "sea ray.com",
+    "boston whaler.com",
+    "grady-white.com",
+)
+
+# Viability-check fallback when the extractor schema doesn't expose
+# entity keywords. Identical to the pre-#463 hardcoded list in
+# ``WorkflowRunner._validate_viable``.
+ENTITY_KEYWORDS: tuple[str, ...] = (
+    "make", "model", "hull", "engine", "console", "cabin",
+    "grady", "boston whaler", "sea hunt", "tracker", "yamaha",
+    "mercury", "suzuki", "honda", "evinrude", "intrepid",
+    "azimut", "sea ray", "sundeck", "walkaround", "sportfish",
+    "bayliner", "chaparral", "everglades", "cigarette", "century",
+    "cobia", "nor-tech", "may-craft", "key west", "robalo",
+)
+
+# Gallery-trap recovery copy. ``{entity_name}`` is interpolated by
+# ``WorkflowRunner._distill_learning``. Marketplace listings always have
+# a photo + name + price + 'View Details' surface; this copy is the
+# pre-#463 verbatim wording, parameterised on the entity-name only.
+GALLERY_TRAP_HINT = (
+    "You clicked the PHOTO and got trapped in an image gallery. "
+    "Press Escape then Alt+Left to go back. "
+    "NEXT TIME: do NOT click the {entity_name} photo. Instead click one of these:\n"
+    "  - The {entity_name} NAME TEXT (e.g. '2022 Grady-White Freedom 235')\n"
+    "  - The PRICE text (e.g. '$145,000')\n"
+    "  - A 'View Details', 'See Details', or 'Contact Seller' link\n"
+    "These open the detail page WITHOUT the gallery trap."
+)
+
+
+# Loader contract — keys mirror LoopConfig field names.
+LOOP_OVERRIDES: dict[str, object] = {
+    "entity_name": ENTITY_NAME,
+    "spam_signals": SPAM_SIGNALS,
+    "offsite_brand_domains": OFFSITE_BRAND_DOMAINS,
+    "entity_keywords": ENTITY_KEYWORDS,
+    "gallery_trap_hint": GALLERY_TRAP_HINT,
+}


### PR DESCRIPTION
## Summary

Splits the WorkflowRunner's generic loop machinery from its embedded
BoatTrader/marketplace-listings heuristics. Plans without a recipe now
get a clean, vertical-neutral loop; the marketplace_listings recipe
supplies its dealer signals, brand domains, entity keywords, and
gallery-trap copy via a new `loop_overrides.py` overlay.

## Surface changes

- **`LoopConfig`** gains five recipe-injectable optional fields
  (`entity_name`, `spam_signals`, `offsite_brand_domains`,
  `entity_keywords`, `gallery_trap_hint`). Empty defaults keep the
  generic runner vertical-neutral.
- **`WorkflowRunner`**: removes `_extract_boattrader_url` (dead code),
  `DEFAULT_DEALER_SIGNALS` (module-level), and the inline dealer/spam
  list in `_validate_viable`. `_distill_learning` becomes an instance
  method so it can read `self.config`. Boat entity-keyword fallback
  deleted; falls through to `LoopConfig.entity_keywords`.
- **`listings_scanner.scroll_directive_for`** gains
  `entity_name="listing"` kwarg. Default produces the pre-PR string
  byte-for-byte (plan-decomposer cache compatibility).
- **`recipes/__init__.py`** gains `load_loop_overrides(name)`
  following the existing `load_site_config` shape.
- **`recipes/marketplace_listings/loop_overrides.py`** is the new
  home for the relocated constants. Reuses
  `DEALER_TEXT_INDICATORS` from `_data.py` to avoid duplication.
- **`deploy/modal/modal_web_tasks_opencua.py`** spreads
  `load_loop_overrides(recipe_name)` into `LoopConfig` when
  `task_config["recipe"]` is set.

Stacked on PR-2 (#467). 

## Test plan

- [x] `pytest tests/test_listings_scanner.py
       tests/test_workflow_runner_recovery_url.py
       tests/test_prompt_hygiene.py` — 18 pass
- [x] Full local suite (`pytest tests/ --ignore=tests/sim_envs`) —
       2719 pass
- [ ] Modal redeploy with `--no-cache`; rerun BoatTrader
       marketplace_listings plan (with `recipe="marketplace_listings"`
       in task_config) and confirm dealer signals still filter,
       gallery-trap recovery still fires.
- [ ] Rerun staff-crm-long without setting a recipe; grep the run log
       for "boat", "dealer", "Grady" — must not appear.

Closes #463