### PR TITLE
feat(framework): MicroPlanRunner defaults to SiteConfig.generic(); drop boats literal (closes #657 PR 3)

### DIFF
--- a/src/mantis_agent/gym/_runner_helpers.py
+++ b/src/mantis_agent/gym/_runner_helpers.py
@@ -490,12 +490,21 @@ def extract_url_from_intent(intent: str) -> str:
 
 
 def derive_filter_tokens(url: str) -> tuple[str, ...]:
+    # #657 PR 3: dropped the ``{"boats"}`` literal exclusion that was
+    # a boattrader-specific hack — every boattrader URL has ``boats``
+    # as a path segment, so excluding it produced cleaner filter tokens
+    # for that one domain. Including it is functionally equivalent
+    # downstream (``url_has_required_filters`` checks tokens are a
+    # subset of the URL — ``boats`` is trivially in every boattrader
+    # URL) and removes the last domain-specific literal from this
+    # framework primitive. ``page-`` skip stays since pagination
+    # segments aren't filters by convention across all sites.
     match = re.search(r'https?://[^/]+/([^?#]+)', url)
     if not match:
         return ()
     tokens = []
     for token in match.group(1).strip("/").split("/"):
-        if not token or token in {"boats"} or token.startswith("page-"):
+        if not token or token.startswith("page-"):
             continue
         tokens.append(token.lower())
     return tuple(tokens)

--- a/src/mantis_agent/gym/micro_runner.py
+++ b/src/mantis_agent/gym/micro_runner.py
@@ -230,7 +230,19 @@ class MicroPlanRunner:
         self.dynamic_verifier = (
             dynamic_verifier or DynamicPlanVerifier(plan_name=session_name)
         )
-        self.site_config = site_config or SiteConfig.default_boattrader()
+        # #657 PR 3: default flipped from ``default_boattrader()`` to
+        # ``generic()``. Callers without a per-domain SiteConfig
+        # (now resolved upstream via DomainProfile in ``build_micro_suite``
+        # — see #657 PR 2) get the neutral shape: empty URL patterns,
+        # ``is_detail_page`` falls back to a path-extension heuristic
+        # against the base URL when supplied, ``is_results_page``
+        # returns False. This stops silently applying boattrader URL
+        # regex to every plan that didn't pass a site_config.
+        # Boattrader plans are unaffected — they flow through
+        # build_micro_suite → DomainProfile["boattrader.com"] →
+        # explicit SiteConfig with the same regex/pagination knobs the
+        # legacy ``default_boattrader()`` hardcoded.
+        self.site_config = site_config or SiteConfig.generic()
         self.extraction_cache = extraction_cache
         self.scanner = ListingsScanner()
         if extraction_cache is not None and extraction_cache.read_enabled:

--- a/tests/test_runner_default_site_config_657.py
+++ b/tests/test_runner_default_site_config_657.py
@@ -1,0 +1,117 @@
+"""#657 PR 3 — ``MicroPlanRunner`` defaults to ``SiteConfig.generic()``
+instead of ``SiteConfig.default_boattrader()``. Stripped the
+``{"boats"}`` literal from ``derive_filter_tokens`` while we're here.
+
+Until this PR, every caller that didn't pass an explicit
+``site_config=`` got the boattrader URL regex applied to its plan —
+silently degrading any non-boattrader workflow's URL classification.
+
+Contract pinned here:
+  - A bare ``MicroPlanRunner(...)`` call without ``site_config=``
+    lands with the neutral ``SiteConfig.generic()`` — empty URL
+    patterns, no pagination synthesis, no boattrader-shaped gate
+    prompt prefix.
+  - Boattrader plans submitted through ``build_micro_suite`` still
+    get the boattrader-shaped ``SiteConfig`` via the DomainProfile
+    registry (#648 / #657 PR 1) — unchanged effective behaviour for
+    the canonical production target.
+  - ``derive_filter_tokens`` no longer special-cases the literal
+    ``"boats"`` path segment; pagination segments (``page-N``) still
+    skip as a domain-neutral convention.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from mantis_agent.gym.micro_runner import MicroPlanRunner
+from mantis_agent.gym._runner_helpers import derive_filter_tokens
+from mantis_agent.site_config import SiteConfig
+
+
+# ── MicroPlanRunner default ───────────────────────────────────────
+
+
+def test_micro_plan_runner_default_site_config_is_generic():
+    """Bare runner construction lands with the neutral SiteConfig —
+    no boattrader URL regex, no domain-specific gate prompt prefix."""
+    r = MicroPlanRunner(brain=MagicMock(), env=MagicMock())
+    assert r.site_config.detail_page_pattern == ""
+    assert r.site_config.results_page_pattern == ""
+    assert r.site_config.pagination_format == ""
+    assert r.site_config.gate_verify_prompt == ""
+    assert r.site_config.filtered_results_url == ""
+
+
+def test_micro_plan_runner_explicit_site_config_wins():
+    """Explicit ``site_config=`` arg still overrides the default —
+    callers that thread a SiteConfig (HTTP path via #657 PR 2's
+    ``_site_config`` plumbing, CLI path via the existing
+    ``modal_cua_server.py:1278-1281`` resolution) are unaffected."""
+    custom = SiteConfig(
+        domain="example.com",
+        detail_page_pattern=r"/item/\d+",
+        results_page_pattern=r"/items/",
+    )
+    r = MicroPlanRunner(brain=MagicMock(), env=MagicMock(), site_config=custom)
+    assert r.site_config.detail_page_pattern == r"/item/\d+"
+    assert r.site_config.results_page_pattern == r"/items/"
+    assert r.site_config.domain == "example.com"
+
+
+def test_generic_default_is_truly_neutral():
+    """The new default's ``is_detail_page`` falls back to the path-
+    extension heuristic when a ``base_url`` is supplied — handles
+    CRM-shape URLs (``/contacts`` → ``/contacts/123``) without needing
+    a regex hardcoded."""
+    r = MicroPlanRunner(brain=MagicMock(), env=MagicMock())
+    # Path-extension heuristic via base_url.
+    assert r.site_config.is_detail_page(
+        "https://example.com/contacts/123",
+        base_url="https://example.com/contacts",
+    )
+    # No regex, no base_url → returns False (no signal).
+    assert not r.site_config.is_detail_page("https://example.com/anything")
+    # ``is_results_page`` without a pattern → False.
+    assert not r.site_config.is_results_page("https://example.com/contacts")
+
+
+# ── derive_filter_tokens drops the "boats" literal exclusion ─────
+
+
+def test_derive_filter_tokens_no_longer_special_cases_boats():
+    """Boattrader URL ``/boats/state-fl/by-owner/`` now yields
+    ``("boats", "state-fl", "by-owner")`` instead of
+    ``("state-fl", "by-owner")``. Functionally equivalent downstream
+    — ``url_has_required_filters`` checks the tokens are a subset of
+    the URL, and ``boats`` is trivially in every boattrader URL."""
+    tokens = derive_filter_tokens(
+        "https://www.boattrader.com/boats/state-fl/by-owner/"
+    )
+    assert "boats" in tokens
+    assert "state-fl" in tokens
+    assert "by-owner" in tokens
+
+
+def test_derive_filter_tokens_still_skips_pagination_segments():
+    """``page-N`` segments aren't filters — that exclusion stays as
+    a domain-neutral pagination convention."""
+    tokens = derive_filter_tokens(
+        "https://www.boattrader.com/boats/state-fl/by-owner/page-3/"
+    )
+    assert "page-3" not in tokens
+    assert "page" not in tokens
+    assert "state-fl" in tokens
+
+
+def test_derive_filter_tokens_handles_non_boattrader_url():
+    """Generic CRM-shape URL — no domain-specific magic, just path
+    segments (minus pagination)."""
+    tokens = derive_filter_tokens("https://crm.example/contacts/active/123")
+    assert tokens == ("contacts", "active", "123")
+
+
+def test_derive_filter_tokens_empty_for_bare_host():
+    """No path → no tokens."""
+    assert derive_filter_tokens("https://example.com") == ()
+    assert derive_filter_tokens("https://example.com/") == ()


### PR DESCRIPTION
## Summary

Third and final PR in the de-boattrader-ification series. Composes with #658 (DomainProfile.to_site_config) and #663 (HTTP path reads `_site_config` from suite).

- **`MicroPlanRunner.__init__` fallback flipped** from `SiteConfig.default_boattrader()` → `SiteConfig.generic()`. Callers without an explicit `site_config=` now get the neutral shape: empty URL patterns, `is_detail_page` falls back to a path-extension heuristic against `base_url` when supplied, no boattrader-shaped gate prompt prefix.
- **`derive_filter_tokens` no longer special-cases `"boats"`**. The literal exclusion was a boattrader-specific hack — removing it is functionally equivalent downstream (`url_has_required_filters` checks tokens are a subset of the URL; `boats` is trivially in every boattrader URL). `page-N` skip stays as a domain-neutral pagination convention.

Closes #657.

## Compatibility

- **Boattrader plans through `build_micro_suite` (HTTP path)**: unchanged. `DomainProfile["boattrader.com"]` provides a `SiteConfig` with the same regex/pagination knobs the legacy `default_boattrader()` hardcoded. Pinned by `test_boattrader_profile_renders_to_default_boattrader_site_config` from #658.
- **Boattrader plans through the CLI path**: unchanged. The CLI already resolves `site_config` at modal_cua_server.py:1278-1281.
- **Plans without a DomainProfile entry**: behaviour change in the right direction — neutral SiteConfig with path-extension fallback instead of boattrader regex that never matched.

## Test plan

- [x] `tests/test_runner_default_site_config_657.py` — 7 new tests:
  - Default runner SiteConfig is generic (empty URL patterns)
  - Explicit `site_config=` arg still wins
  - Generic default's `is_detail_page` falls back to path-extension heuristic
  - `derive_filter_tokens` no longer drops `"boats"`
  - `derive_filter_tokens` still drops `page-N`
  - Non-boattrader URLs yield correct token shape
  - Empty / bare-host URLs return empty tuple
- [x] 216 existing tests across site_config / run_executor / browser_state / fanout / micro_runner / domain_profile suites still green.
- [x] ruff clean

## After this lands

`SiteConfig.default_boattrader()` becomes a legacy factory method invoked only by:
- tests (`test_site_config.py`, recipes/marketplace_listings) — fine
- the legacy `default_mantis_crm` etc. siblings — also fine

Operators with a new vertical now add a `DomainProfile` entry (the sanctioned per-domain extension point) instead of carrying patterns through the runner fallback.

## Series wrap-up

- ✅ #648 — DomainProfile registry + decomposer pass (merged)
- ✅ #658 — DomainProfile.to_site_config() + SiteConfig.generic() (merged)
- ✅ #663 — `build_micro_suite` writes `_site_config`; HTTP path reads it (open)
- ✅ **this PR** — flip the runner default + drop the last literal

After all four land, framework primitives are domain-neutral by default; per-domain knowledge lives entirely in the DomainProfile registry + recipes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)