### PR TITLE
viewer: Take-Over button + proxy egress IP display in live viewer

### DIFF
--- a/deploy/modal/modal_cua_server.py
+++ b/deploy/modal/modal_cua_server.py
@@ -461,7 +461,7 @@ def _run_executor(
     brain.load()
 
     # ── Env + viewer ──
-    env, proxy_proc = setup_env(
+    env, proxy_proc, proxy_diag = setup_env(
         base_url=task_suite.get("base_url", ""),
         run_id=run_id, session_name=session_name, settle_time=2.0,
         proxy_city=str(task_suite.get("_proxy_city") or ""),
@@ -470,7 +470,7 @@ def _run_executor(
         proxy_disabled=bool(task_suite.get("_proxy_disabled", False)),
         profile_dir=profile_dir,
     )
-    viewer_ctx, viewer_event_bus, _viewer_url = setup_viewer(viewer)
+    viewer_ctx, viewer_event_bus, _viewer_url = setup_viewer(viewer, proxy_diag=proxy_diag)
 
     # ── Delegate to shared lifecycle ──
     config = TaskLoopConfig(
@@ -658,7 +658,7 @@ def _run_holo3_executor(
     grounding = ClaudeGrounding()
 
     # Env + viewer via shared helpers
-    env, proxy_proc = setup_env(
+    env, proxy_proc, proxy_diag = setup_env(
         base_url=base_url, run_id=run_id, session_name=session_name,
         settle_time=4.0,  # Holo3 needs longer settle — sees black screen with 2s
         proxy_city=str(task_suite.get("_proxy_city") or ""),
@@ -690,7 +690,12 @@ def _run_holo3_executor(
                 os.environ["DISPLAY"] = display
         except Exception as exc:  # noqa: BLE001 — best-effort
             print(f"  WARNING: ensure_display_ready before viewer failed: {exc}")
-    viewer_ctx, viewer_event_bus, viewer_url = setup_viewer(viewer)
+    viewer_ctx, viewer_event_bus, viewer_url = setup_viewer(
+        viewer,
+        proxy_diag=proxy_diag,
+        api_run_id=api_run_id or "",
+        api_tenant_id=api_tenant_id or "",
+    )
     # #416: persist the tunnel URL so a caller polling ``action=status``
     # gets a hot-link to the live screen. We write to a side-channel
     # ``viewer.json`` rather than merging into the API-owned
@@ -1200,7 +1205,7 @@ def _run_gemma4_cua_executor(
     # ── Env + viewer ──
     task_suite = json.loads(task_file_contents)
     session_name = task_suite.get("session_name", "gemma4_cua")
-    env, proxy_proc = setup_env(
+    env, proxy_proc, proxy_diag = setup_env(
         base_url=task_suite.get("base_url", ""),
         run_id=run_id, session_name=session_name,
         settle_time=2.0, display=":99", start_xvfb=True,
@@ -1210,7 +1215,7 @@ def _run_gemma4_cua_executor(
         proxy_disabled=bool(task_suite.get("_proxy_disabled", False)),
         profile_dir=profile_dir,
     )
-    viewer_ctx, viewer_event_bus, _viewer_url = setup_viewer(viewer)
+    viewer_ctx, viewer_event_bus, _viewer_url = setup_viewer(viewer, proxy_diag=proxy_diag)
 
     # ── Delegate to shared lifecycle ──
     config = TaskLoopConfig(
@@ -1337,7 +1342,7 @@ def _run_claude_executor(
             f.write(json.dumps(traj_entry) + "\n")
 
     # ── Env + viewer ──
-    env, proxy_proc = setup_env(
+    env, proxy_proc, proxy_diag = setup_env(
         base_url=task_suite.get("base_url", ""),
         run_id=run_id, session_name=session_name,
         settle_time=2.0, display=":99", start_xvfb=True,
@@ -1347,7 +1352,7 @@ def _run_claude_executor(
         proxy_disabled=bool(task_suite.get("_proxy_disabled", False)),
         profile_dir=profile_dir,
     )
-    viewer_ctx, viewer_event_bus, _viewer_url = setup_viewer(viewer)
+    viewer_ctx, viewer_event_bus, _viewer_url = setup_viewer(viewer, proxy_diag=proxy_diag)
 
     # ── Delegate to shared lifecycle ──
     config = TaskLoopConfig(

--- a/src/mantis_agent/task_loop.py
+++ b/src/mantis_agent/task_loop.py
@@ -85,6 +85,43 @@ class TaskLoopConfig:
     summary_extras: dict = field(default_factory=dict)
 
 
+def diagnose_proxy_egress(proxy_server: str, *, timeout: float = 8.0) -> dict[str, Any]:
+    """Hit ipinfo.io through ``proxy_server`` and return the egress IP +
+    geo info (#viewer-proxy-diag). Best-effort — never raises.
+
+    Returns one of:
+      * ``{"disabled": True}`` when no proxy is configured
+      * ``{"ip", "city", "region", "country", "org"}`` on success
+      * ``{"error": "..."}`` when the probe fails (network, timeout, 5xx)
+
+    Surfaced to the live-viewer overlay so operators see at a glance
+    which exit IP / geo the run is actually using — bare ``proxy_provider``
+    in the runtime block hides whether the geo modifier landed (e.g.
+    PrivateProxy returning a Romanian IP despite ``city=miami``).
+    """
+    if not proxy_server:
+        return {"disabled": True}
+    try:
+        import requests as _r
+        r = _r.get(
+            "https://ipinfo.io/json",
+            proxies={"http": proxy_server, "https": proxy_server},
+            timeout=timeout,
+        )
+        if r.status_code != 200:
+            return {"error": f"HTTP {r.status_code}"}
+        d = r.json()
+        return {
+            "ip": str(d.get("ip", "") or ""),
+            "city": str(d.get("city", "") or ""),
+            "region": str(d.get("region", "") or ""),
+            "country": str(d.get("country", "") or ""),
+            "org": str(d.get("org", "") or "")[:80],
+        }
+    except Exception as exc:  # noqa: BLE001 — diag, never fatal
+        return {"error": f"{type(exc).__name__}: {str(exc)[:120]}"}
+
+
 def setup_env(
     *,
     base_url: str,
@@ -102,7 +139,7 @@ def setup_env(
     profile_dir: str = "",
     save_screenshots_dir: str = "/data/screenshots",
     reuse_session: bool = False,
-) -> tuple[Any, Any]:
+) -> tuple[Any, Any, dict[str, Any]]:
     """Set up proxy + XdotoolGymEnv.
 
     Args:
@@ -110,7 +147,10 @@ def setup_env(
             test/internal sites that don't need bot-detection bypass and
             shouldn't depend on the residential proxy's availability.
 
-    Returns (env, proxy_proc_or_None).
+    Returns ``(env, proxy_proc_or_None, proxy_diag)`` where ``proxy_diag``
+    is the ipinfo egress probe (``{"ip", "city", "region", ...}`` on
+    success, ``{"disabled": True}`` when proxy is off, ``{"error": ...}``
+    when the probe failed).
     """
     from .gym.xdotool_env import XdotoolGymEnv
 
@@ -129,6 +169,12 @@ def setup_env(
         if proxy:
             provider = proxy_provider or os.environ.get("MANTIS_PROXY_PROVIDER") or "iproyal"
             print(f"  Proxy: {provider} via {proxy.get('server', '')}")
+
+    # #viewer-proxy-diag: best-effort egress probe so the live-viewer
+    # overlay shows the actual IP / city / region instead of just the
+    # provider name. Hits ipinfo.io through the same proxy chain Chrome
+    # uses, so we surface the IP Cloudflare sees.
+    proxy_diag = diagnose_proxy_egress(proxy_server)
 
     if start_xvfb and display:
         subprocess.Popen(
@@ -155,27 +201,40 @@ def setup_env(
         env_kwargs["profile_dir"] = profile_dir
 
     env = XdotoolGymEnv(**env_kwargs)
-    return env, proxy_proc
+    return env, proxy_proc, proxy_diag
 
 
-def setup_viewer(enabled: bool) -> tuple[Any, Any, str | None]:
+def setup_viewer(
+    enabled: bool,
+    *,
+    proxy_diag: dict[str, Any] | None = None,
+    api_run_id: str | None = None,
+    api_tenant_id: str | None = None,
+) -> tuple[Any, Any, str | None]:
     """Set up the Modal viewer if enabled.
 
     Returns ``(viewer_ctx, viewer_event_bus, viewer_url)``. All three
     are ``None`` when ``enabled`` is False or setup fails.
 
-    The third element (``viewer_url``) was added under #416 so the
-    detached ``/v1/predict`` worker can surface the live tunnel URL
-    via ``status.json``. Existing CLI callers — which previously
-    discarded the URL — should destructure all three values and can
-    ignore the third if they don't need it.
+    ``proxy_diag`` is the ipinfo egress probe from :func:`setup_env`
+    (passed through to the viewer's ``/api/proxy_info`` endpoint so
+    the live-viewer header can display the IP / city / region).
+
+    ``api_run_id`` / ``api_tenant_id`` thread through so the viewer's
+    Pause/Resume buttons can POST to the cua-server API on behalf
+    of the user (the cua-server API token stays inside the Modal
+    container — never exposed to the browser).
     """
     if not enabled:
         return None, None, None
     try:
         from .viewer_modal import modal_viewer
 
-        viewer_ctx = modal_viewer()
+        viewer_ctx = modal_viewer(
+            proxy_diag=proxy_diag or {},
+            api_run_id=api_run_id or "",
+            api_tenant_id=api_tenant_id or "",
+        )
         viewer_event_bus, viewer_url = viewer_ctx.__enter__()
         return viewer_ctx, viewer_event_bus, viewer_url
     except Exception as e:

--- a/src/mantis_agent/viewer.py
+++ b/src/mantis_agent/viewer.py
@@ -476,6 +476,44 @@ footer {
     0%, 100% { opacity: 1; }
     50%      { opacity: 0.3; }
 }
+
+/* ── #viewer-takeover: Take Over / Resume button + proxy pill ────── */
+.action-btn {
+    background: var(--blue);
+    color: white;
+    border: none;
+    border-radius: 4px;
+    padding: 4px 12px;
+    font-size: 12px;
+    font-weight: 600;
+    cursor: pointer;
+    font-family: inherit;
+}
+.action-btn:hover {
+    opacity: 0.85;
+}
+.action-btn:active {
+    transform: translateY(1px);
+}
+.action-btn.resume {
+    background: var(--green);
+}
+.action-btn.disabled {
+    background: var(--border);
+    color: var(--text-3);
+    cursor: not-allowed;
+}
+#proxy-info {
+    font-family: 'SF Mono', 'Cascadia Code', 'Fira Code', monospace;
+    font-size: 11px;
+    color: var(--text-2);
+}
+#proxy-info.warn {
+    color: var(--amber);
+}
+#proxy-info.error {
+    color: var(--red);
+}
 </style>
 </head>
 <body>
@@ -484,6 +522,8 @@ footer {
     <div class="logo">MANTIS</div>
     <div class="task" id="task">Waiting for task...</div>
     <div class="stats">
+        <div class="stat" id="proxy-stat" title="Proxy egress IP + geo (from ipinfo through the active proxy)">Proxy: <span id="proxy-info">…</span></div>
+        <button class="action-btn" id="takeover-btn" type="button" title="Pause the runner so you can interact with the page (CAPTCHA, login, etc.)">Take Over</button>
         <div class="stat">Step <strong id="step-num">0</strong>/<strong id="step-max">-</strong></div>
         <div class="stat" id="elapsed">0:00</div>
         <div class="conn-dot" id="conn-dot" title="Disconnected"></div>
@@ -682,6 +722,92 @@ function esc(s) {
     var d = document.createElement('div');
     d.textContent = s;
     return d.innerHTML;
+}
+
+/* ── #viewer-proxy-diag: surface the actual egress IP / city / region
+   so operators can verify the geo modifier landed (e.g.
+   PrivateProxy returning a Romanian IP despite city=miami). One
+   fetch on load, cached server-side. */
+fetch('/api/proxy_info?token=' + TOKEN)
+    .then(function(r) { return r.json(); })
+    .then(function(d) {
+        var el = $('proxy-info');
+        if (!el) return;
+        if (d.disabled) {
+            el.textContent = 'DISABLED';
+            el.className = 'warn';
+        } else if (d.error) {
+            el.textContent = 'probe failed: ' + d.error;
+            el.className = 'error';
+        } else if (d.ip) {
+            var parts = [d.ip];
+            if (d.city) parts.push(d.city);
+            if (d.region) parts.push(d.region);
+            if (d.country) parts.push(d.country);
+            el.textContent = parts.join(' · ');
+            el.className = '';
+            if (d.org) el.title = d.org;
+        } else {
+            el.textContent = 'unknown';
+        }
+    })
+    .catch(function() {
+        var el = $('proxy-info');
+        if (el) { el.textContent = 'fetch failed'; el.className = 'error'; }
+    });
+
+/* ── #viewer-takeover: Take Over button — POSTs action=pause to the
+   cua-server API via the viewer's local /api/pause_run proxy (the
+   real MANTIS_API_TOKEN never leaves the executor container). When
+   the run is paused, button text flips to "Resume" and POSTs
+   action=resume on the next click. Polls /api/run_state every 3s
+   to stay in sync. */
+var takeoverBtn = $('takeover-btn');
+var currentRunStatus = 'running';
+
+function setTakeoverButton(status) {
+    if (!takeoverBtn) return;
+    currentRunStatus = status;
+    if (status === 'paused') {
+        takeoverBtn.textContent = 'Resume';
+        takeoverBtn.classList.add('resume');
+        takeoverBtn.classList.remove('disabled');
+    } else if (status === 'running') {
+        takeoverBtn.textContent = 'Take Over';
+        takeoverBtn.classList.remove('resume');
+        takeoverBtn.classList.remove('disabled');
+    } else {
+        // halted / cancelled / failed → no more actions possible
+        takeoverBtn.textContent = status.charAt(0).toUpperCase() + status.slice(1);
+        takeoverBtn.classList.add('disabled');
+        takeoverBtn.classList.remove('resume');
+    }
+}
+
+if (takeoverBtn) {
+    takeoverBtn.addEventListener('click', function() {
+        if (takeoverBtn.classList.contains('disabled')) return;
+        var path = (currentRunStatus === 'paused')
+            ? '/api/resume_run?token=' + TOKEN
+            : '/api/pause_run?token=' + TOKEN;
+        takeoverBtn.classList.add('disabled');
+        fetch(path, { method: 'POST' })
+            .then(function(r) { return r.json(); })
+            .then(function(d) {
+                if (d.status) setTakeoverButton(d.status);
+                else takeoverBtn.classList.remove('disabled');
+            })
+            .catch(function() { takeoverBtn.classList.remove('disabled'); });
+    });
+
+    // Periodic status sync so the button stays accurate after
+    // server-side auto-pause (cf_challenge) fires without user click.
+    setInterval(function() {
+        fetch('/api/run_state?token=' + TOKEN)
+            .then(function(r) { return r.json(); })
+            .then(function(d) { if (d.status) setTakeoverButton(d.status); })
+            .catch(function() {});
+    }, 3000);
 }
 
 /* ── Init ───────────────────────────────────────────────── */

--- a/src/mantis_agent/viewer_modal.py
+++ b/src/mantis_agent/viewer_modal.py
@@ -62,6 +62,10 @@ def _start_background(
     port: int = 7860,
     fps: float = 3.0,
     monitor: int = 1,
+    *,
+    proxy_diag: dict | None = None,
+    api_run_id: str = "",
+    api_tenant_id: str = "",
 ) -> tuple[ModalViewerBus, str, callable]:
     """Start capture + server in background threads.
 
@@ -166,6 +170,77 @@ def _start_background(
         events_list, _ = event_bus.events_since(0)
         return JSONResponse(events_list)
 
+    # ── #viewer-proxy-diag: surface the actual proxy egress IP /
+    # city / region the run is using. Lets operators verify the geo
+    # modifier (e.g. ``-cc-us-city-miami``) actually landed instead
+    # of trusting the runtime block. ``proxy_diag`` is the
+    # ipinfo-probe dict from ``setup_env`` — already computed once
+    # at executor startup; this endpoint is a cheap re-serve.
+    @app.get("/api/proxy_info")
+    async def proxy_info(token: str = Query(...)):
+        _auth(token)
+        return JSONResponse(proxy_diag or {})
+
+    # ── #viewer-takeover: Pause / Resume controls that proxy to
+    # the cua-server API. The browser POSTs here with the viewer
+    # token; this endpoint uses the executor's ``MANTIS_API_TOKEN``
+    # (env var, server-side only) to call the cua-server API. The
+    # API token never reaches the browser.
+    def _post_to_cua_api(action: str, reason: str = "") -> tuple[int, dict]:
+        """POST {action,run_id,...} to the cua-server API on behalf of
+        the viewer user. Returns (http_status, body_dict)."""
+        import os as _os
+        import requests as _r
+        api_token = _os.environ.get("MANTIS_API_TOKEN", "")
+        if not api_token:
+            return 500, {"detail": "MANTIS_API_TOKEN unset in executor env"}
+        if not api_run_id:
+            return 400, {"detail": "api_run_id not threaded — viewer can't route action"}
+        api_endpoint = _os.environ.get(
+            "MANTIS_API_ENDPOINT",
+            "https://getmason--mantis-cua-server-api.modal.run",
+        )
+        body: dict = {"action": action, "run_id": api_run_id}
+        if reason:
+            body["reason"] = reason
+        try:
+            r = _r.post(
+                f"{api_endpoint}/v1/predict",
+                headers={
+                    "X-Mantis-Token": api_token,
+                    "Content-Type": "application/json",
+                },
+                json=body,
+                timeout=15,
+            )
+            try:
+                return r.status_code, r.json()
+            except Exception:
+                return r.status_code, {"raw": r.text[:300]}
+        except Exception as exc:  # noqa: BLE001
+            return 502, {"detail": f"{type(exc).__name__}: {str(exc)[:200]}"}
+
+    @app.post("/api/pause_run")
+    async def pause_run(token: str = Query(...)):
+        _auth(token)
+        status_code, body = _post_to_cua_api("pause", reason="viewer_takeover")
+        return JSONResponse(body, status_code=status_code)
+
+    @app.post("/api/resume_run")
+    async def resume_run(token: str = Query(...)):
+        _auth(token)
+        status_code, body = _post_to_cua_api("resume")
+        return JSONResponse(body, status_code=status_code)
+
+    @app.get("/api/run_state")
+    async def run_state(token: str = Query(...)):
+        """Proxy to cua-server ``action=status`` so the viewer can
+        poll Pause/Resume button state (paused vs running) without
+        the browser needing the API token."""
+        _auth(token)
+        status_code, body = _post_to_cua_api("status")
+        return JSONResponse(body, status_code=status_code)
+
     # ── Server thread ────────────────────────────────────────────────
     config = uvicorn.Config(
         app, host="0.0.0.0", port=port,
@@ -187,6 +262,10 @@ def modal_viewer(
     port: int = 7860,
     fps: float = 3.0,
     monitor: int = 1,
+    *,
+    proxy_diag: dict | None = None,
+    api_run_id: str = "",
+    api_tenant_id: str = "",
 ):
     """Context manager: starts viewer + Modal tunnel, yields (event_bus, url).
 
@@ -197,6 +276,15 @@ def modal_viewer(
         port: Local port for the viewer server.
         fps: Screen capture rate (2-5 FPS recommended).
         monitor: Which monitor to capture (1=primary, 0=all).
+        proxy_diag: ipinfo egress probe from
+            :func:`task_loop.diagnose_proxy_egress`. Surfaced via
+            ``/api/proxy_info`` so the viewer header shows the actual
+            exit IP / city / region.
+        api_run_id: run identifier for the cua-server API, threaded
+            through so the viewer's ``/api/pause_run`` /
+            ``/api/resume_run`` buttons can route their POST to the
+            right run.
+        api_tenant_id: tenant for the cua-server API call.
 
     Yields:
         (event_bus, url): ModalViewerBus for emitting events, and the
@@ -204,7 +292,12 @@ def modal_viewer(
     """
     import modal
 
-    event_bus, token, stop = _start_background(port, fps, monitor)
+    event_bus, token, stop = _start_background(
+        port, fps, monitor,
+        proxy_diag=proxy_diag or {},
+        api_run_id=api_run_id,
+        api_tenant_id=api_tenant_id,
+    )
 
     with modal.forward(port) as tunnel:
         url = f"{tunnel.url}?token={token}"

--- a/tests/test_chrome_session_reuse.py
+++ b/tests/test_chrome_session_reuse.py
@@ -186,7 +186,7 @@ def test_setup_env_threads_reuse_session_through_kwargs(
     monkeypatch.setattr("mantis_agent.gym.xdotool_env.XdotoolGymEnv", _StubEnv)
 
     from mantis_agent.task_loop import setup_env
-    env, _ = setup_env(
+    env, _, _ = setup_env(
         base_url="https://example.com",
         run_id="r1",
         session_name="s",

--- a/tests/test_task_loop_proxy.py
+++ b/tests/test_task_loop_proxy.py
@@ -10,7 +10,7 @@ def test_setup_env_proxy_disabled_ignores_proxy_env(monkeypatch) -> None:
     monkeypatch.setenv("PROXY_USER", "user")
     monkeypatch.setenv("PROXY_PASS", "pass")
 
-    env, proxy_proc = setup_env(
+    env, proxy_proc, _proxy_diag = setup_env(
         base_url="https://news.ycombinator.com",
         run_id="20260507_000000",
         session_name="hn_smoke",

--- a/tests/test_viewer_takeover_controls.py
+++ b/tests/test_viewer_takeover_controls.py
@@ -1,0 +1,178 @@
+"""Tests for the live-viewer takeover controls (#viewer-takeover).
+
+Two features bundled:
+
+1. **Proxy egress display** — ``task_loop.diagnose_proxy_egress``
+   probes ipinfo through the proxy at startup; the viewer renders the
+   result in the header so operators see the actual exit IP / geo
+   instead of just the provider name.
+
+2. **Take Over / Resume button** — viewer-side button that POSTs to
+   ``/api/pause_run`` / ``/api/resume_run`` (local viewer endpoints
+   that proxy to the cua-server API on behalf of the user). The
+   real ``MANTIS_API_TOKEN`` never leaves the executor container.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+
+
+# ── diagnose_proxy_egress ────────────────────────────────────────────────
+
+
+def test_diagnose_proxy_egress_returns_disabled_for_empty_server():
+    """No proxy configured → ``{"disabled": True}``. Viewer renders
+    that as the ``DISABLED`` chip."""
+    from mantis_agent.task_loop import diagnose_proxy_egress
+    assert diagnose_proxy_egress("") == {"disabled": True}
+
+
+def test_diagnose_proxy_egress_extracts_ip_city_region(monkeypatch):
+    """ipinfo 200 → return the relevant fields. ``org`` truncated to
+    80 chars (some ISPs return long strings)."""
+    from mantis_agent.task_loop import diagnose_proxy_egress
+    fake = MagicMock()
+    fake.status_code = 200
+    fake.json.return_value = {
+        "ip": "76.109.200.135",
+        "city": "Miami",
+        "region": "Florida",
+        "country": "US",
+        "org": "AS7922 Comcast Cable Communications, LLC " + "x" * 200,
+    }
+    with patch("requests.get", return_value=fake):
+        d = diagnose_proxy_egress("http://127.0.0.1:3128")
+    assert d["ip"] == "76.109.200.135"
+    assert d["city"] == "Miami"
+    assert d["region"] == "Florida"
+    assert d["country"] == "US"
+    assert d["org"].startswith("AS7922 Comcast")
+    assert len(d["org"]) <= 80  # truncated
+
+
+def test_diagnose_proxy_egress_returns_error_on_non_200(monkeypatch):
+    """5xx / 403 / etc. → ``{"error": "HTTP 502"}`` (operator can see
+    the upstream failure mode without a Modal log dive)."""
+    from mantis_agent.task_loop import diagnose_proxy_egress
+    fake = MagicMock()
+    fake.status_code = 502
+    fake.text = "Bad Gateway"
+    with patch("requests.get", return_value=fake):
+        d = diagnose_proxy_egress("http://127.0.0.1:3128")
+    assert "error" in d
+    assert "502" in d["error"]
+
+
+def test_diagnose_proxy_egress_swallows_exception(monkeypatch):
+    """Network failure / timeout / proxy auth error → return error
+    dict; NEVER raise (telemetry must not break runs)."""
+    from mantis_agent.task_loop import diagnose_proxy_egress
+    with patch("requests.get", side_effect=ConnectionError("simulated tunnel down")):
+        d = diagnose_proxy_egress("http://127.0.0.1:3128")
+    assert "error" in d
+    assert "ConnectionError" in d["error"]
+
+
+# ── setup_env return-shape contract ──────────────────────────────────────
+
+
+def test_setup_env_returns_three_tuple_with_proxy_diag(monkeypatch, tmp_path):
+    """Signature change: ``setup_env`` now returns ``(env, proxy_proc,
+    proxy_diag)``. All 4 cua-server callers were updated; this test
+    locks the contract."""
+    from mantis_agent import task_loop
+
+    # Patch out the heavy machinery so the function returns quickly.
+    monkeypatch.setattr(
+        task_loop, "build_proxy_config",
+        lambda **kw: {"server": "http://127.0.0.1:3128", "username": "u", "password": "p"},
+    )
+    monkeypatch.setattr(
+        task_loop, "resolve_proxy_server",
+        lambda proxy, **kw: ("http://127.0.0.1:3128", MagicMock()),
+    )
+    # Skip the real probe — patched above wouldn't reach here anyway.
+    monkeypatch.setattr(
+        task_loop, "diagnose_proxy_egress",
+        lambda s, **kw: {"ip": "1.2.3.4", "city": "X"},
+    )
+    monkeypatch.setattr(
+        "mantis_agent.gym.xdotool_env.XdotoolGymEnv",
+        lambda **kw: MagicMock(),
+    )
+
+    result = task_loop.setup_env(
+        base_url="http://test", run_id="r1", session_name="s1",
+    )
+    assert len(result) == 3, f"setup_env must return 3-tuple, got {len(result)}"
+    env, proxy_proc, proxy_diag = result
+    assert proxy_diag == {"ip": "1.2.3.4", "city": "X"}
+
+
+def test_setup_env_returns_disabled_diag_when_proxy_off(monkeypatch):
+    """When ``proxy_disabled=True``, the diag dict is the disabled
+    sentinel (viewer renders ``DISABLED`` chip)."""
+    from mantis_agent import task_loop
+    monkeypatch.setattr(
+        "mantis_agent.gym.xdotool_env.XdotoolGymEnv",
+        lambda **kw: MagicMock(),
+    )
+    monkeypatch.setattr(
+        task_loop, "diagnose_proxy_egress",
+        lambda s, **kw: {"disabled": True} if not s else {"ip": "x"},
+    )
+    _, _, diag = task_loop.setup_env(
+        base_url="http://test", run_id="r1", session_name="s1",
+        proxy_disabled=True,
+    )
+    assert diag == {"disabled": True}
+
+
+# ── setup_viewer signature ──────────────────────────────────────────────
+
+
+def test_setup_viewer_accepts_new_kwargs():
+    """``setup_viewer`` accepts ``proxy_diag`` + ``api_run_id`` +
+    ``api_tenant_id`` so the takeover controls have what they need.
+    When ``enabled=False`` it returns early — easy way to verify
+    the signature without launching the modal tunnel."""
+    from mantis_agent.task_loop import setup_viewer
+    out = setup_viewer(
+        False,
+        proxy_diag={"ip": "1.2.3.4"},
+        api_run_id="run_x",
+        api_tenant_id="tenant_y",
+    )
+    assert out == (None, None, None)
+
+
+# ── VIEWER_HTML wiring (source-level check) ──────────────────────────────
+
+
+def test_viewer_html_has_take_over_button():
+    """Header has a button id=takeover-btn with the JS handler wired
+    to ``/api/pause_run`` and ``/api/resume_run``."""
+    from mantis_agent.viewer import VIEWER_HTML
+    assert 'id="takeover-btn"' in VIEWER_HTML
+    assert "/api/pause_run" in VIEWER_HTML
+    assert "/api/resume_run" in VIEWER_HTML
+
+
+def test_viewer_html_has_proxy_pill():
+    """Header has a proxy-stat element wired to ``/api/proxy_info``."""
+    from mantis_agent.viewer import VIEWER_HTML
+    assert 'id="proxy-stat"' in VIEWER_HTML
+    assert 'id="proxy-info"' in VIEWER_HTML
+    assert "/api/proxy_info" in VIEWER_HTML
+
+
+def test_viewer_html_polls_run_state_for_button_sync():
+    """The button must stay in sync with server-side auto-pause
+    (cf_challenge) — periodic ``/api/run_state`` poll keeps the
+    label correct without user click."""
+    from mantis_agent.viewer import VIEWER_HTML
+    assert "/api/run_state" in VIEWER_HTML
+    # setInterval keeps the poll alive
+    assert "setInterval" in VIEWER_HTML


### PR DESCRIPTION
## Summary
Two coordinated additions to the live viewer surfaced by recent boattrader CF debugging — directly addressing two questions raised in flight:

1. **"Why are we still seeing CF Turnstile?"** — operators couldn't tell from the viewer which IP CF was actually evaluating. Now the header pill shows \`76.109.200.135 · Miami · Florida · US\` (the actual ipinfo-probed egress IP, not the provider name from the runtime block).

2. **"How do I take over via the viewer?"** — required curling the cua-server API from outside. Now there's a **Take Over** button in the viewer header that POSTs to the API on your behalf, **without exposing the API token to the browser**.

## What lands
| Change | File |
|--------|------|
| \`diagnose_proxy_egress(proxy_server)\` — hits ipinfo through the proxy, returns \`{ip,city,region,country,org}\` / \`{disabled}\` / \`{error}\` | \`src/mantis_agent/task_loop.py\` |
| \`setup_env\` signature → returns \`(env, proxy_proc, **proxy_diag**)\` (3-tuple) | \`src/mantis_agent/task_loop.py\` |
| \`setup_viewer\` accepts \`proxy_diag\`, \`api_run_id\`, \`api_tenant_id\` | \`src/mantis_agent/task_loop.py\` |
| Four new viewer endpoints — \`/api/proxy_info\`, \`/api/pause_run\`, \`/api/resume_run\`, \`/api/run_state\` (proxy to cua-server API using server-side \`MANTIS_API_TOKEN\` — never leaves Modal container) | \`src/mantis_agent/viewer_modal.py\` |
| Header gets a Proxy pill + Take Over button; CSS + JS handler; periodic \`/api/run_state\` poll keeps the button label in sync with auto-pause | \`src/mantis_agent/viewer.py\` |
| All 4 cua-server callers (run_executor, holo3, gemma4, claude) updated for the new return shape | \`deploy/modal/modal_cua_server.py\` |
| 10 tests covering diagnose helper edges, setup_env contract, setup_viewer kwargs, VIEWER_HTML wiring | \`tests/test_viewer_takeover_controls.py\` |

## End-to-end flow
1. Submit plan with \`live_viewer: true\`
2. Open viewer URL → see \`Proxy: 76.109.200.135 · Miami · Florida · US\` in header (confirms geo modifier landed)
3. CF challenge fires; auto-pause kicks in OR you click **Take Over**
4. Status → \`paused\`, button flips to \`Resume\`
5. Manually solve CAPTCHA in the viewer (noVNC bidirectional)
6. Click **Resume** → run continues from next step

## Security note
The browser sees only the viewer-local token (\`?token=...\`). The viewer's proxy endpoints (\`/api/pause_run\` etc.) use \`MANTIS_API_TOKEN\` from the executor's env to call the cua-server — that token stays inside Modal.

## Test plan
- [x] \`pytest tests/test_viewer_takeover_controls.py\` — **10 pass**
- [x] All 4 modal_cua_server.py executors AST-parse clean after the signature update
- [x] \`ruff check\` — clean
- [ ] Modal redeploy + boattrader rerun → viewer header shows Miami IP, Take Over button works, auto-pause-on-captcha flips the button to Resume

🤖 Generated with [Claude Code](https://claude.com/claude-code)