### PR TITLE
gym: auto-pause-on-captcha must block in-place (required-step halt was pre-empting it)

### DIFF
--- a/src/mantis_agent/gym/run_executor.py
+++ b/src/mantis_agent/gym/run_executor.py
@@ -1784,18 +1784,23 @@ class RunExecutor:
 
     def _maybe_auto_pause_on_captcha(self, step_result: StepResult) -> None:
         """If a step failed with cf_challenge AND auto-pause is
-        enabled, write the external pause sentinel (#541).
+        enabled, write the external pause sentinel AND block here
+        until the user resumes via the viewer (#541).
 
-        The next iteration's pause check blocks the runner here while
-        keeping Chrome + the noVNC viewer alive. The user takes over
-        via the live-viewer URL — solves the CAPTCHA manually, then
-        ``action=resume`` clears the sentinel.
+        **Why we block in-place instead of relying on the next
+        iteration's pause check:** when the cf_challenge step is
+        ``required``, the runner's retry-budget logic exits the
+        per-step loop after the configured retry count is exhausted —
+        BEFORE the next iteration's pause check runs. Writing the
+        sentinel alone doesn't stop the halt path. Blocking here
+        (via ``wait_while_paused`` immediately after writing the
+        sentinel) keeps the executor process alive — Chrome + noVNC
+        tunnel stay up — so the user can take over and resume.
 
-        Without this, a CF-walled step burns retry budget until
-        ``brain_loop_exhausted``, halting the run with no signal that
-        a human could have unblocked it. With this, the run sits at
-        ``status=paused`` with reason=cf_challenge_human_takeover
-        until either resumed or the wait timeout expires.
+        Without this, a CF-walled REQUIRED step would auto-pause AND
+        then immediately halt because the runner's required-step
+        ``HALTING`` branch runs in ``_tick_preamble`` before the
+        wait-while-paused at the top of the next iteration.
 
         Default-on; opt out per-run via ``MANTIS_PAUSE_ON_CAPTCHA=0``.
         """
@@ -1810,7 +1815,9 @@ class RunExecutor:
                 return
             if external_pause.is_pause_requested():
                 # Sentinel already set (race with external pause or
-                # earlier step). Don't overwrite the reason.
+                # earlier step). Don't overwrite the reason — but DO
+                # block so we don't fall through to the halt branch.
+                external_pause.wait_while_paused()
                 return
             wrote = external_pause.request_pause(reason="cf_challenge_human_takeover")
             if wrote:
@@ -1819,6 +1826,11 @@ class RunExecutor:
                     "— viewer URL is live; resume after manual takeover",
                     getattr(step_result, "step_index", "?"),
                 )
+                # Block IN-PLACE: keeps the executor alive past the
+                # required-step halt branch that would otherwise
+                # exit the runner loop before next iteration's
+                # pause check fires.
+                external_pause.wait_while_paused()
         except Exception as exc:  # noqa: BLE001 — never break a run
             logger.debug("auto-pause-on-captcha raised: %s", exc)
 

--- a/tests/test_external_pause_541.py
+++ b/tests/test_external_pause_541.py
@@ -118,11 +118,26 @@ def test_runner_auto_pauses_on_cf_challenge_step_result(
 ):
     """When _emit_augur_step's adjacent helper sees a step result
     with failure_class='cf_challenge', it must write the pause
-    sentinel so the next iteration of the runner loop blocks."""
+    sentinel AND block in-place via wait_while_paused.
+
+    Mocks wait_while_paused to return immediately so the test
+    doesn't block on the 30-min sentinel timeout. Captures the
+    sentinel state at the moment wait_while_paused is invoked
+    (the sentinel is cleared on wait return when timeout, but
+    we care that it was written before the wait)."""
     from mantis_agent.gym.run_executor import RunExecutor
 
     external_pause.init_paths(tmp_path / "pause.json")
     monkeypatch.delenv("MANTIS_PAUSE_ON_CAPTCHA", raising=False)
+
+    # Mock wait_while_paused — capture sentinel state at call time,
+    # then return immediately (no blocking, no auto-clear).
+    sentinel_at_wait: dict = {}
+    def _spy_wait(*args, **kwargs):
+        sentinel_at_wait["was_requested"] = external_pause.is_pause_requested()
+        sentinel_at_wait["reason"] = external_pause.read_pause_reason()
+        return "resumed"
+    monkeypatch.setattr(external_pause, "wait_while_paused", _spy_wait)
 
     executor = RunExecutor.__new__(RunExecutor)
     executor.parent = MagicMock()
@@ -132,8 +147,11 @@ def test_runner_auto_pauses_on_cf_challenge_step_result(
     sr.failure_class = "cf_challenge"
     executor._maybe_auto_pause_on_captcha(sr)
 
-    assert external_pause.is_pause_requested() is True
-    assert external_pause.read_pause_reason() == "cf_challenge_human_takeover"
+    # Sentinel was written before the wait kicked in.
+    assert sentinel_at_wait.get("was_requested") is True, (
+        "Sentinel must be written before wait_while_paused is called"
+    )
+    assert sentinel_at_wait.get("reason") == "cf_challenge_human_takeover"
 
 
 def test_runner_does_not_auto_pause_on_other_failures(tmp_path: Path, monkeypatch):


### PR DESCRIPTION
## Symptom

Verified end-to-end on Modal today after #541 + #546 merged: a fresh boattrader run halted at \`status=halted\` instead of pausing at the CF challenge, even though:
- Auto-pause-on-captcha is wired (#541)
- Viewer is wired with Take-Over button (#546)
- PrivateProxy geo + stealth + cause-over-symptom all live

Run \`20260520_232709_d2b1397c\` Modal logs:
\`\`\`
[2] agentic recovery: mode=halt — Cloudflare "Performing security verification" block
[2] REQUIRED step failed after 2 retries — HALTING
HALT: Required step 'Verify the BoatTrader results page shows boat list' failed.
\`\`\`

No \`external_pause: auto-paused on cf_challenge\` log line. The sentinel may have been written, but the executor exited the runner loop before \`wait_while_paused\` at the top of the next iteration ever ran.

## Root cause

Runner loop:
\`\`\`
while state.step_index < len(plan.steps):
    if not self._tick_preamble(plan, state):   ← required-step halt path lives here
        break
    # ...
    if external_pause.is_pause_requested():    ← my pause check from #541
        external_pause.wait_while_paused()
    # ... dispatch step ...
    self._emit_augur_step(...)
    self._maybe_auto_pause_on_captcha(...)     ← writes sentinel, then returns
\`\`\`

Sequence on a required cf_challenge step:
1. Step N fails with \`failure_class=cf_challenge\`
2. \`_maybe_auto_pause_on_captcha\` writes the sentinel and returns
3. Next iteration: \`_tick_preamble\` evaluates the required-step retry budget, sees it's exhausted, returns False → \`break\`
4. Runner exits the loop → executor process exits → Chrome + noVNC tunnel die
5. The \`wait_while_paused\` at the top of the new-now-skipped iteration NEVER runs
6. Status flips straight to \`halted\` — no takeover window

## Fix

\`_maybe_auto_pause_on_captcha\` now calls \`wait_while_paused()\` **in-place** right after writing the sentinel, instead of returning and relying on the next iteration. Keeps the executor process alive through the required-step halt window:

\`\`\`python
wrote = external_pause.request_pause(reason="cf_challenge_human_takeover")
if wrote:
    logger.warning("external_pause: auto-paused ...")
    # NEW: block IN-PLACE so we don't fall through to the halt branch
    external_pause.wait_while_paused()
\`\`\`

After the fix the sequence is:
1. Step N fails cf_challenge → sentinel written
2. \`_maybe_auto_pause_on_captcha\` BLOCKS in \`wait_while_paused\` (executor alive, Chrome alive, viewer alive)
3. User opens viewer URL → clicks Turnstile → POSTs \`action=resume\` (Take Over button does this directly)
4. Sentinel cleared → \`wait_while_paused\` returns → \`_maybe_auto_pause_on_captcha\` returns
5. Runner loops to next iteration

## Test plan
- [x] AST + import check clean
- [x] Existing pause tests collect cleanly (no test relies on \`_maybe_auto_pause_on_captcha\` returning immediately — they only assert the sentinel was written, which still happens)
- [ ] Modal redeploy + boattrader rerun → expect \`status=paused\`, viewer accessible, Take Over button reads "Resume", takeover handoff actually works
- Known follow-up not in this PR: after resume, the step still has \`failure_class=cf_challenge\` on record so the runner may halt on the NEXT iteration. The takeover gives the user a chance to clear the page state, but the runner doesn't automatically retry the cleared step. That's a separate UX improvement (mark step as needing-retry after pause-resume).

🤖 Generated with [Claude Code](https://claude.com/claude-code)