### PR TITLE
scripts: stable PROFILE_ID — persist CF clearance across runs (#572 Phase 1)

### DIFF
--- a/scripts/run_boattrader_urlnav_with_proxy.py
+++ b/scripts/run_boattrader_urlnav_with_proxy.py
@@ -9,8 +9,29 @@ Adapted from run_staff_crm_long_no_proxy.py with two differences:
   Secret.from_dotenv (BoatTrader's Cloudflare layer blocks direct
   Modal egress)
 
+Identity model (#572 Phase 1):
+
+* PROFILE_ID is **stable** by default (``boattrader-urlnav-stable``)
+  so the Chrome user-data-dir is reused across runs. Cookies
+  (notably ``cf_clearance``) persist — the FIRST run on a fresh
+  profile may hit a Cloudflare Turnstile widget; subsequent runs
+  within the cookie lifetime (~30 min to several hours) reuse the
+  cached clearance and skip CF entirely. Override per-run via
+  ``MANTIS_PROFILE_ID`` env when you want a clean profile.
+* WORKFLOW_ID is **timestamped** per run so checkpoint files don't
+  collide. Each run still gets its own checkpoint, but they all
+  share the same Chrome profile.
+
+To seed CF clearance on a fresh profile, submit with
+``pause_on_captcha=true`` (the default), open the viewer URL when
+the run auto-pauses, solve the Turnstile widget, click Resume.
+The ``cf_clearance`` cookie lands in the profile and every
+subsequent run skips CF.
+
 Usage::
     MANTIS_API_TOKEN=... uv run python scripts/run_boattrader_urlnav_with_proxy.py
+    # or override the profile:
+    MANTIS_PROFILE_ID=boattrader-clean uv run python scripts/run_boattrader_urlnav_with_proxy.py
 """
 
 from __future__ import annotations
@@ -37,8 +58,13 @@ from mantis_agent.server_utils import (  # noqa: E402
 
 ENDPOINT = "https://getmason--mantis-cua-server-api.modal.run"
 PLAN_PATH = REPO_ROOT / "plans" / "boattrader_scrape_urlnav"
-PROFILE_ID = f"boattrader-urlnav-{int(time.time())}"
-WORKFLOW_ID = PROFILE_ID
+# #572: stable PROFILE_ID by default so CF clearance cookies persist
+# across runs. Override via env when you need a clean profile for
+# debugging (e.g. testing first-run CF behavior).
+PROFILE_ID = os.environ.get("MANTIS_PROFILE_ID", "boattrader-urlnav-stable")
+# WORKFLOW_ID timestamped per run — each run gets its own checkpoint
+# file even though they share the Chrome profile.
+WORKFLOW_ID = f"boattrader-urlnav-{int(time.time())}"
 
 
 def _token() -> str:

--- a/scripts/run_luma_extract.py
+++ b/scripts/run_luma_extract.py
@@ -36,7 +36,10 @@ from mantis_agent.server_utils import (  # noqa: E402
 
 ENDPOINT = "https://getmason--mantis-cua-server-api.modal.run"
 PLAN_PATH = REPO_ROOT / "plans" / "luma-extract.json"
-PROFILE_ID = f"luma-extract-{int(time.time())}"
+# #572: stable PROFILE_ID by default so cookies (including any CF
+# clearance) persist across runs. Override via env for a clean
+# profile. WORKFLOW_ID stays timestamped per run.
+PROFILE_ID = os.environ.get("MANTIS_PROFILE_ID", "luma-extract-stable")
 WORKFLOW_ID = f"luma-extract-{int(time.time())}"
 
 


### PR DESCRIPTION
## Summary

Phase 1 of #572. The two verify scripts (\`run_boattrader_urlnav_with_proxy.py\`, \`run_luma_extract.py\`) were using the same fresh-per-run identity for both PROFILE_ID and WORKFLOW_ID. This meant every run hit Cloudflare cold — no cookie persistence.

This PR splits them:

* **PROFILE_ID** is stable by default (\`<plan>-stable\`) — Chrome user-data-dir reused across runs, so \`cf_clearance\` cookie persists.
* **WORKFLOW_ID** is timestamped — each run has its own checkpoint file.
* Env override: \`MANTIS_PROFILE_ID\` to opt into a clean profile.

## Operational flow

1. First run on a fresh profile may auto-pause on CF (default \`pause_on_captcha=true\`)
2. Viewer URL surfaces, human solves Turnstile, clicks Resume
3. \`cf_clearance\` cookie lands in the persistent profile
4. Every subsequent run within the cookie's lifetime (~30 min — several hours) skips CF entirely

## Test plan

- [x] Linter clean
- [ ] Submit run with default stable profile, observe CF auto-pause first time
- [ ] Solve CF via viewer, observe subsequent run completes without CF challenge

## Out of scope (Phase 2 in #572)

* \`action=solve_cf\` HTTP action to spawn a seed plan
* CF-clearance probe step that warns when the cookie is about to expire
* Multi-profile rotation pool

Issue #572 stays open for Phase 2; this PR does not include \`Closes #572\` on purpose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)