### PR TITLE
fix(executor): skip envelopes bypass _handle_failure (advance directly)

### DIFF
--- a/src/mantis_agent/gym/run_executor.py
+++ b/src/mantis_agent/gym/run_executor.py
@@ -347,6 +347,21 @@ class RunExecutor:
             if step_result.success:
                 self._handle_success(plan, state, step, step_result)
                 continued = True
+            elif step_result.skip:
+                # #643 stage 2 + #246 — skip envelopes (guard False,
+                # recipe rejection, navigation_failed promotion, etc.)
+                # encode "this step didn't produce an action but
+                # that's by design, not a failure". The runner's
+                # recovery policy reads success=False and routes
+                # through ``_handle_click_failure`` etc., burning
+                # an env.step (Escape) and jumping to the next loop
+                # step — which silently corrupts a guarded skip into
+                # a real failure path. Advance to the next step
+                # directly; ``_handle_failure`` semantics apply only
+                # to actual missed actions.
+                state.step_index += 1
+                self._persist(plan, state)
+                continued = True
             else:
                 # #541 + fu: auto-pause on CAPTCHA must run BEFORE
                 # ``_handle_failure`` — the recovery policy decides

--- a/tests/test_effective_step_preserves_guard.py
+++ b/tests/test_effective_step_preserves_guard.py
@@ -62,3 +62,62 @@ def test_effective_step_guard_empty_default_preserved():
     eff = _build_effective_step_via_executor(src)
     assert eff.guard == ""
     assert eff.out_var == ""
+
+
+# ── Skip envelope outer-loop bypass ──────────────────────────────────
+
+
+def test_skip_envelope_advances_without_recovery():
+    """``StepResult(success=False, skip=True)`` is the contract that
+    execute_step's guard branch + recipe-rejection paths emit. The
+    outer loop must advance to the next step directly — calling
+    ``_handle_failure`` on a skip envelope routes the skipped step
+    through the click-recovery branch (Escape + jump to loop), which
+    silently corrupts a deliberate skip into a real failure path.
+
+    Live repro 2026-05-24 boattrader verification run
+    20260524_171431_ece15fbb: step 6 guard correctly resolved
+    has_show_more=False but the skip envelope was processed as a
+    click failure.
+    """
+    import os
+    # The skip-bypass branch lives in _execute_inner. Drive the
+    # branch detection logic directly to keep the test focused +
+    # avoid the deep dependency chain RunExecutor._execute_inner
+    # mounts (env, brain, checkpoint persistence, ...).
+    from mantis_agent.gym.checkpoint import StepResult
+
+    skip_result = StepResult(
+        step_index=6, intent="Click Show More", success=False,
+        data="guard:has_show_more=False:skipped",
+        skip=True, skip_reason="guard_has_show_more_false",
+    )
+    # The outer-loop branch condition:
+    #   if success: success path
+    #   elif skip:  advance directly (THIS PR)
+    #   else:       _handle_failure
+    is_success = bool(skip_result.success)
+    is_skip = bool(getattr(skip_result, "skip", False))
+    # Must hit the skip branch BEFORE the failure branch.
+    assert not is_success
+    assert is_skip
+
+
+def test_skip_envelope_outer_loop_bypass_in_run_executor():
+    """Reads the _execute_inner source to confirm the ``elif
+    step_result.skip:`` branch exists between the success and failure
+    branches. A grep-style structural test — cheaper than mocking the
+    whole MicroPlanRunner just to assert a 4-line control-flow
+    change."""
+    import inspect
+    from mantis_agent.gym.run_executor import RunExecutor
+
+    source = inspect.getsource(RunExecutor._execute_inner)
+    # Find the order of the three branches.
+    success_pos = source.find("step_result.success")
+    skip_pos = source.find("step_result.skip")
+    failure_pos = source.find("_handle_failure")
+    assert success_pos < skip_pos < failure_pos, (
+        f"Expected branch order success({success_pos}) < "
+        f"skip({skip_pos}) < failure({failure_pos}). Source:\n{source[:2000]}"
+    )

--- a/tests/test_effective_step_preserves_guard.py
+++ b/tests/test_effective_step_preserves_guard.py
@@ -80,7 +80,6 @@ def test_skip_envelope_advances_without_recovery():
     has_show_more=False but the skip envelope was processed as a
     click failure.
     """
-    import os
     # The skip-bypass branch lives in _execute_inner. Drive the
     # branch detection logic directly to keep the test focused +
     # avoid the deep dependency chain RunExecutor._execute_inner


### PR DESCRIPTION
## Summary

- `_execute_inner` outer loop now branches `success` → `skip` → `failure`, advancing directly past a step that returned a skip envelope (`success=False, skip=True`).
- Stacks on top of #654 (guard preservation) — depends on its test file.

## Why

`execute_step`'s docstring describes the skip envelope as *"the runner's post-step loop advances past without retry recovery"* — but the wiring was missing. Any `success=False, skip=True` result was routed through `_handle_failure` → `StepRecoveryPolicy.handle_failure` → type-specific recovery (Escape key dispatch, jump-to-loop, etc.), silently corrupting deliberate skips into real failure paths.

Live repro 2026-05-24 boattrader rerun `20260524_171431_ece15fbb`, diagnostic captured:

```
[guard-check] step=6 type=click resolved='has_show_more' top='has_show_more'
  params.guard='' hints.guard='has_show_more' state_vars={'has_show_more': False}
[ 6] FAIL | 0 leads (0 phone) | $0.15 total
[6] CLICK FAILED — skipping to next      ← spurious: step was a deliberate skip
```

After the fix (verified on rerun `…88d4e49e`):
- The `CLICK FAILED — skipping to next` line is gone (recovery never consulted).
- Step 7 (extract_data) ran cleanly and produced 1 viable lead.
- Terminal status: `completed_with_failures` with **no `halt_reason`** (vs prior `halt_reason=click_failed`).

Applies to all skip-envelope paths: `guard` (#643 stage 2), recipe rejection (#246), `navigation_failed` promotion (#250).

## Test plan

- [x] Two new structural tests in `tests/test_effective_step_preserves_guard.py`:
  - `test_skip_envelope_advances_without_recovery` — pins the contract shape.
  - `test_skip_envelope_outer_loop_bypass_in_run_executor` — grep-style structural assertion that the `elif step_result.skip:` branch sits between success and failure in `_execute_inner` source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)