### PR TITLE
augur: fix verdict.status / verdict.score regression on Mantis bundles (closes #530)

### DIFF
--- a/src/mantis_agent/gym/run_executor.py
+++ b/src/mantis_agent/gym/run_executor.py
@@ -372,18 +372,33 @@ class RunExecutor:
             costs=per_step_costs,
             latency=per_step_latency,
         )
-        # #524 — continuous verdict score. The verifier's confidence is
-        # already on the Verdict; pass it through so RLHF/DPO consumers
-        # see the finer-grained signal instead of the binary verdict→
-        # score mapping.
+        # #524 + #530 — continuous verdict score. Derive primarily
+        # from ``sr.success`` (the canonical runner-side truth), then
+        # blend with ``verdict.confidence`` only when the two agree.
+        # Why not use ``verdict.confidence`` directly: a handler may
+        # have optimistically pre-stamped ``Verdict(kind=OK,
+        # confidence=1.0)`` before the runner detected failure;
+        # passing 1.0 through to ``set_score`` on a failed step
+        # produces the surfaced #530 bug (score=1.0 on
+        # status=failed). Trust sr.success first.
         verdict = getattr(step_result, "verdict", None)
         verdict_confidence = float(getattr(verdict, "confidence", 0.0) or 0.0)
-        if verdict_confidence > 0.0:
-            # ``comparator`` must be one of the SDK's canonical values
-            # (verifier / model-judge / exact-match / human) — Mantis's
-            # verifier confidence rolls up under "verifier".
+        if getattr(step_result, "skip", False):
+            score_value: float | None = None  # don't stamp on skipped steps
+        elif getattr(step_result, "success", False):
+            # Success: use verifier confidence if non-zero, else 1.0.
+            score_value = verdict_confidence if verdict_confidence > 0.0 else 1.0
+        else:
+            # Failure: ignore any pre-stamped optimistic confidence —
+            # the runner says the step failed, so the score must
+            # reflect that. Use 0.0 unless the verdict explicitly
+            # marks the failure as recoverable (a partial signal).
+            v_kind = getattr(verdict, "kind", "") if verdict is not None else ""
+            v_kind = v_kind.value if hasattr(v_kind, "value") else str(v_kind)
+            score_value = 0.5 if v_kind == "recoverable" else 0.0
+        if score_value is not None:
             augur.set_score(
-                step_index, verdict_confidence, comparator="verifier",
+                step_index, score_value, comparator="verifier",
             )
         # #524 — upgrade capture mode on first failure. Healthy runs
         # stay cheap (metadata only); failing runs auto-collect

--- a/src/mantis_agent/observability/augur.py
+++ b/src/mantis_agent/observability/augur.py
@@ -890,24 +890,58 @@ class AugurAdapter:
 
         grounding = _build_grounding(sr, last_action, action_type or step_type, action_params)
 
-        # Verdict: prefer the typed slot, fall back to success boolean.
+        # Verdict (#530): derive status from ``sr.success`` as the
+        # canonical truth, then refine with ``verdict.kind`` only to
+        # distinguish ``recoverable`` from ``failed`` on the failure
+        # branch.
+        #
+        # Why not trust ``verdict.kind`` directly: the Mantis
+        # ``Verdict`` dataclass field is ``kind`` (not ``status``,
+        # which the prior code mistakenly read — that typo defaulted
+        # every step to ``"unknown"``). Even after fixing the typo,
+        # handlers that optimistically stamp ``Verdict(kind=OK,
+        # confidence=1.0)`` before failure is detected leave a
+        # misleading verdict on a step the runner later marks
+        # ``success=False``. ``_stamp_verdict`` (run_executor.py:1947)
+        # honors pre-stamped verdicts and won't recompute. Using
+        # ``sr.success`` here closes the gap on the emit side.
         v_obj = getattr(sr, "verdict", None)
-        if v_obj is not None:
-            v_status = getattr(v_obj, "status", "")
-            v_status = (
-                v_status.value if hasattr(v_status, "value") else str(v_status)
-            )
-            verdict: dict[str, Any] = {
-                "status": _VERDICT_STATUS_MAP.get(v_status, "unknown"),
-                "reason": getattr(v_obj, "reason", "") or "",
-                "evidence_refs": [],
-            }
+        if getattr(sr, "skip", False):
+            v_status_mapped = "skipped"
+        elif getattr(sr, "success", False):
+            v_status_mapped = "passed"
         else:
-            verdict = {
-                "status": "passed" if getattr(sr, "success", False) else "failed",
-                "reason": getattr(sr, "failure_class", "") or "",
-                "evidence_refs": [],
-            }
+            # Failed branch: prefer the verdict.kind distinction
+            # (recoverable vs non_recoverable) when present; otherwise
+            # fall through to "failed".
+            v_status_mapped = "failed"
+            if v_obj is not None:
+                v_kind = getattr(v_obj, "kind", "")
+                v_kind = (
+                    v_kind.value if hasattr(v_kind, "value") else str(v_kind)
+                )
+                if v_kind == "recoverable":
+                    v_status_mapped = "recoverable"
+        v_reason = (
+            getattr(v_obj, "reason", "") or ""
+            if v_obj is not None
+            else (getattr(sr, "failure_class", "") or "")
+        )
+        # #530 — surface the verifier's textual evidence as a
+        # reference when set. ``evidence`` is a free-form string on
+        # the Verdict; record it as a single evidence_ref so
+        # downstream consumers can attribute the verdict back to its
+        # rationale.
+        v_evidence_refs: list[str] = []
+        if v_obj is not None:
+            ev = (getattr(v_obj, "evidence", "") or "").strip()
+            if ev:
+                v_evidence_refs = [ev[:500]]
+        verdict: dict[str, Any] = {
+            "status": v_status_mapped,
+            "reason": v_reason,
+            "evidence_refs": v_evidence_refs,
+        }
 
         rd_obj = getattr(sr, "recovery_decision", None)
         recovery_decision: dict[str, Any] | None = None

--- a/tests/test_observability_augur_524.py
+++ b/tests/test_observability_augur_524.py
@@ -212,11 +212,15 @@ def test_run_executor_passes_verdict_confidence_through_set_score(
     augur.close(status="completed")
 
 
-def test_run_executor_skips_set_score_when_confidence_zero(
+def test_run_executor_falls_back_to_one_on_success_when_confidence_zero(
     monkeypatch, tmp_path: Path,
 ):
-    """When verdict.confidence is 0.0 (default / unset), don't pollute
-    Augur with bogus scores — let the SDK's binary mapping apply."""
+    """When verdict.confidence is 0.0 on a successful step, use the
+    derived score 1.0 (canonical from sr.success). Updated from the
+    prior #524-only contract per #530's emission-side defense: the
+    score must always reflect sr.success so downstream RLHF/DPO
+    consumers get a usable signal even when the verifier didn't
+    publish a confidence value."""
     from mantis_agent.gym.run_executor import RunExecutor
 
     monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
@@ -249,7 +253,12 @@ def test_run_executor_skips_set_score_when_confidence_zero(
     executor = RunExecutor.__new__(RunExecutor)
     executor.parent = runner
     executor._emit_augur_step(step_result, "2026-05-20T10:00:00Z")
-    augur_spy.set_score.assert_not_called()
+    augur_spy.set_score.assert_called_once()
+    score = augur_spy.set_score.call_args.args[1]
+    assert score == 1.0, (
+        "Successful step with no confidence must default to score=1.0 "
+        f"(got {score}). Per #530's emission-side defense."
+    )
     augur.close(status="completed")
 
 

--- a/tests/test_observability_augur_530.py
+++ b/tests/test_observability_augur_530.py
@@ -1,0 +1,361 @@
+"""Tests for #530 — verdict.status/score regression on Mantis bundles.
+
+Two-part fix:
+
+1. ``AugurAdapter._build_step_trace`` was reading ``getattr(v_obj,
+   "status", "")`` but the Mantis Verdict dataclass field is
+   ``kind``, not ``status``. The typo defaulted every step to
+   ``status="unknown"`` regardless of outcome.
+
+2. Even after fixing the typo, handlers that optimistically stamp
+   ``Verdict(kind=OK, confidence=1.0)`` before failure detection
+   left a misleading verdict on later-failed steps. The defensive
+   fix derives ``status`` from ``sr.success`` (canonical truth) and
+   uses ``verdict.kind`` only to distinguish recoverable from
+   non_recoverable on the failure branch. The companion
+   ``set_score`` wire in ``run_executor`` was updated to derive
+   the score from ``sr.success`` for the same reason.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip("augur_sdk")
+
+from mantis_agent.observability.augur import AugurAdapter
+
+
+def _make_step_result(*, success: bool, kind_value: str,
+                     confidence: float = 0.0,
+                     skip: bool = False,
+                     evidence: str = "",
+                     failure_class: str = "",
+                     step_index: int = 0):
+    """Build a StepResult-shaped MagicMock with a Verdict object."""
+    class _Kind:
+        def __init__(self, v): self.value = v
+
+    class _V:
+        pass
+    v = _V()
+    v.kind = _Kind(kind_value) if kind_value else ""
+    v.reason = failure_class
+    v.evidence = evidence
+    v.confidence = confidence
+
+    sr = MagicMock(
+        step_index=step_index, intent="x", success=success,
+        skip=skip, reversed=False, duration=0.1,
+        failure_class=failure_class, executor_backend="",
+        last_action=None, verdict=v, recovery_decision=None,
+        screenshot_png=None, data="", page_title="",
+    )
+    return sr
+
+
+def _emit_and_read(tmp_path: Path, sr) -> dict:
+    """Drive record_step + close, return the on-disk step dict."""
+    a = AugurAdapter(
+        run_id="v530", tenant_id="t", session_name="s", out_dir=tmp_path,
+    )
+    a.record_step(
+        step_result=sr,
+        started_at="2026-05-20T18:33:56Z",
+        ended_at="2026-05-20T18:33:57Z",
+    )
+    a.close(status="completed")
+    # SDK writes the step under steps/<augur_index:04d>.json — Mantis
+    # 0-based → Augur 1-based bump, so step_index=20 → 0021.json.
+    idx = int(getattr(sr, "step_index", 0)) + 1
+    return json.loads((tmp_path / "steps" / f"{idx:04d}.json").read_text())
+
+
+# ── status mapping ────────────────────────────────────────────────────────
+
+
+def test_failed_step_with_optimistic_kind_ok_still_maps_to_failed(
+    monkeypatch, tmp_path: Path,
+):
+    """The exact #530 reproducer: a handler pre-stamped
+    Verdict(kind=OK) but sr.success=False (the runner detected
+    failure later). Adapter must trust sr.success and emit
+    status=failed, NOT status=passed."""
+    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
+    sr = _make_step_result(
+        success=False, kind_value="ok", confidence=1.0,
+        failure_class="no_state_change", step_index=20,
+    )
+    step = _emit_and_read(tmp_path, sr)
+    assert step["verdict"]["status"] == "failed", (
+        f"Optimistic kind=OK on a failed step must NOT bypass sr.success "
+        f"(got {step['verdict']['status']!r}). This is the #530 regression."
+    )
+
+
+def test_failed_step_with_recoverable_kind_maps_to_recoverable(
+    monkeypatch, tmp_path: Path,
+):
+    """When sr.success=False AND verdict.kind=recoverable, emit
+    status=recoverable — the verdict's distinction is honored on
+    the failure branch."""
+    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
+    sr = _make_step_result(
+        success=False, kind_value="recoverable", confidence=0.5,
+        failure_class="selector_miss",
+    )
+    step = _emit_and_read(tmp_path, sr)
+    assert step["verdict"]["status"] == "recoverable"
+
+
+def test_failed_step_with_non_recoverable_kind_maps_to_failed(
+    monkeypatch, tmp_path: Path,
+):
+    """sr.success=False + kind=non_recoverable → status=failed
+    (not 'non_recoverable' — that's a Mantis-internal label)."""
+    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
+    sr = _make_step_result(
+        success=False, kind_value="non_recoverable", confidence=0.9,
+        failure_class="cf_challenge",
+    )
+    step = _emit_and_read(tmp_path, sr)
+    assert step["verdict"]["status"] == "failed"
+
+
+def test_successful_step_maps_to_passed(monkeypatch, tmp_path: Path):
+    """sr.success=True → status=passed regardless of verdict.kind."""
+    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
+    sr = _make_step_result(success=True, kind_value="ok", confidence=1.0)
+    step = _emit_and_read(tmp_path, sr)
+    assert step["verdict"]["status"] == "passed"
+
+
+def test_skipped_step_maps_to_skipped(monkeypatch, tmp_path: Path):
+    """sr.skip=True → status=skipped even when success=False."""
+    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
+    sr = _make_step_result(
+        success=False, skip=True, kind_value="recoverable", confidence=0.5,
+    )
+    step = _emit_and_read(tmp_path, sr)
+    assert step["verdict"]["status"] == "skipped"
+
+
+def test_verdict_missing_falls_back_to_success_boolean(
+    monkeypatch, tmp_path: Path,
+):
+    """When sr.verdict is None entirely, use sr.success."""
+    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
+    sr = MagicMock(
+        step_index=0, intent="x", success=False,
+        skip=False, reversed=False, duration=0.1,
+        failure_class="cf_challenge", executor_backend="",
+        last_action=None, verdict=None, recovery_decision=None,
+        screenshot_png=None, data="", page_title="",
+    )
+    step = _emit_and_read(tmp_path, sr)
+    assert step["verdict"]["status"] == "failed"
+
+
+# ── evidence_refs population ─────────────────────────────────────────────
+
+
+def test_verdict_evidence_string_lands_as_evidence_ref(
+    monkeypatch, tmp_path: Path,
+):
+    """Mantis Verdict.evidence is a free-form string the verifier
+    writes. Surface it as a single evidence_ref entry instead of
+    dropping it (the previous behavior left evidence_refs empty)."""
+    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
+    sr = _make_step_result(
+        success=False, kind_value="non_recoverable",
+        confidence=0.9, evidence="URL unchanged after click",
+        failure_class="no_state_change",
+    )
+    step = _emit_and_read(tmp_path, sr)
+    assert step["verdict"]["evidence_refs"] == ["URL unchanged after click"]
+
+
+def test_verdict_empty_evidence_leaves_evidence_refs_empty(
+    monkeypatch, tmp_path: Path,
+):
+    """No evidence string → no evidence_refs entries (don't fabricate)."""
+    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
+    sr = _make_step_result(
+        success=True, kind_value="ok", confidence=1.0, evidence="",
+    )
+    step = _emit_and_read(tmp_path, sr)
+    assert step["verdict"]["evidence_refs"] == []
+
+
+# ── reason field still flows correctly ───────────────────────────────────
+
+
+def test_verdict_reason_threads_from_verdict_reason_when_present(
+    monkeypatch, tmp_path: Path,
+):
+    """Verdict.reason populates verdict.reason on the bundle —
+    confirms the field-name fix didn't accidentally break the
+    reason path (different field, but adjacent code)."""
+    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
+    sr = _make_step_result(
+        success=False, kind_value="non_recoverable", confidence=0.9,
+        failure_class="cf_challenge",
+    )
+    step = _emit_and_read(tmp_path, sr)
+    # Verdict.reason mirrors failure_class in _make_step_result.
+    assert step["verdict"]["reason"] == "cf_challenge"
+
+
+# ── set_score wire (run_executor) ────────────────────────────────────────
+
+
+def test_set_score_zeros_on_failed_step_even_with_optimistic_confidence(
+    monkeypatch, tmp_path: Path,
+):
+    """The companion run_executor wire: a failed step with
+    optimistically-stamped Verdict(confidence=1.0) must NOT pass
+    1.0 through to set_score. Fix derives score from sr.success."""
+    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
+    from mantis_agent.gym.run_executor import RunExecutor
+
+    augur = AugurAdapter(
+        run_id="exec_530", tenant_id="t", session_name="s", out_dir=tmp_path,
+    )
+    augur_spy = MagicMock(wraps=augur)
+    runner = MagicMock()
+    runner._augur = augur_spy
+    runner._augur_capture_upgraded = False
+    runner._healing_events = []
+    runner.time_meter = None
+    runner._invoke_step_callback = lambda *a, **kw: None
+    runner.cost_meter = MagicMock()
+    runner.cost_meter.costs = {}
+
+    # The #530 reproducer: failed step + optimistic verdict
+    sr = _make_step_result(
+        success=False, kind_value="ok", confidence=1.0,
+        failure_class="no_state_change", step_index=20,
+    )
+    sr.reasoning = ""
+
+    executor = RunExecutor.__new__(RunExecutor)
+    executor.parent = runner
+    executor._emit_augur_step(sr, "2026-05-20T18:33:56Z")
+    augur.close(status="completed")
+
+    # set_score must have been called with 0.0, not the 1.0 the
+    # verdict.confidence carried.
+    augur_spy.set_score.assert_called_once()
+    score = augur_spy.set_score.call_args.args[1]
+    assert score == 0.0, (
+        f"Failed step's set_score must use 0.0 (canonical truth from "
+        f"sr.success=False), not the optimistic verdict.confidence "
+        f"({sr.verdict.confidence}). Got score={score}."
+    )
+
+
+def test_set_score_uses_05_for_recoverable_failure(
+    monkeypatch, tmp_path: Path,
+):
+    """Failed + verdict.kind=recoverable → score=0.5 (partial signal)."""
+    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
+    from mantis_agent.gym.run_executor import RunExecutor
+
+    augur = AugurAdapter(
+        run_id="exec_recoverable", tenant_id="t", session_name="s", out_dir=tmp_path,
+    )
+    augur_spy = MagicMock(wraps=augur)
+    runner = MagicMock()
+    runner._augur = augur_spy
+    runner._augur_capture_upgraded = False
+    runner._healing_events = []
+    runner.time_meter = None
+    runner._invoke_step_callback = lambda *a, **kw: None
+    runner.cost_meter = MagicMock()
+    runner.cost_meter.costs = {}
+
+    sr = _make_step_result(
+        success=False, kind_value="recoverable", confidence=0.5,
+    )
+    sr.reasoning = ""
+
+    executor = RunExecutor.__new__(RunExecutor)
+    executor.parent = runner
+    executor._emit_augur_step(sr, "2026-05-20T18:33:56Z")
+    augur.close(status="completed")
+
+    augur_spy.set_score.assert_called_once()
+    score = augur_spy.set_score.call_args.args[1]
+    assert score == 0.5
+
+
+def test_set_score_uses_confidence_when_available_on_success(
+    monkeypatch, tmp_path: Path,
+):
+    """Successful step + non-zero verdict.confidence → pass the
+    confidence through (the original #524 contract)."""
+    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
+    from mantis_agent.gym.run_executor import RunExecutor
+
+    augur = AugurAdapter(
+        run_id="exec_conf", tenant_id="t", session_name="s", out_dir=tmp_path,
+    )
+    augur_spy = MagicMock(wraps=augur)
+    runner = MagicMock()
+    runner._augur = augur_spy
+    runner._augur_capture_upgraded = False
+    runner._healing_events = []
+    runner.time_meter = None
+    runner._invoke_step_callback = lambda *a, **kw: None
+    runner.cost_meter = MagicMock()
+    runner.cost_meter.costs = {}
+
+    sr = _make_step_result(success=True, kind_value="ok", confidence=0.83)
+    sr.reasoning = ""
+
+    executor = RunExecutor.__new__(RunExecutor)
+    executor.parent = runner
+    executor._emit_augur_step(sr, "2026-05-20T18:33:56Z")
+    augur.close(status="completed")
+
+    augur_spy.set_score.assert_called_once()
+    score = augur_spy.set_score.call_args.args[1]
+    assert score == 0.83
+
+
+def test_set_score_skipped_step_does_not_emit_score(
+    monkeypatch, tmp_path: Path,
+):
+    """Skipped steps (sr.skip=True) must NOT emit a score — there's
+    no verdict to score for steps that didn't run."""
+    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
+    from mantis_agent.gym.run_executor import RunExecutor
+
+    augur = AugurAdapter(
+        run_id="exec_skipped", tenant_id="t", session_name="s", out_dir=tmp_path,
+    )
+    augur_spy = MagicMock(wraps=augur)
+    runner = MagicMock()
+    runner._augur = augur_spy
+    runner._augur_capture_upgraded = False
+    runner._healing_events = []
+    runner.time_meter = None
+    runner._invoke_step_callback = lambda *a, **kw: None
+    runner.cost_meter = MagicMock()
+    runner.cost_meter.costs = {}
+
+    sr = _make_step_result(
+        success=False, skip=True, kind_value="recoverable", confidence=0.5,
+    )
+    sr.reasoning = ""
+
+    executor = RunExecutor.__new__(RunExecutor)
+    executor.parent = runner
+    executor._emit_augur_step(sr, "2026-05-20T18:33:56Z")
+    augur.close(status="completed")
+
+    augur_spy.set_score.assert_not_called()


### PR DESCRIPTION
## Summary
Closes #530. The Augur workspace's per-step \`verdict\` was landing as \`{"status": "unknown", "score": 1.0}\` on every step (including failed ones), breaking the verifier-disagreement surface and making the score signal useless for downstream RLHF/DPO training.

## Root cause — two compounding bugs

### 1. Field-name typo in the adapter
\`AugurAdapter._build_step_trace\` read \`getattr(v_obj, "status", "")\` but the Mantis \`Verdict\` dataclass field is **\`kind\`** (a \`VerdictKind\` enum), NOT \`status\`. The typo returned \`""\` for every step, \`_VERDICT_STATUS_MAP.get("", "unknown")\` defaulted to \`"unknown"\`, and the failure was invisible because \`"unknown"\` is a legal Augur enum value.

### 2. Pre-stamped optimistic verdicts on later-failed steps
Some handlers stamp \`Verdict(kind=OK, confidence=1.0)\` eagerly before the runner detects failure. \`_stamp_verdict\` honors any pre-stamped verdict and won't recompute, so the optimistic stamp persists even after \`sr.success\` flips to False — meaning even after the field-name fix, those steps would land as status=passed.

## Fix — emission-side defense, single source of truth

- **\`_build_step_trace\`**: derives \`verdict.status\` from \`sr.success\` (canonical truth), then refines with \`verdict.kind\` only to distinguish \`recoverable\` from \`failed\` on the failure branch. Skipped steps map to \`skipped\`. Reading \`kind\` (the right field name) is retained for the recoverable distinction.
- **\`run_executor._emit_augur_step\`'s \`set_score\` wire** (added in #528): derives score from \`sr.success\` too — success → 1.0 (or \`verdict.confidence\` when set); failure → 0.0 (or 0.5 when \`verdict.kind=recoverable\`); skipped → no emission.
- **\`verdict.evidence_refs\`**: now carries Mantis's \`Verdict.evidence\` string (truncated to 500 chars) when set; previously hardcoded \`[]\`. Surfaces the verifier's textual rationale.

## Test plan
- [x] \`pytest tests/test_observability_augur_530.py\` — **13 new pass**
- [x] \`pytest tests/test_observability_augur_524.py tests/test_observability_augur_530.py tests/test_observability_augur.py tests/test_observability_augur_518.py\` — **60 pass** (the one #524 test about confidence=0 was updated to reflect the new contract: successful step now lands score=1.0 instead of skipping emission)
- [x] \`ruff check\` — clean
- [x] Local reproduction of the exact #530 shape now lands \`{"status": "failed", "score": 0.0, "evidence_refs": ["post-click URL unchanged"]}\` instead of \`{"status": "unknown", "score": 1.0, "evidence_refs": []}\`
- [ ] Modal redeploy + plan run → verify the new bundle from a fresh staff-crm-long run shows correct status/score on failed steps

## Related
- **#536** (also new, just filed): \`Model\` column empty on live runs — independent issue, will ship as a separate PR (small fix: flush initial session-only \`trace.json\` at session start)

🤖 Generated with [Claude Code](https://claude.com/claude-code)