### PR TITLE
fix(augur): bump SDK to 0.3.1 across pyproject + Modal images (live set_costs)

### DIFF
--- a/deploy/modal/modal_cua_server.py
+++ b/deploy/modal/modal_cua_server.py
@@ -226,13 +226,13 @@ executor_image = (
         # 0.1.2+ fires an immediate session-opened heartbeat so the
         # workspace's connection badge updates the moment the SDK is
         # wired up, before the first step lands.
-        # Must match pyproject.toml (``augur-sdk>=0.3.0,<0.4``). 0.2.x
+        # Must match pyproject.toml (``augur-sdk>=0.3.1,<0.4``). 0.2.x
         # added ``branch_context`` to ``DebugSession.__init__``, which
         # the fan-out runner needs to label Phase-1/Phase-2 worker
         # sessions under a shared parent_run_id. Stale 0.1.x pins
         # silently drop events from every fan-out worker — the adapter
         # catches the TypeError and the worker session never opens.
-        "augur-sdk>=0.3.0,<0.4",
+        "augur-sdk>=0.3.1,<0.4",
     )
     .add_local_python_source("mantis_agent")
     .add_local_dir(_PROMPTS_FILES_LOCAL, remote_path=_PROMPTS_FILES_REMOTE)
@@ -1423,13 +1423,13 @@ def _run_gemma4_cua_executor(
         "openai", "requests", "pillow", "mss",
         "fastapi>=0.100", "uvicorn>=0.20", "websocket-client",
         # #509: parity with run_holo3 — Gemma4 also runs the augur wedge.
-        # Must match pyproject.toml (``augur-sdk>=0.3.0,<0.4``). 0.2.x
+        # Must match pyproject.toml (``augur-sdk>=0.3.1,<0.4``). 0.2.x
         # added ``branch_context`` to ``DebugSession.__init__``, which
         # the fan-out runner needs to label Phase-1/Phase-2 worker
         # sessions under a shared parent_run_id. Stale 0.1.x pins
         # silently drop events from every fan-out worker — the adapter
         # catches the TypeError and the worker session never opens.
-        "augur-sdk>=0.3.0,<0.4",
+        "augur-sdk>=0.3.1,<0.4",
     ).add_local_python_source("mantis_agent").add_local_dir(_PROMPTS_FILES_LOCAL, remote_path=_PROMPTS_FILES_REMOTE),
     volumes={"/data": vol},
     secrets=[modal.Secret.from_dotenv()],
@@ -1476,13 +1476,13 @@ claude_executor_image = (
         # #509: parity with run_holo3 / run_gemma4_cua — Claude executor
         # also runs the augur wedge so bundles + streaming work for the
         # Anthropic-API tier.
-        # Must match pyproject.toml (``augur-sdk>=0.3.0,<0.4``). 0.2.x
+        # Must match pyproject.toml (``augur-sdk>=0.3.1,<0.4``). 0.2.x
         # added ``branch_context`` to ``DebugSession.__init__``, which
         # the fan-out runner needs to label Phase-1/Phase-2 worker
         # sessions under a shared parent_run_id. Stale 0.1.x pins
         # silently drop events from every fan-out worker — the adapter
         # catches the TypeError and the worker session never opens.
-        "augur-sdk>=0.3.0,<0.4",
+        "augur-sdk>=0.3.1,<0.4",
     )
     .add_local_python_source("mantis_agent")
     .add_local_dir(_PROMPTS_FILES_LOCAL, remote_path=_PROMPTS_FILES_REMOTE)
@@ -1615,13 +1615,13 @@ api_image = (
         # is lazy-imported but if augur_sdk is missing it falls back
         # silently — keeping the dep here makes the import succeed and
         # lets future API-side bundle reads work without a redeploy.
-        # Must match pyproject.toml (``augur-sdk>=0.3.0,<0.4``). 0.2.x
+        # Must match pyproject.toml (``augur-sdk>=0.3.1,<0.4``). 0.2.x
         # added ``branch_context`` to ``DebugSession.__init__``, which
         # the fan-out runner needs to label Phase-1/Phase-2 worker
         # sessions under a shared parent_run_id. Stale 0.1.x pins
         # silently drop events from every fan-out worker — the adapter
         # catches the TypeError and the worker session never opens.
-        "augur-sdk>=0.3.0,<0.4",
+        "augur-sdk>=0.3.1,<0.4",
     )
     .add_local_python_source("mantis_agent")
     .add_local_dir(_PROMPTS_FILES_LOCAL, remote_path=_PROMPTS_FILES_REMOTE)
@@ -2480,13 +2480,13 @@ def api():
         # so augur-sdk has to be added here separately. Without this the
         # AugurAdapter init logs sdk_available=False and is a no-op even
         # though the package is in executor_image for the other tiers.
-        # Must match pyproject.toml (``augur-sdk>=0.3.0,<0.4``). 0.2.x
+        # Must match pyproject.toml (``augur-sdk>=0.3.1,<0.4``). 0.2.x
         # added ``branch_context`` to ``DebugSession.__init__``, which
         # the fan-out runner needs to label Phase-1/Phase-2 worker
         # sessions under a shared parent_run_id. Stale 0.1.x pins
         # silently drop events from every fan-out worker — the adapter
         # catches the TypeError and the worker session never opens.
-        "augur-sdk>=0.3.0,<0.4",
+        "augur-sdk>=0.3.1,<0.4",
     ).add_local_python_source("mantis_agent").add_local_dir(_PROMPTS_FILES_LOCAL, remote_path=_PROMPTS_FILES_REMOTE).add_local_dir(_WEBGL_SPOOF_LOCAL, remote_path=_WEBGL_SPOOF_REMOTE),
     volumes={"/data": vol},
     secrets=[modal.Secret.from_dotenv()],

--- a/deploy/modal/modal_plan_runner.py
+++ b/deploy/modal/modal_plan_runner.py
@@ -115,7 +115,7 @@ runner_image = (
         # #509: per-run Augur DebugSession bundle + optional live streaming.
         # 0.1.2+ fires an immediate session-opened heartbeat for faster
         # workspace badge updates.
-        "augur-sdk>=0.3.0,<0.4",
+        "augur-sdk>=0.3.1,<0.4",
     )
     .add_local_python_source("mantis_agent")
     .add_local_dir(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,7 @@ observability = [
     # ``observability/augur.py``: first emission for a given
     # ``step_index`` routes through ``record_step``; subsequent
     # emissions route through ``record_step_iteration``.
-    "augur-sdk>=0.3.0,<0.4",
+    "augur-sdk>=0.3.1,<0.4",
 ]
 # Self-host the FastAPI server that fronts /predict and /v1/chat/completions.
 # Used by the Baseten / EKS / GKE deployments.

--- a/uv.lock
+++ b/uv.lock
@@ -241,7 +241,7 @@ wheels = [
 
 [[package]]
 name = "augur-sdk"
-version = "0.3.0"
+version = "0.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "augur-schema" },
@@ -249,9 +249,9 @@ dependencies = [
     { name = "referencing" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a4/97/195ecb8983854d7f92e29bb03d8f024a6f748fcd2a5400e38bd5223dd2e9/augur_sdk-0.3.0.tar.gz", hash = "sha256:325f9bbb771759c4cb2bca31e52017be9c09428b495fb26d9fe651559d7288b5", size = 102238, upload-time = "2026-05-25T01:22:13.706Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/40/06/4a14358bce3751bd5cfa2febb09aef735fd3edd0be04f1fb5a1df7d925f7/augur_sdk-0.3.1.tar.gz", hash = "sha256:97851b296e1b2f7f0af422a663f6859234a98dda85dd7fdcc5b9b9c9f07ab4b7", size = 105678, upload-time = "2026-05-25T03:29:47.822Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/19/1c/b7cfff0f368da05febd4e42dd194dc75fc270394edcc8fd8b0971d41cf6d/augur_sdk-0.3.0-py3-none-any.whl", hash = "sha256:7107970308a1d96514fbd30a998114e1e90379ae2c4b426bb52b8eb40a31d4a4", size = 70246, upload-time = "2026-05-25T01:22:12.006Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/e2/145464dfd008e175d82b166a8d52da2f240e7ed3ee3437fa618470cbb9d5/augur_sdk-0.3.1-py3-none-any.whl", hash = "sha256:540011efa774da6061feb936edade69e67531c712ee55d82b56a90f2e452a829", size = 70968, upload-time = "2026-05-25T03:29:46.18Z" },
 ]
 
 [[package]]
@@ -1552,7 +1552,7 @@ viewer = [
 [package.metadata]
 requires-dist = [
     { name = "accelerate", marker = "extra == 'gpu'", specifier = ">=0.30" },
-    { name = "augur-sdk", marker = "extra == 'observability'", specifier = ">=0.3.0,<0.4" },
+    { name = "augur-sdk", marker = "extra == 'observability'", specifier = ">=0.3.1,<0.4" },
     { name = "bitsandbytes", marker = "extra == 'gpu'", specifier = ">=0.43" },
     { name = "fastapi", marker = "extra == 'server'", specifier = ">=0.100" },
     { name = "fastapi", marker = "extra == 'viewer'", specifier = ">=0.100" },


### PR DESCRIPTION
## Summary

augur-sdk 0.3.1 (released 2026-05-24, closes upstream [augur-sdk#34](https://github.com/mercurialsolo/augur-sdk/issues/34) which we filed yesterday) makes `DebugSession.set_costs(...)` stream live. Every call now PUTs the cumulative cost dict to `/api/v1/runs/{run_id}/costs` immediately instead of waiting for `close()`.

After this PR ships + a Modal redeploy, the Augur Runs-list COST column tracks the producer's running total in real time on every step — fixing the live-UI half of #659.

## Pin sweep

Per the lessons from #669, bumped everywhere the image is built:

| File | Line | Old | New |
|---|---|---|---|
| `pyproject.toml` | 107 | `>=0.3.0,<0.4` | `>=0.3.1,<0.4` |
| `deploy/modal/modal_plan_runner.py` | 118 | same | same |
| `deploy/modal/modal_cua_server.py` × 5 | image defs | same | same |

Matching `Must match pyproject.toml` doc comments updated in the same sweep so the intended floor is visible.

## Composes with already-shipped producer wiring

- **#667** added `_publish_run_costs_to_augur` called from `_emit_augur_step`. Pre-0.3.1, the call updated SDK-local state but didn't ship. Post-0.3.1, every call lands a PUT on the wire.
- **#668** routed loop-iteration emissions through `record_step_iteration`. The non-monotonic UI value was a side effect of iteration PUTs overwriting per-step costs — that pressure is gone now because the live `session.costs` PUT is the canonical surface for run-level cost (server stores latest; doesn't derive from sum-of-step-costs).

## Test plan

- [x] 98 existing augur regression tests pass against 0.3.1; no test changes required (the SDK's behavioural change is server-side observable only — `set_costs` keeps the same surface, it just additionally fires a PUT).
- [x] `uv lock` updated cleanly (augur-sdk v0.3.0 → v0.3.1).
- [x] Local `uv run python -c "import inspect, augur_sdk; print('put_session_costs' in inspect.getsource(augur_sdk.DebugSession.set_costs))"` confirms streaming code is present in the installed SDK.
- [ ] Production verification: after merge → `modal app stop mantis-cua-server` → `modal deploy` → next boattrader rerun should show monotonic live cost in the Augur UI throughout the run (no more `0.19 → 0.10` drops we saw on the $3-cap rerun).

## Related

- `mercurialsolo/augur-sdk#34` (closed) — upstream feature we filed yesterday.
- `mercurialsolo/augur-sdk#137` — server-side endpoint that lands the streamed `set_costs` PUTs.
- #659 — the downstream observability gap; live-cost half is closed by this PR.
- #667 — producer-side `_publish_run_costs_to_augur` already on main.
- #668 — SDK 0.3.0 step-iteration adoption already on main.
- #669 — earlier image pin sweep (0.2.x → 0.3.0); this PR is the 0.3.0 → 0.3.1 follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)