### PR TITLE
feat(plan-tuning): DomainProfile.to_site_config() + SiteConfig.generic() (#657 PR 1)

### DIFF
--- a/src/mantis_agent/plan_tuning/profiles.py
+++ b/src/mantis_agent/plan_tuning/profiles.py
@@ -89,6 +89,55 @@ class DomainProfile:
     # tuple means no opinion.
     expect_url_contains: tuple[str, ...] = field(default_factory=tuple)
 
+    # ── URL classification + pagination knobs (#657) ──
+    # These mirror :class:`mantis_agent.site_config.SiteConfig` fields
+    # so a single DomainProfile entry can drive both the decomposer
+    # pass (scroll/nav knobs above) AND the runner's SiteConfig
+    # (URL patterns + gate prompt below). Empty defaults preserve the
+    # neutral case — a profile without URL fields produces a generic
+    # SiteConfig that's safe for any domain.
+    #
+    # Why on DomainProfile rather than two parallel registries: every
+    # domain that wants tuned scroll/wait usually ALSO wants the right
+    # URL classification (the same operator that observed "scroll
+    # overshoots short pages" already knows what a detail page URL
+    # looks like). Co-locating keeps the per-domain knowledge in one
+    # spot.
+    detail_page_pattern: str = ""        # e.g. r"/boat/[\w-]+"
+    results_page_pattern: str = ""       # e.g. r"/boats/"
+    pagination_format: str = ""          # e.g. "/page-{n}/", "?page={n}"
+    pagination_type: str = ""            # "path_suffix" | "query_param" | "next_button"
+    pagination_strip_pattern: str = ""   # regex stripping the page param
+    filtered_results_url: str = ""       # canonical filter URL for filter-recovery
+    gate_verify_prompt: str = ""         # prefix for verify_gate prompts
+
+    def to_site_config(self) -> "SiteConfig":
+        """Render the profile as a :class:`SiteConfig`.
+
+        Empty URL fields stay empty — the resulting SiteConfig is the
+        "generic" shape (``is_detail_page`` falls back to the path-
+        extension heuristic, ``is_results_page`` returns False, no
+        pagination synthesis). Domains with concrete URL knobs get
+        the full classification + pagination behavior.
+
+        The plan-tuning knobs (scroll_backend, scroll_count,
+        nav_wait_seconds, expect_url_contains, pagination_url_template)
+        are NOT mirrored onto SiteConfig — they're consumed by the
+        decomposer pass and stamped on individual plan steps, not on
+        the runner's per-run SiteConfig.
+        """
+        from ..site_config import SiteConfig
+        return SiteConfig(
+            domain=self.domain,
+            detail_page_pattern=self.detail_page_pattern,
+            results_page_pattern=self.results_page_pattern,
+            pagination_format=self.pagination_format,
+            pagination_type=self.pagination_type or "path_suffix",
+            pagination_strip_pattern=self.pagination_strip_pattern,
+            filtered_results_url=self.filtered_results_url,
+            gate_verify_prompt=self.gate_verify_prompt,
+        )
+
 
 # ── Registry ─────────────────────────────────────────────────────────
 #
@@ -117,6 +166,20 @@ DOMAIN_PROFILES: dict[str, DomainProfile] = {
             "8s nav wait covers CF-proxy first paint."
         ),
         expect_url_contains=("/boat/",),
+        # URL classification + pagination — mirrors the legacy
+        # ``SiteConfig.default_boattrader()`` so the runner gets the
+        # same per-domain SiteConfig that's hardcoded today. After
+        # #657 the runner reads SiteConfig from the suite (built via
+        # ``to_site_config()``), this is the source of truth.
+        detail_page_pattern=r"/boat/[\w-]+",
+        results_page_pattern=r"/boats/",
+        pagination_format="/page-{n}/",
+        pagination_type="path_suffix",
+        pagination_strip_pattern=r"/page-\d+/?$",
+        filtered_results_url="https://www.boattrader.com/boats/by-owner/",
+        gate_verify_prompt=(
+            "Page is a filtered results page with these active filters: "
+        ),
     ),
     # lu.ma — SPA cold-mount: Vite/React app hasn't mounted in 4s on
     # a fresh profile. ``feedback_spa_cold_mount_wait.md`` documents

--- a/src/mantis_agent/plan_tuning/profiles.py
+++ b/src/mantis_agent/plan_tuning/profiles.py
@@ -34,6 +34,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from ..plan_decomposer import MicroPlan
+    from ..site_config import SiteConfig
 
 
 @dataclass(frozen=True)

--- a/src/mantis_agent/site_config.py
+++ b/src/mantis_agent/site_config.py
@@ -245,6 +245,24 @@ class SiteConfig:
         )
 
     @classmethod
+    def generic(cls) -> SiteConfig:
+        """The neutral default — no URL patterns, no pagination synthesis,
+        no gate-prompt prefix.
+
+        ``is_detail_page`` falls back to the path-extension heuristic
+        when a ``base_url`` is supplied (works for CRM-shape URLs like
+        ``/contacts/123``), else returns False. ``is_results_page``
+        returns False. ``paginated_url`` returns the base URL unchanged.
+
+        Use this as the default for callers that don't have a
+        :class:`~mantis_agent.plan_tuning.DomainProfile` lookup — the
+        framework primitives are designed to no-op cleanly on
+        unset patterns rather than apply boattrader-shaped defaults.
+        See #657 for context.
+        """
+        return cls()
+
+    @classmethod
     def default_boattrader(cls) -> SiteConfig:
         """The current hardcoded BoatTrader patterns for backward compatibility."""
         return cls(

--- a/tests/test_domain_profile_to_site_config_657.py
+++ b/tests/test_domain_profile_to_site_config_657.py
@@ -1,0 +1,165 @@
+"""#657 PR 1 — DomainProfile.to_site_config() + SiteConfig.generic().
+
+Foundational PR for the de-boattrader-ification work. Pins:
+
+  - DomainProfile carries the URL-classification + pagination fields
+    that today live only on ``SiteConfig.default_boattrader()``.
+  - ``DomainProfile.to_site_config()`` renders a SiteConfig that's
+    byte-equal (on the load-bearing fields) to the legacy default for
+    boattrader.com — proves the registry can replace the hardcoded
+    default with no regression.
+  - ``SiteConfig.generic()`` is the neutral fallback for unknown
+    domains: empty patterns, falls back to the path-extension
+    heuristic when a base_url is available.
+  - Profiles without URL fields produce a generic-shaped SiteConfig
+    (lu.ma, staffai today — they only set nav_wait, not URL patterns).
+"""
+
+from __future__ import annotations
+
+from mantis_agent.plan_tuning import DOMAIN_PROFILES, DomainProfile, resolve_domain_profile
+from mantis_agent.site_config import SiteConfig
+
+
+# ── SiteConfig.generic() ────────────────────────────────────────────
+
+
+def test_generic_site_config_has_empty_url_patterns():
+    s = SiteConfig.generic()
+    assert s.detail_page_pattern == ""
+    assert s.results_page_pattern == ""
+    assert s.pagination_format == ""
+    assert s.gate_verify_prompt == ""
+    assert s.filtered_results_url == ""
+
+
+def test_generic_is_detail_page_falls_back_to_path_extension():
+    """Without a regex, ``is_detail_page`` returns True when child
+    URL extends the base path with at least one new segment — the
+    CRM-shape pattern (``/contacts`` → ``/contacts/123``)."""
+    s = SiteConfig.generic()
+    assert s.is_detail_page(
+        "https://example.com/contacts/123",
+        "https://example.com/contacts",
+    )
+    # Same URL → not a detail page.
+    assert not s.is_detail_page(
+        "https://example.com/contacts",
+        "https://example.com/contacts",
+    )
+    # No base_url → returns False (no signal).
+    assert not s.is_detail_page("https://example.com/anything")
+
+
+def test_generic_is_results_page_returns_false_when_no_pattern():
+    s = SiteConfig.generic()
+    assert not s.is_results_page("https://example.com/listings")
+
+
+def test_generic_paginated_url_returns_base_unchanged():
+    s = SiteConfig.generic()
+    assert s.paginated_url("https://example.com/listings", 2) == (
+        "https://example.com/listings"
+    )
+
+
+# ── DomainProfile.to_site_config() ─────────────────────────────────
+
+
+def _site_config_load_bearing_fields(s: SiteConfig) -> tuple:
+    """The fields callers actually read at runtime (used by tests to
+    compare without dragging in implementation-detail fields like
+    ``prefer_som_grounding`` that aren't yet on DomainProfile)."""
+    return (
+        s.domain,
+        s.detail_page_pattern,
+        s.results_page_pattern,
+        s.pagination_format,
+        s.pagination_type,
+        s.pagination_strip_pattern,
+        s.gate_verify_prompt,
+        s.filtered_results_url,
+    )
+
+
+def test_boattrader_profile_renders_to_default_boattrader_site_config():
+    """The boattrader DomainProfile must produce a SiteConfig
+    byte-equal (on load-bearing fields) to
+    ``SiteConfig.default_boattrader()`` — proves the registry can
+    drop-in replace the hardcoded default without behavior change."""
+    profile = DOMAIN_PROFILES["boattrader.com"]
+    rendered = profile.to_site_config()
+    legacy = SiteConfig.default_boattrader()
+    assert _site_config_load_bearing_fields(rendered) == _site_config_load_bearing_fields(legacy)
+
+
+def test_profile_without_url_fields_renders_to_generic_shape():
+    """A DomainProfile with only the plan-tuning knobs set (lu.ma,
+    staffai) produces a SiteConfig whose URL patterns are all empty
+    — equivalent to ``SiteConfig.generic()`` apart from the ``domain``
+    label."""
+    p = DOMAIN_PROFILES["lu.ma"]
+    rendered = p.to_site_config()
+    assert rendered.detail_page_pattern == ""
+    assert rendered.results_page_pattern == ""
+    assert rendered.pagination_format == ""
+    assert rendered.filtered_results_url == ""
+    assert rendered.gate_verify_prompt == ""
+    # Domain label is preserved so observability surfaces can show
+    # which domain the SiteConfig is for.
+    assert rendered.domain == "lu.ma"
+
+
+def test_to_site_config_pagination_type_defaults_to_path_suffix():
+    """When the profile doesn't set ``pagination_type``, SiteConfig
+    gets the legacy default ``"path_suffix"`` (matches
+    ``SiteConfig.__dataclass_fields__`` default)."""
+    p = DomainProfile(domain="test.com")
+    s = p.to_site_config()
+    assert s.pagination_type == "path_suffix"
+
+
+def test_to_site_config_honors_query_param_pagination():
+    """A profile that opts into query-param pagination (Zillow-shape)
+    gets that flavor preserved end to end."""
+    p = DomainProfile(
+        domain="example.com",
+        # ``pagination_format`` for query_param is just the
+        # ``key=value`` body — ``paginated_url`` adds the leading
+        # ``?`` (first param) or ``&`` (subsequent) separator.
+        pagination_format="page={n}",
+        pagination_type="query_param",
+        pagination_strip_pattern=r"[?&]page=\d+",
+    )
+    s = p.to_site_config()
+    assert s.pagination_format == "page={n}"
+    assert s.pagination_type == "query_param"
+    # Verify the actual URL synthesis matches the profile.
+    assert s.paginated_url("https://example.com/listings", 3) == (
+        "https://example.com/listings?page=3"
+    )
+
+
+def test_resolve_then_to_site_config_round_trip_for_subdomain():
+    """A plan that lands on a subdomain still resolves to the
+    parent's profile (suffix match), and the SiteConfig renders
+    with the parent's URL knobs."""
+    p = resolve_domain_profile("www.boattrader.com")
+    assert p is not None
+    s = p.to_site_config()
+    assert s.detail_page_pattern == r"/boat/[\w-]+"
+    assert s.is_detail_page("https://www.boattrader.com/boat/1986-marine-trader-europa-10167773/")
+
+
+# ── Round-trip via to_dict / from_dict ─────────────────────────────
+
+
+def test_site_config_round_trips_through_dict():
+    """The SiteConfig produced by a DomainProfile must survive
+    ``to_dict`` / ``from_dict`` — needed by #657 PR 2 which writes
+    the SiteConfig into the suite payload as JSON."""
+    profile = DOMAIN_PROFILES["boattrader.com"]
+    rendered = profile.to_site_config()
+    serialised = rendered.to_dict()
+    revived = SiteConfig.from_dict(serialised)
+    assert _site_config_load_bearing_fields(rendered) == _site_config_load_bearing_fields(revived)

--- a/tests/test_domain_profile_to_site_config_657.py
+++ b/tests/test_domain_profile_to_site_config_657.py
@@ -12,7 +12,7 @@ Foundational PR for the de-boattrader-ification work. Pins:
     domains: empty patterns, falls back to the path-extension
     heuristic when a base_url is available.
   - Profiles without URL fields produce a generic-shaped SiteConfig
-    (lu.ma, staffai today — they only set nav_wait, not URL patterns).
+    (lu.ma, mantis-crm today — only set nav_wait, not URL patterns).
 """
 
 from __future__ import annotations
@@ -95,9 +95,9 @@ def test_boattrader_profile_renders_to_default_boattrader_site_config():
 
 def test_profile_without_url_fields_renders_to_generic_shape():
     """A DomainProfile with only the plan-tuning knobs set (lu.ma,
-    staffai) produces a SiteConfig whose URL patterns are all empty
-    — equivalent to ``SiteConfig.generic()`` apart from the ``domain``
-    label."""
+    mantis-crm) produces a SiteConfig whose URL patterns are all
+    empty — equivalent to ``SiteConfig.generic()`` apart from the
+    ``domain`` label."""
     p = DOMAIN_PROFILES["lu.ma"]
     rendered = p.to_site_config()
     assert rendered.detail_page_pattern == ""


### PR DESCRIPTION
## Summary

Foundational PR for #657 — lifts boattrader's hardcoded SiteConfig defaults into the per-domain DomainProfile registry. Pure plumbing; no behaviour change at runtime. Stacks on #652 (the DomainProfile registry).

- `DomainProfile` gains URL-classification + pagination knobs (`detail_page_pattern`, `results_page_pattern`, `pagination_format`, `pagination_type`, `pagination_strip_pattern`, `filtered_results_url`, `gate_verify_prompt`).
- `DomainProfile.to_site_config()` renders these into a `SiteConfig`. Empty fields render to the neutral shape.
- Boattrader profile populated with the exact values today's `SiteConfig.default_boattrader()` hardcodes — guarantees zero regression once PR 2 wires consumers.
- `SiteConfig.generic()` factory documents the neutral default for callers without a DomainProfile match.

## PR series for #657

| PR | Scope |
|---|---|
| **This PR (PR 1)** | DomainProfile URL fields + `.to_site_config()` + `SiteConfig.generic()` |
| PR 2 (next) | `build_micro_suite` writes `_site_config`; HTTP `_run_holo3_executor` reads it |
| PR 3 (next) | Swap `MicroPlanRunner` default to `generic()`; strip `{"boats"}` + `/boat/` literals; `DEFAULT_PAGINATION_URL_TEMPLATE` → `""` |

## Regression risk

**Zero for boattrader plans.** Boattrader DomainProfile entry now carries every field `SiteConfig.default_boattrader()` hardcodes. Once PR 2 wires consumers, the runtime SiteConfig is byte-identical for any plan with `domain="boattrader.com"`. Pinned by `test_boattrader_profile_renders_to_default_boattrader_site_config`.

**Improvement (not regression) for non-boattrader plans** after PR 3 lands: the runner stops silently applying boattrader regex to lu.ma/staffai/anything-else.com URLs.

## Test plan

- [x] `tests/test_domain_profile_to_site_config_657.py` — 10 new tests:
  - `SiteConfig.generic()` shape + path-extension fallback for `is_detail_page`.
  - Boattrader `to_site_config()` byte-equal to `default_boattrader()` on load-bearing fields.
  - Profile without URL fields → generic-shape SiteConfig (lu.ma, staffai).
  - Query-param pagination round-trip (Zillow-shape).
  - Subdomain resolution → parent profile URL knobs.
  - `to_dict` / `from_dict` round-trip for suite-payload writes (PR 2 dependency).
- [x] Existing 25 DomainProfile tests (#652) still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)