### PR TITLE
fix(scroll): cap CDP scroll_no_movement retries at 3 (#647)

### DIFF
--- a/src/mantis_agent/gym/step_handlers/scroll.py
+++ b/src/mantis_agent/gym/step_handlers/scroll.py
@@ -90,8 +90,28 @@ class MechanicalScrollHandler:
 
     step_type = "scroll"
 
+    # After this many consecutive ``scroll_no_movement`` returns on the
+    # same step_index, the handler stops emitting the deterministic
+    # failure_class and instead returns ``success=True`` with a
+    # ``scroll_no_movement_skipped`` data line. Cap is per (handler
+    # instance, step_index): a fresh step_index resets the counter.
+    #
+    # Why: the recovery layer (``step_recovery``) doesn't cap retries
+    # for ``scroll_no_movement`` (it isn't in
+    # ``REWRITE_TRIGGERING_CLASSES``) — without this cap the runner
+    # re-dispatches the same scroll indefinitely. Observed on v8
+    # boattrader run: worker w2 stuck 46 min / 114 retries on a page
+    # shorter than ``params.count`` viewports. After the cap, the
+    # handler reports success the Nth time so the runner advances to
+    # the next step naturally.
+    NO_MOVEMENT_RETRY_CAP: int = 3
+
     def __init__(self, runner: "MicroPlanRunner") -> None:
         self.parent = runner
+        # Per-step counter for consecutive ``scroll_no_movement``
+        # returns. Cleared on success (any verified scroll motion on
+        # the same index resets) and on cap-exceeded skip.
+        self._no_movement_counts: dict[int, int] = {}
 
     def applies_to(self, step: "MicroIntent") -> bool:
         """Mechanical scroll takes over when EITHER ``params.count`` is
@@ -251,11 +271,34 @@ class MechanicalScrollHandler:
         if pre_y >= 0 and post_y >= 0:
             delta = post_y - pre_y if direction == "down" else pre_y - post_y
             if delta < 50:
+                # Per-step counter: cap consecutive no-movement returns
+                # so the runner can't loop forever (the recovery layer
+                # doesn't gate this failure class). See class-level
+                # ``NO_MOVEMENT_RETRY_CAP`` comment.
+                attempts = self._no_movement_counts.get(index, 0) + 1
+                self._no_movement_counts[index] = attempts
+                if attempts >= self.NO_MOVEMENT_RETRY_CAP:
+                    logger.warning(
+                        "  [scroll] no-movement cap reached on step %d "
+                        "(attempt %d/%d, pre=%.0f post=%.0f); reporting "
+                        "success so recovery advances — page is likely "
+                        "already at scroll limit",
+                        index, attempts, self.NO_MOVEMENT_RETRY_CAP,
+                        pre_y, post_y,
+                    )
+                    self._no_movement_counts.pop(index, None)
+                    return StepResult(
+                        step_index=index, intent=step.intent, success=True,
+                        data=(
+                            f"scroll_no_movement_skipped:"
+                            f"attempts={attempts}_pre={pre_y:.0f}_post={post_y:.0f}"
+                        ),
+                    )
                 logger.warning(
                     "  [scroll] mechanical scroll fired but scrollY didn't "
-                    "move (pre=%.0f post=%.0f delta=%.0f); failing "
-                    "deterministically so recovery sees a real signal",
-                    pre_y, post_y, delta,
+                    "move (pre=%.0f post=%.0f delta=%.0f, attempt %d/%d); "
+                    "failing deterministically so recovery sees a real signal",
+                    pre_y, post_y, delta, attempts, self.NO_MOVEMENT_RETRY_CAP,
                 )
                 return StepResult(
                     step_index=index, intent=step.intent, success=False,
@@ -268,6 +311,10 @@ class MechanicalScrollHandler:
                 pre_y, post_y, delta,
             )
 
+        # Any verified motion (or no CDP to verify) clears the
+        # no-movement counter for this step — next time the step runs
+        # it gets a fresh budget.
+        self._no_movement_counts.pop(index, None)
         return StepResult(
             step_index=index, intent=step.intent, success=True,
             data=f"scroll:{direction}x{count}",

--- a/tests/test_scroll_handler_mechanical.py
+++ b/tests/test_scroll_handler_mechanical.py
@@ -296,6 +296,102 @@ def test_cdp_backend_falls_back_to_xdotool_when_no_cdp_evaluate():
     assert env.step.call_count == 2
 
 
+# ── #647: no-movement retry cap (CDP backend hangs indefinitely guard) ──
+
+
+def test_no_movement_cap_skips_step_after_n_consecutive_returns():
+    """After ``NO_MOVEMENT_RETRY_CAP`` consecutive ``scroll_no_movement``
+    returns on the same step_index, the handler stops emitting the
+    failure class and instead reports success with a
+    ``scroll_no_movement_skipped`` data line. This prevents the recovery
+    layer (which doesn't gate ``scroll_no_movement``) from looping the
+    runner forever on a page shorter than ``params.count`` viewports."""
+    h = MechanicalScrollHandler(MagicMock())
+    cap = h.NO_MOVEMENT_RETRY_CAP
+
+    # Attempts 1 .. cap-1 must fail with ``scroll_no_movement``.
+    for attempt in range(1, cap):
+        env = _env_with_scroll(pre=500.0, post=500.0)
+        res = h.execute(
+            MicroIntent(intent="x", type="scroll", params={"count": 1}),
+            _ctx(env, index=7),
+        )
+        assert res.success is False, f"attempt {attempt} should still fail"
+        assert res.failure_class == "scroll_no_movement"
+
+    # Attempt == cap: handler reports success so recovery advances.
+    env = _env_with_scroll(pre=500.0, post=500.0)
+    res = h.execute(
+        MicroIntent(intent="x", type="scroll", params={"count": 1}),
+        _ctx(env, index=7),
+    )
+    assert res.success is True
+    # Skip path doesn't tag a failure class — runner advances.
+    assert not res.failure_class
+    assert "scroll_no_movement_skipped" in res.data
+    assert f"attempts={cap}" in res.data
+
+    # After the cap fires the counter resets, so a fresh sequence of
+    # no-movement returns on the same step_index starts a new budget.
+    env = _env_with_scroll(pre=500.0, post=500.0)
+    res = h.execute(
+        MicroIntent(intent="x", type="scroll", params={"count": 1}),
+        _ctx(env, index=7),
+    )
+    assert res.success is False
+    assert res.failure_class == "scroll_no_movement"
+
+
+def test_no_movement_counter_isolates_per_step_index():
+    """Two different step_indices accumulate independent
+    no-movement counters — w workers / step indices don't share budget."""
+    h = MechanicalScrollHandler(MagicMock())
+    # step 3: 1 no-movement
+    env = _env_with_scroll(pre=500.0, post=500.0)
+    h.execute(
+        MicroIntent(intent="x", type="scroll", params={"count": 1}),
+        _ctx(env, index=3),
+    )
+    # step 5: 1 no-movement — should still fail (not cap-skip), because
+    # the step_index=3 counter is irrelevant to step_index=5.
+    env = _env_with_scroll(pre=500.0, post=500.0)
+    res = h.execute(
+        MicroIntent(intent="x", type="scroll", params={"count": 1}),
+        _ctx(env, index=5),
+    )
+    assert res.success is False
+    assert res.failure_class == "scroll_no_movement"
+
+
+def test_no_movement_counter_reset_on_verified_motion():
+    """A successful scroll on the same step_index clears the
+    no-movement counter — page that scrolls once then jams shouldn't
+    cap-skip prematurely on a later jam."""
+    h = MechanicalScrollHandler(MagicMock())
+    # Two no-movement attempts to build up the counter.
+    for _ in range(2):
+        env = _env_with_scroll(pre=500.0, post=500.0)
+        h.execute(
+            MicroIntent(intent="x", type="scroll", params={"count": 1}),
+            _ctx(env, index=4),
+        )
+    # Verified motion clears the counter.
+    env = _env_with_scroll(pre=100.0, post=900.0)
+    res = h.execute(
+        MicroIntent(intent="x", type="scroll", params={"count": 1}),
+        _ctx(env, index=4),
+    )
+    assert res.success is True
+    # Next no-movement should fail (not skip) — counter was reset.
+    env = _env_with_scroll(pre=900.0, post=900.0)
+    res = h.execute(
+        MicroIntent(intent="x", type="scroll", params={"count": 1}),
+        _ctx(env, index=4),
+    )
+    assert res.success is False
+    assert res.failure_class == "scroll_no_movement"
+
+
 def test_cdp_backend_dispatch_error_returned_with_failure_class():
     """When CDP dispatch raises (Chrome devtools disconnected etc.),
     the handler returns ``scroll_dispatch_error`` rather than


### PR DESCRIPTION
## Summary

- `MechanicalScrollHandler.execute` now caps consecutive `scroll_no_movement` returns at 3 per step_index — after the cap the handler reports success with a `scroll_no_movement_skipped` data line so the runner advances naturally.
- Counter resets on any verified scroll motion on the same step_index (so a page that scrolls once then jams later still gets a fresh budget).
- Counters are isolated per step_index — fan-out workers and reused handlers don't share the budget.

Closes #647.

## Why

`scroll_no_movement` isn't in `REWRITE_TRIGGERING_CLASSES`, so `step_recovery` re-dispatches the same scroll indefinitely. v8 boattrader run had worker w2 stuck 46 min / 114 retries on URL #3 step 11 before the 50-minute `max_time_minutes` cap killed the run (~12 URLs of capacity lost).

## Test plan

- [x] `tests/test_scroll_handler_mechanical.py` — 3 new tests pinning the cap + counter-reset + per-step-index isolation contracts (`test_no_movement_cap_skips_step_after_n_consecutive_returns`, `test_no_movement_counter_isolates_per_step_index`, `test_no_movement_counter_reset_on_verified_motion`).
- [x] Existing 20 scroll-handler tests still green.
- [x] `tests/test_handler_registry_default.py` still green (scroll registration unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)