### PR TITLE
scroll: CDP backend opt-in via params.backend or hints.prefer_cdp_scroll (#643 stage 1)

### DIFF
--- a/src/mantis_agent/gym/step_handlers/scroll.py
+++ b/src/mantis_agent/gym/step_handlers/scroll.py
@@ -28,6 +28,18 @@ the Submit button is visible") can OMIT the ``count`` param and the
 runner will fall through to ``Holo3StepHandler`` — the brain still
 owns goal-shaped scrolling. Mechanical scroll is opt-in via
 ``params.count`` being set.
+
+Backend selection (#643 follow-up): when ``hints.prefer_cdp_scroll``
+or ``params.backend == "cdp"`` is set, the handler skips xdotool
+wheel events entirely and dispatches scroll via the CDP path used
+by ``step_recovery``: ``window.scrollBy + scrollingElement.scrollBy
++ PageDown KeyboardEvent``. The CDP path bypasses any inner-element
+wheel-capture handlers (SPA results-panel patterns, sticky
+overlays) that swallow xdotool wheel events. Use when v5 boattrader
+profiling shows the default xdotool path repeatedly hits
+``scroll_no_movement`` on a domain — the CDP backend is a
+strictly-more-powerful fallback that doesn't require the brain at
+all.
 """
 
 from __future__ import annotations
@@ -82,13 +94,24 @@ class MechanicalScrollHandler:
         self.parent = runner
 
     def applies_to(self, step: "MicroIntent") -> bool:
-        """Mechanical scroll only takes over when ``params.count`` is
-        provided. Plans without an explicit count fall through to
-        the legacy Holo3-mediated path so vision-goal scrolling
-        (``"scroll until X visible"``) keeps working.
+        """Mechanical scroll takes over when EITHER ``params.count`` is
+        provided OR the plan/operator asked for the CDP backend via
+        ``hints.prefer_cdp_scroll`` / ``params.backend == "cdp"``.
+
+        The CDP-backend gate exists so plans on domains where vision
+        scroll repeatedly hits ``brain_loop_exhausted`` (boattrader
+        listings, observed v5: 173 incidents) can pin the deterministic
+        CDP path even when they don't want to specify a concrete
+        per-step count. Default ``count=1`` applies in that case — one
+        ``window.innerHeight`` scroll per step.
         """
         params = step.params or {}
+        hints = step.hints or {}
         count = params.get("count")
+        backend = str(params.get("backend") or "").lower()
+        prefer_cdp = bool(hints.get("prefer_cdp_scroll"))
+        if backend == "cdp" or prefer_cdp:
+            return True
         try:
             return count is not None and int(count) > 0
         except (TypeError, ValueError):
@@ -98,6 +121,7 @@ class MechanicalScrollHandler:
         index = int(ctx.state.get("index", 0))
         env = ctx.env
         params = step.params or {}
+        hints = step.hints or {}
 
         try:
             count = max(1, int(params.get("count", 1)))
@@ -115,6 +139,16 @@ class MechanicalScrollHandler:
 
         cdp_eval = getattr(env, "cdp_evaluate", None)
 
+        # Backend selection: opt into CDP when the operator pinned it
+        # via plan hints. CDP scroll bypasses Chrome's wheel handlers
+        # (which inner-element scrollers / sticky overlays sometimes
+        # swallow) and routes through document-level scroll mechanisms,
+        # matching the recovery-layer fallback in step_recovery.py.
+        use_cdp = (
+            str(params.get("backend") or "").lower() == "cdp"
+            or bool(hints.get("prefer_cdp_scroll"))
+        )
+
         def _read_scroll_y() -> float:
             if not callable(cdp_eval):
                 return -1.0  # sentinel — CDP unavailable, skip verification
@@ -129,34 +163,88 @@ class MechanicalScrollHandler:
         pre_y = _read_scroll_y()
         logger.info(
             "  [scroll] mechanical dispatch: count=%d direction=%s "
-            "notches/count=%d pre_scrollY=%s",
+            "notches/count=%d backend=%s pre_scrollY=%s",
             count, direction, notches_per_count,
+            "cdp" if use_cdp else "xdotool",
             f"{pre_y:.0f}" if pre_y >= 0 else "n/a",
         )
 
-        for i in range(count):
-            try:
-                env.step(Action(
-                    action_type=ActionType.SCROLL,
-                    params={
-                        "direction": direction,
-                        "amount": notches_per_count,
-                    },
-                ))
-            except Exception as exc:  # noqa: BLE001
+        if use_cdp:
+            if not callable(cdp_eval):
+                # CDP backend requested but env doesn't expose it. Fall
+                # through to xdotool so the step still has a chance —
+                # better than failing outright when the operator's hint
+                # was just optimistic.
                 logger.warning(
-                    "  [scroll] env.step failed on iteration %d/%d: %s",
-                    i + 1, count, exc,
+                    "  [scroll] backend=cdp requested but env has no "
+                    "cdp_evaluate; falling back to xdotool wheel"
                 )
-                return StepResult(
-                    step_index=index, intent=step.intent, success=False,
-                    data=f"scroll_dispatch_error:{type(exc).__name__}",
-                    failure_class="scroll_dispatch_error",
-                )
-            # Cheap settle between iterations so a slow framework can
-            # catch up. Bounded — adaptive_settle picks the right
-            # ceiling per page based on previous frame hash deltas.
-            adaptive_settle.settle_after_action(env, max_seconds=1.5)
+                use_cdp = False
+
+        if use_cdp:
+            # Triple-prong CDP scroll dispatch — same payload the
+            # recovery layer uses in step_recovery.py:285. Covers
+            # <body>-as-scrolling-root pages, <html>-as-scrolling-root
+            # pages, and SPA inner scrollers that subscribe to keyboard
+            # events. Dispatched ``count`` times for a count-aware
+            # scroll budget; each dispatch advances by one
+            # ``window.innerHeight``.
+            sign = "" if direction == "down" else "-"
+            scroll_js = (
+                "(function(){"
+                "  var h = " + sign + "window.innerHeight;"
+                "  window.scrollBy(0, h);"
+                "  if (document.scrollingElement) "
+                "    document.scrollingElement.scrollBy(0, h);"
+                "  document.dispatchEvent(new KeyboardEvent("
+                "    'keydown',"
+                "    {key:'" + ("PageDown" if direction == "down" else "PageUp") + "', "
+                "     code:'" + ("PageDown" if direction == "down" else "PageUp") + "', "
+                "     keyCode:" + ("34" if direction == "down" else "33") + ", "
+                "     which:" + ("34" if direction == "down" else "33") + ", "
+                "     bubbles:true}"
+                "  ));"
+                "})()"
+            )
+            for i in range(count):
+                try:
+                    cdp_eval(scroll_js)
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning(
+                        "  [scroll] CDP backend dispatch failed on "
+                        "iteration %d/%d: %s",
+                        i + 1, count, exc,
+                    )
+                    return StepResult(
+                        step_index=index, intent=step.intent, success=False,
+                        data=f"scroll_cdp_dispatch_error:{type(exc).__name__}",
+                        failure_class="scroll_dispatch_error",
+                    )
+                adaptive_settle.settle_after_action(env, max_seconds=1.5)
+        else:
+            for i in range(count):
+                try:
+                    env.step(Action(
+                        action_type=ActionType.SCROLL,
+                        params={
+                            "direction": direction,
+                            "amount": notches_per_count,
+                        },
+                    ))
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning(
+                        "  [scroll] env.step failed on iteration %d/%d: %s",
+                        i + 1, count, exc,
+                    )
+                    return StepResult(
+                        step_index=index, intent=step.intent, success=False,
+                        data=f"scroll_dispatch_error:{type(exc).__name__}",
+                        failure_class="scroll_dispatch_error",
+                    )
+                # Cheap settle between iterations so a slow framework can
+                # catch up. Bounded — adaptive_settle picks the right
+                # ceiling per page based on previous frame hash deltas.
+                adaptive_settle.settle_after_action(env, max_seconds=1.5)
 
         post_y = _read_scroll_y()
         # Verify via post-action scrollY readback when CDP is wired up.

--- a/tests/test_scroll_handler_mechanical.py
+++ b/tests/test_scroll_handler_mechanical.py
@@ -205,3 +205,112 @@ def test_notches_per_count_param_passes_through_to_env():
         _ctx(env),
     )
     assert env.step.call_args.args[0].params["amount"] == 5
+
+
+# ── #643 follow-up: CDP backend (skips Chrome wheel handlers entirely) ──
+
+
+def test_applies_to_when_backend_is_cdp_even_without_count():
+    """``params.backend == "cdp"`` activates the mechanical handler
+    even when no count is specified — operator pinning the CDP backend
+    is enough to opt out of vision scroll."""
+    h = MechanicalScrollHandler(MagicMock())
+    yes = MicroIntent(
+        intent="scroll", type="scroll", params={"backend": "cdp"},
+    )
+    assert h.applies_to(yes) is True
+
+
+def test_applies_to_when_hint_prefer_cdp_scroll_set():
+    """``hints.prefer_cdp_scroll == True`` is the plan-author / hint-
+    memory channel for opting into CDP scroll. Same activation as the
+    explicit ``params.backend``."""
+    h = MechanicalScrollHandler(MagicMock())
+    yes = MicroIntent(
+        intent="scroll", type="scroll", hints={"prefer_cdp_scroll": True},
+    )
+    assert h.applies_to(yes) is True
+
+
+def test_cdp_backend_dispatches_scrollBy_js_per_count():
+    """``params.backend=cdp count=3`` → 3 cdp_evaluate calls that
+    each carry the scrollBy + scrollingElement.scrollBy + KeyboardEvent
+    payload (the same triple-prong dispatch used by step_recovery.py).
+    No env.step (xdotool) calls fire."""
+    env = MagicMock()
+    # 1 pre-scroll readback + 3 dispatch calls + 1 post-scroll readback = 5
+    env.cdp_evaluate = MagicMock(side_effect=[0.0, None, None, None, 2000.0])
+    h = MechanicalScrollHandler(MagicMock())
+    res = h.execute(
+        MicroIntent(
+            intent="x", type="scroll",
+            params={"count": 3, "backend": "cdp"},
+        ),
+        _ctx(env),
+    )
+    assert res.success is True
+    # xdotool path is dormant.
+    assert env.step.call_count == 0
+    # 1 pre-readback + 3 dispatches + 1 post-readback.
+    assert env.cdp_evaluate.call_count == 5
+    # Inspect one of the dispatch calls to confirm the JS payload.
+    dispatch_js = env.cdp_evaluate.call_args_list[1].args[0]
+    assert "window.scrollBy" in dispatch_js
+    assert "scrollingElement" in dispatch_js
+    assert "PageDown" in dispatch_js
+
+
+def test_cdp_backend_direction_up_uses_pageup_and_negative_height():
+    env = MagicMock()
+    env.cdp_evaluate = MagicMock(side_effect=[1000.0, None, 400.0])
+    h = MechanicalScrollHandler(MagicMock())
+    res = h.execute(
+        MicroIntent(
+            intent="x", type="scroll",
+            params={"count": 1, "backend": "cdp", "direction": "up"},
+        ),
+        _ctx(env),
+    )
+    assert res.success is True
+    dispatch_js = env.cdp_evaluate.call_args_list[1].args[0]
+    assert "-window.innerHeight" in dispatch_js
+    assert "PageUp" in dispatch_js
+
+
+def test_cdp_backend_falls_back_to_xdotool_when_no_cdp_evaluate():
+    """If the env doesn't expose ``cdp_evaluate`` (test stubs, etc.),
+    the operator's hint was optimistic — fall through to xdotool
+    rather than crash. The handler still produces a valid result so
+    the runner doesn't halt."""
+    env = MagicMock(spec=["step"])  # no cdp_evaluate
+    h = MechanicalScrollHandler(MagicMock())
+    res = h.execute(
+        MicroIntent(
+            intent="x", type="scroll",
+            params={"count": 2, "backend": "cdp"},
+        ),
+        _ctx(env),
+    )
+    assert res.success is True
+    # Fell through to xdotool because env had no CDP.
+    assert env.step.call_count == 2
+
+
+def test_cdp_backend_dispatch_error_returned_with_failure_class():
+    """When CDP dispatch raises (Chrome devtools disconnected etc.),
+    the handler returns ``scroll_dispatch_error`` rather than
+    propagating."""
+    env = MagicMock()
+    env.cdp_evaluate = MagicMock(
+        side_effect=[0.0, RuntimeError("devtools disconnected")],
+    )
+    h = MechanicalScrollHandler(MagicMock())
+    res = h.execute(
+        MicroIntent(
+            intent="x", type="scroll",
+            params={"count": 1, "backend": "cdp"},
+        ),
+        _ctx(env),
+    )
+    assert res.success is False
+    assert res.failure_class == "scroll_dispatch_error"


### PR DESCRIPTION
## Summary

- v5 boattrader profiling logged **173 `brain_loop_exhausted` events on the scroll step** alone — each a multi-iteration Holo3 vision retry trying to scroll a page where Chrome wheel events get swallowed by inner-element scrollers / sticky overlays.
- The CDP fallback in `step_recovery.py:285` already exists (`window.scrollBy + scrollingElement.scrollBy + PageDown KeyboardEvent`) and DOES work on these pages — but it only fires after `brain_loop_exhausted` is hit. We pay 1–3 wasted vision retries per scroll step before falling back.
- This PR lets plans opt directly into the CDP backend, skipping the brain pass entirely.

## Activation

Either of:

```json
{ "type": "scroll", "params": {"count": 4, "backend": "cdp"} }
```

or

```json
{ "type": "scroll", "hints": {"prefer_cdp_scroll": true} }
```

The `hints` channel is the one the future #643 hint-memory feature will populate when a per-domain learner observes N vision-scroll failures.

## Why this validates #643

The scroll story refines #643's framing. The original issue scope was "preferred_target_description" (visual anchors for click targets) — but v5 data shows the dominant cost driver is action-backend selection on scroll, not visual targeting.

If pinning `backend: "cdp"` on the boattrader scroll step cuts the 173 `brain_loop_exhausted` events ~10×, that's empirical evidence that hint memory's actual leverage is **action-backend preference** (per-domain `prefer_cdp_scroll` learned from failures), not just visual-anchor recall. The two are complementary; this PR proves the simpler half first.

## Test plan

- [x] 15 existing scroll-handler tests still green.
- [x] 5 new CDP-backend tests:
  - `applies_to` activates on `params.backend == "cdp"` even without count
  - `applies_to` activates on `hints.prefer_cdp_scroll == True`
  - CDP dispatch fires `count` times with the triple-prong JS payload (no xdotool calls)
  - direction=up uses PageUp + negative innerHeight
  - falls back to xdotool when env has no `cdp_evaluate`
  - dispatch errors return `scroll_dispatch_error` rather than propagating
- [x] Ruff clean.
- [ ] End-to-end verify on boattrader-FL rerun with `params.backend = "cdp"` on the scroll step → expect dramatic drop in `brain_loop_exhausted` events vs v5 baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)