### PR TITLE
Fan-out follow-ups: orchestrator counts, loop_count budgets, cross-partition dedup

### DIFF
--- a/deploy/modal/modal_cua_server.py
+++ b/deploy/modal/modal_cua_server.py
@@ -2818,14 +2818,16 @@ def main(
                 print(f"    [fanout] partition {i + 1}/{len(partitions)} spawned")
 
             print(f"\n  Waiting for {len(partition_handles)} partition workers...")
-            from mantis_agent.gym.fanout_runner import read_partition_result
-            merged_total = 0
+            from mantis_agent.gym.fanout_runner import (
+                dedup_leads_by_url, read_partition_result,
+            )
             merged_phone = 0
+            per_partition_leads: list[list[dict]] = []
             for i, handle in partition_handles:
                 try:
                     summary = read_partition_result(handle.get())
-                    merged_total += summary["viable"]
                     merged_phone += summary["with_phone"]
+                    per_partition_leads.append(summary["leads"])
                     print(
                         f"    [fanout] partition {i + 1}: "
                         f"viable={summary['viable']} phone={summary['with_phone']}"
@@ -2833,10 +2835,24 @@ def main(
                 except Exception as e:
                     print(f"    [fanout] partition {i + 1}: ERROR — {e}")
 
+            # #621: cross-partition dedup by listing_url. Featured /
+            # sponsored listings repeat across pages, and pagination
+            # drift mid-run can shift listings onto adjacent pages —
+            # the orchestrator deduplicates so ``Total leads`` is the
+            # true unique-count, not a naive sum.
+            _deduped, raw_total, dedup_total = dedup_leads_by_url(
+                per_partition_leads,
+            )
             print("\n  ═══ FANOUT RESULTS ═══")
-            print(f"  Partitions:  {len(partitions)}")
-            print(f"  Total leads: {merged_total}")
-            print(f"  With phone:  {merged_phone}")
+            print(f"  Partitions:    {len(partitions)}")
+            print(f"  Total leads (raw):     {raw_total}")
+            print(f"  Total leads (deduped): {dedup_total}")
+            if raw_total > dedup_total:
+                print(
+                    f"  Duplicates collapsed: {raw_total - dedup_total} "
+                    f"(cross-partition URL overlap)"
+                )
+            print(f"  With phone:    {merged_phone}")
             return
 
     # ── Single worker (default) ──────────────────────────────────

--- a/deploy/modal/modal_cua_server.py
+++ b/deploy/modal/modal_cua_server.py
@@ -2818,20 +2818,25 @@ def main(
                 print(f"    [fanout] partition {i + 1}/{len(partitions)} spawned")
 
             print(f"\n  Waiting for {len(partition_handles)} partition workers...")
+            from mantis_agent.gym.fanout_runner import read_partition_result
             merged_total = 0
+            merged_phone = 0
             for i, handle in partition_handles:
                 try:
-                    result = handle.get()
-                    score = result.get("score", 0)
-                    leads = result.get("leads_count", 0)
-                    merged_total += leads
-                    print(f"    [fanout] partition {i + 1}: score={score} leads={leads}")
+                    summary = read_partition_result(handle.get())
+                    merged_total += summary["viable"]
+                    merged_phone += summary["with_phone"]
+                    print(
+                        f"    [fanout] partition {i + 1}: "
+                        f"viable={summary['viable']} phone={summary['with_phone']}"
+                    )
                 except Exception as e:
                     print(f"    [fanout] partition {i + 1}: ERROR — {e}")
 
             print("\n  ═══ FANOUT RESULTS ═══")
             print(f"  Partitions:  {len(partitions)}")
             print(f"  Total leads: {merged_total}")
+            print(f"  With phone:  {merged_phone}")
             return
 
     # ── Single worker (default) ──────────────────────────────────

--- a/src/mantis_agent/gym/fanout_runner.py
+++ b/src/mantis_agent/gym/fanout_runner.py
@@ -297,6 +297,41 @@ def _run_one_subplan(
     return runner.run(plan)
 
 
+# ── #623: orchestrator-side worker result reader ──────────────────────
+
+
+def read_partition_result(result: dict | None) -> dict:
+    """Extract the lead-count fields from a worker's return dict.
+
+    The Modal worker's return shape is whatever ``build_micro_result``
+    in ``server_utils`` produces — keys ``viable`` (count),
+    ``leads_with_phone`` (count), and ``leads`` (the list).
+
+    The original #617 orchestrator read ``leads_count`` / ``score``
+    instead — keys that no MicroPlanRunner-backed executor returns.
+    Both lookups silently defaulted to 0, so ``Total leads`` always
+    printed 0 even when every partition successfully extracted leads.
+
+    Returns a normalized dict with:
+
+      * ``viable``: total leads in the partition (int, defaults to 0).
+      * ``with_phone``: subset that carry a phone (int, defaults to 0).
+      * ``leads``: the raw lead rows list (used by #621's cross-partition
+        dedup pass; absent in worker shapes that elide the rows for
+        bandwidth — defaults to an empty list).
+
+    Tolerant of ``None`` input (when ``handle.get()`` itself failed
+    upstream) — returns the zero shape rather than raising.
+    """
+    if not isinstance(result, dict):
+        return {"viable": 0, "with_phone": 0, "leads": []}
+    viable = int(result.get("viable", 0) or 0)
+    with_phone = int(result.get("leads_with_phone", 0) or 0)
+    leads_raw = result.get("leads") or []
+    leads = list(leads_raw) if isinstance(leads_raw, list) else []
+    return {"viable": viable, "with_phone": with_phone, "leads": leads}
+
+
 # ── Modal transport — partition prep (#617) ────────────────────────────
 
 

--- a/src/mantis_agent/gym/fanout_runner.py
+++ b/src/mantis_agent/gym/fanout_runner.py
@@ -322,33 +322,65 @@ def _normalize_listing_url(url: str) -> str:
     return s
 
 
+def _lead_url(lead: Any) -> str:
+    """Pull the listing URL from a lead row, regardless of its shape.
+
+    Two formats coexist in the codebase — the verification run for
+    #621 surfaced this when the dict-only first pass treated all 87
+    string-shaped leads as non-dict and dropped them:
+
+      * **String** (the actual production shape from
+        ``build_micro_result``): ``"VIABLE | Year: ... | URL: ..."``.
+        Parsed with ``ListingDedup.lead_key`` — the same helper
+        per-container dedup uses, so cross-partition keys match
+        per-container keys.
+      * **Dict** (defensive — host integrations / future structured
+        paths): ``{"listing_url": "..."}`` or ``{"url": "..."}``.
+
+    Returns the empty string when neither shape yields a URL. The
+    dedup pass treats such leads as "no key" and passes them through
+    unchanged.
+    """
+    if isinstance(lead, str):
+        from .listing_dedup import ListingDedup
+        # lead_key falls back to the row's first 100 chars when no
+        # URL regex match — that fallback isn't a URL and would
+        # collide all no-URL rows under one bucket. Gate on the
+        # ``URL:`` token explicitly.
+        if "URL:" not in lead:
+            return ""
+        return ListingDedup.lead_key(lead)
+    if isinstance(lead, dict):
+        return str(lead.get("listing_url") or lead.get("url") or "")
+    return ""
+
+
 def dedup_leads_by_url(
-    per_partition_leads: list[list[dict]],
-) -> tuple[list[dict], int, int]:
+    per_partition_leads: list[list[Any]],
+) -> tuple[list[Any], int, int]:
     """Cross-partition lead-list merge with URL dedup (#621).
 
     Each worker returns its own ``leads`` list — concatenated naively
     that gives a ``raw`` total, but featured / sponsored listings can
     repeat across pages and pagination drift mid-run can shift the
     same listing onto two adjacent pages. The dedup pass collapses
-    duplicates by normalized ``listing_url``, preserving first-seen
+    duplicates by normalized listing URL, preserving first-seen
     partition order.
 
     Returns ``(deduped, raw_count, deduped_count)``.
 
-    Leads without a ``listing_url`` key (or with an empty value) pass
-    through unchanged — those are typically partial-extract envelopes
-    or already-deduped placeholders the per-container scanner emitted.
+    Lead rows are heterogeneous (str from ``build_micro_result``;
+    dict from host paths). URL extraction is delegated to
+    :func:`_lead_url` which handles both shapes; rows that yield no
+    URL pass through unchanged.
     """
     seen: set[str] = set()
-    deduped: list[dict] = []
+    deduped: list[Any] = []
     raw = 0
     for chunk in per_partition_leads:
         for lead in chunk:
             raw += 1
-            if not isinstance(lead, dict):
-                continue
-            url = _normalize_listing_url(str(lead.get("listing_url", "")))
+            url = _normalize_listing_url(_lead_url(lead))
             if not url:
                 deduped.append(lead)
                 continue

--- a/src/mantis_agent/gym/fanout_runner.py
+++ b/src/mantis_agent/gym/fanout_runner.py
@@ -300,6 +300,65 @@ def _run_one_subplan(
 # ── #623: orchestrator-side worker result reader ──────────────────────
 
 
+def _normalize_listing_url(url: str) -> str:
+    """Canonical form for cross-partition lead-dedup keys (#621).
+
+    Rules:
+      - Strip surrounding whitespace.
+      - Lowercase (most marketplaces use case-insensitive paths).
+      - Drop a trailing slash (BoatTrader emits both ``/boat/<slug>``
+        and ``/boat/<slug>/`` interchangeably across pages).
+
+    No URL-parse / query-string dance — that's per-domain policy. The
+    listing URL primary key is opaque enough that simple normalization
+    catches the common duplication signals (path-case drift, trailing
+    slash) without overreaching.
+    """
+    if not url:
+        return ""
+    s = str(url).strip().lower()
+    if s.endswith("/"):
+        s = s[:-1]
+    return s
+
+
+def dedup_leads_by_url(
+    per_partition_leads: list[list[dict]],
+) -> tuple[list[dict], int, int]:
+    """Cross-partition lead-list merge with URL dedup (#621).
+
+    Each worker returns its own ``leads`` list — concatenated naively
+    that gives a ``raw`` total, but featured / sponsored listings can
+    repeat across pages and pagination drift mid-run can shift the
+    same listing onto two adjacent pages. The dedup pass collapses
+    duplicates by normalized ``listing_url``, preserving first-seen
+    partition order.
+
+    Returns ``(deduped, raw_count, deduped_count)``.
+
+    Leads without a ``listing_url`` key (or with an empty value) pass
+    through unchanged — those are typically partial-extract envelopes
+    or already-deduped placeholders the per-container scanner emitted.
+    """
+    seen: set[str] = set()
+    deduped: list[dict] = []
+    raw = 0
+    for chunk in per_partition_leads:
+        for lead in chunk:
+            raw += 1
+            if not isinstance(lead, dict):
+                continue
+            url = _normalize_listing_url(str(lead.get("listing_url", "")))
+            if not url:
+                deduped.append(lead)
+                continue
+            if url in seen:
+                continue
+            seen.add(url)
+            deduped.append(lead)
+    return deduped, raw, len(deduped)
+
+
 def read_partition_result(result: dict | None) -> dict:
     """Extract the lead-count fields from a worker's return dict.
 

--- a/src/mantis_agent/gym/run_executor.py
+++ b/src/mantis_agent/gym/run_executor.py
@@ -112,7 +112,21 @@ class RunState:
     loop_counters: dict[int, int] = field(default_factory=dict)
     listings_on_page: int = 0
     step_retry_counts: dict[Any, int] = field(default_factory=dict)
-    max_loop_iterations: int = 200  # safety cap
+    # #622: section-aware loop ceiling. The pre-#622 single ``200``
+    # value was the wrong cap for both shapes — pages have ≤25 cards,
+    # scrapes cover ≤10 pages — and on fan-out runs the 200 ceiling
+    # let each per-page partition burn ~$2.50 on dedup-skipped re-clicks
+    # waiting for the budget to drain. Section-aware defaults:
+    #   extraction: 30   (typical page + 20% lazy-load / carousel pad)
+    #   pagination: 10   (typical scrape depth)
+    # Kept as a dict so per-run overrides can target one section
+    # without rebuilding the other. ``max_loop_iterations`` (singular)
+    # stays as a legacy alias that picks the largest value — used by
+    # any caller that didn't migrate to per-section reads.
+    max_loop_iterations_by_section: dict[str, int] = field(
+        default_factory=lambda: {"extraction": 30, "pagination": 10, "default": 50}
+    )
+    max_loop_iterations: int = 200  # legacy single-value cap; kept for tests/back-compat
 
     @classmethod
     def fresh(cls, run_key: str, session_name: str, plan_signature: str) -> RunState:
@@ -701,7 +715,22 @@ class RunExecutor:
             state.loop_counters.get(state.step_index, 0) + 1
         )
         count = state.loop_counters[state.step_index]
-        max_count = step.loop_count or state.max_loop_iterations
+        # #622: section-aware fallback. The legacy single ``max_loop_iterations``
+        # value (200) was the wrong cap for both extraction (pages ≤25) and
+        # pagination (scrapes ≤10) shapes. Resolve in priority order:
+        #   1. ``step.loop_count`` — plan-author / decomposer explicit count
+        #   2. ``max_loop_iterations_by_section[step.section]`` — section default
+        #   3. ``max_loop_iterations_by_section['default']`` — un-sectioned safety
+        #   4. ``max_loop_iterations`` — legacy single-value fallback (kept for
+        #      back-compat with tests/callers that haven't migrated)
+        max_count = step.loop_count
+        if not max_count:
+            section_caps = state.max_loop_iterations_by_section or {}
+            max_count = section_caps.get(step.section, 0) or section_caps.get(
+                "default", 0,
+            )
+        if not max_count:
+            max_count = state.max_loop_iterations
         if count < max_count:
             target = step.loop_target if step.loop_target >= 0 else state.step_index
             state.step_index = target
@@ -710,7 +739,11 @@ class RunExecutor:
                 f"step {state.step_index}"
             )
         else:
-            logger.info("  [loop] max iterations reached")
+            logger.info(
+                "  [loop] max iterations reached (%d/%d, section=%s, source=%s)",
+                count, max_count, step.section,
+                "step.loop_count" if step.loop_count else "section_default",
+            )
             state.step_index += 1
         self._persist(plan, state)
 

--- a/src/mantis_agent/plan_decomposer.py
+++ b/src/mantis_agent/plan_decomposer.py
@@ -646,10 +646,19 @@ RULES:
   fields, scrape, harvest data) keeps gate=false.
 
 LOOP STRUCTURE:
-  Extraction loop: click → URL → scroll → extract → back → loop(target=click, count=N)
-  Pagination loop: paginate → loop(target=click, count=pages)
+  Extraction loop: click → URL → scroll → extract → back → loop(target=click, count=30)
+  Pagination loop: paginate → loop(target=click, count=10)
   The listing loop runs INSIDE the pagination loop.
   Form-only flows do not need loops.
+
+  ALWAYS emit a concrete loop_count integer — never 0, never omitted:
+    • Extraction-section loops: 30 (typical page has ≤25 cards; +20% covers
+      lazy-loaded carousel rotation and dedup-skipped re-clicks).
+    • Pagination-section loops: 10 (typical scrape covers ≤10 pages).
+  If the source plan mentions an explicit count ("scan 50 listings", "go
+  through all 8 pages"), use that number instead. Never default to 0 —
+  the runtime falls back to a 200-iter ceiling and burns ~$2.50/loop on
+  wasted dedup-skipped retries.
 
 PLAIN TEXT PLAN:
 {plan_text}
@@ -690,7 +699,10 @@ STEP TYPES:
                 verification extract_data, not just end-of-setup.
 - navigate_back: Go back (budget=3, section="extraction")
 - paginate: Click Next page (budget=10, grounding=true, section="pagination")
-- loop: Jump back to step index (loop_target=N, loop_count=max)
+- loop: Jump back to step index. ALWAYS emit a concrete loop_count integer:
+        extraction-section: 30 (or source plan's explicit listing count)
+        pagination-section: 10 (or source plan's explicit page count)
+        Never 0; never omit. See LOOP STRUCTURE above for full rationale.
 - fill_field: Click a labelled input and type a value
               (budget=4, params={"label": "<visible field label>", "value": "<text to type>"})
 - submit: Click a SINGLE LABELLED CLICKABLE on a non-listings page — buttons
@@ -786,7 +798,7 @@ class PlanDecomposer:
             domain = m.group(1)
 
         # Check cache — include prompt version in hash to invalidate on schema changes
-        prompt_version = "v30_concrete_neutral_examples"  # Bump this when DECOMPOSE_PROMPT changes
+        prompt_version = "v31_loop_count_concrete_defaults"  # Bump this when DECOMPOSE_PROMPT changes
         plan_hash = hashlib.md5(f"{prompt_version}:{plan_text}".encode()).hexdigest()[:8]
         cache_path = (
             cache_path_template.replace("{hash}", plan_hash)

--- a/tests/test_fanout_runner.py
+++ b/tests/test_fanout_runner.py
@@ -25,7 +25,9 @@ from mantis_agent.gym.checkpoint import StepResult
 from mantis_agent.gym.fanout_runner import (
     DEFAULT_PAGINATION_URL_TEMPLATE,
     LocalFanoutRunner,
+    _normalize_listing_url,
     build_worker_subplan,
+    dedup_leads_by_url,
     fanout_enabled,
     partition_urls,
     partition_urls_for_pagination,
@@ -581,3 +583,116 @@ def test_read_partition_result_coerces_string_counts() -> None:
     out = read_partition_result({"viable": "27", "leads_with_phone": "1"})
     assert out["viable"] == 27
     assert out["with_phone"] == 1
+
+
+# ── #621: cross-partition lead dedup ───────────────────────────────────
+
+
+def test_normalize_listing_url_strips_trailing_slash() -> None:
+    assert _normalize_listing_url("https://example.com/boat/1/") == "https://example.com/boat/1"
+
+
+def test_normalize_listing_url_lowercases() -> None:
+    """Path-case drift across pages (some marketplaces emit /Boat/Foo
+    on one page and /boat/foo on another) should collapse."""
+    assert (
+        _normalize_listing_url("https://Example.com/Boat/Foo/")
+        == "https://example.com/boat/foo"
+    )
+
+
+def test_normalize_listing_url_empty_input() -> None:
+    assert _normalize_listing_url("") == ""
+    assert _normalize_listing_url("   ") == ""
+
+
+def test_dedup_collapses_exact_url_duplicates() -> None:
+    """Featured / sponsored boat appears on two pages — collapse to one."""
+    per_partition = [
+        [
+            {"listing_url": "https://example.com/boat/1/", "make": "A"},
+            {"listing_url": "https://example.com/boat/2/", "make": "B"},
+        ],
+        [
+            {"listing_url": "https://example.com/boat/1/", "make": "A"},  # dup
+            {"listing_url": "https://example.com/boat/3/", "make": "C"},
+        ],
+    ]
+    deduped, raw, dedup_count = dedup_leads_by_url(per_partition)
+    assert raw == 4
+    assert dedup_count == 3
+    assert [d["make"] for d in deduped] == ["A", "B", "C"]
+
+
+def test_dedup_collapses_trailing_slash_variants() -> None:
+    """``/boat/1`` and ``/boat/1/`` are the same listing (BoatTrader emits
+    both interchangeably across pages)."""
+    per_partition = [
+        [{"listing_url": "https://example.com/boat/1/"}],
+        [{"listing_url": "https://example.com/boat/1"}],  # no slash
+    ]
+    deduped, raw, dedup_count = dedup_leads_by_url(per_partition)
+    assert raw == 2
+    assert dedup_count == 1
+
+
+def test_dedup_no_collapse_when_urls_differ() -> None:
+    """Five distinct URLs across two partitions → 5 deduped leads."""
+    per_partition = [
+        [{"listing_url": f"https://example.com/boat/{i}/"} for i in range(3)],
+        [{"listing_url": f"https://example.com/boat/{i}/"} for i in range(3, 5)],
+    ]
+    deduped, raw, dedup_count = dedup_leads_by_url(per_partition)
+    assert raw == 5
+    assert dedup_count == 5
+
+
+def test_dedup_preserves_first_seen_partition_order() -> None:
+    """When the same URL appears in partition 1 first and partition 2
+    later, we keep partition 1's row (its data may be cleaner since
+    partition 1 likely ran first / had warmer cache)."""
+    per_partition = [
+        [{"listing_url": "https://example.com/boat/1/", "asking_price": "$100"}],
+        [{"listing_url": "https://example.com/boat/1/", "asking_price": "$999"}],
+    ]
+    deduped, _, _ = dedup_leads_by_url(per_partition)
+    assert len(deduped) == 1
+    assert deduped[0]["asking_price"] == "$100"
+
+
+def test_dedup_leads_without_url_pass_through() -> None:
+    """Leads without a listing_url key (partial extracts) are passed
+    through unchanged — the orchestrator shouldn't silently drop them
+    just because they lack a dedup key."""
+    per_partition = [
+        [{"listing_url": "https://example.com/boat/1/"}, {"asking_price": "$50"}],
+        [{"listing_url": "https://example.com/boat/1/"}, {"asking_price": "$99"}],
+    ]
+    deduped, raw, dedup_count = dedup_leads_by_url(per_partition)
+    # 4 raw, 1 URL-dup collapsed, 2 no-URL passed through, 1 unique URL = 3
+    assert raw == 4
+    assert dedup_count == 3
+
+
+def test_dedup_handles_empty_partition_lists() -> None:
+    """A partition that returned no leads (worker crashed early) leaves
+    the merge a no-op for that chunk."""
+    per_partition = [
+        [],
+        [{"listing_url": "https://example.com/boat/1/"}],
+        [],
+    ]
+    deduped, raw, dedup_count = dedup_leads_by_url(per_partition)
+    assert raw == 1
+    assert dedup_count == 1
+
+
+def test_dedup_ignores_non_dict_lead_entries() -> None:
+    """Defensive — a malformed lead row (string / None) shouldn't crash
+    the merge. Skip it; keep going."""
+    per_partition = [
+        [{"listing_url": "https://example.com/boat/1/"}, "garbage", None],
+    ]
+    deduped, raw, dedup_count = dedup_leads_by_url(per_partition)
+    assert raw == 3
+    assert dedup_count == 1

--- a/tests/test_fanout_runner.py
+++ b/tests/test_fanout_runner.py
@@ -30,6 +30,7 @@ from mantis_agent.gym.fanout_runner import (
     partition_urls,
     partition_urls_for_pagination,
     prepare_modal_partitions,
+    read_partition_result,
     rewrite_for_fanout,
 )
 from mantis_agent.plan_decomposer import (
@@ -519,3 +520,64 @@ def test_pagination_template_used_from_paginate_step_hint() -> None:
 
 def test_default_pagination_template_constant() -> None:
     assert DEFAULT_PAGINATION_URL_TEMPLATE == "{base}/page-{n}/"
+
+
+# ── #623: read_partition_result ────────────────────────────────────────
+
+
+def test_read_partition_result_canonical_shape() -> None:
+    """build_micro_result returns ``viable`` + ``leads_with_phone`` + ``leads``.
+    The reader must surface those — NOT the legacy ``leads_count`` /
+    ``score`` keys the gemma4 worker used to return."""
+    fake = {
+        "viable": 27,
+        "leads_with_phone": 1,
+        "leads": [{"listing_url": "https://example.com/boat/1/"}],
+        # Extra keys (cost, time, etc) must not interfere.
+        "cost": 10.03,
+        "score": 0.9,  # MUST be ignored — legacy field.
+    }
+    out = read_partition_result(fake)
+    assert out["viable"] == 27
+    assert out["with_phone"] == 1
+    assert out["leads"] == [{"listing_url": "https://example.com/boat/1/"}]
+
+
+def test_read_partition_result_legacy_keys_zeroed() -> None:
+    """A worker that returns only the legacy gemma4 shape (``leads_count``
+    / ``score``, no ``viable``) yields zeros — the orchestrator must NOT
+    silently confuse counts. This pins the bug #623 fixed: the legacy
+    reader saw ``leads_count`` and trusted it; the new reader requires
+    the canonical ``viable`` key."""
+    legacy = {"leads_count": 27, "score": 0.9}
+    out = read_partition_result(legacy)
+    assert out["viable"] == 0
+    assert out["with_phone"] == 0
+    assert out["leads"] == []
+
+
+def test_read_partition_result_none_input_safe() -> None:
+    """``handle.get()`` returning None (worker crash) shouldn't crash
+    the orchestrator — the reader returns the zero shape and the
+    orchestrator's exception handler logs the failure separately."""
+    out = read_partition_result(None)
+    assert out == {"viable": 0, "with_phone": 0, "leads": []}
+
+
+def test_read_partition_result_tolerates_missing_leads_list() -> None:
+    """A worker that returns counts but elides the leads list (some
+    paths drop it to save bandwidth) must not crash the dedup pass
+    (#621); ``leads`` defaults to an empty list."""
+    out = read_partition_result({"viable": 5, "leads_with_phone": 1})
+    assert out["viable"] == 5
+    assert out["with_phone"] == 1
+    assert out["leads"] == []
+
+
+def test_read_partition_result_coerces_string_counts() -> None:
+    """Defensive — some serialisation paths upcast ints to strings.
+    The reader must coerce to int so ``merged_total += summary['viable']``
+    doesn't TypeError on the orchestrator side."""
+    out = read_partition_result({"viable": "27", "leads_with_phone": "1"})
+    assert out["viable"] == 27
+    assert out["with_phone"] == 1

--- a/tests/test_fanout_runner.py
+++ b/tests/test_fanout_runner.py
@@ -687,12 +687,89 @@ def test_dedup_handles_empty_partition_lists() -> None:
     assert dedup_count == 1
 
 
-def test_dedup_ignores_non_dict_lead_entries() -> None:
-    """Defensive — a malformed lead row (string / None) shouldn't crash
-    the merge. Skip it; keep going."""
+def test_dedup_ignores_malformed_lead_entries() -> None:
+    """Defensive — None / int / unknown types shouldn't crash the
+    merge. They pass through unchanged ("no key" path)."""
     per_partition = [
-        [{"listing_url": "https://example.com/boat/1/"}, "garbage", None],
+        [{"listing_url": "https://example.com/boat/1/"}, None, 42],
     ]
     deduped, raw, dedup_count = dedup_leads_by_url(per_partition)
     assert raw == 3
+    # None + 42 yield no URL → pass through (no dedup); dict has URL → counts.
+    assert dedup_count == 3
+
+
+# ── Real production string-lead format (#621 verification regression) ─
+
+
+def _viable_lead(url: str, year: int = 2023, make: str = "Acme") -> str:
+    """Build a lead row in the actual format build_micro_result emits
+    (server_utils.py:820, leads list). VIABLE prefix + pipe-delimited
+    fields + ``URL: <url>``. Matches what ListingDedup.lead_key parses
+    so cross-partition keys match per-container keys."""
+    return (
+        f"VIABLE | Year: {year} | Make: {make} | Model: X | "
+        f"Price: $99,000 | Phone: none | URL: {url}"
+    )
+
+
+def test_dedup_collapses_string_leads_across_partitions() -> None:
+    """The Modal verification run for #621 surfaced this: leads are
+    strings (not dicts), so the dict-only first pass dropped all 87.
+    Fix: extract URL via ListingDedup.lead_key for string leads."""
+    per_partition = [
+        [
+            _viable_lead("boattrader.com/boat/1/", year=2023, make="Pershing"),
+            _viable_lead("boattrader.com/boat/2/", year=2022, make="Freeman"),
+        ],
+        [
+            _viable_lead("boattrader.com/boat/1/", year=2023, make="Pershing"),  # dup
+            _viable_lead("boattrader.com/boat/3/", year=2021, make="Azimut"),
+        ],
+    ]
+    deduped, raw, dedup_count = dedup_leads_by_url(per_partition)
+    assert raw == 4
+    assert dedup_count == 3
+    # First-seen wins (partition 1's Pershing row, not partition 2's)
+    pershing_rows = [
+        d for d in deduped if isinstance(d, str) and "Pershing" in d
+    ]
+    assert len(pershing_rows) == 1
+
+
+def test_dedup_string_leads_collapse_trailing_slash_variants() -> None:
+    """Cross-page emit of the same URL with/without trailing slash is
+    the most common cross-partition overlap case — must collapse to one."""
+    per_partition = [
+        [_viable_lead("boattrader.com/boat/1/")],
+        [_viable_lead("boattrader.com/boat/1")],  # no trailing slash
+    ]
+    deduped, raw, dedup_count = dedup_leads_by_url(per_partition)
+    assert raw == 2
+    assert dedup_count == 1
+
+
+def test_dedup_string_lead_without_url_passes_through() -> None:
+    """A lead row missing the ``URL:`` token (rare partial-extract case)
+    has no dedup key — pass through unchanged rather than collapsing
+    all keyless rows under a single fallback bucket."""
+    no_url = "VIABLE | Year: 2023 | Make: X | Phone: none"
+    per_partition = [[no_url, no_url]]  # two identical keyless rows
+    deduped, raw, dedup_count = dedup_leads_by_url(per_partition)
+    assert raw == 2
+    # Both pass through — better to over-report than silently collapse
+    # rows we can't authoritatively identify as duplicates.
+    assert dedup_count == 2
+
+
+def test_dedup_mixed_string_and_dict_leads() -> None:
+    """Defensive — if a future caller mixes string and dict leads in
+    one partition list, dedup should still work consistently across
+    both shapes by extracted URL."""
+    per_partition = [
+        [_viable_lead("boattrader.com/boat/1/")],
+        [{"listing_url": "boattrader.com/boat/1/", "make": "dict-shaped"}],
+    ]
+    deduped, raw, dedup_count = dedup_leads_by_url(per_partition)
+    assert raw == 2
     assert dedup_count == 1

--- a/tests/test_loop_count_budget.py
+++ b/tests/test_loop_count_budget.py
@@ -1,0 +1,215 @@
+"""Loop-count budget tests (#622).
+
+Two layers under test:
+
+  - DECOMPOSE_PROMPT carries the concrete loop_count guidance (Layer A).
+    Pure prompt-content assertion — verifies the prompt tells Claude
+    to emit 30 / 10 and to never emit 0.
+  - RunState's _handle_loop_step falls through to section-aware defaults
+    when step.loop_count is 0 (Layer B). Direct unit test of the
+    resolver logic with the inner run-executor body invoked.
+
+The end-to-end behaviour (decomposer emits non-zero loop_count;
+runtime caps a buggy 0 at section default) is verified on the next
+Modal redeploy.
+"""
+
+from __future__ import annotations
+
+from mantis_agent.gym.checkpoint import RunCheckpoint
+from mantis_agent.gym.run_executor import RunState
+from mantis_agent.plan_decomposer import DECOMPOSE_PROMPT, MicroIntent, MicroPlan
+
+
+# ── Layer A: prompt guidance ───────────────────────────────────────────
+
+
+def test_prompt_documents_concrete_extraction_loop_count() -> None:
+    """The extraction-loop example in LOOP STRUCTURE shows ``count=30``,
+    not the old ``count=N`` placeholder."""
+    assert "count=30" in DECOMPOSE_PROMPT
+    assert "count=N)" not in DECOMPOSE_PROMPT  # legacy placeholder gone
+
+
+def test_prompt_documents_concrete_pagination_loop_count() -> None:
+    """Pagination-loop example shows ``count=10``, not ``count=pages``."""
+    assert "count=10" in DECOMPOSE_PROMPT
+    assert "count=pages" not in DECOMPOSE_PROMPT
+
+
+def test_prompt_forbids_loop_count_zero() -> None:
+    """The prompt explicitly tells Claude never to emit 0 — that was
+    the pre-#622 default that fell through to the 200-iter ceiling
+    and burned $2.50/loop on dedup-skipped retries."""
+    assert "Never 0" in DECOMPOSE_PROMPT or "never 0" in DECOMPOSE_PROMPT
+
+
+def test_prompt_loop_step_type_doc_updated() -> None:
+    """The ``- loop:`` type-definition line carries the same guidance,
+    not just the LOOP STRUCTURE heading above it. Claude reads the
+    type-definitions section when picking step parameters."""
+    # The new doc reads "ALWAYS emit a concrete loop_count integer:"
+    # Pin that exact phrase so the doc can't silently regress.
+    assert "ALWAYS emit a concrete loop_count integer" in DECOMPOSE_PROMPT
+
+
+# ── Layer B: runtime section-aware fallback ────────────────────────────
+
+
+def _state() -> RunState:
+    """Fresh RunState with the default section-aware caps."""
+    return RunState(
+        checkpoint=RunCheckpoint(run_key="t", plan_signature="x"),
+    )
+
+
+def test_default_section_caps_present() -> None:
+    """RunState ships with the section-aware ceiling dict populated."""
+    state = _state()
+    assert state.max_loop_iterations_by_section == {
+        "extraction": 30, "pagination": 10, "default": 50,
+    }
+
+
+def test_extraction_loop_with_zero_count_caps_at_30() -> None:
+    """When the decomposer (legacy / buggy) emits loop_count=0 on an
+    extraction-section loop, the runtime falls back to 30 — NOT 200."""
+    from mantis_agent.gym.run_executor import RunExecutor
+
+    plan = MicroPlan(domain="x")
+    plan.steps = [
+        MicroIntent(intent="click", type="click", section="extraction"),
+        MicroIntent(
+            intent="loop", type="loop", section="extraction",
+            loop_target=0, loop_count=0,
+        ),
+    ]
+    state = _state()
+    state.step_index = 1  # at the loop step
+
+    class _StubExecutor(RunExecutor):
+        def __init__(self): pass  # bypass parent back-ref
+        def _persist(self, plan, state): pass
+
+    exec_ = _StubExecutor()
+    # Simulate 31 loop fires to confirm the cap kicks in at 30.
+    for i in range(31):
+        state.step_index = 1
+        exec_._handle_loop_step(plan, plan.steps[1], state)
+    # After 30 iterations the loop step advances past itself (step_index
+    # becomes 2, off the end of the plan). On iteration 31 the counter
+    # has tripped — verify by re-firing once more and asserting we're
+    # past the loop.
+    assert state.loop_counters[1] >= 30
+    # The 31st invocation should have already advanced.
+    assert state.step_index == 2
+
+
+def test_pagination_loop_with_zero_count_caps_at_10() -> None:
+    """Pagination-section loop with loop_count=0 caps at 10 (not 30)."""
+    from mantis_agent.gym.run_executor import RunExecutor
+
+    plan = MicroPlan(domain="x")
+    plan.steps = [
+        MicroIntent(intent="paginate", type="paginate", section="pagination"),
+        MicroIntent(
+            intent="loop", type="loop", section="pagination",
+            loop_target=0, loop_count=0,
+        ),
+    ]
+    state = _state()
+
+    class _StubExecutor(RunExecutor):
+        def __init__(self): pass
+        def _persist(self, plan, state): pass
+
+    exec_ = _StubExecutor()
+    for i in range(11):
+        state.step_index = 1
+        exec_._handle_loop_step(plan, plan.steps[1], state)
+    assert state.loop_counters[1] >= 10
+    assert state.step_index == 2
+
+
+def test_explicit_loop_count_overrides_section_default() -> None:
+    """When a plan specifies loop_count=50, that wins over the
+    extraction-section 30 default."""
+    from mantis_agent.gym.run_executor import RunExecutor
+
+    plan = MicroPlan(domain="x")
+    plan.steps = [
+        MicroIntent(intent="click", type="click", section="extraction"),
+        MicroIntent(
+            intent="loop", type="loop", section="extraction",
+            loop_target=0, loop_count=50,
+        ),
+    ]
+    state = _state()
+
+    class _StubExecutor(RunExecutor):
+        def __init__(self): pass
+        def _persist(self, plan, state): pass
+
+    exec_ = _StubExecutor()
+    # Fire 40 times — should still be looping (under the 50 explicit cap).
+    for i in range(40):
+        state.step_index = 1
+        exec_._handle_loop_step(plan, plan.steps[1], state)
+    # Still on the loop's jump-back target (step 0).
+    assert state.step_index == 0
+    assert state.loop_counters[1] == 40
+
+
+def test_unsectioned_loop_falls_back_to_default_50() -> None:
+    """A loop step with empty ``section`` falls through to the
+    ``default`` bucket (50), not the legacy 200."""
+    from mantis_agent.gym.run_executor import RunExecutor
+
+    plan = MicroPlan(domain="x")
+    plan.steps = [
+        MicroIntent(intent="click", type="click"),
+        MicroIntent(intent="loop", type="loop", loop_target=0, loop_count=0),
+    ]
+    state = _state()
+
+    class _StubExecutor(RunExecutor):
+        def __init__(self): pass
+        def _persist(self, plan, state): pass
+
+    exec_ = _StubExecutor()
+    for i in range(51):
+        state.step_index = 1
+        exec_._handle_loop_step(plan, plan.steps[1], state)
+    assert state.loop_counters[1] >= 50
+    assert state.step_index == 2
+
+
+def test_legacy_max_loop_iterations_still_honoured_when_no_section_caps() -> None:
+    """Caller passes a RunState with the section-cap dict cleared — the
+    code falls through to the legacy single-value field. Preserves
+    behaviour for any external caller / test fixture that hasn't
+    migrated."""
+    from mantis_agent.gym.run_executor import RunExecutor
+
+    plan = MicroPlan(domain="x")
+    plan.steps = [
+        MicroIntent(intent="click", type="click", section="extraction"),
+        MicroIntent(
+            intent="loop", type="loop", section="extraction",
+            loop_target=0, loop_count=0,
+        ),
+    ]
+    state = _state()
+    state.max_loop_iterations_by_section = {}  # legacy caller
+    state.max_loop_iterations = 5  # set tight so we can observe the cap
+
+    class _StubExecutor(RunExecutor):
+        def __init__(self): pass
+        def _persist(self, plan, state): pass
+
+    exec_ = _StubExecutor()
+    for i in range(6):
+        state.step_index = 1
+        exec_._handle_loop_step(plan, plan.steps[1], state)
+    assert state.loop_counters[1] >= 5
+    assert state.step_index == 2


### PR DESCRIPTION
## Summary

Three bug + cost-optimization follow-ups discovered during the #617 end-to-end Modal verification (boattrader run, 175 leads across 5 partitions, $50.09). All three were filed against #617 and are stacked on PR #624; this PR depends on #624 landing first.

- **#623** orchestrator field-name reads — replaced ``leads_count`` / ``score`` (legacy gemma4 fields nobody returns) with ``viable`` / ``leads_with_phone`` (the canonical ``build_micro_result`` shape). ``Total leads`` summary now shows the real number, not 0.
- **#622** loop_count budgets — two-layer fix:
  - **Layer A** (decomposer prompt): concrete ``count=30`` / ``count=10`` defaults with explicit "never 0; never omit" guidance. Prompt version bumped to v31 so cache invalidates.
  - **Layer B** (runtime fallback): ``RunState.max_loop_iterations_by_section`` resolves extraction=30, pagination=10, default=50 instead of the legacy single 200-iter cap.
  - Net cost win: ~$2.50/partition saved (was hitting the $10 cost cap on dedup-skipped re-clicks, now exits at ~30 iters naturally). ~25% of total run cost on a 5-partition fan-out.
- **#621** cross-partition dedup — orchestrator collects per-worker ``leads`` lists and merges via ``dedup_leads_by_url`` (normalized listing URL). Prints both ``raw`` and ``deduped`` totals + ``Duplicates collapsed`` when there's overlap. Catches featured listings + pagination drift.

Plus one mechanical CI fix:
- **9474eeb** — bare ``f"..."`` with no placeholders on the ``FANOUT RESULTS`` header (caught by ruff on #624; cherry of the same fix lives in this PR's base).

## Test plan

- [x] 41 unit tests for fanout_runner (incl. new ``read_partition_result``, ``_normalize_listing_url``, ``dedup_leads_by_url``)
- [x] 10 unit tests for loop_count_budget (prompt content + section-aware runtime fallback)
- [x] No regressions in existing decomposer / classifier / collect_urls tests (134 pass full sweep)
- [x] ruff clean
- [ ] Modal redeploy + boattrader rerun to validate cost drop (~$50 → ~$15-20 expected)

## Stack

This branch is stacked on ``feat/parallel-loop-fanout`` (PR #624). Merge order: #624 → this. Rebase onto main after #624 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)