### PR TITLE
fix: Holo3 brain rejects click()/double_click() with missing or (0,0) coords (#574)

### DIFF
--- a/src/mantis_agent/brain_holo3.py
+++ b/src/mantis_agent/brain_holo3.py
@@ -646,16 +646,44 @@ class Holo3Brain:
             m = re.match(r'-?\d+', str(val).strip())
             return int(m.group(0)) if m else default
 
+        def _has_valid_xy(args: dict) -> bool:
+            """#574: a click is only dispatchable when BOTH x and y were
+            present in the model's args AND not both zero. Missing keys
+            (e.g. ``click()`` or ``click({'button': 'left'})``) and
+            explicit ``(0, 0)`` both indicate the model didn't pin a
+            target — better to fall through to the WAIT(1s) fallback
+            than dispatch to the page origin.
+            """
+            if "x" not in args or "y" not in args:
+                return False
+            x = _safe_int(args["x"], default=-1)
+            y = _safe_int(args["y"], default=-1)
+            if x < 0 or y < 0:
+                # Malformed value that didn't parse to a non-negative int.
+                return False
+            return (x, y) != (0, 0)
+
         # Map to Action
         if func_name in ("click",):
-            x = _safe_int(args.get("x", 0))
-            y = _safe_int(args.get("y", 0))
+            # #574: reject click() with missing or (0,0) coords. Returning
+            # an Action(CLICK, {x:0, y:0}) silently dispatches to the page
+            # origin which always lands off-target (logo / header bg /
+            # off-canvas), producing wrong-page nav and DUPLICATE-URL
+            # loops on listings plans. ``None`` falls through to the
+            # parser chain → eventually Action(WAIT, 1s) at the brain
+            # level → clean no-op step.
+            if not _has_valid_xy(args):
+                return None
+            x = _safe_int(args["x"])
+            y = _safe_int(args["y"])
             sx, sy = _model_coords_to_screen(x, y, screen_size[0], screen_size[1])
             return Action(ActionType.CLICK, {"x": sx, "y": sy, "button": args.get("button", "left")})
 
         if func_name in ("double_click", "doubleclick"):
-            x = _safe_int(args.get("x", 0))
-            y = _safe_int(args.get("y", 0))
+            if not _has_valid_xy(args):
+                return None
+            x = _safe_int(args["x"])
+            y = _safe_int(args["y"])
             sx, sy = _model_coords_to_screen(x, y, screen_size[0], screen_size[1])
             return Action(ActionType.DOUBLE_CLICK, {"x": sx, "y": sy})
 

--- a/tests/test_holo3_null_click_coords.py
+++ b/tests/test_holo3_null_click_coords.py
@@ -1,0 +1,125 @@
+"""Regression tests for #574 — Holo3 click(0,0) silent dispatch.
+
+Before this fix, ``_parse_holo3_action`` returned
+``Action(CLICK, {x:0, y:0})`` whenever the model emitted ``click()``
+without coordinates (or with malformed values that ``_safe_int``
+coerced to 0). On listings/loop plans, that dispatched to the page
+origin → wrong-page extract → DUPLICATE-URL loop → halt with 0 leads.
+
+Empirical 2026-05-21: boattrader run ``20260521_205442_b3428c17``
+logged dozens of ``[click] (0,0) grounding=NO`` lines after CF
+cleared. The fix: parse-fail (None) when x/y are missing or both
+zero; brain's normal fallthrough emits ``Action(WAIT, 1s)`` instead.
+"""
+
+from __future__ import annotations
+
+from mantis_agent.actions import ActionType
+from mantis_agent.brain_holo3 import Holo3Brain
+
+
+SCREEN = (1280, 720)
+
+
+def _parse(text: str):
+    return Holo3Brain._parse_holo3_action(
+        Holo3Brain.__new__(Holo3Brain), text, SCREEN,
+    )
+
+
+# ── click — invalid coord variants must return None ────────────────
+
+
+def test_click_with_no_args_returns_none() -> None:
+    assert _parse("Action: click()") is None
+
+
+def test_click_with_empty_dict_returns_none() -> None:
+    assert _parse("Action: click({})") is None
+
+
+def test_click_with_only_button_arg_returns_none() -> None:
+    assert _parse("Action: click({'button': 'left'})") is None
+
+
+def test_click_with_x_only_returns_none() -> None:
+    assert _parse("Action: click({'x': 500})") is None
+
+
+def test_click_with_y_only_returns_none() -> None:
+    assert _parse("Action: click({'y': 300})") is None
+
+
+def test_click_with_explicit_zero_zero_returns_none() -> None:
+    # Page origin is never a legitimate click target — reject to avoid
+    # the DUPLICATE-URL loop on listings plans.
+    assert _parse("Action: click({'x': 0, 'y': 0})") is None
+
+
+def test_click_with_malformed_xy_returns_none() -> None:
+    # _safe_int(default=-1) returns -1 for non-parseable; we reject < 0.
+    assert _parse("Action: click({'x': 'abc', 'y': 'def'})") is None
+
+
+# ── click — valid coords still dispatch ─────────────────────────────
+
+
+def test_click_with_valid_coords_returns_click_action() -> None:
+    action = _parse("Action: click({'x': 500, 'y': 300})")
+    assert action is not None
+    assert action.action_type == ActionType.CLICK
+    # Coords go through _model_coords_to_screen scaling; verify they're
+    # non-zero (the actual scaled values depend on model-image dims).
+    assert action.params.get("x") != 0 or action.params.get("y") != 0
+
+
+def test_click_with_x_zero_y_nonzero_dispatches() -> None:
+    # Only BOTH-zero is rejected; (0, 300) is a legitimate left-edge click.
+    action = _parse("Action: click({'x': 0, 'y': 300})")
+    assert action is not None
+    assert action.action_type == ActionType.CLICK
+
+
+def test_click_with_x_nonzero_y_zero_dispatches() -> None:
+    action = _parse("Action: click({'x': 500, 'y': 0})")
+    assert action is not None
+    assert action.action_type == ActionType.CLICK
+
+
+# ── double_click — same coverage ───────────────────────────────────
+
+
+def test_double_click_with_no_args_returns_none() -> None:
+    assert _parse("Action: double_click()") is None
+
+
+def test_double_click_with_zero_zero_returns_none() -> None:
+    assert _parse("Action: double_click({'x': 0, 'y': 0})") is None
+
+
+def test_double_click_with_valid_coords_dispatches() -> None:
+    action = _parse("Action: double_click({'x': 500, 'y': 300})")
+    assert action is not None
+    assert action.action_type == ActionType.DOUBLE_CLICK
+
+
+# ── non-click actions unaffected ───────────────────────────────────
+
+
+def test_scroll_unaffected_by_xy_check() -> None:
+    # scroll uses direction + amount, not x/y. Must still parse.
+    action = _parse("Action: scroll({'direction': 'down', 'amount': 5})")
+    assert action is not None
+    assert action.action_type == ActionType.SCROLL
+
+
+def test_type_text_unaffected() -> None:
+    action = _parse("Action: type_text({'text': 'hello'})")
+    assert action is not None
+    assert action.action_type == ActionType.TYPE
+
+
+def test_done_unaffected() -> None:
+    action = _parse("Action: done({'success': true, 'summary': 'ok'})")
+    assert action is not None
+    assert action.action_type == ActionType.DONE


### PR DESCRIPTION
## Summary

When the Holo3 model emits \`click()\` without coordinates (or with malformed values), \`_parse_holo3_action\` previously returned \`Action(CLICK, {x:0, y:0})\` — silently dispatching to the page origin. On listings/loop plans this lands off-target every iteration → DUPLICATE-URL loop → halt with 0 leads.

## Repro

Boattrader run \`20260521_205442_b3428c17\` (2026-05-21 PM). After CF cleared on retry, the extraction loop logged dozens of:

\`\`\`
[click] (0,0) grounding=NO
[som-click] x=0 y=0 → ... els=DIV.embla__container els_text='' ok=False
[runner] plan=False executor=False idx=0 in_range=False
\`\`\`

End state: 10 steps processed, 0 leads, halt_reason=duplicate_listing — same shape as a CF block, different root cause.

## Fix

* New helper \`_has_valid_xy\` in \`_parse_holo3_action\` — requires BOTH x and y present in args AND not both zero
* When invalid, return \`None\` → falls through to the existing \`Action(WAIT, 1s)\` fallback at \`brain_holo3.py:547\`
* Same treatment for \`double_click\`
* Scroll uses direction + amount (no x/y) — unaffected

## Why reject explicit (0,0)?

Page origin is never a legitimate click target on real UIs (logo / header bg / off-canvas). False-rejection cost = one extra WAIT cycle. False-acceptance cost = the entire DUPLICATE loop we just spent a verify cycle confirming.

## Test plan

- [x] Unit tests: \`tests/test_holo3_null_click_coords.py\` (16 cases) — all invalid coord shapes (no args, empty dict, x-only, y-only, (0,0), malformed strings) and the valid-coord positive cases
- [x] Ruff clean
- [x] Local pytest sweep on holo3 / brain surfaces: 34 passed
- [ ] Modal redeploy + boattrader plan rerun shows 0 \`[click] (0,0)\` lines in container logs

Closes #574

🤖 Generated with [Claude Code](https://claude.com/claude-code)