### PR TITLE
gym: auto-pause-on-captcha must run BEFORE _handle_failure (was being pre-empted by halt-break)

### DIFF
--- a/src/mantis_agent/gym/run_executor.py
+++ b/src/mantis_agent/gym/run_executor.py
@@ -281,6 +281,20 @@ class RunExecutor:
                 self._handle_success(plan, state, step, step_result)
                 continued = True
             else:
+                # #541 + fu: auto-pause on CAPTCHA must run BEFORE
+                # ``_handle_failure`` — the recovery policy decides
+                # to halt on required-step exhaustion at line ~284
+                # below, then ``if not continued: break`` exits the
+                # loop. If we wait until AFTER ``_handle_failure``,
+                # the halt-break pre-empts our pause and the
+                # executor exits before the viewer can be used.
+                # Blocking here keeps Chrome + the noVNC tunnel
+                # alive past the halt window; after the user
+                # resumes via the viewer, ``_handle_failure``
+                # runs as usual (recovery policy retries the step
+                # if it still has retry budget — likely succeeds
+                # this time because the user cleared the CF state).
+                self._maybe_auto_pause_on_captcha(step_result)
                 continued = self._handle_failure(plan, state, step, step_result)
                 if not continued:
                     break
@@ -301,15 +315,6 @@ class RunExecutor:
                 step_type=step.type,
                 costs_before=costs_before_step,
             )
-
-            # #541: auto-pause on CAPTCHA. When the step result
-            # carries failure_class='cf_challenge' (Cloudflare
-            # Turnstile etc.), write the pause sentinel so the next
-            # iteration's pause check blocks. Chrome + viewer stay
-            # alive — user takes over via the live-viewer URL and
-            # clears the CAPTCHA manually, then action=resume.
-            # Gated by MANTIS_PAUSE_ON_CAPTCHA (default-on).
-            self._maybe_auto_pause_on_captcha(step_result)
 
         self._finalize(plan, state)
         return state.results


### PR DESCRIPTION
## Symptom
After #547 merged + deployed, fresh boattrader run \`20260521_003606_f94690f4\` STILL halted with no auto-pause:

\`\`\`
[2] REQUIRED step failed — retry 1/2
[2] REQUIRED step failed — retry 2/2
HALT: Required step 'Verify the BoatTrader results page shows boat list' failed.
[2] agentic recovery: mode=halt
[2] REQUIRED step failed after 2 retries — HALTING
\`\`\`

No \`external_pause: auto-paused on cf_challenge\` log line. Status went straight to \`halted\` at t=196s. Same outcome as before #547.

## Root cause
The runner loop in \`run_executor.py\` line 280-312:

\`\`\`python
if step_result.success:
    self._handle_success(...)
    continued = True
else:
    continued = self._handle_failure(...)   # ← recovery halts here
    if not continued:
        break                                # ← exits loop on halt

self._consult_critic(...)
self._emit_augur_step(...)
self._maybe_auto_pause_on_captcha(...)       # ← never reached on halt
\`\`\`

\`_handle_failure\` calls \`StepRecoveryPolicy.handle_failure\` which, for a required step with retries exhausted, returns \`RecoveryOutcome(halt=True)\`. The runner sets \`continued=False\` and \`break\`s out of the loop — **before** \`_maybe_auto_pause_on_captcha\` ever runs.

The #547 in-place block (\`wait_while_paused\` inside \`_maybe_auto_pause_on_captcha\`) was the right semantic — but the function never got called in the first place on a required-step halt path.

## Fix
Move \`_maybe_auto_pause_on_captcha\` to BEFORE \`_handle_failure\` so:
1. CF challenge detected → auto-pause writes sentinel + blocks in-place
2. User takes over via viewer (Chrome + tunnel alive)
3. User clicks Resume → sentinel cleared → \`wait_while_paused\` returns
4. \`_handle_failure\` runs as normal — StepRecoveryPolicy retries the step (likely succeeds since user cleared the CF page state)

## Test plan
- [x] \`pytest tests/test_external_pause_541.py\` — 16 pass (no test asserts the call order beyond function behavior; the move is pure runner-loop ordering)
- [x] AST + import clean
- [ ] Modal redeploy + boattrader rerun → expect \`status=paused\` with \`pause_reason=cf_challenge_human_takeover\`, viewer URL accessible, Take Over button visible. Resume → runner retries step + likely succeeds because CF state cleared by user.

Refs #541 #547

🤖 Generated with [Claude Code](https://claude.com/claude-code)