### PR TITLE
cua: action ontology (#477) + preview-gate primitive (#481)

### DIFF
--- a/src/mantis_agent/cua_contracts/__init__.py
+++ b/src/mantis_agent/cua_contracts/__init__.py
@@ -54,6 +54,12 @@ from .adapters import (
     verdict_from_step_result,
 )
 from .emit import JSONL_FILENAME, TrajectoryEmitter
+from .ontology import (
+    ActionTyped,
+    classify_action,
+    is_irreversible,
+    validate_action_type,
+)
 from .types import (
     ActionResult,
     GroundingTrace,
@@ -77,6 +83,7 @@ from .validation import (
 
 __all__ = [
     "ActionResult",
+    "ActionTyped",
     "ContractValidationError",
     "GroundingTrace",
     "Observation",
@@ -91,9 +98,12 @@ __all__ = [
     "JSONL_FILENAME",
     "TrajectoryEmitter",
     "action_result_from_action",
+    "classify_action",
     "classify_legacy_reversibility",
+    "is_irreversible",
     "observation_from_screenshot_ref",
     "step_from_micro_intent",
+    "validate_action_type",
     "validate_step",
     "validate_task_spec",
     "validate_trajectory_event",

--- a/src/mantis_agent/cua_contracts/adapters.py
+++ b/src/mantis_agent/cua_contracts/adapters.py
@@ -53,41 +53,27 @@ _NON_RECOVERABLE_FAILURE_CLASSES: frozenset[str] = frozenset({
 })
 
 
-# Mapping from legacy MicroIntent.type strings to a coarse
-# reversibility class. The list of step types lives in
-# ``MicroIntent``'s docstring; we preserve the runtime behaviour the
-# step-recovery / preview-gate code already implements implicitly.
-# Anything not listed defaults to REVERSIBLE so unknown step types
-# fail safe rather than fail open (the preview gate will run, not
-# the auto-dispatch path). #477 will refine this with a proper
-# action ontology.
-_LEGACY_TYPE_TO_REVERSIBILITY: dict[str, ReversibilityClass] = {
-    # Read-only — no side effects.
-    "scroll": ReversibilityClass.READ_ONLY,
-    "extract_data": ReversibilityClass.READ_ONLY,
-    "extract_url": ReversibilityClass.READ_ONLY,
-    # Reversible by alt+Left / Escape / Backspace.
-    "click": ReversibilityClass.REVERSIBLE,
-    "navigate": ReversibilityClass.REVERSIBLE,
-    "navigate_back": ReversibilityClass.REVERSIBLE,
-    "fill_field": ReversibilityClass.REVERSIBLE,
-    "select_option": ReversibilityClass.REVERSIBLE,
-    "right_click": ReversibilityClass.REVERSIBLE,
-    "filter": ReversibilityClass.REVERSIBLE,
-    "paginate": ReversibilityClass.REVERSIBLE,
-    "loop": ReversibilityClass.READ_ONLY,
-    # Irreversible — pre-dispatch preview gate should always run.
-    # ``submit`` is the canonical write action; the rest are aliases
-    # plans use for the same semantic (#477 will collapse them).
-    "submit": ReversibilityClass.IRREVERSIBLE,
-}
-
-
 def classify_legacy_reversibility(step_type: str) -> ReversibilityClass:
-    """Public helper — also useful from tests / safety gates."""
-    return _LEGACY_TYPE_TO_REVERSIBILITY.get(
-        step_type, ReversibilityClass.REVERSIBLE,
-    )
+    """Project a legacy ``MicroIntent.type`` string onto the
+    reversibility class registered in :mod:`.ontology`.
+
+    Public helper — also useful from tests / safety gates that
+    operate on the legacy string vocabulary.
+
+    Failure mode: unknown step types default to
+    :class:`ReversibilityClass.REVERSIBLE` rather than raising.
+    Rationale — the adapter is a back-compat shim and the runner
+    has long tolerated unrecognised plan step types (the executor
+    falls through to the Holo3 step handler). Failing closed here
+    would regress that tolerance. Callers that want strict
+    validation should use :func:`.ontology.classify_action` directly,
+    which raises :class:`ContractValidationError` on unknown.
+    """
+    from .ontology import _REVERSIBILITY_MAP, ActionTyped
+    try:
+        return _REVERSIBILITY_MAP[ActionTyped(step_type)]
+    except (ValueError, KeyError):
+        return ReversibilityClass.REVERSIBLE
 
 
 def step_from_micro_intent(mi: "MicroIntent") -> Step:

--- a/src/mantis_agent/cua_contracts/ontology.py
+++ b/src/mantis_agent/cua_contracts/ontology.py
@@ -1,0 +1,201 @@
+"""Action ontology + reversibility classifier (#477).
+
+The canonical action vocabulary the CUA contracts pin against.
+Centralising it here means:
+
+* :issue:`476` typed Step's ``action_type`` field has a closed,
+  validated vocabulary;
+* :issue:`478` canonical event emitter and :issue:`479` grounding
+  trace consumers can dispatch by action class without re-deriving
+  semantics from prose;
+* :issue:`481` preview gate can ask one question ("is this
+  IRREVERSIBLE?") and route deterministically;
+* future planners that emit raw strings get a clear rejection at
+  validation time instead of producing silently-dispatched
+  free-form actions.
+
+The vocabulary is the *union* of two pre-existing surfaces:
+
+* :class:`~mantis_agent.actions.ActionType` — the brain-emitted
+  vocabulary (click / type_text / scroll / wait / done / ...).
+* :class:`~mantis_agent.plan_decomposer.MicroIntent`'s ``type`` —
+  the plan-step vocabulary (navigate / fill_field / submit /
+  extract_data / paginate / loop / ...).
+
+The brain vocabulary describes *what the actor did*; the plan
+vocabulary describes *what the planner asked for*. The two
+intersect (CLICK / TYPE / SCROLL / WAIT / DONE) and diverge — the
+ontology unifies them. The reversibility class is plan-side: it
+asks "if this step is dispatched and turns out wrong, can the
+runner undo it cheaply?".
+
+The vocabulary is intentionally narrow for v1. Aliases (e.g. some
+plans use ``"click_button"`` instead of ``"submit"``) and
+domain-specific verbs (``"confirm_purchase"``, ``"agree_tos"``)
+are NOT separate enum values — they map onto the closest canonical
+verb at the adapter boundary. The reversibility classifier is
+where any domain refinement goes (e.g. a future "confirm_purchase"
+keyword detector could escalate a ``submit`` to
+:class:`ReversibilityClass.IRREVERSIBLE` based on label
+context — but that lives in a separate layer, not the enum).
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+from .types import ReversibilityClass
+from .validation import ContractValidationError
+
+
+class ActionTyped(str, Enum):
+    """Canonical action vocabulary the CUA contracts validate against.
+
+    String values match the existing
+    :class:`~mantis_agent.actions.ActionType` enum where they
+    overlap, so callers passing the legacy enum's ``.value`` keep
+    working without conversion. Plan-side verbs that have no brain
+    counterpart (``fill_field`` is a *plan* op that decomposes into
+    a CLICK + TYPE pair at the actor) carry their plan-side name
+    here so the typed Step in :mod:`.types` round-trips cleanly
+    from a MicroIntent.
+
+    Bump on new value addition: this is a closed vocabulary, but
+    additive changes are backward-compatible because the validator
+    only rejects *unknown* values, not unrecognised-but-defined ones.
+    """
+
+    # Pointer + keyboard primitives (brain vocabulary).
+    CLICK = "click"
+    RIGHT_CLICK = "right_click"
+    DOUBLE_CLICK = "double_click"
+    TYPE = "type_text"
+    KEY_PRESS = "key_press"
+    SCROLL = "scroll"
+    DRAG = "drag"
+    WAIT = "wait"
+    DONE = "done"
+    LAUNCH_APP = "launch_app"
+    TOOL_CALL = "tool_call"
+
+    # Plan-level verbs (MicroIntent.type).
+    NAVIGATE = "navigate"
+    NAVIGATE_BACK = "navigate_back"
+    FILL_FIELD = "fill_field"
+    SELECT_OPTION = "select_option"
+    SUBMIT = "submit"
+    EXTRACT_DATA = "extract_data"
+    EXTRACT_URL = "extract_url"
+    PAGINATE = "paginate"
+    FILTER = "filter"
+    LOOP = "loop"
+
+
+# Reversibility classification per action type. Pinned here so the
+# preview-gate / safety-gate / recovery-policy layers all read from
+# the same map.
+#
+# Rationale per class:
+#
+# * READ_ONLY — pure observation actions. No env mutation possible
+#   short of the screenshot capture itself. Preview gate skips these
+#   entirely.
+# * REVERSIBLE — pointer / keyboard / navigation actions that can be
+#   undone by alt+Left / Esc / Backspace or a re-navigation. Preview
+#   gate may run as advisory but doesn't block.
+# * IRREVERSIBLE — actions that commit state the runner can't
+#   programmatically undo: form submissions, file uploads, app
+#   launches, ToS / purchase / send / delete confirmations dressed
+#   as a submit. Preview gate is MANDATORY before dispatch (#481).
+_REVERSIBILITY_MAP: dict[ActionTyped, ReversibilityClass] = {
+    # Read-only.
+    ActionTyped.SCROLL: ReversibilityClass.READ_ONLY,
+    ActionTyped.WAIT: ReversibilityClass.READ_ONLY,
+    ActionTyped.EXTRACT_DATA: ReversibilityClass.READ_ONLY,
+    ActionTyped.EXTRACT_URL: ReversibilityClass.READ_ONLY,
+    ActionTyped.LOOP: ReversibilityClass.READ_ONLY,
+    # Reversible.
+    ActionTyped.CLICK: ReversibilityClass.REVERSIBLE,
+    ActionTyped.RIGHT_CLICK: ReversibilityClass.REVERSIBLE,
+    ActionTyped.DOUBLE_CLICK: ReversibilityClass.REVERSIBLE,
+    ActionTyped.TYPE: ReversibilityClass.REVERSIBLE,
+    ActionTyped.KEY_PRESS: ReversibilityClass.REVERSIBLE,
+    ActionTyped.DRAG: ReversibilityClass.REVERSIBLE,
+    ActionTyped.NAVIGATE: ReversibilityClass.REVERSIBLE,
+    ActionTyped.NAVIGATE_BACK: ReversibilityClass.REVERSIBLE,
+    ActionTyped.FILL_FIELD: ReversibilityClass.REVERSIBLE,
+    ActionTyped.SELECT_OPTION: ReversibilityClass.REVERSIBLE,
+    ActionTyped.FILTER: ReversibilityClass.REVERSIBLE,
+    ActionTyped.PAGINATE: ReversibilityClass.REVERSIBLE,
+    ActionTyped.DONE: ReversibilityClass.REVERSIBLE,
+    ActionTyped.TOOL_CALL: ReversibilityClass.REVERSIBLE,
+    # Irreversible — preview gate mandatory.
+    ActionTyped.SUBMIT: ReversibilityClass.IRREVERSIBLE,
+    ActionTyped.LAUNCH_APP: ReversibilityClass.IRREVERSIBLE,
+}
+
+
+# Sanity-check: every enum member has a reversibility class. Caught
+# at module import time so a future enum addition without an
+# accompanying map entry fails immediately rather than silently
+# routing through the REVERSIBLE default in production.
+_uncovered = set(ActionTyped) - set(_REVERSIBILITY_MAP)
+if _uncovered:
+    raise RuntimeError(
+        f"ActionTyped members missing from _REVERSIBILITY_MAP: "
+        f"{sorted(a.value for a in _uncovered)} — add an entry "
+        f"before importing this module."
+    )
+
+
+def validate_action_type(value: str) -> ActionTyped:
+    """Parse a raw string into a typed :class:`ActionTyped`.
+
+    Raises :class:`~.validation.ContractValidationError` when the
+    string isn't a known vocabulary member. Empty / None inputs
+    also raise so the validator catches them at the planner
+    boundary rather than letting them pass through to the
+    dispatcher.
+
+    The error message lists the closed vocabulary so the caller
+    (typically a planner / decomposer) can correct without
+    spelunking.
+    """
+    if not value or not isinstance(value, str):
+        raise ContractValidationError(
+            f"action_type must be a non-empty string; got {value!r}"
+        )
+    try:
+        return ActionTyped(value)
+    except ValueError:
+        known = sorted(member.value for member in ActionTyped)
+        raise ContractValidationError(
+            f"unknown action_type {value!r}; must be one of {known}"
+        ) from None
+
+
+def classify_action(action_type: str | ActionTyped) -> ReversibilityClass:
+    """Return the reversibility class for an action type.
+
+    Accepts either a raw string (which is validated against the
+    ontology) or an already-parsed :class:`ActionTyped`. Unknown
+    raw strings raise :class:`ContractValidationError` — the safety
+    contract is "fail closed on unknown", since a default
+    reversibility guess could let a hidden IRREVERSIBLE action
+    through the preview gate.
+    """
+    if isinstance(action_type, ActionTyped):
+        return _REVERSIBILITY_MAP[action_type]
+    parsed = validate_action_type(action_type)
+    return _REVERSIBILITY_MAP[parsed]
+
+
+def is_irreversible(action_type: str | ActionTyped) -> bool:
+    """Convenience predicate for the preview-gate dispatcher (#481).
+
+    Equivalent to ``classify_action(...) ==
+    ReversibilityClass.IRREVERSIBLE`` but reads more cleanly at
+    the callsite. Same fail-closed contract: unknown strings raise
+    rather than silently returning False.
+    """
+    return classify_action(action_type) is ReversibilityClass.IRREVERSIBLE

--- a/src/mantis_agent/gym/preview_gate.py
+++ b/src/mantis_agent/gym/preview_gate.py
@@ -1,0 +1,242 @@
+"""Pre-dispatch preview / cross-check gate for high-risk actions (#481).
+
+The CUA design's safety contract: before dispatching an
+:class:`~mantis_agent.cua_contracts.ReversibilityClass.IRREVERSIBLE`
+action (form submission, file upload, app launch, ToS / purchase /
+send / delete confirmations dressed as a submit), highlight the
+proposed target on a fresh screenshot and ask an independent
+verifier "does this match the planner's intent?". Block dispatch
+when the verifier says no or confidence is low.
+
+This module owns the primitive — a pure function callers invoke
+right before they hit ``env.step(...)``. It does NOT wire itself
+into the existing form / click handlers; that integration is
+intentionally a separate PR so the behaviour change can be
+reviewed independently of the contract.
+
+Why a separate verifier path:
+
+The grounding model that picked the coordinates has already
+committed to its answer. Asking the same model to re-check is a
+near-no-op (it will agree with itself). A useful preview cross-
+checks against either:
+
+* a different model — e.g. the planner uses Claude grounding, the
+  preview asks Holo3 (or vice versa);
+* the same model with a different prompt framing — e.g. "is the
+  highlighted region a Login button?" instead of "where's the
+  Login button?".
+
+For v1 the preview takes a generic ``verifier_fn`` callable so
+callers can plug in whichever cross-check they prefer; the
+infrastructure stays neutral.
+
+Failure mode contract:
+
+* preview PASS → caller dispatches as planned.
+* preview FAIL → caller halts the step with a structured recovery
+  hint; the runner's recovery layer can prompt-for-human or replan.
+* preview ERROR (verifier raised / returned no usable signal) →
+  caller treats as FAIL by default — safety contract is fail-closed
+  on irreversible actions.
+
+Gated by env var ``MANTIS_PREVIEW_GATE`` so production roll-out
+goes: ship code → enable on staging → enable on prod tenant-by-
+tenant. Default off keeps the existing production behaviour
+unchanged.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any, Callable, Protocol
+
+from ..cua_contracts import ReversibilityClass, classify_action
+from ..cua_contracts.validation import ContractValidationError
+
+logger = logging.getLogger(__name__)
+
+
+_PREVIEW_GATE_ENV: str = "MANTIS_PREVIEW_GATE"
+_PREVIEW_CONFIDENCE_THRESHOLD_ENV: str = "MANTIS_PREVIEW_CONFIDENCE_THRESHOLD"
+_DEFAULT_CONFIDENCE_THRESHOLD: float = 0.6
+
+
+@dataclass(frozen=True)
+class PreviewResult:
+    """Outcome of a single preview cross-check.
+
+    Surfaced into the runner as structured recovery metadata when
+    the gate blocks dispatch — populates
+    :class:`~mantis_agent.cua_contracts.ActionResult.grounding_trace`'s
+    ``confirmation_evidence`` field so post-mortems see exactly
+    why an irreversible step was held.
+    """
+
+    passed: bool
+    confidence: float
+    reason: str          # short machine code: "verifier_rejected", "low_confidence", "verifier_error", "skipped"
+    evidence: str = ""   # human-readable verifier prose
+
+
+class _VerifierCallable(Protocol):
+    """Shape callers must satisfy when wiring a preview verifier.
+
+    Given a labelled screenshot + the intent prose, return a
+    ``(passed, confidence, evidence)`` triple. Implementations can
+    wrap Claude / Holo3 / a heuristic — the gate primitive doesn't
+    care which.
+    """
+
+    def __call__(
+        self,
+        *,
+        screenshot: Any,
+        intent: str,
+        target_label: str,
+        target_coordinates: tuple[int, int],
+    ) -> tuple[bool, float, str]:
+        ...
+
+
+def is_enabled() -> bool:
+    """True when the preview gate is opted in via env.
+
+    Off by default. Operators flip the env per tenant / per deploy
+    when rolling out the safety gate. Tests monkeypatch
+    ``MANTIS_PREVIEW_GATE=on``.
+    """
+    return os.environ.get(_PREVIEW_GATE_ENV, "").strip().lower() in {"on", "1", "true", "yes"}
+
+
+def confidence_threshold() -> float:
+    """Configured minimum confidence; below this the gate blocks even
+    when ``passed=True`` (defensive against verifiers that report
+    weak signals as positive)."""
+    raw = os.environ.get(_PREVIEW_CONFIDENCE_THRESHOLD_ENV, "").strip()
+    if not raw:
+        return _DEFAULT_CONFIDENCE_THRESHOLD
+    try:
+        value = float(raw)
+    except ValueError:
+        logger.warning(
+            "preview gate: invalid %s=%r; falling back to default %.2f",
+            _PREVIEW_CONFIDENCE_THRESHOLD_ENV, raw, _DEFAULT_CONFIDENCE_THRESHOLD,
+        )
+        return _DEFAULT_CONFIDENCE_THRESHOLD
+    # Clamp to a sensible range — values outside [0, 1] are config
+    # bugs, not intent.
+    return max(0.0, min(1.0, value))
+
+
+def evaluate(
+    *,
+    action_type: str,
+    intent: str,
+    target_label: str,
+    target_coordinates: tuple[int, int],
+    screenshot: Any,
+    verifier: _VerifierCallable | Callable[..., tuple[bool, float, str]],
+) -> PreviewResult:
+    """Run the pre-dispatch preview cross-check.
+
+    Returns a :class:`PreviewResult` the caller branches on. Never
+    raises — verifier errors are caught and downgraded to
+    ``passed=False, reason="verifier_error"`` so the safety contract
+    holds even when the cross-check infrastructure is broken.
+
+    Skip conditions (return ``passed=True, reason="skipped"``):
+
+    * preview gate disabled via env (production default);
+    * ``action_type`` is not :class:`ReversibilityClass.IRREVERSIBLE`
+      (no need to gate reversible / read-only actions).
+
+    Fail conditions (return ``passed=False`` with a reason code):
+
+    * ``verifier_rejected`` — verifier returned ``passed=False``.
+    * ``low_confidence`` — verifier said ``passed=True`` but
+      confidence < :func:`confidence_threshold`.
+    * ``verifier_error`` — verifier raised, returned a non-
+      conforming value, or the action_type itself was rejected by
+      the ontology.
+
+    The caller is responsible for stamping the result into the
+    StepResult / grounding trace and for emitting a HALT / retry
+    hint accordingly.
+    """
+    if not is_enabled():
+        return PreviewResult(passed=True, confidence=1.0, reason="skipped")
+
+    # Fail-closed on unknown action types — the safety contract is
+    # "no irreversible action passes through ungated"; we can't
+    # honour that if we can't classify.
+    try:
+        cls = classify_action(action_type)
+    except ContractValidationError as exc:
+        logger.warning("preview gate: unknown action_type %r — %s", action_type, exc)
+        return PreviewResult(
+            passed=False, confidence=0.0,
+            reason="verifier_error",
+            evidence=f"unknown action_type: {exc}",
+        )
+
+    if cls is not ReversibilityClass.IRREVERSIBLE:
+        return PreviewResult(passed=True, confidence=1.0, reason="skipped")
+
+    try:
+        passed, confidence, evidence = verifier(
+            screenshot=screenshot,
+            intent=intent,
+            target_label=target_label,
+            target_coordinates=target_coordinates,
+        )
+    except Exception as exc:  # noqa: BLE001 — verifier errors must not crash the runner
+        logger.warning(
+            "preview gate: verifier raised on action_type=%s label=%r — %s",
+            action_type, target_label, exc,
+        )
+        return PreviewResult(
+            passed=False, confidence=0.0,
+            reason="verifier_error",
+            evidence=f"verifier raised: {exc.__class__.__name__}: {exc}",
+        )
+
+    # Coerce types defensively — verifiers are often hand-rolled.
+    try:
+        confidence = float(confidence)
+    except (TypeError, ValueError):
+        logger.warning(
+            "preview gate: verifier returned non-float confidence=%r; failing closed",
+            confidence,
+        )
+        return PreviewResult(
+            passed=False, confidence=0.0,
+            reason="verifier_error",
+            evidence=f"non-float confidence: {confidence!r}",
+        )
+
+    if not passed:
+        return PreviewResult(
+            passed=False, confidence=confidence,
+            reason="verifier_rejected",
+            evidence=str(evidence)[:500],
+        )
+
+    threshold = confidence_threshold()
+    if confidence < threshold:
+        return PreviewResult(
+            passed=False, confidence=confidence,
+            reason="low_confidence",
+            evidence=(
+                f"verifier passed but confidence={confidence:.2f} < "
+                f"threshold={threshold:.2f}: {str(evidence)[:300]}"
+            ),
+        )
+
+    return PreviewResult(
+        passed=True, confidence=confidence,
+        reason="verifier_accepted",
+        evidence=str(evidence)[:500],
+    )

--- a/tests/test_cua_ontology.py
+++ b/tests/test_cua_ontology.py
@@ -1,0 +1,173 @@
+"""Tests for the action ontology + reversibility classifier (#477).
+
+Covers:
+
+* the ``ActionTyped`` enum covers every legacy ``MicroIntent.type``
+  value the runtime accepts (no silent drops);
+* every enum member has a reversibility class registered (the
+  import-time sanity check catches stealth additions);
+* high-risk actions (submit / launch_app) classify as IRREVERSIBLE,
+  pointer / keyboard / nav actions as REVERSIBLE, scroll / extract
+  / loop as READ_ONLY;
+* unknown action strings raise :class:`ContractValidationError`
+  with a useful message (vocabulary listed);
+* the legacy adapter shim (``classify_legacy_reversibility``) now
+  delegates to the ontology and preserves its pre-existing
+  fail-soft contract (REVERSIBLE on unknown, vs the strict path's
+  raise).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mantis_agent.cua_contracts import (
+    ActionTyped,
+    ContractValidationError,
+    ReversibilityClass,
+    classify_action,
+    classify_legacy_reversibility,
+    is_irreversible,
+    validate_action_type,
+)
+from mantis_agent.cua_contracts.ontology import _REVERSIBILITY_MAP
+
+
+# ── Enum coverage ──────────────────────────────────────────────────────
+
+
+def test_every_enum_member_has_reversibility_class() -> None:
+    """Sanity check the module's import-time guard would also catch —
+    pinned in a test so the failure mode is explicit if someone bumps
+    the enum and skips the map update."""
+    assert set(_REVERSIBILITY_MAP) == set(ActionTyped)
+
+
+def test_enum_covers_brain_vocabulary() -> None:
+    """ActionType values from ``mantis_agent.actions.ActionType`` must
+    all round-trip through the ontology — the brain emits these and
+    the contracts have to accept them without a translation layer."""
+    from mantis_agent.actions import ActionType
+    for member in ActionType:
+        # Every brain action must be in the ontology by its value.
+        assert validate_action_type(member.value) is not None
+
+
+def test_enum_covers_plan_step_types() -> None:
+    """Every step type a MicroPlanRunner dispatches must be in the
+    ontology. List mirrors MicroIntent's docstring."""
+    plan_step_types = [
+        "navigate", "navigate_back", "click", "right_click",
+        "fill_field", "submit", "select_option",
+        "extract_data", "extract_url",
+        "scroll", "paginate", "filter", "loop",
+    ]
+    for st in plan_step_types:
+        assert validate_action_type(st) is not None
+
+
+# ── Reversibility classification ───────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "action_type,expected",
+    [
+        # Read-only
+        ("scroll", ReversibilityClass.READ_ONLY),
+        ("wait", ReversibilityClass.READ_ONLY),
+        ("extract_data", ReversibilityClass.READ_ONLY),
+        ("extract_url", ReversibilityClass.READ_ONLY),
+        ("loop", ReversibilityClass.READ_ONLY),
+        # Reversible
+        ("click", ReversibilityClass.REVERSIBLE),
+        ("right_click", ReversibilityClass.REVERSIBLE),
+        ("double_click", ReversibilityClass.REVERSIBLE),
+        ("type_text", ReversibilityClass.REVERSIBLE),
+        ("key_press", ReversibilityClass.REVERSIBLE),
+        ("drag", ReversibilityClass.REVERSIBLE),
+        ("navigate", ReversibilityClass.REVERSIBLE),
+        ("navigate_back", ReversibilityClass.REVERSIBLE),
+        ("fill_field", ReversibilityClass.REVERSIBLE),
+        ("select_option", ReversibilityClass.REVERSIBLE),
+        ("filter", ReversibilityClass.REVERSIBLE),
+        ("paginate", ReversibilityClass.REVERSIBLE),
+        ("done", ReversibilityClass.REVERSIBLE),
+        ("tool_call", ReversibilityClass.REVERSIBLE),
+        # Irreversible
+        ("submit", ReversibilityClass.IRREVERSIBLE),
+        ("launch_app", ReversibilityClass.IRREVERSIBLE),
+    ],
+)
+def test_classify_action_pins_full_map(
+    action_type: str, expected: ReversibilityClass,
+) -> None:
+    assert classify_action(action_type) is expected
+
+
+def test_is_irreversible_predicate_matches_classify() -> None:
+    assert is_irreversible("submit") is True
+    assert is_irreversible("launch_app") is True
+    assert is_irreversible("click") is False
+    assert is_irreversible("scroll") is False
+
+
+def test_classify_action_accepts_typed_enum_directly() -> None:
+    """Callers that already have a typed value shouldn't re-validate
+    via the string path — accept the enum directly."""
+    assert classify_action(ActionTyped.SUBMIT) is ReversibilityClass.IRREVERSIBLE
+    assert classify_action(ActionTyped.CLICK) is ReversibilityClass.REVERSIBLE
+
+
+# ── Validation failure modes ───────────────────────────────────────────
+
+
+def test_validate_action_type_rejects_unknown_with_vocabulary_list() -> None:
+    """Error message must list the known vocabulary so the caller
+    can correct without digging into source."""
+    with pytest.raises(ContractValidationError) as exc_info:
+        validate_action_type("frobnicate_lead")
+    msg = str(exc_info.value)
+    assert "frobnicate_lead" in msg
+    assert "submit" in msg  # the listed vocabulary must contain the canonical members
+    assert "click" in msg
+
+
+@pytest.mark.parametrize("value", ["", None])
+def test_validate_action_type_rejects_empty(value) -> None:
+    with pytest.raises(ContractValidationError, match="non-empty"):
+        validate_action_type(value)  # type: ignore[arg-type]
+
+
+def test_classify_action_fails_closed_on_unknown() -> None:
+    """Strict path: classify_action raises on unknown — preview gate
+    relies on this to never silently let an irreversible action
+    through under a default."""
+    with pytest.raises(ContractValidationError):
+        classify_action("some_new_verb_we_dont_know")
+
+
+def test_is_irreversible_fails_closed_on_unknown() -> None:
+    with pytest.raises(ContractValidationError):
+        is_irreversible("some_new_verb_we_dont_know")
+
+
+# ── Legacy adapter shim preserves fail-soft contract ───────────────────
+
+
+def test_classify_legacy_reversibility_still_fail_soft_on_unknown() -> None:
+    """``classify_legacy_reversibility`` is the back-compat shim —
+    the existing executor falls through to Holo3 on unknown step
+    types, so the shim returns REVERSIBLE rather than raising.
+    Callers that want strict validation should use
+    :func:`classify_action` directly."""
+    assert (
+        classify_legacy_reversibility("not_in_the_ontology")
+        is ReversibilityClass.REVERSIBLE
+    )
+
+
+def test_classify_legacy_reversibility_routes_through_ontology() -> None:
+    """The shim now delegates to the ontology — pinned mappings hold."""
+    assert classify_legacy_reversibility("submit") is ReversibilityClass.IRREVERSIBLE
+    assert classify_legacy_reversibility("scroll") is ReversibilityClass.READ_ONLY
+    assert classify_legacy_reversibility("click") is ReversibilityClass.REVERSIBLE

--- a/tests/test_preview_gate.py
+++ b/tests/test_preview_gate.py
@@ -1,0 +1,234 @@
+"""Tests for the pre-dispatch preview gate primitive (#481).
+
+Covers:
+
+* gate is OFF by default (production parity until rolled out);
+* IRREVERSIBLE actions get the verifier called; reversible / read-
+  only actions skip the verifier (perf);
+* PASS / FAIL / low-confidence / verifier-error / unknown-action
+  outcomes all return distinct ``reason`` codes;
+* the gate never raises — verifier exceptions are caught and
+  downgraded to a fail-closed result;
+* confidence threshold is configurable via env, clamped sensibly,
+  defaults to 0.6.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mantis_agent.gym.preview_gate import (
+    PreviewResult,
+    confidence_threshold,
+    evaluate,
+    is_enabled,
+)
+
+
+def _accept_verifier(**_kwargs) -> tuple[bool, float, str]:
+    """Verifier that always says yes with high confidence."""
+    return (True, 0.95, "looks like the right button")
+
+
+def _reject_verifier(**_kwargs) -> tuple[bool, float, str]:
+    return (False, 0.3, "highlighted region is a checkbox, not Submit")
+
+
+def _low_conf_verifier(**_kwargs) -> tuple[bool, float, str]:
+    return (True, 0.4, "ambiguous — could be Submit, could be Save")
+
+
+def _raises_verifier(**_kwargs) -> tuple[bool, float, str]:
+    raise RuntimeError("simulated verifier crash")
+
+
+def _evaluate(verifier, *, action_type: str = "submit", monkeypatch=None):
+    """Helper — enables the gate via env, runs evaluate with stub args."""
+    if monkeypatch is not None:
+        monkeypatch.setenv("MANTIS_PREVIEW_GATE", "on")
+    return evaluate(
+        action_type=action_type,
+        intent="Click the Submit button",
+        target_label="Submit",
+        target_coordinates=(420, 568),
+        screenshot=object(),  # opaque — verifier doesn't actually use it
+        verifier=verifier,
+    )
+
+
+# ── Env gating ─────────────────────────────────────────────────────────
+
+
+def test_is_enabled_off_by_default(monkeypatch) -> None:
+    monkeypatch.delenv("MANTIS_PREVIEW_GATE", raising=False)
+    assert is_enabled() is False
+
+
+@pytest.mark.parametrize("value", ["on", "1", "true", "yes", "ON", "True"])
+def test_is_enabled_honours_truthy_values(monkeypatch, value: str) -> None:
+    monkeypatch.setenv("MANTIS_PREVIEW_GATE", value)
+    assert is_enabled() is True
+
+
+@pytest.mark.parametrize("value", ["", "off", "0", "false", "no"])
+def test_is_enabled_rejects_falsy_values(monkeypatch, value: str) -> None:
+    monkeypatch.setenv("MANTIS_PREVIEW_GATE", value)
+    assert is_enabled() is False
+
+
+def test_evaluate_skips_when_gate_disabled(monkeypatch) -> None:
+    """Default off — preserves production behaviour until rollout."""
+    monkeypatch.delenv("MANTIS_PREVIEW_GATE", raising=False)
+    out = evaluate(
+        action_type="submit", intent="x", target_label="Submit",
+        target_coordinates=(0, 0), screenshot=object(),
+        verifier=_reject_verifier,  # would FAIL if it ran
+    )
+    assert out.passed is True
+    assert out.reason == "skipped"
+
+
+# ── Reversibility-based skip ───────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "action_type",
+    ["click", "scroll", "navigate", "fill_field", "extract_data"],
+)
+def test_evaluate_skips_for_non_irreversible_actions(monkeypatch, action_type: str) -> None:
+    """Reversible / read-only actions don't need the gate. Verifier
+    is never called — confirmed by passing one that would raise."""
+    monkeypatch.setenv("MANTIS_PREVIEW_GATE", "on")
+    out = evaluate(
+        action_type=action_type, intent="x", target_label="x",
+        target_coordinates=(0, 0), screenshot=object(),
+        verifier=_raises_verifier,
+    )
+    assert out.passed is True
+    assert out.reason == "skipped"
+
+
+def test_evaluate_fires_verifier_for_irreversible_actions(monkeypatch) -> None:
+    """``submit`` is IRREVERSIBLE — must call the verifier and report
+    its verdict."""
+    out = _evaluate(_accept_verifier, monkeypatch=monkeypatch)
+    assert out.passed is True
+    assert out.reason == "verifier_accepted"
+    assert out.confidence == 0.95
+    assert "looks like the right button" in out.evidence
+
+
+def test_evaluate_fires_verifier_for_launch_app(monkeypatch) -> None:
+    """``launch_app`` is the other IRREVERSIBLE member of the
+    ontology — gate it too."""
+    out = _evaluate(_accept_verifier, action_type="launch_app", monkeypatch=monkeypatch)
+    assert out.passed is True
+    assert out.reason == "verifier_accepted"
+
+
+# ── Verifier outcomes ──────────────────────────────────────────────────
+
+
+def test_evaluate_returns_verifier_rejected_on_explicit_false(monkeypatch) -> None:
+    out = _evaluate(_reject_verifier, monkeypatch=monkeypatch)
+    assert out.passed is False
+    assert out.reason == "verifier_rejected"
+    assert "checkbox" in out.evidence
+
+
+def test_evaluate_blocks_on_low_confidence_even_when_passed(monkeypatch) -> None:
+    """Defensive against verifiers that report weak signals as
+    positive — confidence floor enforced by the gate."""
+    out = _evaluate(_low_conf_verifier, monkeypatch=monkeypatch)
+    assert out.passed is False
+    assert out.reason == "low_confidence"
+    assert out.confidence == 0.4
+    assert "ambiguous" in out.evidence
+
+
+def test_evaluate_catches_verifier_exception(monkeypatch) -> None:
+    """Verifier crashes never propagate — fail-closed instead."""
+    out = _evaluate(_raises_verifier, monkeypatch=monkeypatch)
+    assert out.passed is False
+    assert out.reason == "verifier_error"
+    assert "simulated verifier crash" in out.evidence
+
+
+def test_evaluate_handles_non_float_confidence(monkeypatch) -> None:
+    """Hand-rolled verifiers sometimes return strings — coerce
+    defensively, fail-closed if uncoercible."""
+    monkeypatch.setenv("MANTIS_PREVIEW_GATE", "on")
+
+    def _bad_verifier(**_kw) -> tuple[bool, str, str]:
+        return (True, "not-a-number", "evidence")
+
+    out = evaluate(
+        action_type="submit", intent="x", target_label="x",
+        target_coordinates=(0, 0), screenshot=object(),
+        verifier=_bad_verifier,
+    )
+    assert out.passed is False
+    assert out.reason == "verifier_error"
+
+
+def test_evaluate_fails_closed_on_unknown_action_type(monkeypatch) -> None:
+    """Safety contract: an action_type the ontology doesn't recognise
+    cannot pass the gate — we can't guarantee it isn't IRREVERSIBLE."""
+    monkeypatch.setenv("MANTIS_PREVIEW_GATE", "on")
+    out = evaluate(
+        action_type="unknown_action", intent="x", target_label="x",
+        target_coordinates=(0, 0), screenshot=object(),
+        verifier=_accept_verifier,
+    )
+    assert out.passed is False
+    assert out.reason == "verifier_error"
+    assert "unknown action_type" in out.evidence
+
+
+# ── Confidence threshold configuration ────────────────────────────────
+
+
+def test_confidence_threshold_default(monkeypatch) -> None:
+    monkeypatch.delenv("MANTIS_PREVIEW_CONFIDENCE_THRESHOLD", raising=False)
+    assert confidence_threshold() == 0.6
+
+
+def test_confidence_threshold_honours_env(monkeypatch) -> None:
+    monkeypatch.setenv("MANTIS_PREVIEW_CONFIDENCE_THRESHOLD", "0.9")
+    assert confidence_threshold() == 0.9
+
+
+def test_confidence_threshold_clamps_to_unit_interval(monkeypatch) -> None:
+    """Out-of-range values are config bugs, not intent — clamp."""
+    monkeypatch.setenv("MANTIS_PREVIEW_CONFIDENCE_THRESHOLD", "1.5")
+    assert confidence_threshold() == 1.0
+    monkeypatch.setenv("MANTIS_PREVIEW_CONFIDENCE_THRESHOLD", "-0.1")
+    assert confidence_threshold() == 0.0
+
+
+def test_confidence_threshold_falls_back_on_garbage(monkeypatch) -> None:
+    monkeypatch.setenv("MANTIS_PREVIEW_CONFIDENCE_THRESHOLD", "high")
+    assert confidence_threshold() == 0.6  # default
+
+
+def test_high_threshold_blocks_otherwise_passing_verifier(monkeypatch) -> None:
+    monkeypatch.setenv("MANTIS_PREVIEW_GATE", "on")
+    monkeypatch.setenv("MANTIS_PREVIEW_CONFIDENCE_THRESHOLD", "0.99")
+    out = evaluate(
+        action_type="submit", intent="x", target_label="x",
+        target_coordinates=(0, 0), screenshot=object(),
+        verifier=_accept_verifier,  # returns 0.95 < 0.99
+    )
+    assert out.passed is False
+    assert out.reason == "low_confidence"
+
+
+# ── Result shape ───────────────────────────────────────────────────────
+
+
+def test_preview_result_is_frozen() -> None:
+    """Immutability — callers don't get to mutate the evidence after
+    the gate emits it. Matches the rest of the cua_contracts shape."""
+    out = PreviewResult(passed=True, confidence=1.0, reason="skipped")
+    with pytest.raises(Exception):  # FrozenInstanceError
+        out.passed = False  # type: ignore[misc]


### PR DESCRIPTION
## Summary

Two more P0 reliability-foundation pieces — closes out the action-ontology + step-safety substrate from epics #472 and #473.

### #477 — Action ontology + reversibility classifier

\`src/mantis_agent/cua_contracts/ontology.py\`:

- \`ActionTyped\` enum with 21 canonical action names, unifying the brain vocabulary (click, type_text, scroll, ...) and the plan-step vocabulary (navigate, fill_field, submit, extract_data, ...).
- \`_REVERSIBILITY_MAP\` pins every enum member → \`ReversibilityClass\`. Import-time sanity check raises if an enum addition skips the map update — stealth changes fail loud.
- \`classify_action()\` / \`is_irreversible()\` / \`validate_action_type()\` fail-closed on unknown strings with a vocabulary-listing error message.
- Migrated \`adapters.classify_legacy_reversibility\` to delegate to the ontology while keeping its fail-soft contract (REVERSIBLE on unknown) for back-compat with the executor's Holo3 fallthrough on unrecognised plan step types.

### #481 — Preview-gate primitive

\`src/mantis_agent/gym/preview_gate.py\`:

- \`evaluate(...)\` returns \`PreviewResult(passed, confidence, reason, evidence)\` the caller branches on.
- Gated by \`MANTIS_PREVIEW_GATE\` env — off by default, on=truthy. Production keeps current behaviour until rollout flips the env per tenant.
- Skip conditions: gate disabled OR action class is not IRREVERSIBLE. Reversible / read-only actions pass instantly — zero overhead outside the high-risk surface.
- Fail conditions all surface distinct reason codes: \`verifier_rejected\`, \`low_confidence\` (< \`MANTIS_PREVIEW_CONFIDENCE_THRESHOLD\`, default 0.6, clamped \[0,1]), \`verifier_error\` (verifier raised / returned non-conforming / unknown action_type).
- Never raises — verifier exceptions are caught and downgraded to fail-closed results so the safety contract holds even when cross-check infrastructure is broken.

**Deliberately NOT wired into form / click handlers in this PR.** That integration changes runtime behaviour for IRREVERSIBLE actions and deserves separate review. This PR ships the substrate; the wiring is the next PR.

## Test plan

- [x] Full local suite passes: 3073 passed.
- [x] Ruff clean.
- [x] 21 new tests in \`test_cua_ontology.py\` pin the full enum-to-reversibility map, validate-failure modes, and the legacy adapter's fail-soft behaviour.
- [x] 31 new tests in \`test_preview_gate.py\` cover: env on/off parsing, IRREVERSIBLE-only firing, accept / reject / low-confidence / verifier-error / unknown-action / non-float-confidence outcomes, threshold env knob with clamping + fallback.
- [ ] Modal verification deferred — this PR is pure substrate (no handler-level behaviour change). The preview gate's runtime effect lives behind \`MANTIS_PREVIEW_GATE\` and the env stays unset; the ontology classifier is pure-Python with no I/O.

Closes #477
Closes #481
Refs #472, #473

🤖 Generated with [Claude Code](https://claude.com/claude-code)