### PR TITLE
feat(plan-tuning): build_micro_suite writes _site_config; HTTP path reads it (#657 PR 2)

### DIFF
--- a/deploy/modal/modal_cua_server.py
+++ b/deploy/modal/modal_cua_server.py
@@ -892,6 +892,23 @@ def _run_holo3_executor(
             if workflow_id else _uuid_for_augur.uuid4().hex[:12]
         )
 
+        # #657 PR 2: read the per-domain ``SiteConfig`` from the suite
+        # (written by ``build_micro_suite`` after resolving
+        # ``MicroPlan.domain`` → DomainProfile). Passing it explicitly
+        # here means the HTTP path stops silently inheriting the
+        # runner's ``default_boattrader()`` fallback for any plan that
+        # doesn't have a profile entry. ``None`` → runner picks its
+        # default (today still boattrader; flipped to generic in
+        # #657 PR 3).
+        site_config_for_runner = None
+        _sc_dict = task_suite.get("_site_config")
+        if _sc_dict:
+            try:
+                from mantis_agent.site_config import SiteConfig as _SiteConfig
+                site_config_for_runner = _SiteConfig.from_dict(_sc_dict)
+            except Exception as exc:  # noqa: BLE001
+                print(f"  WARNING: _site_config deserialization failed: {exc}")
+
         micro_runner = MicroPlanRunner(
             brain=brain, env=env,
             grounding=grounding, extractor=extractor,
@@ -905,6 +922,11 @@ def _run_holo3_executor(
             on_checkpoint=vol.commit,
             max_cost=task_suite.get("_max_cost", 10.0),
             max_time_minutes=task_suite.get("_max_time_minutes", 180),
+            # #657 PR 2: per-domain SiteConfig resolved from suite.
+            # None means "use runner default" (preserves legacy
+            # behaviour for callers that pre-build a suite without
+            # going through ``build_micro_suite``).
+            site_config=site_config_for_runner,
             # #560: ``None`` (key absent) → runner falls back to
             # ``Holo3StepHandler.DEFAULT_BRAIN_BUDGET_CAPS``.
             brain_budgets=task_suite.get("_brain_budgets"),

--- a/src/mantis_agent/server_utils.py
+++ b/src/mantis_agent/server_utils.py
@@ -1220,7 +1220,7 @@ def build_micro_suite(
     # HTTP path's executor can pick it up. Without this, every HTTP
     # submission silently inherits ``SiteConfig.default_boattrader()``
     # via the runner's fallback at ``micro_runner.py:233`` — boattrader
-    # URL regex applied to lu.ma / staffai / any non-boattrader plan.
+    # URL regex applied to lu.ma / mantis-crm / any non-boattrader plan.
     # Empty DomainProfile match means we skip writing the field; the
     # runner's fallback then takes over (still boattrader-shaped today;
     # #657 PR 3 flips that default to ``SiteConfig.generic()``).

--- a/src/mantis_agent/server_utils.py
+++ b/src/mantis_agent/server_utils.py
@@ -1215,6 +1215,22 @@ def build_micro_suite(
     # param then the default.
     if pagination_url_template:
         suite["_pagination_url_template"] = str(pagination_url_template)
+    # #657 PR 2: resolve a per-domain ``SiteConfig`` from the
+    # DomainProfile registry and persist it as ``_site_config`` so the
+    # HTTP path's executor can pick it up. Without this, every HTTP
+    # submission silently inherits ``SiteConfig.default_boattrader()``
+    # via the runner's fallback at ``micro_runner.py:233`` — boattrader
+    # URL regex applied to lu.ma / staffai / any non-boattrader plan.
+    # Empty DomainProfile match means we skip writing the field; the
+    # runner's fallback then takes over (still boattrader-shaped today;
+    # #657 PR 3 flips that default to ``SiteConfig.generic()``).
+    try:
+        from .plan_tuning import resolve_domain_profile
+        _profile = resolve_domain_profile(domain or "")
+    except Exception:  # noqa: BLE001 — never break suite construction
+        _profile = None
+    if _profile is not None:
+        suite["_site_config"] = _profile.to_site_config().to_dict()
     return suite
 
 

--- a/tests/test_build_suite_writes_site_config_657.py
+++ b/tests/test_build_suite_writes_site_config_657.py
@@ -3,7 +3,7 @@ DomainProfile registry; the HTTP path's runner reads it.
 
 Before this PR, every HTTP submission silently inherited
 ``SiteConfig.default_boattrader()`` via ``MicroPlanRunner.__init__``'s
-fallback. lu.ma / staffai / any non-boattrader plan got boattrader
+fallback. lu.ma / mantis-crm / any non-boattrader plan got boattrader
 URL regex applied to its URLs — ``is_detail_page`` / ``is_results_page``
 returned False everywhere, silently degrading recovery + URL gates.
 

--- a/tests/test_build_suite_writes_site_config_657.py
+++ b/tests/test_build_suite_writes_site_config_657.py
@@ -1,0 +1,111 @@
+"""#657 PR 2 — ``build_micro_suite`` writes ``_site_config`` from the
+DomainProfile registry; the HTTP path's runner reads it.
+
+Before this PR, every HTTP submission silently inherited
+``SiteConfig.default_boattrader()`` via ``MicroPlanRunner.__init__``'s
+fallback. lu.ma / staffai / any non-boattrader plan got boattrader
+URL regex applied to its URLs — ``is_detail_page`` / ``is_results_page``
+returned False everywhere, silently degrading recovery + URL gates.
+
+Contract pinned here:
+  - ``build_micro_suite(domain="boattrader.com", ...)`` writes a
+    ``_site_config`` dict in the suite that round-trips via
+    ``SiteConfig.from_dict`` to a config with the boattrader URL
+    patterns.
+  - ``build_micro_suite(domain="lu.ma", ...)`` writes a generic-shaped
+    SiteConfig (empty regex fields) — the lu.ma DomainProfile sets
+    only nav_wait_seconds, not URL patterns.
+  - ``build_micro_suite(domain="totally-unknown.tld", ...)`` does NOT
+    write ``_site_config`` (no DomainProfile match) — the runner's
+    fallback then takes over.
+  - ``build_micro_suite(domain="", ...)`` does NOT write
+    ``_site_config`` either (empty domain → no profile resolution).
+  - Suite construction must never raise on DomainProfile lookup errors
+    — best-effort and silent on resolution failure.
+"""
+
+from __future__ import annotations
+
+from mantis_agent.server_utils import build_micro_suite
+from mantis_agent.site_config import SiteConfig
+
+
+def _empty_steps() -> list[dict]:
+    return [{"intent": "navigate", "type": "navigate", "params": {}}]
+
+
+def test_boattrader_domain_writes_site_config():
+    suite = build_micro_suite(_empty_steps(), domain="boattrader.com")
+    assert "_site_config" in suite
+    sc = SiteConfig.from_dict(suite["_site_config"])
+    assert sc.detail_page_pattern == r"/boat/[\w-]+"
+    assert sc.results_page_pattern == r"/boats/"
+    assert sc.pagination_format == "/page-{n}/"
+
+
+def test_boattrader_subdomain_matches_via_suffix():
+    """``www.boattrader.com`` resolves to the parent's profile."""
+    suite = build_micro_suite(_empty_steps(), domain="www.boattrader.com")
+    assert "_site_config" in suite
+    sc = SiteConfig.from_dict(suite["_site_config"])
+    assert sc.detail_page_pattern == r"/boat/[\w-]+"
+
+
+def test_luma_domain_writes_generic_shaped_site_config():
+    """lu.ma DomainProfile sets only nav_wait_seconds. The resulting
+    SiteConfig has empty URL patterns — equivalent to generic shape,
+    just with the domain label preserved."""
+    suite = build_micro_suite(_empty_steps(), domain="lu.ma")
+    assert "_site_config" in suite
+    sc = SiteConfig.from_dict(suite["_site_config"])
+    assert sc.domain == "lu.ma"
+    assert sc.detail_page_pattern == ""
+    assert sc.results_page_pattern == ""
+    assert sc.pagination_format == ""
+
+
+def test_unknown_domain_does_not_write_site_config():
+    """Domain without a DomainProfile match → no ``_site_config`` key
+    in the suite. The runner's fallback then takes over (today still
+    boattrader; #657 PR 3 flips that to generic)."""
+    suite = build_micro_suite(_empty_steps(), domain="totally-unknown-12345.tld")
+    assert "_site_config" not in suite
+
+
+def test_empty_domain_does_not_write_site_config():
+    """Empty / missing domain string → no resolution attempt → no
+    ``_site_config`` key. Same fallback behaviour as unknown domain."""
+    suite = build_micro_suite(_empty_steps(), domain="")
+    assert "_site_config" not in suite
+
+
+def test_site_config_round_trips_to_runtime_shape():
+    """End-to-end shape check: the suite's ``_site_config`` dict must
+    deserialize back to a SiteConfig instance whose URL classifiers
+    behave correctly on real URLs."""
+    suite = build_micro_suite(_empty_steps(), domain="boattrader.com")
+    sc = SiteConfig.from_dict(suite["_site_config"])
+    assert sc.is_detail_page("https://www.boattrader.com/boat/1986-marine-trader-europa-10167773/")
+    assert sc.is_results_page("https://www.boattrader.com/boats/state-fl/by-owner/")
+    # Pagination synth: page 2 → /page-2/
+    assert sc.paginated_url("https://www.boattrader.com/boats/state-fl/by-owner/", 2).endswith("/page-2/")
+
+
+def test_site_config_resolution_is_best_effort(monkeypatch):
+    """If DomainProfile resolution raises, suite construction still
+    succeeds — observability never breaks the build path."""
+    def _boom(domain):
+        raise RuntimeError("simulated DomainProfile lookup failure")
+
+    # Resolution is imported inside build_micro_suite — patch the
+    # module path callers will see at runtime.
+    monkeypatch.setattr(
+        "mantis_agent.plan_tuning.resolve_domain_profile",
+        _boom,
+    )
+    suite = build_micro_suite(_empty_steps(), domain="boattrader.com")
+    # No crash, no _site_config (because resolution failed).
+    assert "_site_config" not in suite
+    # Other suite fields still landed.
+    assert "_micro_plan" in suite
+    assert suite["_micro_plan"] == _empty_steps()


### PR DESCRIPTION
## Summary

Wire the per-domain `SiteConfig` from the DomainProfile registry (#648 / #657 PR 1) into the HTTP `/v1/predict` execution path. After this lands, any plan with a known domain gets its proper `SiteConfig` automatically; plans without a match continue to fall through to the runner default (still `default_boattrader()` until #657 PR 3 flips that).

Closes #657 (PR 2 of 3).

## Why

Before this PR, every submission through the HTTP path silently inherited `SiteConfig.default_boattrader()` via `MicroPlanRunner.__init__`'s fallback at `micro_runner.py:233`. lu.ma / staffai / any non-boattrader plan got boattrader URL regex applied to its URLs — `is_detail_page` / `is_results_page` returned False everywhere, silently degrading recovery + URL gates.

## Changes

- **`server_utils.build_micro_suite`** resolves the plan's `domain` through the DomainProfile registry and serializes the resulting `SiteConfig.to_dict()` into the suite under `_site_config`. Unknown / empty domains skip the field (preserves legacy behaviour for callers without a profile match).
- **`deploy/modal/modal_cua_server.py:_run_holo3_executor`** deserializes `_site_config` from the suite and threads it to `MicroPlanRunner(site_config=...)`. Mirrors the CLI path's existing `_site_config` handling at modal_cua_server.py:1278-1281.
- Best-effort: a DomainProfile lookup raising never breaks suite construction (silent fallthrough).

## Compatibility

- **Boattrader plans (production target)**: `boattrader.com` profile has the same URL knobs `default_boattrader()` hardcodes → effective `SiteConfig` is byte-identical. Pinned by `test_boattrader_profile_renders_to_default_boattrader_site_config` from #658.
- **Non-boattrader plans**: behavior change in the right direction — `lu.ma` now gets a SiteConfig with empty URL patterns (path-extension heuristic), instead of boattrader regex that never matched.
- **Plans without a DomainProfile entry**: no `_site_config` key in the suite → runner's existing fallback applies (still boattrader, until #657 PR 3).

## Test plan

- [x] `tests/test_build_suite_writes_site_config_657.py` (7 tests):
  - boattrader → SiteConfig has the right regex / pagination
  - www.boattrader.com → suffix-matches the parent profile
  - lu.ma → generic-shaped (only nav_wait, no URL fields)
  - totally-unknown.tld → no `_site_config` written (fallthrough)
  - empty domain → same
  - SiteConfig round-trips through to_dict / from_dict and behaves correctly on real URLs
  - DomainProfile resolution failure → silent fallthrough (best-effort norm)
- [x] ruff clean
- [x] modal_cua_server.py syntax check passes

## Coming next

**#657 PR 3** — Swap `MicroPlanRunner.__init__` fallback from `SiteConfig.default_boattrader()` to `SiteConfig.generic()`. Strip the `{"boats"}` literal from `derive_filter_tokens`. Drop the `DEFAULT_PAGINATION_URL_TEMPLATE = "{base}/page-{n}/"` framework-level default (orchestrator already reads from `MicroPlan.pagination_url_template`, set by DomainProfile). After PR 3, framework primitives are domain-neutral by default; per-domain knowledge lives entirely in the DomainProfile registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)