### PR TITLE
runtime: pause_on_captcha field — opt out of cf_challenge 30-min wait

### DIFF
--- a/deploy/modal/modal_cua_server.py
+++ b/deploy/modal/modal_cua_server.py
@@ -882,6 +882,9 @@ def _run_holo3_executor(
             # #560: ``None`` (key absent) → runner falls back to
             # ``Holo3StepHandler.DEFAULT_BRAIN_BUDGET_CAPS``.
             brain_budgets=task_suite.get("_brain_budgets"),
+            # #570: ``None`` → runner falls back to
+            # ``MANTIS_PAUSE_ON_CAPTCHA`` env (default on).
+            pause_on_captcha=task_suite.get("_pause_on_captcha"),
         )
 
         # Reasoning-trace stream → ``<run_dir>/reasoning.jsonl``. The
@@ -1582,6 +1585,9 @@ def _build_suite_from_payload(payload: dict) -> str:
         # #560: forward only when the caller supplied one — ``None``
         # lets the runner pick its DEFAULT_BRAIN_BUDGET_CAPS.
         brain_budgets=payload.get("brain_budgets"),
+        # #570: per-run cf_challenge auto-pause override. ``None`` →
+        # runner falls back to MANTIS_PAUSE_ON_CAPTCHA env.
+        pause_on_captcha=payload.get("pause_on_captcha"),
     )
     return json.dumps(suite)
 

--- a/src/mantis_agent/baseten_server/runtime.py
+++ b/src/mantis_agent/baseten_server/runtime.py
@@ -954,6 +954,7 @@ class BasetenCUARuntime:
             proxy_state=str(payload.get("proxy_state") or os.environ.get("MANTIS_PROXY_STATE", "")),
             proxy_disabled=bool(payload.get("proxy_disabled", False)),
             brain_budgets=payload.get("brain_budgets"),
+            pause_on_captcha=payload.get("pause_on_captcha"),
         )
 
     def _resolve_path(self, raw_path: str) -> Path:
@@ -1051,6 +1052,7 @@ class BasetenCUARuntime:
             proxy_disabled=bool(payload.get("proxy_disabled", False)),
             objective=objective_dict,
             brain_budgets=payload.get("brain_budgets"),
+            pause_on_captcha=payload.get("pause_on_captcha"),
         )
         return suite
 
@@ -1536,6 +1538,7 @@ class BasetenCUARuntime:
                 max_cost=task_suite.get("_max_cost", 10.0),
                 max_time_minutes=task_suite.get("_max_time_minutes", 180),
                 brain_budgets=task_suite.get("_brain_budgets"),
+                pause_on_captcha=task_suite.get("_pause_on_captcha"),
                 extraction_cache=cache,
                 routing_policy=routing_policy,
             )

--- a/src/mantis_agent/gym/external_pause.py
+++ b/src/mantis_agent/gym/external_pause.py
@@ -217,11 +217,22 @@ def wait_while_paused(*, max_seconds: int = 1800, poll_seconds: float = 2.0) -> 
     return "resumed"
 
 
-def is_captcha_autopause_enabled() -> bool:
+def is_captcha_autopause_enabled(override: bool | None = None) -> bool:
     """Whether to auto-pause when a step fails with
-    ``failure_class='cf_challenge'``. Default ``True``; set
-    ``MANTIS_PAUSE_ON_CAPTCHA=0`` to fall back to legacy halt-on-
-    cf_challenge behavior."""
+    ``failure_class='cf_challenge'``.
+
+    Resolution order (first non-``None`` wins):
+
+    1. ``override`` kwarg — the per-run ``pause_on_captcha`` runtime
+       field threaded through ``MicroPlanRunner.pause_on_captcha``.
+       Lets a single submission opt out of the 30-min pause loop
+       (e.g. CI / verify reruns) without touching the Modal Secret.
+    2. ``MANTIS_PAUSE_ON_CAPTCHA`` env var — legacy deploy-wide
+       toggle. ``0/false/no/off`` disables; any other value enables.
+    3. Default ``True`` — auto-pause on cf_challenge.
+    """
+    if override is not None:
+        return bool(override)
     raw = os.environ.get("MANTIS_PAUSE_ON_CAPTCHA", "").strip().lower()
     if not raw:
         return True

--- a/src/mantis_agent/gym/micro_runner.py
+++ b/src/mantis_agent/gym/micro_runner.py
@@ -100,6 +100,7 @@ class MicroPlanRunner:
         routing_policy: Any = None,  # RoutingPolicy | None — typed in body to avoid import cycle
         seed: int | None = None,
         brain_budgets: dict[str, int] | None = None,
+        pause_on_captcha: bool | None = None,
     ):
         # Seed the global RNG so per-action human_speed delays
         # (random.uniform / random.randint in playwright_env.py +
@@ -120,6 +121,14 @@ class MicroPlanRunner:
             dict(DEFAULT_BRAIN_BUDGET_CAPS) if brain_budgets is None
             else dict(brain_budgets)
         )
+        # #570: per-run override for the cf_challenge auto-pause loop
+        # (PR #555). ``None`` → env var fallback
+        # (``MANTIS_PAUSE_ON_CAPTCHA``, default on); ``False`` → fail
+        # fast on cf_challenge (CI / verify reruns where 30-min human-
+        # takeover wait is a tax, not a feature); ``True`` → force
+        # auto-pause even if env disables it. Read by
+        # ``RunExecutor._maybe_auto_pause_on_captcha``.
+        self.pause_on_captcha: bool | None = pause_on_captcha
         self.brain, self.env, self.grounding, self.extractor = (
             brain, env, grounding, extractor
         )

--- a/src/mantis_agent/gym/run_executor.py
+++ b/src/mantis_agent/gym/run_executor.py
@@ -1816,7 +1816,16 @@ class RunExecutor:
             if failure_class != "cf_challenge":
                 return
             from . import external_pause
-            if not external_pause.is_captcha_autopause_enabled():
+            # #570: per-run override via runtime field
+            # ``pause_on_captcha`` (None = fall back to env var).
+            override = getattr(self.parent, "pause_on_captcha", None)
+            if not external_pause.is_captcha_autopause_enabled(override=override):
+                logger.warning(
+                    "external_pause: auto-pause disabled by runtime field "
+                    "(pause_on_captcha=False) — failing fast on cf_challenge "
+                    "at step %s",
+                    getattr(step_result, "step_index", "?"),
+                )
                 return
             if external_pause.is_pause_requested():
                 # Sentinel already set (race with external pause or

--- a/src/mantis_agent/server_utils.py
+++ b/src/mantis_agent/server_utils.py
@@ -994,6 +994,12 @@ _RUNTIME_KEYS = (
     # ``DEFAULT_BRAIN_BUDGET_CAPS`` (scroll=3, click=4). Pass ``{}`` to
     # disable all caps for a single submission.
     "brain_budgets",
+    # #570: override the cf_challenge auto-pause loop (PR #555).
+    # ``None`` falls back to MANTIS_PAUSE_ON_CAPTCHA env var; ``False``
+    # fails fast on cf_challenge instead of sleeping 30 min for human
+    # takeover (useful for CI / verify reruns); ``True`` forces auto-
+    # pause on regardless of env.
+    "pause_on_captcha",
 )
 
 
@@ -1082,6 +1088,7 @@ def build_micro_suite(
     proxy_disabled: bool = False,
     objective: dict[str, Any] | None = None,
     brain_budgets: dict[str, int] | None = None,
+    pause_on_captcha: bool | None = None,
 ) -> dict[str, Any]:
     """Build a task_suite dict for micro-intent execution.
 
@@ -1141,6 +1148,11 @@ def build_micro_suite(
     # explicitly disable caps for this run).
     if brain_budgets is not None:
         suite["_brain_budgets"] = dict(brain_budgets)
+    # #570: same shape — persist only when the caller specified an
+    # override, so the runner falls through to env-var resolution
+    # (MANTIS_PAUSE_ON_CAPTCHA) otherwise.
+    if pause_on_captcha is not None:
+        suite["_pause_on_captcha"] = bool(pause_on_captcha)
     return suite
 
 

--- a/tests/test_pause_on_captcha_runtime_field.py
+++ b/tests/test_pause_on_captcha_runtime_field.py
@@ -16,7 +16,6 @@ Covers:
 
 from __future__ import annotations
 
-import os
 from unittest.mock import MagicMock
 
 import pytest

--- a/tests/test_pause_on_captcha_runtime_field.py
+++ b/tests/test_pause_on_captcha_runtime_field.py
@@ -1,0 +1,117 @@
+"""Tests for the runtime ``pause_on_captcha`` field (#570).
+
+Promotes ``MANTIS_PAUSE_ON_CAPTCHA`` from a deploy-wide env var to a
+per-submission runtime field. A single submission can opt out of the
+30-min cf_challenge auto-pause loop (PR #555) without touching the
+Modal Secret — useful for CI / verify reruns where a real human won't
+solve the CF widget in time anyway.
+
+Covers:
+
+1. ``is_captcha_autopause_enabled(override=...)`` resolution order
+2. ``MicroPlanRunner.pause_on_captcha`` stored as-passed
+3. ``build_micro_suite`` round-trips through ``_pause_on_captcha``
+4. ``merge_runtime`` accepts the field
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock
+
+import pytest
+
+from mantis_agent.gym import external_pause
+from mantis_agent.gym.micro_runner import MicroPlanRunner
+from mantis_agent.server_utils import build_micro_suite, merge_runtime
+
+
+# ── is_captcha_autopause_enabled resolution ────────────────────────
+
+
+def test_override_false_disables_regardless_of_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MANTIS_PAUSE_ON_CAPTCHA", "1")
+    assert external_pause.is_captcha_autopause_enabled(override=False) is False
+
+
+def test_override_true_enables_regardless_of_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MANTIS_PAUSE_ON_CAPTCHA", "0")
+    assert external_pause.is_captcha_autopause_enabled(override=True) is True
+
+
+def test_override_none_reads_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MANTIS_PAUSE_ON_CAPTCHA", "0")
+    assert external_pause.is_captcha_autopause_enabled(override=None) is False
+    monkeypatch.setenv("MANTIS_PAUSE_ON_CAPTCHA", "1")
+    assert external_pause.is_captcha_autopause_enabled(override=None) is True
+
+
+def test_override_none_defaults_on_when_env_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("MANTIS_PAUSE_ON_CAPTCHA", raising=False)
+    assert external_pause.is_captcha_autopause_enabled() is True
+    assert external_pause.is_captcha_autopause_enabled(override=None) is True
+
+
+def test_backward_compat_no_kwarg_still_reads_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The legacy call-without-kwarg shape must keep working — nothing
+    # outside MicroPlanRunner threads the override yet.
+    monkeypatch.setenv("MANTIS_PAUSE_ON_CAPTCHA", "false")
+    assert external_pause.is_captcha_autopause_enabled() is False
+
+
+# ── MicroPlanRunner storage ────────────────────────────────────────
+
+
+def _runner(**kwargs) -> MicroPlanRunner:
+    return MicroPlanRunner(brain=MagicMock(), env=MagicMock(), **kwargs)
+
+
+def test_runner_default_pause_on_captcha_is_none() -> None:
+    # None preserves the env-var fallback path — must not be coerced
+    # to True/False at construction.
+    runner = _runner()
+    assert runner.pause_on_captcha is None
+
+
+def test_runner_explicit_false_stored() -> None:
+    runner = _runner(pause_on_captcha=False)
+    assert runner.pause_on_captcha is False
+
+
+def test_runner_explicit_true_stored() -> None:
+    runner = _runner(pause_on_captcha=True)
+    assert runner.pause_on_captcha is True
+
+
+# ── build_micro_suite round-trip ───────────────────────────────────
+
+
+def test_suite_omits_pause_on_captcha_when_caller_passes_none() -> None:
+    suite = build_micro_suite([], "example.com")
+    assert "_pause_on_captcha" not in suite
+
+
+def test_suite_persists_explicit_false() -> None:
+    suite = build_micro_suite([], "example.com", pause_on_captcha=False)
+    assert suite["_pause_on_captcha"] is False
+
+
+def test_suite_persists_explicit_true() -> None:
+    suite = build_micro_suite([], "example.com", pause_on_captcha=True)
+    assert suite["_pause_on_captcha"] is True
+
+
+# ── merge_runtime accepts pause_on_captcha ─────────────────────────
+
+
+def test_merge_runtime_threads_pause_on_captcha() -> None:
+    merged = merge_runtime({"pause_on_captcha": False})
+    assert merged["pause_on_captcha"] is False
+
+
+def test_merge_runtime_override_wins_over_plan_default() -> None:
+    merged = merge_runtime(
+        {"pause_on_captcha": True},
+        pause_on_captcha=False,
+    )
+    assert merged["pause_on_captcha"] is False


### PR DESCRIPTION
## Summary

Promotes \`MANTIS_PAUSE_ON_CAPTCHA\` from a deploy-wide env var to a per-submission runtime field. A single submission can opt out of PR #555's cf_challenge auto-pause loop (max 30 min ` wait_while_paused\`) without touching the Modal Secret.

**Use case:** CI / verify reruns where the 30-min human-takeover wait is a tax rather than a feature. The harness should halt cleanly on cf_challenge with \`failure_class=cf_challenge\` and move on, not sleep an A100 for half an hour.

## Behavior

Resolution order in \`is_captcha_autopause_enabled(override=...)\`:

1. \`override\` kwarg (runtime field) — wins when not None
2. \`MANTIS_PAUSE_ON_CAPTCHA\` env var — legacy fallback
3. Default True (auto-pause enabled)

\`\`\`python
runtime = merge_runtime({\"pause_on_captcha\": False})  # fail fast on CF
suite = build_micro_suite(steps, domain, **runtime)
# → suite[\"_pause_on_captcha\"] = False
# → MicroPlanRunner(pause_on_captcha=False)
# → _maybe_auto_pause_on_captcha calls is_captcha_autopause_enabled(override=False) → False → halt
\`\`\`

## Touchpoints (same shape as #560 brain_budgets)

* \`gym/external_pause.py\` — \`is_captcha_autopause_enabled\` accepts \`override\` kwarg
* \`gym/run_executor.py\` — \`_maybe_auto_pause_on_captcha\` reads \`runner.pause_on_captcha\`
* \`gym/micro_runner.py\` — \`pause_on_captcha: bool | None\` ctor kwarg
* \`server_utils.py\` — \`_RUNTIME_KEYS\` + \`build_micro_suite\` kwarg → \`_pause_on_captcha\` on suite
* \`deploy/modal/modal_cua_server.py\` — payload → suite → runner
* \`baseten_server/runtime.py\` — same 3 sites

## Test plan

- [x] Unit tests: \`tests/test_pause_on_captcha_runtime_field.py\` (13 cases) — resolution order, runner storage, suite round-trip, \`merge_runtime\`, legacy no-kwarg back-compat
- [ ] Modal redeploy + boattrader submit with \`pause_on_captcha: false\` — expect halt within ~1-2 min on CF instead of 30-min pause

## Context

Filed during #560 verify-cycle debugging on 2026-05-21. The boattrader plan was hitting CF Turnstile, triggering PR #555's auto-pause, which sat for the full 30-min ceiling per run. Without this PR, the only way to disable auto-pause was a Modal Secret edit + push + redeploy. With this PR, the verify script can pass \`pause_on_captcha: false\` per submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)