### PR TITLE
collect_urls: multi-page Phase-1 harvest (#638 axis 2)

### DIFF
--- a/deploy/modal/modal_cua_server.py
+++ b/deploy/modal/modal_cua_server.py
@@ -2890,6 +2890,7 @@ def main(
         from mantis_agent.gym.fanout_runner import (
             find_url_collect_group, prepare_modal_partitions,
             prepare_phase1_suite, prepare_phase2_suites,
+            resolve_phase1_max_pages,
         )
 
         # #627: create a per-run shared seen-URL set keyed by a unique
@@ -2938,8 +2939,23 @@ def main(
         url_collect_group = find_url_collect_group(task_suite)
         if url_collect_group is not None:
             executor_fn = EXECUTOR_MAP.get(model, run_holo3)
-            print("\n  ═══ PHASE-1 (#628): URL collection on 1 container ═══")
-            phase1_suite = prepare_phase1_suite(task_suite, url_collect_group)
+            # #638 axis 2: walk N pagination pages in Phase-1 so the
+            # serial URL-harvest container can dominate the per-page
+            # fanout on coverage. Cap derived from the plan's
+            # parallelizable_pagination loop_count (clamped) or from an
+            # explicit ``_fanout_phase1_max_pages`` suite override.
+            phase1_max_pages, phase1_template = resolve_phase1_max_pages(
+                task_suite,
+            )
+            print(
+                f"\n  ═══ PHASE-1 (#628): URL collection on 1 container "
+                f"(max_pages={phase1_max_pages}, template={phase1_template!r}) ═══"
+            )
+            phase1_suite = prepare_phase1_suite(
+                task_suite, url_collect_group,
+                max_pages=phase1_max_pages,
+                pagination_url_template=phase1_template,
+            )
             # #631: per-partition branch_id for Augur grouping.
             phase1_suite["_fanout_branch_id"] = (
                 f"{fanout_parent_run_id}:phase1"

--- a/deploy/modal/modal_cua_server.py
+++ b/deploy/modal/modal_cua_server.py
@@ -864,6 +864,12 @@ def _run_holo3_executor(
         workflow_id = task_suite.get("_workflow_id", state_key)
         checkpoint_path = task_suite.get("_checkpoint_path") or f"/data/checkpoints/micro_{session_name}_{run_id}.json"
         plan_signature = task_suite.get("_plan_signature", "")
+        # #638 axis 2 follow-up: stable human-readable plan identifier
+        # (e.g. ``boattrader_scrape_urlnav``). Set by the orchestrator
+        # at suite-build time from the source file stem. The Augur
+        # adapter reads ``runner.plan_name`` and emits it as a tag so
+        # the Runs list can group different runs of the same plan.
+        plan_name = task_suite.get("_plan_name", "")
 
         print(f"\n  === MICRO-INTENT MODE ({len(micro_plan.steps)} steps) ===")
         print(micro_plan.summary())
@@ -933,6 +939,12 @@ def _run_holo3_executor(
         # ``log_progress`` falls back to the legacy format unchanged.
         branch_id = str(task_suite.get("_fanout_branch_id", "") or "")
         micro_runner._worker_tag = branch_id.rsplit(":", 1)[-1] if ":" in branch_id else ""
+        # #638 axis 2 follow-up: expose the plan_name as a runner
+        # attribute so ``RunExecutor`` can emit it as an Augur tag.
+        # Empty string is fine — Augur stores it as a tag regardless,
+        # and ad-hoc runs with no plan-file source legitimately have no
+        # canonical name.
+        micro_runner.plan_name = plan_name
 
         # Reasoning-trace stream → ``<run_dir>/reasoning.jsonl``. The
         # API container's ``action=reasoning_trace`` reads this file
@@ -1670,6 +1682,11 @@ def _build_suite_from_payload(payload: dict) -> str:
         max_recoveries_per_run=payload.get("max_recoveries_per_run"),
         max_recoveries_per_step=payload.get("max_recoveries_per_step"),
     )
+    # #638 axis 2 follow-up: stamp a human-readable plan_name on the
+    # suite so the Augur Runs list can group runs of the same plan.
+    # ``payload['plan_name']`` wins when the caller sets it; otherwise
+    # fall back to the source file stem (e.g. ``boattrader_scrape_urlnav``).
+    suite["_plan_name"] = str(payload.get("plan_name") or path.stem or "")
     return json.dumps(suite)
 
 
@@ -2818,7 +2835,13 @@ def main(
             with open(micro) as f:
                 raw = json.load(f)
             raw_steps = raw["steps"] if isinstance(raw, dict) and "steps" in raw else raw
-            micro_plan = MicroPlan(domain="direct_json")
+            # #638 axis 2 follow-up: domain mirrors the file stem so
+            # Augur tags expose the same human-readable identifier as
+            # the suite-level _plan_name (set on the suite below). The
+            # legacy hardcode ``"direct_json"`` made every JSON-micro
+            # run look identical in the Runs list regardless of plan.
+            from pathlib import Path as _Path
+            micro_plan = MicroPlan(domain=_Path(micro).stem)
             for s in raw_steps:
                 micro_plan.steps.append(PlanDecomposer._build_intent(s))
             # Hand-authored / cached step lists frequently omit
@@ -2890,6 +2913,14 @@ def main(
                 micro_plan, "pagination_url_template", "",
             ) or "",
         )
+        # #638 axis 2 follow-up: stable human-readable plan identifier
+        # for Augur grouping. ``micro_plan.domain`` is already set from
+        # the source file stem (JSON-micro / freetext path) or
+        # ``decomposer.decompose(micro)`` returns it. Stamping on the
+        # suite makes it explicit for the executor + survives the
+        # fan-out partition rewrite (each partition inherits via
+        # ``dict(suite_dict)`` in prepare_phase1/2_suite).
+        task_suite["_plan_name"] = str(micro_plan.domain or "")
 
         print(f"  Profile:  {task_suite['_profile_id']}")
         print(f"  Workflow: {task_suite['_workflow_id']}")

--- a/deploy/modal/modal_cua_server.py
+++ b/deploy/modal/modal_cua_server.py
@@ -226,7 +226,13 @@ executor_image = (
         # 0.1.2+ fires an immediate session-opened heartbeat so the
         # workspace's connection badge updates the moment the SDK is
         # wired up, before the first step lands.
-        "augur-sdk>=0.1.9",
+        # Must match pyproject.toml (``augur-sdk>=0.2.1,<0.3``). 0.2.x
+        # added ``branch_context`` to ``DebugSession.__init__``, which
+        # the fan-out runner needs to label Phase-1/Phase-2 worker
+        # sessions under a shared parent_run_id. Stale 0.1.x pins
+        # silently drop events from every fan-out worker — the adapter
+        # catches the TypeError and the worker session never opens.
+        "augur-sdk>=0.2.1,<0.3",
     )
     .add_local_python_source("mantis_agent")
     .add_local_dir(_PROMPTS_FILES_LOCAL, remote_path=_PROMPTS_FILES_REMOTE)
@@ -1359,7 +1365,13 @@ def _run_gemma4_cua_executor(
         "openai", "requests", "pillow", "mss",
         "fastapi>=0.100", "uvicorn>=0.20", "websocket-client",
         # #509: parity with run_holo3 — Gemma4 also runs the augur wedge.
-        "augur-sdk>=0.1.9",
+        # Must match pyproject.toml (``augur-sdk>=0.2.1,<0.3``). 0.2.x
+        # added ``branch_context`` to ``DebugSession.__init__``, which
+        # the fan-out runner needs to label Phase-1/Phase-2 worker
+        # sessions under a shared parent_run_id. Stale 0.1.x pins
+        # silently drop events from every fan-out worker — the adapter
+        # catches the TypeError and the worker session never opens.
+        "augur-sdk>=0.2.1,<0.3",
     ).add_local_python_source("mantis_agent").add_local_dir(_PROMPTS_FILES_LOCAL, remote_path=_PROMPTS_FILES_REMOTE),
     volumes={"/data": vol},
     secrets=[modal.Secret.from_dotenv()],
@@ -1406,7 +1418,13 @@ claude_executor_image = (
         # #509: parity with run_holo3 / run_gemma4_cua — Claude executor
         # also runs the augur wedge so bundles + streaming work for the
         # Anthropic-API tier.
-        "augur-sdk>=0.1.9",
+        # Must match pyproject.toml (``augur-sdk>=0.2.1,<0.3``). 0.2.x
+        # added ``branch_context`` to ``DebugSession.__init__``, which
+        # the fan-out runner needs to label Phase-1/Phase-2 worker
+        # sessions under a shared parent_run_id. Stale 0.1.x pins
+        # silently drop events from every fan-out worker — the adapter
+        # catches the TypeError and the worker session never opens.
+        "augur-sdk>=0.2.1,<0.3",
     )
     .add_local_python_source("mantis_agent")
     .add_local_dir(_PROMPTS_FILES_LOCAL, remote_path=_PROMPTS_FILES_REMOTE)
@@ -1539,7 +1557,13 @@ api_image = (
         # is lazy-imported but if augur_sdk is missing it falls back
         # silently — keeping the dep here makes the import succeed and
         # lets future API-side bundle reads work without a redeploy.
-        "augur-sdk>=0.1.9",
+        # Must match pyproject.toml (``augur-sdk>=0.2.1,<0.3``). 0.2.x
+        # added ``branch_context`` to ``DebugSession.__init__``, which
+        # the fan-out runner needs to label Phase-1/Phase-2 worker
+        # sessions under a shared parent_run_id. Stale 0.1.x pins
+        # silently drop events from every fan-out worker — the adapter
+        # catches the TypeError and the worker session never opens.
+        "augur-sdk>=0.2.1,<0.3",
     )
     .add_local_python_source("mantis_agent")
     .add_local_dir(_PROMPTS_FILES_LOCAL, remote_path=_PROMPTS_FILES_REMOTE)
@@ -2393,7 +2417,13 @@ def api():
         # so augur-sdk has to be added here separately. Without this the
         # AugurAdapter init logs sdk_available=False and is a no-op even
         # though the package is in executor_image for the other tiers.
-        "augur-sdk>=0.1.9",
+        # Must match pyproject.toml (``augur-sdk>=0.2.1,<0.3``). 0.2.x
+        # added ``branch_context`` to ``DebugSession.__init__``, which
+        # the fan-out runner needs to label Phase-1/Phase-2 worker
+        # sessions under a shared parent_run_id. Stale 0.1.x pins
+        # silently drop events from every fan-out worker — the adapter
+        # catches the TypeError and the worker session never opens.
+        "augur-sdk>=0.2.1,<0.3",
     ).add_local_python_source("mantis_agent").add_local_dir(_PROMPTS_FILES_LOCAL, remote_path=_PROMPTS_FILES_REMOTE).add_local_dir(_WEBGL_SPOOF_LOCAL, remote_path=_WEBGL_SPOOF_REMOTE),
     volumes={"/data": vol},
     secrets=[modal.Secret.from_dotenv()],

--- a/deploy/modal/modal_cua_server.py
+++ b/deploy/modal/modal_cua_server.py
@@ -924,6 +924,16 @@ def _run_holo3_executor(
         except Exception as exc:  # noqa: BLE001
             print(f"  WARNING: fanout branch_context init failed: {exc}")
 
+        # #638 axis 2 follow-up: derive a short worker tag from the
+        # fan-out branch_id so per-step log lines can be greppable per-
+        # worker in the interleaved orchestrator stdout. The branch_id
+        # shape is ``{parent_run_id}:{phase_tag}`` (e.g.
+        # ``fanout-XXX:phase2_w3``) — take only the suffix after ``:``.
+        # Empty when no branch_id is set (single-container runs) so
+        # ``log_progress`` falls back to the legacy format unchanged.
+        branch_id = str(task_suite.get("_fanout_branch_id", "") or "")
+        micro_runner._worker_tag = branch_id.rsplit(":", 1)[-1] if ":" in branch_id else ""
+
         # Reasoning-trace stream → ``<run_dir>/reasoning.jsonl``. The
         # API container's ``action=reasoning_trace`` reads this file
         # so a viewer overlay can render a structured timeline of

--- a/deploy/modal/modal_cua_server.py
+++ b/deploy/modal/modal_cua_server.py
@@ -2771,12 +2771,25 @@ def main(
 
         elif micro.endswith(".json"):
             print(f"  Mode:    Micro-Intent → {cua_config['name']}")
-            # Load pre-built micro-plan JSON directly (no decomposition)
+            # Load pre-built micro-plan JSON directly (no decomposition).
+            # Accept either a raw steps list OR a dict with a ``steps`` key
+            # — the latter is what plan files (e.g. ``plans/boattrader_*``)
+            # carry alongside ``shapes`` metadata.
             with open(micro) as f:
-                raw_steps = json.load(f)
+                raw = json.load(f)
+            raw_steps = raw["steps"] if isinstance(raw, dict) and "steps" in raw else raw
             micro_plan = MicroPlan(domain="direct_json")
             for s in raw_steps:
                 micro_plan.steps.append(PlanDecomposer._build_intent(s))
+            # Hand-authored / cached step lists frequently omit
+            # ``loop_target`` (issue #605) — the orchestrator's fan-out
+            # classifier then sees self-pointing loops and falls back to
+            # ``sequential``, defeating the parallelizable_url_collect /
+            # parallelizable_pagination path entirely. Run the same
+            # normalization + classification that ``decompose()`` runs so
+            # ``--micro <file.json> --workers N`` actually fans out.
+            PlanDecomposer._fix_loop_targets(micro_plan)
+            PlanDecomposer._classify_loop_groups(micro_plan)
         else:
             print(f"  Mode:    Micro-Intent → {cua_config['name']}")
             # Decompose plain text plan into micro-intents (Claude Sonnet, cached)

--- a/src/mantis_agent/gym/_runner_helpers.py
+++ b/src/mantis_agent/gym/_runner_helpers.py
@@ -362,6 +362,12 @@ def log_progress(
         proxy_cost=proxy_cost,
         total_cost=total_cost,
         elapsed_seconds=elapsed,
+        # #638 axis 2 follow-up: prefix per-step lines with the
+        # fan-out worker tag (e.g. ``phase2_w3``) so the interleaved
+        # orchestrator stdout from N concurrent containers is greppable
+        # per-worker. Empty string in single-container runs preserves
+        # the legacy format byte-for-byte.
+        worker_tag=getattr(runner, "_worker_tag", "") or "",
     ))
     runner.cost_meter.emit_inflight_gauges(
         gpu_cost, claude_cost, proxy_cost, total_cost

--- a/src/mantis_agent/gym/fanout_runner.py
+++ b/src/mantis_agent/gym/fanout_runner.py
@@ -723,6 +723,70 @@ def find_url_collect_group(suite_dict: dict) -> LoopGroup | None:
     return None
 
 
+def resolve_phase1_max_pages(suite_dict: dict) -> tuple[int, str]:
+    """Decide how many pages Phase-1 should walk + the URL template.
+
+    Resolution order for ``max_pages``:
+
+      1. Explicit ``_fanout_phase1_max_pages`` override on the suite
+         (operator/test escape hatch).
+      2. ``loop_count`` of the plan's ``parallelizable_pagination``
+         group, clamped to :data:`DEFAULT_PHASE1_MAX_PAGES` (so a
+         50-page pagination plan doesn't burn $5 in Phase-1).
+      3. Default of 1 (single page — backward compatible with the
+         original #628 Phase-1 shape).
+
+    Resolution order for ``url_template``:
+
+      1. Plan-level ``_pagination_url_template`` (set by #629).
+      2. ``params['url_template']`` on the ``paginate`` step inside
+         the pagination group (back-compat).
+      3. :data:`DEFAULT_PAGINATION_URL_TEMPLATE`.
+
+    Returns ``(max_pages, url_template)``. Callers pass both into
+    :func:`prepare_phase1_suite` as keyword args.
+    """
+    if not suite_dict.get("_micro_plan"):
+        return 1, ""
+    plan = _build_plan_from_suite(suite_dict)
+    explicit = suite_dict.get("_fanout_phase1_max_pages")
+    pagination_group = next(
+        (g for g in plan.loop_groups if g.shape == "parallelizable_pagination"),
+        None,
+    )
+
+    template = DEFAULT_PAGINATION_URL_TEMPLATE
+    plan_tpl = (
+        getattr(plan, "pagination_url_template", "") or ""
+    ).strip()
+    if plan_tpl:
+        template = plan_tpl
+    elif pagination_group is not None:
+        body_start, body_end = pagination_group.body_range
+        paginate_step = next(
+            (s for s in plan.steps[body_start:body_end] if s.type == "paginate"),
+            None,
+        )
+        if paginate_step is not None:
+            custom = (paginate_step.params or {}).get("url_template")
+            if custom:
+                template = str(custom)
+
+    if explicit is not None:
+        try:
+            max_pages = max(1, int(explicit))
+        except (TypeError, ValueError):
+            max_pages = 1
+    elif pagination_group is not None:
+        loop_count = int(
+            plan.steps[pagination_group.loop_step_idx].loop_count or 1
+        )
+        max_pages = max(1, min(loop_count, DEFAULT_PHASE1_MAX_PAGES))
+    else:
+        max_pages = 1
+    return max_pages, template
+
+
 def _step_dict_clone(step_dict: dict) -> dict:
     """Shallow-clone a step dict, deep-copying ``params`` + ``hints`` so
     sub-suite mutations don't leak into the source plan."""
@@ -732,30 +796,51 @@ def _step_dict_clone(step_dict: dict) -> dict:
     return cloned
 
 
+#: Default cap on Phase-1 multi-page harvest. Each page costs one
+#: ``collect_urls`` invocation (~$0.05-0.10 with multi-viewport scan)
+#: plus one navigate (~$0.01) — capping at 3 keeps Phase-1 cost
+#: bounded at ~$0.30 in the worst case. Plans that need broader
+#: coverage can lift via ``_fanout_phase1_max_pages`` in the suite,
+#: or via ``paginate.params['url_template']`` + the orchestrator's
+#: pagination loop_count.
+DEFAULT_PHASE1_MAX_PAGES = 3
+
+
 def prepare_phase1_suite(
     suite_dict: dict, group: LoopGroup,
+    *,
+    max_pages: int = 1,
+    pagination_url_template: str = "",
 ) -> dict:
     """Build a one-container Phase-1 sub-suite that harvests listing URLs.
 
-    The Phase-1 worker runs the plan's setup chain (everything BEFORE
-    the extraction loop body) and then a synthesized ``collect_urls``
-    step (#615). The worker returns its harvested URL list to the
-    orchestrator via the result envelope's ``collected_urls`` field
-    (added by :func:`build_micro_result`).
+    Phase-1 runs the plan's setup chain (everything BEFORE the
+    extraction loop body), then walks ``max_pages`` paginated pages
+    accumulating URLs via the ``collect_urls`` handler. The worker
+    returns its harvested URL list to the orchestrator via the result
+    envelope's ``collected_urls`` field (added by
+    :func:`build_micro_result`).
 
-    Phase-1 is a serial bottleneck — one Modal container, no fan-out —
-    so its cost is bounded by the cost of one navigate + a single
-    Claude scan call (~$0.02-0.05). For a 5-page plan this typically
-    runs in ~30-60 seconds vs the ~3-5 min the pagination-fanout's
-    setup chain takes per partition.
+    On ``max_pages=1`` (default) the sub-suite is:
+        setup_steps + collect_urls
+    On ``max_pages=N > 1`` the sub-suite is (#638 axis 2):
+        setup_steps + collect_urls
+                    + navigate(page-2) + collect_urls
+                    + navigate(page-3) + collect_urls
+                    + ...
+    The collect_urls handler appends-with-dedup to
+    ``runner._collected_urls``, so URLs from all pages accumulate
+    into a single list that crosses to the orchestrator on return.
 
-    Steps in the returned sub-suite's ``_micro_plan``:
+    Phase-1 is a serial bottleneck — one Modal container, no fan-out
+    inside. Each page costs ~$0.05-0.10 (multi-viewport scan) + ~$0.01
+    (navigate); ``max_pages=3`` caps the worst-case Phase-1 cost at
+    ~$0.30.
 
-      - All steps BEFORE the loop body (setup navigate, filters,
-        verification gates).
-      - One injected ``collect_urls`` step (claude_only=True,
-        section=extraction) that runs ``CollectUrlsHandler``.
-      - No loop body, no pagination — that's Phase 2's job.
+    ``pagination_url_template`` defaults to the same
+    :data:`DEFAULT_PAGINATION_URL_TEMPLATE` the per-page fan-out uses
+    so the URL synthesis is consistent across both paths. Set to a
+    custom template (e.g. ``"{base}?page={n}"``) to override.
     """
     body_start, _body_end = group.body_range
     loop_idx = group.loop_step_idx
@@ -763,30 +848,76 @@ def prepare_phase1_suite(
     setup_steps = [
         _step_dict_clone(s) for s in steps_raw[:body_start]
     ]
-    collect_step = {
-        "intent": "Collect every listing URL visible on this results page",
-        "type": "collect_urls",
-        "section": "extraction",
-        "claude_only": True,
-        "budget": 0,
-        # required=False (not True) so the runner's step-recovery
-        # policy doesn't trigger agentic_recovery + add_hint retries
-        # on collect_urls failure. The orchestrator already handles
-        # empty collect_urls by falling through to the pagination
-        # path — burning ~$0.20 on 3 doomed Claude scan retries +
-        # critic-row-link recovery attempts is wasted budget.
-        "required": False,
-        "params": {},
-        "hints": {},
-        "gate": False,
-        "loop_target": -1,
-        "loop_count": 0,
-        "grounding": False,
-        "verify": "",
-        "reverse": "",
-    }
+
+    def _collect_step() -> dict:
+        return {
+            "intent": "Collect every listing URL visible on this results page",
+            "type": "collect_urls",
+            "section": "extraction",
+            "claude_only": True,
+            "budget": 0,
+            # required=False (not True) so the runner's step-recovery
+            # policy doesn't trigger agentic_recovery + add_hint retries
+            # on collect_urls failure. The orchestrator already handles
+            # empty collect_urls by falling through to the pagination
+            # path — burning ~$0.20 on 3 doomed Claude scan retries +
+            # critic-row-link recovery attempts is wasted budget.
+            "required": False,
+            "params": {},
+            "hints": {},
+            "gate": False,
+            "loop_target": -1,
+            "loop_count": 0,
+            "grounding": False,
+            "verify": "",
+            "reverse": "",
+        }
+
+    def _navigate_step(url: str) -> dict:
+        return {
+            "intent": f"Navigate to {url}",
+            "type": "navigate",
+            "section": "extraction",
+            "budget": 3,
+            "required": False,
+            "params": {"url": url, "wait_after_load_seconds": 6},
+            "hints": {},
+            "claude_only": False,
+            "gate": False,
+            "loop_target": -1,
+            "loop_count": 0,
+            "grounding": False,
+            "verify": "",
+            "reverse": "",
+        }
+
+    plan_steps: list[dict] = list(setup_steps) + [_collect_step()]
+
+    if max_pages > 1:
+        # Resolve the base URL from the setup navigate so we can
+        # synthesize per-page URLs from the same template the per-page
+        # fanout uses (#629). If no base URL is found, fall back to
+        # single-page mode silently — the operator gets fewer URLs but
+        # no crash.
+        base_url = ""
+        for s in setup_steps:
+            if s.get("type") == "navigate":
+                base_url = (s.get("params") or {}).get("url", "") or ""
+                if base_url:
+                    break
+        template = pagination_url_template or DEFAULT_PAGINATION_URL_TEMPLATE
+        if base_url and "{base}" in template and "{n}" in template:
+            per_page_urls = partition_urls_for_pagination(
+                base_url, max_pages, template=template,
+            )
+            # per_page_urls[0] is the base URL the setup already
+            # navigated to; skip it and append pages 2..max_pages.
+            for url in per_page_urls[1:]:
+                plan_steps.append(_navigate_step(url))
+                plan_steps.append(_collect_step())
+
     sub_suite = dict(suite_dict)
-    sub_suite["_micro_plan"] = setup_steps + [collect_step]
+    sub_suite["_micro_plan"] = plan_steps
     sub_suite["session_name"] = (
         f"{suite_dict.get('session_name', 'fanout')}_phase1"
     )
@@ -799,6 +930,9 @@ def prepare_phase1_suite(
     # Loop_idx is unused but documenting the source body span helps
     # operators when reading the suite payload in dispatch logs.
     sub_suite["_fanout_source_loop_step"] = loop_idx
+    # Record max_pages so the operator can see (in the dispatch log)
+    # how many pages Phase-1 was asked to walk.
+    sub_suite["_fanout_phase1_pages"] = max_pages
     return sub_suite
 
 

--- a/src/mantis_agent/gym/fanout_runner.py
+++ b/src/mantis_agent/gym/fanout_runner.py
@@ -778,8 +778,14 @@ def resolve_phase1_max_pages(suite_dict: dict) -> tuple[int, str]:
         except (TypeError, ValueError):
             max_pages = 1
     elif pagination_group is not None:
+        # Hand-authored plans frequently omit ``loop_count`` on the
+        # pagination loop (the per-page partition path defaults this to
+        # ``5``). Treat absent loop_count as "walk up to
+        # DEFAULT_PHASE1_MAX_PAGES" — the existence of a pagination group
+        # is enough signal that Phase-1 should harvest beyond page 1.
         loop_count = int(
-            plan.steps[pagination_group.loop_step_idx].loop_count or 1
+            plan.steps[pagination_group.loop_step_idx].loop_count
+            or DEFAULT_PHASE1_MAX_PAGES
         )
         max_pages = max(1, min(loop_count, DEFAULT_PHASE1_MAX_PAGES))
     else:

--- a/src/mantis_agent/gym/run_executor.py
+++ b/src/mantis_agent/gym/run_executor.py
@@ -257,6 +257,14 @@ class RunExecutor:
             session_name=str(getattr(runner, "session_name", "") or ""),
             extra_tags={
                 "plan_signature": runner.plan_signature or "",
+                # #638 axis 2 follow-up: human-readable plan identifier
+                # (e.g. ``boattrader_scrape_urlnav``) for Augur grouping.
+                # ``plan_signature`` already groups exact-match plans by
+                # hash; ``plan_name`` lets operators filter the Runs list
+                # by plan-family rather than memorising 12-char hashes.
+                # Stable across runs of the same source plan; empty
+                # string for ad-hoc runs that didn't set one.
+                "plan_name": str(getattr(runner, "plan_name", "") or ""),
                 "model": model_name,
                 # #542: surface the plan's total step count as a tag so
                 # the Augur runs-list can render "X / N steps" instead

--- a/src/mantis_agent/gym/run_reporter.py
+++ b/src/mantis_agent/gym/run_reporter.py
@@ -54,6 +54,7 @@ class RunReporter:
         proxy_cost: float,
         total_cost: float,
         elapsed_seconds: float,
+        worker_tag: str = "",
     ) -> str:
         """Build the single-line progress message printed after each step.
 
@@ -61,12 +62,19 @@ class RunReporter:
         verbatim — same field order, same number widths, same minute
         rounding. Tests in test_micro_runner_hooks.py compare this line
         format.
+
+        ``worker_tag`` (#638 axis 2 follow-up): when set, emitted as a
+        ``[tag]`` prefix BEFORE the ``[step_index]`` so per-worker lines
+        in fan-out runs can be grepped out of the interleaved
+        orchestrator stdout. Empty (default) preserves single-container
+        format byte-for-byte — existing format-pinning tests stay green.
         """
         unique_leads, phone_leads = ListingDedup.lead_counts(results)
         cost_per_lead = total_cost / max(unique_leads, 1)
         cost_per_phone_lead = total_cost / max(phone_leads, 1)
+        tag_prefix = f"[{worker_tag}]" if worker_tag else ""
         return (
-            f"  [{step_index:2d}] {'OK' if success else 'FAIL'} "
+            f"  {tag_prefix}[{step_index:2d}] {'OK' if success else 'FAIL'} "
             f"| {unique_leads} leads ({phone_leads} phone) | ${total_cost:.2f} total "
             f"(${cost_per_lead:.2f}/lead, ${cost_per_phone_lead:.2f}/phone lead) | "
             f"GPU ${gpu_cost:.2f} Claude ${claude_cost:.2f} Proxy ${proxy_cost:.2f} | "

--- a/src/mantis_agent/gym/step_handlers/collect_urls.py
+++ b/src/mantis_agent/gym/step_handlers/collect_urls.py
@@ -168,8 +168,17 @@ class CollectUrlsHandler:
             )
         )
 
-        urls: list[str] = []
-        seen: set[str] = set()
+        # #638 axis 2: accumulate across calls so multi-page Phase-1
+        # plans (navigate(page-1) → collect_urls → navigate(page-2) →
+        # collect_urls → ...) carry forward URLs from prior pages.
+        # ``urls`` and ``seen`` are seeded from ``runner._collected_urls``
+        # so this invocation's dedup catches both within-this-page
+        # duplicates (viewport overlap) AND cross-page duplicates
+        # (featured listings rendered on multiple pages). On a single-
+        # page invocation the seed is empty and behaviour is unchanged.
+        urls: list[str] = list(getattr(runner, "_collected_urls", []) or [])
+        seen: set[str] = set(urls)
+        new_urls_this_call = 0  # tracked for the per-call log line
         total_cards = 0
         total_unresolved = 0
         first_signal: str | None = None
@@ -236,6 +245,7 @@ class CollectUrlsHandler:
                 seen.add(href)
                 urls.append(href)
                 new_this_stage += 1
+                new_urls_this_call += 1
             total_unresolved += unresolved_this_stage
 
             logger.warning(
@@ -285,17 +295,25 @@ class CollectUrlsHandler:
             )
 
         coverage = resolved / max(total_cards, 1)
+        # The CUMULATIVE total (resolved) is what the orchestrator reads;
+        # the NEW count (new_urls_this_call) shows what this specific
+        # invocation contributed. Same value on single-page Phase-1, but
+        # diverges on multi-page (#638 axis 2) where each subsequent
+        # navigate+collect_urls pair adds to the running total.
         if coverage < 0.8:
             logger.warning(
-                "  [collect_urls] FINAL: %d unique URLs from %d cards "
-                "across viewport stages (%.0f%% coverage, %d unresolved)",
-                resolved, total_cards, coverage * 100, total_unresolved,
+                "  [collect_urls] FINAL: %d new URLs this call, "
+                "%d cumulative from %d cards across viewport stages "
+                "(%.0f%% coverage, %d unresolved)",
+                new_urls_this_call, resolved, total_cards,
+                coverage * 100, total_unresolved,
             )
         else:
             logger.warning(
-                "  [collect_urls] FINAL: %d unique URLs from %d cards "
-                "across viewport stages (%.0f%% coverage)",
-                resolved, total_cards, coverage * 100,
+                "  [collect_urls] FINAL: %d new URLs this call, "
+                "%d cumulative from %d cards across viewport stages "
+                "(%.0f%% coverage)",
+                new_urls_this_call, resolved, total_cards, coverage * 100,
             )
 
         return StepResult(

--- a/tests/test_collect_urls_handler.py
+++ b/tests/test_collect_urls_handler.py
@@ -353,6 +353,85 @@ def test_multi_viewport_stage0_blocked_aborts(monkeypatch) -> None:
     assert runner.costs["claude_extract"] == 1
 
 
+# ── #638 axis 2: multi-page accumulation ──────────────────────────────
+
+
+def test_second_invocation_appends_to_existing_collected_urls(monkeypatch) -> None:
+    """When the runner already has URLs from a prior collect_urls call
+    (Phase-1 multi-page: navigate(page-1) → collect → navigate(page-2) →
+    collect), the second invocation appends to the existing list rather
+    than replacing it."""
+    monkeypatch.setattr(
+        "mantis_agent.gym.step_handlers.collect_urls.adaptive_content_settle",
+        lambda *_, **__: None,
+    )
+    runner = _FakeRunner()
+    # Simulate page-1 already harvested.
+    runner._collected_urls = [
+        "https://example.com/boat/1/",
+        "https://example.com/boat/2/",
+    ]
+
+    extractor = MagicMock()
+    # Page-2 scan returns 2 new cards.
+    extractor.find_all_listings.return_value = [
+        (100, 200, "Boat 3"),
+        (100, 400, "Boat 4"),
+    ]
+    env = MagicMock()
+    env.screenshot.return_value = MagicMock()
+    env.cdp_evaluate.side_effect = [
+        "https://example.com/boat/3/",
+        "https://example.com/boat/4/",
+    ]
+
+    result = CollectUrlsHandler(runner).execute(_step(), _ctx(env, extractor))
+
+    assert result.success is True
+    # Order preserved: page-1 URLs first, page-2 URLs appended.
+    assert runner._collected_urls == [
+        "https://example.com/boat/1/",
+        "https://example.com/boat/2/",
+        "https://example.com/boat/3/",
+        "https://example.com/boat/4/",
+    ]
+    # data string reports the CUMULATIVE count (4) over THIS-CALL cards (2).
+    assert result.data == "urls:4/2"
+
+
+def test_second_invocation_dedups_against_prior_urls(monkeypatch) -> None:
+    """Featured / sponsored listings frequently appear on every paginated
+    page. The cross-call dedup catches them via the seeded ``seen`` set."""
+    monkeypatch.setattr(
+        "mantis_agent.gym.step_handlers.collect_urls.adaptive_content_settle",
+        lambda *_, **__: None,
+    )
+    runner = _FakeRunner()
+    runner._collected_urls = [
+        "https://example.com/boat/1/",  # featured — will re-appear on page-2
+        "https://example.com/boat/2/",
+    ]
+    extractor = MagicMock()
+    extractor.find_all_listings.return_value = [
+        (100, 200, "Featured"),
+        (100, 400, "New"),
+    ]
+    env = MagicMock()
+    env.screenshot.return_value = MagicMock()
+    env.cdp_evaluate.side_effect = [
+        "https://example.com/boat/1/",  # duplicate from page-1
+        "https://example.com/boat/9/",  # genuinely new
+    ]
+
+    CollectUrlsHandler(runner).execute(_step(), _ctx(env, extractor))
+
+    assert runner._collected_urls == [
+        "https://example.com/boat/1/",
+        "https://example.com/boat/2/",
+        "https://example.com/boat/9/",
+    ]
+
+
 def test_max_viewport_stages_hint_overrides_default(monkeypatch) -> None:
     """``step.hints['max_viewport_stages']`` is the operator knob —
     pin it to 2 and verify the loop respects it even when more cards

--- a/tests/test_fanout_runner.py
+++ b/tests/test_fanout_runner.py
@@ -1007,6 +1007,20 @@ def test_resolve_phase1_max_pages_uses_pagination_loop_count() -> None:
     assert max_pages == min(4, DEFAULT_PHASE1_MAX_PAGES)
 
 
+def test_resolve_phase1_max_pages_unset_loop_count_defaults_to_cap() -> None:
+    """When the pagination loop has no loop_count (None / 0) but the
+    group exists, default to DEFAULT_PHASE1_MAX_PAGES — the existence of
+    a parallelizable_pagination group is enough signal that Phase-1
+    should harvest beyond page 1. Mirrors the per-page partitioning
+    path's ``or 5`` default."""
+    suite = _pagination_plan_suite()
+    for step in suite["_micro_plan"]:
+        if step.get("type") == "loop" and step.get("section") == "pagination":
+            step["loop_count"] = 0  # mimic _fix_loop_targets leaving it unset
+    max_pages, _ = resolve_phase1_max_pages(suite)
+    assert max_pages == DEFAULT_PHASE1_MAX_PAGES
+
+
 def test_resolve_phase1_max_pages_clamps_to_default_cap() -> None:
     """A plan with loop_count=50 should be clamped to DEFAULT_PHASE1_MAX_PAGES
     so Phase-1 cost stays bounded."""

--- a/tests/test_fanout_runner.py
+++ b/tests/test_fanout_runner.py
@@ -24,6 +24,7 @@ from typing import Any
 from mantis_agent.gym.checkpoint import StepResult
 from mantis_agent.gym.fanout_runner import (
     DEFAULT_PAGINATION_URL_TEMPLATE,
+    DEFAULT_PHASE1_MAX_PAGES,
     LocalFanoutRunner,
     NullSharedSeenSet,
     _InMemorySharedSeenSet,
@@ -39,6 +40,7 @@ from mantis_agent.gym.fanout_runner import (
     prepare_phase1_suite,
     prepare_phase2_suites,
     read_partition_result,
+    resolve_phase1_max_pages,
     rewrite_for_fanout,
 )
 from mantis_agent.plan_decomposer import (
@@ -897,6 +899,142 @@ def test_phase1_suite_tags_phase_metadata() -> None:
     phase1 = prepare_phase1_suite(suite, g)
     assert phase1["_fanout_phase"] == "phase1_collect"
     assert phase1["session_name"].endswith("_phase1")
+
+
+# ── #638 axis 2: multi-page Phase-1 ──────────────────────────────────
+
+
+def test_phase1_suite_max_pages_one_is_single_collect() -> None:
+    """max_pages=1 → no navigate inserted after the setup chain; one
+    collect_urls only. Backward compatible with the original #628 shape."""
+    suite = _url_collect_suite()
+    g = find_url_collect_group(suite)
+    phase1 = prepare_phase1_suite(suite, g, max_pages=1)
+    types = [s["type"] for s in phase1["_micro_plan"]]
+    assert types == ["navigate", "collect_urls"]
+
+
+def test_phase1_suite_max_pages_three_chains_nav_collect() -> None:
+    """max_pages=3 → setup navigate + collect_urls + navigate(page-2) +
+    collect_urls + navigate(page-3) + collect_urls."""
+    suite = _url_collect_suite()
+    g = find_url_collect_group(suite)
+    phase1 = prepare_phase1_suite(suite, g, max_pages=3)
+    types = [s["type"] for s in phase1["_micro_plan"]]
+    assert types == [
+        "navigate", "collect_urls",
+        "navigate", "collect_urls",
+        "navigate", "collect_urls",
+    ]
+
+
+def test_phase1_suite_max_pages_three_synthesizes_page_urls() -> None:
+    """Pages 2..N synthesised via the default pagination url_template,
+    matching what the per-page fan-out path uses."""
+    suite = _url_collect_suite()
+    # Setup navigate base URL is https://x.com/listings.
+    g = find_url_collect_group(suite)
+    phase1 = prepare_phase1_suite(suite, g, max_pages=3)
+    nav_urls = [
+        s["params"]["url"] for s in phase1["_micro_plan"]
+        if s["type"] == "navigate"
+    ]
+    # First navigate is the original setup URL; pages 2 and 3 follow
+    # the default ``{base}/page-{n}/`` template.
+    assert nav_urls[0] == "https://x.com/listings"
+    assert nav_urls[1].endswith("/page-2/")
+    assert nav_urls[2].endswith("/page-3/")
+
+
+def test_phase1_suite_max_pages_template_override() -> None:
+    """Custom url_template propagates from caller into the synthesised
+    page-N navigate steps."""
+    suite = _url_collect_suite()
+    g = find_url_collect_group(suite)
+    phase1 = prepare_phase1_suite(
+        suite, g, max_pages=2, pagination_url_template="{base}?p={n}",
+    )
+    nav_urls = [
+        s["params"]["url"] for s in phase1["_micro_plan"]
+        if s["type"] == "navigate"
+    ]
+    assert nav_urls[1].endswith("?p=2")
+
+
+def test_phase1_suite_records_max_pages_metadata() -> None:
+    suite = _url_collect_suite()
+    g = find_url_collect_group(suite)
+    phase1 = prepare_phase1_suite(suite, g, max_pages=3)
+    assert phase1["_fanout_phase1_pages"] == 3
+
+
+def test_phase1_suite_max_pages_silently_falls_back_without_base_url() -> None:
+    """If the setup chain has no navigate (degenerate plan), Phase-1 falls
+    back to single-page mode rather than crashing — the operator gets
+    fewer URLs but the worker still runs."""
+    suite = _url_collect_suite()
+    # Strip the setup navigate by truncating the micro_plan from
+    # body_start. Rebuild loop_groups against the stripped sequence.
+    g = find_url_collect_group(suite)
+    body_start, _ = g.body_range
+    # Replace the setup navigate with a dummy non-navigate step so the
+    # body range stays valid but base_url resolution returns "".
+    suite["_micro_plan"][0]["type"] = "wait"
+    suite["_micro_plan"][0]["params"] = {}
+    phase1 = prepare_phase1_suite(suite, g, max_pages=3)
+    types = [s["type"] for s in phase1["_micro_plan"]]
+    # Only one collect_urls fires — no page-2/page-3 chain because no
+    # base URL was resolvable.
+    assert types.count("collect_urls") == 1
+    assert "navigate" not in types  # only the wait step remains
+
+
+# ── #638 axis 2: resolve_phase1_max_pages ────────────────────────────
+
+
+def test_resolve_phase1_max_pages_default_when_no_pagination_group() -> None:
+    """Plan without a parallelizable_pagination group → max_pages=1."""
+    suite = _url_collect_suite()
+    max_pages, template = resolve_phase1_max_pages(suite)
+    assert max_pages == 1
+    assert template == DEFAULT_PAGINATION_URL_TEMPLATE
+
+
+def test_resolve_phase1_max_pages_uses_pagination_loop_count() -> None:
+    """Pagination loop_count=4 → max_pages=min(4, DEFAULT_PHASE1_MAX_PAGES)."""
+    suite = _pagination_plan_suite()
+    max_pages, _ = resolve_phase1_max_pages(suite)
+    assert max_pages == min(4, DEFAULT_PHASE1_MAX_PAGES)
+
+
+def test_resolve_phase1_max_pages_clamps_to_default_cap() -> None:
+    """A plan with loop_count=50 should be clamped to DEFAULT_PHASE1_MAX_PAGES
+    so Phase-1 cost stays bounded."""
+    suite = _pagination_plan_suite()
+    # Bump the outer loop count past the cap.
+    for step in suite["_micro_plan"]:
+        if step.get("type") == "loop" and step.get("section") == "pagination":
+            step["loop_count"] = 50
+    max_pages, _ = resolve_phase1_max_pages(suite)
+    assert max_pages == DEFAULT_PHASE1_MAX_PAGES
+
+
+def test_resolve_phase1_max_pages_honours_explicit_override() -> None:
+    """An explicit ``_fanout_phase1_max_pages`` on the suite overrides
+    the pagination loop_count + the default cap."""
+    suite = _pagination_plan_suite()
+    suite["_fanout_phase1_max_pages"] = 7
+    max_pages, _ = resolve_phase1_max_pages(suite)
+    assert max_pages == 7
+
+
+def test_resolve_phase1_max_pages_picks_up_plan_template_override() -> None:
+    """Plan-level ``_pagination_url_template`` (set by #629) wins over
+    the default."""
+    suite = _pagination_plan_suite()
+    suite["_pagination_url_template"] = "{base}?page={n}"
+    _, template = resolve_phase1_max_pages(suite)
+    assert template == "{base}?page={n}"
 
 
 # ── prepare_phase2_suites ────────────────────────────────────────────

--- a/tests/test_run_reporter.py
+++ b/tests/test_run_reporter.py
@@ -56,6 +56,56 @@ def test_step_progress_line_failed_step():
     assert "[ 7] FAIL" in line
 
 
+# ── #638 axis 2 follow-up: worker_tag prefix ────────────────────────
+
+
+def test_step_progress_line_no_worker_tag_preserves_legacy_format():
+    """``worker_tag=""`` (default) → no prefix; output identical to
+    pre-fanout single-container format. Pinning here so any future
+    tweak to the tag injection can't silently regress single-runner
+    behaviour."""
+    line = RunReporter.step_progress_line(
+        step_index=4,
+        success=True,
+        results=[],
+        gpu_cost=0.1, claude_cost=0.0, proxy_cost=0.0,
+        total_cost=0.1, elapsed_seconds=60.0,
+    )
+    # ``  [`` followed immediately by the step index — no extra prefix
+    # bracket between leading whitespace and the step-index bracket.
+    assert line.startswith("  [ 4] OK ")
+
+
+def test_step_progress_line_worker_tag_prefixes_step_index():
+    """With ``worker_tag="phase2_w3"`` the line is greppable per-worker
+    out of the orchestrator's interleaved stdout."""
+    line = RunReporter.step_progress_line(
+        step_index=4,
+        success=True,
+        results=[],
+        gpu_cost=0.1, claude_cost=0.0, proxy_cost=0.0,
+        total_cost=0.1, elapsed_seconds=60.0,
+        worker_tag="phase2_w3",
+    )
+    assert "[phase2_w3][ 4] OK" in line
+
+
+def test_step_progress_line_empty_worker_tag_no_prefix():
+    """Explicit empty string is treated as no-prefix — guards against
+    accidentally emitting ``[][ 4] OK`` if the suite carries
+    ``_fanout_branch_id=""`` (single-container parent path)."""
+    line = RunReporter.step_progress_line(
+        step_index=4,
+        success=True,
+        results=[],
+        gpu_cost=0.1, claude_cost=0.0, proxy_cost=0.0,
+        total_cost=0.1, elapsed_seconds=60.0,
+        worker_tag="",
+    )
+    assert "[][" not in line
+    assert "  [ 4] OK" in line
+
+
 def test_step_progress_line_with_viable_lead():
     """Lead summary in result.data → counted by ListingDedup, divisor reflected."""
     results = [_viable(3, "VIABLE | year:2020 | make:Acme | url:http://x")]

--- a/tests/test_stealth_parity_modal.py
+++ b/tests/test_stealth_parity_modal.py
@@ -189,6 +189,40 @@ def test_build_suite_from_payload_preserves_proxy_provider():
     )
 
 
+def test_build_suite_from_payload_stamps_plan_name():
+    """#638 axis 2 follow-up: ``_plan_name`` must be stamped on the
+    suite so the Augur Runs list can group runs of the same plan.
+    Default is the source file stem; ``payload['plan_name']`` wins
+    when the caller sets it explicitly."""
+    from deploy.modal import modal_cua_server as m
+    src = inspect.getsource(m._build_suite_from_payload)
+    assert '_plan_name' in src, (
+        "_plan_name must be stamped onto the suite from the micro JSON "
+        "path so Augur tags get a human-readable plan identifier"
+    )
+    assert "path.stem" in src, (
+        "_plan_name must default to the source file stem when payload "
+        "doesn't supply an explicit plan_name override"
+    )
+
+
+def test_run_executor_emits_plan_name_tag_to_augur():
+    """#638 axis 2 follow-up: RunExecutor must forward ``runner.plan_name``
+    into the AugurAdapter ``extra_tags`` dict so the Augur Runs list
+    can group runs of the same plan. Source-level check matches the
+    existing plan_signature / plan_step_count pattern."""
+    from mantis_agent.gym import run_executor as re_mod
+    src = inspect.getsource(re_mod)
+    assert '"plan_name":' in src, (
+        "RunExecutor must emit a 'plan_name' tag in the AugurAdapter "
+        "extra_tags dict"
+    )
+    assert 'getattr(runner, "plan_name"' in src, (
+        "plan_name must be read off the runner via getattr so single-"
+        "container runs without the attribute don't AttributeError"
+    )
+
+
 def test_build_micro_suite_stamps_proxy_provider_into_suite():
     """build_micro_suite must persist ``proxy_provider`` into the
     suite dict at ``_proxy_provider`` so downstream executors


### PR DESCRIPTION
## Summary

- Phase-1 now walks **up to `DEFAULT_PHASE1_MAX_PAGES = 3` paginated pages** in a single container instead of one. The serial URL-harvest path can now dominate per-page fan-out on both cost-per-lead AND absolute throughput, rather than trading one against the other.
- `CollectUrlsHandler.execute()` accumulates URLs across calls (seeds `urls` / `seen` from `runner._collected_urls`), so multi-page chains naturally cross-page-dedup featured listings without extra plumbing.
- `prepare_phase1_suite()` accepts `max_pages` + `pagination_url_template` keyword args and emits a `navigate → collect_urls` chain (pages 2..N synthesised via the same template the per-page fan-out uses).
- New `resolve_phase1_max_pages(suite_dict)` helper derives `max_pages` from (in priority order): explicit `_fanout_phase1_max_pages` suite override → `parallelizable_pagination.loop_count` clamped to `DEFAULT_PHASE1_MAX_PAGES` → default `1`. URL template resolves from `_pagination_url_template` (#629) → `paginate.params['url_template']` → default.
- Modal orchestrator (`modal_cua_server.py`) calls the resolver and passes both values into `prepare_phase1_suite`, with a dispatch-log line surfacing `max_pages` + template for operator visibility.

Cost envelope: each extra Phase-1 page ≈ one `collect_urls` (~$0.05–0.10 with multi-viewport scan) + one navigate (~$0.01). The default cap of 3 keeps worst-case Phase-1 cost at ~$0.30.

## Test plan

- [x] `tests/test_collect_urls_handler.py` — 2 new tests pin the cumulative `_collected_urls` behaviour:
  - second invocation appends to existing list (`urls:4/2` data string reports cumulative-over-this-call)
  - cross-call dedup against URLs seeded from page-1
- [x] `tests/test_fanout_runner.py` — 11 new tests cover:
  - `prepare_phase1_suite(max_pages=1)` backward-compat (`navigate, collect_urls`)
  - `prepare_phase1_suite(max_pages=3)` emits `nav, collect, nav, collect, nav, collect`
  - synthesised page URLs use default `{base}/page-{n}/` template
  - custom `pagination_url_template` propagates
  - `_fanout_phase1_pages` metadata recorded
  - silent fallback to single-page when no base URL is resolvable
  - `resolve_phase1_max_pages` returns `1` without a pagination group
  - `resolve_phase1_max_pages` uses pagination `loop_count` (clamped to `DEFAULT_PHASE1_MAX_PAGES`)
  - `resolve_phase1_max_pages` clamps oversized loop_count
  - explicit `_fanout_phase1_max_pages` override wins
  - plan-level `_pagination_url_template` (#629) wins over default
- [x] `ruff check` clean on all touched files.
- [x] Full fan-out adjacent suite (`test_fanout_runner` + `test_collect_urls_handler` + `test_decomposer_loop_classifier` + `test_fanout_branch_context`) — 111 passed.
- [ ] Modal redeploy + A/B verification: re-run boattrader with workers≥2; verify dispatch log shows `max_pages=3`, Phase-1 harvest meaningfully larger than the axis-1 baseline of 21 URLs, and Phase-2 dispatch picks up the expanded URL set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)