### PR TITLE
cua: generalize graph probe/enhancer/learner prompts (#464)

### DIFF
--- a/src/mantis_agent/graph/enhancer.py
+++ b/src/mantis_agent/graph/enhancer.py
@@ -32,6 +32,46 @@ from .probe import ProbeResult
 logger = logging.getLogger(__name__)
 
 
+_KEYWORD_VALUE_PATTERNS: dict[str, re.Pattern[str]] = {
+    "zip": re.compile(r"(?:zip\s*(?:code)?\s*)(\d{5})"),
+    "zip code": re.compile(r"(?:zip\s*(?:code)?\s*)(\d{5})"),
+    "price": re.compile(r"\$\s*([\d,]+)"),
+    "min price": re.compile(r"\$\s*([\d,]+)"),
+    "minimum price": re.compile(r"\$\s*([\d,]+)"),
+    "city": re.compile(r"\b(?:near|in)\s+([a-z][a-z\-]+)"),
+    "location": re.compile(r"\b(?:near|in)\s+([a-z][a-z\-]+)"),
+    "state": re.compile(r"\b(florida|california|texas|new york)\b"),
+}
+
+_STATE_ABBREVIATIONS: dict[str, str] = {
+    "florida": "fl", "california": "ca", "texas": "tx", "new york": "ny",
+}
+
+
+def _extract_filter_value(keyword: str, objective_text: str) -> str:
+    """Extract the value for a templated filter keyword from objective text.
+
+    Driven by ``_KEYWORD_VALUE_PATTERNS``; returns the empty string when
+    no match is found. State names are normalized to two-letter codes
+    so the URL segment matches the canonical site convention (``fl``
+    not ``florida``).
+    """
+    pattern = _KEYWORD_VALUE_PATTERNS.get(keyword.lower())
+    if not pattern:
+        return ""
+    match = pattern.search(objective_text)
+    if not match:
+        return ""
+    value = match.group(1).lower()
+    if keyword.lower() == "state":
+        return _STATE_ABBREVIATIONS.get(value, value)
+    if keyword.lower() in ("price", "min price", "minimum price"):
+        return value.replace(",", "")
+    if value in ("the", "a", "an", "all"):
+        return ""
+    return value
+
+
 ENHANCE_PROMPT = """\
 You are enhancing a CUA (Computer Use Agent) plan with concrete site knowledge.
 
@@ -58,13 +98,13 @@ Based on the probe results, determine the BEST approach for each step:
    If filters can be URL-encoded, build the full filtered URL.
    If not, use the base results page URL.
 
-3. LISTING CLICK TARGET: How should listing cards be clicked?
-   Describe the card layout based on probe results.
+3. ITEM CLICK TARGET: How should each item / row / card be clicked?
+   Describe the item layout based on probe results.
 
 4. DETAIL PAGE ACTIONS: What needs to happen on the detail page?
    - How many scrolls to reach key content?
    - Are there expandable sections? Which ones?
-   - Where is contact/phone information?
+   - Where is the relevant detail / contact information located?
 
 5. PAGINATION: How does pagination work?
    - URL-based (/page-N/), query param (?page=N), or button click?
@@ -87,11 +127,30 @@ Output ONLY valid JSON:
 
 
 class PlanEnhancer:
-    """Fill gaps in vague plans using site probe knowledge."""
+    """Fill gaps in vague plans using site probe knowledge.
 
-    def __init__(self, api_key: str = "", model: str = "claude-opus-4-7"):
+    ``filter_url_strategies`` (issue #464) maps lowercased objective
+    keywords to URL path-segment templates. When non-empty, the
+    enhancer attempts to encode required filters as URL segments
+    (the BoatTrader / marketplace_listings pattern). When empty
+    (the default), the URL builder is a no-op — generic CRM / admin
+    flows don't carry predictable URL encoding rules and shouldn't
+    inherit boattrader-shaped URL guesses.
+
+    Recipes populate this via ``SiteConfig.filter_url_strategies``;
+    see ``recipes/marketplace_listings/site_config.py`` for the
+    reference set.
+    """
+
+    def __init__(
+        self,
+        api_key: str = "",
+        model: str = "claude-opus-4-7",
+        filter_url_strategies: dict[str, str] | None = None,
+    ):
         self.api_key = api_key or os.environ.get("ANTHROPIC_API_KEY", "")
         self.model = model
+        self.filter_url_strategies: dict[str, str] = dict(filter_url_strategies or {})
 
     def enhance(
         self,
@@ -209,25 +268,27 @@ class PlanEnhancer:
         url = self._try_build_filtered_url(url, objective)
 
         # Determine filter strategy per filter
-        # If the URL was enhanced with filter segments, mark those as "url" method
+        # If the URL was enhanced with filter segments, mark those as "url" method.
+        # The keyword→segment-template mapping comes from the active recipe via
+        # ``self.filter_url_strategies``; when empty, no filter is classified as
+        # url-encoded (generic flow).
         url_lower = url.lower()
         filter_strategy = []
         for filt in objective.required_filters:
             filt_lower = filt.lower()
             method = "unknown"
 
-            # Check if this filter got encoded into the URL
+            # Check if this filter got encoded into the URL by looking at the
+            # recipe's templates. ``segment_prefix`` strips ``{value}`` so we
+            # can match segments like ``zip-33101`` against template ``zip-{value}``.
             url_encoded = False
-            if "by-owner" in url_lower and filt_lower in ("private seller", "by owner"):
-                url_encoded = True
-            elif "zip-" in url_lower and filt_lower in ("zip", "location", "zip code"):
-                url_encoded = True
-            elif "price-" in url_lower and filt_lower in ("price", "min price", "minimum price"):
-                url_encoded = True
-            elif "city-" in url_lower and filt_lower in ("city", "location"):
-                url_encoded = True
-            elif "state-" in url_lower and filt_lower in ("state", "location"):
-                url_encoded = True
+            for keyword, template in self.filter_url_strategies.items():
+                if keyword.lower() != filt_lower:
+                    continue
+                segment_prefix = template.split("{value}")[0]
+                if segment_prefix and segment_prefix in url_lower:
+                    url_encoded = True
+                    break
 
             if url_encoded:
                 method = "url"
@@ -286,72 +347,55 @@ class PlanEnhancer:
     def _try_build_filtered_url(self, base_url: str, objective: ObjectiveSpec) -> str:
         """Try to build a URL with filters encoded in the path.
 
-        Scans the objective text for filter values (zip codes, price,
-        seller type keywords) and attempts to encode them as URL segments.
-        Returns the enhanced URL, or the original if no pattern detected.
+        Drives URL-segment encoding off ``self.filter_url_strategies``
+        (issue #464). When that mapping is empty the function is a no-op
+        and returns ``base_url`` unchanged — the pre-#464 hardcoded
+        BoatTrader patterns now live in the marketplace_listings recipe's
+        ``site_config.py`` and only apply when that recipe is selected.
+
+        Keyword entries with no ``{value}`` placeholder are boolean
+        filters (toggle the segment when the keyword appears in the
+        objective text). Entries with ``{value}`` are extracted-value
+        filters — the function scans the objective text for the
+        keyword's expected value pattern (zip = 5 digits, price = $N,
+        city/state = first word after "in"/"near") and substitutes it.
+
+        Empty mapping → no encoding. Empty objective text → returns
+        ``base_url`` unchanged. Generic CRM / admin / inspect-only
+        plans never picked up URL guesses, even before.
         """
-        if not base_url:
+        if not base_url or not self.filter_url_strategies:
             return base_url
 
         raw = objective.raw_text.lower()
         url = base_url.rstrip("/")
         segments: list[str] = []
 
-        # Detect common URL-encodable filter patterns from the objective text
-        # Private seller / by owner
-        if "private seller" in raw or "by owner" in raw or "by-owner" in raw:
-            if "/by-owner" not in url:
-                segments.append("by-owner")
-
-        # Zip code
-        zip_match = re.search(r"(?:zip\s*(?:code)?\s*)(\d{5})", raw)
-        if zip_match:
-            zipcode = zip_match.group(1)
-            if f"zip-{zipcode}" not in url:
-                segments.append(f"zip-{zipcode}")
-
-        # State
-        state_match = re.search(r"\b(florida|california|texas|new york|miami)\b", raw)
-        if state_match:
-            state_name = state_match.group(1)
-            state_map = {
-                "florida": "state-fl", "california": "state-ca",
-                "texas": "state-tx", "new york": "state-ny",
-            }
-            state_seg = state_map.get(state_name, "")
-            if state_seg and state_seg not in url:
-                segments.append(state_seg)
-
-        # City
-        city_match = re.search(r"\b(?:near|in)\s+(\w+)(?:\s+(?:fl|ca|tx|ny))?\b", raw)
-        if city_match:
-            city = city_match.group(1).lower()
-            if city not in ("the", "a", "an", "all") and f"city-{city}" not in url:
-                segments.append(f"city-{city}")
-
-        # Price
-        price_match = re.search(r"\$\s*([\d,]+)", raw)
-        if price_match:
-            price = price_match.group(1).replace(",", "")
-            if f"price-{price}" not in url:
-                segments.append(f"price-{price}")
+        # Group strategies into boolean toggles vs templated. We iterate
+        # in insertion order so recipes can document the canonical
+        # segment order by listing them in that order.
+        seen_segments: set[str] = set()
+        for keyword, template in self.filter_url_strategies.items():
+            kw_lower = keyword.lower()
+            if "{value}" not in template:
+                # Boolean toggle — encode if the keyword appears in
+                # the objective and the segment isn't already on the URL.
+                if kw_lower in raw and template not in url and template not in seen_segments:
+                    segments.append(template)
+                    seen_segments.add(template)
+                continue
+            # Templated — extract a value for the keyword.
+            value = _extract_filter_value(keyword, raw)
+            if not value:
+                continue
+            seg = template.format(value=value)
+            if seg not in url and seg not in seen_segments:
+                segments.append(seg)
+                seen_segments.add(seg)
 
         if not segments:
             return base_url
 
-        # Sort segments in canonical order: state → city → zip → by-owner → price
-        # This matches the URL pattern used by BoatTrader and similar sites
-        ORDER = {"state-": 0, "city-": 1, "zip-": 2, "by-owner": 3, "price-": 4}
-
-        def seg_order(seg: str) -> int:
-            for prefix, rank in ORDER.items():
-                if seg.startswith(prefix) or seg == prefix.rstrip("-"):
-                    return rank
-            return 5
-
-        segments.sort(key=seg_order)
-
-        # Append segments to URL path
         enhanced = url
         for seg in segments:
             enhanced = f"{enhanced}/{seg}"
@@ -442,10 +486,20 @@ class PlanEnhancer:
         )
 
         # ── Extraction phases ──
+        # Click intent: bias toward organic results when the objective
+        # supplies forbidden_actions ("Contact Seller", "Sponsored", etc.);
+        # stay neutral otherwise so non-marketplace flows don't get
+        # listings-shaped guidance.
         card_desc = enhancement.get("card_description", "")
-        click_intent = f"Click an organic {entity} title; skip sponsored and dealer cards"
-        if card_desc:
-            click_intent = f"Click the title text of an organic {entity} card ({card_desc}); skip sponsored cards"
+        if objective.forbidden_actions:
+            skip_hint = ", ".join(objective.forbidden_actions[:3])
+            click_intent = f"Click an organic {entity} title; skip items matching: {skip_hint}"
+            if card_desc:
+                click_intent = f"Click the title text of an organic {entity} card ({card_desc}); skip items matching: {skip_hint}"
+        else:
+            click_intent = f"Click the {entity} title text on the results page"
+            if card_desc:
+                click_intent = f"Click the title text of a {entity} card ({card_desc})"
 
         phases["admit_candidate"] = PhaseNode(
             id="admit_candidate",

--- a/src/mantis_agent/graph/learner.py
+++ b/src/mantis_agent/graph/learner.py
@@ -54,15 +54,15 @@ The phases form a DAG: setup runs first, then extraction loops, then pagination.
 Use these phase roles:
 - SETUP: navigate to URL, apply filters (required=true)
 - GATE: verify page state after setup (gate=true, claude_only=true)
-- DISCOVERY: scan visible listings on current page
-- ADMISSION: click a listing card (grounding=true)
+- DISCOVERY: scan visible items / rows / cards on current page
+- ADMISSION: click into one item (grounding=true)
 - EXTRACTION: read data from detail page (claude_only=true)
 - REJECTION: decide keep/reject based on entity rules (claude_only=true)
 - RETURN: go back to results page
-- PAGINATION: click Next page (grounding=true)
+- PAGINATION: advance to the next page or page section (grounding=true)
 
 For the intent_template of each phase, write a clear 1-sentence CUA instruction.
-Customize based on what the probe found (filter names, listing layout, pagination type).
+Customize based on what the probe found (filter names, page layout, pagination type).
 
 Output ONLY valid JSON:
 {{
@@ -88,9 +88,8 @@ Output ONLY valid JSON:
 RULES:
 - POSITIVE framing only: "Click the title text" not "Don't click the photo"
 - Each intent_template: ONE action, ONE sentence, under 20 words
-- Include WHAT + WHERE: "Click Private Seller text in left sidebar"
-- Extraction steps must inspect contact area AND expanded description
-- Reject dealers, brokers, sponsored, MarineMax listings even if phone visible
+- Include WHAT + WHERE: e.g. "Click <filter label> in the left sidebar"
+- Extraction steps must inspect the primary content area AND any expanded sections
 - Use allowed reveal actions: {allowed_reveals}
 - Avoid forbidden actions: {forbidden_actions}
 """
@@ -161,7 +160,17 @@ class GraphLearner:
             prober = SiteProber(env=self.env, api_key=self.api_key)
             probe = prober.probe(objective.start_url, objective)
 
-        # 4. Enhance plan — fill gaps using probe knowledge
+        # 4. Enhance plan — fill gaps using probe knowledge. Recipe-supplied
+        # URL-filter encoding strategies (#464) flow in via
+        # ``PlanEnhancer(filter_url_strategies=...)``. GraphLearner does
+        # not yet resolve a recipe name → SiteConfig mapping (follow-up:
+        # wire ``self.recipe_name`` through ``learn()``), so the
+        # enhancer's URL builder is a no-op here today. The pre-#464
+        # behavior — implicit BoatTrader URL encoding for every
+        # objective — is intentionally retired; callers needing it
+        # should construct ``PlanEnhancer`` directly with the
+        # marketplace_listings recipe's
+        # ``SiteConfig.filter_url_strategies``.
         from .enhancer import PlanEnhancer
         enhancer = PlanEnhancer(api_key=self.api_key)
         enhancement = enhancer.enhance(objective, probe)

--- a/src/mantis_agent/graph/probe.py
+++ b/src/mantis_agent/graph/probe.py
@@ -98,8 +98,8 @@ Analyze the page and output ONLY valid JSON:
     "location": "bottom center or bottom right or ...",
     "next_text": "Next or > or ..."
   }},
-  "dealer_signals": ["text patterns that indicate dealer/company listings, e.g. More From This Dealer"],
-  "sponsored_signals": ["text patterns that indicate sponsored/ad content, e.g. Sponsored, Advertisement"],
+  "dealer_signals": ["text patterns that indicate non-organic / brokered items the agent should skip (vary by site)"],
+  "sponsored_signals": ["text patterns that indicate sponsored/ad content, e.g. Sponsored, Advertisement, Promoted"],
   "estimated_listings_per_page": 25
 }}
 
@@ -107,7 +107,7 @@ Focus on:
 - What UI elements are filter controls (dropdowns, checkboxes, links)?
 - How are search results displayed (cards, rows, tiles)?
 - Where is the pagination (page numbers, Next button, infinite scroll)?
-- What distinguishes organic results from sponsored/dealer content?
+- What distinguishes organic / first-party results from sponsored / brokered ones?
 """
 
 
@@ -121,14 +121,14 @@ I'm showing you {n_screenshots} screenshots of a detail page at different scroll
 
 Analyze the page and output ONLY valid JSON:
 {{
-  "url_pattern": "pattern in the URL that identifies detail pages, e.g. /boat/<slug>/",
+  "url_pattern": "pattern in the URL that identifies detail pages, e.g. /<entity>/<id>/ or /<entity>/<slug>/",
   "has_phone_section": true,
-  "phone_location": "where phone numbers appear, e.g. right sidebar contact section",
+  "phone_location": "where contact / phone information appears, e.g. right sidebar contact section",
   "has_expandable_sections": true,
   "expandable_sections": ["section names that can be expanded, e.g. Description, More Details"],
   "expand_controls": ["text of expand buttons, e.g. Show more, Read more, See full description"],
-  "seller_info_location": "where seller info appears",
-  "key_fields_visible": ["fields visible without scrolling, e.g. title, price, year"],
+  "seller_info_location": "where seller / owner / poster info appears",
+  "key_fields_visible": ["fields visible without scrolling, e.g. title, price, date"],
   "key_fields_hidden": ["fields that require scrolling or expanding, e.g. phone, description"]
 }}
 """

--- a/src/mantis_agent/recipes/marketplace_listings/site_config.py
+++ b/src/mantis_agent/recipes/marketplace_listings/site_config.py
@@ -1,20 +1,51 @@
 """SiteConfig overlay for the marketplace_listings recipe.
 
-Carries URL/pagination patterns and gate-prompt scaffolding for boat-
-trader-style listing sites. Sibling to ``schema.py``: where the schema
-exports ``SCHEMA: ExtractionSchema``, this module exports
-``SITE_CONFIG: SiteConfig``. Both are picked up by the symmetric
-loaders in ``recipes/__init__.py``.
+Carries URL/pagination patterns, gate-prompt scaffolding, and URL-filter
+encoding rules for boat-trader-style listing sites. Sibling to
+``schema.py``: where the schema exports ``SCHEMA: ExtractionSchema``,
+this module exports ``SITE_CONFIG: SiteConfig``. Both are picked up by
+the symmetric loaders in ``recipes/__init__.py``.
 
 Per issue #224 this is an overlay, not a primary config — it
 extends the probe-derived default with patterns the probe can't
 infer from a single landing screenshot (the detail-URL slug shape is
 the canonical example).
+
+Per issue #464 the ``filter_url_strategies`` mapping also carries the
+BoatTrader URL-encoding rules that used to be hardcoded inside
+``graph/enhancer.py:_try_build_filtered_url``. Moving them here lets
+non-marketplace plans use the graph enhancer without picking up
+boattrader-shaped URL guesses.
 """
 
 from __future__ import annotations
 
+from dataclasses import replace
+
 from ...site_config import SiteConfig
 
 
-SITE_CONFIG: SiteConfig = SiteConfig.default_boattrader()
+# Maps objective-text keywords (lowercased) to URL path segments. A
+# ``{value}`` placeholder is substituted with extracted numeric / city
+# / state values; keyword-only entries are boolean filters.
+_FILTER_URL_STRATEGIES: dict[str, str] = {
+    # Private-seller / by-owner toggle
+    "private seller": "by-owner",
+    "by owner": "by-owner",
+    "by-owner": "by-owner",
+    # Numeric / extracted-value segments
+    "zip": "zip-{value}",
+    "zip code": "zip-{value}",
+    "price": "price-{value}",
+    "min price": "price-{value}",
+    "minimum price": "price-{value}",
+    "city": "city-{value}",
+    "state": "state-{value}",
+    "location": "city-{value}",
+}
+
+
+SITE_CONFIG: SiteConfig = replace(
+    SiteConfig.default_boattrader(),
+    filter_url_strategies=_FILTER_URL_STRATEGIES,
+)

--- a/src/mantis_agent/site_config.py
+++ b/src/mantis_agent/site_config.py
@@ -18,7 +18,7 @@ Usage:
 from __future__ import annotations
 
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 from urllib.parse import urlparse
 
@@ -81,6 +81,20 @@ class SiteConfig:
     # pin a regression on photo coordinates. Empty tuple = no forced
     # grounding (default; routine clicks still benefit from #117 cache).
     require_independent_grounding: tuple[str, ...] = ()
+
+    # #464: URL-filter encoding rules. Maps objective-text keywords (e.g.
+    # "private seller") to URL path segments (e.g. "by-owner") for the
+    # PlanEnhancer's filtered-URL builder. Empty dict = no URL-segment
+    # building (default — generic CRM/admin flows don't have predictable
+    # URL filter formats). The marketplace_listings recipe populates this
+    # with the BoatTrader pattern set; recipes for other URL-driven sites
+    # should do the same.
+    #
+    # Value shape: keyword → URL segment template. Templates support one
+    # {value} placeholder for numeric / extracted values (e.g.
+    # "zip-{value}" → "zip-33101"). Keyword-only entries (without a
+    # placeholder) are treated as boolean filters.
+    filter_url_strategies: dict[str, str] = field(default_factory=dict)
 
     def is_detail_page(self, url: str, base_url: str = "") -> bool:
         """Check if ``url`` is a post-click detail page.
@@ -377,9 +391,14 @@ class SiteConfig:
                 if other.require_independent_grounding
                 else self.require_independent_grounding
             ),
+            filter_url_strategies=(
+                dict(other.filter_url_strategies)
+                if other.filter_url_strategies
+                else dict(self.filter_url_strategies)
+            ),
         )
 
-    def to_dict(self) -> dict[str, str | bool]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "domain": self.domain,
             "detail_page_pattern": self.detail_page_pattern,
@@ -391,6 +410,7 @@ class SiteConfig:
             "filtered_results_url": self.filtered_results_url,
             "prefer_som_grounding": self.prefer_som_grounding,
             "require_independent_grounding": list(self.require_independent_grounding),
+            "filter_url_strategies": dict(self.filter_url_strategies),
         }
 
     @classmethod

--- a/tests/test_prompt_hygiene.py
+++ b/tests/test_prompt_hygiene.py
@@ -22,6 +22,9 @@ from pathlib import Path
 
 import pytest
 
+from mantis_agent.graph.enhancer import ENHANCE_PROMPT
+from mantis_agent.graph.learner import GENERATE_SKELETON_PROMPT
+from mantis_agent.graph.probe import PROBE_DETAIL_PROMPT, PROBE_RESULTS_PROMPT
 from mantis_agent.plan_decomposer import DECOMPOSE_PROMPT
 
 _RECOVERY_TXT = (
@@ -62,12 +65,16 @@ def _generic_prompts() -> list[tuple[str, str]]:
     """Return (label, body) pairs for every generic-framework prompt
     that the cleanup chain has reached so far.
 
-    Add an entry here in the PR that scrubs that surface:
-    - PR-4 will add the three ``graph.*`` prompts
+    The PR chain (#460-#464) is now complete; new generic prompts
+    added in future work should be appended here.
     """
     return [
         ("prompts/files/recovery_analysis.txt", _RECOVERY_TXT.read_text()),
         ("plan_decomposer.DECOMPOSE_PROMPT", DECOMPOSE_PROMPT),
+        ("graph.learner.GENERATE_SKELETON_PROMPT", GENERATE_SKELETON_PROMPT),
+        ("graph.probe.PROBE_RESULTS_PROMPT", PROBE_RESULTS_PROMPT),
+        ("graph.probe.PROBE_DETAIL_PROMPT", PROBE_DETAIL_PROMPT),
+        ("graph.enhancer.ENHANCE_PROMPT", ENHANCE_PROMPT),
     ]
 
 


### PR DESCRIPTION
## Summary

Generalizes the graph-learn stack — `GraphLearner`, `SiteProber`,
`PlanEnhancer` — so it produces correct-shaped graphs for any objective,
not just marketplace listings. The stack is gated behind
`--graph-learn` so this isn't unblocking a default-path regression;
it's about correctness when used on CRM / form / inspect-only
objectives.

## Surface changes

**Prompt scrubs** (covered by extended hygiene test):
- `GENERATE_SKELETON_PROMPT` — drop hardcoded "Private Seller" example
  and "Reject dealers, brokers, sponsored, MarineMax" rule (already
  injected via `{forbidden_actions}` placeholder).
- `PROBE_RESULTS_PROMPT` — rephrase dealer-signal field description
  to "non-organic / brokered items" (vary by site). Field names
  preserved for ProbeResult compatibility.
- `PROBE_DETAIL_PROMPT` — `/boat/<slug>/` → `/<entity>/<id>/`.
- `ENHANCE_PROMPT` — "LISTING CLICK TARGET" → "ITEM CLICK TARGET".

**Skip-text generalization** (`build_enhanced_phases`):
- Drop hardcoded "skip sponsored and dealer cards" from click intent.
- When `objective.forbidden_actions` is non-empty, use those terms as
  skip hints; otherwise emit a neutral click intent.

**URL-encoding migration**:
- New `SiteConfig.filter_url_strategies` field — maps objective keyword
  → URL segment template. Empty default = no URL encoding.
- `PlanEnhancer` constructor takes `filter_url_strategies` kwarg.
- `_try_build_filtered_url` is now data-driven and a no-op when the
  strategy map is empty. `_enhance_heuristic`'s url-encoded
  classification driven by the same map. Centralized
  `_extract_filter_value` helper for keyword → value regex extraction.
- `recipes/marketplace_listings/site_config.py` populates
  `filter_url_strategies` with the legacy BoatTrader patterns so the
  marketplace_listings recipe retains equivalent URL building.
- `SiteConfig.overlay()` + `to_dict()` updated to round-trip the new field.

**Known follow-up**: `GraphLearner` does not yet resolve a recipe name
→ SiteConfig mapping; the comment in `learner.py` documents the gap.
Unscoped `--graph-learn` calls lose the implicit BoatTrader URL
encoding they used to get. To restore parity for the BoatTrader
graph-learn workflow, callers should construct `PlanEnhancer` directly
with the `marketplace_listings` recipe's `SiteConfig.filter_url_strategies`.

Stacked on PR-3 (#468).

## Test plan

- [x] `pytest tests/test_prompt_hygiene.py tests/test_graph.py
       tests/test_plan_enhancement.py tests/test_run_probe.py
       tests/test_site_config.py` — 70 pass
- [x] Full local suite (`pytest tests/ --ignore=tests/sim_envs`) —
       2723 pass
- [ ] Run `--graph-learn` on a non-marketplace objective (CRM record
       update, helpdesk ticket flow); confirm no "listing" /
       "dealer" / "MarineMax" tokens appear in the generated
       skeleton or enhancement.

Closes #464