### PR TITLE
click: pre-scroll past sticky header before scan (closes #600)

### DIFF
--- a/src/mantis_agent/gym/run_executor.py
+++ b/src/mantis_agent/gym/run_executor.py
@@ -1384,7 +1384,20 @@ class RunExecutor:
     def _handle_duplicate(self, plan: "MicroPlan", state: RunState) -> None:
         """extract_url returned DUPLICATE → return to results, jump to loop."""
         runner = self.parent
-        logger.info(f"  [{state.step_index}] DEDUP — skipping to next listing")
+        # WARNING-level (#600 follow-up): the dedup branch dominates
+        # the "0 leads, halt=duplicate_listing" outcome; surface it in
+        # production logs where INFO is suppressed. Carries the step
+        # index + the data payload so we can see which URL fired and
+        # whether it was extract_url or extract_data that flagged it.
+        last_data = ""
+        try:
+            last_data = (state.results[-1].data or "") if state.results else ""
+        except (AttributeError, IndexError):
+            pass
+        logger.warning(
+            "  [%d] DEDUP — skipping to next listing (data=%s)",
+            state.step_index, last_data[:160],
+        )
         try:
             runner._return_to_results_page()
         except Exception:

--- a/src/mantis_agent/gym/step_handlers/claude_step.py
+++ b/src/mantis_agent/gym/step_handlers/claude_step.py
@@ -241,7 +241,14 @@ class ClaudeStepHandler:
 
             # Dedup check (Phase 4: scanner owns the predicate now).
             if runner.scanner.is_duplicate(url):
-                logger.info(f"  [dedup] Already seen: {url[:50]}")
+                # WARNING-level so the dedup decision shows up in Modal
+                # logs (INFO is suppressed in production). Without this
+                # the "0 leads, halt=duplicate_listing" diagnosis is
+                # un-debuggable from logs alone (#600 follow-up).
+                logger.warning(
+                    "  [dedup] extract_url already seen: %s (step=%d)",
+                    url[:80], index,
+                )
                 dynamic_verifier.record_item_completed(
                     page=runner._current_page,
                     item=runner._current_item_label(data),
@@ -336,9 +343,14 @@ class ClaudeStepHandler:
             # listing and produce duplicate entries in the lead set.
             extracted_url = getattr(data, "url", "") if data else ""
             if runner.scanner.is_duplicate(extracted_url):
-                logger.info(
-                    "  [dedup] extract_data skip already-seen: %s",
-                    extracted_url[:80],
+                # WARNING-level (#600 follow-up): the "0 leads, halt=
+                # duplicate_listing" outcome turned out to be this gate
+                # firing immediately after extract_url marked the SAME
+                # URL seen one step earlier. We need the per-step URL
+                # in production logs to verify the mark→check race.
+                logger.warning(
+                    "  [dedup] extract_data already seen: %s (step=%d)",
+                    extracted_url[:80], index,
                 )
                 dynamic_verifier.record_item_completed(
                     page=runner._current_page,
@@ -404,7 +416,11 @@ class ClaudeStepHandler:
                 )
             if data and data.dealer_reason():
                 reason = data.dealer_reason()
-                logger.info("  [extract] Rejected non-private listing: %s", reason)
+                # WARNING-level (#600 follow-up) for production visibility.
+                logger.warning(
+                    "  [extract] Rejected non-private listing: %s url=%s",
+                    reason, (data.url or "")[:80],
+                )
                 runner._last_extracted = {
                     **runner._last_extracted,
                     "last_rejected_url": data.url,
@@ -441,7 +457,13 @@ class ClaudeStepHandler:
             extraction_context = _resolve_extraction_context(runner, data)
             if data and data.missing_required_reason(extraction_context):
                 reason = data.missing_required_reason(extraction_context)
-                logger.info("  [extract] Rejected incomplete lead: %s", reason)
+                # WARNING-level (#600 follow-up). Include URL + the
+                # extraction_context so we can tell DETAIL_PAGE-strict
+                # vs SEARCH_TILE-loose contracts apart in production.
+                logger.warning(
+                    "  [extract] Rejected incomplete lead: %s url=%s ctx=%s",
+                    reason, (data.url or "")[:80], extraction_context,
+                )
                 runner._last_extracted = {
                     **runner._last_extracted,
                     "last_rejected_url": data.url,
@@ -465,6 +487,16 @@ class ClaudeStepHandler:
                     data=f"REJECTED_INCOMPLETE|{reason}|{data.to_summary()[:160]}",
                     skip=skip, skip_reason=skip_reason,
                 )
+            # Catch-all: extract returned but didn't pass viable / dealer
+            # / missing-required gates. Previously silent; promote to
+            # WARNING (#600 follow-up) so the "0 leads, halt=…" outcome
+            # can be triaged from logs alone.
+            logger.warning(
+                "  [extract] Catch-all reject (not viable, no dealer flag, no required-miss): "
+                "url=%s data_present=%s",
+                (getattr(data, "url", "") or "")[:80],
+                bool(data),
+            )
             dynamic_verifier.record_item_completed(
                 page=runner._current_page,
                 item=item_label,

--- a/src/mantis_agent/gym/step_handlers/click.py
+++ b/src/mantis_agent/gym/step_handlers/click.py
@@ -65,6 +65,23 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Issue #600: the deterministic Home + N Page_Down scroll-restore would
+# place viewport stage 0 at the very top of the page, where a typical
+# results page shows a sticky header / search bar / promo band and the
+# first row of cards is only peeking in at the bottom edge (just the
+# photos, no titles or prices visible yet). ``find_all_listings`` then
+# returned ``title="unknown"`` for every card and the runner fell back
+# to coord placeholders — which (a) made PR #597's already-clicked
+# prefilter inert and (b) made the brain re-click the same screen
+# coordinates next iteration, hitting the URL-dedup gate.
+#
+# Adding a single Page_Down before stage 0 pushes the header off the
+# top so the first card row is fully visible (title + price + dealer
+# tag) when the scan + click both fire. The constant applies to both
+# the scan-time scroll and the click-time scroll so the brain clicks
+# at the same Y the scan reported.
+HEADER_PRESCROLL_PAGE_DOWNS = 1
+
 
 class ClaudeGuidedClickHandler:
     """Implements :class:`~..step_context.StepHandler` for listings ``click``.
@@ -106,13 +123,13 @@ class ClaudeGuidedClickHandler:
                 try:
                     env.step(Action(action_type=ActionType.KEY_PRESS, params={"keys": "Home"}))
                     time.sleep(0.5)
-                    for _ in range(runner._viewport_stage):
+                    for _ in range(HEADER_PRESCROLL_PAGE_DOWNS + runner._viewport_stage):
                         env.step(Action(action_type=ActionType.KEY_PRESS, params={"keys": "Page_Down"}))
                         time.sleep(0.5)
                     runner._set_scroll_state(
                         context="results_scan",
                         url=runner._current_results_page_url() or runner._results_base_url,
-                        page_downs=runner._viewport_stage,
+                        page_downs=HEADER_PRESCROLL_PAGE_DOWNS + runner._viewport_stage,
                         wheel_downs=0,
                         viewport_stage=runner._viewport_stage,
                     )
@@ -256,17 +273,19 @@ class ClaudeGuidedClickHandler:
             viewport_stage=runner._viewport_stage,
         )
 
-        # Scroll to the correct viewport (Home + N Page_Downs)
+        # Scroll to the correct viewport (Home + header-prescroll +
+        # N Page_Downs). The header prescroll must match the scan-time
+        # one (Issue #600) so the brain clicks the same Y the scan saw.
         try:
             env.step(Action(action_type=ActionType.KEY_PRESS, params={"keys": "Home"}))
             time.sleep(0.5)
-            for _ in range(runner._viewport_stage):
+            for _ in range(HEADER_PRESCROLL_PAGE_DOWNS + runner._viewport_stage):
                 env.step(Action(action_type=ActionType.KEY_PRESS, params={"keys": "Page_Down"}))
                 time.sleep(0.5)
             runner._set_scroll_state(
                 context="results_click",
                 url=runner._current_results_page_url() or runner._results_base_url,
-                page_downs=runner._viewport_stage,
+                page_downs=HEADER_PRESCROLL_PAGE_DOWNS + runner._viewport_stage,
                 wheel_downs=0,
                 viewport_stage=runner._viewport_stage,
             )
@@ -700,7 +719,8 @@ class ClaudeGuidedClickHandler:
                 env.step(Action(action_type=ActionType.KEY_PRESS, params={"keys": "Escape"}))
                 env.step(Action(action_type=ActionType.KEY_PRESS, params={"keys": "Home"}))
                 time.sleep(0.3)
-                for _ in range(runner._viewport_stage):
+                # Match the scan-time header prescroll (Issue #600).
+                for _ in range(HEADER_PRESCROLL_PAGE_DOWNS + runner._viewport_stage):
                     env.step(Action(action_type=ActionType.KEY_PRESS, params={"keys": "Page_Down"}))
                     time.sleep(0.3)
                 logger.info(

--- a/tests/test_click_handler_header_prescroll.py
+++ b/tests/test_click_handler_header_prescroll.py
@@ -1,0 +1,142 @@
+"""Tests for issue #600 — pre-scroll past the page header before scan.
+
+Without the prescroll, viewport stage 0 lands at Home + 0 Page_Downs.
+On a typical results page that puts a sticky header + search bar +
+promo band in the visible area and the first row of cards peeks in
+only as photo crops at the bottom edge — no titles, prices, or any
+text. ``find_all_listings`` correctly returns ``title="unknown"`` for
+all cards, the runner falls back to coord placeholders, and PR #597's
+already-clicked prefilter has nothing semantic to dedupe against.
+The brain then re-clicks the same screen coordinates next iteration,
+hitting the listing-dedup gate and halting with ``duplicate_listing``.
+
+These tests pin: the ``HEADER_PRESCROLL_PAGE_DOWNS`` constant is set
+to 1, both the scan-time scroll and the click-time scroll honor it
+(so the brain clicks at the same Y the scan reported), and the
+``_set_scroll_state`` page_downs argument reflects the prescroll-aware
+position (so checkpoint resume restores the correct scroll).
+
+The same prescroll is applied in the probe-area fallback scroll
+(line ~703 in click.py) so any retry path scrolling is consistent.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from mantis_agent.actions import ActionType
+from mantis_agent.gym.step_handlers import click as click_module
+from mantis_agent.gym.step_handlers.click import (
+    HEADER_PRESCROLL_PAGE_DOWNS,
+    ClaudeGuidedClickHandler,
+)
+from mantis_agent.plan_decomposer import MicroIntent
+
+from test_click_handler import _ctx, _FakeRunner  # type: ignore[import-not-found]
+
+
+def _step() -> MicroIntent:
+    return MicroIntent(intent="Click next listing", type="click", section="extraction")
+
+
+def _page_down_count(env: MagicMock) -> int:
+    """Count Page_Down keypresses sent to the env."""
+    return sum(
+        1
+        for c in env.step.call_args_list
+        if getattr(c.args[0], "action_type", None) == ActionType.KEY_PRESS
+        and c.args[0].params.get("keys") == "Page_Down"
+    )
+
+
+def test_constant_is_one() -> None:
+    """The prescroll defaults to 1 Page_Down — enough to push the
+    sticky header off the top so the first card row is fully visible
+    on a 720-pixel viewport (header band ≈ 500–600 px on typical
+    results pages)."""
+    assert HEADER_PRESCROLL_PAGE_DOWNS == 1
+
+
+def test_stage_0_scan_fires_one_page_down(monkeypatch) -> None:
+    """At viewport stage 0, scan-time scroll should send exactly
+    HEADER_PRESCROLL_PAGE_DOWNS Page_Down keypresses (not zero).
+    Without this fix, stage 0 sent 0 Page_Downs and the scan saw the
+    page header instead of the cards."""
+    monkeypatch.setattr("mantis_agent.gym.step_handlers.click.time.sleep", lambda *_: None)
+
+    runner = _FakeRunner()
+    runner._max_viewport_stages = 1  # stop after one scan
+    extractor = MagicMock()
+    extractor.find_all_listings.return_value = []  # empty → page_exhausted, no click path
+    env = MagicMock()
+    ctx = _ctx(runner, env=env, extractor=extractor)
+
+    ClaudeGuidedClickHandler(runner).execute(_step(), ctx)
+
+    # Stage 0 + prescroll of 1 = 1 Page_Down keypress on the scan path.
+    assert _page_down_count(env) == HEADER_PRESCROLL_PAGE_DOWNS
+
+
+def test_stage_2_scan_fires_prescroll_plus_two_page_downs(monkeypatch) -> None:
+    """Stage N's scan-time scroll sends HEADER_PRESCROLL + N Page_Downs.
+    Verifies the prescroll stacks on top of the viewport-stage advance,
+    not in place of it."""
+    monkeypatch.setattr("mantis_agent.gym.step_handlers.click.time.sleep", lambda *_: None)
+
+    runner = _FakeRunner()
+    runner._max_viewport_stages = 3
+    runner._viewport_stage = 2  # already advanced past stages 0 and 1
+    extractor = MagicMock()
+    extractor.find_all_listings.return_value = []
+    env = MagicMock()
+    ctx = _ctx(runner, env=env, extractor=extractor)
+
+    ClaudeGuidedClickHandler(runner).execute(_step(), ctx)
+
+    # Stage 2 fires once (the only remaining stage), so 1 scan call =
+    # HEADER_PRESCROLL + 2 Page_Downs.
+    assert _page_down_count(env) == HEADER_PRESCROLL_PAGE_DOWNS + 2
+
+
+def test_scroll_state_records_prescroll_position(monkeypatch) -> None:
+    """``_set_scroll_state`` should record page_downs = PRESCROLL + stage
+    so checkpoint persistence / verifier diagnostics see the actual
+    scroll position, not the logical viewport stage."""
+    monkeypatch.setattr("mantis_agent.gym.step_handlers.click.time.sleep", lambda *_: None)
+
+    runner = _FakeRunner()
+    runner._max_viewport_stages = 1
+    runner._viewport_stage = 0
+    extractor = MagicMock()
+    extractor.find_all_listings.return_value = []
+    env = MagicMock()
+    ctx = _ctx(runner, env=env, extractor=extractor)
+
+    ClaudeGuidedClickHandler(runner).execute(_step(), ctx)
+
+    # Exactly one _set_scroll_state call from the scan path.
+    scan_calls = [c for c in runner.scroll_state_calls if c.get("context") == "results_scan"]
+    assert len(scan_calls) == 1
+    assert scan_calls[0]["page_downs"] == HEADER_PRESCROLL_PAGE_DOWNS
+    # The logical viewport stage stays 0 — the prescroll is an
+    # absolute offset, not a re-staging.
+    assert scan_calls[0]["viewport_stage"] == 0
+
+
+def test_multiple_stages_scroll_loop_count_matches(monkeypatch) -> None:
+    """Across stages 0 and 1 (empty scans), the total Page_Down count
+    is (PRESCROLL + 0) + (PRESCROLL + 1) — each stage starts from
+    Home and counts from scratch, not cumulative."""
+    monkeypatch.setattr("mantis_agent.gym.step_handlers.click.time.sleep", lambda *_: None)
+
+    runner = _FakeRunner()
+    runner._max_viewport_stages = 2
+    extractor = MagicMock()
+    extractor.find_all_listings.return_value = []  # both stages empty
+    env = MagicMock()
+    ctx = _ctx(runner, env=env, extractor=extractor)
+
+    ClaudeGuidedClickHandler(runner).execute(_step(), ctx)
+
+    expected = (HEADER_PRESCROLL_PAGE_DOWNS + 0) + (HEADER_PRESCROLL_PAGE_DOWNS + 1)
+    assert _page_down_count(env) == expected

--- a/tests/test_click_handler_header_prescroll.py
+++ b/tests/test_click_handler_header_prescroll.py
@@ -25,7 +25,6 @@ from __future__ import annotations
 from unittest.mock import MagicMock
 
 from mantis_agent.actions import ActionType
-from mantis_agent.gym.step_handlers import click as click_module
 from mantis_agent.gym.step_handlers.click import (
     HEADER_PRESCROLL_PAGE_DOWNS,
     ClaudeGuidedClickHandler,


### PR DESCRIPTION
## Summary

- Adds `HEADER_PRESCROLL_PAGE_DOWNS = 1` to `click.py`, applied to the scan-time, click-time, and probe-fallback Home + N Page_Down scroll-restore loops.
- Diagnosed via debug artifact pull: the scan was seeing the page header + photo crops, not the cards (titles below the fold). The page was fully loaded — this is purely a scroll-position issue.
- 5 new tests pin the prescroll constant + per-stage Page_Down count; 22 existing click-handler tests still pass.

## Why this fix moves leads-count

Run `20260522_225202_fb5fef29` halted on `duplicate_listing` with 0 leads. Debug artifacts (`claude_find_all_1779490379.*` on the osworld-data volume) showed:

- Screenshot: page top, sticky header consuming visible space, 3 boat cards visible only as photo crops at y=625 (no titles, no prices).
- Claude response: `title="unknown"` × 3 with reason "partially visible". Claude was correct — the title text was below the fold.
- Knock-on: `_extracted_titles` filled with coord placeholders (`unknown@v0:500,625`), so PR #597's prefilter had nothing semantic to dedupe, and the brain re-clicked the same coords every iteration → URL-dedup gate halted.

The prescroll pushes the header off the top of the viewport so titles + prices + dealer tags are visible to the scan call, restoring the semantic signal that #597's prefilter and downstream dedup both depend on.

## Test plan

- [x] `pytest tests/test_click_handler_header_prescroll.py` — 5 new pin tests pass
- [x] `pytest tests/test_click_handler.py tests/test_find_all_listings_already_clicked.py` — 22 existing tests still pass
- [x] `pytest tests/test_listings_scanner.py tests/test_click_*.py` — 53 adjacent tests still pass
- [ ] Modal redeploy + boattrader rerun: capture a fresh `claude_find_all_*.png` to confirm the scan viewport now shows cards-with-titles, and observe non-zero lead count.

Closes #600

🤖 Generated with [Claude Code](https://claude.com/claude-code)