### PR TITLE
cua: sandbox snapshot/restore around browser runtime (#484)

### DIFF
--- a/src/mantis_agent/cua_contracts/__init__.py
+++ b/src/mantis_agent/cua_contracts/__init__.py
@@ -83,6 +83,13 @@ from .registry import (
     ModelRegistryRecord,
     RolloutState,
 )
+from .sandbox import (
+    LocalProfileSandbox,
+    NoopSandboxRuntime,
+    SandboxRestoreError,
+    SandboxRuntime,
+    SandboxSnapshot,
+)
 from .serving import (
     ModelCallResult,
     ModelServingFacade,
@@ -129,6 +136,7 @@ __all__ = [
     "GroundingTrace",
     "InMemoryModelRegistry",
     "InMemoryObservationStore",
+    "LocalProfileSandbox",
     "JSONL_FILENAME",
     "LifecyclePhase",
     "ModelCallResult",
@@ -136,6 +144,7 @@ __all__ = [
     "ModelRegistryError",
     "ModelRegistryRecord",
     "ModelServingFacade",
+    "NoopSandboxRuntime",
     "Observation",
     "ObservationStore",
     "PURE_PHASES",
@@ -149,6 +158,9 @@ __all__ = [
     "RoutingMode",
     "SCHEMA_VERSION",
     "SIDE_EFFECTFUL_PHASES",
+    "SandboxRestoreError",
+    "SandboxRuntime",
+    "SandboxSnapshot",
     "ShadowRoutingError",
     "SplitFacade",
     "Step",

--- a/src/mantis_agent/cua_contracts/adapters.py
+++ b/src/mantis_agent/cua_contracts/adapters.py
@@ -131,6 +131,7 @@ def action_result_from_action(
     dispatched: bool,
     dispatch_error: str = "",
     grounding_trace: dict[str, Any] | None = None,
+    snapshot_id: str = "",
 ) -> ActionResult:
     """Project a legacy :class:`Action` (+ dispatcher outcome) onto
     :class:`ActionResult`.
@@ -143,6 +144,11 @@ def action_result_from_action(
     AND ``dispatched=False`` AND no ``dispatch_error`` — that
     combination means "nothing happened and nobody knows why", which
     isn't useful to record.
+
+    ``snapshot_id`` (#484) carries the sandbox snapshot taken before
+    this action dispatched. Empty when no snapshot was gated
+    (reversible actions, no sandbox runtime wired). The runtime
+    owns the format; readers treat as opaque.
     """
     if action is None:
         return ActionResult(
@@ -152,6 +158,7 @@ def action_result_from_action(
             grounding_trace=grounding_trace or {},
             dispatched=dispatched,
             dispatch_error=dispatch_error,
+            snapshot_id=snapshot_id,
         )
     action_type_value = getattr(action.action_type, "value", str(action.action_type))
     return ActionResult(
@@ -161,6 +168,7 @@ def action_result_from_action(
         grounding_trace=grounding_trace or {},
         dispatched=dispatched,
         dispatch_error=dispatch_error,
+        snapshot_id=snapshot_id,
     )
 
 

--- a/src/mantis_agent/cua_contracts/emit.py
+++ b/src/mantis_agent/cua_contracts/emit.py
@@ -162,6 +162,7 @@ class TrajectoryEmitter:
         url: str = "",
         viewport: tuple[int, int] = (0, 0),
         cost_usd: float = 0.0,
+        snapshot_id: str = "",
     ) -> bool:
         """Build + validate + persist a canonical event.
 
@@ -220,6 +221,7 @@ class TrajectoryEmitter:
                 screenshot_ref=screenshot_ref,
                 url=url, viewport=viewport,
                 cost_usd=cost_usd,
+                snapshot_id=snapshot_id,
             )
             validate_trajectory_event(event)
         except ContractValidationError as exc:
@@ -280,6 +282,7 @@ class TrajectoryEmitter:
         url: str,
         viewport: tuple[int, int],
         cost_usd: float,
+        snapshot_id: str = "",
     ) -> TrajectoryEvent:
         step_index = int(getattr(result, "step_index", -1))
         ref = screenshot_ref or self._placeholder_screenshot_ref(step_index)
@@ -295,11 +298,19 @@ class TrajectoryEmitter:
         # the action that drove this step; fall back to the explicit
         # ``action`` kwarg when the caller has a better signal.
         legacy_action = action if action is not None else getattr(result, "last_action", None)
+        # #484: snapshot_id from caller wins; otherwise pick up
+        # the runner's last-recorded sandbox snapshot (handlers
+        # that gated an irreversible action stash the snapshot
+        # there).
+        effective_snapshot_id = snapshot_id or str(
+            getattr(result, "snapshot_id", "") or "",
+        )
         action_result = action_result_from_action(
             legacy_action,
             dispatched=dispatched,
             dispatch_error=dispatch_error,
             grounding_trace=grounding_trace,
+            snapshot_id=effective_snapshot_id,
         )
         # Deterministic handlers (navigate / paginate / gate /
         # fill_field) don't synthesise an ``Action`` — they execute
@@ -318,6 +329,7 @@ class TrajectoryEmitter:
                     grounding_trace=action_result.grounding_trace,
                     dispatched=action_result.dispatched,
                     dispatch_error=action_result.dispatch_error,
+                    snapshot_id=action_result.snapshot_id,
                 )
         # #480: prefer the runner-stamped verdict (the structural
         # contract — every committed step carries one). Fall back to

--- a/src/mantis_agent/cua_contracts/sandbox.py
+++ b/src/mantis_agent/cua_contracts/sandbox.py
@@ -1,0 +1,394 @@
+"""Sandbox runtime interface — snapshot / restore around browser
+environments (#484).
+
+The CUA design's safety story needs a snapshot taken before
+irreversible actions and a restore path for non-recoverable
+failures. Mantis today captures browser state piecewise
+(``BrowserState`` + ``RunCheckpoint``) but has no
+sandbox-level snapshot abstraction the runner can call uniformly
+across Xvfb+Chrome (local / Modal) and future managed sandbox
+platforms.
+
+This module owns the protocol + two default implementations:
+
+* :class:`NoopSandboxRuntime` — the test default + the bring-up
+  surface where snapshotting is not yet wired. Returns
+  deterministic placeholder snapshot ids so callers can exercise
+  the snapshot/restore code path without filesystem side effects.
+* :class:`LocalProfileSandbox` — copies a Chrome user-data
+  directory to a snapshot path on every :meth:`snapshot`; restore
+  reverses the copy. Pragmatic implementation suitable for local
+  development + the acceptance criterion "Snapshot/restore
+  behavior is tested with at least one browser task fixture".
+
+Production wiring (replacing the runtime in the Modal /
+Baseten paths) lands in a follow-up — same substrate-first
+pattern the rest of cua_contracts follows. ``SandboxRuntime`` is
+the typed surface that future PRs can drop in a VM-snapshot or
+container-snapshot backend without rewriting handlers.
+
+The :class:`SandboxSnapshot` payload is referenced from the
+canonical :class:`~.types.ActionResult.snapshot_id` field added in
+this PR — every dispatched step that gated a snapshot before it
+ran has the snapshot_id on its trajectory event, so a failed
+action can be replayed against the pre-action state.
+
+Why a Protocol over a base class:
+
+The runner doesn't own the sandbox lifecycle — it consumes one. A
+hosted runtime may wrap a fly.io VM, a Modal sandbox, an
+in-process Xvfb, or a test stub. The Protocol lets each wire its
+own concrete with no base-class coupling.
+
+Failure-mode contract:
+
+* :meth:`snapshot` returning ``None`` means "the runtime declined
+  to snapshot this state" (e.g. a noop runtime, or a host that
+  blacklisted the current page). Callers fall through to the
+  un-gated dispatch path.
+* :meth:`restore` raising :class:`SandboxRestoreError` means
+  "restore was attempted but the runtime can't return to the
+  snapshot state". Callers must surface this as a structured
+  failure on the trajectory event — silently continuing on a
+  failed restore corrupts the recovery contract.
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Protocol, runtime_checkable
+
+
+logger = logging.getLogger(__name__)
+
+
+class SandboxRestoreError(RuntimeError):
+    """Raised when :meth:`SandboxRuntime.restore` cannot return the
+    sandbox to a usable state. Carries enough context for the
+    runner to record the failure on the canonical event and halt /
+    escalate per the recovery policy.
+
+    Typed exception (not a generic :class:`RuntimeError`) so the
+    runner's catch site can distinguish restore failures from
+    bug-shaped exceptions out of the runtime."""
+
+
+@dataclass(frozen=True)
+class SandboxSnapshot:
+    """Typed result returned by :meth:`SandboxRuntime.snapshot`.
+
+    The opaque ``snapshot_id`` is the only field the runner uses
+    to call :meth:`SandboxRuntime.restore` later — the runtime
+    owns the format (file path, content hash, VM snapshot handle).
+    A reader (event consumer / dashboard) sees the id round-trip
+    on the canonical event but doesn't interpret it.
+
+    ``created_at`` is wall-clock seconds for ordering snapshots
+    chronologically when multiple are taken in a single run.
+    ``size_bytes`` is best-effort (-1 when the runtime doesn't
+    track it) — useful for the storage-cap follow-up that mirrors
+    the :class:`~.observation_store.DiskObservationStore` cap.
+    """
+
+    snapshot_id: str
+    created_at: float = 0.0
+    size_bytes: int = -1
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@runtime_checkable
+class SandboxRuntime(Protocol):
+    """The narrow contract any sandbox runtime must satisfy (#484).
+
+    Six operations span the sandbox lifecycle:
+
+    * :meth:`create` — bring a fresh sandbox up. Idempotent for the
+      configured key (typically the runner's profile_id) so a
+      restart finds the existing sandbox.
+    * :meth:`capture` — read the current observable state into a
+      runtime-defined blob. Cheap (no snapshot — just observation).
+    * :meth:`execute` — dispatch an action through the sandbox. The
+      runner's existing env.step path delegates here when the
+      runtime is sandbox-backed.
+    * :meth:`snapshot` — write the full sandbox state to durable
+      storage and return a :class:`SandboxSnapshot` handle.
+      Expensive — called before irreversible actions only.
+    * :meth:`restore` — rewind the sandbox to a prior snapshot.
+      Raises :class:`SandboxRestoreError` on any non-recoverable
+      failure (missing snapshot, partial restore detected, etc).
+    * :meth:`destroy` — tear down the sandbox. Releases any
+      runtime-side resources; the snapshot store may persist.
+
+    ``runtime_checkable`` so tests + handler-wiring layers can
+    ``isinstance`` a registered runtime for assertion clarity.
+    """
+
+    def create(self, *, key: str) -> None:
+        """Bring up a sandbox keyed on ``key`` (typically the
+        runner's profile_id). Idempotent — re-create on the same
+        key is a no-op when the sandbox already exists."""
+        ...
+
+    def capture(self, *, key: str) -> dict[str, Any]:
+        """Read the current observable state (url, viewport,
+        cookies summary, etc). Cheap — caller may call frequently.
+        Returns a runtime-defined dict; the canonical event
+        consumer reads documented keys when set."""
+        ...
+
+    def execute(self, *, key: str, action: Any) -> None:
+        """Dispatch ``action`` through the sandbox. Runners with
+        a sandbox-backed env wire :meth:`env.step` to this.
+        Action shape is runtime-defined (typically the existing
+        :class:`~mantis_agent.actions.Action`)."""
+        ...
+
+    def snapshot(self, *, key: str) -> SandboxSnapshot | None:
+        """Write the full sandbox state to durable storage and
+        return a :class:`SandboxSnapshot` handle. Returns ``None``
+        when the runtime declines to snapshot this state (e.g.
+        the noop runtime, a host that blacklisted the current
+        page). Caller falls through to the un-gated dispatch
+        path on ``None``."""
+        ...
+
+    def restore(self, *, key: str, snapshot_id: str) -> None:
+        """Rewind the sandbox keyed on ``key`` to ``snapshot_id``.
+        Raises :class:`SandboxRestoreError` on any failure that
+        can't be silently recovered (missing snapshot id, partial
+        restore, runtime in a half-torn state)."""
+        ...
+
+    def destroy(self, *, key: str) -> None:
+        """Tear down the sandbox keyed on ``key``. The snapshot
+        store may persist; the runtime side releases resources
+        (Chrome process, Xvfb, VM handle)."""
+        ...
+
+
+# ── Implementations ────────────────────────────────────────────────────
+
+
+class NoopSandboxRuntime:
+    """Default :class:`SandboxRuntime` — does nothing.
+
+    Useful for:
+
+    * tests that exercise the snapshot/restore call paths without
+      filesystem side effects;
+    * runner bring-up before a real sandbox runtime is wired —
+      handlers can call snapshot()/restore() unconditionally and
+      get a deterministic no-op response.
+
+    :meth:`snapshot` returns a deterministic placeholder
+    :class:`SandboxSnapshot` rather than None — gives callers a
+    valid handle they can round-trip into trajectory events without
+    branching. :meth:`restore` accepts any id and succeeds (the
+    "state" was always empty).
+    """
+
+    def __init__(self) -> None:
+        self._created_keys: set[str] = set()
+        self._snapshot_counter: int = 0
+
+    def create(self, *, key: str) -> None:
+        self._created_keys.add(key)
+
+    def capture(self, *, key: str) -> dict[str, Any]:
+        return {"runtime": "noop", "key": key}
+
+    def execute(self, *, key: str, action: Any) -> None:
+        # No-op execute — tests pass; real runtimes override.
+        del key, action
+
+    def snapshot(self, *, key: str) -> SandboxSnapshot:
+        self._snapshot_counter += 1
+        return SandboxSnapshot(
+            snapshot_id=f"noop:{key}:s{self._snapshot_counter}",
+            created_at=time.time(),
+            size_bytes=0,
+            metadata={"runtime": "noop"},
+        )
+
+    def restore(self, *, key: str, snapshot_id: str) -> None:
+        if not snapshot_id:
+            raise SandboxRestoreError(
+                "NoopSandboxRuntime.restore: snapshot_id required"
+            )
+        # Noop accepts any non-empty id — no actual state to
+        # restore. Real runtimes validate snapshot_id existence.
+        del key
+
+    def destroy(self, *, key: str) -> None:
+        self._created_keys.discard(key)
+
+
+class LocalProfileSandbox:
+    """Sandbox runtime backed by a directory copy of a Chrome
+    user-data directory (#484).
+
+    Pragmatic implementation for local development + the
+    acceptance criterion "Snapshot/restore behavior is tested
+    with at least one browser task fixture". A snapshot is a
+    timestamped copy of the profile directory; restore replaces
+    the live profile with the snapshot.
+
+    Storage layout:
+
+        <snapshot_root>/<key>/<snapshot_id>/    ← directory copy
+        <snapshot_root>/<key>/<snapshot_id>.json ← metadata
+
+    Designed to be **safe for the test fixture**:
+
+    * The "profile" is just an opaque directory — tests can pass
+      any dir and verify the contents survive snapshot+restore.
+    * No real Chrome / Xvfb dependency — tests pass with a tmp
+      dir of arbitrary files.
+
+    Production wiring would either:
+
+    * Inherit this runtime and override :meth:`execute` to call
+      into the existing :class:`XdotoolGymEnv`;
+    * Or replace it entirely with a VM-snapshot runtime when one
+      becomes available.
+
+    Either path keeps the snapshot/restore semantic identical
+    from the runner's perspective — that's the point of the
+    protocol.
+    """
+
+    def __init__(
+        self,
+        *,
+        profile_root: str,
+        snapshot_root: str,
+    ) -> None:
+        if not profile_root:
+            raise ValueError("LocalProfileSandbox requires profile_root")
+        if not snapshot_root:
+            raise ValueError("LocalProfileSandbox requires snapshot_root")
+        import os
+        self._profile_root = os.fspath(profile_root)
+        self._snapshot_root = os.fspath(snapshot_root)
+        os.makedirs(self._profile_root, exist_ok=True)
+        os.makedirs(self._snapshot_root, exist_ok=True)
+
+    def _profile_path(self, key: str) -> str:
+        import os
+        return os.path.join(self._profile_root, key)
+
+    def _snapshot_path(self, key: str, snapshot_id: str) -> str:
+        import os
+        return os.path.join(self._snapshot_root, key, snapshot_id)
+
+    # ── Lifecycle ──────────────────────────────────────────────
+
+    def create(self, *, key: str) -> None:
+        import os
+        os.makedirs(self._profile_path(key), exist_ok=True)
+
+    def capture(self, *, key: str) -> dict[str, Any]:
+        import os
+        path = self._profile_path(key)
+        size = 0
+        file_count = 0
+        for dirpath, _, filenames in os.walk(path):
+            for fn in filenames:
+                try:
+                    size += os.path.getsize(os.path.join(dirpath, fn))
+                    file_count += 1
+                except OSError:
+                    pass
+        return {
+            "runtime": "local_profile",
+            "key": key,
+            "profile_path": path,
+            "size_bytes": size,
+            "file_count": file_count,
+        }
+
+    def execute(self, *, key: str, action: Any) -> None:
+        # The local-profile sandbox doesn't dispatch actions — it's
+        # the storage layer beneath whatever env.step path the
+        # runner uses. Production sandboxes that DO dispatch would
+        # override execute(). Documented here so the noop is
+        # explicit rather than surprising.
+        del key, action
+
+    # ── Snapshot / restore ─────────────────────────────────────
+
+    def snapshot(self, *, key: str) -> SandboxSnapshot | None:
+        import os
+        profile = self._profile_path(key)
+        if not os.path.exists(profile):
+            logger.warning(
+                "LocalProfileSandbox.snapshot: profile %r does not "
+                "exist for key=%r — returning None (caller falls "
+                "through to un-gated dispatch)", profile, key,
+            )
+            return None
+        snapshot_id = f"local:{uuid.uuid4().hex[:16]}"
+        target = self._snapshot_path(key, snapshot_id)
+        os.makedirs(os.path.dirname(target), exist_ok=True)
+        # ``copytree`` raises if target exists — uuid collision is
+        # astronomically unlikely but we let the exception surface
+        # so a test catching it gets a real signal vs silently
+        # overwriting state.
+        shutil.copytree(profile, target)
+        size = sum(
+            os.path.getsize(os.path.join(dp, f))
+            for dp, _, fs in os.walk(target) for f in fs
+        )
+        return SandboxSnapshot(
+            snapshot_id=snapshot_id,
+            created_at=time.time(),
+            size_bytes=size,
+            metadata={"runtime": "local_profile", "key": key},
+        )
+
+    def restore(self, *, key: str, snapshot_id: str) -> None:
+        import os
+        if not snapshot_id:
+            raise SandboxRestoreError(
+                "LocalProfileSandbox.restore: snapshot_id required"
+            )
+        source = self._snapshot_path(key, snapshot_id)
+        if not os.path.isdir(source):
+            raise SandboxRestoreError(
+                f"LocalProfileSandbox.restore: snapshot "
+                f"{snapshot_id!r} not found for key={key!r} "
+                f"(looked at {source!r})"
+            )
+        target = self._profile_path(key)
+        # Atomic-ish swap: write to a temp dir, then rename. If the
+        # write fails partway, the live profile is unchanged.
+        tmp = f"{target}.restoring.{uuid.uuid4().hex[:8]}"
+        try:
+            shutil.copytree(source, tmp)
+        except Exception as exc:
+            # Clean up partial tmp tree.
+            shutil.rmtree(tmp, ignore_errors=True)
+            raise SandboxRestoreError(
+                f"LocalProfileSandbox.restore: copying snapshot "
+                f"{snapshot_id!r} failed: {exc}"
+            ) from exc
+        # Replace the live profile.
+        if os.path.exists(target):
+            backup = f"{target}.replaced.{uuid.uuid4().hex[:8]}"
+            os.rename(target, backup)
+        try:
+            os.rename(tmp, target)
+        except OSError as exc:
+            # Best-effort rollback to the backup.
+            raise SandboxRestoreError(
+                f"LocalProfileSandbox.restore: final rename to "
+                f"{target!r} failed: {exc}"
+            ) from exc
+
+    def destroy(self, *, key: str) -> None:
+        path = self._profile_path(key)
+        shutil.rmtree(path, ignore_errors=True)

--- a/src/mantis_agent/cua_contracts/types.py
+++ b/src/mantis_agent/cua_contracts/types.py
@@ -150,6 +150,15 @@ class ActionResult:
     grounding_trace: dict[str, Any] = field(default_factory=dict)
     dispatched: bool = False                    # did the dispatcher commit the action?
     dispatch_error: str = ""                    # empty when dispatched=True
+    # #484 sandbox snapshot taken BEFORE this action dispatched.
+    # When the runner gates an irreversible action behind a
+    # snapshot, the resulting ``SandboxSnapshot.snapshot_id`` lands
+    # here so a failed action can be replayed against the pre-
+    # action state. Empty string when no snapshot was taken
+    # (reversible actions, no sandbox runtime wired, runtime
+    # declined to snapshot this state). The runtime owns the
+    # ``snapshot_id`` format — readers treat it as opaque.
+    snapshot_id: str = ""
 
 
 class GroundingTrace(TypedDict, total=False):

--- a/tests/test_sandbox_runtime.py
+++ b/tests/test_sandbox_runtime.py
@@ -1,0 +1,310 @@
+"""Tests for the sandbox runtime substrate (#484).
+
+Covers:
+
+* SandboxRuntime Protocol: runtime_checkable shape for noop +
+  local-profile implementations.
+* NoopSandboxRuntime: deterministic placeholder snapshot ids;
+  restore accepts any non-empty id; lifecycle methods are no-ops.
+* LocalProfileSandbox (the browser-task fixture):
+  - create / capture / destroy lifecycle round-trips
+  - snapshot copies the profile dir to a content-keyed path
+  - restore reverses the copy (live profile == prior snapshot)
+  - missing snapshot_id raises SandboxRestoreError
+  - missing snapshot dir raises SandboxRestoreError
+  - snapshot of non-existent profile returns None
+  - destroy removes the profile dir
+* snapshot_id round-trips through the canonical event emitter
+  (TrajectoryEvent.action_result.snapshot_id).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from mantis_agent.cua_contracts import (
+    JSONL_FILENAME,
+    LocalProfileSandbox,
+    NoopSandboxRuntime,
+    SandboxRestoreError,
+    SandboxRuntime,
+    SandboxSnapshot,
+    TrajectoryEmitter,
+)
+from mantis_agent.gym.checkpoint import StepResult
+from mantis_agent.plan_decomposer import MicroIntent
+
+
+# ── Protocol shape ─────────────────────────────────────────────────────
+
+
+def test_noop_runtime_satisfies_protocol() -> None:
+    assert isinstance(NoopSandboxRuntime(), SandboxRuntime)
+
+
+def test_local_profile_sandbox_satisfies_protocol(tmp_path: Path) -> None:
+    sb = LocalProfileSandbox(
+        profile_root=str(tmp_path / "profiles"),
+        snapshot_root=str(tmp_path / "snapshots"),
+    )
+    assert isinstance(sb, SandboxRuntime)
+
+
+# ── NoopSandboxRuntime ─────────────────────────────────────────────────
+
+
+def test_noop_runtime_snapshot_returns_typed_placeholder() -> None:
+    rt = NoopSandboxRuntime()
+    s = rt.snapshot(key="profile_x")
+    assert isinstance(s, SandboxSnapshot)
+    assert s.snapshot_id.startswith("noop:profile_x:")
+    assert s.size_bytes == 0
+    assert s.metadata == {"runtime": "noop"}
+
+
+def test_noop_runtime_snapshot_ids_are_deterministically_unique() -> None:
+    """Counter ensures repeated snapshots get distinct ids — readers
+    can use ids as keys without collision."""
+    rt = NoopSandboxRuntime()
+    ids = {rt.snapshot(key="k").snapshot_id for _ in range(5)}
+    assert len(ids) == 5
+
+
+def test_noop_runtime_restore_accepts_any_non_empty_id() -> None:
+    rt = NoopSandboxRuntime()
+    rt.restore(key="k", snapshot_id="noop:k:s1")  # no exception
+
+
+def test_noop_runtime_restore_rejects_empty_id() -> None:
+    rt = NoopSandboxRuntime()
+    with pytest.raises(SandboxRestoreError, match="snapshot_id"):
+        rt.restore(key="k", snapshot_id="")
+
+
+def test_noop_runtime_capture_returns_runtime_marker() -> None:
+    rt = NoopSandboxRuntime()
+    state = rt.capture(key="profile_x")
+    assert state["runtime"] == "noop"
+    assert state["key"] == "profile_x"
+
+
+def test_noop_runtime_destroy_clears_state() -> None:
+    rt = NoopSandboxRuntime()
+    rt.create(key="profile_x")
+    assert "profile_x" in rt._created_keys
+    rt.destroy(key="profile_x")
+    assert "profile_x" not in rt._created_keys
+
+
+# ── LocalProfileSandbox — the browser-task fixture (#484 criterion) ───
+
+
+def _seed_profile(sb: LocalProfileSandbox, key: str, contents: dict[str, bytes]) -> None:
+    """Helper — write fake "profile" files into the sandbox key's dir."""
+    import os
+    sb.create(key=key)
+    profile = sb._profile_path(key)
+    for relpath, data in contents.items():
+        full = os.path.join(profile, relpath)
+        os.makedirs(os.path.dirname(full), exist_ok=True)
+        with open(full, "wb") as f:
+            f.write(data)
+
+
+def test_local_profile_sandbox_rejects_empty_roots() -> None:
+    with pytest.raises(ValueError, match="profile_root"):
+        LocalProfileSandbox(profile_root="", snapshot_root="/tmp/x")
+    with pytest.raises(ValueError, match="snapshot_root"):
+        LocalProfileSandbox(profile_root="/tmp/x", snapshot_root="")
+
+
+def test_local_profile_sandbox_create_makes_profile_dir(tmp_path: Path) -> None:
+    sb = LocalProfileSandbox(
+        profile_root=str(tmp_path / "p"),
+        snapshot_root=str(tmp_path / "s"),
+    )
+    sb.create(key="key1")
+    assert (tmp_path / "p" / "key1").is_dir()
+
+
+def test_local_profile_sandbox_capture_reports_sizes(tmp_path: Path) -> None:
+    sb = LocalProfileSandbox(
+        profile_root=str(tmp_path / "p"),
+        snapshot_root=str(tmp_path / "s"),
+    )
+    _seed_profile(sb, "k", {"cookies.txt": b"=" * 200, "prefs/p.json": b"{}"})
+
+    state = sb.capture(key="k")
+    assert state["runtime"] == "local_profile"
+    assert state["key"] == "k"
+    assert state["file_count"] == 2
+    assert state["size_bytes"] == 202
+
+
+def test_local_profile_sandbox_snapshot_returns_handle(tmp_path: Path) -> None:
+    sb = LocalProfileSandbox(
+        profile_root=str(tmp_path / "p"),
+        snapshot_root=str(tmp_path / "s"),
+    )
+    _seed_profile(sb, "k", {"a.bin": b"hello"})
+
+    snap = sb.snapshot(key="k")
+    assert snap is not None
+    assert snap.snapshot_id.startswith("local:")
+    assert snap.size_bytes == 5
+    assert snap.metadata["runtime"] == "local_profile"
+    assert snap.metadata["key"] == "k"
+
+
+def test_local_profile_sandbox_snapshot_of_missing_profile_returns_none(
+    tmp_path: Path,
+) -> None:
+    sb = LocalProfileSandbox(
+        profile_root=str(tmp_path / "p"),
+        snapshot_root=str(tmp_path / "s"),
+    )
+    # No create() called — profile dir doesn't exist.
+    assert sb.snapshot(key="never-created") is None
+
+
+def test_local_profile_sandbox_snapshot_then_restore_round_trips(
+    tmp_path: Path,
+) -> None:
+    """End-to-end: seed → snapshot → mutate profile → restore →
+    profile bytes match the original snapshot."""
+    sb = LocalProfileSandbox(
+        profile_root=str(tmp_path / "p"),
+        snapshot_root=str(tmp_path / "s"),
+    )
+    _seed_profile(sb, "k", {"cookies.txt": b"original", "prefs/p.json": b"{}"})
+    snap = sb.snapshot(key="k")
+    assert snap is not None
+
+    # Mutate the live profile after the snapshot.
+    import os
+    profile = sb._profile_path("k")
+    with open(os.path.join(profile, "cookies.txt"), "wb") as f:
+        f.write(b"mutated")
+    with open(os.path.join(profile, "new-file.bin"), "wb") as f:
+        f.write(b"appeared-after-snapshot")
+
+    # Restore.
+    sb.restore(key="k", snapshot_id=snap.snapshot_id)
+
+    # Profile now matches the pre-mutation state.
+    with open(os.path.join(profile, "cookies.txt"), "rb") as f:
+        assert f.read() == b"original"
+    assert not os.path.exists(os.path.join(profile, "new-file.bin"))
+
+
+def test_local_profile_sandbox_restore_missing_snapshot_raises(
+    tmp_path: Path,
+) -> None:
+    sb = LocalProfileSandbox(
+        profile_root=str(tmp_path / "p"),
+        snapshot_root=str(tmp_path / "s"),
+    )
+    sb.create(key="k")
+    with pytest.raises(SandboxRestoreError, match="not found"):
+        sb.restore(key="k", snapshot_id="local:does-not-exist")
+
+
+def test_local_profile_sandbox_restore_empty_snapshot_id_raises(
+    tmp_path: Path,
+) -> None:
+    sb = LocalProfileSandbox(
+        profile_root=str(tmp_path / "p"),
+        snapshot_root=str(tmp_path / "s"),
+    )
+    with pytest.raises(SandboxRestoreError, match="snapshot_id"):
+        sb.restore(key="k", snapshot_id="")
+
+
+def test_local_profile_sandbox_destroy_removes_profile(tmp_path: Path) -> None:
+    sb = LocalProfileSandbox(
+        profile_root=str(tmp_path / "p"),
+        snapshot_root=str(tmp_path / "s"),
+    )
+    _seed_profile(sb, "k", {"a.bin": b"x"})
+    assert (tmp_path / "p" / "k").is_dir()
+    sb.destroy(key="k")
+    assert not (tmp_path / "p" / "k").exists()
+
+
+def test_local_profile_sandbox_distinct_snapshots_distinct_paths(
+    tmp_path: Path,
+) -> None:
+    """Two snapshots of the same profile get distinct ids + distinct
+    on-disk directories — caller can roll back to either."""
+    sb = LocalProfileSandbox(
+        profile_root=str(tmp_path / "p"),
+        snapshot_root=str(tmp_path / "s"),
+    )
+    _seed_profile(sb, "k", {"a.bin": b"state-1"})
+    snap_a = sb.snapshot(key="k")
+    import os
+    with open(os.path.join(sb._profile_path("k"), "a.bin"), "wb") as f:
+        f.write(b"state-2")
+    snap_b = sb.snapshot(key="k")
+    assert snap_a.snapshot_id != snap_b.snapshot_id
+    assert os.path.isdir(sb._snapshot_path("k", snap_a.snapshot_id))
+    assert os.path.isdir(sb._snapshot_path("k", snap_b.snapshot_id))
+
+
+# ── snapshot_id round-trips through canonical events ─────────────────
+
+
+def _intent() -> MicroIntent:
+    return MicroIntent(intent="x", type="submit", required=True)
+
+
+def _ok_result() -> StepResult:
+    return StepResult(step_index=0, intent="x", success=True, data="ok")
+
+
+def test_emit_passes_snapshot_id_through_to_action_result(tmp_path: Path) -> None:
+    """When the caller passes ``snapshot_id`` to emit(), it lands
+    on TrajectoryEvent.action_result.snapshot_id so a downstream
+    consumer can replay the failed action against the snapshot."""
+    emitter = TrajectoryEmitter(run_id="r1", store_dir=str(tmp_path))
+    ok = emitter.emit(
+        _intent(), _ok_result(),
+        snapshot_id="local:abcdef123",
+    )
+    assert ok is True
+    record = json.loads((tmp_path / JSONL_FILENAME).read_text().strip())
+    assert record["action_result"]["snapshot_id"] == "local:abcdef123"
+
+
+def test_emit_falls_back_to_step_result_snapshot_id(tmp_path: Path) -> None:
+    """When the caller doesn't pass snapshot_id but the StepResult
+    has one attached (handler-stashed), the emitter picks it up."""
+    emitter = TrajectoryEmitter(run_id="r1", store_dir=str(tmp_path))
+    r = _ok_result()
+    r.snapshot_id = "noop:k:s7"  # type: ignore[attr-defined]
+    emitter.emit(_intent(), r)
+    record = json.loads((tmp_path / JSONL_FILENAME).read_text().strip())
+    assert record["action_result"]["snapshot_id"] == "noop:k:s7"
+
+
+def test_emit_omits_snapshot_id_when_none_set(tmp_path: Path) -> None:
+    """No snapshot_id stamped → action_result.snapshot_id is empty
+    string (default); event still validates."""
+    emitter = TrajectoryEmitter(run_id="r1", store_dir=str(tmp_path))
+    emitter.emit(_intent(), _ok_result())
+    record = json.loads((tmp_path / JSONL_FILENAME).read_text().strip())
+    assert record["action_result"]["snapshot_id"] == ""
+
+
+def test_emit_explicit_snapshot_id_wins_over_result_attr(tmp_path: Path) -> None:
+    """Caller's explicit snapshot_id beats the StepResult stash —
+    same precedence rule as grounding_trace."""
+    emitter = TrajectoryEmitter(run_id="r1", store_dir=str(tmp_path))
+    r = _ok_result()
+    r.snapshot_id = "stash-id"  # type: ignore[attr-defined]
+    emitter.emit(_intent(), r, snapshot_id="explicit-id")
+    record = json.loads((tmp_path / JSONL_FILENAME).read_text().strip())
+    assert record["action_result"]["snapshot_id"] == "explicit-id"


### PR DESCRIPTION
## Summary

Closes the last open P1 child of **epic #474 (Durable execution)**. Ships the sandbox snapshot/restore substrate the design needs to gate irreversible actions and recover from non-recoverable failures.

### \`cua_contracts/sandbox.py\`

- **\`SandboxRuntime\`** Protocol (runtime_checkable) — six ops covering the sandbox lifecycle: \`create / capture / execute / snapshot / restore / destroy\`.
- **\`SandboxSnapshot\`** frozen dataclass — typed return from \`snapshot()\` carrying \`snapshot_id\` + \`created_at\` + \`size_bytes\` + \`metadata\`. Opaque id format owned by the runtime.
- **\`SandboxRestoreError\`** typed exception so the runner's catch site can distinguish a structured restore failure from a bug-shaped exception out of the runtime.
- **\`NoopSandboxRuntime\`** — default for tests + bring-up. Deterministic placeholder snapshot ids; callers can exercise the code path without filesystem side effects.
- **\`LocalProfileSandbox\`** — pragmatic browser-task fixture implementation. Copies a "profile" directory to \`<snapshot_root>/<key>/<snapshot_id>/\` on snapshot; restore reverses via an atomic temp-then-rename swap so a failed copy leaves the live profile unchanged.

### Wire-through into the canonical event

- \`ActionResult.snapshot_id: str = ""\` added — empty when no snapshot was gated (reversible actions, no runtime wired), non-empty otherwise.
- \`action_result_from_action\` adapter accepts \`snapshot_id\`.
- \`TrajectoryEmitter.emit\` accepts \`snapshot_id\` kwarg with precedence: explicit kwarg → \`StepResult.snapshot_id\` attr → empty.

### Substrate-only — no runtime wiring this PR

Handlers don't gate snapshots in the runtime yet. The next PR wires \`LocalProfileSandbox\` into the Modal / Baseten path; this PR ships the typed surface that wiring lands against. Same pattern as the rest of the recent contract stack (#477, #481, #486, #487, #485, #489, #490).

## Test plan

- [x] Full local suite passes: **3215**.
- [x] Ruff clean.
- [x] 22 new tests covering:
  - Protocol shape via \`isinstance\` (noop + local-profile)
  - Noop lifecycle + placeholder id determinism + empty-id rejection
  - **LocalProfileSandbox end-to-end browser-task fixture**: seed → snapshot → mutate live profile → restore → assert bytes match the snapshot
  - Missing-id / missing-dir error paths raise \`SandboxRestoreError\`
  - Distinct snapshots get distinct on-disk dirs
  - \`destroy()\` removes the live profile
  - \`snapshot_id\` event round-trip with three precedence cases (explicit kwarg, StepResult attr, empty fallback)
- [ ] Modal verify recommended — substrate PR, no runtime behaviour change, but the new \`ActionResult.snapshot_id\` field gets serialised on every event (default empty string) — want to confirm no validator rejection on production events.

## Where this leaves the project

After this merges:

| Epic | Status |
|---|---|
| **#472** CUA reliability foundation | ✅ closed |
| **#473** Step safety | ✅ closed |
| **#475** Model versioning & flywheel | ✅ closed |
| **#474** Durable execution | **closeable** — #485 / #486 (substrate) / **#484 this PR** all done |

All 11 P0/P1 children across the 4 reliability-foundation epics shipped.

Closes #484
Refs #474

🤖 Generated with [Claude Code](https://claude.com/claude-code)