### PR TITLE
feat(augur): adopt 0.6.0 task_spec + group_id + loop_detected (Phase A of #680)

### DIFF
--- a/deploy/modal/modal_cua_server.py
+++ b/deploy/modal/modal_cua_server.py
@@ -226,17 +226,16 @@ executor_image = (
         # 0.1.2+ fires an immediate session-opened heartbeat so the
         # workspace's connection badge updates the moment the SDK is
         # wired up, before the first step lands.
-        # Must match pyproject.toml (``augur-sdk>=0.4.0,<0.5``). 0.2.x
-        # added ``branch_context`` to ``DebugSession.__init__``, which
-        # the fan-out runner needs to label Phase-1/Phase-2 worker
-        # sessions under a shared parent_run_id. 0.4.0
-        # (mercurialsolo/augur-sdk#38) adds
-        # ``DebugSession.open_orchestrator(...)`` — the parent-only
-        # session that surfaces the fan-out grouping row in the viewer
-        # (mercurialsolo/augur#138). Stale <0.4 pins make the
-        # orchestrator opener fall back to no-op (server still
-        # synthesizes a parent row from children, but no aggregate tags).
-        "augur-sdk>=0.4.0,<0.5",
+        # Must match pyproject.toml (``augur-sdk>=0.6.0,<0.7``). 0.2.x
+        # added ``branch_context`` to ``DebugSession.__init__``; 0.4.0
+        # (mercurialsolo/augur-sdk#38) added
+        # ``DebugSession.open_orchestrator(...)``; 0.6.0 (#680) adds
+        # ``task_spec`` / ``group_id`` / ``set_loop_detected`` /
+        # ``record_subgoal_completion`` and the ``set_score`` kwargs
+        # ``should_stop`` / ``uncertainty``. Stale <0.6 pins silently
+        # drop the new fields — adapter swallows the TypeError and the
+        # bundle ships without RL-training metadata.
+        "augur-sdk>=0.6.0,<0.7",
     )
     .add_local_python_source("mantis_agent")
     .add_local_dir(_PROMPTS_FILES_LOCAL, remote_path=_PROMPTS_FILES_REMOTE)
@@ -1029,6 +1028,16 @@ def _run_holo3_executor(
         except Exception as exc:  # noqa: BLE001
             print(f"  WARNING: fanout branch_context init failed: {exc}")
 
+        # #680: forward the orchestrator-set ``_fanout_group_id`` to
+        # the runner so AugurAdapter opens the child session with
+        # ``group_id=`` (GRPO sibling-rollout correlation). Same value
+        # as ``branch_context.parent_run_id`` today — kept on a
+        # separate attribute so a future loop with rollouts that don't
+        # share a parent can set group_id alone.
+        micro_runner._fanout_group_id = str(
+            task_suite.get("_fanout_group_id", "") or ""
+        ) or None
+
         # #638 axis 2 follow-up: derive a short worker tag from the
         # fan-out branch_id so per-step log lines can be greppable per-
         # worker in the interleaved orchestrator stdout. The branch_id
@@ -1486,17 +1495,16 @@ def _run_gemma4_cua_executor(
         "openai", "requests", "pillow", "mss",
         "fastapi>=0.100", "uvicorn>=0.20", "websocket-client",
         # #509: parity with run_holo3 — Gemma4 also runs the augur wedge.
-        # Must match pyproject.toml (``augur-sdk>=0.4.0,<0.5``). 0.2.x
-        # added ``branch_context`` to ``DebugSession.__init__``, which
-        # the fan-out runner needs to label Phase-1/Phase-2 worker
-        # sessions under a shared parent_run_id. 0.4.0
-        # (mercurialsolo/augur-sdk#38) adds
-        # ``DebugSession.open_orchestrator(...)`` — the parent-only
-        # session that surfaces the fan-out grouping row in the viewer
-        # (mercurialsolo/augur#138). Stale <0.4 pins make the
-        # orchestrator opener fall back to no-op (server still
-        # synthesizes a parent row from children, but no aggregate tags).
-        "augur-sdk>=0.4.0,<0.5",
+        # Must match pyproject.toml (``augur-sdk>=0.6.0,<0.7``). 0.2.x
+        # added ``branch_context`` to ``DebugSession.__init__``; 0.4.0
+        # (mercurialsolo/augur-sdk#38) added
+        # ``DebugSession.open_orchestrator(...)``; 0.6.0 (#680) adds
+        # ``task_spec`` / ``group_id`` / ``set_loop_detected`` /
+        # ``record_subgoal_completion`` and the ``set_score`` kwargs
+        # ``should_stop`` / ``uncertainty``. Stale <0.6 pins silently
+        # drop the new fields — adapter swallows the TypeError and the
+        # bundle ships without RL-training metadata.
+        "augur-sdk>=0.6.0,<0.7",
     ).add_local_python_source("mantis_agent").add_local_dir(_PROMPTS_FILES_LOCAL, remote_path=_PROMPTS_FILES_REMOTE),
     volumes={"/data": vol},
     secrets=[modal.Secret.from_dotenv()],
@@ -1543,17 +1551,16 @@ claude_executor_image = (
         # #509: parity with run_holo3 / run_gemma4_cua — Claude executor
         # also runs the augur wedge so bundles + streaming work for the
         # Anthropic-API tier.
-        # Must match pyproject.toml (``augur-sdk>=0.4.0,<0.5``). 0.2.x
-        # added ``branch_context`` to ``DebugSession.__init__``, which
-        # the fan-out runner needs to label Phase-1/Phase-2 worker
-        # sessions under a shared parent_run_id. 0.4.0
-        # (mercurialsolo/augur-sdk#38) adds
-        # ``DebugSession.open_orchestrator(...)`` — the parent-only
-        # session that surfaces the fan-out grouping row in the viewer
-        # (mercurialsolo/augur#138). Stale <0.4 pins make the
-        # orchestrator opener fall back to no-op (server still
-        # synthesizes a parent row from children, but no aggregate tags).
-        "augur-sdk>=0.4.0,<0.5",
+        # Must match pyproject.toml (``augur-sdk>=0.6.0,<0.7``). 0.2.x
+        # added ``branch_context`` to ``DebugSession.__init__``; 0.4.0
+        # (mercurialsolo/augur-sdk#38) added
+        # ``DebugSession.open_orchestrator(...)``; 0.6.0 (#680) adds
+        # ``task_spec`` / ``group_id`` / ``set_loop_detected`` /
+        # ``record_subgoal_completion`` and the ``set_score`` kwargs
+        # ``should_stop`` / ``uncertainty``. Stale <0.6 pins silently
+        # drop the new fields — adapter swallows the TypeError and the
+        # bundle ships without RL-training metadata.
+        "augur-sdk>=0.6.0,<0.7",
     )
     .add_local_python_source("mantis_agent")
     .add_local_dir(_PROMPTS_FILES_LOCAL, remote_path=_PROMPTS_FILES_REMOTE)
@@ -1686,17 +1693,16 @@ api_image = (
         # is lazy-imported but if augur_sdk is missing it falls back
         # silently — keeping the dep here makes the import succeed and
         # lets future API-side bundle reads work without a redeploy.
-        # Must match pyproject.toml (``augur-sdk>=0.4.0,<0.5``). 0.2.x
-        # added ``branch_context`` to ``DebugSession.__init__``, which
-        # the fan-out runner needs to label Phase-1/Phase-2 worker
-        # sessions under a shared parent_run_id. 0.4.0
-        # (mercurialsolo/augur-sdk#38) adds
-        # ``DebugSession.open_orchestrator(...)`` — the parent-only
-        # session that surfaces the fan-out grouping row in the viewer
-        # (mercurialsolo/augur#138). Stale <0.4 pins make the
-        # orchestrator opener fall back to no-op (server still
-        # synthesizes a parent row from children, but no aggregate tags).
-        "augur-sdk>=0.4.0,<0.5",
+        # Must match pyproject.toml (``augur-sdk>=0.6.0,<0.7``). 0.2.x
+        # added ``branch_context`` to ``DebugSession.__init__``; 0.4.0
+        # (mercurialsolo/augur-sdk#38) added
+        # ``DebugSession.open_orchestrator(...)``; 0.6.0 (#680) adds
+        # ``task_spec`` / ``group_id`` / ``set_loop_detected`` /
+        # ``record_subgoal_completion`` and the ``set_score`` kwargs
+        # ``should_stop`` / ``uncertainty``. Stale <0.6 pins silently
+        # drop the new fields — adapter swallows the TypeError and the
+        # bundle ships without RL-training metadata.
+        "augur-sdk>=0.6.0,<0.7",
     )
     .add_local_python_source("mantis_agent")
     .add_local_dir(_PROMPTS_FILES_LOCAL, remote_path=_PROMPTS_FILES_REMOTE)
@@ -2555,17 +2561,16 @@ def api():
         # so augur-sdk has to be added here separately. Without this the
         # AugurAdapter init logs sdk_available=False and is a no-op even
         # though the package is in executor_image for the other tiers.
-        # Must match pyproject.toml (``augur-sdk>=0.4.0,<0.5``). 0.2.x
-        # added ``branch_context`` to ``DebugSession.__init__``, which
-        # the fan-out runner needs to label Phase-1/Phase-2 worker
-        # sessions under a shared parent_run_id. 0.4.0
-        # (mercurialsolo/augur-sdk#38) adds
-        # ``DebugSession.open_orchestrator(...)`` — the parent-only
-        # session that surfaces the fan-out grouping row in the viewer
-        # (mercurialsolo/augur#138). Stale <0.4 pins make the
-        # orchestrator opener fall back to no-op (server still
-        # synthesizes a parent row from children, but no aggregate tags).
-        "augur-sdk>=0.4.0,<0.5",
+        # Must match pyproject.toml (``augur-sdk>=0.6.0,<0.7``). 0.2.x
+        # added ``branch_context`` to ``DebugSession.__init__``; 0.4.0
+        # (mercurialsolo/augur-sdk#38) added
+        # ``DebugSession.open_orchestrator(...)``; 0.6.0 (#680) adds
+        # ``task_spec`` / ``group_id`` / ``set_loop_detected`` /
+        # ``record_subgoal_completion`` and the ``set_score`` kwargs
+        # ``should_stop`` / ``uncertainty``. Stale <0.6 pins silently
+        # drop the new fields — adapter swallows the TypeError and the
+        # bundle ships without RL-training metadata.
+        "augur-sdk>=0.6.0,<0.7",
     ).add_local_python_source("mantis_agent").add_local_dir(_PROMPTS_FILES_LOCAL, remote_path=_PROMPTS_FILES_REMOTE).add_local_dir(_WEBGL_SPOOF_LOCAL, remote_path=_WEBGL_SPOOF_REMOTE),
     volumes={"/data": vol},
     secrets=[modal.Secret.from_dotenv()],

--- a/deploy/modal/modal_plan_runner.py
+++ b/deploy/modal/modal_plan_runner.py
@@ -115,7 +115,7 @@ runner_image = (
         # #509: per-run Augur DebugSession bundle + optional live streaming.
         # 0.1.2+ fires an immediate session-opened heartbeat for faster
         # workspace badge updates.
-        "augur-sdk>=0.4.0,<0.5",
+        "augur-sdk>=0.6.0,<0.7",
     )
     .add_local_python_source("mantis_agent")
     .add_local_dir(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,7 +114,24 @@ observability = [
     # (mercurialsolo/augur#138) instead of flat siblings. Exports
     # ``ORCHESTRATOR_TAG_KEY`` / ``ORCHESTRATOR_TAG_VALUE`` constants
     # used by ``observability/augur.open_orchestrator_session``.
-    "augur-sdk>=0.4.0,<0.5",
+    #
+    # 0.5.0 — per-token logprob capture (training-data quality).
+    # Adds ``DebugSession(capture_logprobs=True)`` + the
+    # ``ModelApiAdapterBase.extract_logprobs_from_response`` helper
+    # that maps OpenAI ``choices[].logprobs.content[]`` and Anthropic
+    # ``content[].logprobs[]`` to a canonical
+    # ``[{token, token_id?, logprob, top_alternatives?}]`` shape.
+    # Mantis Phase B opt-in via ``MANTIS_CAPTURE_LOGPROBS=1``.
+    #
+    # 0.6.0 — TaskSpec, group_id, set_loop_detected, set_score(...,
+    # should_stop=, uncertainty=), record_subgoal_completion. Wired
+    # into ``observability/augur.open_orchestrator_session`` (task_spec
+    # + group_id on the orchestrator row) and the AugurAdapter init
+    # path (group_id propagation to fan-out children). The schema
+    # floor is ``augur-schema>=0.4.1`` (0.4.0 had a loader bug that
+    # left ``task_spec`` / ``subgoals_completed`` unregistered; pip
+    # resolves transitively).
+    "augur-sdk>=0.6.0,<0.7",
 ]
 # Self-host the FastAPI server that fronts /predict and /v1/chat/completions.
 # Used by the Baseten / EKS / GKE deployments.

--- a/src/mantis_agent/gym/fanout_runner.py
+++ b/src/mantis_agent/gym/fanout_runner.py
@@ -1495,10 +1495,28 @@ def run_fanout_dispatch(
     session_name = (
         f"fanout-{plan_signature[:12]}" if plan_signature else "fanout"
     )
+    # augur-sdk 0.6.0 (#680): compose a TaskSpec from suite metadata
+    # and propagate ``group_id`` to every child session via the suite
+    # envelope. Both are passthrough kwargs on
+    # ``open_orchestrator_session`` — silently ignored by older SDKs.
+    task_spec = _build_task_spec_from_suite(
+        task_suite,
+        phase1_workers=phase1_workers,
+        phase1_max_pages=phase1_max_pages,
+        phase2_workers=workers,
+        max_steps=max_steps,
+    )
+    # Children read this on AugurAdapter init and forward to
+    # ``DebugSession(group_id=...)``; the GRPO/RL sibling correlation
+    # in the Augur viewer keys on the same field that already drives
+    # branch_context.parent_run_id grouping.
+    task_suite["_fanout_group_id"] = fanout_parent_run_id
     with open_orchestrator_session(
         run_id=fanout_parent_run_id,
         session_name=session_name,
         tags=orchestrator_tags,
+        task_spec=task_spec,
+        group_id=fanout_parent_run_id,
     ):
         return _dispatch_phases(
             task_suite,
@@ -1732,3 +1750,70 @@ def _default_json_dumps(obj: Any) -> str:
     """
     import json
     return json.dumps(obj)
+
+
+def _build_task_spec_from_suite(
+    task_suite: dict,
+    *,
+    phase1_workers: int,
+    phase1_max_pages: int,
+    phase2_workers: int,
+    max_steps: int,
+) -> dict[str, Any]:
+    """Compose an ``augur_sdk.TaskSpec`` dict from a fan-out suite.
+
+    Surfaces in the Augur viewer on the orchestrator (parent) row, so
+    downstream RL trainers can read the canonical task definition
+    instead of reconstructing it from worker bundles. Every field is
+    optional in the 0.6.0 schema; we only emit keys we have.
+
+    Field mapping (suite → task_spec):
+
+    * ``_plan_name`` + domain → ``task_spec_id`` (``<domain>.<plan>.v1``)
+    * ``_plan_name`` → ``instruction`` fallback when the plan didn't
+      ship a top-level natural-language brief
+    * domain from ``_site_config.url_patterns[0]`` → ``task_class``
+    * ``max_steps`` arg → ``max_steps`` (planner-level budget, not the
+      per-step LLM token budget)
+    * Fan-out shape (Phase-1 max-pages, worker counts) → ``env_id``
+      annotation so siblings produced by the same dispatch share an
+      env identity in the trainer's eyes.
+    """
+    plan_name = str(task_suite.get("_plan_name") or "").strip()
+    site_config = task_suite.get("_site_config") or {}
+    domain = ""
+    if isinstance(site_config, dict):
+        domain = str(site_config.get("domain") or "").strip()
+    if not domain:
+        # Fallback: try to read off the first URL pattern in the suite.
+        url_patterns = (
+            site_config.get("url_patterns") if isinstance(site_config, dict)
+            else None
+        )
+        if isinstance(url_patterns, list) and url_patterns:
+            first = str(url_patterns[0])
+            if "//" in first:
+                domain = first.split("//", 1)[1].split("/", 1)[0]
+    task_class = domain or "unknown"
+    task_spec_id = (
+        f"{task_class}.{plan_name}.v1" if plan_name and task_class != "unknown"
+        else (f"{task_class}.fanout.v1" if task_class != "unknown" else "")
+    )
+    spec: dict[str, Any] = {}
+    if task_spec_id:
+        spec["task_spec_id"] = task_spec_id
+    if plan_name:
+        spec["instruction"] = plan_name.replace("_", " ")
+    if task_class != "unknown":
+        spec["task_class"] = task_class
+    if max_steps and max_steps > 0:
+        spec["max_steps"] = int(max_steps)
+    # ``env_id`` is the trainer-visible identity of the env the
+    # rollout exercised. Stamp the Modal app + fan-out shape so
+    # sibling rollouts (Phase-1 workers, Phase-2 workers) read as
+    # variants of one env, not independent envs.
+    spec["env_id"] = (
+        f"modal:mantis-cua-server:fanout"
+        f"(p1={phase1_workers}xp{phase1_max_pages},p2={phase2_workers})"
+    )
+    return spec

--- a/src/mantis_agent/gym/micro_runner.py
+++ b/src/mantis_agent/gym/micro_runner.py
@@ -283,6 +283,11 @@ class MicroPlanRunner:
         # ``None`` for non-fanout / single-worker runs — AugurAdapter
         # opens without branch_context, preserving today's shape.
         self._fanout_branch_context: dict | None = None
+        # #680 (augur-sdk 0.6.0): per-rollout ``group_id`` for GRPO
+        # sibling correlation. Same fan-out parent_run_id today;
+        # separate attr so a future loop with non-parent rollouts can
+        # set group_id alone.
+        self._fanout_group_id: str | None = None
         self._active_checkpoint_context = None
         self._pre_step_snapshot, self._final_status = None, "running"
         # #audit item 4: halt_reason last set by ``_persist`` — read by

--- a/src/mantis_agent/gym/run_executor.py
+++ b/src/mantis_agent/gym/run_executor.py
@@ -295,6 +295,14 @@ class RunExecutor:
             # orchestrator (Modal main) sets ``_fanout_branch_context``
             # on the runner before run() — None for non-fanout runs.
             branch_context=getattr(runner, "_fanout_branch_context", None),
+            # #680: fan-out workers also carry ``group_id`` so the
+            # viewer's GRPO sibling-rollout correlation works without
+            # joining steps back to the session record. The
+            # orchestrator sets ``_fanout_group_id`` on the runner
+            # (same value as branch_context.parent_run_id today; kept
+            # as separate hook so a future GRPO loop with rollouts
+            # that don't share a parent can set group_id alone).
+            group_id=getattr(runner, "_fanout_group_id", None),
         )
 
         if not runner._results_base_url and plan.steps:

--- a/src/mantis_agent/observability/augur.py
+++ b/src/mantis_agent/observability/augur.py
@@ -201,6 +201,8 @@ def open_orchestrator_session(
     tenant_id: str | None = None,
     session_name: str | None = None,
     tags: dict[str, str] | None = None,
+    task_spec: dict[str, Any] | None = None,
+    group_id: str | None = None,
 ):
     """Yield an Augur orchestrator (parent-only) :class:`DebugSession`.
 
@@ -210,6 +212,14 @@ def open_orchestrator_session(
     logical fan-out. Children carry ``branch_context.parent_run_id``
     pointing at ``run_id``; the server / viewer groups by that field
     (mercurialsolo/augur#138).
+
+    ``task_spec`` and ``group_id`` (augur-sdk 0.6.0+, #680) attach the
+    structured RL-training metadata that 0.4.0 lacked. Both flow
+    through the SDK's ``**session_kwargs`` passthrough, so older SDKs
+    that don't accept them silently degrade — the opener call still
+    succeeds, the fields just don't land in the bundle. When the
+    installed SDK predates 0.6.0 the kwargs are stripped before the
+    call to avoid ``TypeError: unexpected keyword argument``.
 
     Yields ``None`` (and runs the body unchanged) when:
 
@@ -241,6 +251,11 @@ def open_orchestrator_session(
     # helper also sets this internally; we set it eagerly so the
     # session-metadata flush at __enter__ already carries it.
     merged_tags.setdefault(_ORCHESTRATOR_TAG_KEY, _ORCHESTRATOR_TAG_VALUE)
+    extra_kwargs: dict[str, Any] = {}
+    if task_spec is not None:
+        extra_kwargs["task_spec"] = task_spec
+    if group_id is not None:
+        extra_kwargs["group_id"] = group_id
     try:
         ctx = opener(
             run_id=run_id,
@@ -249,7 +264,40 @@ def open_orchestrator_session(
             session_name=session_name,
             tenant_id=tenant_id,
             tags={str(k): str(v) for k, v in merged_tags.items()},
+            **extra_kwargs,
         )
+    except TypeError as exc:
+        # SDK predates 0.6.0 — ``task_spec`` / ``group_id`` aren't
+        # accepted kwargs yet. Retry without them so the orchestrator
+        # row still opens (server-side grouping by parent_run_id keeps
+        # working; only the RL-training metadata is dropped).
+        if extra_kwargs:
+            logger.warning(
+                "open_orchestrator_session: SDK rejected 0.6.0 kwargs "
+                "(%s) — retrying without task_spec/group_id", exc,
+            )
+            try:
+                ctx = opener(
+                    run_id=run_id,
+                    client_name="mantis",
+                    out_dir=str(target_dir),
+                    session_name=session_name,
+                    tenant_id=tenant_id,
+                    tags={str(k): str(v) for k, v in merged_tags.items()},
+                )
+            except Exception as retry_exc:  # noqa: BLE001
+                logger.warning(
+                    "open_orchestrator_session: retry without 0.6.0 "
+                    "kwargs raised: %s", retry_exc,
+                )
+                yield None
+                return
+        else:
+            logger.warning(
+                "open_orchestrator_session: opener raised: %s", exc,
+            )
+            yield None
+            return
     except Exception as exc:  # noqa: BLE001
         logger.warning("open_orchestrator_session: opener raised: %s", exc)
         yield None
@@ -403,6 +451,7 @@ class AugurAdapter:
         dsn: str | None = None,
         extra_tags: dict[str, str] | None = None,
         branch_context: dict | None = None,
+        group_id: str | None = None,
     ) -> None:
         self._session: Any = None
         self._emitted_event_count: int = 0
@@ -475,7 +524,31 @@ class AugurAdapter:
                         branch_context.get("parent_run_id", ""),
                         branch_context.get("branch_id", ""),
                     )
-            session = DebugSession(**session_kwargs)
+            # augur-sdk 0.6.0+ (#680): forward ``group_id`` for GRPO /
+            # fan-out sibling correlation. Carried separately from
+            # ``branch_context.parent_run_id`` because the viewer reads
+            # the two for different rollup behaviours (parent_run_id =
+            # tree grouping; group_id = sibling-rollout correlation).
+            # Stripped before the DebugSession call on older SDKs that
+            # raise TypeError on unknown kwargs.
+            if group_id:
+                session_kwargs["group_id"] = str(group_id)
+            try:
+                session = DebugSession(**session_kwargs)
+            except TypeError as exc:
+                # SDK predates 0.6.0 → ``group_id`` isn't accepted.
+                # Drop the 0.6.0 kwarg and retry — preserves the
+                # production path on older pins.
+                if "group_id" in session_kwargs:
+                    if _verbose:
+                        logger.warning(
+                            "AugurAdapter init: SDK rejected group_id "
+                            "(%s) — retrying without it", exc,
+                        )
+                    session_kwargs.pop("group_id", None)
+                    session = DebugSession(**session_kwargs)
+                else:
+                    raise
             # DebugSession is designed as a context manager — ``__enter__``
             # flips the open flag and starts the streaming sink (if any).
             # We drive that explicitly because the Mantis run lifecycle
@@ -661,12 +734,62 @@ class AugurAdapter:
             else:
                 self._session.record_step(trace)
                 self._canonical_step_recorded.add(augur_index)
+            # #680 (augur-sdk 0.6.0): auto-stamp ``set_loop_detected``
+            # whenever the step's ``failure_class`` is loop-shaped. The
+            # runner already classifies these explicitly — we just
+            # forward the signal to the bundle so RL trainers / the
+            # viewer's loop-detection chip read it without joining
+            # against ``failure_class``. Best-effort; no-op on older
+            # SDKs without the method.
+            self._maybe_stamp_loop_detected(
+                augur_index, getattr(step_result, "failure_class", ""),
+            )
         except Exception as exc:  # noqa: BLE001
             # Verbose deploys want this visible; production stays at debug.
             if is_verbose():
                 logger.warning("AugurAdapter.record_step failed: %r", exc)
             else:
                 logger.debug("AugurAdapter.record_step failed: %s", exc)
+
+    # Failure-class strings that indicate the runner detected a loop
+    # (perceptual or behavioural) at this step — surfaced to Augur via
+    # ``set_loop_detected`` per #680. Kept in one place so adding a
+    # new loop class is a one-line change.
+    _LOOP_FAILURE_CLASSES = frozenset({
+        "no_state_change",
+        "brain_loop_exhausted",
+        "scroll_no_movement",
+        "loop",
+        "hard_loop",
+        "soft_loop",
+    })
+
+    def _maybe_stamp_loop_detected(
+        self, augur_index: int, failure_class: Any,
+    ) -> None:
+        """Forward a runner-side loop signal to the SDK if available.
+
+        Reads the step's ``failure_class`` against the loop set and
+        calls ``session.set_loop_detected(step_index=...)`` when it
+        matches. Silently no-ops when the SDK predates 0.6.0 (no such
+        method) or the session is inactive — the failure_class is
+        still on the trace, so the loop-detection signal survives in
+        the bundle one way or the other.
+        """
+        if not failure_class:
+            return
+        if str(failure_class) not in self._LOOP_FAILURE_CLASSES:
+            return
+        loop_fn = getattr(self._session, "set_loop_detected", None)
+        if not callable(loop_fn):
+            return
+        try:
+            loop_fn(step_index=augur_index)
+        except Exception as exc:  # noqa: BLE001
+            if is_verbose():
+                logger.warning(
+                    "AugurAdapter.set_loop_detected failed: %r", exc,
+                )
 
     def set_score(
         self,

--- a/tests/test_augur_sdk_0_6_task_spec_680.py
+++ b/tests/test_augur_sdk_0_6_task_spec_680.py
@@ -52,10 +52,21 @@ from mantis_agent.plan_decomposer import MicroIntent, MicroPlan, PlanDecomposer
 @pytest.fixture
 def force_augur_available(monkeypatch):
     """CI runners don't install ``augur-sdk`` (it's an opt-in extra).
-    Flip the module's SDK-available flag and patches against
-    ``DebugSession`` start landing."""
+    Flip the module's SDK-available flag AND stub the imported names
+    so the adapter init's pre-DebugSession helpers (notably
+    ``_resolve_capture_mode``, which calls ``CaptureMode(...)``) don't
+    crash before the test's ``patch.object`` on ``DebugSession`` even
+    has a chance to land.
+    """
     monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
     monkeypatch.setattr(augur_mod, "_AUGUR_AVAILABLE", True)
+    # CaptureMode is a real enum at runtime; on CI without augur-sdk
+    # it's None at module load. Use a lambda that returns a sentinel
+    # so ``_resolve_capture_mode`` succeeds — the DebugSession mock
+    # in each test ignores the actual value.
+    monkeypatch.setattr(
+        augur_mod, "CaptureMode", lambda v=None: f"capture_mode:{v}",
+    )
 
 
 # ── _build_task_spec_from_suite ────────────────────────────────────

--- a/tests/test_augur_sdk_0_6_task_spec_680.py
+++ b/tests/test_augur_sdk_0_6_task_spec_680.py
@@ -125,13 +125,13 @@ def test_task_spec_fallback_domain_from_url_pattern():
     spec = _build_task_spec_from_suite(
         {
             "_plan_name": "foo",
-            "_site_config": {"url_patterns": ["https://staffai.crm/x"]},
+            "_site_config": {"url_patterns": ["https://mantis-crm/x"]},
         },
         phase1_workers=1, phase1_max_pages=1, phase2_workers=1,
         max_steps=10,
     )
-    assert spec["task_class"] == "staffai.crm"
-    assert spec["task_spec_id"] == "staffai.crm.foo.v1"
+    assert spec["task_class"] == "mantis-crm"
+    assert spec["task_spec_id"] == "mantis-crm.foo.v1"
 
 
 # ── open_orchestrator_session — passes task_spec + group_id ────────

--- a/tests/test_augur_sdk_0_6_task_spec_680.py
+++ b/tests/test_augur_sdk_0_6_task_spec_680.py
@@ -1,0 +1,464 @@
+"""#680 — augur-sdk 0.6.0 adoption: task_spec, group_id, loop_detected.
+
+The orchestrator session opened by ``open_orchestrator_session`` now
+forwards ``task_spec`` (composed from suite metadata) and ``group_id``
+(== fan-out parent_run_id) as augur-sdk 0.6.0 kwargs. Children opened
+via ``AugurAdapter(group_id=...)`` carry the matching group_id so the
+viewer can correlate sibling rollouts (GRPO).
+
+The adapter's ``record_step`` auto-stamps ``set_loop_detected`` when
+the step's ``failure_class`` is loop-shaped — bridges the runner-side
+detection into the SDK signal without per-call instrumentation.
+
+Contract pinned here:
+
+* ``_build_task_spec_from_suite`` produces a TaskSpec dict with
+  ``task_spec_id`` / ``instruction`` / ``task_class`` / ``max_steps``
+  / ``env_id`` keys from suite metadata; empty fields are dropped.
+* ``open_orchestrator_session`` forwards ``task_spec=`` and
+  ``group_id=`` through to the SDK opener via ``**session_kwargs``.
+* Older SDKs that raise ``TypeError`` on the new kwargs trigger a
+  retry without them (best-effort observability).
+* ``AugurAdapter(group_id=...)`` forwards to
+  ``DebugSession(group_id=...)``.
+* ``AugurAdapter.record_step`` calls
+  ``session.set_loop_detected(step_index=...)`` for the documented
+  loop failure classes.
+* SDK without ``set_loop_detected`` (pre-0.6.0) is a clean no-op.
+* ``run_fanout_dispatch`` sets ``_fanout_group_id`` on the suite and
+  forwards it as both the orchestrator session's ``group_id`` AND a
+  child-readable suite envelope key.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import mantis_agent.observability.augur as augur_mod
+from mantis_agent.gym.fanout_runner import (
+    _build_task_spec_from_suite,
+    run_fanout_dispatch,
+)
+from mantis_agent.observability.augur import (
+    AugurAdapter,
+    open_orchestrator_session,
+)
+from mantis_agent.plan_decomposer import MicroIntent, MicroPlan, PlanDecomposer
+
+
+@pytest.fixture
+def force_augur_available(monkeypatch):
+    """CI runners don't install ``augur-sdk`` (it's an opt-in extra).
+    Flip the module's SDK-available flag and patches against
+    ``DebugSession`` start landing."""
+    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
+    monkeypatch.setattr(augur_mod, "_AUGUR_AVAILABLE", True)
+
+
+# ── _build_task_spec_from_suite ────────────────────────────────────
+
+
+def test_task_spec_full_suite_yields_all_fields():
+    """A suite with plan_name + site_config.domain produces a fully
+    populated TaskSpec (id + instruction + class + max_steps + env_id)."""
+    spec = _build_task_spec_from_suite(
+        {
+            "_plan_name": "boattrader_scrape_urlnav",
+            "_site_config": {"domain": "boattrader.com"},
+        },
+        phase1_workers=4, phase1_max_pages=4, phase2_workers=4,
+        max_steps=240,
+    )
+    assert spec["task_spec_id"] == "boattrader.com.boattrader_scrape_urlnav.v1"
+    assert spec["instruction"] == "boattrader scrape urlnav"
+    assert spec["task_class"] == "boattrader.com"
+    assert spec["max_steps"] == 240
+    assert "fanout(p1=4xp4,p2=4)" in spec["env_id"]
+    assert spec["env_id"].startswith("modal:mantis-cua-server:")
+
+
+def test_task_spec_without_plan_name_drops_id_and_instruction():
+    """Missing ``_plan_name`` → task_spec_id / instruction omitted but
+    task_class + env_id + max_steps still populated."""
+    spec = _build_task_spec_from_suite(
+        {"_site_config": {"domain": "example.com"}},
+        phase1_workers=2, phase1_max_pages=2, phase2_workers=4,
+        max_steps=100,
+    )
+    assert "task_spec_id" not in spec or spec["task_spec_id"] == "example.com.fanout.v1"
+    assert "instruction" not in spec
+    assert spec["task_class"] == "example.com"
+    assert spec["max_steps"] == 100
+
+
+def test_task_spec_without_domain_falls_back_to_unknown():
+    """No site_config → task_class becomes ``unknown`` and we skip
+    the task_spec_id (no useful canonical name to mint)."""
+    spec = _build_task_spec_from_suite(
+        {"_plan_name": "rogue_plan"},
+        phase1_workers=1, phase1_max_pages=1, phase2_workers=1,
+        max_steps=10,
+    )
+    assert "task_class" not in spec
+    assert "task_spec_id" not in spec
+    assert spec["instruction"] == "rogue plan"
+    assert spec["max_steps"] == 10
+
+
+def test_task_spec_fallback_domain_from_url_pattern():
+    """Domain absent on _site_config but URL patterns present → derive
+    from the first pattern's host."""
+    spec = _build_task_spec_from_suite(
+        {
+            "_plan_name": "foo",
+            "_site_config": {"url_patterns": ["https://staffai.crm/x"]},
+        },
+        phase1_workers=1, phase1_max_pages=1, phase2_workers=1,
+        max_steps=10,
+    )
+    assert spec["task_class"] == "staffai.crm"
+    assert spec["task_spec_id"] == "staffai.crm.foo.v1"
+
+
+# ── open_orchestrator_session — passes task_spec + group_id ────────
+
+
+def test_orchestrator_session_forwards_task_spec_and_group_id(force_augur_available):
+    """The opener receives ``task_spec`` and ``group_id`` as kwargs."""
+    fake_ctx = MagicMock()
+    fake_ctx.__enter__ = MagicMock(return_value=MagicMock())
+    fake_ctx.__exit__ = MagicMock(return_value=False)
+    opener = MagicMock(return_value=fake_ctx)
+    stub = MagicMock()
+    stub.open_orchestrator = opener
+    with patch.object(augur_mod, "DebugSession", stub):
+        with open_orchestrator_session(
+            run_id="fanout-rid", tags={"phase1_workers": "2"},
+            task_spec={"task_spec_id": "x.y.v1", "instruction": "do it"},
+            group_id="fanout-rid",
+        ):
+            pass
+    opener.assert_called_once()
+    call_kwargs = opener.call_args.kwargs
+    assert call_kwargs["task_spec"] == {
+        "task_spec_id": "x.y.v1", "instruction": "do it",
+    }
+    assert call_kwargs["group_id"] == "fanout-rid"
+
+
+def test_orchestrator_session_retries_without_06_kwargs_on_TypeError(
+    force_augur_available,
+):
+    """An SDK that predates 0.6.0 raises ``TypeError`` on the new
+    kwargs. The helper retries WITHOUT them so the parent row still
+    opens (server-side grouping via parent_run_id keeps working;
+    only the RL-training metadata is dropped)."""
+    fake_ctx = MagicMock()
+    fake_ctx.__enter__ = MagicMock(return_value=MagicMock())
+    fake_ctx.__exit__ = MagicMock(return_value=False)
+    # First call (with task_spec/group_id) raises TypeError;
+    # retry without them succeeds.
+    opener = MagicMock(
+        side_effect=[TypeError("got unexpected keyword 'task_spec'"), fake_ctx],
+    )
+    stub = MagicMock()
+    stub.open_orchestrator = opener
+    with patch.object(augur_mod, "DebugSession", stub):
+        with open_orchestrator_session(
+            run_id="r", task_spec={"a": "b"}, group_id="g", tags={},
+        ) as s:
+            assert s is not None
+    assert opener.call_count == 2
+    # First call carried the 0.6.0 kwargs.
+    first = opener.call_args_list[0].kwargs
+    assert "task_spec" in first and "group_id" in first
+    # Retry stripped them.
+    retry = opener.call_args_list[1].kwargs
+    assert "task_spec" not in retry and "group_id" not in retry
+
+
+def test_orchestrator_session_no_06_kwargs_when_caller_omits(force_augur_available):
+    """Caller didn't pass task_spec / group_id → opener call has
+    neither key. (Confirms the kwargs are conditional, not stamped
+    with ``None`` defaults that the SDK might reject.)"""
+    fake_ctx = MagicMock()
+    fake_ctx.__enter__ = MagicMock(return_value=MagicMock())
+    fake_ctx.__exit__ = MagicMock(return_value=False)
+    opener = MagicMock(return_value=fake_ctx)
+    stub = MagicMock()
+    stub.open_orchestrator = opener
+    with patch.object(augur_mod, "DebugSession", stub):
+        with open_orchestrator_session(run_id="r", tags={}):
+            pass
+    kw = opener.call_args.kwargs
+    assert "task_spec" not in kw
+    assert "group_id" not in kw
+
+
+# ── AugurAdapter forwards group_id to DebugSession ─────────────────
+
+
+def test_augur_adapter_forwards_group_id_to_debug_session(force_augur_available):
+    """When ``AugurAdapter(group_id=...)`` is passed, the SDK session
+    is opened with ``group_id`` as a constructor kwarg."""
+    fake_session = MagicMock()
+    fake_session._stream = None
+    debug_session_cls = MagicMock(return_value=fake_session)
+    with patch.object(augur_mod, "DebugSession", debug_session_cls):
+        AugurAdapter(
+            run_id="child-rid", tenant_id="t", session_name="s",
+            group_id="fanout-parent-rid",
+        )
+    debug_session_cls.assert_called_once()
+    kwargs = debug_session_cls.call_args.kwargs
+    assert kwargs["group_id"] == "fanout-parent-rid"
+
+
+def test_augur_adapter_retries_without_group_id_on_TypeError(force_augur_available):
+    """Pre-0.6.0 SDKs raise ``TypeError`` on ``group_id``. The adapter
+    retries without it so the child session still opens (loses the
+    GRPO correlation but keeps the rest of the bundle intact)."""
+    fake_session = MagicMock()
+    fake_session._stream = None
+    debug_session_cls = MagicMock(
+        side_effect=[TypeError("got unexpected keyword 'group_id'"), fake_session],
+    )
+    with patch.object(augur_mod, "DebugSession", debug_session_cls):
+        a = AugurAdapter(
+            run_id="child-rid", tenant_id="t", session_name="s",
+            group_id="fanout-parent-rid",
+        )
+    assert debug_session_cls.call_count == 2
+    # First call carried group_id; retry stripped it.
+    assert "group_id" in debug_session_cls.call_args_list[0].kwargs
+    assert "group_id" not in debug_session_cls.call_args_list[1].kwargs
+    # Adapter still ended up with an active session.
+    assert a._session is fake_session
+
+
+def test_augur_adapter_omits_group_id_when_caller_omits(force_augur_available):
+    """No ``group_id=`` on the adapter → the kwarg isn't forwarded to
+    DebugSession (production-path preservation; today most runs are
+    non-fanout single-runner)."""
+    fake_session = MagicMock()
+    fake_session._stream = None
+    debug_session_cls = MagicMock(return_value=fake_session)
+    with patch.object(augur_mod, "DebugSession", debug_session_cls):
+        AugurAdapter(run_id="solo-rid", tenant_id="t", session_name="s")
+    kw = debug_session_cls.call_args.kwargs
+    assert "group_id" not in kw
+
+
+# ── record_step auto-stamps set_loop_detected ──────────────────────
+
+
+def _stub_step_result(*, step_index: int, failure_class: str = ""):
+    return SimpleNamespace(
+        step_index=step_index, intent=f"step{step_index}",
+        success=False, verdict=SimpleNamespace(kind="failed", reason="", confidence=1.0),
+        data="", failure_class=failure_class, last_action=None, duration=0.0,
+        page_title="", executor_backend="", reasoning="",
+    )
+
+
+@pytest.mark.parametrize(
+    "fc",
+    [
+        "no_state_change",
+        "brain_loop_exhausted",
+        "scroll_no_movement",
+        "loop",
+        "hard_loop",
+        "soft_loop",
+    ],
+)
+def test_record_step_stamps_loop_detected_on_loop_failure_class(tmp_path, fc):
+    """For every documented loop failure class, ``record_step`` calls
+    ``session.set_loop_detected(step_index=augur_index)`` exactly once
+    per step emission."""
+    a = AugurAdapter(
+        run_id="loop_test", tenant_id="t", session_name="s",
+        out_dir=tmp_path,
+    )
+    if not a.active:
+        pytest.skip("AugurAdapter inactive — SDK not installed in this env")
+    a._session = MagicMock()
+    a._session.record_step = MagicMock()
+    a._session.record_step_iteration = MagicMock()
+    a._session.set_loop_detected = MagicMock()
+
+    a.record_step(step_result=_stub_step_result(step_index=3, failure_class=fc))
+
+    a._session.set_loop_detected.assert_called_once_with(step_index=4)
+
+
+def test_record_step_does_not_stamp_loop_detected_on_success(tmp_path):
+    """Successful steps (no failure_class) don't trip
+    ``set_loop_detected``."""
+    a = AugurAdapter(
+        run_id="loop_test", tenant_id="t", session_name="s",
+        out_dir=tmp_path,
+    )
+    if not a.active:
+        pytest.skip("AugurAdapter inactive")
+    a._session = MagicMock()
+    a._session.record_step = MagicMock()
+    a._session.set_loop_detected = MagicMock()
+    a.record_step(step_result=_stub_step_result(step_index=3, failure_class=""))
+    a._session.set_loop_detected.assert_not_called()
+
+
+def test_record_step_skips_loop_detected_on_unrelated_failure_class(tmp_path):
+    """Failure classes outside the loop set (selector_miss,
+    wrong_target, ...) do NOT trip ``set_loop_detected``."""
+    a = AugurAdapter(
+        run_id="loop_test", tenant_id="t", session_name="s",
+        out_dir=tmp_path,
+    )
+    if not a.active:
+        pytest.skip("AugurAdapter inactive")
+    a._session = MagicMock()
+    a._session.record_step = MagicMock()
+    a._session.set_loop_detected = MagicMock()
+    a.record_step(step_result=_stub_step_result(
+        step_index=3, failure_class="selector_miss",
+    ))
+    a._session.set_loop_detected.assert_not_called()
+
+
+def test_record_step_no_op_when_sdk_lacks_set_loop_detected(tmp_path):
+    """Pre-0.6.0 SDKs without ``set_loop_detected`` → stamp call is
+    skipped cleanly (no exception, step trace still recorded)."""
+    a = AugurAdapter(
+        run_id="loop_test", tenant_id="t", session_name="s",
+        out_dir=tmp_path,
+    )
+    if not a.active:
+        pytest.skip("AugurAdapter inactive")
+    # MagicMock(spec=[...]) strips attrs not in the spec list, so
+    # ``set_loop_detected`` is absent — matches pre-0.6.0 SDK shape.
+    a._session = MagicMock(spec=["record_step"])
+    a._session.record_step = MagicMock()
+    # No exception even though set_loop_detected isn't on the session.
+    a.record_step(step_result=_stub_step_result(
+        step_index=3, failure_class="no_state_change",
+    ))
+    a._session.record_step.assert_called_once()
+
+
+# ── run_fanout_dispatch sets _fanout_group_id on the suite ─────────
+
+
+def _make_eligible_suite() -> dict:
+    plan = MicroPlan(domain="boattrader.com")
+    plan.steps = [
+        MicroIntent(
+            intent="Navigate", type="navigate", section="setup",
+            params={"url": "https://www.boattrader.com/boats/by-owner/"},
+        ),
+        MicroIntent(intent="Click card", type="click", section="extraction"),
+        MicroIntent(intent="Read URL", type="extract_url", section="extraction"),
+        MicroIntent(intent="Scroll", type="scroll", section="extraction"),
+        MicroIntent(intent="Extract", type="extract_data", section="extraction"),
+        MicroIntent(intent="Back", type="navigate_back", section="extraction"),
+        MicroIntent(
+            intent="Inner loop", type="loop", section="extraction",
+            loop_target=1, loop_count=40,
+        ),
+    ]
+    PlanDecomposer._classify_loop_groups(plan)
+    return {
+        "session_name": "x",
+        "_plan_name": "boattrader_scrape_urlnav",
+        "_plan_signature": "boattrader-test-sig",
+        "_site_config": {"domain": "boattrader.com"},
+        "_fanout_phase1_workers": 1,
+        "_micro_plan": [
+            {
+                "intent": s.intent, "type": s.type, "section": s.section,
+                "params": dict(s.params or {}),
+                "loop_target": s.loop_target, "loop_count": s.loop_count,
+                "claude_only": s.claude_only, "gate": s.gate,
+                "required": s.required, "grounding": s.grounding,
+                "verify": s.verify, "reverse": s.reverse,
+                "budget": s.budget, "hints": dict(s.hints or {}),
+            }
+            for s in plan.steps
+        ],
+        "_loop_groups": [
+            {
+                "loop_step_idx": g.loop_step_idx,
+                "body_range": list(g.body_range),
+                "shape": g.shape,
+            }
+            for g in plan.loop_groups
+        ],
+    }
+
+
+def _make_executor_stub(*, phase1_urls: list[str]):
+    handle_p1 = MagicMock()
+    handle_p1.get.return_value = {
+        "viable": 0, "leads_with_phone": 0, "leads": [],
+        "collected_urls": phase1_urls, "shared_seen_hits": 0,
+    }
+    handle_p2 = MagicMock()
+    handle_p2.get.return_value = {
+        "viable": 1, "leads_with_phone": 0,
+        "leads": [{"url": phase1_urls[0]}] if phase1_urls else [],
+        "shared_seen_hits": 0,
+    }
+    executor = MagicMock()
+    executor.spawn.side_effect = [handle_p1, handle_p2]
+    return executor
+
+
+def test_run_fanout_dispatch_stamps_fanout_group_id_on_suite(force_augur_available):
+    """``run_fanout_dispatch`` sets ``_fanout_group_id`` on the suite
+    dict so the worker entrypoint (Modal HTTP path) can forward it to
+    ``AugurAdapter.group_id``."""
+    fake_ctx = MagicMock()
+    fake_ctx.__enter__ = MagicMock(return_value=MagicMock())
+    fake_ctx.__exit__ = MagicMock(return_value=False)
+    stub = MagicMock()
+    stub.open_orchestrator = MagicMock(return_value=fake_ctx)
+    suite = _make_eligible_suite()
+    with patch.object(augur_mod, "DebugSession", stub):
+        run_fanout_dispatch(
+            suite,
+            executor_fn=_make_executor_stub(phase1_urls=["https://x/d/1"]),
+            model="holo3", claude_model="",
+            max_steps=10, workers=1,
+            fanout_parent_run_id="fanout-678",
+        )
+    assert suite["_fanout_group_id"] == "fanout-678"
+
+
+def test_run_fanout_dispatch_forwards_task_spec_and_group_id_to_opener(
+    force_augur_available,
+):
+    """The orchestrator session opens with task_spec + group_id
+    derived from the suite."""
+    fake_ctx = MagicMock()
+    fake_ctx.__enter__ = MagicMock(return_value=MagicMock())
+    fake_ctx.__exit__ = MagicMock(return_value=False)
+    opener = MagicMock(return_value=fake_ctx)
+    stub = MagicMock()
+    stub.open_orchestrator = opener
+    with patch.object(augur_mod, "DebugSession", stub):
+        run_fanout_dispatch(
+            _make_eligible_suite(),
+            executor_fn=_make_executor_stub(phase1_urls=["https://x/d/1"]),
+            model="holo3", claude_model="",
+            max_steps=240, workers=4,
+            fanout_parent_run_id="fanout-678",
+        )
+    kw = opener.call_args.kwargs
+    assert kw["group_id"] == "fanout-678"
+    spec = kw["task_spec"]
+    assert spec["task_class"] == "boattrader.com"
+    assert spec["task_spec_id"] == "boattrader.com.boattrader_scrape_urlnav.v1"
+    assert spec["max_steps"] == 240

--- a/uv.lock
+++ b/uv.lock
@@ -241,7 +241,7 @@ wheels = [
 
 [[package]]
 name = "augur-sdk"
-version = "0.3.1"
+version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "augur-schema" },
@@ -249,9 +249,9 @@ dependencies = [
     { name = "referencing" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/40/06/4a14358bce3751bd5cfa2febb09aef735fd3edd0be04f1fb5a1df7d925f7/augur_sdk-0.3.1.tar.gz", hash = "sha256:97851b296e1b2f7f0af422a663f6859234a98dda85dd7fdcc5b9b9c9f07ab4b7", size = 105678, upload-time = "2026-05-25T03:29:47.822Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/09/f98defc20dceb6109b0df4501a9d70eb58eaf48036605e07152abf79ff3b/augur_sdk-0.4.0.tar.gz", hash = "sha256:3302a34b799da8888c6262f5da91bdb7780895d20fbb7d708bd3f65692333dbb", size = 109998, upload-time = "2026-05-25T17:33:34.714Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/e2/145464dfd008e175d82b166a8d52da2f240e7ed3ee3437fa618470cbb9d5/augur_sdk-0.3.1-py3-none-any.whl", hash = "sha256:540011efa774da6061feb936edade69e67531c712ee55d82b56a90f2e452a829", size = 70968, upload-time = "2026-05-25T03:29:46.18Z" },
+    { url = "https://files.pythonhosted.org/packages/80/75/688453a74497d437a539eb0db05e8209d2bf81151e770c9fdade3ca42c1b/augur_sdk-0.4.0-py3-none-any.whl", hash = "sha256:bc24e8e85dbab5156f5973a9fe4b22c88cc3ed2b100d99959c838e6a045b0ea9", size = 72163, upload-time = "2026-05-25T17:33:32.863Z" },
 ]
 
 [[package]]
@@ -1552,7 +1552,7 @@ viewer = [
 [package.metadata]
 requires-dist = [
     { name = "accelerate", marker = "extra == 'gpu'", specifier = ">=0.30" },
-    { name = "augur-sdk", marker = "extra == 'observability'", specifier = ">=0.3.1,<0.4" },
+    { name = "augur-sdk", marker = "extra == 'observability'", specifier = ">=0.4.0,<0.5" },
     { name = "bitsandbytes", marker = "extra == 'gpu'", specifier = ">=0.43" },
     { name = "fastapi", marker = "extra == 'server'", specifier = ">=0.100" },
     { name = "fastapi", marker = "extra == 'viewer'", specifier = ">=0.100" },


### PR DESCRIPTION
## Summary

Phase A of #680 — pin bump to **augur-sdk 0.6.0** and wire the three additive surfaces that 0.5.0/0.6.0 shipped:

1. **`task_spec` on the orchestrator session** — composed from suite metadata (`_plan_name`, `_site_config.domain`, `max_steps`) via a new `_build_task_spec_from_suite` helper. Renders the canonical task definition on the parent row in the Augur viewer so RL trainers read it directly instead of reconstructing from worker bundles.

2. **`group_id` propagation** — orchestrator opens with `group_id=<fanout_parent_run_id>`; children's `AugurAdapter` forwards via the new `group_id=` kwarg through to `DebugSession(group_id=...)`. GRPO sibling-rollout correlation now keys on a dedicated field.

3. **`set_loop_detected` auto-stamping** — `AugurAdapter.record_step` forwards loop-shaped `failure_class` values (`no_state_change`, `brain_loop_exhausted`, `scroll_no_movement`, `loop`, `hard_loop`, `soft_loop`) to `session.set_loop_detected(step_index=...)`. Bridges the existing runner-side detection into the SDK signal — no per-call instrumentation needed.

## Backwards compatibility

Every new SDK kwarg is forwarded inside a `try/except TypeError → retry without it` block, so a stale pin in production silently degrades to the 0.4.0 shape instead of crashing the bundle. `set_loop_detected` lookup uses `getattr` so pre-0.6.0 SDKs skip the call cleanly.

## Out of scope (deferred to follow-ups)

- **Phase B**: logprob capture (`MANTIS_CAPTURE_LOGPROBS=1` gated; doubles OpenAI response payload size).
- **Phase C**: full subgoal taxonomy (Phase-1 / Phase-2 boundaries as `record_subgoal_completion` calls).

## Pin sites bumped (7)

`pyproject.toml` + 5× `deploy/modal/modal_cua_server.py` + `deploy/modal/modal_plan_runner.py`: `augur-sdk>=0.4.0,<0.5` → `>=0.6.0,<0.7`. Transitively pulls `augur-schema>=0.4.1` (0.4.0 had a loader bug that left task_spec / subgoals_completed unregistered).

## Test plan

- [x] `tests/test_augur_sdk_0_6_task_spec_680.py` — 21 new tests pin: task_spec field composition + fallbacks, opener/adapter forward + retry-on-TypeError + omit-when-absent paths, `set_loop_detected` auto-stamp for each documented loop class, dispatcher stamps `_fanout_group_id` + forwards task_spec/group_id to opener
- [x] `tests/test_open_orchestrator_session_678.py` + dispatch/iteration/step-id/observability tests — 81 augur-related tests all green
- [x] `ruff check` — clean on the touched files
- [ ] Modal redeploy + boattrader rerun ($2 cap) — expect parent row with `task_spec.instruction=boattrader scrape urlnav`, 4 Phase-2 children carrying `group_id=fanout-…`, loop-detection chip on any step that classified as `no_state_change`

Closes #680 (Phase A only — issue stays open for Phase B/C tracking).

🤖 Generated with [Claude Code](https://claude.com/claude-code)