### PR TITLE
gate: URL-substring short-circuit before Claude verify (#563)

### DIFF
--- a/src/mantis_agent/gym/_runner_helpers.py
+++ b/src/mantis_agent/gym/_runner_helpers.py
@@ -874,6 +874,17 @@ def execute_step(
         return _stamp_backend(registry.get("submit").execute(synthesised, ctx), ctx)
 
     if step.gate and runner.extractor:
+        # #563: URL-substring short-circuit. When the plan author
+        # supplied ``expect_url_contains`` / ``expect_url_excludes``
+        # hints, check the address bar BEFORE paying for a Claude
+        # vision verify (~10-15s + $0.01-0.02 per gate). All listed
+        # substrings must be present (and any excludes absent) for
+        # the short-circuit to fire — falls through to the vision
+        # path otherwise. Hints are plan-author-opted-in; gates
+        # without hints are unchanged.
+        sc = _try_url_shortcircuit_gate(runner, step, index)
+        if sc is not None:
+            return sc
         print(f"  [gate] Verifying: {(step.verify or step.intent)[:80]}")
         time.sleep(2)
         screenshot = runner.env.screenshot()
@@ -916,6 +927,73 @@ def execute_step(
         return _stamp_backend(handler.execute(step, ctx), ctx)
 
     return runner._execute_holo3_step(step, index)
+
+
+def _try_url_shortcircuit_gate(
+    runner: Any, step: Any, index: int,
+) -> StepResult | None:
+    """#563: bypass the Claude verify_gate call when URL hints suffice.
+
+    Returns a PASS ``StepResult`` when the current URL matches
+    ``step.hints.expect_url_contains`` (all substrings present) and
+    does NOT match ``step.hints.expect_url_excludes`` (none present).
+    Returns ``None`` when no usable hints, when the current URL is
+    unavailable, or when the hint check doesn't conclusively pass —
+    caller falls through to the full Claude vision path.
+
+    Conservative on three fronts:
+
+    * Both hint lists must be parseable as ``list[str]`` — malformed
+      hints (dict, scalar, None) fall through silently.
+    * An empty ``expect_url_contains`` is treated as "no opinion"
+      (fall through). Plans that want pure-exclude gating can add
+      the domain itself to the expect list.
+    * Substring match is case-sensitive — URL paths are inherently
+      case-sensitive on most servers; case-insensitive matching could
+      false-positive on look-alike segments.
+
+    WARNING-level log on every short-circuit fire so production logs
+    surface the cost-savings path (Modal suppresses INFO).
+    """
+    hints = getattr(step, "hints", None) or {}
+    if not isinstance(hints, dict):
+        return None
+    expect = hints.get("expect_url_contains")
+    excludes = hints.get("expect_url_excludes")
+    expect_list: list[str] = []
+    excludes_list: list[str] = []
+    if isinstance(expect, (list, tuple)):
+        expect_list = [str(s) for s in expect if str(s)]
+    if isinstance(excludes, (list, tuple)):
+        excludes_list = [str(s) for s in excludes if str(s)]
+    if not expect_list:
+        # No expect-list → no signal strong enough to skip vision.
+        return None
+
+    url = ""
+    try:
+        url = str(getattr(runner.env, "current_url", "") or "")
+    except Exception:  # noqa: BLE001 — env adapter may not expose; fall through
+        return None
+    if not url:
+        return None
+
+    missing = [s for s in expect_list if s not in url]
+    if missing:
+        return None  # Vision still needed.
+    hit_excludes = [s for s in excludes_list if s in url]
+    if hit_excludes:
+        return None  # Exclude hit — vision still needed to disambiguate.
+
+    logger.warning(
+        "  [gate] URL short-circuit PASS — step %s expect=%s excludes=%s "
+        "url=%s (saved ~10-15s + Claude verify_gate cost)",
+        index, expect_list, excludes_list, url[:120],
+    )
+    return StepResult(
+        step_index=index, intent=step.intent, success=True,
+        data=f"gate:PASS:url_shortcircuit:{','.join(expect_list)}",
+    )
 
 
 def _stamp_backend(result: StepResult, ctx: Any) -> StepResult:

--- a/tests/test_url_shortcircuit_gate.py
+++ b/tests/test_url_shortcircuit_gate.py
@@ -1,0 +1,143 @@
+r"""Tests for #563 — URL-substring gate short-circuit.
+
+Before this PR, every ``extract_data`` step with ``gate=True`` paid
+for a Claude vision verify (~10-15s + \$0.01-0.02). On plans like
+boattrader where step 1 is a navigate-verify against a known URL
+pattern, that cost is gratuitous — the URL alone is enough signal.
+
+This helper checks ``step.hints.expect_url_contains`` (all substrings
+present) and ``expect_url_excludes`` (none present) against
+``runner.env.current_url`` BEFORE dispatching the vision call. On a
+clean match, returns a PASS StepResult and the runner moves on. On
+any ambiguity, returns ``None`` and the caller falls through to the
+existing Claude path — never a false positive.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from mantis_agent.gym._runner_helpers import _try_url_shortcircuit_gate
+
+
+def _step(hints: dict | None = None, intent: str = "Verify page") -> SimpleNamespace:
+    return SimpleNamespace(intent=intent, hints=hints or {})
+
+
+def _runner(url: str) -> SimpleNamespace:
+    env = SimpleNamespace(current_url=url)
+    return SimpleNamespace(env=env)
+
+
+# ── Happy path: all substrings present → PASS ──────────────────────
+
+
+def test_all_substrings_present_returns_pass() -> None:
+    step = _step({"expect_url_contains": ["zip-33101", "by-owner"]})
+    runner = _runner("https://www.boattrader.com/boats/state-fl/zip-33101/by-owner/")
+    result = _try_url_shortcircuit_gate(runner, step, index=1)
+    assert result is not None
+    assert result.success is True
+    assert "url_shortcircuit" in result.data
+
+
+def test_single_substring_present_returns_pass() -> None:
+    step = _step({"expect_url_contains": ["lu.ma/discover"]})
+    runner = _runner("https://lu.ma/discover")
+    result = _try_url_shortcircuit_gate(runner, step, index=0)
+    assert result is not None
+    assert result.success is True
+
+
+# ── Fall-through: some substring missing → None (use Claude path) ─
+
+
+def test_missing_substring_returns_none() -> None:
+    step = _step({"expect_url_contains": ["zip-33101", "by-owner"]})
+    runner = _runner("https://www.boattrader.com/boats/state-fl/zip-33101/")
+    # by-owner missing → can't short-circuit
+    assert _try_url_shortcircuit_gate(runner, step, index=1) is None
+
+
+def test_no_expect_list_returns_none() -> None:
+    # No signal strong enough to skip vision.
+    assert _try_url_shortcircuit_gate(_runner("https://x.com/"), _step({}), 0) is None
+    assert _try_url_shortcircuit_gate(_runner("https://x.com/"), _step(), 0) is None
+    assert _try_url_shortcircuit_gate(_runner("https://x.com/"), _step({"expect_url_contains": []}), 0) is None
+
+
+# ── Excludes guard against false positives ─────────────────────────
+
+
+def test_excludes_blocks_shortcircuit() -> None:
+    step = _step({
+        "expect_url_contains": ["boattrader.com"],
+        "expect_url_excludes": ["error", "404"],
+    })
+    runner = _runner("https://www.boattrader.com/error/404")
+    # boattrader.com is present, but so is "error" — fall through to vision.
+    assert _try_url_shortcircuit_gate(runner, step, 0) is None
+
+
+def test_excludes_absent_allows_shortcircuit() -> None:
+    step = _step({
+        "expect_url_contains": ["boattrader.com"],
+        "expect_url_excludes": ["error", "404"],
+    })
+    runner = _runner("https://www.boattrader.com/boats/")
+    result = _try_url_shortcircuit_gate(runner, step, 0)
+    assert result is not None
+    assert result.success is True
+
+
+# ── Robust against malformed hints / missing env ───────────────────
+
+
+def test_malformed_expect_falls_through() -> None:
+    # Not a list — defensive parse, no crash, no short-circuit.
+    step = _step({"expect_url_contains": "boattrader.com"})  # str, not list
+    runner = _runner("https://www.boattrader.com/")
+    assert _try_url_shortcircuit_gate(runner, step, 0) is None
+
+
+def test_no_hints_attr_returns_none() -> None:
+    step = SimpleNamespace(intent="Verify", hints=None)
+    runner = _runner("https://www.boattrader.com/")
+    assert _try_url_shortcircuit_gate(runner, step, 0) is None
+
+
+def test_empty_current_url_returns_none() -> None:
+    step = _step({"expect_url_contains": ["x"]})
+    runner = _runner("")
+    assert _try_url_shortcircuit_gate(runner, step, 0) is None
+
+
+def test_env_current_url_raises_returns_none() -> None:
+    class _BadEnv:
+        @property
+        def current_url(self) -> str:
+            raise RuntimeError("env not ready")
+
+    runner = SimpleNamespace(env=_BadEnv())
+    step = _step({"expect_url_contains": ["x"]})
+    assert _try_url_shortcircuit_gate(runner, step, 0) is None
+
+
+def test_case_sensitive_match() -> None:
+    # URL paths are case-sensitive on most servers; refuse to
+    # case-fold the match.
+    step = _step({"expect_url_contains": ["BoatTrader"]})
+    runner = _runner("https://www.boattrader.com/boats/")
+    assert _try_url_shortcircuit_gate(runner, step, 0) is None
+
+
+# ── String coercion of hint values ─────────────────────────────────
+
+
+def test_non_string_hint_entries_coerced() -> None:
+    # Plans may emit ints (e.g. zip codes) — coerce to str before match.
+    step = _step({"expect_url_contains": [33101, "by-owner"]})
+    runner = _runner("https://www.boattrader.com/zip-33101/by-owner/")
+    result = _try_url_shortcircuit_gate(runner, step, 0)
+    assert result is not None
+    assert result.success is True


### PR DESCRIPTION
## Summary

Bypasses the Claude vision verify_gate call (~10-15s + \$0.01-0.02) when the plan author supplied URL-substring hints that already conclusively confirm the gate condition.

Hooks into the existing \`step.gate and runner.extractor\` dispatch in \`_runner_helpers.py\` — before the screenshot + verify_gate path, calls \`_try_url_shortcircuit_gate\`. PASS short-circuit when:

* \`step.hints.expect_url_contains\` is a non-empty list AND every substring is in \`runner.env.current_url\`
* AND \`step.hints.expect_url_excludes\` (optional) has no substring in the URL

Otherwise returns \`None\` → falls through to the existing Claude vision path.

## Example plan step

\`\`\`json
{
  \"type\": \"extract_data\",
  \"intent\": \"Verify the page heading reads 'Boats for sale...'\",
  \"claude_only\": true,
  \"gate\": true,
  \"hints\": {
    \"expect_url_contains\": [\"zip-33101\", \"by-owner\"],
    \"expect_url_excludes\": [\"error\", \"404\"]
  }
}
\`\`\`

After navigate succeeds and URL = \`https://www.boattrader.com/boats/state-fl/zip-33101/by-owner/\`, the URL match is conclusive — skip the Claude call.

## Conservative on three fronts (never false-positive)

| Concern | Defence |
|---|---|
| Malformed hint shape (dict/scalar/None) | Type-check; fall through to vision |
| Empty \`expect_url_contains\` | No signal strong enough → fall through |
| Case-insensitive look-alike URLs | Match is case-sensitive (URL paths are case-sensitive on most servers) |

WARNING-level log on every short-circuit fire so production logs surface the cost-savings path (Modal suppresses INFO).

## Touchpoints

* \`gym/_runner_helpers.py\` — new \`_try_url_shortcircuit_gate\` helper + call site in the gate dispatch

## Test plan

- [x] Unit tests: \`tests/test_url_shortcircuit_gate.py\` (12 cases) — happy path, missing substrings, excludes guard, malformed hints, env errors, case sensitivity, hint coercion
- [x] Ruff clean
- [x] Touched-surface regression: 83 passed
- [ ] Modal redeploy + boattrader rerun (step 1 has \`expect_url_contains\` already from the decomposer per issue text) — observe \`[gate] URL short-circuit PASS\` log line + reduced Claude extract count

## Expected impact

Per issue: ~10-15s + \$0.01-0.02 saved per navigate-gate step with URL hints. Boattrader has 1 such gate (step 1).

Closes #563

🤖 Generated with [Claude Code](https://claude.com/claude-code)