### PR TITLE
fix(executor): skip envelopes bypass _handle_failure (re-land of stranded #655)

### DIFF
--- a/src/mantis_agent/gym/run_executor.py
+++ b/src/mantis_agent/gym/run_executor.py
@@ -363,6 +363,21 @@ class RunExecutor:
             if step_result.success:
                 self._handle_success(plan, state, step, step_result)
                 continued = True
+            elif step_result.skip:
+                # #643 stage 2 + #246 — skip envelopes (guard False,
+                # recipe rejection, navigation_failed promotion, etc.)
+                # encode "this step didn't produce an action but
+                # that's by design, not a failure". The runner's
+                # recovery policy reads success=False and routes
+                # through ``_handle_click_failure`` etc., burning
+                # an env.step (Escape) and jumping to the next loop
+                # step — which silently corrupts a guarded skip into
+                # a real failure path. Advance to the next step
+                # directly; ``_handle_failure`` semantics apply only
+                # to actual missed actions.
+                state.step_index += 1
+                self._persist(plan, state)
+                continued = True
             else:
                 # #541 + fu: auto-pause on CAPTCHA must run BEFORE
                 # ``_handle_failure`` — the recovery policy decides

--- a/tests/test_effective_step_preserves_guard.py
+++ b/tests/test_effective_step_preserves_guard.py
@@ -62,3 +62,62 @@ def test_effective_step_guard_empty_default_preserved():
     eff = _build_effective_step_via_executor(src)
     assert eff.guard == ""
     assert eff.out_var == ""
+
+
+# ── Skip envelope outer-loop bypass ──────────────────────────────────
+
+
+def test_skip_envelope_advances_without_recovery():
+    """``StepResult(success=False, skip=True)`` is the contract that
+    execute_step's guard branch + recipe-rejection paths emit. The
+    outer loop must advance to the next step directly — calling
+    ``_handle_failure`` on a skip envelope routes the skipped step
+    through the click-recovery branch (Escape + jump to loop), which
+    silently corrupts a deliberate skip into a real failure path.
+
+    Live repro 2026-05-24 boattrader verification run
+    20260524_171431_ece15fbb: step 6 guard correctly resolved
+    has_show_more=False but the skip envelope was processed as a
+    click failure.
+    """
+    import os
+    # The skip-bypass branch lives in _execute_inner. Drive the
+    # branch detection logic directly to keep the test focused +
+    # avoid the deep dependency chain RunExecutor._execute_inner
+    # mounts (env, brain, checkpoint persistence, ...).
+    from mantis_agent.gym.checkpoint import StepResult
+
+    skip_result = StepResult(
+        step_index=6, intent="Click Show More", success=False,
+        data="guard:has_show_more=False:skipped",
+        skip=True, skip_reason="guard_has_show_more_false",
+    )
+    # The outer-loop branch condition:
+    #   if success: success path
+    #   elif skip:  advance directly (THIS PR)
+    #   else:       _handle_failure
+    is_success = bool(skip_result.success)
+    is_skip = bool(getattr(skip_result, "skip", False))
+    # Must hit the skip branch BEFORE the failure branch.
+    assert not is_success
+    assert is_skip
+
+
+def test_skip_envelope_outer_loop_bypass_in_run_executor():
+    """Reads the _execute_inner source to confirm the ``elif
+    step_result.skip:`` branch exists between the success and failure
+    branches. A grep-style structural test — cheaper than mocking the
+    whole MicroPlanRunner just to assert a 4-line control-flow
+    change."""
+    import inspect
+    from mantis_agent.gym.run_executor import RunExecutor
+
+    source = inspect.getsource(RunExecutor._execute_inner)
+    # Find the order of the three branches.
+    success_pos = source.find("step_result.success")
+    skip_pos = source.find("step_result.skip")
+    failure_pos = source.find("_handle_failure")
+    assert success_pos < skip_pos < failure_pos, (
+        f"Expected branch order success({success_pos}) < "
+        f"skip({skip_pos}) < failure({failure_pos}). Source:\n{source[:2000]}"
+    )

--- a/tests/test_effective_step_preserves_guard.py
+++ b/tests/test_effective_step_preserves_guard.py
@@ -80,7 +80,6 @@ def test_skip_envelope_advances_without_recovery():
     has_show_more=False but the skip envelope was processed as a
     click failure.
     """
-    import os
     # The skip-bypass branch lives in _execute_inner. Drive the
     # branch detection logic directly to keep the test focused +
     # avoid the deep dependency chain RunExecutor._execute_inner


### PR DESCRIPTION
## Summary

Re-applies the fix from PR #655, which was stranded on its stacked branch base when #654 merged out from under it (classic stacked-PR merge-order trap per \`feedback_stacked_pr_merge_order_traps.md\`).

PR #655 shows MERGED on GitHub but the merge commit landed on \`fix/effective-step-preserves-guard\` AFTER that branch had already been merged to main — net result, #655's content never reached main.

## Verification of the strand

\`\`\`bash
git log origin/main --oneline | grep "skip envelope"  # → empty
grep "elif step_result.skip:" src/mantis_agent/gym/run_executor.py  # → no match on main
\`\`\`

#655's merge commit \`4016915e0c1\` is no longer reachable from main.

## What this PR contains

Cherry-pick of the two commits from #655's branch onto fresh main:

- \`fix(executor): skip envelopes bypass _handle_failure (advance directly)\` — the actual fix
- \`fix(tests): drop unused os import (#655 ruff)\` — the ruff cleanup

The fix inserts an \`elif step_result.skip:\` branch in \`_execute_inner\` between the success and failure branches, so skip envelopes (guard False, recipe rejection, navigation_failed promotion) advance to \`step_index+1\` directly without routing through \`_handle_failure\` → recovery policy.

Live repro 2026-05-24 boattrader rerun \`20260524_171431_ece15fbb\` already validated the fix works end-to-end before #655 was stranded.

## Test plan

- [x] \`tests/test_effective_step_preserves_guard.py\` — 5 tests all green
- [x] ruff clean

Original PR #655 has the full discussion + production log evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)