### PR TITLE
navigate_back: mechanical CDP-back primary path (closes #608)

### DIFF
--- a/src/mantis_agent/gym/step_handlers/__init__.py
+++ b/src/mantis_agent/gym/step_handlers/__init__.py
@@ -33,6 +33,7 @@ from .filter import ClaudeGuidedFilterHandler
 from .form import ClaudeGuidedFormHandler
 from .holo3 import Holo3StepHandler
 from .navigate import NavigateHandler
+from .navigate_back import MechanicalNavigateBackHandler
 from .paginate import PaginateHandler
 from .scroll import MechanicalScrollHandler
 
@@ -46,6 +47,7 @@ __all__ = [
     "ClaudeGuidedFormHandler",
     "ClaudeStepHandler",
     "Holo3StepHandler",
+    "MechanicalNavigateBackHandler",
     "MechanicalScrollHandler",
     "NavigateHandler",
     "PaginateHandler",
@@ -104,10 +106,13 @@ def default_registry(runner: "MicroPlanRunner") -> HandlerRegistry:
     # MechanicalScrollHandler when the plan supplies ``params.count``
     # (deterministic, no brain), falling through to Holo3StepHandler
     # for goal-shaped scroll intents that need vision mediation
-    # ("scroll until X is visible"). ``navigate_back`` stays on
-    # Holo3 — it's a goal-shaped step type by nature.
+    # ("scroll until X is visible"). ``navigate_back`` does the same:
+    # mechanical CDP-back first (one history.back() + URL-change
+    # poll), falling through to Holo3 when CDP back is unavailable,
+    # didn't move the URL, or landed on another detail page (#608).
     holo3 = Holo3StepHandler(runner)
     mechanical_scroll = MechanicalScrollHandler(runner)
+    mechanical_back = MechanicalNavigateBackHandler(runner)
 
     class _ScrollDispatcher:
         step_type = "scroll"
@@ -117,6 +122,20 @@ def default_registry(runner: "MicroPlanRunner") -> HandlerRegistry:
                 return mechanical_scroll.execute(step, ctx)
             return holo3.execute(step, ctx)
 
+    class _NavigateBackDispatcher:
+        step_type = "navigate_back"
+
+        def execute(self, step, ctx):
+            if not mechanical_back.applies_to(step):
+                return holo3.execute(step, ctx)
+            result = mechanical_back.execute(step, ctx)
+            if result.success:
+                return result
+            # Mechanical CDP back didn't work (no history, dispatch
+            # failure, landed on another detail page). Let the brain
+            # try via its action vocabulary.
+            return holo3.execute(step, ctx)
+
     reg.register(_ScrollDispatcher())
-    reg.register_for_types(holo3, ("navigate_back",))
+    reg.register(_NavigateBackDispatcher())
     return reg

--- a/src/mantis_agent/gym/step_handlers/navigate_back.py
+++ b/src/mantis_agent/gym/step_handlers/navigate_back.py
@@ -1,0 +1,177 @@
+"""MechanicalNavigateBackHandler — deterministic CDP back navigation.
+
+Why this exists: ``navigate_back`` steps routed through the Holo3
+brain handler gave the model an open-ended N-step inner loop for what
+is, on every site, the same mechanical action: pop one history entry.
+The brain typically burnt ~8 budget steps trying clicks / keypresses /
+scrolls before declaring failure, then ``step_recovery`` did up to 3
+CDP-back / Alt+Left attempts (with a Claude extract per attempt to
+verify the URL). The brain wasn't adding value — the recovery layer's
+mechanical attempts were doing the actual navigation.
+
+Live repro: boattrader run 20260523_041241_b12b4194 — extracted 11
+leads in 31 minutes; per-iteration the brain's navigate_back burnt
+~$0.04 GPU + 3 claude_extract calls (~$0.036) in recovery, ~8 sec
+wall. Over 11 iterations that's ~$0.83 and ~88 seconds (~3 minutes
+of the run's wall time) spent on a primitive operation.
+
+This handler bypasses the brain by calling ``env.cdp_history_back()``
+directly. The CDP primitive already polls for URL change as success
+verification (see ``xdotool_env.cdp_history_back``). On success we
+return immediately; on CDP unavailability OR landing on another
+detail page (history had multiple detail entries), we return failure
+so the dispatcher falls through to the Holo3 brain.
+
+Plans that genuinely need the brain to navigate "back" via a custom
+UI control (e.g. an in-app breadcrumb on a SPA without history
+support) can still get there via fall-through.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from ..checkpoint import StepResult
+from ..step_context import StepContext
+
+if TYPE_CHECKING:
+    from ..micro_runner import MicroPlanRunner
+    from ...plan_decomposer import MicroIntent
+
+logger = logging.getLogger(__name__)
+
+
+class MechanicalNavigateBackHandler:
+    """Implements :class:`~..step_context.StepHandler` for ``navigate_back``
+    steps that can be served by CDP ``window.history.back()`` — i.e.
+    most listings-extraction iteration bodies on most sites.
+
+    Behaviour:
+
+    * Reads the env's ``cdp_history_back`` primitive (added in #583).
+      Returns ``applies_to=False`` if the env doesn't expose it OR if
+      the runner is in ``_opened_detail_in_new_tab`` mode (existing
+      ``execute_close_detail_tab`` handler covers that).
+    * Reads the current URL via ``runner._best_effort_current_url()``
+      (cheap CDP read, no Claude tokens) so we can verify the result.
+    * Calls ``cdp_history_back(settle_seconds=2.0)`` — already polls
+      for URL change internally and returns True/False.
+    * Verifies the new URL isn't still a detail page (history may have
+      had multiple detail entries; landing on another detail page is
+      a fall-through condition so the brain can re-attempt).
+
+    Returns ``StepResult.success = True`` with ``data=back_via_cdp:<url>``
+    on verified motion to a non-detail page; ``False`` with an explicit
+    ``failure_class`` when CDP back didn't move the URL or landed on
+    another detail page (caller's dispatcher falls through to Holo3).
+
+    WARNING-level log on success so production logs surface the
+    cost-savings path (Modal suppresses INFO).
+    """
+
+    step_type = "navigate_back"
+
+    def __init__(self, runner: "MicroPlanRunner") -> None:
+        self.parent = runner
+
+    def applies_to(self, step: "MicroIntent") -> bool:
+        """Mechanical back applies when CDP back is available AND the
+        runner isn't in new-tab mode. Plans / runtime configs can also
+        opt out via ``params.brain_required=True`` for sites where
+        history.back() is known to fail (SPA with intercepted history).
+        """
+        runner = self.parent
+        # New-tab close path is dispatched BEFORE the handler registry
+        # in _runner_helpers; if we're in new-tab mode we shouldn't
+        # see this step here, but guard defensively.
+        if getattr(runner, "_opened_detail_in_new_tab", False):
+            return False
+        params = step.params or {}
+        if params.get("brain_required"):
+            return False
+        return callable(getattr(runner.env, "cdp_history_back", None))
+
+    def execute(self, step: "MicroIntent", ctx: StepContext) -> StepResult:
+        index = int(ctx.state.get("index", 0))
+        runner = self.parent
+        env = ctx.env
+
+        # Cheap URL read for the pre-state. The env's CDP read is the
+        # same primitive cdp_history_back uses internally; we read it
+        # again so we can log the transition for production triage.
+        url_before = ""
+        try:
+            url_before = runner._best_effort_current_url() or ""
+        except Exception:  # noqa: BLE001 — fall through on any URL-read failure
+            pass
+
+        cdp_back = env.cdp_history_back
+        moved = False
+        try:
+            moved = bool(cdp_back(settle_seconds=2.0))
+        except Exception as exc:  # noqa: BLE001 — fall through on dispatch failure
+            logger.warning(
+                "  [back] mechanical CDP back raised %s; falling through",
+                type(exc).__name__,
+            )
+            return StepResult(
+                step_index=index, intent=step.intent, success=False,
+                data=f"cdp_back_exception:{type(exc).__name__}",
+                failure_class="cdp_back_exception",
+            )
+
+        if not moved:
+            # cdp_history_back polled settle_seconds and didn't see a
+            # URL change. Could mean: history was empty, browser
+            # intercepted the call, or the SPA didn't update the URL.
+            # Fall through to brain.
+            logger.info(
+                "  [back] mechanical CDP back: URL did not change "
+                "from %s — falling through",
+                url_before[:60],
+            )
+            return StepResult(
+                step_index=index, intent=step.intent, success=False,
+                data="cdp_back_no_url_change",
+                failure_class="cdp_back_no_change",
+            )
+
+        url_after = ""
+        try:
+            url_after = runner._best_effort_current_url() or ""
+        except Exception:  # noqa: BLE001
+            pass
+        if url_after:
+            runner._last_known_url = url_after
+
+        site_config = getattr(runner, "site_config", None)
+        is_detail = (
+            url_after
+            and site_config is not None
+            and callable(getattr(site_config, "is_detail_page", None))
+            and site_config.is_detail_page(url_after)
+        )
+        if is_detail:
+            # URL changed but to ANOTHER detail page (history had
+            # multiple detail-page entries). Fall through to brain so
+            # it can re-attempt or use a different strategy.
+            logger.info(
+                "  [back] CDP back landed on another detail page (%s) — "
+                "falling through to brain",
+                url_after[:60],
+            )
+            return StepResult(
+                step_index=index, intent=step.intent, success=False,
+                data=f"back_to_detail_page:{url_after[:80]}",
+                failure_class="back_to_detail_page",
+            )
+
+        logger.warning(
+            "  [back] mechanical CDP back: %s → %s",
+            url_before[:60] or "?", url_after[:60] or "?",
+        )
+        return StepResult(
+            step_index=index, intent=step.intent, success=True,
+            data=f"back_via_cdp:{url_after[:120]}",
+        )

--- a/tests/test_handler_registry_default.py
+++ b/tests/test_handler_registry_default.py
@@ -17,6 +17,7 @@ from mantis_agent.gym.step_handlers import (
     ClaudeGuidedFormHandler,
     ClaudeStepHandler,
     Holo3StepHandler,
+    MechanicalNavigateBackHandler,
     MechanicalScrollHandler,
     NavigateHandler,
     PaginateHandler,
@@ -86,10 +87,50 @@ def test_claude_step_types_share_one_handler_instance():
     assert url is data
 
 
-def test_navigate_back_binds_to_Holo3StepHandler():
-    """``navigate_back`` is a goal-shaped step type — it stays on the
-    brain. Only ``scroll`` was peeled off into the dispatcher."""
-    assert isinstance(_registry().get("navigate_back"), Holo3StepHandler)
+def test_navigate_back_uses_dispatcher_routing_to_mechanical_or_holo3():
+    """``navigate_back`` was promoted from a Holo3-only step type to
+    a dispatcher (issue #608). Mechanical CDP-back fires first when
+    the env supports it; Holo3 owns the fall-through (no CDP, new-tab
+    mode, no URL change, landed on another detail page).
+
+    Previously the brain ran an N-step loop on every navigate_back
+    step, declared failure, and step_recovery did 3× CDP+Alt+Left
+    attempts. The mechanical primary skips ~$0.04 + ~8 sec / iter.
+    """
+    reg = _registry()
+    dispatcher = reg.get("navigate_back")
+    assert dispatcher is not None
+    # Dispatcher is NOT the Holo3 instance directly.
+    assert not isinstance(dispatcher, Holo3StepHandler)
+    # Dispatcher exposes the right step_type marker for registry binding.
+    assert dispatcher.step_type == "navigate_back"
+
+
+def test_mechanical_navigate_back_handler_applies_to_predicate():
+    """The mechanical handler claims a navigate_back step when the
+    env exposes ``cdp_history_back`` AND the runner isn't in new-tab
+    mode AND the plan didn't opt out via ``params.brain_required``."""
+    runner = MagicMock()
+    runner._opened_detail_in_new_tab = False
+    runner.env = MagicMock()
+    runner.env.cdp_history_back = lambda **_: True
+    mech = MechanicalNavigateBackHandler(runner)
+
+    assert mech.applies_to(MicroIntent(intent="x", type="navigate_back"))
+    # New-tab mode → existing close-tab path owns it.
+    runner._opened_detail_in_new_tab = True
+    assert not mech.applies_to(MicroIntent(intent="x", type="navigate_back"))
+    runner._opened_detail_in_new_tab = False
+    # Opt-out via params.brain_required.
+    assert not mech.applies_to(
+        MicroIntent(
+            intent="x", type="navigate_back",
+            params={"brain_required": True},
+        )
+    )
+    # Env without cdp_history_back → fall through to Holo3.
+    runner.env = type("E", (), {})()  # plain object, no cdp_history_back
+    assert not mech.applies_to(MicroIntent(intent="x", type="navigate_back"))
 
 
 def test_scroll_uses_dispatcher_routing_to_mechanical_or_holo3():

--- a/tests/test_navigate_back_mechanical_608.py
+++ b/tests/test_navigate_back_mechanical_608.py
@@ -1,0 +1,251 @@
+"""Tests for issue #608 — mechanical CDP-back primary path for the
+``navigate_back`` step type.
+
+Before the fix, ``navigate_back`` routed through ``Holo3StepHandler``
+which gave the brain an open-ended N-step inner loop. The brain
+typically burnt ~8 budget steps before declaring failure, then
+``step_recovery`` fired up to 3 CDP-back/Alt+Left attempts with a
+Claude extract per attempt. Live repro: boattrader run
+20260523_041241_b12b4194 — 11 navigate_back failures, ~$0.83 +
+~88 seconds wasted across the run.
+
+These tests pin: the mechanical handler tries ``env.cdp_history_back``,
+verifies the URL moved off the detail page, and returns success on
+the happy path. They also pin the fall-through conditions (no CDP,
+new-tab mode, no URL change, landed on another detail page) so the
+brain still owns the cases the brain is needed for.
+
+The dispatcher wiring (mechanical first, Holo3 on fall-through) is
+exercised by the integration tests in ``test_step_registry.py`` —
+unit tests here cover the handler in isolation.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+from mantis_agent.gym.step_context import StepContext
+from mantis_agent.gym.step_handlers.navigate_back import (
+    MechanicalNavigateBackHandler,
+)
+from mantis_agent.plan_decomposer import MicroIntent
+
+
+class _FakeRunner:
+    """Minimal back-reference. Tests poke ``env``, ``site_config``,
+    ``_best_effort_current_url``, ``_last_known_url``, and
+    ``_opened_detail_in_new_tab``.
+    """
+
+    def __init__(self) -> None:
+        self.env = MagicMock()
+        self.site_config = MagicMock()
+        self._opened_detail_in_new_tab = False
+        self._last_known_url = ""
+        self._url_seq: list[str] = []
+
+    def _best_effort_current_url(self) -> str:
+        if not self._url_seq:
+            return ""
+        if len(self._url_seq) == 1:
+            return self._url_seq[0]
+        return self._url_seq.pop(0)
+
+
+def _ctx(runner: _FakeRunner) -> StepContext:
+    return StepContext(
+        env=runner.env,
+        brain=None,
+        extractor=None,
+        grounding=None,
+        cost_meter=None,
+        dynamic_verifier=MagicMock(),
+        scanner=None,
+        site_config=runner.site_config,
+        tool_channel=None,
+        extraction_cache=None,
+        state={"index": 6},
+    )
+
+
+def _step() -> MicroIntent:
+    return MicroIntent(
+        intent="Return to the search results page",
+        type="navigate_back", section="extraction",
+    )
+
+
+# ── applies_to gates ───────────────────────────────────────────────
+
+
+def test_applies_to_when_cdp_back_available_and_not_new_tab():
+    runner = _FakeRunner()
+    runner.env.cdp_history_back = lambda **_: True
+    handler = MechanicalNavigateBackHandler(runner)
+    assert handler.applies_to(_step()) is True
+
+
+def test_does_not_apply_when_env_has_no_cdp_back():
+    """Test stubs / older env mocks without cdp_history_back fall
+    through to Holo3."""
+    runner = _FakeRunner()
+    # MagicMock-default env: every attribute is itself a MagicMock,
+    # which IS callable — defeats the ``callable(...)`` check via
+    # falsy intent. Explicitly delete the attr.
+    del runner.env.cdp_history_back
+    runner.env = type("E", (), {})()  # plain object, no cdp_history_back
+    handler = MechanicalNavigateBackHandler(runner)
+    assert handler.applies_to(_step()) is False
+
+
+def test_does_not_apply_when_opened_detail_in_new_tab():
+    """When the runner opened the detail in a new tab, the executor's
+    inline ``execute_close_detail_tab`` path handles back navigation
+    via ctrl+w. Mechanical CDP back would try to history.back() on the
+    new tab which has no listings-page history entry."""
+    runner = _FakeRunner()
+    runner.env.cdp_history_back = lambda **_: True
+    runner._opened_detail_in_new_tab = True
+    handler = MechanicalNavigateBackHandler(runner)
+    assert handler.applies_to(_step()) is False
+
+
+def test_does_not_apply_when_params_brain_required():
+    """Plans / runtime configs can opt out of mechanical back via
+    ``params.brain_required=True`` for sites with intercepted history."""
+    runner = _FakeRunner()
+    runner.env.cdp_history_back = lambda **_: True
+    handler = MechanicalNavigateBackHandler(runner)
+    step = MicroIntent(
+        intent="back", type="navigate_back",
+        params={"brain_required": True},
+    )
+    assert handler.applies_to(step) is False
+
+
+# ── execute happy path ─────────────────────────────────────────────
+
+
+def test_cdp_back_to_results_page_returns_success():
+    """CDP back changes URL from detail to results → handler returns
+    success without invoking the brain."""
+    runner = _FakeRunner()
+    runner._url_seq = [
+        "https://boattrader.com/boat/1997-caroff-chatam-52-10130796/",  # pre
+        "https://boattrader.com/boats/state-fl/city-miami/by-owner/",   # post
+    ]
+    runner.env.cdp_history_back = MagicMock(return_value=True)
+    runner.site_config.is_detail_page = lambda url: "/boat/" in url
+
+    result = MechanicalNavigateBackHandler(runner).execute(_step(), _ctx(runner))
+
+    assert result.success is True
+    assert result.data.startswith("back_via_cdp:")
+    assert "by-owner" in result.data
+    # cdp_history_back called once with settle.
+    assert runner.env.cdp_history_back.call_count == 1
+    # Runner's last_known_url updated to the post URL.
+    assert "by-owner" in runner._last_known_url
+
+
+# ── execute fall-through cases ─────────────────────────────────────
+
+
+def test_cdp_back_no_url_change_returns_failure():
+    """CDP back didn't move the URL (empty history, intercepted call,
+    SPA without history support) → return failure so dispatcher falls
+    through to Holo3."""
+    runner = _FakeRunner()
+    runner._url_seq = ["https://boattrader.com/boat/1997-caroff-chatam-52-10130796/"]
+    runner.env.cdp_history_back = MagicMock(return_value=False)
+    runner.site_config.is_detail_page = lambda url: "/boat/" in url
+
+    result = MechanicalNavigateBackHandler(runner).execute(_step(), _ctx(runner))
+
+    assert result.success is False
+    assert result.data == "cdp_back_no_url_change"
+    assert result.failure_class == "cdp_back_no_change"
+
+
+def test_cdp_back_to_another_detail_page_returns_failure():
+    """CDP back moved the URL, but to another detail page (history had
+    multiple detail entries). Brain should re-attempt or use a
+    different strategy."""
+    runner = _FakeRunner()
+    runner._url_seq = [
+        "https://boattrader.com/boat/1997-caroff-chatam-52-10130796/",  # pre
+        "https://boattrader.com/boat/1987-beneteau-idylle-15-50-10139/",  # post — STILL detail
+    ]
+    runner.env.cdp_history_back = MagicMock(return_value=True)
+    runner.site_config.is_detail_page = lambda url: "/boat/" in url
+
+    result = MechanicalNavigateBackHandler(runner).execute(_step(), _ctx(runner))
+
+    assert result.success is False
+    assert result.data.startswith("back_to_detail_page:")
+    assert result.failure_class == "back_to_detail_page"
+
+
+def test_cdp_back_raises_exception_returns_failure():
+    """If cdp_history_back raises (e.g. CDP socket closed mid-call),
+    handler returns a failure with a labeled failure_class — caller
+    falls through to Holo3."""
+    runner = _FakeRunner()
+    runner._url_seq = ["https://boattrader.com/boat/x/"]
+
+    def _boom(**_kwargs: Any) -> bool:
+        raise RuntimeError("websocket disconnected")
+
+    runner.env.cdp_history_back = _boom
+    runner.site_config.is_detail_page = lambda url: "/boat/" in url
+
+    result = MechanicalNavigateBackHandler(runner).execute(_step(), _ctx(runner))
+
+    assert result.success is False
+    assert result.data.startswith("cdp_back_exception:")
+    assert "RuntimeError" in result.data
+    assert result.failure_class == "cdp_back_exception"
+
+
+def test_step_type_property():
+    handler = MechanicalNavigateBackHandler(_FakeRunner())
+    assert handler.step_type == "navigate_back"
+
+
+# ── dispatcher integration: registry routes navigate_back through
+# the dispatcher; mechanical fires first on the happy path ─────────
+
+
+def test_registry_routes_navigate_back_through_dispatcher_mechanical_wins(monkeypatch):
+    """End-to-end through the registry: a runner whose env supports
+    CDP back and whose URL moves off detail dispatches via the
+    mechanical handler — the Holo3 brain handler is NOT invoked."""
+    from mantis_agent.gym.step_handlers import default_registry
+
+    runner = _FakeRunner()
+    runner._url_seq = [
+        "https://boattrader.com/boat/x/",
+        "https://boattrader.com/boats/by-owner/",
+    ]
+    runner.env.cdp_history_back = MagicMock(return_value=True)
+    runner.site_config.is_detail_page = lambda url: "/boat/" in url
+    # Other runner attributes the registry constructor's handlers may
+    # poke at construction time — stub generously.
+    runner.scanner = MagicMock()
+    runner.extractor = None
+    runner.costs = {}
+    runner.brain = MagicMock()
+    runner.dynamic_verifier = MagicMock()
+    runner.tool_channel = None
+    runner.grounding = None
+
+    reg = default_registry(runner)
+    handler = reg.get("navigate_back")
+    assert handler is not None
+    assert handler.step_type == "navigate_back"
+    result = handler.execute(_step(), _ctx(runner))
+    assert result.success is True
+    assert result.data.startswith("back_via_cdp:")
+    # Brain was NOT consulted — mechanical took the request.
+    runner.brain.assert_not_called()


### PR DESCRIPTION
## Summary

- New ``MechanicalNavigateBackHandler`` calls ``env.cdp_history_back()`` directly and verifies the URL moved off the detail page. Brain is bypassed on the happy path.
- New ``_NavigateBackDispatcher`` in ``default_registry``: mechanical first, Holo3 on fall-through.
- 10 new pin tests + 2 dispatcher tests + 1 updated registry-binding pin.

## Why this fixes the recovery storm

Production run ``20260523_041241_b12b4194`` (the 11-leads verification of #606) showed ``[6] BACK FAILED — retrying CDP-back then Alt+Left`` firing 11+ times — once per iteration. The brain was burning ~8 budget steps trying to navigate back, declaring failure, then ``step_recovery`` was doing 3× CDP-back/Alt+Left attempts with a Claude extract per attempt.

Per iteration that's ~$0.04 GPU + ~$0.036 Claude (~$0.076 wasted) and ~8 seconds wall. Over the 11-iteration run: ~$0.83 + ~88 seconds (~3 min of a 31-min run) spent on what is, on every site, ``window.history.back()`` + a URL-change poll.

The mechanical primitive (``xdotool_env.cdp_history_back``, added in #583) was already used by the recovery layer — this PR lifts it into the primary path so the brain only handles the cases the brain is needed for.

## Fall-through conditions (Holo3 still owns)

- Env doesn't expose ``cdp_history_back`` (test stubs)
- Runner is in ``_opened_detail_in_new_tab`` mode (existing close-tab handler covers this)
- Plan opted out via ``params.brain_required`` (sites with intercepted history)
- CDP back didn't change the URL (no history, intercepted call, SPA without history support)
- URL changed but landed on another detail page (history had multiple detail entries)
- ``cdp_history_back`` raised

## Test plan

- [x] ``pytest tests/test_navigate_back_mechanical_608.py`` — 10 new pin tests pass
- [x] ``pytest tests/test_handler_registry_default.py`` — registry binding pin updated, still passes
- [x] ``pytest tests/ -k "scroll or navigate or handler_registry or registry or recovery"`` — 360 tests pass
- [x] Ruff clean
- [ ] Modal redeploy + boattrader rerun: expect ``[back] mechanical CDP back`` WARNING lines, NO ``[6] BACK FAILED`` storm, more leads per minute, lower cost per lead.

Closes #608

🤖 Generated with [Claude Code](https://claude.com/claude-code)