### PR TITLE
viewer: bidirectional input dispatch via xdotool (post-pause click/keys/scroll)

### DIFF
--- a/src/mantis_agent/viewer.py
+++ b/src/mantis_agent/viewer.py
@@ -810,6 +810,121 @@ if (takeoverBtn) {
     }, 3000);
 }
 
+/* ── #viewer-input-dispatch: click / keys / scroll relay to xdotool.
+   The MJPEG stream is one-way; we POST input events to server
+   endpoints that dispatch via xdotool on the Xvfb display. Only
+   forwards input while the run is paused — sending clicks while
+   the agent is running would fight the brain's mouse moves. */
+var feedImg = $('feed');
+var desktopW = 1280, desktopH = 720;  // updated from /api/desktop_info
+
+// Fetch desktop dimensions for browser→desktop coord scaling.
+fetch('/api/desktop_info?token=' + TOKEN)
+    .then(function(r) { return r.json(); })
+    .then(function(d) {
+        if (d.ready) { desktopW = d.width; desktopH = d.height; }
+    })
+    .catch(function() {});
+
+function browserToDesktop(evt) {
+    // Map click in rendered <img> (CSS pixels) to desktop (capture) px.
+    var rect = feedImg.getBoundingClientRect();
+    if (rect.width === 0 || rect.height === 0) return null;
+    var cx = evt.clientX - rect.left;
+    var cy = evt.clientY - rect.top;
+    var dx = Math.round((cx / rect.width) * desktopW);
+    var dy = Math.round((cy / rect.height) * desktopH);
+    return { x: dx, y: dy };
+}
+
+if (feedImg) {
+    // Use mousedown so right-click and middle-click are catchable
+    // before the browser's native menu fires.
+    feedImg.addEventListener('mousedown', function(evt) {
+        // Only dispatch when paused — otherwise we'd fight the agent.
+        if (currentRunStatus !== 'paused') return;
+        var pt = browserToDesktop(evt);
+        if (!pt) return;
+        var btn = { 0: 'left', 1: 'middle', 2: 'right' }[evt.button] || 'left';
+        evt.preventDefault();
+        fetch('/api/dispatch_click?token=' + TOKEN +
+              '&x=' + pt.x + '&y=' + pt.y + '&button=' + btn,
+              { method: 'POST' })
+            .catch(function() {});
+    });
+    feedImg.addEventListener('contextmenu', function(evt) {
+        // Suppress the browser context menu so right-click dispatches
+        // cleanly when paused.
+        if (currentRunStatus === 'paused') evt.preventDefault();
+    });
+    // Block default drag of the <img> so click+drag doesn't pick up
+    // the image instead of dispatching.
+    feedImg.addEventListener('dragstart', function(evt) {
+        evt.preventDefault();
+    });
+}
+
+// Keyboard relay — only when the viewer page is focused AND paused.
+// Captures keystrokes globally because the <img> can't receive focus.
+document.addEventListener('keydown', function(evt) {
+    if (currentRunStatus !== 'paused') return;
+    // Skip if user is typing in a real input (we don't have any but
+    // future-proof against an embedded form).
+    var tgt = evt.target;
+    if (tgt && (tgt.tagName === 'INPUT' || tgt.tagName === 'TEXTAREA')) return;
+    // For printable single chars, use the type endpoint so xdotool
+    // handles shift/symbol correctly. For named keys (Enter, Tab,
+    // arrows, F-keys, modifier combos) use dispatch_keys.
+    var key = evt.key;
+    var isModifier = evt.ctrlKey || evt.altKey || evt.metaKey;
+    var isPrintable = key.length === 1 && !isModifier;
+    evt.preventDefault();
+    if (isPrintable) {
+        fetch('/api/dispatch_type?token=' + TOKEN +
+              '&text=' + encodeURIComponent(key),
+              { method: 'POST' })
+            .catch(function() {});
+    } else {
+        // Map common JS key names to xdotool key names.
+        var xkey = {
+            'Enter': 'Return',
+            'Backspace': 'BackSpace',
+            'ArrowUp': 'Up', 'ArrowDown': 'Down',
+            'ArrowLeft': 'Left', 'ArrowRight': 'Right',
+            'Escape': 'Escape',
+            'Tab': 'Tab',
+            'Delete': 'Delete', 'Home': 'Home', 'End': 'End',
+            'PageUp': 'Page_Up', 'PageDown': 'Page_Down',
+        }[key] || key;
+        // Build modifier prefix (xdotool uses ctrl+, alt+, super+, shift+).
+        var mods = [];
+        if (evt.ctrlKey)  mods.push('ctrl');
+        if (evt.altKey)   mods.push('alt');
+        if (evt.metaKey)  mods.push('super');
+        if (evt.shiftKey && key.length > 1) mods.push('shift');
+        var combo = (mods.length ? mods.join('+') + '+' : '') + xkey;
+        fetch('/api/dispatch_keys?token=' + TOKEN +
+              '&keys=' + encodeURIComponent(combo),
+              { method: 'POST' })
+            .catch(function() {});
+    }
+});
+
+// Wheel scroll relay — relay vertical wheel events to xdotool while paused.
+if (feedImg) {
+    feedImg.addEventListener('wheel', function(evt) {
+        if (currentRunStatus !== 'paused') return;
+        evt.preventDefault();
+        var dir = evt.deltaY > 0 ? 'down' : 'up';
+        // One wheel "notch" per ~100px deltaY, capped at 5 per event.
+        var notches = Math.max(1, Math.min(5, Math.round(Math.abs(evt.deltaY) / 100) || 1));
+        fetch('/api/dispatch_scroll?token=' + TOKEN +
+              '&direction=' + dir + '&amount=' + notches,
+              { method: 'POST' })
+            .catch(function() {});
+    }, { passive: false });
+}
+
 /* ── Init ───────────────────────────────────────────────── */
 connectSSE();
 

--- a/src/mantis_agent/viewer_modal.py
+++ b/src/mantis_agent/viewer_modal.py
@@ -241,6 +241,111 @@ def _start_background(
         status_code, body = _post_to_cua_api("status")
         return JSONResponse(body, status_code=status_code)
 
+    # ── #viewer-input-dispatch: bidirectional input via xdotool.
+    # The MJPEG stream is one-way (server pushes frames to browser);
+    # we add HTTP endpoints that take browser-coord clicks / keys /
+    # text and dispatch them on the Xvfb display via xdotool. Lets
+    # the operator click the CF Turnstile checkbox + solve CAPTCHA
+    # via the live viewer after Take-Over.
+    #
+    # Endpoint accepts DESKTOP coords directly — the browser-side JS
+    # does the scaling (browser-px → screen-px) because it knows the
+    # rendered <img> dimensions. Keeps the server stateless.
+    import subprocess as _subprocess
+
+    def _xdotool(args: list[str]) -> tuple[int, str]:
+        """Run xdotool with the active DISPLAY. Returns (rc, stderr_tail)."""
+        import os as _os
+        env = {**_os.environ, "DISPLAY": _os.environ.get("DISPLAY", ":99")}
+        try:
+            p = _subprocess.run(
+                ["xdotool", *args], env=env,
+                capture_output=True, text=True, timeout=5,
+            )
+            return p.returncode, (p.stderr or "")[-300:]
+        except FileNotFoundError:
+            return 127, "xdotool not installed in this container"
+        except Exception as exc:  # noqa: BLE001
+            return 1, f"{type(exc).__name__}: {exc}"
+
+    @app.post("/api/dispatch_click")
+    async def dispatch_click(
+        token: str = Query(...),
+        x: int = Query(..., ge=0),
+        y: int = Query(..., ge=0),
+        button: str = Query("left"),
+    ):
+        """Move to (x, y) on the Xvfb display and click. Coords are
+        in DESKTOP pixel space (browser-side JS scales from rendered
+        image pixels).
+
+        button: ``left`` (1) / ``middle`` (2) / ``right`` (3) — passed
+        verbatim to xdotool's button id."""
+        _auth(token)
+        button_id = {"left": "1", "middle": "2", "right": "3"}.get(button, "1")
+        rc, err = _xdotool(["mousemove", str(x), str(y), "click", button_id])
+        return JSONResponse(
+            {"ok": rc == 0, "x": x, "y": y, "button": button, "error": err if rc else ""},
+            status_code=200 if rc == 0 else 500,
+        )
+
+    @app.post("/api/dispatch_keys")
+    async def dispatch_keys(token: str = Query(...), keys: str = Query(...)):
+        """Send a keystroke or key combo via xdotool ``key`` (e.g.
+        ``Return``, ``Tab``, ``ctrl+l``, ``Page_Down``)."""
+        _auth(token)
+        rc, err = _xdotool(["key", "--", keys])
+        return JSONResponse(
+            {"ok": rc == 0, "keys": keys, "error": err if rc else ""},
+            status_code=200 if rc == 0 else 500,
+        )
+
+    @app.post("/api/dispatch_type")
+    async def dispatch_type(token: str = Query(...), text: str = Query(...)):
+        """Type literal text via xdotool ``type``. Use for filling
+        text inputs after a click-to-focus."""
+        _auth(token)
+        rc, err = _xdotool(["type", "--delay", "30", "--", text])
+        return JSONResponse(
+            {"ok": rc == 0, "len": len(text), "error": err if rc else ""},
+            status_code=200 if rc == 0 else 500,
+        )
+
+    @app.post("/api/dispatch_scroll")
+    async def dispatch_scroll(
+        token: str = Query(...),
+        direction: str = Query("down"),
+        amount: int = Query(3, ge=1, le=20),
+    ):
+        """Scroll via xdotool ``click`` on buttons 4 (up) / 5 (down).
+        ``amount`` is the wheel-notch count."""
+        _auth(token)
+        button_id = {"up": "4", "down": "5"}.get(direction, "5")
+        # Repeat the click N times for the desired scroll depth.
+        rc = 0
+        err = ""
+        for _ in range(amount):
+            rc, err = _xdotool(["click", button_id])
+            if rc != 0:
+                break
+        return JSONResponse(
+            {"ok": rc == 0, "direction": direction, "amount": amount, "error": err if rc else ""},
+            status_code=200 if rc == 0 else 500,
+        )
+
+    @app.get("/api/desktop_info")
+    async def desktop_info(token: str = Query(...)):
+        """Return the desktop's current pixel dimensions so the
+        browser JS can scale browser-coords → desktop-coords."""
+        _auth(token)
+        # Read from the most recent captured frame — same source the
+        # MJPEG stream uses, so the dimensions are guaranteed to match.
+        frame = streamer.latest
+        if frame is None:
+            return JSONResponse({"width": 0, "height": 0, "ready": False})
+        w, h = frame.image.size
+        return JSONResponse({"width": w, "height": h, "ready": True})
+
     # ── Server thread ────────────────────────────────────────────────
     config = uvicorn.Config(
         app, host="0.0.0.0", port=port,

--- a/tests/test_viewer_input_dispatch.py
+++ b/tests/test_viewer_input_dispatch.py
@@ -1,0 +1,124 @@
+"""Source-level checks for the viewer's input-relay endpoints
+(#viewer-input-dispatch).
+
+The MJPEG stream is one-way; we add server endpoints that take
+browser-coord clicks / keys / scroll and dispatch via xdotool on
+the Xvfb display. Only fires when the run is paused (otherwise
+the agent and user fight for the cursor).
+
+End-to-end smoke (xdotool subprocess + real Xvfb) isn't viable in
+CI; these tests pin the wire-up:
+
+* /api/dispatch_click / dispatch_keys / dispatch_type /
+  dispatch_scroll / desktop_info — endpoints exist in viewer_modal
+* VIEWER_HTML has the mousedown/keydown/wheel handlers + the
+  pause-gate (clicks suppressed unless currentRunStatus=paused)
+* browser→desktop coord scaling code present
+"""
+
+from __future__ import annotations
+
+import inspect
+
+
+# ── Endpoint registration (viewer_modal.py) ──────────────────────────────
+
+
+def test_dispatch_click_endpoint_registered():
+    """``POST /api/dispatch_click`` must be defined in
+    ``viewer_modal._start_background``."""
+    from mantis_agent.viewer_modal import _start_background
+    src = inspect.getsource(_start_background)
+    assert '"/api/dispatch_click"' in src or "'/api/dispatch_click'" in src
+
+
+def test_dispatch_keys_endpoint_registered():
+    from mantis_agent.viewer_modal import _start_background
+    src = inspect.getsource(_start_background)
+    assert "dispatch_keys" in src
+
+
+def test_dispatch_type_endpoint_registered():
+    from mantis_agent.viewer_modal import _start_background
+    src = inspect.getsource(_start_background)
+    assert "dispatch_type" in src
+
+
+def test_dispatch_scroll_endpoint_registered():
+    from mantis_agent.viewer_modal import _start_background
+    src = inspect.getsource(_start_background)
+    assert "dispatch_scroll" in src
+
+
+def test_desktop_info_endpoint_registered():
+    """The browser needs desktop dimensions to scale coords —
+    /api/desktop_info exposes them from the latest captured frame."""
+    from mantis_agent.viewer_modal import _start_background
+    src = inspect.getsource(_start_background)
+    assert "desktop_info" in src
+
+
+def test_xdotool_helper_present():
+    """Internal ``_xdotool(args)`` helper that runs the command with
+    the right DISPLAY env. Without it endpoints can't dispatch."""
+    from mantis_agent.viewer_modal import _start_background
+    src = inspect.getsource(_start_background)
+    assert "xdotool" in src
+    assert "DISPLAY" in src
+
+
+# ── HTML wiring ──────────────────────────────────────────────────────────
+
+
+def test_html_has_mousedown_handler():
+    """The <img id=feed> must have a mousedown listener that POSTs
+    to /api/dispatch_click."""
+    from mantis_agent.viewer import VIEWER_HTML
+    assert "mousedown" in VIEWER_HTML
+    assert "/api/dispatch_click" in VIEWER_HTML
+
+
+def test_html_has_keydown_handler():
+    """Global keydown listener for typing + named keys (Enter,
+    Tab, modifiers)."""
+    from mantis_agent.viewer import VIEWER_HTML
+    assert "keydown" in VIEWER_HTML
+    assert "/api/dispatch_type" in VIEWER_HTML
+    assert "/api/dispatch_keys" in VIEWER_HTML
+
+
+def test_html_has_wheel_scroll_handler():
+    """Wheel scroll relays to xdotool button 4/5."""
+    from mantis_agent.viewer import VIEWER_HTML
+    assert "wheel" in VIEWER_HTML
+    assert "/api/dispatch_scroll" in VIEWER_HTML
+
+
+def test_html_gates_input_on_paused_status():
+    """CRITICAL: input dispatch must ONLY fire when run is paused.
+    Sending clicks while the agent is running creates a mouse race —
+    user and brain fighting for the same cursor."""
+    from mantis_agent.viewer import VIEWER_HTML
+    # The gate appears in the mousedown handler (and keydown + wheel).
+    assert "currentRunStatus !== 'paused'" in VIEWER_HTML, (
+        "Input dispatch handlers must guard on currentRunStatus=='paused'"
+    )
+
+
+def test_html_does_coord_scaling():
+    """browser→desktop pixel scaling — clicks land in the right
+    place even when the <img> is rendered smaller than the desktop
+    capture size."""
+    from mantis_agent.viewer import VIEWER_HTML
+    assert "browserToDesktop" in VIEWER_HTML
+    assert "/api/desktop_info" in VIEWER_HTML
+    assert "getBoundingClientRect" in VIEWER_HTML
+
+
+def test_html_suppresses_context_menu_and_drag():
+    """Right-click should dispatch a right-click via xdotool, NOT
+    show the browser context menu. <img> drag should also be
+    suppressed so click+drag dispatches properly."""
+    from mantis_agent.viewer import VIEWER_HTML
+    assert "contextmenu" in VIEWER_HTML
+    assert "dragstart" in VIEWER_HTML


### PR DESCRIPTION
## Why
The current viewer streams MJPEG (server pushes JPEG frames) — **one-way only**. After Take Over (paused), the operator can SEE the page but **clicks in the browser don't reach the desktop**, so they can't actually solve the CF Turnstile checkbox. Direct user feedback from production: "Click is not going through in right place".

## Fix
Add HTTP endpoints on the viewer's local FastAPI that take browser-coord input events and dispatch them via \`xdotool\` on the Xvfb display. Browser-side JS captures clicks / keys / wheel, scales coords from rendered \`<img>\` px to desktop capture px, and POSTs.

### New endpoints (\`viewer_modal.py\`)
| Endpoint | Action |
|---|---|
| \`POST /api/dispatch_click {x,y,button}\` | \`xdotool mousemove + click\` |
| \`POST /api/dispatch_keys {keys}\` | named keys + modifier combos (\`Return\`, \`ctrl+l\`, \`Page_Down\`) |
| \`POST /api/dispatch_type {text}\` | literal text with \`--delay 30ms\` |
| \`POST /api/dispatch_scroll {direction,amount}\` | wheel-notch scroll via button 4/5 |
| \`GET /api/desktop_info\` | \`{width, height, ready}\` for browser-side coord scaling |

### Browser-side wiring (\`viewer.py\`)
- \`mousedown\` listener on \`<img id=feed>\` — POSTs scaled coords to dispatch_click
- \`contextmenu\` + \`dragstart\` suppression so right-click + click+drag dispatch cleanly
- Global \`keydown\` listener — printable chars → dispatch_type, named keys + modifiers → dispatch_keys
- \`wheel\` listener relays to dispatch_scroll
- \`browserToDesktop\` helper scales via \`getBoundingClientRect\` + the \`/api/desktop_info\` dimensions

## Critical safety guard: pause-only dispatch
Input ONLY relays when \`currentRunStatus === 'paused'\`. Sending clicks while the brain is running would create a **mouse race** — agent's coord and user's coord fighting on the same Xvfb cursor. Pause precondition keeps the modes cleanly separated:
- **Running** → agent owns the cursor
- **Paused** → user owns the cursor (via this PR)

## Test plan
- [x] \`pytest tests/test_viewer_input_dispatch.py\` — **12 pass**
- [x] \`ruff check\` — clean
- 12 source-level tests cover: all 5 endpoints registered, all 4 client handlers wired (mousedown / keydown / wheel / contextmenu), the pause-gate is in place, coord-scaling code present
- [ ] Modal redeploy + paused-run takeover → click the CF Turnstile in the viewer → see Chrome cursor move + checkbox toggle

## Future
Could swap to noVNC for proper native bidirectional desktop (no JS shim, modifier handling automatic). This PR is the smaller intermediate step — works with the existing MJPEG stream + adds \`xdotool\` relay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)