### PR TITLE
sim-envs/mantis-boattrader: pixel-match fidelity pass (v=46→v=81)

### DIFF
--- a/deploy/sim_envs/mantis_boattrader/FIDELITY.md
+++ b/deploy/sim_envs/mantis_boattrader/FIDELITY.md
@@ -1,0 +1,317 @@
+# `mantis_boattrader` — Fidelity match log
+
+Working doc tracking each element's match status against
+`https://www.boattrader.com/`. Update as iterations land.
+
+Last updated: **v=81** (2026-05-22)
+
+Live URL: `https://8080-014f48ab-eeb1-4ca5-947e-42e169d1fcc8.daytonaproxy01.net/boats/`
+(token rotates per sandbox restart; current: `yw28zp1uej5nibwnhgx_trmu8w8k8qin`)
+
+## Methodology
+
+Each row records the element/region, the real BT measurement
+(via Chrome MCP `getComputedStyle` / `getBoundingClientRect`), and
+the current state. Status legend:
+
+- ✅ exact (within 1-2px rendering tolerance)
+- 🟡 close (matches structurally; minor pixel diff)
+- ⏳ partial (some pieces match, more work needed)
+- ❌ missing / broken
+- 🚫 intentionally not matched (e.g. real photos vs SVG placeholders)
+
+## Global
+
+| Element | Real BT | Mine | Status |
+|---|---|---|---|
+| Font family | Roboto, -apple-system, ... (system fallback; no actual Roboto loaded) | same — no Google Fonts link, system fallback | ✅ |
+| Nav weight | 500 medium via system font | 500 medium via system font | ✅ |
+| Page container width (SRP/home) | 1440px max, 36px side margin | same | ✅ |
+| Page container width (BDP) | ~1335px content | 1400px content (mine 65px wider) | 🟡 |
+
+## Header
+
+| Element | Real BT | Mine | Status |
+|---|---|---|---|
+| Logo SVG | 150×19 at x=30, y=20 | 150×19 at x=30 | ✅ |
+| Header bg | white | white | ✅ |
+| First nav item x (Find) | 338 | 338 | ✅ |
+| Nav item padding | 23px 20px 26px 25px | 23px 20px 26px 25px | ✅ |
+| Nav item color | rgb(7,50,79) navy | rgb(7,50,79) navy | ✅ |
+| Nav item font-size | 15px | 15px | ✅ |
+| Nav item weight | 500 | 500 | ✅ |
+| Sign up / Log in (right) | rendered at x≈1437/1497 | same position | ✅ |
+
+## Blue prequal ribbon
+
+| Element | Real BT | Mine | Status |
+|---|---|---|---|
+| Height | 40px | 40px | ✅ |
+| Bg | rgb(37,102,176) | same | ✅ |
+| Inner padding | 10px 16px | 10px 16px | ✅ |
+| "Get started" CTA | plain inline bold text | plain inline bold text | ✅ |
+| Hidden on BDP | yes (no ribbon on BDP) | hidden via `{% block ribbon %}{% endblock %}` | ✅ |
+
+## SRP page
+
+### Page header / breadcrumb / H1
+
+| Element | Real BT | Mine | Status |
+|---|---|---|---|
+| Breadcrumb font-size | 12px / 400 | 12px / 400 | ✅ |
+| Breadcrumb color | #757575 | #757575 | ✅ |
+| Breadcrumb padding | 7px 15px | 7px 0 (vertical) | ✅ |
+| H1 "Boats for sale" font-size | 32px | 32px | ✅ |
+| H1 weight | 700 | 700 | ✅ |
+| H1 color | rgb(64,64,64) #404040 | #404040 | ✅ |
+| H1 line-height | 32px | 32px | ✅ |
+| Bc → H1 visual gap | ~19px (via padding) | ~19px | ✅ |
+| Ribbon → bc gap | small (system padding) | small | ✅ |
+
+### Search bar ("Try" + quote)
+
+| Element | Real BT | Mine | Status |
+|---|---|---|---|
+| Outer card bg | linear-gradient(135deg, #2566b0, #2b82d9 45%, #3391fc) | same | ✅ |
+| Outer card border-radius | 12px | 12px | ✅ |
+| Outer card padding | 12.25px 16px | 12px 16px | ✅ |
+| Inner white field br | 10px | 10px | ✅ |
+| "Try" weight | 700 | 700 | ✅ |
+| "Try" font-size | 16px | 16px | ✅ |
+| "Try" color | rgb(100,116,139) #64748b | same | ✅ |
+| Quote placeholder | 16/400 #64748b | 16/400 #64748b | ✅ |
+| Sparkle icon | small SVG ai.svg (4-point star) | inline SVG 4-point star | ✅ |
+| Submit icon | magnifier SVG | inline SVG circle+handle | ✅ |
+
+### Pre-qualify banner
+
+| Element | Real BT | Mine | Status |
+|---|---|---|---|
+| Bg | light blue gradient | light blue gradient | ✅ |
+| Bank icon shape | rounded square 8px radius | rounded square 8px radius | ✅ |
+| Bank icon bg | blue gradient (135deg) | linear-gradient(135deg, #3b78c0, #2566b0 55%, #1d569a) | ✅ |
+| Bank icon size | 40×40 | 40×40 | ✅ |
+| Title font | 14/700 | 14/700 | ✅ |
+| Title color | rgb(16,24,40) #101828 | #101828 | ✅ |
+| Subtext | 11/400 #4a5565 | 11/400 #4a5565 | ✅ |
+| "Get Started" button | 13/700 white, 100px br, 0 24px pad, h=36 | same | ✅ |
+
+### Filter sidebar
+
+| Element | Real BT | Mine | Status |
+|---|---|---|---|
+| Outer card bg/border/radius | white, 1px gray, 5px br | white, 1px #e0e0e0, 6px br | ✅ |
+| Card padding | 15px sides | 15px 15px 18px | ✅ |
+| Save Search button | 270×40, blue pill, 16/700, 50px br | 268×38, same | ✅ |
+| Save Search → Location gap | ~50-60px | 51px | ✅ |
+| Section divider | 1px solid #ededed | 1px solid #ededed | ✅ |
+| Section label | 15/400 #333 | 15/400 #333 | ✅ |
+| Chevron | down arrow ~10px | down arrow ~10px via border trick | ✅ |
+| Zip/City/Other segmented | 282×59 gray track, 50px br, 4px pad | 268×60 same shape | ✅ |
+| 25 miles select | 106×40, 1px #ededed, 8px br | 106×40, same | ✅ |
+| All/New/Used segmented | same shape as zip toggle | same | ✅ |
+| Length / Year / Price sliders | 22×22 blue thumb w/ 2px white border, 4px rail #e9e9e9, blue fill | same exact spec | ✅ |
+| **Slider handle URL sync** | rc-slider auto-positions handles from URL | JS in base.html reads input min/max/value, sets handle positions | ✅ |
+| Beam filter | range slider + min/max ft | added | ✅ |
+| Max Draft filter | range slider + min/max ft | added | ✅ |
+| Fuel Type filter | dropdown | added (Gas/Diesel/Electric/Other) | ✅ |
+| Hull filter | dropdown | added (Fiberglass/Aluminum/Composite/Steel/Wood/Other) | ✅ |
+| Engines filter | Number (segmented) + Engine Type (radio list) | added | ✅ |
+| For Sale By filter | Any/Dealer/Private Seller radios | added | ✅ |
+
+### Boat Loan Calculator widget (below filter card)
+
+| Element | Real BT | Mine | Status |
+|---|---|---|---|
+| Title | "Boat Loan Calculator" 18/700 | same | ✅ |
+| Loan Amount field | input with $ | added | ✅ |
+| Loan Term dropdown | 240/180/120/60 months | added | ✅ |
+| Interest Rate (APR) | 6.49% default | added | ✅ |
+| Calculate button | blue outline | added | ✅ |
+| Monthly Payment result | "$0.00" centered | added | ✅ |
+| "Get Pre-Qualified" CTA | blue filled pill | added | ✅ |
+| Fineprint help text | small gray | added | ✅ |
+
+### Listing cards (SRP)
+
+| Element | Real BT | Mine | Status |
+|---|---|---|---|
+| Card dimensions | 351×389 | 351×388 | ✅ |
+| Card border | 1px #e0e0e0 | 1px #e0e0e0 | ✅ |
+| Card filter (drop-shadow) | drop-shadow(rgba(0,0,0,0.2) 0px 2px 1px) | same | ✅ |
+| Card border-radius | 4px | 4px | ✅ |
+| Grid gap | 10px | 10px | ✅ |
+| Image aspect | 3:2 (349×232) | 3:2 (347×231) | ✅ |
+| Title | 18/700 #404040, ellipsis | 18/700 #404040 | ✅ |
+| Price | 16/400 #404040 | 16/400 #404040 | ✅ |
+| Monthly | 14/700 rgb(19,154,245) blue | same | ✅ |
+| Monthly ⓘ info icon | small circled "i" | small circled "i" italic | ✅ |
+| Click ⓘ → sticky tooltip | bottom-card blue banner, white text, × close | implemented via JS toggle | ✅ |
+| Meta (city, dealer) | 12/400 #9e9e9e | 12/400 #9e9e9e | ✅ |
+| Footer dealer logo | dark badge + dealer name | dark badge + dealer initial+name | ✅ |
+| Footer divider above | 1px #e0e0e0 | 1px #e0e0e0 | ✅ |
+| "Contact Seller" pill | blue outline, 14/700 | blue outline, 14/700 | ✅ |
+| Owner cards | no dealer logo, "Contact Owner" | template uses `{% if not b.is_owner_listed %}` | ✅ |
+| Featured badge | white pill 4px pad 16px br | same | ✅ |
+| Heart icon (top-right of img) | SVG outline heart 16px in 28px circle | SVG outline heart, white-translucent circle | ✅ |
+| Sponsored card border | same as others (no special) | 1px #e0e0e0 | ✅ |
+
+### Sort row
+
+| Element | Real BT | Mine | Status |
+|---|---|---|---|
+| Layout | plain inline "Sort:[strong] Recommended ▾" | same | ✅ |
+| Border | none | none | ✅ |
+| Font | 14/500 #404040 | 14/500 #404040 | ✅ |
+| Chevron | inline SVG | inline SVG (bg-image data URL) | ✅ |
+
+### Pagination
+
+| Element | Real BT | Mine | Status |
+|---|---|---|---|
+| Style | plain text links | plain text links | ✅ |
+| Font | 14/400 #0a0a0a | 14/400 #0a0a0a | ✅ |
+| Active page | bold dark + underline | bold dark + 2px blue underline | ✅ |
+| Prev/Next | plain blue | plain blue | ✅ |
+| "of N" | dim gray | #757575 dim | ✅ |
+
+## BDP page
+
+### Top strip
+
+| Element | Real BT | Mine | Status |
+|---|---|---|---|
+| Sponsor ad strip | 728×90 leaderboard on #f7f7f7 strip, 122px tall | same exactly | ✅ |
+| Blue ribbon on BDP | not present | hidden via `{% block ribbon %}` override | ✅ |
+| Back to Search link | 12/400 #139af5 light blue | same | ✅ |
+| Sticky breadcrumb | 15/400 #333 | 15/400 #333 | ✅ |
+| Next Boat link | 12/400 #139af5 light blue | same | ✅ |
+
+### Gallery
+
+| Element | Real BT | Mine | Status |
+|---|---|---|---|
+| Main image aspect | 3:2 (890×593) | 3:2 (auto-scales by width) | ✅ |
+| Main image border-radius | 8px | 8px | ✅ |
+| Prev/Next/Share/Like buttons | 40×40 circle, rgba(0,0,0,0.3) bg | same | ✅ |
+| Thumbnail strip | 5 thumbs, 175×116, 8px br | 5 thumbs, ~181×123, 8px br | 🟡 |
+
+### Right rail (Featured card)
+
+| Element | Real BT | Mine | Status |
+|---|---|---|---|
+| Width | 366px | 366px | ✅ |
+| Bg / border / radius | white, 1px #ededed, 8px br | same | ✅ |
+| Padding | 16px | 16px | ✅ |
+| Drop-shadow | rgba(0,0,0,0.2) 0 2px 2px 0 | same | ✅ |
+| Featured badge | small white pill | same | ✅ |
+| H1 boat title | 20/700 rgb(51,51,51) | same | ✅ |
+| Address | 14/400 #757575 | similar | ✅ |
+| Price | 20/700 #333 | same | ✅ |
+| "Own this boat for $X/mo" | 16/400 BT blue link | 16/400 blue | ✅ |
+| Views/Saves/Listed strip | 12/400 with SVG icons | 12/400 with SVG eye/heart/calendar | ✅ |
+| Contact name (H3) | 18/500 dark | 18/500 dark | ✅ |
+| Lead form inputs | 40px h, 4px br, 1px #c2c2c2 | same | ✅ |
+| Lead form padding | 8px 12px 4px (floating-label friendly) | same | ✅ |
+| Contact Seller submit | blue pill | blue pill | ✅ |
+| Call (outline) button | 2px blue outline, 14/700, pill | same | ✅ |
+| "Show Phone Number" (owner) | hidden until click → SVG number reveal | implemented | ✅ |
+
+### Below-gallery content
+
+| Element | Real BT | Mine | Status |
+|---|---|---|---|
+| Stats strip (Length / Year / etc.) | label 14/700 #303030, value 14/400 #333 | same | ✅ |
+| "What Owners Say" + Owner Highlights | section heading + pill tags | implemented | ✅ |
+| Owner-highlight pills | bg #e3f1fe, color #2566b0, 12/700, 4px 8px pad, 5px br | same | ✅ |
+| Boat Details H2 section | 20/700 #333, bg #f5f9ff, 8px br, 20px 16px pad | same | ✅ |
+| Description accordion (H3) | open by default | open by default | ✅ |
+| Measurements accordion (H3) → Dimensions/Weights/Tanks (H4) | collapsed, h4 subgroups | added | ✅ |
+| Propulsion accordion (H3) | collapsed | implemented | ✅ |
+| More Details accordion (H3) | real BT uses H4 | implemented as H3 | 🟡 |
+| Location accordion (H3) | real BT uses H4 | implemented as H3 | 🟡 |
+| Dealership card | dealership-card with logo, address, stats | implemented | ✅ |
+| "Get pre-qualified in minutes" rail card | 18/700 heading + checkmarks + outline btn | implemented (heading bumped to 18px in v=56) | ✅ |
+| More From This Dealer carousel | horizontal scroll of small cards | implemented | ✅ |
+| Still have a question? card | 24/700 question h2, body 18px | implemented | ✅ |
+| Other Services tiles | 14/700 label, tile names 14/400 #4d4d4d | implemented | ✅ |
+
+## Home page
+
+| Element | Real BT | Mine | Status |
+|---|---|---|---|
+| Hero search panel (dark navy) | left column with "Find your perfect boat" header | implemented | ✅ |
+| Hero ad (right) | full-bleed sponsor banner | gradient placeholder ad | ✅ |
+| "Sell Your Boat Fast!" callout | sailboat icon + label + Sell pill | implemented | ✅ |
+
+## Behaviors
+
+| Behavior | Real BT | Mine | Status |
+|---|---|---|---|
+| Filter URL → state sync | sidebar reflects URL params | condition pill, length inputs sync; slider handles position via JS | ✅ |
+| Click ⓘ on monthly | opens sticky banner | implemented | ✅ |
+| Click outside tooltip | closes | implemented | ✅ |
+| Detail page sticky bar | appears on scroll | `bdp-scrolled` body class via scroll listener | ✅ |
+
+## Open work / known minor diffs
+
+- 🟡 **BDP content area width**: mine is 1400px, real BT is ~1335px (65px wider).
+  Decided not to narrow per page since the SRP container width is intentionally 1440.
+- 🟡 **Real photos vs SVG placeholder boats**: user accepted placeholder content.
+- 🟡 **More Details / Location H-level in Boat Details accordion**: mine uses H3,
+  real BT uses H4. Trivial fix when needed.
+- 🟡 **Thumbnail size**: 181×123 vs real 175×116 — auto-scales with column,
+  visually equivalent.
+
+## Data variety (fixtures)
+
+| Trait | Distribution |
+|---|---|
+| Listing type | 67% dealer / 25% owner / 8% sponsored |
+| POA boats | ~8% of dealers — `display_price="Request a Price"`, no monthly, no ⓘ |
+| Price drop badge | ~18% of dealer listings (rare for owners) |
+| Owner listings | "Contact Owner" CTA, no dealer logo, phone hidden behind click |
+| Engine hours | 0 (new) or 20-950 (used) |
+| Engine count | 1 / 2 / 3 by length |
+| Badges | Featured / In-Stock / Price Drop / New Arrival / Sponsored — variable subset |
+| Description blurbs | 5+ templates rotated by listing_type |
+| Days listed | 0-120 → "New to Market" / "Listed N days/months ago" |
+
+## Iteration log (versions)
+
+`v=46` BDP ribbon removed, SRP card heights, meta color
+`v=47` BDP grid 1fr+80+366
+`v=48` ribbon 40px
+`v=49` filter card border + padding
+`v=50` dealer logos in cards
+`v=51` badge color uniform, sponsored card border
+`v=52` SRP H1 color and line-height
+`v=53` owner-tag pills
+`v=54` BDP rail padding + shadow
+`v=55` lead form inputs 4px radius, outline button 2px
+`v=56` prequal heading 18/700, Boat Details bg
+`v=57` BDP back/next colors
+`v=58` sticky-breadcrumb 15/400/#333
+`v=59` ad-strip 728×90
+`v=60` brand margin → Find at x=338
+`v=61` logo 150×19 compact + system fallback
+`v=62` SRP breadcrumb 12/400/#757575
+`v=63` info icon + sticky tooltip
+`v=64` tooltip click-toggle JS
+`v=65` card grid gap 10px
+`v=66` breadcrumb padding 7px
+`v=67` removed breadcrumb top margin
+`v=68` Sort plain inline + SVG icons (sparkle/magnifier/heart)
+`v=69` SVG icons (eye/calendar/phone)
+`v=70` slider thumbs 22×22
+`v=71` sort weight 500, rounded square bank icon gradient
+`v=72` gallery buttons 40×40
+`v=73` slider handle JS URL sync
+`v=74` price input max attribute
+`v=75` pagination plain-text
+`v=76` Save Search bottom margin attempt
+`v=77` fixed margin specificity override
+`v=78` removed Google Fonts (use system font for nav weight)
+`v=79` BDP gallery 3:2 aspect
+`v=80` added Beam/Max Draft/Fuel Type/Hull/Engines/For Sale By + Boat Loan Calculator widget
+`v=81` accordion section h3 + measurements subsection h4

--- a/deploy/sim_envs/mantis_boattrader/app/static/app.css
+++ b/deploy/sim_envs/mantis_boattrader/app/static/app.css
@@ -666,7 +666,10 @@ header.main {
   width: 100%;
   max-width: 100%;
   align-self: stretch;
-  margin: 0 0 18px;
+  /* Real BT leaves ~50px between Save Search button and Location label.
+     Combined with .filter-group summary's 18px top padding, this 32px
+     bottom margin yields ~50px gap. */
+  margin: 0 0 32px;
 }
 /* The Save Search button row gets its own bottom divider so it sits
    above the first filter group cleanly. Real BT uses a thin 1px divider. */
@@ -817,8 +820,11 @@ header.main {
   cursor: pointer;
   box-sizing: border-box;
 }
-.range-handle-min { left: 6%; }
-.range-handle-max { left: calc(94% - 22px); }
+/* Default handle positions (before JS sync). JS in base.html overrides
+   these via inline `style.left` based on the active min/max input values. */
+.range-handle-min { left: calc(0% - 11px); }
+.range-handle-max { left: calc(100% - 11px); }
+.range-fill { left: 0%; right: 0%; }
 
 .range-row { display: flex; align-items: center; gap: 8px; margin-top: 8px; }
 .range-row .filter-input { flex: 1; min-width: 0; height: 40px; padding: 8px 12px; font-size: 14px; }
@@ -827,7 +833,91 @@ header.main {
 .checkbox-row { display: flex; align-items: center; gap: 8px; margin-top: 12px; font-size: 14px; }
 .apply-filters { margin-top: 14px; }
 .filter-clear { display: block; text-align: center; font-size: 14px; margin-top: 10px; }
-.filters-form > .btn-primary { margin: 10px 0 14px; }
+.filters-form > .btn-primary { margin: 10px 0 32px; }
+
+/* Sub-label inside Engines / etc — small bold heading above sub-controls. */
+.filter-sublabel {
+  display: block;
+  font-size: 14px; font-weight: 700; color: #303030;
+  margin: 0 0 8px;
+}
+.radio-list { display: flex; flex-direction: column; gap: 6px; }
+.radio-row {
+  display: flex; align-items: center; gap: 8px;
+  font-size: 14px; color: #333; cursor: pointer;
+}
+.radio-row input[type="radio"] {
+  appearance: none; -webkit-appearance: none;
+  width: 18px; height: 18px; min-width: 18px;
+  border: 1px solid #c2c2c2; border-radius: 50%;
+  background: #fff; position: relative;
+  cursor: pointer;
+}
+.radio-row input[type="radio"]:checked {
+  border-color: var(--bt-blue);
+}
+.radio-row input[type="radio"]:checked::after {
+  content: ''; position: absolute; top: 50%; left: 50%;
+  width: 10px; height: 10px;
+  background: var(--bt-blue); border-radius: 50%;
+  transform: translate(-50%, -50%);
+}
+
+/* Boat Loan Calculator widget below filter card. */
+.loan-calc-card {
+  background: #fff;
+  border: 1px solid #e0e0e0;
+  border-radius: 6px;
+  padding: 18px 16px;
+  margin-top: 18px;
+  display: flex; flex-direction: column; gap: 12px;
+}
+.loan-calc-title {
+  font-size: 18px; font-weight: 700; color: #303030;
+  margin: 0;
+}
+.loan-calc-field { display: flex; flex-direction: column; gap: 4px; }
+.loan-calc-label { font-size: 13px; color: #4a5565; }
+.loan-calc-input {
+  width: 100%;
+  height: 40px;
+  border: 1px solid #c2c2c2; border-radius: 4px;
+  padding: 8px 12px; font-size: 14px; color: #1f2937;
+  background: #fff; box-sizing: border-box;
+}
+.loan-calc-input-row {
+  display: flex; align-items: center; gap: 6px;
+}
+.loan-calc-input-row .loan-calc-input { flex: 1; }
+.loan-calc-unit { color: #4a5565; font-size: 14px; }
+.loan-calc-button {
+  align-self: stretch;
+  margin: 6px 0 4px;
+}
+.loan-calc-result {
+  text-align: center; padding: 10px 0;
+  border-top: 1px solid #ededed;
+}
+.loan-calc-result-label {
+  font-size: 18px; font-weight: 700; color: #303030;
+}
+.loan-calc-result-value {
+  font-size: 22px; font-weight: 700; color: #303030;
+  margin-top: 2px;
+}
+.loan-calc-prompt {
+  text-align: center; font-size: 14px; color: #303030;
+  margin: 0;
+}
+.loan-calc-cta {
+  align-self: stretch;
+  display: inline-flex; align-items: center; justify-content: center; gap: 6px;
+}
+.loan-calc-fineprint {
+  font-size: 11px; color: #757575; line-height: 1.4;
+  margin: 0; text-align: center;
+}
+.loan-calc-fineprint a { color: var(--bt-blue); text-decoration: underline; }
 
 .srp-results { min-width: 0; }
 /* AI search bar — blue gradient outer card (12px radius) wraps a
@@ -947,18 +1037,27 @@ header.main {
   text-align: center;
 }
 .srp-empty strong { display: block; font-size: 18px; margin-bottom: 6px; color: var(--bt-navy); }
+/* Real BT pagination: plain text links, no border boxes. 14/400 dark
+   #0a0a0a; active page is bold-darker; "of N" total dimmer. */
 .pagination {
   display: flex; align-items: center; justify-content: center;
-  gap: 6px; margin: 26px 0;
-  font-size: 14px;
+  gap: 4px; margin: 26px 0;
+  font-size: 14px; font-weight: 400;
 }
 .pagination a {
-  padding: 6px 12px; border: 1px solid var(--bt-border);
-  border-radius: var(--bt-radius); color: var(--bt-blue);
+  padding: 8px 14px; border: 0;
+  border-radius: 0; color: #0a0a0a;
   text-decoration: none;
+  background: transparent;
 }
-.pagination a.active { background: var(--bt-blue); color: #fff; border-color: var(--bt-blue); }
-.page-total { color: var(--bt-text-dim); }
+.pagination a:hover { color: var(--bt-blue); }
+.pagination a.active {
+  color: #0a0a0a; font-weight: 700;
+  background: transparent;
+  border-bottom: 2px solid var(--bt-blue);
+}
+.page-prev, .page-next { color: var(--bt-blue) !important; font-weight: 400; }
+.page-total { color: #757575; margin: 0 4px; }
 
 /* ── Boat Detail Page (BDP) ───────────────────────────────────── */
 
@@ -1085,16 +1184,21 @@ body.bdp-scrolled .bdp-sticky-bar { display: block; }
   width: 366px;
   margin: 0;
 }
+/* Real BT BDP main gallery image: 3:2 aspect ratio (890×593 at width 890,
+   or whatever the column width gives us — the image always scales to 3:2). */
 .bdp-main-image {
   position: relative;
   background: #000; border-radius: var(--bt-radius-lg); overflow: hidden;
+  aspect-ratio: 3 / 2;
 }
-.bdp-main-image img { width: 100%; max-height: 520px; object-fit: cover; }
+.bdp-main-image img { width: 100%; height: 100%; object-fit: cover; display: block; }
+/* Real BT BDP gallery buttons: 40×40 circle, rgba(0,0,0,0.3) bg. */
 .gallery-prev, .gallery-next, .gallery-share, .gallery-like {
   position: absolute; top: 50%; transform: translateY(-50%);
-  background: rgba(0,0,0,0.35); color: #fff; border: 0;
-  width: 36px; height: 36px; border-radius: 50%;
+  background: rgba(0,0,0,0.3); color: #fff; border: 0;
+  width: 40px; height: 40px; border-radius: 50%;
   font-size: 18px; cursor: pointer;
+  display: flex; align-items: center; justify-content: center;
 }
 .gallery-prev { left: 12px; }
 .gallery-next { right: 12px; }
@@ -1113,8 +1217,9 @@ body.bdp-scrolled .bdp-sticky-bar { display: block; }
   border: 3px solid transparent;
   transition: border-color 120ms ease;
 }
+/* Real BT BDP thumbs: 175×116 ≈ 3:2 aspect, same as the main image. */
 .bdp-thumb img {
-  width: 100%; aspect-ratio: 16 / 11; object-fit: cover;
+  width: 100%; aspect-ratio: 3 / 2; object-fit: cover;
   display: block;
 }
 .bdp-thumb.is-active {
@@ -1457,6 +1562,15 @@ body.bdp-scrolled .bdp-sticky-bar { display: block; }
   margin: 0 0 16px;
 }
 .bdp-accordion summary { font-size: 16px; font-weight: 700; }
+.bdp-accordion .accordion-title {
+  font-size: 16px; font-weight: 700; color: #303030;
+  margin: 0; padding: 0; flex: 1;
+}
+.bdp-accordion .accordion-subhead {
+  font-size: 14px; font-weight: 700; color: #303030;
+  margin: 14px 0 6px;
+}
+.bdp-accordion .accordion-subhead:first-child { margin-top: 0; }
 .accordion-body { font-size: 15px; line-height: 1.45; }
 .bdp-accordion {
   background: #fff;

--- a/deploy/sim_envs/mantis_boattrader/app/templates/base.html
+++ b/deploy/sim_envs/mantis_boattrader/app/templates/base.html
@@ -4,10 +4,12 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>{% block title %}Boat Trader - #1 marketplace to buy & sell boats in the US{% endblock %}</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap" />
-  <link rel="stylesheet" href="/static/app.css?v=71" />
+  {# Real BT declares 'Roboto, -apple-system, system-ui, ...' as font-family
+     but does NOT actually load Roboto — it falls back to the system font
+     (San Francisco on macOS, Segoe UI on Windows). Loading Roboto Medium
+     from Google Fonts makes our text render heavier than real BT, so we
+     match by NOT loading Roboto and letting the system fallback render. #}
+  <link rel="stylesheet" href="/static/app.css?v=81" />
   <meta name="description" content="{% block description %}Buy and sell new & used boats. Find boats, yachts, sailboats, fishing boats, pontoons, and more.{% endblock %}" />
 </head>
 <body class="bt-body">
@@ -129,6 +131,54 @@
         if (!t.contains(ev.target)) t.setAttribute('hidden', '');
       });
     }, true);
+  })();
+  // Sync range-slider handle positions + fill bar from the min/max
+  // number inputs in the same filter group. Runs on load and whenever
+  // an input changes so the visual handles always reflect the URL state.
+  (function(){
+    function syncOne(wrap) {
+      var group = wrap.closest('.filter-group-body');
+      if (!group) return;
+      var inputs = group.querySelectorAll('input[type="number"]');
+      if (inputs.length < 2) return;
+      var minIn = inputs[0], maxIn = inputs[1];
+      var lo = parseFloat(minIn.min);
+      var hi = parseFloat(minIn.max);
+      if (isNaN(lo) || isNaN(hi) || hi <= lo) return;
+      var curMin = parseFloat(minIn.value);
+      var curMax = parseFloat(maxIn.value);
+      if (isNaN(curMin)) curMin = lo;
+      if (isNaN(curMax)) curMax = hi;
+      curMin = Math.max(lo, Math.min(hi, curMin));
+      curMax = Math.max(lo, Math.min(hi, curMax));
+      var minPct = ((curMin - lo) / (hi - lo)) * 100;
+      var maxPct = ((curMax - lo) / (hi - lo)) * 100;
+      // Account for 22px handle width: shift max-handle so right edge
+      // aligns with maxPct, and the fill bar matches both.
+      var hMin = wrap.querySelector('.range-handle-min');
+      var hMax = wrap.querySelector('.range-handle-max');
+      var fill = wrap.querySelector('.range-fill');
+      if (hMin) hMin.style.left = 'calc(' + minPct + '% - 11px)';
+      if (hMax) hMax.style.left = 'calc(' + maxPct + '% - 11px)';
+      if (fill) {
+        fill.style.left = minPct + '%';
+        fill.style.right = (100 - maxPct) + '%';
+      }
+    }
+    function syncAll() {
+      document.querySelectorAll('.range-slider-wrap').forEach(syncOne);
+    }
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', syncAll);
+    } else {
+      syncAll();
+    }
+    document.addEventListener('input', function(ev){
+      if (ev.target.matches && ev.target.matches('.filter-group-body input[type="number"]')) {
+        var wrap = ev.target.closest('.filter-group-body').querySelector('.range-slider-wrap');
+        if (wrap) syncOne(wrap);
+      }
+    });
   })();
 </script>
 

--- a/deploy/sim_envs/mantis_boattrader/app/templates/boat_detail.html
+++ b/deploy/sim_envs/mantis_boattrader/app/templates/boat_detail.html
@@ -298,7 +298,7 @@
 
   <details class="bdp-accordion" open>
     <summary>
-      <span class="accordion-title">Description</span>
+      <h3 class="accordion-title">Description</h3>
       <span class="accordion-chevron"></span>
     </summary>
     <div class="accordion-body">
@@ -324,15 +324,22 @@
 
   <details class="bdp-accordion">
     <summary>
-      <span class="accordion-title">Measurements</span>
+      <h3 class="accordion-title">Measurements</h3>
       <span class="accordion-chevron"></span>
     </summary>
     <div class="accordion-body">
+      <h4 class="accordion-subhead">Dimensions</h4>
       <dl class="spec-grid">
         <div><dt>Length Overall</dt><dd>{{ boat.length_ft }} ft</dd></div>
         <div><dt>Beam</dt><dd>{{ boat.beam_ft }} ft</dd></div>
         <div><dt>Draft</dt><dd>{{ "%.1f"|format(boat.length_ft * 0.09) }} ft</dd></div>
+      </dl>
+      <h4 class="accordion-subhead">Weights</h4>
+      <dl class="spec-grid">
         <div><dt>Dry Weight</dt><dd>{{ (boat.length_ft * 280)|int }} lbs</dd></div>
+      </dl>
+      <h4 class="accordion-subhead">Tanks</h4>
+      <dl class="spec-grid">
         <div><dt>Fuel Capacity</dt><dd>{{ boat.fuel_capacity_gal }} gal</dd></div>
         <div><dt>Fresh Water Capacity</dt><dd>{{ (boat.length_ft * 1.2)|int }} gal</dd></div>
       </dl>
@@ -341,7 +348,7 @@
 
   <details class="bdp-accordion">
     <summary>
-      <span class="accordion-title">Propulsion</span>
+      <h3 class="accordion-title">Propulsion</h3>
       <span class="accordion-chevron"></span>
     </summary>
     <div class="accordion-body">
@@ -358,7 +365,7 @@
 
   <details class="bdp-accordion">
     <summary>
-      <span class="accordion-title">More Details</span>
+      <h3 class="accordion-title">More Details</h3>
       <span class="accordion-chevron"></span>
     </summary>
     <div class="accordion-body">
@@ -375,7 +382,7 @@
 
   <details class="bdp-accordion">
     <summary>
-      <span class="accordion-title">Location</span>
+      <h3 class="accordion-title">Location</h3>
       <span class="accordion-chevron"></span>
     </summary>
     <div class="accordion-body">

--- a/deploy/sim_envs/mantis_boattrader/app/templates/boats.html
+++ b/deploy/sim_envs/mantis_boattrader/app/templates/boats.html
@@ -104,9 +104,9 @@
               <div class="range-handle range-handle-max"></div>
             </div>
             <div class="range-row">
-              <input class="filter-input range-input" type="number" min="0" step="1000" name="price_min" placeholder="No Min" value="{{ f.price_min or '' }}" />
+              <input class="filter-input range-input" type="number" min="{{ facets.price_range[0]|int }}" max="{{ facets.price_range[1]|int }}" step="1000" name="price_min" placeholder="No Min" value="{{ f.price_min or '' }}" />
               <span>to</span>
-              <input class="filter-input range-input" type="number" min="0" step="1000" name="price_max" placeholder="No Max" value="{{ f.price_max or '' }}" />
+              <input class="filter-input range-input" type="number" min="{{ facets.price_range[0]|int }}" max="{{ facets.price_range[1]|int }}" step="1000" name="price_max" placeholder="No Max" value="{{ f.price_max or '' }}" />
             </div>
             <label class="checkbox-row">
               <input type="checkbox" name="price_drop" value="1" {% if f.price_drop %}checked{% endif %} />
@@ -139,9 +139,151 @@
           </div>
         </details>
 
+        <details class="filter-group" data-testid="filter-beam">
+          <summary><span class="filter-group-label">Beam</span><span class="filter-chevron"></span></summary>
+          <div class="filter-group-body">
+            <div class="range-slider-wrap" aria-hidden="true">
+              <div class="range-track"></div>
+              <div class="range-fill"></div>
+              <div class="range-handle range-handle-min"></div>
+              <div class="range-handle range-handle-max"></div>
+            </div>
+            <div class="range-row">
+              <input class="filter-input range-input" type="number" min="0" max="40" name="beam_min" placeholder="No Min" value="{{ f.beam_min or '' }}" />
+              <span>to</span>
+              <input class="filter-input range-input" type="number" min="0" max="40" name="beam_max" placeholder="No Max" value="{{ f.beam_max or '' }}" />
+              <span class="range-unit">ft.</span>
+            </div>
+          </div>
+        </details>
+
+        <details class="filter-group" data-testid="filter-draft">
+          <summary><span class="filter-group-label">Max Draft</span><span class="filter-chevron"></span></summary>
+          <div class="filter-group-body">
+            <div class="range-slider-wrap" aria-hidden="true">
+              <div class="range-track"></div>
+              <div class="range-fill"></div>
+              <div class="range-handle range-handle-min"></div>
+              <div class="range-handle range-handle-max"></div>
+            </div>
+            <div class="range-row">
+              <input class="filter-input range-input" type="number" min="0" max="20" name="draft_min" placeholder="No Min" value="{{ f.draft_min or '' }}" />
+              <span>to</span>
+              <input class="filter-input range-input" type="number" min="0" max="20" name="draft_max" placeholder="No Max" value="{{ f.draft_max or '' }}" />
+              <span class="range-unit">ft.</span>
+            </div>
+          </div>
+        </details>
+
+        <details class="filter-group" data-testid="filter-fuel">
+          <summary><span class="filter-group-label">Fuel Type</span><span class="filter-chevron"></span></summary>
+          <div class="filter-group-body">
+            <select class="filter-select" name="fuel">
+              <option value="">All Fuel Types</option>
+              <option value="gas">Gas</option>
+              <option value="diesel">Diesel</option>
+              <option value="electric">Electric</option>
+              <option value="other">Other</option>
+            </select>
+          </div>
+        </details>
+
+        <details class="filter-group" data-testid="filter-hull">
+          <summary><span class="filter-group-label">Hull</span><span class="filter-chevron"></span></summary>
+          <div class="filter-group-body">
+            <select class="filter-select" name="hull">
+              <option value="">All Hull Types</option>
+              <option value="fiberglass">Fiberglass</option>
+              <option value="aluminum">Aluminum</option>
+              <option value="composite">Composite</option>
+              <option value="steel">Steel</option>
+              <option value="wood">Wood</option>
+              <option value="other">Other</option>
+            </select>
+          </div>
+        </details>
+
+        <details class="filter-group" data-testid="filter-engines">
+          <summary><span class="filter-group-label">Engines</span><span class="filter-chevron"></span></summary>
+          <div class="filter-group-body">
+            <label class="filter-sublabel">Number of Engines</label>
+            <div class="seg-control" role="radiogroup" data-engines-count>
+              {% for v in ['any','1','2','3','4+'] %}
+              <label class="seg {% if (f.engines_count or 'any')==v %}active{% endif %}">
+                <input type="radio" name="engines_count" value="{{ v }}" {% if (f.engines_count or 'any')==v %}checked{% endif %} /> {{ v|capitalize if v=='any' else v }}
+              </label>
+              {% endfor %}
+            </div>
+            <label class="filter-sublabel" style="margin-top: 14px">Engine Type</label>
+            <div class="radio-list">
+              {% for v, label in [('all','All'), ('direct','Direct Drive'), ('jet','Jet Drive'), ('none','None'), ('other','Other'), ('inboard','Single Inboard'), ('outboard','Outboard')] %}
+              <label class="radio-row">
+                <input type="radio" name="engine_type" value="{{ v }}" {% if (f.engine_type or 'all')==v %}checked{% endif %} />
+                <span>{{ label }}</span>
+              </label>
+              {% endfor %}
+            </div>
+          </div>
+        </details>
+
+        <details class="filter-group" data-testid="filter-for-sale-by">
+          <summary><span class="filter-group-label">For Sale By</span><span class="filter-chevron"></span></summary>
+          <div class="filter-group-body">
+            <div class="radio-list">
+              <label class="radio-row">
+                <input type="radio" name="for_sale_by" value="any" {% if (f.for_sale_by or 'any')=='any' %}checked{% endif %} />
+                <span>Any</span>
+              </label>
+              <label class="radio-row">
+                <input type="radio" name="for_sale_by" value="dealer" {% if f.for_sale_by=='dealer' %}checked{% endif %} />
+                <span>Dealer</span>
+              </label>
+              <label class="radio-row">
+                <input type="radio" name="for_sale_by" value="owner" {% if f.for_sale_by=='owner' %}checked{% endif %} />
+                <span>Private Seller</span>
+              </label>
+            </div>
+          </div>
+        </details>
+
         <button type="submit" class="btn btn-primary btn-block apply-filters" data-testid="apply-filters">Apply Filters</button>
         <a href="/boats/" class="filter-clear">Clear all</a>
       </form>
+
+      {# ─── Boat Loan Calculator widget (below the filter card) ─── #}
+      <div class="loan-calc-card" data-testid="loan-calc-card">
+        <h3 class="loan-calc-title">Boat Loan Calculator</h3>
+        <label class="loan-calc-field">
+          <span class="loan-calc-label">Loan Amount *</span>
+          <input type="number" class="loan-calc-input" name="loan_amount" placeholder="$" value="" />
+        </label>
+        <label class="loan-calc-field">
+          <span class="loan-calc-label">Loan Term *</span>
+          <select class="loan-calc-input">
+            <option>240 months</option>
+            <option>180 months</option>
+            <option>120 months</option>
+            <option>60 months</option>
+          </select>
+        </label>
+        <label class="loan-calc-field">
+          <span class="loan-calc-label">Interest Rate (APR) *</span>
+          <div class="loan-calc-input-row">
+            <input type="number" class="loan-calc-input" value="6.49" step="0.01" />
+            <span class="loan-calc-unit">%</span>
+          </div>
+        </label>
+        <button type="button" class="btn btn-secondary loan-calc-button">Calculate</button>
+        <div class="loan-calc-result">
+          <div class="loan-calc-result-label">Monthly Payment</div>
+          <div class="loan-calc-result-value">$0.00</div>
+        </div>
+        <p class="loan-calc-prompt">Ready for the next step?</p>
+        <a href="/boat-loans/pre-qualify/" class="btn btn-primary loan-calc-cta">↗ Get Pre-Qualified</a>
+        <p class="loan-calc-fineprint">
+          Adjust the loan term, down payment amount and interest rate to see results based on the numbers you provide — and how any changes to those numbers may affect your payment. *For more information on the APR rates, please visit our <a href="/boat-loans/">Boat Loans</a> page.
+        </p>
+      </div>
     </aside>
 
     <section class="srp-results">


### PR DESCRIPTION
## Summary

35+ deploy cycles tightening the `mantis_boattrader` sim env against real `boattrader.com` across home / SRP / BDP pages. Now a near-pixel-perfect replica suitable for CUA grading and fixture-level UI testing.

## What changed

### Header / chrome
- Compact logo SVG **150×19 at x=30**, full-width nav, first item at x=338
- Removed Google Fonts Roboto link — real BT also relies on system font fallback for nav weight (matches their rendering)
- Blue pre-qual ribbon: **40px tall**, plain inline CTA, hidden on BDP via `{% block ribbon %}` override

### SRP page
- Search bar: gradient outer card (12px br) wrapping inner white field, **Try** bold + quote regular (16/Roboto/#64748b), inline SVG sparkle + magnifier icons
- Pre-qualify banner: rounded **square** blue gradient bank icon (40×40, 8px br), 14/700 title + 11/400 sub + 13/700 button
- **Filter sidebar** added missing sections: **Beam, Max Draft, Fuel Type, Hull, Engines (Number + Type), For Sale By**
- **Boat Loan Calculator widget** below filter card (Loan Amount / Term / APR + Calculate + Get Pre-Qualified)
- Filter slider thumbs **22×22 blue** with 2px white border; **JS URL→handle sync** (reads min/max inputs, positions handles + fill bar; live-updates on typing)
- Listing cards: **351×388** with **10px grid gap**, dealer-logo dark badge in footer, click ⓘ → **sticky bottom blue tooltip** with × close, neutral white **Featured** badge, monthly+info hidden for POA listings
- H1 "Boats for sale" 32/700 #404040 / lh 32px; breadcrumb 12/400 #757575
- Sort row: plain inline `Sort: Recommended ▾`, no border
- Pagination: plain text links with active underline

### BDP page
- No ribbon (real BT BDP has none)
- Grid: `1fr + 80px gap + 366px rail`
- Right rail card: 16px pad, drop-shadow `rgba(0,0,0,0.2) 0 2px 2px 0`, 8px br
- Gallery: **3:2 aspect** (was 16:9), 40×40 circular nav buttons at `rgba(0,0,0,0.3)`
- Boat Details accordion with semantic **H2 → H3 → H4** structure: Description, Measurements (Dimensions/Weights/Tanks), Propulsion, More Details, Location
- Lead form: 40px inputs with 4px radius, 1px #c2c2c2 border, 8/12/4 padding
- Outline buttons: **2px** blue border, pill br, 14/700
- "Get pre-qualified in minutes" rail card heading bumped to **18/700**
- Owner Highlights pills: light-blue bg `#e3f1fe`, 12/700 BT blue text

### Fixture variety preserved
- 67% dealer / 25% owner / 8% sponsored
- 8% of dealer listings are POA (`price=None` → "Request a Price", no monthly, no info icon)
- Owner phone hidden behind "Show Phone Number" click → reveals SVG (anti-scrape, mirrors real BT)
- Engine hours: 0 for new, 20-950 for used, `—` when absent

## Working doc

`deploy/sim_envs/mantis_boattrader/FIDELITY.md` — section-by-section match matrix vs real BT with status legend (✅ exact · 🟡 close · ⏳ partial · ❌ missing · 🚫 won't-match by design) and a per-version iteration log so future fidelity passes can resume cold.

## Test plan

- [ ] Visit live URL (token rotates per Daytona restart): `https://8080-014f48ab-eeb1-4ca5-947e-42e169d1fcc8.daytonaproxy01.net/boats/`
- [ ] Side-by-side compare with `https://www.boattrader.com/boats/` at viewport 1512 → 1568
- [ ] Click ⓘ next to any monthly `$X/mo*` on a listing card → blue sticky banner appears at card bottom
- [ ] Filter URL like `?condition=new&length_min=20&length_max=40` → length slider handles position at correct % automatically
- [ ] Open a BDP, click Show Phone Number on an owner-listed boat → SVG phone reveals
- [ ] Verify BDP heading hierarchy: H1 boat title → H2 sections → H3 accordion titles → H4 sub-headers within Measurements
- [ ] Sandbox restart cycles the preview token; redeploy via `.venv-daytona/bin/python deploy/sim_envs/_daytona_patch.py 014f48ab-eeb1-4ca5-947e-42e169d1fcc8`

🤖 Generated with [Claude Code](https://claude.com/claude-code)