### PR TITLE
plan_decomposer: default unset loop_target to click_idx (closes #605)

### DIFF
--- a/src/mantis_agent/plan_decomposer.py
+++ b/src/mantis_agent/plan_decomposer.py
@@ -749,6 +749,15 @@ class PlanDecomposer:
                 for s in cached_steps:
                     plan.steps.append(self._build_intent(s))
 
+                # Issue #605: re-run loop-target normalization on cache
+                # load too. Cached plans from before this fix have
+                # ``loop_target: null`` (-> -1) on loop steps, which
+                # causes the runner to self-spin. The fix is idempotent,
+                # so running it on every load (cached or fresh) is safe
+                # and means we don't have to invalidate all existing
+                # cache files when shipping plan-normalization fixes.
+                self._fix_loop_targets(plan)
+
                 logger.info(f"Loaded cached micro-plan: {cache_path} ({len(plan.steps)} steps)")
                 return plan
             except Exception:

--- a/src/mantis_agent/plan_decomposer.py
+++ b/src/mantis_agent/plan_decomposer.py
@@ -1163,6 +1163,16 @@ class PlanDecomposer:
 
         The decomposer often generates loop→extract_url instead of loop→click.
         Find the first extraction click step and retarget all loops to it.
+
+        Issue #605: Claude also frequently OMITS ``loop_target`` entirely
+        on loop steps, so the field defaults to ``-1`` at parse time
+        (line ``loop_target=s.get("loop_target", -1)``). The runner's
+        loop handler then computes ``target = state.step_index`` (the
+        loop step's own index), causing the loop to self-spin instead
+        of jumping back into the iteration body. Only one pass through
+        the body ever runs and the plan extracts at most one lead.
+        Default unset targets to ``click_idx`` so listings-extraction
+        plans loop on click→extract→back→loop as designed.
         """
         click_idx = None
         for i, s in enumerate(plan.steps):
@@ -1174,11 +1184,24 @@ class PlanDecomposer:
             return
 
         for s in plan.steps:
-            if s.loop_target >= 0 and s.loop_target != click_idx:
-                # Only fix if the target is close (off by 1-2, typical decomposer error)
-                if abs(s.loop_target - click_idx) <= 2:
-                    logger.info(f"  [fix] Loop target {s.loop_target} → {click_idx} (click step)")
-                    s.loop_target = click_idx
+            if s.type != "loop":
+                continue
+            if s.loop_target < 0:
+                # Claude omitted loop_target; default to the extraction
+                # click step. Without this the loop self-spins
+                # (see issue #605).
+                logger.info(
+                    "  [fix] Loop target unset (-1) → %d (click step)",
+                    click_idx,
+                )
+                s.loop_target = click_idx
+            elif s.loop_target != click_idx and abs(s.loop_target - click_idx) <= 2:
+                # Only fix close targets (off by 1-2, typical decomposer error)
+                logger.info(
+                    "  [fix] Loop target %d → %d (click step)",
+                    s.loop_target, click_idx,
+                )
+                s.loop_target = click_idx
 
     # ── Plan-shape extraction (parsed from Claude's JSON output) ────────
 

--- a/tests/test_fix_loop_targets_default_605.py
+++ b/tests/test_fix_loop_targets_default_605.py
@@ -1,0 +1,159 @@
+"""Tests for issue #605 — default unset loop_target to the click step.
+
+Claude frequently omits ``loop_target`` on ``loop`` steps in its
+decomposition output. The parse layer falls back to
+``s.get("loop_target", -1) = -1`` (plan_decomposer.py:979). The
+runner's loop handler then computes ``target = state.step_index``
+(the loop step's own index), so the loop SELF-SPINS for
+``max_loop_iterations`` (200) cycles before advancing — no actual
+iteration of the click→extract body ever runs.
+
+Production run ``20260523_001336_a88df3d0`` extracted exactly 1 lead
+this way: the dedup fix from #604 let the first iteration succeed,
+then the loop step self-spun and the plan ended with 0 additional
+iterations.
+
+These tests pin: ``_fix_loop_targets`` defaults any ``loop`` step
+with ``loop_target < 0`` to the first extraction-section ``click``
+step. They also pin that the existing close-target retarget behavior
+is preserved (regression guard on the original Fix 3 behavior).
+"""
+
+from __future__ import annotations
+
+from mantis_agent.plan_decomposer import MicroIntent, MicroPlan, PlanDecomposer
+
+
+def _plan(*steps: MicroIntent) -> MicroPlan:
+    plan = MicroPlan(steps=list(steps))
+    for i, s in enumerate(plan.steps):
+        s.index = i
+    return plan
+
+
+def test_unset_loop_target_defaults_to_click_idx():
+    """A loop step with ``loop_target=-1`` (Claude omitted) must be
+    retargeted to the first extraction click step."""
+    plan = _plan(
+        MicroIntent(intent="navigate", type="navigate", section="setup"),
+        MicroIntent(intent="click listing", type="click", section="extraction"),
+        MicroIntent(intent="extract_url", type="extract_url", section="extraction"),
+        MicroIntent(intent="extract_data", type="extract_data", section="extraction"),
+        MicroIntent(intent="loop", type="loop", section="extraction"),
+    )
+    # Claude omitted loop_target → parse-time default is -1.
+    assert plan.steps[4].loop_target == -1
+
+    PlanDecomposer._fix_loop_targets(plan)
+
+    # Should now point at the click step (index 1).
+    assert plan.steps[4].loop_target == 1
+
+
+def test_loop_target_already_correct_unchanged():
+    """A loop step that already points at the click step should be
+    left alone — the fix is idempotent."""
+    plan = _plan(
+        MicroIntent(intent="click", type="click", section="extraction"),
+        MicroIntent(intent="extract_data", type="extract_data", section="extraction"),
+        MicroIntent(intent="loop", type="loop", section="extraction", loop_target=0),
+    )
+    PlanDecomposer._fix_loop_targets(plan)
+    assert plan.steps[2].loop_target == 0
+
+
+def test_close_wrong_target_retargets_to_click():
+    """Pre-existing behavior: a loop_target that's 1-2 off from the
+    click step gets snapped to the click step (typical decomposer
+    error: pointing at extract_url instead of click)."""
+    plan = _plan(
+        MicroIntent(intent="click", type="click", section="extraction"),     # 0
+        MicroIntent(intent="extract_url", type="extract_url", section="extraction"),  # 1
+        MicroIntent(intent="extract_data", type="extract_data", section="extraction"),  # 2
+        MicroIntent(intent="loop", type="loop", section="extraction", loop_target=1),  # 3
+    )
+    PlanDecomposer._fix_loop_targets(plan)
+    # loop_target was 1 (extract_url); should snap to 0 (click).
+    assert plan.steps[3].loop_target == 0
+
+
+def test_far_wrong_target_left_alone():
+    """Pre-existing behavior: a loop_target that's 3+ off from click
+    is NOT retargeted — too risky to assume the decomposer's intent."""
+    plan = _plan(
+        MicroIntent(intent="click", type="click", section="extraction"),     # 0
+        MicroIntent(intent="extract_url", type="extract_url", section="extraction"),  # 1
+        MicroIntent(intent="extract_data", type="extract_data", section="extraction"),  # 2
+        MicroIntent(intent="scroll", type="scroll", section="extraction"),    # 3
+        MicroIntent(intent="navigate_back", type="navigate_back", section="extraction"),  # 4
+        MicroIntent(intent="loop", type="loop", section="extraction", loop_target=4),  # 5
+    )
+    PlanDecomposer._fix_loop_targets(plan)
+    # 4 - 0 = 4, more than abs ≤ 2 — leave alone.
+    assert plan.steps[5].loop_target == 4
+
+
+def test_no_click_in_extraction_section_does_nothing():
+    """When the plan has no extraction-section click step, the fix
+    skips entirely (no click_idx to default to)."""
+    plan = _plan(
+        MicroIntent(intent="navigate", type="navigate", section="setup"),
+        MicroIntent(intent="extract_data", type="extract_data", section="extraction"),
+        MicroIntent(intent="loop", type="loop", section="extraction"),
+    )
+    assert plan.steps[2].loop_target == -1
+    PlanDecomposer._fix_loop_targets(plan)
+    # No click step to anchor on → -1 preserved.
+    assert plan.steps[2].loop_target == -1
+
+
+def test_setup_section_click_does_not_anchor():
+    """Only EXTRACTION-section clicks anchor the loop default. A
+    click in setup (e.g., cookie banner dismiss) is the wrong target
+    — the loop body wraps the listing-card click, not the setup."""
+    plan = _plan(
+        MicroIntent(intent="navigate", type="navigate", section="setup"),
+        MicroIntent(intent="dismiss cookie banner", type="click", section="setup"),  # 1
+        MicroIntent(intent="click listing", type="click", section="extraction"),    # 2
+        MicroIntent(intent="extract_data", type="extract_data", section="extraction"),
+        MicroIntent(intent="loop", type="loop", section="extraction"),
+    )
+    PlanDecomposer._fix_loop_targets(plan)
+    # The fix should pick the extraction click (index 2), not the
+    # setup click (index 1).
+    assert plan.steps[4].loop_target == 2
+
+
+def test_multiple_loops_all_get_defaulted():
+    """Both the inner (per-listing) and outer (per-page) loop steps
+    should get the same default if both are unset — they both want
+    to re-enter at the click step after their respective control."""
+    plan = _plan(
+        MicroIntent(intent="navigate", type="navigate", section="setup"),
+        MicroIntent(intent="click listing", type="click", section="extraction"),     # 1
+        MicroIntent(intent="extract_data", type="extract_data", section="extraction"),
+        MicroIntent(intent="navigate_back", type="navigate_back", section="extraction"),
+        MicroIntent(intent="loop body", type="loop", section="extraction"),          # 4
+        MicroIntent(intent="paginate", type="paginate", section="pagination"),
+        MicroIntent(intent="loop page", type="loop", section="pagination"),          # 6
+    )
+    PlanDecomposer._fix_loop_targets(plan)
+    assert plan.steps[4].loop_target == 1
+    assert plan.steps[6].loop_target == 1
+
+
+def test_non_loop_steps_with_negative_loop_target_untouched():
+    """Defensive: non-loop steps that happen to have ``loop_target=-1``
+    (the dataclass default) must not be mutated — only ``type=='loop'``
+    steps consume the field."""
+    plan = _plan(
+        MicroIntent(intent="click", type="click", section="extraction"),
+        MicroIntent(intent="extract_data", type="extract_data", section="extraction"),
+        MicroIntent(intent="loop", type="loop", section="extraction"),
+    )
+    PlanDecomposer._fix_loop_targets(plan)
+    # click + extract_data still have the dataclass default.
+    assert plan.steps[0].loop_target == -1
+    assert plan.steps[1].loop_target == -1
+    # loop got the click_idx default.
+    assert plan.steps[2].loop_target == 0


### PR DESCRIPTION
## Summary

- When Claude omits ``loop_target`` on a ``loop`` step, the parse layer defaults to -1. The runner's loop handler then computes ``target = state.step_index`` (the loop step's own index), causing the loop to self-spin 200x instead of jumping to the click step.
- Fix in ``_fix_loop_targets``: any ``loop`` step with ``loop_target < 0`` now defaults to the first extraction-section ``click`` step.
- Caught by production run ``20260523_001336_a88df3d0`` (on the #604 build): with dedup correctly fixed, the first iteration saved a lead (1997 Caroff CHATAM 52). Plan then ended at Steps:11 with Leads:1 — no second iteration despite 8 more visible listings.

## Why this surfaced now

Prior runs always halted upstream — Cloudflare blocks, scan returning all-"unknown" titles (#600), or the dedup race (#603). The plan never made it past the first iteration to reach the loop step. #604 was the first fix that let extract_data succeed; the loop-target bug surfaced as the immediate next bottleneck.

## Test plan

- [x] ``pytest tests/test_fix_loop_targets_default_605.py`` — 8 new pin tests pass
- [x] ``pytest tests/ -k "decomposer or loop_target or plan_validator"`` — 133 tests pass
- [x] Ruff clean
- [ ] Modal redeploy + boattrader rerun: expect multiple iterations, multiple leads, halt_reason from pagination or page-exhaust rather than completion-with-1-lead.

Closes #605

🤖 Generated with [Claude Code](https://claude.com/claude-code)