### PR TITLE
cost(telemetry): real GPU billing, per-task spend, terminal histograms

### DIFF
--- a/src/mantis_agent/gym/_runner_helpers.py
+++ b/src/mantis_agent/gym/_runner_helpers.py
@@ -1014,6 +1014,14 @@ def extract_listing_data_deep(runner, initial_screenshot):
 
 
 def final_summary(runner: "MicroPlanRunner", results: list[StepResult]) -> None:
+    # #351: sync gpu_seconds from the TimeMeter's ``think`` bucket
+    # at terminal time so totals() returns real brain-inference
+    # wall time (not the pre-#351 ``steps × per-step`` synthetic).
+    # No-op when the runner doesn't have a TimeMeter — CostMeter's
+    # sync helper guards.
+    _time_meter = getattr(runner, "time_meter", None)
+    if _time_meter is not None:
+        runner.cost_meter.sync_gpu_seconds_from_time_meter(_time_meter)
     gpu_cost, claude_cost, proxy_cost, total_cost = runner.cost_meter.totals()
     elapsed = time.time() - runner._run_start
     print()
@@ -1035,6 +1043,26 @@ def final_summary(runner: "MicroPlanRunner", results: list[StepResult]) -> None:
         final_status=runner._final_status,
         checkpoint_path=runner.checkpoint_path,
     )
+    # #349: emit the terminal cost + duration histograms so
+    # dashboards (docs/operations/cost.md PromQL examples) have
+    # real series to query. Mirrors the inflight gauge's label set
+    # so panels grouped by tenant_id / model / status align. Skip
+    # silently when no tenant_id is set so local / script runs
+    # don't pollute the registry with default-label series; same
+    # discipline as the inflight gauge.
+    tenant_id = str(getattr(runner, "tenant_id", "") or "")
+    if tenant_id:
+        try:
+            from .. import metrics as _metrics
+            labels = {
+                "tenant_id": tenant_id,
+                "model": str(getattr(runner, "model_name", "") or ""),
+                "status": str(getattr(runner, "_final_status", "") or "completed"),
+            }
+            _metrics.RUN_COST_USD.labels(**labels).observe(total_cost)
+            _metrics.RUN_DURATION_SECONDS.labels(**labels).observe(elapsed)
+        except Exception as exc:  # noqa: BLE001 — observability, never fatal
+            logger.debug("terminal cost/duration histogram emit failed: %s", exc)
 
 
 def _capture_browser_state_safe(runner: "MicroPlanRunner"):

--- a/src/mantis_agent/gym/cost_meter.py
+++ b/src/mantis_agent/gym/cost_meter.py
@@ -4,7 +4,11 @@ micro_runner.py (#115, step 3).
 Tracks four counters per run:
 
 * ``gpu_steps``       — number of brain-driven steps
-* ``gpu_seconds``     — derived from ``gpu_steps * cost_config.gpu_seconds_per_step``
+* ``gpu_seconds``     — actual brain-inference wall time from
+  :class:`~.time_meter.TimeMeter`'s ``think`` bucket when a meter
+  is wired (#351). Falls back to the legacy synthetic
+  ``gpu_steps * cost_config.gpu_seconds_per_step`` when no meter
+  is available (tests, legacy hosts).
 * ``claude_extract``  — Claude API calls for extraction / verification / grounding callthroughs
 * ``claude_grounding``— Claude API calls for click coordinate grounding
 * ``proxy_mb``        — estimated egress bandwidth in megabytes
@@ -30,6 +34,7 @@ from ..cost_config import CostConfig
 if TYPE_CHECKING:
     from ..plan_decomposer import MicroIntent
     from .checkpoint import StepResult
+    from .time_meter import TimeMeter
 
 logger = logging.getLogger(__name__)
 
@@ -86,18 +91,43 @@ class CostMeter:
 
     # ── Per-step accounting ─────────────────────────────────────────────
 
-    def record_step(self, step: "MicroIntent", step_result: "StepResult") -> None:
+    def record_step(
+        self,
+        step: "MicroIntent",
+        step_result: "StepResult",
+        *,
+        time_meter: "TimeMeter | None" = None,
+    ) -> None:
         """Apply a step's resource usage to the counters.
 
-        Mirrors the pre-#115 ``MicroPlanRunner._record_step_costs`` exactly:
-        GPU time scales with step count, Claude extraction is one call per
-        ``claude_only`` step, grounding is one call per click step,
-        navigation/scroll add proxy MB per the config rate.
+        Claude / proxy accounting unchanged. GPU accounting depends
+        on ``time_meter``:
+
+        * **With time_meter (production, since #351)** — bumps
+          ``gpu_steps`` only; ``gpu_seconds`` is owned by
+          :meth:`sync_gpu_seconds_from_time_meter` which sets it
+          from the meter's ``think`` bucket (actual brain-inference
+          wall time). Caller invokes the sync at terminal time +
+          optionally per-step for live dashboards.
+        * **Without time_meter (tests, legacy hosts)** — keeps the
+          pre-#351 synthetic ``steps × per-step`` accumulation so
+          existing callers see no behaviour change.
         """
         cfg = self.cost_config
         if step_result.steps_used > 0:
             self.costs["gpu_steps"] += step_result.steps_used
-            self.costs["gpu_seconds"] += step_result.steps_used * cfg.gpu_seconds_per_step
+            if time_meter is None:
+                # Legacy synthetic path — kept so tests / hosts that
+                # don't wire a TimeMeter see the pre-#351 numbers.
+                self.costs["gpu_seconds"] += (
+                    step_result.steps_used * cfg.gpu_seconds_per_step
+                )
+            else:
+                # Production path — gpu_seconds owned by
+                # sync_gpu_seconds_from_time_meter. We still sync
+                # here so per-step ``log_progress`` reads the real
+                # number instead of a stale value.
+                self.sync_gpu_seconds_from_time_meter(time_meter)
         if step.claude_only:
             self.costs["claude_extract"] += 1
         if step.grounding:
@@ -106,6 +136,69 @@ class CostMeter:
             self.costs["proxy_mb"] += cfg.proxy_mb_per_nav
         elif step.type == "scroll":
             self.costs["proxy_mb"] += cfg.proxy_mb_per_scroll
+
+    def totals_from(self, costs: dict[str, Any]) -> dict[str, float]:
+        """Compute the USD-cost breakdown for an arbitrary counters dict
+        (#350).
+
+        Used for per-task cost attribution in
+        :func:`mantis_agent.task_loop._run_loop` — callers snapshot
+        ``cost_meter.costs`` before / after each task and pass the
+        delta here to get a {gpu, claude, proxy, total} dict shaped
+        like the run-level ``_final_costs``. Missing keys default to
+        zero so partial dicts are safe.
+        """
+        cfg = self.cost_config
+        gpu = cfg.gpu_cost(float(costs.get("gpu_seconds", 0.0) or 0.0))
+        claude = cfg.claude_cost(
+            int(costs.get("claude_extract", 0) or 0)
+            + int(costs.get("claude_grounding", 0) or 0)
+        )
+        proxy = cfg.proxy_cost(float(costs.get("proxy_mb", 0.0) or 0.0))
+        return {
+            "gpu": gpu,
+            "claude": claude,
+            "proxy": proxy,
+            "total": gpu + claude + proxy,
+            "gpu_steps": int(costs.get("gpu_steps", 0) or 0),
+            "gpu_seconds": float(costs.get("gpu_seconds", 0.0) or 0.0),
+            "claude_extract": int(costs.get("claude_extract", 0) or 0),
+            "claude_grounding": int(costs.get("claude_grounding", 0) or 0),
+            "proxy_mb": float(costs.get("proxy_mb", 0.0) or 0.0),
+        }
+
+    def sync_gpu_seconds_from_time_meter(self, time_meter: "TimeMeter") -> None:
+        """Set ``costs["gpu_seconds"]`` from the meter's ``think``
+        bucket (#351).
+
+        ``think`` is the canonical brain-inference wall-time bucket
+        (see :data:`~.time_meter.BUCKETS`) — credited by the brain
+        ladder's ``publish_dispatch`` context whenever a Holo3 /
+        Gemma4 / Claude inference call runs. Using it directly means
+        per-run cost reflects what Modal actually billed for brain
+        compute, instead of ``steps × 3s`` (the pre-#351 fake).
+
+        Idempotent: sets (not increments) so calling repeatedly is
+        safe. Best-effort: a missing ``think`` bucket leaves
+        ``gpu_seconds`` alone — guards against monkey-patched
+        TimeMeters in tests.
+        """
+        try:
+            totals = time_meter.totals
+        except AttributeError:
+            return
+        if "think" not in (totals or {}):
+            # Missing bucket → no signal to sync from. Leave the
+            # caller's pre-existing (possibly legacy-synthetic) value
+            # intact rather than zeroing it.
+            return
+        try:
+            think_seconds = float(totals.get("think", 0.0) or 0.0)
+        except (TypeError, ValueError):
+            return
+        if think_seconds < 0:
+            return
+        self.costs["gpu_seconds"] = think_seconds
 
     # ── Restore from checkpoint ─────────────────────────────────────────
 

--- a/src/mantis_agent/gym/run_executor.py
+++ b/src/mantis_agent/gym/run_executor.py
@@ -497,7 +497,17 @@ class RunExecutor:
         state.results.append(step_result)
         runner._enforce_screenshot_cap(state.results)
         runner._invoke_step_callback(step_result)
-        runner._record_step_costs(effective_step, step_result)
+        # #351: pass the runner's TimeMeter so CostMeter uses real
+        # brain-inference wall time (the ``think`` bucket) instead
+        # of the pre-#351 ``steps × per-step`` synthetic. Bypasses
+        # the COLLAB_METHODS shim (which doesn't thread the kwarg)
+        # by calling cost_meter directly. Backward-compat: when
+        # ``time_meter`` is None (host without it wired), CostMeter
+        # falls back to the legacy synthetic accounting.
+        runner.cost_meter.record_step(
+            effective_step, step_result,
+            time_meter=getattr(runner, "time_meter", None),
+        )
         runner._log_progress(step_result, state.results)
         runner._log_step_diff(pre_snapshot, effective_step, step_result)
         _emit_action_metric(runner, effective_step, step_result)

--- a/src/mantis_agent/task_loop.py
+++ b/src/mantis_agent/task_loop.py
@@ -366,6 +366,7 @@ def run_task_loop(
 
     Returns (scores, task_details).
     """
+    from .gym.cost_meter import make_initial_costs
     from .gym.runner import GymRunner
 
     t0 = t0 or time.time()
@@ -384,6 +385,25 @@ def run_task_loop(
 
         print(f"\nTask {i + 1}/{len(tasks)}: {task_id}")
         task_start = time.time()
+        # #350: per-task cost attribution. Each standard task creates
+        # its own GymRunner with a fresh CostMeter; primary + micro
+        # fallback + resume runners each accumulate independently.
+        # We merge their counters here so detail["costs"] reflects
+        # the whole task's spend.
+        task_cost_acc: dict[str, Any] = make_initial_costs()
+        last_cost_meter: Any = None
+
+        def _merge_runner_costs(_runner: Any) -> None:
+            nonlocal last_cost_meter
+            meter = getattr(_runner, "cost_meter", None)
+            if meter is None:
+                return
+            last_cost_meter = meter
+            for k, v in (meter.costs or {}).items():
+                try:
+                    task_cost_acc[k] = task_cost_acc.get(k, 0) + v
+                except TypeError:
+                    pass
 
         try:
             if task_config.get("require_session") and config.env.has_session(
@@ -526,6 +546,7 @@ def run_task_loop(
                 task_id=task_id,
                 start_url=task_config.get("start_url", ""),
             )
+            _merge_runner_costs(runner)
 
             if not result.success and config.fallback_brain is not None:
                 fallback_retries = int(
@@ -577,6 +598,7 @@ def run_task_loop(
                         ),
                         start_url=task_config.get("fallback_start_url", ""),
                     )
+                    _merge_runner_costs(fallback_runner)
                     try:
                         setattr(micro_result, "fallback_used", config.fallback_label)
                     except (AttributeError, TypeError):
@@ -606,6 +628,7 @@ def run_task_loop(
                         ),
                         start_url="",
                     )
+                    _merge_runner_costs(resume_runner)
                     try:
                         setattr(result, "fallback_used", config.fallback_label)
                     except (AttributeError, TypeError):
@@ -627,16 +650,19 @@ def run_task_loop(
 
             success = result.success
             scores.append(1.0 if success else 0.0)
-            task_details.append(
-                {
-                    "task_id": task_id,
-                    "success": success,
-                    "steps": result.total_steps,
-                    "duration_s": round(time.time() - task_start),
-                    "termination_reason": result.termination_reason,
-                    "final_url": config.env.current_url,
-                }
-            )
+            detail_entry: dict[str, Any] = {
+                "task_id": task_id,
+                "success": success,
+                "steps": result.total_steps,
+                "duration_s": round(time.time() - task_start),
+                "termination_reason": result.termination_reason,
+                "final_url": config.env.current_url,
+            }
+            if last_cost_meter is not None:
+                detail_entry["costs"] = last_cost_meter.totals_from(
+                    task_cost_acc
+                )
+            task_details.append(detail_entry)
             print(f"  {'PASS' if success else 'FAIL'} ({result.total_steps} steps)")
 
             if (
@@ -656,14 +682,19 @@ def run_task_loop(
             traceback.print_exc()
             print(f"  ERROR: {e}")
             scores.append(0.0)
-            task_details.append(
-                {
-                    "task_id": task_id,
-                    "success": False,
-                    "error": str(e),
-                    "duration_s": round(time.time() - task_start),
-                }
-            )
+            error_detail: dict[str, Any] = {
+                "task_id": task_id,
+                "success": False,
+                "error": str(e),
+                "duration_s": round(time.time() - task_start),
+            }
+            # #350: even on exception, attribute whatever spend happened
+            # before the throw — partial runs still cost real money.
+            if last_cost_meter is not None:
+                error_detail["costs"] = last_cost_meter.totals_from(
+                    task_cost_acc
+                )
+            task_details.append(error_detail)
 
         save_progress()
         if (

--- a/tests/test_cost_meter.py
+++ b/tests/test_cost_meter.py
@@ -235,3 +235,122 @@ def test_runner_cost_totals_delegates_to_meter() -> None:
     assert claude == 0.0
     assert proxy == 0.0
     assert total == pytest.approx(1.625)
+
+
+# ── #351: sync_gpu_seconds_from_time_meter ───────────────────────────────
+
+
+class _FakeTimeMeter:
+    def __init__(self, think_seconds: float = 0.0, **extra) -> None:
+        self.totals: dict[str, float] = {"think": think_seconds, **extra}
+
+
+def test_sync_gpu_seconds_overwrites_with_think_bucket() -> None:
+    meter = CostMeter()
+    meter.costs["gpu_seconds"] = 999.0  # pre-existing synthetic value
+    meter.sync_gpu_seconds_from_time_meter(_FakeTimeMeter(think_seconds=42.5))
+    assert meter.costs["gpu_seconds"] == 42.5
+
+
+def test_sync_gpu_seconds_idempotent_on_repeated_calls() -> None:
+    meter = CostMeter()
+    tm = _FakeTimeMeter(think_seconds=10.0)
+    meter.sync_gpu_seconds_from_time_meter(tm)
+    meter.sync_gpu_seconds_from_time_meter(tm)
+    assert meter.costs["gpu_seconds"] == 10.0
+
+
+def test_sync_gpu_seconds_missing_think_bucket_leaves_value_alone() -> None:
+    meter = CostMeter()
+    meter.costs["gpu_seconds"] = 5.0
+
+    class _NoThink:
+        totals: dict[str, float] = {}
+
+    meter.sync_gpu_seconds_from_time_meter(_NoThink())
+    assert meter.costs["gpu_seconds"] == 5.0
+
+
+def test_sync_gpu_seconds_negative_value_rejected() -> None:
+    meter = CostMeter()
+    meter.costs["gpu_seconds"] = 7.0
+    meter.sync_gpu_seconds_from_time_meter(_FakeTimeMeter(think_seconds=-1.0))
+    assert meter.costs["gpu_seconds"] == 7.0
+
+
+def test_record_step_with_time_meter_syncs_gpu_seconds() -> None:
+    """When a TimeMeter is wired in, gpu_seconds comes from ``think``
+    rather than the legacy ``steps × per-step`` multiplier."""
+    meter = CostMeter(cost_config=CostConfig(gpu_seconds_per_step=99.0))
+    tm = _FakeTimeMeter(think_seconds=8.0)
+    meter.record_step(_FakeStep(), _FakeStepResult(steps_used=2), time_meter=tm)
+    assert meter.costs["gpu_steps"] == 2
+    # Real wall-time wins over the 99×2=198 synthetic value.
+    assert meter.costs["gpu_seconds"] == 8.0
+
+
+def test_record_step_without_time_meter_uses_legacy_multiplier() -> None:
+    """Tests / legacy callers without a TimeMeter keep the pre-#351 behaviour."""
+    meter = CostMeter(cost_config=CostConfig(gpu_seconds_per_step=4.0))
+    meter.record_step(_FakeStep(), _FakeStepResult(steps_used=3))
+    assert meter.costs["gpu_seconds"] == 12.0
+
+
+# ── #350: totals_from helper ─────────────────────────────────────────────
+
+
+def test_totals_from_returns_breakdown_dict() -> None:
+    cfg = CostConfig(
+        gpu_hourly_usd=3.6,  # → $0.001/sec
+        claude_call_usd=0.01,
+        proxy_per_gb_usd=10.0,
+    )
+    meter = CostMeter(cost_config=cfg)
+    delta = {
+        "gpu_steps": 5,
+        "gpu_seconds": 100.0,  # → $0.10
+        "claude_extract": 3,
+        "claude_grounding": 2,  # 5 calls × $0.01 = $0.05
+        "proxy_mb": 102.4,  # 0.1 GB × $10 = $1.00
+    }
+    out = meter.totals_from(delta)
+    assert out["gpu"] == pytest.approx(0.10)
+    assert out["claude"] == pytest.approx(0.05)
+    assert out["proxy"] == pytest.approx(1.00)
+    assert out["total"] == pytest.approx(1.15)
+    # Counters echo through for downstream reporters.
+    assert out["gpu_steps"] == 5
+    assert out["gpu_seconds"] == 100.0
+    assert out["claude_extract"] == 3
+    assert out["claude_grounding"] == 2
+    assert out["proxy_mb"] == 102.4
+
+
+def test_totals_from_tolerates_partial_dict() -> None:
+    meter = CostMeter()
+    out = meter.totals_from({"gpu_seconds": 3600})
+    assert out["gpu"] == pytest.approx(3.25)
+    assert out["claude"] == 0.0
+    assert out["proxy"] == 0.0
+    assert out["claude_grounding"] == 0
+    assert out["proxy_mb"] == 0.0
+
+
+def test_totals_from_matches_totals_for_full_dict() -> None:
+    """For a costs dict identical to meter.costs, totals_from() must
+    agree with totals() — the two helpers are the same arithmetic
+    seen from different angles."""
+    meter = CostMeter()
+    meter.costs.update({
+        "gpu_steps": 4,
+        "gpu_seconds": 12.0,
+        "claude_extract": 2,
+        "claude_grounding": 1,
+        "proxy_mb": 50.0,
+    })
+    gpu, claude, proxy, total = meter.totals()
+    out = meter.totals_from(meter.costs)
+    assert out["gpu"] == pytest.approx(gpu)
+    assert out["claude"] == pytest.approx(claude)
+    assert out["proxy"] == pytest.approx(proxy)
+    assert out["total"] == pytest.approx(total)

--- a/tests/test_observability_metrics.py
+++ b/tests/test_observability_metrics.py
@@ -255,3 +255,73 @@ def test_brain_escalation_metric_increments_on_ladder_think():
         tenant_id="", from_brain="primary", to_brain="fallback",
     )
     assert after_fallback - before_fallback == pytest.approx(1.0)
+
+
+# ── #349: terminal RUN_COST_USD + RUN_DURATION_SECONDS histograms ─────
+
+
+def _histogram_count(histogram, **labels) -> float:
+    try:
+        sample = histogram.labels(**labels)
+        return sample._sum.get()
+    except Exception:
+        return 0.0
+
+
+def test_final_summary_emits_terminal_histograms_when_tenant_set():
+    """``final_summary`` must observe both histograms with the same
+    label set as the inflight gauge so dashboards align."""
+    import time as _time
+
+    from mantis_agent.gym._runner_helpers import final_summary
+    from mantis_agent.gym.cost_meter import CostMeter
+    from mantis_agent.metrics import RUN_COST_USD, RUN_DURATION_SECONDS
+
+    runner = MagicMock()
+    runner.tenant_id = "tenant-final-A"
+    runner.model_name = "holo3"
+    runner._final_status = "completed"
+    runner._run_start = _time.time() - 5.0
+    runner.checkpoint_path = ""
+    runner.cost_meter = CostMeter(tenant_id="tenant-final-A")
+    runner.cost_meter.costs["gpu_seconds"] = 60.0
+    runner.costs = runner.cost_meter.costs
+    runner.time_meter = None
+
+    labels = {"tenant_id": "tenant-final-A", "model": "holo3", "status": "completed"}
+    cost_before = _histogram_count(RUN_COST_USD, **labels)
+    dur_before = _histogram_count(RUN_DURATION_SECONDS, **labels)
+
+    final_summary(runner, results=[])
+
+    cost_after = _histogram_count(RUN_COST_USD, **labels)
+    dur_after = _histogram_count(RUN_DURATION_SECONDS, **labels)
+    # 60s at $3.25/hr = $0.0542 — observed exactly once.
+    assert cost_after - cost_before == pytest.approx(0.054166666, rel=1e-3)
+    assert dur_after - dur_before >= 5.0
+
+
+def test_final_summary_skips_histograms_without_tenant_id():
+    """Local / script runs (no tenant_id) must not pollute the
+    registry with default-label series."""
+    import time as _time
+
+    from mantis_agent.gym._runner_helpers import final_summary
+    from mantis_agent.gym.cost_meter import CostMeter
+    from mantis_agent.metrics import RUN_COST_USD
+
+    runner = MagicMock()
+    runner.tenant_id = ""  # explicit empty
+    runner.model_name = "holo3"
+    runner._final_status = "completed"
+    runner._run_start = _time.time() - 1.0
+    runner.checkpoint_path = ""
+    runner.cost_meter = CostMeter(tenant_id="")
+    runner.costs = runner.cost_meter.costs
+    runner.time_meter = None
+
+    labels = {"tenant_id": "", "model": "holo3", "status": "completed"}
+    before = _histogram_count(RUN_COST_USD, **labels)
+    final_summary(runner, results=[])
+    after = _histogram_count(RUN_COST_USD, **labels)
+    assert after == before

--- a/tests/test_task_loop_loop_config.py
+++ b/tests/test_task_loop_loop_config.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+import pytest
+
 from mantis_agent import task_loop
 from mantis_agent.gym import runner as runner_module
 from mantis_agent.gym import workflow_runner
@@ -219,3 +221,160 @@ def test_standard_task_uses_small_default_step_cap(monkeypatch, tmp_path) -> Non
     task_loop.run_task_loop([{"task_id": "submit", "intent": "click submit"}], config)
 
     assert captured == [15]
+
+
+# ── #350: per-task CostMeter snapshot/delta ─────────────────────────────
+
+
+def test_standard_task_attaches_per_task_costs(monkeypatch, tmp_path) -> None:
+    """Each standard task's detail dict carries a ``costs`` entry
+    summed across primary + fallback + resume runners."""
+    from mantis_agent.gym.cost_meter import CostMeter
+
+    class FakeEnv:
+        current_url = "https://example.test/"
+
+    class FakeGymRunner:
+        # Each instance starts with its own fresh meter, then we
+        # pre-seed it so the run() call returns a known cost shape.
+        def __init__(self, *, brain, **_kwargs):
+            self.brain = brain
+            self.cost_meter = CostMeter()
+            # 4 brain steps for primary, 2 for any non-primary runner.
+            self._seed_steps = 4 if brain == "holo3" else 2
+
+        def run(self, **_kwargs):
+            self.cost_meter.costs["gpu_steps"] += self._seed_steps
+            self.cost_meter.costs["gpu_seconds"] += float(self._seed_steps)
+            return SimpleNamespace(
+                success=True,
+                total_steps=self._seed_steps,
+                termination_reason="done",
+                trajectory=[],
+            )
+
+    monkeypatch.setattr(runner_module, "GymRunner", FakeGymRunner)
+
+    config = task_loop.TaskLoopConfig(
+        run_id="run",
+        session_name="session",
+        model_name="model",
+        results_prefix="test",
+        brain="holo3",
+        env=FakeEnv(),
+        results_dir=str(tmp_path),
+    )
+
+    scores, details = task_loop.run_task_loop(
+        [
+            {"task_id": "submit_1", "intent": "click submit"},
+            {"task_id": "submit_2", "intent": "click submit"},
+        ],
+        config,
+    )
+
+    assert scores == [1.0, 1.0]
+    # Each task gets its own cost dict — meters don't leak across tasks.
+    for d in details:
+        assert "costs" in d
+        assert d["costs"]["gpu_steps"] == 4
+        assert d["costs"]["gpu_seconds"] == pytest.approx(4.0)
+        assert d["costs"]["total"] == pytest.approx(d["costs"]["gpu"])
+        assert d["costs"]["gpu"] > 0
+
+
+def test_standard_task_costs_sum_fallback_and_resume_runners(
+    monkeypatch, tmp_path
+) -> None:
+    """Primary failure → micro-fallback + resume both bill into the
+    same per-task costs entry (no cost gets dropped on the floor)."""
+    from mantis_agent.gym.cost_meter import CostMeter
+
+    class FakeEnv:
+        current_url = "https://example.test/"
+
+    class FakeGymRunner:
+        def __init__(self, *, brain, **_kwargs):
+            self.brain = brain
+            self.cost_meter = CostMeter()
+            self._seed = {"holo3": 3, "claude": 5}.get(brain, 1)
+
+        def run(self, **kwargs):
+            self.cost_meter.costs["gpu_steps"] += self._seed
+            self.cost_meter.costs["gpu_seconds"] += float(self._seed)
+            success = self.brain == "claude" or "resume_after" in kwargs["task_id"]
+            return SimpleNamespace(
+                success=success,
+                total_steps=self._seed,
+                termination_reason="done" if success else "loop",
+                trajectory=[],
+            )
+
+    monkeypatch.setattr(runner_module, "GymRunner", FakeGymRunner)
+
+    config = task_loop.TaskLoopConfig(
+        run_id="run",
+        session_name="session",
+        model_name="model",
+        results_prefix="test",
+        brain="holo3",
+        fallback_brain="claude",
+        fallback_label="claude",
+        fallback_micro_retries=1,
+        fallback_micro_max_steps=5,
+        env=FakeEnv(),
+        results_dir=str(tmp_path),
+    )
+
+    _scores, details = task_loop.run_task_loop(
+        [{"task_id": "fill_filters", "intent": "fill filters"}],
+        config,
+    )
+
+    # primary holo3 (3) + claude micro-fallback (5) + resume holo3 (3) = 11
+    assert details[0]["costs"]["gpu_steps"] == 11
+    assert details[0]["costs"]["gpu_seconds"] == pytest.approx(11.0)
+
+
+def test_failed_task_still_carries_costs(monkeypatch, tmp_path) -> None:
+    """A primary-only failure must still attribute the spend it
+    incurred (failures cost real money too)."""
+    from mantis_agent.gym.cost_meter import CostMeter
+
+    class FakeEnv:
+        current_url = "https://example.test/"
+
+    class FakeGymRunner:
+        def __init__(self, **_kwargs):
+            self.cost_meter = CostMeter()
+
+        def run(self, **_kwargs):
+            self.cost_meter.costs["gpu_steps"] += 2
+            self.cost_meter.costs["gpu_seconds"] += 6.0
+            return SimpleNamespace(
+                success=False,
+                total_steps=2,
+                termination_reason="loop",
+                trajectory=[],
+            )
+
+    monkeypatch.setattr(runner_module, "GymRunner", FakeGymRunner)
+
+    config = task_loop.TaskLoopConfig(
+        run_id="run",
+        session_name="session",
+        model_name="model",
+        results_prefix="test",
+        brain="holo3",
+        env=FakeEnv(),
+        results_dir=str(tmp_path),
+    )
+
+    _scores, details = task_loop.run_task_loop(
+        [{"task_id": "submit", "intent": "click submit"}],
+        config,
+    )
+
+    assert details[0]["success"] is False
+    assert details[0]["costs"]["gpu_steps"] == 2
+    assert details[0]["costs"]["gpu_seconds"] == pytest.approx(6.0)


### PR DESCRIPTION
## Summary

Three companion cost-telemetry fixes that turn the meters from approximations into truth:

- **#351 — Real GPU billing.** `CostMeter.sync_gpu_seconds_from_time_meter()` reads the `TimeMeter.think` bucket so `gpu_seconds` reflects actual brain-inference wall time instead of the synthetic `steps × 3.0s`. `record_step` accepts an optional `time_meter` kwarg; `run_executor` wires the runner's meter through; missing `think` bucket leaves the legacy value alone (best-effort guard for monkey-patched test meters).
- **#350 — Per-task spend attribution.** `task_loop` now snapshots cost across primary + micro-fallback + resume runners and attaches a `{gpu, claude, proxy, total, ...}` dict to each `task_details` entry. Failed tasks still carry the spend they incurred. Backed by a new `CostMeter.totals_from(delta)` helper that mirrors the run-level `_final_costs` shape.
- **#349 — Terminal histogram emission.** `final_summary` now observes `RUN_COST_USD` + `RUN_DURATION_SECONDS` histograms with the same `{tenant_id, model, status}` label set as the inflight gauge so dashboards align. Skipped silently when no `tenant_id` (local/script runs don't pollute the registry).

Closes #349
Closes #350
Closes #351

## Test plan

- [x] `tests/test_cost_meter.py` — `totals_from()` breakdown, partial-dict tolerance, agreement with `totals()`; `sync_gpu_seconds_from_time_meter` idempotency, missing-bucket no-op, negative-value rejection; `record_step(time_meter=…)` real-wall-time path vs legacy multiplier path.
- [x] `tests/test_observability_metrics.py` — `final_summary` observes both histograms with the same tenant/model/status labels; no-tenant path skips emission.
- [x] `tests/test_task_loop_loop_config.py` — per-task `costs` attached to detail dict; fallback + resume costs sum into the same task entry; failed tasks still carry spend.
- [x] Lint clean on touched files.
- [x] Full suite passes locally (3229 tests).
- [ ] Modal redeploy + staff-crm-long verify run after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)