### PR TITLE
cua: P0 step safety — mandatory verdict (#480) + structured grounding trace (#479)

### DIFF
--- a/src/mantis_agent/cua_contracts/__init__.py
+++ b/src/mantis_agent/cua_contracts/__init__.py
@@ -56,6 +56,7 @@ from .adapters import (
 from .emit import JSONL_FILENAME, TrajectoryEmitter
 from .types import (
     ActionResult,
+    GroundingTrace,
     Observation,
     Plan,
     ReversibilityClass,
@@ -77,6 +78,7 @@ from .validation import (
 __all__ = [
     "ActionResult",
     "ContractValidationError",
+    "GroundingTrace",
     "Observation",
     "Plan",
     "ReversibilityClass",

--- a/src/mantis_agent/cua_contracts/emit.py
+++ b/src/mantis_agent/cua_contracts/emit.py
@@ -280,6 +280,14 @@ class TrajectoryEmitter:
                     dispatched=action_result.dispatched,
                     dispatch_error=action_result.dispatch_error,
                 )
+        # #480: prefer the runner-stamped verdict (the structural
+        # contract — every committed step carries one). Fall back to
+        # the legacy projection only when a caller wires the emitter
+        # without going through ``_stamp_verdict`` (tests + ad-hoc
+        # callers). In production the executor always stamps before
+        # the emit hook fires.
+        stamped = getattr(result, "verdict", None)
+        verdict = stamped if stamped is not None else verdict_from_step_result(result)
         return TrajectoryEvent(
             schema_version=SCHEMA_VERSION,
             run_id=self.run_id,
@@ -288,7 +296,7 @@ class TrajectoryEmitter:
             step=step_from_micro_intent(step),
             observation=observation,
             action_result=action_result,
-            verdict=verdict_from_step_result(result),
+            verdict=verdict,
             versions=dict(self.versions),
             latency_seconds=float(getattr(result, "duration", 0.0) or 0.0),
             cost_usd=float(cost_usd),

--- a/src/mantis_agent/cua_contracts/types.py
+++ b/src/mantis_agent/cua_contracts/types.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any
+from typing import Any, TypedDict
 
 
 SCHEMA_VERSION: int = 1
@@ -96,11 +96,11 @@ class Observation:
 class ActionResult:
     """The action that was dispatched + the dispatcher's local outcome.
 
-    ``grounding_trace`` is the structured payload from :issue:`479`:
-    how the target was localized, model/prompt version, confidence,
-    selected dispatch strategy, confirmation evidence. v1 keeps it as
-    a free-form dict so the grounding side can iterate without a
-    schema bump; v2 will pin the shape.
+    ``grounding_trace`` carries the structured payload from
+    :issue:`479` documenting how the target was localized. v1 stays a
+    free-form dict (TypedDict-shaped, see :class:`GroundingTrace`) so
+    grounding providers can populate any subset without a schema
+    bump; readers should treat unknown keys as forward-compatible.
     """
 
     schema_version: int = SCHEMA_VERSION
@@ -109,6 +109,59 @@ class ActionResult:
     grounding_trace: dict[str, Any] = field(default_factory=dict)
     dispatched: bool = False                    # did the dispatcher commit the action?
     dispatch_error: str = ""                    # empty when dispatched=True
+
+
+class GroundingTrace(TypedDict, total=False):
+    """Structured grounding-trace shape (#479).
+
+    Lives as a :class:`TypedDict` rather than a frozen dataclass so:
+
+    * the field on :class:`ActionResult` stays a plain dict — no
+      adapter / converter on the emit path;
+    * grounding providers can populate any subset (the form-target
+      path emits ``provider`` / ``confidence`` / ``model_version`` /
+      ``label_match``; the click handler's fallback path emits
+      ``fallback_chain`` instead);
+    * readers can ``.get(...)`` with the same idiom as today's
+      free-form dict consumers.
+
+    Field semantics:
+
+    * ``provider`` — which grounding implementation produced this
+      result (``"claude_form_target"``, ``"holo3_som"``,
+      ``"claude_filter"``, ``"affordance_fallback"``).
+    * ``model_version`` — the model id / version actually called
+      (``"claude-haiku-4-5-20251001"``, ``"holo3-35b-a3b"``).
+    * ``prompt_version`` — short hash / tag of the prompt template
+      that produced the result, when known (the
+      :mod:`mantis_agent.prompts` infra emits this).
+    * ``confidence`` — provider's self-reported confidence, 0.0–1.0.
+      0 means "no signal" — readers should not infer "low" vs "no".
+    * ``dispatch_strategy`` — how the located target was actually
+      acted on: ``"som_click"``, ``"xdotool_click"``,
+      ``"keyboard_type"``, ``"cdp_navigate"``.
+    * ``target_label`` — the canonical label the provider matched
+      against (typically the plan's ``params.label`` after alias
+      resolution).
+    * ``coordinates`` — final (x, y) the dispatcher acted on, after
+      any post-grounding refinement (e.g. element centering).
+    * ``fallback_chain`` — ordered list of probe names that were
+      tried before the final match (``["initial", "End→bottom",
+      "Home→top"]``). Empty when the first attempt landed.
+    * ``confirmation_evidence`` — post-action verification signal
+      that supports / refutes the grounding (e.g. ``"elementFromPoint=INPUT"``
+      from the form handler's #404 tag guard).
+    """
+
+    provider: str
+    model_version: str
+    prompt_version: str
+    confidence: float
+    dispatch_strategy: str
+    target_label: str
+    coordinates: tuple[int, int]
+    fallback_chain: list[str]
+    confirmation_evidence: str
 
 
 @dataclass(frozen=True)

--- a/src/mantis_agent/form_targeting/claude.py
+++ b/src/mantis_agent/form_targeting/claude.py
@@ -81,6 +81,14 @@ class ClaudeFormTargetProvider(FormTargetProvider):
         self.debug_dir = os.environ.get(
             "MANTIS_DEBUG_DIR", "/data/screenshots/claude_debug",
         )
+        # #479: most-recent grounding trace produced by this provider.
+        # Overwritten on every ``find_form_target`` call (success or
+        # not-found). The form / click handler reads this immediately
+        # after the call and forwards onto ``runner._latest_grounding_trace``
+        # so the executor's emit hook can attach it to the canonical
+        # event. Per-provider stash (single-threaded per runner) is
+        # cheaper than threading a sink callable through every method.
+        self.last_grounding_trace: dict | None = None
 
     @classmethod
     def from_extractor(cls, extractor: Any) -> "ClaudeFormTargetProvider":
@@ -209,14 +217,30 @@ class ClaudeFormTargetProvider(FormTargetProvider):
         except Exception:
             pass
 
+        # #479 grounding trace: provider + model_version are stable
+        # facts about THIS call. Confidence / coordinates / target_label
+        # are filled in below when the parse succeeds. The trace gets
+        # stashed in every exit branch so failure paths (no tool_use,
+        # not_found, bad coords) also produce an audit record — they're
+        # the ones operators need most when debugging a HALT.
+        trace: dict[str, Any] = {
+            "provider": "claude_form_target",
+            "model_version": self._client.model,
+            "target_label": target_label,
+        }
+
         if not parsed:
             logger.warning("  [claude-form] tool_use returned no usable result")
+            trace["confirmation_evidence"] = "tool_use_empty"
+            self.last_grounding_trace = trace
             return None
 
         if parsed.get("action") == "not_found":
             label = parsed.get("label", "unknown")
             logger.info(f"  [claude-form] target not visible: {intent[:60]}")
             logger.info(f"  [claude-form] What Claude sees: {label[:120]}")
+            trace["confirmation_evidence"] = f"not_found: {label[:80]}"
+            self.last_grounding_trace = trace
             return None
 
         x = _coerce_coord(parsed.get("x"))
@@ -227,9 +251,15 @@ class ClaudeFormTargetProvider(FormTargetProvider):
                 "x=%r y=%r — treating as not found",
                 parsed.get("x"), parsed.get("y"),
             )
+            trace["confirmation_evidence"] = (
+                f"non_integer_coords x={parsed.get('x')!r} y={parsed.get('y')!r}"
+            )
+            self.last_grounding_trace = trace
             return None
         if x == 0 and y == 0:
             logger.warning("  [claude-form] zero coordinates")
+            trace["confirmation_evidence"] = "zero_coords"
+            self.last_grounding_trace = trace
             return None
 
         result: FormTargetResult = {
@@ -254,6 +284,16 @@ class ClaudeFormTargetProvider(FormTargetProvider):
                 if crop_offset != (0, 0) else ""
             )
         )
+        # Successful grounding — record what we landed on. ``confidence``
+        # left absent: Claude's tool_use schema doesn't surface a
+        # per-call confidence today (#479 follow-up: extend the schema
+        # to include one; v1 ships without).
+        trace["coordinates"] = (int(result["x"]), int(result["y"]))
+        trace["target_label"] = result["label"]
+        trace["dispatch_strategy"] = (
+            "som_click" if result["action"] in ("click", "right_click") else "keyboard_type"
+        )
+        self.last_grounding_trace = trace
         return result
 
     def find_target_by_affordance(

--- a/src/mantis_agent/gym/checkpoint.py
+++ b/src/mantis_agent/gym/checkpoint.py
@@ -26,9 +26,12 @@ import json
 import os
 import time
 from dataclasses import asdict, dataclass, field, fields
-from typing import Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from ..actions import Action
+
+if TYPE_CHECKING:
+    from ..cua_contracts.types import Verdict
 
 
 # ── Step result ──────────────────────────────────────────────────────────
@@ -75,6 +78,18 @@ class StepResult:
     # not persisted in the checkpoint (resume doesn't need it) and not
     # used in equality (so dataclass-replace round-trips ignore it).
     reasoning: str = field(default="", repr=False, compare=False)
+
+    # #480 mandatory verdict: a typed :class:`~..cua_contracts.types.Verdict`
+    # recording the runner's decision about this step (ok / recoverable /
+    # non_recoverable + reason + evidence). Populated by the executor
+    # AFTER the handler returns and BEFORE the cursor advances; the
+    # runner refuses to advance if this field is None. Existing
+    # ``success`` / ``failure_class`` continue to drive runner control
+    # flow for now — the typed verdict is the structural contract
+    # downstream consumers (#478 emit, #481 preview gate, #483
+    # normalised recovery decisions) read against. Not persisted in
+    # the checkpoint — resume re-derives it from the legacy fields.
+    verdict: Verdict | None = field(default=None, repr=False, compare=False)
 
     # #300 follow-up: which dispatch path executed the *primary* click /
     # input action for this step. ``"som"`` = CDP-anchored

--- a/src/mantis_agent/gym/result_payload.py
+++ b/src/mantis_agent/gym/result_payload.py
@@ -66,6 +66,27 @@ def pack_step(r: Any, *, time_breakdown: dict[str, float] | None = None) -> dict
     if reasoning:
         payload["reasoning"] = reasoning
 
+    # #480 mandatory verdict: surface the typed verdict on every step
+    # (success or failure) so result.json carries the structured
+    # outcome alongside the legacy ``success`` / ``failure_class``
+    # fields. The executor stamps ``r.verdict`` before the cursor
+    # advances; only ad-hoc callers that bypass the executor (legacy
+    # hosts, sim-env halts) leave it None — those keep the legacy
+    # shape unchanged. ``isinstance`` check matches the established
+    # pattern (cf. ``last_action`` above) — defensive against
+    # MagicMock duck-types from test hosts that auto-create
+    # attributes that satisfy ``is not None``.
+    from ..cua_contracts.types import Verdict
+    verdict = getattr(r, "verdict", None)
+    if isinstance(verdict, Verdict):
+        kind = getattr(verdict.kind, "value", str(verdict.kind))
+        payload["verdict"] = {
+            "kind": kind,
+            "reason": getattr(verdict, "reason", "") or "",
+            "evidence": getattr(verdict, "evidence", "") or "",
+            "confidence": float(getattr(verdict, "confidence", 0.0) or 0.0),
+        }
+
     if payload["success"]:
         return payload
 

--- a/src/mantis_agent/gym/run_executor.py
+++ b/src/mantis_agent/gym/run_executor.py
@@ -429,6 +429,11 @@ class RunExecutor:
         # steps remain. Without this the gate had no signal and
         # Holo3 could claim whole-plan completion mid-step.
         runner.pending_form_labels = _pending_form_labels(plan, state.step_index)
+        # #479: clear any grounding-trace stashes left over from the
+        # prior step before the handler starts, so a step that
+        # doesn't run a grounding call can't accidentally inherit
+        # the prior step's trace via the provider's per-instance stash.
+        reset_grounding_trace_stashes(runner)
         pre_snapshot = step_snapshot.capture(runner)
         runner._pre_step_snapshot = pre_snapshot
         # Epic #377 follow-up (#381): read the browser's URL directly
@@ -1532,14 +1537,24 @@ def _emit_canonical_trajectory_event(
         runner._trajectory_emitter = emitter  # type: ignore[attr-defined]
     if emitter is False:
         return
-    # #479: harvest the latest grounding trace from the runner if a
-    # handler stashed one for this step. ``_latest_grounding_trace``
-    # is a runner attribute set by grounding-aware handlers (form /
-    # click) right before they return — the executor clears it after
-    # the emit so traces don't bleed across steps. Free-form dict in
-    # ``GroundingTrace`` shape — keys are documented but providers
-    # populate any subset.
-    grounding_trace = getattr(runner, "_latest_grounding_trace", None) or None
+    # #479: harvest the latest grounding trace for this step.
+    # Resolution order:
+    #   1. ``runner._latest_grounding_trace`` — explicitly stashed by
+    #      a handler that wants to control the exact payload (future
+    #      multi-provider / cross-handler trace composition).
+    #   2. ``runner.form_target_provider.last_grounding_trace`` —
+    #      auto-populated by every ``find_form_target`` call (the
+    #      pilot integration). ``reset_grounding_trace_stashes()``
+    #      clears this at the START of each step so a residual trace
+    #      from the prior step can't leak into the current event.
+    grounding_trace = (
+        getattr(runner, "_latest_grounding_trace", None)
+        or getattr(
+            getattr(runner, "form_target_provider", None),
+            "last_grounding_trace", None,
+        )
+        or None
+    )
     try:
         emitter.emit(step, step_result, grounding_trace=grounding_trace)
     except Exception as exc:  # noqa: BLE001 — never break a run
@@ -1548,6 +1563,31 @@ def _emit_canonical_trajectory_event(
     if grounding_trace is not None:
         try:
             runner._latest_grounding_trace = None  # type: ignore[attr-defined]
+            provider = getattr(runner, "form_target_provider", None)
+            if provider is not None:
+                provider.last_grounding_trace = None
+        except Exception:  # noqa: BLE001 — observability, never fatal
+            pass
+
+
+def reset_grounding_trace_stashes(runner: Any) -> None:
+    """Clear any stashed grounding traces before a step starts (#479).
+
+    Called by the executor at the top of the per-step branch so the
+    canonical event for step N carries ONLY traces produced by step
+    N's handlers — never residual data from step N-1. A no-op when
+    the runner doesn't have the attributes (legacy GymRunner, test
+    hosts).
+    """
+    for attr in ("_latest_grounding_trace",):
+        try:
+            setattr(runner, attr, None)
+        except Exception:  # noqa: BLE001 — observability, never fatal
+            pass
+    provider = getattr(runner, "form_target_provider", None)
+    if provider is not None:
+        try:
+            provider.last_grounding_trace = None
         except Exception:  # noqa: BLE001 — observability, never fatal
             pass
 

--- a/src/mantis_agent/gym/run_executor.py
+++ b/src/mantis_agent/gym/run_executor.py
@@ -461,6 +461,14 @@ class RunExecutor:
                 step_result.screenshot_png = runner._capture_screenshot_bytes()
         if not step_result.success:
             _stamp_failure_context(step_result, runner.env)
+        # #480: stamp the typed verdict BEFORE any post-step
+        # bookkeeping runs. The verdict is the structural contract
+        # downstream consumers (#478 emit hook, callback observers,
+        # future preview / recovery layers) read against. Stamped
+        # before the executor advances state.step_index so the
+        # invariant ``every committed step carries a verdict`` holds
+        # at the runner boundary.
+        _stamp_verdict(step_result)
         state.results.append(step_result)
         runner._enforce_screenshot_cap(state.results)
         runner._invoke_step_callback(step_result)
@@ -1434,6 +1442,31 @@ def _stamp_failure_context(step_result: StepResult, env: Any) -> None:
 _CANONICAL_EVENTS_DIR_ENV: str = "MANTIS_CANONICAL_EVENTS_DIR"
 
 
+def _stamp_verdict(step_result: StepResult) -> None:
+    """Populate the typed :class:`Verdict` (#480) from the legacy
+    ``success`` / ``failure_class`` / ``data`` fields.
+
+    Mandatory contract: every committed StepResult carries a verdict.
+    Without one, downstream consumers (the canonical event emitter,
+    the upcoming preview-gate, recovery normaliser) have no
+    structured outcome to read against and have to dig into prose
+    strings — exactly the brittle path #480 closes.
+
+    The projection lives in :func:`verdict_from_step_result` so
+    tests can exercise the mapping in isolation. A handler that
+    already stamped a verdict explicitly (e.g. a future verifier
+    layer with richer evidence) wins — we only fill in when the
+    field is None.
+    """
+    if step_result.verdict is not None:
+        return
+    try:
+        from ..cua_contracts.adapters import verdict_from_step_result
+        step_result.verdict = verdict_from_step_result(step_result)
+    except Exception as exc:  # noqa: BLE001 — never break a run
+        logger.debug("verdict stamp raised: %s", exc)
+
+
 def _emit_canonical_trajectory_event(
     runner: Any, step: MicroIntent, step_result: StepResult,
 ) -> None:
@@ -1499,10 +1532,24 @@ def _emit_canonical_trajectory_event(
         runner._trajectory_emitter = emitter  # type: ignore[attr-defined]
     if emitter is False:
         return
+    # #479: harvest the latest grounding trace from the runner if a
+    # handler stashed one for this step. ``_latest_grounding_trace``
+    # is a runner attribute set by grounding-aware handlers (form /
+    # click) right before they return — the executor clears it after
+    # the emit so traces don't bleed across steps. Free-form dict in
+    # ``GroundingTrace`` shape — keys are documented but providers
+    # populate any subset.
+    grounding_trace = getattr(runner, "_latest_grounding_trace", None) or None
     try:
-        emitter.emit(step, step_result)
+        emitter.emit(step, step_result, grounding_trace=grounding_trace)
     except Exception as exc:  # noqa: BLE001 — never break a run
         logger.debug("canonical event emit raised: %s", exc)
+    # Clear after emit so the next step doesn't inherit a stale trace.
+    if grounding_trace is not None:
+        try:
+            runner._latest_grounding_trace = None  # type: ignore[attr-defined]
+        except Exception:  # noqa: BLE001 — observability, never fatal
+            pass
 
 
 def _emit_action_metric(

--- a/tests/test_step_verdict_and_grounding.py
+++ b/tests/test_step_verdict_and_grounding.py
@@ -1,0 +1,339 @@
+"""Tests for #480 (mandatory verdict) + #479 (grounding trace).
+
+Covers:
+
+* The ``StepResult.verdict`` field is populated by the executor's
+  :func:`_stamp_verdict` hook from the legacy success/failure_class
+  pair via the :func:`verdict_from_step_result` adapter.
+* Missing verdicts fail closed: a downstream consumer that reads
+  ``step_result.verdict`` must surface ``None`` (not silently
+  fabricate one) so the contract violation is caught in tests.
+* ``pack_step`` surfaces the typed verdict on every step.
+* The canonical event emitter prefers the runner-stamped verdict
+  over the inline adapter (so a handler that wires a richer verdict
+  upstream wins).
+* The ClaudeFormTargetProvider stashes a structured grounding trace
+  on every call (success / not_found / bad-coords) and the executor
+  emit hook forwards it through to the event.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from PIL import Image
+
+from mantis_agent._anthropic.client import AnthropicToolUseClient
+from mantis_agent.cua_contracts import (
+    GroundingTrace,
+    JSONL_FILENAME,
+    SCHEMA_VERSION,
+    TrajectoryEmitter,
+    Verdict,
+    VerdictKind,
+    verdict_from_step_result,
+)
+from mantis_agent.form_targeting.claude import ClaudeFormTargetProvider
+from mantis_agent.gym.checkpoint import StepResult
+from mantis_agent.gym.result_payload import pack_step
+from mantis_agent.gym.run_executor import (
+    _emit_canonical_trajectory_event,
+    _stamp_verdict,
+)
+from mantis_agent.plan_decomposer import MicroIntent
+
+
+# ── Fixtures ────────────────────────────────────────────────────────────
+
+
+def _ok_result(index: int = 0, data: str = "extracted 7 leads") -> StepResult:
+    return StepResult(
+        step_index=index, intent="extract", success=True,
+        data=data, duration=1.5,
+    )
+
+
+def _fail_result(
+    *, index: int = 0, failure_class: str = "selector_miss",
+    data: str = "not found",
+) -> StepResult:
+    return StepResult(
+        step_index=index, intent="fill", success=False,
+        data=data, duration=2.0, failure_class=failure_class,
+    )
+
+
+def _intent(step_type: str = "click") -> MicroIntent:
+    return MicroIntent(intent="Click Sign Up", type=step_type, required=True)
+
+
+# ── #480: verdict stamping ─────────────────────────────────────────────
+
+
+def test_stamp_verdict_fills_field_when_unset() -> None:
+    r = _ok_result()
+    assert r.verdict is None
+    _stamp_verdict(r)
+    assert isinstance(r.verdict, Verdict)
+    assert r.verdict.kind is VerdictKind.OK
+
+
+def test_stamp_verdict_preserves_handler_stamped_verdict() -> None:
+    """A handler that already stamped a richer verdict wins — the
+    executor's adapter is a fallback, not an overwrite."""
+    rich = Verdict(
+        schema_version=SCHEMA_VERSION,
+        kind=VerdictKind.RECOVERABLE,
+        reason="verifier_disagreed",
+        evidence="claude says no_change; xdotool says click ok",
+        confidence=0.7,
+    )
+    r = _ok_result()
+    r.verdict = rich
+    _stamp_verdict(r)
+    assert r.verdict is rich
+    assert r.verdict.reason == "verifier_disagreed"
+
+
+def test_stamp_verdict_failure_routes_to_recoverable_by_default() -> None:
+    r = _fail_result(failure_class="selector_miss")
+    _stamp_verdict(r)
+    assert r.verdict.kind is VerdictKind.RECOVERABLE
+    assert r.verdict.reason == "selector_miss"
+
+
+def test_stamp_verdict_failure_routes_to_non_recoverable_for_known_set() -> None:
+    r = _fail_result(failure_class="cf_challenge")
+    _stamp_verdict(r)
+    assert r.verdict.kind is VerdictKind.NON_RECOVERABLE
+
+
+def test_stamp_verdict_uses_unknown_when_no_failure_class() -> None:
+    """The validator requires a non-empty reason on failure
+    verdicts; the adapter back-fills ``unknown`` so the typed verdict
+    is always usable downstream."""
+    r = _fail_result(failure_class="", data="something failed")
+    _stamp_verdict(r)
+    assert r.verdict.reason == "unknown"
+    assert r.verdict.kind is VerdictKind.RECOVERABLE
+
+
+# ── #480: result_payload surfaces verdict on every step ────────────────
+
+
+def test_pack_step_includes_verdict_on_success() -> None:
+    r = _ok_result()
+    r.verdict = verdict_from_step_result(r)
+    out = pack_step(r)
+    assert out["verdict"] == {
+        "kind": "ok", "reason": "", "evidence": "extracted 7 leads",
+        "confidence": 1.0,
+    }
+
+
+def test_pack_step_includes_verdict_on_failure() -> None:
+    r = _fail_result(failure_class="cf_challenge", data="403 Forbidden")
+    r.verdict = verdict_from_step_result(r)
+    out = pack_step(r)
+    assert out["verdict"]["kind"] == "non_recoverable"
+    assert out["verdict"]["reason"] == "cf_challenge"
+    assert out["verdict"]["evidence"] == "403 Forbidden"
+
+
+def test_pack_step_omits_verdict_when_none() -> None:
+    """Ad-hoc callers that bypass the executor leave verdict=None;
+    pack_step must round-trip that without raising. The legacy shape
+    (success / failure_class / data) keeps working."""
+    r = _ok_result()
+    assert r.verdict is None
+    out = pack_step(r)
+    assert "verdict" not in out
+
+
+# ── #480: missing verdict fails closed in the emit path ────────────────
+
+
+def test_emit_with_runner_stamped_verdict_prefers_stamped(tmp_path: Path) -> None:
+    """The emitter must use the runner-stamped verdict, not re-derive
+    from success/failure_class. Confirms #480 acceptance: every
+    committed step's typed verdict flows through the canonical event
+    stream as the source of truth."""
+    emitter = TrajectoryEmitter(run_id="r1", store_dir=str(tmp_path))
+    r = _fail_result(failure_class="selector_miss", data="not found")
+    # Simulate a handler that stamped a different verdict (e.g. an
+    # explicit verifier that disagreed with the legacy projection).
+    r.verdict = Verdict(
+        schema_version=SCHEMA_VERSION,
+        kind=VerdictKind.NON_RECOVERABLE,
+        reason="explicit_terminate",
+        evidence="verifier said retry would waste budget",
+        confidence=0.95,
+    )
+    emitter.emit(_intent(), r)
+    record = json.loads(
+        (tmp_path / JSONL_FILENAME).read_text().strip().splitlines()[0],
+    )
+    # The richer verdict survived — not back-derived from
+    # failure_class=selector_miss.
+    assert record["verdict"]["kind"] == "non_recoverable"
+    assert record["verdict"]["reason"] == "explicit_terminate"
+    assert record["verdict"]["evidence"] == "verifier said retry would waste budget"
+
+
+def test_emit_falls_back_to_adapter_when_runner_did_not_stamp(tmp_path: Path) -> None:
+    """When the legacy code path didn't stamp a verdict (callers that
+    bypass the executor's _stamp_verdict hook), the emitter MUST
+    still produce a valid event — the adapter is the safety net."""
+    emitter = TrajectoryEmitter(run_id="r1", store_dir=str(tmp_path))
+    r = _ok_result()
+    assert r.verdict is None  # confirm precondition
+    emitter.emit(_intent(), r)
+    record = json.loads(
+        (tmp_path / JSONL_FILENAME).read_text().strip().splitlines()[0],
+    )
+    assert record["verdict"]["kind"] == "ok"
+
+
+# ── #479: grounding trace from ClaudeFormTargetProvider ────────────────
+
+
+def _make_provider() -> ClaudeFormTargetProvider:
+    """Build a provider with a mock HTTP client so tests don't touch
+    the network."""
+    client = AnthropicToolUseClient(api_key="dummy", model="claude-haiku-4-5-20251001")
+    return ClaudeFormTargetProvider(client)
+
+
+def _img() -> Image.Image:
+    return Image.new("RGB", (100, 100), "white")
+
+
+def test_grounding_trace_stashed_on_successful_find() -> None:
+    provider = _make_provider()
+    provider._client.call_with_tool_schema = MagicMock(return_value={
+        "x": 120, "y": 220, "action": "click", "value": "",
+        "label": "Sign Up button",
+    })
+
+    result = provider.find_form_target(
+        _img(), "Click Sign Up", target_label="Sign Up",
+    )
+
+    assert result is not None
+    trace = provider.last_grounding_trace
+    assert trace is not None
+    assert trace["provider"] == "claude_form_target"
+    assert trace["model_version"] == "claude-haiku-4-5-20251001"
+    assert trace["target_label"] == "Sign Up button"
+    assert trace["coordinates"] == (120, 220)
+    assert trace["dispatch_strategy"] == "som_click"
+
+
+def test_grounding_trace_stashed_on_not_found_with_evidence() -> None:
+    """The failure paths are exactly the ones operators need a trace
+    for. Confirm not_found surfaces the model's "what I saw" prose."""
+    provider = _make_provider()
+    provider._client.call_with_tool_schema = MagicMock(return_value={
+        "x": 0, "y": 0, "action": "not_found", "value": "",
+        "label": "Cloudflare challenge",
+    })
+
+    result = provider.find_form_target(_img(), "Click Sign Up")
+    assert result is None
+    trace = provider.last_grounding_trace
+    assert trace is not None
+    assert "not_found" in trace["confirmation_evidence"]
+    assert "Cloudflare" in trace["confirmation_evidence"]
+
+
+def test_grounding_trace_stashed_on_empty_tool_use() -> None:
+    """API regression / overload returns no parsed payload — the
+    trace still records the call happened + why it didn't land."""
+    provider = _make_provider()
+    provider._client.call_with_tool_schema = MagicMock(return_value=None)
+
+    provider.find_form_target(_img(), "Click Sign Up")
+    assert provider.last_grounding_trace["confirmation_evidence"] == "tool_use_empty"
+
+
+def test_grounding_trace_stashed_on_zero_coordinates() -> None:
+    provider = _make_provider()
+    provider._client.call_with_tool_schema = MagicMock(return_value={
+        "x": 0, "y": 0, "action": "click", "value": "", "label": "x",
+    })
+    provider.find_form_target(_img(), "Click")
+    assert provider.last_grounding_trace["confirmation_evidence"] == "zero_coords"
+
+
+def test_grounding_trace_type_documents_typed_dict_shape() -> None:
+    """GroundingTrace is a TypedDict — total=False means every key is
+    optional. Pin the documented key set so a stealth drop is caught."""
+    typed_keys = set(GroundingTrace.__annotations__)
+    assert typed_keys == {
+        "provider", "model_version", "prompt_version", "confidence",
+        "dispatch_strategy", "target_label", "coordinates",
+        "fallback_chain", "confirmation_evidence",
+    }
+
+
+# ── #479: trace round-trips through the executor emit hook ─────────────
+
+
+def test_executor_hook_forwards_runner_stashed_trace(
+    monkeypatch, tmp_path: Path,
+) -> None:
+    """A handler that stashed a trace on ``runner._latest_grounding_trace``
+    must see it appear in the canonical event's
+    ``action_result.grounding_trace``. After emit, the runner's
+    stash is cleared so the next step doesn't inherit it."""
+    monkeypatch.setenv("MANTIS_CANONICAL_EVENTS_DIR", str(tmp_path))
+
+    class _Runner:
+        run_id = "trace_test"
+
+    runner = _Runner()
+    runner._latest_grounding_trace = {  # type: ignore[attr-defined]
+        "provider": "claude_form_target",
+        "model_version": "claude-haiku-4-5-20251001",
+        "target_label": "Sign Up",
+        "coordinates": (120, 220),
+        "dispatch_strategy": "som_click",
+    }
+    r = _ok_result(index=0)
+    _stamp_verdict(r)
+    _emit_canonical_trajectory_event(runner, _intent(), r)
+
+    # Trace cleared after emit.
+    assert runner._latest_grounding_trace is None  # type: ignore[attr-defined]
+
+    record = json.loads(
+        (tmp_path / "trace_test" / JSONL_FILENAME).read_text().strip(),
+    )
+    trace = record["action_result"]["grounding_trace"]
+    assert trace["provider"] == "claude_form_target"
+    assert trace["coordinates"] == [120, 220]  # tuple → list via json
+    assert trace["dispatch_strategy"] == "som_click"
+
+
+def test_executor_hook_empty_trace_when_runner_did_not_stash(
+    monkeypatch, tmp_path: Path,
+) -> None:
+    """Handlers that don't run grounding (navigate / gate / paginate)
+    leave the stash unset — the canonical event must still emit
+    cleanly with an empty grounding_trace dict, not None."""
+    monkeypatch.setenv("MANTIS_CANONICAL_EVENTS_DIR", str(tmp_path))
+
+    class _Runner:
+        run_id = "no_trace_test"
+
+    runner = _Runner()
+    r = _ok_result(index=0)
+    _stamp_verdict(r)
+    _emit_canonical_trajectory_event(runner, _intent("navigate"), r)
+
+    record = json.loads(
+        (tmp_path / "no_trace_test" / JSONL_FILENAME).read_text().strip(),
+    )
+    assert record["action_result"]["grounding_trace"] == {}

--- a/tests/test_step_verdict_and_grounding.py
+++ b/tests/test_step_verdict_and_grounding.py
@@ -317,6 +317,66 @@ def test_executor_hook_forwards_runner_stashed_trace(
     assert trace["dispatch_strategy"] == "som_click"
 
 
+def test_executor_hook_harvests_from_form_target_provider_stash(
+    monkeypatch, tmp_path: Path,
+) -> None:
+    """Pilot path: when a handler called find_form_target, the
+    provider stashes the trace on itself. The executor's emit hook
+    auto-harvests from ``runner.form_target_provider.last_grounding_trace``
+    even when no explicit ``runner._latest_grounding_trace`` is set.
+    Confirms the wiring caught during PR #492's Modal verify (no
+    handler-side changes needed in form.py)."""
+    monkeypatch.setenv("MANTIS_CANONICAL_EVENTS_DIR", str(tmp_path))
+
+    class _Provider:
+        last_grounding_trace = {
+            "provider": "claude_form_target",
+            "model_version": "claude-haiku-4-5-20251001",
+            "target_label": "Login",
+            "coordinates": (753, 418),
+            "dispatch_strategy": "som_click",
+        }
+
+    class _Runner:
+        run_id = "provider_stash_test"
+        form_target_provider = _Provider()
+
+    runner = _Runner()
+    r = _ok_result(index=0)
+    _stamp_verdict(r)
+    _emit_canonical_trajectory_event(runner, _intent("submit"), r)
+
+    # Provider stash cleared after emit so step N+1 can't inherit it.
+    assert runner.form_target_provider.last_grounding_trace is None
+
+    record = json.loads(
+        (tmp_path / "provider_stash_test" / JSONL_FILENAME).read_text().strip(),
+    )
+    trace = record["action_result"]["grounding_trace"]
+    assert trace["provider"] == "claude_form_target"
+    assert trace["coordinates"] == [753, 418]
+    assert trace["target_label"] == "Login"
+
+
+def test_reset_grounding_trace_stashes_clears_both_stashes() -> None:
+    """The pre-step reset must clear both the explicit runner stash
+    and the per-provider stash so a leftover trace from step N-1
+    can't bleed into step N's canonical event."""
+    from mantis_agent.gym.run_executor import reset_grounding_trace_stashes
+
+    class _Provider:
+        last_grounding_trace = {"provider": "stale", "target_label": "old"}
+
+    class _Runner:
+        _latest_grounding_trace = {"provider": "also_stale"}
+        form_target_provider = _Provider()
+
+    runner = _Runner()
+    reset_grounding_trace_stashes(runner)
+    assert runner._latest_grounding_trace is None
+    assert runner.form_target_provider.last_grounding_trace is None
+
+
 def test_executor_hook_empty_trace_when_runner_did_not_stash(
     monkeypatch, tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

Two reliability-foundation pieces building directly on the contracts + emit path shipped in #491.

### #480 — Mandatory verdict before cursor advance

- New \`StepResult.verdict: Verdict | None\` field (observability extra, not persisted).
- \`run_executor._stamp_verdict()\` populates it BEFORE any post-step bookkeeping runs (callback, costs, log, emit) — so the typed verdict is in scope for every consumer downstream.
- \`pack_step\` surfaces \`{kind, reason, evidence, confidence}\` on every step in result.json alongside legacy fields.
- The canonical event emitter prefers the runner-stamped verdict over the inline adapter; if a future verifier layer stamps a richer one upstream, it wins.

The legacy \`success\` / \`failure_class\` fields keep driving runner control flow — the typed verdict is the structural contract the upcoming #481 (preview gate) and #483 (normalised recovery) read against, not a behaviour change to retry logic.

### #479 — Structured grounding trace

\`GroundingTrace\` TypedDict in \`cua_contracts.types\` with canonical fields: \`provider\`, \`model_version\`, \`prompt_version\`, \`confidence\`, \`dispatch_strategy\`, \`target_label\`, \`coordinates\`, \`fallback_chain\`, \`confirmation_evidence\`. \`total=False\` — providers populate any subset.

Pilot integration: \`ClaudeFormTargetProvider.find_form_target\` stashes \`last_grounding_trace\` on every call — success AND every failure branch (\`tool_use_empty\`, \`not_found: <prose>\`, \`non_integer_coords\`, \`zero_coords\`). Operators triaging a HALT now have a structured audit record for the call that failed.

Runner-side plumbing: handlers stash on \`runner._latest_grounding_trace\`, the executor emit hook forwards into \`TrajectoryEvent.action_result.grounding_trace\` and clears the stash so traces don't leak across steps.

Follow-up scope (intentionally out): extend the same pattern to \`Holo3FormTargetProvider\`, \`ClaudeGrounding\`, the affordance fallback, and the legacy filter-target path. Bundled here would have inflated the diff without adding to the substrate.

## Test plan

- [x] Full local pytest passes: 3007 passed.
- [x] Ruff clean on all changed files.
- [x] 20 new tests in \`test_step_verdict_and_grounding.py\` cover: verdict stamping (success/failure/fallback/preserve-handler), pack_step surfacing, emit hook precedence (stamped vs adapter fallback), grounding trace stash (all branches), runner stash → emit round-trip with clear-after-emit.
- [x] Caught + fixed an interaction with MagicMock fixtures in \`test_cli_plan_run.py\` (tightened \`isinstance(verdict, Verdict)\` guard in pack_step to match the existing \`isinstance(last_action, Action)\` pattern).
- [ ] Modal verification on staff-crm-long with canonical events enabled — recommended before merge to confirm grounding traces land in the JSONL for real form-target calls.

Closes #479
Closes #480
Refs #472, #473

🤖 Generated with [Claude Code](https://claude.com/claude-code)