### PR TITLE
fix(augur): mint unique step_id per emission so loop iterations don't collapse (#659)

### DIFF
--- a/src/mantis_agent/observability/augur.py
+++ b/src/mantis_agent/observability/augur.py
@@ -304,6 +304,15 @@ class AugurAdapter:
     ) -> None:
         self._session: Any = None
         self._emitted_event_count: int = 0
+        # #659: per-step-index emission counter — used by
+        # :meth:`_build_step_trace` to mint a unique ``step_id`` for
+        # each emission even when the same plan ``step_index`` fires
+        # multiple times (inner-loop iterations). Without this, all
+        # iterations of step 2 in a 30-card extraction loop write to
+        # ``step-0003`` on the Augur server and last-write-wins,
+        # collapsing the trace down to one row per plan position. Keyed
+        # by the 1-based ``augur_index`` (matches ``step_id`` prefix).
+        self._step_emission_counts: dict[int, int] = {}
         # Verbose diagnostic — gated by ``MANTIS_AUGUR_VERBOSE``. WARN
         # is the only level that survives Modal's INFO/DEBUG suppression,
         # so when verifying a deploy operators flip the flag and get one
@@ -1156,8 +1165,17 @@ class AugurAdapter:
         # uses the 1-based index too so it lines up with the URL path.
         raw_index = int(getattr(sr, "step_index", 0))
         augur_index = raw_index + 1
+        # #659: per-emission ``step_id`` so loop-iterated dispatches
+        # don't collapse on the Augur server. ``step_index`` stays the
+        # plan position (Augur UI groups by it); ``step_id`` carries
+        # the iteration suffix (``-000`` for the first emission of a
+        # given index, ``-001`` for the second, …). Cumulative emission
+        # count per index is exposed via the suffix for downstream
+        # consumers that want "how many iterations did step N run".
+        emission = self._step_emission_counts.get(augur_index, 0)
+        self._step_emission_counts[augur_index] = emission + 1
         trace: dict[str, Any] = {
-            "step_id": f"step-{augur_index:04d}",
+            "step_id": f"step-{augur_index:04d}-{emission:03d}",
             "step_index": augur_index,
             "intent": str(getattr(sr, "intent", "") or "")[:500] or "(no intent)",
             "step_type": action_type or step_type or "unknown",

--- a/tests/test_augur_step_id_unique_per_emission_659.py
+++ b/tests/test_augur_step_id_unique_per_emission_659.py
@@ -28,7 +28,15 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
-from mantis_agent.observability.augur import AugurAdapter
+import pytest
+
+# Match the convention from ``tests/test_observability_augur.py``:
+# skip the whole module when ``augur_sdk`` isn't importable so CI
+# environments that don't bundle the SDK don't fail on attribute access
+# against a ``None`` session.
+pytest.importorskip("augur_sdk")
+
+from mantis_agent.observability.augur import AugurAdapter  # noqa: E402
 
 
 def _stub_step_result(step_index: int, *, success: bool = True) -> SimpleNamespace:
@@ -184,6 +192,12 @@ def test_record_step_increments_counter_via_public_api(tmp_path, monkeypatch):
     surface (not just the internal ``_build_step_trace`` helper)."""
     monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
     a = _open_adapter(tmp_path)
+    # Guard against environments where ``augur-sdk`` is importable but
+    # the SDK refuses to open a session (DSN policy / version skew).
+    # Without this the spy on the next line dereferences ``None``.
+    if not a.active:
+        pytest.skip("AugurAdapter inactive — SDK opened no session")
+
     # Stash a spy on the session so we capture the trace dicts the
     # SDK would have received.
     captured: list[dict] = []

--- a/tests/test_augur_step_id_unique_per_emission_659.py
+++ b/tests/test_augur_step_id_unique_per_emission_659.py
@@ -1,0 +1,204 @@
+"""#659 — Augur ``step_id`` must be unique per emission so loop-iterated
+plan steps don't collapse on the Augur server.
+
+Live repro (boattrader rerun ``20260524_180432_d308f9de``,
+workflow_id ``boattrader-verify-upgrades-rerun-1779645859``):
+
+  Worker MICRO-PLAN COMPLETE: ``Steps: 291`` over 60 min
+  Augur UI:                    ``10 steps``
+
+The inner extraction loop iterated step 2 (click) 33 times. Each
+emission wrote to ``step_id="step-0003"``. Augur server keyed on
+``step_id`` and replaced in place — net 1 row visible per plan
+position.
+
+Contract pinned here:
+  - First emission for ``step_index=N`` → ``step_id=step-{N+1:04d}-000``
+  - Second emission for the same index → ``…-001``
+  - Different indices accumulate counts independently.
+  - The ``step_index`` field STAYS the plan position so Augur UI can
+    group by it.
+  - The adapter's ``_step_emission_counts`` resets across adapter
+    instances (each run gets a fresh AugurAdapter, fresh counts).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from mantis_agent.observability.augur import AugurAdapter
+
+
+def _stub_step_result(step_index: int, *, success: bool = True) -> SimpleNamespace:
+    """Minimal StepResult shape that ``_build_step_trace`` reads."""
+    return SimpleNamespace(
+        step_index=step_index,
+        intent=f"step{step_index}",
+        success=success,
+        verdict=SimpleNamespace(kind="ok", reason="", confidence=1.0),
+        data="",
+        failure_class="",
+        last_action=None,
+        duration=0.0,
+        page_title="",
+        executor_backend="",
+        reasoning="",
+    )
+
+
+def _open_adapter(tmp_path: Path) -> AugurAdapter:
+    """AugurAdapter writing to ``tmp_path`` so we exercise the real
+    streaming path without polluting global ``data/augur/`` dir."""
+    return AugurAdapter(
+        run_id="step_id_test", tenant_id="t", session_name="s",
+        out_dir=tmp_path,
+    )
+
+
+def test_first_emission_for_index_carries_suffix_zero(tmp_path):
+    a = _open_adapter(tmp_path)
+    trace = a._build_step_trace(
+        _stub_step_result(step_index=0),
+        started_at="", ended_at="",
+        observation_pre=None, observation_post=None,
+    )
+    assert trace["step_id"] == "step-0001-000"
+    assert trace["step_index"] == 1
+
+
+def test_second_emission_for_same_index_increments_suffix(tmp_path):
+    """Loop iteration shape — same plan position, multiple emissions."""
+    a = _open_adapter(tmp_path)
+    a._build_step_trace(
+        _stub_step_result(step_index=2),
+        started_at="", ended_at="",
+        observation_pre=None, observation_post=None,
+    )
+    second = a._build_step_trace(
+        _stub_step_result(step_index=2),
+        started_at="", ended_at="",
+        observation_pre=None, observation_post=None,
+    )
+    assert second["step_id"] == "step-0003-001"
+    # step_index still tracks plan position (so Augur UI can group).
+    assert second["step_index"] == 3
+
+
+def test_loop_iteration_produces_n_distinct_step_ids(tmp_path):
+    """33 inner-loop iterations of step 2 → 33 distinct step_ids."""
+    a = _open_adapter(tmp_path)
+    seen_ids: set[str] = set()
+    for _ in range(33):
+        trace = a._build_step_trace(
+            _stub_step_result(step_index=2),
+            started_at="", ended_at="",
+            observation_pre=None, observation_post=None,
+        )
+        seen_ids.add(trace["step_id"])
+    assert len(seen_ids) == 33
+    # Sanity: lowest and highest suffix bracket the range.
+    assert "step-0003-000" in seen_ids
+    assert "step-0003-032" in seen_ids
+
+
+def test_emission_counts_isolated_per_step_index(tmp_path):
+    """Different plan step_indices accumulate counts independently —
+    re-emitting step 2 doesn't bump step 5's counter."""
+    a = _open_adapter(tmp_path)
+    a._build_step_trace(
+        _stub_step_result(step_index=2),
+        started_at="", ended_at="",
+        observation_pre=None, observation_post=None,
+    )
+    a._build_step_trace(
+        _stub_step_result(step_index=2),
+        started_at="", ended_at="",
+        observation_pre=None, observation_post=None,
+    )
+    # Step 5's first emission gets suffix 0 (not 2).
+    trace5 = a._build_step_trace(
+        _stub_step_result(step_index=5),
+        started_at="", ended_at="",
+        observation_pre=None, observation_post=None,
+    )
+    assert trace5["step_id"] == "step-0006-000"
+
+
+def test_fresh_adapter_instance_starts_with_zero_counts(tmp_path):
+    """Each run gets a fresh AugurAdapter → fresh emission counts.
+    Pins the 'no cross-run leakage' invariant."""
+    a1 = _open_adapter(tmp_path / "a1")
+    a1._build_step_trace(
+        _stub_step_result(step_index=0),
+        started_at="", ended_at="",
+        observation_pre=None, observation_post=None,
+    )
+    a2 = _open_adapter(tmp_path / "a2")
+    trace = a2._build_step_trace(
+        _stub_step_result(step_index=0),
+        started_at="", ended_at="",
+        observation_pre=None, observation_post=None,
+    )
+    assert trace["step_id"] == "step-0001-000"
+
+
+def test_step_id_suffix_zero_padded_to_3_digits(tmp_path):
+    """The suffix is 3-digit zero-padded so lexicographic sort matches
+    numeric sort up through 999 iterations. (1000+ iterations is well
+    beyond any realistic plan; if it ever matters, expand padding —
+    until then 3 digits is the sweet spot for trace UIs.)"""
+    a = _open_adapter(tmp_path)
+    for i in range(15):
+        trace = a._build_step_trace(
+            _stub_step_result(step_index=4),
+            started_at="", ended_at="",
+            observation_pre=None, observation_post=None,
+        )
+    # 15th emission (0-indexed): suffix should be '014'
+    assert trace["step_id"] == "step-0005-014"
+
+
+def test_step_index_field_unchanged_across_emissions(tmp_path):
+    """``step_index`` is the Augur grouping key — must NOT change
+    across iterations of the same plan position."""
+    a = _open_adapter(tmp_path)
+    indices = []
+    for _ in range(5):
+        trace = a._build_step_trace(
+            _stub_step_result(step_index=2),
+            started_at="", ended_at="",
+            observation_pre=None, observation_post=None,
+        )
+        indices.append(trace["step_index"])
+    assert indices == [3, 3, 3, 3, 3]
+
+
+# ── End-to-end shape: record_step → counter increments ──
+
+
+def test_record_step_increments_counter_via_public_api(tmp_path, monkeypatch):
+    """``record_step`` is the canonical entrypoint — verify the
+    per-emission counter advances when callers use the documented
+    surface (not just the internal ``_build_step_trace`` helper)."""
+    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
+    a = _open_adapter(tmp_path)
+    # Stash a spy on the session so we capture the trace dicts the
+    # SDK would have received.
+    captured: list[dict] = []
+    real_record = a._session.record_step
+    a._session.record_step = MagicMock(side_effect=lambda t: captured.append(t) or real_record(t))
+
+    for _ in range(4):
+        a.record_step(
+            step_result=_stub_step_result(step_index=2),
+            started_at="2026-05-24T00:00:00Z", ended_at="2026-05-24T00:00:01Z",
+            step_type="click",
+        )
+
+    ids = [t["step_id"] for t in captured]
+    assert ids == [
+        "step-0003-000", "step-0003-001",
+        "step-0003-002", "step-0003-003",
+    ]

--- a/tests/test_observability_augur.py
+++ b/tests/test_observability_augur.py
@@ -511,7 +511,10 @@ def test_step_index_and_attempt_are_clamped_to_augur_minimums(monkeypatch, tmp_p
     sr.recovery_decision = SimpleNamespace(type="retry", reason="x", attempt=0)
     trace = a._build_step_trace(sr, "2026-05-19T10:00:00Z", "2026-05-19T10:00:01Z", None, None)
     assert trace["step_index"] == 1, "Mantis 0 → Augur 1"
-    assert trace["step_id"] == "step-0001"
+    # #659: step_id carries the per-emission suffix so loop-iterated
+    # dispatches don't collapse on the Augur server. First emission
+    # for step_index=0 → ``step-0001-000``.
+    assert trace["step_id"] == "step-0001-000"
     assert trace["recovery_decision"]["attempt"] == 1, "0 clamped to schema minimum"
 
     # Observation paths should also be 1-based (line up with step_id)


### PR DESCRIPTION
## Summary

`AugurAdapter._build_step_trace` was keying `step_id` solely on the plan-level `step_index`. When the inner extraction loop iterates the same plan position N times, all N emissions wrote to the same `step_id` and the Augur server upserted in place — leaving only 1 row visible per plan position regardless of iteration count.

Closes #659.

## Live repro

Boattrader rerun `20260524_180432_d308f9de` (workflow_id `boattrader-verify-upgrades-rerun-1779645859`):

| Source | Step count |
|---|---:|
| Worker MICRO-PLAN COMPLETE summary | **291 dispatches** (60 min cap) |
| Augur UI | **10 steps** |
| Leads extracted | 34 |

Historical CLI fan-out runs (v5: 51 / v6: 64 / v7: 33 steps) showed many more rows because `prepare_phase2_suites` rewrites the inner loop into a flat per-URL sequence — each URL gets a unique `step_index`. The sequential HTTP path's loop iteration collapses on the upsert key.

## Fix

`AugurAdapter` tracks a per-step-index emission counter. `_build_step_trace` mints:

```python
emission = self._step_emission_counts.get(augur_index, 0)
self._step_emission_counts[augur_index] = emission + 1
step_id = f"step-{augur_index:04d}-{emission:03d}"
```

- First emission for `step_index=2` → `step-0003-000`
- Second emission for same index → `step-0003-001`
- 33-iteration loop produces 33 distinct step_ids
- `step_index` field unchanged → Augur UI still groups by plan position
- Per-step-index counts isolated (emitting step 2 doesn't bump step 5)
- Adapter-local state — resets across instances (fresh AugurAdapter per run)

## Backward compat

`step_id` is opaque to the SDK / server. Existing tests pinning `step-0001` format updated to `step-0001-000`.

## Test plan

- [x] 8 new tests in `tests/test_augur_step_id_unique_per_emission_659.py`
  - first emission suffix `000`
  - second emission for same index → `001`
  - 33-iteration shape produces 33 distinct step_ids
  - per-step-index isolation
  - fresh adapter instance starts with zero counts
  - 3-digit zero-padded suffix (lex sort = numeric sort up to 999)
  - `step_index` field unchanged across emissions
  - `record_step` public API end-to-end shape
- [x] Existing 69 Augur observability tests still green (1 updated for the new step_id format).
- [x] ruff clean

## Verification

After this lands, a sequential boattrader rerun should show 200+ step rows in Augur (one per worker dispatch) matching what the worker's `MICRO-PLAN COMPLETE` line reports — restoring per-iteration trace visibility lost in #644's pre-fanout-on-HTTP era.

🤖 Generated with [Claude Code](https://claude.com/claude-code)