### PR TITLE
runtime: settle_ceiling_seconds — global clamp on adaptive_settle (#561)

### DIFF
--- a/deploy/modal/modal_cua_server.py
+++ b/deploy/modal/modal_cua_server.py
@@ -885,6 +885,8 @@ def _run_holo3_executor(
             # #570: ``None`` → runner falls back to
             # ``MANTIS_PAUSE_ON_CAPTCHA`` env (default on).
             pause_on_captcha=task_suite.get("_pause_on_captcha"),
+            # #561: ``None`` → no ceiling, each settle uses its own max.
+            settle_ceiling_seconds=task_suite.get("_settle_ceiling_seconds"),
         )
 
         # Reasoning-trace stream → ``<run_dir>/reasoning.jsonl``. The
@@ -1588,6 +1590,8 @@ def _build_suite_from_payload(payload: dict) -> str:
         # #570: per-run cf_challenge auto-pause override. ``None`` →
         # runner falls back to MANTIS_PAUSE_ON_CAPTCHA env.
         pause_on_captcha=payload.get("pause_on_captcha"),
+        # #561: per-run ceiling on adaptive_settle waits.
+        settle_ceiling_seconds=payload.get("settle_ceiling_seconds"),
     )
     return json.dumps(suite)
 

--- a/src/mantis_agent/baseten_server/runtime.py
+++ b/src/mantis_agent/baseten_server/runtime.py
@@ -955,6 +955,7 @@ class BasetenCUARuntime:
             proxy_disabled=bool(payload.get("proxy_disabled", False)),
             brain_budgets=payload.get("brain_budgets"),
             pause_on_captcha=payload.get("pause_on_captcha"),
+            settle_ceiling_seconds=payload.get("settle_ceiling_seconds"),
         )
 
     def _resolve_path(self, raw_path: str) -> Path:
@@ -1053,6 +1054,7 @@ class BasetenCUARuntime:
             objective=objective_dict,
             brain_budgets=payload.get("brain_budgets"),
             pause_on_captcha=payload.get("pause_on_captcha"),
+            settle_ceiling_seconds=payload.get("settle_ceiling_seconds"),
         )
         return suite
 
@@ -1539,6 +1541,7 @@ class BasetenCUARuntime:
                 max_time_minutes=task_suite.get("_max_time_minutes", 180),
                 brain_budgets=task_suite.get("_brain_budgets"),
                 pause_on_captcha=task_suite.get("_pause_on_captcha"),
+                settle_ceiling_seconds=task_suite.get("_settle_ceiling_seconds"),
                 extraction_cache=cache,
                 routing_policy=routing_policy,
             )

--- a/src/mantis_agent/gym/adaptive_settle.py
+++ b/src/mantis_agent/gym/adaptive_settle.py
@@ -47,6 +47,49 @@ def is_enabled() -> bool:
     return os.environ.get(_ENV_TOGGLE, "enabled").lower() != "disabled"
 
 
+# #561: per-run ceiling applied to every ``settle_after_action`` call.
+# Set via ``set_runtime_ceiling`` by ``MicroPlanRunner.__init__`` when
+# the suite carries a ``settle_ceiling_seconds`` runtime field.
+# ``None`` (default) preserves each call site's existing ``max_seconds``
+# argument — no clamp. When set, every settle is clamped to
+# ``min(call_site_max, ceiling)``.
+#
+# Module-level state is safe in this codebase: Modal executors are
+# single-process per run; only one ``MicroPlanRunner`` instance is
+# active at a time per process. Tests reset via ``set_runtime_ceiling(None)``.
+_runtime_ceiling: float | None = None
+
+
+def set_runtime_ceiling(seconds: float | None) -> None:
+    """Set the per-run global ceiling for ``settle_after_action`` calls.
+
+    Pass ``None`` to clear (every call uses its own ``max_seconds``).
+    Pass a positive float to clamp every settle to at most that many
+    seconds — typical pattern is the runner setting this at init from
+    the suite's ``_settle_ceiling_seconds`` field.
+
+    Non-positive values are treated as ``None`` (clear) — a ceiling
+    of 0 would brick every settle, never intended.
+    """
+    global _runtime_ceiling
+    if seconds is None or seconds <= 0:
+        _runtime_ceiling = None
+    else:
+        _runtime_ceiling = float(seconds)
+
+
+def get_runtime_ceiling() -> float | None:
+    """Current ceiling, or ``None`` when unset."""
+    return _runtime_ceiling
+
+
+def _apply_ceiling(max_seconds: float) -> float:
+    """Clamp ``max_seconds`` to ``_runtime_ceiling`` if set."""
+    if _runtime_ceiling is None:
+        return max_seconds
+    return min(max_seconds, _runtime_ceiling)
+
+
 def wait_until_stable(
     capture: Callable[[], "Image.Image | None"],
     *,
@@ -135,19 +178,22 @@ def settle_after_action(
 
     Returns seconds actually waited.
     """
-    if not is_enabled() or max_seconds <= 0:
-        if max_seconds > 0:
-            time.sleep(max_seconds)
-        elapsed = max_seconds if max_seconds > 0 else 0.0
+    # #561: apply the per-run ceiling BEFORE the early-exit and fixed-
+    # sleep branches so all paths honor it consistently.
+    effective_max = _apply_ceiling(max_seconds)
+    if not is_enabled() or effective_max <= 0:
+        if effective_max > 0:
+            time.sleep(effective_max)
+        elapsed = effective_max if effective_max > 0 else 0.0
         _credit_settle(elapsed)
         return elapsed
     capture = getattr(env, "_screenshot", None) or getattr(env, "screenshot", None)
     if not callable(capture):
-        time.sleep(max_seconds)
-        _credit_settle(max_seconds)
-        return max_seconds
+        time.sleep(effective_max)
+        _credit_settle(effective_max)
+        return effective_max
     elapsed = wait_until_stable(
-        capture, max_seconds=max_seconds, poll_interval=poll_interval,
+        capture, max_seconds=effective_max, poll_interval=poll_interval,
     )
     _credit_settle(elapsed)
     return elapsed

--- a/src/mantis_agent/gym/micro_runner.py
+++ b/src/mantis_agent/gym/micro_runner.py
@@ -101,6 +101,7 @@ class MicroPlanRunner:
         seed: int | None = None,
         brain_budgets: dict[str, int] | None = None,
         pause_on_captcha: bool | None = None,
+        settle_ceiling_seconds: float | None = None,
     ):
         # Seed the global RNG so per-action human_speed delays
         # (random.uniform / random.randint in playwright_env.py +
@@ -121,6 +122,16 @@ class MicroPlanRunner:
             dict(DEFAULT_BRAIN_BUDGET_CAPS) if brain_budgets is None
             else dict(brain_budgets)
         )
+        # #561: per-run global ceiling on every ``settle_after_action``
+        # call. ``None`` → no ceiling, each call uses its own max_seconds
+        # (existing behavior). Set this via the ``settle_ceiling_seconds``
+        # runtime field to globally clamp page-stabilisation waits — most
+        # pages settle in 1-1.5s, the 2-3s tail past that is pure tax.
+        # Module-level state in ``adaptive_settle`` is safe here:
+        # executors are single-process per run.
+        from . import adaptive_settle as _adaptive_settle
+        self.settle_ceiling_seconds: float | None = settle_ceiling_seconds
+        _adaptive_settle.set_runtime_ceiling(settle_ceiling_seconds)
         # #570: per-run override for the cf_challenge auto-pause loop
         # (PR #555). ``None`` → env var fallback
         # (``MANTIS_PAUSE_ON_CAPTCHA``, default on); ``False`` → fail

--- a/src/mantis_agent/server_utils.py
+++ b/src/mantis_agent/server_utils.py
@@ -1000,6 +1000,11 @@ _RUNTIME_KEYS = (
     # takeover (useful for CI / verify reruns); ``True`` forces auto-
     # pause on regardless of env.
     "pause_on_captcha",
+    # #561: global ceiling (seconds) clamping every ``settle_after_action``
+    # call site. ``None`` (= key absent) preserves per-call max_seconds.
+    # Typical override is 2.0 — most pages stabilise in 1-1.5s; the 2-3s
+    # tail past that is pure wall-clock tax.
+    "settle_ceiling_seconds",
 )
 
 
@@ -1089,6 +1094,7 @@ def build_micro_suite(
     objective: dict[str, Any] | None = None,
     brain_budgets: dict[str, int] | None = None,
     pause_on_captcha: bool | None = None,
+    settle_ceiling_seconds: float | None = None,
 ) -> dict[str, Any]:
     """Build a task_suite dict for micro-intent execution.
 
@@ -1153,6 +1159,10 @@ def build_micro_suite(
     # (MANTIS_PAUSE_ON_CAPTCHA) otherwise.
     if pause_on_captcha is not None:
         suite["_pause_on_captcha"] = bool(pause_on_captcha)
+    # #561: same shape — persist only when supplied; absent means
+    # "no ceiling" (each call uses its own max_seconds).
+    if settle_ceiling_seconds is not None:
+        suite["_settle_ceiling_seconds"] = float(settle_ceiling_seconds)
     return suite
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,6 +31,11 @@ _SETTLE_TEST_FILES: frozenset[str] = frozenset({
     # cases trigger a real wait (they call adaptive_settle directly
     # with tiny budgets), so the suite stays fast.
     "test_time_meter.py",
+    # #561: settle_ceiling tests verify the runtime ceiling actually
+    # clamps real settle_after_action calls; instant-return stub would
+    # bypass the assertions. Tests mock ``time.sleep`` themselves so
+    # the suite stays fast.
+    "test_settle_ceiling_runtime_field.py",
 })
 
 

--- a/tests/test_settle_ceiling_runtime_field.py
+++ b/tests/test_settle_ceiling_runtime_field.py
@@ -1,0 +1,167 @@
+"""Tests for runtime ``settle_ceiling_seconds`` field (#561).
+
+Promotes the per-run cap on ``adaptive_settle.settle_after_action``
+from "edit each caller's max_seconds" to a single runtime field.
+A single submission can globally clamp every page-stabilisation wait
+to e.g. 2.0s without touching the 20+ call sites scattered across
+step handlers.
+
+Most pages stabilise in 1-1.5s; the 2-3s tail past that is pure
+wall-clock tax that adds up across a 100+ step plan.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from mantis_agent.gym import adaptive_settle
+from mantis_agent.gym.micro_runner import MicroPlanRunner
+from mantis_agent.server_utils import build_micro_suite, merge_runtime
+
+
+@pytest.fixture(autouse=True)
+def _reset_ceiling():
+    """Reset module-level ceiling between tests so they don't leak."""
+    adaptive_settle.set_runtime_ceiling(None)
+    yield
+    adaptive_settle.set_runtime_ceiling(None)
+
+
+# ── set_runtime_ceiling / get_runtime_ceiling ─────────────────────
+
+
+def test_default_ceiling_is_none() -> None:
+    assert adaptive_settle.get_runtime_ceiling() is None
+
+
+def test_set_ceiling_stores_value() -> None:
+    adaptive_settle.set_runtime_ceiling(2.0)
+    assert adaptive_settle.get_runtime_ceiling() == 2.0
+
+
+def test_set_ceiling_none_clears() -> None:
+    adaptive_settle.set_runtime_ceiling(2.0)
+    adaptive_settle.set_runtime_ceiling(None)
+    assert adaptive_settle.get_runtime_ceiling() is None
+
+
+def test_set_ceiling_zero_treated_as_none() -> None:
+    adaptive_settle.set_runtime_ceiling(0)
+    assert adaptive_settle.get_runtime_ceiling() is None
+
+
+def test_set_ceiling_negative_treated_as_none() -> None:
+    adaptive_settle.set_runtime_ceiling(-1.0)
+    assert adaptive_settle.get_runtime_ceiling() is None
+
+
+# ── _apply_ceiling arithmetic ──────────────────────────────────────
+
+
+def test_apply_ceiling_no_clamp_when_unset() -> None:
+    adaptive_settle.set_runtime_ceiling(None)
+    assert adaptive_settle._apply_ceiling(5.0) == 5.0
+
+
+def test_apply_ceiling_clamps_when_max_above_ceiling() -> None:
+    adaptive_settle.set_runtime_ceiling(2.0)
+    assert adaptive_settle._apply_ceiling(5.0) == 2.0
+
+
+def test_apply_ceiling_preserves_when_max_below_ceiling() -> None:
+    adaptive_settle.set_runtime_ceiling(2.0)
+    assert adaptive_settle._apply_ceiling(1.0) == 1.0
+
+
+def test_apply_ceiling_preserves_when_max_equals_ceiling() -> None:
+    adaptive_settle.set_runtime_ceiling(2.0)
+    assert adaptive_settle._apply_ceiling(2.0) == 2.0
+
+
+# ── settle_after_action end-to-end ─────────────────────────────────
+
+
+def test_settle_after_action_respects_ceiling(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When ceiling is set and the call site asks for more, the
+    actual sleep is capped at the ceiling."""
+    slept = []
+    monkeypatch.setattr("mantis_agent.gym.adaptive_settle.time.sleep", lambda s: slept.append(s))
+
+    # Plain object with no _screenshot / screenshot attrs → forces the
+    # no-capture fixed-sleep branch where we can read elapsed directly.
+    class _NoCaptureEnv:
+        pass
+
+    env = _NoCaptureEnv()
+
+    adaptive_settle.set_runtime_ceiling(2.0)
+    elapsed = adaptive_settle.settle_after_action(env, max_seconds=5.0)
+    assert elapsed == 2.0
+    assert slept == [2.0]
+
+
+def test_settle_after_action_no_ceiling_uses_full_max(monkeypatch: pytest.MonkeyPatch) -> None:
+    slept = []
+    monkeypatch.setattr("mantis_agent.gym.adaptive_settle.time.sleep", lambda s: slept.append(s))
+
+    class _NoCaptureEnv:
+        pass
+
+    env = _NoCaptureEnv()
+    adaptive_settle.set_runtime_ceiling(None)
+    elapsed = adaptive_settle.settle_after_action(env, max_seconds=5.0)
+    assert elapsed == 5.0
+    assert slept == [5.0]
+
+
+# ── MicroPlanRunner ctor wires the ceiling ─────────────────────────
+
+
+def _runner(**kwargs) -> MicroPlanRunner:
+    return MicroPlanRunner(brain=MagicMock(), env=MagicMock(), **kwargs)
+
+
+def test_runner_default_does_not_set_ceiling() -> None:
+    _runner()
+    assert adaptive_settle.get_runtime_ceiling() is None
+
+
+def test_runner_explicit_ceiling_applies_globally() -> None:
+    _runner(settle_ceiling_seconds=2.0)
+    assert adaptive_settle.get_runtime_ceiling() == 2.0
+
+
+def test_runner_stores_ceiling_on_self() -> None:
+    runner = _runner(settle_ceiling_seconds=1.5)
+    assert runner.settle_ceiling_seconds == 1.5
+
+
+# ── build_micro_suite round-trip ───────────────────────────────────
+
+
+def test_suite_omits_ceiling_when_caller_passes_none() -> None:
+    suite = build_micro_suite([], "example.com")
+    assert "_settle_ceiling_seconds" not in suite
+
+
+def test_suite_persists_explicit_ceiling() -> None:
+    suite = build_micro_suite([], "example.com", settle_ceiling_seconds=2.0)
+    assert suite["_settle_ceiling_seconds"] == 2.0
+
+
+# ── merge_runtime accepts settle_ceiling_seconds ───────────────────
+
+
+def test_merge_runtime_threads_ceiling() -> None:
+    merged = merge_runtime({"settle_ceiling_seconds": 2.0})
+    assert merged["settle_ceiling_seconds"] == 2.0
+
+
+def test_merge_runtime_override_wins_over_plan_default() -> None:
+    merged = merge_runtime(
+        {"settle_ceiling_seconds": 2.0},
+        settle_ceiling_seconds=1.5,
+    )
+    assert merged["settle_ceiling_seconds"] == 1.5


### PR DESCRIPTION
## Summary

Promotes the per-call \`max_seconds\` cap on every \`settle_after_action\` from a 20+ scattered call-site default to a single runtime field.

A submission can pass \`settle_ceiling_seconds: 2.0\` to globally clamp every page-stabilisation wait without editing any handler.

## Why

Most pages stabilise in 1-1.5s; the 2-3s tail past that is pure wall-clock tax. A 100-step plan with avg 3s settle spends ~5 min waiting on already-stable pages. The outliers today are:

* \`paginate.py\` — 8.0s and 10.0s call sites
* \`form.py\` — 4.0s
* \`_runner_helpers._SUBMIT_SETTLE_MAX_SECONDS\` — 8.0s

All clamped by a single \`2.0\` ceiling without touching any of them.

## Behavior

Resolution in \`settle_after_action\`:

\`\`\`python
effective_max = min(max_seconds, ceiling) if ceiling else max_seconds
\`\`\`

\`\`\`python
runtime = merge_runtime({\"settle_ceiling_seconds\": 2.0})
suite = build_micro_suite(steps, domain, **runtime)
# → suite[\"_settle_ceiling_seconds\"] = 2.0
# → MicroPlanRunner(settle_ceiling_seconds=2.0)
# → adaptive_settle.set_runtime_ceiling(2.0)
# → every settle_after_action(env, max_seconds=N) clamped to min(N, 2.0)
\`\`\`

## Touchpoints (same shape as #560 / #571)

* \`gym/adaptive_settle.py\` — module-level \`_runtime_ceiling\` + \`set_runtime_ceiling\` / \`get_runtime_ceiling\` / \`_apply_ceiling\`; \`settle_after_action\` applies the clamp on every path
* \`gym/micro_runner.py\` — \`settle_ceiling_seconds\` ctor kwarg; calls \`adaptive_settle.set_runtime_ceiling\` at init
* \`server_utils.py\` — \`_RUNTIME_KEYS\` + \`build_micro_suite\` kwarg → \`_settle_ceiling_seconds\` on suite
* \`deploy/modal/modal_cua_server.py\` — payload → suite → runner
* \`baseten_server/runtime.py\` — same 3 sites
* \`tests/conftest.py\` — add the new test file to the allowlist so the autouse instant-return stub doesn't bypass the assertions

## Why module-level state

Modal executors are single-process per run; only one \`MicroPlanRunner\` lives in the process at a time. Threading the ceiling through every call site (20+ places) is invasive churn for no benefit.

## Test plan

- [x] Unit tests: \`tests/test_settle_ceiling_runtime_field.py\` (18 cases)
- [x] Ruff clean
- [x] Touched-surface regression: 148 passed
- [ ] Modal redeploy + boattrader rerun with \`settle_ceiling_seconds: 2.0\` — measure wall-clock delta vs unclamped baseline

## Expected impact

Per #561: 2-3 min saved per boattrader-class run.

Closes #561

🤖 Generated with [Claude Code](https://claude.com/claude-code)