### PR TITLE
feat(plan-tuning): DomainProfile registry + decomposer pass (#648)

### DIFF
--- a/src/mantis_agent/plan_decomposer.py
+++ b/src/mantis_agent/plan_decomposer.py
@@ -891,6 +891,11 @@ class PlanDecomposer:
                 self._fix_loop_targets(plan)
                 # #614: classify loop bodies for the fan-out runner.
                 self._classify_loop_groups(plan)
+                # #648: stamp per-domain decomposer defaults (scroll
+                # backend, scroll count, first-navigate wait, pagination
+                # URL template). Idempotent — only sets a field when the
+                # source plan / cache didn't already pin it.
+                self._apply_domain_tuning(plan)
 
                 logger.info(f"Loaded cached micro-plan: {cache_path} ({len(plan.steps)} steps)")
                 return plan
@@ -1013,6 +1018,12 @@ class PlanDecomposer:
         # per gate whose preceding navigate had a literal URL with
         # distinctive path segments.
         self._inject_gate_url_hints(plan)
+        # #648: stamp per-domain decomposer defaults (scroll backend,
+        # scroll count, first-navigate wait, pagination URL template).
+        # Idempotent — only sets a field when the source plan didn't
+        # already pin it. Runs AFTER the structural fixes so the
+        # profile sees the final-shape plan.
+        self._apply_domain_tuning(plan)
 
         # Cache the full parsed structure (object or legacy array) so the
         # cached path round-trips through both schemas. #629: also persist
@@ -1271,6 +1282,35 @@ class PlanDecomposer:
             if any(ch.isdigit() for ch in s) or "-" in s
         ]
         return distinctive
+
+    @staticmethod
+    def _apply_domain_tuning(plan: "MicroPlan") -> None:
+        """#648: stamp per-domain decomposer defaults on ``plan`` in place.
+
+        Looks up a :class:`~mantis_agent.plan_tuning.DomainProfile` for
+        ``plan.domain`` (suffix-matched against the registry) and, if a
+        profile exists, applies its knobs via
+        :func:`~mantis_agent.plan_tuning.apply_domain_profile`. Idempotent
+        — every decision checks "did the source plan already set this?"
+        before stamping, so plan-author values win and the pass can run
+        on cached plans without drift.
+
+        Silently no-ops for unknown domains (the registry is sparse on
+        purpose). Surfacing a hit at INFO so operators can confirm the
+        profile fired in the decompose log.
+        """
+        from .plan_tuning import apply_domain_profile, resolve_domain_profile
+
+        profile = resolve_domain_profile(plan.domain or "")
+        if profile is None:
+            return
+        apply_domain_profile(plan, profile)
+        logger.info(
+            "  [decomposer] applied DomainProfile for %s "
+            "(scroll_backend=%r scroll_count=%d nav_wait_seconds=%d)",
+            profile.domain, profile.scroll_backend or "",
+            profile.scroll_count, profile.nav_wait_seconds,
+        )
 
     @staticmethod
     def _inject_gate_url_hints(plan: MicroPlan) -> None:

--- a/src/mantis_agent/plan_tuning/__init__.py
+++ b/src/mantis_agent/plan_tuning/__init__.py
@@ -1,0 +1,21 @@
+"""Plan-tuning layer — per-domain knobs the decomposer applies after
+step generation.
+
+See :mod:`.profiles` for the :class:`DomainProfile` dataclass, the
+registry of known domains, and the
+:func:`apply_domain_profile` pass.
+"""
+
+from .profiles import (
+    DOMAIN_PROFILES,
+    DomainProfile,
+    apply_domain_profile,
+    resolve_domain_profile,
+)
+
+__all__ = [
+    "DOMAIN_PROFILES",
+    "DomainProfile",
+    "apply_domain_profile",
+    "resolve_domain_profile",
+]

--- a/src/mantis_agent/plan_tuning/profiles.py
+++ b/src/mantis_agent/plan_tuning/profiles.py
@@ -1,0 +1,245 @@
+"""DomainProfile registry — per-domain decomposer knobs (#648).
+
+A :class:`DomainProfile` records the safe defaults the decomposer
+should stamp on steps when a plan targets a known domain — values that
+operators repeatedly discovered by trial and error in past runs.
+Today: scroll count / backend, first-navigate wait, pagination URL
+template. Tomorrow (#643 hint memory): the same registry becomes the
+write target for the auto-learner.
+
+Authoring rules
+---------------
+
+1. **Plan-author override wins.** ``apply_domain_profile`` only stamps
+   a field when the source plan didn't set it. Operators retain full
+   control by writing the knob explicitly.
+2. **Profile defaults are opinions, not facts.** An entry exists when
+   we've observed a recurring failure pattern across multiple runs of
+   the same domain. Speculative entries belong on a feature branch,
+   not in ``DOMAIN_PROFILES``.
+3. **Domain matching is suffix-based.** ``plan.domain="www.boattrader.com"``
+   matches a registry entry ``"boattrader.com"``. Exact match wins
+   over suffix match.
+
+The decomposer wires the pass in
+:meth:`mantis_agent.plan_decomposer.PlanDecomposer.decompose_text`
+after the fresh / cache paths and before the loop / URL / gate
+normalization passes — see the call site for the integration.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ..plan_decomposer import MicroPlan
+
+
+@dataclass(frozen=True)
+class DomainProfile:
+    """Per-domain knobs that the decomposer applies after step
+    generation. Frozen so operators can hand instances around without
+    worrying about accidental mutation.
+
+    Fields with the sentinel ``0`` (ints) or ``""`` (strings) signal
+    "no opinion" — the apply pass skips them. Use small explicit values
+    (``count=2``, ``nav_wait_seconds=8``) rather than re-encoding "no
+    opinion" with negative numbers.
+
+    Attributes
+    ----------
+    domain
+        Suffix-matched against ``MicroPlan.domain``. Typically the
+        registrable hostname (``boattrader.com``, ``lu.ma``).
+    scroll_backend
+        Default ``params.backend`` for ``scroll`` steps. ``"cdp"`` opts
+        into the deterministic CDP path that bypasses Chrome wheel
+        handlers — set on domains where vision scroll repeatedly hits
+        ``brain_loop_exhausted`` (sticky overlays, inner-element
+        scrollers). Empty ``""`` means "no opinion".
+    scroll_count
+        Default ``params.count`` for ``scroll`` steps. Positive int
+        replaces decomposer-emitted counts when the plan didn't pin
+        one; ``0`` means no opinion. Used to stop overshoot on short
+        detail pages.
+    nav_wait_seconds
+        Default ``params.wait_after_load_seconds`` for the FIRST
+        ``navigate`` step in the plan. Set on JS-heavy SPAs / CF-gated
+        domains where the 4-second adaptive settle expires before
+        first paint. ``0`` means no opinion.
+    pagination_url_template
+        Sets ``MicroPlan.pagination_url_template`` when the LLM didn't
+        infer one. Must contain ``{base}`` and ``{n}`` placeholders.
+        Empty string means no opinion.
+    """
+
+    domain: str
+    scroll_backend: str = ""
+    scroll_count: int = 0
+    nav_wait_seconds: int = 0
+    pagination_url_template: str = ""
+    # Free-form note explaining WHY the entry exists — read by future
+    # operators / the hint-memory writer (#643). Not consumed by the
+    # apply pass.
+    note: str = ""
+    # Optional URL substring hints that any ``gate`` step on this
+    # domain should expect (e.g. ``("/boat/", "boat-")`` so the
+    # extract_data gate short-circuits via #563 URL match). Empty
+    # tuple means no opinion.
+    expect_url_contains: tuple[str, ...] = field(default_factory=tuple)
+
+
+# ── Registry ─────────────────────────────────────────────────────────
+#
+# Add an entry when you've observed a recurring failure pattern on a
+# domain that the decomposer's generic defaults didn't catch. Keep the
+# entry small and motivated by concrete run data.
+DOMAIN_PROFILES: dict[str, DomainProfile] = {
+    # boattrader.com — v7/v8 runs:
+    #   * count=4 overshoots short detail pages (description in
+    #     footer) → count=2 lands the Description heading mid-viewport.
+    #   * vision scroll hits ``brain_loop_exhausted`` 173x per run on
+    #     listing pages → CDP backend skips Chrome wheel handlers.
+    #   * CF-protected proxy fetch sometimes hasn't rendered by the 4s
+    #     adaptive settle → 8s on the first navigate.
+    #   * /page-{n}/ pagination shape observed across the by-owner /
+    #     by-make / state-wide variants.
+    "boattrader.com": DomainProfile(
+        domain="boattrader.com",
+        scroll_backend="cdp",
+        scroll_count=2,
+        nav_wait_seconds=8,
+        pagination_url_template="{base}/page-{n}/",
+        note=(
+            "v7/v8: CDP scroll skips brain_loop_exhausted; "
+            "count=2 lands Description mid-viewport on short pages; "
+            "8s nav wait covers CF-proxy first paint."
+        ),
+        expect_url_contains=("/boat/",),
+    ),
+    # lu.ma — SPA cold-mount: Vite/React app hasn't mounted in 4s on
+    # a fresh profile. ``feedback_spa_cold_mount_wait.md`` documents
+    # the pattern. Mechanical scroll knobs unset — lu.ma pages are
+    # generally short and vision scroll is fine there.
+    "lu.ma": DomainProfile(
+        domain="lu.ma",
+        nav_wait_seconds=8,
+        note=(
+            "SPA cold-mount: Vite/React app needs 8s before first "
+            "interactive element renders on a fresh Chrome profile."
+        ),
+    ),
+    # staff-crm-long (synthetic test app served by sim_envs) — same
+    # SPA cold-mount story as lu.ma, plus tab-walk grounding is
+    # finicky enough that operators have repeatedly added an 8s wait
+    # to the first navigate. See ``project_staff_crm_long_*`` memory
+    # files for the multi-day debug history.
+    "staffai.com": DomainProfile(
+        domain="staffai.com",
+        nav_wait_seconds=8,
+        note=(
+            "Multi-day stress test surfaced session layout drift + "
+            "trust-gated dispatch (PR #447). 8s nav wait makes the "
+            "first interactive paint reliable."
+        ),
+    ),
+}
+
+
+def resolve_domain_profile(domain: str) -> DomainProfile | None:
+    """Look up a :class:`DomainProfile` for ``domain``.
+
+    Exact match wins over suffix match. ``""`` / unknown domains
+    return ``None``. Case-insensitive: the registry is canonicalised
+    on lookup so plan authors don't have to lowercase their URLs.
+    """
+    if not domain:
+        return None
+    needle = domain.strip().lower()
+    if not needle:
+        return None
+    # Exact match — direct hit.
+    hit = DOMAIN_PROFILES.get(needle)
+    if hit is not None:
+        return hit
+    # Suffix match — registry "boattrader.com" matches plan
+    # "www.boattrader.com" / "boats.boattrader.com" / etc.
+    # We prefer the longest registry key that suffix-matches so a
+    # specific subdomain entry (if ever added) wins over a generic
+    # parent entry.
+    best: DomainProfile | None = None
+    best_len = -1
+    for key, profile in DOMAIN_PROFILES.items():
+        if needle.endswith("." + key) or needle == key:
+            if len(key) > best_len:
+                best, best_len = profile, len(key)
+    return best
+
+
+def apply_domain_profile(
+    plan: "MicroPlan",
+    profile: DomainProfile,
+) -> "MicroPlan":
+    """Stamp profile defaults on ``plan`` in place; return ``plan``.
+
+    Idempotent — running twice yields the same plan because every
+    decision checks "did the source plan / a prior pass already set
+    this?" before stamping.
+
+    Decisions
+    ---------
+
+    * For every ``scroll`` step:
+      - if profile.scroll_backend and not step.params["backend"]:
+            step.params["backend"] = profile.scroll_backend
+      - if profile.scroll_count > 0 and not step.params["count"]:
+            step.params["count"] = profile.scroll_count
+    * For the FIRST ``navigate`` step in the plan:
+      - if profile.nav_wait_seconds > 0 and
+            not step.params["wait_after_load_seconds"]:
+            step.params["wait_after_load_seconds"] = profile.nav_wait_seconds
+    * For every ``gate`` step:
+      - if profile.expect_url_contains and
+            not step.hints["expect_url_contains"]:
+            step.hints["expect_url_contains"] = list(profile.expect_url_contains)
+    * Plan-level:
+      - if profile.pagination_url_template and not plan.pagination_url_template:
+            plan.pagination_url_template = profile.pagination_url_template
+    """
+    saw_navigate = False
+    for step in plan.steps:
+        stype = step.type
+        params = step.params if step.params is not None else {}
+        hints = step.hints if step.hints is not None else {}
+
+        if stype == "scroll":
+            if profile.scroll_backend and not params.get("backend"):
+                params["backend"] = profile.scroll_backend
+            if profile.scroll_count > 0 and not params.get("count"):
+                params["count"] = profile.scroll_count
+
+        if stype == "navigate" and not saw_navigate:
+            saw_navigate = True
+            if (
+                profile.nav_wait_seconds > 0
+                and not params.get("wait_after_load_seconds")
+            ):
+                params["wait_after_load_seconds"] = profile.nav_wait_seconds
+
+        if step.gate and profile.expect_url_contains:
+            if not hints.get("expect_url_contains"):
+                hints["expect_url_contains"] = list(profile.expect_url_contains)
+
+        # Re-assign so dataclass instances always carry concrete dicts
+        # (some MicroIntent fields default to a fresh dict; mutation
+        # is observable on the original, but explicit assignment is
+        # safer for future field-shape changes).
+        step.params = params
+        step.hints = hints
+
+    if profile.pagination_url_template and not plan.pagination_url_template:
+        if "{base}" in profile.pagination_url_template and "{n}" in profile.pagination_url_template:
+            plan.pagination_url_template = profile.pagination_url_template
+
+    return plan

--- a/src/mantis_agent/plan_tuning/profiles.py
+++ b/src/mantis_agent/plan_tuning/profiles.py
@@ -130,13 +130,12 @@ DOMAIN_PROFILES: dict[str, DomainProfile] = {
             "interactive element renders on a fresh Chrome profile."
         ),
     ),
-    # staff-crm-long (synthetic test app served by sim_envs) — same
-    # SPA cold-mount story as lu.ma, plus tab-walk grounding is
-    # finicky enough that operators have repeatedly added an 8s wait
-    # to the first navigate. See ``project_staff_crm_long_*`` memory
-    # files for the multi-day debug history.
-    "staffai.com": DomainProfile(
-        domain="staffai.com",
+    # mantis-crm (synthetic sim_envs CRM — same domain used by
+    # ``SiteConfig.default_mantis_crm()``). SPA cold-mount story like
+    # lu.ma, plus tab-walk grounding is finicky enough that operators
+    # repeatedly added an 8s wait to the first navigate.
+    "mantis-crm": DomainProfile(
+        domain="mantis-crm",
         nav_wait_seconds=8,
         note=(
             "Multi-day stress test surfaced session layout drift + "

--- a/tests/test_domain_profile_tuning_648.py
+++ b/tests/test_domain_profile_tuning_648.py
@@ -1,0 +1,308 @@
+"""#648 — DomainProfile autonomous plan tuning.
+
+Pins the contract for per-domain decomposer defaults:
+
+  - Profile resolution: exact match wins, suffix match falls back.
+  - Apply pass: stamps scroll backend / count, first-navigate wait,
+    gate ``expect_url_contains``, and plan.pagination_url_template
+    when the source plan didn't already pin them.
+  - Idempotent: running twice yields the same plan.
+  - Plan-author override: explicit values in the source plan / a prior
+    pass survive — the profile never overwrites them.
+  - Unknown domain: silent no-op.
+"""
+
+from __future__ import annotations
+
+from mantis_agent.plan_decomposer import MicroIntent, MicroPlan, PlanDecomposer
+from mantis_agent.plan_tuning import (
+    DOMAIN_PROFILES,
+    DomainProfile,
+    apply_domain_profile,
+    resolve_domain_profile,
+)
+
+
+# ── Resolution ────────────────────────────────────────────────────────
+
+
+def test_resolve_returns_none_for_empty_or_unknown_domain():
+    assert resolve_domain_profile("") is None
+    assert resolve_domain_profile("totally-unknown-12345.tld") is None
+
+
+def test_resolve_exact_match():
+    p = resolve_domain_profile("boattrader.com")
+    assert p is not None
+    assert p.domain == "boattrader.com"
+
+
+def test_resolve_suffix_match_for_subdomain():
+    """``plan.domain="www.boattrader.com"`` matches the registry's
+    ``"boattrader.com"`` via suffix matching."""
+    p = resolve_domain_profile("www.boattrader.com")
+    assert p is not None
+    assert p.domain == "boattrader.com"
+
+
+def test_resolve_is_case_insensitive():
+    p = resolve_domain_profile("BoatTrader.COM")
+    assert p is not None
+    assert p.domain == "boattrader.com"
+
+
+def test_resolve_strips_whitespace():
+    assert resolve_domain_profile("  boattrader.com  ") is not None
+
+
+# ── Apply: scroll knobs ───────────────────────────────────────────────
+
+
+def _plan_with(steps: list[MicroIntent], domain: str = "boattrader.com") -> MicroPlan:
+    return MicroPlan(steps=steps, domain=domain)
+
+
+def test_apply_stamps_scroll_backend_when_unset():
+    plan = _plan_with([MicroIntent(intent="x", type="scroll", params={})])
+    profile = DomainProfile(domain="boattrader.com", scroll_backend="cdp")
+    apply_domain_profile(plan, profile)
+    assert plan.steps[0].params["backend"] == "cdp"
+
+
+def test_apply_respects_plan_author_scroll_backend():
+    plan = _plan_with(
+        [MicroIntent(intent="x", type="scroll", params={"backend": "xdotool"})],
+    )
+    profile = DomainProfile(domain="boattrader.com", scroll_backend="cdp")
+    apply_domain_profile(plan, profile)
+    assert plan.steps[0].params["backend"] == "xdotool"
+
+
+def test_apply_stamps_scroll_count_when_unset():
+    plan = _plan_with([MicroIntent(intent="x", type="scroll", params={})])
+    profile = DomainProfile(domain="boattrader.com", scroll_count=2)
+    apply_domain_profile(plan, profile)
+    assert plan.steps[0].params["count"] == 2
+
+
+def test_apply_respects_plan_author_scroll_count():
+    plan = _plan_with(
+        [MicroIntent(intent="x", type="scroll", params={"count": 5})],
+    )
+    profile = DomainProfile(domain="boattrader.com", scroll_count=2)
+    apply_domain_profile(plan, profile)
+    assert plan.steps[0].params["count"] == 5
+
+
+def test_apply_skips_scroll_count_when_profile_unset():
+    """profile.scroll_count == 0 → "no opinion" → don't stamp anything."""
+    plan = _plan_with([MicroIntent(intent="x", type="scroll", params={})])
+    profile = DomainProfile(domain="x.com")  # scroll_count=0 default
+    apply_domain_profile(plan, profile)
+    assert "count" not in plan.steps[0].params
+
+
+# ── Apply: first-navigate wait ────────────────────────────────────────
+
+
+def test_apply_stamps_first_navigate_wait_seconds_when_unset():
+    plan = _plan_with([
+        MicroIntent(intent="go", type="navigate", params={"url": "https://x.com"}),
+        MicroIntent(intent="scroll", type="scroll"),
+    ])
+    profile = DomainProfile(domain="x.com", nav_wait_seconds=8)
+    apply_domain_profile(plan, profile)
+    assert plan.steps[0].params["wait_after_load_seconds"] == 8
+
+
+def test_apply_only_stamps_FIRST_navigate_wait():
+    """Subsequent navigate steps don't get the cold-mount wait —
+    that's specifically for the initial proxy/SPA paint."""
+    plan = _plan_with([
+        MicroIntent(intent="go 1", type="navigate"),
+        MicroIntent(intent="scroll", type="scroll"),
+        MicroIntent(intent="go 2", type="navigate"),
+    ])
+    profile = DomainProfile(domain="x.com", nav_wait_seconds=8)
+    apply_domain_profile(plan, profile)
+    assert plan.steps[0].params.get("wait_after_load_seconds") == 8
+    assert "wait_after_load_seconds" not in plan.steps[2].params
+
+
+def test_apply_respects_plan_author_first_navigate_wait():
+    plan = _plan_with([
+        MicroIntent(
+            intent="go", type="navigate",
+            params={"wait_after_load_seconds": 2},
+        ),
+    ])
+    profile = DomainProfile(domain="x.com", nav_wait_seconds=8)
+    apply_domain_profile(plan, profile)
+    assert plan.steps[0].params["wait_after_load_seconds"] == 2
+
+
+# ── Apply: gate expect_url_contains ───────────────────────────────────
+
+
+def test_apply_stamps_expect_url_contains_on_gate_steps():
+    plan = _plan_with([
+        MicroIntent(intent="verify", type="extract_data", gate=True),
+    ])
+    profile = DomainProfile(
+        domain="boattrader.com",
+        expect_url_contains=("/boat/", "boat-"),
+    )
+    apply_domain_profile(plan, profile)
+    assert plan.steps[0].hints["expect_url_contains"] == ["/boat/", "boat-"]
+
+
+def test_apply_skips_expect_url_contains_on_non_gate_steps():
+    plan = _plan_with([
+        MicroIntent(intent="extract", type="extract_data", gate=False),
+    ])
+    profile = DomainProfile(
+        domain="boattrader.com",
+        expect_url_contains=("/boat/",),
+    )
+    apply_domain_profile(plan, profile)
+    assert "expect_url_contains" not in plan.steps[0].hints
+
+
+def test_apply_respects_plan_author_expect_url_contains():
+    plan = _plan_with([
+        MicroIntent(
+            intent="verify", type="extract_data", gate=True,
+            hints={"expect_url_contains": ["custom-path"]},
+        ),
+    ])
+    profile = DomainProfile(
+        domain="boattrader.com",
+        expect_url_contains=("/boat/",),
+    )
+    apply_domain_profile(plan, profile)
+    assert plan.steps[0].hints["expect_url_contains"] == ["custom-path"]
+
+
+# ── Apply: plan-level pagination_url_template ─────────────────────────
+
+
+def test_apply_stamps_pagination_url_template_when_plan_unset():
+    plan = _plan_with([])
+    profile = DomainProfile(
+        domain="boattrader.com",
+        pagination_url_template="{base}/page-{n}/",
+    )
+    apply_domain_profile(plan, profile)
+    assert plan.pagination_url_template == "{base}/page-{n}/"
+
+
+def test_apply_respects_plan_pagination_url_template():
+    plan = _plan_with([])
+    plan.pagination_url_template = "{base}/listing?p={n}"
+    profile = DomainProfile(
+        domain="boattrader.com",
+        pagination_url_template="{base}/page-{n}/",
+    )
+    apply_domain_profile(plan, profile)
+    assert plan.pagination_url_template == "{base}/listing?p={n}"
+
+
+def test_apply_rejects_malformed_pagination_template():
+    """Missing ``{base}`` or ``{n}`` placeholders → don't stamp."""
+    plan = _plan_with([])
+    profile = DomainProfile(
+        domain="x.com",
+        pagination_url_template="https://x.com/?page=N",  # no placeholders
+    )
+    apply_domain_profile(plan, profile)
+    assert plan.pagination_url_template == ""
+
+
+# ── Idempotency ───────────────────────────────────────────────────────
+
+
+def test_apply_is_idempotent():
+    """Running the pass twice yields the same plan as running it once."""
+    plan = _plan_with([
+        MicroIntent(intent="go", type="navigate", params={}),
+        MicroIntent(intent="scroll", type="scroll", params={}),
+        MicroIntent(intent="verify", type="extract_data", gate=True, hints={}),
+    ])
+    profile = DomainProfile(
+        domain="boattrader.com",
+        scroll_backend="cdp",
+        scroll_count=2,
+        nav_wait_seconds=8,
+        pagination_url_template="{base}/page-{n}/",
+        expect_url_contains=("/boat/",),
+    )
+    apply_domain_profile(plan, profile)
+    snapshot = (
+        plan.steps[0].params.copy(),
+        plan.steps[1].params.copy(),
+        plan.steps[2].hints.copy(),
+        plan.pagination_url_template,
+    )
+    apply_domain_profile(plan, profile)
+    assert (
+        plan.steps[0].params,
+        plan.steps[1].params,
+        plan.steps[2].hints,
+        plan.pagination_url_template,
+    ) == snapshot
+
+
+# ── Registry sanity ──────────────────────────────────────────────────
+
+
+def test_boattrader_profile_known_knobs():
+    p = DOMAIN_PROFILES["boattrader.com"]
+    assert p.scroll_backend == "cdp"
+    assert p.scroll_count == 2
+    assert p.nav_wait_seconds == 8
+    assert "{base}" in p.pagination_url_template
+    assert "{n}" in p.pagination_url_template
+
+
+def test_luma_profile_nav_wait_only():
+    p = DOMAIN_PROFILES["lu.ma"]
+    assert p.nav_wait_seconds == 8
+    # No scroll opinions on lu.ma (short pages, vision scroll is fine).
+    assert p.scroll_backend == ""
+    assert p.scroll_count == 0
+
+
+# ── Decomposer wiring ────────────────────────────────────────────────
+
+
+def test_decomposer_apply_domain_tuning_pass_on_known_domain():
+    """``_apply_domain_tuning`` stamps profile defaults on a plan whose
+    ``domain`` resolves to a known profile."""
+    plan = MicroPlan(domain="boattrader.com")
+    plan.steps = [
+        MicroIntent(intent="go", type="navigate"),
+        MicroIntent(intent="scroll", type="scroll"),
+    ]
+    PlanDecomposer._apply_domain_tuning(plan)
+    # First-navigate wait stamped from profile.
+    assert plan.steps[0].params.get("wait_after_load_seconds") == 8
+    # Scroll knobs stamped from profile.
+    assert plan.steps[1].params.get("backend") == "cdp"
+    assert plan.steps[1].params.get("count") == 2
+    # Plan-level template stamped from profile.
+    assert plan.pagination_url_template == "{base}/page-{n}/"
+
+
+def test_decomposer_apply_domain_tuning_is_silent_on_unknown_domain():
+    plan = MicroPlan(domain="totally-unknown-12345.tld")
+    plan.steps = [MicroIntent(intent="x", type="scroll")]
+    PlanDecomposer._apply_domain_tuning(plan)
+    assert plan.steps[0].params == {}
+
+
+def test_decomposer_apply_domain_tuning_silent_when_no_domain():
+    """``MicroPlan.domain=""`` (regex didn't find a URL) → no-op."""
+    plan = MicroPlan(domain="")
+    plan.steps = [MicroIntent(intent="x", type="scroll")]
+    PlanDecomposer._apply_domain_tuning(plan)
+    assert plan.steps[0].params == {}


### PR DESCRIPTION
## Summary

- New `src/mantis_agent/plan_tuning/` module with a `DomainProfile` dataclass + `DOMAIN_PROFILES` registry. Per-domain knobs: scroll backend, scroll count, first-navigate wait, gate `expect_url_contains`, and plan-level `pagination_url_template`.
- `PlanDecomposer._apply_domain_tuning` wires the pass into both the cache-hit and fresh-decompose paths after the existing loop / URL / gate normalization fixes. Idempotent — plan-author values always win.
- Initial profiles for `boattrader.com`, `lu.ma`, and `staffai.com` based on observed multi-run failure patterns.

Closes #648 (Phase 1).

## Why

Plan authors hand-tune `scroll.params.count`, `scroll.params.backend`, `navigate.params.wait_after_load_seconds`, etc. by trial and error — each iteration costs ~30-45 min wall-clock and ~$5-10. Three recurring patterns surfaced over v6/v7/v8 boattrader runs:

1. `count=4` overshoots short detail pages → `count=2`.
2. Vision scroll hits `brain_loop_exhausted` 173× per run on listings → CDP backend.
3. CF-protected proxy fetch hasn't rendered in 4s adaptive settle → 8s nav wait.

After this PR a single profile entry tunes ALL plans targeting that domain. Future #643 hint memory becomes the auto-write path into the same registry; today operators hand-edit it.

## Test plan

- [x] `tests/test_domain_profile_tuning_648.py` — 25 tests covering:
  - resolve: exact match, suffix match, case-insensitive, unknown → None.
  - apply: stamps scroll knobs, first-navigate wait, gate hints, pagination template when unset.
  - plan-author override always wins.
  - idempotency: running twice == running once.
  - decomposer wiring: known domain stamps, unknown / blank domain no-ops.
  - registry sanity: boattrader / lu.ma profile shapes.
- [x] Existing 112 decomposer tests still green.
- [x] No new dependencies; pure stdlib + existing MicroPlan/MicroIntent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)