### PR TITLE
chore: bump augur-sdk pin to >=0.1.9 (hygiene, no behavior change)

### DIFF
--- a/deploy/modal/modal_cua_server.py
+++ b/deploy/modal/modal_cua_server.py
@@ -174,7 +174,7 @@ executor_image = (
         # 0.1.2+ fires an immediate session-opened heartbeat so the
         # workspace's connection badge updates the moment the SDK is
         # wired up, before the first step lands.
-        "augur-sdk>=0.1.8",
+        "augur-sdk>=0.1.9",
     )
     .add_local_python_source("mantis_agent")
     .add_local_dir(_PROMPTS_FILES_LOCAL, remote_path=_PROMPTS_FILES_REMOTE)
@@ -1224,7 +1224,7 @@ def _run_gemma4_cua_executor(
         "openai", "requests", "pillow", "mss",
         "fastapi>=0.100", "uvicorn>=0.20", "websocket-client",
         # #509: parity with run_holo3 — Gemma4 also runs the augur wedge.
-        "augur-sdk>=0.1.8",
+        "augur-sdk>=0.1.9",
     ).add_local_python_source("mantis_agent").add_local_dir(_PROMPTS_FILES_LOCAL, remote_path=_PROMPTS_FILES_REMOTE),
     volumes={"/data": vol},
     secrets=[modal.Secret.from_dotenv()],
@@ -1257,7 +1257,7 @@ claude_executor_image = (
         # #509: parity with run_holo3 / run_gemma4_cua — Claude executor
         # also runs the augur wedge so bundles + streaming work for the
         # Anthropic-API tier.
-        "augur-sdk>=0.1.8",
+        "augur-sdk>=0.1.9",
     )
     .add_local_python_source("mantis_agent")
     .add_local_dir(_PROMPTS_FILES_LOCAL, remote_path=_PROMPTS_FILES_REMOTE)
@@ -1388,7 +1388,7 @@ api_image = (
         # is lazy-imported but if augur_sdk is missing it falls back
         # silently — keeping the dep here makes the import succeed and
         # lets future API-side bundle reads work without a redeploy.
-        "augur-sdk>=0.1.8",
+        "augur-sdk>=0.1.9",
     )
     .add_local_python_source("mantis_agent")
     .add_local_dir(_PROMPTS_FILES_LOCAL, remote_path=_PROMPTS_FILES_REMOTE)
@@ -2123,7 +2123,7 @@ def api():
         # so augur-sdk has to be added here separately. Without this the
         # AugurAdapter init logs sdk_available=False and is a no-op even
         # though the package is in executor_image for the other tiers.
-        "augur-sdk>=0.1.8",
+        "augur-sdk>=0.1.9",
     ).add_local_python_source("mantis_agent").add_local_dir(_PROMPTS_FILES_LOCAL, remote_path=_PROMPTS_FILES_REMOTE),
     volumes={"/data": vol},
     secrets=[modal.Secret.from_dotenv()],

--- a/deploy/modal/modal_plan_runner.py
+++ b/deploy/modal/modal_plan_runner.py
@@ -115,7 +115,7 @@ runner_image = (
         # #509: per-run Augur DebugSession bundle + optional live streaming.
         # 0.1.2+ fires an immediate session-opened heartbeat for faster
         # workspace badge updates.
-        "augur-sdk>=0.1.8",
+        "augur-sdk>=0.1.9",
     )
     .add_local_python_source("mantis_agent")
     .add_local_dir(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ metrics = [
 # augur_sdk lazily and no-ops when the package isn't installed, so
 # this extra is purely opt-in — no base-install footprint change.
 observability = [
-    "augur-sdk>=0.1.8",
+    "augur-sdk>=0.1.9",
 ]
 # Self-host the FastAPI server that fronts /predict and /v1/chat/completions.
 # Used by the Baseten / EKS / GKE deployments.


### PR DESCRIPTION
## Summary
Pin-only bump from \`augur-sdk>=0.1.8\` → \`>=0.1.9\` across 7 declaration sites. Same shape as the 0.1.8 bump in #525.

## What's in 0.1.9 (per upstream changelog)
**Schema + tests only** — no new public methods, no behavior changes, no breaking changes:

- Vendors \`prior_steps.schema.json\` (closes augur#4) — official schema for the replay workbench's \`replay/<step_index:04d>.prior.json\` artifact. Producers can validate offline via \`augur_sdk._schema.validator_for("prior_steps")\`.
- 13 new tests covering required fields, \`additionalProperties\`, action.type / verdict validation, bundle-disk round-trip.

## Mantis impact: **zero functional**
Mantis doesn't emit replay artifacts today. This bump is hygiene only — stay current with the SDK, pick up future patch fixes, access the new schema if/when we wire replay-artifact emission.

## Files touched (7 sites)
- \`pyproject.toml\` (line 64)
- \`deploy/modal/modal_cua_server.py\` (×5 image declarations: 177, 1227, 1260, 1391, 2126)
- \`deploy/modal/modal_plan_runner.py\` (line 118)

## Test plan
- [x] Local install: \`uv pip install --refresh 'augur-sdk==0.1.9'\` succeeds; \`DebugSession\` carries all six helpers Mantis uses (\`set_costs\`, \`set_step_costs\`, \`record_modelio\`, \`set_score\`, \`set_capture_mode\`, \`append_log\`)
- [x] Full augur-touching test suite (70 cases across 7 files: \`test_observability_augur*\`, \`test_observability_modelio_523\`, \`test_plan_decomposer_modelio_523\`, \`test_form_handler_modelio_523\`, \`test_verifier_modelio_523\`) passes against 0.1.9
- [ ] CI: \`pytest 3.11\` + \`pytest 3.12\` + \`ruff\` + \`mkdocs-strict\` should all pass — pure pin bump, no code touched
- [ ] Modal redeploy — not strictly needed (no behavior change), but worth doing alongside the next code-changing PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)