### PR TITLE
observability: wire augur-sdk DebugSession into the gym runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,11 @@ outputs/
 reports/
 screenshots/
 
+# Local MANTIS_DATA_DIR fallback. Without explicit override, the runner
+# (and the Augur adapter from #509) writes per-run state under ./data/.
+# Always machine-local; never committed.
+data/
+
 # Run output artifacts (CSVs at repo root); CSVs under tasks/ and plans/ stay tracked
 /leads_*.csv
 /boattrader_leads*.csv

--- a/deploy/modal/modal_cua_server.py
+++ b/deploy/modal/modal_cua_server.py
@@ -171,7 +171,10 @@ executor_image = (
         # Pip-installed unconditionally so the wedge in
         # src/mantis_agent/observability/augur.py activates on every
         # executor container. Run-time gate via MANTIS_AUGUR_DISABLED.
-        "augur-sdk>=0.1.0",
+        # 0.1.2+ fires an immediate session-opened heartbeat so the
+        # workspace's connection badge updates the moment the SDK is
+        # wired up, before the first step lands.
+        "augur-sdk>=0.1.2",
     )
     .add_local_python_source("mantis_agent")
     .add_local_dir(_PROMPTS_FILES_LOCAL, remote_path=_PROMPTS_FILES_REMOTE)
@@ -1379,7 +1382,7 @@ api_image = (
         # is lazy-imported but if augur_sdk is missing it falls back
         # silently — keeping the dep here makes the import succeed and
         # lets future API-side bundle reads work without a redeploy.
-        "augur-sdk>=0.1.0",
+        "augur-sdk>=0.1.2",
     )
     .add_local_python_source("mantis_agent")
     .add_local_dir(_PROMPTS_FILES_LOCAL, remote_path=_PROMPTS_FILES_REMOTE)

--- a/deploy/modal/modal_cua_server.py
+++ b/deploy/modal/modal_cua_server.py
@@ -1223,6 +1223,8 @@ def _run_gemma4_cua_executor(
     ).pip_install(
         "openai", "requests", "pillow", "mss",
         "fastapi>=0.100", "uvicorn>=0.20", "websocket-client",
+        # #509: parity with run_holo3 — Gemma4 also runs the augur wedge.
+        "augur-sdk>=0.1.2",
     ).add_local_python_source("mantis_agent").add_local_dir(_PROMPTS_FILES_LOCAL, remote_path=_PROMPTS_FILES_REMOTE),
     volumes={"/data": vol},
     secrets=[modal.Secret.from_dotenv()],
@@ -1252,6 +1254,10 @@ claude_executor_image = (
     .pip_install(
         "requests", "pillow", "mss",
         "fastapi>=0.100", "uvicorn>=0.20", "websocket-client",
+        # #509: parity with run_holo3 / run_gemma4_cua — Claude executor
+        # also runs the augur wedge so bundles + streaming work for the
+        # Anthropic-API tier.
+        "augur-sdk>=0.1.2",
     )
     .add_local_python_source("mantis_agent")
     .add_local_dir(_PROMPTS_FILES_LOCAL, remote_path=_PROMPTS_FILES_REMOTE)
@@ -2113,6 +2119,11 @@ def api():
     ).pip_install(
         "openai", "requests", "pillow", "mss",
         "fastapi>=0.100", "uvicorn>=0.20", "websocket-client",
+        # #509: run_holo3 uses its own inline image (NOT executor_image),
+        # so augur-sdk has to be added here separately. Without this the
+        # AugurAdapter init logs sdk_available=False and is a no-op even
+        # though the package is in executor_image for the other tiers.
+        "augur-sdk>=0.1.2",
     ).add_local_python_source("mantis_agent").add_local_dir(_PROMPTS_FILES_LOCAL, remote_path=_PROMPTS_FILES_REMOTE),
     volumes={"/data": vol},
     secrets=[modal.Secret.from_dotenv()],

--- a/deploy/modal/modal_cua_server.py
+++ b/deploy/modal/modal_cua_server.py
@@ -167,6 +167,11 @@ executor_image = (
         "openai", "requests", "pillow", "mss",
         "huggingface-hub", "transformers", "torch",
         "fastapi>=0.100", "uvicorn>=0.20", "websocket-client",
+        # #509: per-run Augur DebugSession bundle + optional live streaming.
+        # Pip-installed unconditionally so the wedge in
+        # src/mantis_agent/observability/augur.py activates on every
+        # executor container. Run-time gate via MANTIS_AUGUR_DISABLED.
+        "augur-sdk>=0.1.0",
     )
     .add_local_python_source("mantis_agent")
     .add_local_dir(_PROMPTS_FILES_LOCAL, remote_path=_PROMPTS_FILES_REMOTE)
@@ -1369,6 +1374,12 @@ api_image = (
         "pydantic>=2.0",
         "requests",
         "anthropic",
+        # #509: api container imports ``mantis_agent.gym.run_executor``
+        # transitively (via the persist + dispatch paths). The adapter
+        # is lazy-imported but if augur_sdk is missing it falls back
+        # silently — keeping the dep here makes the import succeed and
+        # lets future API-side bundle reads work without a redeploy.
+        "augur-sdk>=0.1.0",
     )
     .add_local_python_source("mantis_agent")
     .add_local_dir(_PROMPTS_FILES_LOCAL, remote_path=_PROMPTS_FILES_REMOTE)

--- a/deploy/modal/modal_plan_runner.py
+++ b/deploy/modal/modal_plan_runner.py
@@ -112,6 +112,8 @@ runner_image = (
         "anthropic>=0.34",
         "mss>=9.0",
         "python-dotenv",
+        # #509: per-run Augur DebugSession bundle + optional live streaming.
+        "augur-sdk>=0.1.0",
     )
     .add_local_python_source("mantis_agent")
     .add_local_dir(

--- a/deploy/modal/modal_plan_runner.py
+++ b/deploy/modal/modal_plan_runner.py
@@ -113,7 +113,9 @@ runner_image = (
         "mss>=9.0",
         "python-dotenv",
         # #509: per-run Augur DebugSession bundle + optional live streaming.
-        "augur-sdk>=0.1.0",
+        # 0.1.2+ fires an immediate session-opened heartbeat for faster
+        # workspace badge updates.
+        "augur-sdk>=0.1.2",
     )
     .add_local_python_source("mantis_agent")
     .add_local_dir(

--- a/docs/integrations/augur.md
+++ b/docs/integrations/augur.md
@@ -1,0 +1,158 @@
+# Augur — per-run debug bundles + live streaming
+
+[`augur-sdk`](https://github.com/mercurialsolo/augur-sdk) instruments any
+screenshot-grounded CUA with a single `DebugSession` context manager.
+Mantis ships the wedge in `src/mantis_agent/observability/augur.py` so
+every gym run produces a path-stable, schema-validated bundle on disk —
+and, when `AUGUR_DSN` is exported, streams the same records live to the
+Augur workspace (Sentry-style DSN, connection-status badge).
+
+> The upstream integration guide is the canonical reference for the
+> bundle layout, schema, and replay contract:
+> <https://mercurialsolo.github.io/augur-sdk/integrations/mantis/>.
+> This page documents how Mantis itself wires in.
+
+## Install
+
+The adapter only activates when the `augur-sdk` package is importable.
+Pick whichever install matches your deployment:
+
+```bash
+# Direct
+pip install augur-sdk
+
+# Or via the Mantis observability extra (adds nothing else)
+pip install 'mantis-agent[observability]'
+
+# Or pull everything Mantis ships
+pip install 'mantis-agent[full]'
+```
+
+When the package isn't installed, the wedge is a hard no-op — no error,
+no overhead, no bundle.
+
+## What gets written
+
+Every gym run that reaches `RunExecutor.execute()` opens a
+`DebugSession`. The default on-disk location is:
+
+```
+${MANTIS_DATA_DIR:-./data}/augur/<run_id>/
+```
+
+Override with `MANTIS_AUGUR_DIR=/custom/root` (the run id is still
+appended). Inside each bundle the SDK writes:
+
+```
+augur/<run_id>/
+├── manifest.json          # bundle metadata (schema_version, paths, ...)
+├── trace.json             # session + step traces
+├── screenshots/0001_post.png ...
+├── events/0001.jsonl      # one DecisionEvent per line, grouped by step
+├── steps/0001.json
+└── schema/                # vendored JSON Schemas for offline validation
+```
+
+Validate any bundle with:
+
+```python
+from augur_sdk.validation import validate_bundle
+issues = validate_bundle("data/augur/<run_id>/")
+assert not issues
+```
+
+## What gets streamed
+
+If `AUGUR_DSN` is set in the runtime environment, the SDK opens a
+streaming sink at session start and forwards every `record_step`,
+`record_event`, and `attach_observation` call to the workspace
+identified by the DSN. The on-disk bundle stays the source of truth —
+streaming is observe-only.
+
+Network failures are non-fatal. A misconfigured DSN, a firewall block,
+or a transient blip lands as a debug log line; the run continues.
+
+## Mantis → Augur vocabulary mapping
+
+The adapter normalizes Mantis-internal layer names to the Augur
+[`DecisionLayer`](https://mercurialsolo.github.io/augur-sdk/spec/#decision-event)
+enum:
+
+| Mantis layer            | Augur layer       |
+|---|---|
+| `critic-frontier`       | `verifier`        |
+| `critic`                | `verifier`        |
+| `gate-decision`         | `verifier`        |
+| `preview-gate`          | `verifier`        |
+| `agentic-recovery`      | `step_recovery`   |
+| `recovery`              | `step_recovery`   |
+| `som-click`             | `grounding`       |
+| `planner`               | `planner`         |
+| anything else           | `runner`          |
+
+Mantis healing-event `kind`s collapse onto Augur's five-state
+`DecisionKind`:
+
+| Mantis kind     | Augur kind        |
+|---|---|
+| `fire` / `skip` / `decision` | `decision`  |
+| `result` / `observation`     | `observation` |
+| `info`          | `info`            |
+| `error`         | `error`           |
+| `metric`        | `metric`          |
+
+Mantis runner status maps onto `RunStatus`:
+
+| Mantis status                                                           | Augur status |
+|---|---|
+| `completed`, `completed_with_failures`, `succeeded`                     | `succeeded`  |
+| `halted`, `budget_exceeded`, `time_exceeded`                            | `halted`     |
+| `failed`                                                                | `failed`     |
+| `cancelled`                                                             | `cancelled`  |
+| `running`, `paused`                                                     | `running`    |
+
+## Environment knobs
+
+| Variable | Effect |
+|---|---|
+| `AUGUR_DSN` | Sentry-style DSN. When set, the SDK opens a streaming sink to the workspace; when unset, only the on-disk bundle is produced. |
+| `AUGUR_CAPTURE_MODE` | One of `off`, `metadata`, `trace`, `screenshots` (default), `video`, `model_io`, `dispatch`, `replay`, `full`. Controls what the SDK captures. |
+| `MANTIS_AUGUR_DIR` | Override the root directory where bundles are written (run id is still appended). |
+| `MANTIS_AUGUR_DISABLED` | `1` / `true` / `yes` → adapter is a no-op even with the SDK installed. Useful for tests / CI. |
+| `MANTIS_DATA_DIR` | Default bundle root when `MANTIS_AUGUR_DIR` is unset. Defaults to `./data`. |
+| `MANTIS_VERSION` | Surfaced as `client.version` on the manifest — useful when bisecting which build produced a bundle. |
+| `MANTIS_GIT_SHA` | Surfaced as `client.git_sha` on the manifest. |
+
+## Coexistence with `TraceExporter`
+
+`mantis_agent.gym.trace_exporter.TraceExporter` keeps writing one JSON
+per run to `MANTIS_TRACE_EXPORT_DIR` when configured. The Augur adapter
+sits alongside it — the two writers don't share state and neither
+replaces the other. Augur's bundle is finer-grained (per-step events,
+typed layers, on-disk screenshots) and supports live streaming; the
+trace export is the legacy coarse-grained record.
+
+## Verification
+
+To confirm streaming works against a workspace:
+
+1. Export `AUGUR_DSN=https://<key>@<host>/<project>` (and any required
+   API key) in the Mantis runtime environment.
+2. Submit any gym run (`/v1/predict`, the CLI, or an embedded
+   `MicroPlanRunner`).
+3. Check the workspace badge — the SDK heartbeats every ~15 s, so the
+   "connected" indicator should turn green within one heartbeat of
+   the first step landing.
+4. After the run finishes, verify the bundle on disk:
+
+   ```bash
+   ls "$MANTIS_DATA_DIR/augur/<run_id>/"
+   python -c "from augur_sdk.validation import validate_bundle; print(validate_bundle('$MANTIS_DATA_DIR/augur/<run_id>/'))"
+   ```
+
+## References
+
+- Augur SDK source: <https://github.com/mercurialsolo/augur-sdk>
+- Integration guide: <https://mercurialsolo.github.io/augur-sdk/integrations/mantis/>
+- Normative SDK spec: <https://mercurialsolo.github.io/augur-sdk/spec/>
+- Adapter authoring: <https://mercurialsolo.github.io/augur-sdk/reference/adapter-authoring/>

--- a/docs/reference/env-vars.md
+++ b/docs/reference/env-vars.md
@@ -77,6 +77,21 @@ See [operations/cost.md](../operations/cost.md) for the full rate-tuning workflo
 | `MANTIS_TRACE_EXPORT_DIR` | unset | Enable per-run trace export. When set, every completed / halted / cancelled / paused run writes `<dir>/<tenant_id>/<run_id>.json` with the full step list, costs, status, and predicted/observed outcomes. Empty `tenant_id` falls back to `__shared__/`. Off by default — feature flag for the continual-fine-tuning pipeline. |
 | `MANTIS_TRACE_INCLUDE_SCREENSHOTS` | unset | When truthy (`1`/`true`/`yes`/`on`) and trace export is enabled, also persists per-step PNG screenshots to `<dir>/<tenant_id>/<run_id>_screens/<step:04d>.png`. Default off because screenshot bytes ~100× the on-disk trace size. |
 
+## Augur observability (#509)
+
+Active only when the `augur-sdk` package is importable; install via
+`pip install 'mantis-agent[observability]'`. See
+[Augur integration](../integrations/augur.md) for the full contract.
+
+| Var | Default | Effect |
+|---|---|---|
+| `AUGUR_DSN` | unset | Sentry-style DSN. When set, the SDK opens a streaming sink to the workspace alongside the on-disk bundle. When unset, only the bundle is written. |
+| `AUGUR_CAPTURE_MODE` | `screenshots` | One of `off` / `metadata` / `trace` / `screenshots` / `video` / `model_io` / `dispatch` / `replay` / `full`. Controls what the SDK captures. |
+| `MANTIS_AUGUR_DIR` | unset | Override the root directory where bundles are written. Run id is still appended. Falls back to `<MANTIS_DATA_DIR>/augur/`. |
+| `MANTIS_AUGUR_DISABLED` | unset | Truthy (`1`/`true`/`yes`/`on`) → adapter is a no-op even with the SDK installed. Useful for tests / CI. |
+| `MANTIS_VERSION` | unset | Surfaced as `client.version` on the bundle manifest — useful for bisecting which build produced a bundle. |
+| `MANTIS_GIT_SHA` | unset | Surfaced as `client.git_sha` on the bundle manifest. |
+
 ## Logging
 
 | Var | Default | Effect |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -128,6 +128,7 @@ nav:
       - Recipes (jobs, e-commerce, news, real-estate): integrations/recipes.md
       - Embedding MicroPlanRunner: integrations/embedding-microplanrunner.md
       - Integrating any agent: integrations/any-agent.md
+      - Augur observability: integrations/augur.md
   - Reference:
       - reference/index.md
       - HTTP API: api.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ metrics = [
 # augur_sdk lazily and no-ops when the package isn't installed, so
 # this extra is purely opt-in — no base-install footprint change.
 observability = [
-    "augur-sdk>=0.1.0",
+    "augur-sdk>=0.1.2",
 ]
 # Self-host the FastAPI server that fronts /predict and /v1/chat/completions.
 # Used by the Baseten / EKS / GKE deployments.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,16 @@ client = [
 metrics = [
     "prometheus-client>=0.20",
 ]
+# Augur observability (#509) — per-run debug bundles + optional live
+# streaming to the Augur workspace via DebugSession. When AUGUR_DSN is
+# set in the environment, every gym run streams; when unset, the same
+# records still land on disk under ${MANTIS_DATA_DIR}/augur/<run_id>/.
+# The wedge in src/mantis_agent/observability/augur.py imports
+# augur_sdk lazily and no-ops when the package isn't installed, so
+# this extra is purely opt-in — no base-install footprint change.
+observability = [
+    "augur-sdk>=0.1.0",
+]
 # Self-host the FastAPI server that fronts /predict and /v1/chat/completions.
 # Used by the Baseten / EKS / GKE deployments.
 server = [
@@ -114,7 +124,7 @@ docs = [
 ]
 # Convenience: install everything.
 full = [
-    "mantis-agent[orchestrator,server,local-cua,viewer,gpu,hud]",
+    "mantis-agent[orchestrator,server,local-cua,viewer,gpu,hud,observability]",
 ]
 
 [project.scripts]

--- a/src/mantis_agent/gym/run_executor.py
+++ b/src/mantis_agent/gym/run_executor.py
@@ -1459,7 +1459,15 @@ class RunExecutor:
             runner._augur = None
 
     def _emit_augur_aggregate_metrics(self, results: list[StepResult]) -> None:
-        """Send cost-meter totals as run-level metric DecisionEvents (#509)."""
+        """Send cost-meter totals as both session tags and metric
+        DecisionEvents (#509).
+
+        The Augur workspace's Cost column reads from session tags
+        (parallel to MODEL — which we already tag). The metric
+        DecisionEvent is the secondary surface for time-series cost
+        analysis. Sending both means the column populates AND the
+        analyst-side query layer has structured data.
+        """
         runner = self.parent
         augur: AugurAdapter | None = getattr(runner, "_augur", None)
         if augur is None or not augur.active:
@@ -1477,6 +1485,16 @@ class RunExecutor:
             elapsed = float(meter.elapsed_seconds() or 0.0)
         except Exception:  # noqa: BLE001
             pass
+        # Tags are what the Run identity panel + run-list COST column
+        # read. Keep them as plain strings (the SDK serializes them
+        # verbatim) — Augur parses ``cost_usd`` as the canonical total.
+        augur.add_tag("cost_usd", f"{total:.4f}")
+        augur.add_tag("cost_gpu_usd", f"{gpu:.4f}")
+        augur.add_tag("cost_claude_usd", f"{claude:.4f}")
+        augur.add_tag("cost_proxy_usd", f"{proxy:.4f}")
+        augur.add_tag("elapsed_seconds", f"{elapsed:.2f}")
+        # The metric event is the structured/query-able surface — keeps
+        # the same data shape as other Augur ``kind="metric"`` events.
         augur.record_cost_metric(
             name="cost_total_usd",
             value=round(total, 4),

--- a/src/mantis_agent/gym/run_executor.py
+++ b/src/mantis_agent/gym/run_executor.py
@@ -183,11 +183,19 @@ class RunExecutor:
         # ``MANTIS_AUGUR_DISABLED`` is set. The adapter is stashed on the
         # runner so the per-step loop below and ``_finalize`` can reach it
         # without an extra parameter on every helper signature.
+        # ``model`` tag populates the workspace's MODEL column. Read the
+        # brain's ``model_name`` (Holo3-35B-A3B / Claude (claude-3.5-…) /
+        # etc.); blank string when the brain doesn't expose one.
+        brain = getattr(runner, "brain", None)
+        model_name = str(getattr(brain, "model_name", "") or "") if brain is not None else ""
         runner._augur = AugurAdapter(
             run_id=str(getattr(runner, "run_key", "") or runner.plan_signature or "run"),
             tenant_id=str(getattr(runner, "tenant_id", "") or ""),
             session_name=str(getattr(runner, "session_name", "") or ""),
-            extra_tags={"plan_signature": runner.plan_signature or ""},
+            extra_tags={
+                "plan_signature": runner.plan_signature or "",
+                "model": model_name,
+            },
         )
 
         if not runner._results_base_url and plan.steps:
@@ -1441,8 +1449,62 @@ class RunExecutor:
         # as ``status.json``. Adapter swallows internal errors.
         augur: AugurAdapter | None = getattr(runner, "_augur", None)
         if augur is not None:
+            # Surface run-aggregate fields the per-step PUTs don't carry
+            # so the Runs-list columns populate: cost metrics + the
+            # canonical failure class for the first failing step (Augur
+            # uses this as the run-level failure class chip).
+            self._emit_augur_aggregate_metrics(state.results)
+            self._emit_augur_failure_class_tag(state.results)
             augur.close(status=runner._final_status or None)
             runner._augur = None
+
+    def _emit_augur_aggregate_metrics(self, results: list[StepResult]) -> None:
+        """Send cost-meter totals as run-level metric DecisionEvents (#509)."""
+        runner = self.parent
+        augur: AugurAdapter | None = getattr(runner, "_augur", None)
+        if augur is None or not augur.active:
+            return
+        meter = getattr(runner, "cost_meter", None)
+        if meter is None:
+            return
+        try:
+            gpu, claude, proxy, total = meter.totals()
+        except Exception as exc:  # noqa: BLE001 — telemetry never breaks runs
+            logger.debug("augur cost-meter totals() failed: %s", exc)
+            return
+        elapsed = 0.0
+        try:
+            elapsed = float(meter.elapsed_seconds() or 0.0)
+        except Exception:  # noqa: BLE001
+            pass
+        augur.record_cost_metric(
+            name="cost_total_usd",
+            value=round(total, 4),
+            detail={
+                "gpu_usd": round(gpu, 4),
+                "claude_usd": round(claude, 4),
+                "proxy_usd": round(proxy, 4),
+                "elapsed_seconds": round(elapsed, 2),
+                "steps_executed": len(results),
+            },
+        )
+
+    def _emit_augur_failure_class_tag(self, results: list[StepResult]) -> None:
+        """Tag the session with the first non-empty failure class (#509)."""
+        runner = self.parent
+        augur: AugurAdapter | None = getattr(runner, "_augur", None)
+        if augur is None or not augur.active:
+            return
+        for r in results:
+            fc = str(getattr(r, "failure_class", "") or "").strip()
+            if fc:
+                augur.add_tag("failure_class", fc)
+                return
+        # Also surface the runner's terminal status so any downstream
+        # filtering ("show me halted runs") can read it as a tag.
+        halt_reason = str(getattr(runner, "_final_halt_reason", "") or "").strip()
+        if halt_reason:
+            augur.add_tag("halt_reason", halt_reason)
 
     # ── Helpers ─────────────────────────────────────────────────────────
 

--- a/src/mantis_agent/gym/run_executor.py
+++ b/src/mantis_agent/gym/run_executor.py
@@ -264,10 +264,22 @@ class RunExecutor:
         augur: AugurAdapter | None = getattr(runner, "_augur", None)
         if augur is None or not augur.active:
             return
+        step_index = int(getattr(step_result, "step_index", 0))
+        png = getattr(step_result, "screenshot_png", None)
+        # Verbose diagnostic — gated by MANTIS_AUGUR_VERBOSE so production
+        # runs stay quiet but deploy verification can confirm the wedge
+        # fires per-step in Modal logs (Modal suppresses INFO/DEBUG).
+        from ..observability.augur import is_verbose as _augur_verbose
+        if _augur_verbose():
+            logger.warning(
+                "AugurAdapter._emit_augur_step: step=%d png_bytes=%d success=%s",
+                step_index, len(png) if png else 0,
+                getattr(step_result, "success", False),
+            )
         observation_post = augur.attach_observation(
-            step_index=int(getattr(step_result, "step_index", 0)),
+            step_index=step_index,
             kind="post",
-            png=getattr(step_result, "screenshot_png", None),
+            png=png,
         )
         augur.record_step(
             step_result=step_result,
@@ -275,6 +287,17 @@ class RunExecutor:
             ended_at=_utc_iso_now(),
             observation_post=observation_post,
         )
+        # #509: surface the brain's planner reasoning as an Augur
+        # planner-layer DecisionEvent. The workspace's "PLANNER REASONING"
+        # panel reads from these — without it the panel falls back to
+        # demo placeholder text. Only fires when the step has reasoning
+        # attached (deterministic handlers like ``navigate`` / ``gate``
+        # don't have any, so they get the panel's normal empty state).
+        reasoning = getattr(step_result, "reasoning", "") or ""
+        if reasoning.strip():
+            augur.record_planner_reasoning(
+                step_index=step_index, reasoning=reasoning,
+            )
         healing = getattr(runner, "_healing_events", None) or []
         augur.drain_healing_events(healing)
 

--- a/src/mantis_agent/gym/run_executor.py
+++ b/src/mantis_agent/gym/run_executor.py
@@ -39,13 +39,20 @@ import logging
 import os
 import time
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 
 from ..actions import Action, ActionType
+from ..observability.augur import AugurAdapter
 from ..plan_decomposer import MicroIntent
 from . import failure_class as failure_class_mod
 from . import step_snapshot
 from .checkpoint import RunCheckpoint, StepResult
+
+
+def _utc_iso_now() -> str:
+    """ISO-8601 UTC timestamp matching the Augur schema's ``YYYY-MM-DDThh:mm:ssZ``."""
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
 
 if TYPE_CHECKING:
     from ..plan_decomposer import MicroPlan
@@ -171,6 +178,18 @@ class RunExecutor:
                 )
                 return state.results
 
+        # #509 Augur observability — open a DebugSession for the whole run.
+        # No-op when ``augur-sdk`` isn't installed or
+        # ``MANTIS_AUGUR_DISABLED`` is set. The adapter is stashed on the
+        # runner so the per-step loop below and ``_finalize`` can reach it
+        # without an extra parameter on every helper signature.
+        runner._augur = AugurAdapter(
+            run_id=str(getattr(runner, "run_key", "") or runner.plan_signature or "run"),
+            tenant_id=str(getattr(runner, "tenant_id", "") or ""),
+            session_name=str(getattr(runner, "session_name", "") or ""),
+            extra_tags={"plan_signature": runner.plan_signature or ""},
+        )
+
         if not runner._results_base_url and plan.steps:
             runner._results_base_url = runner._extract_url_from_intent(
                 plan.steps[0].intent
@@ -202,6 +221,7 @@ class RunExecutor:
                 self._handle_loop_step(plan, step, state)
                 continue
 
+            step_started_at = _utc_iso_now()
             pre_snapshot = self._dispatch_step(plan, state, effective_step)
 
             self._maybe_demote_form_no_change(state, effective_step, pre_snapshot)
@@ -228,8 +248,35 @@ class RunExecutor:
             # plug in via the same hook.
             self._consult_critic(plan, state, step, step_result, continued)
 
+            # #509: emit the step + any healing events accumulated on
+            # this iteration to Augur. Runs after _consult_critic so
+            # critic-emitted healing events are picked up too. Any
+            # adapter failure is swallowed internally — never breaks
+            # the run.
+            self._emit_augur_step(step_result, step_started_at)
+
         self._finalize(plan, state)
         return state.results
+
+    def _emit_augur_step(self, step_result: StepResult, started_at: str) -> None:
+        """Per-step Augur emission — observation, trace, decision events."""
+        runner = self.parent
+        augur: AugurAdapter | None = getattr(runner, "_augur", None)
+        if augur is None or not augur.active:
+            return
+        observation_post = augur.attach_observation(
+            step_index=int(getattr(step_result, "step_index", 0)),
+            kind="post",
+            png=getattr(step_result, "screenshot_png", None),
+        )
+        augur.record_step(
+            step_result=step_result,
+            started_at=started_at,
+            ended_at=_utc_iso_now(),
+            observation_post=observation_post,
+        )
+        healing = getattr(runner, "_healing_events", None) or []
+        augur.drain_healing_events(healing)
 
     def _consult_critic(
         self,
@@ -1364,6 +1411,15 @@ class RunExecutor:
             )
         except Exception as exc:  # noqa: BLE001 — telemetry never breaks runs
             logger.debug("trace export failed: %s", exc)
+
+        # #509 close the Augur DebugSession (flush the on-disk bundle +
+        # finalize the streaming sink). Status mirrors the runner's
+        # terminal verdict so the Augur workspace shows the same outcome
+        # as ``status.json``. Adapter swallows internal errors.
+        augur: AugurAdapter | None = getattr(runner, "_augur", None)
+        if augur is not None:
+            augur.close(status=runner._final_status or None)
+            runner._augur = None
 
     # ── Helpers ─────────────────────────────────────────────────────────
 

--- a/src/mantis_agent/gym/run_executor.py
+++ b/src/mantis_agent/gym/run_executor.py
@@ -264,10 +264,21 @@ class RunExecutor:
         augur: AugurAdapter | None = getattr(runner, "_augur", None)
         if augur is None or not augur.active:
             return
+        step_index = int(getattr(step_result, "step_index", 0))
+        png = getattr(step_result, "screenshot_png", None)
+        png_size = len(png) if png else 0
+        # WARN-level so the per-step emission is visible in Modal logs.
+        # Helps diagnose "workspace shows the run but no timeline" type
+        # bugs where the SDK swallows put_step errors silently.
+        # Remove once #509 is operationally stable.
+        logger.warning(
+            "AugurAdapter._emit_augur_step: step=%d png_bytes=%d success=%s",
+            step_index, png_size, getattr(step_result, "success", False),
+        )
         observation_post = augur.attach_observation(
-            step_index=int(getattr(step_result, "step_index", 0)),
+            step_index=step_index,
             kind="post",
-            png=getattr(step_result, "screenshot_png", None),
+            png=png,
         )
         augur.record_step(
             step_result=step_result,

--- a/src/mantis_agent/gym/run_executor.py
+++ b/src/mantis_agent/gym/run_executor.py
@@ -264,21 +264,10 @@ class RunExecutor:
         augur: AugurAdapter | None = getattr(runner, "_augur", None)
         if augur is None or not augur.active:
             return
-        step_index = int(getattr(step_result, "step_index", 0))
-        png = getattr(step_result, "screenshot_png", None)
-        png_size = len(png) if png else 0
-        # WARN-level so the per-step emission is visible in Modal logs.
-        # Helps diagnose "workspace shows the run but no timeline" type
-        # bugs where the SDK swallows put_step errors silently.
-        # Remove once #509 is operationally stable.
-        logger.warning(
-            "AugurAdapter._emit_augur_step: step=%d png_bytes=%d success=%s",
-            step_index, png_size, getattr(step_result, "success", False),
-        )
         observation_post = augur.attach_observation(
-            step_index=step_index,
+            step_index=int(getattr(step_result, "step_index", 0)),
             kind="post",
-            png=png,
+            png=getattr(step_result, "screenshot_png", None),
         )
         augur.record_step(
             step_result=step_result,

--- a/src/mantis_agent/observability/__init__.py
+++ b/src/mantis_agent/observability/__init__.py
@@ -1,0 +1,6 @@
+"""Mantis observability adapters (#509).
+
+Vendors out per-run telemetry that's optional at install time. Today
+this is a single Augur adapter (DebugSession wrapper); future sinks
+(OpenTelemetry, custom JSONL) plug in the same way.
+"""

--- a/src/mantis_agent/observability/augur.py
+++ b/src/mantis_agent/observability/augur.py
@@ -43,70 +43,6 @@ except Exception:  # noqa: BLE001 — any import-time failure → disabled
     _AUGUR_AVAILABLE = False
 
 
-def _patch_streaming_for_visibility() -> None:
-    """Temporary diagnostic — elevate SDK streaming errors to WARN.
-
-    augur-sdk's ``StreamingSink._post_json`` / ``_post_multipart`` /
-    ``_safe_call`` log at DEBUG when the server returns >=400 or when a
-    background-thread HTTP call raises. Modal suppresses DEBUG, so a
-    server rejection on per-step PUT (the exact #509 verification gap)
-    is invisible in ``modal app logs``. Patch the three methods to
-    emit at WARN instead. Remove once #509 is operationally stable.
-    """
-    if not _AUGUR_AVAILABLE:
-        return
-    try:
-        import augur_sdk.streaming as _stream  # type: ignore[import-not-found]
-    except Exception:  # noqa: BLE001
-        return
-    if getattr(_stream, "_mantis_patched", False):
-        return
-    sink_cls = _stream.StreamingSink
-
-    def _verbose_post_json(self, path, payload, *, method="POST"):  # noqa: ANN001
-        import json
-        url = self.dsn.base_url + path
-        body = json.dumps(payload).encode("utf-8")
-        resp = self._http.request(
-            method, url, body=body, headers={
-                "Content-Type": "application/json",
-                "Authorization": f"Bearer {self.dsn.token}",
-            },
-        )
-        if resp.status >= 400:
-            logger.warning(
-                "augur stream %s %s -> %s %s",
-                method, path, resp.status, resp.data[:200],
-            )
-
-    def _verbose_post_multipart(self, path, payload):  # noqa: ANN001
-        url = self.dsn.base_url + path
-        resp = self._http.request(
-            "POST", url,
-            fields={"image": ("shot.png", payload, "image/png")},
-            headers={"Authorization": f"Bearer {self.dsn.token}"},
-        )
-        if resp.status >= 400:
-            logger.warning(
-                "augur stream upload %s -> %s %s",
-                path, resp.status, resp.data[:200],
-            )
-
-    def _verbose_safe_call(self, fn):  # noqa: ANN001
-        try:
-            fn()
-        except Exception as exc:  # noqa: BLE001
-            logger.warning("augur stream background error: %r", exc)
-
-    sink_cls._post_json = _verbose_post_json
-    sink_cls._post_multipart = _verbose_post_multipart
-    sink_cls._safe_call = _verbose_safe_call
-    _stream._mantis_patched = True
-
-
-_patch_streaming_for_visibility()
-
-
 # ── Mantis → Augur vocabulary maps ───────────────────────────────────
 
 # Mantis ``_healing_events`` carry the per-step reasoning trail with
@@ -272,30 +208,13 @@ class AugurAdapter:
     ) -> None:
         self._session: Any = None
         self._emitted_event_count: int = 0
-        # WARNING-level so it survives Modal log suppression — one line per
-        # run, gates downstream production debugging when the workspace
-        # shows no client. Remove once #509 is operationally stable.
-        dsn_env = os.environ.get("AUGUR_DSN", "")
-        logger.warning(
-            "AugurAdapter init: sdk_available=%s disabled_env=%r dsn_set=%s run_id=%s",
-            _AUGUR_AVAILABLE,
-            os.environ.get("MANTIS_AUGUR_DISABLED", ""),
-            bool(dsn_env),
-            run_id,
-        )
         if not is_enabled():
-            logger.warning("AugurAdapter init: disabled — adapter is a no-op")
             return
         try:
             tags = {"tenant": tenant_id or "", "session": session_name or ""}
             if extra_tags:
                 tags.update({str(k): str(v) for k, v in extra_tags.items()})
             target_dir = Path(out_dir) if out_dir is not None else default_out_dir(run_id)
-            logger.warning(
-                "AugurAdapter init: opening DebugSession out_dir=%s dsn_host=%s",
-                target_dir,
-                dsn_env.split("@")[-1].split("/")[0] if "@" in dsn_env else "(no dsn)",
-            )
             session = DebugSession(
                 run_id=run_id,
                 client_name="mantis",
@@ -313,12 +232,8 @@ class AugurAdapter:
             # (close), neither of which is a ``with`` block.
             session.__enter__()
             self._session = session
-            logger.warning(
-                "AugurAdapter init: opened successfully streaming=%s",
-                session._stream is not None,
-            )
         except Exception as exc:  # noqa: BLE001
-            logger.warning("AugurAdapter init: failed to open DebugSession: %s", exc)
+            logger.debug("AugurAdapter: failed to open DebugSession: %s", exc)
             self._session = None
 
     @property
@@ -383,11 +298,7 @@ class AugurAdapter:
             )
             self._session.record_step(trace)
         except Exception as exc:  # noqa: BLE001
-            # Temporarily elevated from debug → warning to surface
-            # silent put_step failures in Modal logs while #509 is
-            # being verified end-to-end. Revert to ``debug`` once
-            # the workspace timeline reliably populates.
-            logger.warning("AugurAdapter.record_step failed: %r", exc)
+            logger.debug("AugurAdapter.record_step failed: %s", exc)
 
     def drain_healing_events(self, healing_events: list[dict[str, Any]]) -> None:
         """Emit any healing events accumulated past the last cursor.

--- a/src/mantis_agent/observability/augur.py
+++ b/src/mantis_agent/observability/augur.py
@@ -1,0 +1,469 @@
+"""Augur SDK adapter — per-run debug bundles + optional live streaming (#509).
+
+When ``augur-sdk>=0.1.0`` is installed and ``MANTIS_AUGUR_DISABLED`` is
+not set, every gym run produces a path-stable, schema-validated bundle
+at ``${MANTIS_DATA_DIR}/augur/<run_id>/``. When ``AUGUR_DSN`` is also
+exported, the SDK streams the same records to the configured Augur
+workspace (Sentry-style DSN; 15-s heartbeat; connection-status badge).
+
+Spec compliance (https://mercurialsolo.github.io/augur-sdk/spec/):
+
+* §4.3 — Emission failures are non-fatal: every public method on
+  :class:`AugurAdapter` swallows exceptions and demotes to a debug log.
+  A misconfigured DSN, a transient network blip, or an SDK-side schema
+  mismatch can never break a Mantis run.
+* §4.5 — Never reads from Augur during a run. The bundle on disk is the
+  source of truth; streaming is observe-only on top of it.
+
+Coexists with :class:`mantis_agent.gym.trace_exporter.TraceExporter` —
+that writer continues to emit one JSON per run alongside this adapter's
+finer-grained bundle. Neither replaces the other.
+
+This module is import-safe with or without the ``augur-sdk`` package on
+disk: when the import fails, :func:`is_enabled` returns ``False`` and
+every :class:`AugurAdapter` instance is a no-op.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Lazy import — module must load even without augur-sdk installed.
+try:
+    from augur_sdk import CaptureMode, DebugSession
+    _AUGUR_AVAILABLE = True
+except Exception:  # noqa: BLE001 — any import-time failure → disabled
+    CaptureMode = None  # type: ignore[assignment]
+    DebugSession = None  # type: ignore[assignment]
+    _AUGUR_AVAILABLE = False
+
+
+# ── Mantis → Augur vocabulary maps ───────────────────────────────────
+
+# Mantis ``_healing_events`` carry the per-step reasoning trail with
+# layer names that pre-date the Augur DecisionLayer enum. Remap to the
+# nine Augur literals (planner/grounding/model/dispatch/verifier/
+# step_recovery/routing/runner/adapter); unknown layers fall through
+# to "runner" as the catch-all.
+_LAYER_MAP: dict[str, str] = {
+    "critic-frontier": "verifier",
+    "critic": "verifier",
+    "gate-decision": "verifier",
+    "preview-gate": "verifier",
+    "agentic-recovery": "step_recovery",
+    "recovery": "step_recovery",
+    "step_recovery": "step_recovery",
+    "som-click": "grounding",
+    "grounding": "grounding",
+    "planner": "planner",
+    "model": "model",
+    "dispatch": "dispatch",
+    "routing": "routing",
+    "runner": "runner",
+    "adapter": "adapter",
+}
+
+# Mantis healing-event ``kind`` field (fire/skip/decision/result/...)
+# remapped to Augur DecisionKind literals (decision/observation/error/
+# info/metric).
+_KIND_MAP: dict[str, str] = {
+    "fire": "decision",
+    "skip": "decision",
+    "decision": "decision",
+    "result": "observation",
+    "observation": "observation",
+    "info": "info",
+    "error": "error",
+    "metric": "metric",
+}
+
+# Mantis Verdict.status → Augur VerdictStatus.
+_VERDICT_STATUS_MAP: dict[str, str] = {
+    "ok": "passed",
+    "passed": "passed",
+    "recoverable": "recoverable",
+    "non_recoverable": "failed",
+    "failed": "failed",
+    "skipped": "skipped",
+}
+
+# Mantis runner status → Augur RunStatus literal. Mantis uses more
+# granular terminal labels (``completed`` / ``completed_with_failures``
+# / ``budget_exceeded`` / ``time_exceeded``); collapse them onto the
+# Augur five-state enum.
+_RUN_STATUS_MAP: dict[str, str] = {
+    "running": "running",
+    "completed": "succeeded",
+    "completed_with_failures": "succeeded",
+    "succeeded": "succeeded",
+    "failed": "failed",
+    "cancelled": "cancelled",
+    "canceled": "cancelled",
+    "halted": "halted",
+    "budget_exceeded": "halted",
+    "time_exceeded": "halted",
+    "paused": "running",
+}
+
+
+# Mantis RecoveryDecision.type → Augur RecoveryType.
+_RECOVERY_TYPE_MAP: dict[str, str] = {
+    "advance": "none",
+    "none": "none",
+    "retry": "retry",
+    "replan": "replan",
+    "rollback": "alternate_grounding",
+    "alternate_grounding": "alternate_grounding",
+    "terminate": "halt",
+    "halt": "halt",
+    "skip": "skip",
+    "human_handoff": "human_handoff",
+}
+
+
+def is_enabled() -> bool:
+    """Return ``True`` when the adapter should attach to runs.
+
+    Active when the ``augur-sdk`` package is importable AND
+    ``MANTIS_AUGUR_DISABLED`` is not set to a truthy value. The DSN is
+    NOT required — without it the adapter still writes the on-disk
+    bundle (the source of truth per the spec).
+    """
+    if not _AUGUR_AVAILABLE:
+        return False
+    flag = os.environ.get("MANTIS_AUGUR_DISABLED", "").strip().lower()
+    return flag not in {"1", "true", "yes", "on"}
+
+
+def default_out_dir(run_id: str) -> Path:
+    """Resolve the per-run bundle directory.
+
+    Honors ``MANTIS_AUGUR_DIR`` for explicit overrides, otherwise nests
+    under ``MANTIS_DATA_DIR/augur/<run_id>/`` (with a final fallback of
+    ``./data`` when ``MANTIS_DATA_DIR`` is unset).
+    """
+    override = os.environ.get("MANTIS_AUGUR_DIR", "").strip()
+    if override:
+        return Path(override) / run_id
+    root = os.environ.get("MANTIS_DATA_DIR", "./data").strip() or "./data"
+    return Path(root) / "augur" / run_id
+
+
+def _map_step_status(step_result: Any) -> str:
+    """Mantis StepResult outcome → Augur StepStatus literal."""
+    if getattr(step_result, "skip", False):
+        return "skipped"
+    if getattr(step_result, "success", False):
+        return "succeeded"
+    if getattr(step_result, "reversed", False):
+        return "recovered"
+    return "failed"
+
+
+def _resolve_capture_mode(value: str | None) -> Any:
+    """Coerce a string env value to a ``CaptureMode`` (or None)."""
+    if not _AUGUR_AVAILABLE:
+        return None
+    candidate = (value or os.environ.get("AUGUR_CAPTURE_MODE") or "screenshots").strip().lower()
+    try:
+        return CaptureMode(candidate)
+    except Exception:  # noqa: BLE001
+        return CaptureMode("screenshots")
+
+
+class AugurAdapter:
+    """Wrap an Augur :class:`DebugSession` with non-fatal emission.
+
+    One instance per Mantis run. Lifecycle:
+
+    1. Constructed at the top of ``RunExecutor.execute`` once
+       ``runner.run_key`` is known.
+    2. :meth:`attach_observation` + :meth:`record_step` called after
+       each handler returns; :meth:`drain_healing_events` flushes any
+       reasoning entries the handler accumulated on
+       ``runner._healing_events``.
+    3. :meth:`close` called from ``RunExecutor._finalize`` with the
+       runner's final status.
+
+    When the adapter is disabled (import failed, env opt-out, or
+    constructor raised), every public method is a no-op so callers
+    don't need to branch on availability.
+    """
+
+    def __init__(
+        self,
+        *,
+        run_id: str,
+        tenant_id: str = "",
+        session_name: str = "",
+        out_dir: str | Path | None = None,
+        capture_mode: str | None = None,
+        dsn: str | None = None,
+        extra_tags: dict[str, str] | None = None,
+    ) -> None:
+        self._session: Any = None
+        self._emitted_event_count: int = 0
+        if not is_enabled():
+            return
+        try:
+            tags = {"tenant": tenant_id or "", "session": session_name or ""}
+            if extra_tags:
+                tags.update({str(k): str(v) for k, v in extra_tags.items()})
+            target_dir = Path(out_dir) if out_dir is not None else default_out_dir(run_id)
+            session = DebugSession(
+                run_id=run_id,
+                client_name="mantis",
+                client_version=os.environ.get("MANTIS_VERSION", "") or None,
+                client_git_sha=os.environ.get("MANTIS_GIT_SHA", "") or None,
+                capture_mode=_resolve_capture_mode(capture_mode),
+                out_dir=str(target_dir),
+                dsn=dsn if dsn is not None else (os.environ.get("AUGUR_DSN") or None),
+                tags=tags,
+            )
+            # DebugSession is designed as a context manager — ``__enter__``
+            # flips the open flag and starts the streaming sink (if any).
+            # We drive that explicitly because the Mantis run lifecycle
+            # straddles ``RunExecutor.execute`` (open) and ``_finalize``
+            # (close), neither of which is a ``with`` block.
+            session.__enter__()
+            self._session = session
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("AugurAdapter: failed to open DebugSession: %s", exc)
+            self._session = None
+
+    @property
+    def active(self) -> bool:
+        return self._session is not None
+
+    @property
+    def out_dir(self) -> Path | None:
+        if not self.active:
+            return None
+        try:
+            return Path(self._session.out_dir)
+        except Exception:  # noqa: BLE001
+            return None
+
+    # ── Per-step emission ────────────────────────────────────────────
+
+    def attach_observation(
+        self,
+        *,
+        step_index: int,
+        kind: str,
+        png: bytes | None,
+    ) -> str | None:
+        """Stage a screenshot. Returns the bundle-relative path or None.
+
+        ``kind`` is ``"pre"`` or ``"post"`` per the SDK convention.
+        Returns the relative path the SDK assigned (which the caller
+        passes back as ``observation_pre`` / ``observation_post`` on
+        the StepTrace) or None on any failure / no PNG.
+        """
+        if not self.active or not png:
+            return None
+        try:
+            return self._session.attach_observation(
+                step_index=step_index, kind=kind, png_bytes=png,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("AugurAdapter.attach_observation failed: %s", exc)
+            return None
+
+    def record_step(
+        self,
+        *,
+        step_result: Any,
+        started_at: str = "",
+        ended_at: str = "",
+        observation_pre: str | None = None,
+        observation_post: str | None = None,
+    ) -> None:
+        """Emit a StepTrace for a completed step."""
+        if not self.active:
+            return
+        try:
+            trace = self._build_step_trace(
+                step_result, started_at, ended_at,
+                observation_pre, observation_post,
+            )
+            self._session.record_step(trace)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("AugurAdapter.record_step failed: %s", exc)
+
+    def drain_healing_events(self, healing_events: list[dict[str, Any]]) -> None:
+        """Emit any healing events accumulated past the last cursor.
+
+        The runner appends to ``_healing_events`` from many sites
+        (critic, recovery, som-click); this method emits each entry as
+        a DecisionEvent. The cursor lives on the adapter so a single
+        call per step picks up exactly the new entries.
+        """
+        if not self.active or not healing_events:
+            return
+        try:
+            new_slice = healing_events[self._emitted_event_count:]
+            for ev in new_slice:
+                self._record_decision_event(ev)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("AugurAdapter.drain_healing_events failed: %s", exc)
+        # Advance the cursor even on partial failure so we don't busy-
+        # retry the same entries on the next step.
+        self._emitted_event_count = len(healing_events)
+
+    def set_live_endpoints(
+        self,
+        *,
+        video_url: str | None = None,
+        status_url: str | None = None,
+        reasoning_url: str | None = None,
+    ) -> None:
+        if not self.active:
+            return
+        try:
+            self._session.set_live_endpoints(
+                status_url=status_url,
+                video_url=video_url,
+                reasoning_url=reasoning_url,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("AugurAdapter.set_live_endpoints failed: %s", exc)
+
+    def close(self, status: str | None = None) -> Any:
+        """Flush the bundle. Returns the BundleManifest or None.
+
+        Mirrors :meth:`DebugSession.__exit__` so the explicit
+        ``__enter__`` we ran in :meth:`__init__` gets its matching
+        teardown. Setting ``status`` overrides the SDK's inferred
+        run status (otherwise inferred as ``succeeded`` if nothing
+        called :meth:`DebugSession.set_status`).
+        """
+        if not self.active:
+            return None
+        try:
+            if status is not None:
+                self._session.set_status(_RUN_STATUS_MAP.get(status, "halted"))
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("AugurAdapter.close set_status failed: %s", exc)
+        try:
+            manifest = self._session.close()
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("AugurAdapter.close failed: %s", exc)
+            manifest = None
+        self._session = None
+        return manifest
+
+    # ── Mappers ──────────────────────────────────────────────────────
+
+    def _build_step_trace(
+        self,
+        sr: Any,
+        started_at: str,
+        ended_at: str,
+        observation_pre: str | None,
+        observation_post: str | None,
+    ) -> dict[str, Any]:
+        last_action = getattr(sr, "last_action", None)
+        action_type = ""
+        action_params: dict[str, Any] = {}
+        if last_action is not None:
+            at = getattr(last_action, "action_type", None)
+            action_type = (
+                at.value if hasattr(at, "value")
+                else (str(at) if at is not None else "")
+            )
+            for attr in ("text", "selector", "key", "x", "y", "dx", "dy", "url"):
+                v = getattr(last_action, attr, None)
+                if v not in (None, ""):
+                    action_params[attr] = v
+
+        action: dict[str, Any] = {
+            "type": action_type or "unknown",
+            "params": action_params,
+            "coordinate_space": "screenshot_px",
+            "dispatch_backend": getattr(sr, "executor_backend", "") or "",
+        }
+
+        # Verdict: prefer the typed slot, fall back to success boolean.
+        v_obj = getattr(sr, "verdict", None)
+        if v_obj is not None:
+            v_status = getattr(v_obj, "status", "")
+            v_status = (
+                v_status.value if hasattr(v_status, "value") else str(v_status)
+            )
+            verdict: dict[str, Any] = {
+                "status": _VERDICT_STATUS_MAP.get(v_status, "unknown"),
+                "reason": getattr(v_obj, "reason", "") or "",
+                "evidence_refs": [],
+            }
+        else:
+            verdict = {
+                "status": "passed" if getattr(sr, "success", False) else "failed",
+                "reason": getattr(sr, "failure_class", "") or "",
+                "evidence_refs": [],
+            }
+
+        rd_obj = getattr(sr, "recovery_decision", None)
+        recovery_decision: dict[str, Any] | None = None
+        if rd_obj is not None:
+            rd_type = getattr(rd_obj, "type", "")
+            rd_type = (
+                rd_type.value if hasattr(rd_type, "value") else str(rd_type)
+            )
+            recovery_decision = {
+                "type": _RECOVERY_TYPE_MAP.get(rd_type, "none"),
+                "reason": getattr(rd_obj, "reason", "") or "",
+                "attempt": int(getattr(rd_obj, "attempt", 0) or 0),
+            }
+
+        # All optional TypedDict fields (total=False) must be either
+        # absent or non-empty for the schema validator. Build the
+        # required-only base, then conditionally add the optionals.
+        trace: dict[str, Any] = {
+            "step_id": f"step-{int(getattr(sr, 'step_index', 0)):04d}",
+            "step_index": int(getattr(sr, "step_index", 0)),
+            "intent": str(getattr(sr, "intent", "") or "")[:500] or "(no intent)",
+            "step_type": action_type or "unknown",
+            "required": True,
+            "status": _map_step_status(sr),
+            "started_at": started_at or "",
+            "ended_at": ended_at or started_at or "",
+            "duration_ms": int((getattr(sr, "duration", 0.0) or 0.0) * 1000),
+            "action": action,
+            "verdict": verdict,
+            "events": [],
+            "logs": [],
+        }
+        failure_class = str(getattr(sr, "failure_class", "") or "")
+        if failure_class:
+            trace["failure_class"] = failure_class
+        if observation_pre:
+            trace["observation_pre"] = observation_pre
+        if observation_post:
+            trace["observation_post"] = observation_post
+        if recovery_decision is not None:
+            trace["recovery_decision"] = recovery_decision
+        return trace
+
+    def _record_decision_event(self, ev: dict[str, Any]) -> None:
+        layer_in = str(ev.get("layer") or "runner")
+        layer = _LAYER_MAP.get(layer_in, "runner")
+        kind_in = str(ev.get("kind") or "decision")
+        kind = _KIND_MAP.get(kind_in, "decision")
+        detail = ev.get("detail")
+        if not isinstance(detail, dict):
+            detail = {"raw": detail} if detail is not None else {}
+        event: dict[str, Any] = {
+            "ts": str(ev.get("ts") or ""),
+            "step_index": int(ev.get("step_index") or 0),
+            "layer": layer,
+            "kind": kind,
+            "summary": str(ev.get("summary") or "")[:200],
+            "detail": detail,
+        }
+        self._session.record_event(event)

--- a/src/mantis_agent/observability/augur.py
+++ b/src/mantis_agent/observability/augur.py
@@ -208,13 +208,30 @@ class AugurAdapter:
     ) -> None:
         self._session: Any = None
         self._emitted_event_count: int = 0
+        # WARNING-level so it survives Modal log suppression — one line per
+        # run, gates downstream production debugging when the workspace
+        # shows no client. Remove once #509 is operationally stable.
+        dsn_env = os.environ.get("AUGUR_DSN", "")
+        logger.warning(
+            "AugurAdapter init: sdk_available=%s disabled_env=%r dsn_set=%s run_id=%s",
+            _AUGUR_AVAILABLE,
+            os.environ.get("MANTIS_AUGUR_DISABLED", ""),
+            bool(dsn_env),
+            run_id,
+        )
         if not is_enabled():
+            logger.warning("AugurAdapter init: disabled — adapter is a no-op")
             return
         try:
             tags = {"tenant": tenant_id or "", "session": session_name or ""}
             if extra_tags:
                 tags.update({str(k): str(v) for k, v in extra_tags.items()})
             target_dir = Path(out_dir) if out_dir is not None else default_out_dir(run_id)
+            logger.warning(
+                "AugurAdapter init: opening DebugSession out_dir=%s dsn_host=%s",
+                target_dir,
+                dsn_env.split("@")[-1].split("/")[0] if "@" in dsn_env else "(no dsn)",
+            )
             session = DebugSession(
                 run_id=run_id,
                 client_name="mantis",
@@ -232,8 +249,12 @@ class AugurAdapter:
             # (close), neither of which is a ``with`` block.
             session.__enter__()
             self._session = session
+            logger.warning(
+                "AugurAdapter init: opened successfully streaming=%s",
+                session._stream is not None,
+            )
         except Exception as exc:  # noqa: BLE001
-            logger.debug("AugurAdapter: failed to open DebugSession: %s", exc)
+            logger.warning("AugurAdapter init: failed to open DebugSession: %s", exc)
             self._session = None
 
     @property

--- a/src/mantis_agent/observability/augur.py
+++ b/src/mantis_agent/observability/augur.py
@@ -508,10 +508,19 @@ class AugurAdapter:
             rd_type = (
                 rd_type.value if hasattr(rd_type, "value") else str(rd_type)
             )
+            # Augur's schema requires ``attempt >= 1``. Mantis's
+            # RecoveryDecision.attempt convention isn't strictly
+            # 0-based or 1-based across handlers — clamp to >=1 on
+            # the way out so server-side validation passes without
+            # us guessing semantics. The server's error message for
+            # a violation is the misleading
+            # ``"step: 0 is less than the minimum of 1"`` (it reports
+            # the field VALUE, not the field PATH), which is what
+            # actually surfaced during the #509 verification cycle.
             recovery_decision = {
                 "type": _RECOVERY_TYPE_MAP.get(rd_type, "none"),
                 "reason": getattr(rd_obj, "reason", "") or "",
-                "attempt": int(getattr(rd_obj, "attempt", 0) or 0),
+                "attempt": max(1, int(getattr(rd_obj, "attempt", 0) or 0)),
             }
 
         # All optional TypedDict fields (total=False) must be either

--- a/src/mantis_agent/observability/augur.py
+++ b/src/mantis_agent/observability/augur.py
@@ -43,6 +43,70 @@ except Exception:  # noqa: BLE001 — any import-time failure → disabled
     _AUGUR_AVAILABLE = False
 
 
+def _patch_streaming_for_visibility() -> None:
+    """Temporary diagnostic — elevate SDK streaming errors to WARN.
+
+    augur-sdk's ``StreamingSink._post_json`` / ``_post_multipart`` /
+    ``_safe_call`` log at DEBUG when the server returns >=400 or when a
+    background-thread HTTP call raises. Modal suppresses DEBUG, so a
+    server rejection on per-step PUT (the exact #509 verification gap)
+    is invisible in ``modal app logs``. Patch the three methods to
+    emit at WARN instead. Remove once #509 is operationally stable.
+    """
+    if not _AUGUR_AVAILABLE:
+        return
+    try:
+        import augur_sdk.streaming as _stream  # type: ignore[import-not-found]
+    except Exception:  # noqa: BLE001
+        return
+    if getattr(_stream, "_mantis_patched", False):
+        return
+    sink_cls = _stream.StreamingSink
+
+    def _verbose_post_json(self, path, payload, *, method="POST"):  # noqa: ANN001
+        import json
+        url = self.dsn.base_url + path
+        body = json.dumps(payload).encode("utf-8")
+        resp = self._http.request(
+            method, url, body=body, headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {self.dsn.token}",
+            },
+        )
+        if resp.status >= 400:
+            logger.warning(
+                "augur stream %s %s -> %s %s",
+                method, path, resp.status, resp.data[:200],
+            )
+
+    def _verbose_post_multipart(self, path, payload):  # noqa: ANN001
+        url = self.dsn.base_url + path
+        resp = self._http.request(
+            "POST", url,
+            fields={"image": ("shot.png", payload, "image/png")},
+            headers={"Authorization": f"Bearer {self.dsn.token}"},
+        )
+        if resp.status >= 400:
+            logger.warning(
+                "augur stream upload %s -> %s %s",
+                path, resp.status, resp.data[:200],
+            )
+
+    def _verbose_safe_call(self, fn):  # noqa: ANN001
+        try:
+            fn()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("augur stream background error: %r", exc)
+
+    sink_cls._post_json = _verbose_post_json
+    sink_cls._post_multipart = _verbose_post_multipart
+    sink_cls._safe_call = _verbose_safe_call
+    _stream._mantis_patched = True
+
+
+_patch_streaming_for_visibility()
+
+
 # ── Mantis → Augur vocabulary maps ───────────────────────────────────
 
 # Mantis ``_healing_events`` carry the per-step reasoning trail with
@@ -282,15 +346,19 @@ class AugurAdapter:
         """Stage a screenshot. Returns the bundle-relative path or None.
 
         ``kind`` is ``"pre"`` or ``"post"`` per the SDK convention.
-        Returns the relative path the SDK assigned (which the caller
-        passes back as ``observation_pre`` / ``observation_post`` on
-        the StepTrace) or None on any failure / no PNG.
+        Callers pass Mantis's 0-based ``StepResult.step_index``; the
+        adapter bumps to 1-based on the way into the SDK so the path
+        / URL match :meth:`_build_step_trace`'s 1-based numbering
+        (Augur's schema requires ``step_index >= 1``). Returns the
+        relative path the SDK assigned (which the caller passes back
+        as ``observation_pre`` / ``observation_post`` on the StepTrace)
+        or None on any failure / no PNG.
         """
         if not self.active or not png:
             return None
         try:
             return self._session.attach_observation(
-                step_index=step_index, kind=kind, png_bytes=png,
+                step_index=step_index + 1, kind=kind, png_bytes=png,
             )
         except Exception as exc:  # noqa: BLE001
             logger.debug("AugurAdapter.attach_observation failed: %s", exc)
@@ -315,7 +383,11 @@ class AugurAdapter:
             )
             self._session.record_step(trace)
         except Exception as exc:  # noqa: BLE001
-            logger.debug("AugurAdapter.record_step failed: %s", exc)
+            # Temporarily elevated from debug → warning to surface
+            # silent put_step failures in Modal logs while #509 is
+            # being verified end-to-end. Revert to ``debug`` once
+            # the workspace timeline reliably populates.
+            logger.warning("AugurAdapter.record_step failed: %r", exc)
 
     def drain_healing_events(self, healing_events: list[dict[str, Any]]) -> None:
         """Emit any healing events accumulated past the last cursor.
@@ -445,9 +517,18 @@ class AugurAdapter:
         # All optional TypedDict fields (total=False) must be either
         # absent or non-empty for the schema validator. Build the
         # required-only base, then conditionally add the optionals.
+        #
+        # Augur's step_index schema requires ``>= 1`` (1-based), but
+        # Mantis's StepResult.step_index is 0-based. Bump by 1 on the
+        # way out so server-side validation passes — the server returns
+        # 422 ``"step: 0 is less than the minimum of 1"`` otherwise,
+        # silently dropping every per-step PUT. The ``step_id`` string
+        # uses the 1-based index too so it lines up with the URL path.
+        raw_index = int(getattr(sr, "step_index", 0))
+        augur_index = raw_index + 1
         trace: dict[str, Any] = {
-            "step_id": f"step-{int(getattr(sr, 'step_index', 0)):04d}",
-            "step_index": int(getattr(sr, "step_index", 0)),
+            "step_id": f"step-{augur_index:04d}",
+            "step_index": augur_index,
             "intent": str(getattr(sr, "intent", "") or "")[:500] or "(no intent)",
             "step_type": action_type or "unknown",
             "required": True,
@@ -479,9 +560,13 @@ class AugurAdapter:
         detail = ev.get("detail")
         if not isinstance(detail, dict):
             detail = {"raw": detail} if detail is not None else {}
+        # Match the 1-based ``step_index`` convention used by
+        # :meth:`_build_step_trace` so DecisionEvents line up with
+        # StepTraces in the workspace timeline.
+        raw_index = int(ev.get("step_index") or 0)
         event: dict[str, Any] = {
             "ts": str(ev.get("ts") or ""),
-            "step_index": int(ev.get("step_index") or 0),
+            "step_index": raw_index + 1,
             "layer": layer,
             "kind": kind,
             "summary": str(ev.get("summary") or "")[:200],

--- a/src/mantis_agent/observability/augur.py
+++ b/src/mantis_agent/observability/augur.py
@@ -28,10 +28,18 @@ from __future__ import annotations
 
 import logging
 import os
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
 logger = logging.getLogger(__name__)
+
+
+def _utc_now_iso() -> str:
+    """ISO-8601 UTC timestamp matching the Augur schema's
+    ``YYYY-MM-DDThh:mm:ssZ`` shape. Used as the default ``ts`` on
+    DecisionEvents the SDK requires the field on every event."""
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
 
 # Lazy import — module must load even without augur-sdk installed.
 try:
@@ -140,6 +148,90 @@ def is_enabled() -> bool:
     return flag not in {"1", "true", "yes", "on"}
 
 
+def is_verbose() -> bool:
+    """Whether to surface adapter + SDK errors at WARN (else DEBUG).
+
+    Gated by ``MANTIS_AUGUR_VERBOSE`` — opt-in because:
+
+    * Modal suppresses INFO/DEBUG. WARN is the only level reliably
+      visible in ``modal app logs``. For deploy verification we WANT
+      the per-step emission noise and SDK-side rejections elevated.
+    * For steady-state production we don't want a WARN line per step.
+
+    Set ``MANTIS_AUGUR_VERBOSE=1`` on the runtime to enable. The flag
+    also drives :func:`_patch_streaming_for_visibility` — when on, the
+    monkey-patch elevates ``StreamingSink._post_json`` / ``_post_multipart``
+    / ``_safe_call`` errors from DEBUG → WARN.
+    """
+    flag = os.environ.get("MANTIS_AUGUR_VERBOSE", "").strip().lower()
+    return flag in {"1", "true", "yes", "on"}
+
+
+def _patch_streaming_for_visibility() -> None:
+    """When :func:`is_verbose` is true, replace SDK streaming methods
+    with WARN-logging variants.
+
+    augur-sdk's ``StreamingSink._post_json`` / ``_post_multipart`` /
+    ``_safe_call`` log at DEBUG when the server returns >=400 or when a
+    background-thread HTTP call raises. Modal suppresses DEBUG, so
+    silent rejections (the exact #509 verification gap) are invisible.
+    This monkey-patch elevates the same logs to WARN — kept gated so
+    production runs stay quiet.
+
+    Idempotent: re-running has no effect (uses ``_mantis_patched``
+    sentinel on the module).
+    """
+    if not _AUGUR_AVAILABLE or not is_verbose():
+        return
+    try:
+        import augur_sdk.streaming as _stream  # type: ignore[import-not-found]
+    except Exception:  # noqa: BLE001
+        return
+    if getattr(_stream, "_mantis_patched", False):
+        return
+    sink_cls = _stream.StreamingSink
+
+    def _verbose_post_json(self, path, payload, *, method="POST"):  # noqa: ANN001
+        import json
+        url = self.dsn.base_url + path
+        body = json.dumps(payload).encode("utf-8")
+        resp = self._http.request(
+            method, url, body=body, headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {self.dsn.token}",
+            },
+        )
+        if resp.status >= 400:
+            logger.warning(
+                "augur stream %s %s -> %s %s",
+                method, path, resp.status, resp.data[:200],
+            )
+
+    def _verbose_post_multipart(self, path, payload):  # noqa: ANN001
+        url = self.dsn.base_url + path
+        resp = self._http.request(
+            "POST", url,
+            fields={"image": ("shot.png", payload, "image/png")},
+            headers={"Authorization": f"Bearer {self.dsn.token}"},
+        )
+        if resp.status >= 400:
+            logger.warning(
+                "augur stream upload %s -> %s %s",
+                path, resp.status, resp.data[:200],
+            )
+
+    def _verbose_safe_call(self, fn):  # noqa: ANN001
+        try:
+            fn()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("augur stream background error: %r", exc)
+
+    sink_cls._post_json = _verbose_post_json
+    sink_cls._post_multipart = _verbose_post_multipart
+    sink_cls._safe_call = _verbose_safe_call
+    _stream._mantis_patched = True
+
+
 def default_out_dir(run_id: str) -> Path:
     """Resolve the per-run bundle directory.
 
@@ -208,13 +300,33 @@ class AugurAdapter:
     ) -> None:
         self._session: Any = None
         self._emitted_event_count: int = 0
+        # Verbose diagnostic — gated by ``MANTIS_AUGUR_VERBOSE``. WARN
+        # is the only level that survives Modal's INFO/DEBUG suppression,
+        # so when verifying a deploy operators flip the flag and get one
+        # line per adapter open + per-step emission.
+        _verbose = is_verbose()
+        if _verbose:
+            dsn_env = os.environ.get("AUGUR_DSN", "")
+            logger.warning(
+                "AugurAdapter init: sdk_available=%s disabled_env=%r dsn_set=%s run_id=%s",
+                _AUGUR_AVAILABLE,
+                os.environ.get("MANTIS_AUGUR_DISABLED", ""),
+                bool(dsn_env),
+                run_id,
+            )
         if not is_enabled():
+            if _verbose:
+                logger.warning("AugurAdapter init: disabled — adapter is a no-op")
             return
         try:
             tags = {"tenant": tenant_id or "", "session": session_name or ""}
             if extra_tags:
                 tags.update({str(k): str(v) for k, v in extra_tags.items()})
             target_dir = Path(out_dir) if out_dir is not None else default_out_dir(run_id)
+            # Refresh the streaming-error patch if verbose flipped on
+            # after module import (env var set later in the process).
+            if _verbose:
+                _patch_streaming_for_visibility()
             session = DebugSession(
                 run_id=run_id,
                 client_name="mantis",
@@ -232,8 +344,13 @@ class AugurAdapter:
             # (close), neither of which is a ``with`` block.
             session.__enter__()
             self._session = session
+            if _verbose:
+                logger.warning(
+                    "AugurAdapter init: opened successfully streaming=%s out_dir=%s",
+                    session._stream is not None, target_dir,
+                )
         except Exception as exc:  # noqa: BLE001
-            logger.debug("AugurAdapter: failed to open DebugSession: %s", exc)
+            logger.warning("AugurAdapter: failed to open DebugSession: %s", exc)
             self._session = None
 
     @property
@@ -298,7 +415,44 @@ class AugurAdapter:
             )
             self._session.record_step(trace)
         except Exception as exc:  # noqa: BLE001
-            logger.debug("AugurAdapter.record_step failed: %s", exc)
+            # Verbose deploys want this visible; production stays at debug.
+            if is_verbose():
+                logger.warning("AugurAdapter.record_step failed: %r", exc)
+            else:
+                logger.debug("AugurAdapter.record_step failed: %s", exc)
+
+    def record_planner_reasoning(
+        self, *, step_index: int, reasoning: str,
+    ) -> None:
+        """Emit the brain's reasoning for one step as a planner-layer
+        DecisionEvent (#509).
+
+        Mantis's :attr:`StepResult.reasoning` carries the planner /
+        brain text that produced this step. The Augur workspace shows
+        it in the per-step "PLANNER REASONING" panel — without this
+        method it falls back to demo placeholder text. The ``summary``
+        is a short prefix (≤200 chars); the full text lands on
+        ``detail.text`` so the workspace can render long reasoning
+        without truncation.
+        """
+        if not self.active or not reasoning.strip():
+            return
+        text = reasoning.strip()
+        event: dict[str, Any] = {
+            "ts": _utc_now_iso(),
+            "step_index": step_index + 1,
+            "layer": "planner",
+            "kind": "info",
+            "summary": text[:200],
+            "detail": {"text": text},
+        }
+        try:
+            self._session.record_event(event)
+        except Exception as exc:  # noqa: BLE001
+            if is_verbose():
+                logger.warning("AugurAdapter.record_planner_reasoning failed: %r", exc)
+            else:
+                logger.debug("AugurAdapter.record_planner_reasoning failed: %s", exc)
 
     def drain_healing_events(self, healing_events: list[dict[str, Any]]) -> None:
         """Emit any healing events accumulated past the last cursor.
@@ -482,10 +636,12 @@ class AugurAdapter:
             detail = {"raw": detail} if detail is not None else {}
         # Match the 1-based ``step_index`` convention used by
         # :meth:`_build_step_trace` so DecisionEvents line up with
-        # StepTraces in the workspace timeline.
+        # StepTraces in the workspace timeline. ``ts`` is required by
+        # the SDK's EventRecorder; default to UTC-now if the upstream
+        # Mantis healing event didn't carry a timestamp.
         raw_index = int(ev.get("step_index") or 0)
         event: dict[str, Any] = {
-            "ts": str(ev.get("ts") or ""),
+            "ts": str(ev.get("ts") or "") or _utc_now_iso(),
             "step_index": raw_index + 1,
             "layer": layer,
             "kind": kind,

--- a/src/mantis_agent/observability/augur.py
+++ b/src/mantis_agent/observability/augur.py
@@ -421,6 +421,60 @@ class AugurAdapter:
             else:
                 logger.debug("AugurAdapter.record_step failed: %s", exc)
 
+    def add_tag(self, key: str, value: str) -> None:
+        """Attach a tag to the open DebugSession (#509).
+
+        The Augur workspace's Runs-list ``MODEL`` column and similar
+        derived chips read from session tags. Idempotent + safe to
+        call multiple times — last write wins per key.
+        """
+        if not self.active or not key:
+            return
+        try:
+            self._session.add_tag(str(key), str(value))
+        except Exception as exc:  # noqa: BLE001
+            if is_verbose():
+                logger.warning("AugurAdapter.add_tag(%s) failed: %r", key, exc)
+            else:
+                logger.debug("AugurAdapter.add_tag(%s) failed: %s", key, exc)
+
+    def record_cost_metric(
+        self,
+        *,
+        name: str,
+        value: float,
+        detail: dict[str, Any] | None = None,
+    ) -> None:
+        """Emit a run-level metric DecisionEvent (#509).
+
+        Mantis's :class:`gym.cost_meter.CostMeter` tracks per-bucket
+        and total USD spend. Surfacing them as Augur ``kind="metric"``
+        events lets the workspace's COST column populate and gives
+        cost-vs-time analyses something to query against. Layer is
+        ``runner`` (the Mantis runner owns the meter); step_index=0
+        because cost is run-aggregate, not per-step.
+        """
+        if not self.active:
+            return
+        payload = {"name": str(name), "value": float(value)}
+        if detail:
+            payload.update(detail)
+        event: dict[str, Any] = {
+            "ts": _utc_now_iso(),
+            "step_index": 1,  # Augur requires >=1; run-level uses min
+            "layer": "runner",
+            "kind": "metric",
+            "summary": f"{name}={value}",
+            "detail": payload,
+        }
+        try:
+            self._session.record_event(event)
+        except Exception as exc:  # noqa: BLE001
+            if is_verbose():
+                logger.warning("AugurAdapter.record_cost_metric failed: %r", exc)
+            else:
+                logger.debug("AugurAdapter.record_cost_metric failed: %s", exc)
+
     def record_planner_reasoning(
         self, *, step_index: int, reasoning: str,
     ) -> None:

--- a/tests/test_observability_augur.py
+++ b/tests/test_observability_augur.py
@@ -243,6 +243,59 @@ def test_non_fatal_on_emit_error(monkeypatch, tmp_path: Path):
     assert a.close(status="halted") is None
 
 
+def test_planner_reasoning_becomes_planner_decision_event(monkeypatch, tmp_path: Path):
+    """``record_planner_reasoning`` emits a DecisionEvent with
+    layer='planner' / kind='info' / summary=text-prefix / detail.text
+    so the workspace's PLANNER REASONING panel populates instead of
+    showing demo placeholder text."""
+    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
+    a = AugurAdapter(run_id="reasoning_v1", tenant_id="t", session_name="s", out_dir=tmp_path)
+    a.record_step(
+        step_result=_FakeStepResult(step_index=0),
+        started_at="2026-05-20T10:00:00Z",
+        ended_at="2026-05-20T10:00:01Z",
+    )
+    a.record_planner_reasoning(
+        step_index=0,
+        reasoning="I should click the Login button to authenticate.",
+    )
+    # Empty / whitespace reasoning is silently dropped
+    a.record_planner_reasoning(step_index=0, reasoning="   ")
+    a.close(status="completed")
+
+    # Mantis step_index=0 → Augur 1-based → events/0001.jsonl
+    events_file = tmp_path / "events" / "0001.jsonl"
+    assert events_file.exists()
+    lines = [json.loads(ln) for ln in events_file.read_text().splitlines() if ln.strip()]
+    planner = [e for e in lines if e.get("layer") == "planner"]
+    assert len(planner) == 1, "exactly one planner event from non-empty reasoning"
+    assert planner[0]["kind"] == "info"
+    assert planner[0]["step_index"] == 1
+    assert "Login button" in planner[0]["summary"]
+    assert planner[0]["detail"]["text"].startswith("I should")
+
+
+def test_verbose_flag_gates_diagnostic_logging(monkeypatch, tmp_path: Path, caplog):
+    """MANTIS_AUGUR_VERBOSE=1 elevates diagnostics to WARN; default-off
+    keeps the log quiet so production runs stay un-noisy."""
+    import logging
+    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
+
+    # Default: quiet
+    monkeypatch.delenv("MANTIS_AUGUR_VERBOSE", raising=False)
+    caplog.set_level(logging.WARNING, logger="mantis_agent.observability.augur")
+    AugurAdapter(run_id="quiet_v1", tenant_id="t", session_name="s", out_dir=tmp_path / "quiet")
+    init_warnings_quiet = [r for r in caplog.records if "AugurAdapter init" in r.message]
+    assert init_warnings_quiet == [], "default-off → no AugurAdapter init WARN lines"
+
+    # Verbose: chatty
+    caplog.clear()
+    monkeypatch.setenv("MANTIS_AUGUR_VERBOSE", "1")
+    AugurAdapter(run_id="loud_v1", tenant_id="t", session_name="s", out_dir=tmp_path / "loud")
+    init_warnings_loud = [r for r in caplog.records if "AugurAdapter init" in r.message]
+    assert init_warnings_loud, "verbose=on → init WARN line emitted"
+
+
 def test_step_index_and_attempt_are_clamped_to_augur_minimums(monkeypatch, tmp_path: Path):
     """Augur's StepTrace schema requires step_index>=1 and
     recovery_decision.attempt>=1. Mantis is 0-based for both; the

--- a/tests/test_observability_augur.py
+++ b/tests/test_observability_augur.py
@@ -296,6 +296,51 @@ def test_verbose_flag_gates_diagnostic_logging(monkeypatch, tmp_path: Path, capl
     assert init_warnings_loud, "verbose=on → init WARN line emitted"
 
 
+def test_add_tag_surfaces_on_session(monkeypatch, tmp_path: Path):
+    """``add_tag`` writes to the session so the workspace can render
+    chips like MODEL in the Runs list."""
+    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
+    a = AugurAdapter(run_id="tag_v1", tenant_id="t", session_name="s", out_dir=tmp_path)
+    a.add_tag("model", "Holo3-35B-A3B")
+    a.add_tag("failure_class", "selector_miss")
+    # Empty key is silently dropped
+    a.add_tag("", "ignored")
+    a.close(status="completed")
+
+    manifest = json.loads((tmp_path / "trace.json").read_text())
+    tags = manifest.get("session", {}).get("tags", {})
+    assert tags.get("model") == "Holo3-35B-A3B"
+    assert tags.get("failure_class") == "selector_miss"
+
+
+def test_cost_metric_emits_runner_metric_decision_event(monkeypatch, tmp_path: Path):
+    """``record_cost_metric`` emits a layer='runner' / kind='metric'
+    DecisionEvent so the workspace's COST column can derive totals
+    from the standard SDK surface (no custom server-side parsing)."""
+    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
+    a = AugurAdapter(run_id="cost_v1", tenant_id="t", session_name="s", out_dir=tmp_path)
+    a.record_cost_metric(
+        name="cost_total_usd",
+        value=2.345,
+        detail={"gpu_usd": 0.5, "claude_usd": 1.8, "proxy_usd": 0.045,
+                "elapsed_seconds": 120.5, "steps_executed": 9},
+    )
+    a.close(status="completed")
+
+    # step_index=1 is the synthetic run-level slot
+    events_file = tmp_path / "events" / "0001.jsonl"
+    assert events_file.exists()
+    lines = [json.loads(ln) for ln in events_file.read_text().splitlines() if ln.strip()]
+    metrics = [e for e in lines if e.get("kind") == "metric"]
+    assert len(metrics) == 1
+    m = metrics[0]
+    assert m["layer"] == "runner"
+    assert m["detail"]["name"] == "cost_total_usd"
+    assert m["detail"]["value"] == 2.345
+    assert m["detail"]["claude_usd"] == 1.8
+    assert m["detail"]["steps_executed"] == 9
+
+
 def test_step_index_and_attempt_are_clamped_to_augur_minimums(monkeypatch, tmp_path: Path):
     """Augur's StepTrace schema requires step_index>=1 and
     recovery_decision.attempt>=1. Mantis is 0-based for both; the

--- a/tests/test_observability_augur.py
+++ b/tests/test_observability_augur.py
@@ -134,7 +134,8 @@ def test_bundle_writes_and_validates(monkeypatch, tmp_path: Path):
     assert manifest is not None
     assert (tmp_path / "manifest.json").exists()
     assert (tmp_path / "trace.json").exists()
-    assert (tmp_path / "screenshots" / "0002_post.png").exists()
+    # Mantis step_index=2 → Augur 1-based step_index=3 → screenshots/0003_post.png
+    assert (tmp_path / "screenshots" / "0003_post.png").exists()
 
     issues = validate_bundle(tmp_path)
     assert issues == [], f"bundle failed validation: {issues}"
@@ -158,7 +159,8 @@ def test_three_augur_layers_land(monkeypatch, tmp_path: Path):
     ])
     a.close(status="completed")
 
-    events_file = tmp_path / "events" / "0001.jsonl"
+    # Mantis step_index=1 → Augur 1-based → events/0002.jsonl
+    events_file = tmp_path / "events" / "0002.jsonl"
     assert events_file.exists()
     layers = {
         json.loads(line)["layer"]
@@ -180,7 +182,8 @@ def test_unknown_layer_falls_back_to_runner(monkeypatch, tmp_path: Path):
          "summary": "should not crash", "detail": {}},
     ])
     a.close(status="completed")
-    events_file = tmp_path / "events" / "0001.jsonl"
+    # Mantis step_index=1 → Augur 1-based → events/0002.jsonl
+    events_file = tmp_path / "events" / "0002.jsonl"
     layers = [json.loads(line)["layer"] for line in events_file.read_text().splitlines() if line.strip()]
     assert layers == ["runner"]
 

--- a/tests/test_observability_augur.py
+++ b/tests/test_observability_augur.py
@@ -241,3 +241,26 @@ def test_non_fatal_on_emit_error(monkeypatch, tmp_path: Path):
     # set_status path swallowed too:
     a._session.set_status = boom  # type: ignore[assignment]
     assert a.close(status="halted") is None
+
+
+def test_step_index_and_attempt_are_clamped_to_augur_minimums(monkeypatch, tmp_path: Path):
+    """Augur's StepTrace schema requires step_index>=1 and
+    recovery_decision.attempt>=1. Mantis is 0-based for both; the
+    adapter must bump on the way out so per-step PUTs aren't silently
+    rejected with HTTP 422 ``"step: 0 is less than the minimum of 1"``
+    (the actual symptom from the #509 verification cycle).
+    """
+    from types import SimpleNamespace
+    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
+    a = AugurAdapter(run_id="bump_v1", tenant_id="t", session_name="s", out_dir=tmp_path)
+    # 0-based attempt — typical Mantis RecoveryDecision shape
+    sr = _FakeStepResult(step_index=0)
+    sr.recovery_decision = SimpleNamespace(type="retry", reason="x", attempt=0)
+    trace = a._build_step_trace(sr, "2026-05-19T10:00:00Z", "2026-05-19T10:00:01Z", None, None)
+    assert trace["step_index"] == 1, "Mantis 0 → Augur 1"
+    assert trace["step_id"] == "step-0001"
+    assert trace["recovery_decision"]["attempt"] == 1, "0 clamped to schema minimum"
+
+    # Observation paths should also be 1-based (line up with step_id)
+    post = a.attach_observation(step_index=0, kind="post", png=_PNG)
+    assert post == "screenshots/0001_post.png"

--- a/tests/test_observability_augur.py
+++ b/tests/test_observability_augur.py
@@ -1,0 +1,240 @@
+"""Tests for the Augur DebugSession adapter (#509).
+
+Pinning the per-run behavior the issue's acceptance criteria call out:
+
+* Without ``AUGUR_DSN`` set, the adapter still writes a path-stable
+  bundle on disk that passes :func:`augur_sdk.validation.validate_bundle`.
+* At least one DecisionEvent per Augur layer (``verifier`` /
+  ``step_recovery`` / ``grounding``) lands when the corresponding
+  Mantis ``_healing_events`` are forwarded.
+* Disabling via ``MANTIS_AUGUR_DISABLED=1`` is a clean no-op.
+* SDK-side emission failures don't propagate — adapter swallows.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("augur_sdk")
+
+from augur_sdk.validation import validate_bundle
+
+from mantis_agent.observability.augur import (
+    AugurAdapter,
+    default_out_dir,
+    is_enabled,
+)
+
+
+# Minimal-but-valid 1×1 PNG so attach_observation has bytes to copy.
+_PNG = (
+    b"\x89PNG\r\n\x1a\n"
+    + b"\x00\x00\x00\rIHDR"
+    + b"\x00" * 13
+    + b"\x00\x00\x00\x00IEND\xaeB\x60\x82"
+)
+
+
+class _FakeAction:
+    action_type = "click"
+    text = ""
+    selector = ""
+    x = 100
+    y = 200
+
+
+class _FakeStepResult:
+    """Stand-in for ``mantis_agent.gym.checkpoint.StepResult``."""
+
+    def __init__(
+        self,
+        *,
+        step_index: int = 1,
+        intent: str = "Click submit",
+        success: bool = True,
+        failure_class: str = "",
+        skip: bool = False,
+        reversed_: bool = False,
+        duration: float = 0.42,
+    ) -> None:
+        self.step_index = step_index
+        self.intent = intent
+        self.success = success
+        self.skip = skip
+        self.reversed = reversed_
+        self.duration = duration
+        self.failure_class = failure_class
+        self.executor_backend = "som"
+        self.last_action = _FakeAction()
+        self.verdict = None
+        self.recovery_decision = None
+        self.screenshot_png = _PNG
+
+
+def test_enabled_when_sdk_installed_and_no_opt_out(monkeypatch):
+    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
+    assert is_enabled() is True
+
+
+def test_disabled_via_env(monkeypatch):
+    monkeypatch.setenv("MANTIS_AUGUR_DISABLED", "1")
+    assert is_enabled() is False
+    a = AugurAdapter(run_id="r", tenant_id="t", session_name="s")
+    assert a.active is False
+    # All public methods are no-ops when disabled
+    a.attach_observation(step_index=1, kind="post", png=_PNG)
+    a.record_step(step_result=_FakeStepResult())
+    a.drain_healing_events([{"layer": "critic-frontier", "step_index": 1}])
+    assert a.close(status="completed") is None
+
+
+def test_default_out_dir_uses_mantis_data_dir(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv("MANTIS_DATA_DIR", str(tmp_path))
+    monkeypatch.delenv("MANTIS_AUGUR_DIR", raising=False)
+    out = default_out_dir("run_xyz")
+    assert out == tmp_path / "augur" / "run_xyz"
+
+
+def test_default_out_dir_override(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv("MANTIS_AUGUR_DIR", str(tmp_path / "bundles"))
+    out = default_out_dir("run_xyz")
+    assert out == tmp_path / "bundles" / "run_xyz"
+
+
+def test_bundle_writes_and_validates(monkeypatch, tmp_path: Path):
+    """The full happy path: 1 step + 3 healing events → valid bundle."""
+    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
+    monkeypatch.delenv("AUGUR_DSN", raising=False)  # no streaming for unit test
+    a = AugurAdapter(run_id="unit_v1", tenant_id="t", session_name="s", out_dir=tmp_path)
+    assert a.active
+
+    sr = _FakeStepResult(step_index=2)
+    post = a.attach_observation(step_index=2, kind="post", png=_PNG)
+    assert post and post.startswith("screenshots/")
+
+    a.record_step(
+        step_result=sr,
+        started_at="2026-05-19T10:00:00Z",
+        ended_at="2026-05-19T10:00:01Z",
+        observation_post=post,
+    )
+    a.drain_healing_events([
+        {"ts": "2026-05-19T10:00:00Z", "step_index": 2, "layer": "critic-frontier",
+         "kind": "fire", "summary": "edit_step", "detail": {"op": "ReplaceStep"}},
+        {"ts": "2026-05-19T10:00:00Z", "step_index": 2, "layer": "som-click",
+         "kind": "result", "summary": "clicked", "detail": {"x": 100, "y": 200}},
+        {"ts": "2026-05-19T10:00:00Z", "step_index": 2, "layer": "agentic-recovery",
+         "kind": "decision", "summary": "retry", "detail": {}},
+    ])
+    manifest = a.close(status="completed")
+
+    assert manifest is not None
+    assert (tmp_path / "manifest.json").exists()
+    assert (tmp_path / "trace.json").exists()
+    assert (tmp_path / "screenshots" / "0002_post.png").exists()
+
+    issues = validate_bundle(tmp_path)
+    assert issues == [], f"bundle failed validation: {issues}"
+
+
+def test_three_augur_layers_land(monkeypatch, tmp_path: Path):
+    """AC: at least one verifier / step_recovery / grounding event per bundle."""
+    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
+    monkeypatch.delenv("AUGUR_DSN", raising=False)
+    a = AugurAdapter(run_id="layers_v1", tenant_id="t", session_name="s", out_dir=tmp_path)
+    a.attach_observation(step_index=1, kind="post", png=_PNG)
+    a.record_step(
+        step_result=_FakeStepResult(step_index=1),
+        started_at="2026-05-19T10:00:00Z",
+        ended_at="2026-05-19T10:00:01Z",
+    )
+    a.drain_healing_events([
+        {"step_index": 1, "layer": "critic-frontier", "kind": "fire", "summary": "v"},
+        {"step_index": 1, "layer": "som-click", "kind": "result", "summary": "g"},
+        {"step_index": 1, "layer": "agentic-recovery", "kind": "decision", "summary": "r"},
+    ])
+    a.close(status="completed")
+
+    events_file = tmp_path / "events" / "0001.jsonl"
+    assert events_file.exists()
+    layers = {
+        json.loads(line)["layer"]
+        for line in events_file.read_text().splitlines()
+        if line.strip()
+    }
+    assert {"verifier", "step_recovery", "grounding"} <= layers
+
+
+def test_unknown_layer_falls_back_to_runner(monkeypatch, tmp_path: Path):
+    """Unmapped layer strings shouldn't crash — they map to the catch-all."""
+    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
+    a = AugurAdapter(run_id="fb_v1", tenant_id="t", session_name="s", out_dir=tmp_path)
+    a.record_step(step_result=_FakeStepResult(step_index=1),
+                  started_at="2026-05-19T10:00:00Z",
+                  ended_at="2026-05-19T10:00:01Z")
+    a.drain_healing_events([
+        {"step_index": 1, "layer": "completely-made-up", "kind": "decision",
+         "summary": "should not crash", "detail": {}},
+    ])
+    a.close(status="completed")
+    events_file = tmp_path / "events" / "0001.jsonl"
+    layers = [json.loads(line)["layer"] for line in events_file.read_text().splitlines() if line.strip()]
+    assert layers == ["runner"]
+
+
+def test_cursor_only_emits_new_events(monkeypatch, tmp_path: Path):
+    """Two drain calls on a growing list should emit each event exactly once."""
+    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
+    a = AugurAdapter(run_id="cur_v1", tenant_id="t", session_name="s", out_dir=tmp_path)
+    healing: list[dict] = []
+    a.record_step(step_result=_FakeStepResult(step_index=1),
+                  started_at="2026-05-19T10:00:00Z",
+                  ended_at="2026-05-19T10:00:01Z")
+    healing.append({"step_index": 1, "layer": "critic-frontier", "kind": "fire", "summary": "first"})
+    a.drain_healing_events(healing)
+    a.record_step(step_result=_FakeStepResult(step_index=2),
+                  started_at="2026-05-19T10:00:01Z",
+                  ended_at="2026-05-19T10:00:02Z")
+    healing.append({"step_index": 2, "layer": "som-click", "kind": "result", "summary": "second"})
+    a.drain_healing_events(healing)
+    a.close(status="completed")
+
+    events_dir = tmp_path / "events"
+    summaries: list[str] = []
+    for jsonl in sorted(events_dir.glob("*.jsonl")):
+        for line in jsonl.read_text().splitlines():
+            if line.strip():
+                summaries.append(json.loads(line)["summary"])
+    # Each event emitted exactly once, no duplicate from the second drain
+    assert summaries.count("first") == 1
+    assert summaries.count("second") == 1
+
+
+def test_non_fatal_on_emit_error(monkeypatch, tmp_path: Path):
+    """SDK-side exceptions during emission must not propagate."""
+    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
+    a = AugurAdapter(run_id="err_v1", tenant_id="t", session_name="s", out_dir=tmp_path)
+    assert a.active
+
+    # Monkey-patch the underlying session so every emission method blows up.
+    def boom(*_a, **_k):
+        raise RuntimeError("simulated SDK failure")
+
+    a._session.record_step = boom  # type: ignore[assignment]
+    a._session.record_event = boom  # type: ignore[assignment]
+    a._session.attach_observation = boom  # type: ignore[assignment]
+
+    # None of these should raise.
+    assert a.attach_observation(step_index=1, kind="post", png=_PNG) is None
+    a.record_step(step_result=_FakeStepResult(step_index=1))
+    a.drain_healing_events([{"step_index": 1, "layer": "critic-frontier",
+                              "kind": "fire", "summary": "x"}])
+
+    # Close itself should also tolerate a busted session.
+    a._session.close = boom  # type: ignore[assignment]
+    # set_status path swallowed too:
+    a._session.set_status = boom  # type: ignore[assignment]
+    assert a.close(status="halted") is None

--- a/uv.lock
+++ b/uv.lock
@@ -228,16 +228,16 @@ wheels = [
 
 [[package]]
 name = "augur-sdk"
-version = "0.1.0"
+version = "0.1.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonschema" },
     { name = "referencing" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4a/0e/232f6425e8957e81ff3f71a4837c3fe8aaca1d91c3f7d284078f2903aac0/augur_sdk-0.1.0.tar.gz", hash = "sha256:e2263dde6527800b9b83344bba09544a0c0433e6a6764eb919f4ff69510d4030", size = 42320, upload-time = "2026-05-19T23:10:41.86Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/c5/fefcda0c4da072afcc3162d16d11c6d41af1eb5f1d95cf045e47b44bce46/augur_sdk-0.1.2.tar.gz", hash = "sha256:01d9aaef20a2f1a068e1f2fb25e7bfaa9b89878719a835ebd15223c9f709243f", size = 44086, upload-time = "2026-05-20T00:54:44.714Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/dd/24/b84288223ab790129290a83f035955d947f9b0b0161294010e2d46479695/augur_sdk-0.1.0-py3-none-any.whl", hash = "sha256:9ebf596141b340c7b6d3db2a648b90c4532e308814a4b7c0e970ebe390870e52", size = 50039, upload-time = "2026-05-19T23:10:40.25Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/df/7860a7dbe6dbbe42bb611d06d2afcccc4fc4cdeaac79afa58a3a4aaba623/augur_sdk-0.1.2-py3-none-any.whl", hash = "sha256:d896e2c3eff452167b99aec6eef8f0339096f44af525d05743893958aeaac4a2", size = 50274, upload-time = "2026-05-20T00:54:43.151Z" },
 ]
 
 [[package]]
@@ -1537,7 +1537,7 @@ viewer = [
 [package.metadata]
 requires-dist = [
     { name = "accelerate", marker = "extra == 'gpu'", specifier = ">=0.30" },
-    { name = "augur-sdk", marker = "extra == 'observability'", specifier = ">=0.1.0" },
+    { name = "augur-sdk", marker = "extra == 'observability'", specifier = ">=0.1.2" },
     { name = "bitsandbytes", marker = "extra == 'gpu'", specifier = ">=0.43" },
     { name = "fastapi", marker = "extra == 'server'", specifier = ">=0.100" },
     { name = "fastapi", marker = "extra == 'viewer'", specifier = ">=0.100" },

--- a/uv.lock
+++ b/uv.lock
@@ -227,6 +227,20 @@ wheels = [
 ]
 
 [[package]]
+name = "augur-sdk"
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jsonschema" },
+    { name = "referencing" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4a/0e/232f6425e8957e81ff3f71a4837c3fe8aaca1d91c3f7d284078f2903aac0/augur_sdk-0.1.0.tar.gz", hash = "sha256:e2263dde6527800b9b83344bba09544a0c0433e6a6764eb919f4ff69510d4030", size = 42320, upload-time = "2026-05-19T23:10:41.86Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dd/24/b84288223ab790129290a83f035955d947f9b0b0161294010e2d46479695/augur_sdk-0.1.0-py3-none-any.whl", hash = "sha256:9ebf596141b340c7b6d3db2a648b90c4532e308814a4b7c0e970ebe390870e52", size = 50039, upload-time = "2026-05-19T23:10:40.25Z" },
+]
+
+[[package]]
 name = "authlib"
 version = "1.6.9"
 source = { registry = "https://pypi.org/simple" }
@@ -1466,6 +1480,7 @@ docs = [
 ]
 full = [
     { name = "accelerate" },
+    { name = "augur-sdk" },
     { name = "bitsandbytes" },
     { name = "fastapi" },
     { name = "hud-python" },
@@ -1499,6 +1514,9 @@ local-cua = [
 metrics = [
     { name = "prometheus-client" },
 ]
+observability = [
+    { name = "augur-sdk" },
+]
 orchestrator = [
     { name = "pydantic" },
     { name = "requests" },
@@ -1519,13 +1537,14 @@ viewer = [
 [package.metadata]
 requires-dist = [
     { name = "accelerate", marker = "extra == 'gpu'", specifier = ">=0.30" },
+    { name = "augur-sdk", marker = "extra == 'observability'", specifier = ">=0.1.0" },
     { name = "bitsandbytes", marker = "extra == 'gpu'", specifier = ">=0.43" },
     { name = "fastapi", marker = "extra == 'server'", specifier = ">=0.100" },
     { name = "fastapi", marker = "extra == 'viewer'", specifier = ">=0.100" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.24" },
     { name = "hud-python", marker = "extra == 'hud'", specifier = ">=0.5.34" },
     { name = "jsonschema", marker = "extra == 'dev'", specifier = ">=4.0" },
-    { name = "mantis-agent", extras = ["orchestrator", "server", "local-cua", "viewer", "gpu", "hud"], marker = "extra == 'full'" },
+    { name = "mantis-agent", extras = ["orchestrator", "server", "local-cua", "viewer", "gpu", "hud", "observability"], marker = "extra == 'full'" },
     { name = "mkdocs", marker = "extra == 'docs'", specifier = ">=1.6" },
     { name = "mkdocs-awesome-pages-plugin", marker = "extra == 'docs'", specifier = ">=2.9" },
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.5" },
@@ -1555,7 +1574,7 @@ requires-dist = [
     { name = "uvicorn", marker = "extra == 'server'", specifier = ">=0.20" },
     { name = "uvicorn", marker = "extra == 'viewer'", specifier = ">=0.20" },
 ]
-provides-extras = ["orchestrator", "client", "metrics", "server", "local-cua", "viewer", "gpu", "hud", "dev", "docs", "full"]
+provides-extras = ["orchestrator", "client", "metrics", "observability", "server", "local-cua", "viewer", "gpu", "hud", "dev", "docs", "full"]
 
 [[package]]
 name = "markdown"


### PR DESCRIPTION
## Summary

Closes #509.

Every gym run now produces a path-stable, schema-validated **Augur bundle on disk**, and — when `AUGUR_DSN` is exported — **streams the same records live** to the configured workspace via [`augur-sdk`](https://github.com/mercurialsolo/augur-sdk) (Sentry-style DSN, 15 s heartbeat, connection-status badge).

### What changed
- New `observability` optional extra in `pyproject.toml` (just `augur-sdk>=0.1.0`). Import is lazy; without the package the adapter is a hard no-op — zero base-install footprint change.
- `src/mantis_agent/observability/augur.py` — thin wrapper around `augur_sdk.DebugSession`:
  - Lifecycle: explicit `__enter__` at construction (the SDK class is context-manager-shaped but Mantis's `execute` and `_finalize` aren't a `with` block), `close` from `_finalize`.
  - Cursor on the adapter tracks already-emitted healing events so per-step `drain_healing_events` only emits the new ones.
  - All emission paths swallow exceptions per SDK spec §4.3 — a misconfigured DSN, transient network blip, or schema mismatch can never break a Mantis run.
  - Mappers: `StepResult` → Augur `StepTrace`; `runner._healing_events` → Augur `DecisionEvent` (layer remap: `critic-frontier`/`gate-decision` → `verifier`, `agentic-recovery` → `step_recovery`, `som-click` → `grounding`, ...). Mantis runner status collapses onto Augur's five-state `RunStatus`.
  - Bundle path: `${MANTIS_DATA_DIR}/augur/<run_id>/` by default, overrideable via `MANTIS_AUGUR_DIR`; disable via `MANTIS_AUGUR_DISABLED=1`.
- `src/mantis_agent/gym/run_executor.py` wedge — open at the top of `execute`, per-step emission runs after `_consult_critic` (so critic-emitted healing events land too), `close` fires from `_finalize` alongside the existing `TraceExporter` call. Both writers coexist by design.
- `.gitignore` — add `data/` (local `MANTIS_DATA_DIR` fallback).

### Tests
- `tests/test_observability_augur.py` (9 cases) pin the acceptance criteria:
  - Bundle written + `augur_sdk.validation.validate_bundle()` returns no issues without `AUGUR_DSN` set.
  - `verifier` / `step_recovery` / `grounding` layers all present in the bundle's `events/*.jsonl`.
  - Unknown layer falls back to `runner` (catch-all).
  - Cursor only emits new events across multiple `drain_healing_events` calls on a growing list.
  - `MANTIS_AUGUR_DISABLED=1` is a clean no-op (no session, no files).
  - SDK-side exceptions in every emission method don't propagate.
- 227 tests pass across the touched surfaces (server_utils, micro_runner, checkpoint, extractor, artifacts endpoint, video endpoint, ...).

### Docs
- New `docs/integrations/augur.md` — bundle layout, vocabulary mapping, env knobs, verification flow.
- `docs/reference/env-vars.md` — `AUGUR_DSN`, `AUGUR_CAPTURE_MODE`, `MANTIS_AUGUR_DIR`, `MANTIS_AUGUR_DISABLED`, `MANTIS_VERSION`, `MANTIS_GIT_SHA`.
- `mkdocs.yml` — nav entry under Integrations.

## Test plan

- [x] Unit tests pass with `augur-sdk` installed (9/9 new + 218 adjacent green)
- [x] Adapter is a hard no-op when `augur-sdk` is absent (lazy import in module body)
- [x] `validate_bundle()` returns `[]` for a real generated bundle
- [ ] Modal `mantis-cua-server` redeployed with `augur-sdk` in the image; staff-crm run produces a bundle on disk under `/data/augur/<run_id>/`
- [ ] Live streaming verified — connection-status badge turns green in the Augur workspace after the first step lands (workspace endpoint already in `.env`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)