### PR TITLE
feat: vision-only conditional steps — detect_visible + step.guard (#643 stage 2)

### DIFF
--- a/src/mantis_agent/gym/_runner_helpers.py
+++ b/src/mantis_agent/gym/_runner_helpers.py
@@ -766,6 +766,28 @@ def execute_step(
 ) -> StepResult:
     registry = runner._handler_registry
 
+    # #643 stage 2: vision-only conditional steps. When the plan author
+    # set ``step.guard`` naming a state variable that an earlier
+    # ``detect_visible`` step bound to False (or never bound at all),
+    # skip THIS step entirely — no vision call, no env action. The
+    # guard check is free; the alternative is paying brain-budget on a
+    # step the operator marked conditional on a prior detection.
+    #
+    # Skip envelope returns (success=False, skip=True) so the runner's
+    # post-step loop advances past without retry recovery. The
+    # ``data`` line carries the guard name + observed value so trace
+    # consumers (Augur, ops logs) can see why the step was skipped.
+    guard_name = (getattr(step, "guard", "") or "").strip()
+    if guard_name:
+        state_vars = getattr(runner, "_state_vars", {}) or {}
+        guard_value = bool(state_vars.get(guard_name, False))
+        if not guard_value:
+            return StepResult(
+                step_index=index, intent=step.intent, success=False,
+                data=f"guard:{guard_name}=False:skipped",
+                skip=True, skip_reason=f"guard_{guard_name}_false",
+            )
+
     # Agentic handler-escalation — issue #224 follow-up. When prior
     # failures on this step indicate the default handler is the
     # wrong tool (canonical case: text-matching submit handler keeps

--- a/src/mantis_agent/gym/_runner_helpers.py
+++ b/src/mantis_agent/gym/_runner_helpers.py
@@ -777,7 +777,14 @@ def execute_step(
     # post-step loop advances past without retry recovery. The
     # ``data`` line carries the guard name + observed value so trace
     # consumers (Augur, ops logs) can see why the step was skipped.
-    guard_name = (getattr(step, "guard", "") or "").strip()
+    #
+    # Triple-fallback lookup via :func:`resolve_guard_name` —
+    # top-level field, then params, then hints. Robust against Modal
+    # source-mount caching that occasionally serves stale dataclass
+    # definitions to workers (the params/hints dicts have round-
+    # tripped reliably for ages).
+    from .step_handlers.detect_visible import resolve_guard_name
+    guard_name = resolve_guard_name(step)
     if guard_name:
         state_vars = getattr(runner, "_state_vars", {}) or {}
         guard_value = bool(state_vars.get(guard_name, False))

--- a/src/mantis_agent/gym/micro_runner.py
+++ b/src/mantis_agent/gym/micro_runner.py
@@ -231,6 +231,12 @@ class MicroPlanRunner:
         # check ``len(runner._collected_urls)`` to decide whether to
         # fan out vs fall back to the sequential extraction loop.
         self._collected_urls: list[str] = []
+        # #643 stage 2: plan-state variable bag for vision-only
+        # conditional steps. ``DetectVisibleHandler.execute`` binds
+        # boolean answers here (keyed by ``step.out_var``); the
+        # ``execute_step`` dispatcher reads it before each step to
+        # honour ``step.guard``. Empty for plans without conditionals.
+        self._state_vars: dict[str, Any] = {}
         # #627: cross-worker seen-URL set. Default is a no-op
         # (NullSharedSeenSet); the Modal orchestrator overrides via the
         # suite's ``_fanout_seen_dict_name`` field so spawned workers

--- a/src/mantis_agent/gym/step_handlers/__init__.py
+++ b/src/mantis_agent/gym/step_handlers/__init__.py
@@ -30,6 +30,7 @@ from ..step_context import HandlerRegistry
 from .claude_step import ClaudeStepHandler
 from .click import ClaudeGuidedClickHandler
 from .collect_urls import CollectUrlsHandler
+from .detect_visible import DetectVisibleHandler
 from .filter import ClaudeGuidedFilterHandler
 from .form import ClaudeGuidedFormHandler
 from .holo3 import Holo3StepHandler
@@ -48,6 +49,7 @@ __all__ = [
     "ClaudeGuidedFormHandler",
     "ClaudeStepHandler",
     "CollectUrlsHandler",
+    "DetectVisibleHandler",
     "Holo3StepHandler",
     "MechanicalNavigateBackHandler",
     "MechanicalScrollHandler",
@@ -100,6 +102,11 @@ def default_registry(runner: "MicroPlanRunner") -> HandlerRegistry:
     # Stashes urls on runner._collected_urls; safe to run standalone too
     # (sequential plan can use it for a URL-list dump).
     reg.register(CollectUrlsHandler(runner))
+    # #643 stage 2: vision-only ``detect_visible`` for conditional
+    # steps. Composes with the ``guard`` field on subsequent
+    # MicroIntents — one Claude verify-shaped call against the
+    # current screenshot, boolean bound to runner._state_vars.
+    reg.register(DetectVisibleHandler(runner))
     reg.register_for_types(
         ClaudeGuidedFormHandler(runner),
         ("fill_field", "submit", "select_option", "right_click"),

--- a/src/mantis_agent/gym/step_handlers/detect_visible.py
+++ b/src/mantis_agent/gym/step_handlers/detect_visible.py
@@ -76,7 +76,21 @@ class DetectVisibleHandler:
         env = ctx.env
         extractor = ctx.extractor
         index = int(ctx.state.get("index", 0))
-        out_var = (step.out_var or "").strip()
+        # Read out_var from the top-level MicroIntent field, falling
+        # back to ``params["out_var"]`` then ``hints["out_var"]``.
+        # The fallbacks exist because params + hints are dict-typed
+        # fields that have round-tripped reliably through the
+        # orchestrator → JSON → worker → MicroIntent(**s) chain for a
+        # long time; new top-level dataclass fields (added 2026-05-24)
+        # depend on Modal picking up the new MicroIntent class on the
+        # worker — which Modal's source-mount cache occasionally
+        # serves stale. The dict-field path is the load-bearing
+        # contract; the top-level field is the ergonomic alias.
+        out_var = (
+            (step.out_var or "").strip()
+            or str((step.params or {}).get("out_var") or "").strip()
+            or str((step.hints or {}).get("out_var") or "").strip()
+        )
 
         if not out_var:
             logger.warning(
@@ -152,3 +166,18 @@ class DetectVisibleHandler:
             state_vars = {}
             runner._state_vars = state_vars
         state_vars[name] = value
+
+
+def resolve_guard_name(step: "MicroIntent") -> str:
+    """Read the guard variable name with the same triple fallback the
+    detect_visible handler uses for ``out_var``.
+
+    Top-level MicroIntent.guard field wins; falls back to
+    ``params['guard']`` then ``hints['guard']``. Empty string means
+    "no guard" — the runner runs the step unconditionally.
+    """
+    return (
+        (getattr(step, "guard", "") or "").strip()
+        or str((getattr(step, "params", None) or {}).get("guard") or "").strip()
+        or str((getattr(step, "hints", None) or {}).get("guard") or "").strip()
+    )

--- a/src/mantis_agent/gym/step_handlers/detect_visible.py
+++ b/src/mantis_agent/gym/step_handlers/detect_visible.py
@@ -1,0 +1,154 @@
+"""DetectVisibleHandler — vision-only yes/no element existence check.
+
+Why this exists: plans that include optional steps (``click(Show More)``
+when Show More may or may not be rendered, ``click(Accept cookies)``
+when the banner may already be dismissed, ``select(Older messages)``
+when the toggle is only there for long threads) today burn full
+brain-budget vision passes trying to LOCATE a target that isn't on
+the page, hit ``brain_loop_exhausted``, then skip. Cost: ~$0.10-0.30
+per missing-target step. Across a 60-listing run that's ~$10-20 of
+pure waste.
+
+This handler takes one screenshot, asks Claude/Holo3 a single
+yes/no question ("is this element visible?"), and binds the boolean
+to ``runner._state_vars[step.out_var]``. Subsequent steps with
+``step.guard`` naming that variable are skipped for free when the
+guard evaluates False — no vision call, no env action.
+
+Cost per detect: ~$0.02-0.05 (one Claude verify-shaped call).
+Compared to the multi-attempt brain-loop on missing targets, this
+is a 3-10× cost reduction on optional paths.
+
+CUA-purity (``feedback_cua_no_dom_access.md``): the detection is one
+vision call against the current screenshot. The plan's NL intent
+prose describes what to look for ("Is a 'Show More' toggle visible
+inside the Description block?"). No DOM access, no selector lookup
+— purely screenshot-grounded.
+
+Output is stashed on ``runner._state_vars[out_var]`` as a bool, AND
+emitted in ``StepResult.data`` for trace visibility. The detect step
+itself is never marked failed when the answer is False — "absent"
+is a valid finding, not a failure. The success boolean reflects
+whether the vision call returned a parseable result; the answer
+(yes/no) lives in ``_state_vars``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from ..checkpoint import StepResult
+from ..step_context import StepContext
+
+if TYPE_CHECKING:
+    from ..micro_runner import MicroPlanRunner
+    from ...plan_decomposer import MicroIntent
+
+logger = logging.getLogger(__name__)
+
+
+class DetectVisibleHandler:
+    """Implements :class:`~..step_context.StepHandler` for ``detect_visible``.
+
+    Required step fields:
+        * ``intent`` — natural-language description of what to look
+          for (e.g. *"Is a 'Show More' toggle visible inside the
+          Description block?"*). Used verbatim as the vision-call
+          prompt.
+        * ``out_var`` — name of the runner state variable that
+          receives the boolean. Subsequent steps with ``guard ==
+          out_var`` will skip when the variable is False.
+
+    Optional:
+        * No params today. Future-proofing slots: ``params.threshold``
+          (confidence floor), ``params.invert`` (treat absent as
+          True), etc. — add when a real plan needs them.
+    """
+
+    step_type = "detect_visible"
+
+    def __init__(self, runner: "MicroPlanRunner") -> None:
+        self.parent = runner
+
+    def execute(self, step: "MicroIntent", ctx: StepContext) -> StepResult:
+        runner = self.parent
+        env = ctx.env
+        extractor = ctx.extractor
+        index = int(ctx.state.get("index", 0))
+        out_var = (step.out_var or "").strip()
+
+        if not out_var:
+            logger.warning(
+                "  [detect_visible] step has no ``out_var`` — result "
+                "would be unreachable; skipping vision call"
+            )
+            return StepResult(
+                step_index=index, intent=step.intent, success=False,
+                data="detect_visible:no_out_var", skip=True,
+                skip_reason="detect_visible_no_out_var",
+            )
+
+        if not extractor:
+            logger.warning(
+                "  [detect_visible] no extractor wired — defaulting "
+                "%s=False so dependent steps skip safely",
+                out_var,
+            )
+            self._bind(runner, out_var, False)
+            return StepResult(
+                step_index=index, intent=step.intent, success=False,
+                data=f"detect_visible:{out_var}=False:no_extractor",
+            )
+
+        screenshot = env.screenshot()
+        # Reuse ``verify_gate`` as the vision primitive — same
+        # input shape (screenshot + NL expected condition), same
+        # tool-schema-validated (passed: bool, reason: str) output.
+        # The "gate" semantics align: detect_visible is conceptually a
+        # gate that doesn't halt; the runner reads the result into a
+        # variable instead of treating False as a fatal failure.
+        try:
+            passed, reason = extractor.verify_gate(
+                screenshot, step.intent or "Is the described element visible?",
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "  [detect_visible] verify_gate raised — defaulting "
+                "%s=False (%s)", out_var, type(exc).__name__,
+            )
+            self._bind(runner, out_var, False)
+            return StepResult(
+                step_index=index, intent=step.intent, success=False,
+                data=f"detect_visible:{out_var}=False:exception",
+            )
+
+        runner.costs["claude_extract"] = (
+            runner.costs.get("claude_extract", 0) + 1
+        )
+        self._bind(runner, out_var, bool(passed))
+
+        logger.warning(
+            "  [detect_visible] %s = %s — %s",
+            out_var, "True" if passed else "False",
+            (reason or "")[:80],
+        )
+
+        return StepResult(
+            step_index=index, intent=step.intent, success=True,
+            data=f"detect_visible:{out_var}={'True' if passed else 'False'}",
+        )
+
+    @staticmethod
+    def _bind(runner: "MicroPlanRunner", name: str, value: bool) -> None:
+        """Stash the boolean on the runner's plan-state variable bag.
+
+        Defaults the bag to empty dict if absent — the runner's init
+        creates ``_state_vars`` but defensive in case an older
+        runner-shim caller bypassed init.
+        """
+        state_vars = getattr(runner, "_state_vars", None)
+        if state_vars is None:
+            state_vars = {}
+            runner._state_vars = state_vars
+        state_vars[name] = value

--- a/src/mantis_agent/plan_decomposer.py
+++ b/src/mantis_agent/plan_decomposer.py
@@ -156,6 +156,20 @@ class MicroIntent:
     # Anything that used to be hardcoded in the extractor should now flow
     # through this field. See issue #86 for the redesign.
     hints: dict[str, Any] = field(default_factory=dict)
+    # Vision-only conditional step support (#643 stage 2). The plan
+    # composes a ``detect_visible`` step that asks Holo3/Claude
+    # "is X visible?" against the current screenshot and binds the
+    # boolean result to ``runner._state_vars[out_var]``. Subsequent
+    # steps then carry a ``guard`` field naming that variable — if
+    # the variable is False (or absent), the runner skips the step
+    # for free (no vision call, no env action).
+    #
+    # ``guard`` is empty for unconditional steps (the default).
+    # ``out_var`` is set on ``detect_visible`` steps; ignored elsewhere.
+    # Pure-vision: detection is one Claude/Holo3 call against the
+    # screenshot, never a DOM probe. CUA-purity preserved.
+    guard: str = ""
+    out_var: str = ""
 
 
 @dataclass
@@ -1127,7 +1141,10 @@ class PlanDecomposer:
                 "grounding",
                 step_type in ("click", "filter", "paginate") + PlanDecomposer.FORM_STEP_TYPES,
             ),
-            claude_only=s.get("claude_only", step_type in ("extract_url", "extract_data")),
+            claude_only=s.get(
+                "claude_only",
+                step_type in ("extract_url", "extract_data", "detect_visible"),
+            ),
             loop_target=s.get("loop_target", -1),
             loop_count=s.get("loop_count", 0),
             section=section,
@@ -1135,6 +1152,8 @@ class PlanDecomposer:
             gate=gate,
             params=params,
             hints=hints,
+            guard=str(s.get("guard", "") or ""),
+            out_var=str(s.get("out_var", "") or ""),
         )
 
     @staticmethod

--- a/src/mantis_agent/server_utils.py
+++ b/src/mantis_agent/server_utils.py
@@ -991,6 +991,11 @@ def micro_plan_steps_to_dicts(steps: list[Any]) -> list[dict[str, Any]]:
             "gate": s.gate,
             "params": dict(getattr(s, "params", {}) or {}),
             "hints": dict(getattr(s, "hints", {}) or {}),
+            # #643 stage 2: vision-only conditional step support.
+            # Empty strings on legacy plans so the receiving
+            # MicroIntent gets the field defaults.
+            "guard": str(getattr(s, "guard", "") or ""),
+            "out_var": str(getattr(s, "out_var", "") or ""),
         }
         for s in steps
     ]

--- a/tests/test_detect_visible_handler.py
+++ b/tests/test_detect_visible_handler.py
@@ -1,0 +1,137 @@
+"""DetectVisibleHandler unit tests (#643 stage 2).
+
+Pins the vision-only conditional-step contract:
+
+- detect_visible binds a boolean to ``runner._state_vars[out_var]``
+  based on the extractor's verify_gate yes/no answer
+- absent out_var → handler returns a skip envelope (no vision call)
+- absent extractor → defaults the var to False so dependent steps
+  skip safely (don't strand callers on a missing extractor)
+- verify_gate exceptions → default to False + log warning (never
+  propagate; the step itself is non-fatal)
+- claude_extract cost counter incremented on each successful call
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from mantis_agent.gym.step_context import StepContext
+from mantis_agent.gym.step_handlers.detect_visible import DetectVisibleHandler
+from mantis_agent.plan_decomposer import MicroIntent
+
+
+class _FakeRunner:
+    def __init__(self) -> None:
+        self.costs: dict[str, float] = {"claude_extract": 0}
+        self._state_vars: dict[str, object] = {}
+
+
+def _ctx(env, extractor) -> StepContext:
+    return StepContext(
+        env=env, brain=None, extractor=extractor,
+        grounding=None, cost_meter=None,
+        dynamic_verifier=MagicMock(), scanner=MagicMock(),
+        site_config=MagicMock(), tool_channel=None,
+        extraction_cache=None, state={"index": 5},
+    )
+
+
+def test_detects_visible_binds_true_when_verify_gate_passes():
+    runner = _FakeRunner()
+    extractor = MagicMock()
+    extractor.verify_gate.return_value = (True, "Show More toggle clearly visible below the description")
+    env = MagicMock()
+    env.screenshot.return_value = MagicMock()
+
+    step = MicroIntent(
+        intent="Is a 'Show More' toggle visible inside the Description block?",
+        type="detect_visible", out_var="has_show_more",
+    )
+    result = DetectVisibleHandler(runner).execute(step, _ctx(env, extractor))
+
+    assert result.success is True
+    assert runner._state_vars == {"has_show_more": True}
+    assert result.data == "detect_visible:has_show_more=True"
+    assert runner.costs["claude_extract"] == 1
+
+
+def test_detects_visible_binds_false_when_verify_gate_fails():
+    """verify_gate returning (False, reason) is the canonical 'element
+    not visible' signal — handler still returns success=True (the
+    detection itself completed); the BOOLEAN is what dependent steps
+    consume via their ``guard``."""
+    runner = _FakeRunner()
+    extractor = MagicMock()
+    extractor.verify_gate.return_value = (False, "No Show More toggle in viewport")
+    env = MagicMock()
+    env.screenshot.return_value = MagicMock()
+
+    step = MicroIntent(
+        intent="Is a 'Show More' toggle visible?",
+        type="detect_visible", out_var="has_show_more",
+    )
+    result = DetectVisibleHandler(runner).execute(step, _ctx(env, extractor))
+
+    # Detection itself succeeded — the result is "False", that's a
+    # valid finding not a failure.
+    assert result.success is True
+    assert runner._state_vars == {"has_show_more": False}
+    assert result.data == "detect_visible:has_show_more=False"
+
+
+def test_missing_out_var_returns_skip_envelope_no_vision_call():
+    """A detect_visible step with no out_var is malformed — the
+    detected value would be unreachable. Skip without burning the
+    vision call so the operator sees the misconfiguration cleanly."""
+    runner = _FakeRunner()
+    extractor = MagicMock()
+    env = MagicMock()
+
+    step = MicroIntent(intent="Look for X", type="detect_visible")
+    result = DetectVisibleHandler(runner).execute(step, _ctx(env, extractor))
+
+    assert result.success is False
+    assert result.skip is True
+    assert result.skip_reason == "detect_visible_no_out_var"
+    # No vision call attempted.
+    extractor.verify_gate.assert_not_called()
+    env.screenshot.assert_not_called()
+
+
+def test_no_extractor_defaults_var_to_false_safely():
+    """When the extractor isn't wired (test stubs, headless paths),
+    default the variable to False so dependent guarded steps skip
+    cleanly rather than crash on a missing key."""
+    runner = _FakeRunner()
+    env = MagicMock()
+    env.screenshot.return_value = MagicMock()
+
+    step = MicroIntent(
+        intent="x", type="detect_visible", out_var="has_show_more",
+    )
+    result = DetectVisibleHandler(runner).execute(step, _ctx(env, extractor=None))
+
+    assert result.success is False
+    assert runner._state_vars == {"has_show_more": False}
+    assert "no_extractor" in result.data
+
+
+def test_verify_gate_exception_defaults_to_false_no_raise():
+    """If verify_gate raises (network blip, schema parse error), the
+    handler swallows + defaults False. The runner never sees the
+    exception — the step is non-fatal by design."""
+    runner = _FakeRunner()
+    extractor = MagicMock()
+    extractor.verify_gate.side_effect = RuntimeError("haiku quota exceeded")
+    env = MagicMock()
+    env.screenshot.return_value = MagicMock()
+
+    step = MicroIntent(
+        intent="x", type="detect_visible", out_var="has_show_more",
+    )
+    result = DetectVisibleHandler(runner).execute(step, _ctx(env, extractor))
+
+    assert result.success is False
+    assert runner._state_vars == {"has_show_more": False}
+    assert "exception" in result.data

--- a/tests/test_guard_skip_envelope.py
+++ b/tests/test_guard_skip_envelope.py
@@ -1,0 +1,136 @@
+"""Tests for #643 stage 2 — vision-only conditional step guard.
+
+Sixth tactical sibling in the skip-envelope family (#246 recipe
+rejection, #250 navigation halt, #254 context budget, #248
+exploration substrate, #255 already-seen URL). Same envelope
+contract, sixth trigger source: when ``step.guard`` names a state
+variable that is False (or absent), ``execute_step`` short-circuits
+with ``StepResult.skip=True / skip_reason='guard_<name>_false'``
+and never dispatches to the handler — no vision call, no env
+action.
+
+The variable is bound by an earlier ``detect_visible`` step (or
+left empty for plans that haven't run the detection yet — those
+are treated identically to "guard False" so dependent steps don't
+fire prematurely).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from mantis_agent.gym._runner_helpers import execute_step
+from mantis_agent.plan_decomposer import MicroIntent
+
+
+def _runner_with_state(state_vars: dict | None = None) -> MagicMock:
+    """Minimum runner stub: only the fields execute_step's guard branch
+    reads before deciding to skip. ``_handler_registry`` is set but
+    never resolved when the guard fires (skip path is pre-dispatch).
+    """
+    runner = MagicMock()
+    runner._handler_registry = MagicMock()
+    runner._state_vars = state_vars or {}
+    return runner
+
+
+def test_guard_false_short_circuits_with_skip_envelope():
+    """A step whose guard names a state variable bound to False is
+    skipped entirely — handler.execute is never called, env is not
+    touched, the skip envelope is what the runner returns."""
+    runner = _runner_with_state({"has_show_more": False})
+    step = MicroIntent(
+        intent="Click Show More", type="click",
+        guard="has_show_more",
+    )
+
+    result = execute_step(runner, step, index=5)
+
+    assert result.success is False
+    assert result.skip is True
+    assert result.skip_reason == "guard_has_show_more_false"
+    assert "guard:has_show_more=False" in result.data
+    # Registry was never asked for a handler — the skip is pre-dispatch.
+    runner._handler_registry.get.assert_not_called()
+
+
+def test_guard_absent_var_treated_as_false():
+    """A guard naming a variable that was never bound (no detect_visible
+    step ran first) is treated identically to ``False`` — the step
+    skips. Conservative: don't fire conditional actions when the
+    condition was never evaluated."""
+    runner = _runner_with_state({})
+    step = MicroIntent(
+        intent="Click Show More", type="click",
+        guard="has_show_more",
+    )
+
+    result = execute_step(runner, step, index=5)
+
+    assert result.skip is True
+    assert result.skip_reason == "guard_has_show_more_false"
+
+
+def test_guard_empty_string_disables_branching():
+    """No guard set (the default, every legacy step) → fall through to
+    the regular handler dispatch. The guard branch must be a no-op
+    for plans that don't use conditionals."""
+    runner = _runner_with_state({"has_show_more": True})
+    # Stub the handler registry to return a dummy handler whose execute
+    # returns a recognisable sentinel. If the guard branch wrongly
+    # short-circuits when guard=="", this assertion fires.
+    sentinel = SimpleNamespace(
+        step_index=5, intent="x", success=True, data="dispatched",
+        skip=False, skip_reason="", failure_class="",
+        executor_backend="",
+    )
+    runner._handler_registry.get.return_value = MagicMock(
+        execute=MagicMock(return_value=sentinel),
+    )
+    # No agentic escalation, no gate, no special routing.
+    runner._step_handler_override = {}
+    runner._step_failure_history = {}
+    runner.extractor = None
+    runner._opened_detail_in_new_tab = False
+
+    step = MicroIntent(
+        intent="Click something always", type="click",
+        # guard="" (default)
+    )
+
+    result = execute_step(runner, step, index=5)
+
+    # We don't care which exact handler path executed — only that
+    # the guard branch DIDN'T short-circuit. The result must NOT
+    # carry the guard skip envelope.
+    assert result.skip is False or result.skip_reason != "guard__false"
+    assert "guard:" not in (result.data or "")
+
+
+def test_guard_true_proceeds_to_dispatch():
+    """When the guard variable is True the step runs normally. We
+    verify by asserting the handler.execute path was reached (not the
+    skip envelope)."""
+    runner = _runner_with_state({"has_show_more": True})
+    sentinel = SimpleNamespace(
+        step_index=5, intent="x", success=True, data="dispatched",
+        skip=False, skip_reason="", failure_class="",
+        executor_backend="",
+    )
+    runner._handler_registry.get.return_value = MagicMock(
+        execute=MagicMock(return_value=sentinel),
+    )
+    runner._step_handler_override = {}
+    runner._step_failure_history = {}
+    runner.extractor = None
+    runner._opened_detail_in_new_tab = False
+
+    step = MicroIntent(
+        intent="Click Show More", type="click",
+        guard="has_show_more",
+    )
+
+    result = execute_step(runner, step, index=5)
+
+    assert "guard:" not in (result.data or "")

--- a/tests/test_handler_registry_default.py
+++ b/tests/test_handler_registry_default.py
@@ -48,6 +48,10 @@ def test_registry_covers_every_step_type_phase2_lifted():
         # #615: collect_urls primitive — single-pass listing URL harvest
         # for the fan-out runner (#616, #617).
         "collect_urls",
+        # #643 stage 2: vision-only yes/no element existence check —
+        # binds boolean to runner._state_vars for ``step.guard`` to
+        # consume on subsequent conditional steps.
+        "detect_visible",
     }
     assert set(reg.types()) == expected
 


### PR DESCRIPTION
## Summary

Adds the pure-vision conditional-step primitive flagged in #643. Today optional steps (``click(Show More)`` when the button may or may not be rendered) burn full brain-budget vision passes trying to LOCATE a target that isn't on the page, hit ``brain_loop_exhausted``, then skip. Cost: ~$0.10–0.30 per missing-target step. Across a 60-listing run that's ~$5–15 of pure waste — exactly the pattern v5/v6 boattrader showed.

### Two new primitives

1. **`detect_visible` step type** — takes one screenshot, asks the extractor "is the described element visible?" via the same ``verify_gate`` Haiku+escalation path the existing gate flow uses, binds the boolean to ``runner._state_vars[step.out_var]``. Cost: ~$0.02–0.05 per detect.

2. **`MicroIntent.guard` field** — subsequent steps with ``guard == <varname>`` are skipped pre-dispatch when the variable is False (or absent). No vision call, no env action. Skip envelope ``(success=False, skip=True, skip_reason="guard_<name>_false")`` mirrors the existing skip family (#246/#250/#254/#248/#255).

### Plan shape

```json
{"type": "scroll", "params": {"count": 4, "backend": "cdp"}},
{"type": "detect_visible",
 "intent": "Is a 'Show More' toggle visible inside the Description block?",
 "out_var": "has_show_more"},
{"type": "click",
 "intent": "Click the Show More toggle",
 "guard": "has_show_more"}
```

### CUA-purity

Per ``feedback_cua_no_dom_access.md``: detection is one Claude vision call against the screenshot. The plan's NL intent describes what to look for; no DOM probe, no ``querySelector``, no CDP-derived decision. CDP is still only legal for DISPATCHING vision-derived actions (#645 scroll backend), never for deriving them. Vision-based detect doesn't touch DOM at all.

### Cost model (expected)

Current (today): brain_loop_exhausted on missing Show More → ~$0.20 per non-existent listing × 50 listings/run = ~$10 wasted.

With this PR: `detect_visible(False)` → guarded click skipped for free → ~$0.03 per non-existent listing × 50 listings/run = ~$1.50. Net savings: ~$8.50/run.

### Test plan

- [x] 5 new tests in `test_detect_visible_handler.py` — binds True, binds False, no-out_var skip, no-extractor safe-default, exception-safe.
- [x] 4 new tests in `test_guard_skip_envelope.py` — guard=False skips, absent var = False, guard="" no-ops, guard=True dispatches normally.
- [x] All 153 tests in the related suites green (fanout, collect_urls, scroll, run_reporter, plus the two new files).
- [x] Ruff clean on all touched files.
- [x] End-to-end plan validation: boattrader plan w/ new detect→guard pair → Phase-2 propagates `[navigate, scroll, detect_visible, click, extract_data]` per URL; ``guard`` + ``out_var`` survive the suite-clone.
- [ ] **Live verification on boattrader-FL rerun** — measure cost reduction vs v6 baseline (where Show More click burned $0.30+ per missing-element listing).

### Future composition

Once #643 hint memory lands, the learner can auto-populate per-domain detect prompts after observing N `brain_loop_exhausted` events. Today's plan authors get the same lever manually via the explicit `detect_visible` step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)