### PR TITLE
collect_urls: multi-viewport scan for full-page URL harvest (#638 axis 1)

### DIFF
--- a/deploy/modal/modal_cua_server.py
+++ b/deploy/modal/modal_cua_server.py
@@ -3019,7 +3019,10 @@ def main(
                 )
                 return
 
-            print("    [phase1] no URLs harvested — falling through to single worker")
+            print(
+                "    [phase1] no URLs harvested — falling through to "
+                "pagination-partition path (#617)"
+            )
 
         # ── #617: per-page partitioning for parallelizable_pagination ─
         partitions = prepare_modal_partitions(task_suite, workers)

--- a/deploy/modal/modal_cua_server.py
+++ b/deploy/modal/modal_cua_server.py
@@ -1038,6 +1038,17 @@ def _run_holo3_executor(
             # otherwise sees a stripped dict and writes nothing).
             "leads": leads,
             "artifacts": result.get("artifacts", []),
+            # #628 / #631 follow-up: forward the orchestrator-side
+            # contract fields. read_partition_result on the orchestrator
+            # reads these to drive Phase-2 (collected_urls), aggregate
+            # phone counts (leads_with_phone), and report shared-seen
+            # savings (shared_seen_hits). Without this re-export, the
+            # envelope at line 1016 strips them — Phase-1 silently
+            # collected URLs and silently dropped them on return,
+            # making Phase-1/Phase-2 fail every time.
+            "collected_urls": result.get("collected_urls", []),
+            "leads_with_phone": result.get("leads_with_phone", 0),
+            "shared_seen_hits": result.get("shared_seen_hits", 0),
         }
         # #347: surface paused state to the Modal API container. The poll
         # path detects ``_paused`` on the FunctionCall result and writes

--- a/deploy/modal/modal_cua_server.py
+++ b/deploy/modal/modal_cua_server.py
@@ -2566,7 +2566,13 @@ def _print_shared_seen_metrics(
         try:
             import modal as _modal
             _shared = _modal.Dict.from_name(dict_name)
-            final_size = len(_shared)
+            # modal.Dict doesn't implement __len__; use .len() method
+            # (returns int) and fall back to counting keys() on older
+            # SDKs that may not expose it.
+            if hasattr(_shared, "len"):
+                final_size = int(_shared.len())
+            else:
+                final_size = sum(1 for _ in _shared.keys())
         except Exception as exc:
             print(
                 f"  [shared-seen] could not query final dict size "

--- a/deploy/modal/modal_cua_server.py
+++ b/deploy/modal/modal_cua_server.py
@@ -2945,7 +2945,25 @@ def main(
                 dedup_leads_by_url, read_partition_result,
             )
             try:
-                phase1_summary = read_partition_result(phase1_handle.get())
+                _phase1_raw = phase1_handle.get()
+                # Diagnostic: surface the raw result keys + lengths so a
+                # collected_urls vs viable mismatch is debuggable from
+                # the orchestrator log (worker container logs are tail-
+                # trimmed by Modal on stopped ephemeral apps).
+                if isinstance(_phase1_raw, dict):
+                    _urls_in_result = _phase1_raw.get("collected_urls", "MISSING")
+                    _urls_type = type(_urls_in_result).__name__
+                    _urls_len = (
+                        len(_urls_in_result)
+                        if isinstance(_urls_in_result, list) else "n/a"
+                    )
+                    print(
+                        f"    [phase1] raw result: "
+                        f"viable={_phase1_raw.get('viable', 'MISSING')} "
+                        f"collected_urls_type={_urls_type} "
+                        f"collected_urls_len={_urls_len}"
+                    )
+                phase1_summary = read_partition_result(_phase1_raw)
                 collected_urls = phase1_summary["collected_urls"]
             except Exception as exc:
                 print(f"    [phase1] ERROR: {exc} — aborting fan-out")

--- a/src/mantis_agent/gym/_runner_helpers.py
+++ b/src/mantis_agent/gym/_runner_helpers.py
@@ -934,6 +934,16 @@ def execute_step(
         )
 
     if step.claude_only:
+        # Type-based dispatch wins when a registered handler exists for
+        # the specific step.type — covers new claude-only types like
+        # ``collect_urls`` (#615) without losing the legacy
+        # extract_url / extract_data fallback for plans that set
+        # claude_only=True without a matching specific handler.
+        if step.type and registry.get(step.type) is not None:
+            ctx = build_step_context(runner, index)
+            return _stamp_backend(
+                registry.get(step.type).execute(step, ctx), ctx,
+            )
         ctx = build_step_context(runner, index)
         return _stamp_backend(registry.get("extract_url").execute(step, ctx), ctx)
 

--- a/src/mantis_agent/gym/fanout_runner.py
+++ b/src/mantis_agent/gym/fanout_runner.py
@@ -769,7 +769,13 @@ def prepare_phase1_suite(
         "section": "extraction",
         "claude_only": True,
         "budget": 0,
-        "required": True,
+        # required=False (not True) so the runner's step-recovery
+        # policy doesn't trigger agentic_recovery + add_hint retries
+        # on collect_urls failure. The orchestrator already handles
+        # empty collect_urls by falling through to the pagination
+        # path — burning ~$0.20 on 3 doomed Claude scan retries +
+        # critic-row-link recovery attempts is wasted budget.
+        "required": False,
         "params": {},
         "hints": {},
         "gate": False,

--- a/src/mantis_agent/gym/fanout_runner.py
+++ b/src/mantis_agent/gym/fanout_runner.py
@@ -138,8 +138,13 @@ class _ModalDictSharedSeenSet:
             logger.warning("[shared-seen] add() raised: %s", exc)
 
     def size(self) -> int:
+        # modal.Dict doesn't implement __len__; use the SDK's .len()
+        # method (returns int) and fall back to counting keys() if even
+        # that's missing on older SDKs.
         try:
-            return len(self._dict)
+            if hasattr(self._dict, "len"):
+                return int(self._dict.len())
+            return sum(1 for _ in self._dict.keys())
         except Exception as exc:  # noqa: BLE001
             logger.debug("[shared-seen] size() raised: %s", exc)
             return 0

--- a/src/mantis_agent/gym/run_executor.py
+++ b/src/mantis_agent/gym/run_executor.py
@@ -185,7 +185,40 @@ class RunExecutor:
         # tokens to this run without being passed the meter as an arg.
         # Mirrors the dispatch-context publish for ``TimeMeter``.
         with publish_cost_meter(getattr(runner, "cost_meter", None)):
-            return self._execute_inner(plan, state, resume=resume)
+            try:
+                return self._execute_inner(plan, state, resume=resume)
+            except BaseException:
+                # #544: ensure the Augur DebugSession closes even when
+                # ``_execute_inner`` exits abnormally (uncaught exception,
+                # KeyboardInterrupt). The normal path calls _finalize →
+                # augur.close(); abnormal paths bypass _finalize and
+                # would leave the bundle in ``status: "running"``
+                # forever, which Augur consumers (CLI, MCP, training)
+                # then mis-render as live.
+                self._maybe_close_augur_on_abnormal_exit()
+                raise
+
+    def _maybe_close_augur_on_abnormal_exit(self) -> None:
+        """Close the Augur session when the run's normal terminate path
+        (``_finalize``) was bypassed by an exception (#544).
+
+        Idempotent — ``_finalize`` clears ``runner._augur`` to None
+        after its normal close, so re-entry on a successful path is a
+        no-op. Status is forced to ``"halted"`` so the bundle's
+        terminal status reflects the abnormal exit, not the SDK's
+        default ``"succeeded"`` inference.
+        """
+        runner = self.parent
+        augur = getattr(runner, "_augur", None)
+        if augur is None:
+            return
+        try:
+            augur.close(status="halted")
+        except Exception as exc:  # noqa: BLE001 — never re-raise in cleanup
+            logger.debug(
+                "AugurAdapter.close on abnormal exit failed: %s", exc,
+            )
+        runner._augur = None
 
     def _execute_inner(
         self,
@@ -225,6 +258,12 @@ class RunExecutor:
             extra_tags={
                 "plan_signature": runner.plan_signature or "",
                 "model": model_name,
+                # #542: surface the plan's total step count as a tag so
+                # the Augur runs-list can render "X / N steps" instead
+                # of just "X". The Augur UI reads ``plan_step_count``
+                # off the session tag set; consumers fall back to no-
+                # denominator behaviour when the tag is absent.
+                "plan_step_count": str(len(plan.steps)),
             },
             # #631: fan-out workers carry a branch_context that labels
             # their session under a shared parent_run_id so the Augur

--- a/src/mantis_agent/gym/step_handlers/collect_urls.py
+++ b/src/mantis_agent/gym/step_handlers/collect_urls.py
@@ -96,10 +96,13 @@ class CollectUrlsHandler:
                 data="no_extractor",
             )
 
-        # Settle briefly so lazy-rendered cards are present in the
-        # screenshot. Same min/max as ClaudeStepHandler's pre-extract
-        # pause for behavioral parity with the click loop.
-        adaptive_content_settle(env, min_seconds=0.2, max_seconds=1.0)
+        # Settle for the cold-load case. BoatTrader on a proxied
+        # cold-cache fetch can take 3-5s before listings render; the
+        # 1s pre-extract pause is the right floor for warm pages but
+        # leaves Phase-1 fan-out scanning a half-rendered page (cards
+        # not yet hydrated). Settle up to 4s here — collect_urls runs
+        # ONCE per Phase-1 dispatch, so the cost is bounded.
+        adaptive_content_settle(env, min_seconds=1.0, max_seconds=4.0)
 
         screenshot = env.screenshot()
         scan = extractor.find_all_listings(screenshot)
@@ -113,18 +116,31 @@ class CollectUrlsHandler:
                 signal,
             )
             runner._collected_urls = []
+            # Skip envelope (success=False, skip=True) so the runner's
+            # retry policy advances past this step instead of burning
+            # ~9 retries (each costs another Claude scan call) on the
+            # same blocked / empty page state.
             return StepResult(
                 step_index=index, intent=step.intent, success=False,
                 data=f"scan_signal:{signal}",
+                skip=True, skip_reason=f"collect_urls_signal_{signal}",
             )
 
         runner.costs["claude_extract"] += 1
         card_count = len(scan)
+        # Always-on WARNING so operators (and the orchestrator's local
+        # CLI grep) see the scan outcome even when Modal trims worker
+        # log tails. Format: ``[collect_urls] scan returned N cards``.
+        logger.warning(
+            "  [collect_urls] scan returned %d card(s)", card_count,
+        )
         urls: list[str] = []
         seen: set[str] = set()
+        unresolved = 0
         for x, y, _title in scan:
             href = self._resolve_href(env, int(x), int(y))
             if not href:
+                unresolved += 1
                 continue
             # Dedup: lazy-loaded results pages occasionally render the
             # same card twice with slightly different y; the URL is the
@@ -138,18 +154,32 @@ class CollectUrlsHandler:
         runner._last_known_url = runner._last_known_url or ""
         resolved = len(urls)
         coverage = resolved / max(card_count, 1)
-        # WARNING when coverage is degraded so Modal logs surface the
-        # fallback signal; INFO for the healthy case.
+        # Always-on WARNING so the resolved-vs-found ratio is visible.
+        # When unresolved == card_count the CDP href lookup is failing
+        # universally (elementFromPoint miss, wrong chromeH calc, page
+        # not yet hydrated) — operator needs this signal to diagnose.
         if coverage < 0.8:
             logger.warning(
                 "  [collect_urls] coverage degraded: %d/%d cards resolved hrefs "
-                "(%.0f%%) — fan-out runner should consider sequential fallback",
-                resolved, card_count, coverage * 100,
+                "(%.0f%%, %d unresolved) — fan-out runner should consider "
+                "sequential fallback",
+                resolved, card_count, coverage * 100, unresolved,
             )
         else:
-            logger.info(
+            logger.warning(
                 "  [collect_urls] resolved %d/%d card hrefs (%.0f%% coverage)",
                 resolved, card_count, coverage * 100,
+            )
+
+        # Fail-fast skip envelope when EVERY card failed CDP resolution.
+        # Triggers the same runner-side advance as the scan-signal path
+        # — no point retrying because the cdp_evaluate JS will return
+        # the same null on every retry against the same screenshot.
+        if card_count > 0 and resolved == 0:
+            return StepResult(
+                step_index=index, intent=step.intent, success=False,
+                data=f"urls:0/{card_count}:all_unresolved",
+                skip=True, skip_reason="collect_urls_all_unresolved",
             )
 
         return StepResult(

--- a/src/mantis_agent/gym/step_handlers/collect_urls.py
+++ b/src/mantis_agent/gym/step_handlers/collect_urls.py
@@ -41,10 +41,24 @@ logger = logging.getLogger(__name__)
 
 # JS payload: takes (sx, sy) in screen-space, translates to viewport
 # coords using the same chromeH offset cdp_click_at_point applies,
-# walks up the DOM from elementFromPoint to find the nearest ``<a>``
-# ancestor, returns its absolute href. Returns None when no anchor is
-# found above the point — caller treats that as a card without a
-# resolvable URL and silently drops it from the partition.
+# walks the element tree at that point to find a navigable URL. Returns
+# the resolved URL string or null when no candidate is found.
+#
+# Resolution priority (matches what production listing cards use across
+# common marketplace sites):
+#   1. ``<a href>`` ancestor — BoatTrader's listing card wraps in an
+#      anchor. ``el.closest('a[href]')`` finds it cross-browser.
+#   2. ``[href]`` ancestor — anchor-less elements that nevertheless
+#      carry an href attribute (rare but seen on some SPAs).
+#   3. ``<a href>`` descendant of the topmost ancestor at the point —
+#      catches cards where the click target is a wrapping ``<div>``
+#      with the navigable ``<a>`` rendered INSIDE (BoatTrader's
+#      sponsored-listing variant does this).
+#   4. ``data-href`` / ``data-url`` on any ancestor — common React
+#      pattern for click-handled divs that synthesise navigation in JS.
+#
+# Returns null only when none of the above yield a value, indicating
+# the card is genuinely non-navigable (e.g. an in-page modal trigger).
 _HREF_LOOKUP_JS = """
 (() => {
   const oh = window.outerHeight;
@@ -54,13 +68,32 @@ _HREF_LOOKUP_JS = """
   const sy = {sy};
   const vx = sx;
   const vy = sy - chromeH;
-  let el = document.elementFromPoint(vx, vy);
+  const el = document.elementFromPoint(vx, vy);
   if (!el) return null;
-  while (el && el.tagName !== 'A') {
-    el = el.parentElement;
+  // 1. anchor ancestor (most common)
+  const anchor = el.closest('a[href]');
+  if (anchor && anchor.href) return anchor.href;
+  // 2. any [href] ancestor
+  const hrefAncestor = el.closest('[href]');
+  if (hrefAncestor && hrefAncestor.href) return hrefAncestor.href;
+  // 3. find an anchor inside the topmost "card-like" ancestor at the
+  //    point — walk up to the nearest element with role="link",
+  //    data-test*="listing", or a class hint, then look for an <a>
+  //    descendant. Cap at 5 levels to bound search.
+  let card = el;
+  for (let i = 0; i < 5 && card; i++) {
+    const aDesc = card.querySelector && card.querySelector('a[href]');
+    if (aDesc && aDesc.href) return aDesc.href;
+    card = card.parentElement;
   }
-  if (!el) return null;
-  return el.href || null;
+  // 4. data-href / data-url ancestor (React click-handled cards)
+  const dataAncestor = el.closest('[data-href], [data-url]');
+  if (dataAncestor) {
+    const v = dataAncestor.getAttribute('data-href')
+              || dataAncestor.getAttribute('data-url');
+    if (v) return v;
+  }
+  return null;
 })()
 """
 

--- a/src/mantis_agent/gym/step_handlers/collect_urls.py
+++ b/src/mantis_agent/gym/step_handlers/collect_urls.py
@@ -1,4 +1,4 @@
-"""CollectUrlsHandler — single-pass listing URL harvest (#615).
+"""CollectUrlsHandler — multi-viewport listing URL harvest (#615, #638).
 
 The extraction-loop body today is ``click → extract_url → scroll →
 extract_data → navigate_back``. The ``click → extract_url`` chain costs
@@ -7,12 +7,18 @@ brain just clicked. For the fan-out runner (#617) to work, each worker
 needs to ``navigate(url)`` directly to its slice — which means the URL
 list has to be known up front, not discovered iteratively.
 
-This handler runs ONE Claude pass via ``ClaudeExtractor.find_all_listings``
-to locate every visible card on the results page, then resolves each
+This handler walks the page through multiple viewport stages, calling
+``ClaudeExtractor.find_all_listings`` at each stop and resolving each
 card's anchor href via CDP ``Runtime.evaluate`` on
 ``document.elementFromPoint(vx, vy)`` — same screen-to-viewport
 coordinate translation the click handler's ``cdp_click_at_point`` uses
-(``xdotool_env.py:610``).
+(``xdotool_env.py:610``). Mirrors the existing viewport-stage scanner
+in ``ClaudeGuidedClickHandler`` (gym/step_handlers/click.py:120).
+
+#638: the original single-viewport implementation harvested only 3
+URLs vs the ~25 listings a typical results page actually carries (the
+rest sit below the fold). Multi-viewport scan brings throughput to the
+full page complement at the cost of N Claude calls instead of 1.
 
 Provenance is CUA-pure under ``feedback_cua_cdp_post_action_verify.md``:
 vision picks the target (find_all_listings), CDP only reads the
@@ -26,8 +32,10 @@ Output is stashed on ``runner._collected_urls`` for the fan-out runner
 from __future__ import annotations
 
 import logging
+import time
 from typing import TYPE_CHECKING
 
+from ...actions import Action, ActionType
 from .._runner_helpers import adaptive_content_settle
 from ..checkpoint import StepResult
 from ..step_context import StepContext
@@ -37,6 +45,18 @@ if TYPE_CHECKING:
     from ...plan_decomposer import MicroIntent
 
 logger = logging.getLogger(__name__)
+
+# Default cap on viewport stages — matches ClaudeGuidedClickHandler's
+# ``_max_viewport_stages`` (4). Bounds the per-Phase-1 Claude scan cost
+# at ~$0.02 × 4 = ~$0.08 in the worst case. Plans that need more can
+# override via ``step.hints['max_viewport_stages']``.
+DEFAULT_MAX_VIEWPORT_STAGES = 4
+
+# How many Page_Down keypresses per viewport stage. 2 page-downs ≈
+# 1.5 viewport heights, which gives ~30-40% overlap between adjacent
+# stages — keeps each card visible to find_all_listings in at least
+# one stage even when its centroid sits near a stage boundary.
+PAGE_DOWNS_PER_STAGE = 2
 
 
 # JS payload: takes (sx, sy) in screen-space, translates to viewport
@@ -133,93 +153,187 @@ class CollectUrlsHandler:
         # cold-cache fetch can take 3-5s before listings render; the
         # 1s pre-extract pause is the right floor for warm pages but
         # leaves Phase-1 fan-out scanning a half-rendered page (cards
-        # not yet hydrated). Settle up to 4s here — collect_urls runs
-        # ONCE per Phase-1 dispatch, so the cost is bounded.
+        # not yet hydrated). Settle up to 4s before the first viewport
+        # scan; subsequent viewports use the shorter intra-loop wait.
         adaptive_content_settle(env, min_seconds=1.0, max_seconds=4.0)
 
-        screenshot = env.screenshot()
-        scan = extractor.find_all_listings(screenshot)
-        # find_all_listings returns either list[(x, y, title)] or a
-        # signal tuple (("empty",) / ("blocked",) / ("error",)) — drop
-        # the signal cases as empty harvests rather than crashing.
-        if not isinstance(scan, list):
-            signal = scan[0] if scan else "unknown"
-            logger.warning(
-                "  [collect_urls] find_all_listings returned signal=%s — empty harvest",
-                signal,
+        # #638: per-step override for the viewport-stage cap. Plans that
+        # know the catalog is paginated and small can pin a tighter cap;
+        # plans on infinite-scroll feeds can lift it. Falls back to the
+        # module default (4) which matches the click handler's own
+        # ``_max_viewport_stages``.
+        max_stages = int(
+            (step.hints or {}).get(
+                "max_viewport_stages", DEFAULT_MAX_VIEWPORT_STAGES,
             )
-            runner._collected_urls = []
-            # Skip envelope (success=False, skip=True) so the runner's
-            # retry policy advances past this step instead of burning
-            # ~9 retries (each costs another Claude scan call) on the
-            # same blocked / empty page state.
-            return StepResult(
-                step_index=index, intent=step.intent, success=False,
-                data=f"scan_signal:{signal}",
-                skip=True, skip_reason=f"collect_urls_signal_{signal}",
-            )
-
-        runner.costs["claude_extract"] += 1
-        card_count = len(scan)
-        # Always-on WARNING so operators (and the orchestrator's local
-        # CLI grep) see the scan outcome even when Modal trims worker
-        # log tails. Format: ``[collect_urls] scan returned N cards``.
-        logger.warning(
-            "  [collect_urls] scan returned %d card(s)", card_count,
         )
+
         urls: list[str] = []
         seen: set[str] = set()
-        unresolved = 0
-        for x, y, _title in scan:
-            href = self._resolve_href(env, int(x), int(y))
-            if not href:
-                unresolved += 1
+        total_cards = 0
+        total_unresolved = 0
+        first_signal: str | None = None
+        consecutive_empty_stages = 0
+
+        # Reset to the top of the results page once, then advance one
+        # viewport per stage. Mirrors ClaudeGuidedClickHandler's
+        # deterministic Home → Page_Down chain so each viewport is
+        # reproducible across retries.
+        self._scroll_to_top(env)
+
+        for stage in range(max_stages):
+            if stage > 0:
+                self._page_down_to_stage(env, stage)
+                # Short settle between stages — lazy-loaded marketplaces
+                # often render the next-viewport cards within ~1s of the
+                # scroll event firing.
+                adaptive_content_settle(env, min_seconds=0.5, max_seconds=2.0)
+
+            screenshot = env.screenshot()
+            scan = extractor.find_all_listings(screenshot)
+            runner.costs["claude_extract"] += 1
+
+            # find_all_listings returns either list[(x, y, title)] or a
+            # signal tuple (("empty",) / ("blocked",) / ("error",)).
+            # Blocked / error at stage 0 is fatal (whole page is gone);
+            # blocked at later stages may just mean we scrolled off the
+            # bottom — treat as empty and let the early-exit fire.
+            if not isinstance(scan, list):
+                signal = scan[0] if scan else "unknown"
+                if stage == 0:
+                    if first_signal is None:
+                        first_signal = signal
+                    logger.warning(
+                        "  [collect_urls] stage 0: signal=%s — empty harvest",
+                        signal,
+                    )
+                    break
+                logger.warning(
+                    "  [collect_urls] stage %d: signal=%s (treating as empty)",
+                    stage, signal,
+                )
+                consecutive_empty_stages += 1
+                if consecutive_empty_stages >= 2:
+                    break
                 continue
-            # Dedup: lazy-loaded results pages occasionally render the
-            # same card twice with slightly different y; the URL is the
-            # right primary key anyway.
-            if href in seen:
-                continue
-            seen.add(href)
-            urls.append(href)
+
+            card_count = len(scan)
+            total_cards += card_count
+            new_this_stage = 0
+            unresolved_this_stage = 0
+            for x, y, _title in scan:
+                href = self._resolve_href(env, int(x), int(y))
+                if not href:
+                    unresolved_this_stage += 1
+                    continue
+                # Cross-stage dedup: the same card often appears in
+                # multiple adjacent viewports because PAGE_DOWNS_PER_STAGE
+                # is < 1 full viewport — that overlap is intentional
+                # (keeps cards near stage boundaries discoverable), and
+                # the seen set absorbs the redundancy.
+                if href in seen:
+                    continue
+                seen.add(href)
+                urls.append(href)
+                new_this_stage += 1
+            total_unresolved += unresolved_this_stage
+
+            logger.warning(
+                "  [collect_urls] stage %d: scan=%d cards, "
+                "new_urls=%d, unresolved=%d, total_so_far=%d",
+                stage, card_count, new_this_stage,
+                unresolved_this_stage, len(urls),
+            )
+
+            # Early exit: two consecutive stages added zero new URLs
+            # means we've either run off the bottom or the page only
+            # had what we already have. Caps wasted Claude calls on
+            # short results pages without forcing operators to tune
+            # max_viewport_stages per plan.
+            if new_this_stage == 0:
+                consecutive_empty_stages += 1
+                if consecutive_empty_stages >= 2:
+                    logger.warning(
+                        "  [collect_urls] early exit at stage %d "
+                        "(2 consecutive empty stages)", stage,
+                    )
+                    break
+            else:
+                consecutive_empty_stages = 0
 
         runner._collected_urls = urls
         runner._last_known_url = runner._last_known_url or ""
         resolved = len(urls)
-        coverage = resolved / max(card_count, 1)
-        # Always-on WARNING so the resolved-vs-found ratio is visible.
-        # When unresolved == card_count the CDP href lookup is failing
-        # universally (elementFromPoint miss, wrong chromeH calc, page
-        # not yet hydrated) — operator needs this signal to diagnose.
+
+        # Stage-0 signal path — no scan succeeded, advance past the step.
+        if first_signal is not None and resolved == 0:
+            return StepResult(
+                step_index=index, intent=step.intent, success=False,
+                data=f"scan_signal:{first_signal}",
+                skip=True,
+                skip_reason=f"collect_urls_signal_{first_signal}",
+            )
+
+        # All-unresolved path — scans succeeded but every CDP href
+        # lookup returned null. Same skip envelope as before so the
+        # runner advances past the step.
+        if total_cards > 0 and resolved == 0:
+            return StepResult(
+                step_index=index, intent=step.intent, success=False,
+                data=f"urls:0/{total_cards}:all_unresolved",
+                skip=True, skip_reason="collect_urls_all_unresolved",
+            )
+
+        coverage = resolved / max(total_cards, 1)
         if coverage < 0.8:
             logger.warning(
-                "  [collect_urls] coverage degraded: %d/%d cards resolved hrefs "
-                "(%.0f%%, %d unresolved) — fan-out runner should consider "
-                "sequential fallback",
-                resolved, card_count, coverage * 100, unresolved,
+                "  [collect_urls] FINAL: %d unique URLs from %d cards "
+                "across viewport stages (%.0f%% coverage, %d unresolved)",
+                resolved, total_cards, coverage * 100, total_unresolved,
             )
         else:
             logger.warning(
-                "  [collect_urls] resolved %d/%d card hrefs (%.0f%% coverage)",
-                resolved, card_count, coverage * 100,
-            )
-
-        # Fail-fast skip envelope when EVERY card failed CDP resolution.
-        # Triggers the same runner-side advance as the scan-signal path
-        # — no point retrying because the cdp_evaluate JS will return
-        # the same null on every retry against the same screenshot.
-        if card_count > 0 and resolved == 0:
-            return StepResult(
-                step_index=index, intent=step.intent, success=False,
-                data=f"urls:0/{card_count}:all_unresolved",
-                skip=True, skip_reason="collect_urls_all_unresolved",
+                "  [collect_urls] FINAL: %d unique URLs from %d cards "
+                "across viewport stages (%.0f%% coverage)",
+                resolved, total_cards, coverage * 100,
             )
 
         return StepResult(
             step_index=index, intent=step.intent,
             success=bool(urls),
-            data=f"urls:{resolved}/{card_count}",
+            data=f"urls:{resolved}/{total_cards}",
         )
+
+    @staticmethod
+    def _scroll_to_top(env) -> None:
+        """Reset the page to the top before stage 0. Mirrors the
+        Home-key reset in ClaudeGuidedClickHandler's viewport scanner.
+        Best-effort — never raises."""
+        try:
+            env.step(Action(action_type=ActionType.KEY_PRESS, params={"keys": "Home"}))
+            time.sleep(0.5)
+        except Exception as exc:  # noqa: BLE001 — never break the scan
+            logger.debug("collect_urls scroll-to-top failed: %s", exc)
+
+    @staticmethod
+    def _page_down_to_stage(env, stage: int) -> None:
+        """Advance ``PAGE_DOWNS_PER_STAGE`` viewport positions for the
+        given stage. Stage 0 is the top (no Page_Down), stage N issues
+        ``N × PAGE_DOWNS_PER_STAGE`` Page_Down presses cumulatively —
+        but since each call only advances ONE stage's worth (not
+        cumulative from top), this is called per-stage."""
+        try:
+            for _ in range(PAGE_DOWNS_PER_STAGE):
+                env.step(Action(
+                    action_type=ActionType.KEY_PRESS,
+                    params={"keys": "Page_Down"},
+                ))
+                time.sleep(0.5)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug(
+                "collect_urls page_down stage %d failed: %s",
+                stage, exc,
+            )
 
     @staticmethod
     def _resolve_href(env, x: int, y: int) -> str:

--- a/src/mantis_agent/gym/step_recovery.py
+++ b/src/mantis_agent/gym/step_recovery.py
@@ -1130,6 +1130,21 @@ class StepRecoveryPolicy:
             "  [%d] agentic recovery: mode=%s — %s",
             step_index, decision.mode, decision.reasoning[:200],
         )
+        # #634 follow-up: surface recovery rationale to the Augur
+        # Reasoning-trace tab. ``decision.reasoning`` is the Claude
+        # explanation for why this recovery mode was chosen — already
+        # logged at WARN, also worth structured surfacing alongside
+        # brain + verifier reasoning.
+        augur = getattr(runner, "_augur", None)
+        if augur is not None and decision.reasoning:
+            try:
+                augur.record_reasoning(
+                    step_index=step_index,
+                    format="recovery",
+                    content=f"mode={decision.mode}: {decision.reasoning}",
+                )
+            except Exception:  # noqa: BLE001 — never block recovery
+                pass
 
         if decision.mode == "halt":
             return None  # fall through to legacy halt

--- a/tests/test_collect_urls_handler.py
+++ b/tests/test_collect_urls_handler.py
@@ -44,9 +44,17 @@ def _ctx(env, extractor) -> StepContext:
     )
 
 
-def _step() -> MicroIntent:
+def _step(max_viewport_stages: int = 1) -> MicroIntent:
+    """Build a collect_urls MicroIntent.
+
+    Default ``max_viewport_stages=1`` pins the multi-viewport loop
+    (#638) to a single iteration so existing single-pass tests still
+    pin a single ``find_all_listings`` call + one set of CDP returns.
+    Tests that exercise the multi-viewport scan pass a larger value.
+    """
     return MicroIntent(
         intent="Collect listing URLs", type="collect_urls", section="extraction",
+        hints={"max_viewport_stages": max_viewport_stages},
     )
 
 
@@ -193,3 +201,189 @@ def test_cards_without_anchor_silently_drop(monkeypatch) -> None:
 
     assert runner._collected_urls == ["https://example.com/boat/1/"]
     assert result.data == "urls:1/2"
+
+
+# ── #638: multi-viewport scan ──────────────────────────────────────────
+
+
+def test_multi_viewport_accumulates_urls_across_stages(monkeypatch) -> None:
+    """Three viewport stages, each scans 3 distinct cards → 9 unique URLs.
+    Verifies the handler scrolls + rescans + accumulates across stages."""
+    monkeypatch.setattr(
+        "mantis_agent.gym.step_handlers.collect_urls.adaptive_content_settle",
+        lambda *_, **__: None,
+    )
+    monkeypatch.setattr(
+        "mantis_agent.gym.step_handlers.collect_urls.time.sleep",
+        lambda *_: None,
+    )
+    runner = _FakeRunner()
+    extractor = MagicMock()
+    # Stage 0, 1, 2 each return 3 distinct cards.
+    extractor.find_all_listings.side_effect = [
+        [(100, 200, f"S0-{i}") for i in range(3)],
+        [(100, 200, f"S1-{i}") for i in range(3)],
+        [(100, 200, f"S2-{i}") for i in range(3)],
+    ]
+    env = MagicMock()
+    env.screenshot.return_value = MagicMock()
+    # 9 distinct URLs (3 cards × 3 stages).
+    env.cdp_evaluate.side_effect = [
+        f"https://example.com/boat/{i}/" for i in range(9)
+    ]
+
+    result = CollectUrlsHandler(runner).execute(
+        _step(max_viewport_stages=3), _ctx(env, extractor),
+    )
+
+    assert result.success is True
+    assert len(runner._collected_urls) == 9
+    assert result.data == "urls:9/9"
+    # 3 stages = 3 Claude scan calls (one per find_all_listings invocation).
+    assert runner.costs["claude_extract"] == 3
+    # Page_Down keypress fired at least once (between stage 0→1 and 1→2).
+    assert env.step.call_count >= 1
+
+
+def test_multi_viewport_dedups_overlap_between_stages(monkeypatch) -> None:
+    """PAGE_DOWNS_PER_STAGE < 1 viewport so adjacent stages overlap —
+    the same card appears in stages N and N+1. The seen-URL set
+    collapses the redundancy."""
+    monkeypatch.setattr(
+        "mantis_agent.gym.step_handlers.collect_urls.adaptive_content_settle",
+        lambda *_, **__: None,
+    )
+    monkeypatch.setattr(
+        "mantis_agent.gym.step_handlers.collect_urls.time.sleep",
+        lambda *_: None,
+    )
+    runner = _FakeRunner()
+    extractor = MagicMock()
+    # Both stages return overlapping cards (boat/1 + boat/2 in both,
+    # plus a new card in each).
+    extractor.find_all_listings.side_effect = [
+        [(100, 100, "B1"), (100, 200, "B2"), (100, 300, "B3")],
+        [(100, 100, "B2"), (100, 200, "B3"), (100, 300, "B4")],
+    ]
+    env = MagicMock()
+    env.screenshot.return_value = MagicMock()
+    env.cdp_evaluate.side_effect = [
+        "https://example.com/boat/1/", "https://example.com/boat/2/",
+        "https://example.com/boat/3/",  # stage 0
+        "https://example.com/boat/2/", "https://example.com/boat/3/",
+        "https://example.com/boat/4/",  # stage 1 — 2 dup, 1 new
+    ]
+
+    CollectUrlsHandler(runner).execute(
+        _step(max_viewport_stages=2), _ctx(env, extractor),
+    )
+
+    # 4 unique URLs (1, 2, 3, 4) from 6 raw cards across stages.
+    assert len(runner._collected_urls) == 4
+    assert set(runner._collected_urls) == {
+        "https://example.com/boat/1/", "https://example.com/boat/2/",
+        "https://example.com/boat/3/", "https://example.com/boat/4/",
+    }
+
+
+def test_multi_viewport_early_exit_on_two_empty_stages(monkeypatch) -> None:
+    """Two consecutive stages adding 0 new URLs triggers early exit
+    without burning the rest of the budget. Caps wasted Claude calls
+    on short results pages."""
+    monkeypatch.setattr(
+        "mantis_agent.gym.step_handlers.collect_urls.adaptive_content_settle",
+        lambda *_, **__: None,
+    )
+    monkeypatch.setattr(
+        "mantis_agent.gym.step_handlers.collect_urls.time.sleep",
+        lambda *_: None,
+    )
+    runner = _FakeRunner()
+    extractor = MagicMock()
+    # Stage 0 returns 2 cards; stages 1+2 return same 2 cards (all dups);
+    # stages 3+ never reached because early exit fires after 2 empty.
+    same_two = [(100, 100, "B1"), (100, 200, "B2")]
+    extractor.find_all_listings.side_effect = [
+        same_two, same_two, same_two,
+        # Unreached:
+        [(100, 100, "BX")], [(100, 100, "BY")],
+    ]
+    env = MagicMock()
+    env.screenshot.return_value = MagicMock()
+    # 6 cdp calls for the 3 stages we DO execute; nothing after.
+    env.cdp_evaluate.side_effect = [
+        "https://example.com/boat/1/", "https://example.com/boat/2/",
+    ] * 3
+
+    CollectUrlsHandler(runner).execute(
+        _step(max_viewport_stages=5), _ctx(env, extractor),
+    )
+
+    assert len(runner._collected_urls) == 2
+    # 3 Claude calls (not 5) — early exit at stage 2 after 2 zero-new stages.
+    assert runner.costs["claude_extract"] == 3
+
+
+def test_multi_viewport_stage0_blocked_aborts(monkeypatch) -> None:
+    """find_all_listings returning ('blocked',) at stage 0 means the
+    whole page is gone — abort with skip envelope, don't waste budget
+    on subsequent stages."""
+    monkeypatch.setattr(
+        "mantis_agent.gym.step_handlers.collect_urls.adaptive_content_settle",
+        lambda *_, **__: None,
+    )
+    monkeypatch.setattr(
+        "mantis_agent.gym.step_handlers.collect_urls.time.sleep",
+        lambda *_: None,
+    )
+    runner = _FakeRunner()
+    extractor = MagicMock()
+    extractor.find_all_listings.return_value = ("blocked", "cf challenge")
+    env = MagicMock()
+    env.screenshot.return_value = MagicMock()
+
+    result = CollectUrlsHandler(runner).execute(
+        _step(max_viewport_stages=4), _ctx(env, extractor),
+    )
+
+    assert result.success is False
+    assert result.skip is True
+    assert result.skip_reason == "collect_urls_signal_blocked"
+    # ONE Claude call before bailing — not 4.
+    assert runner.costs["claude_extract"] == 1
+
+
+def test_max_viewport_stages_hint_overrides_default(monkeypatch) -> None:
+    """``step.hints['max_viewport_stages']`` is the operator knob —
+    pin it to 2 and verify the loop respects it even when more cards
+    could be found at later stages."""
+    monkeypatch.setattr(
+        "mantis_agent.gym.step_handlers.collect_urls.adaptive_content_settle",
+        lambda *_, **__: None,
+    )
+    monkeypatch.setattr(
+        "mantis_agent.gym.step_handlers.collect_urls.time.sleep",
+        lambda *_: None,
+    )
+    runner = _FakeRunner()
+    extractor = MagicMock()
+    extractor.find_all_listings.side_effect = [
+        [(100, 100, "B1")],
+        [(100, 200, "B2")],
+        # Stage 3+ never reached because hint capped at 2.
+        [(100, 300, "B3")],
+        [(100, 400, "B4")],
+    ]
+    env = MagicMock()
+    env.screenshot.return_value = MagicMock()
+    env.cdp_evaluate.side_effect = [
+        "https://example.com/boat/1/",
+        "https://example.com/boat/2/",
+    ]
+
+    CollectUrlsHandler(runner).execute(
+        _step(max_viewport_stages=2), _ctx(env, extractor),
+    )
+
+    assert len(runner._collected_urls) == 2
+    assert runner.costs["claude_extract"] == 2


### PR DESCRIPTION
## Summary

The first end-to-end Phase-1/Phase-2 verification on Modal (commit 2f34a3f → run ``bhpj8p2fp``) ran ``$0.32 / 3 leads / ~4m`` vs the pagination baseline's ``$14.85 / 55 leads / ~47m``. Architecturally superior: **2.5× better cost/lead, 12× faster wall-clock**. But absolute throughput was crushed by Phase-1's URL harvest — captured only 3 URLs vs the ~25 listings the first BoatTrader page actually carries (rest below the fold).

This PR ships axis #1 of #638: multi-viewport URL collection. Scrolls the page through up to 4 viewport stages, accumulates URLs across stages, dedups via the existing normalized-URL set.

## Approach

Mirrors the existing viewport-stage scanner in ``ClaudeGuidedClickHandler`` (gym/step_handlers/click.py:120). Two knobs:

- ``DEFAULT_MAX_VIEWPORT_STAGES = 4`` — matches click handler's cap. Per-plan override via ``step.hints['max_viewport_stages']``.
- ``PAGE_DOWNS_PER_STAGE = 2`` — ~30-40% overlap between adjacent stages so cards near stage boundaries are discoverable in at least one stage.

Early-exit signals:
- Stage 0 ``('blocked'/'error')`` → abort with skip envelope (don't waste 3 more scans on a CF-walled page).
- Two consecutive zero-new-URL stages → break.
- Later-stage ``'blocked'`` counted as empty (scrolled past the footer).

## Test plan

- [x] 11 collect_urls handler tests pass (6 existing pinned to single-stage via ``hints['max_viewport_stages']: 1`` on the test fixture; 5 new for multi-stage accumulation / dedup / early-exit / blocked-abort / hint override)
- [x] 79 tests pass across fanout + collect_urls suites
- [x] ruff clean
- [ ] Modal redeploy + boattrader rerun: Phase-1 harvests ~25 URLs (vs prior 3); Phase-2 runs across N parallel workers with K=~12 URLs/worker

## What's NOT in this PR

Axis #2 (multi-page harvest) and axis #3 (parallelize Phase-1 itself) remain deferred per the issue body. Multi-viewport alone should be enough for plans whose results page fits in 4 viewports — for boattrader that's ~25 listings, plenty for one fan-out cycle.

## Stack

Off main; no dependencies. PR #637 (augur instrumentation) is a parallel branch with shared base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)