### PR TITLE
feat(hint-memory): store + types + key derivation (#643 Phase 1)

### DIFF
--- a/src/mantis_agent/gym/hint_memory.py
+++ b/src/mantis_agent/gym/hint_memory.py
@@ -1,0 +1,278 @@
+"""Trajectory hint memory (#643) — Phase 1: store + types.
+
+Records successful grounding anchors per
+``(plan_signature, intent_hash, url_pattern)`` so subsequent runs of
+the same plan can replay them as ``hints.preferred_target_description``
+on grounding-heavy steps (``click(Show More)``, ad-hoc reveal toggles,
+custom DOM widgets).
+
+This Phase ships the foundation only: store protocol, in-memory + null
+backends, key-derivation helpers, and the :class:`HintRecord`
+schema. The recording hook (read anchor metadata from Holo3, write to
+the store on step success) and the injection hook (read hints from the
+store, stamp ``preferred_target_description`` on the step) land in
+Phase 1b.
+
+Why a foundation-first split: the anchor metadata that flows out of
+Holo3 today varies by step type (click → `elv_text` + screen xy;
+detect_visible → reason text; extract_data → schema-field anchors).
+Phase 1b will introduce a small adapter per step type so the
+``HintStore`` can stay schema-stable across the lifetime of #643's
+follow-ups (URL-pattern key inference, confidence decay, persistent
+disk backend).
+
+CUA purity (``feedback_cua_no_dom_access.md``): anchors recorded here
+are always visual — screen coordinates relative to a text anchor or
+``elv_text`` strings Holo3 read from the screenshot. No CSS selectors,
+no DOM probes. The store records what the brain SAW, not what the
+DOM CONTAINS.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import re
+import time
+from collections import OrderedDict
+from dataclasses import dataclass, field
+from typing import Iterable, Protocol
+
+logger = logging.getLogger(__name__)
+
+
+# ── Schema ──────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class HintRecord:
+    """One observed anchor — what Holo3 used to ground a step, plus
+    enough metadata for downstream injection / decay.
+
+    Fields
+    ------
+    anchor_text
+        Visual text label the brain anchored on (e.g. ``"Show More"``,
+        ``"Description"``, the ``elv_text`` field Holo3 returned).
+        Always derived from the screenshot, never from the DOM.
+    anchor_xy_offset
+        ``(dx, dy)`` pixel offset from the nearest text anchor in the
+        viewport at click / scroll time. Optional — empty tuple when
+        the recording side doesn't know the offset (e.g. when the
+        anchor IS the click target). Used by the injection side to
+        bias Holo3's grounding window.
+    viewport_stage
+        Scroll stage (0 = above-the-fold, 1 = first scroll, …) the
+        anchor was found at. Helps the injection side warm Holo3 to
+        scroll before grounding rather than searching the wrong slice.
+    confidence
+        How confident the recording call was that this anchor worked.
+        Range ``[0.0, 1.0]``. The recording side picks the value
+        (typically derived from the grounding pass's own confidence
+        signal or 1.0 on plain success); the injection side uses it
+        to skip low-quality records.
+    recorded_at
+        Unix timestamp. Used by ``InMemoryHintStore``'s LRU eviction
+        (oldest record at cap drops out) and by future confidence-
+        decay layers (#643 Phase 2+).
+    source_url
+        URL the anchor was recorded on. Diagnostic — surfaced in the
+        store's iteration interface for operator queries; not used
+        for matching (that's the ``url_pattern`` key).
+    """
+
+    anchor_text: str
+    anchor_xy_offset: tuple[int, int] = (0, 0)
+    viewport_stage: int = 0
+    confidence: float = 1.0
+    recorded_at: float = field(default_factory=time.time)
+    source_url: str = ""
+
+
+@dataclass(frozen=True)
+class HintKey:
+    """Compound key for the hint store.
+
+    Three axes establish "this anchor will probably work HERE":
+
+    * ``plan_signature`` — the 12-char hash of the source plan
+      (already populated everywhere). Same plan ⇒ same flow shape.
+    * ``intent_hash`` — short hash of the step's intent text + step
+      type. Same intent on the same plan ⇒ same target. Decoupled
+      from ``step_index`` because plan refactors (insert / reorder
+      / split) shift indices but rarely rewrite intent prose.
+    * ``url_pattern`` — regex / substring that the recorded source URL
+      matched. Phase 1 uses the registrable domain + first path
+      segment (e.g. ``boattrader.com/boat``); Phase 2 / future work
+      can specialize per recipe.
+    """
+
+    plan_signature: str
+    intent_hash: str
+    url_pattern: str
+
+    def as_tuple(self) -> tuple[str, str, str]:
+        return (self.plan_signature, self.intent_hash, self.url_pattern)
+
+
+# ── Store protocol + backends ──────────────────────────────────────
+
+
+class HintStore(Protocol):
+    """Per-deploy backend for recorded hints. Implementations:
+
+    * :class:`NullHintStore` — every method no-ops; default when the
+      runner isn't wired to a backend. Lets the recording hook fire
+      unconditionally without a feature flag.
+    * :class:`InMemoryHintStore` — single-process backend used by
+      tests and the local fan-out runner; bounded LRU per key.
+    * ``ModalDictHintStore`` (Phase 1b) — modal.Dict backend that
+      survives across fan-out worker boundaries within one deploy.
+    * Disk store (Phase 2) — persists across deploys on the
+      ``/data/hints/`` volume.
+    """
+
+    def add(self, key: HintKey, record: HintRecord) -> None: ...
+    def get(self, key: HintKey) -> list[HintRecord]: ...
+    def size(self) -> int: ...
+
+
+class NullHintStore:
+    """No-op backend. ``add`` swallows, ``get`` returns an empty
+    list, ``size`` is always 0. Lets the recording hook fire on every
+    eligible step without a per-step ``if store is None`` guard.
+    """
+
+    def add(self, key: HintKey, record: HintRecord) -> None:  # noqa: ARG002
+        return None
+
+    def get(self, key: HintKey) -> list[HintRecord]:  # noqa: ARG002
+        return []
+
+    def size(self) -> int:
+        return 0
+
+
+class InMemoryHintStore:
+    """Single-process backend with LRU eviction.
+
+    Keeps up to :attr:`max_per_key` records per key (default 10) —
+    the recording side appends; once full the oldest record drops.
+    Different keys accumulate independently (no global cap in
+    Phase 1; a global ceiling can land in Phase 2 once we observe
+    real memory pressure).
+
+    Records are kept in insertion order; ``get`` returns the list in
+    newest-first order to make injection trivial (pick the top N).
+    """
+
+    def __init__(self, *, max_per_key: int = 10) -> None:
+        # OrderedDict[HintKey.as_tuple(), list[HintRecord]] —
+        # the inner list is mutable; eviction drops the oldest entry
+        # at index 0 when the list reaches ``max_per_key + 1``.
+        self._buckets: OrderedDict[
+            tuple[str, str, str], list[HintRecord]
+        ] = OrderedDict()
+        self.max_per_key = max(1, int(max_per_key))
+
+    def add(self, key: HintKey, record: HintRecord) -> None:
+        bucket = self._buckets.setdefault(key.as_tuple(), [])
+        bucket.append(record)
+        if len(bucket) > self.max_per_key:
+            # LRU eviction — drop the oldest (front of list).
+            bucket.pop(0)
+
+    def get(self, key: HintKey) -> list[HintRecord]:
+        bucket = self._buckets.get(key.as_tuple(), [])
+        # Newest-first for the injection side's "pick top N by
+        # confidence × recency" lookup.
+        return list(reversed(bucket))
+
+    def size(self) -> int:
+        return sum(len(b) for b in self._buckets.values())
+
+    # ── Operator surface ──
+
+    def iter_records(self) -> Iterable[tuple[HintKey, HintRecord]]:
+        """Yield every stored (key, record) pair — diagnostic only.
+        Order isn't guaranteed across implementations; tests should
+        sort or collect into sets before asserting."""
+        for raw_key, bucket in self._buckets.items():
+            plan_sig, intent_hash, url_pattern = raw_key
+            key = HintKey(
+                plan_signature=plan_sig,
+                intent_hash=intent_hash,
+                url_pattern=url_pattern,
+            )
+            for rec in bucket:
+                yield (key, rec)
+
+
+# ── Key derivation helpers ──────────────────────────────────────────
+
+
+def intent_hash_for(step: object) -> str:
+    """Stable 12-hex-char hash of ``step.intent`` + ``step.type``.
+
+    Decoupled from ``step_index`` so plan refactors (insert / reorder
+    / split) that shift indices but preserve intent prose keep the
+    same key. Empty intent / type yield a non-empty hash too (the
+    hashing pipeline never returns "") — defensive against callers
+    that hand us partially-filled step dicts.
+    """
+    intent = str(getattr(step, "intent", "") or "")
+    step_type = str(getattr(step, "type", "") or "")
+    raw = f"{step_type}|{intent}"
+    return hashlib.sha1(raw.encode("utf-8")).hexdigest()[:12]
+
+
+_URL_HOST_SEG_RE = re.compile(
+    r"^https?://(?:www\.)?([^/]+)(?:/([^/?#]+))?",
+    re.IGNORECASE,
+)
+
+
+def url_pattern_for(url: str) -> str:
+    """Phase 1 URL pattern: ``<registrable-host>/<first-path-segment>``.
+
+    Examples:
+        ``https://www.boattrader.com/boat/1986-marine-trader-europa-10/``
+            → ``boattrader.com/boat``
+        ``https://lu.ma/event/abc-123``
+            → ``lu.ma/event``
+        ``https://example.com/`` → ``example.com``
+        ``""`` → ``""``
+
+    Phase 2 / future work (#643 follow-ups): per-recipe URL pattern
+    inference. The marketplace_listings recipe can specialize to
+    include the make/model token so "Show More click anchor for
+    Cruisers Yachts" is keyed separately from generic boat detail
+    pages. Phase 1 keeps the pattern broad (one bucket per host +
+    section) since the in-memory store's per-key LRU cap of 10
+    handles the spread.
+    """
+    if not url:
+        return ""
+    m = _URL_HOST_SEG_RE.match(url.strip())
+    if not m:
+        return ""
+    host = (m.group(1) or "").lower()
+    first_seg = (m.group(2) or "").lower()
+    if not host:
+        return ""
+    if not first_seg:
+        return host
+    return f"{host}/{first_seg}"
+
+
+def hint_key_for(
+    plan_signature: str, step: object, url: str,
+) -> HintKey:
+    """One-shot constructor — derives the per-axis keys and bundles
+    them into a :class:`HintKey`. Phase 1b's recording / injection
+    hooks call this once at their entry points."""
+    return HintKey(
+        plan_signature=str(plan_signature or ""),
+        intent_hash=intent_hash_for(step),
+        url_pattern=url_pattern_for(url),
+    )

--- a/tests/test_hint_memory_643.py
+++ b/tests/test_hint_memory_643.py
@@ -1,0 +1,269 @@
+"""#643 Phase 1 — trajectory hint memory store + types.
+
+Pins the foundation that Phase 1b's recording / injection hooks
+build on. No runner integration yet.
+
+Coverage:
+    - HintRecord schema (defaults, frozen)
+    - HintKey shape + ``as_tuple``
+    - NullHintStore is a complete no-op
+    - InMemoryHintStore: add / get / size; LRU eviction at cap;
+      per-key isolation; newest-first read order
+    - intent_hash_for: stable; intent prose drives the key, not
+      step_index
+    - url_pattern_for: registrable host + first segment; handles
+      empty / malformed URLs
+    - hint_key_for: end-to-end bundle
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from mantis_agent.gym.hint_memory import (
+    HintKey,
+    HintRecord,
+    InMemoryHintStore,
+    NullHintStore,
+    hint_key_for,
+    intent_hash_for,
+    url_pattern_for,
+)
+
+
+# ── HintRecord ──────────────────────────────────────────────────────
+
+
+def test_hint_record_minimal_construction():
+    r = HintRecord(anchor_text="Show More")
+    assert r.anchor_text == "Show More"
+    assert r.anchor_xy_offset == (0, 0)
+    assert r.viewport_stage == 0
+    assert r.confidence == 1.0
+    assert r.source_url == ""
+    assert r.recorded_at > 0  # default_factory ran
+
+
+def test_hint_record_is_frozen():
+    from dataclasses import FrozenInstanceError
+    r = HintRecord(anchor_text="x")
+    try:
+        r.anchor_text = "y"  # type: ignore[misc]
+    except FrozenInstanceError:
+        pass
+    else:
+        raise AssertionError("HintRecord should be frozen")
+
+
+# ── HintKey ─────────────────────────────────────────────────────────
+
+
+def test_hint_key_as_tuple_round_trips():
+    k = HintKey(plan_signature="abc", intent_hash="def", url_pattern="x.com/y")
+    assert k.as_tuple() == ("abc", "def", "x.com/y")
+
+
+def test_hint_key_distinct_axes_produce_distinct_keys():
+    a = HintKey(plan_signature="p1", intent_hash="i1", url_pattern="u1")
+    b = HintKey(plan_signature="p2", intent_hash="i1", url_pattern="u1")
+    assert a != b
+    assert a.as_tuple() != b.as_tuple()
+
+
+# ── NullHintStore ───────────────────────────────────────────────────
+
+
+def test_null_store_is_complete_no_op():
+    s = NullHintStore()
+    k = HintKey(plan_signature="p", intent_hash="i", url_pattern="u")
+    s.add(k, HintRecord(anchor_text="x"))
+    assert s.get(k) == []
+    assert s.size() == 0
+
+
+# ── InMemoryHintStore ───────────────────────────────────────────────
+
+
+def test_in_memory_store_round_trips_record():
+    s = InMemoryHintStore()
+    k = HintKey(plan_signature="p", intent_hash="i", url_pattern="u")
+    rec = HintRecord(anchor_text="Show More", anchor_xy_offset=(10, -20))
+    s.add(k, rec)
+    out = s.get(k)
+    assert len(out) == 1
+    assert out[0].anchor_text == "Show More"
+    assert out[0].anchor_xy_offset == (10, -20)
+
+
+def test_in_memory_store_get_returns_newest_first():
+    s = InMemoryHintStore()
+    k = HintKey(plan_signature="p", intent_hash="i", url_pattern="u")
+    s.add(k, HintRecord(anchor_text="first"))
+    s.add(k, HintRecord(anchor_text="second"))
+    s.add(k, HintRecord(anchor_text="third"))
+    out = s.get(k)
+    assert [r.anchor_text for r in out] == ["third", "second", "first"]
+
+
+def test_in_memory_store_lru_evicts_oldest_at_cap():
+    s = InMemoryHintStore(max_per_key=3)
+    k = HintKey(plan_signature="p", intent_hash="i", url_pattern="u")
+    for label in ["a", "b", "c", "d", "e"]:
+        s.add(k, HintRecord(anchor_text=label))
+    out = s.get(k)
+    # Cap = 3; only the 3 newest survive.
+    assert [r.anchor_text for r in out] == ["e", "d", "c"]
+
+
+def test_in_memory_store_keys_isolated():
+    s = InMemoryHintStore()
+    k1 = HintKey(plan_signature="p1", intent_hash="i", url_pattern="u")
+    k2 = HintKey(plan_signature="p2", intent_hash="i", url_pattern="u")
+    s.add(k1, HintRecord(anchor_text="k1-rec"))
+    s.add(k2, HintRecord(anchor_text="k2-rec"))
+    assert [r.anchor_text for r in s.get(k1)] == ["k1-rec"]
+    assert [r.anchor_text for r in s.get(k2)] == ["k2-rec"]
+    assert s.size() == 2
+
+
+def test_in_memory_store_size_counts_all_buckets():
+    s = InMemoryHintStore(max_per_key=2)
+    k1 = HintKey(plan_signature="p1", intent_hash="i", url_pattern="u")
+    k2 = HintKey(plan_signature="p2", intent_hash="i", url_pattern="u")
+    # 2 keys × 2 records each = 4.
+    for k in (k1, k2):
+        s.add(k, HintRecord(anchor_text="r1"))
+        s.add(k, HintRecord(anchor_text="r2"))
+    assert s.size() == 4
+
+
+def test_in_memory_store_max_per_key_floor_is_one():
+    """max_per_key=0 / negative → clamps to 1 so the store doesn't
+    accidentally become a no-op when an operator misconfigures it."""
+    s = InMemoryHintStore(max_per_key=0)
+    k = HintKey(plan_signature="p", intent_hash="i", url_pattern="u")
+    s.add(k, HintRecord(anchor_text="a"))
+    s.add(k, HintRecord(anchor_text="b"))
+    out = s.get(k)
+    assert [r.anchor_text for r in out] == ["b"]  # only newest survives
+
+
+def test_in_memory_store_iter_records():
+    s = InMemoryHintStore()
+    k1 = HintKey(plan_signature="p1", intent_hash="i", url_pattern="u")
+    k2 = HintKey(plan_signature="p2", intent_hash="i", url_pattern="u")
+    s.add(k1, HintRecord(anchor_text="a"))
+    s.add(k2, HintRecord(anchor_text="b"))
+    pairs = list(s.iter_records())
+    keys = {p[0].plan_signature for p in pairs}
+    anchors = {p[1].anchor_text for p in pairs}
+    assert keys == {"p1", "p2"}
+    assert anchors == {"a", "b"}
+
+
+# ── intent_hash_for ─────────────────────────────────────────────────
+
+
+def test_intent_hash_for_stable_across_calls():
+    step = SimpleNamespace(intent="Click the Show More toggle", type="click")
+    a = intent_hash_for(step)
+    b = intent_hash_for(step)
+    assert a == b
+    assert len(a) == 12
+    assert all(c in "0123456789abcdef" for c in a)
+
+
+def test_intent_hash_for_varies_with_intent():
+    s1 = SimpleNamespace(intent="Click Show More", type="click")
+    s2 = SimpleNamespace(intent="Click Show Less", type="click")
+    assert intent_hash_for(s1) != intent_hash_for(s2)
+
+
+def test_intent_hash_for_varies_with_type():
+    """Same prose but different step.type → different keys
+    (a ``click`` of "Show More" is a different action from a
+    ``detect_visible`` for the same label)."""
+    s1 = SimpleNamespace(intent="Show More", type="click")
+    s2 = SimpleNamespace(intent="Show More", type="detect_visible")
+    assert intent_hash_for(s1) != intent_hash_for(s2)
+
+
+def test_intent_hash_for_handles_missing_attrs():
+    """Robust against partially-filled step dicts — empty fields
+    still produce a stable non-empty hash."""
+    s = SimpleNamespace()  # no intent, no type
+    h = intent_hash_for(s)
+    assert h
+    assert len(h) == 12
+
+
+def test_intent_hash_for_does_not_depend_on_step_index():
+    """Plan refactors (insert / reorder) shift indices but
+    rarely rewrite intent prose. Same prose ⇒ same key."""
+    s1 = SimpleNamespace(intent="Show More", type="click", step_index=2)
+    s2 = SimpleNamespace(intent="Show More", type="click", step_index=5)
+    assert intent_hash_for(s1) == intent_hash_for(s2)
+
+
+# ── url_pattern_for ─────────────────────────────────────────────────
+
+
+def test_url_pattern_for_boattrader_detail():
+    assert url_pattern_for(
+        "https://www.boattrader.com/boat/1986-marine-trader-europa-10167773/"
+    ) == "boattrader.com/boat"
+
+
+def test_url_pattern_for_strips_www():
+    assert url_pattern_for("https://www.lu.ma/event/abc") == "lu.ma/event"
+
+
+def test_url_pattern_for_no_path_returns_host_only():
+    assert url_pattern_for("https://example.com/") == "example.com"
+    assert url_pattern_for("https://example.com") == "example.com"
+
+
+def test_url_pattern_for_handles_query_and_fragment():
+    """First-path-segment extraction stops at ``?`` and ``#`` so
+    ``/contacts?status=active`` and ``/contacts#tab`` both yield
+    ``example.com/contacts``."""
+    assert url_pattern_for("https://example.com/contacts?status=active") == "example.com/contacts"
+    assert url_pattern_for("https://example.com/contacts#section") == "example.com/contacts"
+
+
+def test_url_pattern_for_empty_and_malformed():
+    assert url_pattern_for("") == ""
+    assert url_pattern_for("not a url") == ""
+    assert url_pattern_for("ftp://example.com") == ""
+
+
+def test_url_pattern_for_case_insensitive_host():
+    """Hosts vary in case; the pattern is normalised to lowercase
+    so ``BoatTrader.com`` and ``boattrader.com`` match the same key."""
+    assert url_pattern_for(
+        "https://BoatTrader.COM/Boat/1986-marine-trader/"
+    ) == "boattrader.com/boat"
+
+
+# ── hint_key_for end-to-end ────────────────────────────────────────
+
+
+def test_hint_key_for_bundles_all_axes():
+    step = SimpleNamespace(intent="Click Show More", type="click")
+    k = hint_key_for(
+        plan_signature="boattrader-v8",
+        step=step,
+        url="https://www.boattrader.com/boat/1986-marine-trader/",
+    )
+    assert k.plan_signature == "boattrader-v8"
+    assert k.intent_hash == intent_hash_for(step)
+    assert k.url_pattern == "boattrader.com/boat"
+
+
+def test_hint_key_for_handles_empty_args():
+    step = SimpleNamespace()
+    k = hint_key_for(plan_signature="", step=step, url="")
+    assert k.plan_signature == ""
+    assert k.url_pattern == ""
+    # intent_hash never empty (hash of empty input is deterministic).
+    assert k.intent_hash


### PR DESCRIPTION
## Summary

Phase 1 of #643 — trajectory hint memory. Ships the foundation that Phase 1b's recording / injection hooks build on. No runner integration yet.

**This PR's scope**: store protocol, in-memory + null backends, key-derivation helpers, `HintRecord` schema.

**Out of scope** (deferred to Phase 1b):
- The recording hook (read anchor metadata from Holo3, write to the store on step success)
- The injection hook (read hints from the store, stamp `preferred_target_description` on the step)
- ModalDictHintStore backend for cross-worker hint sharing

**Out of scope** (deferred to Phase 2):
- Persistent disk store on `/data/hints/`
- URL-pattern key inference per recipe

## Why foundation-first

The anchor metadata that flows out of Holo3 today varies by step type (click → `elv_text` + screen xy; detect_visible → reason text; extract_data → schema-field anchors). Phase 1b will introduce a small per-step-type adapter so the store can stay schema-stable across future #643 follow-ups.

## New module: `src/mantis_agent/gym/hint_memory.py`

- **`HintRecord`** (frozen dataclass) — anchor_text + xy_offset + viewport_stage + confidence + recorded_at + source_url.
- **`HintKey`** — three-axis compound key (plan_signature, intent_hash, url_pattern).
- **`HintStore` protocol + backends**:
  - `NullHintStore` — complete no-op. Default when the runner isn't wired to a backend; lets the recording hook fire unconditionally without a feature flag.
  - `InMemoryHintStore` — single-process backend used by tests and the local fan-out runner. LRU eviction at `max_per_key` (10 default); per-key isolation; newest-first read order.
- **Key-derivation helpers**:
  - `intent_hash_for(step)` — stable 12-char hash of intent prose + step type. Decoupled from `step_index` so plan refactors keep the same key.
  - `url_pattern_for(url)` — Phase 1 pattern: `<registrable-host>/<first-path-segment>`.
  - `hint_key_for(plan_signature, step, url)` — one-shot bundle.

## CUA purity

Per `feedback_cua_no_dom_access.md`: anchors recorded here are always **visual** — screen coordinates relative to a text anchor or `elv_text` strings Holo3 read from the screenshot. No CSS selectors, no DOM probes. The store records what the brain **saw**, not what the DOM **contains**.

## Test plan

- [x] 25 tests in `tests/test_hint_memory_643.py`:
  - HintRecord shape + frozen-ness
  - HintKey shape + `as_tuple`
  - NullHintStore complete no-op
  - InMemoryHintStore: round-trip, newest-first read order, LRU eviction, per-key isolation, total size, max_per_key floor, iter_records diagnostic surface
  - intent_hash_for: stable, varies with intent / type, step_index-independent, robust to missing attrs
  - url_pattern_for: boattrader / lu.ma / empty / malformed / case-insensitive / query+fragment handling
  - hint_key_for end-to-end bundle
- [x] ruff clean
- [x] No runner / suite / handler changes — pure new module + tests

## Coming next (#643 Phase 1b — separate PR)

1. `ModalDictHintStore` backend (cross-worker hint sharing within one deploy).
2. Recording hook in `run_executor._dispatch_step` post-step: when `step.grounding=True` and `step_result.success=True`, derive a `HintRecord` from Holo3's grounding trace and write to the store.
3. Injection hook in `_run_holo3_executor` or `build_micro_suite`: for each step with `grounding=True` or `claude_only=True`, look up the store and inject `hints['preferred_target_description']` + `hints['preferred_target_offset']` on the highest-confidence record.
4. Suite plumbing for backend selection (`_hint_store_dict_name` parallel to `_fanout_seen_dict_name` from #627).

Once Phase 1b lands, every successful run becomes training data for the next — grounding cost on canonical plans should compound down over time as the store warms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)