### PR TITLE
runtime: brain_budgets caps Holo3 max_steps at dispatch (#560)

### DIFF
--- a/deploy/modal/modal_cua_server.py
+++ b/deploy/modal/modal_cua_server.py
@@ -879,6 +879,9 @@ def _run_holo3_executor(
             on_checkpoint=vol.commit,
             max_cost=task_suite.get("_max_cost", 10.0),
             max_time_minutes=task_suite.get("_max_time_minutes", 180),
+            # #560: ``None`` (key absent) → runner falls back to
+            # ``Holo3StepHandler.DEFAULT_BRAIN_BUDGET_CAPS``.
+            brain_budgets=task_suite.get("_brain_budgets"),
         )
 
         # Reasoning-trace stream → ``<run_dir>/reasoning.jsonl``. The
@@ -1576,6 +1579,9 @@ def _build_suite_from_payload(payload: dict) -> str:
         proxy_provider=str(payload.get("proxy_provider") or ""),
         proxy_country=str(payload.get("proxy_country") or ""),
         proxy_disabled=bool(payload.get("proxy_disabled", False)),
+        # #560: forward only when the caller supplied one — ``None``
+        # lets the runner pick its DEFAULT_BRAIN_BUDGET_CAPS.
+        brain_budgets=payload.get("brain_budgets"),
     )
     return json.dumps(suite)
 

--- a/src/mantis_agent/baseten_server/runtime.py
+++ b/src/mantis_agent/baseten_server/runtime.py
@@ -953,6 +953,7 @@ class BasetenCUARuntime:
             proxy_city=str(payload.get("proxy_city") or os.environ.get("MANTIS_PROXY_CITY", "")),
             proxy_state=str(payload.get("proxy_state") or os.environ.get("MANTIS_PROXY_STATE", "")),
             proxy_disabled=bool(payload.get("proxy_disabled", False)),
+            brain_budgets=payload.get("brain_budgets"),
         )
 
     def _resolve_path(self, raw_path: str) -> Path:
@@ -1049,6 +1050,7 @@ class BasetenCUARuntime:
             proxy_state=str(payload.get("proxy_state") or os.environ.get("MANTIS_PROXY_STATE", "")),
             proxy_disabled=bool(payload.get("proxy_disabled", False)),
             objective=objective_dict,
+            brain_budgets=payload.get("brain_budgets"),
         )
         return suite
 
@@ -1533,6 +1535,7 @@ class BasetenCUARuntime:
                 resume_state=resume_state,
                 max_cost=task_suite.get("_max_cost", 10.0),
                 max_time_minutes=task_suite.get("_max_time_minutes", 180),
+                brain_budgets=task_suite.get("_brain_budgets"),
                 extraction_cache=cache,
                 routing_policy=routing_policy,
             )

--- a/src/mantis_agent/gym/micro_runner.py
+++ b/src/mantis_agent/gym/micro_runner.py
@@ -99,6 +99,7 @@ class MicroPlanRunner:
         seen_url_predicate: Any = None,  # Callable[[str], bool] | None
         routing_policy: Any = None,  # RoutingPolicy | None — typed in body to avoid import cycle
         seed: int | None = None,
+        brain_budgets: dict[str, int] | None = None,
     ):
         # Seed the global RNG so per-action human_speed delays
         # (random.uniform / random.randint in playwright_env.py +
@@ -108,6 +109,17 @@ class MicroPlanRunner:
         if seed is not None:
             random.seed(seed)
         self.seed = seed
+        # #560: per-step-type ceilings on Holo3 ``max_steps``. ``None``
+        # falls back to ``Holo3StepHandler.DEFAULT_BRAIN_BUDGET_CAPS``
+        # (scroll=3, click=4); an explicit ``{}`` disables all caps and
+        # honours each step's decomposer ``budget`` verbatim. Submitters
+        # pass this via the ``brain_budgets`` runtime field (threaded by
+        # ``build_micro_suite`` → ``_brain_budgets`` on the suite dict).
+        from .step_handlers.holo3 import DEFAULT_BRAIN_BUDGET_CAPS
+        self.brain_budgets: dict[str, int] = (
+            dict(DEFAULT_BRAIN_BUDGET_CAPS) if brain_budgets is None
+            else dict(brain_budgets)
+        )
         self.brain, self.env, self.grounding, self.extractor = (
             brain, env, grounding, extractor
         )

--- a/src/mantis_agent/gym/step_handlers/holo3.py
+++ b/src/mantis_agent/gym/step_handlers/holo3.py
@@ -204,8 +204,16 @@ class Holo3StepHandler:
         grounding = ctx.grounding
         index = int(ctx.state.get("index", 0))
 
-        max_steps = effective_brain_budget(
-            step.type, step.budget, getattr(runner, "brain_budgets", None),
+        caps = getattr(runner, "brain_budgets", None)
+        max_steps = effective_brain_budget(step.type, step.budget, caps)
+        # #560 verify telemetry: WARNING (not INFO — INFO is suppressed
+        # by ``modal app logs`` per feedback_modal_info_log_suppression).
+        # Emits one line per Holo3 dispatch so production logs show
+        # the cap that fired. ``clamped=True`` when the runtime cap
+        # actually trimmed the decomposer's budget.
+        logger.warning(
+            "holo3 dispatch step_idx=%s type=%s decomposer_budget=%s effective=%s clamped=%s",
+            index, step.type, step.budget, max_steps, max_steps < step.budget,
         )
         gym_runner = GymRunner(
             brain=brain,

--- a/src/mantis_agent/gym/step_handlers/holo3.py
+++ b/src/mantis_agent/gym/step_handlers/holo3.py
@@ -49,6 +49,43 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+# #560: per-step-type ceilings on the Holo3 brain loop. The decomposer
+# prompt still advertises higher upper bounds (scroll=10, click=8) so
+# its LLM can reason about worst-case effort, but past these caps the
+# brain typically exhausts into ``brain_loop_exhausted`` and falls
+# through to recovery anyway (scroll_cdp_fallback / pointer_retry) —
+# the slack burned GPU + wall-clock for no gain.
+#
+# Runtime override: a submission can pass ``brain_budgets`` (dict
+# step_type → cap) through ``merge_runtime`` / ``build_micro_suite`` /
+# the runner constructor to retune per plan. ``None`` on the runner
+# falls back to these defaults; an explicit empty dict disables all
+# caps and honours each step's ``budget`` verbatim (escape hatch).
+DEFAULT_BRAIN_BUDGET_CAPS: dict[str, int] = {
+    "scroll": 3,
+    "click": 4,
+}
+
+
+def effective_brain_budget(
+    step_type: str, step_budget: int, caps: dict[str, int] | None
+) -> int:
+    """Return the brain ``max_steps`` after applying the runtime cap.
+
+    ``caps`` is the per-run dict (``runner.brain_budgets``). A missing
+    key means "no cap for this type" — return ``step_budget`` unchanged.
+    Caps below 1 are ignored (defensive: a cap of 0 would brick the
+    handler; we'd rather honour the decomposer's value than dispatch
+    a zero-step Holo3 loop).
+    """
+    if not caps:
+        return step_budget
+    cap = caps.get(step_type)
+    if cap is None or cap < 1:
+        return step_budget
+    return min(step_budget, cap)
+
+
 # The shared retry-attempts module owns the window cap + line format
 # (#435 item 7: Claude / Fara prompt builders use the same shape).
 # Re-export the private helpers here for back-compat with existing
@@ -167,10 +204,13 @@ class Holo3StepHandler:
         grounding = ctx.grounding
         index = int(ctx.state.get("index", 0))
 
+        max_steps = effective_brain_budget(
+            step.type, step.budget, getattr(runner, "brain_budgets", None),
+        )
         gym_runner = GymRunner(
             brain=brain,
             env=env,
-            max_steps=step.budget,
+            max_steps=max_steps,
             frames_per_inference=1,
             grounding=grounding if step.grounding else None,
             on_step=runner.on_step,

--- a/src/mantis_agent/server_utils.py
+++ b/src/mantis_agent/server_utils.py
@@ -989,6 +989,11 @@ _RUNTIME_KEYS = (
     "proxy_country",
     "max_cost",
     "max_time_minutes",
+    # #560: per-step-type Holo3 brain-loop caps (dict step_type → int).
+    # ``None`` (= key absent) lets the runner apply
+    # ``DEFAULT_BRAIN_BUDGET_CAPS`` (scroll=3, click=4). Pass ``{}`` to
+    # disable all caps for a single submission.
+    "brain_budgets",
 )
 
 
@@ -1076,6 +1081,7 @@ def build_micro_suite(
     proxy_country: str = "",
     proxy_disabled: bool = False,
     objective: dict[str, Any] | None = None,
+    brain_budgets: dict[str, int] | None = None,
 ) -> dict[str, Any]:
     """Build a task_suite dict for micro-intent execution.
 
@@ -1130,6 +1136,11 @@ def build_micro_suite(
     }
     if objective:
         suite["_objective"] = objective
+    # #560: ``None`` means "let the runner apply DEFAULT_BRAIN_BUDGET_CAPS".
+    # Persist only when an override was supplied (including ``{}`` to
+    # explicitly disable caps for this run).
+    if brain_budgets is not None:
+        suite["_brain_budgets"] = dict(brain_budgets)
     return suite
 
 

--- a/tests/test_brain_budget_clamp.py
+++ b/tests/test_brain_budget_clamp.py
@@ -1,0 +1,128 @@
+"""Tests for runtime brain-budget clamps (#560).
+
+The decomposer LLM advertises generous upper bounds (scroll=10, click=8)
+so it can reason about worst case. The runtime clamps each step's
+``max_steps`` at Holo3 dispatch — capping wasted brain cycles without
+forcing the decomposer to internalise per-deploy cost preferences.
+
+Three behaviours covered:
+
+1. ``effective_brain_budget`` picks the lower of (step.budget, cap).
+2. ``MicroPlanRunner.brain_budgets`` defaults to
+   ``DEFAULT_BRAIN_BUDGET_CAPS`` when constructor kwarg is ``None``,
+   and honours an explicit ``{}`` as "no caps".
+3. ``build_micro_suite(brain_budgets=...)`` round-trips through the
+   suite dict so submitters can override per run.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from mantis_agent.gym.micro_runner import MicroPlanRunner
+from mantis_agent.gym.step_handlers.holo3 import (
+    DEFAULT_BRAIN_BUDGET_CAPS,
+    effective_brain_budget,
+)
+from mantis_agent.server_utils import build_micro_suite, merge_runtime
+
+
+# ── effective_brain_budget ─────────────────────────────────────────
+
+
+def test_clamp_returns_cap_when_step_budget_higher() -> None:
+    assert effective_brain_budget("scroll", 10, {"scroll": 3}) == 3
+    assert effective_brain_budget("click", 8, {"click": 4}) == 4
+
+
+def test_clamp_returns_step_budget_when_cap_higher() -> None:
+    assert effective_brain_budget("scroll", 2, {"scroll": 3}) == 2
+
+
+def test_clamp_returns_step_budget_when_type_missing_from_caps() -> None:
+    # paginate isn't in DEFAULT_BRAIN_BUDGET_CAPS — passthrough.
+    assert effective_brain_budget("paginate", 10, {"scroll": 3}) == 10
+
+
+def test_clamp_none_caps_means_no_cap() -> None:
+    assert effective_brain_budget("scroll", 10, None) == 10
+
+
+def test_clamp_empty_caps_means_no_cap() -> None:
+    # Explicit ``{}`` is the escape hatch: honour every step's budget verbatim.
+    assert effective_brain_budget("scroll", 10, {}) == 10
+
+
+def test_clamp_ignores_invalid_cap_below_one() -> None:
+    # A cap of 0 would brick the handler; fall back to step.budget.
+    assert effective_brain_budget("scroll", 10, {"scroll": 0}) == 10
+    assert effective_brain_budget("scroll", 10, {"scroll": -1}) == 10
+
+
+# ── MicroPlanRunner storage ────────────────────────────────────────
+
+
+def _runner(**kwargs) -> MicroPlanRunner:
+    return MicroPlanRunner(brain=MagicMock(), env=MagicMock(), **kwargs)
+
+
+def test_runner_defaults_to_DEFAULT_BRAIN_BUDGET_CAPS() -> None:
+    runner = _runner()
+    assert runner.brain_budgets == DEFAULT_BRAIN_BUDGET_CAPS
+
+
+def test_runner_default_is_a_copy_not_shared_reference() -> None:
+    # Mutating one runner's caps must not leak into the next default.
+    runner_a = _runner()
+    runner_a.brain_budgets["scroll"] = 99
+    runner_b = _runner()
+    assert runner_b.brain_budgets["scroll"] == DEFAULT_BRAIN_BUDGET_CAPS["scroll"]
+
+
+def test_runner_explicit_empty_dict_disables_caps() -> None:
+    runner = _runner(brain_budgets={})
+    assert runner.brain_budgets == {}
+
+
+def test_runner_explicit_override_replaces_defaults() -> None:
+    runner = _runner(brain_budgets={"scroll": 5, "paginate": 6})
+    assert runner.brain_budgets == {"scroll": 5, "paginate": 6}
+    # Note: ``click`` default isn't reinstated — explicit override is
+    # authoritative. Submitters who want partial overrides must merge
+    # client-side.
+
+
+# ── build_micro_suite round-trip ───────────────────────────────────
+
+
+def test_suite_omits_brain_budgets_when_caller_passes_none() -> None:
+    suite = build_micro_suite([], "example.com")
+    assert "_brain_budgets" not in suite
+
+
+def test_suite_persists_explicit_brain_budgets() -> None:
+    suite = build_micro_suite([], "example.com", brain_budgets={"scroll": 2})
+    assert suite["_brain_budgets"] == {"scroll": 2}
+
+
+def test_suite_persists_explicit_empty_dict() -> None:
+    # The escape-hatch "no caps" must survive the round-trip; the
+    # runner reads ``{}`` (not None) and disables clamps.
+    suite = build_micro_suite([], "example.com", brain_budgets={})
+    assert suite["_brain_budgets"] == {}
+
+
+# ── merge_runtime accepts brain_budgets ────────────────────────────
+
+
+def test_merge_runtime_threads_brain_budgets() -> None:
+    merged = merge_runtime({"brain_budgets": {"scroll": 2}})
+    assert merged["brain_budgets"] == {"scroll": 2}
+
+
+def test_merge_runtime_override_wins_over_plan_default() -> None:
+    merged = merge_runtime(
+        {"brain_budgets": {"scroll": 2}},
+        brain_budgets={"scroll": 5},
+    )
+    assert merged["brain_budgets"] == {"scroll": 5}


### PR DESCRIPTION
## Summary

Replaces the prompt-edit shape proposed in #560 with a runtime-clamp layer.

The decomposer LLM keeps advertising upper bounds (scroll=10, click=8) so it can reason about worst case; the runner enforces per-step-type ceilings at Holo3 dispatch via \`effective_brain_budget\`.

**Defaults:** \`{\"scroll\": 3, \"click\": 4}\` — past these caps the brain usually exhausts into \`brain_loop_exhausted\` and falls through to recovery (scroll_cdp_fallback / pointer_retry) anyway. The slack was pure GPU + wall-clock cost.

**Override path** mirrors the shape #567 will use for recovery caps:

\`\`\`python
runtime = merge_runtime({\"brain_budgets\": {\"scroll\": 5, \"click\": 2}})
\`\`\`

\`{}\` is the escape hatch — disables all caps, honours decomposer budgets verbatim.

## Why this instead of the prompt edit

The issue proposed lowering the budgets in the decomposer prompt. That bakes per-deploy cost preferences into LLM guidance, requires re-prompting to retune, and doesn't help when the LLM ignores the hint. A runtime clamp decouples the layers:

* Decomposer keeps emitting whatever bounds it thinks are right (single source of behavioral truth — \"how many cycles MIGHT this need\").
* Runner enforces per-deploy ceilings (single source of cost truth — \"how many cycles am I willing to PAY for\").
* A single submission can retune per plan without code or prompt changes.
* Same shape as #567's recovery caps — consistency wins.

## Touchpoints

* \`gym/step_handlers/holo3.py\` — \`DEFAULT_BRAIN_BUDGET_CAPS\` + \`effective_brain_budget\` helper + clamp call site
* \`gym/micro_runner.py\` — ctor kwarg + storage (copy of defaults)
* \`server_utils.py\` — \`_RUNTIME_KEYS\` + \`build_micro_suite\` kwarg → suite dict
* \`deploy/modal/modal_cua_server.py\` — payload → suite → runner (2 sites)
* \`baseten_server/runtime.py\` — same (3 sites)

## Test plan

- [x] Unit tests: \`tests/test_brain_budget_clamp.py\` (15 cases) — clamp arithmetic, runner default/override, suite round-trip, \`merge_runtime\` acceptance
- [x] Full suite: 3490+ pass; flake in \`test_stealth_parity_modal.py\` is pre-existing on main (confirmed by running clean main), unrelated
- [ ] Modal redeploy + boattrader plan rerun — verify scroll-step cost drops from \$0.05-0.10 → \$0.02-0.04 per attempt

## Expected impact

~30-90s + \$0.30-0.45 saved per boattrader-class run.

Closes #560

🤖 Generated with [Claude Code](https://claude.com/claude-code)