### PR TITLE
augur-sdk: bump pin to 0.1.4 + document the new diagnostic rule

### DIFF
--- a/deploy/modal/modal_cua_server.py
+++ b/deploy/modal/modal_cua_server.py
@@ -174,7 +174,7 @@ executor_image = (
         # 0.1.2+ fires an immediate session-opened heartbeat so the
         # workspace's connection badge updates the moment the SDK is
         # wired up, before the first step lands.
-        "augur-sdk>=0.1.3",
+        "augur-sdk>=0.1.4",
     )
     .add_local_python_source("mantis_agent")
     .add_local_dir(_PROMPTS_FILES_LOCAL, remote_path=_PROMPTS_FILES_REMOTE)
@@ -1224,7 +1224,7 @@ def _run_gemma4_cua_executor(
         "openai", "requests", "pillow", "mss",
         "fastapi>=0.100", "uvicorn>=0.20", "websocket-client",
         # #509: parity with run_holo3 — Gemma4 also runs the augur wedge.
-        "augur-sdk>=0.1.3",
+        "augur-sdk>=0.1.4",
     ).add_local_python_source("mantis_agent").add_local_dir(_PROMPTS_FILES_LOCAL, remote_path=_PROMPTS_FILES_REMOTE),
     volumes={"/data": vol},
     secrets=[modal.Secret.from_dotenv()],
@@ -1257,7 +1257,7 @@ claude_executor_image = (
         # #509: parity with run_holo3 / run_gemma4_cua — Claude executor
         # also runs the augur wedge so bundles + streaming work for the
         # Anthropic-API tier.
-        "augur-sdk>=0.1.3",
+        "augur-sdk>=0.1.4",
     )
     .add_local_python_source("mantis_agent")
     .add_local_dir(_PROMPTS_FILES_LOCAL, remote_path=_PROMPTS_FILES_REMOTE)
@@ -1388,7 +1388,7 @@ api_image = (
         # is lazy-imported but if augur_sdk is missing it falls back
         # silently — keeping the dep here makes the import succeed and
         # lets future API-side bundle reads work without a redeploy.
-        "augur-sdk>=0.1.3",
+        "augur-sdk>=0.1.4",
     )
     .add_local_python_source("mantis_agent")
     .add_local_dir(_PROMPTS_FILES_LOCAL, remote_path=_PROMPTS_FILES_REMOTE)
@@ -2123,7 +2123,7 @@ def api():
         # so augur-sdk has to be added here separately. Without this the
         # AugurAdapter init logs sdk_available=False and is a no-op even
         # though the package is in executor_image for the other tiers.
-        "augur-sdk>=0.1.3",
+        "augur-sdk>=0.1.4",
     ).add_local_python_source("mantis_agent").add_local_dir(_PROMPTS_FILES_LOCAL, remote_path=_PROMPTS_FILES_REMOTE),
     volumes={"/data": vol},
     secrets=[modal.Secret.from_dotenv()],

--- a/deploy/modal/modal_plan_runner.py
+++ b/deploy/modal/modal_plan_runner.py
@@ -115,7 +115,7 @@ runner_image = (
         # #509: per-run Augur DebugSession bundle + optional live streaming.
         # 0.1.2+ fires an immediate session-opened heartbeat for faster
         # workspace badge updates.
-        "augur-sdk>=0.1.3",
+        "augur-sdk>=0.1.4",
     )
     .add_local_python_source("mantis_agent")
     .add_local_dir(

--- a/docs/integrations/augur.md
+++ b/docs/integrations/augur.md
@@ -123,6 +123,21 @@ Mantis runner status maps onto `RunStatus`:
 | `MANTIS_VERSION` | Surfaced as `client.version` on the manifest — useful when bisecting which build produced a bundle. |
 | `MANTIS_GIT_SHA` | Surfaced as `client.git_sha` on the manifest. |
 
+## Failure-class hygiene diagnostic (augur-sdk 0.1.4+)
+
+0.1.4 added a server-side rule, **`cua.uncategorized_failure`**, that
+flags any step landing with `status: "failed"` but an empty or literal-
+`"unknown"` `failure_class`. The rule surfaces in the per-run
+**Diagnostics** panel with severity `low` and recommends tightening
+the producer's classifier.
+
+No code change on the Mantis side — purely a server-side surface that
+audits the bundles we already ship. Practical impact: a few Mantis
+recovery paths emit `failure_class="unknown"` (most visibly on
+halted click steps); after the 0.1.4 bump those will start showing
+up as `low`-severity diagnostics. Addressing them is hygiene work
+for a follow-up, not a regression in the wedge.
+
 ## Log streaming (augur-sdk 0.1.3+)
 
 `AugurAdapter.append_log(text, *, step_index=None, name="run")` is a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ metrics = [
 # augur_sdk lazily and no-ops when the package isn't installed, so
 # this extra is purely opt-in — no base-install footprint change.
 observability = [
-    "augur-sdk>=0.1.3",
+    "augur-sdk>=0.1.4",
 ]
 # Self-host the FastAPI server that fronts /predict and /v1/chat/completions.
 # Used by the Baseten / EKS / GKE deployments.

--- a/uv.lock
+++ b/uv.lock
@@ -228,16 +228,16 @@ wheels = [
 
 [[package]]
 name = "augur-sdk"
-version = "0.1.3"
+version = "0.1.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonschema" },
     { name = "referencing" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5f/cb/9edb1f2c3c253a03bc8ad5aee5c2f2f620bb16b199d29e1547438800acf4/augur_sdk-0.1.3.tar.gz", hash = "sha256:b2abdb69a99a4511ec08d8a75dc5fadb39224930202f0417953c6a74cc3dd3cf", size = 46578, upload-time = "2026-05-20T05:08:40.012Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/00/162dd7201ad692ac1c801184c3ab6bfd203989fc585e69fd15035853d1b2/augur_sdk-0.1.4.tar.gz", hash = "sha256:fbf04d1ff95e6e14f1e33cad11cada08414ac9f819fd703a0b08eaeee95fe211", size = 47675, upload-time = "2026-05-20T05:24:56.854Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4f/30/d977c4edb9cd55bffa9a5aafc2033baa523be0f3975fa35c4e572748b0c4/augur_sdk-0.1.3-py3-none-any.whl", hash = "sha256:19d9cc2d4913471515c0861fe15900fb3fecbe6dc3012e013e5bf4b67916f2a4", size = 51563, upload-time = "2026-05-20T05:08:38.311Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/e2/89ef53017c8949971c3913004fab1f554e1c14b48706517558c715eacd64/augur_sdk-0.1.4-py3-none-any.whl", hash = "sha256:98f6e3f8ca3983dee683be59337f302b1d060d907b6e57825fec42789a4ab761", size = 51935, upload-time = "2026-05-20T05:24:54.946Z" },
 ]
 
 [[package]]
@@ -1537,7 +1537,7 @@ viewer = [
 [package.metadata]
 requires-dist = [
     { name = "accelerate", marker = "extra == 'gpu'", specifier = ">=0.30" },
-    { name = "augur-sdk", marker = "extra == 'observability'", specifier = ">=0.1.3" },
+    { name = "augur-sdk", marker = "extra == 'observability'", specifier = ">=0.1.4" },
     { name = "bitsandbytes", marker = "extra == 'gpu'", specifier = ">=0.43" },
     { name = "fastapi", marker = "extra == 'server'", specifier = ">=0.100" },
     { name = "fastapi", marker = "extra == 'viewer'", specifier = ">=0.100" },


### PR DESCRIPTION
## Summary

Follow-up to #516 (which merged at 0.1.3 ~an hour before 0.1.4 was published).

augur-sdk 0.1.4 ships a single change, purely additive:

> **Added** — new \`cua.uncategorized_failure\` diagnostic rule (severity \`low\`). Fires when a step has \`status: "failed"\` but \`failure_class\` is empty or the literal \`"unknown"\`. Surfaces in the workspace Diagnostics panel as hygiene feedback to adapter authors.

It's a **server-side** rule applied to bundles we already ship. No client API change → no adapter code change. Just the pin bump + one doc paragraph explaining what the rule does and what to expect.

## Mantis-side impact

Several Mantis recovery paths emit \`failure_class="unknown"\` (every halted click step in the #509 verification screenshots). After this bump those will surface as \`low\`-severity diagnostics in the workspace Diagnostics panel. Tightening Mantis's failure-class taxonomy is hygiene work for a follow-up issue — not a wedge regression.

## Files

- \`pyproject.toml\` — bump the \`observability\` extra pin
- Six Modal image \`pip_install\` lists in \`modal_cua_server.py\` + \`modal_plan_runner.py\`
- \`uv.lock\` — refreshed against 0.1.4
- \`docs/integrations/augur.md\` — new section explaining the diagnostic, placed before the existing \`Log streaming\` section that #516 added

## Test plan

- [x] 22/22 in \`tests/test_observability_augur.py\` pass against augur-sdk 0.1.4 with no adapter changes
- [ ] Optional: Modal redeploy verifies image pip_install picks up 0.1.4 (typically rebuilds in ~3s when no layer changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)