### PR TITLE
fix: ClaudeExtractor — domain fields optional in tool_use schema

### DIFF
--- a/src/mantis_agent/extraction/extractor.py
+++ b/src/mantis_agent/extraction/extractor.py
@@ -645,27 +645,39 @@ class ClaudeExtractor:
 
         - When ``self.schema`` is set: every schema field becomes a
           property; the universal ``is_spam`` boolean is appended.
+          Only ``is_spam`` is server-required — every domain field
+          is OPTIONAL so the brain can return partial data when a
+          field isn't visible on the page (phone behind a "Show"
+          button, asking_price set to "Make Offer", seller_name
+          not displayed, etc.). Without this, a single missing
+          field server-side-rejects the whole tool call and every
+          extract step fails — produced "0 viable leads from 53
+          steps" on the boattrader plan (run 20260521_064044).
+          Per-field presence-checking belongs downstream where
+          incomplete leads can be filtered or post-flagged, not
+          at the model API boundary.
         - Otherwise: falls back to the legacy marketplace shape
           (year / make / model / price / phone / url / seller /
           is_dealer) so callers without a schema still get a
-          validated response.
+          validated response. Legacy required set kept for back
+          compat — callers depending on the strict shape are
+          off the schema path.
         """
         if self.schema:
             properties: dict[str, dict[str, Any]] = {}
-            required: list[str] = []
             for field in self.schema.fields:
                 name = field["name"]
                 json_type = self._EXTRACT_FIELD_JSON_TYPES.get(
                     str(field.get("type", "str")).lower(), "string",
                 )
                 properties[name] = {"type": json_type}
-                required.append(name)
             properties["is_spam"] = {"type": "boolean"}
-            required.append("is_spam")
             return {
                 "type": "object",
                 "properties": properties,
-                "required": required,
+                # Only is_spam is required — domain fields are optional
+                # so partial extractions land instead of failing.
+                "required": ["is_spam"],
             }
         # Legacy / no-schema fallback shape.
         return {

--- a/tests/test_extractor_tool_use_migration.py
+++ b/tests/test_extractor_tool_use_migration.py
@@ -381,9 +381,18 @@ def test_extract_dynamic_schema_built_from_extraction_schema_fields() -> None:
     assert props["salary_min"] == {"type": "integer"}
     assert props["remote"] == {"type": "boolean"}
     assert props["is_spam"] == {"type": "boolean"}
-    # Every property is required — the structure-validating effect is
-    # what makes tool_use stronger than prompt-only "Output JSON".
-    assert set(input_schema["required"]) == set(props.keys())
+    # Only ``is_spam`` is server-required. Domain fields are optional
+    # so partial extractions (e.g. phone behind a "Show" button, or
+    # asking_price set to "Make Offer") land instead of triggering
+    # an Anthropic server-side schema rejection and collapsing every
+    # extract step. Live repro: boattrader run 20260521_064044 got
+    # "0 viable leads from 53 steps" because every listing had at
+    # least one strict field unavailable.
+    assert input_schema["required"] == ["is_spam"]
+    # Domain fields STILL appear in properties — Claude is asked to
+    # populate them when present, just not required to.
+    for k in ("title", "company", "salary_min", "remote"):
+        assert k in props
 
 
 def test_extract_returns_low_confidence_when_tool_returns_none() -> None:


### PR DESCRIPTION
## Summary

``ClaudeExtractor._build_extract_input_schema`` marked **every** schema
field as required in the Anthropic tool_use ``input_schema``. When the
brain tried to call the tool with a partial extraction (phone behind a
"Show phone" button, asking_price set to "Make Offer", seller_name not
displayed), the Anthropic API server-side rejected the call → extractor
returned None → extract_data step failed.

## Live repro

Boattrader run ``20260521_064044_1e4bd37e``:
- 1888s (31 min, hit time_cap)
- 53 steps executed across many listings
- **0 viable leads** (every detail-page extract failed for the same reason)

## Fix

Only ``is_spam`` stays in ``required``. Domain fields appear in
``properties`` (Claude is asked to populate them) but aren't required,
so partial returns succeed. Downstream parsing already uses
``parsed.get(field, "")`` — missing keys → empty strings, no consumer
changes needed.

## Test plan

- [x] ``pytest tests/ -k extract`` — 217/217 pass after updating one assertion
- [x] ``ruff check`` clean
- [ ] Modal redeploy + boattrader rerun → expect leads > 0 (manual gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)