### PR TITLE
fix: extract_data URL-drift recovery (CDP Page.navigate to anchored URL)

### DIFF
--- a/src/mantis_agent/gym/step_recovery.py
+++ b/src/mantis_agent/gym/step_recovery.py
@@ -329,6 +329,112 @@ class StepRecoveryPolicy:
                         )
                         # Fall through to the normal retry path below.
 
+            # Deterministic URL-drift recovery for extract_data /
+            # extract_url failures where the browser has navigated
+            # away from the last anchored page. Common pattern: a
+            # ``scroll`` step burns its brain budget and ends up
+            # misclicking a listing card → page navigates to the
+            # detail page → subsequent ``extract_data`` runs against
+            # the wrong page → agentic_recovery (correctly) picks
+            # halt because the gate condition can't be satisfied by
+            # the new page. Live repro: boattrader run
+            # 20260521_033843_7d67208d — search results URL
+            # /boats/state-fl/.../by-owner/radius-25/ drifted to
+            # /boat/1997-caroff-chatam-52/... after step 1's scroll
+            # attempt and the extract_data gate halted with reason
+            # "the current page is a single boat detail page".
+            #
+            # The fix mirrors the existing _ensure_results_filters
+            # rollback used for click login_redirect failures, but
+            # extends it to extract_* failures by checking URL drift
+            # explicitly. Action-only CDP dispatch (Page.navigate to
+            # the previously anchored URL) + safe substring check
+            # (first non-empty path segment) — no DOM-derived
+            # targeting, per feedback_cua_no_dom_access.
+            #
+            # Trigger: extract_data / extract_url step, attempt >= 2,
+            # current URL's first path segment differs from
+            # ``runner._last_known_url``'s first path segment. The
+            # segment check (not bytewise equality) avoids false
+            # positives from query-string churn (?page=2) or trailing-
+            # slash variants while reliably catching deep-link drift
+            # like /boats/... → /boat/... .
+            if (
+                step.type in ("extract_data", "extract_url")
+                and attempt >= 2
+            ):
+                anchor_url = str(getattr(runner, "_last_known_url", "") or "")
+                env = getattr(runner, "env", None)
+                if anchor_url and env is not None:
+                    try:
+                        current_url = str(getattr(env, "current_url", "") or "")
+                    except Exception:
+                        current_url = ""
+
+                    def _first_path_segment(u: str) -> str:
+                        if "://" not in u:
+                            return ""
+                        try:
+                            rest = u.split("://", 1)[1]
+                            path = rest.split("/", 1)[1] if "/" in rest else ""
+                            for seg in path.split("/"):
+                                if seg:
+                                    return seg.lower()
+                        except Exception:
+                            return ""
+                        return ""
+
+                    anchor_seg = _first_path_segment(anchor_url)
+                    current_seg = _first_path_segment(current_url)
+                    if (
+                        anchor_seg
+                        and current_seg
+                        and anchor_seg != current_seg
+                    ):
+                        # Prefer the env's high-level navigate helper
+                        # (handles CDP Page.navigate + omnibox fallback +
+                        # post-navigate settle); fall back to the raw
+                        # CDP call if the env exposes _cdp_call directly
+                        # (lighter test stubs).
+                        nav_helper = getattr(env, "_navigate_running_browser", None)
+                        cdp_call = getattr(env, "_cdp_call", None)
+                        navigated = False
+                        if callable(nav_helper):
+                            try:
+                                nav_helper(anchor_url)
+                                navigated = True
+                            except Exception as exc:  # noqa: BLE001
+                                logger_.warning(
+                                    f"  [{step_index}] {step.type} attempt "
+                                    f"{attempt} — URL drift detected ("
+                                    f"anchor='/{anchor_seg}' current='/"
+                                    f"{current_seg}'); _navigate_running_browser "
+                                    f"dispatch failed: {exc}"
+                                )
+                        elif callable(cdp_call):
+                            try:
+                                cdp_call("Page.navigate", {"url": anchor_url})
+                                navigated = True
+                            except Exception as exc:  # noqa: BLE001
+                                logger_.warning(
+                                    f"  [{step_index}] {step.type} attempt "
+                                    f"{attempt} — URL drift "
+                                    f"recovery CDP Page.navigate failed: {exc}"
+                                )
+                        if navigated:
+                            step_retry_counts[step_index] = attempt
+                            logger_.warning(
+                                f"  [{step_index}] {step.type} attempt "
+                                f"{attempt} — URL drift detected "
+                                f"(anchor='/{anchor_seg}' current='/"
+                                f"{current_seg}'); restoring "
+                                f"_last_known_url and retrying"
+                            )
+                            return RecoveryOutcome(
+                                halt=False, step_index=step_index,
+                                halt_reason="extract_url_drift_restore",
+                            )
+
             # Deterministic scroll-to-top fallback for extract_data /
             # extract_url failures where the page is scrolled past the
             # extraction target. Common pattern: an upstream plan step

--- a/tests/test_step_recovery_policy.py
+++ b/tests/test_step_recovery_policy.py
@@ -660,6 +660,143 @@ def test_scroll_brain_loop_cdp_fallback_no_viewport_delta_keeps_step(monkeypatch
     runner.env.cdp_evaluate.assert_called_once()  # CDP did fire
 
 
+def test_required_extract_data_attempt2_url_drift_restores_anchor(monkeypatch):
+    """A required extract_data step on attempt 2 with URL drifted
+    away from runner._last_known_url (first path segment differs)
+    fires a deterministic CDP Page.navigate back to the anchored
+    URL + retries. Mirrors the scroll-to-top pattern for the
+    wrong-page failure mode (boattrader run 20260521_033843_7d67208d:
+    search results URL drifted to a single boat detail page after
+    Holo3 misclicked a card during a scroll step)."""
+    monkeypatch.setattr("mantis_agent.gym.step_recovery.time.sleep", lambda *_: None)
+    runner = _runner_stub()
+    runner._last_known_url = "https://www.boattrader.com/boats/state-fl/city-miami/zip-33101/by-owner/radius-25/"
+    runner.env.current_url = "https://www.boattrader.com/boat/1997-caroff-chatam-52/9876543/"
+    # nav helper present + succeeds.
+    nav_calls: list[str] = []
+    def _nav(url: str) -> None:
+        nav_calls.append(url)
+    runner.env._navigate_running_browser = _nav
+
+    policy = StepRecoveryPolicy(runner)
+    retries: dict = {0: 1}
+    outcome = policy.handle_failure(
+        step=MicroIntent(
+            intent="Verify listings render",
+            type="extract_data", required=True,
+        ),
+        step_result=_result(),
+        plan=_plan("extract_data"),
+        step_index=0,
+        step_retry_counts=retries,
+        loop_counters={},
+        max_retries=2,
+        listings_on_page=0,
+    )
+    assert outcome.halt is False
+    assert outcome.step_index == 0  # retry same step
+    assert outcome.halt_reason == "extract_url_drift_restore"
+    assert nav_calls == [runner._last_known_url]
+    # Counter consistent with attempt arithmetic.
+    assert retries[0] == 2
+
+
+def test_required_extract_data_attempt2_url_drift_uses_cdp_fallback(monkeypatch):
+    """When the env doesn't expose ``_navigate_running_browser``
+    (light test stub) the fallback path dispatches the raw CDP
+    ``Page.navigate`` call directly. Same retry behavior."""
+    monkeypatch.setattr("mantis_agent.gym.step_recovery.time.sleep", lambda *_: None)
+    runner = _runner_stub()
+    runner._last_known_url = "https://boattrader.com/boats/state-fl/by-owner/"
+    runner.env.current_url = "https://boattrader.com/boat/1997-caroff-chatam-52/"
+    # No nav helper — must use _cdp_call.
+    if hasattr(runner.env, "_navigate_running_browser"):
+        del runner.env._navigate_running_browser
+    cdp_calls: list[tuple] = []
+    def _cdp_call(method: str, params: dict | None = None):
+        cdp_calls.append((method, params or {}))
+        return (True, {})
+    runner.env._cdp_call = _cdp_call
+
+    policy = StepRecoveryPolicy(runner)
+    outcome = policy.handle_failure(
+        step=MicroIntent(intent="Read", type="extract_data", required=True),
+        step_result=_result(),
+        plan=_plan("extract_data"),
+        step_index=0,
+        step_retry_counts={0: 1},
+        loop_counters={},
+        max_retries=2,
+        listings_on_page=0,
+    )
+    assert outcome.halt_reason == "extract_url_drift_restore"
+    assert ("Page.navigate", {"url": runner._last_known_url}) in cdp_calls
+
+
+def test_required_extract_data_attempt2_same_url_skips_drift_fallback(monkeypatch):
+    """When the URL hasn't drifted (same first path segment), the
+    fallback is a no-op and we fall through to the scroll-to-top
+    check / normal retry path. Don't redundantly re-navigate the
+    page we're already on."""
+    monkeypatch.setattr("mantis_agent.gym.step_recovery.time.sleep", lambda *_: None)
+    runner = _runner_stub()
+    runner._last_known_url = "https://boattrader.com/boats/state-fl/city-miami/page-1"
+    # Same first path segment — only query / page suffix differs.
+    runner.env.current_url = "https://boattrader.com/boats/state-fl/city-miami/page-2"
+    nav_calls: list[str] = []
+    runner.env._navigate_running_browser = lambda u: nav_calls.append(u)
+    # cdp_evaluate returns 0 for scrollY / 720 for innerHeight so
+    # the scroll-to-top check also skips and we land on the normal
+    # retry path.
+    def _eval(expr: str):
+        if "innerHeight" in expr:
+            return 720.0
+        if "scrollY" in expr:
+            return 100.0  # near top
+        return None
+    runner.env.cdp_evaluate.side_effect = _eval
+
+    policy = StepRecoveryPolicy(runner)
+    outcome = policy.handle_failure(
+        step=MicroIntent(intent="Read", type="extract_data", required=True),
+        step_result=_result(),
+        plan=_plan("extract_data"),
+        step_index=0,
+        step_retry_counts={0: 1},
+        loop_counters={},
+        max_retries=2,
+        listings_on_page=0,
+    )
+    assert nav_calls == [], "must not re-navigate when URL hasn't drifted"
+    assert outcome.halt_reason == "required_retry:extract_data:2"
+
+
+def test_required_extract_data_attempt1_skips_drift_fallback(monkeypatch):
+    """Same defer-to-brain-first pattern as the scroll-to-top
+    fallback — don't fire the drift recovery until the brain has
+    burned at least one retry."""
+    monkeypatch.setattr("mantis_agent.gym.step_recovery.time.sleep", lambda *_: None)
+    runner = _runner_stub()
+    runner._last_known_url = "https://boattrader.com/boats/state-fl/"
+    runner.env.current_url = "https://boattrader.com/boat/1997-caroff/"
+    nav_calls: list[str] = []
+    runner.env._navigate_running_browser = lambda u: nav_calls.append(u)
+
+    policy = StepRecoveryPolicy(runner)
+    outcome = policy.handle_failure(
+        step=MicroIntent(intent="Read", type="extract_data", required=True),
+        step_result=_result(),
+        plan=_plan("extract_data"),
+        step_index=0,
+        step_retry_counts={},  # attempt 1
+        loop_counters={},
+        max_retries=2,
+        listings_on_page=0,
+    )
+    assert nav_calls == []
+    assert outcome.halt_reason == "required_retry:extract_data:1"
+
+
 def test_required_extract_data_attempt2_scrolled_past_target_scrolls_to_top(monkeypatch):
     """A required extract_data step on attempt 2 with scrollY past
     one viewport height fires a deterministic CDP scrollTo(0,0) +


### PR DESCRIPTION
## Summary

After PR #550 made boattrader CF-clean and PR #551 unblocked the
local proxy on warm-container reuse, runs still halted with
``required_failed:extract_data`` — but the root cause shifted.

**Live repro: run ``20260521_033843_7d67208d``**

| step | type | result | notes |
|---|---|---|---|
| 0 | navigate | ✓ | search results URL ``/boats/state-fl/.../by-owner/radius-25/`` |
| 1 | scroll | brain_loop_exhausted | Holo3 misclicked a card while attempting to scroll |
| 2 | extract_data | failed → ``halt`` | page is now ``/boat/1997-caroff-chatam-52/...`` |

Agentic recovery (correctly) picked ``halt``: *"the current
page is a single boat detail page, not the search results page."*
The recovery couldn't fix it because no plan tweak helps when the
browser is on the wrong URL.

## Fix

Generic URL-drift recovery in ``StepRecoveryPolicy.handle_failure``,
mirroring the existing ``extract_scroll_to_top_fallback`` / 
``scroll_cdp_fallback`` pattern:

- Trigger: ``extract_data`` / ``extract_url`` failure, attempt ≥ 2,
  first non-empty path segment of ``env.current_url`` differs from
  ``runner._last_known_url`` (the URL the most recent successful
  ``navigate`` step anchored — already maintained by NavigateHandler).
- Action: dispatch ``env._navigate_running_browser(anchor_url)``
  (CDP Page.navigate + omnibox fallback + post-navigate settle) and
  retry the same step.
- New halt_reason: ``extract_url_drift_restore`` for observability.

Path-segment comparison (not bytewise) so ``?page=2`` /
trailing-slash variants don't trigger false positives while
``/boats/...`` → ``/boat/...`` reliably does.

Action-only CDP dispatch + no DOM-derived targeting — same
provenance contract as the other deterministic fallbacks
(``feedback_cua_no_dom_access``).

## Test plan

- [x] ``pytest tests/test_step_recovery_policy.py`` — 38/38 pass (4 new)
- [x] ``ruff check`` clean
- [ ] Modal redeploy + boattrader rerun (manual gate); expect
      production log ``extract_url_drift_restore`` on extract attempt 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)