### PR TITLE
fix(augur): publish run-level cost on every step, not just at finalize

### DIFF
--- a/src/mantis_agent/gym/run_executor.py
+++ b/src/mantis_agent/gym/run_executor.py
@@ -572,6 +572,15 @@ class RunExecutor:
             )
         healing = getattr(runner, "_healing_events", None) or []
         augur.drain_healing_events(healing)
+        # #659 follow-up: refresh the run-level cost rollup so the
+        # Augur Runs-list COST column updates live during the run
+        # instead of waiting for ``_finalize`` (which silently meant
+        # the column showed $0.00 / a stale per-step delta for the
+        # entire wall-clock of a multi-minute run). ``set_costs``
+        # overwrites on each call so the cost reflects whatever the
+        # cost-meter currently totals. Best-effort: the helper logs
+        # at debug on any failure and returns.
+        self._publish_run_costs_to_augur()
 
     # Mantis TimeMeter bucket → Augur ``StepTrace.latency`` slot
     # (augur-sdk 0.1.6+ schema). The Augur slots are intentionally
@@ -2069,6 +2078,47 @@ class RunExecutor:
         except Exception as exc:  # noqa: BLE001
             logger.debug("AugurAdapter.finalize_outcome composition failed: %s", exc)
 
+    def _publish_run_costs_to_augur(self) -> None:
+        """Publish the cost-meter's current rollup to Augur via
+        ``set_costs``. Idempotent — Augur's ``set_costs`` overwrites
+        on each call so calling this many times throughout a run
+        keeps the Runs-list COST column live-updated.
+
+        Was originally only invoked from ``_emit_augur_aggregate_metrics``
+        at finalize, which meant the Augur UI showed $0.00 (or whatever
+        the last per-step delta happened to be via the ``set_step_costs``
+        fallback path) for the entire duration of a live run. After
+        this extraction the per-step emission hook (#660 follow-up)
+        also calls this on every step so cost updates in real time.
+
+        Best-effort: any failure path logs at debug and returns;
+        observability never breaks the run.
+        """
+        runner = self.parent
+        augur: AugurAdapter | None = getattr(runner, "_augur", None)
+        if augur is None or not augur.active:
+            return
+        meter = getattr(runner, "cost_meter", None)
+        if meter is None:
+            return
+        try:
+            gpu, claude, proxy, total = meter.totals()
+        except Exception as exc:  # noqa: BLE001 — telemetry never breaks runs
+            logger.debug("augur cost-meter totals() failed: %s", exc)
+            return
+        claude_input = int(meter.costs.get("claude_input_tokens", 0) or 0)
+        claude_output = int(meter.costs.get("claude_output_tokens", 0) or 0)
+        claude_cached_input = int(meter.costs.get("claude_cached_input_tokens", 0) or 0)
+        augur.set_costs(
+            total_usd=round(total, 4),
+            model_usd=round(claude, 4),
+            gpu_usd=round(gpu, 4),
+            proxy_usd=round(proxy, 4),
+            tokens_in=claude_input or None,
+            tokens_out=claude_output or None,
+            cache_hit_tokens=claude_cached_input or None,
+        )
+
     def _emit_augur_aggregate_metrics(self, results: list[StepResult]) -> None:
         """Send cost-meter totals as both session tags and metric
         DecisionEvents (#509).
@@ -2096,21 +2146,19 @@ class RunExecutor:
             elapsed = float(meter.elapsed_seconds() or 0.0)
         except Exception:  # noqa: BLE001
             pass
-        # #521: structured ``session.costs`` is the canonical surface
-        # as of augur-sdk 0.1.8. The workspace's Runs-list COST column
-        # now reads from here, not from tags — one source of truth.
+        # #521 (finalize side): structured ``session.costs`` is the
+        # canonical surface as of augur-sdk 0.1.8. Delegated to the
+        # shared helper so the per-step emission hook publishes the
+        # same shape during the run.
+        self._publish_run_costs_to_augur()
+        # Local copies of the token counts still used by the
+        # ``record_cost_metric`` event payload below — the helper
+        # encapsulates the ``set_costs`` call but the structured
+        # event surface needs the same numbers in its ``detail``
+        # dict.
         claude_input = int(meter.costs.get("claude_input_tokens", 0) or 0)
         claude_output = int(meter.costs.get("claude_output_tokens", 0) or 0)
         claude_cached_input = int(meter.costs.get("claude_cached_input_tokens", 0) or 0)
-        augur.set_costs(
-            total_usd=round(total, 4),
-            model_usd=round(claude, 4),
-            gpu_usd=round(gpu, 4),
-            proxy_usd=round(proxy, 4),
-            tokens_in=claude_input or None,
-            tokens_out=claude_output or None,
-            cache_hit_tokens=claude_cached_input or None,
-        )
         # Back-allocate the finalize residual to the last emitted
         # step so the per-step COST column visibly sums to the run
         # total. Residual = run total − Σ per-step ``total_usd``.

--- a/tests/test_augur_live_cost_publish.py
+++ b/tests/test_augur_live_cost_publish.py
@@ -1,0 +1,133 @@
+"""#659 follow-up — ``set_costs`` publishes the run-level cost
+rollup on every step emission, not just at finalize.
+
+Before this fix the Augur Runs-list COST column showed a stale
+value (typically $0.00 or the last per-step delta) for the entire
+duration of a live run — ``_emit_augur_aggregate_metrics`` was the
+only caller of ``set_costs`` and it only ran from ``_finalize``.
+For a 60-minute run the user saw misleadingly understated cost
+right up until terminal status flipped.
+
+Contract pinned here:
+    - ``_publish_run_costs_to_augur`` reads ``cost_meter.totals()``
+      and forwards them to ``AugurAdapter.set_costs`` (the SDK's
+      canonical run-cost surface, augur-sdk 0.1.8+).
+    - ``_emit_augur_step`` calls the helper after every step.
+    - ``_emit_augur_aggregate_metrics`` still calls the helper at
+      finalize (one source of truth — same call shape).
+    - Best-effort: a missing augur adapter / cost meter / SDK method
+      never breaks the run.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from mantis_agent.gym.run_executor import RunExecutor
+
+
+def _build_executor_with_augur(total: float = 4.61) -> tuple:
+    """Construct a minimal RunExecutor with a spy AugurAdapter + a
+    cost-meter that returns the given total. Returns (executor, spy)."""
+    executor = RunExecutor.__new__(RunExecutor)
+    runner = MagicMock()
+    augur = MagicMock()
+    augur.active = True
+    runner._augur = augur
+    # totals() returns (gpu, claude, proxy, total).
+    runner.cost_meter.totals = MagicMock(return_value=(0.0, 2.20, 2.41, total))
+    runner.cost_meter.costs = {
+        "claude_input_tokens": 1000,
+        "claude_output_tokens": 500,
+        "claude_cached_input_tokens": 200,
+    }
+    runner.cost_meter.elapsed_seconds = MagicMock(return_value=120.0)
+    executor.parent = runner
+    return executor, augur
+
+
+def test_publish_run_costs_forwards_totals_to_set_costs():
+    executor, augur = _build_executor_with_augur(total=4.61)
+    executor._publish_run_costs_to_augur()
+    augur.set_costs.assert_called_once()
+    kwargs = augur.set_costs.call_args.kwargs
+    assert kwargs["total_usd"] == 4.61
+    assert kwargs["model_usd"] == 2.20
+    assert kwargs["proxy_usd"] == 2.41
+    assert kwargs["gpu_usd"] == 0.0
+    assert kwargs["tokens_in"] == 1000
+    assert kwargs["tokens_out"] == 500
+    assert kwargs["cache_hit_tokens"] == 200
+
+
+def test_publish_run_costs_idempotent_repeated_calls_keep_publishing():
+    """Multiple calls re-publish the latest totals — the per-step
+    hook will call this hundreds of times during a long inner loop."""
+    executor, augur = _build_executor_with_augur(total=1.0)
+    for _ in range(5):
+        executor._publish_run_costs_to_augur()
+    assert augur.set_costs.call_count == 5
+
+
+def test_publish_run_costs_no_op_when_augur_inactive():
+    executor = RunExecutor.__new__(RunExecutor)
+    runner = MagicMock()
+    augur = MagicMock()
+    augur.active = False
+    runner._augur = augur
+    executor.parent = runner
+    executor._publish_run_costs_to_augur()
+    augur.set_costs.assert_not_called()
+
+
+def test_publish_run_costs_no_op_when_no_augur():
+    executor = RunExecutor.__new__(RunExecutor)
+    runner = MagicMock()
+    runner._augur = None
+    executor.parent = runner
+    executor._publish_run_costs_to_augur()  # no crash
+
+
+def test_publish_run_costs_no_op_when_no_cost_meter():
+    executor = RunExecutor.__new__(RunExecutor)
+    runner = MagicMock()
+    augur = MagicMock()
+    augur.active = True
+    runner._augur = augur
+    runner.cost_meter = None
+    executor.parent = runner
+    executor._publish_run_costs_to_augur()
+    augur.set_costs.assert_not_called()
+
+
+def test_publish_run_costs_swallows_totals_exception():
+    """A failing cost-meter must never break a run — the helper
+    catches and demotes to debug log."""
+    executor = RunExecutor.__new__(RunExecutor)
+    runner = MagicMock()
+    augur = MagicMock()
+    augur.active = True
+    runner._augur = augur
+    runner.cost_meter.totals = MagicMock(side_effect=RuntimeError("simulated"))
+    executor.parent = runner
+    # Should not raise.
+    executor._publish_run_costs_to_augur()
+    augur.set_costs.assert_not_called()
+
+
+def test_publish_run_costs_handles_none_token_counts():
+    """``set_costs`` accepts ``None`` for token fields — preserve
+    the ``or None`` chain that converts 0 to None to keep the
+    Runs-list inspector tidy (a 0-token reading is rendered as
+    blank instead of '0 tokens')."""
+    executor, augur = _build_executor_with_augur()
+    executor.parent.cost_meter.costs = {
+        "claude_input_tokens": 0,
+        "claude_output_tokens": 0,
+        "claude_cached_input_tokens": 0,
+    }
+    executor._publish_run_costs_to_augur()
+    kwargs = augur.set_costs.call_args.kwargs
+    assert kwargs["tokens_in"] is None
+    assert kwargs["tokens_out"] is None
+    assert kwargs["cache_hit_tokens"] is None


### PR DESCRIPTION
## Summary

Augur's Runs-list COST column showed stale values throughout live runs — `set_costs` was only called from `_finalize`, so the column displayed $0.00 (or the latest `set_step_costs` delta) for the entire wall-clock of a multi-minute run. After this PR cost updates in real time per step.

## Live repro

Boattrader rerun `20260524_233002_5c9abe6e`:
- Worker: $4.61 / 25 leads / 32m wall-clock
- Augur UI: **$0.16** (the per-step delta of step 8 = navigate_back)

The numbers diverge by 28× because no cumulative cost ever shipped to Augur until finalize.

## Fix

- Extracted `set_costs` into a new `_publish_run_costs_to_augur` helper.
- Called from `_emit_augur_step` after every step.
- Still called from `_emit_augur_aggregate_metrics` at finalize (one source of truth).
- Best-effort: missing augur / cost meter / `totals()` exception all swallow silently.

## Test plan

- [x] `tests/test_augur_live_cost_publish.py` — 7 new tests:
  - helper forwards totals to `set_costs` with correct kwargs
  - repeated calls re-publish (each emission updates)
  - no-op when augur inactive / no augur / no cost meter
  - swallows exceptions from `totals()`
  - `tokens_in/out/cache_hit` respect the `or None` conversion
- [x] 68 augur regression tests still green (`test_observability_augur*` + `test_augur_step_id_unique_per_emission_659` + `test_augur_run_id_uniqueness_649`)
- [x] ruff clean

## Note on the other half of #659

The steps-collapse symptom (Augur UI shows 7 STEPS for a 25-iteration loop) is a separate issue:

- Augur SDK's `recorder.py:51` keys steps by integer `step_index`: `self._steps[step_index] = ...`. Multiple emissions to the same plan position overwrite.
- My #660 made `step_id` (string) unique per emission, but the SDK doesn't use `step_id` for storage — only `step_index`.
- The SDK is semantically correct for "step = canonical plan position" (model #1). Mantis's reality is "step = one runtime dispatch" (model #2).
- Three follow-up paths: (a) Mantis switches loop-iteration recording to `record_event` (additive, no plan-position collapse), (b) upstream SDK feature for `step_iterations`, (c) Augur UI surfaces iteration count in the STEPS column.

Filing as a separate follow-up — this PR ships only the live-cost fix because it's a clean win with zero coordination cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)