### PR TITLE
feat: MechanicalScrollHandler — deterministic scroll dispatch for plans with explicit count

### DIFF
--- a/src/mantis_agent/gym/step_handlers/__init__.py
+++ b/src/mantis_agent/gym/step_handlers/__init__.py
@@ -34,6 +34,7 @@ from .form import ClaudeGuidedFormHandler
 from .holo3 import Holo3StepHandler
 from .navigate import NavigateHandler
 from .paginate import PaginateHandler
+from .scroll import MechanicalScrollHandler
 
 if TYPE_CHECKING:
     from ..micro_runner import MicroPlanRunner
@@ -45,6 +46,7 @@ __all__ = [
     "ClaudeGuidedFormHandler",
     "ClaudeStepHandler",
     "Holo3StepHandler",
+    "MechanicalScrollHandler",
     "NavigateHandler",
     "PaginateHandler",
     "default_registry",
@@ -98,8 +100,23 @@ def default_registry(runner: "MicroPlanRunner") -> HandlerRegistry:
         ClaudeStepHandler(runner),
         ("extract_url", "extract_data"),
     )
-    reg.register_for_types(
-        Holo3StepHandler(runner),
-        ("scroll", "navigate_back"),
-    )
+    # ``scroll`` routes through a dispatcher that prefers the
+    # MechanicalScrollHandler when the plan supplies ``params.count``
+    # (deterministic, no brain), falling through to Holo3StepHandler
+    # for goal-shaped scroll intents that need vision mediation
+    # ("scroll until X is visible"). ``navigate_back`` stays on
+    # Holo3 — it's a goal-shaped step type by nature.
+    holo3 = Holo3StepHandler(runner)
+    mechanical_scroll = MechanicalScrollHandler(runner)
+
+    class _ScrollDispatcher:
+        step_type = "scroll"
+
+        def execute(self, step, ctx):
+            if mechanical_scroll.applies_to(step):
+                return mechanical_scroll.execute(step, ctx)
+            return holo3.execute(step, ctx)
+
+    reg.register(_ScrollDispatcher())
+    reg.register_for_types(holo3, ("navigate_back",))
     return reg

--- a/src/mantis_agent/gym/step_handlers/scroll.py
+++ b/src/mantis_agent/gym/step_handlers/scroll.py
@@ -1,0 +1,186 @@
+"""MechanicalScrollHandler — deterministic scroll dispatch (no brain).
+
+Why this exists: scroll steps routed through ``Holo3StepHandler``
+gave the brain the full action vocabulary (click, type, scroll, key)
+inside an N-step inner loop. When visible state didn't change
+between scroll dispatches (e.g. the page renders everything above
+the fold, or Holo3 saw a stale screenshot), the brain would fall
+back to clicking visible elements to "make something happen" —
+landing on listing cards / ad-links and navigating the tab away
+from the anchored URL.
+
+Live repro: boattrader run 20260521_042509_b358f06f. The plan's
+"scroll down once" step burned its budget=4 doing
+``scroll x3 → scroll x3 → click(983, 316) → click(976, 312)``;
+the final click hit the "Boat Loans" ad in the search header and
+navigated the tab to ``/boat-loans/``. Subsequent ``extract_data``
+then failed against the wrong page, triggering recovery cascades.
+
+This handler bypasses the brain entirely for scroll steps that
+specify a concrete ``count``. The runner dispatches ``count`` scroll
+notches via the env's existing ``ActionType.SCROLL`` primitive,
+verifies the scroll actually moved the viewport via post-action
+``window.scrollY`` readback, and returns success/failure
+deterministically.
+
+Plans that have a vision-mediated scroll intent (e.g. "scroll until
+the Submit button is visible") can OMIT the ``count`` param and the
+runner will fall through to ``Holo3StepHandler`` — the brain still
+owns goal-shaped scrolling. Mechanical scroll is opt-in via
+``params.count`` being set.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from ...actions import Action, ActionType
+from .. import adaptive_settle
+from ..checkpoint import StepResult
+from ..step_context import StepContext
+
+if TYPE_CHECKING:
+    from ..micro_runner import MicroPlanRunner
+    from ...plan_decomposer import MicroIntent
+
+logger = logging.getLogger(__name__)
+
+
+class MechanicalScrollHandler:
+    """Implements :class:`~..step_context.StepHandler` for ``scroll``
+    steps that specify an explicit ``params.count`` (and optionally
+    ``params.direction``).
+
+    Behaviour:
+
+    * Reads ``params.count`` (int, default falls through to Holo3),
+      ``params.direction`` (``"down"`` | ``"up"``, default ``"down"``),
+      and ``params.notches_per_count`` (int, default 3 — matches the
+      env's ``ActionType.SCROLL`` default amount).
+    * Dispatches ``count`` ``ActionType.SCROLL`` actions through the
+      env (which fans out to xdotool wheel events under Xvfb).
+    * Runs the standard ``settle_after_action`` between dispatches
+      so a slow framework can stabilise before the next scroll.
+    * Verifies via post-action ``window.scrollY`` readback when the
+      env exposes ``cdp_evaluate``: a successful "scroll down" must
+      move ``scrollY`` forward by at least 50px total. If the env
+      doesn't expose CDP (test stub), success defers to
+      ``env.step()`` not raising.
+
+    Returns ``StepResult.success = True`` on verified scroll motion;
+    ``False`` with ``failure_class="scroll_no_movement"`` when the
+    page didn't move at all (page at top/bottom, overflow:hidden
+    body, sub-element scroller swallowing wheel events). The
+    deterministic failure class is more actionable to the recovery
+    layer than the previous ``brain_loop_exhausted``.
+    """
+
+    step_type = "scroll"
+
+    def __init__(self, runner: "MicroPlanRunner") -> None:
+        self.parent = runner
+
+    def applies_to(self, step: "MicroIntent") -> bool:
+        """Mechanical scroll only takes over when ``params.count`` is
+        provided. Plans without an explicit count fall through to
+        the legacy Holo3-mediated path so vision-goal scrolling
+        (``"scroll until X visible"``) keeps working.
+        """
+        params = step.params or {}
+        count = params.get("count")
+        try:
+            return count is not None and int(count) > 0
+        except (TypeError, ValueError):
+            return False
+
+    def execute(self, step: "MicroIntent", ctx: StepContext) -> StepResult:
+        index = int(ctx.state.get("index", 0))
+        env = ctx.env
+        params = step.params or {}
+
+        try:
+            count = max(1, int(params.get("count", 1)))
+        except (TypeError, ValueError):
+            count = 1
+        direction = str(params.get("direction") or "down").lower().strip()
+        if direction not in ("down", "up"):
+            direction = "down"
+        try:
+            notches_per_count = max(
+                1, int(params.get("notches_per_count", 3)),
+            )
+        except (TypeError, ValueError):
+            notches_per_count = 3
+
+        cdp_eval = getattr(env, "cdp_evaluate", None)
+
+        def _read_scroll_y() -> float:
+            if not callable(cdp_eval):
+                return -1.0  # sentinel — CDP unavailable, skip verification
+            try:
+                v = cdp_eval(
+                    "(window.scrollY || document.documentElement.scrollTop || 0)"
+                )
+                return float(v) if v is not None else 0.0
+            except Exception:  # noqa: BLE001
+                return -1.0
+
+        pre_y = _read_scroll_y()
+        logger.info(
+            "  [scroll] mechanical dispatch: count=%d direction=%s "
+            "notches/count=%d pre_scrollY=%s",
+            count, direction, notches_per_count,
+            f"{pre_y:.0f}" if pre_y >= 0 else "n/a",
+        )
+
+        for i in range(count):
+            try:
+                env.step(Action(
+                    action_type=ActionType.SCROLL,
+                    params={
+                        "direction": direction,
+                        "amount": notches_per_count,
+                    },
+                ))
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "  [scroll] env.step failed on iteration %d/%d: %s",
+                    i + 1, count, exc,
+                )
+                return StepResult(
+                    step_index=index, intent=step.intent, success=False,
+                    data=f"scroll_dispatch_error:{type(exc).__name__}",
+                    failure_class="scroll_dispatch_error",
+                )
+            # Cheap settle between iterations so a slow framework can
+            # catch up. Bounded — adaptive_settle picks the right
+            # ceiling per page based on previous frame hash deltas.
+            adaptive_settle.settle_after_action(env, max_seconds=1.5)
+
+        post_y = _read_scroll_y()
+        # Verify via post-action scrollY readback when CDP is wired up.
+        if pre_y >= 0 and post_y >= 0:
+            delta = post_y - pre_y if direction == "down" else pre_y - post_y
+            if delta < 50:
+                logger.warning(
+                    "  [scroll] mechanical scroll fired but scrollY didn't "
+                    "move (pre=%.0f post=%.0f delta=%.0f); failing "
+                    "deterministically so recovery sees a real signal",
+                    pre_y, post_y, delta,
+                )
+                return StepResult(
+                    step_index=index, intent=step.intent, success=False,
+                    data=f"scroll_no_movement:pre={pre_y:.0f}_post={post_y:.0f}",
+                    failure_class="scroll_no_movement",
+                )
+            logger.info(
+                "  [scroll] verified scroll motion: scrollY %.0f → %.0f "
+                "(delta=%.0f)",
+                pre_y, post_y, delta,
+            )
+
+        return StepResult(
+            step_index=index, intent=step.intent, success=True,
+            data=f"scroll:{direction}x{count}",
+        )

--- a/tests/test_handler_registry_default.py
+++ b/tests/test_handler_registry_default.py
@@ -17,10 +17,12 @@ from mantis_agent.gym.step_handlers import (
     ClaudeGuidedFormHandler,
     ClaudeStepHandler,
     Holo3StepHandler,
+    MechanicalScrollHandler,
     NavigateHandler,
     PaginateHandler,
     default_registry,
 )
+from mantis_agent.plan_decomposer import MicroIntent
 
 
 def _registry():
@@ -84,14 +86,74 @@ def test_claude_step_types_share_one_handler_instance():
     assert url is data
 
 
-def test_holo3_types_share_one_handler_instance():
-    """scroll / navigate_back fall through to Holo3 in legacy dispatch;
-    after cleanup they share one Holo3StepHandler in the registry."""
+def test_navigate_back_binds_to_Holo3StepHandler():
+    """``navigate_back`` is a goal-shaped step type — it stays on the
+    brain. Only ``scroll`` was peeled off into the dispatcher."""
+    assert isinstance(_registry().get("navigate_back"), Holo3StepHandler)
+
+
+def test_scroll_uses_dispatcher_routing_to_mechanical_or_holo3():
+    """``scroll`` routes through a dispatcher that prefers the
+    deterministic mechanical handler when ``params.count`` is set,
+    falling through to Holo3 for goal-shaped scroll intents.
+
+    This is the (a) Layer-1 fix: a ``scroll`` step with explicit
+    count never goes through the brain, so the brain can't fall
+    back to clicking visible elements (the "misclick on ad-link"
+    pattern that drove every recent boattrader halt).
+    """
     reg = _registry()
-    scroll = reg.get("scroll")
-    nav_back = reg.get("navigate_back")
-    assert isinstance(scroll, Holo3StepHandler)
-    assert scroll is nav_back
+    dispatcher = reg.get("scroll")
+    # Dispatcher is NOT the Holo3 instance directly; it's a wrapper.
+    assert dispatcher is not None
+    assert not isinstance(dispatcher, Holo3StepHandler)
+
+    # Build a fake StepContext + env that records env.step dispatches.
+    env = MagicMock()
+    # Simulate scrollY going from 0 → 600 so the verification gate passes.
+    env.cdp_evaluate = MagicMock(side_effect=[0.0, 600.0])
+    ctx = MagicMock()
+    ctx.env = env
+    ctx.state = {"index": 0}
+
+    # With params.count = 1 → mechanical path fires (env.step called).
+    mech_step = MicroIntent(
+        intent="scroll down once",
+        type="scroll",
+        params={"count": 1, "direction": "down"},
+    )
+    dispatcher.execute(mech_step, ctx)
+    assert env.step.called, (
+        "scroll with params.count should dispatch via mechanical "
+        "handler (env.step), not the brain"
+    )
+
+
+def test_mechanical_scroll_handler_applies_to_predicate_gated_on_count():
+    """The mechanical handler claims a step only when ``params.count``
+    is present + positive. Steps without count fall through to Holo3
+    so vision-mediated scrolling ("scroll until X visible") still
+    works for plans that need it."""
+    runner = MagicMock()
+    mech = MechanicalScrollHandler(runner)
+    assert mech.applies_to(
+        MicroIntent(intent="x", type="scroll", params={"count": 1})
+    )
+    assert mech.applies_to(
+        MicroIntent(intent="x", type="scroll", params={"count": 3, "direction": "up"})
+    )
+    # No count → Holo3 should own this step.
+    assert not mech.applies_to(
+        MicroIntent(intent="scroll until target visible", type="scroll", params={})
+    )
+    # Count of 0 or negative → not valid; defer to Holo3.
+    assert not mech.applies_to(
+        MicroIntent(intent="x", type="scroll", params={"count": 0})
+    )
+    # Non-numeric count → defer to Holo3.
+    assert not mech.applies_to(
+        MicroIntent(intent="x", type="scroll", params={"count": "many"})
+    )
 
 
 def test_unregistered_step_types_return_none():

--- a/tests/test_scroll_handler_mechanical.py
+++ b/tests/test_scroll_handler_mechanical.py
@@ -1,0 +1,207 @@
+"""MechanicalScrollHandler unit tests — (a) Layer-1 fix.
+
+Pins the deterministic-dispatch contract for ``scroll`` steps that
+specify an explicit ``params.count``. Routes around the brain so
+Holo3 can't fall back to clicking visible elements when its inner
+scroll loop doesn't observe page change (the failure mode behind
+boattrader run 20260521_042509_b358f06f).
+
+Coverage:
+  - applies_to gating (count present + positive → True; missing,
+    zero, negative, non-numeric → False)
+  - dispatch count = N produces N env.step(SCROLL) calls
+  - direction param honored (down/up; bogus values normalised to down)
+  - scrollY readback verifies motion (delta >= 50px → success)
+  - scrollY readback flags no-movement deterministically
+    (failure_class='scroll_no_movement' instead of brain_loop_exhausted)
+  - missing cdp_evaluate (no CDP) → success defers to env.step not raising
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from mantis_agent.actions import ActionType
+from mantis_agent.gym.step_handlers.scroll import MechanicalScrollHandler
+from mantis_agent.plan_decomposer import MicroIntent
+
+
+def _ctx(env: MagicMock, index: int = 0):
+    ctx = MagicMock()
+    ctx.env = env
+    ctx.state = {"index": index}
+    return ctx
+
+
+def _env_with_scroll(pre: float = 0.0, post: float = 600.0) -> MagicMock:
+    env = MagicMock()
+    # CDP read returns pre on first call, post on second (verification).
+    env.cdp_evaluate = MagicMock(side_effect=[pre, post])
+    return env
+
+
+def test_applies_to_requires_positive_count():
+    h = MechanicalScrollHandler(MagicMock())
+    yes = MicroIntent(intent="x", type="scroll", params={"count": 1})
+    assert h.applies_to(yes) is True
+
+
+def test_applies_to_rejects_missing_count():
+    h = MechanicalScrollHandler(MagicMock())
+    no = MicroIntent(intent="scroll until X visible", type="scroll", params={})
+    assert h.applies_to(no) is False
+
+
+def test_applies_to_rejects_zero_count():
+    h = MechanicalScrollHandler(MagicMock())
+    no = MicroIntent(intent="x", type="scroll", params={"count": 0})
+    assert h.applies_to(no) is False
+
+
+def test_applies_to_rejects_non_numeric_count():
+    h = MechanicalScrollHandler(MagicMock())
+    no = MicroIntent(intent="x", type="scroll", params={"count": "many"})
+    assert h.applies_to(no) is False
+
+
+def test_dispatch_count_n_makes_n_env_step_calls():
+    """count=3 → 3 env.step(SCROLL) dispatches."""
+    env = _env_with_scroll(pre=0.0, post=2000.0)
+    h = MechanicalScrollHandler(MagicMock())
+    h.execute(
+        MicroIntent(intent="x", type="scroll", params={"count": 3}),
+        _ctx(env),
+    )
+    assert env.step.call_count == 3
+    # Each call dispatched a SCROLL action.
+    for call in env.step.call_args_list:
+        action = call.args[0]
+        assert action.action_type == ActionType.SCROLL
+
+
+def test_direction_down_default():
+    env = _env_with_scroll(pre=0.0, post=600.0)
+    h = MechanicalScrollHandler(MagicMock())
+    h.execute(
+        MicroIntent(intent="x", type="scroll", params={"count": 1}),
+        _ctx(env),
+    )
+    action = env.step.call_args.args[0]
+    assert action.params["direction"] == "down"
+
+
+def test_direction_up_honored():
+    # Going up: pre=1000, post=400 → delta_up = 600
+    env = MagicMock()
+    env.cdp_evaluate = MagicMock(side_effect=[1000.0, 400.0])
+    h = MechanicalScrollHandler(MagicMock())
+    res = h.execute(
+        MicroIntent(intent="x", type="scroll", params={"count": 1, "direction": "up"}),
+        _ctx(env),
+    )
+    action = env.step.call_args.args[0]
+    assert action.params["direction"] == "up"
+    assert res.success is True
+
+
+def test_direction_bogus_normalised_to_down():
+    env = _env_with_scroll(pre=0.0, post=600.0)
+    h = MechanicalScrollHandler(MagicMock())
+    h.execute(
+        MicroIntent(
+            intent="x", type="scroll",
+            params={"count": 1, "direction": "sideways"},
+        ),
+        _ctx(env),
+    )
+    assert env.step.call_args.args[0].params["direction"] == "down"
+
+
+def test_scroll_motion_verified_via_cdp_readback():
+    """When CDP confirms scrollY moved by >= 50px in the requested
+    direction, success=True with deterministic data."""
+    env = _env_with_scroll(pre=100.0, post=900.0)  # delta=800 >> 50
+    h = MechanicalScrollHandler(MagicMock())
+    res = h.execute(
+        MicroIntent(intent="x", type="scroll", params={"count": 1}),
+        _ctx(env),
+    )
+    assert res.success is True
+    assert "scroll:down" in res.data
+
+
+def test_no_movement_fails_with_scroll_no_movement_class():
+    """When the page doesn't move (overflow:hidden body, sub-element
+    scroller swallowing wheel, page already at top/bottom), the
+    handler fails deterministically with
+    failure_class='scroll_no_movement'. This is more actionable to
+    the recovery layer than the previous brain_loop_exhausted."""
+    env = _env_with_scroll(pre=500.0, post=500.0)  # no motion
+    h = MechanicalScrollHandler(MagicMock())
+    res = h.execute(
+        MicroIntent(intent="x", type="scroll", params={"count": 1}),
+        _ctx(env),
+    )
+    assert res.success is False
+    assert res.failure_class == "scroll_no_movement"
+    assert "pre=500" in res.data
+    assert "post=500" in res.data
+
+
+def test_below_50px_threshold_counts_as_no_movement():
+    """Edge case: a 30-pixel scroll delta is below the meaningful-
+    motion threshold (the page may have shifted by a CSS animation,
+    not by our scroll dispatch). Treated as no movement."""
+    env = _env_with_scroll(pre=100.0, post=130.0)  # delta=30 < 50
+    h = MechanicalScrollHandler(MagicMock())
+    res = h.execute(
+        MicroIntent(intent="x", type="scroll", params={"count": 1}),
+        _ctx(env),
+    )
+    assert res.success is False
+    assert res.failure_class == "scroll_no_movement"
+
+
+def test_missing_cdp_evaluate_skips_verification():
+    """Test stub env without ``cdp_evaluate``: success defers to
+    env.step() not raising. Keeps the handler testable in environments
+    that don't mount Chrome (CI / unit tests)."""
+    env = MagicMock(spec=["step"])  # no cdp_evaluate attribute
+    h = MechanicalScrollHandler(MagicMock())
+    res = h.execute(
+        MicroIntent(intent="x", type="scroll", params={"count": 2}),
+        _ctx(env),
+    )
+    assert res.success is True
+    assert env.step.call_count == 2
+
+
+def test_env_step_failure_returns_dispatch_error():
+    """If env.step raises (xdotool crashed, container shutting
+    down, etc.), the handler returns a deterministic failure with
+    failure_class='scroll_dispatch_error' rather than propagating."""
+    env = MagicMock()
+    env.cdp_evaluate = MagicMock(return_value=0.0)
+    env.step.side_effect = OSError("xdotool not found")
+    h = MechanicalScrollHandler(MagicMock())
+    res = h.execute(
+        MicroIntent(intent="x", type="scroll", params={"count": 1}),
+        _ctx(env),
+    )
+    assert res.success is False
+    assert res.failure_class == "scroll_dispatch_error"
+
+
+def test_notches_per_count_param_passes_through_to_env():
+    """The plan can tune wheel notches per count via
+    ``params.notches_per_count``. Default is 3 (env-level default)."""
+    env = _env_with_scroll(pre=0.0, post=600.0)
+    h = MechanicalScrollHandler(MagicMock())
+    h.execute(
+        MicroIntent(
+            intent="x", type="scroll",
+            params={"count": 1, "notches_per_count": 5},
+        ),
+        _ctx(env),
+    )
+    assert env.step.call_args.args[0].params["amount"] == 5


### PR DESCRIPTION
## Summary

Scroll steps routed through ``Holo3StepHandler`` give the brain the
full action vocabulary (scroll / click / type / key). When visible
state doesn't change between scroll dispatches, the brain falls
back to clicking visible elements to "make something happen" —
which on a search results page lands on an ad-link or a listing
card and navigates the tab away.

**Live repro: boattrader run 20260521_042509_b358f06f.**

Plan said *"scroll down once to trigger lazy-loading"* with
``budget=4``. Brain emitted:

```
scroll x3 → scroll x3 → click(983, 316) → click(976, 312)
```

The final click hit the "Boat Loans" ad in the search header
and navigated to ``/boat-loans/``. Every downstream step then ran
against the wrong page.

## Fix

New ``MechanicalScrollHandler`` that bypasses the brain entirely
for scroll steps with explicit ``params.count``. Dispatches
``ActionType.SCROLL`` directly through the env, verifies motion
via CDP ``window.scrollY`` readback, returns deterministic success/
failure.

Registry now routes ``scroll`` through a small dispatcher that
checks ``params.count`` — present + positive → mechanical, else
fall through to Holo3. Plans with vision-mediated scrolling
(``"scroll until X visible"``) keep working unchanged; plans that
want safe scrolls opt in by setting ``count``.

## Why this is the right surgical fix vs alternatives

| Option | Why not |
|---|---|
| Restrict brain action vocab per step type | Bigger refactor; Holo3 brain adapter doesn't have step-type-aware tool filtering yet |
| Replace plan's scroll step with navigate | Doesn't generalise — other plans legitimately need scroll |
| Train Holo3 to scroll reliably | Vision model fix, not a runner fix |
| Mechanical scroll handler (this PR) | Opt-in via params, backward compat preserved, deterministic primitive |

## Test plan

- [x] 12 new ``test_scroll_handler_mechanical.py`` tests (every branch + edge cases)
- [x] 2 updated ``test_handler_registry_default.py`` tests pinning dispatcher routing
- [x] 25/25 targeted tests pass
- [x] ``ruff check`` clean
- [ ] Modal redeploy + boattrader plan with ``params: {count: 1}`` on scroll step → no misclick into ads (manual gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)