### PR TITLE
augur: flush session-only trace.json at session open (closes #536)

### DIFF
--- a/src/mantis_agent/observability/augur.py
+++ b/src/mantis_agent/observability/augur.py
@@ -348,9 +348,65 @@ class AugurAdapter:
                     "AugurAdapter init: opened successfully streaming=%s out_dir=%s",
                     session._stream is not None, target_dir,
                 )
+            # #536 — flush a session-only trace.json immediately so the
+            # Augur workspace's Runs-list ``Model`` column populates
+            # live (within one poll cycle ~5s) instead of waiting
+            # until the run halts. Tags (including ``model``) are
+            # already on the session record at this point because
+            # ``DebugSession(tags=...)`` carried them in.
+            self._flush_session_metadata_to_stream()
         except Exception as exc:  # noqa: BLE001
             logger.warning("AugurAdapter: failed to open DebugSession: %s", exc)
             self._session = None
+
+    def _flush_session_metadata_to_stream(self) -> None:
+        """Send a session-only ``trace.json`` PUT to the streaming sink
+        right after session open (#536).
+
+        Workspace's Runs-list ``Model`` column reads
+        ``session.tags.model`` off ``trace.json``. The SDK only writes
+        the full trace.json at session ``close()`` (when steps are
+        finalized), so during a live run the column would stay null
+        until the run halts. A session-only payload with empty
+        ``steps: []`` is enough to land the session block (including
+        tags) on the server immediately.
+
+        Reaches into the SDK's private ``_stream`` because there's no
+        public ``flush_session_metadata`` helper today. No-op when
+        streaming isn't configured (``AUGUR_DSN`` unset → on-disk
+        bundle only, no live-poll behavior to fix).
+        """
+        sess = self._session
+        if sess is None:
+            return
+        stream = getattr(sess, "_stream", None)
+        if stream is None:
+            return
+        try:
+            record_fn = getattr(sess, "_session_record", None)
+            if record_fn is None:
+                return
+            payload = {"session": dict(record_fn()), "steps": []}
+            redaction = getattr(sess, "redaction_policy", None)
+            if redaction is not None:
+                payload = redaction.apply(payload)
+            stream.put_trace(payload)
+            if is_verbose():
+                logger.warning(
+                    "AugurAdapter._flush_session_metadata_to_stream: "
+                    "session-only trace flushed",
+                )
+        except Exception as exc:  # noqa: BLE001
+            if is_verbose():
+                logger.warning(
+                    "AugurAdapter._flush_session_metadata_to_stream failed: %r",
+                    exc,
+                )
+            else:
+                logger.debug(
+                    "AugurAdapter._flush_session_metadata_to_stream failed: %s",
+                    exc,
+                )
 
     @property
     def active(self) -> bool:

--- a/tests/test_observability_augur_536.py
+++ b/tests/test_observability_augur_536.py
@@ -1,0 +1,166 @@
+"""Tests for #536 — early session metadata flush so the Augur Runs
+list shows the ``Model`` column live (not only after the run halts).
+
+The fix: ``AugurAdapter.__init__`` calls
+``_flush_session_metadata_to_stream()`` right after the SDK session
+opens. That posts a session-only ``trace.json`` (session block +
+empty steps) to the streaming sink, landing tags including ``model``
+on the workspace within one poll cycle.
+
+No-op behavior contracts to preserve:
+
+* Streaming not configured (``AUGUR_DSN`` unset) → no put_trace call,
+  no error
+* Adapter disabled (``MANTIS_AUGUR_DISABLED=1``) → wrapper never runs
+* SDK exception inside put_trace → swallowed at WARN/DEBUG (telemetry
+  never breaks runs)
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip("augur_sdk")
+
+from mantis_agent.observability.augur import AugurAdapter
+
+
+def test_flush_session_metadata_called_at_init_with_active_stream(
+    monkeypatch, tmp_path: Path,
+):
+    """When the SDK session has an active ``_stream`` (i.e.
+    ``AUGUR_DSN`` is set), the adapter's init must call
+    ``put_trace(session_only_payload)`` once. Tags (including
+    ``model``) must be present on the session block."""
+    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
+    a = AugurAdapter(
+        run_id="early_flush_v1", tenant_id="t", session_name="s",
+        out_dir=tmp_path,
+        extra_tags={"model": "Holo3-35B-A3B"},
+    )
+    # Inject a fake stream so put_trace becomes observable.
+    fake_stream = MagicMock()
+    a._session._stream = fake_stream
+    # Re-fire the flush — first call in __init__ ran with _stream=None
+    # (the SDK only opens _stream when AUGUR_DSN is set). For testing
+    # we drive the helper directly with the stream now in place.
+    a._flush_session_metadata_to_stream()
+
+    fake_stream.put_trace.assert_called_once()
+    payload = fake_stream.put_trace.call_args.args[0]
+    assert "session" in payload
+    assert "steps" in payload
+    assert payload["steps"] == [], (
+        "Steps must be empty at session-open (no steps recorded yet)"
+    )
+    # Model tag must be on the session payload — that's the whole
+    # point of the fix.
+    tags = payload["session"].get("tags", {})
+    assert tags.get("model") == "Holo3-35B-A3B", (
+        f"model tag missing from flushed session payload — tags={tags!r}"
+    )
+    a.close(status="completed")
+
+
+def test_flush_session_metadata_noop_when_stream_absent(
+    monkeypatch, tmp_path: Path,
+):
+    """No streaming sink (``AUGUR_DSN`` not set) → no put_trace call,
+    no error. The on-disk bundle path doesn't need an early flush
+    because there's no live consumer."""
+    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
+    monkeypatch.delenv("AUGUR_DSN", raising=False)
+    a = AugurAdapter(
+        run_id="early_flush_no_stream", tenant_id="t", session_name="s",
+        out_dir=tmp_path,
+        extra_tags={"model": "claude-opus-4-7"},
+    )
+    # The SDK won't have created a _stream when AUGUR_DSN isn't set.
+    assert a._session._stream is None
+    # Calling the helper explicitly must still be a clean no-op.
+    a._flush_session_metadata_to_stream()  # MUST NOT raise
+    a.close(status="completed")
+
+
+def test_flush_session_metadata_noop_when_adapter_disabled(
+    monkeypatch, tmp_path: Path,
+):
+    """Disabled adapter → no session, no flush attempted, no error."""
+    monkeypatch.setenv("MANTIS_AUGUR_DISABLED", "1")
+    a = AugurAdapter(
+        run_id="early_flush_disabled", tenant_id="t", session_name="s",
+        out_dir=tmp_path,
+        extra_tags={"model": "x"},
+    )
+    assert not a.active
+    # MUST NOT raise.
+    a._flush_session_metadata_to_stream()
+
+
+def test_flush_session_metadata_swallows_stream_exception(
+    monkeypatch, tmp_path: Path,
+):
+    """If put_trace raises (e.g. server 5xx), the wrapper must swallow
+    it. Telemetry never breaks runs. Per Augur spec §4.3."""
+    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
+    a = AugurAdapter(
+        run_id="early_flush_err", tenant_id="t", session_name="s",
+        out_dir=tmp_path,
+        extra_tags={"model": "x"},
+    )
+    fake_stream = MagicMock()
+    fake_stream.put_trace.side_effect = RuntimeError(
+        "simulated 503 from Augur server"
+    )
+    a._session._stream = fake_stream
+    # MUST NOT raise even when the stream call blows up.
+    a._flush_session_metadata_to_stream()
+    a.close(status="completed")
+
+
+def test_flush_session_metadata_includes_run_id_for_routing(
+    monkeypatch, tmp_path: Path,
+):
+    """The streaming sink routes ``put_trace`` via
+    ``payload['session']['run_id']`` to its
+    ``PUT /runs/{id}/trace`` endpoint. Confirm the run_id makes it
+    into the payload."""
+    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
+    a = AugurAdapter(
+        run_id="route_check_xyz", tenant_id="t", session_name="s",
+        out_dir=tmp_path,
+        extra_tags={"model": "x"},
+    )
+    fake_stream = MagicMock()
+    a._session._stream = fake_stream
+    a._flush_session_metadata_to_stream()
+    payload = fake_stream.put_trace.call_args.args[0]
+    assert payload["session"]["run_id"] == "route_check_xyz"
+
+
+def test_flush_session_metadata_applies_redaction_policy(
+    monkeypatch, tmp_path: Path,
+):
+    """The session-only flush must run the SDK's redaction policy
+    (same as the close-time flush) so passwords / tokens in the
+    session payload are masked before they hit the network."""
+    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
+    a = AugurAdapter(
+        run_id="redact_check", tenant_id="t", session_name="s",
+        out_dir=tmp_path,
+        extra_tags={"model": "x"},
+    )
+    fake_stream = MagicMock()
+    a._session._stream = fake_stream
+    # Spy on the redaction policy's apply method.
+    real_apply = a._session.redaction_policy.apply
+    redaction_spy = MagicMock(side_effect=real_apply)
+    a._session.redaction_policy.apply = redaction_spy
+    a._flush_session_metadata_to_stream()
+    # apply must have been called (the SDK's policy walks the payload
+    # recursively, so we get N calls — at least one on the root dict).
+    assert redaction_spy.called
+    fake_stream.put_trace.assert_called_once()


### PR DESCRIPTION
## Summary
Closes #536. The Augur workspace's Runs-list \`Model\` column reads \`session.tags.model\` off \`trace.json\` — but the SDK only writes the full trace.json at session \`close()\`, so during a live run the column stays null until the run halts.

**Option A from the issue:** fire one session-only \`trace.json\` PUT right after \`DebugSession\` opens. Tags (including \`model\`) are already populated from \`extra_tags={"model": ...}\` at construction, so they ride along. The Runs list picks up the model within one poll cycle (~5s).

## Implementation
New private helper \`AugurAdapter._flush_session_metadata_to_stream()\` that:
- Reaches into the SDK's private \`_session._stream\` (no public \`flush_session_metadata\` API exists today — happy to open an upstream issue for one)
- Builds the session-only payload via \`_session._session_record()\` + empty \`steps: []\`
- Applies the SDK's redaction policy before forwarding
- Calls \`stream.put_trace(payload)\` → \`PUT /runs/{id}/trace\`

Called once from \`AugurAdapter.__init__\` immediately after \`session.__enter__()\` succeeds.

## Behavior contract
- **No-op when streaming isn't configured** (\`AUGUR_DSN\` unset → on-disk bundle only, no live consumer to populate)
- **No-op when adapter is disabled** (\`MANTIS_AUGUR_DISABLED=1\`)
- **Telemetry never breaks runs**: any exception (5xx, network blip, redaction error) is swallowed at WARN/DEBUG per spec §4.3

## Test plan
- [x] \`pytest tests/test_observability_augur_536.py\` — **6 new pass**
- [x] \`pytest tests/test_observability_augur_536.py tests/test_observability_augur.py tests/test_observability_augur_518.py tests/test_observability_augur_524.py\` — **53 pass** (no regressions)
- [x] \`ruff check\` — clean
- [ ] Modal redeploy + start a run → confirm the Augur Runs list shows the model name within one poll cycle of session start, not after halt

## Related
- **#530** (in flight as PR #537): verdict.status/score regression — different bug in the adapter's verdict emit; independent change

🤖 Generated with [Claude Code](https://claude.com/claude-code)