### PR TITLE
runtime: max_recoveries_per_run/_step — agentic-recovery budgets as runtime fields (#567)

### DIFF
--- a/deploy/modal/modal_cua_server.py
+++ b/deploy/modal/modal_cua_server.py
@@ -887,6 +887,9 @@ def _run_holo3_executor(
             pause_on_captcha=task_suite.get("_pause_on_captcha"),
             # #561: ``None`` → no ceiling, each settle uses its own max.
             settle_ceiling_seconds=task_suite.get("_settle_ceiling_seconds"),
+            # #567: ``None`` → fall back to DEFAULT_MAX_RECOVERIES_PER_*.
+            max_recoveries_per_run=task_suite.get("_max_recoveries_per_run"),
+            max_recoveries_per_step=task_suite.get("_max_recoveries_per_step"),
         )
 
         # Reasoning-trace stream → ``<run_dir>/reasoning.jsonl``. The
@@ -1592,6 +1595,9 @@ def _build_suite_from_payload(payload: dict) -> str:
         pause_on_captcha=payload.get("pause_on_captcha"),
         # #561: per-run ceiling on adaptive_settle waits.
         settle_ceiling_seconds=payload.get("settle_ceiling_seconds"),
+        # #567: per-run agentic-recovery budget overrides.
+        max_recoveries_per_run=payload.get("max_recoveries_per_run"),
+        max_recoveries_per_step=payload.get("max_recoveries_per_step"),
     )
     return json.dumps(suite)
 

--- a/src/mantis_agent/agentic_recovery.py
+++ b/src/mantis_agent/agentic_recovery.py
@@ -69,8 +69,38 @@ RECOVERY_PROMPT_VERSION = "v1"
 # Per-step + per-run recovery budgets. The policy enforces these
 # before invoking the LLM call so a pathological page / step can't
 # burn the run on recovery alone.
+#
+# #567: a submission can override these via the
+# ``max_recoveries_per_step`` / ``max_recoveries_per_run`` runtime
+# fields (threaded through ``MicroPlanRunner.max_recoveries_per_step``
+# and ``.max_recoveries_per_run``). The DEFAULT_* values remain the
+# fallback when no override is supplied — preserves legacy behavior
+# for callers that don't set the runtime fields.
 DEFAULT_MAX_RECOVERIES_PER_STEP = 2
 DEFAULT_MAX_RECOVERIES_PER_RUN = 5
+
+
+def effective_max_recoveries(runner: Any) -> tuple[int, int]:
+    """Resolve the per-step + per-run recovery caps for this run.
+
+    Reads ``runner.max_recoveries_per_step`` / ``.max_recoveries_per_run``
+    when set (positive int), else falls back to the module DEFAULTS.
+    Defensive: handles ``None``, missing attr, non-positive values
+    by treating them as "use default" — never returns 0 (would brick
+    the recovery layer entirely).
+    """
+    per_step = DEFAULT_MAX_RECOVERIES_PER_STEP
+    per_run = DEFAULT_MAX_RECOVERIES_PER_RUN
+    try:
+        v = getattr(runner, "max_recoveries_per_step", None)
+        if isinstance(v, int) and v > 0:
+            per_step = v
+        v = getattr(runner, "max_recoveries_per_run", None)
+        if isinstance(v, int) and v > 0:
+            per_run = v
+    except Exception:  # noqa: BLE001 — never break recovery
+        pass
+    return per_step, per_run
 
 
 @dataclass

--- a/src/mantis_agent/baseten_server/runtime.py
+++ b/src/mantis_agent/baseten_server/runtime.py
@@ -956,6 +956,8 @@ class BasetenCUARuntime:
             brain_budgets=payload.get("brain_budgets"),
             pause_on_captcha=payload.get("pause_on_captcha"),
             settle_ceiling_seconds=payload.get("settle_ceiling_seconds"),
+            max_recoveries_per_run=payload.get("max_recoveries_per_run"),
+            max_recoveries_per_step=payload.get("max_recoveries_per_step"),
         )
 
     def _resolve_path(self, raw_path: str) -> Path:
@@ -1055,6 +1057,8 @@ class BasetenCUARuntime:
             brain_budgets=payload.get("brain_budgets"),
             pause_on_captcha=payload.get("pause_on_captcha"),
             settle_ceiling_seconds=payload.get("settle_ceiling_seconds"),
+            max_recoveries_per_run=payload.get("max_recoveries_per_run"),
+            max_recoveries_per_step=payload.get("max_recoveries_per_step"),
         )
         return suite
 
@@ -1542,6 +1546,8 @@ class BasetenCUARuntime:
                 brain_budgets=task_suite.get("_brain_budgets"),
                 pause_on_captcha=task_suite.get("_pause_on_captcha"),
                 settle_ceiling_seconds=task_suite.get("_settle_ceiling_seconds"),
+                max_recoveries_per_run=task_suite.get("_max_recoveries_per_run"),
+                max_recoveries_per_step=task_suite.get("_max_recoveries_per_step"),
                 extraction_cache=cache,
                 routing_policy=routing_policy,
             )

--- a/src/mantis_agent/gym/critic.py
+++ b/src/mantis_agent/gym/critic.py
@@ -664,30 +664,28 @@ class ExecutionCritic:
                 step_index, type(per_step_dict).__name__, type(total_attempts).__name__,
             )
             return None
+        # #567: per-run override via runtime fields; fallback to DEFAULT_*.
         try:
-            from ..agentic_recovery import (
-                DEFAULT_MAX_RECOVERIES_PER_RUN,
-                DEFAULT_MAX_RECOVERIES_PER_STEP,
-            )
+            from ..agentic_recovery import effective_max_recoveries
         except Exception as exc:  # noqa: BLE001 — never break runs
             logger.warning(
                 "  [critic-frontier] step %d: skipped — agentic_recovery "
                 "import failed: %s", step_index, exc,
             )
             return None
-        if per_step_dict.get(step_index, 0) >= DEFAULT_MAX_RECOVERIES_PER_STEP:
+        max_per_step, max_per_run = effective_max_recoveries(self.runner)
+        if per_step_dict.get(step_index, 0) >= max_per_step:
             logger.warning(
                 "  [critic-frontier] step %d: skipped — per-step budget "
                 "exhausted (%d/%d) before critic could fire",
-                step_index, per_step_dict.get(step_index, 0),
-                DEFAULT_MAX_RECOVERIES_PER_STEP,
+                step_index, per_step_dict.get(step_index, 0), max_per_step,
             )
             return None
-        if total_attempts >= DEFAULT_MAX_RECOVERIES_PER_RUN:
+        if total_attempts >= max_per_run:
             logger.warning(
                 "  [critic-frontier] step %d: skipped — per-run budget "
                 "exhausted (%d/%d)",
-                step_index, total_attempts, DEFAULT_MAX_RECOVERIES_PER_RUN,
+                step_index, total_attempts, max_per_run,
             )
             return None
         # All gates passed — Claude call below logs result.

--- a/src/mantis_agent/gym/micro_runner.py
+++ b/src/mantis_agent/gym/micro_runner.py
@@ -102,6 +102,8 @@ class MicroPlanRunner:
         brain_budgets: dict[str, int] | None = None,
         pause_on_captcha: bool | None = None,
         settle_ceiling_seconds: float | None = None,
+        max_recoveries_per_run: int | None = None,
+        max_recoveries_per_step: int | None = None,
     ):
         # Seed the global RNG so per-action human_speed delays
         # (random.uniform / random.randint in playwright_env.py +
@@ -132,6 +134,15 @@ class MicroPlanRunner:
         from . import adaptive_settle as _adaptive_settle
         self.settle_ceiling_seconds: float | None = settle_ceiling_seconds
         _adaptive_settle.set_runtime_ceiling(settle_ceiling_seconds)
+        # #567: per-run override for agentic-recovery budgets. ``None``
+        # → caller didn't override, callers fall back to
+        # ``DEFAULT_MAX_RECOVERIES_PER_*`` via
+        # ``agentic_recovery.effective_max_recoveries(runner)``. Positive
+        # int → caps raised or lowered for this submission. Read by
+        # ``StepRecoveryPolicy`` + ``FrontierCritic`` before each
+        # recovery / critic dispatch.
+        self.max_recoveries_per_run: int | None = max_recoveries_per_run
+        self.max_recoveries_per_step: int | None = max_recoveries_per_step
         # #570: per-run override for the cf_challenge auto-pause loop
         # (PR #555). ``None`` → env var fallback
         # (``MANTIS_PAUSE_ON_CAPTCHA``, default on); ``False`` → fail

--- a/src/mantis_agent/gym/step_recovery.py
+++ b/src/mantis_agent/gym/step_recovery.py
@@ -930,22 +930,22 @@ class StepRecoveryPolicy:
                 type(total_attempts).__name__,
             )
             return None
-        from ..agentic_recovery import (
-            DEFAULT_MAX_RECOVERIES_PER_RUN,
-            DEFAULT_MAX_RECOVERIES_PER_STEP,
-        )
+        # #567: per-run override via runtime fields wins over the
+        # module DEFAULT_* fallback. Same shape as #560/#561/#571.
+        from ..agentic_recovery import effective_max_recoveries
+        max_per_step, max_per_run = effective_max_recoveries(self.parent)
         per_step = per_step_dict.get(step_index, 0)
         per_run = total_attempts
-        if per_step >= DEFAULT_MAX_RECOVERIES_PER_STEP:
+        if per_step >= max_per_step:
             logger.warning(
                 "  [%d] recovery_skipped: per-step budget exhausted (%d/%d)",
-                step_index, per_step, DEFAULT_MAX_RECOVERIES_PER_STEP,
+                step_index, per_step, max_per_step,
             )
             return None
-        if per_run >= DEFAULT_MAX_RECOVERIES_PER_RUN:
+        if per_run >= max_per_run:
             logger.warning(
                 "  [%d] recovery_skipped: per-run budget exhausted (%d/%d)",
-                step_index, per_run, DEFAULT_MAX_RECOVERIES_PER_RUN,
+                step_index, per_run, max_per_run,
             )
             return None
 

--- a/src/mantis_agent/server_utils.py
+++ b/src/mantis_agent/server_utils.py
@@ -1005,6 +1005,14 @@ _RUNTIME_KEYS = (
     # Typical override is 2.0 — most pages stabilise in 1-1.5s; the 2-3s
     # tail past that is pure wall-clock tax.
     "settle_ceiling_seconds",
+    # #567: per-run agentic-recovery budgets. ``None`` (= key absent)
+    # falls back to ``DEFAULT_MAX_RECOVERIES_PER_*`` constants in
+    # ``agentic_recovery.py``. Positive int raises or lowers the cap
+    # for a single submission — useful for long-running plans that
+    # legitimately need more recovery cycles, or CI runs that want
+    # tighter fail-fast.
+    "max_recoveries_per_run",
+    "max_recoveries_per_step",
 )
 
 
@@ -1095,6 +1103,8 @@ def build_micro_suite(
     brain_budgets: dict[str, int] | None = None,
     pause_on_captcha: bool | None = None,
     settle_ceiling_seconds: float | None = None,
+    max_recoveries_per_run: int | None = None,
+    max_recoveries_per_step: int | None = None,
 ) -> dict[str, Any]:
     """Build a task_suite dict for micro-intent execution.
 
@@ -1163,6 +1173,11 @@ def build_micro_suite(
     # "no ceiling" (each call uses its own max_seconds).
     if settle_ceiling_seconds is not None:
         suite["_settle_ceiling_seconds"] = float(settle_ceiling_seconds)
+    # #567: same shape — persist only when caller supplied an override.
+    if max_recoveries_per_run is not None:
+        suite["_max_recoveries_per_run"] = int(max_recoveries_per_run)
+    if max_recoveries_per_step is not None:
+        suite["_max_recoveries_per_step"] = int(max_recoveries_per_step)
     return suite
 
 

--- a/tests/test_recovery_caps_runtime_field.py
+++ b/tests/test_recovery_caps_runtime_field.py
@@ -1,0 +1,160 @@
+"""Tests for runtime ``max_recoveries_per_run`` / ``max_recoveries_per_step`` (#567).
+
+Promotes the hardcoded ``DEFAULT_MAX_RECOVERIES_PER_*`` constants in
+``agentic_recovery.py`` to per-submission runtime fields. A single
+submission can raise caps for plans that legitimately need many
+recoveries (long extraction loops, flaky pages) or lower caps for CI
+runs that want tighter fail-fast — both without touching code or
+redeploying.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from mantis_agent.agentic_recovery import (
+    DEFAULT_MAX_RECOVERIES_PER_RUN,
+    DEFAULT_MAX_RECOVERIES_PER_STEP,
+    effective_max_recoveries,
+)
+from mantis_agent.gym.micro_runner import MicroPlanRunner
+from mantis_agent.server_utils import build_micro_suite, merge_runtime
+
+
+# ── effective_max_recoveries resolution ────────────────────────────
+
+
+def test_no_overrides_returns_defaults() -> None:
+    runner = SimpleNamespace()  # no attrs at all
+    per_step, per_run = effective_max_recoveries(runner)
+    assert per_step == DEFAULT_MAX_RECOVERIES_PER_STEP
+    assert per_run == DEFAULT_MAX_RECOVERIES_PER_RUN
+
+
+def test_explicit_overrides_win() -> None:
+    runner = SimpleNamespace(
+        max_recoveries_per_step=7, max_recoveries_per_run=42,
+    )
+    per_step, per_run = effective_max_recoveries(runner)
+    assert per_step == 7
+    assert per_run == 42
+
+
+def test_none_override_falls_back_to_default() -> None:
+    runner = SimpleNamespace(
+        max_recoveries_per_step=None, max_recoveries_per_run=None,
+    )
+    per_step, per_run = effective_max_recoveries(runner)
+    assert per_step == DEFAULT_MAX_RECOVERIES_PER_STEP
+    assert per_run == DEFAULT_MAX_RECOVERIES_PER_RUN
+
+
+def test_zero_override_falls_back_to_default() -> None:
+    # 0 would brick the recovery layer entirely — treat as default.
+    runner = SimpleNamespace(
+        max_recoveries_per_step=0, max_recoveries_per_run=0,
+    )
+    per_step, per_run = effective_max_recoveries(runner)
+    assert per_step == DEFAULT_MAX_RECOVERIES_PER_STEP
+    assert per_run == DEFAULT_MAX_RECOVERIES_PER_RUN
+
+
+def test_negative_override_falls_back_to_default() -> None:
+    runner = SimpleNamespace(
+        max_recoveries_per_step=-1, max_recoveries_per_run=-5,
+    )
+    per_step, per_run = effective_max_recoveries(runner)
+    assert per_step == DEFAULT_MAX_RECOVERIES_PER_STEP
+    assert per_run == DEFAULT_MAX_RECOVERIES_PER_RUN
+
+
+def test_mixed_overrides() -> None:
+    # Per-step set, per-run left default.
+    runner = SimpleNamespace(
+        max_recoveries_per_step=10, max_recoveries_per_run=None,
+    )
+    per_step, per_run = effective_max_recoveries(runner)
+    assert per_step == 10
+    assert per_run == DEFAULT_MAX_RECOVERIES_PER_RUN
+
+
+def test_runner_without_attrs_does_not_raise() -> None:
+    class _Bare:
+        pass
+
+    # No getattr raises, just returns defaults.
+    per_step, per_run = effective_max_recoveries(_Bare())
+    assert per_step == DEFAULT_MAX_RECOVERIES_PER_STEP
+    assert per_run == DEFAULT_MAX_RECOVERIES_PER_RUN
+
+
+# ── MicroPlanRunner storage ────────────────────────────────────────
+
+
+def _runner(**kwargs) -> MicroPlanRunner:
+    return MicroPlanRunner(brain=MagicMock(), env=MagicMock(), **kwargs)
+
+
+def test_runner_default_recoveries_are_none() -> None:
+    runner = _runner()
+    assert runner.max_recoveries_per_run is None
+    assert runner.max_recoveries_per_step is None
+
+
+def test_runner_explicit_recoveries_stored() -> None:
+    runner = _runner(max_recoveries_per_run=50, max_recoveries_per_step=5)
+    assert runner.max_recoveries_per_run == 50
+    assert runner.max_recoveries_per_step == 5
+
+
+def test_runner_effective_max_recoveries_picks_up_overrides() -> None:
+    runner = _runner(max_recoveries_per_run=50, max_recoveries_per_step=5)
+    per_step, per_run = effective_max_recoveries(runner)
+    assert per_step == 5
+    assert per_run == 50
+
+
+# ── build_micro_suite round-trip ───────────────────────────────────
+
+
+def test_suite_omits_recovery_caps_when_caller_passes_none() -> None:
+    suite = build_micro_suite([], "example.com")
+    assert "_max_recoveries_per_run" not in suite
+    assert "_max_recoveries_per_step" not in suite
+
+
+def test_suite_persists_explicit_recovery_caps() -> None:
+    suite = build_micro_suite(
+        [], "example.com",
+        max_recoveries_per_run=50, max_recoveries_per_step=5,
+    )
+    assert suite["_max_recoveries_per_run"] == 50
+    assert suite["_max_recoveries_per_step"] == 5
+
+
+def test_suite_persists_only_supplied_cap() -> None:
+    # Per-run only.
+    suite = build_micro_suite([], "example.com", max_recoveries_per_run=50)
+    assert suite["_max_recoveries_per_run"] == 50
+    assert "_max_recoveries_per_step" not in suite
+
+
+# ── merge_runtime accepts the fields ───────────────────────────────
+
+
+def test_merge_runtime_threads_recovery_caps() -> None:
+    merged = merge_runtime({
+        "max_recoveries_per_run": 50,
+        "max_recoveries_per_step": 5,
+    })
+    assert merged["max_recoveries_per_run"] == 50
+    assert merged["max_recoveries_per_step"] == 5
+
+
+def test_merge_runtime_override_wins_over_plan_default() -> None:
+    merged = merge_runtime(
+        {"max_recoveries_per_run": 50},
+        max_recoveries_per_run=25,
+    )
+    assert merged["max_recoveries_per_run"] == 25


### PR DESCRIPTION
## Summary

Promotes \`DEFAULT_MAX_RECOVERIES_PER_RUN\` (5) and \`DEFAULT_MAX_RECOVERIES_PER_STEP\` (2) from hardcoded \`agentic_recovery.py\` constants to per-submission runtime fields.

A submission opts in via:

\`\`\`python
runtime = merge_runtime({\"max_recoveries_per_run\": 50, \"max_recoveries_per_step\": 5})
\`\`\`

## Resolution (same shape as #560 / #561 / #571 / #576)

1. \`MicroPlanRunner.max_recoveries_per_*\` runtime field — wins when set (positive int)
2. \`DEFAULT_MAX_RECOVERIES_PER_*\` module constant — fallback

Both consumer sites (\`step_recovery.py\` and \`critic.py\`) call new \`agentic_recovery.effective_max_recoveries(runner)\` so the resolution lives in one place.

Defensive: \`None\` / \`0\` / negative override → fall back to default (never returns 0).

## Touchpoints

* \`agentic_recovery.py\` — new \`effective_max_recoveries\` helper
* \`gym/step_recovery.py\` — replaces constant read with helper call
* \`gym/critic.py\` — same swap in FrontierCritic
* \`gym/micro_runner.py\` — \`max_recoveries_per_*\` ctor kwargs
* \`server_utils.py\` — \`_RUNTIME_KEYS\` + \`build_micro_suite\` kwargs → \`_max_recoveries_per_*\`
* \`deploy/modal/modal_cua_server.py\` + \`baseten_server/runtime.py\` — payload → suite → runner threading

## Test plan

- [x] Unit tests: \`tests/test_recovery_caps_runtime_field.py\` (15 cases) — \`effective_max_recoveries\` resolution, runner storage, suite round-trip, \`merge_runtime\`
- [x] Ruff clean
- [x] Touched-surface regression: 250 passed
- [ ] Modal redeploy + boattrader rerun (no behavior change expected since defaults preserved)

## Backward compat

Callers that don't supply the runtime fields get identical behavior to before — DEFAULT_* are the fallback in every path. The PR is a no-op until someone actually passes the field.

Closes #567

🤖 Generated with [Claude Code](https://claude.com/claude-code)