### PR TITLE
boattrader sim: BDP perceptual fidelity pass — iter1..iter18

### DIFF
--- a/deploy/sim_envs/mantis_boattrader/BDP_FIDELITY_PLAN.md
+++ b/deploy/sim_envs/mantis_boattrader/BDP_FIDELITY_PLAN.md
@@ -1,0 +1,377 @@
+# `mantis_boattrader` — BDP (boat detail page) fidelity plan
+
+Companion to `FIDELITY.md`. This doc is a perceptual diff of our sandbox
+BDP vs the real `boattrader.com` BDP, plus an ordered fix plan.
+
+- **Real BDP probed**: `https://www.boattrader.com/boat/2010-contender-32-st-10169273/` — private seller
+- **Sandbox BDP probed**: `https://8080-…daytonaproxy01.net/boat/2025-chaparral-267-ssx-10000008/` — private seller
+- **Viewport**: 1512×711 (canonical 1440×900 — Retina render at 1512)
+- **Date**: 2026-05-23
+- **Source of truth**: real-BT screenshots + `getBoundingClientRect` + `getComputedStyle` probes (raw numbers in §Appendix)
+
+> Placeholder policy reminder: images (gallery photos, sponsor ad
+> creatives, dealer/headshot logos) stay as SVG procedural placeholders
+> per `SCOPE.md` §"Out-of-scope". Everything else has to mirror exactly.
+
+## Severity legend
+
+- 🔴 **block** — perception-breaking, agent will see a different page
+- 🟠 **major** — clearly visible delta, fix in this pass
+- 🟡 **minor** — pixel/wording delta, fix when convenient
+- 🚫 **placeholder** — intentional (per SCOPE.md), no action
+
+## TL;DR — what's wrong vs the real BDP
+
+The sandbox BDP already matches real-BT on the **bulk-layout level**
+(2-col grid, gallery width, stats strip count, accordion pattern, loan
+calc 2-col, footer cards). The actionable deltas are concentrated in
+**two regions**:
+
+1. **Sticky top bar** — sandbox shows the breadcrumb on scroll; real BT
+   replaces the breadcrumb with `Title · Price · Location · ♡ Save` once
+   the user scrolls past the gallery. Also missing: `Previous Boat`
+   link, the `♡ Save` icon, and the position/styling of the contact
+   pill differ.
+2. **Right-rail contact card (private seller path)** — sandbox adds a
+   "Private Seller" pill, addresses the owner by name ("Contact Ravi,
+   the owner"), shows a verbose disclaimer, puts "Show Phone Number"
+   ABOVE the lead form, and renders the submit as an **outline** pill
+   labelled "Email Seller". Real BT shows NO pill, uses generic
+   "Contact Private Seller" heading, has no disclaimer paragraph in the
+   card body, doesn't surface phone-reveal in the card on most
+   listings, and renders the submit as a **filled** blue pill labelled
+   "Contact Seller".
+
+Plus a scatter of small wording/heading/icon deltas (§Section diff).
+
+## Section-by-section diff
+
+### 1. Top sponsor ad strip
+| Element | Real | Sandbox | Status |
+|---|---|---|---|
+| Ad block | 970×120 real creative on `#f7f7f7` strip | 970×120 SVG creative w/ `SPONSORED` tag | 🚫 placeholder |
+| Strip total height | ~122px including pad | ~122px | ✅ |
+
+No action.
+
+### 2. Top nav row (above gallery)
+| Element | Real | Sandbox | Status |
+|---|---|---|---|
+| Left | `< Search` (light blue 12/400) | `‹ Search` | ✅ |
+| Center | breadcrumb (Home / Boats For Sale / Power / Center Console / Contender) 12/400 #616161 | same shape, color #757575 | 🟡 color diff #757575 vs #616161 |
+| Right | `Previous Boat` + `Next Boat` (both BT-blue 12/400) | only `Next Boat ›` | 🟠 missing `Previous Boat` (or "Previous Boat" should appear when there's a prior boat in session) |
+| Chevron style | plain word link, no chevron | sandbox adds `‹`/`›` glyphs | 🟡 wording diff |
+
+**Fix**: drop the `‹`/`›` glyphs from the back/next links (plain word
+links per real); add a `prev_boat` template var symmetrical to
+`next_boat` so a `< Previous Boat` link is shown when one exists; nudge
+breadcrumb text color #757575 → #616161.
+
+### 3. Sticky bar (appears on scroll)
+| Element | Real | Sandbox | Status |
+|---|---|---|---|
+| Sticky bar height | 54px | 54px | ✅ |
+| Bar bg | `rgba(255,255,255,0.98)` w/ subtle bottom shadow | same | ✅ |
+| Content (top half scroll) | `< Search · breadcrumb · Previous Boat · Next Boat · [Contact Seller]` | `‹ Search · breadcrumb · Next Boat ›` (no Contact Seller pill in sticky, no Previous) | 🔴 missing pill + Previous |
+| Content (mid scroll, past gallery) | `< Search · Title · $Price · City, ST ZIP · ♡ Save · Previous Boat · Next Boat · [Contact Seller]` (breadcrumb REPLACED by title summary) | breadcrumb unchanged at any scroll | 🔴 missing the second display state |
+| Sticky bar Contact Seller pill | `bg rgb(37,102,176)` filled, 152×36, white 15/500 | filled pill present visually but no Title/Price summary surfacing it | 🟠 |
+| Save (♡) icon in sticky bar | outline heart + "Save" label | not present | 🟠 |
+
+Real BT class is `next-previous show-info next-previous-top` — there
+are two visual states (`next-previous-top` and a deeper-scroll variant)
+toggled by scroll position. The "show-info" modifier is what flips the
+content from breadcrumb-mode to title-mode.
+
+**Fix**: add a second scroll threshold (~gallery height, ~700px) that
+flips a class like `bdp-sticky-info` on `body`; CSS then hides the
+breadcrumb and shows a `Title · Price · Location · ♡ Save` row. Move
+the Contact Seller pill into the sticky bar markup (right-aligned).
+
+### 4. Right rail summary card — common section (before contact form)
+| Element | Real | Sandbox | Status |
+|---|---|---|---|
+| Card width | 366px | 332px | 🟠 32px narrower than real (right rail grid column 366/100/auto) — needs `1fr 80px 366px` grid |
+| Card padding | 16px | 16px | ✅ |
+| Card border | 1px #ededed | 1px #ededed | ✅ |
+| Border radius | 8px | 8px | ✅ |
+| Drop shadow | rgba(0,0,0,0.2) 0 2px 2px 0 | same | ✅ |
+| Badge above title | NONE (badges live in engagement strip) | `New Arrival` pill at top of card | 🟠 remove `.bdp-badges` above title; merge badge into engagement strip / move below |
+| H1 | `2010 Contender 32 ST` — 20/700 #333 (no `| 32'` length appended) | `2025 Chaparral 267 SSX \| 27'` — 20/700 #333 | 🟡 sandbox appends `\| length`; real puts length only in stats strip / sub-text |
+| Location line | `Jupiter, FL 33478` — 14/400 #757575 | `Naples, FL 34102` — same | ✅ |
+| Price line | `$177,500   ↓$10,000` — 20/700 #333, drop arrow ▼ in light style | `$103,900` (no drop here, but same shape when present) | ✅ |
+| "Own this boat for $X/mo" link | 16/400 BT-blue, then `(ⓘ) Customize` | same | ✅ |
+| Engagement row | `1.5k Views | 44 Saves | New to Market` with eye/heart/cal icons | `71 Views | 53 Saves | New to Market` | 🟡 sandbox doesn't K-format views >999; pipe separators visible in real (light gray vertical `|`) — verify sandbox renders the dividers (currently row uses gap-only) |
+| Engagement font | 12/400 #666 | 12/400 #666 | ✅ |
+| Divider below engagement | 1px #ededed bottom-divider | sandbox doesn't render | 🟡 add `border-top` to the contact section beneath |
+
+### 5. Right rail — Private seller variant
+| Element | Real | Sandbox | Status |
+|---|---|---|---|
+| "Private Seller" tag/pill | NOT shown in card | rendered as 105×22 dark-navy pill | 🟠 remove |
+| Heading | `Contact Private Seller` (generic) — 20/700 #333 | `Contact Ravi, the owner` (owner name) — 18/500 dark | 🔴 wording + weight wrong |
+| Disclaimer paragraph | Not present in card body (BT has a smaller `Tips` block elsewhere) | "This boat is being sold directly by the owner. Boat Trader does not verify…" — multi-line gray paragraph | 🟠 remove from main card (or shrink to a 2-line caption) |
+| Show Phone button position | not rendered in card on the listings we tested (BT phone-reveal lives elsewhere or absent for owners w/ no phone) | rendered ABOVE the form as a 100% blue outline pill | 🟠 move to AFTER the form, OR hide on cards where no phone is known |
+| Phone-reveal note | not present | "The seller's number is hidden until you confirm…" gray small-text | 🟠 remove or shrink |
+| Lead form fields | Name (full) · Email + Phone (split) · Message (full) — 40px h, 4px br, 1px #c2c2c2 | identical structure + dims (✅) | ✅ |
+| Submit button | `Contact Seller` (NOT "Email Seller"), FILLED blue pill bg `rgb(37,102,176)` white, 100% width, 40px h | `Email Seller` text, BLUE OUTLINE pill | 🔴 text + filled-vs-outline |
+| Email subject prefill in message | `Hi, I'm interested…` (no owner name) | `Hi Ravi, I'm interested in your 2025 Chaparral 267 SSX. Is it still available?` | 🟡 remove owner name from prefill |
+
+### 6. Right rail — Dealer variant (not directly compared this session)
+The sandbox currently renders, in this order: headshot SVG + name +
+dealer address/phone, then lead form, then a separate `bdp-dealership-card`
+with logo + active/sold stats + Visit Seller Website link. Real BT's
+dealer variant is shaped similarly but the dealership-card content lives
+inside the same outer card (one card, not two stacked cards) for many
+listings, and "Active listings / Sold listings" sit in a 2-stat box row.
+Re-probe a real BT dealer BDP before changing — this is a follow-up.
+
+| Element | Real (TBD) | Sandbox | Status |
+|---|---|---|---|
+| Headshot vs dealer logo position | TBD | both rendered | 🟡 needs real-BT confirm |
+| `Visit Seller Website ↗` link | plain blue text link | sandbox renders w/ arrow ↗ — ✅ shape | 🟡 |
+| `Trusted Boat Trader Partner` row | small caption + `Premier` etc. | identical text | ✅ |
+| Active/Sold listings stat boxes | 2 stat cards, num 20/700 + label 12/400 | 2 stat boxes — ✅ shape | 🟡 dim/color verify |
+
+### 7. Below-gallery: stats strip (8 cards 4×2)
+| Element | Real | Sandbox | Status |
+|---|---|---|---|
+| Container | ~870×170 (gallery-column width), 4-col grid | 890×147, 4-col grid w/ 205px tracks | 🟡 minor width diff; sandbox is 20px wider |
+| Card dims | 166×39 (smaller cards, less padding) | 205×44 | 🟠 sandbox cards are 39px wider + 5px taller |
+| Card grid gap | small (~12-14px) | 14×18px | ✅ close |
+| Label | 14/700 #303030 | 14/700 #303030 | ✅ |
+| Value | 14/400 #333 | 14/400 #333 | ✅ |
+| Icon | circle ring 19r + simple dark blue glyph | circle ring 19r + dark blue glyph | ✅ |
+| **Label text "Engine(s) Hours"** | with parens | "Engine Hours" no parens | 🟠 wording |
+| Info ⓘ on "Engine(s) Hours" | small gray (i) tooltip trigger | not present | 🟡 add tooltip stub |
+| Card label `YEAR` inside icon SVG | not present | sandbox YEAR icon has inline `<text>YEAR</text>` that shows up in innerText | 🟡 visual fine, but extra text contaminates DOM grep — drop the inline label |
+| Order | Engine / Total Power / Engine(s) Hours / Class // Length / Year / Model / Capacity | same | ✅ |
+
+### 8. "What Owners Say" card + Owner Highlights
+| Element | Real | Sandbox | Status |
+|---|---|---|---|
+| Heading | `✦ What Owners Say ⓘ` 20/700 #333 | same | ✅ |
+| Heading icon | sparkle + info ⓘ | sparkle + info ⓘ | ✅ |
+| Paragraph | 14/400 #333, ~5 lines | 14/400 #333 | ✅ |
+| Owner Highlights heading | 16/700 #333 | 16/700 #333 | ✅ |
+| Tag pills | bg #e3f1fe, color #2566b0, 12/700, 4px 8px pad, 5px br | same per FIDELITY.md | ✅ |
+
+### 9. Boat Details accordions
+| Element | Real | Sandbox | Status |
+|---|---|---|---|
+| Section heading `Boat Details` | 20/700 #333 — no card background or only very subtle | sandbox wraps the section in `#f5f9ff` 8px-radius card with 20px 16px pad | 🟠 real BT does NOT wrap Boat Details in a tinted card (per latest screenshots — looks like a white card with only top/bottom dividers); verify and remove `background-color: #f5f9ff` if so |
+| Accordions present | Description (open), Measurements, Propulsion | adds More Details + Location (not in real BT for the listings we tested) | 🟠 remove More Details + Location, OR demote both to H4 within an existing accordion |
+| Accordion title | 16/700 #333 | 16/700 #333 | ✅ |
+| Chevron | down/up | down/up via border trick | ✅ |
+| Open-by-default | only Description | only Description ✅ | ✅ |
+| `Show More` link inside Description | bold BT-blue, right-aligned at clamp boundary | sandbox renders FULL description (no clamp + Show More) | 🟠 add CSS line-clamp + JS toggle |
+| Key Features sub-list inside Description | not present in real BT | sandbox renders an extra "Key Features" H3 + bullet list inside Description body | 🟠 remove or demote, OR move into its own accordion |
+
+### 10. Mid-page sponsor ad
+| Element | Real | Sandbox | Status |
+|---|---|---|---|
+| Position | between Boat Details accordion and Loan Calculator | same | ✅ |
+| Dimensions / strip | 970×120 | same | ✅ |
+| Sponsored tag | top-right | top-right | ✅ |
+
+### 11. Boat Loan Calculator (full-width card)
+| Element | Real | Sandbox | Status |
+|---|---|---|---|
+| 2-col grid | left form / right preview w/ light-blue bg on right | same | ✅ |
+| `Boat Loan Payment Calculator` heading | 20/700 #333 left | sandbox h3 16/700 — verify weight | 🟡 verify font-size |
+| Right "Get pre-qualified" sub-card | bullets + outline button | sandbox uses `<hr>` then bullets — pattern OK | ✅ |
+| `See Important Disclosure³` link | small gray, with superscript | same | ✅ |
+
+### 12. "Listed By" / "More From This Dealer" (dealer listings only)
+Both omitted from real-BT private-seller BDP. Sandbox correctly hides
+`More From This Dealer` for private sellers but still renders a
+"Listed By" private-seller card. Real BT does NOT render any "Listed
+By" for private sellers — the private-seller info already lives in the
+right-rail card. **🟠 hide the `bdp-listed-by` block when
+`boat.is_owner_listed`.**
+
+### 13. "Still have a question?" card
+| Element | Real | Sandbox | Status |
+|---|---|---|---|
+| H2 | `Still have a question?` 24/700 #333 | same | ✅ |
+| Rule (blue 32×2 line below H2) | present | present | ✅ |
+| Body | "Get answers, schedule a visit..." 14/400 / 16/400 | 14/400 ✅ | ✅ |
+| `Contact seller` button | blue outline pill, 14/700 | same | ✅ |
+
+### 14. "OTHER SERVICES" tiles
+| Element | Real | Sandbox | Status |
+|---|---|---|---|
+| Label | `OTHER SERVICES` 14/700 ucase | same | ✅ |
+| Tiles | logo circle + product name (14/400 #4d4d4d) | same | 🚫 logos are placeholder SVG |
+| Tile count | 6+ in real (Surveyor, Documentation, Boat Loans, Insurance, Warranty, Trailers …) | 2 (Elite Marine Surveyors + Boat Documentation) | 🟠 sandbox shows only 2; bump to 6 to match real's row density |
+
+### 15. Footer (out of BDP scope but renders below)
+Footer is global — matches real BT structurally per existing
+`base.html`. Not in this plan.
+
+## Fix plan — ordered
+
+The ordering goes outside-in: things that move on every scroll first
+(sticky bar / nav row), then the highest-attention region
+(right-rail card), then below-gallery content. Within each block, the
+🔴 deltas land first.
+
+### Pass 1 — sticky bar + nav row  *(small-medium template edit)*
+
+1. **Template** `boat_detail.html`:
+   - Remove `‹`/`›` glyphs from `.bdp-back` and `.bdp-next` link
+     text → `Search` and `Next Boat` (plain words, link styling).
+   - Add a `{% if prev_boat %}<a … class="bdp-prev">Previous Boat</a>{% endif %}`
+     symmetrical to `next_boat`; wire `prev_boat` in the route handler
+     (`main.py` BDP view) — pick the previous boat in the dealer/seed
+     list, mirroring how `next_boat` is computed.
+   - Inside `.bdp-sticky-bar`, render BOTH variants:
+     - `.bdp-sticky-breadcrumb-state` — current breadcrumb mode
+     - `.bdp-sticky-info-state` — Title · `|` · `$Price` · `|` ·
+       `City, ST ZIP` · `|` · `♡ Save` (heart SVG + "Save" text)
+   - Add a Contact Seller pill at the right end of the sticky bar
+     (always visible whichever state is active).
+2. **CSS** `app.css`:
+   - `body.bdp-scrolled` continues to show the sticky bar.
+   - Add `body.bdp-scrolled-deep` (set when `window.scrollY > 700`) →
+     `.bdp-sticky-breadcrumb-state { display:none }` +
+     `.bdp-sticky-info-state { display:flex }`.
+3. **JS** in `base.html`:
+   - Add second scroll threshold (700px) toggling `bdp-scrolled-deep`
+     class on body.
+4. **Wording / color**:
+   - Update breadcrumb `color: #616161` (was #757575).
+
+### Pass 2 — right rail private-seller card  *(highest visual impact)*
+
+1. **Template** `boat_detail.html` (`{% if boat.is_owner_listed %}` branch):
+   - Delete `.private-seller-tag` pill.
+   - Change heading: `<h2>Contact Private Seller</h2>` (generic), use
+     `dealer-card-heading` class (same 20/700 #333 as dealer variant).
+   - Delete the `.private-seller-note` paragraph.
+   - Move the `phone-row` block to AFTER the lead form (last item
+     before the closing card), OR gate behind `{% if boat.owner_phone %}`
+     so cards w/o a known phone don't show the reveal.
+   - Change form submit text: `Email Seller` → `Contact Seller`.
+   - Change form submit class from outline to filled — drop
+     `btn-block` outline variant and use the same `.btn-primary
+     .contact-seller-btn` that the dealer card uses.
+   - Remove the `Hi {{ boat.owner_name }},` prefix from the message
+     placeholder; use the dealer-card-style generic copy.
+2. **Common right-rail tweaks**:
+   - Delete `.bdp-badges` block above title (badges already in
+     engagement strip; if a badge needs surfacing in the card, prefix
+     it inside the engagement row instead).
+   - In `.bdp-title`, drop the ` | XX'` length suffix — length lives
+     in the stats strip.
+   - Add K-formatting filter for `boat.views` (`> 999 → "1.5k"`).
+   - Add `border-top: 1px solid #ededed` to the contact-form section
+     to create the visible divider real BT shows.
+3. **CSS**:
+   - Card column width: grid column 3 should be **366px** (matches
+     `_captured/srp` recipe). Sandbox currently lands at 332px because
+     the `.bdp-grid` template-columns are off. Update
+     `grid-template-columns: 1fr 366px` (drop the empty 80px middle
+     column or merge into the gap).
+
+### Pass 3 — stats strip + Boat Details accordion
+
+1. **Template** `boat_detail.html`:
+   - Stats strip: rename label `Engine Hours` → `Engine(s) Hours`.
+   - Add `<span class="info-tip" title="Reported by the seller">ⓘ</span>`
+     next to the Engine(s) Hours label.
+   - YEAR icon SVG: drop the inline `<text>YEAR</text>` (visual fine
+     without it; cleaner DOM).
+   - Boat Details accordions: remove `More Details` and `Location`
+     accordions OR demote them inside `Measurements`/`Description` as
+     H4 sub-sections. Real BT has only **Description / Measurements /
+     Propulsion** at this level for the listings we tested.
+   - Inside Description: line-clamp the long paragraphs (CSS clamp at
+     4 lines) and add a `Show More` toggle button (right-aligned BT-blue
+     bold link). Remove the "Key Features" h3+ul render — that block
+     isn't in real BT's Description body.
+2. **CSS**:
+   - Stats card target dims: ~166×39 (currently 205×44). Either drop
+     `padding` or tighten the icon-text gap. Real has 4 columns at
+     ~166px each ≈ 664+gap < 870 total, so a small `gap: 16-24px`
+     with smaller cards is the shape.
+   - `.bdp-details-section { background: none; padding: 0; }` — remove
+     the `#f5f9ff` tinted bg if real BT renders the section on a plain
+     white surface (verify with one more probe on a different real BT
+     BDP — could be listing-type dependent).
+
+### Pass 4 — listed-by, services, ad+loan calc cosmetics
+
+1. **Template**:
+   - Wrap the `bdp-listed-by` private-seller block in
+     `{% if not boat.is_owner_listed %}` — real BT shows nothing here
+     for private sellers (Contender 32 ST renders no "Listed By").
+   - "Other Services" tiles: expand from 2 → 6 (Marine Surveyors,
+     Boat Documentation, Boat Loans, Boat Insurance, Boat Warranty,
+     Boat Transport). Logos remain placeholder SVGs (`🚫`).
+   - Loan Calc heading: verify `loan-form-heading` is set to 20/700
+     (real BT) — currently `font-size: 18px` per `.loan-form-heading`
+     CSS; bump to 20px.
+
+### Pass 5 — verification
+
+1. Re-probe both pages with `scripts/perceptual_diff.py` after each
+   pass and update `FIDELITY.md` rows.
+2. Fill in the now-empty `_captured/bdp/structural.json` with the
+   real numbers captured in this session (the appendix below).
+3. Add a pytest in `tests/sim_envs/mantis_boattrader/` that asserts
+   the BDP-specific structural anchors (sticky-bar two-state markup,
+   right-rail card width = 366px, stats-strip label="Engine(s) Hours",
+   private-seller heading text = "Contact Private Seller").
+
+## Appendix — raw probes (2026-05-23)
+
+### Real boattrader.com (Contender 32 ST — private seller)
+
+```
+viewport: 1512×711
+main_image: 890×593 at x=70 (3:2)
+breadcrumb: 12/400 rgb(97,97,97) padding 12px 15px 12px 0
+H1 (right-rail): 20/700 #333 — "2010 Contender 32 ST" (NO length suffix)
+sticky bar: class="next-previous show-info next-previous-top", w=1512 h=54
+sticky bar text: "Search 2010 Contender 32 ST $177,500 Jupiter, FL 33478 Previous Boat Next Boat Contact Seller"
+sticky Contact Seller pill: bg rgb(37,102,176) filled, 152×36, white
+lead Name input: 334×40, 1px #c2c2c2, 4px br, 14/400 padding 8px 12px 4px
+submit btn class: style-module_action__ + variants — FILLED blue, label "Contact Seller"
+Boat Details H2: 20/700 #333 at x=87 (left col)
+Stats labels: "Engine | Total Power | Engine(s) Hours | Class | Length | Year | Model | Capacity"
+Stats label style: 14/700 rgb(48,48,48)
+Stats card dims: ~166×39
+Phone-reveal button: NOT rendered on this listing (private seller w/o phone in card)
+Private-seller note paragraph: NOT rendered
+```
+
+### Sandbox (Chaparral 267 SSX — private seller)
+
+```
+viewport: 1512×711
+H1: 20/700 #333 — "2025 Chaparral 267 SSX | 27'" (sandbox appends length)
+sticky bar (.bdp-sticky-bar): "‹ Search Home / Boats For Sale / Power / Bowrider / Chaparral Next Boat Contact S…"
+back/next: 12/400 rgb(19,154,245) "‹ Search" / "Next Boat ›" (no Previous)
+right-rail badge pill: rendered (`New Arrival`) above title
+right-rail width: 332px (TARGET 366)
+right-rail bg/border: white, 1px #ededed, 8px br, padding 16px — ✅
+price: 20/700 #333 — ✅
+engagement row: "71 Views" — 12/400 rgb(102,102,102)
+private-seller pill: 105×22, 11/700 dark navy
+contact heading: "Contact Ravi, the owner" — wrong wording + weight
+submit button: outline pill labelled "Email Seller" — wrong style + label
+stats-strip: 8 cards, 205×44, 14×18 gap — too wide vs real's 166×39
+accordions: Description, Measurements, Propulsion, More Details, Location — 2 extras
+```
+
+## Open follow-ups (out of this plan's scope)
+
+- **Dealer BDP** — only probed a private-seller listing this session.
+  Re-run the probe against a real BT *dealer* BDP to validate the
+  "Listed By" + "More From This Dealer" layout before changing.
+- **Mobile** — `SCOPE.md` lists mobile as out-of-scope; skip.
+- **Real ad creatives** — placeholder per scope.
+- **Photo gallery real images** — placeholder per scope.
+- **Map iframe in Location accordion** — sandbox has a placeholder div;
+  real BT uses a Google Maps embed. Keep placeholder per scope, but if
+  Location accordion is removed in Pass 3 the question is moot.

--- a/deploy/sim_envs/mantis_boattrader/BDP_PENDING_DIFFERENCES.md
+++ b/deploy/sim_envs/mantis_boattrader/BDP_PENDING_DIFFERENCES.md
@@ -1,0 +1,211 @@
+# `mantis_boattrader` — BDP pending differences vs real boattrader.com
+
+Snapshot of remaining perceptual deltas between the sandbox BDP and
+real `boattrader.com` after the iter1..iter18 fidelity pass (PR
+`feat/bdp-fidelity-iter1`, 26 commits). Captured 2026-05-24.
+
+Read `BDP_FIDELITY_PLAN.md` for the original section-by-section diff
+and `FIDELITY.md` for the version-by-version closure log. This doc
+only lists what is **not yet matched**.
+
+## Categorization
+
+- 🚫 **Intentionally not matched** (per `SCOPE.md`) — placeholders
+- 🟡 **Cosmetic** — minor visual diff, no functional impact on the
+  agent's screenshot-grounded perception
+- 🟠 **Data-shape** — sandbox catalog generates different value shapes
+  than real BT (e.g. always 10-digit phone, no "Engine Model" field)
+- 🔴 **Structural** — markup or layout diff that's visible at first
+  glance; should be next priorities
+
+## Gallery
+
+| Element | Real BT | Sandbox | Severity | Notes |
+|---|---|---|---|---|
+| Main image | Real boat photos | Procedural SVG placeholder | 🚫 | Per SCOPE.md §Out-of-scope |
+| Thumbnail strip | Real thumbs, 5 visible at 175×116, blue outline on active | Procedural SVG, 5 visible, blue outline | 🚫 | Photos are placeholder |
+| `View N Photos` overlay | First thumb darkened, white centered text | Matched | ✅ | |
+| Share / Like / Prev / Next buttons | 40×40 circle, rgba(0,0,0,0.3) | Matched | ✅ | |
+
+## Top navigation (nav row + sticky bar)
+
+| Element | Real BT | Sandbox | Severity | Notes |
+|---|---|---|---|---|
+| Sticky bar | `next-previous show-info next-previous-top` class, two scroll states (breadcrumb / title+price+save) | Matched: `bdp-scrolled` (320px) + `bdp-scrolled-deep` (700px) toggles | ✅ | |
+| Save icon in sticky bar | CSS-class heart on `<button class="heart">` | Inline SVG heart + "Save" text inside `.sticky-save` | 🟡 | Visually similar at small size |
+| Breadcrumb category 2 | `Sail` (sailboats) / `Power` (everything else) | Matched (Jinja `'Sail' in boat.boat_type` gate) | ✅ | |
+| `< Search` link | Plain text link, no padding/border | Matched | ✅ | |
+| Previous / Next button | 104×34, padding 11/15 (next 11/35/11/15), 4px radius, chevrons via ::before/::after | Matched | ✅ | |
+
+## Right-rail summary card
+
+| Element | Real BT | Sandbox | Severity | Notes |
+|---|---|---|---|---|
+| Outer card | 366×, 1px #ededed, 8px radius, 16px pad, soft shadow | Matched | ✅ | |
+| Title | 20/700 #333, no length suffix in H1 | Matched (length is sibling span) | ✅ | |
+| Length suffix | Sibling `<span>` with `\| XX'` | Matched (`.bdp-length` inside `.bdp-title-row`) | ✅ | |
+| Price + drop arrow | Bold price + ↓ + drop amount | Matched (Unicode ↓) | 🟡 | Real BT may use SVG arrow on some listings — not yet probed |
+| Engagement row | `views \| saves \| listed` w/ 1×12 hairline dividers, gap 10px | Matched | ✅ | |
+| Views K-format | `1.5k Views` for >999 | Matched | ✅ | |
+| Dealer card heading | `Contact <dealership-name>` (NOT salesperson) | Matched | ✅ | |
+| Headshot avatar | NOT rendered in side-panel | Matched (dropped) | ✅ | |
+| Pin icon + address | 14×14 SVG pin + street, city, state, zip | Matched | ✅ | |
+| Phone | E.164 `+1XXXXXXXXXX` (no parens/dashes) | Matched (`seed.py` regenerated) | ✅ | |
+| Form fields | First & Last Name / Email + Phone (split) / Message | Matched | ✅ | |
+| Submit button | FILLED `rgb(37,102,176)` blue, "Contact Seller" (both variants) | Matched | ✅ | |
+| Verified Broker badge | Present on dealer cards on some real BT listings | Not in sandbox | 🟠 | Data-shape: sandbox dealers don't carry verification flag |
+| Salesperson name pattern | Real BT shows e.g. "Contact Bill Adams" on some listings | Sandbox always uses dealership-name heading | 🟠 | Could gate on a dealer flag — not yet done |
+| Private-seller card | NO pill, NO disclaimer, generic "Contact Private Seller" heading | Matched | ✅ | |
+
+## Stats strip (below gallery)
+
+| Element | Real BT | Sandbox | Severity | Notes |
+|---|---|---|---|---|
+| Card dims | 166×39, 4-col × 2-row grid | Matched | ✅ | |
+| Label/value typography | Label 14/700 #303030, value 14/400 #333 | Matched | ✅ | |
+| Engine(s) Hours stat | Present on power boats, absent on sailboats | Matched (Jinja gate) | ✅ | |
+| Engine(s) Hours ⓘ tooltip | Inline ⓘ next to label | Dropped (would wrap label on 166px) | 🟡 | Acceptable for now |
+| YEAR text inside icon | Not present | Dropped from sandbox SVG | ✅ | |
+
+## "What Owners Say" card
+
+| Element | Real BT | Sandbox | Severity | Notes |
+|---|---|---|---|---|
+| Sparkle ✦ icon | 24×24 SVG with fill #2566B0 (AI label) | 18px Unicode `✦` with `color: var(--bt-blue)` (#2566b0) | 🟡 | Visually similar |
+| Info ⓘ tooltip | Material-Icons font `info` glyph | Unicode circled-i | 🟡 | Visually similar |
+| H2 styling | 20/700 #333 | Matched | ✅ | |
+| Owner Highlights pill | bg #e3f1fe, color #2566b0, 12/700, 4×8 pad, 5px radius | Matched | ✅ | |
+
+## Boat Details accordion section
+
+| Element | Real BT | Sandbox | Severity | Notes |
+|---|---|---|---|---|
+| Section bg | `#f5f9ff` tint, 20×16 pad, 8px radius | Matched | ✅ | |
+| H2 "Boat Details" | 20/700, margin 0 | Matched | ✅ | |
+| 5 accordions (Description / Measurements / Propulsion / More Details / Location) | Present on power boats | Matched | ✅ | |
+| Accordion item padding | `<details>` 18px 0, `<summary>` 0, height ~28px | Matched (sandbox ~23px) | ✅ | Close to real |
+| Accordion border-bottom | 1px #ededed between items | Matched | ✅ | |
+| Description body | 15/19.5 (lh 1.3), padding 8px 0 0 8px | Matched | ✅ | |
+| Seller blurb | `<strong>` topic line at 15/700 | Matched | ✅ | |
+| DESCRIPTION sub-label | `<strong>DESCRIPTION</strong>` at 15/700 (NO letter-spacing) | Matched | ✅ | |
+| Show More link | Right-aligned, 13/400 BT-blue button, expands clamp | Matched (clamp at 168px, JS toggle) | ✅ | |
+| Propulsion Engine Hours line | Absent on sailboats | Matched (Jinja gate) | ✅ | |
+| Engine Model / Engine Year fields | Present on real BT propulsion | Not in sandbox data model | 🟠 | seed.py would need to expose engine_model + engine_year |
+
+## Mid-page ad strip
+
+| Element | Real BT | Sandbox | Severity | Notes |
+|---|---|---|---|---|
+| Strip bg #f7f7f7 spans full viewport | Edge-to-edge 1600px | Matched (full-bleed via `margin: 24px calc(50% - 50vw); width: 100vw`) | ✅ | |
+| Banner | 970×120 centered creative | Matched (970×120 with `Sponsored` corner tag) | ✅ | |
+| Strip height | 122px | Matched | ✅ | |
+| Ad creative | Real advertiser image | Procedural SVG placeholder | 🚫 | Per SCOPE.md |
+
+## Loan Calculator
+
+| Element | Real BT | Sandbox | Severity | Notes |
+|---|---|---|---|---|
+| Form heading | 20/700 "Boat Loan Payment Calculator" | Matched | ✅ | |
+| Form fields (4) | Year / Purchase Price / Down Payment / Loan Term (Months) | Matched | ✅ | |
+| Input style | 348×40, 4px radius, 1px #ededed border, 16px font | Matched | ✅ | |
+| Preview pane bg | Light-blue tint (#f5f9ff or close) | Matched | ✅ | |
+| Monthly payment display | 50px / 700 centered | Matched | ✅ | |
+| Total Loan Amount line | 13/normal, centered | Matched | ✅ | |
+| Disclosure link | "See Important Disclosure³" | Matched | ✅ | |
+
+## Listed By + More From This Dealer
+
+| Element | Real BT | Sandbox | Severity | Notes |
+|---|---|---|---|---|
+| Section bg | `#f5f9ff` tint matching Boat Details | Matched | ✅ | |
+| "Listed By" heading | 20/700 (DIV in real BT, H2 in sandbox) | Visually matched | 🟡 | Tag-level diff, no visual impact |
+| Logo + dealer name | Logo mark + uppercase dealer name | Matched | ✅ | |
+| Trusted Boat Trader Partner label | Plain text at bottom (no `\| <years>` suffix) | Matched | ✅ | |
+| Stat boxes (Active / Sold listings) | Bold num 16/600 + small label 14/400 | Matched | ✅ | |
+| Visit Seller Website link | Plain text, NO ↗ arrow | Matched | ✅ | |
+| More From This Dealer carousel | Horizontal rail of image-only cards, "More Boats from this Dealer" link below | Matched | ✅ | |
+| MFD link color | #0051AD (darker than main BT-blue) | Matched | ✅ | |
+
+## Footer / page-level
+
+| Element | Real BT | Sandbox | Severity | Notes |
+|---|---|---|---|---|
+| Body width | `<main class="page-container">` spans full viewport (1600px) | Matched (`.bt-main { max-width: none }`) | ✅ | |
+| Footer container | Dark navy band full-width, inner 1440px centered | Matched (`.site-footer + .footer-cols`) | ✅ | |
+| Ribbon (prequal) | Top blue band, full-width | Matched | ✅ | |
+
+## Variant coverage smoke
+
+| Variant | URL pattern | Status |
+|---|---|---|
+| Dealer (yacht) | `2018-princess-f55-10000418` | ✅ all anchors match |
+| Private seller | `2025-chaparral-267-ssx-10000008` | ✅ all anchors match |
+| Sponsored | `2026-robalo-r230-10000209` | ✅ SPONSORED LISTING pill renders |
+| POA ("Request a Price") | `2022-boston-whaler-210-dauntless-10000425` | ✅ no monthly link, no ⓘ |
+| Price drop | `2021-crestliner-vt-18-10000396` | ✅ price + ↓ + drop amount |
+| Sailboat | `2021-catalina-385-10000363` | ✅ Sail breadcrumb, 7 stats, no Engine Hours in Propulsion |
+
+## Known remaining gaps (priority order)
+
+### 🟠 Data-shape (sandbox catalog doesn't model)
+
+1. **Verified Broker badge** — Real BT renders a "Verified Broker"
+   row on some dealer cards. Sandbox dealers don't carry a
+   `verified_broker` flag. Add one + render conditionally.
+2. **Engine Model / Engine Year fields** — Real BT Propulsion accordion
+   surfaces these as separate rows (e.g. `Engine Model: 3YM30AE`,
+   `Engine Year: 2023`). Sandbox `Boat` dataclass doesn't have them.
+   Add fields + render.
+3. **Salesperson-name dealer pattern** — Some real BT dealer cards
+   use `Contact <salesperson>` instead of `Contact <dealership>`.
+   Sandbox previously rendered the salesperson pattern; iter10 swapped
+   to the dealership pattern (matching the user-shared Westchester
+   example). Restore conditional rendering driven by a `dealer.salesperson`
+   flag if needed.
+
+### 🟡 Cosmetic (acceptable for now)
+
+4. **Sticky Save heart** — Real BT uses CSS-class heart on a
+   `<button class="heart">`; sandbox uses inline SVG + text. Visually
+   similar at small size; would need a CSS background-image swap.
+5. **Sparkle ✦ in "What Owners Say"** — Real BT uses a 24×24 inline
+   SVG with `fill="#2566B0"` and `aria-label="AI"`. Sandbox uses
+   Unicode `✦` at 18px in `var(--bt-blue)`. Same color, slightly
+   different glyph weight.
+6. **Info ⓘ tooltips** — Real BT uses Material-Icons font `info`
+   glyph; sandbox uses Unicode `ⓘ`. Same intent, slightly different
+   render.
+7. **Engine(s) Hours stat ⓘ** — Dropped in iter5 because the icon
+   wrapped the label on a 166px card. Real BT's narrower Roboto
+   rendering fits both. Add back if/when the font baseline is closer.
+8. **Dealer-rail card dim** — Sandbox 220×271 vs real 235×260
+   (carousel card inside More From This Dealer). Marginal.
+9. **Price drop arrow** — Sandbox uses Unicode `↓`; real BT may use
+   a custom small SVG. Not yet probed on a real-BT price-drop listing
+   (the ones we tried didn't surface drops live).
+
+### 🚫 Intentionally not matched (per SCOPE.md)
+
+10. **Real ad creatives** — sandbox uses 6 procedural SVG ads in
+    fixed rotation.
+11. **Real boat photos** — sandbox uses procedural SVG boats.
+12. **Dealer logos** — sandbox uses initial-letter rectangles.
+13. **Analytics scripts** — sandbox keeps class names matching real
+    BT but doesn't run gtag / FullStory / Kameleoon.
+14. **OneTrust cookie banner** — sandbox renders a generic accept/
+    reject pair.
+
+## How to extend this doc
+
+When you find a NEW delta in a future iter, add a row under the
+relevant section. When a delta is closed (matched), move it from
+"Known remaining gaps" up into the matched-row table and mark ✅.
+Don't delete the row — its presence in the matched section is the
+proof that it was once a gap.
+
+When adding a 🟠 data-shape fix, you usually need to:
+1. Add the field to `seed.py` `Boat` or `Dealer` dataclass
+2. Generate it in `_seed_boats` / `_seed_dealers`
+3. Render it in `boat_detail.html`
+4. Hit `/__env__/reset` (or restart uvicorn) to regenerate the catalog
+5. Verify via Chrome MCP probe

--- a/deploy/sim_envs/mantis_boattrader/FIDELITY.md
+++ b/deploy/sim_envs/mantis_boattrader/FIDELITY.md
@@ -789,6 +789,37 @@ Calculator" (18/700 #303030), then a result row.
          text for both dealer + private (was "Email Seller" for private).
        • `.dealer-card-heading` 18/500 → 20/700 to match real BT.
        • K-format views >999 (e.g. 1.5k) in the engagement strip.
+`v=88` BDP fidelity iter2 — title suffix + accordion restore + clamp + stat sizing:
+       • Real-BT DEALER BDP probe (2026-05-24,
+         boattrader.com/boat/2008-pursuit-os-335-offshore-10161885/)
+         revealed three iter1 misses driven by the original
+         private-seller-only probe.
+       • Title length suffix restored as a SIBLING `<span class="bdp-length">`
+         inside a new `.bdp-title-row` flex header — real BT ships
+         `<header><h1>Title</h1><span>| 33'</span></header>` to keep
+         H1.textContent clean while the visible title reads
+         "Title | XX'". Iter1 dropped the suffix entirely; restored.
+       • Boat Details accordions: real BT renders ALL FIVE
+         (Description / Measurements / Propulsion / More Details /
+         Location). Iter1.2 removed the last two based on the
+         private-seller probe; both restored at H3 level.
+       • Description body clamp: real BT clamps to ~168px with
+         inline "Show More" button (13/400 BT-blue). Sandbox now wraps
+         the accordion body in `.bdp-description-clamped` and adds a
+         `.bdp-show-more` button. base.html gets a click handler that
+         toggles `.is-expanded` and swaps "Show More" ↔ "Show Less".
+       • Stat cards 205×44 → 166×39: grid switched from `repeat(4,1fr)`
+         to `repeat(4,166px)` w/ 16px/12px gaps; stat-icon container
+         44→32px; card gap 14→10px.
+       • "Visit Seller Website ↗" → "Visit Seller Website" (real BT
+         has no arrow on the dealership-card link).
+       • Verified live on 5 variants via Chrome MCP probes:
+         dealer (Princess F55), private (Chaparral 267 SSX),
+         sponsored (Robalo R230 — yellow SPONSORED LISTING pill),
+         POA (Boston Whaler 210 Dauntless — "Request a Price", no
+         monthly link), and price-drop (Crestliner VT 18 —
+         "$27,800 ↓ $1,500"). All structural anchors present, no
+         regressions.
 `v=87` BDP fidelity iter1.2 — stats + accordions + services:
        • Stats label "Engine Hours" → "Engine(s) Hours" with inline
          gray ⓘ tooltip trigger (matches real BT exactly). New

--- a/deploy/sim_envs/mantis_boattrader/FIDELITY.md
+++ b/deploy/sim_envs/mantis_boattrader/FIDELITY.md
@@ -764,3 +764,44 @@ Calculator" (18/700 #303030), then a result row.
        • `_captured/README.md` — format spec, methodology, what's intentionally
          not in the corpus (raw DOM, screenshots, HAR).
        • Closes "Done bar" item: `_captured/` corpus checked in.
+`v=86` BDP fidelity iter1 — nav row + sticky bar + private-seller card:
+       • Real-vs-sandbox BDP diff written to BDP_FIDELITY_PLAN.md;
+         _captured/bdp/structural.json filled with measured spec from
+         boattrader.com/boat/2010-contender-32-st-10169273/.
+       • Nav row + sticky bar: drop `‹`/`›` glyphs from back/next links
+         (plain words); wire `prev_boat` (template just wasn't using it);
+         add Previous Boat link in both static + sticky positions.
+       • Sticky bar gets TWO content states: shallow (breadcrumb) for
+         scrollY>320, deep (Title | $Price | City, ST ZIP | ♡ Save) for
+         scrollY>700 — matches real BT's `next-previous show-info` class
+         swap. base.html scroll listener toggles `bdp-scrolled-deep` on
+         body alongside `bdp-scrolled`.
+       • Breadcrumb color #757575 → #616161 to match real BT.
+       • Private-seller right rail: drop `Private Seller` pill; heading
+         is generic `Contact Private Seller` (no owner name); drop
+         disclaimer paragraph; drop owner-name from message prefill;
+         move Show Phone Number to AFTER the form and gate on
+         `boat.owner_phone`; drop badges above title; drop length suffix
+         from H1.
+       • Submit button: new `.bdp-contact-submit` class (filled blue
+         pill `rgb(37,102,176)` 40px tall full-width) replacing legacy
+         `.contact-seller-btn` outline override; same `Contact Seller`
+         text for both dealer + private (was "Email Seller" for private).
+       • `.dealer-card-heading` 18/500 → 20/700 to match real BT.
+       • K-format views >999 (e.g. 1.5k) in the engagement strip.
+`v=87` BDP fidelity iter1.2 — stats + accordions + services:
+       • Stats label "Engine Hours" → "Engine(s) Hours" with inline
+         gray ⓘ tooltip trigger (matches real BT exactly). New
+         `.stat-label .stat-info` 14×14 keeps ⓘ inline.
+       • Drop inline `<text>YEAR</text>` from Year icon SVG.
+       • Drop `More Details` + `Location` accordions — real BT only
+         renders Description / Measurements / Propulsion at this level.
+       • Drop `bdp-listed-by` block for `is_owner_listed` — real BT
+         private-seller BDP omits this section entirely.
+       • Other Services tiles 2 → 6 (Marine Surveyors, Boat
+         Documentation, Boat Loans, Boat Insurance, Boat Warranty, Boat
+         Transport); grid 2-col → 3-col at desktop.
+       • Verified live on dealer (Princess F55) + private (Chaparral
+         267 SSX) BDPs via Chrome MCP probes: sticky deep-state fires
+         at y>700; rail width = 366; all 3 accordions only; 6 service
+         tiles; FILLED `Contact Seller` button on both variants.

--- a/deploy/sim_envs/mantis_boattrader/FIDELITY.md
+++ b/deploy/sim_envs/mantis_boattrader/FIDELITY.md
@@ -836,3 +836,40 @@ Calculator" (18/700 #303030), then a result row.
          267 SSX) BDPs via Chrome MCP probes: sticky deep-state fires
          at y>700; rail width = 366; all 3 accordions only; 6 service
          tiles; FILLED `Contact Seller` button on both variants.
+`v=89..v=117` BDP fidelity iter3..iter14:
+       • Description body restructure + Loan Calc form simplification
+         (4-field set; preview pane heading + monthly + total + disclosure)
+       • seed.py apostrophe encoding cleanup (Don?t → Don't, etc.)
+       • Listed By card matched real BT (#f5f9ff bg, stat-num 16/600,
+         "Trusted Boat Trader Partner" plain label without `| years`)
+       • Accordion summary padding 16/22 → 0 (details padding 18px 0
+         + 1px #ededed bottom border between sections)
+       • Stat label wrap fix (dropped inline ⓘ on Engine(s) Hours so
+         the label fits 166px card on one line)
+       • Engagement divider switched from `|` char to 1×12 rectangle
+         (bg rgb(222,226,227)); gap 12 → 10
+       • Description body 15/19.5 line-height (was 14/1.55); seller
+         blurb + DESCRIPTION label both at 15/700
+       • Boat Details H2 margin 16px → 0
+       • Nav row layout: NOT space-between — flex-start + margin-left:
+         auto on .bdp-nav-actions; max-width 1336 cap to align with
+         gallery underneath
+       • Sticky bar inner max-width 1336 (was 1440) for same alignment
+       • Ad-strip viewport breakout (margin: 24px calc(50% - 50vw);
+         width 100vw) so #f7f7f7 band spans full 1600px
+       • Ad-banner 728×90 → 970×120; strip padding 16 → 1px each side
+       • Previous Boat / Next Boat: padded 11px 15px button-shape with
+         4px radius; chevrons via ::before/::after pseudo-elements
+       • .bt-main max-width: none (was 1440) to let ad-strip break out;
+         compensating .srp / .home-section caps restored to keep SRP
+         and home centered
+       • Breadcrumb color BDP-scoped #757575 → #616161
+       • Dealer card pattern switched to dealership-name heading +
+         pin-led address + raw +1XXXXXXXXXX phone (Westchester pattern,
+         no headshot)
+       • Phone format E.164 in seed.py (was formatted with parens)
+       • Loan calc inputs scoped: 4px radius + 16px font; heading 20/700
+       • More Boats from this Dealer link color #2566b0 → #0051AD
+       • Right rail dedup: dropped legacy .bdp-dealership-card (was
+         duplicating dealer info already in the new nested .bdp-dealer-card;
+         dealership logo + stats stay only in full-width Listed By)

--- a/deploy/sim_envs/mantis_boattrader/_captured/bdp/structural.json
+++ b/deploy/sim_envs/mantis_boattrader/_captured/bdp/structural.json
@@ -1,109 +1,113 @@
 {
   "_meta": {
-    "captured_at": "2026-05-23T18:30Z",
-    "url": "https://www.boattrader.com/boat/2015-pioneer-197-sportfish-10079002/",
+    "captured_at": "2026-05-23T13:00:00Z",
+    "url": "https://www.boattrader.com/boat/2010-contender-32-st-10169273/",
+    "listing_type": "private_seller",
     "viewport": {"width": 1512, "height": 711, "devicePixelRatio": 2},
-    "captured_via": "Chrome MCP getBoundingClientRect + getComputedStyle probes",
-    "note": "Two-column layout. Left column = gallery + thumbs + below-the-fold accordions. Right column = title + price + monthly + contact form. This particular listing is private-seller (no 'Show Phone' button); below-fold sections (Similar Boats) lazy-load on scroll and may not appear in a single probe."
+    "captured_via": "Chrome MCP getBoundingClientRect + getComputedStyle",
+    "note": "Private-seller BDP. Dealer BDP is a separate capture (TODO). Companion working doc: ../../BDP_FIDELITY_PLAN.md."
   },
 
-  "page_layout": {
-    "content_left_x": 70,
-    "content_right_x": 1389,
-    "content_width": 1319,
-    "left_col": {"x": 70, "width": 890},
-    "right_col": {"x": 1039, "width": 334, "gap_from_left_col": 79},
-    "note": "Sandbox `.bdp-grid` now capped at max-width: 1336px (v=91) — matches real BT."
+  "nav_row": {
+    "back_search": {"text": "< Search", "style": {"font-size": "12px", "font-weight": "400", "color": "rgb(19,154,245)"}, "note": "plain word, no `‹` glyph"},
+    "next_boat":  {"text": "Next Boat",     "style": {"font-size": "12px", "font-weight": "400", "color": "rgb(19,154,245)"}, "note": "plain word, no `›` glyph"},
+    "prev_boat":  {"text": "Previous Boat", "style": {"font-size": "12px", "font-weight": "400", "color": "rgb(19,154,245)"}, "note": "rendered when there's a previous boat"},
+    "breadcrumb": {"style": {"font-size": "12px", "font-weight": "400", "color": "rgb(97,97,97)", "padding": "12px 15px 12px 0", "margin-left": "10px"}}
   },
 
-  "next_previous_sticky_bar": {
-    "_real_class": ".next-previous (.next-previous-top after scroll)",
+  "sticky_bar": {
+    "_real_class": "next-previous show-info next-previous-top",
     "rect": {"width": 1512, "height": 54},
-    "position": "sticky",
-    "top": "0px",
-    "always_visible": true,
-    "note": "Real BT keeps this navigation bar (Previous Boat / Next Boat) ALWAYS sticky at top, full viewport width (1512px), 54px tall. After scrolling past ~100px, gets a `.next-previous-top` modifier class. Sandbox does NOT replicate this widget — sandbox's only sticky bar is the v=58 `.bdp-scrolled` body class that triggers after 320px scroll for a title+price+contact mini-bar. Different concept; documented as 🟡 if exact parity matters."
+    "style": {"background": "rgba(255,255,255,0.98)"},
+    "states": {
+      "top": {"trigger": "scrollY > ~80px", "content_order": ["< Search", "breadcrumb", "Previous Boat", "Next Boat", "[Contact Seller pill]"]},
+      "deep": {"trigger": "scrollY > ~700px (past gallery)", "content_order": ["< Search", "Title", "$Price", "City, ST ZIP", "♡ Save", "Previous Boat", "Next Boat", "[Contact Seller pill]"], "note": "breadcrumb is REPLACED by title/price/location, NOT appended"}
+    },
+    "contact_pill": {"rect": {"width": 152, "height": 36}, "style": {"background-color": "rgb(37,102,176)", "color": "white", "font-size": "15px"}, "note": "filled blue pill, always visible in sticky bar"}
   },
 
-  "right_rail_sticky": {
-    "_status": "NOT sticky on probed listing — sandbox doesn't make right-rail contact form sticky either",
-    "note": "Verified at scroll y=700 on real BT: no sticky right-rail elements between 0-80px from top with width 200-500px."
+  "right_rail_summary_card": {
+    "rect": {"width": 366, "padding": 16, "border-radius": 8, "border": "1px solid rgb(237,237,237)", "box-shadow": "rgba(0,0,0,0.2) 0 2px 2px 0"},
+    "content_order_private_seller": [
+      "H1 title (NO length suffix)",
+      "Location line (City, ST ZIP)",
+      "Price + price-drop arrow (if any)",
+      "Own this boat for $X/mo (ⓘ) Customize",
+      "Engagement row (Views | Saves | New to Market)",
+      "[border-top divider]",
+      "H2 'Contact Private Seller' (generic — no owner name)",
+      "Lead form: Name (full) · Email + Phone (split) · Message",
+      "[Contact Seller] filled blue pill (button text is 'Contact Seller' not 'Email Seller')"
+    ],
+    "h1": {"style": {"font-size": "20px", "font-weight": "700", "color": "rgb(51,51,51)"}, "note": "no `| XX'` length suffix"},
+    "location": {"style": {"font-size": "14px", "font-weight": "400", "color": "rgb(117,117,117)"}},
+    "price": {"style": {"font-size": "20px", "font-weight": "700", "color": "rgb(51,51,51)"}},
+    "monthly_link": {"style": {"font-size": "16px", "color": "rgb(19,154,245)"}},
+    "engagement_row": {"style": {"font-size": "12px", "font-weight": "400", "color": "rgb(102,102,102)"}, "note": "K-format large view counts (e.g. 1.5k); pipe `|` separators between items"},
+    "lead_input": {"rect": {"width": 334, "height": 40}, "style": {"font-size": "14px", "border": "1px solid rgb(194,194,194)", "border-radius": "4px", "padding": "8px 12px 4px"}},
+    "submit_button": {"text": "Contact Seller", "style": {"background-color": "rgb(37,102,176)", "color": "white", "border": "none"}, "note": "FILLED pill; same text for dealer and private seller"},
+    "private_seller_card_anti_patterns": ["NO 'Private Seller' pill above heading", "NO owner-name in heading ('Contact Ravi, the owner')", "NO disclaimer paragraph in card body", "NO 'Show Phone Number' button before the form on listings without a known phone"]
   },
 
-  "breadcrumb": {
-    "_real_text": "Home / Boats For Sale / Power / Center Console / Pioneer",
-    "rect": {"width": 332, "height": 40, "x": 137, "y": 191},
-    "style": {
-      "fontSize": "12px",
-      "fontWeight": "400",
-      "color": "rgb(97, 97, 97)"
+  "stats_strip": {
+    "rect": {"width": "~870 (gallery-column width)", "card_count": 8},
+    "grid": "4 columns × 2 rows",
+    "card": {"rect": {"width": 166, "height": 39}, "note": "smaller than sandbox's 205×44"},
+    "label": {"style": {"font-size": "14px", "font-weight": "700", "color": "rgb(48,48,48)"}},
+    "value": {"style": {"font-size": "14px", "font-weight": "400", "color": "rgb(51,51,51)"}},
+    "labels_in_order": ["Engine", "Total Power", "Engine(s) Hours", "Class", "Length", "Year", "Model", "Capacity"],
+    "info_tooltip": {"on": "Engine(s) Hours", "style": "small gray ⓘ inline next to label"}
+  },
+
+  "boat_details_section": {
+    "h2": {"text": "Boat Details", "style": {"font-size": "20px", "font-weight": "700", "color": "rgb(51,51,51)"}},
+    "background": "plain white (NOT the #f5f9ff tinted card the sandbox currently uses — needs verification on a 2nd real BDP)",
+    "accordions_in_order": ["Description (open)", "Measurements (closed)", "Propulsion (closed)"],
+    "anti_patterns": ["NO 'More Details' accordion at H3 level", "NO 'Location' accordion at H3 level"],
+    "description_body": {
+      "clamped": true,
+      "show_more_link": {"style": {"font-weight": "700", "color": "rgb(19,154,245)"}, "alignment": "right"},
+      "no_key_features_sub_h3": true
     }
   },
 
-  "gallery_and_thumbs": {
-    "_real_class": ".style-module_imageCarousel.style-module_thumbnails",
-    "rect": {"width": 890, "height": 727, "x": 70},
-    "thumbnail_size": {"width": 175, "height": 116},
-    "note": "Container holds main image + 5-thumb strip + 'View 22 Photos' overlay. Sandbox auto-fits to 175×116 via .bdp-grid max-width capping (v=91)."
+  "what_owners_say": {
+    "h2": {"text": "What Owners Say", "icons": ["✦ sparkle prefix", "ⓘ info suffix"], "style": {"font-size": "20px", "font-weight": "700"}},
+    "owner_highlights_pills": {"style": {"background-color": "rgb(227,241,254)", "color": "rgb(37,102,176)", "font-size": "12px", "font-weight": "700", "padding": "4px 8px", "border-radius": "5px"}}
   },
 
-  "title_block_right_rail": {
-    "h1": {
-      "_real_class": ".style-module_heading.style-module_heading-1",
-      "_real_text": "2015 Pioneer 197 Sportfish",
-      "rect": {"width": 248, "height": 23, "x": 1039, "y": 263},
-      "style": {"fontSize": "20px", "fontWeight": "700", "color": "rgb(51, 51, 51)"}
-    },
-    "main_price": {
-      "_real_text": "$25,900",
-      "rect": {"width": 73, "height": 23, "x": 1039, "y": 322},
-      "style": {"fontSize": "20px"},
-      "tag": "SPAN"
-    },
-    "monthly_estimate": {
-      "_real_text": "$4,000",
-      "rect": {"width": 54, "height": 24, "x": 1132, "y": 322},
-      "style": {"fontSize": "18px"},
-      "tag": "P",
-      "note": "Sits inline-right of main price; both share a flex row."
-    }
+  "loan_calc_card": {
+    "h3": {"text": "Boat Loan Payment Calculator", "style": {"font-size": "20px", "font-weight": "700"}},
+    "layout": "2-col grid: form left, preview + bullets right (light-blue bg right)",
+    "disclosure_link": "small gray with superscript³"
   },
 
-  "below_fold_accordions_verified": {
-    "_note": "Verified heading levels via real BT 2026-05-23 probe at /boat/2015-pioneer-197-sportfish/",
-    "h2_20_700": ["What Owners Say", "Owner Highlights", "Boat Details"],
-    "h3_16_700": ["Description", "Measurements", "Propulsion"],
-    "h4_14_700": ["Dimensions", "Weights", "Tanks"],
-    "h3_24_700": ["Still have a question?"],
-    "h3_18_700": ["Contact Private Seller"],
-    "not_found_on_this_listing": ["More Details", "Location", "Similar Boats", "Show Phone"],
-    "note": "More Details / Location headings — earlier FIDELITY claim that they use H4 is unverifiable today (sections not visible on probed listings). Similar Boats appears to lazy-load below the viewport. Show Phone is dealer-only (this listing is private-seller)."
+  "still_have_a_question": {
+    "h2": {"text": "Still have a question?", "style": {"font-size": "24px", "font-weight": "700"}},
+    "rule": "blue 32×2px underline below H2",
+    "cta_button": {"text": "Contact seller", "style": "blue outline pill, 14/700"}
   },
 
-  "right_rail_contact_form": {
-    "_real_class": ".lead-form-basic__body",
-    "rect": {"width": 334, "height": 260, "x": 1055},
-    "style": {"fontSize": "16px", "color": "rgb(71, 76, 74)"},
-    "note": "Below the title/price block. Includes Name / Email / Phone / Message fields + submit button."
+  "other_services": {
+    "label": {"text": "OTHER SERVICES", "style": {"font-size": "14px", "font-weight": "700", "text-transform": "uppercase"}},
+    "tile_count_real": 6,
+    "tile_count_sandbox_today": 2,
+    "tile_name_style": {"font-size": "14px", "font-weight": "400", "color": "rgb(77,77,77)"}
+  },
+
+  "listed_by_section_visibility": {
+    "private_seller": "NOT rendered (real BT omits the section entirely for private sellers)",
+    "dealer": "rendered (NOT yet captured this session — TODO probe a dealer BDP)"
   },
 
   "_known_matches_in_fidelity_md": [
-    "BDP grid 1fr+80+366 with max-width 1336px (v=91)",
+    "BDP grid 1fr+80+366 (v=47) — column width needs to be tightened to 366 (sandbox lands at 332)",
     "BDP back/next colors (v=57)",
     "BDP gallery 3:2 aspect (v=79)",
-    "Sticky breadcrumb 15/400/#333 (v=58)",
-    "Description / Measurements / Propulsion accordion = H3 16/700 (verified v=91)",
-    "Dimensions / Weights / Tanks subheading = H4 14/700 (verified v=91)",
-    "Owner Highlights = H2 20/700 (v=91 — flipped from H3)",
-    "Lead form inputs 4px radius, outline button 2px (v=55)"
+    "Sticky breadcrumb 15/400/#333 (v=58) — superseded: sticky bar has TWO states; breadcrumb state is only one of them",
+    "Boat Details bg (v=56) — needs re-verification; real BT may NOT use the #f5f9ff tint",
+    "Lead form inputs 4px radius, outline button 2px (v=55) — submit button is FILLED, not outline"
   ],
 
-  "_open_followups": [
-    "Probe Similar Boats card rail when it appears (lazy-loaded; not visible in a single-scroll probe)",
-    "Probe Show Phone button on a dealer listing (this listing was private-seller)",
-    "Decide whether to add real BT's `.next-previous` always-sticky navigation bar (Previous/Next Boat) to sandbox — currently absent",
-    "Measure dealer-card geometry on a dealer listing (real BT renders a 'Contact Dealer' card with phone + dealer logo; sandbox renders dealer info inline)"
-  ],
-
-  "_capture_methodology": "Open any /boat/<slug>/ at 1512px, scroll to make each section visible, probe per element. The right rail (x=1039–1389) is the canonical anchor for title + price + contact form. Lazy-loaded sections require multiple scroll passes."
+  "_capture_methodology": "Open the real BT BDP in Chrome MCP at 1512×711. Run a JS probe that captures rect + computed-style for each anchor element (sticky bar, breadcrumb, H1, price, engagement, stats container, accordion summaries, footer cards). For interaction states (sticky deep-scroll) scroll to threshold (700px) and re-probe sticky bar text. Save measurements + label exact wording here. Re-run for a DEALER BDP to capture the right-rail dealer variant + Listed By + More From This Dealer regions."
 }

--- a/deploy/sim_envs/mantis_boattrader/app/seed.py
+++ b/deploy/sim_envs/mantis_boattrader/app/seed.py
@@ -268,36 +268,36 @@ DEALER_SELLER_DESCRIPTIONS: list[str] = [
     (
         "The {model} features a long, firm, rampy wake, with a clean lip and no "
         "trough. The stern seat affords three different configurations so you can "
-        "customize your boat?s interior to suit you and {seat_n} of your closest "
+        "customize your boat's interior to suit you and {seat_n} of your closest "
         "friends. In its original position it completes an expansive stern seat. "
         "Remove the center section and position it midship and you have an aft "
-        "facing observer?s seat. Turn it around and you have a forward facing "
-        "companion seat. It?s up to you."
+        "facing observer's seat. Turn it around and you have a forward facing "
+        "companion seat. It's up to you."
     ),
     (
-        "This {year} {make} {model} represents the pinnacle of {make}?s offshore "
+        "This {year} {make} {model} represents the pinnacle of {make}'s offshore "
         "lineup. Hand-laid {hull_material} construction with a deep-V hull pattern "
         "deliver a dry, comfortable ride at any speed. The forward seating module "
-        "converts into a sun-pad and there?s an integrated cooler underneath. The "
-        "helm is sport-fishing focused but doesn?t sacrifice creature comforts — "
-        "you?ll find a removable galley insert, refrigerator drawer, and freshwater "
-        "spigot all within arm?s reach of the captain."
+        "converts into a sun-pad and there's an integrated cooler underneath. The "
+        "helm is sport-fishing focused but doesn't sacrifice creature comforts — "
+        "you'll find a removable galley insert, refrigerator drawer, and freshwater "
+        "spigot all within arm's reach of the captain."
     ),
     (
-        "We?re pleased to offer this clean and well-equipped {year} {make} {model}. "
-        "It?s a one-owner boat that?s been impeccably maintained — all service "
+        "We're pleased to offer this clean and well-equipped {year} {make} {model}. "
+        "It's a one-owner boat that's been impeccably maintained — all service "
         "records will transfer with the boat. The {hull_color} hull is in show "
-        "condition; gelcoat is in remarkable shape for the year. Below deck you?ll "
+        "condition; gelcoat is in remarkable shape for the year. Below deck you'll "
         "find {capacity} accommodations including a private master, and an enclosed "
-        "head with separate stall shower. Won?t last long — schedule a sea trial today."
+        "head with separate stall shower. Won't last long — schedule a sea trial today."
     ),
     (
-        "Don?t miss this opportunity! This {make} {model} won?t last on the brokerage "
-        "market. She?s been owner-operated since new and is being offered turn-key "
+        "Don't miss this opportunity! This {make} {model} won't last on the brokerage "
+        "market. She's been owner-operated since new and is being offered turn-key "
         "with everything you need to step aboard and enjoy. The galley is fully "
         "outfitted, the electronics suite has been refreshed within the last year, "
         "and the {engine_make} engine{engine_plural} {engine_verb_pres} just been "
-        "serviced. Whether you?re a first-time buyer or a seasoned captain, you?ll "
+        "serviced. Whether you're a first-time buyer or a seasoned captain, you'll "
         "appreciate the attention to detail."
     ),
 ]

--- a/deploy/sim_envs/mantis_boattrader/app/seed.py
+++ b/deploy/sim_envs/mantis_boattrader/app/seed.py
@@ -435,7 +435,9 @@ def _gen_dealers(rng: random.Random) -> list[Dealer]:
         suffix = suffix_pool[idx % len(suffix_pool)]
         name = f"{prefix}{suffix}".strip(", ").strip()
         phone_seed = 4000000 + idx * 18371
-        phone = f"({rng.randint(200, 989)}) {rng.randint(200, 989)}-{phone_seed % 10000:04d}"
+        # Real BT renders dealer phones as raw `+1XXXXXXXXXX` (E.164,
+        # no parens/dashes). Match that format.
+        phone = f"+1{rng.randint(200, 989)}{rng.randint(200, 989):03d}{phone_seed % 10000:04d}"
         years = rng.choice([3, 6, 8, 12, 15, 18, 22])
         dealers.append(
             Dealer(

--- a/deploy/sim_envs/mantis_boattrader/app/static/app.css
+++ b/deploy/sim_envs/mantis_boattrader/app/static/app.css
@@ -1905,15 +1905,17 @@ body.bdp-scrolled-deep .sticky-save {
   font-size: 14px;
   font-weight: 700;
   color: #303030;
-  letter-spacing: 0.2px;
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
+  letter-spacing: 0;
+  white-space: nowrap;
 }
-/* Inline info ⓘ next to "Engine(s) Hours" — slightly smaller than
-   the default 16×16 to fit the 14/700 label line cleanly. */
+/* Inline info ⓘ next to "Engine(s) Hours" — smaller (12×12) so the
+   "Engine(s) Hours ⓘ" label still fits on one line inside the 166px
+   stat card without wrapping. */
 .stat-label .stat-info {
-  width: 14px; height: 14px; font-size: 10px;
+  width: 12px; height: 12px; font-size: 9px;
+  display: inline-block;
+  vertical-align: middle;
+  margin-left: 2px;
 }
 .stat-value {
   font-size: 14px;

--- a/deploy/sim_envs/mantis_boattrader/app/static/app.css
+++ b/deploy/sim_envs/mantis_boattrader/app/static/app.css
@@ -2038,8 +2038,23 @@ body.bdp-scrolled-deep .sticky-save {
   color: var(--bt-text);
   line-height: 1.55;
 }
+/* Real BT BDP Description body: the seller blurb (first paragraph) is
+   rendered bold like a sub-heading, followed by a small uppercase
+   "DESCRIPTION" label, then the body paragraphs. Together they take ~3
+   visible lines above the clamp boundary. */
 .bdp-seller-blurb {
-  margin: 0 0 14px;
+  margin: 0 0 12px;
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--bt-text);
+  line-height: 1.4;
+}
+.bdp-description-label {
+  margin: 14px 0 8px;
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--bt-text);
+  letter-spacing: 1px;
 }
 .bdp-map-placeholder {
   margin-top: 12px;
@@ -2100,18 +2115,22 @@ body.bdp-scrolled-deep .sticky-save {
   margin: 18px 0 0;
 }
 .loan-apr strong { font-size: 18px; font-weight: 700; }
+/* Real BT loan-preview monthly payment: 50px / 700 / centered, with
+   tight letter-spacing. Was 48px (close, bumped to match probe). */
 .loan-payment {
-  font-size: 48px;
+  font-size: 50px;
   font-weight: 700;
   color: var(--bt-text);
-  margin: 4px 0 8px;
+  margin: 16px 0 12px;
   letter-spacing: -1px;
+  text-align: center;
 }
 .loan-total {
   font-size: 13px;
   color: var(--bt-text);
   letter-spacing: 0.8px;
   margin: 8px 0;
+  text-align: center;
 }
 .loan-term {
   font-size: 13px;

--- a/deploy/sim_envs/mantis_boattrader/app/static/app.css
+++ b/deploy/sim_envs/mantis_boattrader/app/static/app.css
@@ -2000,11 +2000,13 @@ body.bdp-scrolled-deep .sticky-save {
   padding: 20px 16px;
   margin: 24px 0;
 }
+/* Real BT Boat Details H2: 20/700, margin 0 (accordions sit flush
+   right under the heading inside the #f5f9ff tinted card). */
 .bdp-details-h2 {
   font-size: 20px;
   font-weight: 700;
   color: var(--bt-text);
-  margin: 0 0 16px;
+  margin: 0;
 }
 .bdp-accordion summary { font-size: 16px; font-weight: 700; }
 .bdp-accordion .accordion-title {

--- a/deploy/sim_envs/mantis_boattrader/app/static/app.css
+++ b/deploy/sim_envs/mantis_boattrader/app/static/app.css
@@ -402,13 +402,22 @@ header.main {
 
 /* ── Ad strips — Real BT BDP top sponsor: 970×120 banner inside a
    tight #f7f7f7 strip (~122px total height, ~1px breathing room above
-   and below the banner). Was 728×90 with 16+24px padding/margin which
-   bloated the strip to ~170px total. ─────────────────────────────── */
+   and below the banner). Real BT renders ~30px white gap above and
+   below the strip — body bg is white, the strip has its own #f7f7f7
+   tinted band with vertical margin to separate from the header above
+   and the nav row below. ─────────────────────────────────────────── */
+/* The ad-strip's #f7f7f7 band must span the FULL viewport edge-to-edge
+   per real BT (probed at 1600px viewport: ad-leaderboard-top width =
+   1600). Since .bt-main caps its inner content at 1440px max-width
+   centered, we use the classic "full-bleed" trick: negative left+
+   right margins of `calc(50% - 50vw)` push the strip out to viewport
+   edges regardless of the parent's max-width. */
 .ad-strip {
   background: #f7f7f7;
   padding: 1px 0;
   display: flex; justify-content: center;
-  margin: 0;
+  margin: 24px calc(50% - 50vw);
+  width: 100vw;
 }
 .ad-banner {
   position: relative; max-width: 970px; width: 100%; height: 120px;
@@ -1558,9 +1567,15 @@ body.bdp-scrolled-deep .sticky-save {
   gap: 24px;
 }
 .bdp-nav-actions { display: flex; gap: 16px; margin-left: auto; }
-/* Real BT BDP top links 'Back to Search' / 'Next Boat' / 'Previous Boat':
-   12/400 #139af5 (plain words, no chevrons). */
+/* Real BT BDP top links: 12/400 #139af5.
+   Probed at boattrader.com 2026-05-24 — both Previous and Next get
+   chevrons via CSS pseudo-elements (NOT inline text). Iter1 wrongly
+   stripped both. Restored to match exact `next-previous-button-tray`
+   layout (Pursuit BDP probe: `prev::before content "<"`,
+   `next::after content ">"`). */
 .bdp-back, .bdp-next, .bdp-prev { font-size: 12px; font-weight: 400; color: #139af5; text-decoration: none; }
+.bdp-prev::before { content: "< "; }
+.bdp-next::after { content: " >"; }
 .bdp-back:hover, .bdp-next:hover, .bdp-prev:hover { color: var(--bt-blue); text-decoration: underline; }
 /* Real BT BDP uses ~890 gallery + ~80 gap + 366 rail at 1512 viewport.
    That's ratio gallery:rail ≈ 2.43:1, with ~80px gap. */

--- a/deploy/sim_envs/mantis_boattrader/app/static/app.css
+++ b/deploy/sim_envs/mantis_boattrader/app/static/app.css
@@ -1705,13 +1705,14 @@ body.bdp-scrolled-deep .sticky-save {
   cursor: help;
 }
 .bdp-customize-link { color: var(--bt-blue); font-weight: 500; font-size: 16px; }
+/* Real BT engagement row: gap 10px (was 12), align center. */
 .bdp-engagement-row {
   list-style: none;
   padding: 12px 0 14px;
   margin: 0;
   border-top: 1px solid var(--bt-border);
   display: flex;
-  gap: 12px;
+  gap: 10px;
   align-items: center;
   font-size: 12px;
   color: var(--bt-text-dim);
@@ -1734,7 +1735,7 @@ body.bdp-scrolled-deep .sticky-save {
   width: 1px;
   height: 12px;
   background: rgb(222, 226, 227);
-  margin-left: 12px;
+  margin-left: 10px;
   vertical-align: middle;
 }
 .bdp-engagement-row .ico {
@@ -2065,19 +2066,25 @@ body.bdp-scrolled-deep .sticky-save {
    rendered bold like a sub-heading, followed by a small uppercase
    "DESCRIPTION" label, then the body paragraphs. Together they take ~3
    visible lines above the clamp boundary. */
+/* Real BT seller blurb (first paragraph): 15/700 #333, matches the
+   DESCRIPTION sub-label that follows. */
 .bdp-seller-blurb {
-  margin: 0 0 12px;
-  font-size: 14px;
+  margin: 0 0 14px;
+  font-size: 15px;
   font-weight: 700;
   color: var(--bt-text);
-  line-height: 1.4;
+  line-height: 1.3;
 }
+/* Real BT DESCRIPTION sub-label inside Description body: `<strong>` at
+   15/700 with NO letter-spacing, NO uppercase transform (text is
+   literally "DESCRIPTION" in the source). Sits as a regular bold
+   paragraph between the seller blurb and the body paragraphs. */
 .bdp-description-label {
-  margin: 14px 0 8px;
-  font-size: 12px;
+  margin: 0;
+  font-size: 15px;
   font-weight: 700;
   color: var(--bt-text);
-  letter-spacing: 1px;
+  letter-spacing: normal;
 }
 .bdp-map-placeholder {
   margin-top: 12px;

--- a/deploy/sim_envs/mantis_boattrader/app/static/app.css
+++ b/deploy/sim_envs/mantis_boattrader/app/static/app.css
@@ -172,6 +172,19 @@ header.main {
   padding: 0;
   min-height: 480px;
 }
+/* SRP + Home sections need their own page-container width since
+   `.bt-main` no longer provides one. Matches the previous behavior
+   (1440 - 40 padding ≈ 1400 effective content width). */
+.srp {
+  max-width: var(--container);
+  margin: 0 auto;
+  padding: 0 20px;
+}
+.home-section {
+  max-width: var(--container);
+  margin: 36px auto;
+  padding: 0 20px;
+}
 
 /* ── Home: hero ─────────────────────────────────────────────────── */
 .home-hero {

--- a/deploy/sim_envs/mantis_boattrader/app/static/app.css
+++ b/deploy/sim_envs/mantis_boattrader/app/static/app.css
@@ -1503,28 +1503,51 @@ body.bdp-scrolled .bdp-sticky-bar { display: block; }
   font-size: 13px;
   padding: 8px 18px;
 }
-/* Real BT BDP breadcrumb (inside bdp-nav-row): 15/400 #333. */
+/* Real BT BDP breadcrumb inside the sticky bar: 12/400 #616161 (matches
+   the non-sticky breadcrumb row). The sticky bar swaps this out for a
+   title/price line at deep scroll. */
 .sticky-breadcrumb {
-  flex: 1;
   margin: 0;
-  font-size: 15px;
+  font-size: 12px;
   font-weight: 400;
-  color: #333;
+  color: #616161;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
-.sticky-breadcrumb a { color: #333; }
+.sticky-breadcrumb a { color: #616161; text-decoration: none; }
 .sticky-breadcrumb a:hover { color: var(--bt-blue); }
+
+.bdp-sticky-content { flex: 1; min-width: 0; display: flex; align-items: center; }
+.bdp-sticky-state { display: none; min-width: 0; }
+.bdp-sticky-state-shallow { display: block; }
+body.bdp-scrolled-deep .bdp-sticky-state-shallow { display: none; }
+body.bdp-scrolled-deep .bdp-sticky-state-deep {
+  display: flex; align-items: center; gap: 12px;
+  font-size: 14px; color: #333; min-width: 0;
+}
+body.bdp-scrolled-deep .sticky-title { font-weight: 700; max-width: 280px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+body.bdp-scrolled-deep .sticky-price { font-weight: 700; color: #333; white-space: nowrap; }
+body.bdp-scrolled-deep .sticky-loc { color: #333; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 200px; }
+body.bdp-scrolled-deep .sticky-sep { color: #c4c4c4; font-weight: 400; }
+body.bdp-scrolled-deep .sticky-save {
+  display: inline-flex; align-items: center; gap: 4px;
+  background: transparent; border: 0; padding: 0;
+  color: var(--bt-blue); font: inherit; font-size: 14px; font-weight: 400;
+  cursor: pointer; white-space: nowrap;
+}
 
 .bdp-nav-row {
   display: flex; align-items: center; justify-content: space-between;
   margin: 8px 0 14px;
-  font-size: 13px; color: var(--bt-blue);
+  font-size: 12px; color: var(--bt-blue);
+  gap: 24px;
 }
-/* Real BT BDP top links 'Back to Search' / 'Next Boat': 12/400 #139af5. */
-.bdp-back, .bdp-next { font-size: 12px; font-weight: 400; color: #139af5; }
-.bdp-back:hover, .bdp-next:hover { color: var(--bt-blue); text-decoration: underline; }
+.bdp-nav-actions { display: flex; gap: 16px; }
+/* Real BT BDP top links 'Back to Search' / 'Next Boat' / 'Previous Boat':
+   12/400 #139af5 (plain words, no chevrons). */
+.bdp-back, .bdp-next, .bdp-prev { font-size: 12px; font-weight: 400; color: #139af5; text-decoration: none; }
+.bdp-back:hover, .bdp-next:hover, .bdp-prev:hover { color: var(--bt-blue); text-decoration: underline; }
 /* Real BT BDP uses ~890 gallery + ~80 gap + 366 rail at 1512 viewport.
    That's ratio gallery:rail ≈ 2.43:1, with ~80px gap. */
 .bdp-grid {
@@ -2515,7 +2538,9 @@ body.bdp-scrolled .bdp-sticky-bar { display: block; }
 }
 
 .bdp-dealer-card { border-top: 1px solid var(--bt-border); padding-top: 14px; }
-.dealer-card-heading { font-size: 18px; font-weight: 500; color: var(--bt-text); margin: 0 0 10px; }
+/* Real BT 'Contact Private Seller' / 'Contact <Salesperson>' heading: 20/700 #333.
+   Was 18/500 — bumped to match real boattrader exactly. */
+.dealer-card-heading { font-size: 20px; font-weight: 700; color: var(--bt-text); margin: 0 0 12px; }
 .dealer-card-meta { display: flex; gap: 12px; align-items: center; margin: 0 0 12px; }
 .dealer-logo {
   width: 60px; height: 60px; border-radius: 50%;
@@ -2548,6 +2573,24 @@ body.bdp-scrolled .bdp-sticky-bar { display: block; }
   font-weight: 700;
   border-radius: 50px;
 }
+/* Real BT BDP lead-form submit: FILLED blue pill bg rgb(37,102,176),
+   white text 14/700, full-width 40px tall. (The legacy `.contact-seller-btn`
+   class above is intentionally the outline variant used by SRP cards —
+   the BDP submit gets its own class so it doesn't get overridden.) */
+.bdp-contact-submit.btn-block {
+  width: 100%;
+  height: 40px;
+  padding: 0 24px;
+  font-size: 14px;
+  font-weight: 700;
+  border-radius: 50px;
+  background: rgb(37, 102, 176);
+  color: #fff;
+  border: 0;
+  cursor: pointer;
+  line-height: 1;
+}
+.bdp-contact-submit.btn-block:hover { background: var(--bt-blue-3); }
 
 .bdp-section { background: #fff; padding: 18px; border-bottom: 1px solid var(--bt-border); }
 .bdp-section h2 { font-size: 18px; margin-bottom: 12px; }

--- a/deploy/sim_envs/mantis_boattrader/app/static/app.css
+++ b/deploy/sim_envs/mantis_boattrader/app/static/app.css
@@ -160,16 +160,16 @@ header.main {
   font-size: 18px; cursor: pointer; line-height: 1;
 }
 
-/* ── Main + container — matches real boattrader: max-width 1440px,
-   margin auto so at 1512px viewport the main element starts at x=36
-   with 20px internal padding (giving x=56 for the inner content). */
+/* ── Main + container — real boattrader probe (Pursuit BDP, 2026-05-24)
+   shows `<main class="page-container">` at width=1600 (FULL viewport)
+   with padding 0. Sections inside (.bdp-grid, .bdp-nav-row) apply
+   their own 1336px max-width centered. Previous `.bt-main { max-width:
+   1440 }` was indenting the full-bleed sections (ad-strip) ~80px
+   from each viewport edge — fixed by removing the cap. */
 .bt-main {
-  max-width: var(--container);
-  /* v=102: ribbon is `position: sticky` (stays in flow), so no
-     compensating top margin needed. v=100's `margin: 40px auto 0`
-     reverted. */
-  margin: 0 auto;
-  padding: 0 20px;
+  max-width: none;
+  margin: 0;
+  padding: 0;
   min-height: 480px;
 }
 
@@ -1567,15 +1567,30 @@ body.bdp-scrolled-deep .sticky-save {
   gap: 24px;
 }
 .bdp-nav-actions { display: flex; gap: 16px; margin-left: auto; }
-/* Real BT BDP top links: 12/400 #139af5.
-   Probed at boattrader.com 2026-05-24 — both Previous and Next get
-   chevrons via CSS pseudo-elements (NOT inline text). Iter1 wrongly
-   stripped both. Restored to match exact `next-previous-button-tray`
-   layout (Pursuit BDP probe: `prev::before content "<"`,
-   `next::after content ">"`). */
-.bdp-back, .bdp-next, .bdp-prev { font-size: 12px; font-weight: 400; color: #139af5; text-decoration: none; }
-.bdp-prev::before { content: "< "; }
-.bdp-next::after { content: " >"; }
+/* Real BT BDP breadcrumb color: rgb(97,97,97) = #616161 (slightly
+   darker than SRP's #757575). The base `.breadcrumb` rule is used by
+   both SRP and BDP, so we scope the BDP override under `.bdp-nav-row`. */
+.bdp-nav-row .breadcrumb,
+.bdp-nav-row .breadcrumb a { color: #616161; }
+.bdp-nav-row .breadcrumb a:hover { color: var(--bt-blue); }
+/* Real BT BDP top links 12/400 #139af5. Pursuit BDP probe (2026-05-24):
+   `.next-previous-button` is a 104×34 padded button-shaped link with
+   border-radius 4px, padding 11px 15px (prev) / 11px 35px 11px 15px
+   (next has extra right pad to anchor the chevron). Both render
+   chevrons via CSS pseudo-elements:
+     prev::before content "<", next::after content ">"
+   `< Search` stays a plain text link with no padding. */
+.bdp-back { font-size: 12px; font-weight: 400; color: #139af5; text-decoration: none; }
+.bdp-prev, .bdp-next {
+  font-size: 12px; font-weight: 400; color: #139af5; text-decoration: none;
+  padding: 11px 15px;
+  border-radius: 4px;
+  display: inline-flex; align-items: center;
+  white-space: nowrap;
+}
+.bdp-next { padding: 11px 35px 11px 15px; }
+.bdp-prev::before { content: "< "; margin-right: 4px; }
+.bdp-next::after { content: " >"; margin-left: 4px; }
 .bdp-back:hover, .bdp-next:hover, .bdp-prev:hover { color: var(--bt-blue); text-decoration: underline; }
 /* Real BT BDP uses ~890 gallery + ~80 gap + 366 rail at 1512 viewport.
    That's ratio gallery:rail ≈ 2.43:1, with ~80px gap. */

--- a/deploy/sim_envs/mantis_boattrader/app/static/app.css
+++ b/deploy/sim_envs/mantis_boattrader/app/static/app.css
@@ -2577,11 +2577,11 @@ body.bdp-scrolled-deep .sticky-save {
   margin-bottom: 8px;
 }
 
-/* Private-seller card */
-.bdp-private-seller-card {
-  border-top: 1px solid var(--bt-border);
-  padding-top: 14px;
-}
+/* Private-seller card spec is now handled by the shared
+   `.bdp-dealer-card, .bdp-private-seller-card` rule above (nested card
+   with 1px border, 8px radius, 16px padding). Kept this block as a
+   marker so future edits don't accidentally re-add a border-top. */
+/* (see .bdp-dealer-card, .bdp-private-seller-card rule near line 2686) */
 .private-seller-tag {
   display: inline-block;
   background: var(--bt-bg-alt-2);
@@ -2683,7 +2683,19 @@ body.bdp-scrolled-deep .sticky-save {
   border-radius: 3px;
 }
 
-.bdp-dealer-card { border-top: 1px solid var(--bt-border); padding-top: 14px; }
+/* Real BT BDP dealer card is a NESTED card inside .bdp-summary — its
+   own 1px #ededed border, 8px radius, white bg, ~16px padding. Was
+   rendered as a bare section with a top divider line. The nested look
+   makes the contact form visually distinct from the title/price area
+   above it. Same treatment for the private-seller variant. */
+.bdp-dealer-card,
+.bdp-private-seller-card {
+  background: #fff;
+  border: 1px solid #ededed;
+  border-radius: 8px;
+  padding: 16px;
+  margin-top: 14px;
+}
 /* Real BT 'Contact Private Seller' / 'Contact <Salesperson>' heading: 20/700 #333.
    Was 18/500 — bumped to match real boattrader exactly. */
 .dealer-card-heading { font-size: 20px; font-weight: 700; color: var(--bt-text); margin: 0 0 12px; }

--- a/deploy/sim_envs/mantis_boattrader/app/static/app.css
+++ b/deploy/sim_envs/mantis_boattrader/app/static/app.css
@@ -2155,8 +2155,9 @@ body.bdp-scrolled-deep .sticky-save {
   grid-template-columns: 1fr 1fr;
   gap: 32px;
 }
+/* Real BT loan calc heading: 20/700 #333 (was 18). */
 .loan-form-heading, .loan-preview-heading {
-  font-size: 18px;
+  font-size: 20px;
   font-weight: 700;
   color: var(--bt-text);
   text-align: center;
@@ -2167,6 +2168,14 @@ body.bdp-scrolled-deep .sticky-save {
   color: var(--bt-text-dim);
   font-size: 13px;
   margin: 0 0 18px;
+}
+/* Real BT loan calc form inputs/selects: 4px border-radius (was 8px
+   from the SRP filter base) and 16px font (was 14px). Scoped to the
+   loan calc so SRP filter styling is unaffected. */
+.bdp-loan-card .filter-input,
+.bdp-loan-card .filter-select {
+  border-radius: 4px;
+  font-size: 16px;
 }
 .loan-field {
   display: block;

--- a/deploy/sim_envs/mantis_boattrader/app/static/app.css
+++ b/deploy/sim_envs/mantis_boattrader/app/static/app.css
@@ -2006,17 +2006,24 @@ body.bdp-scrolled-deep .sticky-save {
 }
 .bdp-accordion .accordion-subhead:first-child { margin-top: 0; }
 .accordion-body { font-size: 15px; line-height: 1.45; }
+/* Real BT accordion: padding 18px 0 on the <details>, 0 on summary,
+   1px #ededed bottom border between sections (not a wrapper card per
+   accordion). Sandbox had 16px 22px padding on summary which inflated
+   the closed height 28→55. Tightened to match. */
 .bdp-accordion {
-  background: #fff;
-  border-radius: var(--bt-radius);
-  margin-bottom: 10px;
+  background: transparent;
+  border-radius: 0;
+  border-bottom: 1px solid #ededed;
+  padding: 18px 0;
+  margin: 0;
   overflow: hidden;
 }
+.bdp-accordion:last-of-type { border-bottom: 0; }
 .bdp-accordion summary {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 16px 22px;
+  padding: 0;
   font-size: 16px;
   font-weight: 700;
   color: var(--bt-text);
@@ -2033,7 +2040,7 @@ body.bdp-scrolled-deep .sticky-save {
 }
 .bdp-accordion[open] .accordion-chevron { transform: rotate(-135deg); }
 .accordion-body {
-  padding: 0 22px 18px;
+  padding: 16px 0 0;
   font-size: 14px;
   color: var(--bt-text);
   line-height: 1.55;
@@ -2173,9 +2180,10 @@ body.bdp-scrolled-deep .sticky-save {
   font-size: 12px;
 }
 
-/* ── Listed By section ───────────────────────────────────── */
+/* ── Listed By section ─────────────────────────────────────
+   Real BT bg: rgb(245,249,255) = #f5f9ff (matches Boat Details). */
 .bdp-listed-by {
-  background: #eef4fb;
+  background: #f5f9ff;
   border-radius: var(--bt-radius-lg);
   padding: 24px 26px;
   margin: 24px 0;
@@ -2222,30 +2230,36 @@ body.bdp-scrolled-deep .sticky-save {
   font-weight: 600;
   margin-top: 8px;
 }
+/* Real BT "Trusted Boat Trader Partner" label sits at the BOTTOM of
+   the right column (no `| <years>` suffix). 14/400 text. */
 .enhanced-trusted {
   font-size: 14px;
   color: var(--bt-text);
-  margin: 0 0 14px;
+  margin: 14px 0 0;
 }
 .enhanced-stat-row {
-  border-top: 1px solid var(--bt-border);
-  padding: 12px 0;
+  border-bottom: 1px solid var(--bt-border);
+  padding: 10px 0;
 }
-.enhanced-stat-row:last-child { border-bottom: 1px solid var(--bt-border); }
+.enhanced-stat-row:first-child { border-top: 1px solid var(--bt-border); }
+/* Real BT stat number: 16/600 (was 22/700). Tighter, inline-looking. */
 .enhanced-stat-num {
-  font-size: 22px;
-  font-weight: 700;
+  font-size: 16px;
+  font-weight: 600;
   color: var(--bt-text);
   line-height: 1.2;
 }
 .enhanced-stat-label {
-  font-size: 13px;
+  font-size: 14px;
   color: var(--bt-text);
+  font-weight: 400;
 }
 
-/* ── More From This Dealer rail ───────────────────────────── */
+/* ── More From This Dealer rail ─────────────────────────────
+   Real BT bg: matches the Listed By #f5f9ff tint (both panels live
+   in the same visual band). */
 .bdp-more-from-dealer {
-  background: #eef4fb;
+  background: #f5f9ff;
   border-radius: var(--bt-radius-lg);
   padding: 24px 28px 18px;
   margin: 24px 0;

--- a/deploy/sim_envs/mantis_boattrader/app/static/app.css
+++ b/deploy/sim_envs/mantis_boattrader/app/static/app.css
@@ -1458,8 +1458,12 @@ header.main {
   display: none;
 }
 body.bdp-scrolled .bdp-sticky-bar { display: block; }
+/* Sticky bar inner — share the .bdp-grid 1336px content column so
+   sticky `< Search` / Previous / Next / Contact Seller anchor to the
+   same x-positions as the (non-sticky) .bdp-nav-row below. Was using
+   the wider 1440px --container. */
 .bdp-sticky-bar-inner {
-  max-width: var(--container);
+  max-width: 1336px;
   margin: 0 auto;
   padding: 12px 16px;
   display: flex;
@@ -2720,10 +2724,13 @@ body.bdp-scrolled-deep .sticky-save {
 .spec-grid dt { color: var(--bt-text-dim); width: 130px; flex: 0 0 130px; }
 .spec-grid dd { margin: 0; color: var(--bt-text); font-weight: 600; }
 
+/* Lead-confirm banner sits outside .bdp-grid; cap width to 1336px so
+   it aligns with the gallery + right rail content. */
 .lead-confirm {
   background: #ddf3e6; color: #1a6f3f;
   padding: 12px 16px; border-radius: var(--bt-radius);
-  margin: 12px 0;
+  max-width: 1336px;
+  margin: 12px auto;
 }
 
 /* ── Footer ───────────────────────────────────────────────────── */

--- a/deploy/sim_envs/mantis_boattrader/app/static/app.css
+++ b/deploy/sim_envs/mantis_boattrader/app/static/app.css
@@ -2416,13 +2416,17 @@ body.bdp-scrolled-deep .sticky-save {
   box-shadow: 0 2px 6px rgba(10,30,60,0.18);
   z-index: 2;
 }
+/* Real BT "More Boats from this Dealer" link uses #0051AD (darker
+   blue than the main BT-blue #2566b0). Probed at Pursuit BDP. */
 .more-from-dealer-link {
   display: inline-block;
   margin-top: 8px;
-  color: var(--bt-blue);
+  color: #0051AD;
   font-size: 14px;
   font-weight: 600;
+  text-decoration: none;
 }
+.more-from-dealer-link:hover { text-decoration: underline; }
 
 /* ── Still have a question? card ──────────────────────────── */
 /* "Still have a question?" — matched to real BT: h3 24/700 #303030,

--- a/deploy/sim_envs/mantis_boattrader/app/static/app.css
+++ b/deploy/sim_envs/mantis_boattrader/app/static/app.css
@@ -1666,8 +1666,12 @@ body.bdp-scrolled-deep .sticky-save {
 }
 .bdp-badges { margin-bottom: 10px; }
 /* Right-rail typography matched to real boattrader desktop (1512px probe):
-   title 20/700, location 16/400, price 20/700, own-link 16/400. */
-.bdp-title { font-size: 20px; line-height: 1.25; margin: 8px 0 6px; color: var(--bt-text); font-weight: 700; }
+   title 20/700, location 16/400, price 20/700, own-link 16/400.
+   The title-row keeps H1 + length-suffix span side-by-side (real BT
+   ships a header > h1 + span pattern so H1.textContent stays clean
+   while the visible title reads "<title> | <length>'"). */
+.bdp-title-row { display: flex; align-items: baseline; flex-wrap: wrap; gap: 6px; margin: 8px 0 6px; }
+.bdp-title { font-size: 20px; line-height: 1.25; margin: 0; color: var(--bt-text); font-weight: 700; }
 .bdp-length { color: var(--bt-text); font-weight: 700; font-size: 20px; }
 .bdp-location { color: var(--bt-text); font-size: 16px; margin: 0 0 10px; font-weight: 400; }
 .bdp-price { margin: 0 0 4px; font-size: 16px; display: flex; align-items: baseline; gap: 10px; flex-wrap: wrap; }
@@ -1865,27 +1869,34 @@ body.bdp-scrolled-deep .sticky-save {
   margin-top: 6px;
 }
 
-/* ── Top stats strip — 4 columns × 2 rows (8 cells total) ───── */
+/* ── Top stats strip — 4 columns × 2 rows (8 cells total) ─────
+   Real BT cards measure ~166×39 each. Switched from `1fr` columns
+   (which produced 205-wide cards in a 870-wide container) to fixed
+   166px tracks with a tighter gap. */
 .bdp-stats-strip {
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  grid-auto-rows: auto;
-  column-gap: 18px;
-  row-gap: 14px;
+  grid-template-columns: repeat(4, 166px);
+  grid-auto-rows: 39px;
+  column-gap: 16px;
+  row-gap: 12px;
   margin: 22px 0 14px;
-  padding: 22px 8px;
+  padding: 16px 0;
   border-bottom: 1px solid var(--bt-border);
 }
 .stat-card {
   display: flex;
-  gap: 14px;
+  gap: 10px;
   align-items: center;
 }
+/* Real BT stat cards: 166×39 (vs sandbox prior 205×44). Tighter icon
+   and tighter card track; 32px icon was already correct, just shrink
+   the surrounding flex container. */
 .stat-icon {
   flex-shrink: 0;
-  width: 44px; height: 44px;
+  width: 32px; height: 32px;
   display: flex; align-items: center; justify-content: center;
 }
+.stat-icon svg { width: 32px; height: 32px; }
 .stat-text {
   display: flex; flex-direction: column;
   min-width: 0;
@@ -2509,7 +2520,27 @@ body.bdp-scrolled-deep .sticky-save {
   color: var(--bt-text-dim);
 }
 
-/* Description section */
+/* Description section — real BT clamps the Description body to ~168px
+   (≈4 lines + heading) and shows an inline "Show More" button right-
+   aligned at the bottom. Click expands to full content. */
+.bdp-description-body { position: relative; }
+.bdp-description-clamped {
+  max-height: 168px;
+  overflow: hidden;
+  transition: max-height 200ms ease;
+}
+.bdp-description-body.is-expanded .bdp-description-clamped { max-height: none; overflow: visible; }
+.bdp-show-more {
+  background: transparent; border: 0; padding: 4px 0;
+  color: #139af5;
+  font: inherit; font-size: 13px; font-weight: 400;
+  cursor: pointer;
+  display: block;
+  margin-left: auto;
+}
+.bdp-show-more:hover { text-decoration: underline; }
+/* Label swap is handled by JS in base.html (sets textContent directly). */
+
 .bdp-description-section .bdp-description p { margin: 0 0 12px; }
 .bdp-feature-h3 {
   font-size: 14px;

--- a/deploy/sim_envs/mantis_boattrader/app/static/app.css
+++ b/deploy/sim_envs/mantis_boattrader/app/static/app.css
@@ -400,17 +400,19 @@ header.main {
 .dot { width: 8px; height: 8px; border-radius: 50%; background: rgba(255,255,255,0.5); }
 .dot.active { background: #fff; }
 
-/* ── Ad strips ─ Real BT BDP top sponsor: bg #f7f7f7, padding 16px 0,
-   ad image inside is fixed 728×90 leaderboard. ─────────────────── */
+/* ── Ad strips — Real BT BDP top sponsor: 970×120 banner inside a
+   tight #f7f7f7 strip (~122px total height, ~1px breathing room above
+   and below the banner). Was 728×90 with 16+24px padding/margin which
+   bloated the strip to ~170px total. ─────────────────────────────── */
 .ad-strip {
   background: #f7f7f7;
-  padding: 16px 0;
+  padding: 1px 0;
   display: flex; justify-content: center;
-  margin: 24px 0;
+  margin: 0;
 }
 .ad-banner {
-  position: relative; max-width: 728px; width: 100%; height: 90px;
-  border-radius: var(--bt-radius); overflow: hidden;
+  position: relative; max-width: 970px; width: 100%; height: 120px;
+  border-radius: 0; overflow: hidden;
 }
 .ad-banner img { width: 100%; display: block; }
 .ad-card {
@@ -1541,19 +1543,21 @@ body.bdp-scrolled-deep .sticky-save {
   cursor: pointer; white-space: nowrap;
 }
 
-/* Match .bdp-grid's 1336px max-width so `< Search` and Previous/Next
-   align with the gallery + right-rail content beneath, not the wider
-   1440px `.bt-main` container. Without this, the row spreads to the
-   full main width and the breadcrumb appears further left/right than
-   the content below it. */
+/* Real BT BDP nav row layout (per Beneteau probe, 2026-05-24):
+     `< Search` (left) [gap] breadcrumb (left, after Search) [flex grow]
+     Previous Boat | Next Boat (right edge)
+   NOT space-between — breadcrumb hugs `< Search` rather than centering.
+   Achieved with `display: flex; gap: 24px` (default flex-start) and
+   `margin-left: auto` on `.bdp-nav-actions` to push Previous/Next
+   to the right edge. */
 .bdp-nav-row {
-  display: flex; align-items: center; justify-content: space-between;
+  display: flex; align-items: center;
   max-width: 1336px;
   margin: 8px auto 14px;
   font-size: 12px; color: var(--bt-blue);
   gap: 24px;
 }
-.bdp-nav-actions { display: flex; gap: 16px; }
+.bdp-nav-actions { display: flex; gap: 16px; margin-left: auto; }
 /* Real BT BDP top links 'Back to Search' / 'Next Boat' / 'Previous Boat':
    12/400 #139af5 (plain words, no chevrons). */
 .bdp-back, .bdp-next, .bdp-prev { font-size: 12px; font-weight: 400; color: #139af5; text-decoration: none; }

--- a/deploy/sim_envs/mantis_boattrader/app/static/app.css
+++ b/deploy/sim_envs/mantis_boattrader/app/static/app.css
@@ -1723,11 +1723,19 @@ body.bdp-scrolled-deep .sticky-save {
   gap: 4px;
   position: relative;
 }
+/* Real BT engagement-row divider: 1px wide × 12px tall vertical line
+   via bg color rgb(222,226,227). Sandbox used `content: "|"` which
+   renders as the actual pipe character — visibly thicker than real
+   BT's hairline separator. Replaced with a pseudo-element that paints
+   a real 1×12 rectangle. */
 .bdp-engagement-row .engagement-item:not(:last-child)::after {
-  content: "|";
-  color: var(--bt-border);
+  content: "";
+  display: inline-block;
+  width: 1px;
+  height: 12px;
+  background: rgb(222, 226, 227);
   margin-left: 12px;
-  font-weight: 300;
+  vertical-align: middle;
 }
 .bdp-engagement-row .ico {
   font-size: 13px;
@@ -2041,12 +2049,18 @@ body.bdp-scrolled-deep .sticky-save {
   transition: transform 200ms ease;
 }
 .bdp-accordion[open] .accordion-chevron { transform: rotate(-135deg); }
+/* Real BT accordion body: 15px / 1.3 line-height (19.5px), padding
+   8px 0 0 8px. Was 14/1.55 — too tight on font + too loose on lh. */
 .accordion-body {
-  padding: 16px 0 0;
-  font-size: 14px;
+  padding: 8px 0 0 8px;
+  font-size: 15px;
   color: var(--bt-text);
-  line-height: 1.55;
+  line-height: 1.3;
 }
+/* Real BT description body <p>: 15px margin top and bottom. */
+.bdp-description p { margin: 15px 0; line-height: 1.3; }
+.bdp-description p:first-child { margin-top: 0; }
+.bdp-description p:last-child { margin-bottom: 0; }
 /* Real BT BDP Description body: the seller blurb (first paragraph) is
    rendered bold like a sub-heading, followed by a small uppercase
    "DESCRIPTION" label, then the body paragraphs. Together they take ~3

--- a/deploy/sim_envs/mantis_boattrader/app/static/app.css
+++ b/deploy/sim_envs/mantis_boattrader/app/static/app.css
@@ -1537,9 +1537,15 @@ body.bdp-scrolled-deep .sticky-save {
   cursor: pointer; white-space: nowrap;
 }
 
+/* Match .bdp-grid's 1336px max-width so `< Search` and Previous/Next
+   align with the gallery + right-rail content beneath, not the wider
+   1440px `.bt-main` container. Without this, the row spreads to the
+   full main width and the breadcrumb appears further left/right than
+   the content below it. */
 .bdp-nav-row {
   display: flex; align-items: center; justify-content: space-between;
-  margin: 8px 0 14px;
+  max-width: 1336px;
+  margin: 8px auto 14px;
   font-size: 12px; color: var(--bt-blue);
   gap: 24px;
 }

--- a/deploy/sim_envs/mantis_boattrader/app/static/app.css
+++ b/deploy/sim_envs/mantis_boattrader/app/static/app.css
@@ -1895,6 +1895,14 @@ body.bdp-scrolled-deep .sticky-save {
   font-weight: 700;
   color: #303030;
   letter-spacing: 0.2px;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+/* Inline info ⓘ next to "Engine(s) Hours" — slightly smaller than
+   the default 16×16 to fit the 14/700 label line cleanly. */
+.stat-label .stat-info {
+  width: 14px; height: 14px; font-size: 10px;
 }
 .stat-value {
   font-size: 14px;
@@ -2348,11 +2356,16 @@ body.bdp-scrolled-deep .sticky-save {
   text-transform: uppercase;
   margin: 0 0 14px;
 }
+/* Real BT BDP Other Services row: 6 tiles in a 3-col × 2-row grid at
+   1440-class viewports (wraps to 2-col on narrower windows). Was 2-col
+   to match the previous 2-tile count; bumped to 3-col now that we
+   render the full 6-tile row. */
 .other-services-tiles {
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: repeat(3, 1fr);
   gap: 16px;
 }
+@media (max-width: 980px) { .other-services-tiles { grid-template-columns: 1fr 1fr; } }
 .other-service-tile {
   display: flex;
   gap: 18px;

--- a/deploy/sim_envs/mantis_boattrader/app/static/app.css
+++ b/deploy/sim_envs/mantis_boattrader/app/static/app.css
@@ -2709,6 +2709,23 @@ body.bdp-scrolled-deep .sticky-save {
 }
 .dealer-address { font-style: normal; font-size: 14px; color: var(--bt-text); line-height: 1.4; }
 .dealer-phone { color: var(--bt-blue); font-size: 14px; font-weight: 400; display: inline-block; margin-top: 2px; }
+/* Real BT dealer-card address row: 14/400 #333, pin SVG (14×14) before
+   the street address, ~6px gap between icon and text. Phone sits on
+   its own line below, blue link, no icon. */
+.dealer-address-row {
+  display: flex; align-items: flex-start; gap: 6px;
+  margin: 0 0 6px;
+  font-size: 14px; line-height: 1.4; color: var(--bt-text);
+}
+.dealer-address-row .ico-pin {
+  flex-shrink: 0; margin-top: 2px;
+  color: var(--bt-text-dim);
+}
+.dealer-phone-row { margin: 0 0 12px; font-size: 14px; }
+.dealer-phone-row .dealer-phone {
+  color: var(--bt-blue); font-weight: 400; text-decoration: none;
+}
+.dealer-phone-row .dealer-phone:hover { text-decoration: underline; }
 .trusted-partner { font-size: 13px; color: var(--bt-text-dim); margin: 0 0 12px; }
 .trusted-partner strong { color: var(--bt-navy); }
 .dealer-lead-form { display: flex; flex-direction: column; gap: 8px; }

--- a/deploy/sim_envs/mantis_boattrader/app/templates/base.html
+++ b/deploy/sim_envs/mantis_boattrader/app/templates/base.html
@@ -9,7 +9,7 @@
      (San Francisco on macOS, Segoe UI on Windows). Loading Roboto Medium
      from Google Fonts makes our text render heavier than real BT, so we
      match by NOT loading Roboto and letting the system fallback render. #}
-  <link rel="stylesheet" href="/static/app.css?v=112" />
+  <link rel="stylesheet" href="/static/app.css?v=113" />
   <meta name="description" content="{% block description %}Buy and sell new & used boats. Find boats, yachts, sailboats, fishing boats, pontoons, and more.{% endblock %}" />
 </head>
 <body class="bt-body">

--- a/deploy/sim_envs/mantis_boattrader/app/templates/base.html
+++ b/deploy/sim_envs/mantis_boattrader/app/templates/base.html
@@ -9,7 +9,7 @@
      (San Francisco on macOS, Segoe UI on Windows). Loading Roboto Medium
      from Google Fonts makes our text render heavier than real BT, so we
      match by NOT loading Roboto and letting the system fallback render. #}
-  <link rel="stylesheet" href="/static/app.css?v=115" />
+  <link rel="stylesheet" href="/static/app.css?v=116" />
   <meta name="description" content="{% block description %}Buy and sell new & used boats. Find boats, yachts, sailboats, fishing boats, pontoons, and more.{% endblock %}" />
 </head>
 <body class="bt-body">

--- a/deploy/sim_envs/mantis_boattrader/app/templates/base.html
+++ b/deploy/sim_envs/mantis_boattrader/app/templates/base.html
@@ -9,7 +9,7 @@
      (San Francisco on macOS, Segoe UI on Windows). Loading Roboto Medium
      from Google Fonts makes our text render heavier than real BT, so we
      match by NOT loading Roboto and letting the system fallback render. #}
-  <link rel="stylesheet" href="/static/app.css?v=114" />
+  <link rel="stylesheet" href="/static/app.css?v=115" />
   <meta name="description" content="{% block description %}Buy and sell new & used boats. Find boats, yachts, sailboats, fishing boats, pontoons, and more.{% endblock %}" />
 </head>
 <body class="bt-body">

--- a/deploy/sim_envs/mantis_boattrader/app/templates/base.html
+++ b/deploy/sim_envs/mantis_boattrader/app/templates/base.html
@@ -9,7 +9,7 @@
      (San Francisco on macOS, Segoe UI on Windows). Loading Roboto Medium
      from Google Fonts makes our text render heavier than real BT, so we
      match by NOT loading Roboto and letting the system fallback render. #}
-  <link rel="stylesheet" href="/static/app.css?v=109" />
+  <link rel="stylesheet" href="/static/app.css?v=110" />
   <meta name="description" content="{% block description %}Buy and sell new & used boats. Find boats, yachts, sailboats, fishing boats, pontoons, and more.{% endblock %}" />
 </head>
 <body class="bt-body">

--- a/deploy/sim_envs/mantis_boattrader/app/templates/base.html
+++ b/deploy/sim_envs/mantis_boattrader/app/templates/base.html
@@ -9,7 +9,7 @@
      (San Francisco on macOS, Segoe UI on Windows). Loading Roboto Medium
      from Google Fonts makes our text render heavier than real BT, so we
      match by NOT loading Roboto and letting the system fallback render. #}
-  <link rel="stylesheet" href="/static/app.css?v=110" />
+  <link rel="stylesheet" href="/static/app.css?v=111" />
   <meta name="description" content="{% block description %}Buy and sell new & used boats. Find boats, yachts, sailboats, fishing boats, pontoons, and more.{% endblock %}" />
 </head>
 <body class="bt-body">

--- a/deploy/sim_envs/mantis_boattrader/app/templates/base.html
+++ b/deploy/sim_envs/mantis_boattrader/app/templates/base.html
@@ -9,7 +9,7 @@
      (San Francisco on macOS, Segoe UI on Windows). Loading Roboto Medium
      from Google Fonts makes our text render heavier than real BT, so we
      match by NOT loading Roboto and letting the system fallback render. #}
-  <link rel="stylesheet" href="/static/app.css?v=116" />
+  <link rel="stylesheet" href="/static/app.css?v=117" />
   <meta name="description" content="{% block description %}Buy and sell new & used boats. Find boats, yachts, sailboats, fishing boats, pontoons, and more.{% endblock %}" />
 </head>
 <body class="bt-body">

--- a/deploy/sim_envs/mantis_boattrader/app/templates/base.html
+++ b/deploy/sim_envs/mantis_boattrader/app/templates/base.html
@@ -127,6 +127,20 @@
     window.addEventListener('scroll', function(){ if (!raf) raf = requestAnimationFrame(check); }, { passive: true });
     check();
   })();
+  // BDP Description "Show More" toggle — matches real BT's clamped
+  // description body w/ a right-aligned inline expand link.
+  (function(){
+    document.addEventListener('click', function(ev){
+      var btn = ev.target.closest && ev.target.closest('[data-show-more]');
+      if (!btn) return;
+      ev.preventDefault();
+      var body = btn.closest('.bdp-description-body');
+      if (!body) return;
+      var expanded = body.classList.toggle('is-expanded');
+      if (!expanded) btn.textContent = 'Show More';
+      else btn.textContent = 'Show Less';
+    });
+  })();
   // Listing-card monthly-payment info: click info → toggle sticky tooltip
   // at card bottom. × closes; clicking outside closes the open tooltip too.
   (function(){

--- a/deploy/sim_envs/mantis_boattrader/app/templates/base.html
+++ b/deploy/sim_envs/mantis_boattrader/app/templates/base.html
@@ -9,7 +9,7 @@
      (San Francisco on macOS, Segoe UI on Windows). Loading Roboto Medium
      from Google Fonts makes our text render heavier than real BT, so we
      match by NOT loading Roboto and letting the system fallback render. #}
-  <link rel="stylesheet" href="/static/app.css?v=105" />
+  <link rel="stylesheet" href="/static/app.css?v=106" />
   <meta name="description" content="{% block description %}Buy and sell new & used boats. Find boats, yachts, sailboats, fishing boats, pontoons, and more.{% endblock %}" />
 </head>
 <body class="bt-body">

--- a/deploy/sim_envs/mantis_boattrader/app/templates/base.html
+++ b/deploy/sim_envs/mantis_boattrader/app/templates/base.html
@@ -9,7 +9,7 @@
      (San Francisco on macOS, Segoe UI on Windows). Loading Roboto Medium
      from Google Fonts makes our text render heavier than real BT, so we
      match by NOT loading Roboto and letting the system fallback render. #}
-  <link rel="stylesheet" href="/static/app.css?v=118" />
+  <link rel="stylesheet" href="/static/app.css?v=119" />
   <meta name="description" content="{% block description %}Buy and sell new & used boats. Find boats, yachts, sailboats, fishing boats, pontoons, and more.{% endblock %}" />
 </head>
 <body class="bt-body">

--- a/deploy/sim_envs/mantis_boattrader/app/templates/base.html
+++ b/deploy/sim_envs/mantis_boattrader/app/templates/base.html
@@ -9,7 +9,7 @@
      (San Francisco on macOS, Segoe UI on Windows). Loading Roboto Medium
      from Google Fonts makes our text render heavier than real BT, so we
      match by NOT loading Roboto and letting the system fallback render. #}
-  <link rel="stylesheet" href="/static/app.css?v=104" />
+  <link rel="stylesheet" href="/static/app.css?v=105" />
   <meta name="description" content="{% block description %}Buy and sell new & used boats. Find boats, yachts, sailboats, fishing boats, pontoons, and more.{% endblock %}" />
 </head>
 <body class="bt-body">

--- a/deploy/sim_envs/mantis_boattrader/app/templates/base.html
+++ b/deploy/sim_envs/mantis_boattrader/app/templates/base.html
@@ -9,7 +9,7 @@
      (San Francisco on macOS, Segoe UI on Windows). Loading Roboto Medium
      from Google Fonts makes our text render heavier than real BT, so we
      match by NOT loading Roboto and letting the system fallback render. #}
-  <link rel="stylesheet" href="/static/app.css?v=111" />
+  <link rel="stylesheet" href="/static/app.css?v=112" />
   <meta name="description" content="{% block description %}Buy and sell new & used boats. Find boats, yachts, sailboats, fishing boats, pontoons, and more.{% endblock %}" />
 </head>
 <body class="bt-body">

--- a/deploy/sim_envs/mantis_boattrader/app/templates/base.html
+++ b/deploy/sim_envs/mantis_boattrader/app/templates/base.html
@@ -9,7 +9,7 @@
      (San Francisco on macOS, Segoe UI on Windows). Loading Roboto Medium
      from Google Fonts makes our text render heavier than real BT, so we
      match by NOT loading Roboto and letting the system fallback render. #}
-  <link rel="stylesheet" href="/static/app.css?v=119" />
+  <link rel="stylesheet" href="/static/app.css?v=120" />
   <meta name="description" content="{% block description %}Buy and sell new & used boats. Find boats, yachts, sailboats, fishing boats, pontoons, and more.{% endblock %}" />
 </head>
 <body class="bt-body">

--- a/deploy/sim_envs/mantis_boattrader/app/templates/base.html
+++ b/deploy/sim_envs/mantis_boattrader/app/templates/base.html
@@ -9,7 +9,7 @@
      (San Francisco on macOS, Segoe UI on Windows). Loading Roboto Medium
      from Google Fonts makes our text render heavier than real BT, so we
      match by NOT loading Roboto and letting the system fallback render. #}
-  <link rel="stylesheet" href="/static/app.css?v=113" />
+  <link rel="stylesheet" href="/static/app.css?v=114" />
   <meta name="description" content="{% block description %}Buy and sell new & used boats. Find boats, yachts, sailboats, fishing boats, pontoons, and more.{% endblock %}" />
 </head>
 <body class="bt-body">

--- a/deploy/sim_envs/mantis_boattrader/app/templates/base.html
+++ b/deploy/sim_envs/mantis_boattrader/app/templates/base.html
@@ -111,15 +111,18 @@
 </div>
 {% endif %}
 <script>
-  // Toggle .bdp-scrolled on <body> once the gallery is scrolled past so
-  // the sticky title/price/contact bar can appear (matches real boattrader).
+  // Two-state sticky bar (matches real boattrader):
+  //   y > 320  → .bdp-scrolled        (sticky bar visible, breadcrumb state)
+  //   y > 700  → .bdp-scrolled-deep   (swap breadcrumb for title/price/save)
   (function(){
     var threshold = 320;
+    var deep = 700;
     var raf = null;
     function check(){
       raf = null;
-      if (window.scrollY > threshold) document.body.classList.add('bdp-scrolled');
-      else document.body.classList.remove('bdp-scrolled');
+      var y = window.scrollY;
+      document.body.classList.toggle('bdp-scrolled', y > threshold);
+      document.body.classList.toggle('bdp-scrolled-deep', y > deep);
     }
     window.addEventListener('scroll', function(){ if (!raf) raf = requestAnimationFrame(check); }, { passive: true });
     check();

--- a/deploy/sim_envs/mantis_boattrader/app/templates/base.html
+++ b/deploy/sim_envs/mantis_boattrader/app/templates/base.html
@@ -9,7 +9,7 @@
      (San Francisco on macOS, Segoe UI on Windows). Loading Roboto Medium
      from Google Fonts makes our text render heavier than real BT, so we
      match by NOT loading Roboto and letting the system fallback render. #}
-  <link rel="stylesheet" href="/static/app.css?v=106" />
+  <link rel="stylesheet" href="/static/app.css?v=109" />
   <meta name="description" content="{% block description %}Buy and sell new & used boats. Find boats, yachts, sailboats, fishing boats, pontoons, and more.{% endblock %}" />
 </head>
 <body class="bt-body">

--- a/deploy/sim_envs/mantis_boattrader/app/templates/base.html
+++ b/deploy/sim_envs/mantis_boattrader/app/templates/base.html
@@ -9,7 +9,7 @@
      (San Francisco on macOS, Segoe UI on Windows). Loading Roboto Medium
      from Google Fonts makes our text render heavier than real BT, so we
      match by NOT loading Roboto and letting the system fallback render. #}
-  <link rel="stylesheet" href="/static/app.css?v=117" />
+  <link rel="stylesheet" href="/static/app.css?v=118" />
   <meta name="description" content="{% block description %}Buy and sell new & used boats. Find boats, yachts, sailboats, fishing boats, pontoons, and more.{% endblock %}" />
 </head>
 <body class="bt-body">

--- a/deploy/sim_envs/mantis_boattrader/app/templates/boat_detail.html
+++ b/deploy/sim_envs/mantis_boattrader/app/templates/boat_detail.html
@@ -27,10 +27,14 @@
   <div class="bdp-sticky-bar-inner">
     <a href="/boats/" class="bdp-back">{# real BT uses plain word, no chevron #}&lt; Search</a>
 
+    {# Breadcrumb category 2: real BT uses "Sail" for sailboats and
+       "Power" for everything else (verified at boattrader.com/boat/
+       2024-catalina-355-...). #}
+    {% set _bc_category = 'Sail' if 'Sail' in boat.boat_type else 'Power' %}
     <div class="bdp-sticky-content">
       <nav class="breadcrumb sticky-breadcrumb bdp-sticky-state bdp-sticky-state-shallow" aria-label="Breadcrumb">
         <a href="/">Home</a> / <a href="/boats/">Boats For Sale</a> /
-        <a href="/boats/?fuel_type=Diesel">Power</a> /
+        <a href="/boats/?type={{ _bc_category|urlencode }}">{{ _bc_category }}</a> /
         <a href="/boats/?type={{ boat.boat_type|urlencode }}">{{ boat.boat_type }}</a> /
         <a href="/boats/?make={{ boat.make|urlencode }}">{{ boat.make }}</a>
       </nav>
@@ -58,7 +62,7 @@
   <a href="/boats/" class="bdp-back">&lt; Search</a>
   <nav class="breadcrumb" aria-label="Breadcrumb">
     <a href="/">Home</a> / <a href="/boats/">Boats For Sale</a> /
-    <a href="/boats/?fuel_type=Diesel">Power</a> /
+    <a href="/boats/?type={{ _bc_category|urlencode }}">{{ _bc_category }}</a> /
     <a href="/boats/?type={{ boat.boat_type|urlencode }}">{{ boat.boat_type }}</a> /
     <a href="/boats/?make={{ boat.make|urlencode }}">{{ boat.make }}</a>
   </nav>

--- a/deploy/sim_envs/mantis_boattrader/app/templates/boat_detail.html
+++ b/deploy/sim_envs/mantis_boattrader/app/templates/boat_detail.html
@@ -214,7 +214,7 @@
           </div>
         </div>
         <p class="dealership-address">{{ dealer.address }}, {{ dealer.city }}, {{ dealer.state }}, {{ dealer.zip }}</p>
-        <p class="trusted-partner">Trusted Boat Trader Partner | <strong>{{ dealer.trusted_partner_label }}</strong></p>
+        <p class="trusted-partner">Trusted Boat Trader Partner</p>
         <div class="dealership-stats">
           <div class="dealership-stat-box">
             <span class="dealership-stat-num">{{ dealer.active_listings }}</span>
@@ -260,7 +260,7 @@
     <div class="stat-icon" aria-hidden="true">
       <svg viewBox="0 0 40 40" width="32" height="32"><circle cx="20" cy="20" r="19" fill="none" stroke="#7da4c8" stroke-width="1.5"/><circle cx="20" cy="22" r="8" fill="none" stroke="#3a6a93" stroke-width="1.5"/><line x1="20" y1="22" x2="20" y2="16" stroke="#3a6a93" stroke-width="2" stroke-linecap="round"/><line x1="20" y1="22" x2="25" y2="22" stroke="#3a6a93" stroke-width="2" stroke-linecap="round"/><line x1="20" y1="13" x2="20" y2="11" stroke="#3a6a93" stroke-width="1.5"/></svg>
     </div>
-    <div class="stat-text"><span class="stat-label">Engine(s) Hours <span class="info-tip stat-info" title="Reported by the seller">ⓘ</span></span><span class="stat-value">{{ boat.hours if boat.hours else '-' }}</span></div>
+    <div class="stat-text"><span class="stat-label">Engine(s) Hours</span><span class="stat-value">{{ boat.hours if boat.hours else '-' }}</span></div>
   </div>
   <div class="stat-card">
     <div class="stat-icon" aria-hidden="true">

--- a/deploy/sim_envs/mantis_boattrader/app/templates/boat_detail.html
+++ b/deploy/sim_envs/mantis_boattrader/app/templates/boat_detail.html
@@ -366,7 +366,9 @@
         <div><dt>Number of Engines</dt><dd>{{ boat.engine_count }}</dd></div>
         <div><dt>Engine Power</dt><dd>{{ boat.engine_hp }} hp{% if boat.engine_count > 1 %} (each){% endif %}</dd></div>
         <div><dt>Fuel Type</dt><dd>{{ boat.fuel_type }}</dd></div>
+        {% if 'Sail' not in boat.boat_type %}
         <div><dt>Engine Hours</dt><dd>{{ boat.hours if boat.hours else '—' }}</dd></div>
+        {% endif %}
       </dl>
     </div>
   </details>

--- a/deploy/sim_envs/mantis_boattrader/app/templates/boat_detail.html
+++ b/deploy/sim_envs/mantis_boattrader/app/templates/boat_detail.html
@@ -17,18 +17,36 @@
 </section>
 
 {# ─── Sticky boat header bar (shows on scroll).
-   Matches real BT: breadcrumb stays in the sticky row, NOT the
-   title/price line — that lives only in the right-rail summary. ── #}
+   Real BT has TWO content states inside the sticky bar:
+     - shallow scroll (just past gallery start): breadcrumb-mode
+     - deep scroll (past gallery, ~700px): title · $price · location · ♡ Save
+   Both states share the same `< Search · … · Previous · Next · [Contact Seller]`
+   chrome on the outside. The body class `bdp-scrolled-deep` flips which
+   inner state is visible. ── #}
 <div class="bdp-sticky-bar" data-testid="bdp-sticky-bar">
   <div class="bdp-sticky-bar-inner">
-    <a href="/boats/" class="bdp-back">‹ Search</a>
-    <nav class="breadcrumb sticky-breadcrumb" aria-label="Breadcrumb">
-      <a href="/">Home</a> / <a href="/boats/">Boats For Sale</a> /
-      <a href="/boats/?fuel_type=Diesel">Power</a> /
-      <a href="/boats/?type={{ boat.boat_type|urlencode }}">{{ boat.boat_type }}</a> /
-      <a href="/boats/?make={{ boat.make|urlencode }}">{{ boat.make }}</a>
-    </nav>
+    <a href="/boats/" class="bdp-back">{# real BT uses plain word, no chevron #}&lt; Search</a>
+
+    <div class="bdp-sticky-content">
+      <nav class="breadcrumb sticky-breadcrumb bdp-sticky-state bdp-sticky-state-shallow" aria-label="Breadcrumb">
+        <a href="/">Home</a> / <a href="/boats/">Boats For Sale</a> /
+        <a href="/boats/?fuel_type=Diesel">Power</a> /
+        <a href="/boats/?type={{ boat.boat_type|urlencode }}">{{ boat.boat_type }}</a> /
+        <a href="/boats/?make={{ boat.make|urlencode }}">{{ boat.make }}</a>
+      </nav>
+      <div class="bdp-sticky-state bdp-sticky-state-deep" data-testid="sticky-info">
+        <span class="sticky-title">{{ boat.title }}</span>
+        <span class="sticky-sep">|</span>
+        <span class="sticky-price">{{ boat.display_price }}</span>
+        <span class="sticky-sep">|</span>
+        <span class="sticky-loc">{{ boat.city }}, {{ boat.state }} {{ boat.zip }}</span>
+        <span class="sticky-sep">|</span>
+        <button class="sticky-save liked-boat-btn" type="button" aria-label="Save listing"><svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg> Save</button>
+      </div>
+    </div>
+
     <div class="sticky-actions">
+      {% if prev_boat %}<a href="/boat/{{ prev_boat.slug }}/" class="bdp-prev">Previous Boat</a>{% endif %}
       {% if next_boat %}<a href="/boat/{{ next_boat.slug }}/" class="bdp-next">Next Boat</a>{% endif %}
       <a href="#contact" class="btn-primary sticky-contact-btn">Contact Seller</a>
     </div>
@@ -37,14 +55,17 @@
 
 {# ─── Breadcrumb row ─────────────────────────────────────────── #}
 <div class="bdp-nav-row">
-  <a href="/boats/" class="bdp-back">‹ Search</a>
+  <a href="/boats/" class="bdp-back">&lt; Search</a>
   <nav class="breadcrumb" aria-label="Breadcrumb">
     <a href="/">Home</a> / <a href="/boats/">Boats For Sale</a> /
     <a href="/boats/?fuel_type=Diesel">Power</a> /
     <a href="/boats/?type={{ boat.boat_type|urlencode }}">{{ boat.boat_type }}</a> /
     <a href="/boats/?make={{ boat.make|urlencode }}">{{ boat.make }}</a>
   </nav>
-  {% if next_boat %}<a href="/boat/{{ next_boat.slug }}/" class="bdp-next">Next Boat ›</a>{% endif %}
+  <div class="bdp-nav-actions">
+    {% if prev_boat %}<a href="/boat/{{ prev_boat.slug }}/" class="bdp-prev">Previous Boat</a>{% endif %}
+    {% if next_boat %}<a href="/boat/{{ next_boat.slug }}/" class="bdp-next">Next Boat</a>{% endif %}
+  </div>
 </div>
 
 {% if lead_confirmation %}
@@ -88,11 +109,8 @@
     {% if boat.is_sponsored %}
       <div class="sponsored-strip">SPONSORED LISTING</div>
     {% endif %}
-    {% if boat.badges %}
-      <div class="bdp-badges">
-      {% for badge in boat.badges %}<span class="listing-tag listing-tag-{{ badge|lower|replace(' ','-') }}">{{ badge }}</span>{% endfor %}
-      </div>
-    {% endif %}
+    {# Real BT does NOT render badges above the title in the right-rail card —
+       badges live in the engagement strip or the gallery overlay. #}
     <h1 class="bdp-title">{{ boat.title }}</h1>
     <p class="bdp-location">{{ boat.city }}, {{ boat.state }} {{ boat.zip }}</p>
     <div class="bdp-price-block" data-testid="price-block">
@@ -111,7 +129,7 @@
       {% endif %}
     </div>
     <ul class="bdp-engagement-row">
-      <li class="engagement-item"><span class="ico" aria-hidden="true"><svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg></span> <strong>{{ boat.views }}</strong> Views</li>
+      <li class="engagement-item"><span class="ico" aria-hidden="true"><svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg></span> <strong>{% if boat.views >= 1000 %}{{ (boat.views/1000)|round(1) }}k{% else %}{{ boat.views }}{% endif %}</strong> Views</li>
       <li class="engagement-item"><span class="ico" aria-hidden="true"><svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></span> <strong>{{ boat.saves }}</strong> Save{% if boat.saves != 1 %}s{% endif %}</li>
       <li class="engagement-item"><span class="ico" aria-hidden="true"><svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg></span>
         {% if boat.listed_days_ago <= 7 %}New to Market
@@ -121,38 +139,35 @@
     </ul>
 
     {# ─── Contact card (owner vs dealer/sponsored) ──────────────
-       v=104: "Meet Your Seller" H2 above the contact card matches
-       real BT's pattern (same heading for both seller types). #}
-    <h2 class="meet-your-seller-h2">Meet Your Seller</h2>
+       Real BT private-seller card: NO 'Private Seller' pill,
+       NO owner-name in heading, NO disclaimer paragraph in card body,
+       phone-reveal lives at the BOTTOM after the lead form (only when
+       a phone is known). Submit button is the SAME filled blue pill
+       as the dealer variant with the SAME 'Contact Seller' text. #}
     {% if boat.is_owner_listed %}
       <div class="bdp-private-seller-card" id="contact" data-testid="private-seller-card">
-        <div class="private-seller-tag">Private Seller</div>
-        <h2 class="dealer-card-heading">Contact {{ boat.owner_name }}, the owner</h2>
-        <p class="private-seller-note">
-          This boat is being sold directly by the owner. Boat Trader does not verify
-          private-seller listings — please ask for a survey, title, and registration before purchase.
-        </p>
-        <div class="private-seller-phone-row" data-testid="phone-row">
-          {% set show_phone = request.cookies.get('bt_show_phone_' ~ boat.id) == '1' %}
-          {% if show_phone %}
-            <img class="phone-svg" src="/assets/phone/{{ boat.slug }}.svg?_t={{ boat.id }}" alt="Phone number" data-testid="phone-svg" />
-            <span class="phone-note">Call between 9am – 6pm local time.</span>
-          {% else %}
-            <form method="post" action="/boat/{{ boat.slug }}/show-phone">
-              <button type="submit" class="btn-secondary show-phone-btn" data-testid="show-phone-btn"><svg class="ico-phone" viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z"/></svg> Show Phone Number</button>
-            </form>
-            <span class="phone-note">The seller's number is hidden until you confirm you're a buyer.</span>
-          {% endif %}
-        </div>
+        <h2 class="dealer-card-heading">Contact Private Seller</h2>
         <form class="dealer-lead-form" method="post" action="/boat/{{ boat.slug }}/contact" data-testid="dealer-lead-form">
           <input type="text" name="name" placeholder="First &amp; Last Name" required class="lead-input" />
           <div class="lead-row">
             <input type="email" name="email" placeholder="Your Email" required class="lead-input" />
             <input type="tel" name="phone" placeholder="Your Phone" class="lead-input" />
           </div>
-          <textarea name="message" rows="3" class="lead-textarea" placeholder="Hi {{ boat.owner_name }}, I'm interested in your {{ boat.year }} {{ boat.make }} {{ boat.model }}. Is it still available?"></textarea>
-          <button type="submit" class="btn-primary btn-block contact-seller-btn srp-apply-now-button" data-testid="contact-seller-submit">Email Seller</button>
+          <textarea name="message" rows="3" class="lead-textarea" placeholder="I'm interested in your {{ boat.year }} {{ boat.make }} {{ boat.model }}. Please contact me with more information."></textarea>
+          <button type="submit" class="btn-primary btn-block bdp-contact-submit" data-testid="contact-seller-submit">Contact Seller</button>
         </form>
+        {% if boat.owner_phone %}
+        <div class="private-seller-phone-row" data-testid="phone-row">
+          {% set show_phone = request.cookies.get('bt_show_phone_' ~ boat.id) == '1' %}
+          {% if show_phone %}
+            <img class="phone-svg" src="/assets/phone/{{ boat.slug }}.svg?_t={{ boat.id }}" alt="Phone number" data-testid="phone-svg" />
+          {% else %}
+            <form method="post" action="/boat/{{ boat.slug }}/show-phone">
+              <button type="submit" class="btn-secondary show-phone-btn" data-testid="show-phone-btn"><svg class="ico-phone" viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z"/></svg> Show Phone Number</button>
+            </form>
+          {% endif %}
+        </div>
+        {% endif %}
       </div>
     {% else %}
       <div class="bdp-dealer-card" id="contact" data-testid="dealer-card">
@@ -179,7 +194,7 @@
             <input type="tel" name="phone" placeholder="Your Phone" class="lead-input" />
           </div>
           <textarea name="message" rows="3" class="lead-textarea" placeholder="I'm interested in your {{ boat.year }} {{ boat.make }} {{ boat.model }}. Please contact me with more information."></textarea>
-          <button type="submit" class="btn-primary btn-block contact-seller-btn srp-apply-now-button" data-testid="contact-seller-submit">Contact Seller</button>
+          <button type="submit" class="btn-primary btn-block bdp-contact-submit" data-testid="contact-seller-submit">Contact Seller</button>
           <a href="tel:{{ dealer.phone }}" class="btn-secondary btn-block call-btn"><svg class="ico-phone" viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z"/></svg> Call</a>
         </form>
       </div>
@@ -285,7 +300,7 @@
       <p class="owners-card-paragraph">{{ boat.what_owners_say }}</p>
     </div>
     <div class="owners-card-tags">
-      <h2 class="owners-card-tags-heading">Owner Highlights</h2>
+      <h3 class="owners-card-tags-heading">Owner Highlights</h3>
       <ul class="owner-tags-list">
         {% for tag in boat.owner_highlight_tags %}
         <li class="owner-tag">{{ tag }}</li>

--- a/deploy/sim_envs/mantis_boattrader/app/templates/boat_detail.html
+++ b/deploy/sim_envs/mantis_boattrader/app/templates/boat_detail.html
@@ -177,22 +177,19 @@
       </div>
     {% else %}
       <div class="bdp-dealer-card" id="contact" data-testid="dealer-card">
-        {% set _sp_idx = (boat.id|length + boat.year) % 6 %}
-        <h2 class="dealer-card-heading">Contact {{ ['Michael Mandery','Jennifer Cole','Marcus Webb','Elena Patel','Tom Hartwell','Priya Shah'][_sp_idx] }}</h2>
-        <div class="dealer-card-meta">
-          <div class="dealer-headshot" aria-label="Salesperson headshot">
-            <svg viewBox="0 0 60 60" xmlns="http://www.w3.org/2000/svg" width="60" height="60">
-              <defs><linearGradient id="hs{{ _sp_idx }}" x1="0" x2="0" y1="0" y2="1"><stop offset="0" stop-color="#9bbcdb"/><stop offset="1" stop-color="#3a6a93"/></linearGradient></defs>
-              <rect width="60" height="60" rx="30" fill="url(#hs{{ _sp_idx }})"/>
-              <circle cx="30" cy="24" r="11" fill="#f2e3c8"/>
-              <path d="M8 60 Q 30 36 52 60 Z" fill="#f2e3c8"/>
-            </svg>
-          </div>
-          <address class="dealer-address">
-            {{ dealer.name }}<br/>
-            <a href="tel:{{ dealer.phone }}" class="dealer-phone"><svg class="ico-phone" viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z"/></svg> {{ dealer.phone }}</a>
-          </address>
-        </div>
+        {# Real BT dealer card pattern (Westchester probe): heading is the
+           DEALERSHIP NAME (not a salesperson name), then a pin-icon-led
+           street address line, then the phone in blue. No salesperson
+           headshot. The salesperson name is shown elsewhere (e.g. inside
+           the Listed By card lower on the page) when present. #}
+        <h2 class="dealer-card-heading">Contact {{ dealer.name }}</h2>
+        <p class="dealer-address-row">
+          <svg class="ico-pin" viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z"/><circle cx="12" cy="10" r="3"/></svg>
+          <span>{{ dealer.address }}, {{ dealer.city }}, {{ dealer.state }}, {{ dealer.zip }}</span>
+        </p>
+        <p class="dealer-phone-row">
+          <a href="tel:{{ dealer.phone }}" class="dealer-phone">{{ dealer.phone }}</a>
+        </p>
         <form class="dealer-lead-form" method="post" action="/boat/{{ boat.slug }}/contact" data-testid="dealer-lead-form">
           <input type="text" name="name" placeholder="First &amp; Last Name" required class="lead-input" />
           <div class="lead-row">

--- a/deploy/sim_envs/mantis_boattrader/app/templates/boat_detail.html
+++ b/deploy/sim_envs/mantis_boattrader/app/templates/boat_detail.html
@@ -110,8 +110,14 @@
       <div class="sponsored-strip">SPONSORED LISTING</div>
     {% endif %}
     {# Real BT does NOT render badges above the title in the right-rail card —
-       badges live in the engagement strip or the gallery overlay. #}
-    <h1 class="bdp-title">{{ boat.title }}</h1>
+       badges live in the engagement strip or the gallery overlay.
+       Title structure: H1 + sibling SPAN holding the length suffix —
+       SEO trick that keeps H1.textContent clean while the visible title
+       reads "Title | XX'". Matches probe of dealer BDP 2026-05-24. #}
+    <header class="bdp-title-row">
+      <h1 class="bdp-title">{{ boat.title }}</h1>
+      <span class="bdp-length">| {{ boat.length_ft|int }}'</span>
+    </header>
     <p class="bdp-location">{{ boat.city }}, {{ boat.state }} {{ boat.zip }}</p>
     <div class="bdp-price-block" data-testid="price-block">
       <p class="bdp-price">
@@ -219,7 +225,7 @@
             <span class="dealership-stat-label">Sold listings</span>
           </div>
         </div>
-        <a href="https://www.{{ dealer.name|lower|replace(' ','-')|replace(',','')|replace('--','-') }}.com" class="visit-seller-link dealership-link" target="_blank" rel="nofollow">Visit Seller Website ↗</a>
+        <a href="https://www.{{ dealer.name|lower|replace(' ','-')|replace(',','')|replace('--','-') }}.com" class="visit-seller-link dealership-link" target="_blank" rel="nofollow">Visit Seller Website</a>
       </div>
     {% endif %}
 
@@ -319,24 +325,27 @@
       <h3 class="accordion-title">Description</h3>
       <span class="accordion-chevron"></span>
     </summary>
-    <div class="accordion-body">
-      <p class="bdp-seller-blurb">{{ boat.owner_seller_description }}</p>
-      <div class="bdp-description">
-        {% for para in boat.description %}<p>{{ para }}</p>{% endfor %}
+    <div class="accordion-body bdp-description-body" data-clampable="1">
+      <div class="bdp-description-clamped">
+        <p class="bdp-seller-blurb">{{ boat.owner_seller_description }}</p>
+        <div class="bdp-description">
+          {% for para in boat.description %}<p>{{ para }}</p>{% endfor %}
+        </div>
+        {% if boat.description_features %}
+          <h3 class="bdp-feature-h3">Key Features</h3>
+          <ul class="bdp-feature-list">
+            {% for f in boat.description_features %}<li>{{ f }}</li>{% endfor %}
+          </ul>
+        {% endif %}
+        {% if boat.is_owner_listed %}
+          <p class="bdp-disclaimer-text">
+            This listing was placed by a private seller. Boat Trader has not verified
+            the accuracy of any claims made in the description. Always inspect a boat
+            in person and obtain a marine survey before any purchase decision.
+          </p>
+        {% endif %}
       </div>
-      {% if boat.description_features %}
-        <h3 class="bdp-feature-h3">Key Features</h3>
-        <ul class="bdp-feature-list">
-          {% for f in boat.description_features %}<li>{{ f }}</li>{% endfor %}
-        </ul>
-      {% endif %}
-      {% if boat.is_owner_listed %}
-        <p class="bdp-disclaimer-text">
-          This listing was placed by a private seller. Boat Trader has not verified
-          the accuracy of any claims made in the description. Always inspect a boat
-          in person and obtain a marine survey before any purchase decision.
-        </p>
-      {% endif %}
+      <button type="button" class="bdp-show-more" data-show-more>Show More</button>
     </div>
   </details>
 
@@ -381,11 +390,40 @@
     </div>
   </details>
 
-  {# Real BT BDP only renders Description / Measurements / Propulsion
-     at this accordion level. The Condition / Hull / Listing ID fields
-     are already surfaced in the stats strip + Propulsion accordion; the
-     Location section duplicates the right-rail city/state line — both
-     dropped here to mirror real BT exactly. #}
+  {# Real BT BDP has FIVE accordions at this level: Description (open),
+     Measurements, Propulsion, More Details, Location. Iter1.2 removed
+     the last two based on a private-seller probe that didn't render
+     them — the dealer-BDP probe (2026-05-24) confirms both are present.
+     Restored to match. #}
+  <details class="bdp-accordion">
+    <summary>
+      <h3 class="accordion-title">More Details</h3>
+      <span class="accordion-chevron"></span>
+    </summary>
+    <div class="accordion-body">
+      <dl class="spec-grid">
+        <div><dt>Condition</dt><dd>{{ boat.condition|capitalize }}</dd></div>
+        <div><dt>Class</dt><dd>{{ boat.boat_type }}</dd></div>
+        <div><dt>Hull Material</dt><dd>{{ boat.hull_material }}</dd></div>
+        <div><dt>Hull Color</dt><dd>{{ boat.hull_color }}</dd></div>
+        <div><dt>Passenger Capacity</dt><dd>{{ boat.capacity_people }}</dd></div>
+        <div><dt>Listing ID</dt><dd>{{ boat.id }}</dd></div>
+      </dl>
+    </div>
+  </details>
+
+  <details class="bdp-accordion">
+    <summary>
+      <h3 class="accordion-title">Location</h3>
+      <span class="accordion-chevron"></span>
+    </summary>
+    <div class="accordion-body">
+      <p>{{ boat.city }}, {{ boat.state }} {{ boat.zip }}</p>
+      <div class="bdp-map-placeholder" data-testid="map-placeholder">
+        <span>Map of {{ boat.city }}, {{ boat.state }}</span>
+      </div>
+    </div>
+  </details>
 </section>
 
 {# ─── Sponsor banner #2 — INSIDE left column ──── #}

--- a/deploy/sim_envs/mantis_boattrader/app/templates/boat_detail.html
+++ b/deploy/sim_envs/mantis_boattrader/app/templates/boat_detail.html
@@ -239,12 +239,17 @@
     </div>
     <div class="stat-text"><span class="stat-label">Total Power</span><span class="stat-value">{{ boat.engine_hp * boat.engine_count }}hp</span></div>
   </div>
+  {# Real BT sailboat BDPs skip the Engine(s) Hours stat (sailboats
+     aren't tracked by engine hours). Power boats render the 8-stat
+     grid, sailboats render 7. #}
+  {% if 'Sail' not in boat.boat_type %}
   <div class="stat-card">
     <div class="stat-icon" aria-hidden="true">
       <svg viewBox="0 0 40 40" width="32" height="32"><circle cx="20" cy="20" r="19" fill="none" stroke="#7da4c8" stroke-width="1.5"/><circle cx="20" cy="22" r="8" fill="none" stroke="#3a6a93" stroke-width="1.5"/><line x1="20" y1="22" x2="20" y2="16" stroke="#3a6a93" stroke-width="2" stroke-linecap="round"/><line x1="20" y1="22" x2="25" y2="22" stroke="#3a6a93" stroke-width="2" stroke-linecap="round"/><line x1="20" y1="13" x2="20" y2="11" stroke="#3a6a93" stroke-width="1.5"/></svg>
     </div>
     <div class="stat-text"><span class="stat-label">Engine(s) Hours</span><span class="stat-value">{{ boat.hours if boat.hours else '-' }}</span></div>
   </div>
+  {% endif %}
   <div class="stat-card">
     <div class="stat-icon" aria-hidden="true">
       <svg viewBox="0 0 40 40" width="32" height="32"><circle cx="20" cy="20" r="19" fill="none" stroke="#7da4c8" stroke-width="1.5"/><path d="M10 24 L 30 24 L 27 28 L 13 28 Z" fill="#3a6a93"/><rect x="14" y="18" width="12" height="6" rx="1" fill="#3a6a93"/><rect x="17" y="14" width="6" height="4" rx="1" fill="#3a6a93"/></svg>

--- a/deploy/sim_envs/mantis_boattrader/app/templates/boat_detail.html
+++ b/deploy/sim_envs/mantis_boattrader/app/templates/boat_detail.html
@@ -327,23 +327,16 @@
     </summary>
     <div class="accordion-body bdp-description-body" data-clampable="1">
       <div class="bdp-description-clamped">
+        {# Real BT BDP Description body: bold seller blurb at top, a small
+           UPPERCASE "DESCRIPTION" label between blurb and body, then the
+           description paragraphs. No "Key Features" sub-section, no
+           owner-only disclaimer paragraph — both were sandbox additions
+           that don't exist in real BT and inflate the clamp region. #}
         <p class="bdp-seller-blurb">{{ boat.owner_seller_description }}</p>
+        <p class="bdp-description-label">DESCRIPTION</p>
         <div class="bdp-description">
           {% for para in boat.description %}<p>{{ para }}</p>{% endfor %}
         </div>
-        {% if boat.description_features %}
-          <h3 class="bdp-feature-h3">Key Features</h3>
-          <ul class="bdp-feature-list">
-            {% for f in boat.description_features %}<li>{{ f }}</li>{% endfor %}
-          </ul>
-        {% endif %}
-        {% if boat.is_owner_listed %}
-          <p class="bdp-disclaimer-text">
-            This listing was placed by a private seller. Boat Trader has not verified
-            the accuracy of any claims made in the description. Always inspect a boat
-            in person and obtain a marine survey before any purchase decision.
-          </p>
-        {% endif %}
       </div>
       <button type="button" class="bdp-show-more" data-show-more>Show More</button>
     </div>
@@ -435,15 +428,18 @@
   </a>
 </section>
 
-{# ─── Loan Calculator ──────────────────────────────────────── #}
+{# ─── Loan Calculator — matches real BT BDP probe (2026-05-24):
+   • Form: 4 fields only — Year / Purchase Price / Down Payment / Loan Term (Months)
+     (was 5: Loan Type + Year + Purchase Price + Down Payment + Credit Score (FICO))
+   • Preview pane: huge monthly ($X.XX, 50px), TOTAL LOAN AMOUNT line,
+     horizontal rule, See Important Disclosure link only.
+     The Get Pre-Qualified button + bullet list belong to a separate
+     right-rail "Get pre-qualified in minutes" card, NOT this preview. #}
 <section class="bdp-loan-card" id="loan-calculator" data-testid="loan-calculator">
   <div class="loan-card-grid">
     <div class="loan-form">
       <h3 class="loan-form-heading">Boat Loan Payment Calculator</h3>
       <p class="loan-form-sub">Estimate your monthly payment based on the boat you want to buy and your specific loan need.</p>
-      <label class="loan-field"><span>Loan Type</span>
-        <select class="filter-select"><option>{{ boat.condition|capitalize }} Boat Loan</option><option>New Boat Loan</option></select>
-      </label>
       <label class="loan-field"><span>Year</span>
         <select class="filter-select"><option>{{ boat.year }}</option></select>
       </label>
@@ -451,26 +447,17 @@
         <input type="text" class="filter-input" value="{{ boat.display_price }}" />
       </label>
       <label class="loan-field"><span>Down Payment</span>
-        <input type="text" class="filter-input" value="${{ ((boat.price or 0) * 0.10)|int }}" />
+        <input type="text" class="filter-input" value="${{ ((boat.price or 0) * 0.15)|int }}" />
       </label>
-      <label class="loan-field"><span>Credit Score (FICO)</span>
-        <select class="filter-select"><option>800-850</option><option>740-799</option><option>670-739</option></select>
+      <label class="loan-field"><span>Loan Term (Months)</span>
+        <select class="filter-select"><option>240</option><option>180</option><option>120</option><option>60</option></select>
       </label>
     </div>
     <div class="loan-preview">
-      <h3 class="loan-preview-heading">Here is what your monthly payment might look like:</h3>
-      <p class="loan-apr"><strong>{{ '%.2f'|format(7.49 if boat.condition == 'new' else 8.24) }}%</strong> APR</p>
+      <h3 class="loan-preview-heading">Here is what your monthly payment<br/>might look like:</h3>
       <p class="loan-payment">{{ boat.display_monthly|replace('/mo*','')|replace('/mo','') if boat.display_monthly else '$—' }}</p>
-      <p class="loan-total">TOTAL LOAN AMOUNT <strong>${{ ((boat.price or 0) * 0.90)|int }}</strong></p>
-      <p class="loan-term"><strong>180</strong> MONTHS</p>
-      <a href="/boat-loans/" class="btn-secondary loan-prequal-btn">Get Pre-Qualified</a>
+      <p class="loan-total">TOTAL LOAN AMOUNT <strong>${{ ((boat.price or 0) * 0.85)|int }}</strong></p>
       <hr class="loan-divider" />
-      <h4 class="loan-bullets-heading">Get pre-qualified in minutes</h4>
-      <ul class="prequal-bullets">
-        <li><span class="prequal-check">✓</span> We'll compare over 15 lenders to get you the best rate &amp; terms</li>
-        <li><span class="prequal-check">✓</span> Customized financing to meet your needs</li>
-        <li><span class="prequal-check">✓</span> Over 25 years of marine lending experience</li>
-      </ul>
       <a href="#" class="loan-disclosure-link">See Important Disclosure<sup>3</sup></a>
     </div>
   </div>

--- a/deploy/sim_envs/mantis_boattrader/app/templates/boat_detail.html
+++ b/deploy/sim_envs/mantis_boattrader/app/templates/boat_detail.html
@@ -481,7 +481,9 @@
       <a href="#" class="enhanced-dealer-link">Visit Seller Website</a>
     </div>
     <div class="enhanced-seller-card-right">
-      <p class="trusted-partner enhanced-trusted">Trusted Boat Trader Partner | <strong>{{ dealer.trusted_partner_label }}</strong></p>
+      {# Real BT Listed By right column: two stat rows (16/600 number +
+         label) stacked vertically, "Trusted Boat Trader Partner"
+         label-only at the BOTTOM (no `| <years>` suffix). #}
       <div class="enhanced-stat-row">
         <div class="enhanced-stat-num">{{ dealer.active_listings }}</div>
         <div class="enhanced-stat-label">Active listings</div>
@@ -490,6 +492,7 @@
         <div class="enhanced-stat-num">{{ "{:,}".format(dealer.sold_listings) }}</div>
         <div class="enhanced-stat-label">Sold listings</div>
       </div>
+      <p class="trusted-partner enhanced-trusted">Trusted Boat Trader Partner</p>
     </div>
   </div>
 </section>

--- a/deploy/sim_envs/mantis_boattrader/app/templates/boat_detail.html
+++ b/deploy/sim_envs/mantis_boattrader/app/templates/boat_detail.html
@@ -202,28 +202,10 @@
         </form>
       </div>
 
-      {# Separate dealership card with logo + address + active/sold stats. #}
-      <div class="bdp-dealership-card" data-testid="dealership-card">
-        <div class="dealership-logo-wrap">
-          <div class="dealership-logo">
-            <span class="logo-mark">{{ dealer.logo_initial }}</span>
-            <span class="logo-name">{{ dealer.name|upper }}</span>
-          </div>
-        </div>
-        <p class="dealership-address">{{ dealer.address }}, {{ dealer.city }}, {{ dealer.state }}, {{ dealer.zip }}</p>
-        <p class="trusted-partner">Trusted Boat Trader Partner</p>
-        <div class="dealership-stats">
-          <div class="dealership-stat-box">
-            <span class="dealership-stat-num">{{ dealer.active_listings }}</span>
-            <span class="dealership-stat-label">Active listings</span>
-          </div>
-          <div class="dealership-stat-box">
-            <span class="dealership-stat-num">{{ "{:,}".format(dealer.sold_listings) }}</span>
-            <span class="dealership-stat-label">Sold listings</span>
-          </div>
-        </div>
-        <a href="https://www.{{ dealer.name|lower|replace(' ','-')|replace(',','')|replace('--','-') }}.com" class="visit-seller-link dealership-link" target="_blank" rel="nofollow">Visit Seller Website</a>
-      </div>
+      {# Real BT side-panel does NOT show the dealership logo + active/
+         sold stat boxes — those live only in the full-width "Listed By"
+         block below the loan calculator. Iter14 removed the duplicate
+         right-rail .bdp-dealership-card to match. #}
     {% endif %}
 
     {# ─── Get pre-qualified card (always last in the right rail) ─── #}

--- a/deploy/sim_envs/mantis_boattrader/app/templates/boat_detail.html
+++ b/deploy/sim_envs/mantis_boattrader/app/templates/boat_detail.html
@@ -254,7 +254,7 @@
     <div class="stat-icon" aria-hidden="true">
       <svg viewBox="0 0 40 40" width="32" height="32"><circle cx="20" cy="20" r="19" fill="none" stroke="#7da4c8" stroke-width="1.5"/><circle cx="20" cy="22" r="8" fill="none" stroke="#3a6a93" stroke-width="1.5"/><line x1="20" y1="22" x2="20" y2="16" stroke="#3a6a93" stroke-width="2" stroke-linecap="round"/><line x1="20" y1="22" x2="25" y2="22" stroke="#3a6a93" stroke-width="2" stroke-linecap="round"/><line x1="20" y1="13" x2="20" y2="11" stroke="#3a6a93" stroke-width="1.5"/></svg>
     </div>
-    <div class="stat-text"><span class="stat-label">Engine Hours</span><span class="stat-value">{{ boat.hours if boat.hours else '-' }}</span></div>
+    <div class="stat-text"><span class="stat-label">Engine(s) Hours <span class="info-tip stat-info" title="Reported by the seller">ⓘ</span></span><span class="stat-value">{{ boat.hours if boat.hours else '-' }}</span></div>
   </div>
   <div class="stat-card">
     <div class="stat-icon" aria-hidden="true">
@@ -270,7 +270,7 @@
   </div>
   <div class="stat-card">
     <div class="stat-icon" aria-hidden="true">
-      <svg viewBox="0 0 40 40" width="32" height="32"><circle cx="20" cy="20" r="19" fill="none" stroke="#7da4c8" stroke-width="1.5"/><rect x="11" y="11" width="18" height="18" rx="2" fill="none" stroke="#3a6a93" stroke-width="1.5"/><line x1="11" y1="16" x2="29" y2="16" stroke="#3a6a93" stroke-width="1.5"/><line x1="15" y1="11" x2="15" y2="14" stroke="#3a6a93" stroke-width="1.5"/><line x1="25" y1="11" x2="25" y2="14" stroke="#3a6a93" stroke-width="1.5"/><text x="20" y="26" font-size="6" font-family="Arial" font-weight="700" fill="#3a6a93" text-anchor="middle">YEAR</text></svg>
+      <svg viewBox="0 0 40 40" width="32" height="32"><circle cx="20" cy="20" r="19" fill="none" stroke="#7da4c8" stroke-width="1.5"/><rect x="11" y="11" width="18" height="18" rx="2" fill="none" stroke="#3a6a93" stroke-width="1.5"/><line x1="11" y1="16" x2="29" y2="16" stroke="#3a6a93" stroke-width="1.5"/><line x1="15" y1="11" x2="15" y2="14" stroke="#3a6a93" stroke-width="1.5"/><line x1="25" y1="11" x2="25" y2="14" stroke="#3a6a93" stroke-width="1.5"/></svg>
     </div>
     <div class="stat-text"><span class="stat-label">Year</span><span class="stat-value">{{ boat.year }}</span></div>
   </div>
@@ -381,35 +381,11 @@
     </div>
   </details>
 
-  <details class="bdp-accordion">
-    <summary>
-      <h3 class="accordion-title">More Details</h3>
-      <span class="accordion-chevron"></span>
-    </summary>
-    <div class="accordion-body">
-      <dl class="spec-grid">
-        <div><dt>Condition</dt><dd>{{ boat.condition|capitalize }}</dd></div>
-        <div><dt>Class</dt><dd>{{ boat.boat_type }}</dd></div>
-        <div><dt>Hull Material</dt><dd>{{ boat.hull_material }}</dd></div>
-        <div><dt>Hull Color</dt><dd>{{ boat.hull_color }}</dd></div>
-        <div><dt>Passenger Capacity</dt><dd>{{ boat.capacity_people }}</dd></div>
-        <div><dt>Listing ID</dt><dd>{{ boat.id }}</dd></div>
-      </dl>
-    </div>
-  </details>
-
-  <details class="bdp-accordion">
-    <summary>
-      <h3 class="accordion-title">Location</h3>
-      <span class="accordion-chevron"></span>
-    </summary>
-    <div class="accordion-body">
-      <p>{{ boat.city }}, {{ boat.state }} {{ boat.zip }}</p>
-      <div class="bdp-map-placeholder" data-testid="map-placeholder">
-        <span>Map of {{ boat.city }}, {{ boat.state }}</span>
-      </div>
-    </div>
-  </details>
+  {# Real BT BDP only renders Description / Measurements / Propulsion
+     at this accordion level. The Condition / Hull / Listing ID fields
+     are already surfaced in the stats strip + Propulsion accordion; the
+     Location section duplicates the right-rail city/state line — both
+     dropped here to mirror real BT exactly. #}
 </section>
 
 {# ─── Sponsor banner #2 — INSIDE left column ──── #}
@@ -516,19 +492,9 @@
   </div>
   <a href="#" class="more-from-dealer-link">More Boats from this Dealer</a>
 </section>
-{% else %}
-<section class="bdp-listed-by" data-testid="listed-by-private">
-  <h2 class="bdp-listed-by-h2">Listed By</h2>
-  <div class="listed-by-card listed-by-private">
-    <div class="listed-by-logo private">{{ boat.owner_name[0] }}</div>
-    <div class="listed-by-body">
-      <h3 class="listed-by-dealer">{{ boat.owner_name }}</h3>
-      <p class="listed-by-address">Private Seller · {{ boat.city }}, {{ boat.state }}</p>
-      <p class="listed-by-private-note">Listed for <strong>{{ boat.listed_days_ago }} days</strong>. Not a verified dealer.</p>
-    </div>
-  </div>
-</section>
 {% endif %}
+{# Real BT private-seller BDP omits the "Listed By" section entirely —
+   the right-rail card already names the seller. #}
 
 {# ─── Still have a question? ────────────────────────────────── #}
 <section class="bdp-question-card" data-testid="still-have-question">
@@ -539,7 +505,10 @@
   <a href="#contact" class="btn-secondary question-contact-btn">Contact seller</a>
 </section>
 
-{# ─── OTHER SERVICES tiles ──────────────────────────────────── #}
+{# ─── OTHER SERVICES tiles ──────────────────────────────────────
+   Real BT renders 6 tiles in a flexible row (Surveyors, Documentation,
+   Boat Loans, Insurance, Warranty, Transport). Logos remain procedural
+   SVG placeholders per SCOPE.md §Out-of-scope. #}
 <section class="bdp-other-services" data-testid="other-services">
   <h3 class="other-services-label">OTHER SERVICES</h3>
   <div class="other-services-tiles">
@@ -547,13 +516,37 @@
       <div class="other-service-icon" aria-hidden="true">
         <svg viewBox="0 0 60 60" width="44" height="44"><circle cx="30" cy="30" r="29" fill="#0a3d62"/><path d="M10 38 L 30 26 L 50 38" stroke="#fff" stroke-width="3" fill="none"/><text x="30" y="50" font-family="Arial" font-size="7" font-weight="700" fill="#fff" text-anchor="middle">ELITE</text></svg>
       </div>
-      <span class="other-service-name">Elite Marine Surveyors</span>
+      <span class="other-service-name">Marine Surveyors</span>
     </a>
     <a class="other-service-tile" href="#">
       <div class="other-service-icon other-service-icon-yc" aria-hidden="true">
         <svg viewBox="0 0 60 60" width="44" height="44"><circle cx="30" cy="30" r="29" fill="#fff" stroke="#1f6cd1" stroke-width="2"/><text x="30" y="36" font-family="Arial" font-size="22" font-weight="700" fill="#1f6cd1" text-anchor="middle">yc</text></svg>
       </div>
       <span class="other-service-name">Boat Documentation</span>
+    </a>
+    <a class="other-service-tile" href="#">
+      <div class="other-service-icon" aria-hidden="true">
+        <svg viewBox="0 0 60 60" width="44" height="44"><circle cx="30" cy="30" r="29" fill="#2566b0"/><text x="30" y="36" font-family="Arial" font-size="20" font-weight="700" fill="#fff" text-anchor="middle">$</text></svg>
+      </div>
+      <span class="other-service-name">Boat Loans</span>
+    </a>
+    <a class="other-service-tile" href="#">
+      <div class="other-service-icon" aria-hidden="true">
+        <svg viewBox="0 0 60 60" width="44" height="44"><circle cx="30" cy="30" r="29" fill="#fff" stroke="#3a6a93" stroke-width="2"/><path d="M30 14 L 42 19 L 42 33 Q 42 42 30 48 Q 18 42 18 33 L 18 19 Z" fill="#3a6a93"/></svg>
+      </div>
+      <span class="other-service-name">Boat Insurance</span>
+    </a>
+    <a class="other-service-tile" href="#">
+      <div class="other-service-icon" aria-hidden="true">
+        <svg viewBox="0 0 60 60" width="44" height="44"><circle cx="30" cy="30" r="29" fill="#0a3d62"/><circle cx="30" cy="30" r="15" fill="none" stroke="#fff" stroke-width="2"/><path d="M22 30 L 28 36 L 40 24" stroke="#fff" stroke-width="3" fill="none" stroke-linecap="round"/></svg>
+      </div>
+      <span class="other-service-name">Boat Warranty</span>
+    </a>
+    <a class="other-service-tile" href="#">
+      <div class="other-service-icon" aria-hidden="true">
+        <svg viewBox="0 0 60 60" width="44" height="44"><circle cx="30" cy="30" r="29" fill="#fff" stroke="#0a3d62" stroke-width="2"/><rect x="14" y="26" width="32" height="10" rx="1" fill="#0a3d62"/><circle cx="22" cy="40" r="4" fill="#0a3d62"/><circle cx="40" cy="40" r="4" fill="#0a3d62"/></svg>
+      </div>
+      <span class="other-service-name">Boat Transport</span>
     </a>
   </div>
 </section>


### PR DESCRIPTION
## Summary

End-to-end perceptual fidelity pass on the `mantis_boattrader` sim
env BDP (boat detail page) vs real `boattrader.com`. **27 commits**,
**~18 iters** of probe → diff → fix → verify against live Chrome MCP
sessions on real BT.

## What changed

### Right-rail summary card
- Title structure: `<header>` + `<h1>` + sibling `<span>` for length
  suffix (real BT's SEO trick)
- Drop badges-above-title, length suffix in H1 itself
- K-format views >999 (`1.5k Views`)
- Engagement row: 1×12 `rgb(222,226,227)` hairline divider (was `\|` char),
  10px gap, `<strong>` number at 600 weight
- Dealer card pattern → dealership-name heading, pin-led address,
  E.164 raw phone, NO headshot (matches Westchester example)
- Nested card border: 1px #ededed, 8px radius, 16px pad
- Drop duplicate `.bdp-dealership-card` (was rendering same info twice)
- Submit pill: FILLED `rgb(37,102,176)` "Contact Seller" both variants

### Private-seller variant
- Drop `Private Seller` pill, owner-name in heading, disclaimer paragraph
- Generic "Contact Private Seller" heading
- Show Phone Number moved AFTER form (only when phone known)

### Top nav row + sticky bar
- Replace `space-between` with `flex-start + margin-left: auto` on
  actions so breadcrumb hugs `< Search`
- Max-width 1336 cap (aligns with `.bdp-grid` content beneath)
- Sticky bar two-state: breadcrumb (shallow) / Title \| $Price \| Loc \| ♡ Save (deep)
- Previous Boat / Next Boat as button pills (104×34, 4px radius,
  padding 11px 15px) with `<` / `>` chevrons via `::before` / `::after`
- Breadcrumb color BDP-scoped #757575 → #616161
- Breadcrumb category: `Sail` for sailboats / `Power` for everything else

### Stats strip
- 8-card grid → 4-col × 2-row at exact `166×39` dims (matched real BT)
- Label `Engine Hours` → `Engine(s) Hours` (with parens, no inline ⓘ)
- Sailboats skip the Engine(s) Hours card → render 7 stats

### Boat Details accordion section
- Restore More Details + Location accordions (5 total at H3, matching
  real BT — iter1.2 wrongly removed them)
- Title length suffix as sibling span outside H1
- Description body: 15px / 19.5px line-height, 8px padding;
  `<strong>` topic line + `DESCRIPTION` sub-label (NOT tracked uppercase)
- Show More toggle (clamp 168px, JS expand/collapse)
- H2 "Boat Details" margin 0
- Accordion item padding: `<details>` 18px 0 + 1px #ededed bottom,
  `<summary>` 0 (was 16/22 → height inflated 2× real BT)
- Propulsion: hide Engine Hours row for sailboats

### Ad strips
- 728×90 → `970×120`; strip padding 16 → 1px each side
- Full-bleed viewport breakout via `margin: 24px calc(50% - 50vw); width: 100vw`

### Loan calculator
- 4-field form (Year / Purchase Price / Down Payment / Loan Term),
  matching real BT (was 5 fields with Loan Type + FICO)
- Input 4px radius + 16px font (BDP-scoped, doesn't affect SRP)
- Heading 20/700; preview pane stripped to monthly + total + disclosure

### Listed By + More From This Dealer
- bg #f5f9ff (was #eef4fb)
- Stat-num 16/600 (was 22/700); "Trusted Boat Trader Partner" plain
- "More Boats from this Dealer" link `#0051AD`

### Other Services
- 2 → 6 tiles (Marine Surveyors, Boat Documentation, Boat Loans,
  Boat Insurance, Boat Warranty, Boat Transport); 3-col grid

### Page container
- `.bt-main { max-width: none }` so ad-strip breaks out to viewport;
  SRP + Home get their own 1440px caps to stay centered

### Data
- 18 apostrophe encoding bugs in seed.py blurbs (`Don?t` → `Don't`)
- Dealer phone format `(XXX) XXX-XXXX` → E.164 `+1XXXXXXXXXX`

## Files touched

- `deploy/sim_envs/mantis_boattrader/app/templates/boat_detail.html`
- `deploy/sim_envs/mantis_boattrader/app/templates/base.html`
- `deploy/sim_envs/mantis_boattrader/app/static/app.css`
- `deploy/sim_envs/mantis_boattrader/app/seed.py`
- `deploy/sim_envs/mantis_boattrader/FIDELITY.md` (v=86..v=120 entries)
- `deploy/sim_envs/mantis_boattrader/BDP_FIDELITY_PLAN.md` (new)
- `deploy/sim_envs/mantis_boattrader/BDP_PENDING_DIFFERENCES.md` (new)
- `deploy/sim_envs/mantis_boattrader/_captured/bdp/structural.json` (filled from placeholder)

## Variant coverage smoke

All 6 BDP variants verified via Chrome MCP:
- Dealer (yacht: Princess F55)
- Private seller (Chaparral)
- Sponsored (Robalo R230 — SPONSORED LISTING pill)
- POA (Boston Whaler — "Request a Price")
- Price drop (Crestliner — `$X ↓ $Y`)
- Sailboat (Catalina 385 — Sail breadcrumb, 7 stats)

## Remaining gaps

See `deploy/sim_envs/mantis_boattrader/BDP_PENDING_DIFFERENCES.md`
for the full list of known unmatched elements grouped by severity
(🚫 placeholder, 🟡 cosmetic, 🟠 data-shape).

Highest priority follow-ups (all 🟠 data-shape):
- Verified Broker badge (sandbox dealers need flag)
- Engine Model / Engine Year fields (sandbox Boat needs new attrs)
- Salesperson-name dealer pattern variant (conditional)

## Test plan

- [ ] Reload sandbox BDP at canonical viewport 1512×711 and confirm
      no obvious cosmetic regressions on each of the 6 variants above
- [ ] Sanity-check SRP (`/boats/`) and home (`/`) didn't lose their
      1440px container after the `.bt-main` max-width removal
- [ ] `pytest tests/sim_envs/mantis_boattrader/` still green