### PR TITLE
cua: version stamps on every event (#488) + lifecycle substrate (#486)

### DIFF
--- a/src/mantis_agent/cua_contracts/__init__.py
+++ b/src/mantis_agent/cua_contracts/__init__.py
@@ -60,6 +60,13 @@ from .ontology import (
     is_irreversible,
     validate_action_type,
 )
+from .lifecycle import (
+    PURE_PHASES,
+    SIDE_EFFECTFUL_PHASES,
+    Activity,
+    LifecyclePhase,
+)
+from .versions import VERSION_KEYS, collect_versions
 from .types import (
     ActionResult,
     GroundingTrace,
@@ -84,15 +91,20 @@ from .validation import (
 __all__ = [
     "ActionResult",
     "ActionTyped",
+    "Activity",
     "ContractValidationError",
     "GroundingTrace",
+    "LifecyclePhase",
     "Observation",
+    "PURE_PHASES",
     "Plan",
     "ReversibilityClass",
     "SCHEMA_VERSION",
+    "SIDE_EFFECTFUL_PHASES",
     "Step",
     "TaskSpec",
     "TrajectoryEvent",
+    "VERSION_KEYS",
     "Verdict",
     "VerdictKind",
     "JSONL_FILENAME",
@@ -100,6 +112,7 @@ __all__ = [
     "action_result_from_action",
     "classify_action",
     "classify_legacy_reversibility",
+    "collect_versions",
     "is_irreversible",
     "observation_from_screenshot_ref",
     "step_from_micro_intent",

--- a/src/mantis_agent/cua_contracts/emit.py
+++ b/src/mantis_agent/cua_contracts/emit.py
@@ -120,9 +120,16 @@ class TrajectoryEmitter:
         self.run_id = run_id
         self.store_dir = store_dir
         # ``versions`` is the slot for #487 / #488 stamps (planner /
-        # grounding / browser / sandbox). Empty dict is fine in v1 —
-        # the validator only requires presence, not contents.
-        self.versions: dict[str, str] = dict(versions or {})
+        # grounding / browser / sandbox). The validator requires
+        # ``action_ontology`` + ``contracts_schema`` on every event,
+        # so the emitter ALWAYS merges in the static stamps from
+        # :func:`.versions.collect_versions` even when the caller
+        # passes ``versions=None`` or an empty dict. Caller-supplied
+        # entries take precedence so tests can pin specific values.
+        from .versions import collect_versions
+        self.versions: dict[str, str] = dict(collect_versions())
+        if versions:
+            self.versions.update(versions)
         self._jsonl_path: str = os.path.join(store_dir, JSONL_FILENAME)
         # Per-step attempt counter. Incremented on every emit for a
         # given ``step_index``; the next attempt's event carries the

--- a/src/mantis_agent/cua_contracts/lifecycle.py
+++ b/src/mantis_agent/cua_contracts/lifecycle.py
@@ -1,0 +1,129 @@
+"""Plan-Observe-Act-Verify-Emit lifecycle substrate (#486).
+
+The CUA design's durable-execution model splits each step into
+five phases the runner orchestrates explicitly:
+
+* **Plan**     — pick the next step (from a pre-decomposed plan or
+                 by asking the planner).
+* **Observe**  — capture the pre-action screenshot + URL + viewport
+                 (the substrate ``Observation`` reference).
+* **Act**      — dispatch the typed action through the env. The
+                 only phase that mutates the outside world.
+* **Verify**   — read the post-action screenshot, ask the verifier
+                 whether the intent was achieved, stamp a typed
+                 :class:`Verdict`.
+* **Emit**     — append the canonical :class:`TrajectoryEvent` to
+                 the event store.
+
+Today's :class:`~mantis_agent.gym.run_executor.RunExecutor` already
+walks these phases implicitly. This module defines the typed
+substrate (the phase enum + an :class:`Activity` protocol) so a
+future refactor can split each phase into a serializable
+input/output pair and isolate side-effectful operations as
+"activities" in the Temporal sense.
+
+**Substrate-only in this PR.** No runner refactor yet — the goal
+is to give downstream work (a real workflow boundary, replay-safe
+activity classes, Temporal migration) a typed surface to hook
+into. Production behaviour is unchanged.
+
+Design notes for the upcoming refactor (#486 follow-up):
+
+* Plan / Verify can be **pure** (deterministic given inputs +
+  model versions). They become workflow code in a Temporal sense.
+* Observe / Act / Emit are **side-effectful** (touch browser,
+  network, disk). They become Activities in a Temporal sense —
+  retried at the activity boundary with idempotency keys.
+* Each Activity's inputs must be replay-safe and serializable —
+  the :class:`Activity` protocol enforces this with a typed
+  result + a contract that no Python-only state crosses the
+  boundary.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any, Protocol, runtime_checkable
+
+
+class LifecyclePhase(str, Enum):
+    """The five phases of a single CUA step (#486).
+
+    String values match the design doc's phase names so logs /
+    metrics / event annotations can use the enum's ``.value``
+    directly without a translation layer.
+
+    Phase ordering is fixed: ``PLAN → OBSERVE → ACT → VERIFY →
+    EMIT``. The :class:`~..gym.run_executor.RunExecutor` walks them
+    in order for every step.
+    """
+
+    PLAN = "plan"
+    OBSERVE = "observe"
+    ACT = "act"
+    VERIFY = "verify"
+    EMIT = "emit"
+
+
+# Phases that mutate the outside world. Used by the upcoming
+# workflow/activity split to decide which calls become activities
+# (retried at the activity boundary with idempotency keys) vs
+# workflow code (replayed deterministically by the orchestrator).
+SIDE_EFFECTFUL_PHASES: frozenset[LifecyclePhase] = frozenset({
+    LifecyclePhase.OBSERVE,  # env.screenshot mutates capture state
+    LifecyclePhase.ACT,      # the only phase that touches the browser
+    LifecyclePhase.EMIT,     # disk / network write of the canonical event
+})
+
+
+# Phases that are pure / deterministic given their typed inputs.
+# Become workflow code in a Temporal sense — replayed by the
+# orchestrator without re-execution of side effects.
+PURE_PHASES: frozenset[LifecyclePhase] = frozenset({
+    LifecyclePhase.PLAN,
+    LifecyclePhase.VERIFY,
+})
+
+
+@runtime_checkable
+class Activity(Protocol):
+    """The narrow contract a side-effectful phase implementation
+    must satisfy.
+
+    An Activity is a unit of work the orchestrator hands off to a
+    worker pool — its inputs and outputs cross the workflow /
+    activity boundary, so both must be **replay-safe** and
+    **serializable** (the orchestrator's replay path will rebuild
+    the workflow state by replaying activity outputs from history).
+
+    The two requirements:
+
+    * ``phase`` returns the :class:`LifecyclePhase` this activity
+      implements. Used by the orchestrator's dispatcher to route
+      ``ACT`` work to the actor pool, ``OBSERVE`` work to the
+      browser pool, etc.
+    * ``execute`` takes a JSON-serializable input dict and returns
+      a JSON-serializable output dict. The orchestrator records
+      both in the activity history for replay.
+
+    For v1 the protocol is intentionally minimal. The follow-up
+    refactor adds idempotency keys + retry-budget metadata + a
+    typed-input/output binding for each phase. Keeping the v1
+    surface narrow means handlers can satisfy it by adapting their
+    existing callable signatures without a wholesale rewrite.
+
+    ``runtime_checkable`` so the orchestrator can ``isinstance``
+    a registered activity for assertion clarity in tests.
+    """
+
+    @property
+    def phase(self) -> LifecyclePhase:
+        """Which lifecycle phase this activity implements."""
+        ...
+
+    def execute(self, payload: dict[str, Any]) -> dict[str, Any]:
+        """Run the activity. Both ``payload`` and the return value
+        must be JSON-serializable so the activity's input/output
+        round-trips through the orchestrator's history.
+        """
+        ...

--- a/src/mantis_agent/cua_contracts/validation.py
+++ b/src/mantis_agent/cua_contracts/validation.py
@@ -170,3 +170,58 @@ def validate_trajectory_event(event: TrajectoryEvent) -> None:
             "TrajectoryEvent.versions must be a dict (slot for model / "
             "prompt / browser stamps — #488)"
         )
+    _validate_versions(event.versions)
+
+
+# Keys the validator REQUIRES on every committed event (#488). Both
+# are static facts about the writer's contract / ontology shape;
+# they're populated by :func:`~.versions.collect_versions` at
+# emitter-construction time so a writer that goes through the
+# normal path always has them.
+#
+# Model / prompt / runtime stamps are optional in v1 — they
+# populate incrementally as handlers + deploy scripts thread their
+# stamps through. A future bump can promote some of those to
+# required once population is universal.
+_REQUIRED_VERSION_KEYS: frozenset[str] = frozenset({
+    "action_ontology",
+    "contracts_schema",
+})
+
+
+def _validate_versions(versions: dict) -> None:
+    """Enforce the minimum required set + shape on ``versions``.
+
+    Required keys (per :issue:`488` acceptance: "Missing required
+    version fields fail validation"):
+
+    * ``action_ontology`` — bump signal for the closed action enum.
+    * ``contracts_schema`` — bump signal for the cua_contracts
+      package itself.
+
+    All other keys (model + prompt stamps, runtime stamps) are
+    optional in v1 — populated where available. Values must be
+    non-empty strings; an empty string is "we tried but couldn't
+    determine" and is rejected so the event stream stays
+    interpretable.
+    """
+    missing = _REQUIRED_VERSION_KEYS - set(versions)
+    if missing:
+        raise ContractValidationError(
+            f"TrajectoryEvent.versions missing required keys: "
+            f"{sorted(missing)}; the canonical writer must stamp "
+            f"these on every event (#488)"
+        )
+    for key, value in versions.items():
+        if not isinstance(key, str) or not isinstance(value, str):
+            raise ContractValidationError(
+                f"TrajectoryEvent.versions entries must be str→str; "
+                f"got {key!r}={value!r}"
+            )
+        if not value.strip():
+            raise ContractValidationError(
+                f"TrajectoryEvent.versions[{key!r}] is empty — drop "
+                f"unset keys rather than emit empty strings, so "
+                f"readers can distinguish 'not stamped' from "
+                f"'stamped as blank'"
+            )

--- a/src/mantis_agent/cua_contracts/versions.py
+++ b/src/mantis_agent/cua_contracts/versions.py
@@ -1,0 +1,154 @@
+"""Version metadata stamping for canonical trajectory events (#488).
+
+Every committed :class:`~.types.TrajectoryEvent` carries a
+``versions: dict[str, str]`` slot that this module owns. The
+purpose is regression attribution — when a run starts behaving
+differently after a deploy, an operator should be able to read the
+event stream and answer "did the planner model change?" / "did the
+grounding prompt change?" / "did the browser image change?" without
+spelunking through deploy history.
+
+The canonical key set lives here so writer (this module) and reader
+(downstream consumers — model registry, shadow-router diff, eval
+attribution) agree on what to look for.
+
+Keys (additive — readers must tolerate unknown / missing entries
+on v1 events, since rollout populates the dict incrementally):
+
+* ``planner_model`` — model id used to decompose the plan
+  (claude-opus-4-7, ...).
+* ``planner_prompt`` — short hash / tag of the decomposer prompt
+  template that produced the plan.
+* ``grounding_model`` — model id used by the form-target /
+  click-target grounding path (claude-haiku-4-5-..., holo3-35b-a3b).
+* ``grounding_prompt`` — short hash / tag of the grounding prompt
+  template.
+* ``actor_model`` — model id driving the Holo3 / Claude action
+  loop when a brain is in the loop.
+* ``actor_prompt`` — prompt hash for the actor's tool-call /
+  scoped-task template.
+* ``verifier_model`` — model id used by ``verify_gate`` /
+  ``StepVerifier`` (typically Haiku since #421).
+* ``verifier_prompt`` — verifier prompt hash.
+* ``action_ontology`` — schema_version of :class:`ActionTyped`
+  (always populated; pinned per release).
+* ``contracts_schema`` — schema_version of the cua_contracts
+  package (always populated; pinned per release).
+* ``browser_image`` — Modal / docker image tag of the executor
+  container.
+* ``sandbox_runtime`` — runtime identifier (e.g. ``modal/holo3``,
+  ``baseten/claude``).
+
+Population semantics:
+
+* Static keys (``action_ontology``, ``contracts_schema``) populate
+  at emitter construction time from module constants.
+* Runtime keys (``browser_image``, ``sandbox_runtime``) populate
+  from process env vars where the deploy script stashes them
+  (Modal sets ``MODAL_IMAGE_BUILDER_VERSION``; Baseten sets
+  ``BASETEN_DEPLOYMENT_ID``; etc).
+* Model / prompt keys populate from the runner's
+  ``runtime_versions`` dict — handlers / brains that know their
+  model id stash it there. Missing keys land as empty string in
+  v1; the validator allows that.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from .ontology import ActionTyped
+from .types import SCHEMA_VERSION
+
+
+# Canonical ordered list — writers populate from this set, readers
+# match against it. New keys added here only; the validator allows
+# unknown keys for forward-compat but the dashboards / eval
+# attribution will key off this list.
+VERSION_KEYS: tuple[str, ...] = (
+    # Model + prompt pairs per role.
+    "planner_model", "planner_prompt",
+    "grounding_model", "grounding_prompt",
+    "actor_model", "actor_prompt",
+    "verifier_model", "verifier_prompt",
+    # Static contract / ontology versions.
+    "action_ontology", "contracts_schema",
+    # Runtime / deploy stamps.
+    "browser_image", "sandbox_runtime",
+)
+
+
+# Environment-variable names the deploy scripts use to stash
+# runtime stamps. Centralised here so a deploy-config change has
+# one place to update.
+_BROWSER_IMAGE_ENV: str = "MANTIS_BROWSER_IMAGE"
+_SANDBOX_RUNTIME_ENV: str = "MANTIS_SANDBOX_RUNTIME"
+
+
+def _action_ontology_version() -> str:
+    """The action-ontology version tag, derived from the enum's
+    membership snapshot. Bumping the enum is a contract change and
+    surfaces here so downstream consumers see a different
+    ``action_ontology`` value in events post-bump.
+
+    Format: ``v1.<member_count>`` — short, grep-able, monotonically
+    increases on additive changes. A non-additive change (rename /
+    drop) bumps SCHEMA_VERSION too, which surfaces in
+    ``contracts_schema`` independently.
+    """
+    return f"v{SCHEMA_VERSION}.{len(ActionTyped)}"
+
+
+def _contracts_schema_version() -> str:
+    """The cua_contracts package's pinned schema_version stamp.
+    Single source of truth for "are reader and writer talking the
+    same contract?"."""
+    return f"v{SCHEMA_VERSION}"
+
+
+def _runtime_env_stamp() -> dict[str, str]:
+    """Pull deploy-time stamps off the process env. Missing env
+    vars stay missing in the dict — the validator allows empty
+    values in v1 so a partially-populated env doesn't break the
+    write."""
+    out: dict[str, str] = {}
+    browser = os.environ.get(_BROWSER_IMAGE_ENV, "").strip()
+    if browser:
+        out["browser_image"] = browser
+    sandbox = os.environ.get(_SANDBOX_RUNTIME_ENV, "").strip()
+    if sandbox:
+        out["sandbox_runtime"] = sandbox
+    return out
+
+
+def collect_versions(runner: Any | None = None) -> dict[str, str]:
+    """Build the version dict for the emitter at construction time.
+
+    Combines:
+
+    * Static contract / ontology stamps (always populated).
+    * Runtime / deploy env stamps (populated when env vars are set).
+    * Per-runner model + prompt stamps from
+      ``runner.runtime_versions`` — handlers / brains that know
+      their model id stash it on the runner before the executor
+      builds the emitter.
+
+    Returns a *new* dict on every call so the emitter's stored
+    snapshot doesn't share state with future runner mutations.
+    The dict is intentionally permissive — populates whatever's
+    available, leaves the rest absent. Validators on the reader
+    side surface missing keys as warnings, not failures.
+    """
+    versions: dict[str, str] = {
+        "action_ontology": _action_ontology_version(),
+        "contracts_schema": _contracts_schema_version(),
+    }
+    versions.update(_runtime_env_stamp())
+    if runner is not None:
+        from_runner = getattr(runner, "runtime_versions", None)
+        if isinstance(from_runner, dict):
+            for k, v in from_runner.items():
+                if isinstance(k, str) and isinstance(v, str) and v:
+                    versions[k] = v
+    return versions

--- a/src/mantis_agent/gym/run_executor.py
+++ b/src/mantis_agent/gym/run_executor.py
@@ -1524,11 +1524,24 @@ def _emit_canonical_trajectory_event(
         # later reader can address one run by directory listing.
         store_dir = os.path.join(base_dir, run_id)
         try:
-            from ..cua_contracts import TrajectoryEmitter
+            from ..cua_contracts import TrajectoryEmitter, collect_versions
+            # #488: stamp the canonical version dict at emitter
+            # construction so every event carries the contract
+            # schema version + ontology version + any runtime / per-
+            # role model + prompt stamps the runner has surfaced via
+            # ``runner.runtime_versions``. Legacy
+            # ``_canonical_event_versions`` is honoured as an explicit
+            # override for callers that want full control of the
+            # stamp dict.
+            override = getattr(runner, "_canonical_event_versions", None)
+            if isinstance(override, dict) and override:
+                versions = dict(override)
+            else:
+                versions = collect_versions(runner)
             emitter = TrajectoryEmitter(
                 run_id=run_id,
                 store_dir=store_dir,
-                versions=dict(getattr(runner, "_canonical_event_versions", {}) or {}),
+                versions=versions,
             )
         except Exception as exc:  # noqa: BLE001 — never break a run
             logger.debug("canonical event emitter init failed: %s", exc)

--- a/tests/test_cua_contracts.py
+++ b/tests/test_cua_contracts.py
@@ -152,7 +152,14 @@ def _valid_event(**overrides) -> TrajectoryEvent:
             action_type="click", params={"x": 1, "y": 2}, dispatched=True,
         ),
         "verdict": Verdict(kind=VerdictKind.OK),
-        "versions": {"planner": "claude-opus-4-7"},
+        # #488 requires action_ontology + contracts_schema on every
+        # event; tests pin specific values so the validator's
+        # required-set behaviour is exercised end-to-end.
+        "versions": {
+            "action_ontology": "v1.21",
+            "contracts_schema": "v1",
+            "planner_model": "claude-opus-4-7",
+        },
     }
     base.update(overrides)
     return TrajectoryEvent(**base)
@@ -200,10 +207,46 @@ def test_trajectory_event_missing_versions_dict_rejected() -> None:
         validate_trajectory_event(_valid_event(versions=None))  # type: ignore[arg-type]
 
 
-def test_trajectory_event_empty_versions_dict_accepted() -> None:
-    """Empty versions dict is fine in v1 — the shape isn't pinned until
-    the version-stamping work lands. Presence is what matters."""
-    validate_trajectory_event(_valid_event(versions={}))
+def test_trajectory_event_empty_versions_dict_rejected() -> None:
+    """#488: empty versions dict is no longer acceptable — the
+    canonical writer must stamp ``action_ontology`` +
+    ``contracts_schema`` on every event so regression attribution
+    can answer 'did the ontology bump?' / 'did the contracts
+    package bump?' without spelunking deploy history."""
+    with pytest.raises(ContractValidationError, match="missing required keys"):
+        validate_trajectory_event(_valid_event(versions={}))
+
+
+def test_trajectory_event_missing_required_version_key_rejected() -> None:
+    """Single missing required key fails — the error lists which
+    so the writer's bug is obvious."""
+    with pytest.raises(ContractValidationError, match="contracts_schema"):
+        validate_trajectory_event(_valid_event(versions={
+            "action_ontology": "v1.21",
+            "planner_model": "claude-opus-4-7",
+        }))
+
+
+def test_trajectory_event_empty_version_value_rejected() -> None:
+    """Empty / whitespace values are rejected — readers must be
+    able to distinguish 'not stamped' (key absent) from 'stamped
+    as blank' (key present but value empty). The latter is a
+    writer bug; reject it at the boundary."""
+    with pytest.raises(ContractValidationError, match="empty"):
+        validate_trajectory_event(_valid_event(versions={
+            "action_ontology": "v1.21",
+            "contracts_schema": "v1",
+            "planner_model": "",
+        }))
+
+
+def test_trajectory_event_non_string_version_value_rejected() -> None:
+    with pytest.raises(ContractValidationError, match="must be str"):
+        validate_trajectory_event(_valid_event(versions={
+            "action_ontology": "v1.21",
+            "contracts_schema": "v1",
+            "planner_model": 4,  # type: ignore[dict-item]
+        }))
 
 
 def test_observation_inline_base64_blob_rejected() -> None:

--- a/tests/test_cua_emit.py
+++ b/tests/test_cua_emit.py
@@ -256,16 +256,24 @@ def test_emit_carries_explicit_action(tmp_path: Path) -> None:
 
 def test_emit_carries_versions_dict(tmp_path: Path) -> None:
     """The versions slot (#487 / #488) round-trips so model / prompt
-    / browser stamps surface in every event."""
+    / browser stamps surface in every event. Caller-supplied entries
+    take precedence; the static stamps (#488 action_ontology +
+    contracts_schema) are auto-merged in by the emitter so the
+    validator's required-set is always satisfied."""
     emitter = TrajectoryEmitter(
         run_id="r1", store_dir=str(tmp_path),
-        versions={"planner": "claude-opus-4-7", "grounding": "claude-haiku-4-5"},
+        versions={"planner_model": "claude-opus-4-7", "grounding_model": "claude-haiku-4-5"},
     )
     emitter.emit(_intent(), _ok_step_result())
     record = json.loads((tmp_path / JSONL_FILENAME).read_text().strip())
-    assert record["versions"] == {
-        "planner": "claude-opus-4-7", "grounding": "claude-haiku-4-5",
-    }
+    # User-supplied entries surface verbatim.
+    assert record["versions"]["planner_model"] == "claude-opus-4-7"
+    assert record["versions"]["grounding_model"] == "claude-haiku-4-5"
+    # Auto-merged static stamps are also present so the validator
+    # accepts the event without the caller having to know about
+    # them.
+    assert "action_ontology" in record["versions"]
+    assert "contracts_schema" in record["versions"]
 
 
 def test_emit_returns_false_when_validation_fails(tmp_path: Path, caplog) -> None:

--- a/tests/test_versions_and_lifecycle.py
+++ b/tests/test_versions_and_lifecycle.py
@@ -1,0 +1,276 @@
+"""Tests for #488 (version stamps) + #486 (lifecycle substrate).
+
+Covers:
+
+* ``collect_versions`` always populates the static required keys
+  (``action_ontology`` + ``contracts_schema``), pulls runtime
+  stamps off env, and merges in per-runner model/prompt stamps.
+* Validator enforces the required-set: empty dict, missing single
+  key, empty value, non-string value all fail closed.
+* Emitter auto-merges the static stamps so callers that don't
+  pass ``versions=`` produce events that validate.
+* ``LifecyclePhase`` enum + phase-class predicates pin the
+  contract (5 ordered phases, 3 side-effectful, 2 pure).
+* ``Activity`` protocol's ``runtime_checkable`` instance check
+  works for objects that satisfy the shape.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from mantis_agent.cua_contracts import (
+    Activity,
+    ContractValidationError,
+    JSONL_FILENAME,
+    LifecyclePhase,
+    PURE_PHASES,
+    SCHEMA_VERSION,
+    SIDE_EFFECTFUL_PHASES,
+    TrajectoryEmitter,
+    VERSION_KEYS,
+    collect_versions,
+)
+from mantis_agent.cua_contracts.validation import _validate_versions
+from mantis_agent.gym.checkpoint import StepResult
+from mantis_agent.plan_decomposer import MicroIntent
+
+
+# ── #488: collect_versions ─────────────────────────────────────────────
+
+
+def test_collect_versions_always_includes_required_static_keys() -> None:
+    """The two required keys (action_ontology + contracts_schema)
+    must be present on every collect_versions() return — they're
+    derived from module constants, not env, so a missing-env
+    deploy still produces a validation-passing event."""
+    v = collect_versions()
+    assert "action_ontology" in v
+    assert "contracts_schema" in v
+    assert v["contracts_schema"] == f"v{SCHEMA_VERSION}"
+    assert v["action_ontology"].startswith(f"v{SCHEMA_VERSION}.")
+
+
+def test_collect_versions_reads_runtime_env_stamps(monkeypatch) -> None:
+    monkeypatch.setenv("MANTIS_BROWSER_IMAGE", "modal/chromium@abc123")
+    monkeypatch.setenv("MANTIS_SANDBOX_RUNTIME", "modal/holo3")
+    v = collect_versions()
+    assert v["browser_image"] == "modal/chromium@abc123"
+    assert v["sandbox_runtime"] == "modal/holo3"
+
+
+def test_collect_versions_skips_missing_env_stamps(monkeypatch) -> None:
+    """Missing env vars stay missing in the dict — they don't land
+    as empty strings (the validator rejects empty values)."""
+    monkeypatch.delenv("MANTIS_BROWSER_IMAGE", raising=False)
+    monkeypatch.delenv("MANTIS_SANDBOX_RUNTIME", raising=False)
+    v = collect_versions()
+    assert "browser_image" not in v
+    assert "sandbox_runtime" not in v
+
+
+def test_collect_versions_merges_runtime_versions_from_runner() -> None:
+    """Per-runner stamps that handlers stash on
+    ``runner.runtime_versions`` get pulled in — that's how the
+    planner / grounding / verifier model+prompt versions surface
+    on every event without each handler reaching into the
+    emitter."""
+    class _Runner:
+        runtime_versions = {
+            "planner_model": "claude-opus-4-7",
+            "grounding_prompt": "fft_v3",
+            "actor_model": "holo3-35b-a3b",
+        }
+
+    v = collect_versions(_Runner())
+    assert v["planner_model"] == "claude-opus-4-7"
+    assert v["grounding_prompt"] == "fft_v3"
+    assert v["actor_model"] == "holo3-35b-a3b"
+    # Static stamps still present.
+    assert "contracts_schema" in v
+
+
+def test_collect_versions_skips_empty_runner_values() -> None:
+    """Empty / non-string values from the runner get dropped — the
+    validator would reject them anyway, and we want the dict to
+    stay clean."""
+    class _Runner:
+        runtime_versions = {
+            "planner_model": "",          # empty
+            "actor_model": None,          # non-string
+            "verifier_model": "haiku-4-5",
+        }
+
+    v = collect_versions(_Runner())
+    assert "planner_model" not in v
+    assert "actor_model" not in v
+    assert v["verifier_model"] == "haiku-4-5"
+
+
+def test_version_keys_documents_canonical_set() -> None:
+    """The VERSION_KEYS tuple is the documented contract — pinned
+    here so a stealth bump caused by an unintended import-order
+    change fails CI."""
+    assert "action_ontology" in VERSION_KEYS
+    assert "contracts_schema" in VERSION_KEYS
+    assert "planner_model" in VERSION_KEYS
+    assert "grounding_model" in VERSION_KEYS
+    assert "actor_model" in VERSION_KEYS
+    assert "verifier_model" in VERSION_KEYS
+    assert "browser_image" in VERSION_KEYS
+    assert "sandbox_runtime" in VERSION_KEYS
+
+
+# ── #488: validator required-set enforcement ──────────────────────────
+
+
+def test_validate_versions_accepts_full_required_set() -> None:
+    _validate_versions({
+        "action_ontology": "v1.21",
+        "contracts_schema": "v1",
+    })
+
+
+def test_validate_versions_rejects_empty_dict() -> None:
+    with pytest.raises(ContractValidationError, match="missing required keys"):
+        _validate_versions({})
+
+
+def test_validate_versions_rejects_missing_action_ontology() -> None:
+    with pytest.raises(ContractValidationError, match="action_ontology"):
+        _validate_versions({"contracts_schema": "v1"})
+
+
+def test_validate_versions_rejects_missing_contracts_schema() -> None:
+    with pytest.raises(ContractValidationError, match="contracts_schema"):
+        _validate_versions({"action_ontology": "v1.21"})
+
+
+def test_validate_versions_rejects_empty_value() -> None:
+    """Empty / whitespace value is a writer bug — readers can't
+    distinguish 'not stamped' from 'stamped as blank'. Reject."""
+    with pytest.raises(ContractValidationError, match="empty"):
+        _validate_versions({
+            "action_ontology": "v1.21",
+            "contracts_schema": "v1",
+            "planner_model": "   ",
+        })
+
+
+def test_validate_versions_rejects_non_string_value() -> None:
+    with pytest.raises(ContractValidationError, match="must be str"):
+        _validate_versions({
+            "action_ontology": "v1.21",
+            "contracts_schema": "v1",
+            "planner_model": 42,  # type: ignore[dict-item]
+        })
+
+
+# ── #488: emitter auto-merges static stamps ────────────────────────────
+
+
+def _intent() -> MicroIntent:
+    return MicroIntent(intent="x", type="click", required=False)
+
+
+def _ok_result() -> StepResult:
+    return StepResult(step_index=0, intent="x", success=True, data="ok")
+
+
+def test_emit_auto_merges_static_stamps_when_versions_unset(tmp_path: Path) -> None:
+    """A caller that doesn't pass ``versions=`` still produces a
+    validating event — the emitter merges in the static stamps
+    via collect_versions()."""
+    emitter = TrajectoryEmitter(run_id="r1", store_dir=str(tmp_path))
+    assert emitter.emit(_intent(), _ok_result()) is True
+    record = json.loads((tmp_path / JSONL_FILENAME).read_text().strip())
+    assert "action_ontology" in record["versions"]
+    assert "contracts_schema" in record["versions"]
+
+
+def test_emit_caller_versions_take_precedence(tmp_path: Path) -> None:
+    """When the caller pins specific values, those win — even when
+    they collide with the static stamps. Lets tests / shadow
+    routing pin a particular contract version."""
+    emitter = TrajectoryEmitter(
+        run_id="r1", store_dir=str(tmp_path),
+        versions={"contracts_schema": "v-test-override"},
+    )
+    emitter.emit(_intent(), _ok_result())
+    record = json.loads((tmp_path / JSONL_FILENAME).read_text().strip())
+    assert record["versions"]["contracts_schema"] == "v-test-override"
+
+
+# ── #486: LifecyclePhase enum + protocol ──────────────────────────────
+
+
+def test_lifecycle_phase_has_five_ordered_phases() -> None:
+    """Pin the phase set + order. A bump is a contract change that
+    must come with reader updates."""
+    assert [p.value for p in LifecyclePhase] == [
+        "plan", "observe", "act", "verify", "emit",
+    ]
+
+
+def test_side_effectful_phases_match_design() -> None:
+    """Three phases mutate the outside world; the
+    workflow/activity split routes these through the activity pool."""
+    assert SIDE_EFFECTFUL_PHASES == {
+        LifecyclePhase.OBSERVE,
+        LifecyclePhase.ACT,
+        LifecyclePhase.EMIT,
+    }
+
+
+def test_pure_phases_match_design() -> None:
+    """Two phases are pure; they become workflow code (replayed
+    deterministically by the orchestrator)."""
+    assert PURE_PHASES == {LifecyclePhase.PLAN, LifecyclePhase.VERIFY}
+
+
+def test_pure_and_side_effectful_phases_partition_the_enum() -> None:
+    """Every phase is either pure OR side-effectful — never both,
+    never neither."""
+    assert PURE_PHASES.isdisjoint(SIDE_EFFECTFUL_PHASES)
+    assert PURE_PHASES | SIDE_EFFECTFUL_PHASES == set(LifecyclePhase)
+
+
+def test_activity_protocol_runtime_check_accepts_conforming_object() -> None:
+    """runtime_checkable means an arbitrary object with the right
+    shape satisfies isinstance — the future workflow orchestrator
+    uses this for registration / dispatch."""
+
+    class _Capture:
+        @property
+        def phase(self) -> LifecyclePhase:
+            return LifecyclePhase.OBSERVE
+
+        def execute(self, payload: dict) -> dict:
+            return {"screenshot_ref": "runs/abc/step_0.png"}
+
+    instance = _Capture()
+    assert isinstance(instance, Activity)
+    assert instance.phase is LifecyclePhase.OBSERVE
+    out = instance.execute({"step_index": 0})
+    assert out == {"screenshot_ref": "runs/abc/step_0.png"}
+
+
+def test_activity_protocol_runtime_check_rejects_non_conforming_object() -> None:
+    """An object without both ``phase`` AND ``execute`` is not an
+    Activity. Protocol's structural typing catches this at the
+    registration boundary."""
+
+    class _NoExecute:
+        @property
+        def phase(self) -> LifecyclePhase:
+            return LifecyclePhase.ACT
+
+    class _NoPhase:
+        def execute(self, payload: dict) -> dict:
+            return {}
+
+    assert not isinstance(_NoExecute(), Activity)
+    assert not isinstance(_NoPhase(), Activity)


### PR DESCRIPTION
## Summary

Opens epics #474 (durable execution) + #475 (model versioning). Closes #488 fully and lays the typed substrate for #486.

### #488 — Version stamps on every canonical event

Fills the empty \`TrajectoryEvent.versions\` slot reserved in #476. Every committed event now carries:

| Key | Source |
|---|---|
| \`action_ontology\` | derived from \`ActionTyped\` enum membership |
| \`contracts_schema\` | pinned to \`SCHEMA_VERSION\` |
| \`browser_image\` | \`MANTIS_BROWSER_IMAGE\` env (when set) |
| \`sandbox_runtime\` | \`MANTIS_SANDBOX_RUNTIME\` env (when set) |
| \`{planner,grounding,actor,verifier}_model\` | \`runner.runtime_versions\` |
| \`{planner,grounding,actor,verifier}_prompt\` | \`runner.runtime_versions\` |

Validator enforces the required-set (\`action_ontology\` + \`contracts_schema\`). Empty dict / missing keys / empty values / non-string values all fail closed.

Emitter auto-merges the static stamps so legacy callers that don't pass \`versions=\` still produce validating events. Caller-supplied entries take precedence so tests / shadow routing can pin specific values.

### #486 — Lifecycle substrate

\`cua_contracts/lifecycle.py\`:

- \`LifecyclePhase\` enum: \`PLAN\` / \`OBSERVE\` / \`ACT\` / \`VERIFY\` / \`EMIT\`
- \`PURE_PHASES\` (\`{PLAN, VERIFY}\`) — replayed deterministically by a future orchestrator
- \`SIDE_EFFECTFUL_PHASES\` (\`{OBSERVE, ACT, EMIT}\`) — wrapped as Activities by the future workflow split
- \`Activity\` Protocol with \`phase\` + \`execute(payload)\` — minimal v1 surface; refined when the workflow orchestrator actually lands

**Substrate-only**: no runner refactor in this PR. The typed surface lets the next PR split each phase into a serializable input/output pair without guessing at the API shape.

## Test plan

- [x] Full local suite passes: **3096**.
- [x] Ruff clean.
- [x] 20 new tests in \`test_versions_and_lifecycle.py\` covering:
  - \`collect_versions\` (static + env + runner-stash + skip-empty fallbacks)
  - Validator required-set enforcement (every failure mode)
  - Emitter auto-merge + caller-precedence
  - Lifecycle phase ordering + pure/side-effectful partition
  - \`Activity\` protocol \`isinstance\` shape check
- [x] Updated 3 existing tests for the new validator contract.
- [ ] Modal verify recommended (this PR adds a write-time validator check that runs on every emit; want to confirm no rejection-warning floods in production logs).

## Where this leaves the epics

After this merges:
- **#474 (Durable execution)** — #486 substrate done; #484 (sandbox snapshot) + #485 (observation store) remain
- **#475 (Model versioning)** — #488 done; #487 (model facade) + #489 (shadow routing) + #490 (registry+eval) remain

Closes #488
Refs #486, #474, #475

🤖 Generated with [Claude Code](https://claude.com/claude-code)