### PR TITLE
fanout: propagate in-page click steps into Phase-2 per-URL sequence

### DIFF
--- a/src/mantis_agent/gym/fanout_runner.py
+++ b/src/mantis_agent/gym/fanout_runner.py
@@ -972,16 +972,59 @@ def prepare_phase2_suites(
     # navigates directly to a listing URL, no results-page touch.
     steps_raw = suite_dict.get("_micro_plan") or []
 
-    # Find the extract_data body step to clone — that's the per-listing
-    # extraction operator the Phase-1/Phase-2 split is built around.
-    # Fall back to a minimal hand-built extract_data if absent.
     body_dicts = steps_raw[group.body_range[0]: group.body_range[1]]
-    extract_template = next(
-        (_step_dict_clone(s) for s in body_dicts if s.get("type") == "extract_data"),
+
+    # Per-URL extraction sequence: everything in the loop body from the
+    # first ``scroll`` step onwards, minus ``navigate_back`` (loop-iter
+    # mechanics — Phase-2 already isolates each URL into its own
+    # navigate). Captures any in-page interactions the plan author
+    # placed BETWEEN scroll and extract_data (e.g. ``click(Show More)``
+    # to expand a truncated description so phone numbers buried in the
+    # freeform text become extractable).
+    #
+    # Steps BEFORE the first scroll (typically ``click(listing_card)``
+    # + ``extract_url``) are loop-navigation: they're how the original
+    # plan transitions from results-page → detail-page. Phase-2 skips
+    # them because each worker navigates directly to a known URL.
+    #
+    # Fallback: when the body has no ``scroll`` (degenerate plans) we
+    # synthesize the legacy ``(scroll, extract_data)`` pair so existing
+    # tests + production plans built before this rewrite continue to
+    # work unchanged.
+    first_scroll_idx = next(
+        (i for i, s in enumerate(body_dicts) if s.get("type") == "scroll"),
         None,
     )
-    if extract_template is None:
-        extract_template = {
+    if first_scroll_idx is not None:
+        per_url_templates = [
+            _step_dict_clone(s)
+            for s in body_dicts[first_scroll_idx:]
+            if s.get("type") != "navigate_back"
+        ]
+    else:
+        per_url_templates = [
+            {
+                "intent": "Scroll the listing page to surface description + more details",
+                "type": "scroll",
+                "section": "extraction",
+                "budget": 10,
+                "required": False,
+                "params": {},
+                "hints": {},
+                "claude_only": False,
+                "gate": False,
+                "loop_target": -1,
+                "loop_count": 0,
+                "grounding": False,
+                "verify": "",
+                "reverse": "",
+            },
+        ]
+        extract_from_body = next(
+            (_step_dict_clone(s) for s in body_dicts if s.get("type") == "extract_data"),
+            None,
+        )
+        per_url_templates.append(extract_from_body or {
             "intent": "Extract structured fields from the listing detail page",
             "type": "extract_data",
             "section": "extraction",
@@ -996,23 +1039,7 @@ def prepare_phase2_suites(
             "grounding": False,
             "verify": "",
             "reverse": "",
-        }
-    scroll_template = {
-        "intent": "Scroll the listing page to surface description + more details",
-        "type": "scroll",
-        "section": "extraction",
-        "budget": 10,
-        "required": False,
-        "params": {},
-        "hints": {},
-        "claude_only": False,
-        "gate": False,
-        "loop_target": -1,
-        "loop_count": 0,
-        "grounding": False,
-        "verify": "",
-        "reverse": "",
-    }
+        })
 
     def _navigate_step(url: str) -> dict:
         return {
@@ -1037,8 +1064,8 @@ def prepare_phase2_suites(
         plan_steps: list[dict] = []
         for url in chunk:
             plan_steps.append(_navigate_step(url))
-            plan_steps.append(dict(scroll_template))
-            plan_steps.append(dict(extract_template))
+            for tmpl in per_url_templates:
+                plan_steps.append(_step_dict_clone(tmpl))
         sub_suite = dict(suite_dict)
         sub_suite["_micro_plan"] = plan_steps
         # Drop loop_groups — the rewritten plan has no loops.

--- a/tests/test_fanout_runner.py
+++ b/tests/test_fanout_runner.py
@@ -1106,6 +1106,75 @@ def test_phase2_suites_no_urls_returns_empty_list() -> None:
     assert prepare_phase2_suites(suite, [], g, workers=4) == []
 
 
+def test_phase2_suites_propagate_in_page_click_between_scroll_and_extract() -> None:
+    """Per-URL extraction sequence preserves any in-page click steps
+    the plan author placed BETWEEN ``scroll`` and ``extract_data``
+    (e.g. ``click(Show More)`` to expand a truncated description so
+    phone numbers buried in freeform text become extractable).
+
+    Steps BEFORE the first scroll (listing_card click + extract_url)
+    are loop-iteration mechanics — Phase-2 already isolates each URL
+    via a direct navigate, so those steps must be dropped. Same for
+    ``navigate_back`` which is the loop-tail return.
+    """
+    plan = MicroPlan(domain="x.com")
+    plan.steps = [
+        MicroIntent(
+            intent="Navigate", type="navigate", section="setup",
+            params={"url": "https://x.com/listings"},
+        ),
+        MicroIntent(intent="Click card", type="click", section="extraction"),
+        MicroIntent(intent="Read URL", type="extract_url", section="extraction"),
+        MicroIntent(intent="Scroll", type="scroll", section="extraction"),
+        MicroIntent(
+            intent="Click Show More", type="click", section="extraction",
+        ),
+        MicroIntent(intent="Extract", type="extract_data", section="extraction"),
+        MicroIntent(intent="Back", type="navigate_back", section="extraction"),
+        MicroIntent(
+            intent="Inner loop", type="loop", section="extraction",
+            loop_target=1, loop_count=20,
+        ),
+    ]
+    PlanDecomposer._classify_loop_groups(plan)
+    suite = {
+        "session_name": "x",
+        "_micro_plan": [
+            {
+                "intent": s.intent, "type": s.type, "section": s.section,
+                "params": dict(s.params or {}),
+                "loop_target": s.loop_target, "loop_count": s.loop_count,
+                "claude_only": s.claude_only, "gate": s.gate,
+                "required": s.required, "grounding": s.grounding,
+                "verify": s.verify, "reverse": s.reverse,
+                "budget": s.budget, "hints": dict(s.hints or {}),
+            }
+            for s in plan.steps
+        ],
+        "_loop_groups": [
+            {
+                "loop_step_idx": g.loop_step_idx,
+                "body_range": list(g.body_range),
+                "shape": g.shape,
+            }
+            for g in plan.loop_groups
+        ],
+    }
+    g = find_url_collect_group(suite)
+    suites = prepare_phase2_suites(suite, ["https://x.com/boat/1/"], g, workers=1)
+    types = [s["type"] for s in suites[0]["_micro_plan"]]
+    # Pre-scroll body (click(listing card), extract_url) is dropped.
+    # navigate_back is dropped. Show More click sits between scroll
+    # and extract_data and gets propagated.
+    assert types == ["navigate", "scroll", "click", "extract_data"]
+    # Verify the click step's intent is the Show More one, not the
+    # listing-card click that was dropped.
+    click_intent = next(
+        s["intent"] for s in suites[0]["_micro_plan"] if s["type"] == "click"
+    )
+    assert "Show More" in click_intent
+
+
 def test_phase2_navigate_carries_wait_after_load() -> None:
     """Phase-2 worker hits a detail page directly (cold cache). The
     navigate step needs wait_after_load_seconds so the runner pauses


### PR DESCRIPTION
## Summary

- Phase-2 per-URL extraction was hard-coded to `(navigate, scroll, extract_data)`. Plans that placed an in-page click BETWEEN scroll and extract_data (e.g. `click(Show More)` to expand a truncated description) had that step silently dropped on the fan-out path.
- `prepare_phase2_suites` now clones all body steps from the FIRST scroll onwards, minus `navigate_back` (loop-tail mechanics). Pre-scroll steps (`click(listing_card)`, `extract_url`) stay dropped — Phase-2 already isolates each URL via direct navigate.
- Motivated by boattrader-by-owner phone extraction: most private-seller phones live inside the freeform Description text, which BoatTrader truncates behind a Show More toggle. Without the expand click the extractor only saw the first ~3 lines and missed phones placed near the bottom.

## Backward compat

- Plans with the legacy `(scroll, extract_data)` body produce the same Phase-2 sequence as before.
- Plans with no scroll fall back to a synthesized `(scroll, extract_data)` pair (preserves the prior fallback behaviour).

## Test plan

- [x] Existing 80 fanout-runner tests still pass.
- [x] New test `test_phase2_suites_propagate_in_page_click_between_scroll_and_extract` pins the new behaviour: body `(click_card, extract_url, scroll, click(Show More), extract_data, navigate_back)` → per-URL `(navigate, scroll, click, extract_data)` with the listing-card click + extract_url + navigate_back dropped.
- [x] Ruff clean.
- [ ] End-to-end verify on boattrader rerun with updated plan (Show More click + sharpened extract_data intent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)