### PR TITLE
cost: bill Claude API by token count, not call count

### DIFF
--- a/src/mantis_agent/_anthropic/client.py
+++ b/src/mantis_agent/_anthropic/client.py
@@ -95,6 +95,52 @@ def _credit_claude_time(bucket: str, t0: float) -> None:
         logger.debug("anthropic time_meter credit failed: %s", exc)
 
 
+def credit_claude_tokens_from_response(response: Any) -> None:
+    """Read ``usage.{input_tokens,output_tokens,...}`` off an Anthropic
+    response and credit them to the currently-published CostMeter (#514).
+
+    Accepts the parsed JSON dict OR a ``requests.Response`` object —
+    callers that already have the dict can pass it directly; raw
+    response objects get parsed here. Best-effort: a missing usage
+    block, malformed JSON, or no published meter all silently no-op.
+
+    The Anthropic API returns:
+
+    * ``usage.input_tokens`` — total input tokens (includes cached)
+    * ``usage.output_tokens`` — generated tokens
+    * ``usage.cache_read_input_tokens`` — subset of input that hit cache
+    * ``usage.cache_creation_input_tokens`` — input written to cache
+      (billed at higher rate than standard input; for now we treat as
+      ``input_tokens`` and let the standard rate apply)
+
+    Source of truth for the surface:
+    https://docs.anthropic.com/en/api/messages#response-usage
+    """
+    try:
+        if response is None:
+            return
+        if hasattr(response, "json") and callable(response.json):
+            try:
+                payload = response.json()
+            except Exception:  # noqa: BLE001
+                return
+        else:
+            payload = response
+        if not isinstance(payload, dict):
+            return
+        usage = payload.get("usage") or {}
+        if not isinstance(usage, dict):
+            return
+        from ..gym.cost_meter import record_claude_tokens_to_current
+        record_claude_tokens_to_current(
+            input_tokens=int(usage.get("input_tokens", 0) or 0),
+            output_tokens=int(usage.get("output_tokens", 0) or 0),
+            cached_input_tokens=int(usage.get("cache_read_input_tokens", 0) or 0),
+        )
+    except Exception as exc:  # noqa: BLE001 — observability never fatal
+        logger.debug("anthropic cost_meter token credit failed: %s", exc)
+
+
 class AnthropicToolUseClient:
     """Anthropic ``/v1/messages`` client tuned for schema-validated tool_use.
 
@@ -289,7 +335,9 @@ class AnthropicToolUseClient:
                     resp.text[:500],
                 )
                 return None
-            for block in resp.json().get("content", []):
+            payload_json = resp.json()
+            credit_claude_tokens_from_response(payload_json)
+            for block in payload_json.get("content", []):
                 if block.get("type") == "tool_use" and block.get("name") == tool_name:
                     tool_input = block.get("input")
                     if isinstance(tool_input, dict):
@@ -370,7 +418,9 @@ class AnthropicToolUseClient:
                     resp.text[:500],
                 )
                 return None
-            for block in resp.json().get("content", []):
+            payload_json = resp.json()
+            credit_claude_tokens_from_response(payload_json)
+            for block in payload_json.get("content", []):
                 if block.get("type") == "tool_use" and block.get("name") == tool_name:
                     tool_input = block.get("input")
                     if isinstance(tool_input, dict):
@@ -391,4 +441,5 @@ __all__ = [
     "_TRANSIENT_STATUS_CODES",
     "_retry_delay",
     "_credit_claude_time",
+    "credit_claude_tokens_from_response",
 ]

--- a/src/mantis_agent/cost_config.py
+++ b/src/mantis_agent/cost_config.py
@@ -39,10 +39,30 @@ def _env_float(key: str, default: float) -> float:
 
 @dataclass(frozen=True)
 class CostConfig:
-    """Per-resource pricing knobs for the CUA runtime."""
+    """Per-resource pricing knobs for the CUA runtime.
+
+    Claude cost has two parallel surfaces:
+
+    * **Per-token** (preferred, since #514) — bills against actual
+      ``input_tokens`` / ``output_tokens`` returned by the Anthropic
+      API on every response. Defaults track Claude Sonnet 4 list
+      prices ($3 / $15 / $0.30 per M tokens for input / output /
+      cached-input). Override per deployment via env when the
+      production model is different (Opus is ~5x; Haiku is ~5x lower).
+    * **Per-call** (legacy) — flat ``claude_call_usd`` × call count.
+      Kept for back-compat with callers + tests that still rely on
+      the older :meth:`claude_cost` API. New code paths should use
+      :meth:`claude_token_cost` which is the canonical surface.
+    """
 
     gpu_hourly_usd: float = 3.25
     claude_call_usd: float = 0.003
+    # Per-million-token rates (USD). Defaults: Claude Sonnet 4 list prices.
+    claude_input_per_mtok: float = 3.0
+    claude_output_per_mtok: float = 15.0
+    # Cached-input rate when the prompt-cache breakpoint hits — Anthropic
+    # charges ~10% of the standard input rate. Defaults match Sonnet 4.
+    claude_cached_input_per_mtok: float = 0.3
     proxy_per_gb_usd: float = 5.0
     gpu_seconds_per_step: float = 3.0
     proxy_mb_per_nav: float = 5.0
@@ -58,6 +78,11 @@ class CostConfig:
         return cls(
             gpu_hourly_usd=_env_float("MANTIS_COST_GPU_HOURLY_USD", 3.25),
             claude_call_usd=_env_float("MANTIS_COST_CLAUDE_CALL_USD", 0.003),
+            claude_input_per_mtok=_env_float("MANTIS_COST_CLAUDE_INPUT_PER_MTOK", 3.0),
+            claude_output_per_mtok=_env_float("MANTIS_COST_CLAUDE_OUTPUT_PER_MTOK", 15.0),
+            claude_cached_input_per_mtok=_env_float(
+                "MANTIS_COST_CLAUDE_CACHED_INPUT_PER_MTOK", 0.3,
+            ),
             proxy_per_gb_usd=_env_float("MANTIS_COST_PROXY_PER_GB_USD", 5.0),
             gpu_seconds_per_step=_env_float("MANTIS_COST_GPU_SECONDS_PER_STEP", 3.0),
             proxy_mb_per_nav=_env_float("MANTIS_COST_PROXY_MB_PER_NAV", 5.0),
@@ -70,7 +95,38 @@ class CostConfig:
         return (gpu_seconds / 3600.0) * self.gpu_hourly_usd
 
     def claude_cost(self, num_calls: int) -> float:
+        """Legacy per-call billing (kept for back-compat).
+
+        New code should use :meth:`claude_token_cost` — call-count
+        billing under-counts real spend by roughly 40x at the
+        $0.003-per-call default. See #514.
+        """
         return num_calls * self.claude_call_usd
+
+    def claude_token_cost(
+        self,
+        *,
+        input_tokens: int = 0,
+        output_tokens: int = 0,
+        cached_input_tokens: int = 0,
+    ) -> float:
+        """Token-billed Claude cost in USD (#514).
+
+        ``cached_input_tokens`` counts INSIDE ``input_tokens`` on
+        Anthropic responses (the API returns both fields; cached
+        tokens are billed at the lower cached rate, the remainder at
+        the standard input rate). We subtract the cached count from
+        ``input_tokens`` here so callers can pass both fields exactly
+        as Anthropic reports them.
+        """
+        ci = max(0, int(cached_input_tokens or 0))
+        ii = max(0, int(input_tokens or 0) - ci)
+        oo = max(0, int(output_tokens or 0))
+        return (
+            (ii / 1_000_000.0) * self.claude_input_per_mtok
+            + (ci / 1_000_000.0) * self.claude_cached_input_per_mtok
+            + (oo / 1_000_000.0) * self.claude_output_per_mtok
+        )
 
     def proxy_cost(self, proxy_mb: float) -> float:
         return (proxy_mb / 1024.0) * self.proxy_per_gb_usd

--- a/src/mantis_agent/extraction/extractor.py
+++ b/src/mantis_agent/extraction/extractor.py
@@ -43,6 +43,7 @@ from .._anthropic.client import (
     AnthropicToolUseClient,
     _credit_claude_time,
     _retry_delay,
+    credit_claude_tokens_from_response,
 )
 from .result import ExtractionResult
 from .schema import ExtractionSchema
@@ -405,7 +406,9 @@ class ClaudeExtractor:
                     resp.text[:500],
                 )
                 return ""
-            for block in resp.json().get("content", []):
+            payload_json = resp.json()
+            credit_claude_tokens_from_response(payload_json)
+            for block in payload_json.get("content", []):
                 if block.get("type") == "text":
                     return block["text"].strip()
         except Exception as e:
@@ -543,7 +546,9 @@ class ClaudeExtractor:
                     resp.text[:500],
                 )
                 return ""
-            for block in resp.json().get("content", []):
+            payload_json = resp.json()
+            credit_claude_tokens_from_response(payload_json)
+            for block in payload_json.get("content", []):
                 if block.get("type") == "text":
                     return block["text"].strip()
         except Exception as e:

--- a/src/mantis_agent/gym/cost_meter.py
+++ b/src/mantis_agent/gym/cost_meter.py
@@ -25,8 +25,11 @@ sites to ``meter.add_*()`` helpers; this PR keeps the diff minimal.
 
 from __future__ import annotations
 
+import contextlib
+import contextvars
 import logging
 import time
+from collections.abc import Iterator
 from typing import TYPE_CHECKING, Any
 
 from ..cost_config import CostConfig
@@ -42,8 +45,15 @@ logger = logging.getLogger(__name__)
 _INITIAL_COSTS: dict[str, Any] = {
     "gpu_steps": 0,        # Total Holo3 steps
     "gpu_seconds": 0.0,    # Approx GPU time
-    "claude_extract": 0,   # Claude extraction calls
-    "claude_grounding": 0, # Claude grounding calls
+    "claude_extract": 0,   # Claude extraction calls (legacy call counter)
+    "claude_grounding": 0, # Claude grounding calls  (legacy call counter)
+    # Per-token usage from the Anthropic API responses (#514). These
+    # are the canonical Claude billing surface — call-count counters
+    # above stay for compatibility but stop being used in cost math
+    # once tokens are populated.
+    "claude_input_tokens": 0,
+    "claude_output_tokens": 0,
+    "claude_cached_input_tokens": 0,
     "proxy_mb": 0.0,       # Estimated proxy bandwidth
 }
 
@@ -77,14 +87,65 @@ class CostMeter:
     # ── Pure cost computation ───────────────────────────────────────────
 
     def totals(self) -> tuple[float, float, float, float]:
-        """Return (gpu, claude, proxy, total) USD for the current counters."""
+        """Return (gpu, claude, proxy, total) USD for the current counters.
+
+        Claude cost prefers per-token billing (#514) when token
+        counters are populated by the Anthropic client. Falls back to
+        the legacy per-call count × ``claude_call_usd`` when no
+        tokens were recorded (tests, callers that bypass the shared
+        client, hosts that haven't deployed the token-credit hook).
+        """
         cfg = self.cost_config
         gpu_cost = cfg.gpu_cost(self.costs["gpu_seconds"])
-        claude_cost = cfg.claude_cost(
-            self.costs["claude_extract"] + self.costs["claude_grounding"]
-        )
+        input_tokens = int(self.costs.get("claude_input_tokens", 0) or 0)
+        output_tokens = int(self.costs.get("claude_output_tokens", 0) or 0)
+        cached_tokens = int(self.costs.get("claude_cached_input_tokens", 0) or 0)
+        if input_tokens or output_tokens:
+            claude_cost = cfg.claude_token_cost(
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                cached_input_tokens=cached_tokens,
+            )
+        else:
+            claude_cost = cfg.claude_cost(
+                self.costs["claude_extract"] + self.costs["claude_grounding"]
+            )
         proxy_cost = cfg.proxy_cost(self.costs["proxy_mb"])
         return gpu_cost, claude_cost, proxy_cost, gpu_cost + claude_cost + proxy_cost
+
+    # ── Claude token accounting (#514) ──────────────────────────────────
+
+    def record_claude_tokens(
+        self,
+        *,
+        input_tokens: int = 0,
+        output_tokens: int = 0,
+        cached_input_tokens: int = 0,
+    ) -> None:
+        """Credit the per-call token usage to the meter (#514).
+
+        Called from the Anthropic-client wrappers right after each
+        ``messages.create`` response lands. ``cached_input_tokens``
+        counts INSIDE ``input_tokens`` on Anthropic responses — pass
+        both fields exactly as the API reports them; the cost math
+        in :meth:`CostConfig.claude_token_cost` subtracts cached from
+        plain input so the same byte isn't billed twice.
+        """
+        ii = max(0, int(input_tokens or 0))
+        oo = max(0, int(output_tokens or 0))
+        ci = max(0, int(cached_input_tokens or 0))
+        if ii:
+            self.costs["claude_input_tokens"] = int(
+                self.costs.get("claude_input_tokens", 0) or 0
+            ) + ii
+        if oo:
+            self.costs["claude_output_tokens"] = int(
+                self.costs.get("claude_output_tokens", 0) or 0
+            ) + oo
+        if ci:
+            self.costs["claude_cached_input_tokens"] = int(
+                self.costs.get("claude_cached_input_tokens", 0) or 0
+            ) + ci
 
     def elapsed_seconds(self) -> float:
         return time.time() - self.run_start
@@ -150,10 +211,20 @@ class CostMeter:
         """
         cfg = self.cost_config
         gpu = cfg.gpu_cost(float(costs.get("gpu_seconds", 0.0) or 0.0))
-        claude = cfg.claude_cost(
-            int(costs.get("claude_extract", 0) or 0)
-            + int(costs.get("claude_grounding", 0) or 0)
-        )
+        input_tokens = int(costs.get("claude_input_tokens", 0) or 0)
+        output_tokens = int(costs.get("claude_output_tokens", 0) or 0)
+        cached_tokens = int(costs.get("claude_cached_input_tokens", 0) or 0)
+        if input_tokens or output_tokens:
+            claude = cfg.claude_token_cost(
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                cached_input_tokens=cached_tokens,
+            )
+        else:
+            claude = cfg.claude_cost(
+                int(costs.get("claude_extract", 0) or 0)
+                + int(costs.get("claude_grounding", 0) or 0)
+            )
         proxy = cfg.proxy_cost(float(costs.get("proxy_mb", 0.0) or 0.0))
         return {
             "gpu": gpu,
@@ -164,6 +235,9 @@ class CostMeter:
             "gpu_seconds": float(costs.get("gpu_seconds", 0.0) or 0.0),
             "claude_extract": int(costs.get("claude_extract", 0) or 0),
             "claude_grounding": int(costs.get("claude_grounding", 0) or 0),
+            "claude_input_tokens": input_tokens,
+            "claude_output_tokens": output_tokens,
+            "claude_cached_input_tokens": cached_tokens,
             "proxy_mb": float(costs.get("proxy_mb", 0.0) or 0.0),
         }
 
@@ -242,4 +316,72 @@ class CostMeter:
             logger.debug("inflight cost gauge update failed: %s", exc)
 
 
-__all__ = ["CostMeter", "make_initial_costs"]
+# ── Cost meter context publisher (#514) ────────────────────────────────
+
+
+# Mirrors :data:`gym.time_meter._CURRENT_DISPATCH` — the runner
+# publishes its CostMeter for the duration of an execution scope so
+# deep helpers (the shared Anthropic client; future cost-emitting
+# subsystems) can credit tokens without being passed the meter as an
+# argument. PEP 567 contextvars keep this scope-correct for asyncio +
+# threaded callers.
+_CURRENT_COST_METER: contextvars.ContextVar["CostMeter | None"] = (
+    contextvars.ContextVar("mantis_cost_meter_current", default=None)
+)
+
+
+def current_cost_meter() -> "CostMeter | None":
+    """Return the runner's :class:`CostMeter` if one was published,
+    else ``None``. Helpers that opportunistically credit costs bail
+    out cleanly when this returns ``None`` — useful for tests +
+    standalone-script runs of the Anthropic client.
+    """
+    return _CURRENT_COST_METER.get()
+
+
+@contextlib.contextmanager
+def publish_cost_meter(meter: "CostMeter | None") -> Iterator[None]:
+    """Publish ``meter`` to the contextvar for the wrapped block.
+
+    ``meter=None`` clears the context — used by tests that exercise
+    Anthropic-client helpers in isolation without a runner present.
+    Always resets on exit, including on exceptions, so a crashed
+    scope can't leak the meter into the next one.
+    """
+    token = _CURRENT_COST_METER.set(meter)
+    try:
+        yield
+    finally:
+        _CURRENT_COST_METER.reset(token)
+
+
+def record_claude_tokens_to_current(
+    *,
+    input_tokens: int = 0,
+    output_tokens: int = 0,
+    cached_input_tokens: int = 0,
+) -> None:
+    """Credit per-call token usage to the currently-published meter (#514).
+
+    Called by the Anthropic-client wrappers right after each
+    ``messages.create`` response lands. No-op when no meter is
+    published — protects test runs + standalone helpers that
+    construct the client outside a runner context.
+    """
+    meter = _CURRENT_COST_METER.get()
+    if meter is None:
+        return
+    meter.record_claude_tokens(
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        cached_input_tokens=cached_input_tokens,
+    )
+
+
+__all__ = [
+    "CostMeter",
+    "current_cost_meter",
+    "make_initial_costs",
+    "publish_cost_meter",
+    "record_claude_tokens_to_current",
+]

--- a/src/mantis_agent/gym/run_executor.py
+++ b/src/mantis_agent/gym/run_executor.py
@@ -48,6 +48,7 @@ from ..plan_decomposer import MicroIntent
 from . import failure_class as failure_class_mod
 from . import step_snapshot
 from .checkpoint import RunCheckpoint, StepResult
+from .cost_meter import publish_cost_meter
 
 
 def _utc_iso_now() -> str:
@@ -164,6 +165,21 @@ class RunExecutor:
         ``state.loop_counters`` / ``state.listings_on_page`` /
         ``state.step_index`` from it before the loop starts.
         """
+        runner = self.parent
+        # #514 publish the cost meter so deep helpers (the shared
+        # Anthropic client; future cost-emitting subsystems) can credit
+        # tokens to this run without being passed the meter as an arg.
+        # Mirrors the dispatch-context publish for ``TimeMeter``.
+        with publish_cost_meter(getattr(runner, "cost_meter", None)):
+            return self._execute_inner(plan, state, resume=resume)
+
+    def _execute_inner(
+        self,
+        plan: "MicroPlan",
+        state: RunState,
+        *,
+        resume: bool = False,
+    ) -> list[StepResult]:
         runner = self.parent
         runner._final_status = "running"
         if not runner.plan_signature:
@@ -1507,6 +1523,17 @@ class RunExecutor:
         augur.add_tag("cost_claude_usd", f"{claude:.4f}")
         augur.add_tag("cost_proxy_usd", f"{proxy:.4f}")
         augur.add_tag("elapsed_seconds", f"{elapsed:.2f}")
+        # #514: also surface token counts on the metric event so the
+        # Augur workspace's query layer can compute per-token spend or
+        # spot model regressions without re-deriving the rate.
+        claude_input = int(meter.costs.get("claude_input_tokens", 0) or 0)
+        claude_output = int(meter.costs.get("claude_output_tokens", 0) or 0)
+        claude_cached_input = int(meter.costs.get("claude_cached_input_tokens", 0) or 0)
+        if claude_input or claude_output:
+            augur.add_tag("claude_input_tokens", str(claude_input))
+            augur.add_tag("claude_output_tokens", str(claude_output))
+            if claude_cached_input:
+                augur.add_tag("claude_cached_input_tokens", str(claude_cached_input))
         # The metric event is the structured/query-able surface — keeps
         # the same data shape as other Augur ``kind="metric"`` events.
         augur.record_cost_metric(
@@ -1518,6 +1545,9 @@ class RunExecutor:
                 "proxy_usd": round(proxy, 4),
                 "elapsed_seconds": round(elapsed, 2),
                 "steps_executed": len(results),
+                "claude_input_tokens": claude_input,
+                "claude_output_tokens": claude_output,
+                "claude_cached_input_tokens": claude_cached_input,
             },
         )
 

--- a/tests/test_cost_meter.py
+++ b/tests/test_cost_meter.py
@@ -36,6 +36,10 @@ def test_make_initial_costs_returns_zeros() -> None:
         "gpu_seconds": 0.0,
         "claude_extract": 0,
         "claude_grounding": 0,
+        # #514 token counters (Anthropic's per-call usage block)
+        "claude_input_tokens": 0,
+        "claude_output_tokens": 0,
+        "claude_cached_input_tokens": 0,
         "proxy_mb": 0.0,
     }
 
@@ -354,3 +358,124 @@ def test_totals_from_matches_totals_for_full_dict() -> None:
     assert out["claude"] == pytest.approx(claude)
     assert out["proxy"] == pytest.approx(proxy)
     assert out["total"] == pytest.approx(total)
+
+
+# ── #514 Claude token cost ──────────────────────────────────────────────
+
+
+def test_record_claude_tokens_accumulates() -> None:
+    """``record_claude_tokens`` adds to existing counters (per-call
+    increment, not set). Three calls of 10k input + 1k output should
+    leave 30k input + 3k output on the meter."""
+    meter = CostMeter()
+    for _ in range(3):
+        meter.record_claude_tokens(input_tokens=10_000, output_tokens=1_000)
+    assert meter.costs["claude_input_tokens"] == 30_000
+    assert meter.costs["claude_output_tokens"] == 3_000
+    assert meter.costs["claude_cached_input_tokens"] == 0
+
+
+def test_totals_prefers_token_billing_when_populated() -> None:
+    """When ``claude_input_tokens`` / ``output_tokens`` are set, the
+    Claude component is computed from per-token rates, NOT from the
+    legacy call counters. The default Sonnet 4 rates make a 30k/2k
+    call land at ~$0.12."""
+    meter = CostMeter()
+    # Also set the legacy call counter to a high value to prove tokens
+    # take precedence — without #514 this'd produce $0.003 × 5 = $0.015.
+    meter.costs["claude_extract"] = 5
+    meter.record_claude_tokens(input_tokens=30_000, output_tokens=2_000)
+    _, claude_cost, _, _ = meter.totals()
+    # 30k × $3/M + 2k × $15/M = $0.09 + $0.030 = $0.12
+    assert claude_cost == pytest.approx(0.12, abs=1e-6)
+
+
+def test_totals_falls_back_to_call_count_when_no_tokens() -> None:
+    """Legacy callers that don't go through the Anthropic-client
+    token-credit hook still get a Claude cost via the per-call counter.
+    This keeps the surface backwards compatible while #514 is rolling
+    out across all call sites."""
+    meter = CostMeter()
+    meter.costs["claude_extract"] = 4
+    meter.costs["claude_grounding"] = 2
+    _, claude_cost, _, _ = meter.totals()
+    # 6 calls × $0.003/call default
+    assert claude_cost == pytest.approx(0.018, abs=1e-6)
+
+
+def test_cached_input_tokens_billed_at_lower_rate() -> None:
+    """Anthropic's cached input is ~10% of the standard input rate
+    (Sonnet 4: $0.30/M vs $3/M). 10k input with 5k cached should bill
+    the cached portion at the discount rate."""
+    meter = CostMeter()
+    meter.record_claude_tokens(
+        input_tokens=10_000, output_tokens=0, cached_input_tokens=5_000,
+    )
+    _, claude_cost, _, _ = meter.totals()
+    # 5k plain × $3/M + 5k cached × $0.30/M = $0.015 + $0.0015 = $0.0165
+    assert claude_cost == pytest.approx(0.0165, abs=1e-6)
+
+
+def test_env_override_changes_per_token_rate(monkeypatch) -> None:
+    """Per-mtok rates honour env-var overrides so operators can pin
+    to whatever model their deployment actually targets."""
+    from mantis_agent.cost_config import CostConfig
+    monkeypatch.setenv("MANTIS_COST_CLAUDE_INPUT_PER_MTOK", "5.0")
+    monkeypatch.setenv("MANTIS_COST_CLAUDE_OUTPUT_PER_MTOK", "25.0")
+    cfg = CostConfig.from_env()
+    cost = cfg.claude_token_cost(input_tokens=1_000_000, output_tokens=100_000)
+    assert cost == pytest.approx(5.0 + 2.5, abs=1e-6)
+
+
+def test_publish_cost_meter_scoping() -> None:
+    """``publish_cost_meter`` makes the meter visible to
+    ``record_claude_tokens_to_current`` for the wrapped block, and
+    cleanly clears on exit."""
+    from mantis_agent.gym import cost_meter as cm
+    assert cm.current_cost_meter() is None
+    meter = cm.CostMeter()
+    with cm.publish_cost_meter(meter):
+        assert cm.current_cost_meter() is meter
+        cm.record_claude_tokens_to_current(input_tokens=2_000, output_tokens=500)
+    # Context popped — no leakage into the next scope.
+    assert cm.current_cost_meter() is None
+    assert meter.costs["claude_input_tokens"] == 2_000
+    assert meter.costs["claude_output_tokens"] == 500
+    # No published meter → silent no-op.
+    cm.record_claude_tokens_to_current(input_tokens=99_999, output_tokens=99_999)
+    assert meter.costs["claude_input_tokens"] == 2_000
+
+
+def test_credit_helper_parses_anthropic_response() -> None:
+    """``credit_claude_tokens_from_response`` reads the standard
+    Anthropic ``usage`` block (``input_tokens``, ``output_tokens``,
+    ``cache_read_input_tokens``) off a response dict and credits the
+    currently-published meter."""
+    from mantis_agent._anthropic.client import credit_claude_tokens_from_response
+    from mantis_agent.gym import cost_meter as cm
+    meter = cm.CostMeter()
+    response_json = {
+        "id": "msg_abc",
+        "model": "claude-sonnet-4-5",
+        "usage": {
+            "input_tokens": 25_000,
+            "output_tokens": 1_500,
+            "cache_read_input_tokens": 3_000,
+        },
+    }
+    with cm.publish_cost_meter(meter):
+        credit_claude_tokens_from_response(response_json)
+    assert meter.costs["claude_input_tokens"] == 25_000
+    assert meter.costs["claude_output_tokens"] == 1_500
+    assert meter.costs["claude_cached_input_tokens"] == 3_000
+
+
+def test_credit_helper_is_noop_without_published_meter() -> None:
+    """Tests + scripts that run the Anthropic client outside a runner
+    context shouldn't crash on missing meter — the helper silently
+    drops the credit."""
+    from mantis_agent._anthropic.client import credit_claude_tokens_from_response
+    # No meter published → no-op (no exception)
+    credit_claude_tokens_from_response({"usage": {"input_tokens": 100, "output_tokens": 50}})
+    credit_claude_tokens_from_response(None)
+    credit_claude_tokens_from_response({"no_usage_block": True})


### PR DESCRIPTION
## Summary

Closes #514.

Verifying #509 surfaced that Mantis under-counts Claude API cost by **~40x**. Before this PR, every API call was billed flat at \`MANTIS_COST_CLAUDE_CALL_USD=\$0.003\`, regardless of input/output token size. A real extract call sends ~30k input + ~2k output tokens at Sonnet 4 rates (\$3 / \$15 per M tokens) → actual spend \~\$0.12/call vs reported \$0.003.

This PR threads token usage from each Anthropic API response into the runner's cost meter via a contextvar-published current-meter hook (mirror of \`TimeMeter\`'s dispatch publish).

## 5-layer wedge

1. **\`cost_config.py\`** — three new env-overridable per-mtok rates (defaults: Sonnet 4 list prices). New \`claude_token_cost(input, output, cached_input)\` method; legacy \`claude_cost(num_calls)\` stays.
2. **\`gym/cost_meter.py\`** — three token counters; \`record_claude_tokens()\`; \`totals()\` + \`totals_from()\` prefer token billing when populated, fall back to call-count for legacy callers.
3. **Contextvar publisher** — \`_CURRENT_COST_METER\` + \`publish_cost_meter()\` + \`record_claude_tokens_to_current()\`. Same pattern as \`TimeMeter\`.
4. **\`_anthropic/client.py\`** — \`credit_claude_tokens_from_response()\` reads Anthropic's standard \`usage.{input_tokens, output_tokens, cache_read_input_tokens}\` block. Wired into the two shared \`call_with_tool_schema*\` helpers (ClaudeExtractor + ClaudeGrounding) + the two legacy \`requests.post\` paths in \`extractor.py\`.
5. **\`gym/run_executor.py\`** — \`execute()\` wraps the loop with \`publish_cost_meter(runner.cost_meter)\`; \`_emit_augur_aggregate_metrics\` surfaces token counts as session tags + on the \`cost_total_usd\` metric event detail.

## Spot-check vs the issue's acceptance criteria

Staff-crm-long run, ~9 Claude calls of ~30k input / ~2k output each:

- **Pre #514**: \`\$0.003 × 9 = \~\$0.03\` Claude (40x undercount)
- **Post #514**: \`(270k × \$3/M) + (18k × \$15/M) = \$0.81 + \$0.27 = \$1.08\` ✅
- Acceptance range from #514: **\$0.90 - \$1.50** — within target

## Test plan

- [x] 7 new cases in \`tests/test_cost_meter.py\` (token accumulate, token-billing preferred over call-count, cached-input math, env-override, contextvar scoping, response-parse helper, no-meter no-op)
- [x] All 209 cost / observability / runner / extractor tests pass
- [ ] Modal redeploy + staff-crm-long verify — confirm the Augur workspace's COST column reports in the \$0.90-\$1.50 range and the cost metric detail includes \`claude_input_tokens\` / \`claude_output_tokens\`

## Out of scope (separate issues when needed)

- 17 other \`requests.post\` call sites (brain_claude, plan_decomposer, objective, graph/*, recipes/marketplace_planner, gym/claude_director, intent_rewriter, verification/step_verifier, agentic_recovery). Mostly cold-path one-shots; the high-volume callers (extractor + grounding) already go through the shared client which IS covered here.
- \`cache_creation_input_tokens\` accounting (Anthropic charges higher-than-input for the cache-write byte; treated as standard input here for now).
- Modal GPU-type detection (separate concern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)