### PR TITLE
extraction quality + new-tab detection + CDP-back: #578 + #579 + #582 + #583

### DIFF
--- a/src/mantis_agent/extraction/result.py
+++ b/src/mantis_agent/extraction/result.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass, field
+from typing import Any, ClassVar
 
 from .schema import ExtractionContext, ExtractionSchema
 
@@ -90,6 +91,25 @@ class ExtractionResult:
         digits = re.sub(r"\D", "", phone)
         return len(digits) >= 10
 
+    # #579: Claude's tool_use schema is permissive (#558) — domain
+    # fields are optional, so the brain may return literal "<UNKNOWN>"
+    # / "none" / "" when it can't read a field off the screenshot.
+    # Treat all of these as "missing" for required-field checks so a
+    # detail-page extract that landed on a marketing CTA (every field
+    # ``<UNKNOWN>``) doesn't get accepted as VIABLE. Without this, the
+    # boattrader-style failure produces a "1 lead" output where the
+    # only "lead" is junk pointing at ``/boat-loans/``.
+    _UNKNOWN_PLACEHOLDERS: ClassVar[frozenset[str]] = frozenset({
+        "", "unknown", "<unknown>", "none", "n/a", "na",
+        "not visible", "not shown", "not available", "tbd",
+    })
+
+    @classmethod
+    def _is_unknown(cls, value: Any) -> bool:
+        """True when the value is empty or one of the documented
+        unknown-placeholder strings (case + whitespace insensitive)."""
+        return str(value or "").strip().lower() in cls._UNKNOWN_PLACEHOLDERS
+
     def missing_required_reason(
         self,
         context: ExtractionContext = ExtractionContext.UNKNOWN,
@@ -118,14 +138,14 @@ class ExtractionResult:
                 fields_to_check = self._schema.required_fields
             missing = [
                 name for name in fields_to_check
-                if not self.extracted_fields.get(name)
+                if self._is_unknown(self.extracted_fields.get(name))
             ]
             return f"missing required field(s): {', '.join(missing)}" if missing else ""
         # Legacy
         missing = []
-        if not self.year:
+        if self._is_unknown(self.year):
             missing.append("year")
-        if not self.make:
+        if self._is_unknown(self.make):
             missing.append("make")
         return f"missing required field(s): {', '.join(missing)}" if missing else ""
 
@@ -162,12 +182,22 @@ class ExtractionResult:
         return "VIABLE | " + " | ".join(parts) if parts else ""
 
     def is_viable(self) -> bool:
-        """Has enough data to be a useful lead (not spam, required fields present)."""
+        """Has enough data to be a useful lead (not spam, required fields present).
+
+        #579: ``<UNKNOWN>`` / ``none`` / empty placeholders all count
+        as missing for the required-field check, so a detail-page
+        extract that landed on a marketing CTA (every field returned
+        as a placeholder) is rejected as non-viable.
+        """
         if self._schema:
             has_required = all(
-                self.extracted_fields.get(name)
+                not self._is_unknown(self.extracted_fields.get(name))
                 for name in self._schema.required_fields
             )
             return has_required and self.is_private_seller()
         # Legacy
-        return bool(self.year and self.make and self.is_private_seller())
+        return bool(
+            not self._is_unknown(self.year)
+            and not self._is_unknown(self.make)
+            and self.is_private_seller()
+        )

--- a/src/mantis_agent/gym/_runner_helpers.py
+++ b/src/mantis_agent/gym/_runner_helpers.py
@@ -431,10 +431,23 @@ def return_to_results_page(runner: "MicroPlanRunner") -> None:
             action_type=ActionType.KEY_PRESS, params={"keys": "ctrl+w"},
         ))
         runner._opened_detail_in_new_tab = False
-    else:
-        runner.env.step(Action(
-            action_type=ActionType.KEY_PRESS, params={"keys": "alt+Left"},
-        ))
+        time.sleep(2)
+        return
+    # #583: prefer CDP ``window.history.back()`` over xdotool ``Alt+Left``.
+    # SPA sites that use ``history.pushState`` don't always pop their
+    # history state cleanly on the keyboard shortcut; the JS call always
+    # does. Fall back to Alt+Left on CDP unavailability / no history
+    # entry to pop. cdp_history_back already polls for URL change.
+    cdp_back = getattr(runner.env, "cdp_history_back", None)
+    if callable(cdp_back):
+        try:
+            if cdp_back():
+                return
+        except Exception as exc:  # noqa: BLE001 — fall through to xdotool
+            logger.debug("cdp_history_back raised, falling back: %s", exc)
+    runner.env.step(Action(
+        action_type=ActionType.KEY_PRESS, params={"keys": "alt+Left"},
+    ))
     time.sleep(2)
 
 

--- a/src/mantis_agent/gym/step_handlers/click.py
+++ b/src/mantis_agent/gym/step_handlers/click.py
@@ -330,6 +330,15 @@ class ClaudeGuidedClickHandler:
         # capability-miss / no-element-at-point. The result is recorded
         # on the StepResult's ``executor_backend`` tag (visible on the
         # /v1/predict response aggregate).
+        # #582: snapshot Chrome tab count BEFORE the click so we can
+        # detect new-tab opens from any click path (plain, SoM, Holo3-
+        # direct, modifier, JS-driven window.open). Today only the
+        # middle-click fallback sets ``_opened_detail_in_new_tab``;
+        # plain-click → window.open() spawns a tab the runner never
+        # knows about → subsequent navigate_back's Alt+Left fails →
+        # ``navigate_back_recovered`` halt cycle.
+        tabs_before_click = _safe_tab_count(env)
+
         primary_click_backend = "vision"
         from ..som_dispatch import try_som_click
         try:
@@ -388,6 +397,21 @@ class ClaudeGuidedClickHandler:
                 url = runner._read_current_url(after)
 
             if url and site_config.is_detail_page(url, base_url=runner._results_base_url):
+                # #582: tab-count diff. If the click opened a new tab
+                # (plain click → site's onclick → window.open(), or a
+                # modifier click that took a path other than the middle-
+                # click fallback), set the flag so subsequent
+                # navigate_back routes through execute_close_detail_tab
+                # (Ctrl+W) instead of Alt+Left.
+                tabs_after = _safe_tab_count(env)
+                if tabs_after > tabs_before_click > 0:
+                    runner._opened_detail_in_new_tab = True
+                    logger.warning(
+                        "  [claude-click] New tab detected via CDP "
+                        "diff (%d → %d) — flagged for Ctrl+W on "
+                        "next navigate_back",
+                        tabs_before_click, tabs_after,
+                    )
                 logger.info(f"  [claude-click] Verified on detail page: {url[:60]}")
                 runner._last_known_url = url
                 dynamic_verifier.record_item_opened(
@@ -770,6 +794,27 @@ _LOGIN_PATH_TOKENS: tuple[str, ...] = (
     "/users/sign_in",
     "/account/login",
 )
+
+
+def _safe_tab_count(env: Any) -> int:
+    """#582: defensively read ``env.cdp_count_pages()`` as an int.
+
+    Returns 0 when the env doesn't expose the method, the call raises,
+    or the result isn't coercible to int. Tests use ``MagicMock`` envs
+    that auto-create attributes returning ``MagicMock`` objects — those
+    can't be compared with ``>``, so we coerce + swallow defensively.
+    Production XdotoolGymEnv returns a real int; this is purely a
+    test-shape compatibility shim.
+    """
+    fn = getattr(env, "cdp_count_pages", None)
+    if not callable(fn):
+        return 0
+    try:
+        return int(fn())
+    except (TypeError, ValueError):
+        return 0
+    except Exception:  # noqa: BLE001 — never break the click path
+        return 0
 
 
 def _looks_like_login_redirect(url: str) -> bool:

--- a/src/mantis_agent/gym/step_recovery.py
+++ b/src/mantis_agent/gym/step_recovery.py
@@ -609,14 +609,21 @@ class StepRecoveryPolicy:
             )
 
         if step.type == "navigate_back":
-            logger_.warning(f"  [{step_index}] BACK FAILED — retrying Alt+Left")
+            logger_.warning(f"  [{step_index}] BACK FAILED — retrying CDP-back then Alt+Left")
+            # #583: prefer CDP history.back() — more reliable than the
+            # xdotool keyboard shortcut on SPA pushState sites. Falls
+            # back to Alt+Left if CDP unavailable or didn't navigate.
+            cdp_back = getattr(runner.env, "cdp_history_back", None)
             for back_attempt in range(3):
                 try:
-                    runner.env.step(Action(
-                        action_type=ActionType.KEY_PRESS,
-                        params={"keys": "alt+Left"},
-                    ))
-                    time.sleep(3)
+                    if callable(cdp_back) and cdp_back():
+                        time.sleep(0.5)
+                    else:
+                        runner.env.step(Action(
+                            action_type=ActionType.KEY_PRESS,
+                            params={"keys": "alt+Left"},
+                        ))
+                        time.sleep(3)
                 except Exception:
                     pass
                 if runner.extractor:

--- a/src/mantis_agent/gym/xdotool_env.py
+++ b/src/mantis_agent/gym/xdotool_env.py
@@ -495,6 +495,51 @@ class XdotoolGymEnv(GymEnvironment):
         ok, _ = self._cdp_call("Input.insertText", {"text": text})
         return ok
 
+    def cdp_count_pages(self) -> int:
+        """#582: count Chrome page-type tabs via ``/json/list``.
+
+        Returns the number of ``type=page`` tabs whose URL isn't a
+        system page (``chrome://`` / ``about:``). Returns ``0`` on any
+        CDP failure (port unreachable, json decode, etc) — caller
+        treats ``0`` as "couldn't check" and skips the diff.
+
+        Used by the click handler to detect new-tab opens from
+        ``window.open()`` / modifier-clicks that bypass the existing
+        middle-click fallback path which is the only writer of
+        ``_opened_detail_in_new_tab`` today. A snapshot before + after
+        the click + comparison sets the flag regardless of which click
+        primitive opened the tab.
+
+        Memory note: per ``feedback_cua_cdp_post_action_verify.md``,
+        post-action CDP reads (verifying our action's side-effect) are
+        allowed. We're checking whether OUR click opened a tab —
+        action-side, not DOM-grounding-side.
+        """
+        try:
+            import json as _json
+            import urllib.request
+            with urllib.request.urlopen(
+                f"http://127.0.0.1:{self._cdp_port}/json/list",
+                timeout=2,
+            ) as resp:
+                tabs = _json.loads(resp.read().decode())
+        except Exception as exc:  # noqa: BLE001 — observability, never fatal
+            logger.debug("cdp_count_pages failed: %s", exc)
+            return 0
+        if not isinstance(tabs, list):
+            return 0
+        count = 0
+        for tab in tabs:
+            if not isinstance(tab, dict):
+                continue
+            if tab.get("type") != "page":
+                continue
+            url = str(tab.get("url") or "")
+            if not url or url.startswith("chrome://") or url.startswith("about:"):
+                continue
+            count += 1
+        return count
+
     def cdp_evaluate(self, expression: str) -> Any:
         """Run a JS expression via CDP ``Runtime.evaluate``.
 

--- a/src/mantis_agent/gym/xdotool_env.py
+++ b/src/mantis_agent/gym/xdotool_env.py
@@ -495,6 +495,47 @@ class XdotoolGymEnv(GymEnvironment):
         ok, _ = self._cdp_call("Input.insertText", {"text": text})
         return ok
 
+    def cdp_history_back(self, *, settle_seconds: float = 1.5) -> bool:
+        """#583: navigate back via ``window.history.back()`` over CDP.
+
+        More reliable than xdotool ``Alt+Left`` on SPA sites that use
+        ``history.pushState`` — the keyboard shortcut sometimes doesn't
+        pop the SPA's history state cleanly; the JS call always does
+        when there's a history entry to pop.
+
+        Returns True when the URL changed within ``settle_seconds`` of
+        the back call, False otherwise (callers fall back to Alt+Left).
+
+        Memory note: per ``feedback_cua_cdp_post_action_verify.md``,
+        CDP for action dispatch + post-action verify is allowed. This
+        is action-side (dispatching back), not DOM-grounding-side.
+        """
+        url_before = self.current_url or ""
+        # Dispatch the back call. ``cdp_evaluate`` returns ``None`` when
+        # the call succeeds (void return) or on failure — we can't
+        # distinguish from the return value, so verify via URL change.
+        try:
+            self.cdp_evaluate("window.history.back()")
+        except Exception as exc:  # noqa: BLE001 — fall back on any failure
+            logger.debug("cdp_history_back: dispatch failed: %s", exc)
+            return False
+        # Poll URL up to ``settle_seconds`` for the change.
+        deadline = time.time() + max(0.1, settle_seconds)
+        poll_interval = 0.1
+        while time.time() < deadline:
+            time.sleep(poll_interval)
+            try:
+                url_after = self.current_url or ""
+            except Exception:  # noqa: BLE001
+                url_after = ""
+            if url_after and url_after != url_before:
+                logger.info(
+                    "  [cdp-back] history.back() succeeded: %s → %s",
+                    url_before[:60], url_after[:60],
+                )
+                return True
+        return False
+
     def cdp_count_pages(self) -> int:
         """#582: count Chrome page-type tabs via ``/json/list``.
 

--- a/src/mantis_agent/plan_decomposer.py
+++ b/src/mantis_agent/plan_decomposer.py
@@ -849,6 +849,12 @@ class PlanDecomposer:
         # asks Claude to mirror the URL there already; this pass catches
         # the residual cases where it paraphrases the URL away entirely.
         self._repair_navigate_urls(plan)
+        # Fix 5 (#578): inject ``expect_url_contains`` hints onto
+        # navigate-verify gates so the runner's #563 URL short-circuit
+        # can fire — skips a ~$0.01-0.02 + ~10-15s Claude verify call
+        # per gate whose preceding navigate had a literal URL with
+        # distinctive path segments.
+        self._inject_gate_url_hints(plan)
 
         # Cache the full parsed structure (object or legacy array) so the
         # cached path round-trips through both schemas.
@@ -1059,6 +1065,96 @@ class PlanDecomposer:
                 f"  [decomposer] navigate step #{i} dropped its URL "
                 f"({step.intent[:60]!r}); repaired with source URL "
                 f"{recovered}. Tighten the decomposer prompt if this recurs."
+            )
+
+    @staticmethod
+    def _extract_url_hint_segments(url: str) -> list[str]:
+        """Pull distinctive path segments from a URL for #563 short-circuit.
+
+        Returns segments containing a digit OR a hyphen — captures
+        boattrader-style filter slugs (``zip-33101``, ``state-fl``,
+        ``by-owner``, ``radius-25``) and excludes bare resource
+        names (``boats``, ``discover``) that would match unrelated
+        pages on the same domain.
+
+        Returns ``[]`` when the URL has no distinctive segments —
+        the runner's short-circuit then falls through to vision
+        verify (no false positives possible).
+        """
+        if not url:
+            return []
+        # Strip scheme + host so we walk only the path. Query strings
+        # and fragments are intentionally excluded — they change
+        # across navigations within the same page (?page=2, #anchor)
+        # and would cause the short-circuit to false-negative.
+        m = re.search(r"https?://[^/]+(/[^?#]*)", url)
+        if not m:
+            return []
+        path = m.group(1)
+        segments = [s for s in path.split("/") if s]
+        # Distinctive = has digit OR hyphen. A bare "boats" matches
+        # too many pages; "zip-33101" / "state-fl" / "by-owner" only
+        # match the intended filtered listings.
+        distinctive = [
+            s for s in segments
+            if any(ch.isdigit() for ch in s) or "-" in s
+        ]
+        return distinctive
+
+    @staticmethod
+    def _inject_gate_url_hints(plan: MicroPlan) -> None:
+        r"""#578: emit ``expect_url_contains`` hints on navigate-verify gates.
+
+        Walks the plan; for each ``extract_data`` step with
+        ``gate=True`` and ``claude_only=True``, finds the nearest
+        preceding ``navigate`` step. If that navigate carries a
+        literal URL (in ``params.url`` or ``intent``), pulls
+        distinctive path segments via :meth:`_extract_url_hint_segments`
+        and merges them into the gate's ``hints.expect_url_contains``.
+
+        Idempotent: if the plan author already supplied hints, they're
+        preserved as-is. Empty / generic URLs (no distinctive segments)
+        are skipped silently — the runner's short-circuit handles
+        absent hints by falling through to vision.
+
+        Activates the ``_try_url_shortcircuit_gate`` path shipped in
+        PR #577 — that helper short-circuits the ~10-15s + \$0.01-0.02
+        Claude verify call when these hints are present and the URL
+        matches.
+        """
+        url_re = re.compile(r"https?://[^\s\"'<>]+")
+        last_navigate_url: str = ""
+        for step in plan.steps:
+            if step.type == "navigate":
+                # Prefer params.url, then any URL in the intent.
+                params = step.params or {}
+                candidate = str(params.get("url") or "").strip()
+                if not candidate:
+                    m = url_re.search(step.intent or "")
+                    if m:
+                        candidate = m.group(0)
+                if candidate:
+                    last_navigate_url = candidate
+                continue
+            if not (step.type == "extract_data" and step.gate and step.claude_only):
+                continue
+            if not last_navigate_url:
+                continue
+            hints = step.hints or {}
+            existing = hints.get("expect_url_contains")
+            if existing:
+                # Plan author already supplied hints — don't override.
+                continue
+            segments = PlanDecomposer._extract_url_hint_segments(last_navigate_url)
+            if not segments:
+                continue
+            new_hints = dict(hints)
+            new_hints["expect_url_contains"] = segments
+            step.hints = new_hints
+            logger.info(
+                "  [decomposer] injected expect_url_contains=%s on gate "
+                "step (intent=%r) from navigate URL %s",
+                segments, step.intent[:60], last_navigate_url[:120],
             )
 
     @staticmethod

--- a/tests/test_cdp_history_back_583.py
+++ b/tests/test_cdp_history_back_583.py
@@ -1,0 +1,185 @@
+"""Tests for #583 — CDP ``window.history.back()`` over xdotool Alt+Left.
+
+Boattrader runs kept ending with ``halt_reason=navigate_back_recovered``
+even after #582's tab-count fix — Alt+Left doesn't reliably pop SPA
+pushState history. CDP-driven ``window.history.back()`` does.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch, MagicMock
+
+from mantis_agent.gym.xdotool_env import XdotoolGymEnv
+
+
+class _StubXdotoolGymEnv(XdotoolGymEnv):
+    """Test subclass that overrides ``current_url`` without mutating
+    the base class — prevents test pollution across the suite.
+    """
+    _stubbed_url: str = ""
+
+    @property  # type: ignore[override]
+    def current_url(self) -> str:
+        return self._stubbed_url
+
+
+def _make_env(initial_url: str = "https://x.com/detail/123") -> _StubXdotoolGymEnv:
+    env = _StubXdotoolGymEnv.__new__(_StubXdotoolGymEnv)
+    env._cdp_port = 9222
+    env._stubbed_url = initial_url
+    return env
+
+
+def test_cdp_back_succeeds_when_url_changes() -> None:
+    env = _make_env(initial_url="https://x.com/detail/123")
+
+    def _evaluate(expr):
+        # Simulate that history.back() succeeded — URL changes to the
+        # listings page on the next poll.
+        env._stubbed_url = "https://x.com/listings/"
+        return None
+
+    with patch.object(env, "cdp_evaluate", side_effect=_evaluate):
+        assert env.cdp_history_back() is True
+
+
+def test_cdp_back_returns_false_when_url_unchanged() -> None:
+    env = _make_env(initial_url="https://x.com/detail/123")
+    # cdp_evaluate succeeds (returns None) but URL never changes —
+    # caller should fall back to Alt+Left.
+    with patch.object(env, "cdp_evaluate", return_value=None):
+        assert env.cdp_history_back(settle_seconds=0.3) is False
+
+
+def test_cdp_back_returns_false_when_cdp_raises() -> None:
+    env = _make_env()
+    with patch.object(env, "cdp_evaluate", side_effect=RuntimeError("ws closed")):
+        # Defensive: any CDP failure → False so caller falls back.
+        assert env.cdp_history_back(settle_seconds=0.2) is False
+
+
+def test_cdp_back_returns_false_on_empty_url_after() -> None:
+    env = _make_env(initial_url="https://x.com/detail/")
+
+    def _evaluate(expr):
+        env._stubbed_url = ""  # No URL after — can't verify success.
+        return None
+
+    with patch.object(env, "cdp_evaluate", side_effect=_evaluate):
+        assert env.cdp_history_back(settle_seconds=0.2) is False
+
+
+def test_cdp_back_settle_seconds_bounded() -> None:
+    """Even with a long settle window, returns quickly when URL changes
+    on the first poll."""
+    env = _make_env()
+    import time as _time
+    started = _time.time()
+
+    def _evaluate(expr):
+        env._stubbed_url = "https://x.com/listings/"
+        return None
+
+    with patch.object(env, "cdp_evaluate", side_effect=_evaluate):
+        assert env.cdp_history_back(settle_seconds=5.0) is True
+    # Should return well under 1s even with 5s ceiling (we poll at 100ms).
+    assert _time.time() - started < 1.0
+
+
+# ── return_to_results_page wiring ─────────────────────────────────
+
+
+def test_return_to_results_prefers_cdp_back_over_alt_left() -> None:
+    from mantis_agent.gym._runner_helpers import return_to_results_page
+
+    env = MagicMock()
+    env.cdp_history_back = MagicMock(return_value=True)
+    runner = MagicMock()
+    runner.env = env
+    runner._opened_detail_in_new_tab = False
+
+    return_to_results_page(runner)
+
+    env.cdp_history_back.assert_called_once()
+    # When CDP-back succeeded, xdotool Alt+Left should NOT have been
+    # dispatched.
+    for call in env.step.call_args_list:
+        action = call.args[0] if call.args else call.kwargs.get("action")
+        if action is not None:
+            params = getattr(action, "params", {}) or {}
+            assert params.get("keys") != "alt+Left", \
+                "Alt+Left dispatched even though CDP-back succeeded"
+
+
+def test_return_to_results_falls_back_to_alt_left_when_cdp_fails() -> None:
+    from mantis_agent.gym._runner_helpers import return_to_results_page
+
+    env = MagicMock()
+    env.cdp_history_back = MagicMock(return_value=False)  # CDP didn't navigate
+    runner = MagicMock()
+    runner.env = env
+    runner._opened_detail_in_new_tab = False
+
+    return_to_results_page(runner)
+
+    env.cdp_history_back.assert_called_once()
+    # Should have fallen back to Alt+Left.
+    alt_left_dispatched = any(
+        getattr(
+            (call.args[0] if call.args else call.kwargs.get("action")),
+            "params", {},
+        ).get("keys") == "alt+Left"
+        for call in env.step.call_args_list
+    )
+    assert alt_left_dispatched
+
+
+def test_return_to_results_uses_ctrl_w_when_new_tab_flag_set() -> None:
+    """The Ctrl+W path is untouched by #583 — new-tab flag still wins."""
+    from mantis_agent.gym._runner_helpers import return_to_results_page
+
+    env = MagicMock()
+    env.cdp_history_back = MagicMock(return_value=True)
+    runner = MagicMock()
+    runner.env = env
+    runner._opened_detail_in_new_tab = True
+
+    return_to_results_page(runner)
+
+    # CDP-back must NOT be invoked when we're closing a new tab.
+    env.cdp_history_back.assert_not_called()
+    # Ctrl+W should be dispatched.
+    ctrl_w_dispatched = any(
+        getattr(
+            (call.args[0] if call.args else call.kwargs.get("action")),
+            "params", {},
+        ).get("keys") == "ctrl+w"
+        for call in env.step.call_args_list
+    )
+    assert ctrl_w_dispatched
+    # Flag should be cleared.
+    assert runner._opened_detail_in_new_tab is False
+
+
+def test_return_to_results_falls_back_when_env_has_no_cdp_back() -> None:
+    """Envs without cdp_history_back (test stubs, legacy adapters) must
+    not crash — fall straight through to Alt+Left."""
+    from mantis_agent.gym._runner_helpers import return_to_results_page
+
+    class _EnvNoCdp:
+        def __init__(self):
+            self.dispatched = []
+        def step(self, action):
+            self.dispatched.append(action)
+
+    env = _EnvNoCdp()
+    runner = MagicMock()
+    runner.env = env
+    runner._opened_detail_in_new_tab = False
+
+    return_to_results_page(runner)
+
+    assert any(
+        getattr(a, "params", {}).get("keys") == "alt+Left"
+        for a in env.dispatched
+    )

--- a/tests/test_click_new_tab_detection_582.py
+++ b/tests/test_click_new_tab_detection_582.py
@@ -1,0 +1,117 @@
+"""Tests for #582 — CDP tab-count diff in the click handler.
+
+Before this fix, ``_opened_detail_in_new_tab`` was set only by the
+middle-click fallback (``step_handlers/click.py:526``). When a plain
+click triggered a site-side ``window.open()`` (boattrader card cards,
+modifier-clicks bypassing middle-click, etc.) a new tab opened but
+the runner never knew → next ``navigate_back`` dispatched ``Alt+Left``
+against the wrong tab → ``navigate_back_recovered`` halt-reason cycle.
+
+The fix: snapshot ``cdp_count_pages()`` before + after the click; if
+count went up AND we landed on a detail page, set the flag.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+from urllib.error import URLError
+
+from mantis_agent.gym.xdotool_env import XdotoolGymEnv
+
+
+def _make_env() -> XdotoolGymEnv:
+    """Construct an env shell with just the attrs ``cdp_count_pages`` reads."""
+    env = XdotoolGymEnv.__new__(XdotoolGymEnv)
+    env._cdp_port = 9222
+    return env
+
+
+def _mock_json_list(payload):
+    """Wrap a payload as a urlopen-compatible response context manager."""
+    class _Resp:
+        def __init__(self, body): self._body = body
+        def __enter__(self): return self
+        def __exit__(self, *_): pass
+        def read(self): return self._body.encode()
+    return _Resp(json.dumps(payload))
+
+
+# ── cdp_count_pages helper ─────────────────────────────────────────
+
+
+def test_counts_page_type_tabs() -> None:
+    env = _make_env()
+    payload = [
+        {"type": "page", "url": "https://x.com/a"},
+        {"type": "page", "url": "https://y.com/b"},
+        {"type": "worker", "url": "https://x.com/sw.js"},  # excluded
+        {"type": "background_page", "url": "chrome-extension://abc/"},  # excluded
+    ]
+    with patch("urllib.request.urlopen", return_value=_mock_json_list(payload)):
+        assert env.cdp_count_pages() == 2
+
+
+def test_excludes_chrome_internal_pages() -> None:
+    env = _make_env()
+    payload = [
+        {"type": "page", "url": "https://x.com/a"},
+        {"type": "page", "url": "chrome://newtab/"},  # excluded
+        {"type": "page", "url": "about:blank"},  # excluded
+    ]
+    with patch("urllib.request.urlopen", return_value=_mock_json_list(payload)):
+        assert env.cdp_count_pages() == 1
+
+
+def test_excludes_empty_url_pages() -> None:
+    env = _make_env()
+    payload = [
+        {"type": "page", "url": "https://x.com/a"},
+        {"type": "page", "url": ""},
+        {"type": "page"},  # url key missing entirely
+    ]
+    with patch("urllib.request.urlopen", return_value=_mock_json_list(payload)):
+        assert env.cdp_count_pages() == 1
+
+
+def test_returns_zero_on_cdp_unreachable() -> None:
+    env = _make_env()
+    with patch("urllib.request.urlopen", side_effect=URLError("connection refused")):
+        # Failure must not raise — caller treats 0 as "couldn't check".
+        assert env.cdp_count_pages() == 0
+
+
+def test_returns_zero_on_json_decode_failure() -> None:
+    env = _make_env()
+
+    class _BadResp:
+        def __enter__(self): return self
+        def __exit__(self, *_): pass
+        def read(self): return b"not-json{{"
+
+    with patch("urllib.request.urlopen", return_value=_BadResp()):
+        assert env.cdp_count_pages() == 0
+
+
+def test_returns_zero_when_payload_not_list() -> None:
+    env = _make_env()
+    with patch("urllib.request.urlopen", return_value=_mock_json_list({"err": "x"})):
+        assert env.cdp_count_pages() == 0
+
+
+def test_handles_non_dict_entries_gracefully() -> None:
+    env = _make_env()
+    payload = [
+        {"type": "page", "url": "https://x.com/a"},
+        "garbage",
+        None,
+        42,
+    ]
+    with patch("urllib.request.urlopen", return_value=_mock_json_list(payload)):
+        assert env.cdp_count_pages() == 1
+
+
+def test_no_tabs_returns_zero() -> None:
+    env = _make_env()
+    with patch("urllib.request.urlopen", return_value=_mock_json_list([])):
+        assert env.cdp_count_pages() == 0

--- a/tests/test_extraction_quality_578_579.py
+++ b/tests/test_extraction_quality_578_579.py
@@ -1,0 +1,226 @@
+r"""Tests for #578 (decomposer emits expect_url_contains) + #579
+(extractor rejects UNKNOWN-only leads).
+
+These two bugs surfaced together on boattrader run
+``20260521_234022_65ddaaff`` (2026-05-21 PM): the agent navigated
+off the listings flow to a marketing CTA (``/boat-loans/``), Claude
+extracted all-``<UNKNOWN>`` fields, the viability check accepted the
+junk row as a "1 lead" output, and there was no URL-hint short-circuit
+on the gate to catch the wrong-page situation upstream.
+
+Both fixes ship in one PR because they're complementary defences for
+the same failure mode — one catches the wrong page (#578 gate hints +
+PR #577 short-circuit fall-through to vision), the other catches the
+junk extract that gets past (#579 viability check).
+"""
+
+from __future__ import annotations
+
+from mantis_agent.extraction.result import ExtractionResult
+from mantis_agent.extraction.schema import ExtractionSchema
+from mantis_agent.plan_decomposer import MicroIntent, MicroPlan, PlanDecomposer
+
+
+# ── #579: ExtractionResult.is_viable rejects UNKNOWN placeholders ──
+
+
+def _result_legacy(**fields) -> ExtractionResult:
+    return ExtractionResult(**fields)
+
+
+def _schema() -> ExtractionSchema:
+    return ExtractionSchema(
+        entity_name="boat",
+        fields=[{"name": "year", "type": "str"}, {"name": "make", "type": "str"}],
+        required_fields=["year", "make"],
+    )
+
+
+def _result_schema(year: str = "", make: str = "") -> ExtractionResult:
+    r = ExtractionResult(_schema=_schema())
+    r.extracted_fields = {"year": year, "make": make}
+    return r
+
+
+def test_legacy_all_empty_not_viable() -> None:
+    assert _result_legacy(year="", make="").is_viable() is False
+
+
+def test_legacy_unknown_placeholder_not_viable() -> None:
+    # The bug from boattrader run 20260521_234022_65ddaaff: model
+    # returned "<UNKNOWN>" for every field, dedup accepted it.
+    r = _result_legacy(year="<UNKNOWN>", make="<UNKNOWN>", seller="private seller")
+    assert r.is_viable() is False
+    assert "year" in r.missing_required_reason()
+    assert "make" in r.missing_required_reason()
+
+
+def test_legacy_none_placeholder_not_viable() -> None:
+    r = _result_legacy(year="none", make="N/A", seller="private seller")
+    assert r.is_viable() is False
+
+
+def test_legacy_real_values_viable() -> None:
+    r = _result_legacy(
+        year="2020", make="Sea Ray", seller="John Smith (private)",
+    )
+    assert r.is_viable() is True
+
+
+def test_legacy_year_real_make_unknown_not_viable() -> None:
+    # Partial-UNKNOWN still fails the required check.
+    r = _result_legacy(year="2020", make="<UNKNOWN>", seller="private")
+    assert r.is_viable() is False
+
+
+def test_schema_all_unknown_not_viable() -> None:
+    r = _result_schema(year="<UNKNOWN>", make="<UNKNOWN>")
+    r.is_dealer = False  # ensure not classified as dealer
+    assert r.is_viable() is False
+    reason = r.missing_required_reason()
+    assert "year" in reason and "make" in reason
+
+
+def test_schema_real_values_viable() -> None:
+    r = _result_schema(year="2020", make="Sea Ray")
+    r.is_dealer = False
+    assert r.is_viable() is True
+
+
+def test_unknown_check_handles_whitespace_and_case() -> None:
+    # Mixed case + whitespace must still be treated as unknown.
+    assert ExtractionResult._is_unknown("  Unknown  ")
+    assert ExtractionResult._is_unknown("<UNKNOWN>")
+    assert ExtractionResult._is_unknown("None")
+    assert ExtractionResult._is_unknown("N/A")
+    assert ExtractionResult._is_unknown("")
+    assert ExtractionResult._is_unknown(None)
+
+
+def test_unknown_check_does_not_strip_real_values() -> None:
+    assert not ExtractionResult._is_unknown("2020")
+    assert not ExtractionResult._is_unknown("Sea Ray")
+    assert not ExtractionResult._is_unknown("0")  # numeric "0" is a real value
+
+
+# ── #578: decomposer injects expect_url_contains on gate steps ─────
+
+
+def _plan_with_navigate_and_gate(nav_url: str = "") -> MicroPlan:
+    return MicroPlan(steps=[
+        MicroIntent(
+            intent=f"Navigate to {nav_url}" if nav_url else "Navigate",
+            type="navigate",
+            params={"url": nav_url} if nav_url else {},
+            section="setup", required=True,
+        ),
+        MicroIntent(
+            intent="Verify page heading shows boats for sale",
+            type="extract_data",
+            params={}, hints={},
+            section="setup", required=True,
+            gate=True, claude_only=True,
+        ),
+    ])
+
+
+def test_url_hint_segments_picks_distinctive_only() -> None:
+    url = "https://www.boattrader.com/boats/state-fl/city-miami/zip-33101/by-owner/radius-25/"
+    segments = PlanDecomposer._extract_url_hint_segments(url)
+    # All distinctive (digit or hyphen). "boats" excluded — too generic.
+    assert "state-fl" in segments
+    assert "city-miami" in segments
+    assert "zip-33101" in segments
+    assert "by-owner" in segments
+    assert "radius-25" in segments
+    assert "boats" not in segments
+
+
+def test_url_hint_segments_excludes_query_and_fragment() -> None:
+    url = "https://x.com/a-b/c-1?page=2#anchor"
+    segments = PlanDecomposer._extract_url_hint_segments(url)
+    assert "a-b" in segments
+    assert "c-1" in segments
+    # Query string and fragment must not leak into the hints — they
+    # change across same-page navigations.
+    assert all("page=" not in s for s in segments)
+    assert all("anchor" not in s for s in segments)
+
+
+def test_url_hint_segments_empty_for_bare_host() -> None:
+    assert PlanDecomposer._extract_url_hint_segments("https://x.com/") == []
+    assert PlanDecomposer._extract_url_hint_segments("") == []
+
+
+def test_url_hint_segments_skips_generic_resource() -> None:
+    # "discover" / "boats" — no digit, no hyphen — too generic.
+    assert PlanDecomposer._extract_url_hint_segments("https://lu.ma/discover") == []
+    assert PlanDecomposer._extract_url_hint_segments("https://x.com/boats/") == []
+
+
+def test_inject_gate_url_hints_from_params_url() -> None:
+    plan = _plan_with_navigate_and_gate(
+        "https://www.boattrader.com/boats/state-fl/zip-33101/by-owner/",
+    )
+    PlanDecomposer._inject_gate_url_hints(plan)
+    gate = plan.steps[1]
+    assert gate.hints["expect_url_contains"] == ["state-fl", "zip-33101", "by-owner"]
+
+
+def test_inject_gate_url_hints_from_intent_when_no_params() -> None:
+    plan = MicroPlan(steps=[
+        MicroIntent(
+            intent="Navigate to https://www.boattrader.com/zip-33101/",
+            type="navigate",
+            params={},  # no URL in params — only in intent
+            section="setup", required=True,
+        ),
+        MicroIntent(
+            intent="Verify on listings page",
+            type="extract_data", params={}, hints={},
+            section="setup", required=True,
+            gate=True, claude_only=True,
+        ),
+    ])
+    PlanDecomposer._inject_gate_url_hints(plan)
+    assert plan.steps[1].hints["expect_url_contains"] == ["zip-33101"]
+
+
+def test_inject_gate_url_hints_preserves_author_hints() -> None:
+    plan = _plan_with_navigate_and_gate(
+        "https://www.boattrader.com/zip-33101/",
+    )
+    plan.steps[1].hints = {"expect_url_contains": ["custom-hint"]}
+    PlanDecomposer._inject_gate_url_hints(plan)
+    # Author-supplied hints win — never overridden.
+    assert plan.steps[1].hints["expect_url_contains"] == ["custom-hint"]
+
+
+def test_inject_gate_url_hints_skips_when_no_navigate() -> None:
+    # Gate without a preceding navigate — nothing to derive from.
+    plan = MicroPlan(steps=[
+        MicroIntent(
+            intent="Verify state", type="extract_data",
+            params={}, hints={}, gate=True, claude_only=True,
+        ),
+    ])
+    PlanDecomposer._inject_gate_url_hints(plan)
+    assert plan.steps[0].hints == {}
+
+
+def test_inject_gate_url_hints_skips_when_url_has_no_distinctive_segments() -> None:
+    # /discover has no digit or hyphen — no hints to inject.
+    plan = _plan_with_navigate_and_gate("https://lu.ma/discover")
+    PlanDecomposer._inject_gate_url_hints(plan)
+    assert "expect_url_contains" not in plan.steps[1].hints
+
+
+def test_inject_gate_url_hints_skips_non_gate_extract_data() -> None:
+    # Deep-extract (gate=False, claude_only=True) is NOT the short-
+    # circuit target — only gate=True. Hints would do nothing here.
+    plan = _plan_with_navigate_and_gate(
+        "https://www.boattrader.com/zip-33101/",
+    )
+    plan.steps[1].gate = False
+    PlanDecomposer._inject_gate_url_hints(plan)
+    assert "expect_url_contains" not in plan.steps[1].hints


### PR DESCRIPTION
## Summary

Bundles three complementary fixes for the same boattrader failure mode:

1. **#582** — CDP tab-count diff in click handler → reliably detects new-tab opens from any click path
2. **#578** — Decomposer injects \`expect_url_contains\` hints onto navigate-verify gates → activates the PR #577 URL short-circuit
3. **#579** — Extractor rejects \`<UNKNOWN>\`-only leads at the viability boundary → no more junk \"1 lead\" outputs

All three observed together on boattrader run \`20260521_234022_65ddaaff\` (#578/#579) and \`20260522_024537_d61fa2d4\` (#582).

## #582 — CDP tab-count diff (new-tab detection)

Before: \`_opened_detail_in_new_tab\` set only by middle-click fallback. Plain click → site's \`window.open()\` opens a tab the runner never knew about → next \`navigate_back\`'s \`Alt+Left\` fails → \`navigate_back_recovered\` cycle.

After: \`XdotoolGymEnv.cdp_count_pages()\` returns count via \`/json/list\`. Click handler snapshots before/after, sets the flag on any tab-count increase. Next \`navigate_back\` correctly dispatches \`Ctrl+W\`.

## #579 — Reject UNKNOWN-only leads

Before: \`is_viable()\` accepted \`<UNKNOWN>\` as a non-empty value → bogus \"1 lead\" outputs from extracts on wrong pages.

After: \`ExtractionResult._is_unknown()\` treats \`<UNKNOWN>\` / \`none\` / \`n/a\` / etc. as missing. Both \`missing_required_reason\` and \`is_viable\` use the helper.

## #578 — Decomposer emits gate URL hints

Before: \`expect_url_contains\` hints never emitted → PR #577 short-circuit never fires.

After: \`_inject_gate_url_hints\` post-process pass injects distinctive path segments (digit-or-hyphen segments — \`zip-33101\`, \`by-owner\`, \`state-fl\`; skips generic \`boats\` / \`discover\`).

## Why bundle

All three are defences against the same wrong-page failure chain:
- #582 catches the new-tab opens that produce \`Alt+Left\` failures
- #578 catches the wrong page upstream via URL-hint short-circuit fall-through to vision
- #579 catches the junk extract that survives both

## Test plan

- [x] 27 unit tests (#578/#579: 19, #582: 8)
- [x] Ruff clean
- [x] Broader regression: 501 passed across click / xdotool_env / extractor / extraction / decomposer
- [ ] Modal redeploy + boattrader rerun — observe: \`[gate] URL short-circuit PASS\`, \`New tab detected via CDP diff\`, no UNKNOWN-only leads, no \`navigate_back_recovered\` halt

Closes #578
Closes #579
Closes #582

🤖 Generated with [Claude Code](https://claude.com/claude-code)