### PR TITLE
augur: planner-layer modelio capture in plan_decomposer (#523 PR B-2)

### DIFF
--- a/src/mantis_agent/plan_decomposer.py
+++ b/src/mantis_agent/plan_decomposer.py
@@ -33,6 +33,7 @@ import json
 import logging
 import os
 import re
+import time
 from dataclasses import dataclass, field, fields
 from typing import Any, ClassVar
 
@@ -758,6 +759,12 @@ class PlanDecomposer:
         # JSON examples (params={"label": ...}) that confuse str.format.
         prompt = DECOMPOSE_PROMPT.replace("{plan_text}", plan_text)
 
+        request_body = {
+            "model": self.model,
+            "max_tokens": 4096,
+            "messages": [{"role": "user", "content": prompt}],
+        }
+        t0 = time.monotonic()
         resp = requests.post(
             "https://api.anthropic.com/v1/messages",
             headers={
@@ -765,16 +772,33 @@ class PlanDecomposer:
                 "anthropic-version": "2023-06-01",
                 "content-type": "application/json",
             },
-            json={
-                "model": self.model,
-                "max_tokens": 4096,
-                "messages": [{"role": "user", "content": prompt}],
-            },
+            json=request_body,
             timeout=60,
         )
 
         if resp.status_code != 200:
             raise RuntimeError(f"Decompose API error: {resp.status_code} {resp.text[:200]}")
+
+        # #523 PR B-2 — capture this call as a modelio record when an
+        # upstream caller has published a layer context (planner). Silent
+        # no-op otherwise (default path until the wrap fires in PR B-2-
+        # integration or later). Best-effort: telemetry never breaks
+        # decomposition.
+        try:
+            from .observability.modelio import (
+                current_modelio_context,
+                record_anthropic_modelio,
+            )
+            ctx = current_modelio_context()
+            if ctx is not None:
+                record_anthropic_modelio(
+                    request_payload=request_body,
+                    response_json=resp.json(),
+                    duration_ms=int((time.monotonic() - t0) * 1000),
+                    ctx=ctx,
+                )
+        except Exception as exc:  # noqa: BLE001 — observability never fatal
+            logger.debug("plan_decomposer modelio capture failed: %s", exc)
 
         text = ""
         for block in resp.json().get("content", []):

--- a/tests/test_plan_decomposer_modelio_523.py
+++ b/tests/test_plan_decomposer_modelio_523.py
@@ -1,0 +1,154 @@
+"""PR B-2 of #523: planner-layer modelio capture in plan_decomposer.
+
+Same shape contract as PR B-1's client wrapper:
+
+* When a caller has published a layer context, decompose_text emits
+  one modelio/<step>-planner-<seq>.json record.
+* When no context has been published (the default), the call is a
+  silent no-op — bundle shape is unchanged from main.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip("augur_sdk")
+
+from mantis_agent.observability.augur import AugurAdapter
+from mantis_agent.observability.modelio import publish_modelio_context
+
+
+_FAKE_PLANNER_RESPONSE: dict = {
+    "id": "msg_planner_001",
+    "model": "claude-opus-4-7",
+    "role": "assistant",
+    "stop_reason": "end_turn",
+    "type": "message",
+    "content": [
+        {
+            "type": "text",
+            "text": '{"shapes": ["form"], "steps": ['
+                    '{"intent": "Click Login", "type": "click", "budget": 3, "verify": "Login form visible"}'
+                    ']}',
+        },
+    ],
+    "usage": {"input_tokens": 800, "output_tokens": 120},
+}
+
+
+def _make_fake_response(payload: dict) -> MagicMock:
+    """Build a fake requests.Response-like object."""
+    r = MagicMock()
+    r.status_code = 200
+    r.json.return_value = payload
+    return r
+
+
+def test_plan_decomposer_emits_modelio_when_context_published(
+    tmp_path: Path, monkeypatch,
+):
+    """End-to-end: with augur open + a planner context published,
+    decompose_text writes a validated modelio record under
+    modelio/<step>-planner-<seq>.json. Confirms the planner-layer wire
+    fires through the SDK's validate=True default."""
+    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+
+    a = AugurAdapter(
+        run_id="planner_e2e", tenant_id="t", session_name="s", out_dir=tmp_path,
+    )
+
+    # Patch out the network call.
+    import mantis_agent.plan_decomposer as pd
+    import requests as _requests
+    monkeypatch.setattr(
+        _requests, "post", lambda *a, **kw: _make_fake_response(_FAKE_PLANNER_RESPONSE),
+    )
+
+    decomposer = pd.PlanDecomposer(api_key="test-key", model="claude-opus-4-7")
+    with publish_modelio_context(a, layer="planner", step_index=None):
+        # Returns a MicroPlan; we only care about side-effects on the
+        # bundle, not the parsed plan shape.
+        decomposer.decompose_text("Click Login")
+    a.close(status="completed")
+
+    files = sorted((tmp_path / "modelio").glob("*planner*.json"))
+    assert files, "plan_decomposer did not write a modelio record"
+    record = json.loads(files[0].read_text())
+    assert record["layer"] == "planner"
+    # Run-scoped: step_index null OR omitted both pass the schema.
+    assert record.get("step_index") in (None, 0)
+    assert record["request"]["model"] == "claude-opus-4-7"
+    # OpenAI usage shape (not Anthropic input_tokens / output_tokens)
+    assert record["response"]["usage"]["prompt_tokens"] == 800
+    assert record["response"]["usage"]["completion_tokens"] == 120
+    # The text response is captured verbatim under response.text.
+    assert "shapes" in record["response"]["text"]
+
+
+def test_plan_decomposer_no_capture_without_context(tmp_path: Path, monkeypatch):
+    """Default path — no caller publishes a context — must be a clean
+    no-op. Bundle/modelio dir untouched. Critical: PR B-2 must NOT
+    change today's on-disk shape for any existing CLI or server caller."""
+    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+
+    a = AugurAdapter(
+        run_id="planner_noop", tenant_id="t", session_name="s", out_dir=tmp_path,
+    )
+
+    import mantis_agent.plan_decomposer as pd
+    import requests as _requests
+    monkeypatch.setattr(
+        _requests, "post", lambda *a, **kw: _make_fake_response(_FAKE_PLANNER_RESPONSE),
+    )
+
+    decomposer = pd.PlanDecomposer(api_key="test-key", model="claude-opus-4-7")
+    # NO publish_modelio_context wrap.
+    decomposer.decompose_text("Click Login")
+    a.close(status="completed")
+
+    modelio_dir = tmp_path / "modelio"
+    if modelio_dir.exists():
+        assert not list(modelio_dir.glob("*.json")), (
+            "PR B-2 should not capture when no context is published — "
+            "found leftover files in modelio/ on a no-context run"
+        )
+
+
+def test_plan_decomposer_capture_failure_does_not_break_decompose(
+    tmp_path: Path, monkeypatch,
+):
+    """If the modelio capture raises (e.g. SDK schema bump), the
+    decomposer must still return its parsed plan — per Augur spec §4.3,
+    telemetry failures are non-fatal."""
+    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+
+    a = AugurAdapter(
+        run_id="planner_capture_err", tenant_id="t", session_name="s", out_dir=tmp_path,
+    )
+
+    import mantis_agent.plan_decomposer as pd
+    import requests as _requests
+    monkeypatch.setattr(
+        _requests, "post", lambda *a, **kw: _make_fake_response(_FAKE_PLANNER_RESPONSE),
+    )
+
+    # Inject a broken record_anthropic_modelio that raises.
+    import mantis_agent.observability.modelio as modelio_mod
+    def _boom(**kwargs):
+        raise RuntimeError("simulated SDK schema mismatch")
+    monkeypatch.setattr(modelio_mod, "record_anthropic_modelio", _boom)
+
+    decomposer = pd.PlanDecomposer(api_key="test-key", model="claude-opus-4-7")
+    with publish_modelio_context(a, layer="planner", step_index=None):
+        # MUST NOT raise — telemetry never breaks the decompose path.
+        plan = decomposer.decompose_text("Click Login")
+    a.close(status="completed")
+    assert plan is not None
+    assert plan.steps  # parsed successfully


### PR DESCRIPTION
## Summary
**PR B-2 of the #523 multi-PR campaign.** Wires the planner layer — \`PlanDecomposer.decompose_text\`, the canonical Mantis "planner" call that consumes free-text plans and produces a MicroPlan.

**Stacked on top of PR #526 (B-1)** — depends on \`observability/modelio.py\` from that PR. Don't squash-merge until #526 lands first.

- Adds the modelio capture call after \`requests.post\` success in \`decompose_text\`
- Captures request/response shape; mapper handles Anthropic→OpenAI usage field-name conversion
- Same behavior contract as PR B-1: silent no-op when no caller has published a layer context

## Why "wire-only" without the caller integration
\`plan_decomposer.decompose_text\` runs **before** \`RunExecutor\` opens augur, so today's CLI / baseten / cache-hit paths don't have an adapter in scope. Plumbing-first ships the wire so:
- A future small PR can open augur earlier and add \`publish_modelio_context(augur, "planner", step_index=None)\` around decompose without touching the decomposer again
- Test harnesses can already exercise the planner capture end-to-end

This mirrors PR B-1's split — land the contract, integrate next.

## Test plan
- [x] \`pytest tests/test_plan_decomposer_modelio_523.py tests/test_observability_modelio_523.py tests/test_observability_augur.py\` — 38 pass
- [x] \`ruff check src/mantis_agent tests/\` — clean
- [x] Real adapter + publish_modelio_context wrap → validated planner record on disk
- [x] No-context default path → no leftover modelio files (regression guard)
- [x] Capture failure → decompose still returns parsed plan (telemetry never breaks runs)
- [ ] Modal redeploy + full plan rerun — verify integration PR (deferred to follow-up)

## What PR B-3..B-5 add next
- **PR B-3 (grounder):** \`publish_modelio_context\` wraps in \`form_targeting/claude.py\` call sites (no client-side change needed — PR B-1's wrapper already captures)
- **PR B-4 (verifier):** wire critic-gate / verify_gate
- **PR B-5 (recovery + judge):** \`agentic_recovery.py\` (raw requests.post — needs same treatment as plan_decomposer here)

Refs #523

🤖 Generated with [Claude Code](https://claude.com/claude-code)