### PR TITLE
augur: modelio capture plumbing — wrapper + contextvar (#523 PR B-1)

### DIFF
--- a/src/mantis_agent/_anthropic/client.py
+++ b/src/mantis_agent/_anthropic/client.py
@@ -230,6 +230,38 @@ def credit_claude_tokens_from_response(response: Any) -> None:
         logger.debug("anthropic cost_meter token credit failed: %s", exc)
 
 
+def _record_modelio_if_active(
+    request_payload: dict[str, Any],
+    response_json: dict[str, Any],
+    duration_ms: int,
+) -> None:
+    """Forward to the modelio capture layer when a context is active.
+
+    Local import to avoid pulling the observability module into every
+    LLM call when no caller has published a layer context (which is the
+    case at module load until PR B-2..B-5 wire individual call sites).
+    """
+    try:
+        from ..observability.modelio import (
+            current_modelio_context,
+            record_anthropic_modelio,
+        )
+    except Exception:  # noqa: BLE001 — import-time issues never block calls
+        return
+    ctx = current_modelio_context()
+    if ctx is None:
+        return
+    try:
+        record_anthropic_modelio(
+            request_payload=request_payload,
+            response_json=response_json,
+            duration_ms=duration_ms,
+            ctx=ctx,
+        )
+    except Exception as exc:  # noqa: BLE001 — Augur spec §4.3
+        logger.debug("modelio capture failed: %s", exc)
+
+
 class AnthropicToolUseClient:
     """Anthropic ``/v1/messages`` client tuned for schema-validated tool_use.
 
@@ -427,6 +459,12 @@ class AnthropicToolUseClient:
                 return None
             payload_json = resp.json()
             credit_claude_tokens_from_response(payload_json)
+            # #523 — capture the modelio record when an upstream caller
+            # has published a layer context (planner / grounding /
+            # verifier / step_recovery / judge). No-op otherwise.
+            _record_modelio_if_active(
+                payload, payload_json, int((time.monotonic() - t0) * 1000),
+            )
             for block in payload_json.get("content", []):
                 if block.get("type") == "tool_use" and block.get("name") == tool_name:
                     tool_input = block.get("input")
@@ -509,6 +547,9 @@ class AnthropicToolUseClient:
                 return None
             payload_json = resp.json()
             credit_claude_tokens_from_response(payload_json)
+            _record_modelio_if_active(
+                payload, payload_json, int((time.monotonic() - t0) * 1000),
+            )
             for block in payload_json.get("content", []):
                 if block.get("type") == "tool_use" and block.get("name") == tool_name:
                     tool_input = block.get("input")

--- a/src/mantis_agent/observability/augur.py
+++ b/src/mantis_agent/observability/augur.py
@@ -550,6 +550,49 @@ class AugurAdapter:
                     exc,
                 )
 
+    def record_modelio(
+        self,
+        record: dict[str, Any],
+        *,
+        step_index: int | None = None,
+        layer: str | None = None,
+        validate: bool = True,
+    ) -> str | None:
+        """Stage one modelio record (#523, SDK 0.1.6+).
+
+        The record must satisfy ``modelio.schema.json``. Use
+        :func:`mantis_agent.observability.modelio.record_anthropic_modelio`
+        rather than building the dict by hand — it handles the
+        Anthropic→OpenAI usage field-name mapping the schema requires.
+
+        Callers pass Mantis's 0-based ``StepResult.step_index``; we
+        bump to 1-based at the boundary (same convention as
+        :meth:`record_step` / :meth:`attach_observation`). Returns the
+        bundle-relative path the SDK assigned, or None on any failure
+        (telemetry never breaks runs).
+        """
+        if not self.active or not hasattr(self._session, "record_modelio"):
+            return None
+        try:
+            return self._session.record_modelio(
+                record,
+                step_index=(int(step_index) + 1) if step_index is not None else None,
+                layer=layer,
+                validate=validate,
+            )
+        except Exception as exc:  # noqa: BLE001
+            if is_verbose():
+                logger.warning(
+                    "AugurAdapter.record_modelio(layer=%s, step=%s) failed: %r",
+                    layer, step_index, exc,
+                )
+            else:
+                logger.debug(
+                    "AugurAdapter.record_modelio(layer=%s, step=%s) failed: %s",
+                    layer, step_index, exc,
+                )
+            return None
+
     def append_log(
         self,
         text: str,

--- a/src/mantis_agent/observability/modelio.py
+++ b/src/mantis_agent/observability/modelio.py
@@ -1,0 +1,246 @@
+"""Per-LLM-call modelio capture wiring (#523, augur-sdk 0.1.6+).
+
+This module provides the plumbing that lets the shared
+``AnthropicToolUseClient`` emit one canonical training-data record
+(``modelio/<step:04d>-<layer>-<seq>.json``) per Anthropic Messages
+call without each call site needing to assemble the record itself.
+
+Two-piece design:
+
+1. A contextvar pair (:func:`publish_modelio_context` /
+   :func:`current_modelio_context`) so callers higher up the stack
+   declare the *layer* the next LLM call belongs to (planner,
+   grounding, verifier, step_recovery, judge). The client reads the
+   contextvar at request time. No layer published → capture is a no-op.
+
+2. :func:`record_anthropic_modelio`, the mapper that converts the
+   Anthropic request payload + raw response JSON to the schema-pinned
+   modelio shape and forwards to :meth:`AugurAdapter.record_modelio`.
+
+**Vendor field-name divergence (memorize this):**
+
+The canonical ``modelio.schema.json`` ``response.usage`` block uses
+**OpenAI** field names — ``prompt_tokens`` / ``completion_tokens``
+— with ``additionalProperties: false``. Anthropic responses ship
+``input_tokens`` / ``output_tokens`` plus
+``cache_creation_input_tokens`` / ``cache_read_input_tokens``. The
+mapper translates at the boundary; downstream SFT/DPO tooling reads
+the OpenAI shape uniformly.
+
+PR B-1 lands this module + the client-side capture hook. No call
+sites publish a context yet — those follow in PR B-2..B-5 (one per
+layer) so blast radius stays narrow.
+"""
+
+from __future__ import annotations
+
+import contextvars
+import logging
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Iterator
+
+logger = logging.getLogger(__name__)
+
+
+_ALLOWED_LAYERS: frozenset[str] = frozenset({
+    "planner", "grounding", "model", "verifier", "step_recovery", "judge",
+})
+
+
+@dataclass(frozen=True)
+class ModelIOContext:
+    """The triple a caller pushes onto the contextvar before invoking
+    the LLM client. ``augur`` is the open adapter; ``layer`` picks the
+    modelio.schema.json layer enum; ``step_index`` is the 0-based
+    Mantis step index (the adapter bumps to 1-based on the way into
+    the SDK)."""
+
+    augur: Any  # AugurAdapter, but typed Any to avoid circular import.
+    layer: str
+    step_index: int | None = None
+
+
+_current: contextvars.ContextVar[ModelIOContext | None] = contextvars.ContextVar(
+    "mantis_current_modelio_context",
+    default=None,
+)
+
+
+def current_modelio_context() -> ModelIOContext | None:
+    """Return the active context if any call up the stack published one."""
+    return _current.get()
+
+
+@contextmanager
+def publish_modelio_context(
+    augur: Any,
+    layer: str,
+    step_index: int | None = None,
+) -> Iterator[None]:
+    """Declare that any LLM call made inside the ``with`` block should
+    be captured as ``layer`` (with optional ``step_index``).
+
+    Validates layer up-front so a typo at a call site surfaces during
+    development rather than silently dropping captures. Falls back to
+    a debug log + no-op when ``augur`` is None or inactive — telemetry
+    never breaks the run.
+    """
+    if layer not in _ALLOWED_LAYERS:
+        logger.warning(
+            "publish_modelio_context: unknown layer %r (allowed=%s); skipping",
+            layer, sorted(_ALLOWED_LAYERS),
+        )
+        yield
+        return
+    if augur is None or not getattr(augur, "active", False):
+        yield
+        return
+    token = _current.set(ModelIOContext(augur=augur, layer=layer, step_index=step_index))
+    try:
+        yield
+    finally:
+        _current.reset(token)
+
+
+def _utc_now_iso() -> str:
+    """ISO-8601 UTC timestamp matching ``modelio.schema.json``'s
+    ``ts`` field (``date-time`` format)."""
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def _map_anthropic_usage(usage: dict[str, Any] | None) -> dict[str, int]:
+    """Anthropic ``response.usage`` → OpenAI-shape ``usage`` block.
+
+    Anthropic ships ``input_tokens`` / ``output_tokens`` plus optional
+    ``cache_creation_input_tokens`` / ``cache_read_input_tokens``;
+    modelio.schema.json's ``usage`` slot requires ``prompt_tokens`` /
+    ``completion_tokens`` with ``cache_hit_tokens`` /
+    ``cache_creation_tokens`` for the cache fields.
+    ``additionalProperties: false`` — so we MUST drop anything else
+    (Anthropic occasionally adds new usage keys; we ignore unknown).
+    """
+    if not isinstance(usage, dict):
+        return {}
+    out: dict[str, int] = {}
+    if (v := usage.get("input_tokens")) is not None:
+        out["prompt_tokens"] = int(v)
+    if (v := usage.get("output_tokens")) is not None:
+        out["completion_tokens"] = int(v)
+    if (v := usage.get("cache_read_input_tokens")) is not None:
+        out["cache_hit_tokens"] = int(v)
+    if (v := usage.get("cache_creation_input_tokens")) is not None:
+        out["cache_creation_tokens"] = int(v)
+    return out
+
+
+def _extract_response_text_and_tools(
+    payload_json: dict[str, Any],
+) -> tuple[str | None, list[dict[str, Any]]]:
+    """Pull a flattened ``text`` + ``tool_calls`` view off an Anthropic
+    response. modelio.schema.json's ``response`` slot accepts both —
+    text is a single concatenated string (null when only tool blocks),
+    tool_calls is the verbatim ``tool_use`` block list (provider-shaped,
+    additionalProperties: true)."""
+    text_parts: list[str] = []
+    tool_calls: list[dict[str, Any]] = []
+    for block in payload_json.get("content", []) or []:
+        btype = block.get("type")
+        if btype == "text":
+            t = block.get("text")
+            if isinstance(t, str) and t:
+                text_parts.append(t)
+        elif btype == "tool_use":
+            tool_calls.append(block)
+    text = "\n".join(text_parts) if text_parts else None
+    return text, tool_calls
+
+
+def record_anthropic_modelio(
+    *,
+    request_payload: dict[str, Any],
+    response_json: dict[str, Any],
+    duration_ms: int,
+    ctx: ModelIOContext | None = None,
+) -> None:
+    """Build a modelio record from an Anthropic Messages call and stage
+    it via :meth:`AugurAdapter.record_modelio`. No-op when no context
+    has been published or the adapter is inactive.
+
+    Failures are swallowed (per Augur spec §4.3 — telemetry never
+    breaks the run). Validation failures are demoted to WARN so a
+    schema-side surprise surfaces in deploy verification but doesn't
+    interrupt the user's run.
+    """
+    ctx = ctx if ctx is not None else current_modelio_context()
+    if ctx is None or ctx.augur is None or not getattr(ctx.augur, "active", False):
+        return
+
+    text, tool_calls = _extract_response_text_and_tools(response_json)
+    usage = _map_anthropic_usage(response_json.get("usage"))
+
+    request_block: dict[str, Any] = {
+        "model": str(request_payload.get("model", "")),
+    }
+    # The schema allows messages / tools / params; keep the ones we
+    # actually sent so SFT pipelines see the exact prompt shape.
+    if "messages" in request_payload:
+        request_block["messages"] = request_payload["messages"]
+    if "tools" in request_payload:
+        request_block["tools"] = request_payload["tools"]
+    if "system" in request_payload:
+        request_block["system"] = request_payload["system"]
+    # Sampling / generation params (provider-shaped). Whitelist the
+    # ones we set to avoid leaking the entire payload twice.
+    params = {
+        k: v for k, v in request_payload.items()
+        if k in {"max_tokens", "temperature", "top_p", "top_k", "stop_sequences", "tool_choice"}
+    }
+    if params:
+        request_block["params"] = params
+
+    response_block: dict[str, Any] = {}
+    if text is not None:
+        response_block["text"] = text
+    if tool_calls:
+        response_block["tool_calls"] = tool_calls
+    stop_reason = response_json.get("stop_reason")
+    if isinstance(stop_reason, str) and stop_reason:
+        response_block["stop_reason"] = stop_reason
+    if usage:
+        response_block["usage"] = usage
+
+    record: dict[str, Any] = {
+        "schema_version": "0.1",
+        "layer": ctx.layer,
+        "ts": _utc_now_iso(),
+        "request": request_block,
+        "response": response_block,
+    }
+    if ctx.step_index is not None:
+        # modelio.schema.json's step_index is 0-based (minimum: 0) —
+        # the file-path bump to 1-based is the SDK's concern.
+        record["step_index"] = int(ctx.step_index)
+    if duration_ms > 0:
+        record["duration_ms"] = int(duration_ms)
+
+    try:
+        ctx.augur.record_modelio(
+            record,
+            step_index=ctx.step_index,
+            layer=ctx.layer,
+        )
+    except Exception as exc:  # noqa: BLE001 — Augur spec §4.3
+        logger.warning(
+            "record_anthropic_modelio: capture failed layer=%s step=%s: %s",
+            ctx.layer, ctx.step_index, exc,
+        )
+
+
+__all__ = [
+    "ModelIOContext",
+    "current_modelio_context",
+    "publish_modelio_context",
+    "record_anthropic_modelio",
+]

--- a/tests/test_observability_modelio_523.py
+++ b/tests/test_observability_modelio_523.py
@@ -1,0 +1,325 @@
+"""Tests for the #523 modelio capture wiring (PR B-1).
+
+PR B-1 only lands the plumbing — the client-side hook + the
+mapper + the contextvar. No call sites push a layer yet, so on
+disk no modelio records get written from a real run. PR B-2..B-5
+wire each layer one at a time.
+
+These tests exercise the plumbing in isolation:
+
+* mapper round-trips (Anthropic input_tokens / output_tokens /
+  cache_read_input_tokens / cache_creation_input_tokens →
+  modelio.schema.json prompt_tokens / completion_tokens /
+  cache_hit_tokens / cache_creation_tokens)
+* contextvar is plumbed and respected by the client
+* validates against the SDK's modelio.schema.json (this is the
+  fix-the-30-minute-debug-cycle test the SDK author flagged)
+* no-op behavior when no context is published (the default)
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip("augur_sdk")
+
+from mantis_agent.observability.augur import AugurAdapter
+from mantis_agent.observability.modelio import (
+    ModelIOContext,
+    _map_anthropic_usage,
+    current_modelio_context,
+    publish_modelio_context,
+    record_anthropic_modelio,
+)
+
+
+# ── usage mapper (the SDK-author-flagged compatibility test) ─────────────
+
+
+def test_map_anthropic_usage_renames_to_openai_shape():
+    """Anthropic's response.usage uses input_tokens / output_tokens;
+    modelio.schema.json's usage block uses prompt_tokens /
+    completion_tokens (additionalProperties: false). Wrong shape
+    raises a Draft 2020-12 validation error in record_modelio — caught
+    once during early integration so we test the mapping locks in."""
+    anthropic_usage = {
+        "input_tokens": 12_345,
+        "output_tokens": 678,
+        "cache_read_input_tokens": 9_000,
+        "cache_creation_input_tokens": 2_500,
+    }
+    mapped = _map_anthropic_usage(anthropic_usage)
+    assert mapped == {
+        "prompt_tokens": 12_345,
+        "completion_tokens": 678,
+        "cache_hit_tokens": 9_000,
+        "cache_creation_tokens": 2_500,
+    }
+    # All-Anthropic-only fields stripped
+    assert "input_tokens" not in mapped
+    assert "output_tokens" not in mapped
+
+
+def test_map_anthropic_usage_handles_missing_fields():
+    """Anthropic always returns input/output; cache fields are only on
+    requests with cache breakpoints. Missing → omitted from the output
+    (the SDK schema allows partial usage blocks)."""
+    assert _map_anthropic_usage({"input_tokens": 100, "output_tokens": 50}) == {
+        "prompt_tokens": 100,
+        "completion_tokens": 50,
+    }
+    assert _map_anthropic_usage({}) == {}
+    assert _map_anthropic_usage(None) == {}
+
+
+def test_map_anthropic_usage_drops_unknown_keys():
+    """additionalProperties: false on the schema — when Anthropic adds
+    a new usage field (they have, repeatedly), we must drop it rather
+    than passing through and breaking validation."""
+    usage = {
+        "input_tokens": 100,
+        "output_tokens": 50,
+        "new_unsupported_field": 999,  # would fail validation
+    }
+    mapped = _map_anthropic_usage(usage)
+    assert "new_unsupported_field" not in mapped
+    assert mapped == {"prompt_tokens": 100, "completion_tokens": 50}
+
+
+# ── contextvar plumbing ──────────────────────────────────────────────────
+
+
+def test_current_modelio_context_returns_none_by_default():
+    """No publish → None. The client's _record_modelio_if_active gates
+    on this — the default path through the hot LLM call site must be
+    a no-op until call sites opt in."""
+    assert current_modelio_context() is None
+
+
+def test_publish_modelio_context_sets_and_resets(tmp_path: Path, monkeypatch):
+    """publish_modelio_context is a contextmanager — leaving the with
+    block must restore the prior value (None or otherwise)."""
+    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
+    a = AugurAdapter(run_id="ctxvar_v1", tenant_id="t", session_name="s", out_dir=tmp_path)
+    assert current_modelio_context() is None
+    with publish_modelio_context(a, layer="planner", step_index=0):
+        ctx = current_modelio_context()
+        assert ctx is not None
+        assert ctx.layer == "planner"
+        assert ctx.step_index == 0
+        assert ctx.augur is a
+    # Reset to None on exit.
+    assert current_modelio_context() is None
+    a.close(status="completed")
+
+
+def test_publish_modelio_context_rejects_unknown_layer(tmp_path: Path, monkeypatch):
+    """Layer typos must surface as a warning, not silently drop captures
+    — yielding through the block as if no context was published."""
+    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
+    a = AugurAdapter(run_id="ctxvar_v2", tenant_id="t", session_name="s", out_dir=tmp_path)
+    with publish_modelio_context(a, layer="bogus_typo", step_index=0):
+        # Unknown layer → no context published.
+        assert current_modelio_context() is None
+    a.close(status="completed")
+
+
+def test_publish_modelio_context_noop_when_adapter_inactive():
+    """When augur is None or inactive, publish should still cleanly
+    yield through — telemetry never breaks the run."""
+    with publish_modelio_context(None, layer="planner", step_index=0):
+        assert current_modelio_context() is None
+
+
+# ── end-to-end: record a real modelio bundle file ────────────────────────
+
+
+_ANTHROPIC_RESPONSE_FIXTURE: dict[str, Any] = {
+    "id": "msg_abc",
+    "model": "claude-sonnet-4-7-20260120",
+    "role": "assistant",
+    "stop_reason": "tool_use",
+    "type": "message",
+    "content": [
+        {
+            "type": "tool_use", "id": "tu_001",
+            "name": "extract_lead",
+            "input": {"name": "Alice", "email": "alice@example.com"},
+        },
+    ],
+    "usage": {
+        "input_tokens": 1_500,
+        "output_tokens": 80,
+        "cache_read_input_tokens": 400,
+    },
+}
+
+_REQUEST_PAYLOAD: dict[str, Any] = {
+    "model": "claude-sonnet-4-7-20260120",
+    "max_tokens": 500,
+    "tools": [{"name": "extract_lead", "description": "...", "input_schema": {}}],
+    "tool_choice": {"type": "tool", "name": "extract_lead"},
+    "messages": [{"role": "user", "content": [{"type": "text", "text": "extract this"}]}],
+}
+
+
+def test_record_anthropic_modelio_writes_validated_bundle_file(
+    tmp_path: Path, monkeypatch,
+):
+    """End-to-end: with a real AugurAdapter open + a context
+    published, record_anthropic_modelio stages a file under modelio/
+    that satisfies modelio.schema.json (validate=True is the default;
+    the SDK raises on shape mismatches)."""
+    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
+    a = AugurAdapter(run_id="modelio_e2e", tenant_id="t", session_name="s", out_dir=tmp_path)
+    with publish_modelio_context(a, layer="planner", step_index=0):
+        record_anthropic_modelio(
+            request_payload=_REQUEST_PAYLOAD,
+            response_json=_ANTHROPIC_RESPONSE_FIXTURE,
+            duration_ms=842,
+        )
+    a.close(status="completed")
+    # Bundle path convention: modelio/<step:04d>-<layer>-<seq>.json
+    modelio_dir = tmp_path / "modelio"
+    assert modelio_dir.exists(), "record_modelio should have created the modelio/ dir"
+    files = sorted(modelio_dir.glob("*.json"))
+    assert files, "no modelio file written"
+    record = json.loads(files[0].read_text())
+    assert record["layer"] == "planner"
+    assert record["step_index"] == 0  # 0-based on the record (path is 1-based)
+    assert record["request"]["model"] == "claude-sonnet-4-7-20260120"
+    # OpenAI-shape usage — NOT input_tokens / output_tokens
+    assert record["response"]["usage"]["prompt_tokens"] == 1_500
+    assert record["response"]["usage"]["completion_tokens"] == 80
+    assert record["response"]["usage"]["cache_hit_tokens"] == 400
+    assert record["duration_ms"] == 842
+    assert record["response"]["stop_reason"] == "tool_use"
+    # The tool_use block is captured verbatim under tool_calls.
+    assert record["response"]["tool_calls"][0]["name"] == "extract_lead"
+
+
+def test_record_anthropic_modelio_noop_without_context(tmp_path: Path, monkeypatch):
+    """Without a published context, the mapper is a clean no-op —
+    no exceptions, no files written."""
+    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
+    a = AugurAdapter(run_id="modelio_noop", tenant_id="t", session_name="s", out_dir=tmp_path)
+    record_anthropic_modelio(
+        request_payload=_REQUEST_PAYLOAD,
+        response_json=_ANTHROPIC_RESPONSE_FIXTURE,
+        duration_ms=100,
+    )  # no context published
+    a.close(status="completed")
+    assert not (tmp_path / "modelio").exists() or not list((tmp_path / "modelio").glob("*.json"))
+
+
+def test_record_anthropic_modelio_step_index_none_means_run_scoped(
+    tmp_path: Path, monkeypatch,
+):
+    """An initial plan call that precedes any step is run-scoped —
+    step_index=None should land as null on the record (schema allows
+    that) and the SDK stages under modelio/0000-*-<seq>.json."""
+    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
+    a = AugurAdapter(run_id="modelio_run_scoped", tenant_id="t", session_name="s", out_dir=tmp_path)
+    with publish_modelio_context(a, layer="planner", step_index=None):
+        record_anthropic_modelio(
+            request_payload=_REQUEST_PAYLOAD,
+            response_json=_ANTHROPIC_RESPONSE_FIXTURE,
+            duration_ms=200,
+        )
+    a.close(status="completed")
+    files = sorted((tmp_path / "modelio").glob("*.json"))
+    assert files
+    record = json.loads(files[0].read_text())
+    assert record.get("step_index") in (None, 0)  # null OR absent both pass schema
+
+
+# ── client integration: capture fires only when context is published ─────
+
+
+def test_anthropic_client_capture_fires_when_context_published(
+    tmp_path: Path, monkeypatch,
+):
+    """When publish_modelio_context() is active during a successful
+    call_with_tool_schema, the client should invoke
+    record_anthropic_modelio via _record_modelio_if_active. Test by
+    asserting a modelio file lands on disk after one captured call."""
+    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    a = AugurAdapter(run_id="client_capture", tenant_id="t", session_name="s", out_dir=tmp_path)
+
+    # Build a fake response object the client thinks came from requests.post.
+    fake_resp = MagicMock()
+    fake_resp.status_code = 200
+    fake_resp.json.return_value = _ANTHROPIC_RESPONSE_FIXTURE
+
+    from mantis_agent._anthropic.client import AnthropicToolUseClient
+    client = AnthropicToolUseClient(api_key="test", model="claude-sonnet-4-7-20260120")
+    monkeypatch.setattr(client, "post_messages_with_retry", lambda *a, **k: fake_resp)
+
+    from PIL import Image
+    img = Image.new("RGB", (100, 100), color="white")
+
+    with publish_modelio_context(a, layer="planner", step_index=0):
+        out = client.call_with_tool_schema(
+            img, "extract this",
+            tool_name="extract_lead",
+            tool_description="...",
+            input_schema={"type": "object"},
+        )
+    a.close(status="completed")
+    assert out == {"name": "Alice", "email": "alice@example.com"}
+    files = sorted((tmp_path / "modelio").glob("*.json"))
+    assert files, "client did not invoke record_modelio with a context active"
+
+
+def test_anthropic_client_capture_skips_when_no_context(
+    tmp_path: Path, monkeypatch,
+):
+    """The default path — no caller publishes a layer — must be a
+    no-op. Critical: PR B-1 should NOT change the on-disk shape of
+    any existing user's run until PR B-2..B-5 wire individual layers."""
+    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    a = AugurAdapter(run_id="client_noop", tenant_id="t", session_name="s", out_dir=tmp_path)
+
+    fake_resp = MagicMock()
+    fake_resp.status_code = 200
+    fake_resp.json.return_value = _ANTHROPIC_RESPONSE_FIXTURE
+
+    from mantis_agent._anthropic.client import AnthropicToolUseClient
+    client = AnthropicToolUseClient(api_key="test", model="claude-sonnet-4-7-20260120")
+    monkeypatch.setattr(client, "post_messages_with_retry", lambda *a, **k: fake_resp)
+
+    from PIL import Image
+    img = Image.new("RGB", (100, 100), color="white")
+
+    # NO publish_modelio_context wrapper.
+    out = client.call_with_tool_schema(
+        img, "extract this",
+        tool_name="extract_lead",
+        tool_description="...",
+        input_schema={"type": "object"},
+    )
+    a.close(status="completed")
+    assert out == {"name": "Alice", "email": "alice@example.com"}
+    # No modelio/ dir, OR an empty one — depends on SDK init.
+    modelio_dir = tmp_path / "modelio"
+    if modelio_dir.exists():
+        assert not list(modelio_dir.glob("*.json"))
+
+
+def test_modelio_context_is_dataclass_with_expected_fields():
+    """The contextvar payload is :class:`ModelIOContext` — guard
+    against accidental rename / drop of fields PR B-2..B-5 will rely
+    on."""
+    ctx = ModelIOContext(augur=object(), layer="planner", step_index=3)
+    assert ctx.layer == "planner"
+    assert ctx.step_index == 3
+    # Frozen — mutation should raise.
+    with pytest.raises(Exception):  # FrozenInstanceError
+        ctx.layer = "grounding"  # type: ignore[misc]


### PR DESCRIPTION
## Summary
**PR B-1 of the #523 multi-PR campaign.** Lands the plumbing only — no LLM call sites are wired in this PR. PR B-2..B-5 wire planner / grounding / verifier / step_recovery / judge one layer at a time so the blast radius stays narrow.

- New module \`observability/modelio.py\` — contextvar pair (\`publish_modelio_context\` / \`current_modelio_context\`) + \`record_anthropic_modelio\` mapper
- \`AugurAdapter.record_modelio(...)\` — thin SDK wrapper, hasattr-guarded for SDK < 0.1.6, Mantis 0-based step_index → Augur 1-based at boundary
- \`AnthropicToolUseClient.call_with_tool_schema(_multi)\` — invoke \`_record_modelio_if_active\` after a successful response; local import so no overhead until a caller publishes a context

## Vendor field-name mapping (SDK author flagged)
Canonical \`modelio.schema.json\` \`response.usage\` uses **OpenAI** names — \`prompt_tokens\` / \`completion_tokens\` with \`additionalProperties: false\`. Anthropic ships \`input_tokens\` / \`output_tokens\` plus \`cache_creation_input_tokens\` / \`cache_read_input_tokens\`. The mapper translates at the boundary; downstream SFT/DPO pipelines read the OpenAI shape uniformly. Locked in via \`test_map_anthropic_usage_renames_to_openai_shape\`.

## Behavior contract
- **Default path (no caller publishes a context):** clean no-op. On-disk bundle shape is unchanged from main.
- **With \`publish_modelio_context(augur, layer, step_index)\`:** the next \`call_with_tool_schema(_multi)\` invocation lands one \`modelio/<step:04d>-<layer>-<seq>.json\` record. Validation runs via the SDK's \`validate=True\` default.
- **Telemetry never breaks runs:** validation failures, missing SDK, inactive adapter — all swallowed to debug logs.

## Test plan
- [x] \`pytest tests/test_observability_modelio_523.py tests/test_observability_augur.py tests/test_cost_meter.py\` — 71 pass (13 new in modelio file)
- [x] \`ruff check src/mantis_agent tests/test_observability_modelio_523.py\` — clean
- [x] End-to-end test writes a validated record to disk + asserts the OpenAI usage shape lands
- [ ] Modal redeploy + smoke run — no behavior change expected at runtime since no layer is wired yet; verify only that the new module imports cleanly under the Modal image

## What PR B-2..B-5 will add
Single call-site wraps the appropriate LLM invocation in \`publish_modelio_context\`, one PR per layer:
- **PR B-2 (planner)** — wrap the plan-analysis / plan-decompose Anthropic call
- **PR B-3 (grounder)** — wrap \`form_targeting/claude.py\` invocations
- **PR B-4 (verifier)** — wrap critic-gate / verify_gate Anthropic calls
- **PR B-5 (recovery + judge)** — recovery decisions + final judge

Refs #523

🤖 Generated with [Claude Code](https://claude.com/claude-code)