### PR TITLE
feat(augur): open orchestrator session for fan-out runs (closes #678)

### DIFF
--- a/deploy/modal/modal_cua_server.py
+++ b/deploy/modal/modal_cua_server.py
@@ -226,13 +226,17 @@ executor_image = (
         # 0.1.2+ fires an immediate session-opened heartbeat so the
         # workspace's connection badge updates the moment the SDK is
         # wired up, before the first step lands.
-        # Must match pyproject.toml (``augur-sdk>=0.3.1,<0.4``). 0.2.x
+        # Must match pyproject.toml (``augur-sdk>=0.4.0,<0.5``). 0.2.x
         # added ``branch_context`` to ``DebugSession.__init__``, which
         # the fan-out runner needs to label Phase-1/Phase-2 worker
-        # sessions under a shared parent_run_id. Stale 0.1.x pins
-        # silently drop events from every fan-out worker — the adapter
-        # catches the TypeError and the worker session never opens.
-        "augur-sdk>=0.3.1,<0.4",
+        # sessions under a shared parent_run_id. 0.4.0
+        # (mercurialsolo/augur-sdk#38) adds
+        # ``DebugSession.open_orchestrator(...)`` — the parent-only
+        # session that surfaces the fan-out grouping row in the viewer
+        # (mercurialsolo/augur#138). Stale <0.4 pins make the
+        # orchestrator opener fall back to no-op (server still
+        # synthesizes a parent row from children, but no aggregate tags).
+        "augur-sdk>=0.4.0,<0.5",
     )
     .add_local_python_source("mantis_agent")
     .add_local_dir(_PROMPTS_FILES_LOCAL, remote_path=_PROMPTS_FILES_REMOTE)
@@ -1482,13 +1486,17 @@ def _run_gemma4_cua_executor(
         "openai", "requests", "pillow", "mss",
         "fastapi>=0.100", "uvicorn>=0.20", "websocket-client",
         # #509: parity with run_holo3 — Gemma4 also runs the augur wedge.
-        # Must match pyproject.toml (``augur-sdk>=0.3.1,<0.4``). 0.2.x
+        # Must match pyproject.toml (``augur-sdk>=0.4.0,<0.5``). 0.2.x
         # added ``branch_context`` to ``DebugSession.__init__``, which
         # the fan-out runner needs to label Phase-1/Phase-2 worker
-        # sessions under a shared parent_run_id. Stale 0.1.x pins
-        # silently drop events from every fan-out worker — the adapter
-        # catches the TypeError and the worker session never opens.
-        "augur-sdk>=0.3.1,<0.4",
+        # sessions under a shared parent_run_id. 0.4.0
+        # (mercurialsolo/augur-sdk#38) adds
+        # ``DebugSession.open_orchestrator(...)`` — the parent-only
+        # session that surfaces the fan-out grouping row in the viewer
+        # (mercurialsolo/augur#138). Stale <0.4 pins make the
+        # orchestrator opener fall back to no-op (server still
+        # synthesizes a parent row from children, but no aggregate tags).
+        "augur-sdk>=0.4.0,<0.5",
     ).add_local_python_source("mantis_agent").add_local_dir(_PROMPTS_FILES_LOCAL, remote_path=_PROMPTS_FILES_REMOTE),
     volumes={"/data": vol},
     secrets=[modal.Secret.from_dotenv()],
@@ -1535,13 +1543,17 @@ claude_executor_image = (
         # #509: parity with run_holo3 / run_gemma4_cua — Claude executor
         # also runs the augur wedge so bundles + streaming work for the
         # Anthropic-API tier.
-        # Must match pyproject.toml (``augur-sdk>=0.3.1,<0.4``). 0.2.x
+        # Must match pyproject.toml (``augur-sdk>=0.4.0,<0.5``). 0.2.x
         # added ``branch_context`` to ``DebugSession.__init__``, which
         # the fan-out runner needs to label Phase-1/Phase-2 worker
-        # sessions under a shared parent_run_id. Stale 0.1.x pins
-        # silently drop events from every fan-out worker — the adapter
-        # catches the TypeError and the worker session never opens.
-        "augur-sdk>=0.3.1,<0.4",
+        # sessions under a shared parent_run_id. 0.4.0
+        # (mercurialsolo/augur-sdk#38) adds
+        # ``DebugSession.open_orchestrator(...)`` — the parent-only
+        # session that surfaces the fan-out grouping row in the viewer
+        # (mercurialsolo/augur#138). Stale <0.4 pins make the
+        # orchestrator opener fall back to no-op (server still
+        # synthesizes a parent row from children, but no aggregate tags).
+        "augur-sdk>=0.4.0,<0.5",
     )
     .add_local_python_source("mantis_agent")
     .add_local_dir(_PROMPTS_FILES_LOCAL, remote_path=_PROMPTS_FILES_REMOTE)
@@ -1674,13 +1686,17 @@ api_image = (
         # is lazy-imported but if augur_sdk is missing it falls back
         # silently — keeping the dep here makes the import succeed and
         # lets future API-side bundle reads work without a redeploy.
-        # Must match pyproject.toml (``augur-sdk>=0.3.1,<0.4``). 0.2.x
+        # Must match pyproject.toml (``augur-sdk>=0.4.0,<0.5``). 0.2.x
         # added ``branch_context`` to ``DebugSession.__init__``, which
         # the fan-out runner needs to label Phase-1/Phase-2 worker
-        # sessions under a shared parent_run_id. Stale 0.1.x pins
-        # silently drop events from every fan-out worker — the adapter
-        # catches the TypeError and the worker session never opens.
-        "augur-sdk>=0.3.1,<0.4",
+        # sessions under a shared parent_run_id. 0.4.0
+        # (mercurialsolo/augur-sdk#38) adds
+        # ``DebugSession.open_orchestrator(...)`` — the parent-only
+        # session that surfaces the fan-out grouping row in the viewer
+        # (mercurialsolo/augur#138). Stale <0.4 pins make the
+        # orchestrator opener fall back to no-op (server still
+        # synthesizes a parent row from children, but no aggregate tags).
+        "augur-sdk>=0.4.0,<0.5",
     )
     .add_local_python_source("mantis_agent")
     .add_local_dir(_PROMPTS_FILES_LOCAL, remote_path=_PROMPTS_FILES_REMOTE)
@@ -2539,13 +2555,17 @@ def api():
         # so augur-sdk has to be added here separately. Without this the
         # AugurAdapter init logs sdk_available=False and is a no-op even
         # though the package is in executor_image for the other tiers.
-        # Must match pyproject.toml (``augur-sdk>=0.3.1,<0.4``). 0.2.x
+        # Must match pyproject.toml (``augur-sdk>=0.4.0,<0.5``). 0.2.x
         # added ``branch_context`` to ``DebugSession.__init__``, which
         # the fan-out runner needs to label Phase-1/Phase-2 worker
-        # sessions under a shared parent_run_id. Stale 0.1.x pins
-        # silently drop events from every fan-out worker — the adapter
-        # catches the TypeError and the worker session never opens.
-        "augur-sdk>=0.3.1,<0.4",
+        # sessions under a shared parent_run_id. 0.4.0
+        # (mercurialsolo/augur-sdk#38) adds
+        # ``DebugSession.open_orchestrator(...)`` — the parent-only
+        # session that surfaces the fan-out grouping row in the viewer
+        # (mercurialsolo/augur#138). Stale <0.4 pins make the
+        # orchestrator opener fall back to no-op (server still
+        # synthesizes a parent row from children, but no aggregate tags).
+        "augur-sdk>=0.4.0,<0.5",
     ).add_local_python_source("mantis_agent").add_local_dir(_PROMPTS_FILES_LOCAL, remote_path=_PROMPTS_FILES_REMOTE).add_local_dir(_WEBGL_SPOOF_LOCAL, remote_path=_WEBGL_SPOOF_REMOTE),
     volumes={"/data": vol},
     secrets=[modal.Secret.from_dotenv()],

--- a/deploy/modal/modal_plan_runner.py
+++ b/deploy/modal/modal_plan_runner.py
@@ -115,7 +115,7 @@ runner_image = (
         # #509: per-run Augur DebugSession bundle + optional live streaming.
         # 0.1.2+ fires an immediate session-opened heartbeat for faster
         # workspace badge updates.
-        "augur-sdk>=0.3.1,<0.4",
+        "augur-sdk>=0.4.0,<0.5",
     )
     .add_local_python_source("mantis_agent")
     .add_local_dir(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,17 @@ observability = [
     # ``observability/augur.py``: first emission for a given
     # ``step_index`` routes through ``record_step``; subsequent
     # emissions route through ``record_step_iteration``.
-    "augur-sdk>=0.3.1,<0.4",
+    #
+    # 0.4.0 (mercurialsolo/augur-sdk#38) — fan-out grouping. Adds
+    # ``DebugSession.open_orchestrator(...)`` for opening parent-only
+    # sessions that carry aggregate metadata (phase counts, fanout
+    # pattern, total budget) for fan-out runs. Wired into
+    # ``gym/fanout_runner.run_fanout_dispatch`` so the Augur viewer
+    # renders one parent row with N children grouped under it
+    # (mercurialsolo/augur#138) instead of flat siblings. Exports
+    # ``ORCHESTRATOR_TAG_KEY`` / ``ORCHESTRATOR_TAG_VALUE`` constants
+    # used by ``observability/augur.open_orchestrator_session``.
+    "augur-sdk>=0.4.0,<0.5",
 ]
 # Self-host the FastAPI server that fronts /predict and /v1/chat/completions.
 # Used by the Baseten / EKS / GKE deployments.

--- a/src/mantis_agent/gym/fanout_runner.py
+++ b/src/mantis_agent/gym/fanout_runner.py
@@ -34,6 +34,7 @@ from concurrent.futures import ProcessPoolExecutor
 from dataclasses import dataclass, field
 from typing import Any, Callable, Protocol
 
+from ..observability.augur import open_orchestrator_session
 from ..plan_decomposer import LoopGroup, MicroIntent, MicroPlan
 from .checkpoint import StepResult
 
@@ -1473,6 +1474,69 @@ def run_fanout_dispatch(
         phase1_workers = 1
     phase1_workers = min(phase1_workers, phase1_max_pages)
 
+    # augur-sdk 0.4.0 (#38) — open a parent-only DebugSession that
+    # carries the fan-out's aggregate metadata (phase counts, fan-out
+    # pattern, plan signature) so the Augur viewer renders one parent
+    # row with N children grouped under it via the children's
+    # ``branch_context.parent_run_id`` (mercurialsolo/augur#138).
+    # The helper is a no-op when augur-sdk is unavailable / disabled /
+    # predates 0.4.0 — the server still synthesizes a parent row in
+    # those cases; the orchestrator session is purely for the
+    # aggregate tags the children can't supply on their own.
+    plan_signature = str(task_suite.get("_plan_signature") or "")
+    orchestrator_tags: dict[str, str] = {
+        "phase1_workers": str(phase1_workers),
+        "phase2_workers_configured": str(workers),
+        "fanout_pattern": "phase1_collect_phase2_extract",
+        "phase1_max_pages": str(phase1_max_pages),
+    }
+    if plan_signature:
+        orchestrator_tags["plan_signature"] = plan_signature[:64]
+    session_name = (
+        f"fanout-{plan_signature[:12]}" if plan_signature else "fanout"
+    )
+    with open_orchestrator_session(
+        run_id=fanout_parent_run_id,
+        session_name=session_name,
+        tags=orchestrator_tags,
+    ):
+        return _dispatch_phases(
+            task_suite,
+            _json=_json,
+            url_collect_group=url_collect_group,
+            phase1_max_pages=phase1_max_pages,
+            phase1_template=phase1_template,
+            phase1_workers=phase1_workers,
+            executor_fn=executor_fn,
+            model=model,
+            claude_model=claude_model,
+            max_steps=max_steps,
+            workers=workers,
+            fanout_parent_run_id=fanout_parent_run_id,
+            shared_seen_printer=shared_seen_printer,
+        )
+
+
+def _dispatch_phases(
+    task_suite: dict,
+    *,
+    _json: Callable[[Any], str],
+    url_collect_group: LoopGroup,
+    phase1_max_pages: int,
+    phase1_template: str | None,
+    phase1_workers: int,
+    executor_fn: Any,
+    model: str,
+    claude_model: str,
+    max_steps: int,
+    workers: int,
+    fanout_parent_run_id: str,
+    shared_seen_printer: Callable[[dict, int], None] | None,
+) -> dict | None:
+    """Inner Phase-1/Phase-2 spawn body — extracted so the outer
+    :func:`run_fanout_dispatch` can wrap it in the orchestrator-session
+    context manager without indenting the original 200-line block.
+    """
     if phase1_workers <= 1:
         # Serial path — exactly the #638 axis-2 behaviour.
         print(

--- a/src/mantis_agent/observability/augur.py
+++ b/src/mantis_agent/observability/augur.py
@@ -26,6 +26,7 @@ every :class:`AugurAdapter` instance is a no-op.
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import os
 from datetime import datetime, timezone
@@ -43,12 +44,25 @@ def _utc_now_iso() -> str:
 
 # Lazy import — module must load even without augur-sdk installed.
 try:
+    import augur_sdk as _augur_sdk_module
     from augur_sdk import CaptureMode, DebugSession
     _AUGUR_AVAILABLE = True
+    # augur-sdk 0.4.0+ (#38) exports these constants for the orchestrator
+    # session marker; fall back to the documented literals when running
+    # against an older SDK.
+    _ORCHESTRATOR_TAG_KEY = getattr(
+        _augur_sdk_module, "ORCHESTRATOR_TAG_KEY", "augur.session_type",
+    )
+    _ORCHESTRATOR_TAG_VALUE = getattr(
+        _augur_sdk_module, "ORCHESTRATOR_TAG_VALUE", "orchestrator",
+    )
 except Exception:  # noqa: BLE001 — any import-time failure → disabled
+    _augur_sdk_module = None  # type: ignore[assignment]
     CaptureMode = None  # type: ignore[assignment]
     DebugSession = None  # type: ignore[assignment]
     _AUGUR_AVAILABLE = False
+    _ORCHESTRATOR_TAG_KEY = "augur.session_type"
+    _ORCHESTRATOR_TAG_VALUE = "orchestrator"
 
 
 # ── Mantis → Augur vocabulary maps ───────────────────────────────────
@@ -178,6 +192,94 @@ def default_out_dir(run_id: str) -> Path:
         return Path(override) / run_id
     root = os.environ.get("MANTIS_DATA_DIR", "./data").strip() or "./data"
     return Path(root) / "augur" / run_id
+
+
+@contextlib.contextmanager
+def open_orchestrator_session(
+    *,
+    run_id: str,
+    tenant_id: str | None = None,
+    session_name: str | None = None,
+    tags: dict[str, str] | None = None,
+):
+    """Yield an Augur orchestrator (parent-only) :class:`DebugSession`.
+
+    Wraps :py:meth:`augur_sdk.DebugSession.open_orchestrator` (augur-sdk
+    0.4.0+, mercurialsolo/augur-sdk#38) — opens a parent row in the
+    viewer's runs-list that aggregates N child sessions under one
+    logical fan-out. Children carry ``branch_context.parent_run_id``
+    pointing at ``run_id``; the server / viewer groups by that field
+    (mercurialsolo/augur#138).
+
+    Yields ``None`` (and runs the body unchanged) when:
+
+    * ``augur-sdk`` is not importable, OR
+    * ``MANTIS_AUGUR_DISABLED`` is set, OR
+    * the installed SDK predates 0.4.0 (no ``open_orchestrator``
+      attribute), OR
+    * opening the session raises.
+
+    The contract is "best-effort observability" — never fail the run
+    because the parent row didn't open. Errors during ``__enter__`` /
+    ``__exit__`` are logged at WARN and swallowed; the server falls
+    back to synthesizing a parent row from the children's shared
+    ``branch_context.parent_run_id`` in any of the no-op cases.
+    """
+    if not is_enabled() or DebugSession is None:
+        yield None
+        return
+    opener = getattr(DebugSession, "open_orchestrator", None)
+    if opener is None:
+        # SDK predates 0.4.0 — fall through, server synthesizes the
+        # parent row from children when augur#138 lands.
+        yield None
+        return
+    target_dir = default_out_dir(run_id)
+    merged_tags = dict(tags or {})
+    # Stamp the SDK's orchestrator marker so the viewer renders this
+    # row as a parent (no step list, aggregate stats only). The 0.4.0
+    # helper also sets this internally; we set it eagerly so the
+    # session-metadata flush at __enter__ already carries it.
+    merged_tags.setdefault(_ORCHESTRATOR_TAG_KEY, _ORCHESTRATOR_TAG_VALUE)
+    try:
+        ctx = opener(
+            run_id=run_id,
+            client_name="mantis",
+            out_dir=str(target_dir),
+            session_name=session_name,
+            tenant_id=tenant_id,
+            tags={str(k): str(v) for k, v in merged_tags.items()},
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("open_orchestrator_session: opener raised: %s", exc)
+        yield None
+        return
+    session: Any = None
+    try:
+        session = ctx.__enter__()
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("open_orchestrator_session: __enter__ raised: %s", exc)
+        yield None
+        return
+    if is_verbose():
+        logger.warning(
+            "orchestrator session opened: run_id=%s out_dir=%s tags=%s",
+            run_id, target_dir, list(merged_tags.keys()),
+        )
+    # From here on the helper holds the session open and is responsible
+    # for closing it on the way out — wrapping ``yield`` in a single
+    # try/finally is the only way to honour the @contextmanager
+    # generator protocol (a second yield inside an exception path
+    # would raise ``RuntimeError: generator didn't stop after throw()``).
+    try:
+        yield session
+    finally:
+        try:
+            ctx.__exit__(None, None, None)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "open_orchestrator_session: __exit__ raised: %s", exc,
+            )
 
 
 def _map_step_status(step_result: Any) -> str:

--- a/tests/test_open_orchestrator_session_678.py
+++ b/tests/test_open_orchestrator_session_678.py
@@ -1,0 +1,388 @@
+"""#678 — orchestrator-session helper + ``run_fanout_dispatch`` wiring.
+
+augur-sdk 0.4.0 (mercurialsolo/augur-sdk#38) added
+``DebugSession.open_orchestrator(...)`` for opening parent-only
+sessions that surface fan-out aggregate metadata (phase counts,
+fan-out pattern) in the Augur viewer's runs-list. Children carry
+``branch_context.parent_run_id`` pointing at this session's run_id;
+the server / viewer (mercurialsolo/augur#138) groups by that field.
+
+Contract pinned here:
+
+* ``open_orchestrator_session`` is a no-op (yields ``None``) when
+  ``MANTIS_AUGUR_DISABLED`` is set OR the SDK predates 0.4.0
+  (``open_orchestrator`` attribute missing) — never raises out.
+* When the SDK is available and active, the helper opens the session
+  before the body runs and closes it on the way out, even when the
+  body raises.
+* The helper stamps the ``augur.session_type=orchestrator`` tag
+  (``_ORCHESTRATOR_TAG_KEY`` / ``_VALUE``) so the viewer recognises
+  the parent-only shape.
+* ``run_fanout_dispatch`` opens the orchestrator session exactly once
+  per dispatch call, before any worker spawn, with aggregate tags
+  (``phase1_workers``, ``phase2_workers_configured``,
+  ``fanout_pattern``, ``phase1_max_pages``, optional
+  ``plan_signature``).
+* Opener exceptions and ``__enter__`` / ``__exit__`` exceptions are
+  swallowed (logged at WARN) — the dispatch body still runs.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import mantis_agent.observability.augur as augur_mod
+from mantis_agent.gym.fanout_runner import run_fanout_dispatch
+from mantis_agent.observability.augur import (
+    _ORCHESTRATOR_TAG_KEY,
+    _ORCHESTRATOR_TAG_VALUE,
+    open_orchestrator_session,
+)
+from mantis_agent.plan_decomposer import MicroIntent, MicroPlan, PlanDecomposer
+
+
+# ── open_orchestrator_session — no-op paths ─────────────────────────
+
+
+def test_yields_none_when_augur_disabled(monkeypatch):
+    """``MANTIS_AUGUR_DISABLED=1`` → helper is a no-op."""
+    monkeypatch.setenv("MANTIS_AUGUR_DISABLED", "1")
+    with open_orchestrator_session(run_id="x", tags={}) as s:
+        assert s is None
+
+
+def test_yields_none_when_sdk_predates_040(monkeypatch):
+    """SDK without ``open_orchestrator`` → no-op (server still
+    synthesizes the parent row from children)."""
+    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
+    # Force the SDK-shape probe to miss the attribute even if the
+    # installed SDK has it. ``DebugSession`` itself stays truthy so we
+    # don't trip the "module missing" branch.
+    stub = MagicMock()
+    # Stripping the attr completely so getattr returns the fallback.
+    if hasattr(stub, "open_orchestrator"):
+        del stub.open_orchestrator
+    with patch.object(augur_mod, "DebugSession", stub):
+        with open_orchestrator_session(run_id="x", tags={}) as s:
+            assert s is None
+
+
+def test_yields_none_when_debugsession_module_missing(monkeypatch):
+    """``DebugSession is None`` (SDK not installed) → no-op."""
+    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
+    with patch.object(augur_mod, "DebugSession", None):
+        with open_orchestrator_session(run_id="x", tags={}) as s:
+            assert s is None
+
+
+def test_opener_exception_is_swallowed(monkeypatch):
+    """If the SDK opener itself raises, fall through to yielding
+    ``None`` (best-effort observability — never break the run)."""
+    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
+    stub = MagicMock()
+    stub.open_orchestrator = MagicMock(side_effect=RuntimeError("boom"))
+    with patch.object(augur_mod, "DebugSession", stub):
+        with open_orchestrator_session(run_id="x", tags={}) as s:
+            assert s is None
+
+
+def test_enter_exception_is_swallowed(monkeypatch):
+    """``__enter__`` raising on the opener's return is also caught."""
+    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
+    fake_ctx = MagicMock()
+    fake_ctx.__enter__ = MagicMock(side_effect=RuntimeError("enter-boom"))
+    stub = MagicMock()
+    stub.open_orchestrator = MagicMock(return_value=fake_ctx)
+    with patch.object(augur_mod, "DebugSession", stub):
+        with open_orchestrator_session(run_id="x", tags={}) as s:
+            assert s is None
+
+
+def test_exit_exception_is_swallowed_after_normal_body(monkeypatch):
+    """``__exit__`` raising after the body completed cleanly → caller
+    still gets back control (no exception propagates)."""
+    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
+    fake_ctx = MagicMock()
+    fake_session = MagicMock(name="orchestrator_session")
+    fake_ctx.__enter__ = MagicMock(return_value=fake_session)
+    fake_ctx.__exit__ = MagicMock(side_effect=RuntimeError("exit-boom"))
+    stub = MagicMock()
+    stub.open_orchestrator = MagicMock(return_value=fake_ctx)
+    with patch.object(augur_mod, "DebugSession", stub):
+        with open_orchestrator_session(run_id="x", tags={}) as s:
+            assert s is fake_session
+    # Reaching here means the exit-exception was swallowed.
+    fake_ctx.__exit__.assert_called_once()
+
+
+# ── open_orchestrator_session — opener call shape ──────────────────
+
+
+def test_opener_called_with_orchestrator_marker_tag(monkeypatch):
+    """The helper stamps ``augur.session_type=orchestrator`` even when
+    the caller passes ``tags`` without it (the SDK 0.4.0 helper also
+    sets this internally; the eager stamp guarantees the session
+    metadata flush at ``__enter__`` already carries it)."""
+    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
+    fake_ctx = MagicMock()
+    fake_ctx.__enter__ = MagicMock(return_value=MagicMock())
+    fake_ctx.__exit__ = MagicMock(return_value=False)
+    opener = MagicMock(return_value=fake_ctx)
+    stub = MagicMock()
+    stub.open_orchestrator = opener
+    with patch.object(augur_mod, "DebugSession", stub):
+        with open_orchestrator_session(
+            run_id="r1", session_name="fanout-x", tags={"phase1_workers": "4"},
+        ):
+            pass
+    opener.assert_called_once()
+    call_tags = opener.call_args.kwargs["tags"]
+    assert call_tags[_ORCHESTRATOR_TAG_KEY] == _ORCHESTRATOR_TAG_VALUE
+    assert call_tags["phase1_workers"] == "4"
+    assert opener.call_args.kwargs["run_id"] == "r1"
+    assert opener.call_args.kwargs["session_name"] == "fanout-x"
+    assert opener.call_args.kwargs["client_name"] == "mantis"
+
+
+def test_opener_caller_tags_take_precedence_over_default_marker(monkeypatch):
+    """A caller that explicitly passes a custom ``augur.session_type``
+    tag wins over the default — the helper only ``setdefault``s the
+    marker. (Edge-case escape hatch for a producer that wants to
+    relabel; doesn't change the contract.)"""
+    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
+    opener = MagicMock(return_value=MagicMock(
+        __enter__=MagicMock(return_value=MagicMock()),
+        __exit__=MagicMock(return_value=False),
+    ))
+    stub = MagicMock()
+    stub.open_orchestrator = opener
+    custom_tags = {_ORCHESTRATOR_TAG_KEY: "custom", "phase1_workers": "2"}
+    with patch.object(augur_mod, "DebugSession", stub):
+        with open_orchestrator_session(run_id="r1", tags=custom_tags):
+            pass
+    call_tags = opener.call_args.kwargs["tags"]
+    assert call_tags[_ORCHESTRATOR_TAG_KEY] == "custom"
+    assert call_tags["phase1_workers"] == "2"
+
+
+# ── run_fanout_dispatch — orchestrator wiring ──────────────────────
+
+
+def _make_eligible_suite() -> dict:
+    """Boattrader-shaped suite with a ``parallelizable_url_collect``
+    loop group — eligible for fan-out dispatch. Same shape as
+    ``test_run_fanout_dispatch_673._make_url_collect_suite``; inlined
+    here so the orchestrator-wiring tests stay self-contained."""
+    plan = MicroPlan(domain="boattrader.com")
+    plan.steps = [
+        MicroIntent(
+            intent="Navigate", type="navigate", section="setup",
+            params={"url": "https://www.boattrader.com/boats/by-owner/"},
+        ),
+        MicroIntent(intent="Click card", type="click", section="extraction"),
+        MicroIntent(intent="Read URL", type="extract_url", section="extraction"),
+        MicroIntent(intent="Scroll", type="scroll", section="extraction"),
+        MicroIntent(intent="Extract", type="extract_data", section="extraction"),
+        MicroIntent(intent="Back", type="navigate_back", section="extraction"),
+        MicroIntent(
+            intent="Inner loop", type="loop", section="extraction",
+            loop_target=1, loop_count=40,
+        ),
+    ]
+    PlanDecomposer._classify_loop_groups(plan)
+    return {
+        "session_name": "x",
+        "_plan_signature": "boattrader-orch-test-sig",
+        "_fanout_phase1_workers": 1,
+        "_micro_plan": [
+            {
+                "intent": s.intent, "type": s.type, "section": s.section,
+                "params": dict(s.params or {}),
+                "loop_target": s.loop_target, "loop_count": s.loop_count,
+                "claude_only": s.claude_only, "gate": s.gate,
+                "required": s.required, "grounding": s.grounding,
+                "verify": s.verify, "reverse": s.reverse,
+                "budget": s.budget, "hints": dict(s.hints or {}),
+            }
+            for s in plan.steps
+        ],
+        "_loop_groups": [
+            {
+                "loop_step_idx": g.loop_step_idx,
+                "body_range": list(g.body_range),
+                "shape": g.shape,
+            }
+            for g in plan.loop_groups
+        ],
+    }
+
+
+def _make_executor_stub(*, phase1_urls: list[str], phase2_viable: int = 1):
+    """Mock executor that returns Phase-1 then Phase-2 results."""
+    handle_p1 = MagicMock()
+    handle_p1.get.return_value = {
+        "viable": 0, "leads_with_phone": 0, "leads": [],
+        "collected_urls": phase1_urls, "shared_seen_hits": 0,
+    }
+    handle_p2 = MagicMock()
+    handle_p2.get.return_value = {
+        "viable": phase2_viable, "leads_with_phone": 0,
+        "leads": [{"url": u} for u in phase1_urls[:phase2_viable]],
+        "shared_seen_hits": 0,
+    }
+    executor = MagicMock()
+    executor.spawn.side_effect = [handle_p1, handle_p2]
+    return executor
+
+
+def test_dispatch_opens_orchestrator_with_aggregate_tags(monkeypatch):
+    """When dispatch runs, the orchestrator session is opened exactly
+    once with phase counts + fan-out pattern + plan signature tags."""
+    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
+    opener = MagicMock(return_value=MagicMock(
+        __enter__=MagicMock(return_value=MagicMock()),
+        __exit__=MagicMock(return_value=False),
+    ))
+    stub = MagicMock()
+    stub.open_orchestrator = opener
+    with patch.object(augur_mod, "DebugSession", stub):
+        result = run_fanout_dispatch(
+            _make_eligible_suite(),
+            executor_fn=_make_executor_stub(phase1_urls=["https://x/d/1"]),
+            model="holo3", claude_model="",
+            max_steps=10, workers=1,
+            fanout_parent_run_id="fanout-test-678",
+        )
+    assert result is not None
+    opener.assert_called_once()
+    kwargs = opener.call_args.kwargs
+    assert kwargs["run_id"] == "fanout-test-678"
+    tags = kwargs["tags"]
+    assert tags[_ORCHESTRATOR_TAG_KEY] == _ORCHESTRATOR_TAG_VALUE
+    assert tags["fanout_pattern"] == "phase1_collect_phase2_extract"
+    assert tags["phase1_workers"] == "1"
+    assert tags["phase2_workers_configured"] == "1"
+    assert tags["phase1_max_pages"] == "1"
+    assert "plan_signature" in tags  # caller passed _plan_signature
+
+
+def test_dispatch_skips_orchestrator_when_disabled(monkeypatch):
+    """``MANTIS_AUGUR_DISABLED=1`` → orchestrator opener is never
+    called; dispatch still returns the aggregate envelope."""
+    monkeypatch.setenv("MANTIS_AUGUR_DISABLED", "1")
+    opener = MagicMock()
+    stub = MagicMock()
+    stub.open_orchestrator = opener
+    with patch.object(augur_mod, "DebugSession", stub):
+        result = run_fanout_dispatch(
+            _make_eligible_suite(),
+            executor_fn=_make_executor_stub(phase1_urls=["https://x/d/1"]),
+            model="holo3", claude_model="",
+            max_steps=10, workers=1,
+            fanout_parent_run_id="fanout-test-678",
+        )
+    assert result is not None
+    opener.assert_not_called()
+
+
+def test_dispatch_skips_orchestrator_when_no_url_collect_group(monkeypatch):
+    """Non-eligible suites short-circuit BEFORE the orchestrator is
+    opened — no point opening a parent row for a single-runner path."""
+    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
+    opener = MagicMock()
+    stub = MagicMock()
+    stub.open_orchestrator = opener
+    with patch.object(augur_mod, "DebugSession", stub):
+        result = run_fanout_dispatch(
+            {"_micro_plan": []},  # no loop group
+            executor_fn=MagicMock(),
+            model="holo3", claude_model="",
+            max_steps=10, workers=1,
+            fanout_parent_run_id="ineligible",
+        )
+    assert result is None
+    opener.assert_not_called()
+
+
+def test_dispatch_passes_workers_count_through_to_tags(monkeypatch):
+    """Aggregate ``phase2_workers_configured`` tag mirrors the
+    ``workers`` argument — the caller-configured Phase-2 fan-out width
+    (actual width post-dedup may be lower; reading both off the
+    envelope is a server / viewer concern)."""
+    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
+    opener = MagicMock(return_value=MagicMock(
+        __enter__=MagicMock(return_value=MagicMock()),
+        __exit__=MagicMock(return_value=False),
+    ))
+    stub = MagicMock()
+    stub.open_orchestrator = opener
+    with patch.object(augur_mod, "DebugSession", stub):
+        run_fanout_dispatch(
+            _make_eligible_suite(),
+            executor_fn=_make_executor_stub(phase1_urls=["https://x/d/1"]),
+            model="holo3", claude_model="",
+            max_steps=10, workers=8,
+            fanout_parent_run_id="fanout-test-678",
+        )
+    assert opener.call_args.kwargs["tags"]["phase2_workers_configured"] == "8"
+
+
+def test_dispatch_session_closed_on_normal_exit(monkeypatch):
+    """``__exit__`` is called on the way out, even on a successful
+    dispatch — sessions don't leak."""
+    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
+    fake_ctx = MagicMock()
+    fake_ctx.__enter__ = MagicMock(return_value=MagicMock())
+    fake_ctx.__exit__ = MagicMock(return_value=False)
+    stub = MagicMock()
+    stub.open_orchestrator = MagicMock(return_value=fake_ctx)
+    with patch.object(augur_mod, "DebugSession", stub):
+        run_fanout_dispatch(
+            _make_eligible_suite(),
+            executor_fn=_make_executor_stub(phase1_urls=["https://x/d/1"]),
+            model="holo3", claude_model="",
+            max_steps=10, workers=1,
+            fanout_parent_run_id="fanout-test-678",
+        )
+    fake_ctx.__exit__.assert_called_once()
+
+
+def test_dispatch_session_closed_when_phase1_returns_no_urls(monkeypatch):
+    """Phase-1 returning zero URLs causes dispatch to return ``None``,
+    but the orchestrator session was already open — it MUST close on
+    the way out so the parent row finalizes."""
+    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
+    fake_ctx = MagicMock()
+    fake_ctx.__enter__ = MagicMock(return_value=MagicMock())
+    fake_ctx.__exit__ = MagicMock(return_value=False)
+    stub = MagicMock()
+    stub.open_orchestrator = MagicMock(return_value=fake_ctx)
+    with patch.object(augur_mod, "DebugSession", stub):
+        result = run_fanout_dispatch(
+            _make_eligible_suite(),
+            executor_fn=_make_executor_stub(phase1_urls=[]),  # empty harvest
+            model="holo3", claude_model="",
+            max_steps=10, workers=1,
+            fanout_parent_run_id="fanout-test-678",
+        )
+    assert result is None
+    fake_ctx.__exit__.assert_called_once()
+
+
+def test_dispatch_session_closed_when_opener_raises(monkeypatch):
+    """Opener exception → orchestrator yields ``None`` AND dispatch
+    body still runs (returns the normal aggregate envelope). The
+    fan-out is best-effort observability — never break the run."""
+    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
+    stub = MagicMock()
+    stub.open_orchestrator = MagicMock(side_effect=RuntimeError("opener-boom"))
+    with patch.object(augur_mod, "DebugSession", stub):
+        result = run_fanout_dispatch(
+            _make_eligible_suite(),
+            executor_fn=_make_executor_stub(phase1_urls=["https://x/d/1"]),
+            model="holo3", claude_model="",
+            max_steps=10, workers=1,
+            fanout_parent_run_id="fanout-test-678",
+        )
+    assert result is not None
+    assert result["collected_urls"] == ["https://x/d/1"]

--- a/tests/test_open_orchestrator_session_678.py
+++ b/tests/test_open_orchestrator_session_678.py
@@ -31,6 +31,8 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 import mantis_agent.observability.augur as augur_mod
 from mantis_agent.gym.fanout_runner import run_fanout_dispatch
 from mantis_agent.observability.augur import (
@@ -39,6 +41,22 @@ from mantis_agent.observability.augur import (
     open_orchestrator_session,
 )
 from mantis_agent.plan_decomposer import MicroIntent, MicroPlan, PlanDecomposer
+
+
+@pytest.fixture
+def force_augur_available(monkeypatch):
+    """Flip ``_AUGUR_AVAILABLE=True`` for tests that exercise the
+    opener path.
+
+    Without this, CI runners that don't install ``augur-sdk`` (the
+    package is an opt-in ``observability`` extra in pyproject.toml)
+    short-circuit ``is_enabled() → False`` and the helper returns
+    ``None`` before reaching the patched ``DebugSession``. The tests
+    pin wiring behaviour, not the SDK install — patch the module's
+    SDK-available flag and the opener path becomes reachable.
+    """
+    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
+    monkeypatch.setattr(augur_mod, "_AUGUR_AVAILABLE", True)
 
 
 # ── open_orchestrator_session — no-op paths ─────────────────────────
@@ -51,10 +69,9 @@ def test_yields_none_when_augur_disabled(monkeypatch):
         assert s is None
 
 
-def test_yields_none_when_sdk_predates_040(monkeypatch):
+def test_yields_none_when_sdk_predates_040(force_augur_available):
     """SDK without ``open_orchestrator`` → no-op (server still
     synthesizes the parent row from children)."""
-    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
     # Force the SDK-shape probe to miss the attribute even if the
     # installed SDK has it. ``DebugSession`` itself stays truthy so we
     # don't trip the "module missing" branch.
@@ -67,18 +84,16 @@ def test_yields_none_when_sdk_predates_040(monkeypatch):
             assert s is None
 
 
-def test_yields_none_when_debugsession_module_missing(monkeypatch):
+def test_yields_none_when_debugsession_module_missing(force_augur_available):
     """``DebugSession is None`` (SDK not installed) → no-op."""
-    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
     with patch.object(augur_mod, "DebugSession", None):
         with open_orchestrator_session(run_id="x", tags={}) as s:
             assert s is None
 
 
-def test_opener_exception_is_swallowed(monkeypatch):
+def test_opener_exception_is_swallowed(force_augur_available):
     """If the SDK opener itself raises, fall through to yielding
     ``None`` (best-effort observability — never break the run)."""
-    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
     stub = MagicMock()
     stub.open_orchestrator = MagicMock(side_effect=RuntimeError("boom"))
     with patch.object(augur_mod, "DebugSession", stub):
@@ -86,9 +101,8 @@ def test_opener_exception_is_swallowed(monkeypatch):
             assert s is None
 
 
-def test_enter_exception_is_swallowed(monkeypatch):
+def test_enter_exception_is_swallowed(force_augur_available):
     """``__enter__`` raising on the opener's return is also caught."""
-    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
     fake_ctx = MagicMock()
     fake_ctx.__enter__ = MagicMock(side_effect=RuntimeError("enter-boom"))
     stub = MagicMock()
@@ -98,10 +112,9 @@ def test_enter_exception_is_swallowed(monkeypatch):
             assert s is None
 
 
-def test_exit_exception_is_swallowed_after_normal_body(monkeypatch):
+def test_exit_exception_is_swallowed_after_normal_body(force_augur_available):
     """``__exit__`` raising after the body completed cleanly → caller
     still gets back control (no exception propagates)."""
-    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
     fake_ctx = MagicMock()
     fake_session = MagicMock(name="orchestrator_session")
     fake_ctx.__enter__ = MagicMock(return_value=fake_session)
@@ -118,12 +131,11 @@ def test_exit_exception_is_swallowed_after_normal_body(monkeypatch):
 # ── open_orchestrator_session — opener call shape ──────────────────
 
 
-def test_opener_called_with_orchestrator_marker_tag(monkeypatch):
+def test_opener_called_with_orchestrator_marker_tag(force_augur_available):
     """The helper stamps ``augur.session_type=orchestrator`` even when
     the caller passes ``tags`` without it (the SDK 0.4.0 helper also
     sets this internally; the eager stamp guarantees the session
     metadata flush at ``__enter__`` already carries it)."""
-    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
     fake_ctx = MagicMock()
     fake_ctx.__enter__ = MagicMock(return_value=MagicMock())
     fake_ctx.__exit__ = MagicMock(return_value=False)
@@ -144,12 +156,11 @@ def test_opener_called_with_orchestrator_marker_tag(monkeypatch):
     assert opener.call_args.kwargs["client_name"] == "mantis"
 
 
-def test_opener_caller_tags_take_precedence_over_default_marker(monkeypatch):
+def test_opener_caller_tags_take_precedence_over_default_marker(force_augur_available):
     """A caller that explicitly passes a custom ``augur.session_type``
     tag wins over the default — the helper only ``setdefault``s the
     marker. (Edge-case escape hatch for a producer that wants to
     relabel; doesn't change the contract.)"""
-    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
     opener = MagicMock(return_value=MagicMock(
         __enter__=MagicMock(return_value=MagicMock()),
         __exit__=MagicMock(return_value=False),
@@ -235,10 +246,9 @@ def _make_executor_stub(*, phase1_urls: list[str], phase2_viable: int = 1):
     return executor
 
 
-def test_dispatch_opens_orchestrator_with_aggregate_tags(monkeypatch):
+def test_dispatch_opens_orchestrator_with_aggregate_tags(force_augur_available):
     """When dispatch runs, the orchestrator session is opened exactly
     once with phase counts + fan-out pattern + plan signature tags."""
-    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
     opener = MagicMock(return_value=MagicMock(
         __enter__=MagicMock(return_value=MagicMock()),
         __exit__=MagicMock(return_value=False),
@@ -304,12 +314,11 @@ def test_dispatch_skips_orchestrator_when_no_url_collect_group(monkeypatch):
     opener.assert_not_called()
 
 
-def test_dispatch_passes_workers_count_through_to_tags(monkeypatch):
+def test_dispatch_passes_workers_count_through_to_tags(force_augur_available):
     """Aggregate ``phase2_workers_configured`` tag mirrors the
     ``workers`` argument — the caller-configured Phase-2 fan-out width
     (actual width post-dedup may be lower; reading both off the
     envelope is a server / viewer concern)."""
-    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
     opener = MagicMock(return_value=MagicMock(
         __enter__=MagicMock(return_value=MagicMock()),
         __exit__=MagicMock(return_value=False),
@@ -327,10 +336,9 @@ def test_dispatch_passes_workers_count_through_to_tags(monkeypatch):
     assert opener.call_args.kwargs["tags"]["phase2_workers_configured"] == "8"
 
 
-def test_dispatch_session_closed_on_normal_exit(monkeypatch):
+def test_dispatch_session_closed_on_normal_exit(force_augur_available):
     """``__exit__`` is called on the way out, even on a successful
     dispatch — sessions don't leak."""
-    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
     fake_ctx = MagicMock()
     fake_ctx.__enter__ = MagicMock(return_value=MagicMock())
     fake_ctx.__exit__ = MagicMock(return_value=False)
@@ -347,11 +355,10 @@ def test_dispatch_session_closed_on_normal_exit(monkeypatch):
     fake_ctx.__exit__.assert_called_once()
 
 
-def test_dispatch_session_closed_when_phase1_returns_no_urls(monkeypatch):
+def test_dispatch_session_closed_when_phase1_returns_no_urls(force_augur_available):
     """Phase-1 returning zero URLs causes dispatch to return ``None``,
     but the orchestrator session was already open — it MUST close on
     the way out so the parent row finalizes."""
-    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
     fake_ctx = MagicMock()
     fake_ctx.__enter__ = MagicMock(return_value=MagicMock())
     fake_ctx.__exit__ = MagicMock(return_value=False)
@@ -369,11 +376,10 @@ def test_dispatch_session_closed_when_phase1_returns_no_urls(monkeypatch):
     fake_ctx.__exit__.assert_called_once()
 
 
-def test_dispatch_session_closed_when_opener_raises(monkeypatch):
+def test_dispatch_session_closed_when_opener_raises(force_augur_available):
     """Opener exception → orchestrator yields ``None`` AND dispatch
     body still runs (returns the normal aggregate envelope). The
     fan-out is best-effort observability — never break the run."""
-    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
     stub = MagicMock()
     stub.open_orchestrator = MagicMock(side_effect=RuntimeError("opener-boom"))
     with patch.object(augur_mod, "DebugSession", stub):

--- a/tests/test_run_fanout_dispatch_673.py
+++ b/tests/test_run_fanout_dispatch_673.py
@@ -22,8 +22,26 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
+import pytest
+
 from mantis_agent.gym.fanout_runner import run_fanout_dispatch
 from mantis_agent.plan_decomposer import MicroIntent, MicroPlan, PlanDecomposer
+
+
+@pytest.fixture(autouse=True)
+def _disable_augur_for_dispatch_tests(monkeypatch):
+    """Keep these dispatch tests focused on the spawn / dedup contract.
+
+    augur-sdk 0.4.0 (#38) added ``open_orchestrator_session`` inside
+    :func:`run_fanout_dispatch` — left enabled, the dispatch helper
+    opens a real ``DebugSession`` that writes a bundle under
+    ``data/augur/<fanout_parent_run_id>/`` and tries to close it on
+    exit. That's a separate concern from the dispatch logic these
+    tests pin, and the bundle close-on-exit interacts badly with the
+    tmp-cwd these tests run in. Orchestrator-session behaviour is
+    pinned by ``test_open_orchestrator_session_678.py``.
+    """
+    monkeypatch.setenv("MANTIS_AUGUR_DISABLED", "1")
 
 
 def _make_url_collect_suite(*, fanout_phase1_workers: int = 1) -> dict:


### PR DESCRIPTION
## Summary

Pulls in **augur-sdk 0.4.0** (mercurialsolo/augur-sdk#38) and wires `DebugSession.open_orchestrator(...)` into the fan-out dispatch path so the Augur viewer renders one parent row with N children grouped under it — closing the observability gap surfaced by PR #677's $2-cap rerun where 4 Phase-2 workers showed as flat siblings.

Stacks on **#677** (HTTP-path fan-out dispatch); rebases to main automatically when #677 lands.

## Changes

- **Pin bump.** `augur-sdk>=0.3.1,<0.4` → `>=0.4.0,<0.5` in `pyproject.toml` + 5 sites in `deploy/modal/modal_cua_server.py` + `deploy/modal/modal_plan_runner.py`.
- **Helper.** `observability.augur.open_orchestrator_session(...)` — contextmanager wrapping `DebugSession.open_orchestrator(...)`. No-ops cleanly when SDK disabled / missing / pre-0.4.0. Opener / `__enter__` / `__exit__` exceptions logged at WARN and swallowed (best-effort observability).
- **Wiring.** `run_fanout_dispatch` opens the orchestrator session **once** before the first Phase-1 spawn with tags:
  - `augur.session_type=orchestrator` (via SDK's `ORCHESTRATOR_TAG_KEY` / `_VALUE`)
  - `phase1_workers`, `phase2_workers_configured`, `fanout_pattern`, `phase1_max_pages`, `plan_signature` (when present)
- **Tests.** 15 new tests in `tests/test_open_orchestrator_session_678.py` pinning no-op paths, exception swallowing, dispatch wiring, tag composition, session close-on-exit. Existing `test_run_fanout_dispatch_673.py` gains an autouse `MANTIS_AUGUR_DISABLED` fixture to keep dispatch tests focused on the spawn / dedup contract.

## Upstream context

- mercurialsolo/augur-sdk#38 → 0.4.0 (`open_orchestrator`, `ORCHESTRATOR_TAG_KEY`/`_VALUE`, docs at [concepts/fanout-grouping](https://mercurialsolo.github.io/augur-sdk/latest/concepts/fanout-grouping/)).
- mercurialsolo/augur#138 → server / viewer groups children under `branch_context.parent_run_id`. The orchestrator session adds the aggregate-metadata row instead of letting the server synthesize a tag-less parent.

## Out of scope (follow-ups)

- **Cost rollup via `set_costs`.** Worker costs aren't returned in the in-process dispatch envelope today. The server aggregates from children's bundles per augur#138, so this is an ergonomic enhancement, not a blocker.
- **`phase2_workers_actual` tag after Phase-1 dedup.** Could update via `parent_session.add_tag(...)`; not load-bearing for grouping UX.

## Test plan

- [x] `tests/test_open_orchestrator_session_678.py` — 15 new tests, all green locally
- [x] `tests/test_run_fanout_dispatch_673.py` — 8 existing tests, still green
- [x] `tests/test_observability_augur.py` + step-iteration / step-id tests — all green
- [x] `ruff check` — clean on the touched files
- [ ] Modal redeploy + boattrader rerun ($2 cap, `_fanout_phase1_workers=4`) — expect ONE parent row with 4 Phase-2 children grouped beneath it in the Augur runs-list

🤖 Generated with [Claude Code](https://claude.com/claude-code)