### PR TITLE
augur: bump augur-sdk pin to >=0.1.11 — live modelio streaming

### DIFF
--- a/docs/integrations/augur.md
+++ b/docs/integrations/augur.md
@@ -156,7 +156,20 @@ training-data record (one file per LLM invocation under the bundle).
 Mantis ships the plumbing in
 `src/mantis_agent/observability/modelio.py` plus a hook inside the
 shared `AnthropicToolUseClient`; per-layer call sites opt in by
-publishing a context:
+publishing a context.
+
+**Live streaming (augur-sdk 0.1.10+):** with the pin bumped to
+`augur-sdk>=0.1.10`, every `record_modelio` call ALSO POSTs the
+redacted record live to `/api/v1/runs/<run_id>/modelio/<relpath>`
+on a background thread (in addition to staging the file for the
+on-close bundle). The local bundle behavior is unchanged — streaming
+is purely additive. If the server returns `403` on the first POST
+(tenant not opted in to modelio streaming), the SDK latches the
+sink off for the rest of the session and bundle-only consumers see
+no regression. `AugurAdapter.record_modelio` is a verbatim forward
+to `DebugSession.record_modelio` so all five wired layers
+(planner / grounding / model / verifier / step_recovery) get the
+streaming behavior automatically with no per-site code changes.
 
 ```python
 from mantis_agent.observability.modelio import publish_modelio_context

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,15 @@ metrics = [
 # augur_sdk lazily and no-ops when the package isn't installed, so
 # this extra is purely opt-in — no base-install footprint change.
 observability = [
-    "augur-sdk>=0.1.9",
+    # 0.1.10 added live modelio streaming via DebugSession.record_modelio
+    # — the same call that stages the local bundle record now also POSTs
+    # to /api/v1/runs/<id>/modelio/<relpath> when AUGUR_DSN is set. The
+    # SDK latches the streaming sink off on first 403 (tenant not opted
+    # in) so bundle-only consumers see no change. 0.1.11 is docs-only.
+    # Existing AugurAdapter.record_modelio wrapper forwards verbatim so
+    # the streaming behavior comes for free across all five wired layers
+    # (planner / grounding / model / verifier / step_recovery).
+    "augur-sdk>=0.1.11",
 ]
 # Self-host the FastAPI server that fronts /predict and /v1/chat/completions.
 # Used by the Baseten / EKS / GKE deployments.

--- a/uv.lock
+++ b/uv.lock
@@ -228,16 +228,16 @@ wheels = [
 
 [[package]]
 name = "augur-sdk"
-version = "0.1.7"
+version = "0.1.11"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonschema" },
     { name = "referencing" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7c/1f/2d904199e2600ea1aee6a316f2698364abc735cbef22f7049619f910af4a/augur_sdk-0.1.7.tar.gz", hash = "sha256:47fa32bcec8e9cb462a3bc87e4d2021bc07c432a2d6fe2f54bf083f4dd1816bc", size = 58357, upload-time = "2026-05-20T10:59:42.808Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/15/f6399097f06d04e323d63b7d66af61eb77ed31f4ee5d61981214ba72b96f/augur_sdk-0.1.11.tar.gz", hash = "sha256:46d8eb27337188b1c2193c4a573d1723e7f558e5691449af763d53d38ae54113", size = 69814, upload-time = "2026-05-23T05:10:39.081Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/f9/297fbcccf509d698a4dee0ceae935721a3e985444ad961c9c5401e6c7b57/augur_sdk-0.1.7-py3-none-any.whl", hash = "sha256:fde3b8674bd00ec6c5ed10f2dccb076e2bc1456b2ab7eee3dd67b667dfeaba0e", size = 61149, upload-time = "2026-05-20T10:59:41.371Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/19/b5b3917707e2d972db69ac7494c1ef9a01a8fd6dab3dd85e3749c4595a1a/augur_sdk-0.1.11-py3-none-any.whl", hash = "sha256:66f1babe73f47d61a98d89eecb7cd3f2f8b3d1cc222ab3500847180a62d9f7db", size = 65895, upload-time = "2026-05-23T05:10:37.689Z" },
 ]
 
 [[package]]
@@ -1537,7 +1537,7 @@ viewer = [
 [package.metadata]
 requires-dist = [
     { name = "accelerate", marker = "extra == 'gpu'", specifier = ">=0.30" },
-    { name = "augur-sdk", marker = "extra == 'observability'", specifier = ">=0.1.7" },
+    { name = "augur-sdk", marker = "extra == 'observability'", specifier = ">=0.1.11" },
     { name = "bitsandbytes", marker = "extra == 'gpu'", specifier = ">=0.43" },
     { name = "fastapi", marker = "extra == 'server'", specifier = ">=0.100" },
     { name = "fastapi", marker = "extra == 'viewer'", specifier = ">=0.100" },


### PR DESCRIPTION
## Summary

- Bumps ``augur-sdk`` pin from ``>=0.1.9`` to ``>=0.1.11``. uv.lock picks up ``0.1.7 → 0.1.11``.
- 0.1.10 added ``StreamingSink.post_modelio()``: every ``DebugSession.record_modelio`` call now ALSO POSTs the redacted record live to ``/api/v1/runs/<run_id>/modelio/<relpath>`` on a background thread, in addition to staging it for the on-close bundle. Local bundle behavior unchanged; streaming is additive.
- 0.1.11 is docs-only (catches the producer-facing API surface up to what shipped in 0.1.10).
- Docs (``docs/integrations/augur.md``) updated with the live-streaming behavior + 403 latch semantics.

## Why no code changes outside the pin + docs

Mantis already shipped the modelio-capture campaign in #526..#533. ``AugurAdapter.record_modelio`` at ``src/mantis_agent/observability/augur.py:675`` is a verbatim forward to ``DebugSession.record_modelio``, so all five wired layers (``planner`` / ``grounding`` / ``model`` / ``verifier`` / ``step_recovery``) get the live streaming behavior automatically once the SDK pin lands. No per-site changes needed.

Verified call sites — all forward through the wrapper, all benefit:

| Layer | Call site |
|---|---|
| planner | ``plan_decomposer.py:803`` (post ``requests.post`` mapping) |
| grounding | ``gym/step_handlers/form.py:614`` (``publish_modelio_context`` wrap) |
| model | ``_anthropic/client.py:255`` (client-side hook in shared ``AnthropicToolUseClient``) |
| verifier | ``gym/_runner_helpers.py:559/906`` (``ensure_results_filters`` + plan-author gate) |
| step_recovery | ``gym/step_recovery.py:1084`` + ``agentic_recovery.py:413`` |

## 403 latch behavior

When a tenant hasn't opted in to modelio streaming, the SDK gets a 403 on the first ``post_modelio`` call and latches ``_modelio_disabled`` on the session — subsequent calls are no-ops with a single info log. Bundle-only consumers see no change. Non-403 errors keep logging at DEBUG without disabling, so transient blips don't permanently silence a session.

## Test plan

- [x] ``pytest tests/ -k "augur or modelio or observability"`` — 110 passed, 11 skipped on the new SDK
- [x] ``mkdocs build --strict`` clean
- [x] ``uv lock`` resolves cleanly
- [ ] Modal redeploy: confirm ``DebugSession.record_modelio`` doesn't raise on the new SDK during a real boattrader run, and that bundle-only mode (no DSN set) still works.
- [ ] (Optional, requires DSN-configured tenant) End-to-end verify a modelio record reaches the Augur workspace's per-tenant ingest route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)