### PR TITLE
fix(executor): preserve guard + out_var on effective_step

### DIFF
--- a/src/mantis_agent/gym/_runner_helpers.py
+++ b/src/mantis_agent/gym/_runner_helpers.py
@@ -785,6 +785,30 @@ def execute_step(
     # tripped reliably for ages).
     from .step_handlers.detect_visible import resolve_guard_name
     guard_name = resolve_guard_name(step)
+    # WARNING-level diagnostic (per
+    # ``feedback_warning_level_for_modal_observability.md``): a step
+    # author opted into guarded behaviour — surface the decision so
+    # "why didn't the guard skip the step" is triagable from Modal
+    # logs without redeploying. Silent on the unconditional common
+    # path (no guard hint anywhere).
+    _guarded_request = (
+        bool(guard_name)
+        or bool(getattr(step, "guard", "") or "")
+        or "guard" in (getattr(step, "params", None) or {})
+        or "guard" in (getattr(step, "hints", None) or {})
+    )
+    if _guarded_request:
+        _sv_now = getattr(runner, "_state_vars", None)
+        _logger = logging.getLogger("mantis_agent.gym._runner_helpers")
+        _logger.warning(
+            "  [guard-check] step=%d type=%s resolved=%r "
+            "top=%r params.guard=%r hints.guard=%r state_vars=%s",
+            index, getattr(step, "type", "?"), guard_name,
+            getattr(step, "guard", ""),
+            (getattr(step, "params", None) or {}).get("guard", ""),
+            (getattr(step, "hints", None) or {}).get("guard", ""),
+            dict(_sv_now) if isinstance(_sv_now, dict) else _sv_now,
+        )
     if guard_name:
         state_vars = getattr(runner, "_state_vars", {}) or {}
         guard_value = bool(state_vars.get(guard_name, False))

--- a/src/mantis_agent/gym/run_executor.py
+++ b/src/mantis_agent/gym/run_executor.py
@@ -769,6 +769,25 @@ class RunExecutor:
             section=step.section, required=step.required, gate=step.gate,
             params=dict(step.params or {}),
             hints=dict(getattr(step, "hints", {}) or {}),
+            # #643 stage 2 fields — vision-only conditional steps. The
+            # executor's outer loop reads ``guard`` (in
+            # ``_runner_helpers.execute_step``) to decide whether to
+            # short-circuit a step against a prior ``detect_visible``
+            # binding. The detect_visible handler reads ``out_var`` to
+            # decide where to bind its boolean result. Dropping these
+            # from the effective_step forced ``resolve_guard_name`` /
+            # ``DetectVisibleHandler.execute`` onto their
+            # ``params`` / ``hints`` fallback paths — which the
+            # boattrader urlnav plan happens to populate, so cache
+            # paths "worked", but any plan that set guard/out_var only
+            # at the top level (the canonical authoring form) would
+            # silently regress: the guarded step ran unconditionally
+            # and burned brain-budget. Live repro 2026-05-24 boattrader
+            # verification run 20260524_155643_b90f0d66: step 6 click
+            # ran despite step 5 detect_visible binding
+            # ``has_show_more=False``.
+            guard=getattr(step, "guard", "") or "",
+            out_var=getattr(step, "out_var", "") or "",
         )
 
     def _handle_loop_step(

--- a/tests/test_effective_step_preserves_guard.py
+++ b/tests/test_effective_step_preserves_guard.py
@@ -1,0 +1,64 @@
+"""Regression test for the boattrader urlnav verification run halt
+(2026-05-24). RunExecutor._build_effective_step was dropping the
+``guard`` and ``out_var`` MicroIntent fields when reconstructing the
+per-dispatch MicroIntent. The canonical authoring form sets these at
+the top level — the executor's hints fallback in ``resolve_guard_name``
+was meant as a backup but the production path silently regressed for
+any plan that didn't ALSO redundantly populate ``hints['guard']``.
+
+The fix preserves both fields verbatim. This test pins the contract.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from mantis_agent.plan_decomposer import MicroIntent
+
+
+def _build_effective_step_via_executor(step: MicroIntent) -> MicroIntent:
+    """Invoke RunExecutor._build_effective_step against a minimal
+    MagicMock runner. Mirrors the production call site path."""
+    from mantis_agent.gym.run_executor import RunExecutor
+    executor = RunExecutor.__new__(RunExecutor)
+    runner = MagicMock()
+    runner._step_intent_overrides = {}
+    runner.scanner.scroll_directive_for = MagicMock(return_value="")
+    executor.parent = runner
+    state = MagicMock()
+    state.step_index = 0
+    state.listings_on_page = 0
+    return executor._build_effective_step(step, state)
+
+
+def test_effective_step_preserves_top_level_guard():
+    """Top-level ``MicroIntent.guard`` survives effective-step
+    reconstruction — the executor must not silently drop dataclass
+    fields the runner downstream reads."""
+    src = MicroIntent(
+        intent="Click Show More", type="click", section="extraction",
+        guard="has_show_more",
+    )
+    eff = _build_effective_step_via_executor(src)
+    assert eff.guard == "has_show_more"
+
+
+def test_effective_step_preserves_top_level_out_var():
+    """Top-level ``MicroIntent.out_var`` survives effective-step
+    reconstruction — detect_visible's binding target must reach the
+    handler verbatim."""
+    src = MicroIntent(
+        intent="Is X visible?", type="detect_visible", section="extraction",
+        out_var="has_x",
+    )
+    eff = _build_effective_step_via_executor(src)
+    assert eff.out_var == "has_x"
+
+
+def test_effective_step_guard_empty_default_preserved():
+    """Unconditional step (default empty guard) stays empty after
+    reconstruction — no spurious value injection."""
+    src = MicroIntent(intent="Click", type="click")
+    eff = _build_effective_step_via_executor(src)
+    assert eff.guard == ""
+    assert eff.out_var == ""


### PR DESCRIPTION
## Summary

- `RunExecutor._build_effective_step` was missing `guard=` and `out_var=` kwargs when reconstructing the per-dispatch MicroIntent — both #643 stage 2 fields were silently dropped.
- The runner's downstream guard short-circuit (`_runner_helpers.execute_step` line 786) has a triple-fallback in `resolve_guard_name` (top → params → hints) meant as Modal stale-dataclass insurance. So plans that ALSO populated `hints['guard']` worked. Plans that only set the canonical top-level field (the authoring style the prompt advertises) silently regressed: the guarded step ran unconditionally.
- Fix preserves both fields verbatim. Regression test pins the contract.

## Why

Live repro 2026-05-24 boattrader verification runs (`20260524_155643_b90f0d66`, `…dd42b519`): step 6 click ran every iteration despite step 5 detect_visible binding `has_show_more=False`. After the fix the diagnostic on a follow-up run (`…88d4e49e`) confirmed:

```
[guard-check] step=6 type=click resolved='has_show_more'
  top='has_show_more' params.guard='' hints.guard='has_show_more'
  state_vars={'has_show_more': False}
```

The structural fix surfaced a deeper bug (skip envelopes routed through `_handle_failure`) — that fix lives in its own PR.

## Test plan

- [x] `tests/test_effective_step_preserves_guard.py` — 3 tests pinning top-level guard / out_var survival + default-empty preservation.
- [x] All existing decomposer / executor tests still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)