### PR TITLE
fix(modal): bump image augur-sdk pin to 0.3.0 (closes #659 stream gap)

### DIFF
--- a/deploy/modal/modal_cua_server.py
+++ b/deploy/modal/modal_cua_server.py
@@ -226,13 +226,13 @@ executor_image = (
         # 0.1.2+ fires an immediate session-opened heartbeat so the
         # workspace's connection badge updates the moment the SDK is
         # wired up, before the first step lands.
-        # Must match pyproject.toml (``augur-sdk>=0.2.1,<0.3``). 0.2.x
+        # Must match pyproject.toml (``augur-sdk>=0.3.0,<0.4``). 0.2.x
         # added ``branch_context`` to ``DebugSession.__init__``, which
         # the fan-out runner needs to label Phase-1/Phase-2 worker
         # sessions under a shared parent_run_id. Stale 0.1.x pins
         # silently drop events from every fan-out worker — the adapter
         # catches the TypeError and the worker session never opens.
-        "augur-sdk>=0.2.1,<0.3",
+        "augur-sdk>=0.3.0,<0.4",
     )
     .add_local_python_source("mantis_agent")
     .add_local_dir(_PROMPTS_FILES_LOCAL, remote_path=_PROMPTS_FILES_REMOTE)
@@ -1423,13 +1423,13 @@ def _run_gemma4_cua_executor(
         "openai", "requests", "pillow", "mss",
         "fastapi>=0.100", "uvicorn>=0.20", "websocket-client",
         # #509: parity with run_holo3 — Gemma4 also runs the augur wedge.
-        # Must match pyproject.toml (``augur-sdk>=0.2.1,<0.3``). 0.2.x
+        # Must match pyproject.toml (``augur-sdk>=0.3.0,<0.4``). 0.2.x
         # added ``branch_context`` to ``DebugSession.__init__``, which
         # the fan-out runner needs to label Phase-1/Phase-2 worker
         # sessions under a shared parent_run_id. Stale 0.1.x pins
         # silently drop events from every fan-out worker — the adapter
         # catches the TypeError and the worker session never opens.
-        "augur-sdk>=0.2.1,<0.3",
+        "augur-sdk>=0.3.0,<0.4",
     ).add_local_python_source("mantis_agent").add_local_dir(_PROMPTS_FILES_LOCAL, remote_path=_PROMPTS_FILES_REMOTE),
     volumes={"/data": vol},
     secrets=[modal.Secret.from_dotenv()],
@@ -1476,13 +1476,13 @@ claude_executor_image = (
         # #509: parity with run_holo3 / run_gemma4_cua — Claude executor
         # also runs the augur wedge so bundles + streaming work for the
         # Anthropic-API tier.
-        # Must match pyproject.toml (``augur-sdk>=0.2.1,<0.3``). 0.2.x
+        # Must match pyproject.toml (``augur-sdk>=0.3.0,<0.4``). 0.2.x
         # added ``branch_context`` to ``DebugSession.__init__``, which
         # the fan-out runner needs to label Phase-1/Phase-2 worker
         # sessions under a shared parent_run_id. Stale 0.1.x pins
         # silently drop events from every fan-out worker — the adapter
         # catches the TypeError and the worker session never opens.
-        "augur-sdk>=0.2.1,<0.3",
+        "augur-sdk>=0.3.0,<0.4",
     )
     .add_local_python_source("mantis_agent")
     .add_local_dir(_PROMPTS_FILES_LOCAL, remote_path=_PROMPTS_FILES_REMOTE)
@@ -1615,13 +1615,13 @@ api_image = (
         # is lazy-imported but if augur_sdk is missing it falls back
         # silently — keeping the dep here makes the import succeed and
         # lets future API-side bundle reads work without a redeploy.
-        # Must match pyproject.toml (``augur-sdk>=0.2.1,<0.3``). 0.2.x
+        # Must match pyproject.toml (``augur-sdk>=0.3.0,<0.4``). 0.2.x
         # added ``branch_context`` to ``DebugSession.__init__``, which
         # the fan-out runner needs to label Phase-1/Phase-2 worker
         # sessions under a shared parent_run_id. Stale 0.1.x pins
         # silently drop events from every fan-out worker — the adapter
         # catches the TypeError and the worker session never opens.
-        "augur-sdk>=0.2.1,<0.3",
+        "augur-sdk>=0.3.0,<0.4",
     )
     .add_local_python_source("mantis_agent")
     .add_local_dir(_PROMPTS_FILES_LOCAL, remote_path=_PROMPTS_FILES_REMOTE)
@@ -2480,13 +2480,13 @@ def api():
         # so augur-sdk has to be added here separately. Without this the
         # AugurAdapter init logs sdk_available=False and is a no-op even
         # though the package is in executor_image for the other tiers.
-        # Must match pyproject.toml (``augur-sdk>=0.2.1,<0.3``). 0.2.x
+        # Must match pyproject.toml (``augur-sdk>=0.3.0,<0.4``). 0.2.x
         # added ``branch_context`` to ``DebugSession.__init__``, which
         # the fan-out runner needs to label Phase-1/Phase-2 worker
         # sessions under a shared parent_run_id. Stale 0.1.x pins
         # silently drop events from every fan-out worker — the adapter
         # catches the TypeError and the worker session never opens.
-        "augur-sdk>=0.2.1,<0.3",
+        "augur-sdk>=0.3.0,<0.4",
     ).add_local_python_source("mantis_agent").add_local_dir(_PROMPTS_FILES_LOCAL, remote_path=_PROMPTS_FILES_REMOTE).add_local_dir(_WEBGL_SPOOF_LOCAL, remote_path=_WEBGL_SPOOF_REMOTE),
     volumes={"/data": vol},
     secrets=[modal.Secret.from_dotenv()],

--- a/deploy/modal/modal_plan_runner.py
+++ b/deploy/modal/modal_plan_runner.py
@@ -115,7 +115,7 @@ runner_image = (
         # #509: per-run Augur DebugSession bundle + optional live streaming.
         # 0.1.2+ fires an immediate session-opened heartbeat for faster
         # workspace badge updates.
-        "augur-sdk>=0.1.9",
+        "augur-sdk>=0.3.0,<0.4",
     )
     .add_local_python_source("mantis_agent")
     .add_local_dir(


### PR DESCRIPTION
## Summary

Modal images hardcoded `augur-sdk>=0.2.1,<0.3` in 5 image definitions in `modal_cua_server.py` + 1 in `modal_plan_runner.py`. pyproject.toml was bumped to `>=0.3.0,<0.4` when #668 landed but the Modal pip_install lists are a separate contract — pin drift here silently degraded observability.

Closes the production half of #659.

## Why this matters

Deployed workers ran the 0.2.x SDK where `record_step_iteration` doesn't exist. The AugurAdapter's routing at `observability/augur.py:553` correctly probes:

```python
iter_fn = getattr(self._session, "record_step_iteration", None)
if (augur_index in self._canonical_step_recorded and callable(iter_fn)):
    iter_fn(augur_index, trace)
else:
    self._session.record_step(trace)
```

When the method is absent, every emission falls through to `record_step`. SDK 0.2.x then collapses on `step_index` — exactly the bug #659 / #660 / #668 were supposed to fix on the producer side. Pre-deploy CI was green because the adapter's defensive probe never raised; the side effect was just silent observability degradation.

User-visible symptom: the in-flight $3-cap boattrader rerun showed "no steps showing up" in the Augur UI past the canonical positions.

## Test plan

- [x] All 6 image pin sites swept to `>=0.3.0,<0.4` (`grep -rn "augur-sdk" deploy/`).
- [x] Syntax check on both modal files.
- [ ] After merge: `modal app stop mantis-cua-server` + `modal deploy` forces a full image rebuild that pulls 0.3.0. Verify on a fresh boattrader rerun that the Augur Runs-list STEPS column shows `N (M)` with M > N once iterations land.

## Related

- Standing memory `feedback_modal_image_pin_drift.md` — caught the same shape on augur-sdk 0.1.x → 0.2.1 on #638.
- #668 — pyproject pin bump that should have included Modal images.
- #659 — the upstream observability gap this closes the producer side of.

🤖 Generated with [Claude Code](https://claude.com/claude-code)