### PR TITLE
plan: optional runtime block (proxy / cost / time defaults inside the plan)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -360,6 +360,25 @@ Key fields:
 | `loop_target` | Step index to jump back to. |
 | `loop_count` | Max loop iterations (clamped to `MANTIS_MAX_LOOP_ITERATIONS`). |
 
+#### Plan-level `runtime` defaults
+
+Plans can wrap the step list in `{steps, runtime}` so they declare their own proxy / cost / time defaults without every caller remembering the right submission flags:
+
+```jsonc
+{
+  "runtime": {
+    "proxy_disabled": false,
+    "proxy_provider": "privateproxy",
+    "proxy_city": "miami",
+    "max_cost": 3.0,
+    "max_time_minutes": 10
+  },
+  "steps": [ /* … */ ]
+}
+```
+
+Submission overrides win — an explicit `proxy_disabled: true` in the HTTP body beats `proxy_disabled: false` in the plan, but omitting the body field falls back to the plan default. Schema and field reference: [Plan formats → Declaring runtime defaults](getting-started/plan-formats.md#declaring-runtime-defaults-inside-the-plan).
+
 ### `task_suite` — multi-task JSON
 
 For Claude-CUA-style autonomous-per-task workflows (the existing

--- a/docs/client/pure-cua.md
+++ b/docs/client/pure-cua.md
@@ -80,10 +80,13 @@ curl -X POST "$ENDPOINT/v1/cua" \
 | `max_cost` | `25.0` | USD cap (mostly informational — pure CUA spends nothing on Claude) |
 | `max_time_minutes` | `60` | Wall-clock cap; clamped against tenant cap |
 | `proxy_city` / `proxy_state` | unset | Geo override (allowlist-gated) |
+| `proxy_provider` | unset | `privateproxy` / `oxylabs` / `iproyal` — defaults to `MANTIS_PROXY_PROVIDER` env |
 | `proxy_disabled` | `false` | Skip the residential proxy entirely |
 | `record_video` | `false` | Capture screencast; fetch via `GET /v1/runs/{run_id}/video` |
 | `video_format` | `"mp4"` | One of `mp4`, `webm`, `gif` |
 | `video_fps` | `5` | Capture rate `[1, 30]` |
+
+The `proxy_*` / `max_cost` / `max_time_minutes` fields can also be declared inside a wrapped plan via the [`runtime` block](../getting-started/plan-formats.md#declaring-runtime-defaults-inside-the-plan). When both are set the HTTP body wins.
 
 ### Sync response
 

--- a/docs/getting-started/plan-formats.md
+++ b/docs/getting-started/plan-formats.md
@@ -75,6 +75,48 @@ A flat JSON list of step objects executed by `MicroPlanRunner`. Best reliability
 
 Field reference is on the [Concepts](concepts.md#step-types-micro-plan-shape) page.
 
+### Declaring runtime defaults inside the plan
+
+A plan can carry a top-level `runtime` block so it's self-describing — no need to remember the right submission flags every time. The bare-array form above stays valid; the wrapped form just adds a sibling next to `steps`:
+
+```jsonc
+{
+  "runtime": {
+    "proxy_disabled": false,
+    "proxy_city": "miami",
+    "max_cost": 3.0,
+    "max_time_minutes": 10
+  },
+  "steps": [
+    { "intent": "...", "type": "navigate" }
+  ]
+}
+```
+
+| Field | Type | Effect |
+| --- | --- | --- |
+| `proxy_disabled` | bool | Skip proxy setup, connect direct. Use for CF-protected SaaS that whitelists the test environment's IP. |
+| `proxy_city` | string | Preferred proxy exit city (passed to the provider's session API). |
+| `proxy_state` | string | Preferred proxy exit state (US two-letter). |
+| `max_cost` | number | Per-run cost ceiling in USD; runner halts when exceeded. |
+| `max_time_minutes` | integer | Per-run wall-clock ceiling in minutes. |
+
+**Submission overrides win.** Whenever the caller passes one of these fields explicitly (CLI flag, HTTP body), the explicit value beats the plan default. Passing `None` (or omitting the field) falls back to the plan. This is what lets a `--proxy-disabled` flag override a `proxy_disabled: false` plan without breaking the plan-as-default contract.
+
+Loader + merger live in `mantis_agent.server_utils`:
+
+```python
+from mantis_agent.server_utils import (
+    load_plan_file, merge_runtime, build_micro_suite,
+)
+
+steps, plan_runtime = load_plan_file("plans/luma-extract.json")
+runtime = merge_runtime(plan_runtime, proxy_disabled=cli.proxy_disabled)
+suite = build_micro_suite(steps, "luma", **runtime)
+```
+
+Reference submitters: `scripts/run_luma_extract.py` (proxy on, declared in plan) and `scripts/run_staff_crm_long_no_proxy.py` (proxy off, declared in plan).
+
 ### Iterate on plan structure without GPU or API cost
 
 Use `MANTIS_BRAIN=mock` to point the runner at a deterministic stub

--- a/docs/getting-started/plan-formats.md
+++ b/docs/getting-started/plan-formats.md
@@ -96,6 +96,7 @@ A plan can carry a top-level `runtime` block so it's self-describing — no need
 | Field | Type | Effect |
 | --- | --- | --- |
 | `proxy_disabled` | bool | Skip proxy setup, connect direct. Use for CF-protected SaaS that whitelists the test environment's IP. |
+| `proxy_provider` | string | `privateproxy` (preferred residential), `oxylabs`, or `iproyal`. Defaults to the runtime's `MANTIS_PROXY_PROVIDER` env. |
 | `proxy_city` | string | Preferred proxy exit city (passed to the provider's session API). |
 | `proxy_state` | string | Preferred proxy exit state (US two-letter). |
 | `max_cost` | number | Per-run cost ceiling in USD; runner halts when exceeded. |

--- a/docs/getting-started/plan-formats.md
+++ b/docs/getting-started/plan-formats.md
@@ -77,18 +77,19 @@ Field reference is on the [Concepts](concepts.md#step-types-micro-plan-shape) pa
 
 ### Declaring runtime defaults inside the plan
 
-A plan can carry a top-level `runtime` block so it's self-describing — no need to remember the right submission flags every time. The bare-array form above stays valid; the wrapped form just adds a sibling next to `steps`:
+A plan can carry a top-level `runtime` block so it's self-describing — no submitter has to remember the right proxy / cost / time flags. The bare-array form above stays valid; the wrapped form adds a sibling next to `steps`:
 
 ```jsonc
 {
   "runtime": {
     "proxy_disabled": false,
+    "proxy_provider": "privateproxy",
     "proxy_city": "miami",
     "max_cost": 3.0,
     "max_time_minutes": 10
   },
   "steps": [
-    { "intent": "...", "type": "navigate" }
+    { "intent": "Navigate to https://lu.ma/discover", "type": "navigate" }
   ]
 }
 ```
@@ -98,13 +99,13 @@ A plan can carry a top-level `runtime` block so it's self-describing — no need
 | `proxy_disabled` | bool | Skip proxy setup, connect direct. Use for CF-protected SaaS that whitelists the test environment's IP. |
 | `proxy_provider` | string | `privateproxy` (preferred residential), `oxylabs`, or `iproyal`. Defaults to the runtime's `MANTIS_PROXY_PROVIDER` env. |
 | `proxy_city` | string | Preferred proxy exit city (passed to the provider's session API). |
-| `proxy_state` | string | Preferred proxy exit state (US two-letter). |
+| `proxy_state` | string | Preferred proxy exit state (US two-letter code). |
 | `max_cost` | number | Per-run cost ceiling in USD; runner halts when exceeded. |
 | `max_time_minutes` | integer | Per-run wall-clock ceiling in minutes. |
 
-**Submission overrides win.** Whenever the caller passes one of these fields explicitly (CLI flag, HTTP body), the explicit value beats the plan default. Passing `None` (or omitting the field) falls back to the plan. This is what lets a `--proxy-disabled` flag override a `proxy_disabled: false` plan without breaking the plan-as-default contract.
+**Override precedence.** Whenever the caller passes one of these fields explicitly (CLI flag, HTTP body, kwarg), the caller's value beats the plan default. Passing `None` (or omitting the field entirely) falls back to the plan's declaration. This is what lets `--proxy-disabled` on the command line override a `proxy_disabled: false` plan without breaking the plan-as-default contract.
 
-Loader + merger live in `mantis_agent.server_utils`:
+**Loader + merger** (Python — for embedded callers and one-shot submit scripts):
 
 ```python
 from mantis_agent.server_utils import (
@@ -112,11 +113,27 @@ from mantis_agent.server_utils import (
 )
 
 steps, plan_runtime = load_plan_file("plans/luma-extract.json")
+
+# proxy_disabled=cli.proxy_disabled is None when the flag wasn't passed,
+# so the plan default wins; pass a real bool to override.
 runtime = merge_runtime(plan_runtime, proxy_disabled=cli.proxy_disabled)
 suite = build_micro_suite(steps, "luma", **runtime)
 ```
 
-Reference submitters: `scripts/run_luma_extract.py` (proxy on, declared in plan) and `scripts/run_staff_crm_long_no_proxy.py` (proxy off, declared in plan).
+Both shipped plan shapes work — `load_plan_file` returns `(steps, {})` for the bare-array form, and `(steps, runtime)` for the wrapped form. Unknown `runtime` keys are dropped silently so future schema additions don't leak into `build_micro_suite` as `TypeError`-causing kwargs.
+
+**Reference plans** carried in this repo:
+
+* [`examples/form_fill_with_runtime.json`](https://github.com/mercurialsolo/mantis/blob/main/examples/form_fill_with_runtime.json) — minimal demo of the wrapped form (proxy off, $0.50 cap, 5 min cap).
+* `scripts/run_luma_extract.py` — submit helper that loads a wrapped plan, calls `merge_runtime`, splats into `build_micro_suite`, then POSTs `/v1/predict`. Use it as the template for new domain-specific submitters.
+
+**End-to-end verification** (against deployed Modal):
+
+| Plan | `runtime.proxy_provider` | Modal worker startup log |
+|---|---|---|
+| `plans/staff-crm-long.json` | unset (proxy disabled) | direct connection — no proxy line |
+| `plans/luma-extract.json` (proxy on, `iproyal`) | unset → env default | `Proxy: iproyal via http://geo.iproyal.com:12321` |
+| `plans/luma-extract.json` (proxy on, `privateproxy`) | `privateproxy` | `Proxy: privateproxy via http://edge1-us.privateproxy.me:8888` |
 
 ### Iterate on plan structure without GPU or API cost
 

--- a/docs/reference/plan.schema.json
+++ b/docs/reference/plan.schema.json
@@ -37,6 +37,11 @@
           "type": "boolean",
           "description": "When true, the runner skips proxy setup and connects directly. Useful for plans whose target site is proxy-hostile (Cloudflare-protected SaaS that whitelists the test environment's IP)."
         },
+        "proxy_provider": {
+          "type": "string",
+          "enum": ["privateproxy", "oxylabs", "iproyal"],
+          "description": "Which proxy backend to use when proxy is enabled. Defaults to the runtime's MANTIS_PROXY_PROVIDER env var (today: iproyal). Prefer ``privateproxy`` for residential exits — uses PRIVATEPROXY_* env vars."
+        },
         "proxy_city": {
           "type": "string",
           "description": "Preferred proxy exit city — passed to the proxy provider's session API."

--- a/docs/reference/plan.schema.json
+++ b/docs/reference/plan.schema.json
@@ -2,12 +2,61 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://mercurialsolo.github.io/mantis/reference/plan.schema.json",
   "title": "Mantis micro-plan",
-  "description": "Top-level shape of a Mantis micro-plan JSON file: a flat array of step objects executed by MicroPlanRunner. Each step must declare an 'intent' (one-sentence description for the brain) and a 'type' (the step kind). Step types accept additional optional fields documented in 'docs/getting-started/plan-formats.md' and 'docs/getting-started/concepts.md'. The schema is intentionally permissive (additionalProperties is true at every level) so plans can carry plan-specific fields without breaking validation — IDE autocomplete still covers the well-known fields.",
-  "type": "array",
-  "items": {
-    "$ref": "#/$defs/Step"
-  },
+  "description": "Top-level shape of a Mantis micro-plan JSON file. Two equivalent forms are accepted: (1) a flat array of step objects (the original shape), or (2) an object {steps, runtime} where the optional 'runtime' block declares plan-level defaults (proxy, cost cap, time cap) so the plan is self-describing instead of requiring every caller to remember the right submission flags. Step types accept additional optional fields documented in 'docs/getting-started/plan-formats.md' and 'docs/getting-started/concepts.md'. The schema is intentionally permissive (additionalProperties is true at every level) so plans can carry plan-specific fields without breaking validation — IDE autocomplete still covers the well-known fields.",
+  "oneOf": [
+    {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/Step"
+      }
+    },
+    {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["steps"],
+      "properties": {
+        "steps": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Step"
+          }
+        },
+        "runtime": {
+          "$ref": "#/$defs/Runtime"
+        }
+      }
+    }
+  ],
   "$defs": {
+    "Runtime": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Plan-level runtime defaults. Submission-time arguments (CLI flags, HTTP body fields) override these when set explicitly; absent submission args fall back to the plan's declared defaults.",
+      "properties": {
+        "proxy_disabled": {
+          "type": "boolean",
+          "description": "When true, the runner skips proxy setup and connects directly. Useful for plans whose target site is proxy-hostile (Cloudflare-protected SaaS that whitelists the test environment's IP)."
+        },
+        "proxy_city": {
+          "type": "string",
+          "description": "Preferred proxy exit city — passed to the proxy provider's session API."
+        },
+        "proxy_state": {
+          "type": "string",
+          "description": "Preferred proxy exit state (US two-letter code)."
+        },
+        "max_cost": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Per-run cost ceiling in USD. The runner halts when exceeded."
+        },
+        "max_time_minutes": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Per-run wall-clock ceiling in minutes. The runner halts when exceeded."
+        }
+      }
+    },
     "Step": {
       "type": "object",
       "additionalProperties": true,

--- a/examples/form_fill_with_runtime.json
+++ b/examples/form_fill_with_runtime.json
@@ -1,0 +1,23 @@
+{
+  "runtime": {
+    "proxy_disabled": true,
+    "max_cost": 0.5,
+    "max_time_minutes": 5
+  },
+  "steps": [
+    {
+      "intent": "Open httpbin's public test form.",
+      "type": "navigate",
+      "url": "https://httpbin.org/forms/post"
+    },
+    {
+      "intent": "Fill out the customer name field with 'Test User'.",
+      "type": "fill_field",
+      "params": { "label": "Customer name", "value": "Test User" }
+    },
+    {
+      "intent": "Submit the form.",
+      "type": "submit"
+    }
+  ]
+}

--- a/scripts/run_luma_extract.py
+++ b/scripts/run_luma_extract.py
@@ -1,0 +1,143 @@
+"""Submit ``plans/luma-extract.json`` to the deployed Modal CUA server.
+
+Companion to ``run_staff_crm_long_no_proxy.py``: same submit/poll
+shape, but exercises the proxy-ON path. The plan's top-level
+``runtime`` block declares ``proxy_disabled: false`` + a Miami exit,
+so this script doesn't need to know anything about proxy config —
+``merge_runtime()`` forwards whatever the plan declares.
+
+Usage::
+
+    uv run python scripts/run_luma_extract.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import requests
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from mantis_agent.plan_decomposer import MicroPlan, PlanDecomposer  # noqa: E402
+from mantis_agent.server_utils import (  # noqa: E402
+    build_micro_suite,
+    load_plan_file,
+    merge_runtime,
+    micro_plan_steps_to_dicts,
+)
+
+
+ENDPOINT = "https://getmason--mantis-cua-server-api.modal.run"
+PLAN_PATH = REPO_ROOT / "plans" / "luma-extract.json"
+PROFILE_ID = f"luma-extract-{int(time.time())}"
+WORKFLOW_ID = f"luma-extract-{int(time.time())}"
+
+
+def _token() -> str:
+    tok = os.environ.get("MANTIS_API_TOKEN", "")
+    if not tok:
+        print("ERROR: MANTIS_API_TOKEN required in env", file=sys.stderr)
+        sys.exit(2)
+    return tok
+
+
+def _post(path: str, body: dict[str, Any]) -> tuple[int, dict[str, Any]]:
+    r = requests.post(
+        f"{ENDPOINT}{path}",
+        headers={
+            "X-Mantis-Token": _token(),
+            "Content-Type": "application/json",
+        },
+        data=json.dumps(body),
+        timeout=120,
+    )
+    try:
+        return r.status_code, r.json()
+    except Exception:
+        return r.status_code, {"raw": r.text}
+
+
+def _build_suite() -> tuple[dict[str, Any], dict[str, Any]]:
+    steps, plan_runtime = load_plan_file(PLAN_PATH)
+    plan = MicroPlan(domain=PLAN_PATH.stem)
+    for step in steps:
+        plan.steps.append(PlanDecomposer._build_intent(step))
+    runtime = merge_runtime(plan_runtime)
+    suite = build_micro_suite(
+        micro_plan_steps_to_dicts(plan.steps),
+        plan.domain,
+        profile_id=PROFILE_ID,
+        workflow_id=WORKFLOW_ID,
+        **runtime,
+    )
+    return suite, runtime
+
+
+def main() -> int:
+    print(f"endpoint:    {ENDPOINT}")
+    print(f"plan:        {PLAN_PATH.name}")
+    print(f"profile_id:  {PROFILE_ID}")
+    print(f"workflow_id: {WORKFLOW_ID}")
+
+    h = requests.get(f"{ENDPOINT}/v1/health", timeout=30)
+    print(f"[health] HTTP {h.status_code}: {h.text[:120]}")
+    if h.status_code != 200:
+        print("aborting — endpoint not healthy", file=sys.stderr)
+        return 3
+
+    suite, runtime = _build_suite()
+    print(f"[plan-runtime] {runtime}")
+    submit_body = {
+        "task_suite": suite,
+        "profile_id": suite["_profile_id"],
+        "workflow_id": suite["_workflow_id"],
+        "cua_model": "holo3",
+        "max_steps": 30,
+        "detached": True,
+        **runtime,
+    }
+    status, resp = _post("/v1/predict", submit_body)
+    print(f"[submit] HTTP {status}")
+    print(f"  run_id={resp.get('run_id')!r}")
+    if status != 200:
+        print(f"  body={json.dumps(resp, indent=2)[:600]}", file=sys.stderr)
+        return 4
+
+    run_id = resp["run_id"]
+    terminal = {"succeeded", "failed", "cancelled", "halted"}
+    last_status = ""
+    started = time.time()
+    poll_n = 0
+    while True:
+        poll_n += 1
+        if time.time() - started > 15 * 60:
+            print("TIMEOUT: 15 minutes without terminal status", file=sys.stderr)
+            return 5
+        s_status, s_resp = _post(
+            "/v1/predict",
+            {"action": "status", "run_id": run_id},
+        )
+        status_str = s_resp.get("status", "?")
+        if status_str != last_status:
+            print(
+                f"[{poll_n:3d}] t={int(time.time() - started):4d}s  "
+                f"status={status_str}"
+            )
+            last_status = status_str
+        if status_str in terminal:
+            print()
+            print("=== TERMINAL STATUS ===")
+            print(json.dumps(s_resp, indent=2)[:2500])
+            return 0
+        time.sleep(20)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/mantis_agent/api_schemas.py
+++ b/src/mantis_agent/api_schemas.py
@@ -265,12 +265,27 @@ class PureCUARequest(BaseModel):
         return self
 
 
-def validate_micro_steps(steps: list[dict[str, Any]]) -> list[dict[str, Any]]:
+def validate_micro_steps(
+    plan: list[dict[str, Any]] | dict[str, Any],
+) -> list[dict[str, Any]]:
     """Validate a parsed micro-plan against MAX_STEPS / MAX_LOOP_ITERATIONS.
+
+    Accepts both shipped plan shapes — a bare array of step objects, or
+    the wrapped ``{"steps": [...], "runtime": {...}}`` form. Unknown
+    wrapper keys are tolerated (forward-compat with future top-level
+    fields like ``runtime``); only the step list is validated here.
 
     Returns the (possibly clamped) step list. Raises ValueError on hard
     violations (e.g., step count exceeds MAX_STEPS_PER_PLAN).
     """
+    if isinstance(plan, dict):
+        steps = plan.get("steps")
+        if not isinstance(steps, list):
+            raise ValueError(
+                "micro plan object must contain a 'steps' array"
+            )
+    else:
+        steps = plan
     if not isinstance(steps, list):
         raise ValueError("micro plan must be a JSON array of step objects")
     if len(steps) > MAX_STEPS_PER_PLAN:

--- a/src/mantis_agent/server_utils.py
+++ b/src/mantis_agent/server_utils.py
@@ -721,6 +721,82 @@ def micro_plan_steps_to_dicts(steps: list[Any]) -> list[dict[str, Any]]:
     ]
 
 
+_RUNTIME_KEYS = (
+    "proxy_disabled",
+    "proxy_city",
+    "proxy_state",
+    "max_cost",
+    "max_time_minutes",
+)
+
+
+def load_plan_file(path: str | Any) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    """Load a plan JSON file and return ``(steps, runtime)``.
+
+    Supports both shipped plan shapes:
+
+    * **Bare-array** (``examples/*.json``) — ``[step, step, ...]`` — the
+      runtime dict comes back empty.
+    * **Wrapped** (``plans/staff-crm-long.json``) — ``{"steps": [...],
+      "runtime": {...}}`` — the optional ``runtime`` block declares
+      plan-level defaults (proxy_disabled, proxy_city, proxy_state,
+      max_cost, max_time_minutes).
+
+    Callers merge the returned ``runtime`` dict with their own explicit
+    submission flags via :func:`merge_runtime` so the plan is
+    self-describing without overriding caller intent.
+    """
+    import json
+    with open(path) as fh:
+        raw = json.load(fh)
+    if isinstance(raw, list):
+        return raw, {}
+    if isinstance(raw, dict):
+        steps = raw.get("steps", [])
+        if not isinstance(steps, list):
+            raise ValueError(
+                f"plan {path}: 'steps' must be a list, got {type(steps).__name__}"
+            )
+        runtime = raw.get("runtime") or {}
+        if not isinstance(runtime, dict):
+            raise ValueError(
+                f"plan {path}: 'runtime' must be an object, got {type(runtime).__name__}"
+            )
+        return steps, {
+            k: v for k, v in runtime.items() if k in _RUNTIME_KEYS
+        }
+    raise ValueError(
+        f"plan {path}: expected array of steps or object with 'steps', "
+        f"got {type(raw).__name__}"
+    )
+
+
+def merge_runtime(
+    plan_runtime: dict[str, Any] | None,
+    /,
+    **overrides: Any,
+) -> dict[str, Any]:
+    """Merge plan-level runtime defaults with submission-time overrides.
+
+    Submission overrides win when set explicitly (not ``None``); ``None``
+    means "fall back to the plan's declared default". Lets callers pass
+    ``merge_runtime(plan_runtime, proxy_disabled=cli_args.proxy_disabled)``
+    without losing the plan's preference when the CLI flag is absent.
+
+    Unknown keys in ``plan_runtime`` are dropped (defensive: forward-
+    compat with future schema additions doesn't leak unrecognised kwargs
+    into :func:`build_micro_suite`).
+    """
+    merged: dict[str, Any] = {}
+    plan_runtime = plan_runtime or {}
+    for k in _RUNTIME_KEYS:
+        if k in plan_runtime:
+            merged[k] = plan_runtime[k]
+        if k in overrides and overrides[k] is not None:
+            merged[k] = overrides[k]
+    return merged
+
+
 def build_micro_suite(
     micro_plan_steps: list[dict[str, Any]],
     domain: str,

--- a/src/mantis_agent/server_utils.py
+++ b/src/mantis_agent/server_utils.py
@@ -723,6 +723,7 @@ def micro_plan_steps_to_dicts(steps: list[Any]) -> list[dict[str, Any]]:
 
 _RUNTIME_KEYS = (
     "proxy_disabled",
+    "proxy_provider",
     "proxy_city",
     "proxy_state",
     "max_cost",
@@ -808,6 +809,7 @@ def build_micro_suite(
     profile_id: str = "",
     workflow_id: str = "",
     checkpoint_dir: str = "/data/checkpoints",
+    proxy_provider: str = "",
     proxy_city: str = "",
     proxy_state: str = "",
     proxy_disabled: bool = False,
@@ -856,6 +858,7 @@ def build_micro_suite(
         "_state_key": resolved_workflow,
         "_checkpoint_path": checkpoint_path,
         "_plan_signature": signature,
+        "_proxy_provider": proxy_provider,
         "_proxy_city": proxy_city,
         "_proxy_state": proxy_state,
         "_proxy_disabled": bool(proxy_disabled),

--- a/tests/test_examples_plans.py
+++ b/tests/test_examples_plans.py
@@ -24,22 +24,32 @@ def _example_plans() -> list[Path]:
     return sorted(EXAMPLES_DIR.glob("*.json"))
 
 
+def _plan_step_count(plan: object) -> int:
+    """Number of steps the validator should pass through, supporting both
+    the bare-array and wrapped ``{steps, runtime}`` plan shapes."""
+    if isinstance(plan, list):
+        return len(plan)
+    if isinstance(plan, dict):
+        return len(plan.get("steps") or [])
+    return 0
+
+
 @pytest.mark.parametrize("plan_path", _example_plans(), ids=lambda p: p.name)
 def test_example_plan_validates(plan_path: Path) -> None:
     with plan_path.open() as f:
-        steps = json.load(f)
-    validated = validate_micro_steps(steps)
+        plan = json.load(f)
+    validated = validate_micro_steps(plan)
     assert isinstance(validated, list)
-    assert len(validated) == len(steps)
+    assert len(validated) == _plan_step_count(plan)
 
 
 @pytest.mark.parametrize("plan_path", RECIPE_PLANS, ids=lambda p: f"{p.parent.name}/plan")
 def test_recipe_plan_validates(plan_path: Path) -> None:
     with plan_path.open() as f:
-        steps = json.load(f)
-    validated = validate_micro_steps(steps)
+        plan = json.load(f)
+    validated = validate_micro_steps(plan)
     assert isinstance(validated, list)
-    assert len(validated) == len(steps)
+    assert len(validated) == _plan_step_count(plan)
 
 
 def test_examples_directory_is_not_empty() -> None:

--- a/tests/test_server_utils.py
+++ b/tests/test_server_utils.py
@@ -833,3 +833,27 @@ def test_merge_runtime_output_splats_into_build_micro_suite(tmp_path: Path) -> N
     assert suite["_proxy_disabled"] is True
     assert suite["_max_cost"] == 3.0
     assert suite["_max_time_minutes"] == 15
+
+
+def test_runtime_proxy_provider_flows_to_suite(tmp_path: Path) -> None:
+    """``proxy_provider`` declared in the plan lands on
+    ``task_suite['_proxy_provider']`` which Modal executors read at
+    submission time."""
+    p = _write_plan(tmp_path, {
+        "runtime": {"proxy_provider": "privateproxy", "proxy_city": "miami"},
+        "steps": [{"intent": "go", "type": "navigate"}],
+    })
+    steps, plan_runtime = load_plan_file(p)
+    runtime = merge_runtime(plan_runtime)
+    suite = build_micro_suite(steps, "luma", **runtime)
+    assert suite["_proxy_provider"] == "privateproxy"
+    assert suite["_proxy_city"] == "miami"
+
+
+def test_runtime_provider_override_wins() -> None:
+    """Submission-time ``proxy_provider`` beats the plan's choice."""
+    out = merge_runtime(
+        {"proxy_provider": "privateproxy"},
+        proxy_provider="oxylabs",
+    )
+    assert out["proxy_provider"] == "oxylabs"

--- a/tests/test_server_utils.py
+++ b/tests/test_server_utils.py
@@ -15,6 +15,8 @@ from mantis_agent.server_utils import (
     build_micro_suite,
     build_proxy_config,
     build_task_loop_result,
+    load_plan_file,
+    merge_runtime,
     micro_plan_steps_to_dicts,
     parse_lead_row,
     plan_signature_from_steps,
@@ -716,3 +718,118 @@ def test_build_task_loop_result():
     assert result["total"] == 3
     assert abs(result["score"] - 66.67) < 0.1
     assert result["mode"] == "tasks"
+
+
+# ── load_plan_file + merge_runtime ─────────────────────────────────
+
+
+def _write_plan(tmp_path: Path, body: object) -> Path:
+    p = tmp_path / "plan.json"
+    p.write_text(json.dumps(body))
+    return p
+
+
+def test_load_plan_file_bare_array(tmp_path: Path) -> None:
+    p = _write_plan(tmp_path, [{"intent": "go", "type": "navigate"}])
+    steps, runtime = load_plan_file(p)
+    assert steps == [{"intent": "go", "type": "navigate"}]
+    assert runtime == {}
+
+
+def test_load_plan_file_wrapped_with_runtime(tmp_path: Path) -> None:
+    p = _write_plan(tmp_path, {
+        "runtime": {"proxy_disabled": True, "max_cost": 2.5},
+        "steps": [{"intent": "go", "type": "navigate"}],
+    })
+    steps, runtime = load_plan_file(p)
+    assert steps == [{"intent": "go", "type": "navigate"}]
+    assert runtime == {"proxy_disabled": True, "max_cost": 2.5}
+
+
+def test_load_plan_file_wrapped_without_runtime(tmp_path: Path) -> None:
+    p = _write_plan(tmp_path, {"steps": [{"intent": "x", "type": "click"}]})
+    steps, runtime = load_plan_file(p)
+    assert steps == [{"intent": "x", "type": "click"}]
+    assert runtime == {}
+
+
+def test_load_plan_file_drops_unknown_runtime_keys(tmp_path: Path) -> None:
+    """Forward-compat: unknown ``runtime`` keys never leak through to
+    callers (who'd hit a ``build_micro_suite`` TypeError)."""
+    p = _write_plan(tmp_path, {
+        "runtime": {"proxy_disabled": True, "future_flag": "ignored"},
+        "steps": [],
+    })
+    _steps, runtime = load_plan_file(p)
+    assert runtime == {"proxy_disabled": True}
+    assert "future_flag" not in runtime
+
+
+def test_load_plan_file_rejects_non_list_steps(tmp_path: Path) -> None:
+    p = _write_plan(tmp_path, {"steps": "oops"})
+    with pytest.raises(ValueError, match="'steps' must be a list"):
+        load_plan_file(p)
+
+
+def test_load_plan_file_rejects_non_object_runtime(tmp_path: Path) -> None:
+    p = _write_plan(tmp_path, {"runtime": "no", "steps": []})
+    with pytest.raises(ValueError, match="'runtime' must be an object"):
+        load_plan_file(p)
+
+
+def test_load_plan_file_rejects_scalar(tmp_path: Path) -> None:
+    p = _write_plan(tmp_path, 42)
+    with pytest.raises(ValueError, match="expected array of steps"):
+        load_plan_file(p)
+
+
+def test_merge_runtime_plan_only() -> None:
+    out = merge_runtime({"proxy_disabled": True, "max_cost": 2.0})
+    assert out == {"proxy_disabled": True, "max_cost": 2.0}
+
+
+def test_merge_runtime_submission_override_wins() -> None:
+    """Explicit non-None overrides beat the plan's declared default."""
+    out = merge_runtime(
+        {"proxy_disabled": True, "max_cost": 2.0},
+        proxy_disabled=False,
+    )
+    assert out["proxy_disabled"] is False
+    assert out["max_cost"] == 2.0  # untouched override falls back to plan
+
+
+def test_merge_runtime_none_override_falls_back_to_plan() -> None:
+    """``None`` means 'caller didn't set this' — keep the plan default."""
+    out = merge_runtime(
+        {"proxy_disabled": True},
+        proxy_disabled=None,
+        max_cost=None,
+    )
+    assert out == {"proxy_disabled": True}
+
+
+def test_merge_runtime_empty_plan() -> None:
+    out = merge_runtime(None, proxy_disabled=True)
+    assert out == {"proxy_disabled": True}
+
+
+def test_merge_runtime_ignores_unknown_overrides() -> None:
+    """Unknown kwargs don't leak into the merge output (so the result
+    can be splatted into ``build_micro_suite(**runtime)`` safely)."""
+    out = merge_runtime({"proxy_disabled": True}, future_flag="x")
+    assert out == {"proxy_disabled": True}
+
+
+def test_merge_runtime_output_splats_into_build_micro_suite(tmp_path: Path) -> None:
+    """End-to-end: load → merge → build_micro_suite consumes without
+    TypeError. Pins the contract callers depend on."""
+    p = _write_plan(tmp_path, {
+        "runtime": {"proxy_disabled": True, "max_cost": 3.0, "max_time_minutes": 15},
+        "steps": [{"intent": "go", "type": "navigate"}],
+    })
+    steps, plan_runtime = load_plan_file(p)
+    runtime = merge_runtime(plan_runtime)
+    suite = build_micro_suite(steps, "test_domain", **runtime)
+    assert suite["_proxy_disabled"] is True
+    assert suite["_max_cost"] == 3.0
+    assert suite["_max_time_minutes"] == 15

--- a/tests/test_tenant_auth.py
+++ b/tests/test_tenant_auth.py
@@ -221,5 +221,10 @@ def test_validate_micro_steps_rejects_missing_fields():
         validate_micro_steps([{"intent": "go"}])
     with pytest.raises(ValueError, match="JSON object"):
         validate_micro_steps(["not a dict"])  # type: ignore[list-item]
-    with pytest.raises(ValueError, match="JSON array"):
+    # Dict-shaped plans without a 'steps' key are rejected with a
+    # message that points at the missing field — the validator now
+    # also accepts the wrapped ``{steps, runtime}`` form, so the
+    # bare-list "JSON array" path applies only to non-list, non-dict
+    # inputs.
+    with pytest.raises(ValueError, match="'steps' array"):
         validate_micro_steps({"not": "a list"})  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

Plans can now ship a top-level `runtime` block alongside `steps` so they're self-describing — no caller has to remember the right submission flags every time:

```json
{
  "runtime": {
    "proxy_disabled": false,
    "proxy_city": "miami",
    "max_cost": 3.0,
    "max_time_minutes": 10
  },
  "steps": [ ... ]
}
```

Submission-time overrides win when set explicitly (`None` falls back to the plan default), so a `--proxy-disabled` CLI flag still beats a `proxy_disabled: false` plan without losing the plan-as-default contract.

## Changes

- `server_utils.load_plan_file(path)` — returns `(steps, runtime)`. Accepts both shipped plan shapes (bare array + wrapped `{steps, runtime}`); drops unknown runtime keys so the splat into `build_micro_suite(**runtime)` stays safe.
- `server_utils.merge_runtime(plan_runtime, **overrides)` — explicit non-None overrides win; `None` means "fall back to plan".
- `plan.schema.json` — `oneOf` over the array / wrapped forms; `$defs/Runtime` documents the five known fields.
- `examples/form_fill_with_runtime.json` — reference plan covered by the existing `test_example_plan_matches_schema` parametrisation.
- `scripts/run_luma_extract.py` — reference submitter; loads the plan and forwards `merge_runtime()` output as-is.
- `docs/getting-started/plan-formats.md` — new section "Declaring runtime defaults inside the plan" with the table + loader snippet.

## Verification

Two reference scripts hit the deployed Modal server with opposing proxy preferences declared in their plans:

- **luma-extract.json** (`proxy_disabled: false`, Miami) → Modal worker logged `Proxy: iproyal via http://geo.iproyal.com:12321`.
- **staff-crm-long.json** (`proxy_disabled: true`) → Modal worker connected direct (verified in the prior #506 run).

## Test plan

- [x] `tests/test_server_utils.py` — 11 new tests covering loader (both shapes, error paths, unknown-key drop) + merger (plan-only, override-wins, None-falls-back, empty plan, unknown kwargs ignored, end-to-end splat into `build_micro_suite`).
- [x] `tests/test_plan_schema.py` — existing parametrised tests now cover the new `examples/form_fill_with_runtime.json` example.
- [x] Lint clean.
- [x] Modal end-to-end verified for both proxy=on and proxy=off plans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)