### PR TITLE
ci: pre-commit lint blocking customer-info leaks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,3 +36,22 @@ repos:
       - id: ruff
         args: [--fix]
       - id: ruff-format
+
+  - repo: local
+    hooks:
+      # Block customer brand names / target domains / seed lead IDs
+      # from ever landing in the repo. See
+      # ``scripts/lint_no_customer_info.py`` for the banned-term list
+      # and the allowlist (tests/, the lint script itself, .gitignore,
+      # this config). Standing rule:
+      # https://github.com/mercurialsolo/mantis/blob/main/AGENTS.md
+      # (auto-memory: feedback_no_customer_names_in_tracked_files).
+      - id: no-customer-info
+        name: no customer-named content (brands / domains / seed IDs)
+        entry: python scripts/lint_no_customer_info.py
+        language: python
+        pass_filenames: true
+        # Run on every file type — banned terms could appear in MD,
+        # YAML, JSON, Python, plain text, etc. Excluded paths are
+        # handled inside the script (tests/, the lint files).
+        types: [text]

--- a/scripts/lint_no_customer_info.py
+++ b/scripts/lint_no_customer_info.py
@@ -1,0 +1,197 @@
+"""Pre-commit lint that blocks customer-named content from being committed.
+
+Per the standing rule (auto-memory:
+``feedback_no_customer_names_in_tracked_files``): scripts, plans,
+prompts, and docs MUST NOT carry customer brand names / target
+domains / seed lead IDs. Use neutral phrasing (e.g. "remote-brain
+integration") or move the artifact to a gitignored path (``/tmp/``,
+``scripts/run_*_with_proxy.py``, ``plans/``).
+
+This script is the pre-commit gate. Run with a list of paths
+(default: ``git diff --cached --name-only --diff-filter=ACM``) and
+exits non-zero on any violation.
+
+Usage::
+
+    # Manual run on staged files
+    python scripts/lint_no_customer_info.py
+
+    # Run on specific files
+    python scripts/lint_no_customer_info.py FILE [FILE ...]
+
+    # As pre-commit framework hook
+    # (see .pre-commit-config.yaml)
+
+The check runs in two passes:
+
+1. **Path block** — filenames containing a banned term anywhere are
+   rejected (e.g. ``scripts/run_acme_co_scraper.py``).
+2. **Content block** — file body grepped (case-insensitive) for
+   banned terms; first hit emits a violation pointing at the line.
+
+Allowlist for legitimate references:
+
+* ``tests/`` — test files can mention customer names in isolation
+  (per the memory's "tests-isolated allowlist" carve-out).
+* The lint script + config themselves — they contain the banned
+  terms as patterns to detect.
+* ``.gitignore`` — it lists banned-pattern filenames so they're
+  blocked from tracking.
+
+Add new banned terms by editing :data:`_BANNED_TERMS` below; keep
+the list short + maintained — too many false positives encourages
+the obvious workaround (``# noqa``).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# ── Banned-term registry ─────────────────────────────────────────────────
+
+# Customer brands, target domains, seed lead identifiers, internal
+# product nicknames that should never appear in tracked files. Match
+# substring (case-insensitive). Keep this list audit-able.
+_BANNED_TERMS: tuple[str, ...] = (
+    # Customer brand names + target sites used in adhoc scripts
+    "boattrader",
+    "staffai",
+    "staff-ai",
+    "staff_crm",
+    "popyachts",
+    # Customer-named test-fixture domains
+    "staffai-test-crm",
+    # Customer-side seed lead identifiers (these appear in adhoc
+    # submit scripts and burn into git history if not gated)
+    "sentinel prime",          # SEED_LEAD_BODY robot_name from staff-crm
+    "pinnacle robotics",       # SEED_LEAD_BODY company
+    "jordan.reyes@pinnacle",   # SEED_LEAD_BODY contact_email
+)
+
+# Paths exempt from content scanning. These files legitimately
+# contain banned terms (the lint script's own pattern list, the
+# gitignore that names blocked files, tests that exercise customer
+# integrations in isolation).
+_ALLOWED_PATHS: tuple[str, ...] = (
+    "scripts/lint_no_customer_info.py",
+    ".pre-commit-config.yaml",
+    ".gitignore",
+    "tests/",
+)
+
+# Path-block: filename substrings that are forbidden even before
+# content scanning. Catches drive-by additions like
+# ``scripts/run_boattrader_urlnav.py``.
+_BANNED_PATH_FRAGMENTS: tuple[str, ...] = (
+    "boattrader",
+    "staffai",
+    "staff_crm",
+    "popyachts",
+)
+
+
+# ── Scanning ─────────────────────────────────────────────────────────────
+
+
+def _is_allowed_path(path: str) -> bool:
+    return any(path == p or path.startswith(p) for p in _ALLOWED_PATHS)
+
+
+def _staged_files() -> list[str]:
+    """Default: files staged for the next commit (added / copied / modified)."""
+    try:
+        out = subprocess.check_output(
+            ["git", "diff", "--cached", "--name-only", "--diff-filter=ACM"],
+            text=True,
+        )
+    except subprocess.CalledProcessError:
+        return []
+    return [line.strip() for line in out.splitlines() if line.strip()]
+
+
+def _scan_file(path: str) -> list[str]:
+    """Return a list of violation messages for ``path``. Empty list = clean."""
+    violations: list[str] = []
+
+    # Path-block first — cheap.
+    fname_lc = path.lower()
+    for frag in _BANNED_PATH_FRAGMENTS:
+        if frag in fname_lc and not _is_allowed_path(path):
+            violations.append(
+                f"{path}: filename contains banned customer term {frag!r} "
+                f"(rename to a neutral term or move to a gitignored path)"
+            )
+
+    # Skip content scan for binary / allowed paths.
+    if _is_allowed_path(path):
+        return violations
+    p = Path(path)
+    if not p.exists() or not p.is_file():
+        return violations
+
+    try:
+        text = p.read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return violations
+
+    text_lc = text.lower()
+    for term in _BANNED_TERMS:
+        if term.lower() not in text_lc:
+            continue
+        # Locate first occurrence + line number for a useful error.
+        for line_no, line in enumerate(text.splitlines(), 1):
+            if term.lower() in line.lower():
+                snippet = line.strip()[:120]
+                violations.append(
+                    f"{path}:{line_no}: banned customer term {term!r} "
+                    f"in line {snippet!r}"
+                )
+                break  # one report per term per file is enough
+
+    return violations
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "files", nargs="*",
+        help="Paths to scan (defaults to staged files)",
+    )
+    args = parser.parse_args(argv)
+
+    files = args.files or _staged_files()
+    if not files:
+        return 0
+
+    all_violations: list[str] = []
+    for f in files:
+        all_violations.extend(_scan_file(f))
+
+    if not all_violations:
+        return 0
+
+    print(
+        "\n❌  Customer-info pre-commit gate failed "
+        "(see auto-memory: feedback_no_customer_names_in_tracked_files):\n",
+        file=sys.stderr,
+    )
+    for v in all_violations:
+        print(f"  {v}", file=sys.stderr)
+    print(
+        "\nFix options:\n"
+        "  1. Rename the file / strip the banned term + use neutral phrasing\n"
+        "  2. Move the file to a gitignored path (e.g. scripts/run_*_with_proxy.py,\n"
+        "     plans/, /tmp/, ~/scratch/)\n"
+        "  3. If this is a legitimate test, place it under tests/ (allowlisted)\n",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/lint_no_customer_info.py
+++ b/scripts/lint_no_customer_info.py
@@ -46,8 +46,6 @@ the obvious workaround (``# noqa``).
 from __future__ import annotations
 
 import argparse
-import os
-import re
 import subprocess
 import sys
 from pathlib import Path

--- a/tests/test_docs_client_isolation.py
+++ b/tests/test_docs_client_isolation.py
@@ -48,6 +48,12 @@ CLIENT_TOKENS: tuple[str, ...] = (
     # Internal product / tenant strings sprinkled through old examples.
     "robotcrm",
     "vision_claude_prod",
+    # Seed lead identifiers from the staff-crm fixture — these
+    # accumulated in adhoc submit scripts and burned into git history
+    # before the pre-commit gate caught them (2026-05-20).
+    "Sentinel Prime",
+    "Pinnacle Robotics",
+    "jordan.reyes@pinnacle",
 )
 
 
@@ -56,6 +62,12 @@ CLIENT_TOKENS: tuple[str, ...] = (
 # fixtures don't carry meaningful prose so they get skipped too.
 ALLOWLIST_PATHS: frozenset[str] = frozenset({
     "tests/test_docs_client_isolation.py",
+    # The pre-commit lint + its tests + config legitimately contain
+    # the banned tokens as patterns to detect (#543). Same self-
+    # allowlist rationale as this file.
+    "scripts/lint_no_customer_info.py",
+    "tests/test_lint_no_customer_info.py",
+    ".pre-commit-config.yaml",
 })
 
 

--- a/tests/test_lint_no_customer_info.py
+++ b/tests/test_lint_no_customer_info.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-import pytest
 
 # Add scripts/ to path so we can import the lint module.
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))

--- a/tests/test_lint_no_customer_info.py
+++ b/tests/test_lint_no_customer_info.py
@@ -1,0 +1,194 @@
+"""Tests for the no-customer-info pre-commit lint.
+
+Per the standing rule (auto-memory:
+``feedback_no_customer_names_in_tracked_files``): scripts, plans,
+prompts, and docs must not carry customer brand names / target
+domains / seed lead IDs. This pre-commit gate stops violations
+from landing.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Add scripts/ to path so we can import the lint module.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+import lint_no_customer_info as lint  # noqa: E402
+
+
+# ── Banned-path detection ────────────────────────────────────────────────
+
+
+def test_path_block_catches_customer_filename(tmp_path: Path, monkeypatch):
+    """``scripts/run_<customer>_scraper.py``-shaped filename must be
+    flagged immediately — these adhoc submit scripts are the canonical
+    near-miss that motivated this lint."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "scripts").mkdir()
+    bad = tmp_path / "scripts" / "run_boattrader_urlnav.py"
+    bad.write_text("# harmless content\nx = 1\n")
+    violations = lint._scan_file("scripts/run_boattrader_urlnav.py")
+    assert violations, "filename containing 'boattrader' must be flagged"
+    assert any("filename contains banned" in v for v in violations)
+
+
+def test_path_block_allowed_for_tests(tmp_path: Path, monkeypatch):
+    """tests/ is allowlisted — test files exercising customer
+    integrations in isolation are permitted (per the memory's
+    'tests-isolated allowlist' carve-out)."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "tests").mkdir()
+    # Even with banned term in the path, tests/ is allowlisted.
+    bad = tmp_path / "tests" / "test_boattrader_integration.py"
+    bad.write_text("def test_x():\n    assert True\n")
+    violations = lint._scan_file("tests/test_boattrader_integration.py")
+    assert not violations, f"tests/ path must be allowlisted, got: {violations}"
+
+
+def test_path_block_allowed_for_lint_script_itself():
+    """The lint script + the .pre-commit-config.yaml + .gitignore
+    contain the banned terms (as patterns). Must be allowlisted."""
+    for p in [
+        "scripts/lint_no_customer_info.py",
+        ".pre-commit-config.yaml",
+        ".gitignore",
+    ]:
+        assert lint._is_allowed_path(p), f"{p} must be allowlisted"
+
+
+# ── Banned-term content detection ────────────────────────────────────────
+
+
+def test_content_block_catches_customer_brand_in_docs(tmp_path: Path):
+    """A doc file referencing a banned customer brand must be flagged
+    with the line number + context."""
+    bad = tmp_path / "docs" / "guide.md"
+    bad.parent.mkdir()
+    bad.write_text(
+        "# Integration guide\n"
+        "Connect via the StaffAI bridge.\n"  # banned: 'staffai'
+        "Done.\n"
+    )
+    violations = lint._scan_file(str(bad))
+    assert any("staffai" in v.lower() for v in violations), violations
+    # Must report the line number (2nd line is the offender).
+    assert any(":2:" in v for v in violations)
+
+
+def test_content_block_catches_seed_lead_identifier(tmp_path: Path):
+    """Customer-side seed lead identifiers (robot_name / contact
+    email) burn into git history if adhoc submit scripts slip in.
+    Must be caught at the term level."""
+    bad = tmp_path / "scripts" / "harness.py"
+    bad.parent.mkdir()
+    bad.write_text(
+        "SEED = {\n"
+        "    'robot_name': 'Sentinel Prime',\n"  # banned
+        "    'company': 'Pinnacle Robotics',\n"  # banned
+        "}\n"
+    )
+    violations = lint._scan_file(str(bad))
+    assert violations, "seed-lead identifiers must be flagged"
+    # Both terms should be caught
+    blob = "\n".join(violations).lower()
+    assert "sentinel prime" in blob
+    assert "pinnacle robotics" in blob
+
+
+def test_content_block_clean_file_passes(tmp_path: Path):
+    """Clean code must not trip the lint."""
+    good = tmp_path / "src" / "module.py"
+    good.parent.mkdir()
+    good.write_text(
+        "def add(a, b):\n"
+        "    \"\"\"Sum two numbers.\"\"\"\n"
+        "    return a + b\n"
+    )
+    assert lint._scan_file(str(good)) == []
+
+
+def test_content_block_case_insensitive(tmp_path: Path):
+    """Match must be case-insensitive — 'BoatTrader' and 'BOATTRADER'
+    are both violations."""
+    bad = tmp_path / "src" / "mixed.py"
+    bad.parent.mkdir()
+    bad.write_text("TARGET = 'BoatTrader'\nALT = 'BOATTRADER'\n")
+    violations = lint._scan_file(str(bad))
+    assert violations
+    assert any("boattrader" in v.lower() for v in violations)
+
+
+def test_content_block_tests_path_is_allowed(tmp_path: Path):
+    """Files under tests/ skip CONTENT scanning too (not just path
+    block) — test fixtures need to use real customer names."""
+    test_file = tmp_path / "tests" / "test_integration.py"
+    test_file.parent.mkdir()
+    test_file.write_text(
+        "def test_boattrader_smoke():\n"
+        "    assert 'boattrader' in 'we test against boattrader.com'\n"
+    )
+    # Path starts with 'tests/' so it's allowlisted
+    import os
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        violations = lint._scan_file("tests/test_integration.py")
+        assert violations == [], f"tests/ must be allowlisted for content: {violations}"
+    finally:
+        os.chdir(cwd)
+
+
+# ── End-to-end main() ────────────────────────────────────────────────────
+
+
+def test_main_returns_zero_on_clean_files(tmp_path: Path, capsys):
+    """No staged files / all clean → exit 0 (allows commit)."""
+    good = tmp_path / "clean.py"
+    good.write_text("x = 1\n")
+    rc = lint.main([str(good)])
+    assert rc == 0
+
+
+def test_main_returns_one_on_violations(tmp_path: Path, capsys):
+    """Any violation → exit 1 (blocks commit) + friendly stderr msg."""
+    bad = tmp_path / "scripts" / "run_boattrader_probe.py"
+    bad.parent.mkdir()
+    bad.write_text("URL = 'https://boattrader.com'\n")
+    rc = lint.main([str(bad)])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "Customer-info pre-commit gate failed" in err
+    assert "boattrader" in err.lower()
+
+
+def test_main_no_args_uses_git_staged(monkeypatch):
+    """Default behavior (no argv) reads staged files from git. We
+    just verify the call site exists — actual git invocation is
+    integration-tested by the pre-commit framework itself."""
+    monkeypatch.setattr(lint, "_staged_files", lambda: [])
+    rc = lint.main([])
+    assert rc == 0  # no files → trivially clean
+
+
+# ── Registry sanity ──────────────────────────────────────────────────────
+
+
+def test_banned_terms_set_is_non_empty():
+    """If someone shrinks this to zero, the lint becomes useless."""
+    assert len(lint._BANNED_TERMS) >= 5
+
+
+def test_banned_path_fragments_subset_of_banned_terms():
+    """Path-block fragments should track the term registry —
+    inconsistencies here mean a banned term could pass the path
+    check but trip on content (or vice versa)."""
+    term_lc = {t.lower() for t in lint._BANNED_TERMS}
+    for frag in lint._BANNED_PATH_FRAGMENTS:
+        # Path fragments may be normalized (underscores etc.), so we
+        # only require substring overlap.
+        assert any(frag in t or t in frag for t in term_lc), (
+            f"path fragment {frag!r} has no related banned term"
+        )


### PR DESCRIPTION
## Summary
Codifies the standing rule (no customer brand names / target domains / seed lead IDs in tracked files) as a pre-commit + repo-lint gate. The 2026-05-20 boattrader-script near-miss demonstrated the rule is too easy to violate by accident — drive-by additions during conflict resolution can sneak customer-named scripts into commits.

## What lands
- **\`scripts/lint_no_customer_info.py\`** — the lint, runnable standalone with explicit paths or via stdin from \`git diff --cached\`. Two-pass scan:
  - Path block: filename containing a banned customer term (catches \`scripts/run_boattrader_*.py\` patterns)
  - Content block: file body grepped case-insensitive for banned terms (brand names, target domains, seed lead identifiers)
- **\`.pre-commit-config.yaml\`** — local hook entry so \`pre-commit install\` + \`git commit\` triggers it
- **\`tests/test_lint_no_customer_info.py\`** — 13 unit tests covering path block, content block, tests/ allowlist, lint-script self-allowlist, case-insensitivity, end-to-end \`main()\` exit codes, registry sanity

## Allowlist
- \`tests/\` — test-isolated allowlist per the existing rule (test fixtures need real names)
- The lint script + \`.pre-commit-config.yaml\` + \`.gitignore\` themselves (they contain the banned terms as patterns)

## Pre-existing violations on main
The lint surfaced ~22 violations already in tracked files: \`AGENTS.md\`, \`CLAUDE.md\`, \`deploy/modal/*.py\`, \`docs/*\`, \`scripts/check_boattrader.sh\`, training data JSONL. The pre-commit gate runs only on STAGED files so existing main is grandfathered — this PR doesn't break the build for anyone.

**Follow-up issue** to track cleanup of those historical violations: separate scope, larger blast radius, will need careful per-file decisions on rename vs. neutral phrasing vs. move-to-gitignored-path.

## Test plan
- [x] \`pytest tests/test_lint_no_customer_info.py\` — **13 pass**
- [x] \`python scripts/lint_no_customer_info.py\` on staged files of this PR — clean (lint, config, tests all allowlisted)
- [x] Manual: created a fake \`scripts/run_boattrader_x.py\` → lint blocks both path + content; renamed to \`scripts/run_helper_x.py\` with clean content → lint passes
- [ ] CI runs pre-commit on push — should pass on this PR (no new violations), should block on future PRs that introduce customer-named content

🤖 Generated with [Claude Code](https://claude.com/claude-code)