### PR TITLE
augur: verifier-layer modelio capture (#523 PR B-4)

### DIFF
--- a/src/mantis_agent/gym/_runner_helpers.py
+++ b/src/mantis_agent/gym/_runner_helpers.py
@@ -541,7 +541,14 @@ def ensure_results_filters(
         )
         requirement = gate_prefix + ", ".join(runner._required_filter_tokens)
         try:
-            passed, reason = runner.extractor.verify_gate(screenshot, requirement)
+            # #523 PR B-4 — capture the verify_gate LLM call as a
+            # ``verifier`` modelio record. No-op when augur is None.
+            from ..observability.modelio import publish_modelio_context
+            with publish_modelio_context(
+                getattr(runner, "_augur", None),
+                layer="verifier", step_index=index,
+            ):
+                passed, reason = runner.extractor.verify_gate(screenshot, requirement)
             runner.costs["claude_extract"] += 1
             if passed:
                 logger.info(
@@ -870,9 +877,16 @@ def execute_step(
         print(f"  [gate] Verifying: {(step.verify or step.intent)[:80]}")
         time.sleep(2)
         screenshot = runner.env.screenshot()
-        passed, reason = runner.extractor.verify_gate(
-            screenshot, step.verify or step.intent,
-        )
+        # #523 PR B-4 — capture the gate verify_gate call as a
+        # ``verifier`` modelio record. No-op when augur is None.
+        from ..observability.modelio import publish_modelio_context
+        with publish_modelio_context(
+            getattr(runner, "_augur", None),
+            layer="verifier", step_index=index,
+        ):
+            passed, reason = runner.extractor.verify_gate(
+                screenshot, step.verify or step.intent,
+            )
         runner.costs["claude_extract"] += 1
         print(f"  [gate] Result: {'PASS' if passed else 'FAIL'} — {reason[:80]}")
         return StepResult(

--- a/tests/test_verifier_modelio_523.py
+++ b/tests/test_verifier_modelio_523.py
@@ -1,0 +1,74 @@
+"""PR B-4 of #523: verifier-layer modelio capture.
+
+Both `verify_gate` call sites in `gym/_runner_helpers.py` (lines
+~544 and ~873) wrap their `runner.extractor.verify_gate(...)`
+invocation in `publish_modelio_context(augur, "verifier",
+step_index=index)`. The underlying `extractor._verify_client` uses
+`AnthropicToolUseClient` so the capture fires automatically once
+the context is published.
+"""
+
+from __future__ import annotations
+
+import inspect
+import re
+
+import pytest
+
+pytest.importorskip("augur_sdk")
+
+
+def test_runner_helpers_wraps_filter_gate_verify():
+    """``ensure_results_filters`` calls ``verify_gate`` inside a
+    ``publish_modelio_context(layer="verifier", step_index=index)``
+    block. AST-light check: the source between the function def
+    and the ``verify_gate`` call must contain a ``publish_modelio
+    _context`` line with ``layer="verifier"``."""
+    from mantis_agent.gym import _runner_helpers
+    src = inspect.getsource(_runner_helpers.ensure_results_filters)
+    assert "verify_gate" in src
+    assert "publish_modelio_context" in src, (
+        "ensure_results_filters must wrap verify_gate in publish_modelio_context"
+    )
+    assert re.search(r'layer\s*=\s*"verifier"', src), (
+        "ensure_results_filters's publish_modelio_context must use layer='verifier'"
+    )
+    # The wrap must appear BEFORE the verify_gate call so the
+    # contextvar is published when the LLM call fires.
+    pub_idx = src.index("publish_modelio_context")
+    call_idx = src.index("verify_gate(")
+    assert pub_idx < call_idx, (
+        "publish_modelio_context must precede verify_gate call"
+    )
+
+
+def test_runner_helpers_wraps_gate_step_verify():
+    """``execute_step`` wraps the ``step.gate``-branch verify_gate
+    call in publish_modelio_context. Same shape contract."""
+    from mantis_agent.gym import _runner_helpers
+    src = inspect.getsource(_runner_helpers.execute_step)
+    assert "verify_gate" in src
+    # Two distinct ``publish_modelio_context`` invocations could exist
+    # in the function (one for each verify_gate call). At least one
+    # must wrap a verify_gate.
+    pub_count = src.count("publish_modelio_context")
+    gate_count = src.count("verify_gate(")
+    assert pub_count >= 1, (
+        f"execute_step must wrap verify_gate in publish_modelio_context "
+        f"(found 0 wraps for {gate_count} verify_gate calls)"
+    )
+
+
+def test_step_index_threaded_into_verifier_context():
+    """The wrap must pass ``step_index=index`` so the resulting
+    modelio record is tagged with the correct step (Mantis 0-based;
+    the adapter bumps to 1-based at the SDK boundary)."""
+    from mantis_agent.gym import _runner_helpers
+    for fn in (_runner_helpers.ensure_results_filters, _runner_helpers.execute_step):
+        src = inspect.getsource(fn)
+        if "publish_modelio_context" not in src:
+            continue
+        # Match: step_index=index OR step_index=<some valid identifier>
+        assert re.search(r"step_index\s*=\s*\w+", src), (
+            f"{fn.__name__}: publish_modelio_context must pass step_index"
+        )


### PR DESCRIPTION
## Summary
**PR B-4 of the #523 multi-PR campaign.** Wires the verifier layer — both `verify_gate` call sites in `gym/_runner_helpers.py`:

1. `ensure_results_filters` (~L544) — visual-gate filter verification (Claude reads the screenshot when the URL parser can't extract active filters)
2. `execute_step` (~L873) — the `step.gate=true` branch (plan-author-declared gates between sections)

Both wrap `runner.extractor.verify_gate(...)` in `publish_modelio_context(augur, layer="verifier", step_index=index)`. The underlying `extractor._verify_client` is an `AnthropicToolUseClient`, so PR B-1's auto-capture hook fires once the context is active. No new files; just two narrow wraps where the runner already has `index` in scope.

## Test plan
- [x] `pytest tests/test_verifier_modelio_523.py` — 3 pass
- [x] `ruff check src/mantis_agent tests/` — clean
- Source-level checks: both verify_gate sites wrapped with `layer="verifier"`, contextmanager precedes the call, `step_index` threaded through
- [ ] Modal redeploy + plan run — confirm `modelio/*-verifier-*.json` records appear when `step.gate=true` and on visual-filter fallback

## Capture semantics
- Default path (augur None/disabled): clean no-op, identical to main
- With augur active: one `modelio/<step:04d>-verifier-<seq>.json` per verify_gate call

## What B-5 adds next (last in the campaign)
- **PR B-5 (recovery)**: wire `agentic_recovery._call_recovery_tool` (raw `requests.post`, line 312) like `plan_decomposer` was wired in PR B-2 — needs both the in-line `record_anthropic_modelio` call AND the caller wrap in `step_recovery._try_agentic_recovery`
- **Judge**: N/A in Mantis — no dedicated judge LLM call site (confirmed via codebase grep)

Refs #523

🤖 Generated with [Claude Code](https://claude.com/claude-code)