### PR TITLE
augur: step_recovery-layer modelio capture (#523 PR B-5 — closes campaign)

### DIFF
--- a/src/mantis_agent/agentic_recovery.py
+++ b/src/mantis_agent/agentic_recovery.py
@@ -49,6 +49,7 @@ from __future__ import annotations
 import base64
 import logging
 import os
+import time
 from dataclasses import dataclass, field
 from io import BytesIO
 from typing import Any
@@ -309,6 +310,21 @@ def _call_recovery_tool(
             logger.debug("recovery: screenshot encode failed: %s", exc)
 
     try:
+        request_body = {
+            "model": model,
+            "max_tokens": 1500,
+            "tools": [{
+                "name": "record_recovery",
+                "description": (
+                    "Record the recovery decision for the failed "
+                    "step."
+                ),
+                "input_schema": _ANALYSIS_TOOL_INPUT_SCHEMA,
+            }],
+            "tool_choice": {"type": "tool", "name": "record_recovery"},
+            "messages": [{"role": "user", "content": content}],
+        }
+        t0 = time.monotonic()
         resp = requests.post(
             "https://api.anthropic.com/v1/messages",
             headers={
@@ -316,20 +332,7 @@ def _call_recovery_tool(
                 "anthropic-version": "2023-06-01",
                 "content-type": "application/json",
             },
-            json={
-                "model": model,
-                "max_tokens": 1500,
-                "tools": [{
-                    "name": "record_recovery",
-                    "description": (
-                        "Record the recovery decision for the failed "
-                        "step."
-                    ),
-                    "input_schema": _ANALYSIS_TOOL_INPUT_SCHEMA,
-                }],
-                "tool_choice": {"type": "tool", "name": "record_recovery"},
-                "messages": [{"role": "user", "content": content}],
-            },
+            json=request_body,
             timeout=30,
         )
         if resp.status_code != 200:
@@ -338,6 +341,26 @@ def _call_recovery_tool(
                 resp.status_code, resp.text[:300],
             )
             return None
+        # #523 PR B-5 — capture this call as a ``step_recovery`` modelio
+        # record when an upstream caller (step_recovery._try_agentic_
+        # recovery via publish_modelio_context) has set the context.
+        # Silent no-op otherwise. Best-effort — telemetry never breaks
+        # recovery analysis.
+        try:
+            from .observability.modelio import (
+                current_modelio_context,
+                record_anthropic_modelio,
+            )
+            ctx = current_modelio_context()
+            if ctx is not None:
+                record_anthropic_modelio(
+                    request_payload=request_body,
+                    response_json=resp.json(),
+                    duration_ms=int((time.monotonic() - t0) * 1000),
+                    ctx=ctx,
+                )
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("agentic_recovery modelio capture failed: %s", exc)
         for block in resp.json().get("content", []):
             if (
                 block.get("type") == "tool_use"

--- a/src/mantis_agent/gym/step_recovery.py
+++ b/src/mantis_agent/gym/step_recovery.py
@@ -977,15 +977,26 @@ class StepRecoveryPolicy:
             stored = hint_map.get(step_index, [])
             if isinstance(stored, list):
                 prior_hints = [str(h) for h in stored if str(h).strip()]
-        decision = analyse_failure_and_recover(
-            step=step,
-            failure_data=str(getattr(step_result, "data", "") or ""),
-            screenshot=screenshot,
-            plan_context=plan_context,
-            attempts=attempts,
-            model=recovery_model,
-            prior_hints=prior_hints,
-        )
+        # #523 PR B-5 — wrap the recovery call in a ``step_recovery``
+        # modelio context. The raw requests.post inside
+        # analyse_failure_and_recover (-> _call_recovery_tool) checks
+        # this contextvar at the boundary and emits one
+        # modelio/<step>-step_recovery-<seq>.json record on success.
+        # No-op when augur is None or inactive.
+        from ..observability.modelio import publish_modelio_context
+        with publish_modelio_context(
+            getattr(runner, "_augur", None),
+            layer="step_recovery", step_index=step_index,
+        ):
+            decision = analyse_failure_and_recover(
+                step=step,
+                failure_data=str(getattr(step_result, "data", "") or ""),
+                screenshot=screenshot,
+                plan_context=plan_context,
+                attempts=attempts,
+                model=recovery_model,
+                prior_hints=prior_hints,
+            )
         if decision is None:
             # #431: even though analyse_failure_and_recover already logs
             # its own warnings for the api-key / api-error / no-tool-use

--- a/tests/test_recovery_modelio_523.py
+++ b/tests/test_recovery_modelio_523.py
@@ -1,0 +1,203 @@
+"""PR B-5 of #523: step_recovery-layer modelio capture.
+
+Two-piece wire because ``agentic_recovery`` uses raw ``requests.post``
+(not the shared AnthropicToolUseClient that auto-captures):
+
+1. ``agentic_recovery._call_recovery_tool`` — adds an inline
+   ``record_anthropic_modelio`` call after a successful response.
+   Fires only when a caller has published a layer context.
+2. ``gym/step_recovery._try_agentic_recovery`` — wraps the
+   ``analyse_failure_and_recover`` call in
+   ``publish_modelio_context(layer="step_recovery", step_index=...)``
+   so the inline wire at (1) sees an active context.
+
+Judge layer (B-6 in the original campaign sketch) is N/A in Mantis —
+no dedicated judge LLM call site exists. This PR closes the campaign.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip("augur_sdk")
+
+from mantis_agent.observability.augur import AugurAdapter
+from mantis_agent.observability.modelio import publish_modelio_context
+
+
+_FAKE_RECOVERY_RESPONSE: dict = {
+    "id": "msg_recovery_001",
+    "model": "claude-haiku-4-5-20251001",
+    "role": "assistant",
+    "stop_reason": "tool_use",
+    "type": "message",
+    "content": [
+        {
+            "type": "tool_use",
+            "id": "tu_rec_001",
+            "name": "record_recovery",
+            "input": {
+                "action": "retry",
+                "rationale": "transient failure",
+                "confidence": 0.7,
+            },
+        },
+    ],
+    "usage": {"input_tokens": 1_200, "output_tokens": 95},
+}
+
+
+# ── agentic_recovery._call_recovery_tool wire (inline capture) ──────────
+
+
+def test_call_recovery_tool_emits_modelio_when_context_published(
+    tmp_path: Path, monkeypatch,
+):
+    """End-to-end: with augur open + step_recovery context published,
+    _call_recovery_tool writes a validated modelio record under
+    modelio/<step>-step_recovery-<seq>.json."""
+    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+
+    import mantis_agent.agentic_recovery as ar
+    import requests as _requests
+
+    def _fake_post(url, **kw):
+        r = MagicMock()
+        r.status_code = 200
+        r.json.return_value = _FAKE_RECOVERY_RESPONSE
+        return r
+
+    monkeypatch.setattr(_requests, "post", _fake_post)
+
+    a = AugurAdapter(
+        run_id="recovery_e2e", tenant_id="t", session_name="s", out_dir=tmp_path,
+    )
+    step = MagicMock(intent="click submit", type="submit")
+    with publish_modelio_context(a, layer="step_recovery", step_index=4):
+        out = ar._call_recovery_tool(
+            step=step,
+            failure_data="no_state_change after click",
+            screenshot=None,
+            plan_context=["fill_field", "click submit"],
+            attempts=2,
+            api_key="test-key",
+            model="claude-haiku-4-5-20251001",
+            prior_hints=[],
+        )
+    a.close(status="completed")
+
+    assert out == {"action": "retry", "rationale": "transient failure", "confidence": 0.7}
+
+    files = sorted((tmp_path / "modelio").glob("*step_recovery*.json"))
+    assert files, "_call_recovery_tool did not write a modelio record"
+    record = json.loads(files[0].read_text())
+    assert record["layer"] == "step_recovery"
+    assert record["step_index"] == 4
+    assert record["request"]["model"] == "claude-haiku-4-5-20251001"
+    assert record["response"]["usage"]["prompt_tokens"] == 1_200
+    assert record["response"]["usage"]["completion_tokens"] == 95
+    # The tool_use block is captured verbatim under tool_calls.
+    assert record["response"]["tool_calls"][0]["name"] == "record_recovery"
+
+
+def test_call_recovery_tool_noop_without_context(tmp_path: Path, monkeypatch):
+    """Default path — no caller publishes a context — must be a clean
+    no-op. Bundle/modelio dir untouched."""
+    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+
+    import mantis_agent.agentic_recovery as ar  # noqa: F401 — ensures module is loaded
+    import requests as _requests
+    monkeypatch.setattr(
+        _requests, "post",
+        lambda *a, **kw: MagicMock(
+            status_code=200, json=lambda: _FAKE_RECOVERY_RESPONSE,
+        ),
+    )
+
+    a = AugurAdapter(
+        run_id="recovery_noop", tenant_id="t", session_name="s", out_dir=tmp_path,
+    )
+    step = MagicMock(intent="click submit", type="submit")
+    # No publish_modelio_context wrap.
+    ar._call_recovery_tool(
+        step=step, failure_data="x", screenshot=None,
+        plan_context=[], attempts=1,
+        api_key="test-key", model="claude-haiku-4-5-20251001",
+    )
+    a.close(status="completed")
+    modelio_dir = tmp_path / "modelio"
+    if modelio_dir.exists():
+        assert not list(modelio_dir.glob("*.json"))
+
+
+def test_call_recovery_tool_capture_failure_does_not_break_recovery(
+    tmp_path: Path, monkeypatch,
+):
+    """If record_anthropic_modelio raises (e.g. SDK schema bump),
+    _call_recovery_tool must still return its parsed decision —
+    telemetry never breaks recovery."""
+    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+
+    import mantis_agent.agentic_recovery as ar  # noqa: F401 — ensures module is loaded
+    import requests as _requests
+    monkeypatch.setattr(
+        _requests, "post",
+        lambda *a, **kw: MagicMock(
+            status_code=200, json=lambda: _FAKE_RECOVERY_RESPONSE,
+        ),
+    )
+    import mantis_agent.observability.modelio as modelio_mod
+    def _boom(**kwargs):
+        raise RuntimeError("simulated SDK schema mismatch")
+    monkeypatch.setattr(modelio_mod, "record_anthropic_modelio", _boom)
+
+    a = AugurAdapter(
+        run_id="recovery_err", tenant_id="t", session_name="s", out_dir=tmp_path,
+    )
+    step = MagicMock(intent="click submit", type="submit")
+    with publish_modelio_context(a, layer="step_recovery", step_index=0):
+        out = ar._call_recovery_tool(
+            step=step, failure_data="x", screenshot=None,
+            plan_context=[], attempts=1,
+            api_key="test-key", model="claude-haiku-4-5-20251001",
+        )
+    a.close(status="completed")
+    # Recovery decision still came through.
+    assert out is not None
+    assert out["action"] == "retry"
+
+
+# ── step_recovery._try_agentic_recovery caller wrap (source-level) ──────
+
+
+def test_step_recovery_wraps_analyse_call_in_publish_modelio_context():
+    """``_try_agentic_recovery`` must wrap its
+    ``analyse_failure_and_recover`` call in
+    ``publish_modelio_context(layer="step_recovery", step_index=...)``
+    so the inline wire in _call_recovery_tool fires."""
+    from mantis_agent.gym.step_recovery import StepRecoveryPolicy
+    src = inspect.getsource(StepRecoveryPolicy._try_agentic_recovery)
+    assert "publish_modelio_context" in src, (
+        "_try_agentic_recovery must wrap analyse_failure_and_recover in "
+        "publish_modelio_context"
+    )
+    assert 'layer="step_recovery"' in src or "layer='step_recovery'" in src, (
+        "The wrap must use layer='step_recovery' (one of the SDK enum literals)"
+    )
+    assert "step_index=step_index" in src, (
+        "The wrap must thread step_index through"
+    )
+    # The publish_modelio_context must appear before the analyse call.
+    pub_idx = src.index("publish_modelio_context")
+    call_idx = src.index("analyse_failure_and_recover(")
+    assert pub_idx < call_idx, (
+        "publish_modelio_context must precede the analyse_failure_and_recover call"
+    )


### PR DESCRIPTION
## Summary
**Final PR of the #523 multi-PR campaign.** Wires the \`step_recovery\` layer — \`agentic_recovery._call_recovery_tool\` is where the recovery analysis LLM call originates.

Two-piece wire (same shape as PR B-2's planner wire) because \`agentic_recovery\` uses raw \`requests.post\` rather than the shared \`AnthropicToolUseClient\` that auto-captures:

1. \`agentic_recovery._call_recovery_tool\` — inline \`record_anthropic_modelio\` call after a successful response. Captures \`duration_ms\` via \`time.monotonic\` deltas at the \`requests.post\` boundary.
2. \`gym/step_recovery.StepRecoveryPolicy._try_agentic_recovery\` — wraps the \`analyse_failure_and_recover\` call in \`publish_modelio_context(layer="step_recovery", step_index=step_index)\` so the inline wire sees an active context.

## Judge layer
**N/A in Mantis** — no dedicated judge LLM call site exists (grepped exhaustively). The five-layer campaign collapses to four wired layers:

| Layer | PR | Status |
|-------|-----|--------|
| Plumbing (modelio module, client hook, adapter wrapper) | #526 | ✅ merged |
| Planner (plan_decomposer) | #527 | ✅ merged |
| Grounder (form handler) | #531 | open |
| Verifier (verify_gate) | #532 | open |
| Step recovery (agentic_recovery) | **this PR** | open |

## Test plan
- [x] \`pytest tests/test_recovery_modelio_523.py\` — 4 pass
- [x] \`pytest tests/test_recovery_modelio_523.py tests/test_observability_modelio_523.py tests/test_plan_decomposer_modelio_523.py tests/test_observability_augur.py\` — 42 pass
- [x] \`ruff check src/mantis_agent tests/\` — clean
- [x] End-to-end test writes a validated record with OpenAI usage shape + correct step_index + step_recovery layer
- [x] No-context default path → no leftover modelio files
- [x] Capture failure → recovery decision still returns (telemetry never breaks runs)
- [x] Source-level: _try_agentic_recovery wraps with right layer + step_index
- [ ] Modal redeploy + plan run with a forced-fail step → confirm \`modelio/*-step_recovery-*.json\` lands when recovery analysis fires

## Campaign close
After this lands the \`modelio/\` directory will populate with records for **all four LLM layers Mantis actually has** whenever augur is active — the primary acceptance criterion of #523 is met for what's realistic in this codebase. The remaining issue acceptance items (references field, redaction policy tightening, capture-mode gating, 50 MB size budget) are separate follow-ups.

Refs #523

🤖 Generated with [Claude Code](https://claude.com/claude-code)