### PR TITLE
feat(augur): adopt augur-sdk 0.3.0 step-iteration semantics

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,22 @@ observability = [
     # partition sessions under a shared parent_run_id (see
     # observability/augur.py). Pinning to 0.2.1 minimum so consumers
     # don't accidentally downgrade past the branch surface.
-    "augur-sdk>=0.2.1,<0.3",
+    #
+    # 0.3.0 (mercurialsolo/augur-sdk#30, #31) — step-iteration semantics.
+    # EventRecorder is now keyed by ``step_id`` rather than
+    # ``step_index``, so loop iterations through the same plan position
+    # no longer collapse into one in-memory slot (the bug surfaced by
+    # boattrader rerun ``20260524_180432_d308f9de`` — 291 worker
+    # dispatches landed as 10 Augur rows). The SDK adds
+    # ``DebugSession.record_step_iteration(step_index, iteration)`` —
+    # producer-side helper that appends an iteration under an existing
+    # canonical step and bumps the canonical's ``step_iterations``
+    # counter. Augur server + viewer already render ``N (M)`` when
+    # iterations > canonical-steps. Mantis migration sits in
+    # ``observability/augur.py``: first emission for a given
+    # ``step_index`` routes through ``record_step``; subsequent
+    # emissions route through ``record_step_iteration``.
+    "augur-sdk>=0.3.0,<0.4",
 ]
 # Self-host the FastAPI server that fronts /predict and /v1/chat/completions.
 # Used by the Baseten / EKS / GKE deployments.

--- a/src/mantis_agent/observability/augur.py
+++ b/src/mantis_agent/observability/augur.py
@@ -313,6 +313,12 @@ class AugurAdapter:
         # collapsing the trace down to one row per plan position. Keyed
         # by the 1-based ``augur_index`` (matches ``step_id`` prefix).
         self._step_emission_counts: dict[int, int] = {}
+        # augur-sdk 0.3.0 (#30) — once a canonical step exists for a
+        # given ``step_index``, subsequent emissions must route through
+        # ``record_step_iteration`` instead of ``record_step`` to land
+        # as iterations rather than emit a DeprecationWarning. Track
+        # which step_indices have already had their canonical emit.
+        self._canonical_step_recorded: set[int] = set()
         # Verbose diagnostic — gated by ``MANTIS_AUGUR_VERBOSE``. WARN
         # is the only level that survives Modal's INFO/DEBUG suppression,
         # so when verifying a deploy operators flip the flag and get one
@@ -530,7 +536,29 @@ class AugurAdapter:
                 costs=costs,
                 latency=latency,
             )
-            self._session.record_step(trace)
+            # augur-sdk 0.3.0 (#30, #31): first emission per
+            # ``step_index`` is the canonical step; subsequent
+            # emissions are iterations under it (Mantis loop bodies
+            # cycle through the same plan position 25-30 times during
+            # a typical extraction run). The SDK's EventRecorder is
+            # keyed on ``step_id`` after 0.3.0 — routing iterations
+            # through ``record_step_iteration`` bumps the canonical
+            # step's ``step_iterations`` counter (the Augur viewer
+            # then renders "N (M)" in the runs-list STEPS column).
+            # Pre-0.3.0 fallback: every call goes through
+            # ``record_step``; the SDK collapses iterations and the
+            # adapter behaves the same as today.
+            raw_index = int(getattr(step_result, "step_index", 0))
+            augur_index = raw_index + 1
+            iter_fn = getattr(self._session, "record_step_iteration", None)
+            if (
+                augur_index in self._canonical_step_recorded
+                and callable(iter_fn)
+            ):
+                iter_fn(augur_index, trace)
+            else:
+                self._session.record_step(trace)
+                self._canonical_step_recorded.add(augur_index)
         except Exception as exc:  # noqa: BLE001
             # Verbose deploys want this visible; production stays at debug.
             if is_verbose():

--- a/tests/test_augur_sdk_0_3_step_iterations.py
+++ b/tests/test_augur_sdk_0_3_step_iterations.py
@@ -1,0 +1,192 @@
+"""augur-sdk 0.3.0 step-iteration semantics (mercurialsolo/augur-sdk#30, #31).
+
+After the upstream SDK release, mantis routes the first emission for
+each plan ``step_index`` through ``record_step`` (canonical) and every
+subsequent emission through ``record_step_iteration`` (appends to the
+canonical's iterations + bumps ``step_iterations``).
+
+Before this change, mantis spammed ``record_step`` for every loop
+iteration. The 0.3.0 SDK accepts that pattern but emits a
+DeprecationWarning AND the Augur viewer can't render the proper
+"N (M)" iteration count. Routing iterations through
+``record_step_iteration`` is the clean migration.
+
+Contract pinned here:
+    - First emission for a given ``step_index`` → ``record_step``.
+    - Subsequent emissions for that same index →
+      ``record_step_iteration``.
+    - Per-index isolation — emitting step 2 then step 5 should produce
+      TWO canonical emissions (one each).
+    - Fallback for pre-0.3.0 SDKs that don't have
+      ``record_step_iteration`` — every call goes through
+      ``record_step``, no behaviour change vs today.
+    - Adapter-internal state (``_canonical_step_recorded``) resets
+      across adapter instances.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip("augur_sdk")
+
+from mantis_agent.observability.augur import AugurAdapter  # noqa: E402
+
+
+def _stub_step_result(step_index: int) -> SimpleNamespace:
+    return SimpleNamespace(
+        step_index=step_index,
+        intent=f"step{step_index}",
+        success=True,
+        verdict=SimpleNamespace(kind="ok", reason="", confidence=1.0),
+        data="",
+        failure_class="",
+        last_action=None,
+        duration=0.0,
+        page_title="",
+        executor_backend="",
+        reasoning="",
+    )
+
+
+def _open_adapter(tmp_path: Path) -> AugurAdapter:
+    return AugurAdapter(
+        run_id="iter_test", tenant_id="t", session_name="s",
+        out_dir=tmp_path,
+    )
+
+
+# ── Routing: canonical vs iteration ─────────────────────────────────
+
+
+def test_first_emission_per_index_routes_to_record_step(tmp_path, monkeypatch):
+    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
+    a = _open_adapter(tmp_path)
+    if not a.active:
+        pytest.skip("AugurAdapter inactive")
+    a._session = MagicMock()
+    a._session.record_step = MagicMock()
+    a._session.record_step_iteration = MagicMock()
+
+    a.record_step(step_result=_stub_step_result(step_index=2))
+
+    a._session.record_step.assert_called_once()
+    a._session.record_step_iteration.assert_not_called()
+    # The set is keyed by 1-based augur_index, matching the SDK.
+    assert 3 in a._canonical_step_recorded
+
+
+def test_subsequent_emissions_route_to_record_step_iteration(tmp_path, monkeypatch):
+    """Same step_index emitted twice → first canonical, second iteration."""
+    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
+    a = _open_adapter(tmp_path)
+    if not a.active:
+        pytest.skip("AugurAdapter inactive")
+    a._session = MagicMock()
+    a._session.record_step = MagicMock()
+    a._session.record_step_iteration = MagicMock()
+
+    a.record_step(step_result=_stub_step_result(step_index=2))
+    a.record_step(step_result=_stub_step_result(step_index=2))
+
+    assert a._session.record_step.call_count == 1
+    assert a._session.record_step_iteration.call_count == 1
+    # Iteration was passed (augur_index, trace) — the 1-based index.
+    iter_args = a._session.record_step_iteration.call_args.args
+    assert iter_args[0] == 3  # augur_index
+
+
+def test_loop_body_30_iterations_yield_1_canonical_29_iterations(tmp_path, monkeypatch):
+    """The boattrader inner-loop shape: same step_index dispatched
+    repeatedly. After 30 emissions: 1 canonical + 29 iterations."""
+    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
+    a = _open_adapter(tmp_path)
+    if not a.active:
+        pytest.skip("AugurAdapter inactive")
+    a._session = MagicMock()
+    a._session.record_step = MagicMock()
+    a._session.record_step_iteration = MagicMock()
+
+    for _ in range(30):
+        a.record_step(step_result=_stub_step_result(step_index=4))
+
+    assert a._session.record_step.call_count == 1
+    assert a._session.record_step_iteration.call_count == 29
+
+
+def test_different_step_indices_each_get_their_own_canonical(tmp_path, monkeypatch):
+    """Emitting steps 0, 1, 2 → 3 distinct canonical record_step calls,
+    zero iterations. Routing is per-index isolated."""
+    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
+    a = _open_adapter(tmp_path)
+    if not a.active:
+        pytest.skip("AugurAdapter inactive")
+    a._session = MagicMock()
+    a._session.record_step = MagicMock()
+    a._session.record_step_iteration = MagicMock()
+
+    a.record_step(step_result=_stub_step_result(step_index=0))
+    a.record_step(step_result=_stub_step_result(step_index=1))
+    a.record_step(step_result=_stub_step_result(step_index=2))
+
+    assert a._session.record_step.call_count == 3
+    a._session.record_step_iteration.assert_not_called()
+
+
+def test_fallback_when_sdk_lacks_record_step_iteration(tmp_path, monkeypatch):
+    """Older SDKs (pre-0.3.0) don't have ``record_step_iteration``;
+    every emission must keep going through ``record_step`` so the
+    adapter stays compatible with the pin floor."""
+    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
+    a = _open_adapter(tmp_path)
+    if not a.active:
+        pytest.skip("AugurAdapter inactive")
+    # Simulate a pre-0.3.0 session that has record_step but NO
+    # record_step_iteration.
+    a._session = MagicMock(spec=["record_step"])
+    a._session.record_step = MagicMock()
+
+    a.record_step(step_result=_stub_step_result(step_index=2))
+    a.record_step(step_result=_stub_step_result(step_index=2))
+
+    # Both calls land on record_step (the SDK then collapses on
+    # step_index — pre-0.3.0 behaviour).
+    assert a._session.record_step.call_count == 2
+
+
+def test_canonical_set_resets_across_adapter_instances(tmp_path, monkeypatch):
+    """Each AugurAdapter instance has its own ``_canonical_step_recorded``
+    set; one run's history doesn't leak into the next."""
+    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
+    a1 = _open_adapter(tmp_path / "a1")
+    a2 = _open_adapter(tmp_path / "a2")
+    if not (a1.active and a2.active):
+        pytest.skip("AugurAdapter inactive")
+    a1._session = MagicMock()
+    a1._session.record_step = MagicMock()
+    a1._session.record_step_iteration = MagicMock()
+    a2._session = MagicMock()
+    a2._session.record_step = MagicMock()
+    a2._session.record_step_iteration = MagicMock()
+
+    a1.record_step(step_result=_stub_step_result(step_index=2))
+    # a2's first emission for step 2 is STILL canonical, even though
+    # a1 already recorded one for the same index.
+    a2.record_step(step_result=_stub_step_result(step_index=2))
+
+    a1._session.record_step.assert_called_once()
+    a2._session.record_step.assert_called_once()
+    a1._session.record_step_iteration.assert_not_called()
+    a2._session.record_step_iteration.assert_not_called()
+
+
+def test_canonical_set_initialized_at_construction(tmp_path, monkeypatch):
+    """Fresh adapter has an empty ``_canonical_step_recorded`` set
+    even before any step emits."""
+    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
+    a = _open_adapter(tmp_path)
+    assert a._canonical_step_recorded == set()

--- a/tests/test_augur_step_id_unique_per_emission_659.py
+++ b/tests/test_augur_step_id_unique_per_emission_659.py
@@ -189,7 +189,13 @@ def test_step_index_field_unchanged_across_emissions(tmp_path):
 def test_record_step_increments_counter_via_public_api(tmp_path, monkeypatch):
     """``record_step`` is the canonical entrypoint — verify the
     per-emission counter advances when callers use the documented
-    surface (not just the internal ``_build_step_trace`` helper)."""
+    surface (not just the internal ``_build_step_trace`` helper).
+
+    After augur-sdk 0.3.0 the first emission for a given step_index
+    lands on ``record_step`` (canonical) and subsequent emissions
+    land on ``record_step_iteration`` — capture from BOTH sinks to
+    verify the full per-emission step_id sequence.
+    """
     monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
     a = _open_adapter(tmp_path)
     # Guard against environments where ``augur-sdk`` is importable but
@@ -198,11 +204,21 @@ def test_record_step_increments_counter_via_public_api(tmp_path, monkeypatch):
     if not a.active:
         pytest.skip("AugurAdapter inactive — SDK opened no session")
 
-    # Stash a spy on the session so we capture the trace dicts the
-    # SDK would have received.
+    # Spy on both the canonical (record_step) and iteration
+    # (record_step_iteration) sinks. After 0.3.0 the first emission
+    # goes through the former and the rest through the latter; the
+    # captured ``step_id`` sequence is identical to the pre-0.3.0
+    # all-on-record_step shape.
     captured: list[dict] = []
     real_record = a._session.record_step
-    a._session.record_step = MagicMock(side_effect=lambda t: captured.append(t) or real_record(t))
+    a._session.record_step = MagicMock(
+        side_effect=lambda t: captured.append(t) or real_record(t),
+    )
+    real_iter = getattr(a._session, "record_step_iteration", None)
+    if real_iter is not None:
+        a._session.record_step_iteration = MagicMock(
+            side_effect=lambda _idx, t: captured.append(t) or real_iter(_idx, t),
+        )
 
     for _ in range(4):
         a.record_step(

--- a/uv.lock
+++ b/uv.lock
@@ -228,20 +228,20 @@ wheels = [
 
 [[package]]
 name = "augur-schema"
-version = "0.3.1"
+version = "0.3.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonschema" },
     { name = "referencing" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7b/bb/1038e930623c65d562b5a06ed0cad3290d045bbd516915cbc5f4d06078ab/augur_schema-0.3.1.tar.gz", hash = "sha256:8835544a49d34031498fdd3c698b6f5a546f291330de137529fc3aa903db0270", size = 23638, upload-time = "2026-05-23T17:53:10.799Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2a/95/4ac4e82d7e5879a65c9adfa9c0942bc280a6c91c8fff4641f6072ab0eb1c/augur_schema-0.3.2.tar.gz", hash = "sha256:2c95dd9d1e61ce61f49c7ce98c6c8a43f65d02ff527c20cadde6ceb4ccec8507", size = 24258, upload-time = "2026-05-25T00:48:14.317Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3d/36/8773a728d99804a8d88cdcf26efe58e5186f4d6c6781a7aa4981741f6b41/augur_schema-0.3.1-py3-none-any.whl", hash = "sha256:69dc30a70e36befccb1d9d83119f7f6a97e2d1140c6f8a2d3c0cd5a9d3b3da5c", size = 31305, upload-time = "2026-05-23T17:53:09.468Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/1f/1f7f4c966c18f7439c5b002f78a2533a5cd4ac64cad77f55f8d9a0bd1ef4/augur_schema-0.3.2-py3-none-any.whl", hash = "sha256:6cb04045bef5bd3cadafbc5bb27b54b47f3260a7237e1d0705623ee83c5ee270", size = 31504, upload-time = "2026-05-25T00:48:12.864Z" },
 ]
 
 [[package]]
 name = "augur-sdk"
-version = "0.2.1"
+version = "0.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "augur-schema" },
@@ -249,9 +249,9 @@ dependencies = [
     { name = "referencing" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6a/3e/f5a04612b80b9624e05756017537ca92d65beb216a86ad52721a3eedfc13/augur_sdk-0.2.1.tar.gz", hash = "sha256:0e9ab3438b3c114f44a52d0da3af9cc4ea4679d694650e469ac6cf16f85ca99b", size = 93340, upload-time = "2026-05-23T22:21:49.117Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/97/195ecb8983854d7f92e29bb03d8f024a6f748fcd2a5400e38bd5223dd2e9/augur_sdk-0.3.0.tar.gz", hash = "sha256:325f9bbb771759c4cb2bca31e52017be9c09428b495fb26d9fe651559d7288b5", size = 102238, upload-time = "2026-05-25T01:22:13.706Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c8/b9/b02d8f19b6b728c0c262b001799d1f72243246f45192511ae4c6b2702ee0/augur_sdk-0.2.1-py3-none-any.whl", hash = "sha256:69f26079d6840b390e29ed0b2af8a1bf998646074616a819210ab178baf2a735", size = 66984, upload-time = "2026-05-23T22:21:47.22Z" },
+    { url = "https://files.pythonhosted.org/packages/19/1c/b7cfff0f368da05febd4e42dd194dc75fc270394edcc8fd8b0971d41cf6d/augur_sdk-0.3.0-py3-none-any.whl", hash = "sha256:7107970308a1d96514fbd30a998114e1e90379ae2c4b426bb52b8eb40a31d4a4", size = 70246, upload-time = "2026-05-25T01:22:12.006Z" },
 ]
 
 [[package]]
@@ -1552,7 +1552,7 @@ viewer = [
 [package.metadata]
 requires-dist = [
     { name = "accelerate", marker = "extra == 'gpu'", specifier = ">=0.30" },
-    { name = "augur-sdk", marker = "extra == 'observability'", specifier = ">=0.2.1,<0.3" },
+    { name = "augur-sdk", marker = "extra == 'observability'", specifier = ">=0.3.0,<0.4" },
     { name = "bitsandbytes", marker = "extra == 'gpu'", specifier = ">=0.43" },
     { name = "fastapi", marker = "extra == 'server'", specifier = ">=0.100" },
     { name = "fastapi", marker = "extra == 'viewer'", specifier = ">=0.100" },


### PR DESCRIPTION
## Summary

Upstream Augur SDK 0.3.0 (mercurialsolo/augur-sdk#30, #31, released 2026-05-24) directly addresses the steps-collapse half of #659. This PR bumps the pin and migrates the producer side to the new `record_step_iteration` surface.

| Before | After |
|---|---|
| Pin `>=0.2.1,<0.3` | Pin `>=0.3.0,<0.4` |
| Every emission → `record_step` (SDK collapses by `step_index`) | First emission per index → `record_step`; subsequent → `record_step_iteration` |
| Augur UI shows N rows (collapsed) | Augur UI shows `N (M)` — N canonical + M iterations |

## What changed upstream (SDK 0.3.0)

- **EventRecorder keyed by `step_id`** rather than `step_index` — loop iterations no longer collapse in the in-memory slot.
- **`DebugSession.record_step_iteration(step_index, iteration)`** — producer-side helper that appends an iteration under an existing canonical step and atomically bumps the canonical's `step_iterations` counter.
- **`record_step()` for an existing step_index with a new step_id** now emits a DeprecationWarning pointing at `record_step_iteration()`. The call still succeeds (preserves working-software for legacy producers).
- **Server / viewer ALREADY render `N (M)`** — the pin bump alone unlocks the UI behaviour change; no upstream Augur server coordination needed.
- **augur-schema bumped to 0.3.2** — `step_trace.schema.json` gains an optional `step_iterations: int` field. Additive; old bundles still validate.

## Mantis-side changes

- `pyproject.toml` — pin bump + comment explaining the migration.
- `observability/augur.py.AugurAdapter`:
  - Tracks `_canonical_step_recorded: set[int]` of plan step_indices that have already had their canonical emit.
  - First emission per index → `record_step` (canonical).
  - Subsequent emissions → `record_step_iteration` when the SDK exposes it; falls through to `record_step` for pre-0.3.0 SDKs.
- `tests/test_augur_step_id_unique_per_emission_659.py` — the existing `test_record_step_increments_counter_via_public_api` test updated to spy on BOTH canonical and iteration sinks. Per-emission `step_id` sequence is unchanged from the pre-0.3.0 shape; only the routing differs.

## #659 status after this PR

- ✅ Steps collapse → fixed (was waiting on SDK; now adopted).
- ✅ Live cost rollup → fixed in #667 (independent, mantis-side fix).

After both #667 and this PR land, the Augur Runs-list shows live cost AND iteration counts during the run, not just at finalize. The 25-iteration boattrader inner loop will render as `9 (75)` (or similar) instead of `7`.

## Test plan

- [x] `tests/test_augur_sdk_0_3_step_iterations.py` (7 new tests):
  - First emission per index → `record_step`
  - Subsequent emissions → `record_step_iteration`
  - 30-iteration loop body → 1 canonical + 29 iterations
  - Different step_indices each get their own canonical
  - Pre-0.3.0 fallback (SDK without `record_step_iteration`)
  - Canonical set isolated per adapter instance
  - `_canonical_step_recorded` initialised at construction
- [x] 84 existing augur regression tests still green (one updated for the new routing).
- [x] ruff clean.

## Composes with #667

Currently `#667` (live cost publish) is in flight. The two PRs are independent and can merge in either order. After both land, the boattrader 5-budget rerun will show **live cost + per-iteration step count** in the Augur UI in real time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)