### PR TITLE
fix(decomposer): loop_target/loop_count fall back to params

### DIFF
--- a/src/mantis_agent/plan_decomposer.py
+++ b/src/mantis_agent/plan_decomposer.py
@@ -1145,8 +1145,24 @@ class PlanDecomposer:
                 "claude_only",
                 step_type in ("extract_url", "extract_data", "detect_visible"),
             ),
-            loop_target=s.get("loop_target", -1),
-            loop_count=s.get("loop_count", 0),
+            # Some plan-authoring styles (and Claude's older response
+            # shapes) put loop_target / loop_count inside ``params``
+            # rather than at the top level. Read top-level first;
+            # fall back to ``params`` so both forms work. Without this
+            # fallback, the canonical boattrader_scrape_urlnav plan
+            # silently degraded to loop_target=-1 / loop_count=0 →
+            # ``_handle_loop_step`` self-spun on its own index and
+            # the inner extraction loop never iterated past the first
+            # card (1 lead vs the expected 25-40). Live repro
+            # 2026-05-24 verification run 20260524_172252_88d4e49e.
+            loop_target=s.get(
+                "loop_target",
+                (s.get("params") or {}).get("loop_target", -1),
+            ),
+            loop_count=s.get(
+                "loop_count",
+                (s.get("params") or {}).get("loop_count", 0),
+            ),
             section=section,
             required=s.get("required", default_required),
             gate=gate,

--- a/src/mantis_agent/plan_decomposer.py
+++ b/src/mantis_agent/plan_decomposer.py
@@ -1155,14 +1155,14 @@ class PlanDecomposer:
             # the inner extraction loop never iterated past the first
             # card (1 lead vs the expected 25-40). Live repro
             # 2026-05-24 verification run 20260524_172252_88d4e49e.
-            loop_target=s.get(
-                "loop_target",
-                (s.get("params") or {}).get("loop_target", -1),
-            ),
-            loop_count=s.get(
-                "loop_count",
-                (s.get("params") or {}).get("loop_count", 0),
-            ),
+            #
+            # Uses the already-validated ``params`` dict (line ~1126
+            # coerces non-dict shapes to {}). Re-fetching via
+            # ``s.get("params")`` would crash on malformed plans where
+            # params is a string (pinned by
+            # ``test_build_intent_params_rejects_non_dict``).
+            loop_target=s.get("loop_target", params.get("loop_target", -1)),
+            loop_count=s.get("loop_count", params.get("loop_count", 0)),
             section=section,
             required=s.get("required", default_required),
             gate=gate,

--- a/tests/test_decomposer_loop_param_fallback.py
+++ b/tests/test_decomposer_loop_param_fallback.py
@@ -1,0 +1,97 @@
+"""Regression test for the boattrader urlnav 1-lead-instead-of-40 gap.
+
+The canonical plan author put ``loop_target`` and ``loop_count`` inside
+``params`` instead of at the top level. ``PlanDecomposer._build_intent``
+read only the top-level keys, so loops landed with
+``loop_target=-1, loop_count=0``. ``_fix_loop_targets`` rescues
+``loop_target`` for extraction loops by retargeting to the first
+extraction click step; nothing rescued ``loop_count``. The runner's
+``_handle_loop_step`` self-spun on the loop step's own index when
+``loop_target < 0`` (pre-_fix_loop_targets) and exhausted the
+section-cap fallback without iterating the body.
+
+The fix lets ``_build_intent`` fall back to ``params['loop_target']``
+and ``params['loop_count']`` when the top-level keys are absent.
+Backward compatible — Claude-emitted plans still set both at the top
+level and win.
+"""
+
+from __future__ import annotations
+
+from mantis_agent.plan_decomposer import PlanDecomposer
+
+
+def test_build_intent_reads_loop_target_from_params_when_top_level_absent():
+    src = {
+        "type": "loop",
+        "section": "extraction",
+        "params": {"loop_target": 2, "loop_count": 40},
+    }
+    mi = PlanDecomposer._build_intent(src)
+    assert mi.loop_target == 2
+    assert mi.loop_count == 40
+
+
+def test_build_intent_top_level_loop_target_wins_over_params():
+    """When BOTH top-level and params have values, top-level wins.
+    Preserves the canonical decomposer output shape."""
+    src = {
+        "type": "loop",
+        "section": "extraction",
+        "loop_target": 5,
+        "loop_count": 15,
+        "params": {"loop_target": 2, "loop_count": 40},
+    }
+    mi = PlanDecomposer._build_intent(src)
+    assert mi.loop_target == 5
+    assert mi.loop_count == 15
+
+
+def test_build_intent_loop_defaults_when_neither_present():
+    """No top-level, no params keys → default sentinels (-1, 0).
+    Preserves the ``_fix_loop_targets`` rescue path's expectations."""
+    src = {"type": "loop", "section": "extraction"}
+    mi = PlanDecomposer._build_intent(src)
+    assert mi.loop_target == -1
+    assert mi.loop_count == 0
+
+
+def test_build_intent_loop_count_falls_back_to_params_alone():
+    """Mixed shape: top-level loop_target present, loop_count only in
+    params — each falls back independently."""
+    src = {
+        "type": "loop",
+        "section": "extraction",
+        "loop_target": 3,
+        "params": {"loop_count": 25},
+    }
+    mi = PlanDecomposer._build_intent(src)
+    assert mi.loop_target == 3
+    assert mi.loop_count == 25
+
+
+def test_canonical_boattrader_loop_steps_resolve_correctly():
+    """Mimics the canonical ``plans/boattrader_scrape_urlnav`` shape.
+    Both inner and outer loops put loop_target / loop_count in params."""
+    inner_loop = {
+        "index": 9,
+        "type": "loop",
+        "intent": "Loop back to process the next listing",
+        "params": {"loop_target": 2, "loop_count": 40},
+        "section": "extraction",
+        "budget": 0,
+        "reverse": "No reverse needed for loop",
+    }
+    outer_loop = {
+        "index": 11,
+        "type": "loop",
+        "intent": "Loop back to extract listings on the next page",
+        "params": {"loop_target": 2, "loop_count": 20},
+        "section": "pagination",
+        "budget": 0,
+        "reverse": "No reverse needed for loop",
+    }
+    mi_inner = PlanDecomposer._build_intent(inner_loop)
+    mi_outer = PlanDecomposer._build_intent(outer_loop)
+    assert (mi_inner.loop_target, mi_inner.loop_count) == (2, 40)
+    assert (mi_outer.loop_target, mi_outer.loop_count) == (2, 20)


### PR DESCRIPTION
## Summary

`PlanDecomposer._build_intent` now reads `loop_target` and `loop_count` from `params` as a fallback when the top-level keys are absent. Top-level still wins when both are present.

## Why

Live repro 2026-05-24 boattrader verification rerun `20260524_172252_88d4e49e`: a 12-step canonical plan extracted **1 viable lead instead of ~25**. The canonical plan author put `loop_target: 2, loop_count: 40` inside `params` rather than at the top level. `_build_intent` read only the top-level keys, so loops landed with sentinel values:

```
loop_target = -1   (handler self-spins on own index per _handle_loop_step:814)
loop_count  = 0    (falls back to section_caps['extraction'] = 30)
```

`_fix_loop_targets` retargets `loop_target` for extraction-section loops to the first click step — but only AFTER decompose_text. Callers that bypass the full decompose chain (e.g. `MicroIntent(**step_dict)` on Modal workers, sim_envs, prebuilt-suite submissions) saw the self-spin path: state.step_index advanced past step 9 without iterating the body, harvesting only the 1 lead from the very first pass.

## Compatibility

- Plans Claude emits via DECOMPOSE_PROMPT have `loop_target` / `loop_count` at the top level — top-level wins, behavior unchanged.
- Mixed-shape plans (top-level loop_target, params loop_count or vice versa) get each field rescued independently.
- Plans with neither field set keep the existing sentinels (`-1`, `0`) so `_fix_loop_targets` and the section-cap fallback still run.

## Test plan

- [x] `tests/test_decomposer_loop_param_fallback.py` — 5 tests covering top-level-wins, params-fallback, mixed-shape, default-sentinels, and the exact canonical boattrader plan shape.
- [x] Existing 59 decomposer tests still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)