### PR TITLE
augur: structured set_costs + set_step_costs (closes #521 #522)

### DIFF
--- a/deploy/modal/modal_cua_server.py
+++ b/deploy/modal/modal_cua_server.py
@@ -174,7 +174,7 @@ executor_image = (
         # 0.1.2+ fires an immediate session-opened heartbeat so the
         # workspace's connection badge updates the moment the SDK is
         # wired up, before the first step lands.
-        "augur-sdk>=0.1.7",
+        "augur-sdk>=0.1.8",
     )
     .add_local_python_source("mantis_agent")
     .add_local_dir(_PROMPTS_FILES_LOCAL, remote_path=_PROMPTS_FILES_REMOTE)
@@ -1224,7 +1224,7 @@ def _run_gemma4_cua_executor(
         "openai", "requests", "pillow", "mss",
         "fastapi>=0.100", "uvicorn>=0.20", "websocket-client",
         # #509: parity with run_holo3 — Gemma4 also runs the augur wedge.
-        "augur-sdk>=0.1.7",
+        "augur-sdk>=0.1.8",
     ).add_local_python_source("mantis_agent").add_local_dir(_PROMPTS_FILES_LOCAL, remote_path=_PROMPTS_FILES_REMOTE),
     volumes={"/data": vol},
     secrets=[modal.Secret.from_dotenv()],
@@ -1257,7 +1257,7 @@ claude_executor_image = (
         # #509: parity with run_holo3 / run_gemma4_cua — Claude executor
         # also runs the augur wedge so bundles + streaming work for the
         # Anthropic-API tier.
-        "augur-sdk>=0.1.7",
+        "augur-sdk>=0.1.8",
     )
     .add_local_python_source("mantis_agent")
     .add_local_dir(_PROMPTS_FILES_LOCAL, remote_path=_PROMPTS_FILES_REMOTE)
@@ -1388,7 +1388,7 @@ api_image = (
         # is lazy-imported but if augur_sdk is missing it falls back
         # silently — keeping the dep here makes the import succeed and
         # lets future API-side bundle reads work without a redeploy.
-        "augur-sdk>=0.1.7",
+        "augur-sdk>=0.1.8",
     )
     .add_local_python_source("mantis_agent")
     .add_local_dir(_PROMPTS_FILES_LOCAL, remote_path=_PROMPTS_FILES_REMOTE)
@@ -2123,7 +2123,7 @@ def api():
         # so augur-sdk has to be added here separately. Without this the
         # AugurAdapter init logs sdk_available=False and is a no-op even
         # though the package is in executor_image for the other tiers.
-        "augur-sdk>=0.1.7",
+        "augur-sdk>=0.1.8",
     ).add_local_python_source("mantis_agent").add_local_dir(_PROMPTS_FILES_LOCAL, remote_path=_PROMPTS_FILES_REMOTE),
     volumes={"/data": vol},
     secrets=[modal.Secret.from_dotenv()],

--- a/deploy/modal/modal_plan_runner.py
+++ b/deploy/modal/modal_plan_runner.py
@@ -115,7 +115,7 @@ runner_image = (
         # #509: per-run Augur DebugSession bundle + optional live streaming.
         # 0.1.2+ fires an immediate session-opened heartbeat for faster
         # workspace badge updates.
-        "augur-sdk>=0.1.7",
+        "augur-sdk>=0.1.8",
     )
     .add_local_python_source("mantis_agent")
     .add_local_dir(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ metrics = [
 # augur_sdk lazily and no-ops when the package isn't installed, so
 # this extra is purely opt-in — no base-install footprint change.
 observability = [
-    "augur-sdk>=0.1.7",
+    "augur-sdk>=0.1.8",
 ]
 # Self-host the FastAPI server that fronts /predict and /v1/chat/completions.
 # Used by the Baseten / EKS / GKE deployments.

--- a/src/mantis_agent/gym/run_executor.py
+++ b/src/mantis_agent/gym/run_executor.py
@@ -1634,25 +1634,24 @@ class RunExecutor:
             elapsed = float(meter.elapsed_seconds() or 0.0)
         except Exception:  # noqa: BLE001
             pass
-        # Tags are what the Run identity panel + run-list COST column
-        # read. Keep them as plain strings (the SDK serializes them
-        # verbatim) — Augur parses ``cost_usd`` as the canonical total.
-        augur.add_tag("cost_usd", f"{total:.4f}")
-        augur.add_tag("cost_gpu_usd", f"{gpu:.4f}")
-        augur.add_tag("cost_claude_usd", f"{claude:.4f}")
-        augur.add_tag("cost_proxy_usd", f"{proxy:.4f}")
-        augur.add_tag("elapsed_seconds", f"{elapsed:.2f}")
-        # #514: also surface token counts on the metric event so the
-        # Augur workspace's query layer can compute per-token spend or
-        # spot model regressions without re-deriving the rate.
+        # #521: structured ``session.costs`` is the canonical surface
+        # as of augur-sdk 0.1.8. The workspace's Runs-list COST column
+        # now reads from here, not from tags — one source of truth.
         claude_input = int(meter.costs.get("claude_input_tokens", 0) or 0)
         claude_output = int(meter.costs.get("claude_output_tokens", 0) or 0)
         claude_cached_input = int(meter.costs.get("claude_cached_input_tokens", 0) or 0)
-        if claude_input or claude_output:
-            augur.add_tag("claude_input_tokens", str(claude_input))
-            augur.add_tag("claude_output_tokens", str(claude_output))
-            if claude_cached_input:
-                augur.add_tag("claude_cached_input_tokens", str(claude_cached_input))
+        augur.set_costs(
+            total_usd=round(total, 4),
+            model_usd=round(claude, 4),
+            gpu_usd=round(gpu, 4),
+            proxy_usd=round(proxy, 4),
+            tokens_in=claude_input or None,
+            tokens_out=claude_output or None,
+            cache_hit_tokens=claude_cached_input or None,
+        )
+        # elapsed_seconds has no slot on the costs record, so it stays
+        # a tag — same parser the workspace already uses for duration.
+        augur.add_tag("elapsed_seconds", f"{elapsed:.2f}")
         # The metric event is the structured/query-able surface — keeps
         # the same data shape as other Augur ``kind="metric"`` events.
         augur.record_cost_metric(

--- a/src/mantis_agent/observability/augur.py
+++ b/src/mantis_agent/observability/augur.py
@@ -467,6 +467,89 @@ class AugurAdapter:
             else:
                 logger.debug("AugurAdapter.add_tag(%s) failed: %s", key, exc)
 
+    def set_costs(
+        self,
+        *,
+        total_usd: float | None = None,
+        model_usd: float | None = None,
+        gpu_usd: float | None = None,
+        proxy_usd: float | None = None,
+        tokens_in: int | None = None,
+        tokens_out: int | None = None,
+        cache_hit_tokens: int | None = None,
+    ) -> None:
+        """Stamp the structured ``session.costs`` rollup (#521, SDK 0.1.8).
+
+        Replaces the prior ``add_tag('cost_usd', ...)`` chain — Augur's
+        Runs list now reads from ``session.costs`` directly, avoiding
+        two-source-of-truth drift between tags and the canonical
+        cost record.
+        """
+        if not self.active or not hasattr(self._session, "set_costs"):
+            return
+        try:
+            self._session.set_costs(
+                total_usd=total_usd,
+                model_usd=model_usd,
+                gpu_usd=gpu_usd,
+                proxy_usd=proxy_usd,
+                tokens_in=tokens_in,
+                tokens_out=tokens_out,
+                cache_hit_tokens=cache_hit_tokens,
+            )
+        except Exception as exc:  # noqa: BLE001 — telemetry never breaks runs
+            if is_verbose():
+                logger.warning("AugurAdapter.set_costs failed: %r", exc)
+            else:
+                logger.debug("AugurAdapter.set_costs failed: %s", exc)
+
+    def set_step_costs(
+        self,
+        step_index: int,
+        *,
+        total_usd: float | None = None,
+        model_usd: float | None = None,
+        tokens_in: int | None = None,
+        tokens_out: int | None = None,
+        cache_hit_tokens: int | None = None,
+    ) -> None:
+        """Patch a recorded step's ``costs`` block (#522, SDK 0.1.8).
+
+        Callers pass Mantis's 0-based ``StepResult.step_index``; we
+        bump to Augur's 1-based convention at the boundary (same
+        convention as :meth:`record_step` / :meth:`attach_observation`
+        / :meth:`record_cost_metric`).
+
+        The in-trace ``trace['costs']`` path (set during
+        ``_build_step_trace`` when cost_meter snapshots are available)
+        is the preferred surface; this helper is the after-the-fact
+        patch for callers that don't know costs at record_step time.
+        """
+        if not self.active or not hasattr(self._session, "set_step_costs"):
+            return
+        try:
+            self._session.set_step_costs(
+                int(step_index) + 1,
+                total_usd=total_usd,
+                model_usd=model_usd,
+                tokens_in=tokens_in,
+                tokens_out=tokens_out,
+                cache_hit_tokens=cache_hit_tokens,
+            )
+        except Exception as exc:  # noqa: BLE001
+            if is_verbose():
+                logger.warning(
+                    "AugurAdapter.set_step_costs(step=%s) failed: %r",
+                    step_index,
+                    exc,
+                )
+            else:
+                logger.debug(
+                    "AugurAdapter.set_step_costs(step=%s) failed: %s",
+                    step_index,
+                    exc,
+                )
+
     def append_log(
         self,
         text: str,

--- a/tests/test_observability_augur_518.py
+++ b/tests/test_observability_augur_518.py
@@ -310,3 +310,148 @@ def test_grounding_call_sites_pass_cache_tools():
         f"Each call_with_tool_schema in form_targeting/claude.py must "
         f"pass cache_tools=True ({opens} calls, {cache_tokens} cache flags)"
     )
+
+
+# ── #521 + #522: structured cost surfaces (augur-sdk 0.1.8) ─────────────
+
+
+def _record_step_minimal(adapter: AugurAdapter, step_index: int = 0) -> None:
+    """Test helper — drives ``record_step`` with just enough fields so the
+    SDK accepts it. Tests below use this to give ``set_step_costs`` a
+    target to patch."""
+    sr = _FakeStepResult(step_index=step_index)
+    sr.success = True
+    sr.failure_class = ""
+    sr.data = ""
+    sr.page_title = ""
+    adapter.record_step(
+        step_result=sr,
+        started_at="2026-05-20T10:00:00Z",
+        ended_at="2026-05-20T10:00:01Z",
+    )
+
+
+def test_set_costs_lands_on_manifest_and_trace(monkeypatch, tmp_path: Path):
+    """#521: ``set_costs`` writes the structured cost rollup to
+    ``manifest.json.costs`` and mirrors it on ``trace.json.session.costs``
+    — the canonical surface for Augur's Runs-list COST column as of
+    SDK 0.1.8."""
+    import json
+    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
+    a = AugurAdapter(
+        run_id="set_costs_v1", tenant_id="t", session_name="s", out_dir=tmp_path,
+    )
+    a.set_costs(
+        total_usd=0.92, model_usd=0.74, gpu_usd=0.15, proxy_usd=0.03,
+        tokens_in=42_000, tokens_out=3_500, cache_hit_tokens=8_000,
+    )
+    a.close(status="completed")
+    manifest = json.loads((tmp_path / "manifest.json").read_text())
+    assert manifest["costs"]["total_usd"] == 0.92
+    assert manifest["costs"]["model_usd"] == 0.74
+    assert manifest["costs"]["gpu_usd"] == 0.15
+    assert manifest["costs"]["proxy_usd"] == 0.03
+    assert manifest["costs"]["tokens_in"] == 42_000
+    assert manifest["costs"]["tokens_out"] == 3_500
+    assert manifest["costs"]["cache_hit_tokens"] == 8_000
+    trace = json.loads((tmp_path / "trace.json").read_text())
+    assert trace["session"]["costs"] == manifest["costs"]
+
+
+def test_set_step_costs_patches_recorded_step_with_index_bump(
+    monkeypatch, tmp_path: Path,
+):
+    """#522: ``set_step_costs`` patches an existing recorded step's
+    ``costs`` block. Confirms the adapter bumps Mantis's 0-based step
+    index to Augur's 1-based convention at the boundary — passing
+    ``step_index=0`` must patch ``steps/0001.json``, not 0000."""
+    import json
+    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
+    a = AugurAdapter(
+        run_id="step_costs_v1", tenant_id="t", session_name="s", out_dir=tmp_path,
+    )
+    _record_step_minimal(a, step_index=0)
+    a.set_step_costs(
+        0,  # Mantis 0-based — adapter bumps to Augur 1
+        total_usd=0.12, model_usd=0.10, tokens_in=2_400, tokens_out=180,
+        cache_hit_tokens=600,
+    )
+    a.close(status="completed")
+    step = json.loads((tmp_path / "steps" / "0001.json").read_text())
+    assert step["costs"]["total_usd"] == 0.12
+    assert step["costs"]["model_usd"] == 0.10
+    assert step["costs"]["tokens_in"] == 2_400
+    assert step["costs"]["cache_hit_tokens"] == 600
+
+
+def test_set_costs_and_set_step_costs_noop_when_disabled(
+    monkeypatch, tmp_path: Path,
+):
+    """Both wrappers must be no-ops when the adapter is disabled —
+    telemetry never breaks a run. Idempotent across repeat calls."""
+    monkeypatch.setenv("MANTIS_AUGUR_DISABLED", "1")
+    a = AugurAdapter(
+        run_id="noop_v1", tenant_id="t", session_name="s", out_dir=tmp_path,
+    )
+    assert not a.active
+    # Neither call should raise even with adapter disabled.
+    a.set_costs(total_usd=0.5, model_usd=0.4)
+    a.set_step_costs(0, total_usd=0.1, model_usd=0.08)
+    a.set_costs()  # all-None permitted
+    # No bundle written.
+    assert not (tmp_path / "manifest.json").exists()
+
+
+def test_run_executor_emits_set_costs_with_token_counts(
+    monkeypatch, tmp_path: Path,
+):
+    """End-to-end-ish: the executor's ``_emit_augur_aggregate_metrics``
+    should call ``set_costs`` (not the legacy tag block) with the
+    cost-meter snapshot's token counts. Catches regressions where the
+    tag-write returns by accident."""
+    from unittest.mock import MagicMock
+
+    from mantis_agent.gym.run_executor import RunExecutor
+
+    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
+    augur = AugurAdapter(
+        run_id="exec_set_costs", tenant_id="t", session_name="s", out_dir=tmp_path,
+    )
+    augur_spy = MagicMock(wraps=augur)
+    runner = MagicMock()
+    runner._augur = augur_spy
+    meter = MagicMock()
+    meter.totals.return_value = (0.05, 0.40, 0.02, 0.47)
+    meter.elapsed_seconds.return_value = 42.5
+    meter.costs = {
+        "claude_input_tokens": 12_000,
+        "claude_output_tokens": 900,
+        "claude_cached_input_tokens": 3_400,
+    }
+    runner.cost_meter = meter
+    executor = RunExecutor.__new__(RunExecutor)
+    executor.parent = runner
+    executor._emit_augur_aggregate_metrics([])  # results unused for totals
+    # Asserts: set_costs was called with the snapshot, NOT the old tag block.
+    augur_spy.set_costs.assert_called_once()
+    kwargs = augur_spy.set_costs.call_args.kwargs
+    assert kwargs["total_usd"] == 0.47
+    assert kwargs["model_usd"] == 0.40
+    assert kwargs["gpu_usd"] == 0.05
+    assert kwargs["proxy_usd"] == 0.02
+    assert kwargs["tokens_in"] == 12_000
+    assert kwargs["tokens_out"] == 900
+    assert kwargs["cache_hit_tokens"] == 3_400
+    # No legacy cost_* tags fired — pre-#521 code wrote cost_usd /
+    # cost_gpu_usd / cost_claude_usd / cost_proxy_usd / claude_*_tokens.
+    tag_keys = {c.args[0] for c in augur_spy.add_tag.call_args_list if c.args}
+    legacy_keys = {
+        "cost_usd", "cost_gpu_usd", "cost_claude_usd", "cost_proxy_usd",
+        "claude_input_tokens", "claude_output_tokens",
+        "claude_cached_input_tokens",
+    }
+    assert tag_keys.isdisjoint(legacy_keys), (
+        f"Legacy cost-tag emission re-introduced: {tag_keys & legacy_keys}"
+    )
+    # elapsed_seconds is still a tag (no schema slot for wallclock).
+    assert "elapsed_seconds" in tag_keys


### PR DESCRIPTION
## Summary
- Bumps augur-sdk pin to **0.1.8** in pyproject + 6 Modal images
- Adds `AugurAdapter.set_costs(...)` / `AugurAdapter.set_step_costs(...)` wrappers (hasattr-guarded for older SDK installs)
- Replaces the 5+3 `add_tag("cost_*", ...)` block in `_emit_augur_aggregate_metrics` with a single `augur.set_costs(...)` call — the workspace's Runs-list COST column now reads from the structured `session.costs` record, not from tags
- Bumps Mantis 0-based step_index → Augur 1-based on `set_step_costs` boundary (matches `record_step` / `attach_observation` convention)

Closes #521
Closes #522

## Why this shape
- **#521**: per the SDK 0.1.8 changelog, `set_costs` is now the canonical surface; tags are demoted to legacy parsers. Single source of truth.
- **#522**: per-step costs already land via `trace['costs']` (atomically with `record_step`) — that path is preferred. `set_step_costs` is provided as the after-the-fact patch for callers that don't know costs at record_step time. Both paths exercised in tests.
- `elapsed_seconds` stays a tag — no schema slot for run wallclock.

## Test plan
- [x] `pytest tests/test_observability_augur_518.py tests/test_observability_augur.py tests/test_cost_meter.py` — 73 pass (15 in 518 file, +4 new cases here)
- [x] `ruff check src/mantis_agent tests/test_observability_augur_518.py` — clean
- [ ] Modal redeploy + lu.ma plan rerun — verify `session.costs` populated on workspace + COST column reads the new field

## New tests
- `test_set_costs_lands_on_manifest_and_trace` — manifest.json.costs + trace.session.costs both stamped
- `test_set_step_costs_patches_recorded_step_with_index_bump` — 0→1 bump verified via steps/0001.json (not 0000)
- `test_set_costs_and_set_step_costs_noop_when_disabled` — telemetry never breaks runs
- `test_run_executor_emits_set_costs_with_token_counts` — confirms `_emit_augur_aggregate_metrics` calls `set_costs`, no legacy `cost_*` tag emissions

🤖 Generated with [Claude Code](https://claude.com/claude-code)