### PR TITLE
cua: P0 reliability foundation — verify cost-cut + per-step reasoning + versioned contracts

### DIFF
--- a/src/mantis_agent/_anthropic/client.py
+++ b/src/mantis_agent/_anthropic/client.py
@@ -212,6 +212,7 @@ class AnthropicToolUseClient:
         input_schema: dict[str, Any],
         max_tokens: int = 500,
         time_bucket: str = "claude_extract",
+        cache_tools: bool = False,
     ) -> dict | None:
         """Send one screenshot + prompt, return the parsed tool_use dict.
 
@@ -237,6 +238,14 @@ class AnthropicToolUseClient:
         ``time_bucket`` flows into :func:`_credit_claude_time` so per-
         step accounting in the TimeMeter still distinguishes extraction
         from grounding when both share this client.
+
+        ``cache_tools`` opts the tool spec into Anthropic's ephemeral
+        prompt cache (#421). The cache breakpoint sits on the last
+        tool definition so the entire ``tools`` block — name +
+        description + input schema — counts as cached input on hits.
+        Worth it for callers that fire the same tool repeatedly with a
+        stable schema (verify_gate is the canonical case); not worth
+        the per-request overhead for one-off calls.
         """
         if not self.api_key:
             logger.warning("%s: no API key", self._log_prefix)
@@ -246,14 +255,18 @@ class AnthropicToolUseClient:
         screenshot.save(buf, format="PNG")
         b64 = base64.b64encode(buf.getvalue()).decode()
 
+        tool_def: dict[str, Any] = {
+            "name": tool_name,
+            "description": tool_description,
+            "input_schema": input_schema,
+        }
+        if cache_tools:
+            tool_def["cache_control"] = {"type": "ephemeral"}
+
         payload = {
             "model": self.model,
             "max_tokens": max_tokens,
-            "tools": [{
-                "name": tool_name,
-                "description": tool_description,
-                "input_schema": input_schema,
-            }],
+            "tools": [tool_def],
             "tool_choice": {"type": "tool", "name": tool_name},
             "messages": [{
                 "role": "user",

--- a/src/mantis_agent/cua_contracts/__init__.py
+++ b/src/mantis_agent/cua_contracts/__init__.py
@@ -1,0 +1,95 @@
+"""Versioned CUA contracts (#476).
+
+Typed, schema-validated data types for the CUA design's source-of-truth
+event stream. These contracts are the substrate for:
+
+- :issue:`478` — canonical per-step trajectory events emitted from the
+  runner. Each emitted event is a :class:`TrajectoryEvent`.
+- :issue:`479` — grounding traces persisted per dispatched step. The
+  :class:`ActionResult.grounding_trace` field carries them.
+- :issue:`480` — mandatory verifier verdict before advancing.
+  :class:`TrajectoryEvent.verdict` is the typed verdict; events without
+  one fail validation.
+- :issue:`477` — action ontology + reversibility classifier. Lives in
+  the sibling :mod:`reversibility` module and is referenced by
+  :class:`Step.reversibility`.
+- :issue:`487`–:issue:`489` — model / prompt / sandbox version stamps.
+  :class:`TrajectoryEvent.versions` is the slot.
+
+**Why a new module instead of extending api_schemas / actions / checkpoint?**
+
+The existing types — ``PredictRequest`` (api_schemas), ``MicroIntent``
+(plan_decomposer), ``Action`` (actions), ``StepResult`` (checkpoint) —
+were built up incrementally and each carries assumptions about its
+caller. The CUA design's reliability story needs *one* canonical
+trajectory record that doesn't drift with the runner refactors and
+that downstream consumers (shadow routing, model registry, eval) can
+target stably.
+
+The first version (``SCHEMA_VERSION = 1``) maps cleanly onto today's
+runtime via adapter functions in :mod:`adapters`. Existing surfaces
+keep working unchanged; the canonical event stream is emitted *in
+parallel* until the new contracts have proven themselves.
+
+Public surface:
+
+- Data types: :class:`TaskSpec`, :class:`Plan`, :class:`Step`,
+  :class:`Observation`, :class:`ActionResult`, :class:`Verdict`,
+  :class:`TrajectoryEvent`.
+- Enums: :class:`ReversibilityClass`, :class:`VerdictKind`.
+- Validation: :func:`validate_task_spec`, :func:`validate_step`,
+  :func:`validate_verdict`, :func:`validate_trajectory_event`.
+- Adapters: :func:`step_from_micro_intent`,
+  :func:`action_result_from_action`.
+- Constants: :data:`SCHEMA_VERSION`.
+"""
+
+from __future__ import annotations
+
+from .adapters import (
+    action_result_from_action,
+    classify_legacy_reversibility,
+    observation_from_screenshot_ref,
+    step_from_micro_intent,
+)
+from .types import (
+    ActionResult,
+    Observation,
+    Plan,
+    ReversibilityClass,
+    SCHEMA_VERSION,
+    Step,
+    TaskSpec,
+    TrajectoryEvent,
+    Verdict,
+    VerdictKind,
+)
+from .validation import (
+    ContractValidationError,
+    validate_step,
+    validate_task_spec,
+    validate_trajectory_event,
+    validate_verdict,
+)
+
+__all__ = [
+    "ActionResult",
+    "ContractValidationError",
+    "Observation",
+    "Plan",
+    "ReversibilityClass",
+    "SCHEMA_VERSION",
+    "Step",
+    "TaskSpec",
+    "TrajectoryEvent",
+    "Verdict",
+    "VerdictKind",
+    "action_result_from_action",
+    "classify_legacy_reversibility",
+    "observation_from_screenshot_ref",
+    "step_from_micro_intent",
+    "validate_step",
+    "validate_task_spec",
+    "validate_trajectory_event",
+    "validate_verdict",
+]

--- a/src/mantis_agent/cua_contracts/__init__.py
+++ b/src/mantis_agent/cua_contracts/__init__.py
@@ -51,7 +51,9 @@ from .adapters import (
     classify_legacy_reversibility,
     observation_from_screenshot_ref,
     step_from_micro_intent,
+    verdict_from_step_result,
 )
+from .emit import JSONL_FILENAME, TrajectoryEmitter
 from .types import (
     ActionResult,
     Observation,
@@ -84,6 +86,8 @@ __all__ = [
     "TrajectoryEvent",
     "Verdict",
     "VerdictKind",
+    "JSONL_FILENAME",
+    "TrajectoryEmitter",
     "action_result_from_action",
     "classify_legacy_reversibility",
     "observation_from_screenshot_ref",
@@ -92,4 +96,5 @@ __all__ = [
     "validate_task_spec",
     "validate_trajectory_event",
     "validate_verdict",
+    "verdict_from_step_result",
 ]

--- a/src/mantis_agent/cua_contracts/adapters.py
+++ b/src/mantis_agent/cua_contracts/adapters.py
@@ -1,0 +1,173 @@
+"""Adapter shims between the new contracts and the existing surface
+(:mod:`mantis_agent.plan_decomposer`, :mod:`mantis_agent.actions`).
+
+These adapters let the runner emit canonical events without
+refactoring every handler in one go. The compatibility direction is
+**existing → new**: take a legacy ``MicroIntent`` / ``Action`` /
+``StepResult`` and project it into the typed contract. The reverse
+direction (new contract back to legacy types) is intentionally not
+implemented — once a callsite is migrated to emit/consume the new
+types, it shouldn't fall back.
+
+The adapters live in their own module so :mod:`types` stays free of
+imports from the legacy execution layer. Downstream consumers of the
+contract types (shadow router, eval, registry) don't pay the import
+cost of the runner stack.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from .types import (
+    ActionResult,
+    Observation,
+    ReversibilityClass,
+    SCHEMA_VERSION,
+    Step,
+)
+
+if TYPE_CHECKING:
+    from ..actions import Action
+    from ..plan_decomposer import MicroIntent
+
+
+# Mapping from legacy MicroIntent.type strings to a coarse
+# reversibility class. The list of step types lives in
+# ``MicroIntent``'s docstring; we preserve the runtime behaviour the
+# step-recovery / preview-gate code already implements implicitly.
+# Anything not listed defaults to REVERSIBLE so unknown step types
+# fail safe rather than fail open (the preview gate will run, not
+# the auto-dispatch path). #477 will refine this with a proper
+# action ontology.
+_LEGACY_TYPE_TO_REVERSIBILITY: dict[str, ReversibilityClass] = {
+    # Read-only — no side effects.
+    "scroll": ReversibilityClass.READ_ONLY,
+    "extract_data": ReversibilityClass.READ_ONLY,
+    "extract_url": ReversibilityClass.READ_ONLY,
+    # Reversible by alt+Left / Escape / Backspace.
+    "click": ReversibilityClass.REVERSIBLE,
+    "navigate": ReversibilityClass.REVERSIBLE,
+    "navigate_back": ReversibilityClass.REVERSIBLE,
+    "fill_field": ReversibilityClass.REVERSIBLE,
+    "select_option": ReversibilityClass.REVERSIBLE,
+    "right_click": ReversibilityClass.REVERSIBLE,
+    "filter": ReversibilityClass.REVERSIBLE,
+    "paginate": ReversibilityClass.REVERSIBLE,
+    "loop": ReversibilityClass.READ_ONLY,
+    # Irreversible — pre-dispatch preview gate should always run.
+    # ``submit`` is the canonical write action; the rest are aliases
+    # plans use for the same semantic (#477 will collapse them).
+    "submit": ReversibilityClass.IRREVERSIBLE,
+}
+
+
+def classify_legacy_reversibility(step_type: str) -> ReversibilityClass:
+    """Public helper — also useful from tests / safety gates."""
+    return _LEGACY_TYPE_TO_REVERSIBILITY.get(
+        step_type, ReversibilityClass.REVERSIBLE,
+    )
+
+
+def step_from_micro_intent(mi: "MicroIntent") -> Step:
+    """Project a legacy :class:`MicroIntent` onto the typed :class:`Step`.
+
+    No information loss in this direction — ``MicroIntent`` is wider
+    (carries ``gate`` / ``claude_only`` / ``budget`` / ``loop_*``
+    fields the typed Step deliberately omits). The dropped fields are
+    runtime-routing concerns, not contract concerns; they belong on
+    the runner-internal :class:`MicroIntent`, not the on-the-wire
+    :class:`Step` consumers see.
+
+    Field map:
+
+    ============================ ==============================
+    ``MicroIntent`` field         ``Step`` field
+    ============================ ==============================
+    ``intent``                    ``intent``
+    ``type``                      ``action_type``
+    ``verify``                    ``expected_outcome``
+    ``required``                  ``required``
+    ``params``                    ``params``
+    ``hints``                     ``hints``
+    (derived from ``type``)       ``reversibility``
+    (planner doesn't emit it)     ``confidence`` = 0.0
+    ============================ ==============================
+    """
+    return Step(
+        schema_version=SCHEMA_VERSION,
+        intent=str(getattr(mi, "intent", "") or ""),
+        action_type=str(getattr(mi, "type", "") or ""),
+        reversibility=classify_legacy_reversibility(
+            str(getattr(mi, "type", "") or ""),
+        ),
+        expected_outcome=str(getattr(mi, "verify", "") or ""),
+        confidence=0.0,
+        params=dict(getattr(mi, "params", {}) or {}),
+        hints=dict(getattr(mi, "hints", {}) or {}),
+        required=bool(getattr(mi, "required", False)),
+    )
+
+
+def action_result_from_action(
+    action: "Action | None",
+    *,
+    dispatched: bool,
+    dispatch_error: str = "",
+    grounding_trace: dict[str, Any] | None = None,
+) -> ActionResult:
+    """Project a legacy :class:`Action` (+ dispatcher outcome) onto
+    :class:`ActionResult`.
+
+    ``action=None`` is the deterministic-handler case (navigate /
+    paginate / gate — handlers that don't synthesise an
+    :class:`Action`). The adapter still produces a valid ActionResult
+    with ``action_type=""`` so the canonical event can be emitted;
+    the validator will reject events whose ``action_type`` is empty
+    AND ``dispatched=False`` AND no ``dispatch_error`` — that
+    combination means "nothing happened and nobody knows why", which
+    isn't useful to record.
+    """
+    if action is None:
+        return ActionResult(
+            schema_version=SCHEMA_VERSION,
+            action_type="",
+            params={},
+            grounding_trace=grounding_trace or {},
+            dispatched=dispatched,
+            dispatch_error=dispatch_error,
+        )
+    action_type_value = getattr(action.action_type, "value", str(action.action_type))
+    return ActionResult(
+        schema_version=SCHEMA_VERSION,
+        action_type=str(action_type_value),
+        params=dict(action.params or {}),
+        grounding_trace=grounding_trace or {},
+        dispatched=dispatched,
+        dispatch_error=dispatch_error,
+    )
+
+
+def observation_from_screenshot_ref(
+    screenshot_ref: str,
+    *,
+    url: str = "",
+    viewport: tuple[int, int] = (0, 0),
+    captured_at: float = 0.0,
+) -> Observation:
+    """Convenience constructor for the runner emit-path.
+
+    Centralises the contract that an Observation is *always* a
+    reference, never a blob. Callers tempted to pass base64 here get
+    rejected at validation time — by then the screenshot is already
+    serialised and the cost is sunk. Building observations through
+    this helper keeps the discipline in the writer instead of relying
+    on the reader to catch it.
+    """
+    return Observation(
+        schema_version=SCHEMA_VERSION,
+        screenshot_ref=screenshot_ref,
+        url=url,
+        viewport=viewport,
+        captured_at=captured_at,
+    )

--- a/src/mantis_agent/cua_contracts/adapters.py
+++ b/src/mantis_agent/cua_contracts/adapters.py
@@ -25,11 +25,32 @@ from .types import (
     ReversibilityClass,
     SCHEMA_VERSION,
     Step,
+    Verdict,
+    VerdictKind,
 )
 
 if TYPE_CHECKING:
     from ..actions import Action
+    from ..gym.checkpoint import StepResult
     from ..plan_decomposer import MicroIntent
+
+
+# Failure classes that genuinely can't be recovered from without
+# operator intervention — re-running them would just churn budget.
+# Anything not in this set defaults to RECOVERABLE so the retry /
+# recovery / replan ladder gets a shot before terminating.
+#
+# Empty ``failure_class`` on a failed step also defaults to
+# RECOVERABLE — the safer choice when classification was missing.
+# #477's action ontology will refine this; for v1 the set stays
+# small and grep-able so an operator auditing a HALT can find the
+# entry quickly.
+_NON_RECOVERABLE_FAILURE_CLASSES: frozenset[str] = frozenset({
+    "cf_challenge",      # Cloudflare bot challenge — needs new IP / browser
+    "http_4xx",          # 401 / 403 / 404 — credential or routing problem
+    "extractor_error",   # extractor itself crashed, not a content miss
+    "budget_exceeded",   # already exhausted the per-step budget
+})
 
 
 # Mapping from legacy MicroIntent.type strings to a coarse
@@ -145,6 +166,51 @@ def action_result_from_action(
         grounding_trace=grounding_trace or {},
         dispatched=dispatched,
         dispatch_error=dispatch_error,
+    )
+
+
+def verdict_from_step_result(r: "StepResult") -> Verdict:
+    """Project a legacy :class:`~mantis_agent.gym.checkpoint.StepResult`
+    onto :class:`Verdict` (#478, #480).
+
+    Until #480 lands a typed verdict at the source, the runner records
+    outcome as a tuple of ``(success: bool, failure_class: str,
+    data: str)``. This adapter is the projection the canonical event
+    emitter uses on every step:
+
+    * ``success=True`` → :class:`VerdictKind.OK`. ``reason`` is empty
+      (happy path needs no recovery code); ``evidence`` carries the
+      runner's ``data`` string (often a brief "extracted 7 leads" /
+      "navigated to /detail/123" note).
+    * ``success=False`` + ``failure_class`` in
+      :data:`_NON_RECOVERABLE_FAILURE_CLASSES` →
+      :class:`VerdictKind.NON_RECOVERABLE`. Recovery loops on these
+      classes burn budget without converging.
+    * ``success=False`` everything else → :class:`VerdictKind.RECOVERABLE`.
+      ``reason`` falls back to ``"unknown"`` when no class was
+      stamped so the validator accepts the verdict (it requires a
+      non-empty reason on failure verdicts).
+    """
+    if r.success:
+        return Verdict(
+            schema_version=SCHEMA_VERSION,
+            kind=VerdictKind.OK,
+            reason="",
+            evidence=str(getattr(r, "data", "") or ""),
+            confidence=1.0,
+        )
+    failure_class = str(getattr(r, "failure_class", "") or "")
+    kind = (
+        VerdictKind.NON_RECOVERABLE
+        if failure_class in _NON_RECOVERABLE_FAILURE_CLASSES
+        else VerdictKind.RECOVERABLE
+    )
+    return Verdict(
+        schema_version=SCHEMA_VERSION,
+        kind=kind,
+        reason=failure_class or "unknown",
+        evidence=str(getattr(r, "data", "") or ""),
+        confidence=0.5 if kind == VerdictKind.RECOVERABLE else 0.9,
     )
 
 

--- a/src/mantis_agent/cua_contracts/emit.py
+++ b/src/mantis_agent/cua_contracts/emit.py
@@ -1,0 +1,329 @@
+"""Canonical per-step trajectory event emitter (#478).
+
+The emitter is the writer half of the contract scaffolding from
+:mod:`mantis_agent.cua_contracts`. It takes legacy ``StepResult`` +
+``MicroIntent`` + dispatcher state and produces a validated
+:class:`TrajectoryEvent`, then appends it to a JSONL store keyed by
+``run_id``.
+
+Idempotency:
+
+* Each ``(run_id, step_index)`` pair emits exactly once.
+* Resumed runs read the existing JSONL on startup and skip indices
+  that were already written — no duplicate-on-retry, no
+  duplicate-on-resume.
+* The emit path is best-effort wrt the runner: a validation /
+  filesystem failure logs and returns ``False`` but does NOT raise.
+  The runner advances regardless — the canonical event stream is a
+  side channel, not a step-blocker. (Future:#480 makes the verdict
+  itself mandatory; that's a separate enforcement.)
+
+Storage shape:
+
+* ``<store_dir>/trajectory.jsonl`` — one JSON-encoded
+  :class:`TrajectoryEvent` per line. Append-only so a partial write
+  is recoverable. The directory is created on first emit.
+* Same shape across local / Modal / Baseten paths so downstream
+  consumers (shadow router, eval, registry) have one reader.
+
+This module deliberately doesn't touch the existing
+:mod:`mantis_agent.gym.trace_exporter` — that file's output stays as
+compatibility plumbing for the trace UI and labelled-trace
+converter. The canonical event stream is the *source of truth* the
+new design will build on; trace_exporter is a view.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from dataclasses import fields, is_dataclass
+from enum import Enum
+from typing import TYPE_CHECKING, Any
+
+from .adapters import (
+    action_result_from_action,
+    observation_from_screenshot_ref,
+    step_from_micro_intent,
+    verdict_from_step_result,
+)
+from .types import ActionResult, SCHEMA_VERSION, TrajectoryEvent
+from .validation import ContractValidationError, validate_trajectory_event
+
+if TYPE_CHECKING:
+    from ..actions import Action
+    from ..gym.checkpoint import StepResult
+    from ..plan_decomposer import MicroIntent
+
+logger = logging.getLogger(__name__)
+
+
+JSONL_FILENAME: str = "trajectory.jsonl"
+
+
+def _dataclass_to_jsonable(obj: Any) -> Any:
+    """Recursive dataclass → plain-dict conversion that also collapses
+    string enums to their ``.value``.
+
+    Stdlib's :func:`dataclasses.asdict` already recurses into nested
+    dataclasses but leaves :class:`Enum` instances as-is, which
+    ``json.dumps`` chokes on without ``default=`` plumbing. We collapse
+    enums up front so callers see plain JSON-friendly dicts (helpful
+    for tests, golden files, and any consumer that round-trips through
+    ``json.loads``).
+    """
+    if is_dataclass(obj) and not isinstance(obj, type):
+        return {f.name: _dataclass_to_jsonable(getattr(obj, f.name)) for f in fields(obj)}
+    if isinstance(obj, Enum):
+        return obj.value
+    if isinstance(obj, dict):
+        return {k: _dataclass_to_jsonable(v) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return [_dataclass_to_jsonable(v) for v in obj]
+    return obj
+
+
+class TrajectoryEmitter:
+    """Append-only, idempotent writer of :class:`TrajectoryEvent` records.
+
+    Construct one per run. The emitter:
+
+    * Validates each event against :func:`validate_trajectory_event`.
+    * Refuses duplicate ``step_index`` writes for the same ``run_id``
+      (in-memory dedup populated from the existing JSONL on init).
+    * Appends one JSON-encoded event per line under
+      ``<store_dir>/trajectory.jsonl``.
+    * Logs + returns ``False`` on validation / IO failure; the runner
+      keeps going.
+
+    The emitter is intentionally narrow: callers pass the runtime
+    artifacts (``MicroIntent``, ``StepResult``, optional ``Action`` /
+    grounding trace / screenshot ref) and it does the projection +
+    persistence. Future wiring (#479 grounding, #480 typed verdict,
+    #487 / #488 version stamps) plumbs richer inputs through these
+    same kwargs without changing the public surface.
+    """
+
+    def __init__(
+        self,
+        run_id: str,
+        store_dir: str,
+        *,
+        versions: dict[str, str] | None = None,
+    ) -> None:
+        if not run_id:
+            raise ValueError("TrajectoryEmitter requires a non-empty run_id")
+        if not store_dir:
+            raise ValueError("TrajectoryEmitter requires a non-empty store_dir")
+        self.run_id = run_id
+        self.store_dir = store_dir
+        # ``versions`` is the slot for #487 / #488 stamps (planner /
+        # grounding / browser / sandbox). Empty dict is fine in v1 —
+        # the validator only requires presence, not contents.
+        self.versions: dict[str, str] = dict(versions or {})
+        self._jsonl_path: str = os.path.join(store_dir, JSONL_FILENAME)
+        self._emitted_indices: set[int] = set()
+        self._load_existing()
+
+    # ── Public API ─────────────────────────────────────────────────
+
+    def emit(
+        self,
+        step: "MicroIntent",
+        result: "StepResult",
+        *,
+        action: "Action | None" = None,
+        dispatched: bool = True,
+        dispatch_error: str = "",
+        grounding_trace: dict[str, Any] | None = None,
+        screenshot_ref: str = "",
+        url: str = "",
+        viewport: tuple[int, int] = (0, 0),
+        cost_usd: float = 0.0,
+    ) -> bool:
+        """Build + validate + persist a canonical event.
+
+        Returns ``True`` on a fresh emit, ``False`` on duplicate or
+        validation / IO failure. The runner treats the boolean as
+        diagnostic — emit is a side channel.
+
+        Idempotency is keyed on ``(run_id, step.step_index)``; a
+        second call with the same index is a silent no-op so handlers
+        that retry / replan / demote a step don't double-record.
+
+        ``screenshot_ref`` defaults to a synthetic
+        ``step_<index>_<run_id>`` placeholder when the caller doesn't
+        have a real reference. The placeholder is short + non-base64,
+        so the validator accepts it; the placeholder makes the JSONL
+        self-contained pending the #479 grounding-trace integration
+        that will plumb real screenshot refs.
+        """
+        step_index = int(getattr(result, "step_index", -1))
+        if step_index in self._emitted_indices:
+            return False
+
+        try:
+            event = self._build_event(
+                step, result,
+                action=action, dispatched=dispatched,
+                dispatch_error=dispatch_error,
+                grounding_trace=grounding_trace,
+                screenshot_ref=screenshot_ref,
+                url=url, viewport=viewport,
+                cost_usd=cost_usd,
+            )
+            validate_trajectory_event(event)
+        except ContractValidationError as exc:
+            logger.warning(
+                "trajectory emit step %d: validation failed: %s",
+                step_index, exc,
+            )
+            return False
+        except Exception as exc:  # noqa: BLE001 — never break a run
+            logger.warning(
+                "trajectory emit step %d: build raised: %s",
+                step_index, exc,
+            )
+            return False
+
+        try:
+            self._append(event)
+        except OSError as exc:
+            logger.warning(
+                "trajectory emit step %d: append failed (%s): %s",
+                step_index, self._jsonl_path, exc,
+            )
+            return False
+
+        self._emitted_indices.add(step_index)
+        return True
+
+    @property
+    def jsonl_path(self) -> str:
+        """Path to the canonical event stream — exposed for tests +
+        downstream consumers that want to mmap / tail the file."""
+        return self._jsonl_path
+
+    def emitted_indices(self) -> set[int]:
+        """Snapshot of step indices already persisted for this run.
+        Useful for assertions in tests + for the runner to skip
+        re-emitting on resume."""
+        return set(self._emitted_indices)
+
+    # ── Internal helpers ───────────────────────────────────────────
+
+    def _build_event(
+        self,
+        step: "MicroIntent",
+        result: "StepResult",
+        *,
+        action: "Action | None",
+        dispatched: bool,
+        dispatch_error: str,
+        grounding_trace: dict[str, Any] | None,
+        screenshot_ref: str,
+        url: str,
+        viewport: tuple[int, int],
+        cost_usd: float,
+    ) -> TrajectoryEvent:
+        step_index = int(getattr(result, "step_index", -1))
+        ref = screenshot_ref or self._placeholder_screenshot_ref(step_index)
+        # captured_at defaults to "now" because legacy StepResult
+        # doesn't carry the pre-action screenshot timestamp. #479's
+        # grounding-trace integration will plumb the real timestamp;
+        # for v1, ``now`` is close enough to bound the observation in
+        # time and the validator accepts any non-negative float.
+        observation = observation_from_screenshot_ref(
+            ref, url=url, viewport=viewport, captured_at=time.time(),
+        )
+        # ``result.last_action`` is the runner's preferred source for
+        # the action that drove this step; fall back to the explicit
+        # ``action`` kwarg when the caller has a better signal.
+        legacy_action = action if action is not None else getattr(result, "last_action", None)
+        action_result = action_result_from_action(
+            legacy_action,
+            dispatched=dispatched,
+            dispatch_error=dispatch_error,
+            grounding_trace=grounding_trace,
+        )
+        # Deterministic handlers (navigate / paginate / gate /
+        # fill_field) don't synthesise an ``Action`` — they execute
+        # the step directly and leave ``StepResult.last_action`` at
+        # None. The validator requires a non-empty ``action_type``,
+        # so we fall back to the legacy ``MicroIntent.type`` (the
+        # canonical name for what the handler dispatched). The
+        # frozen ActionResult is replaced rather than mutated.
+        if not action_result.action_type:
+            step_type = str(getattr(step, "type", "") or "")
+            if step_type:
+                action_result = ActionResult(
+                    schema_version=action_result.schema_version,
+                    action_type=step_type,
+                    params=action_result.params,
+                    grounding_trace=action_result.grounding_trace,
+                    dispatched=action_result.dispatched,
+                    dispatch_error=action_result.dispatch_error,
+                )
+        return TrajectoryEvent(
+            schema_version=SCHEMA_VERSION,
+            run_id=self.run_id,
+            step_index=step_index,
+            step=step_from_micro_intent(step),
+            observation=observation,
+            action_result=action_result,
+            verdict=verdict_from_step_result(result),
+            versions=dict(self.versions),
+            latency_seconds=float(getattr(result, "duration", 0.0) or 0.0),
+            cost_usd=float(cost_usd),
+            committed=True,
+            emitted_at=time.time(),
+        )
+
+    def _placeholder_screenshot_ref(self, step_index: int) -> str:
+        # Short, distinctive, deterministic — keeps the validator
+        # happy (well under the inline-blob length threshold) and
+        # makes a JSONL audit grep-able.
+        return f"placeholder://{self.run_id}/step_{step_index}.png"
+
+    def _append(self, event: TrajectoryEvent) -> None:
+        os.makedirs(self.store_dir, exist_ok=True)
+        line = json.dumps(_dataclass_to_jsonable(event), separators=(",", ":"))
+        # newline-delimited JSON — append in a single write so a
+        # partial write of one record can't corrupt a sibling. The
+        # filesystem guarantees atomic single-syscall writes for
+        # bytes under PIPE_BUF (4KB on Linux/macOS); events well
+        # exceed that, so a crash mid-line is recoverable by
+        # truncating the trailing partial line on next reader open.
+        with open(self._jsonl_path, "a", encoding="utf-8") as f:
+            f.write(line + "\n")
+
+    def _load_existing(self) -> None:
+        """Populate ``_emitted_indices`` from a prior run's JSONL.
+
+        Resume case (#478 acceptance: idempotent across restarts).
+        A trailing partial line — possible if the writer crashed
+        mid-flush — is tolerated: we read what JSON we can and ignore
+        the rest. Subsequent emits will append clean records past
+        the partial line, which downstream readers should handle the
+        same way.
+        """
+        try:
+            f = open(self._jsonl_path, encoding="utf-8")
+        except FileNotFoundError:
+            return
+        with f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError:
+                    # Partial trailing line from a crashed writer —
+                    # stop scanning; next emit will append past it.
+                    break
+                idx = record.get("step_index")
+                if isinstance(idx, int) and idx >= 0:
+                    self._emitted_indices.add(idx)

--- a/src/mantis_agent/cua_contracts/emit.py
+++ b/src/mantis_agent/cua_contracts/emit.py
@@ -124,7 +124,13 @@ class TrajectoryEmitter:
         # the validator only requires presence, not contents.
         self.versions: dict[str, str] = dict(versions or {})
         self._jsonl_path: str = os.path.join(store_dir, JSONL_FILENAME)
-        self._emitted_indices: set[int] = set()
+        # Per-step attempt counter. Incremented on every emit for a
+        # given ``step_index``; the next attempt's event carries the
+        # incremented value so readers can take the highest attempt
+        # per step as the final outcome. Populated from the existing
+        # JSONL on init so resumed runs continue numbering past the
+        # prior process's last attempt.
+        self._attempt_counts: dict[int, int] = {}
         self._load_existing()
 
     # ── Public API ─────────────────────────────────────────────────
@@ -145,28 +151,30 @@ class TrajectoryEmitter:
     ) -> bool:
         """Build + validate + persist a canonical event.
 
-        Returns ``True`` on a fresh emit, ``False`` on duplicate or
-        validation / IO failure. The runner treats the boolean as
-        diagnostic — emit is a side channel.
+        Returns ``True`` on a successful emit, ``False`` on validation
+        / IO failure. The runner treats the boolean as diagnostic —
+        emit is a side channel and never blocks.
 
-        Idempotency is keyed on ``(run_id, step.step_index)``; a
-        second call with the same index is a silent no-op so handlers
-        that retry / replan / demote a step don't double-record.
+        Per-attempt semantics: each call appends a fresh record with
+        an incremented ``attempt_index`` for that ``step_index``. A
+        step that fails → retries → succeeds produces two records
+        (attempt 0 = fail, attempt 1 = ok); readers reconstruct the
+        final outcome by taking the highest attempt per
+        ``(run_id, step_index)``.
 
         ``screenshot_ref`` defaults to a synthetic
-        ``step_<index>_<run_id>`` placeholder when the caller doesn't
-        have a real reference. The placeholder is short + non-base64,
-        so the validator accepts it; the placeholder makes the JSONL
-        self-contained pending the #479 grounding-trace integration
-        that will plumb real screenshot refs.
+        ``placeholder://<run_id>/step_<index>.png`` value when the
+        caller doesn't have a real reference. The placeholder is
+        short + non-base64 so the validator accepts it; the JSONL
+        stays self-contained pending the #479 grounding-trace
+        integration that will plumb real screenshot refs.
         """
         step_index = int(getattr(result, "step_index", -1))
-        if step_index in self._emitted_indices:
-            return False
+        attempt_index = self._attempt_counts.get(step_index, 0)
 
         try:
             event = self._build_event(
-                step, result,
+                step, result, attempt_index,
                 action=action, dispatched=dispatched,
                 dispatch_error=dispatch_error,
                 grounding_trace=grounding_trace,
@@ -177,14 +185,14 @@ class TrajectoryEmitter:
             validate_trajectory_event(event)
         except ContractValidationError as exc:
             logger.warning(
-                "trajectory emit step %d: validation failed: %s",
-                step_index, exc,
+                "trajectory emit step %d attempt %d: validation failed: %s",
+                step_index, attempt_index, exc,
             )
             return False
         except Exception as exc:  # noqa: BLE001 — never break a run
             logger.warning(
-                "trajectory emit step %d: build raised: %s",
-                step_index, exc,
+                "trajectory emit step %d attempt %d: build raised: %s",
+                step_index, attempt_index, exc,
             )
             return False
 
@@ -192,12 +200,12 @@ class TrajectoryEmitter:
             self._append(event)
         except OSError as exc:
             logger.warning(
-                "trajectory emit step %d: append failed (%s): %s",
-                step_index, self._jsonl_path, exc,
+                "trajectory emit step %d attempt %d: append failed (%s): %s",
+                step_index, attempt_index, self._jsonl_path, exc,
             )
             return False
 
-        self._emitted_indices.add(step_index)
+        self._attempt_counts[step_index] = attempt_index + 1
         return True
 
     @property
@@ -208,9 +216,14 @@ class TrajectoryEmitter:
 
     def emitted_indices(self) -> set[int]:
         """Snapshot of step indices already persisted for this run.
-        Useful for assertions in tests + for the runner to skip
-        re-emitting on resume."""
-        return set(self._emitted_indices)
+        Useful for assertions in tests + for the runner to know
+        which steps have been recorded at least once."""
+        return set(self._attempt_counts)
+
+    def attempt_count(self, step_index: int) -> int:
+        """How many attempts have been emitted for ``step_index``.
+        Includes attempts loaded from the existing JSONL on init."""
+        return self._attempt_counts.get(step_index, 0)
 
     # ── Internal helpers ───────────────────────────────────────────
 
@@ -218,6 +231,7 @@ class TrajectoryEmitter:
         self,
         step: "MicroIntent",
         result: "StepResult",
+        attempt_index: int,
         *,
         action: "Action | None",
         dispatched: bool,
@@ -270,6 +284,7 @@ class TrajectoryEmitter:
             schema_version=SCHEMA_VERSION,
             run_id=self.run_id,
             step_index=step_index,
+            attempt_index=attempt_index,
             step=step_from_micro_intent(step),
             observation=observation,
             action_result=action_result,
@@ -300,9 +315,14 @@ class TrajectoryEmitter:
             f.write(line + "\n")
 
     def _load_existing(self) -> None:
-        """Populate ``_emitted_indices`` from a prior run's JSONL.
+        """Populate ``_attempt_counts`` from a prior run's JSONL.
 
         Resume case (#478 acceptance: idempotent across restarts).
+        Counts the prior process's attempts per step_index so the
+        new process's emits continue numbering past them — readers
+        see one contiguous attempt sequence per step regardless of
+        how many process restarts produced it.
+
         A trailing partial line — possible if the writer crashed
         mid-flush — is tolerated: we read what JSON we can and ignore
         the rest. Subsequent emits will append clean records past
@@ -326,4 +346,6 @@ class TrajectoryEmitter:
                     break
                 idx = record.get("step_index")
                 if isinstance(idx, int) and idx >= 0:
-                    self._emitted_indices.add(idx)
+                    # Counting attempts here (not max+1) since the
+                    # next emit increments naturally from the count.
+                    self._attempt_counts[idx] = self._attempt_counts.get(idx, 0) + 1

--- a/src/mantis_agent/cua_contracts/types.py
+++ b/src/mantis_agent/cua_contracts/types.py
@@ -195,8 +195,12 @@ class TaskSpec:
 class TrajectoryEvent:
     """Canonical per-step event (#478).
 
-    Emitted exactly once per completed step, after the verdict is
-    recorded and before the cursor advances. The validator pins:
+    Emitted once per **attempt** (each StepResult the runner
+    produces) — including retries / recovery / demotion. Readers
+    reconstruct the "final outcome" for a step by taking the record
+    with the highest ``attempt_index`` per ``(run_id, step_index)``.
+
+    The validator pins:
 
     * non-zero ``schema_version`` + ``run_id`` + ``step_index`` —
       otherwise the event isn't addressable.
@@ -216,6 +220,12 @@ class TrajectoryEvent:
     schema_version: int = SCHEMA_VERSION
     run_id: str = ""
     step_index: int = -1
+    # 0 for the first attempt at this step_index; incremented per
+    # retry / recovery / demote re-emission. Readers take the record
+    # with the highest ``attempt_index`` per ``(run_id, step_index)``
+    # as the final outcome. Default 0 keeps the field additive-with-
+    # default so v1 consumers that don't know about it stay valid.
+    attempt_index: int = 0
     step: Step | None = None
     observation: Observation | None = None
     action_result: ActionResult | None = None

--- a/src/mantis_agent/cua_contracts/types.py
+++ b/src/mantis_agent/cua_contracts/types.py
@@ -1,0 +1,227 @@
+"""Versioned data types for the CUA trajectory contract (#476).
+
+The dataclasses in this module are the on-the-wire / on-disk shape of
+the canonical trajectory event stream. They are deliberately kept
+**provider-neutral** (no Anthropic / Holo3 / Modal specifics leak
+into a field name) and **independent of the runner internals** (no
+imports from :mod:`mantis_agent.gym`) so they can be loaded by
+downstream consumers — shadow router, model registry, eval — without
+pulling the full execution stack.
+
+Versioning rules:
+
+* Every persisted artifact carries ``schema_version`` and pins to
+  :data:`SCHEMA_VERSION`. A future bump means a writer change AND a
+  reader migration; the validator below enforces the pin.
+* Field additions are backward compatible as long as defaults are
+  supplied; field removals or rename require a schema bump.
+* ``Observation.screenshot_ref`` is a **string reference** (URI / path
+  / opaque content-addressed key), never a base64 blob. Inline blobs
+  would balloon the event size and break the "events are cheap to
+  emit, store, and replay" contract — the validator rejects them.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+
+SCHEMA_VERSION: int = 1
+"""Bump on incompatible changes. Keep an `add-only` field discipline
+between bumps — see module docstring."""
+
+
+class ReversibilityClass(str, Enum):
+    """Coarse risk class for a single action (#477 lives this fully).
+
+    The intended consumer is the step-safety preview gate (#481): an
+    irreversible action gets a cross-check screenshot pass before
+    dispatch; reversible ones don't.
+
+    The vocabulary is intentionally small. Mantis has historically
+    classified by step ``type``; the move to an action ontology will
+    refine this list (drag / file_upload / tab_open all need their
+    own class). For v1 we settle on three classes that capture the
+    decisions we actually make today.
+    """
+
+    READ_ONLY = "read_only"      # scroll, screenshot, extract — no side effects
+    REVERSIBLE = "reversible"    # click, type, key — can be undone by alt+Left / esc / backspace
+    IRREVERSIBLE = "irreversible"  # submit, send, buy, delete, confirm — no programmatic undo
+
+
+class VerdictKind(str, Enum):
+    """Outcome of post-action verification (#480).
+
+    Drives the runner's next action: ``ok`` → advance; ``recoverable``
+    → retry / replan; ``non_recoverable`` → terminate or rollback.
+    Always present on a TrajectoryEvent; the validator rejects events
+    with ``verdict=None``.
+    """
+
+    OK = "ok"
+    RECOVERABLE = "recoverable"
+    NON_RECOVERABLE = "non_recoverable"
+
+
+@dataclass(frozen=True)
+class Observation:
+    """A reference to the screenshot + minimal context the brain saw
+    before emitting an action.
+
+    Stored by reference (``screenshot_ref``) — never inline. The
+    reference can be:
+
+    * a relative path (``runs/abc/step_3.png``) on the host that owns
+      the artifact store;
+    * an s3:// URL (or any URI scheme the host understands);
+    * a content-addressed hash (``sha256:...``) for dedup-by-content
+      storage.
+
+    ``url`` and ``viewport`` are cheap to inline and immediately
+    useful for grepping events without round-tripping to storage,
+    so they ride alongside.
+    """
+
+    schema_version: int = SCHEMA_VERSION
+    screenshot_ref: str = ""
+    url: str = ""
+    viewport: tuple[int, int] = (0, 0)
+    captured_at: float = 0.0  # epoch seconds; 0 = unset
+
+
+@dataclass(frozen=True)
+class ActionResult:
+    """The action that was dispatched + the dispatcher's local outcome.
+
+    ``grounding_trace`` is the structured payload from :issue:`479`:
+    how the target was localized, model/prompt version, confidence,
+    selected dispatch strategy, confirmation evidence. v1 keeps it as
+    a free-form dict so the grounding side can iterate without a
+    schema bump; v2 will pin the shape.
+    """
+
+    schema_version: int = SCHEMA_VERSION
+    action_type: str = ""                       # canonical ontology name (#477)
+    params: dict[str, Any] = field(default_factory=dict)
+    grounding_trace: dict[str, Any] = field(default_factory=dict)
+    dispatched: bool = False                    # did the dispatcher commit the action?
+    dispatch_error: str = ""                    # empty when dispatched=True
+
+
+@dataclass(frozen=True)
+class Verdict:
+    """Typed post-action verifier verdict (#480).
+
+    A step does not advance the cursor until a Verdict is recorded.
+    ``reason`` is a short machine code (``no_state_change``,
+    ``wrong_target``, ``brain_loop_exhausted``, ``cf_challenge``,
+    ``unknown``, ...) — keep it grep-able. ``evidence`` is human-
+    readable prose suitable for surfacing in result.json.
+    """
+
+    schema_version: int = SCHEMA_VERSION
+    kind: VerdictKind = VerdictKind.OK
+    reason: str = ""
+    evidence: str = ""
+    confidence: float = 0.0
+
+
+@dataclass(frozen=True)
+class Step:
+    """One typed step in a Plan.
+
+    Maps onto today's :class:`~mantis_agent.plan_decomposer.MicroIntent`
+    via :func:`~.adapters.step_from_micro_intent`. The new fields
+    relative to MicroIntent are:
+
+    * ``action_type`` — the canonical ontology name (vs MicroIntent's
+      free-form ``type`` string).
+    * ``reversibility`` — explicit class, not inferred from ``type``.
+    * ``expected_outcome`` — what the verifier should check
+      (MicroIntent's ``verify`` field, renamed for clarity).
+    * ``confidence`` — planner's self-rated confidence; downstream
+      can route low-confidence steps through extra preview/verify
+      hops without re-asking the planner.
+    """
+
+    schema_version: int = SCHEMA_VERSION
+    intent: str = ""
+    action_type: str = ""
+    reversibility: ReversibilityClass = ReversibilityClass.REVERSIBLE
+    expected_outcome: str = ""
+    confidence: float = 0.0
+    params: dict[str, Any] = field(default_factory=dict)
+    hints: dict[str, Any] = field(default_factory=dict)
+    required: bool = False
+
+
+@dataclass(frozen=True)
+class Plan:
+    """Ordered list of typed Steps + the source plan text that produced it."""
+
+    schema_version: int = SCHEMA_VERSION
+    steps: tuple[Step, ...] = field(default_factory=tuple)
+    source_plan: str = ""
+    domain: str = ""
+
+
+@dataclass(frozen=True)
+class TaskSpec:
+    """Top-level task envelope. The input to a CUA run.
+
+    ``reversibility_policy`` is the **task-level** posture, not a
+    per-step class. Values:
+
+    * ``"prompt_on_irreversible"`` — pause + ask before any
+      :class:`ReversibilityClass.IRREVERSIBLE` step (the default for
+      production write-action tasks).
+    * ``"halt_on_irreversible"`` — refuse irreversible steps outright
+      (read-only research / scrape tasks).
+    * ``"auto"`` — dispatch without prompting (CI smoke tests, sim envs).
+    """
+
+    schema_version: int = SCHEMA_VERSION
+    task_id: str = ""
+    goal: str = ""
+    reversibility_policy: str = "prompt_on_irreversible"
+    constraints: dict[str, Any] = field(default_factory=dict)
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class TrajectoryEvent:
+    """Canonical per-step event (#478).
+
+    Emitted exactly once per completed step, after the verdict is
+    recorded and before the cursor advances. The validator pins:
+
+    * non-zero ``schema_version`` + ``run_id`` + ``step_index`` —
+      otherwise the event isn't addressable.
+    * an :class:`Observation` with a string reference (no inline
+      base64).
+    * an :class:`ActionResult` and :class:`Verdict` (not None).
+    * a ``versions`` dict — the slot where #487 / #488 model / prompt
+      / browser / sandbox stamps land. v1 doesn't pin its shape; it
+      just requires the key exists so consumers don't get None.
+
+    ``committed`` records the runner's decision to advance off this
+    step. Idempotent re-emits set ``committed=True`` only once per
+    (run_id, step_index) tuple — the dedup happens upstream in the
+    emit path (#478), not in the event itself.
+    """
+
+    schema_version: int = SCHEMA_VERSION
+    run_id: str = ""
+    step_index: int = -1
+    step: Step | None = None
+    observation: Observation | None = None
+    action_result: ActionResult | None = None
+    verdict: Verdict | None = None
+    versions: dict[str, str] = field(default_factory=dict)
+    latency_seconds: float = 0.0
+    cost_usd: float = 0.0
+    committed: bool = False
+    emitted_at: float = 0.0  # epoch seconds

--- a/src/mantis_agent/cua_contracts/validation.py
+++ b/src/mantis_agent/cua_contracts/validation.py
@@ -1,0 +1,172 @@
+"""Schema validators for CUA contracts (#476).
+
+Each validator raises :class:`ContractValidationError` on the first
+issue it finds. The validator surface is small on purpose — these
+checks run on the hot path (every event emit), so they must stay
+cheap. Anything that requires DOM / network / model access belongs
+in a separate layer.
+
+Validators reject the canonical failure modes the acceptance
+criteria call out:
+
+* missing or wrong-version ``schema_version``;
+* missing :class:`~.types.Verdict` on a :class:`~.types.TrajectoryEvent`;
+* inline observation blobs (``screenshot_ref`` that decodes as base64
+  rather than being a string reference);
+* missing ``run_id`` / unset ``step_index`` — without them the event
+  isn't deterministically addressable, which breaks idempotent emit.
+"""
+
+from __future__ import annotations
+
+from .types import (
+    ActionResult,
+    Observation,
+    SCHEMA_VERSION,
+    Step,
+    TaskSpec,
+    TrajectoryEvent,
+    Verdict,
+)
+
+
+# Heuristic that catches an inline base64 PNG masquerading as a
+# ``screenshot_ref``. A real reference is a path / URI / hash —
+# typically < 256 chars and contains a path separator or scheme.
+# Inline base64 PNGs are kilobytes and start with the standard PNG
+# magic when decoded. We don't decode here (cost on every emit); the
+# length cap + magic-prefix check is enough to keep honest callers
+# honest and to bounce callers who confused ``Observation`` with the
+# old screenshot-in-payload pattern.
+_INLINE_BLOB_LEN_THRESHOLD = 1024
+_INLINE_PNG_BASE64_PREFIX = "iVBORw0KGgo"  # base64-encoded "\x89PNG\r\n\x1a\n"
+
+
+class ContractValidationError(ValueError):
+    """Raised when a contract instance fails schema validation."""
+
+
+def _require_current_version(name: str, observed: int) -> None:
+    if observed != SCHEMA_VERSION:
+        raise ContractValidationError(
+            f"{name}: schema_version={observed!r} does not match "
+            f"current SCHEMA_VERSION={SCHEMA_VERSION}. A bump requires "
+            f"a coordinated writer+reader migration; this validator "
+            f"refuses to silently downgrade."
+        )
+
+
+def validate_task_spec(spec: TaskSpec) -> None:
+    """Reject TaskSpecs that can't drive a deterministic run."""
+    _require_current_version("TaskSpec", spec.schema_version)
+    if not spec.task_id:
+        raise ContractValidationError("TaskSpec.task_id is required")
+    if not spec.goal:
+        raise ContractValidationError("TaskSpec.goal is required")
+    allowed_policies = {"prompt_on_irreversible", "halt_on_irreversible", "auto"}
+    if spec.reversibility_policy not in allowed_policies:
+        raise ContractValidationError(
+            f"TaskSpec.reversibility_policy={spec.reversibility_policy!r}; "
+            f"must be one of {sorted(allowed_policies)}"
+        )
+
+
+def validate_step(step: Step) -> None:
+    """Reject Steps that lack the fields the dispatcher needs."""
+    _require_current_version("Step", step.schema_version)
+    if not step.intent:
+        raise ContractValidationError("Step.intent is required")
+    if not step.action_type:
+        raise ContractValidationError("Step.action_type is required")
+
+
+def validate_verdict(verdict: Verdict) -> None:
+    """Reject Verdicts missing the explanation a recoverable verdict
+    needs to drive the next runner decision."""
+    _require_current_version("Verdict", verdict.schema_version)
+    # OK verdicts can omit reason+evidence (happy path); failure verdicts
+    # must surface a reason so the recovery policy / IntentRewriter has
+    # something to key on. Pre-#480, demotions sometimes landed as
+    # ``data="...:no_state_change"`` with no structured field — drove
+    # the unknown-classification debt the failure_class taxonomy work
+    # has been chipping at.
+    if verdict.kind.value != "ok" and not verdict.reason:
+        raise ContractValidationError(
+            f"Verdict.reason is required when kind={verdict.kind.value}; "
+            f"recovery policy can't route without a code"
+        )
+
+
+def _looks_inlined(ref: str) -> bool:
+    """Heuristic: does ``screenshot_ref`` look like an inline base64 blob?"""
+    if len(ref) < _INLINE_BLOB_LEN_THRESHOLD:
+        return False
+    return ref.startswith(_INLINE_PNG_BASE64_PREFIX)
+
+
+def _validate_observation(obs: Observation) -> None:
+    _require_current_version("Observation", obs.schema_version)
+    if not obs.screenshot_ref:
+        raise ContractValidationError(
+            "Observation.screenshot_ref is required — events store "
+            "references, not blobs"
+        )
+    if _looks_inlined(obs.screenshot_ref):
+        raise ContractValidationError(
+            "Observation.screenshot_ref looks like an inline base64 PNG "
+            "blob; events must reference screenshots by path / URI / "
+            "content hash, not embed them"
+        )
+
+
+def _validate_action_result(result: ActionResult) -> None:
+    _require_current_version("ActionResult", result.schema_version)
+    if not result.action_type:
+        raise ContractValidationError("ActionResult.action_type is required")
+    if not result.dispatched and not result.dispatch_error:
+        raise ContractValidationError(
+            "ActionResult: when dispatched=False, dispatch_error must "
+            "carry the failure reason"
+        )
+
+
+def validate_trajectory_event(event: TrajectoryEvent) -> None:
+    """Reject TrajectoryEvents that can't be reconstructed / replayed.
+
+    Acceptance-criteria checks (per :issue:`476`):
+
+    * non-default ``schema_version`` matches ``SCHEMA_VERSION``;
+    * a deterministic addressable key — ``run_id`` + ``step_index >= 0``;
+    * an :class:`Observation` whose ``screenshot_ref`` is a string
+      reference (not an inline base64 blob);
+    * an :class:`ActionResult` and a :class:`Verdict` (neither None);
+    * a ``versions`` dict — slot for model / prompt / browser stamps
+      added by :issue:`488` (presence required, contents free-form in v1).
+    """
+    _require_current_version("TrajectoryEvent", event.schema_version)
+    if not event.run_id:
+        raise ContractValidationError("TrajectoryEvent.run_id is required")
+    if event.step_index < 0:
+        raise ContractValidationError(
+            f"TrajectoryEvent.step_index={event.step_index!r}; must be >= 0"
+        )
+    if event.step is None:
+        raise ContractValidationError("TrajectoryEvent.step is required")
+    validate_step(event.step)
+    if event.observation is None:
+        raise ContractValidationError("TrajectoryEvent.observation is required")
+    _validate_observation(event.observation)
+    if event.action_result is None:
+        raise ContractValidationError("TrajectoryEvent.action_result is required")
+    _validate_action_result(event.action_result)
+    if event.verdict is None:
+        raise ContractValidationError(
+            "TrajectoryEvent.verdict is required — runner must record "
+            "a verdict before emitting the event (#480)"
+        )
+    validate_verdict(event.verdict)
+    if not isinstance(event.versions, dict):
+        raise ContractValidationError(
+            "TrajectoryEvent.versions must be a dict (slot for model / "
+            "prompt / browser stamps — #488)"
+        )

--- a/src/mantis_agent/extraction/extractor.py
+++ b/src/mantis_agent/extraction/extractor.py
@@ -48,6 +48,22 @@ from .result import ExtractionResult
 from .schema import ExtractionSchema
 from .spam import contains_dealer_text, parse_bool, seller_looks_like_dealer
 
+# Default model for cheap binary verifier calls (verify_gate, StepVerifier).
+# Haiku 4.5 is roughly 10× cheaper per token than Opus 4.7 and well-
+# capable of "does the screenshot show X?" boolean judgements. Operators
+# can pin a stronger model per-deployment via ``MANTIS_VERIFY_MODEL``;
+# kept as an env override so a regression can be rolled back without a
+# code change. See #421.
+_VERIFY_MODEL = os.environ.get("MANTIS_VERIFY_MODEL", "claude-haiku-4-5-20251001")
+
+# Escalation model: re-asked once on Haiku ``passed=False`` to avoid
+# false-negative recovery loops (#421 §3). Recovery is the real cost
+# spike (re-navigate + re-extract + re-verify ≈ $0.50+) so a ~$0.003
+# escalation pays for itself many times over.
+_VERIFY_ESCALATION_MODEL = os.environ.get(
+    "MANTIS_VERIFY_ESCALATION_MODEL", "claude-opus-4-7",
+)
+
 logger = logging.getLogger(__name__)
 
 
@@ -204,6 +220,23 @@ class ClaudeExtractor:
             api_key=self.api_key,
             model=self.model,
             log_prefix="ClaudeExtractor",
+        )
+        # Verifier clients (#421). ``verify_gate`` is binary yes/no —
+        # well within Haiku 4.5's range and ~85% cheaper per call. The
+        # escalation client re-asks Opus once on a Haiku FAIL so we
+        # don't trigger expensive recovery loops on a Haiku false-
+        # negative. Both clients share the extractor's api_key and
+        # tag into a distinct time bucket so cost reports can show
+        # ``claude_verify_haiku`` vs ``claude_verify_opus_escalation``.
+        self._verify_client = AnthropicToolUseClient(
+            api_key=self.api_key,
+            model=_VERIFY_MODEL,
+            log_prefix="ClaudeVerifyHaiku",
+        )
+        self._verify_escalation_client = AnthropicToolUseClient(
+            api_key=self.api_key,
+            model=_VERIFY_ESCALATION_MODEL,
+            log_prefix="ClaudeVerifyOpus",
         )
 
     # ── Dynamic prompt generation from schema ─────────────────────
@@ -890,6 +923,29 @@ class ClaudeExtractor:
             _bucket="claude_verify",
         )
 
+    # Stable across all verify_gate calls — split out so prompt caching
+    # (the ``cache_tools=True`` path) actually amortises across a run.
+    # Kept as ClassVar so the Anthropic prompt-cache breakpoint hashes
+    # the same string every call.
+    _VERIFY_GATE_TOOL_DESCRIPTION: ClassVar[str] = (
+        "Report whether the gate condition holds based on what is "
+        "visible in the screenshot."
+    )
+    _VERIFY_GATE_INPUT_SCHEMA: ClassVar[dict[str, Any]] = {
+        "type": "object",
+        "properties": {
+            "passed": {
+                "type": "boolean",
+                "description": "True iff the condition holds.",
+            },
+            "reason": {
+                "type": "string",
+                "description": "What you see that confirms or denies the condition.",
+            },
+        },
+        "required": ["passed", "reason"],
+    }
+
     def verify_gate(self, screenshot: Image.Image, expected: str) -> tuple[bool, str]:
         """Verify a gate condition from a screenshot.
 
@@ -898,6 +954,24 @@ class ClaudeExtractor:
         boolean / string shape is server-validated; any failure mode
         falls through to ``(False, reason)`` so the runner halts on
         an unverified gate (safer than silently passing).
+
+        #421 routing:
+
+        - **Haiku 4.5 first.** The verify client (``_verify_client``)
+          defaults to Haiku — ~10× cheaper per call than Opus and
+          well-capable of binary "is X visible?" judgements. The tool
+          spec is cached (``cache_tools=True``) so the tool def +
+          schema is amortised across all gates in a run.
+        - **Opus escalation on FAIL.** If Haiku returns
+          ``passed=False`` we re-ask Opus once via
+          ``_verify_escalation_client``. The recovery loop a false-
+          negative would trigger costs ≥ $0.50; the escalation costs
+          ~$0.003 so the math is one-sided. If Opus also fails we
+          return that verdict; if Opus passes we trust Opus and emit
+          a WARNING so the disagreement is visible in Modal logs.
+        - **Opus error keeps Haiku verdict.** If the escalation call
+          errors out (None) we fall back to the Haiku verdict rather
+          than hide the original failure behind a None.
         """
         prompt = (
             f"Look at this screenshot ({screenshot.width}x{screenshot.height} pixels).\n\n"
@@ -905,29 +979,14 @@ class ClaudeExtractor:
             f"Look at the page heading, URL bar, result count, and any active filter tags."
         )
 
-        parsed = self._call_with_tool_schema(
+        parsed = self._verify_client.call_with_tool_schema(
             screenshot,
             prompt,
             tool_name="report_gate_verification",
-            tool_description=(
-                "Report whether the gate condition holds based on what is "
-                "visible in the screenshot."
-            ),
-            input_schema={
-                "type": "object",
-                "properties": {
-                    "passed": {
-                        "type": "boolean",
-                        "description": "True iff the condition holds.",
-                    },
-                    "reason": {
-                        "type": "string",
-                        "description": "What you see that confirms or denies the condition.",
-                    },
-                },
-                "required": ["passed", "reason"],
-            },
-            _bucket="claude_verify",
+            tool_description=self._VERIFY_GATE_TOOL_DESCRIPTION,
+            input_schema=self._VERIFY_GATE_INPUT_SCHEMA,
+            time_bucket="claude_verify_haiku",
+            cache_tools=True,
         )
 
         if not parsed:
@@ -935,6 +994,34 @@ class ClaudeExtractor:
 
         passed = bool(parsed.get("passed", False))
         reason = str(parsed.get("reason", ""))
+
+        if not passed:
+            escalated = self._verify_escalation_client.call_with_tool_schema(
+                screenshot,
+                prompt,
+                tool_name="report_gate_verification",
+                tool_description=self._VERIFY_GATE_TOOL_DESCRIPTION,
+                input_schema=self._VERIFY_GATE_INPUT_SCHEMA,
+                time_bucket="claude_verify_opus_escalation",
+                cache_tools=True,
+            )
+            if escalated is not None:
+                escalated_passed = bool(escalated.get("passed", False))
+                escalated_reason = str(escalated.get("reason", ""))
+                if escalated_passed:
+                    # WARNING (not INFO) so the disagreement survives
+                    # Modal's INFO-suppressed log capture — see
+                    # feedback_modal_info_log_suppression. Operators
+                    # auditing whether Haiku-default is regressing
+                    # accuracy can grep production logs for this.
+                    logger.warning(
+                        "  [gate] escalation HAIKU_FAIL → OPUS_PASS: "
+                        "haiku=%r opus=%r",
+                        reason[:80], escalated_reason[:80],
+                    )
+                passed = escalated_passed
+                reason = escalated_reason
+
         logger.info(f"  [gate] {'PASS' if passed else 'FAIL'}: {reason[:80]}")
         return passed, reason
 

--- a/src/mantis_agent/gym/checkpoint.py
+++ b/src/mantis_agent/gym/checkpoint.py
@@ -65,6 +65,17 @@ class StepResult:
     screenshot_png: bytes | None = field(default=None, repr=False, compare=False)
     last_action: Action | None = field(default=None, repr=False, compare=False)
 
+    # #419 audit-triple: the brain's articulated reasoning ("thinking" /
+    # extended-thinking blocks) that produced THIS step's action. Stamped
+    # by handlers that drive a brain (Holo3StepHandler pulls from the
+    # trajectory's final ``thinking`` field); handlers that don't run a
+    # brain (deterministic navigate / paginate / form fill / gate) leave
+    # it empty. Surfaced on every step in ``result.json`` so post-mortems
+    # see the *chain* of thought, not just the last step's. Deliberately
+    # not persisted in the checkpoint (resume doesn't need it) and not
+    # used in equality (so dataclass-replace round-trips ignore it).
+    reasoning: str = field(default="", repr=False, compare=False)
+
     # #300 follow-up: which dispatch path executed the *primary* click /
     # input action for this step. ``"som"`` = CDP-anchored
     # :meth:`~.xdotool_env.XdotoolGymEnv.cdp_click_at_point` (Set-of-Mark

--- a/src/mantis_agent/gym/result_payload.py
+++ b/src/mantis_agent/gym/result_payload.py
@@ -57,6 +57,15 @@ def pack_step(r: Any, *, time_breakdown: dict[str, float] | None = None) -> dict
     if time_breakdown is not None:
         payload["time_breakdown"] = {k: round(v, 3) for k, v in time_breakdown.items()}
 
+    # #419: brain reasoning lands on EVERY step (not just failures) so
+    # the audit triple — reasoning / predicted / observed — is complete
+    # for post-mortem and SFT pipelines. Handlers that don't drive a
+    # brain leave ``reasoning`` empty; the key is omitted in that case
+    # to keep the success-step payload slim.
+    reasoning = _as_str(getattr(r, "reasoning", ""))
+    if reasoning:
+        payload["reasoning"] = reasoning
+
     if payload["success"]:
         return payload
 

--- a/src/mantis_agent/gym/run_executor.py
+++ b/src/mantis_agent/gym/run_executor.py
@@ -36,6 +36,7 @@ so the back-reference can collapse.
 from __future__ import annotations
 
 import logging
+import os
 import time
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
@@ -467,6 +468,18 @@ class RunExecutor:
         runner._log_progress(step_result, state.results)
         runner._log_step_diff(pre_snapshot, effective_step, step_result)
         _emit_action_metric(runner, effective_step, step_result)
+        # #478: append a canonical TrajectoryEvent to the per-run
+        # JSONL store (one-line side channel; failure here never
+        # blocks the run). Gated by ``MANTIS_CANONICAL_EVENTS_DIR``
+        # so production paths can roll out the writer first, then
+        # downstream consumers, then flip the env var without a
+        # redeploy. Emit happens AFTER the post-step bookkeeping
+        # finishes (verdict materialised, classification stamped)
+        # and BEFORE any retry / recovery branch that would
+        # construct a second StepResult for the same logical step —
+        # the emitter is idempotent on step_index but the first emit
+        # is the truthful one.
+        _emit_canonical_trajectory_event(runner, effective_step, step_result)
         if not step_result.success:
             runner._dump_debug_screenshot(
                 f"step{state.step_index}_post_{effective_step.type}",
@@ -1416,6 +1429,62 @@ def _stamp_failure_context(step_result: StepResult, env: Any) -> None:
 
 
 # ── #156 per-action observability ──────────────────────────────────────
+
+
+_CANONICAL_EVENTS_DIR_ENV: str = "MANTIS_CANONICAL_EVENTS_DIR"
+
+
+def _emit_canonical_trajectory_event(
+    runner: Any, step: MicroIntent, step_result: StepResult,
+) -> None:
+    """Append one validated :class:`TrajectoryEvent` per step (#478).
+
+    Side channel — never raises, never blocks the runner. Gated by
+    the ``MANTIS_CANONICAL_EVENTS_DIR`` env var so the writer can be
+    rolled out independently of any reader.
+
+    The per-run :class:`TrajectoryEmitter` is created lazily on first
+    call and stashed on the runner; subsequent steps reuse it (one
+    file handle's worth of overhead per step). Idempotency is owned
+    by the emitter — calling this helper twice on the same
+    ``(run_id, step_index)`` is a silent no-op, which lines up with
+    the retry / recovery / demote paths that can run this code more
+    than once per logical step.
+
+    ``run_id`` resolution honours the same shape the existing
+    result-payload writer expects: prefer ``runner.run_id`` (set by
+    the API path), fall back to ``runner._run_id`` (legacy), then a
+    deterministic placeholder so the emitter doesn't raise on a
+    no-id local script.
+    """
+    store_dir = os.environ.get(_CANONICAL_EVENTS_DIR_ENV, "").strip()
+    if not store_dir:
+        return
+    emitter = getattr(runner, "_trajectory_emitter", None)
+    if emitter is None:
+        run_id = (
+            str(getattr(runner, "run_id", "") or "")
+            or str(getattr(runner, "_run_id", "") or "")
+            or "local_run"
+        )
+        try:
+            from ..cua_contracts import TrajectoryEmitter
+            emitter = TrajectoryEmitter(
+                run_id=run_id,
+                store_dir=store_dir,
+                versions=dict(getattr(runner, "_canonical_event_versions", {}) or {}),
+            )
+        except Exception as exc:  # noqa: BLE001 — never break a run
+            logger.debug("canonical event emitter init failed: %s", exc)
+            runner._trajectory_emitter = False  # type: ignore[attr-defined]
+            return
+        runner._trajectory_emitter = emitter  # type: ignore[attr-defined]
+    if emitter is False:
+        return
+    try:
+        emitter.emit(step, step_result)
+    except Exception as exc:  # noqa: BLE001 — never break a run
+        logger.debug("canonical event emit raised: %s", exc)
 
 
 def _emit_action_metric(

--- a/src/mantis_agent/gym/run_executor.py
+++ b/src/mantis_agent/gym/run_executor.py
@@ -1462,9 +1462,22 @@ def _emit_canonical_trajectory_event(
         return
     emitter = getattr(runner, "_trajectory_emitter", None)
     if emitter is None:
+        # Resolution order:
+        #  1. ``runner.run_id``       — explicit API path
+        #  2. ``runner._run_id``      — legacy/private alias
+        #  3. ``runner.run_key``      — MicroPlanRunner's primary
+        #     identifier (workflow_id or session_name, set by every
+        #     in-process construction in cli.py / modal_cua_server.py /
+        #     baseten runtime / graph learner). This is the right
+        #     fallback for the Modal holo3 path — its outer
+        #     ``run_id`` is only available inside the function scope,
+        #     not on the runner instance.
+        #  4. "local_run"             — last-resort placeholder so the
+        #     emitter constructor doesn't refuse a no-id local script.
         run_id = (
             str(getattr(runner, "run_id", "") or "")
             or str(getattr(runner, "_run_id", "") or "")
+            or str(getattr(runner, "run_key", "") or "")
             or "local_run"
         )
         # ``base_dir`` is the *root* across all runs; the per-run

--- a/src/mantis_agent/gym/run_executor.py
+++ b/src/mantis_agent/gym/run_executor.py
@@ -1457,8 +1457,8 @@ def _emit_canonical_trajectory_event(
     deterministic placeholder so the emitter doesn't raise on a
     no-id local script.
     """
-    store_dir = os.environ.get(_CANONICAL_EVENTS_DIR_ENV, "").strip()
-    if not store_dir:
+    base_dir = os.environ.get(_CANONICAL_EVENTS_DIR_ENV, "").strip()
+    if not base_dir:
         return
     emitter = getattr(runner, "_trajectory_emitter", None)
     if emitter is None:
@@ -1467,6 +1467,11 @@ def _emit_canonical_trajectory_event(
             or str(getattr(runner, "_run_id", "") or "")
             or "local_run"
         )
+        # ``base_dir`` is the *root* across all runs; the per-run
+        # JSONL store lives under ``<base_dir>/<run_id>/`` so events
+        # from concurrent runs don't collide in a single file and a
+        # later reader can address one run by directory listing.
+        store_dir = os.path.join(base_dir, run_id)
         try:
             from ..cua_contracts import TrajectoryEmitter
             emitter = TrajectoryEmitter(

--- a/src/mantis_agent/gym/step_handlers/holo3.py
+++ b/src/mantis_agent/gym/step_handlers/holo3.py
@@ -248,6 +248,18 @@ class Holo3StepHandler:
         failure_class = ""
         if not success and result.termination_reason in ("max_steps", "loop"):
             failure_class = "brain_loop_exhausted"
+        # #419 audit-triple: surface the brain's articulated reasoning
+        # for the action that drove this StepResult. The inner GymRunner
+        # ran some number of think→act iterations; the FINAL trajectory
+        # step's thinking is what produced the committed action — that's
+        # the reasoning that matters for post-mortem triage. Earlier
+        # iterations are visible per-step in the inner trajectory dump.
+        # Empty string when the trajectory is empty (paused immediately,
+        # no brain inference happened) so pack_step's truthiness check
+        # cleanly omits the field.
+        reasoning = ""
+        if result.trajectory:
+            reasoning = result.trajectory[-1].thinking or ""
         return StepResult(
             step_index=index,
             intent=step.intent,
@@ -255,4 +267,5 @@ class Holo3StepHandler:
             steps_used=result.total_steps,
             duration=result.total_time,
             failure_class=failure_class,
+            reasoning=reasoning,
         )

--- a/src/mantis_agent/gym/time_meter.py
+++ b/src/mantis_agent/gym/time_meter.py
@@ -46,7 +46,12 @@ BUCKETS: tuple[str, ...] = (
     "settle",         # post-action wait (fixed or adaptive)
     "claude_ground",  # ClaudeGrounding.refine_click(...) coordinate refinement
     "claude_extract", # ClaudeExtractor.find_* — extraction calls
-    "claude_verify",  # gate verification, DynamicPlanVerifier checks
+    "claude_verify",  # legacy verifier path — multi-screenshot click verification
+    # #421 split: ``verify_gate`` defaults to Haiku 4.5 and escalates
+    # to Opus on FAIL. Tracking the two as separate buckets lets cost
+    # reports show the actual savings + escalation hit-rate per run.
+    "claude_verify_haiku",            # gate verification (cheap default)
+    "claude_verify_opus_escalation",  # gate re-ask after Haiku FAIL
     "load",           # env.reset(url) page-load + Cloudflare wait + proxy CONNECT
     "overhead",       # residual: runner orchestration, dispatch, Python (computed lazily)
 )

--- a/src/mantis_agent/gym/trace_exporter.py
+++ b/src/mantis_agent/gym/trace_exporter.py
@@ -94,6 +94,10 @@ def _step_to_dict(step: StepResult) -> dict[str, Any]:
         "last_action": _action_to_dict(step.last_action),
         "predicted_outcome": getattr(step, "predicted_outcome", "") or "",
         "observed_outcome": getattr(step, "observed_outcome", "") or "",
+        # #419: brain's articulated reasoning for the action that drove
+        # this step. Empty for handlers that don't run a brain
+        # (deterministic navigate / paginate / form fill / gate).
+        "reasoning": getattr(step, "reasoning", "") or "",
     }
 
 

--- a/src/mantis_agent/verification/step_verifier.py
+++ b/src/mantis_agent/verification/step_verifier.py
@@ -98,16 +98,23 @@ Output ONLY valid JSON:
 """
 
 
+_DEFAULT_VERIFY_MODEL = os.environ.get(
+    "MANTIS_VERIFY_MODEL", "claude-haiku-4-5-20251001",
+)
+
+
 class StepVerifier:
     """Verifies CUA step outcomes using before/after screenshots.
 
-    Uses Claude Sonnet API — same pattern as ClaudeGrounding.
-    Cheap (~$0.003/call), fast, vision-capable.
+    Uses Claude Haiku 4.5 by default — same pattern as ClaudeGrounding
+    but on a cheaper verifier-grade model. Cheap (~$0.0003/call), fast,
+    vision-capable. Operators that want the heavier model can pin it
+    via ``MANTIS_VERIFY_MODEL`` (#421).
     """
 
-    def __init__(self, api_key: str = "", model: str = "claude-opus-4-7"):
+    def __init__(self, api_key: str = "", model: str = ""):
         self.api_key = api_key or os.environ.get("ANTHROPIC_API_KEY", "")
-        self.model = model
+        self.model = model or _DEFAULT_VERIFY_MODEL
 
     def _call_claude(self, messages_content: list, max_tokens: int = 200) -> str:
         """Call Claude API with vision content. Returns response text."""

--- a/tests/test_cua_contracts.py
+++ b/tests/test_cua_contracts.py
@@ -1,0 +1,345 @@
+"""Tests for the versioned CUA contracts (#476).
+
+Covers:
+
+* validator acceptance / rejection for TaskSpec, Step, Verdict, and
+  TrajectoryEvent (the four types the acceptance criteria call out);
+* the inline-blob rejection guard on Observation;
+* the legacy-MicroIntent → Step adapter — field projection +
+  reversibility classification;
+* the legacy-Action → ActionResult adapter — including the
+  ``action=None`` deterministic-handler case.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mantis_agent.actions import Action, ActionType
+from mantis_agent.cua_contracts import (
+    ActionResult,
+    ContractValidationError,
+    Observation,
+    ReversibilityClass,
+    SCHEMA_VERSION,
+    Step,
+    TaskSpec,
+    TrajectoryEvent,
+    Verdict,
+    VerdictKind,
+    action_result_from_action,
+    classify_legacy_reversibility,
+    observation_from_screenshot_ref,
+    step_from_micro_intent,
+    validate_step,
+    validate_task_spec,
+    validate_trajectory_event,
+    validate_verdict,
+)
+from mantis_agent.plan_decomposer import MicroIntent
+
+
+# ── Constants pinning ──────────────────────────────────────────────────
+
+
+def test_schema_version_pinned_at_one() -> None:
+    """The on-the-wire schema is v1. A bump is a coordinated reader/
+    writer migration — pinned here so a stealth increment fails CI."""
+    assert SCHEMA_VERSION == 1
+
+
+# ── TaskSpec validation ────────────────────────────────────────────────
+
+
+def _valid_task_spec(**overrides) -> TaskSpec:
+    base = {
+        "schema_version": SCHEMA_VERSION,
+        "task_id": "t_123",
+        "goal": "Extract the top 10 listings",
+        "reversibility_policy": "prompt_on_irreversible",
+    }
+    base.update(overrides)
+    return TaskSpec(**base)
+
+
+def test_valid_task_spec_validates() -> None:
+    validate_task_spec(_valid_task_spec())
+
+
+def test_task_spec_missing_task_id_rejected() -> None:
+    with pytest.raises(ContractValidationError, match="task_id"):
+        validate_task_spec(_valid_task_spec(task_id=""))
+
+
+def test_task_spec_missing_goal_rejected() -> None:
+    with pytest.raises(ContractValidationError, match="goal"):
+        validate_task_spec(_valid_task_spec(goal=""))
+
+
+def test_task_spec_unknown_reversibility_policy_rejected() -> None:
+    with pytest.raises(ContractValidationError, match="reversibility_policy"):
+        validate_task_spec(_valid_task_spec(reversibility_policy="yolo"))
+
+
+def test_task_spec_schema_version_mismatch_rejected() -> None:
+    """An old writer producing v0 events must NOT be silently upgraded —
+    the reader has to opt in to a migration explicitly."""
+    with pytest.raises(ContractValidationError, match="schema_version"):
+        validate_task_spec(_valid_task_spec(schema_version=0))
+
+
+# ── Step validation ────────────────────────────────────────────────────
+
+
+def _valid_step(**overrides) -> Step:
+    base = {
+        "intent": "Click Sign Up",
+        "action_type": "click",
+        "reversibility": ReversibilityClass.REVERSIBLE,
+    }
+    base.update(overrides)
+    return Step(**base)
+
+
+def test_valid_step_validates() -> None:
+    validate_step(_valid_step())
+
+
+def test_step_missing_intent_rejected() -> None:
+    with pytest.raises(ContractValidationError, match="intent"):
+        validate_step(_valid_step(intent=""))
+
+
+def test_step_missing_action_type_rejected() -> None:
+    with pytest.raises(ContractValidationError, match="action_type"):
+        validate_step(_valid_step(action_type=""))
+
+
+# ── Verdict validation ────────────────────────────────────────────────
+
+
+def test_ok_verdict_can_omit_reason() -> None:
+    """Happy-path verdicts don't carry a recovery code — that's the
+    point of the typed kind enum."""
+    validate_verdict(Verdict(kind=VerdictKind.OK))
+
+
+def test_failure_verdict_requires_reason() -> None:
+    """Pre-#480 demotions sometimes shipped without a reason — the
+    recovery policy then routed to ``unknown``, which the
+    IntentRewriter and critic can't do anything with."""
+    with pytest.raises(ContractValidationError, match="Verdict.reason"):
+        validate_verdict(Verdict(kind=VerdictKind.RECOVERABLE, reason=""))
+
+
+def test_non_recoverable_verdict_requires_reason() -> None:
+    with pytest.raises(ContractValidationError, match="Verdict.reason"):
+        validate_verdict(Verdict(kind=VerdictKind.NON_RECOVERABLE, reason=""))
+
+
+# ── TrajectoryEvent validation ────────────────────────────────────────
+
+
+def _valid_event(**overrides) -> TrajectoryEvent:
+    base = {
+        "run_id": "run_abc",
+        "step_index": 0,
+        "step": _valid_step(),
+        "observation": observation_from_screenshot_ref(
+            "runs/run_abc/step_0.png", url="https://example.com",
+        ),
+        "action_result": ActionResult(
+            action_type="click", params={"x": 1, "y": 2}, dispatched=True,
+        ),
+        "verdict": Verdict(kind=VerdictKind.OK),
+        "versions": {"planner": "claude-opus-4-7"},
+    }
+    base.update(overrides)
+    return TrajectoryEvent(**base)
+
+
+def test_valid_trajectory_event_validates() -> None:
+    validate_trajectory_event(_valid_event())
+
+
+def test_trajectory_event_missing_run_id_rejected() -> None:
+    with pytest.raises(ContractValidationError, match="run_id"):
+        validate_trajectory_event(_valid_event(run_id=""))
+
+
+def test_trajectory_event_negative_step_index_rejected() -> None:
+    """``step_index=-1`` is the dataclass default — without an explicit
+    value the event isn't deterministically addressable."""
+    with pytest.raises(ContractValidationError, match="step_index"):
+        validate_trajectory_event(_valid_event(step_index=-1))
+
+
+def test_trajectory_event_missing_verdict_rejected() -> None:
+    """The acceptance criterion: events emit only AFTER the verdict
+    lands. ``verdict=None`` means the runner advanced before
+    verifying — that's the bug #480 closes structurally."""
+    with pytest.raises(ContractValidationError, match="verdict is required"):
+        validate_trajectory_event(_valid_event(verdict=None))
+
+
+def test_trajectory_event_missing_action_result_rejected() -> None:
+    with pytest.raises(ContractValidationError, match="action_result"):
+        validate_trajectory_event(_valid_event(action_result=None))
+
+
+def test_trajectory_event_missing_observation_rejected() -> None:
+    with pytest.raises(ContractValidationError, match="observation"):
+        validate_trajectory_event(_valid_event(observation=None))
+
+
+def test_trajectory_event_missing_versions_dict_rejected() -> None:
+    """``versions`` is the slot for #487 / #488 model + prompt stamps.
+    The dict must exist even when empty so consumers don't crash on
+    None."""
+    with pytest.raises(ContractValidationError, match="versions"):
+        validate_trajectory_event(_valid_event(versions=None))  # type: ignore[arg-type]
+
+
+def test_trajectory_event_empty_versions_dict_accepted() -> None:
+    """Empty versions dict is fine in v1 — the shape isn't pinned until
+    the version-stamping work lands. Presence is what matters."""
+    validate_trajectory_event(_valid_event(versions={}))
+
+
+def test_observation_inline_base64_blob_rejected() -> None:
+    """``Observation.screenshot_ref`` must be a reference. A large
+    string starting with the standard PNG-base64 prefix is the
+    canonical mistake the validator catches."""
+    blob = "iVBORw0KGgo" + ("A" * 2000)
+    obs = Observation(schema_version=SCHEMA_VERSION, screenshot_ref=blob)
+    with pytest.raises(ContractValidationError, match="inline base64"):
+        validate_trajectory_event(_valid_event(observation=obs))
+
+
+def test_observation_missing_screenshot_ref_rejected() -> None:
+    obs = Observation(schema_version=SCHEMA_VERSION, screenshot_ref="")
+    with pytest.raises(ContractValidationError, match="screenshot_ref"):
+        validate_trajectory_event(_valid_event(observation=obs))
+
+
+def test_action_result_missing_action_type_rejected() -> None:
+    """Empty action_type is allowed on the adapter for deterministic
+    handlers, but the validator catches it on the way to persistence —
+    by then the runner has had a chance to fill it in (or to mark
+    dispatched=False with a dispatch_error)."""
+    ar = ActionResult(action_type="", dispatched=True)
+    with pytest.raises(ContractValidationError, match="action_type"):
+        validate_trajectory_event(_valid_event(action_result=ar))
+
+
+def test_action_result_undispatched_without_error_rejected() -> None:
+    """``dispatched=False`` + ``dispatch_error=""`` means "nothing
+    happened and nobody knows why" — useless to record."""
+    ar = ActionResult(action_type="click", dispatched=False, dispatch_error="")
+    with pytest.raises(ContractValidationError, match="dispatch_error"):
+        validate_trajectory_event(_valid_event(action_result=ar))
+
+
+# ── MicroIntent → Step adapter ────────────────────────────────────────
+
+
+def test_step_from_micro_intent_projects_all_relevant_fields() -> None:
+    mi = MicroIntent(
+        intent="Click the Sign Up button",
+        type="submit",
+        verify="URL contains /signup-success",
+        budget=8,
+        required=True,
+        params={"label": "Sign Up", "aliases": ["Register"]},
+        hints={"region": "header"},
+    )
+    step = step_from_micro_intent(mi)
+    assert step.intent == "Click the Sign Up button"
+    assert step.action_type == "submit"
+    assert step.expected_outcome == "URL contains /signup-success"
+    assert step.required is True
+    assert step.params == {"label": "Sign Up", "aliases": ["Register"]}
+    assert step.hints == {"region": "header"}
+    # ``submit`` is irreversible.
+    assert step.reversibility == ReversibilityClass.IRREVERSIBLE
+    # Planner doesn't emit confidence today — adapter defaults to 0.
+    assert step.confidence == 0.0
+
+
+def test_step_adapter_treats_unknown_type_as_reversible_for_safety() -> None:
+    """Fail-safe: an unrecognised step type goes through the preview
+    gate (REVERSIBLE) rather than skipping it (IRREVERSIBLE would
+    over-trigger; READ_ONLY would skip the gate)."""
+    mi = MicroIntent(intent="poke at the iframe", type="poke")
+    step = step_from_micro_intent(mi)
+    assert step.reversibility == ReversibilityClass.REVERSIBLE
+
+
+@pytest.mark.parametrize(
+    "step_type,expected",
+    [
+        ("scroll", ReversibilityClass.READ_ONLY),
+        ("extract_data", ReversibilityClass.READ_ONLY),
+        ("extract_url", ReversibilityClass.READ_ONLY),
+        ("click", ReversibilityClass.REVERSIBLE),
+        ("navigate", ReversibilityClass.REVERSIBLE),
+        ("fill_field", ReversibilityClass.REVERSIBLE),
+        ("select_option", ReversibilityClass.REVERSIBLE),
+        ("submit", ReversibilityClass.IRREVERSIBLE),
+    ],
+)
+def test_classify_legacy_reversibility_covers_canonical_types(
+    step_type: str, expected: ReversibilityClass,
+) -> None:
+    """Pin the reversibility map for the canonical legacy step types
+    — a stealth change to the map alters which steps get the preview
+    gate, which is a safety-relevant decision."""
+    assert classify_legacy_reversibility(step_type) is expected
+
+
+# ── Action → ActionResult adapter ─────────────────────────────────────
+
+
+def test_action_result_from_action_carries_type_and_params() -> None:
+    action = Action(
+        action_type=ActionType.CLICK,
+        params={"x": 100, "y": 200, "button": "left"},
+        reasoning="click sign up",
+    )
+    ar = action_result_from_action(action, dispatched=True)
+    assert ar.action_type == "click"
+    assert ar.params == {"x": 100, "y": 200, "button": "left"}
+    assert ar.dispatched is True
+    assert ar.dispatch_error == ""
+
+
+def test_action_result_from_action_records_dispatch_failure() -> None:
+    action = Action(action_type=ActionType.CLICK, params={"x": 0, "y": 0})
+    ar = action_result_from_action(
+        action, dispatched=False,
+        dispatch_error="elementFromPoint=BUTTON (refused)",
+    )
+    assert ar.dispatched is False
+    assert ar.dispatch_error == "elementFromPoint=BUTTON (refused)"
+
+
+def test_action_result_from_none_action_is_valid_for_deterministic_handlers() -> None:
+    """Deterministic handlers (navigate / paginate / gate) don't
+    synthesise an Action — the adapter accepts ``None`` so they can
+    still emit a canonical event. The result will fail validation if
+    nobody fills in ``action_type`` later, which is the right safety
+    default."""
+    ar = action_result_from_action(None, dispatched=True)
+    assert ar.action_type == ""
+    assert ar.dispatched is True
+
+
+def test_action_result_from_action_carries_grounding_trace() -> None:
+    """The grounding trace dict round-trips so #479's structured
+    payload can ride alongside the action without a second adapter."""
+    action = Action(action_type=ActionType.CLICK, params={"x": 1, "y": 2})
+    trace = {"provider": "claude", "confidence": 0.87, "selector": "som#42"}
+    ar = action_result_from_action(
+        action, dispatched=True, grounding_trace=trace,
+    )
+    assert ar.grounding_trace == trace

--- a/tests/test_cua_emit.py
+++ b/tests/test_cua_emit.py
@@ -290,7 +290,8 @@ def test_run_executor_hook_writes_when_env_set(
     monkeypatch, tmp_path: Path,
 ) -> None:
     """End-to-end through the run_executor helper: env var set →
-    emitter lazy-created → event lands on disk."""
+    emitter lazy-created → event lands on disk under the per-run
+    subdirectory (``<base_dir>/<run_id>/trajectory.jsonl``)."""
     from mantis_agent.gym.run_executor import _emit_canonical_trajectory_event
 
     monkeypatch.setenv("MANTIS_CANONICAL_EVENTS_DIR", str(tmp_path))
@@ -303,10 +304,33 @@ def test_run_executor_hook_writes_when_env_set(
     # Second step on the same runner reuses the emitter.
     _emit_canonical_trajectory_event(runner, _intent(), _ok_step_result(index=1))
 
-    jsonl = (tmp_path / JSONL_FILENAME).read_text(encoding="utf-8").splitlines()
+    run_dir = tmp_path / "wire_in_test"
+    jsonl = (run_dir / JSONL_FILENAME).read_text(encoding="utf-8").splitlines()
     assert len(jsonl) == 2
     indices = [json.loads(line)["step_index"] for line in jsonl]
     assert indices == [0, 1]
+
+
+def test_run_executor_hook_isolates_per_run_directories(
+    monkeypatch, tmp_path: Path,
+) -> None:
+    """Concurrent runs land under distinct ``<base_dir>/<run_id>/``
+    subdirs so the JSONL files never collide."""
+    from mantis_agent.gym.run_executor import _emit_canonical_trajectory_event
+
+    monkeypatch.setenv("MANTIS_CANONICAL_EVENTS_DIR", str(tmp_path))
+
+    class _RunnerA:
+        run_id = "run_a"
+
+    class _RunnerB:
+        run_id = "run_b"
+
+    _emit_canonical_trajectory_event(_RunnerA(), _intent(), _ok_step_result(index=0))
+    _emit_canonical_trajectory_event(_RunnerB(), _intent(), _ok_step_result(index=0))
+
+    assert (tmp_path / "run_a" / JSONL_FILENAME).exists()
+    assert (tmp_path / "run_b" / JSONL_FILENAME).exists()
 
 
 def test_run_executor_hook_idempotent_across_retry(
@@ -325,7 +349,7 @@ def test_run_executor_hook_idempotent_across_retry(
     _emit_canonical_trajectory_event(runner, _intent(), _ok_step_result(index=0))
     _emit_canonical_trajectory_event(runner, _intent(), _fail_step_result(index=0))
 
-    jsonl = (tmp_path / JSONL_FILENAME).read_text(encoding="utf-8").splitlines()
+    jsonl = (tmp_path / "retry_test" / JSONL_FILENAME).read_text(encoding="utf-8").splitlines()
     assert len(jsonl) == 1  # only the first emit landed
 
 
@@ -346,7 +370,7 @@ def test_run_executor_hook_falls_back_to_default_run_id(
     runner = _Runner()
     _emit_canonical_trajectory_event(runner, _intent(), _ok_step_result(index=0))
 
-    jsonl = (tmp_path / JSONL_FILENAME).read_text(encoding="utf-8").splitlines()
+    jsonl = (tmp_path / "local_run" / JSONL_FILENAME).read_text(encoding="utf-8").splitlines()
     assert len(jsonl) == 1
     record = json.loads(jsonl[0])
     assert record["run_id"] == "local_run"

--- a/tests/test_cua_emit.py
+++ b/tests/test_cua_emit.py
@@ -353,6 +353,33 @@ def test_run_executor_hook_idempotent_across_retry(
     assert len(jsonl) == 1  # only the first emit landed
 
 
+def test_run_executor_hook_uses_run_key_when_run_id_absent(
+    monkeypatch, tmp_path: Path,
+) -> None:
+    """MicroPlanRunner exposes ``run_key`` (workflow_id or session_name)
+    but not ``run_id``. The hook's resolution order falls through to
+    ``run_key`` so Modal holo3 runs land under a meaningful directory
+    instead of the ``local_run`` placeholder."""
+    from mantis_agent.gym.run_executor import _emit_canonical_trajectory_event
+
+    monkeypatch.setenv("MANTIS_CANONICAL_EVENTS_DIR", str(tmp_path))
+
+    class _MicroRunnerLike:
+        # No ``run_id`` / ``_run_id`` — the holo3 modal path only
+        # exposes ``run_key``.
+        run_key = "pr491-staffcrm-1234567890"
+
+    runner = _MicroRunnerLike()
+    _emit_canonical_trajectory_event(runner, _intent(), _ok_step_result(index=0))
+
+    jsonl = (
+        tmp_path / "pr491-staffcrm-1234567890" / JSONL_FILENAME
+    ).read_text(encoding="utf-8").splitlines()
+    assert len(jsonl) == 1
+    record = json.loads(jsonl[0])
+    assert record["run_id"] == "pr491-staffcrm-1234567890"
+
+
 def test_run_executor_hook_falls_back_to_default_run_id(
     monkeypatch, tmp_path: Path,
 ) -> None:

--- a/tests/test_cua_emit.py
+++ b/tests/test_cua_emit.py
@@ -122,44 +122,71 @@ def test_emit_writes_one_validated_jsonl_line(tmp_path: Path) -> None:
     assert record["committed"] is True
 
 
-def test_emit_idempotent_on_same_step_index(tmp_path: Path) -> None:
-    """Acceptance criterion: every completed step emits exactly one
-    canonical event, even across retries."""
+def test_emit_per_attempt_with_incremented_attempt_index(tmp_path: Path) -> None:
+    """Each emit() call for the same step_index appends a fresh
+    record with attempt_index = 0, 1, 2, ... Readers reconstruct the
+    final outcome by taking the highest attempt_index per step."""
     emitter = TrajectoryEmitter(run_id="r1", store_dir=str(tmp_path))
     intent = _intent()
-    r0 = _ok_step_result(index=0)
 
-    assert emitter.emit(intent, r0) is True
-    # Same key — must not append a second line.
-    assert emitter.emit(intent, r0) is False
-    # Different StepResult instance, same step_index — also a no-op.
-    r0_retry = _ok_step_result(index=0, data="rerun-evidence")
-    assert emitter.emit(intent, r0_retry) is False
-
-    lines = (tmp_path / JSONL_FILENAME).read_text(encoding="utf-8").splitlines()
-    assert len(lines) == 1
-
-
-def test_emit_resume_loads_existing_indices(tmp_path: Path) -> None:
-    """Acceptance criterion: idempotent across restarts. A new
-    emitter pointed at an existing JSONL must pick up the prior
-    indices and refuse to re-emit them."""
-    first = TrajectoryEmitter(run_id="r1", store_dir=str(tmp_path))
-    intent = _intent()
-    first.emit(intent, _ok_step_result(index=0))
-    first.emit(intent, _ok_step_result(index=1))
-    assert first.emitted_indices() == {0, 1}
-
-    # Simulate a process restart — fresh emitter, same store_dir.
-    resumed = TrajectoryEmitter(run_id="r1", store_dir=str(tmp_path))
-    assert resumed.emitted_indices() == {0, 1}
-    # Trying to re-emit index 0 is a no-op.
-    assert resumed.emit(intent, _ok_step_result(index=0)) is False
-    # Index 2 is fresh — appends normally.
-    assert resumed.emit(intent, _ok_step_result(index=2)) is True
+    # Three attempts at step 0: fail → fail → ok.
+    assert emitter.emit(intent, _fail_step_result(index=0, failure_class="selector_miss")) is True
+    assert emitter.emit(intent, _fail_step_result(index=0, failure_class="no_state_change")) is True
+    assert emitter.emit(intent, _ok_step_result(index=0)) is True
 
     lines = (tmp_path / JSONL_FILENAME).read_text(encoding="utf-8").splitlines()
     assert len(lines) == 3
+    records = [json.loads(line) for line in lines]
+    # Same step_index across all three; attempt_index counts up.
+    assert [r["step_index"] for r in records] == [0, 0, 0]
+    assert [r["attempt_index"] for r in records] == [0, 1, 2]
+    # Final verdict (highest attempt) is OK; the retry path is fully
+    # captured for post-mortem.
+    assert records[-1]["verdict"]["kind"] == "ok"
+    assert records[0]["verdict"]["reason"] == "selector_miss"
+    assert records[1]["verdict"]["reason"] == "no_state_change"
+
+
+def test_emit_attempt_count_exposed_for_each_step(tmp_path: Path) -> None:
+    emitter = TrajectoryEmitter(run_id="r1", store_dir=str(tmp_path))
+    assert emitter.attempt_count(0) == 0
+    emitter.emit(_intent(), _fail_step_result(index=0))
+    emitter.emit(_intent(), _ok_step_result(index=0))
+    emitter.emit(_intent(), _ok_step_result(index=1))
+    assert emitter.attempt_count(0) == 2
+    assert emitter.attempt_count(1) == 1
+    # Unseen step_index: zero attempts.
+    assert emitter.attempt_count(99) == 0
+
+
+def test_emit_resume_continues_attempt_numbering(tmp_path: Path) -> None:
+    """Acceptance criterion: idempotent across restarts — but in
+    per-attempt semantics that means the resumed emitter continues
+    numbering past the prior process's last attempt, so readers see
+    one contiguous attempt sequence per step."""
+    first = TrajectoryEmitter(run_id="r1", store_dir=str(tmp_path))
+    intent = _intent()
+    first.emit(intent, _fail_step_result(index=0))   # attempt 0
+    first.emit(intent, _ok_step_result(index=0))     # attempt 1
+    first.emit(intent, _ok_step_result(index=1))     # attempt 0
+    assert first.attempt_count(0) == 2
+    assert first.attempt_count(1) == 1
+
+    # Simulate a process restart — fresh emitter, same store_dir.
+    resumed = TrajectoryEmitter(run_id="r1", store_dir=str(tmp_path))
+    assert resumed.attempt_count(0) == 2
+    assert resumed.attempt_count(1) == 1
+    # Resumed emits continue the count, not reset.
+    resumed.emit(intent, _ok_step_result(index=0))   # attempt 2
+    resumed.emit(intent, _ok_step_result(index=2))   # attempt 0
+
+    lines = (tmp_path / JSONL_FILENAME).read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 5
+    records = [json.loads(line) for line in lines]
+    step_zero_attempts = [
+        r["attempt_index"] for r in records if r["step_index"] == 0
+    ]
+    assert step_zero_attempts == [0, 1, 2]
 
 
 def test_emit_tolerates_partial_trailing_line(tmp_path: Path) -> None:
@@ -174,7 +201,7 @@ def test_emit_tolerates_partial_trailing_line(tmp_path: Path) -> None:
     jsonl.write_text(valid_line + "\n{ partial-broken-json", encoding="utf-8")
 
     emitter = TrajectoryEmitter(run_id="r1", store_dir=str(tmp_path))
-    assert emitter.emitted_indices() == {0}
+    assert emitter.attempt_count(0) == 1
     # The corrupt trailing line stopped resume scanning early; new
     # emits append past the partial without raising.
     assert emitter.emit(_intent(), _ok_step_result(index=1)) is True
@@ -333,11 +360,14 @@ def test_run_executor_hook_isolates_per_run_directories(
     assert (tmp_path / "run_b" / JSONL_FILENAME).exists()
 
 
-def test_run_executor_hook_idempotent_across_retry(
+def test_run_executor_hook_records_retry_as_separate_attempt(
     monkeypatch, tmp_path: Path,
 ) -> None:
-    """A retry / demote / recovery branch can run the executor helper
-    twice on the same logical step; the second emit must be a no-op."""
+    """A retry / demote / recovery branch runs the executor helper
+    twice on the same logical step. Both attempts must land in the
+    JSONL with distinct attempt_index values — readers take the
+    highest attempt as the final outcome (fixing the pre-fix bug
+    where the first FAIL hid a successful retry)."""
     from mantis_agent.gym.run_executor import _emit_canonical_trajectory_event
 
     monkeypatch.setenv("MANTIS_CANONICAL_EVENTS_DIR", str(tmp_path))
@@ -346,11 +376,19 @@ def test_run_executor_hook_idempotent_across_retry(
         run_id = "retry_test"
 
     runner = _Runner()
+    _emit_canonical_trajectory_event(
+        runner, _intent(), _fail_step_result(index=0, failure_class="no_state_change"),
+    )
     _emit_canonical_trajectory_event(runner, _intent(), _ok_step_result(index=0))
-    _emit_canonical_trajectory_event(runner, _intent(), _fail_step_result(index=0))
 
-    jsonl = (tmp_path / "retry_test" / JSONL_FILENAME).read_text(encoding="utf-8").splitlines()
-    assert len(jsonl) == 1  # only the first emit landed
+    jsonl = (
+        tmp_path / "retry_test" / JSONL_FILENAME
+    ).read_text(encoding="utf-8").splitlines()
+    records = [json.loads(line) for line in jsonl]
+    assert len(records) == 2
+    assert [r["attempt_index"] for r in records] == [0, 1]
+    assert records[0]["verdict"]["kind"] == "recoverable"
+    assert records[1]["verdict"]["kind"] == "ok"
 
 
 def test_run_executor_hook_uses_run_key_when_run_id_absent(

--- a/tests/test_cua_emit.py
+++ b/tests/test_cua_emit.py
@@ -1,0 +1,352 @@
+"""Tests for the canonical trajectory emitter (#478).
+
+Covers:
+
+* the StepResult → Verdict adapter (success / recoverable /
+  non-recoverable mapping);
+* TrajectoryEmitter end-to-end — JSONL round-trip, validation
+  rejection, idempotency on (run_id, step_index), and resume from
+  an existing JSONL store;
+* the opt-in env-var gate so the runner stays a no-op when the
+  feature is disabled.
+
+These tests deliberately don't spin up a runner. The emitter takes
+plain MicroIntent + StepResult inputs and the test focuses on the
+projection + persistence contract — runner integration is exercised
+by the existing executor test suite which doesn't assert on emit
+behaviour yet (gated by env, default off).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from mantis_agent.actions import Action, ActionType
+from mantis_agent.cua_contracts import (
+    JSONL_FILENAME,
+    SCHEMA_VERSION,
+    TrajectoryEmitter,
+    VerdictKind,
+    verdict_from_step_result,
+)
+from mantis_agent.gym.checkpoint import StepResult
+from mantis_agent.plan_decomposer import MicroIntent
+
+
+# ── Verdict adapter ─────────────────────────────────────────────────────
+
+
+def _ok_step_result(index: int = 0, data: str = "extracted 7 leads") -> StepResult:
+    return StepResult(
+        step_index=index, intent="extract", success=True,
+        data=data, duration=1.5,
+    )
+
+
+def _fail_step_result(
+    *, index: int = 0, failure_class: str = "", data: str = "fill_error",
+) -> StepResult:
+    return StepResult(
+        step_index=index, intent="fill", success=False,
+        data=data, duration=2.0, failure_class=failure_class,
+    )
+
+
+def test_verdict_from_success_maps_to_ok() -> None:
+    v = verdict_from_step_result(_ok_step_result(data="navigated to /detail/123"))
+    assert v.kind is VerdictKind.OK
+    assert v.reason == ""  # happy path needs no recovery code
+    assert v.evidence == "navigated to /detail/123"
+    assert v.confidence == 1.0
+
+
+def test_verdict_from_failure_with_recoverable_class() -> None:
+    """Unknown / generic failure classes route to RECOVERABLE so the
+    retry / recovery / replan ladder gets a shot."""
+    v = verdict_from_step_result(
+        _fail_step_result(failure_class="selector_miss", data="not found"),
+    )
+    assert v.kind is VerdictKind.RECOVERABLE
+    assert v.reason == "selector_miss"
+    assert v.evidence == "not found"
+
+
+def test_verdict_from_failure_with_no_failure_class_falls_back_to_unknown() -> None:
+    """The validator requires a non-empty reason on failure verdicts —
+    the adapter must back-fill ``unknown`` when the runner didn't
+    classify the failure."""
+    v = verdict_from_step_result(_fail_step_result(failure_class=""))
+    assert v.kind is VerdictKind.RECOVERABLE
+    assert v.reason == "unknown"
+
+
+@pytest.mark.parametrize(
+    "failure_class",
+    ["cf_challenge", "http_4xx", "extractor_error", "budget_exceeded"],
+)
+def test_verdict_from_known_non_recoverable_failures(failure_class: str) -> None:
+    """Pinned set of failure classes route to NON_RECOVERABLE. A
+    bump to the set is intentional + grep-able from this test."""
+    v = verdict_from_step_result(_fail_step_result(failure_class=failure_class))
+    assert v.kind is VerdictKind.NON_RECOVERABLE
+    assert v.reason == failure_class
+
+
+# ── TrajectoryEmitter ──────────────────────────────────────────────────
+
+
+def _intent(step_type: str = "click", intent: str = "Click Sign Up") -> MicroIntent:
+    return MicroIntent(intent=intent, type=step_type, required=True)
+
+
+def test_emit_writes_one_validated_jsonl_line(tmp_path: Path) -> None:
+    """Happy path: emit projects + validates + appends one line."""
+    emitter = TrajectoryEmitter(run_id="run_abc", store_dir=str(tmp_path))
+    intent = _intent()
+    result = _ok_step_result(index=0)
+
+    assert emitter.emit(intent, result) is True
+
+    jsonl = (tmp_path / JSONL_FILENAME).read_text(encoding="utf-8").splitlines()
+    assert len(jsonl) == 1
+    record = json.loads(jsonl[0])
+    assert record["run_id"] == "run_abc"
+    assert record["step_index"] == 0
+    assert record["schema_version"] == SCHEMA_VERSION
+    assert record["verdict"]["kind"] == "ok"
+    assert record["step"]["action_type"] == "click"
+    assert record["observation"]["screenshot_ref"].startswith("placeholder://")
+    assert record["committed"] is True
+
+
+def test_emit_idempotent_on_same_step_index(tmp_path: Path) -> None:
+    """Acceptance criterion: every completed step emits exactly one
+    canonical event, even across retries."""
+    emitter = TrajectoryEmitter(run_id="r1", store_dir=str(tmp_path))
+    intent = _intent()
+    r0 = _ok_step_result(index=0)
+
+    assert emitter.emit(intent, r0) is True
+    # Same key — must not append a second line.
+    assert emitter.emit(intent, r0) is False
+    # Different StepResult instance, same step_index — also a no-op.
+    r0_retry = _ok_step_result(index=0, data="rerun-evidence")
+    assert emitter.emit(intent, r0_retry) is False
+
+    lines = (tmp_path / JSONL_FILENAME).read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+
+
+def test_emit_resume_loads_existing_indices(tmp_path: Path) -> None:
+    """Acceptance criterion: idempotent across restarts. A new
+    emitter pointed at an existing JSONL must pick up the prior
+    indices and refuse to re-emit them."""
+    first = TrajectoryEmitter(run_id="r1", store_dir=str(tmp_path))
+    intent = _intent()
+    first.emit(intent, _ok_step_result(index=0))
+    first.emit(intent, _ok_step_result(index=1))
+    assert first.emitted_indices() == {0, 1}
+
+    # Simulate a process restart — fresh emitter, same store_dir.
+    resumed = TrajectoryEmitter(run_id="r1", store_dir=str(tmp_path))
+    assert resumed.emitted_indices() == {0, 1}
+    # Trying to re-emit index 0 is a no-op.
+    assert resumed.emit(intent, _ok_step_result(index=0)) is False
+    # Index 2 is fresh — appends normally.
+    assert resumed.emit(intent, _ok_step_result(index=2)) is True
+
+    lines = (tmp_path / JSONL_FILENAME).read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 3
+
+
+def test_emit_tolerates_partial_trailing_line(tmp_path: Path) -> None:
+    """A crashed writer can leave a partial line. The resume reader
+    must stop at the bad line and let subsequent emits append clean
+    records past it."""
+    jsonl = tmp_path / JSONL_FILENAME
+    valid_line = json.dumps({
+        "schema_version": SCHEMA_VERSION,
+        "run_id": "r1", "step_index": 0,
+    })
+    jsonl.write_text(valid_line + "\n{ partial-broken-json", encoding="utf-8")
+
+    emitter = TrajectoryEmitter(run_id="r1", store_dir=str(tmp_path))
+    assert emitter.emitted_indices() == {0}
+    # The corrupt trailing line stopped resume scanning early; new
+    # emits append past the partial without raising.
+    assert emitter.emit(_intent(), _ok_step_result(index=1)) is True
+
+
+def test_emit_appends_separate_files_per_run(tmp_path: Path) -> None:
+    """Each TrajectoryEmitter is per-run; two emitters pointed at
+    different store_dirs must not see each other's events."""
+    dir_a = tmp_path / "run_a"
+    dir_b = tmp_path / "run_b"
+    em_a = TrajectoryEmitter(run_id="a", store_dir=str(dir_a))
+    em_b = TrajectoryEmitter(run_id="b", store_dir=str(dir_b))
+
+    em_a.emit(_intent(), _ok_step_result(index=0))
+    em_b.emit(_intent(), _ok_step_result(index=0))
+
+    assert (dir_a / JSONL_FILENAME).exists()
+    assert (dir_b / JSONL_FILENAME).exists()
+    assert (dir_a / JSONL_FILENAME).read_text().count("\n") == 1
+    assert (dir_b / JSONL_FILENAME).read_text().count("\n") == 1
+
+
+def test_emit_records_failure_verdict_kind(tmp_path: Path) -> None:
+    """Failure steps land with the projected verdict kind so a
+    downstream reader can group by recoverable / non-recoverable
+    without re-reading the legacy ``failure_class``."""
+    emitter = TrajectoryEmitter(run_id="r1", store_dir=str(tmp_path))
+    emitter.emit(_intent(), _fail_step_result(index=0, failure_class="cf_challenge"))
+    record = json.loads((tmp_path / JSONL_FILENAME).read_text().strip())
+    assert record["verdict"]["kind"] == "non_recoverable"
+    assert record["verdict"]["reason"] == "cf_challenge"
+
+
+def test_emit_carries_explicit_action(tmp_path: Path) -> None:
+    """When the caller has a richer signal (Action object), the
+    emitter uses it instead of falling through to
+    ``result.last_action`` (which may be None on deterministic
+    handlers)."""
+    emitter = TrajectoryEmitter(run_id="r1", store_dir=str(tmp_path))
+    action = Action(action_type=ActionType.CLICK, params={"x": 10, "y": 20})
+    emitter.emit(
+        _intent(), _ok_step_result(),
+        action=action, dispatched=True,
+        grounding_trace={"provider": "claude", "confidence": 0.9},
+    )
+    record = json.loads((tmp_path / JSONL_FILENAME).read_text().strip())
+    assert record["action_result"]["action_type"] == "click"
+    assert record["action_result"]["params"] == {"x": 10, "y": 20}
+    assert record["action_result"]["grounding_trace"]["provider"] == "claude"
+    assert record["action_result"]["dispatched"] is True
+
+
+def test_emit_carries_versions_dict(tmp_path: Path) -> None:
+    """The versions slot (#487 / #488) round-trips so model / prompt
+    / browser stamps surface in every event."""
+    emitter = TrajectoryEmitter(
+        run_id="r1", store_dir=str(tmp_path),
+        versions={"planner": "claude-opus-4-7", "grounding": "claude-haiku-4-5"},
+    )
+    emitter.emit(_intent(), _ok_step_result())
+    record = json.loads((tmp_path / JSONL_FILENAME).read_text().strip())
+    assert record["versions"] == {
+        "planner": "claude-opus-4-7", "grounding": "claude-haiku-4-5",
+    }
+
+
+def test_emit_returns_false_when_validation_fails(tmp_path: Path, caplog) -> None:
+    """A malformed event (intent + action_type empty after projection)
+    must be rejected by the validator and the call returns False —
+    the runner keeps going, the bad event doesn't land on disk."""
+    emitter = TrajectoryEmitter(run_id="r1", store_dir=str(tmp_path))
+    # Empty intent + empty type — fails Step validation.
+    bad_intent = MicroIntent(intent="", type="")
+    with caplog.at_level("WARNING"):
+        result = emitter.emit(bad_intent, _ok_step_result())
+    assert result is False
+    assert any("validation failed" in r.message for r in caplog.records)
+    # No JSONL written.
+    assert not (tmp_path / JSONL_FILENAME).exists()
+
+
+def test_emit_construct_rejects_empty_run_id(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="run_id"):
+        TrajectoryEmitter(run_id="", store_dir=str(tmp_path))
+
+
+def test_emit_construct_rejects_empty_store_dir() -> None:
+    with pytest.raises(ValueError, match="store_dir"):
+        TrajectoryEmitter(run_id="r1", store_dir="")
+
+
+# ── Opt-in env gate (run_executor wire-in) ─────────────────────────────
+
+
+def test_run_executor_hook_no_op_when_env_unset(monkeypatch) -> None:
+    """The runner hook is gated by ``MANTIS_CANONICAL_EVENTS_DIR``.
+    With the env unset, the helper returns without touching the
+    runner — keeps the default execution path free of side effects."""
+    from mantis_agent.gym.run_executor import _emit_canonical_trajectory_event
+
+    monkeypatch.delenv("MANTIS_CANONICAL_EVENTS_DIR", raising=False)
+
+    class _Runner:
+        pass
+
+    runner = _Runner()
+    # Should be a silent no-op; no emitter ever attached.
+    _emit_canonical_trajectory_event(runner, _intent(), _ok_step_result())
+    assert not hasattr(runner, "_trajectory_emitter")
+
+
+def test_run_executor_hook_writes_when_env_set(
+    monkeypatch, tmp_path: Path,
+) -> None:
+    """End-to-end through the run_executor helper: env var set →
+    emitter lazy-created → event lands on disk."""
+    from mantis_agent.gym.run_executor import _emit_canonical_trajectory_event
+
+    monkeypatch.setenv("MANTIS_CANONICAL_EVENTS_DIR", str(tmp_path))
+
+    class _Runner:
+        run_id = "wire_in_test"
+
+    runner = _Runner()
+    _emit_canonical_trajectory_event(runner, _intent(), _ok_step_result(index=0))
+    # Second step on the same runner reuses the emitter.
+    _emit_canonical_trajectory_event(runner, _intent(), _ok_step_result(index=1))
+
+    jsonl = (tmp_path / JSONL_FILENAME).read_text(encoding="utf-8").splitlines()
+    assert len(jsonl) == 2
+    indices = [json.loads(line)["step_index"] for line in jsonl]
+    assert indices == [0, 1]
+
+
+def test_run_executor_hook_idempotent_across_retry(
+    monkeypatch, tmp_path: Path,
+) -> None:
+    """A retry / demote / recovery branch can run the executor helper
+    twice on the same logical step; the second emit must be a no-op."""
+    from mantis_agent.gym.run_executor import _emit_canonical_trajectory_event
+
+    monkeypatch.setenv("MANTIS_CANONICAL_EVENTS_DIR", str(tmp_path))
+
+    class _Runner:
+        run_id = "retry_test"
+
+    runner = _Runner()
+    _emit_canonical_trajectory_event(runner, _intent(), _ok_step_result(index=0))
+    _emit_canonical_trajectory_event(runner, _intent(), _fail_step_result(index=0))
+
+    jsonl = (tmp_path / JSONL_FILENAME).read_text(encoding="utf-8").splitlines()
+    assert len(jsonl) == 1  # only the first emit landed
+
+
+def test_run_executor_hook_falls_back_to_default_run_id(
+    monkeypatch, tmp_path: Path,
+) -> None:
+    """When the runner has no ``run_id`` attribute (e.g. a local CLI
+    invocation), the helper synthesises a stable placeholder so
+    emits still land — emitter constructor would otherwise refuse
+    an empty run_id."""
+    from mantis_agent.gym.run_executor import _emit_canonical_trajectory_event
+
+    monkeypatch.setenv("MANTIS_CANONICAL_EVENTS_DIR", str(tmp_path))
+
+    class _Runner:
+        pass  # no run_id / _run_id attributes
+
+    runner = _Runner()
+    _emit_canonical_trajectory_event(runner, _intent(), _ok_step_result(index=0))
+
+    jsonl = (tmp_path / JSONL_FILENAME).read_text(encoding="utf-8").splitlines()
+    assert len(jsonl) == 1
+    record = json.loads(jsonl[0])
+    assert record["run_id"] == "local_run"

--- a/tests/test_extractor_tool_use_migration.py
+++ b/tests/test_extractor_tool_use_migration.py
@@ -56,14 +56,34 @@ def _wired(extractor: ClaudeExtractor) -> tuple[MagicMock, MagicMock]:
 # ── verify_gate ─────────────────────────────────────────────────────────
 
 
-def test_verify_gate_routes_through_tool_schema() -> None:
+def _wire_verify(
+    extractor: ClaudeExtractor,
+) -> tuple[MagicMock, MagicMock, MagicMock]:
+    """Replace the Haiku + Opus verify clients with mocks (#421).
+
+    Returns (haiku_mock, opus_mock, call_mock). The legacy ``_call``
+    seam is also blocked so a regression that drops the tool_use
+    routing surfaces as a test failure rather than silent prose
+    parsing.
+    """
+    haiku = MagicMock()
+    opus = MagicMock()
+    extractor._verify_client.call_with_tool_schema = haiku  # type: ignore[method-assign]
+    extractor._verify_escalation_client.call_with_tool_schema = opus  # type: ignore[method-assign]
+    call = MagicMock(side_effect=AssertionError("legacy _call must not be used"))
+    extractor._call = call  # type: ignore[method-assign]
+    return haiku, opus, call
+
+
+def test_verify_gate_routes_through_haiku_first() -> None:
     extractor = ClaudeExtractor(api_key="dummy")
-    tool, call = _wired(extractor)
-    tool.return_value = {"passed": True, "reason": "Filters applied"}
+    haiku, opus, call = _wire_verify(extractor)
+    haiku.return_value = {"passed": True, "reason": "Filters applied"}
 
     passed, reason = extractor.verify_gate(_img(), "Filters applied")
 
-    tool.assert_called_once()
+    haiku.assert_called_once()
+    opus.assert_not_called()  # no escalation when Haiku says PASS
     call.assert_not_called()
     assert passed is True
     assert reason == "Filters applied"
@@ -72,12 +92,12 @@ def test_verify_gate_routes_through_tool_schema() -> None:
 def test_verify_gate_schema_shape() -> None:
     """The tool's input_schema must lock the boolean / string fields."""
     extractor = ClaudeExtractor(api_key="dummy")
-    tool, _ = _wired(extractor)
-    tool.return_value = {"passed": False, "reason": "Filters missing"}
+    haiku, _, _ = _wire_verify(extractor)
+    haiku.return_value = {"passed": True, "reason": "ok"}
 
     extractor.verify_gate(_img(), "Filters applied")
 
-    schema = tool.call_args.kwargs["input_schema"]
+    schema = haiku.call_args.kwargs["input_schema"]
     assert schema["properties"]["passed"]["type"] == "boolean"
     assert schema["properties"]["reason"]["type"] == "string"
     assert set(schema["required"]) == {"passed", "reason"}
@@ -86,14 +106,85 @@ def test_verify_gate_schema_shape() -> None:
 def test_verify_gate_returns_false_on_no_tool_use() -> None:
     """Server-side validation can't fail on shape, but the tool_use
     block can be missing entirely (API regression). The runner halts
-    on a False gate, which is the right safety default."""
+    on a False gate, which is the right safety default. No escalation
+    fires when the Haiku call itself failed to return a usable result —
+    a transient API blip shouldn't be papered over by burning an Opus
+    call too."""
     extractor = ClaudeExtractor(api_key="dummy")
-    tool, _ = _wired(extractor)
-    tool.return_value = None
+    haiku, opus, _ = _wire_verify(extractor)
+    haiku.return_value = None
 
     passed, reason = extractor.verify_gate(_img(), "anything")
     assert passed is False
     assert "tool_use" in reason
+    opus.assert_not_called()
+
+
+def test_verify_gate_escalates_to_opus_on_haiku_fail() -> None:
+    """Haiku FAIL must trigger one Opus re-ask (#421 §3). Trust Opus
+    when it disagrees — recovery loops on a Haiku false-negative cost
+    ~$0.50, the escalation costs ~$0.003."""
+    extractor = ClaudeExtractor(api_key="dummy")
+    haiku, opus, _ = _wire_verify(extractor)
+    haiku.return_value = {"passed": False, "reason": "haiku-uncertain"}
+    opus.return_value = {"passed": True, "reason": "opus-saw-filter-pill"}
+
+    passed, reason = extractor.verify_gate(_img(), "filters applied")
+
+    haiku.assert_called_once()
+    opus.assert_called_once()
+    assert passed is True
+    assert reason == "opus-saw-filter-pill"
+
+
+def test_verify_gate_keeps_fail_when_opus_also_fails() -> None:
+    """Both verdicts FAIL → final FAIL with Opus's reason (more
+    authoritative than Haiku's)."""
+    extractor = ClaudeExtractor(api_key="dummy")
+    haiku, opus, _ = _wire_verify(extractor)
+    haiku.return_value = {"passed": False, "reason": "haiku-no-filter"}
+    opus.return_value = {"passed": False, "reason": "opus-confirmed-no-filter"}
+
+    passed, reason = extractor.verify_gate(_img(), "filters applied")
+
+    assert passed is False
+    assert reason == "opus-confirmed-no-filter"
+
+
+def test_verify_gate_keeps_haiku_verdict_when_escalation_errors() -> None:
+    """Opus call errors out (returns None) — fall back to Haiku's
+    FAIL verdict rather than hide it behind a None."""
+    extractor = ClaudeExtractor(api_key="dummy")
+    haiku, opus, _ = _wire_verify(extractor)
+    haiku.return_value = {"passed": False, "reason": "haiku-no-filter"}
+    opus.return_value = None
+
+    passed, reason = extractor.verify_gate(_img(), "filters applied")
+
+    assert passed is False
+    assert reason == "haiku-no-filter"
+
+
+def test_verify_gate_opts_into_cache_tools() -> None:
+    """#421 §4: ``verify_gate`` must mark the tool spec as
+    cache-eligible so the schema/description amortise across all
+    gates in a run."""
+    extractor = ClaudeExtractor(api_key="dummy")
+    haiku, _, _ = _wire_verify(extractor)
+    haiku.return_value = {"passed": True, "reason": "ok"}
+
+    extractor.verify_gate(_img(), "anything")
+
+    assert haiku.call_args.kwargs.get("cache_tools") is True
+
+
+def test_verify_gate_uses_haiku_default_model() -> None:
+    """#421 §2: the verify client defaults to Haiku 4.5; the
+    escalation client defaults to Opus 4.7. Operators can pin
+    either via env, but the constructor defaults must be stable."""
+    extractor = ClaudeExtractor(api_key="dummy")
+    assert extractor._verify_client.model == "claude-haiku-4-5-20251001"
+    assert extractor._verify_escalation_client.model == "claude-opus-4-7"
 
 
 # ── find_filter_target ──────────────────────────────────────────────────

--- a/tests/test_result_payload.py
+++ b/tests/test_result_payload.py
@@ -85,6 +85,45 @@ def test_failure_payload_omits_last_action_when_none() -> None:
     assert "last_action" not in out
 
 
+# ── #419: brain reasoning lands on every step ──────────────────────────
+
+
+def test_success_payload_carries_reasoning_when_set() -> None:
+    """#419: the audit triple needs reasoning on success steps too,
+    not only failures. Otherwise post-mortem can't see the chain of
+    thought that LED to the failed step — just the final one."""
+    out = pack_step(_success(reasoning="I clicked the 'Continue' button because..."))
+    assert out["reasoning"] == "I clicked the 'Continue' button because..."
+
+
+def test_success_payload_omits_reasoning_when_empty() -> None:
+    """Handlers that don't drive a brain (navigate / paginate / form
+    fill / gate) leave reasoning empty — the key must stay out so
+    success steps stay slim."""
+    out = pack_step(_success())
+    assert "reasoning" not in out
+
+
+def test_failure_payload_carries_reasoning_alongside_last_action() -> None:
+    """Reasoning is the chain-of-thought for this step (every brain
+    iteration); last_action.reasoning is the FINAL action's reasoning
+    only. Both can be present and they don't redundant — they cover
+    different audit axes."""
+    action = Action(
+        action_type=ActionType.CLICK,
+        params={"x": 100, "y": 200, "button": "left"},
+        reasoning="final action: click submit",
+    )
+    out = pack_step(_failure(
+        last_action=action,
+        reasoning="step-level chain: tried scroll, then refocused, then clicked",
+    ))
+    assert out["reasoning"] == (
+        "step-level chain: tried scroll, then refocused, then clicked"
+    )
+    assert out["last_action"]["reasoning"] == "final action: click submit"
+
+
 def test_failure_payload_base64_encodes_screenshot() -> None:
     png_bytes = b"\x89PNG\r\n\x1a\nfake-png-bytes"
     out = pack_step(_failure(screenshot_png=png_bytes))

--- a/tests/test_time_meter.py
+++ b/tests/test_time_meter.py
@@ -25,10 +25,16 @@ from mantis_agent.gym.time_meter import (
 
 def test_buckets_vocabulary_is_stable() -> None:
     """A widening of the bucket vocabulary should be deliberate — pinned
-    here so a stealth rename / drop forces a docs + dashboard update."""
+    here so a stealth rename / drop forces a docs + dashboard update.
+
+    #421 added ``claude_verify_haiku`` + ``claude_verify_opus_escalation``
+    so the cost report can show the Haiku/Opus split per run.
+    """
     assert BUCKETS == (
         "perceive", "think", "act", "settle", "claude_ground",
-        "claude_extract", "claude_verify", "load", "overhead",
+        "claude_extract", "claude_verify",
+        "claude_verify_haiku", "claude_verify_opus_escalation",
+        "load", "overhead",
     )
 
 
@@ -412,10 +418,11 @@ def test_claude_extractor_call_credits_claude_extract_by_default() -> None:
     assert meter.per_step[0]["claude_extract"] >= 0.01
 
 
-def test_claude_extractor_verify_calls_credit_claude_verify() -> None:
-    """``ClaudeExtractor.verify_gate`` routes through ``_call_with_tool_schema``
-    with ``_bucket="claude_verify"``, so the elapsed time lands in the
-    verify bucket rather than ``claude_extract``."""
+def test_claude_extractor_verify_calls_credit_claude_verify_haiku() -> None:
+    """``ClaudeExtractor.verify_gate`` routes through the Haiku verify
+    client with ``time_bucket="claude_verify_haiku"`` so cost reports
+    can split Haiku-default verify time from Opus escalation time
+    (#421). Neither bucket should leak into ``claude_extract``."""
     from unittest.mock import MagicMock, patch
 
     from PIL import Image
@@ -442,7 +449,10 @@ def test_claude_extractor_verify_calls_credit_claude_verify() -> None:
     with publish_dispatch(meter, step_idx=0):
         with patch("requests.post", _post):
             extractor.verify_gate(img, "filters visible")
-    assert meter.totals["claude_verify"] >= 0.01
+    # Haiku PASS — no escalation fires, so only the haiku bucket
+    # should accrue time.
+    assert meter.totals["claude_verify_haiku"] >= 0.01
+    assert meter.totals["claude_verify_opus_escalation"] == 0.0
     assert meter.totals["claude_extract"] == 0.0
 
 

--- a/tests/test_trace_exporter.py
+++ b/tests/test_trace_exporter.py
@@ -116,7 +116,7 @@ def test_export_payload_schema_top_level_fields(tmp_path):
     # Steps round-trip with the expected fields
     step = payload["steps"][0]
     for field in ("step_index", "intent", "success", "data", "duration", "reversed",
-                  "predicted_outcome", "observed_outcome", "last_action"):
+                  "predicted_outcome", "observed_outcome", "last_action", "reasoning"):
         assert field in step
 
 
@@ -130,6 +130,31 @@ def test_export_serializes_action(tmp_path):
     action_dict = payload["steps"][0]["last_action"]
     assert action_dict["action_type"] == "click"
     assert action_dict["params"] == {"x": 100, "y": 200}
+
+
+def test_export_carries_reasoning_per_step(tmp_path):
+    """#419: brain reasoning surfaces in the trace per-step so
+    SFT pipelines can read it as a feature."""
+    exp = TraceExporter(export_dir=str(tmp_path))
+    runner = _runner_stub()
+    step = _step(0)
+    step.reasoning = "Held the search bar by clicking input, then typed query"
+    out = exp.maybe_export(runner, [step], status="completed")
+    payload = json.loads(Path(out).read_text())
+    assert payload["steps"][0]["reasoning"] == (
+        "Held the search bar by clicking input, then typed query"
+    )
+
+
+def test_export_reasoning_defaults_to_empty_when_handler_did_not_stamp(tmp_path):
+    """Deterministic handlers (navigate / paginate / form fill) don't
+    drive a brain and leave reasoning empty — the trace must still
+    round-trip without raising."""
+    exp = TraceExporter(export_dir=str(tmp_path))
+    runner = _runner_stub()
+    out = exp.maybe_export(runner, [_step(0)], status="completed")
+    payload = json.loads(Path(out).read_text())
+    assert payload["steps"][0]["reasoning"] == ""
 
 
 def test_export_handles_predicted_observed_outcomes(tmp_path):


### PR DESCRIPTION
## Summary

Three reliability-foundation PRs bundled together (each is an
independent commit). Together they close out the immediate quick wins
from epic #472 and lay the substrate for #478 / #479 / #480.

### Commit 1 — verify_gate cost cut (closes #421)

- Defaults \`verify_gate\` + \`StepVerifier\` to Haiku 4.5
  (~10× cheaper per call than Opus 4.7). Env override:
  \`MANTIS_VERIFY_MODEL\` / \`MANTIS_VERIFY_ESCALATION_MODEL\`.
- Opus escalation on Haiku FAIL — one re-ask via a dedicated
  escalation client. Trust Opus on disagreement, log
  \`HAIKU_FAIL_OPUS_PASS\` at WARNING (so it survives Modal's
  INFO-suppressed capture).
- Prompt caching: \`cache_tools\` flag on
  \`AnthropicToolUseClient.call_with_tool_schema\` marks the tool spec
  ephemeral-cache-eligible. \`verify_gate\` opts in.
- TimeMeter split: \`claude_verify_haiku\` +
  \`claude_verify_opus_escalation\` buckets surface the savings + the
  escalation hit-rate per run.

### Commit 2 — per-step brain reasoning (closes #419)

- \`StepResult\` gains a top-level \`reasoning\` field (observability
  extra, not persisted in the checkpoint).
- \`Holo3StepHandler\` stamps reasoning from the inner GymRunner's
  final trajectory step thinking.
- \`pack_step\` surfaces reasoning on **every** step (not just
  failures) so post-mortem sees the chain that LED to the failed
  step, not only the last one.
- \`trace_exporter\` always includes reasoning so SFT pipelines can
  read it as a feature.

### Commit 3 — versioned CUA contracts (closes #476)

New \`src/mantis_agent/cua_contracts/\` package:

- \`types.py\` — TaskSpec, Plan, Step, Observation, ActionResult,
  Verdict, TrajectoryEvent + ReversibilityClass / VerdictKind enums
  + \`SCHEMA_VERSION = 1\`.
- \`validation.py\` — schema validators that reject schema-version
  drift, missing \`run_id\` / \`step_index\` / \`verdict\` /
  \`action_result\` / \`observation\`, inline base64 screenshot
  blobs, and failure verdicts without a reason code.
- \`adapters.py\` — \`step_from_micro_intent\`,
  \`action_result_from_action\`,
  \`observation_from_screenshot_ref\`,
  \`classify_legacy_reversibility\`. Compatibility shims so the
  runner can emit canonical events without refactoring every handler
  at once.

No existing code paths change — the runner still emits via
\`result_payload\` + \`trace_exporter\`. Subsequent PRs (#478 / #479
/ #480) will wire the canonical emit path on top of this module.

## Test plan

- [x] Full local pytest passes: 2965 passed (parallel via xdist).
- [x] Ruff clean on all changed files.
- [ ] Modal redeploy + \`staff-crm-long\` rerun without proxy —
  verify Haiku verify path fires + no regression on the canonical
  stress fixture. **Running now** — will comment with results.

Closes #421
Closes #419
Closes #476
Refs #472

🤖 Generated with [Claude Code](https://claude.com/claude-code)