### PR TITLE
feat(boattrader-fidelity): BDP exact-mirror — v=105..v=133 (29 deploys, 28 fidelity passes)

### DIFF
--- a/deploy/sim_envs/mantis_boattrader/FIDELITY.md
+++ b/deploy/sim_envs/mantis_boattrader/FIDELITY.md
@@ -58,7 +58,7 @@ a wrong probe — re-probe of Pursuit 3070 showed .enhanced-business-
 card-wrapper inside .summary-section at y=858).
 
 Live URL: `https://8080-014f48ab-eeb1-4ca5-947e-42e169d1fcc8.daytonaproxy01.net/boats/`
-(token rotates per sandbox restart; current: `syyxwc54axpktn5xcpo91iedvskoeqhv`)
+(token rotates per sandbox restart; current: `vdn3e1danb38__v4trniindjgnfvuez8`)
 
 ## Methodology
 

--- a/deploy/sim_envs/mantis_boattrader/FIDELITY.md
+++ b/deploy/sim_envs/mantis_boattrader/FIDELITY.md
@@ -3,7 +3,7 @@
 Working doc tracking each element's match status against
 `https://www.boattrader.com/`. Update as iterations land.
 
-Last updated: **v=121** (2026-05-24) — BDP exact-mirror marathon
+Last updated: **v=128** (2026-05-25) — BDP exact-mirror marathon
 (v=105..v=121, 15 deploys across 8 rounds). Re-probed real BT
 dealer (2024 Catalina 355), private (2015 Pioneer 197 Sportfish),
 and Pursuit 3070 listings at 1440×900 and landed structural
@@ -40,6 +40,17 @@ pane stripped to monthly + total + disclosure.
 v=121 breadcrumb 15/400 #333 → 12/400 #616161 per user screenshot.
 v=122 `.bdp-details-section` border-bottom → full border (1px
 #ededed on all 4 sides) per real BT probe.
+v=123 hide right-rail `.prequal-card` (not in real BT).
+v=124 contact form Email+Phone split row + transparent input bg.
+v=125 dealer card "Verified Broker" label + subline 16/#474c4a +
+heading color #1a2022.
+v=126 tighter Still-have-a-question body 18→15px + button 20→14px
++ section margin 24→12px.
+v=127 collapse .bdp-more-from-dealer / .bdp-question-card padding
++ margin (was 116px gap).
+**v=128 ROOT CAUSE — `.bdp-grid-stack` was inheriting `gap: 80px`
+from `.bdp-grid`, which became row-gap between every section.
+Added `row-gap: 0` so sections sit only on their own margins.**
 
 Live URL: `https://8080-014f48ab-eeb1-4ca5-947e-42e169d1fcc8.daytonaproxy01.net/boats/`
 (token rotates per sandbox restart; current: `syyxwc54axpktn5xcpo91iedvskoeqhv`)

--- a/deploy/sim_envs/mantis_boattrader/FIDELITY.md
+++ b/deploy/sim_envs/mantis_boattrader/FIDELITY.md
@@ -3,19 +3,30 @@
 Working doc tracking each element's match status against
 `https://www.boattrader.com/`. Update as iterations land.
 
-Last updated: **v=107** (2026-05-24) — BDP exact-mirror pass:
-re-probed real BT dealer (2024 Catalina 355) + private (2015 Pioneer
-197 Sportfish) at 1440×900. Three rounds: v=105 heading hierarchy +
-cleanup (Meet-Your-Seller H2 removed, Listed-By section deleted,
-Key-Features H3 removed, ✦ sparkle prefix removed, `.next-previous`
-always-sticky bar added, More Details/Location H3→H4, Still-have-a-
-question H2→H3, More From This Dealer H2→H4, dealer-card heading
-H2→H3, Accommodations H4 added); v=106 sticky-bar layout fix
-(flex-direction: column so breadcrumb + listing info stack); v=107
-H1 length-suffix span restored as sibling (v=104 over-corrected),
-dealer card now integrates dealer name+city+phone as inline sublines
-under salesperson H3, redundant `.bdp-dealership-card` hidden.
-Suite now **82 passing** (15 new BDP tests).
+Last updated: **v=117** (2026-05-24) — BDP exact-mirror saga
+(v=105..v=117, 11 deploys across 6 rounds). Re-probed real BT
+dealer (2024 Catalina 355) + private (2015 Pioneer 197 Sportfish)
+at 1440×900 and landed structural deltas in 6 iteration rounds —
+including 3 prompted by user screenshot feedback.
+
+Round 1 (v=105): heading hierarchy + cleanup. Round 2 (v=106): sticky-
+bar layout fix per user screenshot. Round 3 (v=107): H1 length-suffix
+span restored + dealer-card sublines + dealership-card hidden.
+Round 4 (v=108–v=109): simplified sticky bar to `‹ Search /
+breadcrumb / Prev / Next` per user screenshot, inner-wrapper
+constraint (max-width 1400px + margin 0 80px); v=110/v=111 white-
+wash regressed and were reverted in v=112 (light-blue `#f5f9ff`
+restored on Owners/Boat Details/More-From-Dealer + ✦ sparkle re-
+added). v=113 sticky-bar full-viewport bleed (100vw + neg margin).
+v=114 top-section polish: removed sticky-bar border-bottom, removed
+ad-strip 24px margin, added accordion-body white nested-card chrome,
+fixed `.bdp-price` to 20/700, H1 margin → 0, added Boat Details
+border-bottom. Round 5 (v=115): right-rail width 366px → 400px.
+Round 6 (v=116–v=117): ad-strip full-viewport bleed; engagement row
+simplified to plain "Views | Saves" with 1×12px #dee2e3 divider
+(removed icons + Listed/days-ago row).
+
+Suite **83 passing** (16 new BDP tests).
 
 Live URL: `https://8080-014f48ab-eeb1-4ca5-947e-42e169d1fcc8.daytonaproxy01.net/boats/`
 (token rotates per sandbox restart; current: `a_oh4hg7awgeznbwwglbfml0sdlrywzw`)
@@ -460,6 +471,133 @@ Calculator" (18/700 #303030), then a result row.
          + blank placeholder (test_filter_panel_fidelity.py now 26 passing)
        • `.ai-search-v2__try-prefix` kept as a legacy alias for the
          non-rotating prefix used elsewhere (e.g. home hero search)
+`v=117` Engagement row simplified to real BT structure:
+       • Removed 3-item `<ul class="bdp-engagement-row">` (Views +
+         Saves + Listed-days icons) and replaced with a 2-item
+         `<div class="bdp-engagement-row listing-engagement-indicators">`
+         containing just "Views" and "Saves" with a 1×12px #dee2e3
+         vertical divider span between (`.listing-engagement-
+         indicators__divider`). 12/400 #757575 per real BT probe.
+       • No icons, no Listed/days-ago row (real BT doesn't show those).
+       • One new test (test_bdp_engagement_row_simplified_to_views_saves).
+         Suite now **83 passing**.
+`v=116` Ad-strip full-viewport bleed:
+       • User screenshot showed grey #f7f7f7 bg cut off at .bt-main
+         max-width 1440 with ~80px white gutters on each side of
+         the top sponsored ad-leaderboard.
+       • Same fix as v=113 sticky bar: `.ad-strip { width: 100vw;
+         margin-left: calc(-50vw + 50%) }`. Ad image stays centered
+         via flex `justify-content: center`.
+       • `.bdp-grid-stack > .ad-strip` overrides reset width to auto
+         so mid-page leaderboards stay inside their grid column.
+`v=115` Right-rail summary card width 366px → 400px:
+       • Real BT `.summary-section` probe: w=400 x=1066, pad 16px,
+         bg #fff, border 1px #ededed, br 8px, shadow 0 2px 2px
+         rgba(0,0,0,0.2). Sandbox was 366px (too narrow).
+       • Global replace `366px → 400px` (3 sites: .bdp-grid
+         template, .bdp-grid-stack padding offset, .bdp-summary).
+       • Lead-input geometry (border 1px #c2c2c2, br 4px, pad
+         8px 12px 4px, h 40px) already matched per v=55 — no change.
+`v=114` Top-section polish per comprehensive bg/margin/font probe:
+       • `.next-previous { border-bottom: 1px solid #ededed }`
+         REMOVED — real BT probe shows no bottom border. v=105's
+         border was creating a visible divider line in the user
+         screenshot between the top ad-strip and the sticky bar.
+       • `.ad-strip` outer margin `24px 0 → 0`. Real BT renders
+         the leaderboard flush against the page header above and
+         the sticky bar below.
+       • `.bdp-details-section`: added `border-bottom: 1px solid
+         #ededed` per real BT `.accordion-details-section` probe.
+       • `.bdp-price` wrapper bumped 16/400 → 20/700 #333. Real
+         BT price renders at 20/700 on the wrapping element.
+       • `.bdp-title` H1 margin `8px 0 6px → 0` per real BT.
+       • `.accordion-body` (Description inner): added `background:
+         #fff; border-radius: 8px; padding: 0 16px 18px` — real
+         BT renders Description as a nested WHITE card inside the
+         light-blue `.bdp-details-section` parent.
+`v=113` Sticky bar full-viewport bleed (per user screenshot):
+       • User screenshot showed `.next-previous` grey #f7f7f7 bg
+         cut off ~100px before the viewport right edge, leaving
+         a white gap.
+       • Bug: `width: 100%` referred to `.bt-main`'s constrained
+         max-width 1440px, not the viewport. Fix: switched to
+         `width: 100vw; margin-left: calc(-50vw + 50%)` so the
+         bar's bg spans edge-to-edge.
+       • Same fix applied to `.boat-details-gradient` wrapper.
+`v=112` Restored light-blue card bgs + ✦ sparkle (per user screenshot):
+       • v=110/v=111 whitewashed all section cards thinking real
+         BT was plain white. User's real-BT screenshot showed
+         clear light-blue (#f5f9ff) cards on "What Owners Say"
+         and "Boat Details", plus a ✦ sparkle prefix on
+         "What Owners Say".
+       • Re-probed precisely:
+         - `.accordion-details-section` (Boat Details): bg #f5f9ff,
+           br 8px, pad 20px 16px, border-bottom 1px #ededed
+         - `.boat-overview-wrapper.ai-ratings-review-bundle`
+           (Owners + Highlights): bg #f5f9ff, br 8px, pad 20px 16px
+         - `.accordion-details-items` (Description): bg #fff,
+           br 8px, pad 0 16px (nested white card on light-blue)
+       • Sandbox `.bdp-owners-card` bg `#eef4fb` → `#f5f9ff` (exact
+         match to real BT, not the older v=83 tint).
+       • `.bdp-details-section` and `.bdp-more-from-dealer` also
+         set to #f5f9ff with matching geometry.
+       • Re-added `<span class="sparkle-icon">✦</span>` prefix to
+         the `.owners-card-heading` H2 — v=105 had wrongly removed
+         it.
+       • Test `test_bdp_no_sparkle_on_what_owners_say` rewritten
+         to `test_bdp_has_sparkle_on_what_owners_say`.
+`v=111` BDP gradient page wrapper (REVERTED in v=112):
+       • User screenshot of real BT styles.css showed
+         `.boat-details-gradient { background: linear-gradient(180deg,
+         #f7f7f7, transparent 20%) !important }`.
+       • Added `<div class="boat-details boat-details-gradient">`
+         wrapper around the BDP body content after the sticky bar.
+       • Wrapper bleeds full viewport width via the same margin
+         trick as `.next-previous`.
+       • Section bgs (`.bdp-owners-card`, `.bdp-details-section`,
+         `.bdp-more-from-dealer`) set to transparent so the
+         gradient shows through.
+       • PARTIAL REVERT in v=112: kept the gradient wrapper but
+         restored light-blue card bgs since real BT actually has
+         BOTH the gradient wrapper AND the light-blue sections
+         (sections cover the gradient where they sit).
+`v=110` Whitewashed BDP sections (REVERTED in v=112):
+       • Mistakenly read user's "background isn't white it's #fff"
+         comment as wanting EVERY section white. Set
+         `.bdp-owners-card`, `.bdp-details-section`, `.bdp-more-
+         from-dealer` to bg #fff.
+       • Reverted in v=112 after user shared the actual real BT
+         screenshot showing light-blue cards.
+`v=109` Sticky bar inner wrapper + breadcrumb tightening:
+       • Added `.next-previous-inner` div with `max-width: 1400px;
+         margin: 0 80px` matching real BT's container exactly.
+         At 1600px viewport this places "‹ Search" at x≈100 (20px
+         bar padding + 80px wrapper margin), not at x≈25 as v=108
+         had.
+       • `@media (max-width: 1280px)` falls back to `margin: 0 auto`
+         so the bar doesn't crowd out at narrow viewports.
+       • Breadcrumb 14/400 #303030 → 15/400 #333 (matches real BT).
+       • Back/Next buttons: 14/400 → 12/400, padding 8px 14px →
+         11px 15px.
+`v=108` Sticky bar simplified per user real-BT screenshot:
+       • v=105/106/107 sticky bar had too much in it (listing
+         name/price/location row, Save button, Offered-By tag).
+         Real BT screenshot showed bar contains ONLY:
+         "‹ Search / breadcrumb / Previous Boat / Next Boat".
+       • Earlier JS probes had found the listing-info text via
+         `.next-previous-info` but that element is in a hidden
+         absolutely-positioned info layer, NOT the visible row.
+       • Removed `.next-previous-info-container`,
+         `.next-previous-info`, `.next-previous-listing-name`,
+         `.next-previous-listing-price`, `.next-previous-listing-
+         loc`, `.next-previous-save`, `.next-previous-offered-by`.
+       • Changed "‹ Back to Search" → "‹ Search".
+       • Added `Previous Boat` link (sandbox passes `prev_boat`
+         already from `db.adjacent_boats`).
+       • Tests rewritten: `test_bdp_next_previous_has_breadcrumb_
+         and_info` → `test_bdp_next_previous_has_breadcrumb`;
+         `test_bdp_next_previous_info_container_is_column_flex` →
+         `test_bdp_next_previous_actions_only_prev_next`.
 `v=107` BDP exact-mirror — round 3 (H1 length-suffix span + dealer-card sublines):
        • H1 length-suffix re-added as a sibling SPAN inside the H1
          tag (`<h1>{title}<span class="bdp-length"> | {len}'</span></h1>`).

--- a/deploy/sim_envs/mantis_boattrader/FIDELITY.md
+++ b/deploy/sim_envs/mantis_boattrader/FIDELITY.md
@@ -203,15 +203,12 @@ Calculator" (18/700 #303030), then a result row.
 
 | Element | Real BT | Mine | Status |
 |---|---|---|---|
-| Widget concept | output-first (Monthly Payment headline + inputs below) | input-first (Boat Loan Calculator title + inputs + result row) | 🟡 — different widget concept; both work for agent training; rewriting would need user buy-in on which version |
-| Container | `.calc-calculator-body` w=300, transparent bg, no border/radius/shadow | `.loan-calc-card` w=303, bg=#fff, 1px #e0e0e0 border, 6px br, `var(--bt-shadow)` (intentional sandbox chrome) | 🟡 |
-| Title | "Monthly Payment" 22/900 #404040 — also acts as the output display | "Boat Loan Calculator" 18/700 #303030 | 🟡 |
-| Input geometry | 262×39, fs 15.9px, 3.9px br, 1px rgba(0,0,0,0.2) border | 269×40, fs 14px, 4px br | 🟡 — close (within rendering tolerance) |
-| Input placeholders | "Enter purchase price", "Enter Down Payment", "Enter term in years" | "$" only | 🟡 — sandbox's `$` is less informative |
-| Field types | 4 fields (purchase price, down payment, term years, APR) | 3 fields (loan amount, term months, APR) | 🟡 — slightly different inputs but functionally equivalent calc |
-| Calculate button | outline secondary style | blue outline | ✅ visual style matches |
-| "Get Pre-Qualified" CTA | blue filled pill | blue filled pill | ✅ |
-| Fineprint help text | small gray | added | ✅ |
+| Widget concept | split-pane: white form (left) + light-blue preview (right) with huge monthly | sandbox `.bdp-loan-card` split-pane via `.loan-card-grid`, white `.loan-form` + #f5f9ff `.loan-preview` (v=120) | ✅ |
+| Container | `.bdp-loan-card { background: #fff; border: 1px solid #ededed; border-radius: 12px; padding: 0; overflow: hidden }` so the two panes share corners | sandbox matches exactly (v=120) | ✅ |
+| Title | "Boat Loan Payment Calculator" 22/700 #303030 centered | sandbox same (v=120) | ✅ |
+| Input geometry | 4 fields stacked: Loan Type, Year, Purchase Price, Down Payment, Loan Term (Months) defaulting to 240 | sandbox same field set + default (v=120: replaced FICO with Loan Term per real BT) | ✅ |
+| Monthly preview | `Here is what your monthly payment might look like:` heading + huge 64/700 #303030 monthly + TOTAL LOAN AMOUNT + divider + See Important Disclosure | sandbox same; removed APR display, 180 MONTHS caption, Get-Pre-Qualified button, prequal bullets that weren't on real BT (v=120) | ✅ |
+| Right pane bg | #f5f9ff (light blue) | sandbox same (v=120) | ✅ |
 
 ### Listing cards (SRP)
 

--- a/deploy/sim_envs/mantis_boattrader/FIDELITY.md
+++ b/deploy/sim_envs/mantis_boattrader/FIDELITY.md
@@ -3,7 +3,7 @@
 Working doc tracking each element's match status against
 `https://www.boattrader.com/`. Update as iterations land.
 
-Last updated: **v=128** (2026-05-25) — BDP exact-mirror marathon
+Last updated: **v=130** (2026-05-25) — BDP exact-mirror marathon
 (v=105..v=121, 15 deploys across 8 rounds). Re-probed real BT
 dealer (2024 Catalina 355), private (2015 Pioneer 197 Sportfish),
 and Pursuit 3070 listings at 1440×900 and landed structural
@@ -51,6 +51,11 @@ v=127 collapse .bdp-more-from-dealer / .bdp-question-card padding
 **v=128 ROOT CAUSE — `.bdp-grid-stack` was inheriting `gap: 80px`
 from `.bdp-grid`, which became row-gap between every section.
 Added `row-gap: 0` so sections sit only on their own margins.**
+v=129 column widths exactly match real BT: gallery 920→890,
+.bdp-summary right:0→34 so layout is 890+76+400+34=1400 vs real BT.
+v=130 restored right-rail `.bdp-dealership-card` (v=107's hide was
+a wrong probe — re-probe of Pursuit 3070 showed .enhanced-business-
+card-wrapper inside .summary-section at y=858).
 
 Live URL: `https://8080-014f48ab-eeb1-4ca5-947e-42e169d1fcc8.daytonaproxy01.net/boats/`
 (token rotates per sandbox restart; current: `syyxwc54axpktn5xcpo91iedvskoeqhv`)

--- a/deploy/sim_envs/mantis_boattrader/FIDELITY.md
+++ b/deploy/sim_envs/mantis_boattrader/FIDELITY.md
@@ -3,7 +3,19 @@
 Working doc tracking each element's match status against
 `https://www.boattrader.com/`. Update as iterations land.
 
-Last updated: **v=104** (2026-05-23) — BDP visual/perceptual compare (dealer + owner): removed H1 length suffix `| 16'` (real BT format is "Year Make Model"); added H2 "Meet Your Seller" above the contact card on both seller paths matching real BT's pattern. Side-by-side diff saved as `_captured/bdp/SELLER_VS_OWNER_DIFF.md`.
+Last updated: **v=107** (2026-05-24) — BDP exact-mirror pass:
+re-probed real BT dealer (2024 Catalina 355) + private (2015 Pioneer
+197 Sportfish) at 1440×900. Three rounds: v=105 heading hierarchy +
+cleanup (Meet-Your-Seller H2 removed, Listed-By section deleted,
+Key-Features H3 removed, ✦ sparkle prefix removed, `.next-previous`
+always-sticky bar added, More Details/Location H3→H4, Still-have-a-
+question H2→H3, More From This Dealer H2→H4, dealer-card heading
+H2→H3, Accommodations H4 added); v=106 sticky-bar layout fix
+(flex-direction: column so breadcrumb + listing info stack); v=107
+H1 length-suffix span restored as sibling (v=104 over-corrected),
+dealer card now integrates dealer name+city+phone as inline sublines
+under salesperson H3, redundant `.bdp-dealership-card` hidden.
+Suite now **82 passing** (15 new BDP tests).
 
 Live URL: `https://8080-014f48ab-eeb1-4ca5-947e-42e169d1fcc8.daytonaproxy01.net/boats/`
 (token rotates per sandbox restart; current: `a_oh4hg7awgeznbwwglbfml0sdlrywzw`)
@@ -260,8 +272,20 @@ Calculator" (18/700 #303030), then a result row.
 | Description accordion (H3) | open by default | open by default | ✅ |
 | Measurements accordion (H3) → Dimensions/Weights/Tanks (H4) | collapsed, h4 subgroups | added | ✅ |
 | Propulsion accordion (H3) | collapsed | implemented | ✅ |
-| More Details accordion heading | not visible in v=91 probe (real BT may have removed or renamed this section); existing FIDELITY note claimed H4 but unverifiable today | sandbox uses H3 — leave as-is until real BT shows it again | 🟡 |
-| Location accordion heading | not visible in v=91 probe — same caveat as More Details | sandbox uses H3 — leave as-is | 🟡 |
+| More Details accordion heading | `<h4>` 16/700 #333 (re-probed v=107 dealer Catalina 355) | sandbox `<h4>` 16/700 (v=105) | ✅ |
+| Location accordion heading | `<h4>` 16/700 #333 (re-probed v=107) | sandbox `<h4>` 16/700 (v=105) | ✅ |
+| Accommodations subhead under Measurements | `<h4>` 14/700 #333 (re-probed v=107) | sandbox `<h4>` 14/700 (v=105 — derived cabin/berth counts from length) | ✅ |
+| `.next-previous` always-sticky bar | 1600×54 position:sticky top:0 z:110 bg #f7f7f7 padding 5px 20px — Back-to-Search + breadcrumb + listing info (stacked) + Save + Offered By + Next Boat | sandbox `.next-previous` (v=105) with column-stacked rows (v=106) | ✅ |
+| Dealer contact card heading | `<h3>` 18/500 #303030 (dealer: "Contact <Salesperson>", private: "Contact Private Seller") | sandbox `<h3 class="dealer-card-heading">` 18/500 #303030 (v=105 flipped H2→H3; v=107 simplified private path) | ✅ |
+| Dealer name + phone sublines under salesperson H3 | inline name+city + phone-link rows (dealer-only) | sandbox `.dealer-card-subline` rows (v=107) | ✅ |
+| "Meet Your Seller" H2 above contact card | **not present** on either listing (re-probed dealer + private) | removed in v=105 (v=104 added based on stale measurement) | ✅ |
+| H1 length suffix | sibling `<span>` "| <N>'" after H1, 20/700 #333 | sandbox `<span class="bdp-length">` inside H1 (v=107 restored; v=104 had removed) | ✅ |
+| "Listed By" section | **not present** on either listing | removed in v=105 (dealer info now lives in contact card + sticky-bar Offered-By) | ✅ |
+| "Key Features" H3 | **not present** on real BT | removed in v=105 (feature `<ul>` kept as part of Description body) | ✅ |
+| ✦ sparkle prefix on "What Owners Say" | not present on real BT (plain "What Owners Sayinfo") | removed in v=105 | ✅ |
+| "More From This Dealer" heading | `<h4>` 20/700 #414d4a (dealer-only) | sandbox `<h4 class="more-from-dealer-h2">` 20/700 #414d4a (v=105 flipped H2→H4) | ✅ |
+| "Still have a question?" heading | `<h3>` 24/700 #303030 | sandbox `<h3 class="question-card-h2">` 24/700 #303030 (v=105 flipped H2→H3) | ✅ |
+| Right-rail dealership-card (separate logo + stats block) | **not present** on real BT (dealer info integrated above) | `.bdp-dealership-card` wrapped in `{% if false %}` (v=107) | ✅ |
 | Description / Measurements / Propulsion accordion headings | `<h3>` 16/700 #333 (verified) | sandbox `<h3>` 16/700 #333 | ✅ |
 | Dimensions / Weights / Tanks subheadings | `<h4>` 14/700 (verified) | sandbox `<h4>` (already matches) | ✅ |
 | Boat Details / What Owners Say section headers | `<h2>` 20/700 (verified) | sandbox already H2 | ✅ |
@@ -309,27 +333,23 @@ Calculator" (18/700 #303030), then a result row.
 - ✅ ~~BDP content area width~~ — fixed in v=91 via `.bdp-grid { max-width: 1336px }`.
 - 🚫 **Real photos vs SVG placeholder boats**: out-of-scope per `SCOPE.md` —
   sandbox uses procedural SVG by design. Re-classified from 🟡.
-- 🟡 **More Details / Location H-level in Boat Details accordion**: real BT
-  doesn't currently render these headings on probed listings — earlier
-  claim that real BT uses H4 is unverifiable today. Sandbox uses H3.
-  Re-probe + decide once real BT shows these sections again.
+- ✅ ~~More Details / Location H-level~~ — re-probed v=107 on dealer +
+  private listings: both render H4 16/700 #333. Sandbox flipped H3→H4
+  in v=105.
 - ✅ ~~Thumbnail size~~ — auto-fixed by v=91's `.bdp-grid max-width`.
 - ✅ ~~Per-tile geometry on Home page rails~~ — measured in v=93. Real BT
   uses 363×120 boat-listing cards, 266×161 brand tiles, 325×317 article
   cards. Sandbox card-grid pattern matches within typical render
   variance; corpus documents the spec for future verification.
-- 🟡 **BDP `.next-previous` sticky navigation bar**: Real BT renders a
-  1512×54 ALWAYS-sticky bar at top:0 with Previous Boat / Next Boat
-  links. Sandbox doesn't have this widget; instead it has a different
-  sticky pattern (`.bdp-scrolled` body class after 320px scroll for a
-  title+price+contact bar). Different concept — decide whether to add
-  the next-previous widget or accept the divergence.
-- 🟡 **Listing-dependent BDP elements**: Similar Boats rail and
-  Show-Phone button are present on some listings (dealer) and absent on
-  others (private seller). Need a dedicated dealer-listing probe pass
-  to measure these. Sandbox always renders both — divergence from
-  real BT's conditional rendering is functional (agent training fine)
-  but visually divergent.
+- ✅ ~~BDP `.next-previous` sticky navigation bar~~ — added in v=105
+  with v=106 layout fix. Position:sticky top:0, h=54, bg #f7f7f7,
+  z:110, padding 5px 20px; stacked breadcrumb + listing-info rows;
+  "Offered By: <dealer>" tag on dealer listings.
+- ✅ ~~Listing-dependent BDP elements~~ — "More From This Dealer"
+  carousel gated by `is_owner_listed` (dealer-only). "Listed By"
+  section deleted entirely. Show Phone retained as cookie-gated
+  interaction surface on private listings (kept for agent training
+  even though real BT private listings often render without it).
 - 🟡 **Mobile viewport**: no mobile pass yet. CSS has `@media (max-width: 980px)`
   responsive rules but they're not verified against real BT mobile rendering.
 
@@ -440,6 +460,105 @@ Calculator" (18/700 #303030), then a result row.
          + blank placeholder (test_filter_panel_fidelity.py now 26 passing)
        • `.ai-search-v2__try-prefix` kept as a legacy alias for the
          non-rotating prefix used elsewhere (e.g. home hero search)
+`v=107` BDP exact-mirror — round 3 (H1 length-suffix span + dealer-card sublines):
+       • H1 length-suffix re-added as a sibling SPAN inside the H1
+         tag (`<h1>{title}<span class="bdp-length"> | {len}'</span></h1>`).
+         Real BT's pattern is identical but with the SPAN as a true
+         sibling outside H1; visually equivalent and the simpler
+         child-span markup avoids extra DOM nodes. v=104 over-
+         corrected by removing the suffix entirely.
+       • Dealer card restructured: removed the headshot SVG + flex
+         `.dealer-card-meta` row; added `.dealer-card-subline` rows
+         for `{dealer.name} - {dealer.city}` (#303030 14/400) and
+         `{dealer.phone}` (clickable `tel:` link, blue) directly
+         under the salesperson H3, matching real BT's pattern
+         exactly (verified on 2024 Catalina 355).
+       • Private contact form simplified: removed the message
+         `<textarea>` and the .lead-row Email+Phone wrapper (real BT
+         private form is plain stack Name/Email/Phone/Submit). Show
+         Phone button retained as a cookie-gated interaction surface
+         for agent training.
+       • Separate right-rail `.bdp-dealership-card` (logo + active/
+         sold stats block) wrapped in `{% if false %}` — real BT
+         doesn't render a separate dealership card; dealer info
+         lives in the contact card body + the `.next-previous-
+         offered-by` tag inside the sticky bar.
+       • Cache-buster bumped to `?v=107`.
+       • 13 new fidelity tests covering all v=105..v=107 deltas.
+         Suite now **82 passing**. Two stale v=104 tests rewritten:
+         `test_bdp_h1_has_no_length_suffix` → `test_bdp_h1_has_length_
+         suffix_span`; `test_bdp_has_meet_your_seller_heading` →
+         `test_bdp_has_no_meet_your_seller_heading`.
+`v=106` `.next-previous` sticky bar layout fix (per user screenshot):
+       • v=105 shipped the new always-sticky bar but
+         `.next-previous-info-container` defaulted to `display: flex;
+         align-items: center` which put the breadcrumb and the
+         listing-info row side-by-side on one line (user feedback:
+         "this is not at all what the section above the image looks
+         like").
+       • Changed to `flex-direction: column; align-items: flex-start;
+         justify-content: center; gap: 2px; height: 100%` so the
+         breadcrumb sits on the top row (y≈219) and the listing
+         name/price/location row sits beneath (y≈249), matching
+         real BT's stacked-rows pattern.
+       • Cache-buster bumped to `?v=106`.
+`v=105` BDP exact-mirror — round 1 (heading hierarchy + cleanup):
+       Re-probed real BT on 2024-05-24 at 1440×900 against TWO
+       listings to nail down the deltas v=104's single probe missed:
+       dealer 2024 Catalina 355 (real BT) + private 2015 Pioneer 197
+       Sportfish (real BT). Confirmed pattern across BOTH listing
+       types, then landed the following structural changes:
+       • Removed `<h2 class="meet-your-seller-h2">Meet Your Seller</h2>`
+         — v=104 added this based on a stale measurement. Re-probe
+         showed NO Meet-Your-Seller heading on either dealer or
+         private listings on real BT. Selector commented out in CSS.
+       • Dealer contact card heading: `<h2>` → `<h3>` (already styled
+         18/500 #303030 via `.dealer-card-heading`).
+       • Private contact card heading: changed from "Contact
+         `{owner_name}`, the owner" to generic "Contact Private
+         Seller" (real BT private uses generic phrasing).
+       • Removed `private-seller-tag` "Private Seller" div and
+         `private-seller-note` disclaimer paragraph (real BT private
+         doesn't render either).
+       • Boat Details accordion heading levels:
+         * "More Details" `<h3>` → `<h4>` (real BT renders at 16/700)
+         * "Location" `<h3>` → `<h4>` (real BT renders at 16/700)
+         * Added "Accommodations" `<h4>` 14/700 #333 under
+           Measurements alongside Dimensions / Weights / Tanks
+           (real BT has it; sandbox derives cabin/berth counts from
+           length).
+       • "Still have a question?" `<h2>` → `<h3>` (24/700 #303030 per
+         real BT).
+       • "More From This Dealer" `<h2>` → `<h4>` with color #414d4a
+         (real BT carousel-section heading uses this special color).
+       • "More From This Dealer" section wrapped in
+         `{% if not boat.is_owner_listed %}` so it only renders on
+         dealer listings (matches real BT — private listings don't
+         have this rail).
+       • Deleted the entire `.bdp-listed-by` section (both dealer
+         and private paths). Real BT does NOT render a separate
+         Listed By section on either listing type — dealer identity
+         is conveyed via the contact card + the `.next-previous-
+         offered-by` tag in the sticky bar.
+       • Removed "Key Features" `<h3>` heading from the Description
+         accordion (real BT doesn't render this heading). Feature
+         `<ul>` body kept as part of the Description.
+       • Removed `<span class="sparkle-icon">✦</span>` prefix from
+         the "What Owners Say" `<h2>` heading. Real BT renders the
+         heading as plain text + inline info icon.
+       • Added `.next-previous` always-sticky bar at top of BDP
+         (replaces the old 320px-scroll-triggered `.bdp-sticky-bar`,
+         which is now hidden via `display: none !important`).
+         Structure: Back-to-Search button (12/400 #139af5) +
+         `.next-previous-info-container` (breadcrumb + listing
+         name/price/location) + actions (Save + Offered By tag on
+         dealer + Next Boat link). Position:sticky top:0, h:54,
+         bg #f7f7f7, z:110, padding 5px 20px. Matches real BT's
+         `.next-previous` selector measurements exactly.
+       • Hid `.bdp-nav-row` (the duplicate Back+breadcrumb+Next
+         row above the gallery) since its contents now live inside
+         `.next-previous`.
+       • Cache-buster bumped to `?v=105`.
 `v=104` BDP visual/perceptual compare — dealer + owner (user request):
        • Probed real BT private listings (President Trawler + Pioneer
          Sportfish + Sea Fox + Yamaha — all rendered as private with

--- a/deploy/sim_envs/mantis_boattrader/FIDELITY.md
+++ b/deploy/sim_envs/mantis_boattrader/FIDELITY.md
@@ -3,33 +3,46 @@
 Working doc tracking each element's match status against
 `https://www.boattrader.com/`. Update as iterations land.
 
-Last updated: **v=117** (2026-05-24) — BDP exact-mirror saga
-(v=105..v=117, 11 deploys across 6 rounds). Re-probed real BT
-dealer (2024 Catalina 355) + private (2015 Pioneer 197 Sportfish)
-at 1440×900 and landed structural deltas in 6 iteration rounds —
-including 3 prompted by user screenshot feedback.
+Last updated: **v=121** (2026-05-24) — BDP exact-mirror marathon
+(v=105..v=121, 15 deploys across 8 rounds). Re-probed real BT
+dealer (2024 Catalina 355), private (2015 Pioneer 197 Sportfish),
+and Pursuit 3070 listings at 1440×900 and landed structural
+deltas in 8 iteration rounds — 6 prompted by user screenshot
+feedback (sticky-bar layout, white margins, light-blue card bgs +
+✦ sparkle, gradient page wrapper, white gutter on ad strip,
+stats-strip → owners-card gap, loan-calc design, breadcrumb font).
 
-Round 1 (v=105): heading hierarchy + cleanup. Round 2 (v=106): sticky-
-bar layout fix per user screenshot. Round 3 (v=107): H1 length-suffix
-span restored + dealer-card sublines + dealership-card hidden.
-Round 4 (v=108–v=109): simplified sticky bar to `‹ Search /
-breadcrumb / Prev / Next` per user screenshot, inner-wrapper
-constraint (max-width 1400px + margin 0 80px); v=110/v=111 white-
-wash regressed and were reverted in v=112 (light-blue `#f5f9ff`
-restored on Owners/Boat Details/More-From-Dealer + ✦ sparkle re-
-added). v=113 sticky-bar full-viewport bleed (100vw + neg margin).
-v=114 top-section polish: removed sticky-bar border-bottom, removed
-ad-strip 24px margin, added accordion-body white nested-card chrome,
-fixed `.bdp-price` to 20/700, H1 margin → 0, added Boat Details
-border-bottom. Round 5 (v=115): right-rail width 366px → 400px.
-Round 6 (v=116–v=117): ad-strip full-viewport bleed; engagement row
-simplified to plain "Views | Saves" with 1×12px #dee2e3 divider
-(removed icons + Listed/days-ago row).
+Recent rounds:
+- Round 7 (v=118): stripped `.bdp-question-card` chrome (white bg,
+  border, padding) — real BT renders inline on page bg.
+- Round 8 (v=119): tightened stats-strip → owners-card gap from
+  118px to ~32px to match real BT; added 1px #ededed border to
+  `.bdp-owners-card` per real BT probe.
+- Round 8 (v=120): loan calculator redesigned to match real BT:
+  Loan Term (Months) field replaces Credit Score (FICO); right
+  pane stripped to centered heading + huge 64/700 $monthly +
+  TOTAL LOAN AMOUNT + divider + See Important Disclosure (removed
+  APR, 180 MONTHS, Get-Pre-Qualified button, pre-qualified
+  bullets). 12px border-radius outer card with overflow:hidden so
+  the white form + light-blue preview share corners cleanly.
+- Round 8 (v=121): breadcrumb font 15/400 #333 → **12/400 #616161**
+  per user screenshot — v=109's enlarged values mistook the
+  `.next-previous-info-container` wrapper computed style for the
+  actual `.breadcrumb` UL.
 
 Suite **83 passing** (16 new BDP tests).
 
+v=118 stripped `.bdp-question-card` chrome (real BT inline on page bg).
+v=119 stats-strip / owners-card gap fix (118px → 32px) + owners-card
+border + removed strip's spurious border-bottom.
+v=120 loan calc redesign — Loan Term field replaces FICO; right
+pane stripped to monthly + total + disclosure.
+v=121 breadcrumb 15/400 #333 → 12/400 #616161 per user screenshot.
+v=122 `.bdp-details-section` border-bottom → full border (1px
+#ededed on all 4 sides) per real BT probe.
+
 Live URL: `https://8080-014f48ab-eeb1-4ca5-947e-42e169d1fcc8.daytonaproxy01.net/boats/`
-(token rotates per sandbox restart; current: `a_oh4hg7awgeznbwwglbfml0sdlrywzw`)
+(token rotates per sandbox restart; current: `syyxwc54axpktn5xcpo91iedvskoeqhv`)
 
 ## Methodology
 

--- a/deploy/sim_envs/mantis_boattrader/app/static/app.css
+++ b/deploy/sim_envs/mantis_boattrader/app/static/app.css
@@ -2305,11 +2305,13 @@ body.bdp-scrolled .bdp-sticky-bar { display: none !important; }
 /* ── More From This Dealer rail ───────────────────────────────
    v=112: REVERTED v=110/111. Match the light-blue card pattern
    per real BT (probed v=112 — same #f5f9ff family). */
+/* v=127: tightened bottom margin (24px → 8px) — was creating
+   ~116px gap to .bdp-question-card. */
 .bdp-more-from-dealer {
   background: #f5f9ff;
   border-radius: 8px;
-  padding: 24px 28px 18px;
-  margin: 24px 0;
+  padding: 24px 28px 12px;
+  margin: 24px 0 8px;
 }
 /* v=105: Real BT renders this heading as H4 (carousel section title)
    with 20/700 and a distinctive teal-grey #414d4a, not the body
@@ -2397,17 +2399,15 @@ body.bdp-scrolled .bdp-sticky-bar { display: none !important; }
 }
 
 /* ── Still have a question? card ──────────────────────────── */
-/* v=126: tightened margins + reduced body/button font-size per user
-   screenshot. Body text was 18px (now 15px), button was 20px (now
-   14px), section margin was 24px 0 (now 12px 0), paragraph spacing
-   was 0 0 18px (now 0 0 8px). Rule underline width 60px → 40px and
-   bottom margin tightened. */
+/* v=127: tightened further — padding 24px 0 → 8px 0, margin 12px 0
+   → 0 — eliminates the rest of the ~116px gap user pointed out
+   between More-From-Dealer and Still-have-a-question. */
 .bdp-question-card {
   background: transparent;
   border: 0;
   border-radius: 0;
-  padding: 24px 0;
-  margin: 12px 0;
+  padding: 8px 0;
+  margin: 0;
 }
 .question-card-h2 {
   font-size: 24px;
@@ -2440,10 +2440,10 @@ body.bdp-scrolled .bdp-sticky-bar { display: none !important; }
 }
 
 /* ── OTHER SERVICES tiles ─────────────────────────────────── */
-/* v=126: tighter margin (was 24px 0) — reduces whitespace between
-   "Still have a question?" and OTHER SERVICES sections. */
+/* v=127: removed top margin entirely (sat just under .bdp-question-
+   card with its 8px padding-bottom + 18px border-top padding). */
 .bdp-other-services {
-  margin: 12px 0 24px;
+  margin: 0 0 24px;
   padding-top: 18px;
   border-top: 1px solid var(--bt-border);
 }

--- a/deploy/sim_envs/mantis_boattrader/app/static/app.css
+++ b/deploy/sim_envs/mantis_boattrader/app/static/app.css
@@ -2663,12 +2663,15 @@ body.bdp-scrolled .bdp-sticky-bar { display: none !important; }
 .trusted-partner strong { color: var(--bt-navy); }
 .dealer-lead-form { display: flex; flex-direction: column; gap: 8px; }
 /* Real BT lead form input: 40px tall, 4px radius, 1px #c2c2c2 border,
-   8px 12px 4px padding (asymmetric so floating label sits properly). */
+   8px 12px 4px padding (asymmetric so floating label sits properly).
+   v=124: explicit transparent bg to match real BT input bg
+   (rgba(0,0,0,0)) — browser default would be white. */
 .lead-input, .lead-textarea {
   width: 100%; border: 1px solid #c2c2c2;
   border-radius: 4px; padding: 8px 12px 4px; font: inherit; font-size: 14px;
   color: var(--bt-text);
   height: 40px;
+  background: transparent;
   box-sizing: border-box;
 }
 .lead-textarea { height: auto; padding: 10px 12px; }

--- a/deploy/sim_envs/mantis_boattrader/app/static/app.css
+++ b/deploy/sim_envs/mantis_boattrader/app/static/app.css
@@ -1621,7 +1621,7 @@ body.bdp-scrolled .bdp-sticky-bar { display: none !important; }
 /* Real BT BDP uses ~890 gallery + ~80 gap + 366 rail at 1512 viewport.
    That's ratio gallery:rail ≈ 2.43:1, with ~80px gap. */
 .bdp-grid {
-  display: grid; grid-template-columns: 1fr 366px; gap: 80px;
+  display: grid; grid-template-columns: 1fr 400px; gap: 80px;
   align-items: start;
   /* Real BT's BDP renders at ~1319px content area (left col 890 + 79
      gap + right col 334). Cap at 1336 to match — also auto-shrinks
@@ -1637,7 +1637,7 @@ body.bdp-scrolled .bdp-sticky-bar { display: none !important; }
 .bdp-grid-stack {
   position: relative;
   grid-template-columns: minmax(0, 1fr);
-  padding-right: calc(366px + 80px);
+  padding-right: calc(400px + 80px);
 }
 .bdp-grid-stack > .bdp-gallery,
 .bdp-grid-stack > .bdp-stats-strip,
@@ -1669,7 +1669,7 @@ body.bdp-scrolled .bdp-sticky-bar { display: none !important; }
   position: absolute;
   top: 0;
   right: 0;
-  width: 366px;
+  width: 400px;
   margin: 0;
 }
 /* Real BT BDP main gallery image: 3:2 aspect ratio (890×593 at width 890,

--- a/deploy/sim_envs/mantis_boattrader/app/static/app.css
+++ b/deploy/sim_envs/mantis_boattrader/app/static/app.css
@@ -2070,12 +2070,14 @@ body.bdp-scrolled .bdp-sticky-bar { display: none !important; }
 /* ── Boat Details accordion ───────────────────────────────────
    v=114: added `border-bottom: 1px solid #ededed` per real BT's
    `.accordion-details-section` probe (bb: 1px solid #ededed). */
+/* v=122: real BT `.accordion-details-section` has full 1px solid
+   #ededed border (all 4 sides), not just border-bottom. */
 .bdp-details-section {
   background: #f5f9ff;
+  border: 1px solid #ededed;
   border-radius: 8px;
   padding: 20px 16px;
   margin: 24px 0;
-  border-bottom: 1px solid #ededed;
 }
 .bdp-details-h2 {
   font-size: 20px;

--- a/deploy/sim_envs/mantis_boattrader/app/static/app.css
+++ b/deploy/sim_envs/mantis_boattrader/app/static/app.css
@@ -1648,11 +1648,15 @@ body.bdp-scrolled .bdp-sticky-bar { display: none !important; }
 
 /* Stacked variant: all sections live in column 1 stacked vertically.
    The .bdp-summary aside is positioned absolutely over the right rail
-   so its tall content doesn't blow up the gallery row's height. */
+   so its tall content doesn't blow up the gallery row's height.
+   v=128: row-gap: 0 to override the inherited `gap: 80px` from
+   `.bdp-grid` — that was adding 80px between every section vertically
+   (caught between More-From-Dealer and Still-have-a-question). */
 .bdp-grid-stack {
   position: relative;
   grid-template-columns: minmax(0, 1fr);
   padding-right: calc(400px + 80px);
+  row-gap: 0;
 }
 .bdp-grid-stack > .bdp-gallery,
 .bdp-grid-stack > .bdp-stats-strip,

--- a/deploy/sim_envs/mantis_boattrader/app/static/app.css
+++ b/deploy/sim_envs/mantis_boattrader/app/static/app.css
@@ -1450,18 +1450,18 @@ header.main {
 .bdp-sticky-bar,
 body.bdp-scrolled .bdp-sticky-bar { display: none !important; }
 
-/* ── `.next-previous` always-sticky bar (v=105) ────────────────────
-   Real BT: position:sticky top:0, full viewport width, h=54, padding
-   5px 20px, bg #f7f7f7, z:110, fs 15/400 #333. Holds Back-to-Search
-   (link 12/400 #139af5) + listing info (12/400 #616161) +
-   Next-Boat link + "Offered By: <dealer>" label on dealer listings. */
+/* ── `.next-previous` always-sticky bar (v=109: inner-wrapper
+   constraint to match real BT exactly) ────────────────────────────
+   Outer bar: full-viewport-width, bg #f7f7f7, sticky top:0, z:110,
+   padding 5px 20px (the bar bleeds full-width via negative margin
+   so its bg covers edge to edge inside the constrained .bt-main).
+   Inner wrapper: max-width 1400px, margin 0 80px — matches real
+   BT's layout pattern that places "‹ Search" at x≈100 from the
+   viewport edge at 1600px viewport. */
 .next-previous {
   position: sticky;
   top: 0;
   z-index: 110;
-  display: flex;
-  align-items: center;
-  gap: 16px;
   width: 100%;
   height: 54px;
   margin: 0 calc(50% - 50vw);
@@ -1471,6 +1471,19 @@ body.bdp-scrolled .bdp-sticky-bar { display: none !important; }
   font-weight: 400;
   color: #333;
   border-bottom: 1px solid #ededed;
+}
+.next-previous-inner {
+  max-width: 1400px;
+  margin: 0 80px;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+@media (max-width: 1280px) {
+  /* Below 1280px viewport the 80px side margins are excessive — fall
+     back to a more compact 16px gutter so the bar doesn't crowd out. */
+  .next-previous-inner { margin: 0 auto; }
 }
 .next-previous-button {
   display: inline-flex;
@@ -1485,83 +1498,27 @@ body.bdp-scrolled .bdp-sticky-bar { display: none !important; }
 }
 .next-previous-button:hover { text-decoration: underline; }
 .next-previous-back { padding-left: 0; }
-.next-previous-next { padding-right: 0; }
-.next-previous-info-container {
-  position: relative;
+.next-previous-next { padding-right: 0; margin-left: 16px; }
+.next-previous-prev { padding-right: 15px; }
+.next-previous-breadcrumb {
   flex: 1;
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  justify-content: center;
-  gap: 2px;
-  margin: 0 10px;
-  min-width: 0;
-  height: 100%;
-}
-.next-previous-info {
-  display: flex;
-  gap: 12px;
-  align-items: baseline;
-  font-size: 12px;
+  font-size: 15px;
   font-weight: 400;
-  color: #616161;
+  color: #333;
   white-space: nowrap;
   overflow: hidden;
-  max-width: 100%;
-}
-.next-previous-listing-name {
-  font-size: 12px;
-  font-weight: 700;
-  color: #303030;
   text-overflow: ellipsis;
-  overflow: hidden;
+  margin: 0 10px;
+  padding: 0;
 }
-.next-previous-listing-price {
-  font-size: 12px;
-  font-weight: 700;
-  color: #303030;
-}
-.next-previous-listing-loc {
-  font-size: 12px;
-  font-weight: 400;
-  color: #616161;
-}
+.next-previous-breadcrumb a { color: #333; text-decoration: none; }
+.next-previous-breadcrumb a:hover { color: var(--bt-blue); text-decoration: underline; }
 .next-previous-actions {
   display: flex;
   align-items: center;
-  gap: 16px;
+  gap: 0;
   flex-shrink: 0;
 }
-.next-previous-save {
-  background: transparent;
-  border: 0;
-  font: inherit;
-  font-size: 12px;
-  font-weight: 400;
-  color: #139af5;
-  cursor: pointer;
-  padding: 0;
-  white-space: nowrap;
-}
-.next-previous-save:hover { text-decoration: underline; }
-.next-previous-offered-by {
-  font-size: 12px;
-  font-weight: 400;
-  color: #616161;
-}
-.next-previous-offered-by strong { color: #303030; }
-.next-previous-breadcrumb {
-  font-size: 12px;
-  font-weight: 400;
-  color: #616161;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  max-width: 100%;
-  margin: 0;
-}
-.next-previous-breadcrumb a { color: #616161; text-decoration: none; }
-.next-previous-breadcrumb a:hover { color: var(--bt-blue); text-decoration: underline; }
 
 /* v=105: `.bdp-nav-row` hidden — breadcrumb + Back/Next links live
    in the always-sticky `.next-previous` bar (matches real BT). */

--- a/deploy/sim_envs/mantis_boattrader/app/static/app.css
+++ b/deploy/sim_envs/mantis_boattrader/app/static/app.css
@@ -1796,41 +1796,34 @@ body.bdp-scrolled .bdp-sticky-bar { display: none !important; }
   cursor: help;
 }
 .bdp-customize-link { color: var(--bt-blue); font-weight: 500; font-size: 16px; }
+/* v=117: simplified to match real BT `.listing-engagement-indicators`:
+   plain Views | Saves with a 1×12px #dee2e3 divider, 12/400 #757575,
+   container padding 11px 0, no border-top, no icons. */
 .bdp-engagement-row {
-  list-style: none;
-  padding: 12px 0 14px;
+  padding: 11px 0;
   margin: 0;
-  border-top: 1px solid var(--bt-border);
   display: flex;
-  gap: 12px;
+  gap: 10px;
   align-items: center;
   font-size: 12px;
-  color: var(--bt-text-dim);
-  flex-wrap: wrap;
+  font-weight: 400;
+  color: #757575;
 }
 .bdp-engagement-row .engagement-item {
-  display: flex;
+  display: inline-flex;
   align-items: center;
   gap: 4px;
-  position: relative;
 }
-.bdp-engagement-row .engagement-item:not(:last-child)::after {
-  content: "|";
-  color: var(--bt-border);
-  margin-left: 12px;
-  font-weight: 300;
+.listing-engagement-indicators__divider {
+  display: inline-block;
+  width: 1px;
+  height: 12px;
+  background: #dee2e3;
 }
-.bdp-engagement-row .ico {
-  font-size: 13px;
-  color: var(--bt-text-dim);
-  display: inline-flex; align-items: center;
-  margin-right: 4px;
-}
-.bdp-engagement-row .ico svg { display: block; }
 /* Inline phone SVG in dealer-phone link should align with the number. */
 .dealer-phone .ico-phone,
 .show-phone-btn .ico-phone { vertical-align: middle; margin-right: 4px; }
-.bdp-engagement-row strong { font-weight: 600; font-size: 12px; color: var(--bt-text); }
+.bdp-engagement-row strong { font-weight: 700; font-size: 12px; color: #303030; }
 .visit-seller-link {
   display: inline-block;
   margin: 14px 0;

--- a/deploy/sim_envs/mantis_boattrader/app/static/app.css
+++ b/deploy/sim_envs/mantis_boattrader/app/static/app.css
@@ -2666,7 +2666,11 @@ body.bdp-scrolled .bdp-sticky-bar { display: none !important; }
   border-radius: 3px;
 }
 
-.bdp-dealer-card { border-top: 1px solid var(--bt-border); padding-top: 14px; }
+/* v=132: removed `border-top: 1px solid` per user screenshot — real BT
+   doesn't render a divider line between the engagement row and the
+   contact card. The dealer card sits flush. */
+.bdp-dealer-card { padding-top: 14px; }
+.bdp-private-seller-card { padding-top: 14px; }
 /* Real BT contact card heading (dealer + private): H3 18/500 #303030. */
 /* v=125: heading color #303030 → #1a2022 per real BT probe (rgb(26,32,34)). */
 .dealer-card-heading { font-size: 18px; font-weight: 500; color: #1a2022; margin: 0 0 4px; }

--- a/deploy/sim_envs/mantis_boattrader/app/static/app.css
+++ b/deploy/sim_envs/mantis_boattrader/app/static/app.css
@@ -405,12 +405,23 @@ header.main {
 /* v=114: removed `margin: 24px 0` on .ad-strip — real BT renders the
    top ad flush against the page header above and the .next-previous
    sticky bar below (probed margin: 0). The 24px margin was creating
-   visible white-grey transitions in the screenshot. */
+   visible white-grey transitions in the screenshot.
+   v=116: bleed bg full viewport width using the same trick as
+   `.next-previous` and `.boat-details-gradient`. Default `.ad-strip`
+   sits INSIDE `.bt-main` (max-width 1440px) which constrained the
+   grey #f7f7f7 bg to 1440px, leaving white gutters on wider
+   viewports (user screenshot shows ~80px white margins on each
+   side at a wider viewport). The 100vw + negative margin pattern
+   makes the bg span edge-to-edge while the ad image stays centered
+   via the flex justify-content. */
 .ad-strip {
   background: #f7f7f7;
   padding: 16px 0;
   display: flex; justify-content: center;
   margin: 0;
+  width: 100vw;
+  margin-left: calc(-50vw + 50%);
+  box-sizing: border-box;
 }
 .ad-banner {
   position: relative; max-width: 728px; width: 100%; height: 90px;
@@ -1661,9 +1672,15 @@ body.bdp-scrolled .bdp-sticky-bar { display: none !important; }
 }
 /* Make ad-strip inside the left col compact (it was full-page padding before). */
 /* v=114: inside `.bdp-grid-stack` (left column) keep ads transparent
-   and unmargined (mid-page leaderboard sits flush). Outside the grid
-   (top/bottom strips) keep the #f7f7f7 grey strip with 16px 0 padding. */
-.bdp-grid-stack > .ad-strip { margin: 0; padding: 0; background: transparent; }
+   and unmargined (mid-page leaderboard sits flush). v=116: also
+   reset the 100vw bleed (mid-page ads stay inside the grid column). */
+.bdp-grid-stack > .ad-strip {
+  margin: 0;
+  padding: 0;
+  background: transparent;
+  width: auto;
+  margin-left: 0;
+}
 .bdp-grid-stack > .ad-strip .ad-banner { max-width: 100%; }
 .bdp-grid-stack > .bdp-summary {
   position: absolute;

--- a/deploy/sim_envs/mantis_boattrader/app/static/app.css
+++ b/deploy/sim_envs/mantis_boattrader/app/static/app.css
@@ -1144,15 +1144,11 @@ header.main {
 .apply-filters { margin: 18px 0 10px; }
 .filter-clear { display: block; text-align: center; font-size: 14px; margin: 0 0 8px; }
 
-/* "Meet Your Seller" h2 above the BDP contact card (v=104) —
-   matches real BT's 20/700 #404040 heading that appears before
-   the seller info on both private + dealer listings. */
-.meet-your-seller-h2 {
-  font-size: 20px;
-  font-weight: 700;
-  color: #404040;
-  margin: 24px 0 12px;
-}
+/* v=105: removed `.meet-your-seller-h2` — re-probed real BT BDPs
+   (both dealer 2024 Catalina 355 and private 2015 Pioneer 197) show
+   NO "Meet Your Seller" heading above the contact card. v=104's
+   addition was based on a stale measurement. Selector kept commented
+   for historical reference only. */
 
 /* ── Cookie consent banner (v=103) ─────────────────────────────────
    Shown on first visit only (server-rendered conditional in base.html
@@ -1447,17 +1443,129 @@ header.main {
 
 /* ── Boat Detail Page (BDP) ───────────────────────────────────── */
 
-/* Sticky header bar — slides in on scroll. */
-.bdp-sticky-bar {
+/* v=105: `.bdp-sticky-bar` (the 320px-scroll-triggered sticky) is
+   replaced by `.next-previous` (always-sticky, matches real BT). Old
+   selector kept but hidden so any residual JS toggling `bdp-scrolled`
+   doesn't reveal a duplicate bar. */
+.bdp-sticky-bar,
+body.bdp-scrolled .bdp-sticky-bar { display: none !important; }
+
+/* ── `.next-previous` always-sticky bar (v=105) ────────────────────
+   Real BT: position:sticky top:0, full viewport width, h=54, padding
+   5px 20px, bg #f7f7f7, z:110, fs 15/400 #333. Holds Back-to-Search
+   (link 12/400 #139af5) + listing info (12/400 #616161) +
+   Next-Boat link + "Offered By: <dealer>" label on dealer listings. */
+.next-previous {
   position: sticky;
   top: 0;
-  background: rgba(255, 255, 255, 0.98);
-  z-index: 100;
-  border-bottom: 1px solid var(--bt-border);
+  z-index: 110;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  width: 100%;
+  height: 54px;
   margin: 0 calc(50% - 50vw);
-  display: none;
+  padding: 5px 20px;
+  background: #f7f7f7;
+  font-size: 15px;
+  font-weight: 400;
+  color: #333;
+  border-bottom: 1px solid #ededed;
 }
-body.bdp-scrolled .bdp-sticky-bar { display: block; }
+.next-previous-button {
+  display: inline-flex;
+  align-items: center;
+  font-size: 12px;
+  font-weight: 400;
+  color: #139af5;
+  padding: 11px 15px;
+  border-radius: 4px;
+  white-space: nowrap;
+  text-decoration: none;
+}
+.next-previous-button:hover { text-decoration: underline; }
+.next-previous-back { padding-left: 0; }
+.next-previous-next { padding-right: 0; }
+.next-previous-info-container {
+  position: relative;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: center;
+  gap: 2px;
+  margin: 0 10px;
+  min-width: 0;
+  height: 100%;
+}
+.next-previous-info {
+  display: flex;
+  gap: 12px;
+  align-items: baseline;
+  font-size: 12px;
+  font-weight: 400;
+  color: #616161;
+  white-space: nowrap;
+  overflow: hidden;
+  max-width: 100%;
+}
+.next-previous-listing-name {
+  font-size: 12px;
+  font-weight: 700;
+  color: #303030;
+  text-overflow: ellipsis;
+  overflow: hidden;
+}
+.next-previous-listing-price {
+  font-size: 12px;
+  font-weight: 700;
+  color: #303030;
+}
+.next-previous-listing-loc {
+  font-size: 12px;
+  font-weight: 400;
+  color: #616161;
+}
+.next-previous-actions {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-shrink: 0;
+}
+.next-previous-save {
+  background: transparent;
+  border: 0;
+  font: inherit;
+  font-size: 12px;
+  font-weight: 400;
+  color: #139af5;
+  cursor: pointer;
+  padding: 0;
+  white-space: nowrap;
+}
+.next-previous-save:hover { text-decoration: underline; }
+.next-previous-offered-by {
+  font-size: 12px;
+  font-weight: 400;
+  color: #616161;
+}
+.next-previous-offered-by strong { color: #303030; }
+.next-previous-breadcrumb {
+  font-size: 12px;
+  font-weight: 400;
+  color: #616161;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+  margin: 0;
+}
+.next-previous-breadcrumb a { color: #616161; text-decoration: none; }
+.next-previous-breadcrumb a:hover { color: var(--bt-blue); text-decoration: underline; }
+
+/* v=105: `.bdp-nav-row` hidden — breadcrumb + Back/Next links live
+   in the always-sticky `.next-previous` bar (matches real BT). */
+.bdp-nav-row { display: none !important; }
 .bdp-sticky-bar-inner {
   max-width: var(--container);
   margin: 0 auto;
@@ -1904,6 +2012,9 @@ body.bdp-scrolled .bdp-sticky-bar { display: block; }
   color: var(--bt-text);
   margin: 0 0 12px;
 }
+/* v=105: `.sparkle-icon` is no longer used on the BDP — real BT does
+   not render a sparkle prefix on "What Owners Say". Selector kept
+   for any other future use. */
 .sparkle-icon {
   color: var(--bt-blue);
   font-size: 18px;
@@ -2189,10 +2300,13 @@ body.bdp-scrolled .bdp-sticky-bar { display: block; }
   padding: 24px 28px 18px;
   margin: 24px 0;
 }
+/* v=105: Real BT renders this heading as H4 (carousel section title)
+   with 20/700 and a distinctive teal-grey #414d4a, not the body
+   #333. Tag flipped in boat_detail.html; color updated here. */
 .more-from-dealer-h2 {
   font-size: 20px;
   font-weight: 700;
-  color: var(--bt-text);
+  color: #414d4a;
   margin: 0 0 16px;
 }
 .more-from-dealer-rail-wrap {
@@ -2515,7 +2629,13 @@ body.bdp-scrolled .bdp-sticky-bar { display: block; }
 }
 
 .bdp-dealer-card { border-top: 1px solid var(--bt-border); padding-top: 14px; }
-.dealer-card-heading { font-size: 18px; font-weight: 500; color: var(--bt-text); margin: 0 0 10px; }
+/* Real BT contact card heading (dealer + private): H3 18/500 #303030. */
+.dealer-card-heading { font-size: 18px; font-weight: 500; color: #303030; margin: 0 0 4px; }
+/* v=107: dealer subline rows (dealer name + city, phone) — sit
+   directly under the salesperson H3, matching real BT pattern. */
+.dealer-card-subline { display: block; font-size: 14px; line-height: 1.4; margin: 0 0 2px; color: #303030; }
+.dealer-card-subline.dealer-card-phone { color: var(--bt-blue); font-weight: 400; margin: 0 0 12px; text-decoration: none; }
+.dealer-card-subline.dealer-card-phone:hover { text-decoration: underline; }
 .dealer-card-meta { display: flex; gap: 12px; align-items: center; margin: 0 0 12px; }
 .dealer-logo {
   width: 60px; height: 60px; border-radius: 50%;

--- a/deploy/sim_envs/mantis_boattrader/app/static/app.css
+++ b/deploy/sim_envs/mantis_boattrader/app/static/app.css
@@ -2709,11 +2709,31 @@ body.bdp-scrolled .bdp-sticky-bar { display: none !important; }
 .lead-input::placeholder, .lead-textarea::placeholder { color: #9ba5af; }
 .lead-row { display: flex; gap: 8px; }
 .lead-row .lead-input { flex: 1; min-width: 0; }
+/* v=133: BDP contact-seller submit button is a SOLID dark-navy pill
+   (not the white outline used on SRP listing cards). User screenshot
+   showed bg #082F4C (or similar very dark navy) + white text + large
+   pill radius + full-width + ~16/700 text. Overrides the outline
+   defaults from `.contact-seller-btn` via higher specificity. */
 .contact-seller-btn.btn-block {
-  padding: 10px 24px;
-  font-size: 14px;
+  background: #082F4C;
+  color: #fff;
+  border: 0;
+  padding: 16px 20px;
+  font-size: 16px;
   font-weight: 700;
   border-radius: 50px;
+  width: 100%;
+  height: auto;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1.2;
+}
+.contact-seller-btn.btn-block:hover {
+  background: #0a3d62;
+  text-decoration: none;
+  color: #fff;
 }
 
 .bdp-section { background: #fff; padding: 18px; border-bottom: 1px solid var(--bt-border); }

--- a/deploy/sim_envs/mantis_boattrader/app/static/app.css
+++ b/deploy/sim_envs/mantis_boattrader/app/static/app.css
@@ -1650,12 +1650,14 @@ body.bdp-scrolled .bdp-sticky-bar { display: none !important; }
    The .bdp-summary aside is positioned absolutely over the right rail
    so its tall content doesn't blow up the gallery row's height.
    v=128: row-gap: 0 to override the inherited `gap: 80px` from
-   `.bdp-grid` — that was adding 80px between every section vertically
-   (caught between More-From-Dealer and Still-have-a-question). */
+   `.bdp-grid` — that was adding 80px between every section vertically.
+   v=129: padding-right `480px → 510px` so gallery is 890px (not 920)
+   matching real BT exactly. Combined with `.bdp-summary right: 34px`
+   below, summary sits at x=1066 with 34px right margin to wrapper. */
 .bdp-grid-stack {
   position: relative;
   grid-template-columns: minmax(0, 1fr);
-  padding-right: calc(400px + 80px);
+  padding-right: 510px;
   row-gap: 0;
 }
 .bdp-grid-stack > .bdp-gallery,
@@ -1690,10 +1692,12 @@ body.bdp-scrolled .bdp-sticky-bar { display: none !important; }
   margin-left: 0;
 }
 .bdp-grid-stack > .ad-strip .ad-banner { max-width: 100%; }
+/* v=129: right offset 0 → 34px so summary lands at x=1066 (matching
+   real BT's 76px gap between gallery and summary). */
 .bdp-grid-stack > .bdp-summary {
   position: absolute;
   top: 0;
-  right: 0;
+  right: 34px;
   width: 400px;
   margin: 0;
 }

--- a/deploy/sim_envs/mantis_boattrader/app/static/app.css
+++ b/deploy/sim_envs/mantis_boattrader/app/static/app.css
@@ -1520,18 +1520,22 @@ body.bdp-scrolled .bdp-sticky-bar { display: none !important; }
 .next-previous-back { padding-left: 0; }
 .next-previous-next { padding-right: 0; margin-left: 16px; }
 .next-previous-prev { padding-right: 15px; }
+/* v=121: dropped 15/400/#333 override per user screenshot comparison.
+   Real BT breadcrumb probe (`.breadcrumb` UL inside `.next-previous`):
+   12/400 #616161. v=109's enlarged values made the sandbox bar text
+   visibly larger + darker than real BT. */
 .next-previous-breadcrumb {
   flex: 1;
-  font-size: 15px;
+  font-size: 12px;
   font-weight: 400;
-  color: #333;
+  color: #616161;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
   margin: 0 10px;
   padding: 0;
 }
-.next-previous-breadcrumb a { color: #333; text-decoration: none; }
+.next-previous-breadcrumb a { color: #616161; text-decoration: none; }
 .next-previous-breadcrumb a:hover { color: var(--bt-blue); text-decoration: underline; }
 .next-previous-actions {
   display: flex;

--- a/deploy/sim_envs/mantis_boattrader/app/static/app.css
+++ b/deploy/sim_envs/mantis_boattrader/app/static/app.css
@@ -1953,16 +1953,21 @@ body.bdp-scrolled .bdp-sticky-bar { display: none !important; }
   margin-top: 6px;
 }
 
-/* ── Top stats strip — 4 columns × 2 rows (8 cells total) ───── */
+/* ── Top stats strip — 4 columns × 2 rows (8 cells total) ─────
+   v=119: aligned to real BT geometry: `.additional-boat-details`
+   margin 0 10px, padding 0, NO border. The horizontal divider line
+   was a sandbox artifact creating the visible separation user
+   pointed out. Reduced outer margin from 22px 0 14px → 0 0 8px so
+   the gap between strip and the next card matches real BT's 32px
+   (was 118px). */
 .bdp-stats-strip {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
   grid-auto-rows: auto;
   column-gap: 18px;
   row-gap: 14px;
-  margin: 22px 0 14px;
+  margin: 0 0 8px;
   padding: 22px 8px;
-  border-bottom: 1px solid var(--bt-border);
 }
 .stat-card {
   display: flex;
@@ -1994,13 +1999,13 @@ body.bdp-scrolled .bdp-sticky-bar { display: none !important; }
 }
 
 /* ── What Owners Say card ─────────────────────────────────── */
-/* v=112: REVERTED v=110/111 (white/transparent was wrong). Real BT
-   renders this section in a light-blue card. Probed real BT's
-   `.boat-overview-wrapper.ai-ratings-review-bundle`: bg #f5f9ff,
-   br 8px, padding 20px 16px. v=99-104 used #eef4fb which was a
-   slightly different blue tint — corrected to exact #f5f9ff. */
+/* v=119: added `border-top + border-bottom: 1px solid #ededed`
+   matching real BT's `.boat-overview-wrapper.ai-ratings-review-
+   bundle` probe (both borders present). bg #f5f9ff, br 8px,
+   pad 20px 16px, mar 0 0 16px. */
 .bdp-owners-card {
   background: #f5f9ff;
+  border: 1px solid #ededed;
   border-radius: 8px;
   padding: 20px 16px;
   margin: 0 0 16px;
@@ -2135,107 +2140,90 @@ body.bdp-scrolled .bdp-sticky-bar { display: none !important; }
   font-style: italic;
 }
 
-/* ── Loan calculator ─────────────────────────────────────── */
+/* ── Loan calculator (v=120: split-pane with white form + blue
+   preview, monthly payment huge in center) ─────────────────── */
 .bdp-loan-card {
   background: #fff;
-  border: 1px solid var(--bt-border);
-  border-radius: var(--bt-radius-lg);
-  padding: 26px;
+  border: 1px solid #ededed;
+  border-radius: 12px;
+  padding: 0;
   margin: 24px 0;
+  overflow: hidden;
 }
 .loan-card-grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 32px;
+  gap: 0;
+}
+.loan-form {
+  background: #fff;
+  padding: 36px 56px 36px 56px;
 }
 .loan-form-heading, .loan-preview-heading {
-  font-size: 18px;
+  font-size: 22px;
   font-weight: 700;
-  color: var(--bt-text);
+  color: #303030;
   text-align: center;
-  margin: 0 0 8px;
+  margin: 0 0 14px;
 }
 .loan-form-sub {
   text-align: center;
-  color: var(--bt-text-dim);
-  font-size: 13px;
-  margin: 0 0 18px;
+  color: #303030;
+  font-size: 14px;
+  margin: 0 0 28px;
+  line-height: 1.45;
 }
 .loan-field {
   display: block;
-  margin-bottom: 14px;
+  margin-bottom: 16px;
 }
 .loan-field span {
   display: block;
-  font-size: 13px;
+  font-size: 14px;
   font-weight: 700;
-  color: var(--bt-text);
+  color: #303030;
   margin-bottom: 6px;
 }
 .loan-preview {
-  background: var(--bt-bg-alt);
-  border-radius: var(--bt-radius);
-  padding: 22px;
+  background: #f5f9ff;
+  padding: 36px 56px;
   text-align: center;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
 }
-.loan-apr {
-  font-size: 16px;
-  color: var(--bt-text);
-  margin: 18px 0 0;
-}
-.loan-apr strong { font-size: 18px; font-weight: 700; }
 .loan-payment {
-  font-size: 48px;
+  font-size: 64px;
   font-weight: 700;
-  color: var(--bt-text);
-  margin: 4px 0 8px;
-  letter-spacing: -1px;
+  color: #303030;
+  margin: 24px 0 18px;
+  letter-spacing: -1.5px;
+  line-height: 1;
 }
 .loan-total {
-  font-size: 13px;
-  color: var(--bt-text);
-  letter-spacing: 0.8px;
-  margin: 8px 0;
-}
-.loan-term {
-  font-size: 13px;
-  color: var(--bt-text);
-  letter-spacing: 0.8px;
-  margin: 4px 0 18px;
-}
-.loan-term strong { font-weight: 700; }
-.loan-prequal-btn {
-  display: inline-block;
-  border: 2px solid var(--bt-blue);
-  background: #fff;
-  color: var(--bt-blue);
-  border-radius: 999px;
-  padding: 12px 36px;
-  font-weight: 700;
   font-size: 15px;
+  color: #303030;
+  letter-spacing: 0.4px;
+  margin: 8px 0 0;
+  font-weight: 400;
 }
+.loan-total strong { font-weight: 700; }
 .loan-divider {
   border: 0;
-  border-top: 1px solid var(--bt-border);
-  margin: 22px 0 14px;
-}
-.loan-bullets-heading {
-  text-align: center;
-  font-size: 16px;
-  font-weight: 700;
-  color: var(--bt-text);
-  margin: 0 0 12px;
-}
-.loan-preview .prequal-bullets li {
-  text-align: left;
+  border-top: 1px solid #d8dee4;
+  margin: 24px 0 18px;
 }
 .loan-disclosure-link {
   display: block;
   text-align: center;
-  margin-top: 14px;
   text-decoration: underline;
-  color: var(--bt-text);
-  font-size: 12px;
+  color: #303030;
+  font-size: 14px;
+  font-weight: 700;
+}
+@media (max-width: 720px) {
+  .loan-card-grid { grid-template-columns: 1fr; }
+  .loan-form, .loan-preview { padding: 28px 24px; }
 }
 
 /* ── Listed By section ───────────────────────────────────── */
@@ -2403,13 +2391,15 @@ body.bdp-scrolled .bdp-sticky-bar { display: none !important; }
 }
 
 /* ── Still have a question? card ──────────────────────────── */
-/* "Still have a question?" — matched to real BT: h3 24/700 #303030,
-   body 18px regular, button 20/700 in a large pill. */
+/* v=118: removed white card chrome (bg, border, br, large padding).
+   Real BT renders this section inline on the page background —
+   just the H3 + rule + body text + button, no surrounding white box.
+   Probed at x=150 y=2750 with `bg: rgba(0,0,0,0); border: 0 none`. */
 .bdp-question-card {
-  background: #fff;
-  border: 1px solid #e0e0e0;
-  border-radius: 8px;
-  padding: 28px 32px;
+  background: transparent;
+  border: 0;
+  border-radius: 0;
+  padding: 28px 0;
   margin: 24px 0;
 }
 .question-card-h2 {

--- a/deploy/sim_envs/mantis_boattrader/app/static/app.css
+++ b/deploy/sim_envs/mantis_boattrader/app/static/app.css
@@ -1520,6 +1520,22 @@ body.bdp-scrolled .bdp-sticky-bar { display: none !important; }
   flex-shrink: 0;
 }
 
+/* ── BDP body wrapper — v=111 ────────────────────────────────────
+   Real BT wraps the entire BDP body (everything below the
+   `.next-previous` sticky bar) in a `.boat-details.boat-details-
+   gradient` div with `background: linear-gradient(180deg, #f7f7f7,
+   transparent 20%) !important`. This creates a soft grey fade at
+   the top of the BDP page that becomes transparent by 20% down.
+   Sandbox now mirrors this exactly so the page bg matches the
+   user's screenshot of real BT's styles.css:44. */
+.boat-details-gradient {
+  background: linear-gradient(180deg, #f7f7f7, transparent 20%) !important;
+  /* Bleed full-viewport-width like .next-previous so the gradient
+     covers edge-to-edge (the .bt-main container is constrained). */
+  margin: 0 calc(50% - 50vw);
+  padding: 0 calc(50vw - 50%);
+}
+
 /* v=105: `.bdp-nav-row` hidden — breadcrumb + Back/Next links live
    in the always-sticky `.next-previous` bar (matches real BT). */
 .bdp-nav-row { display: none !important; }
@@ -1948,11 +1964,16 @@ body.bdp-scrolled .bdp-sticky-bar { display: none !important; }
 }
 
 /* ── What Owners Say card ─────────────────────────────────── */
+/* v=112: REVERTED v=110/111 (white/transparent was wrong). Real BT
+   renders this section in a light-blue card. Probed real BT's
+   `.boat-overview-wrapper.ai-ratings-review-bundle`: bg #f5f9ff,
+   br 8px, padding 20px 16px. v=99-104 used #eef4fb which was a
+   slightly different blue tint — corrected to exact #f5f9ff. */
 .bdp-owners-card {
-  background: #eef4fb;
-  border-radius: var(--bt-radius-lg);
-  padding: 26px 28px;
-  margin: 24px 0;
+  background: #f5f9ff;
+  border-radius: 8px;
+  padding: 20px 16px;
+  margin: 0 0 16px;
 }
 .owners-card-grid {
   display: grid;
@@ -2007,8 +2028,9 @@ body.bdp-scrolled .bdp-sticky-bar { display: none !important; }
   white-space: nowrap;
 }
 
-/* ── Boat Details accordion — bg #f5f9ff (very light blue), pad 20px 16px,
-   8px radius, matches real BT. */
+/* ── Boat Details accordion ───────────────────────────────────
+   v=112: REVERTED v=110/111. Real BT's `.accordion-details-section`
+   uses bg #f5f9ff, br 8px, padding 20px 16px. */
 .bdp-details-section {
   background: #f5f9ff;
   border-radius: 8px;
@@ -2250,10 +2272,12 @@ body.bdp-scrolled .bdp-sticky-bar { display: none !important; }
   color: var(--bt-text);
 }
 
-/* ── More From This Dealer rail ───────────────────────────── */
+/* ── More From This Dealer rail ───────────────────────────────
+   v=112: REVERTED v=110/111. Match the light-blue card pattern
+   per real BT (probed v=112 — same #f5f9ff family). */
 .bdp-more-from-dealer {
-  background: #eef4fb;
-  border-radius: var(--bt-radius-lg);
+  background: #f5f9ff;
+  border-radius: 8px;
   padding: 24px 28px 18px;
   margin: 24px 0;
 }

--- a/deploy/sim_envs/mantis_boattrader/app/static/app.css
+++ b/deploy/sim_envs/mantis_boattrader/app/static/app.css
@@ -1777,8 +1777,22 @@ body.bdp-scrolled .bdp-sticky-bar { display: none !important; }
    wrapping element itself, not just the `<strong>` child. Bump
    wrapper size + weight so the bare span (when not wrapped in <strong>)
    still hits the right size. */
-.bdp-price { margin: 0 0 4px; font-size: 20px; font-weight: 700; color: var(--bt-text); display: flex; align-items: baseline; gap: 10px; flex-wrap: wrap; }
+/* v=131: price + monthly estimate inline-right on same row, matching
+   real BT's title block ("$25,900  $4,000" pattern). The wrapper P
+   stays as flex row with baseline alignment. */
+.bdp-price { margin: 0 0 4px; font-size: 20px; font-weight: 700; color: var(--bt-text); display: flex; align-items: baseline; gap: 12px; flex-wrap: wrap; }
 .bdp-price strong { font-size: 20px; color: var(--bt-text); font-weight: 700; }
+/* v=131: monthly estimate inline-right of price. Real BT renders at
+   18/400. Sits on same baseline as the price ($XX,XXX). Clickable
+   link to loan calculator (replaces old "Own this boat for / Customize"
+   wrapper that wasn't in real BT). */
+.bdp-monthly-est {
+  font-size: 18px;
+  font-weight: 400;
+  color: var(--bt-text);
+  text-decoration: none;
+}
+.bdp-monthly-est:hover { color: var(--bt-blue); text-decoration: underline; }
 .bdp-price-drop {
   display: inline-flex; align-items: baseline; gap: 4px;
   font-size: 16px; font-weight: 700; color: var(--bt-text);

--- a/deploy/sim_envs/mantis_boattrader/app/static/app.css
+++ b/deploy/sim_envs/mantis_boattrader/app/static/app.css
@@ -2397,16 +2397,17 @@ body.bdp-scrolled .bdp-sticky-bar { display: none !important; }
 }
 
 /* ── Still have a question? card ──────────────────────────── */
-/* v=118: removed white card chrome (bg, border, br, large padding).
-   Real BT renders this section inline on the page background —
-   just the H3 + rule + body text + button, no surrounding white box.
-   Probed at x=150 y=2750 with `bg: rgba(0,0,0,0); border: 0 none`. */
+/* v=126: tightened margins + reduced body/button font-size per user
+   screenshot. Body text was 18px (now 15px), button was 20px (now
+   14px), section margin was 24px 0 (now 12px 0), paragraph spacing
+   was 0 0 18px (now 0 0 8px). Rule underline width 60px → 40px and
+   bottom margin tightened. */
 .bdp-question-card {
   background: transparent;
   border: 0;
   border-radius: 0;
-  padding: 28px 0;
-  margin: 24px 0;
+  padding: 24px 0;
+  margin: 12px 0;
 }
 .question-card-h2 {
   font-size: 24px;
@@ -2417,30 +2418,32 @@ body.bdp-scrolled .bdp-sticky-bar { display: none !important; }
 }
 .question-card-rule {
   display: block;
-  width: 60px;
-  height: 3px;
+  width: 40px;
+  height: 2px;
   background: var(--bt-blue);
-  margin: 14px 0 24px;
+  margin: 10px 0 16px;
 }
-.bdp-question-card p { margin: 0 0 18px; font-size: 18px; color: #303030; line-height: 1.4; }
+.bdp-question-card p { margin: 0 0 8px; font-size: 15px; color: #303030; line-height: 1.45; }
 .question-contact-btn {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  margin-top: 8px;
+  margin-top: 12px;
   border: 2px solid var(--bt-blue);
   background: #fff;
   color: var(--bt-blue);
   border-radius: 50px;
-  padding: 12px 36px;
+  padding: 10px 28px;
   font-weight: 700;
-  font-size: 20px;
+  font-size: 14px;
   line-height: 1;
 }
 
 /* ── OTHER SERVICES tiles ─────────────────────────────────── */
+/* v=126: tighter margin (was 24px 0) — reduces whitespace between
+   "Still have a question?" and OTHER SERVICES sections. */
 .bdp-other-services {
-  margin: 24px 0;
+  margin: 12px 0 24px;
   padding-top: 18px;
   border-top: 1px solid var(--bt-border);
 }

--- a/deploy/sim_envs/mantis_boattrader/app/static/app.css
+++ b/deploy/sim_envs/mantis_boattrader/app/static/app.css
@@ -2643,10 +2643,12 @@ body.bdp-scrolled .bdp-sticky-bar { display: none !important; }
 
 .bdp-dealer-card { border-top: 1px solid var(--bt-border); padding-top: 14px; }
 /* Real BT contact card heading (dealer + private): H3 18/500 #303030. */
-.dealer-card-heading { font-size: 18px; font-weight: 500; color: #303030; margin: 0 0 4px; }
-/* v=107: dealer subline rows (dealer name + city, phone) — sit
-   directly under the salesperson H3, matching real BT pattern. */
-.dealer-card-subline { display: block; font-size: 14px; line-height: 1.4; margin: 0 0 2px; color: #303030; }
+/* v=125: heading color #303030 → #1a2022 per real BT probe (rgb(26,32,34)). */
+.dealer-card-heading { font-size: 18px; font-weight: 500; color: #1a2022; margin: 0 0 4px; }
+/* v=125: subline font 14/#303030 → 16/#474c4a per real BT (rgb(71,76,74)). */
+.dealer-card-subline { display: block; font-size: 16px; line-height: 1.45; margin: 0 0 2px; color: #474c4a; font-weight: 400; }
+/* v=125: "Verified Broker" label above the dealer name. */
+.dealer-card-verified { display: block; font-size: 16px; font-weight: 400; color: #474c4a; margin: 0 0 2px; }
 .dealer-card-subline.dealer-card-phone { color: var(--bt-blue); font-weight: 400; margin: 0 0 12px; text-decoration: none; }
 .dealer-card-subline.dealer-card-phone:hover { text-decoration: underline; }
 .dealer-card-meta { display: flex; gap: 12px; align-items: center; margin: 0 0 12px; }

--- a/deploy/sim_envs/mantis_boattrader/app/static/app.css
+++ b/deploy/sim_envs/mantis_boattrader/app/static/app.css
@@ -402,11 +402,15 @@ header.main {
 
 /* ── Ad strips ─ Real BT BDP top sponsor: bg #f7f7f7, padding 16px 0,
    ad image inside is fixed 728×90 leaderboard. ─────────────────── */
+/* v=114: removed `margin: 24px 0` on .ad-strip — real BT renders the
+   top ad flush against the page header above and the .next-previous
+   sticky bar below (probed margin: 0). The 24px margin was creating
+   visible white-grey transitions in the screenshot. */
 .ad-strip {
   background: #f7f7f7;
   padding: 16px 0;
   display: flex; justify-content: center;
-  margin: 24px 0;
+  margin: 0;
 }
 .ad-banner {
   position: relative; max-width: 728px; width: 100%; height: 90px;
@@ -1462,15 +1466,20 @@ body.bdp-scrolled .bdp-sticky-bar { display: none !important; }
   position: sticky;
   top: 0;
   z-index: 110;
-  width: 100%;
+  /* v=113: width:100vw (NOT 100%) so the bar bleeds to viewport
+     edges instead of being constrained by .bt-main's max-width 1440.
+     Combined with margin-left to align the bar's left edge with the
+     viewport. Fixes the white gap on the right side reported by user. */
+  width: 100vw;
+  margin-left: calc(-50vw + 50%);
   height: 54px;
-  margin: 0 calc(50% - 50vw);
   padding: 5px 20px;
   background: #f7f7f7;
   font-size: 15px;
   font-weight: 400;
   color: #333;
-  border-bottom: 1px solid #ededed;
+  /* v=114: removed `border-bottom: 1px solid #ededed` — real BT has
+     no visible bottom border on .next-previous (probed border:0 none). */
 }
 .next-previous-inner {
   max-width: 1400px;
@@ -1530,10 +1539,13 @@ body.bdp-scrolled .bdp-sticky-bar { display: none !important; }
    user's screenshot of real BT's styles.css:44. */
 .boat-details-gradient {
   background: linear-gradient(180deg, #f7f7f7, transparent 20%) !important;
-  /* Bleed full-viewport-width like .next-previous so the gradient
-     covers edge-to-edge (the .bt-main container is constrained). */
-  margin: 0 calc(50% - 50vw);
-  padding: 0 calc(50vw - 50%);
+  /* v=113: bleed via width:100vw + negative left-margin (same fix as
+     .next-previous). Inner padding compensates so children stay
+     visually inside the .bt-main centered column. */
+  width: 100vw;
+  margin-left: calc(-50vw + 50%);
+  padding-left: calc(50vw - 50%);
+  padding-right: calc(50vw - 50%);
 }
 
 /* v=105: `.bdp-nav-row` hidden — breadcrumb + Back/Next links live
@@ -1648,7 +1660,10 @@ body.bdp-scrolled .bdp-sticky-bar { display: none !important; }
   grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 /* Make ad-strip inside the left col compact (it was full-page padding before). */
-.bdp-grid-stack > .ad-strip { margin: 24px 0; padding: 0; background: transparent; }
+/* v=114: inside `.bdp-grid-stack` (left column) keep ads transparent
+   and unmargined (mid-page leaderboard sits flush). Outside the grid
+   (top/bottom strips) keep the #f7f7f7 grey strip with 16px 0 padding. */
+.bdp-grid-stack > .ad-strip { margin: 0; padding: 0; background: transparent; }
 .bdp-grid-stack > .ad-strip .ad-banner { max-width: 100%; }
 .bdp-grid-stack > .bdp-summary {
   position: absolute;
@@ -1725,10 +1740,15 @@ body.bdp-scrolled .bdp-sticky-bar { display: none !important; }
 .bdp-badges { margin-bottom: 10px; }
 /* Right-rail typography matched to real boattrader desktop (1512px probe):
    title 20/700, location 16/400, price 20/700, own-link 16/400. */
-.bdp-title { font-size: 20px; line-height: 1.25; margin: 8px 0 6px; color: var(--bt-text); font-weight: 700; }
+/* v=114: H1 margin 8px 0 6px → 0 (real BT H1 has margin:0). */
+.bdp-title { font-size: 20px; line-height: 1.25; margin: 0; color: var(--bt-text); font-weight: 700; }
 .bdp-length { color: var(--bt-text); font-weight: 700; font-size: 20px; }
 .bdp-location { color: var(--bt-text); font-size: 16px; margin: 0 0 10px; font-weight: 400; }
-.bdp-price { margin: 0 0 4px; font-size: 16px; display: flex; align-items: baseline; gap: 10px; flex-wrap: wrap; }
+/* v=114: real BT main price `$XX,XXX` renders at 20/700 #333 on the
+   wrapping element itself, not just the `<strong>` child. Bump
+   wrapper size + weight so the bare span (when not wrapped in <strong>)
+   still hits the right size. */
+.bdp-price { margin: 0 0 4px; font-size: 20px; font-weight: 700; color: var(--bt-text); display: flex; align-items: baseline; gap: 10px; flex-wrap: wrap; }
 .bdp-price strong { font-size: 20px; color: var(--bt-text); font-weight: 700; }
 .bdp-price-drop {
   display: inline-flex; align-items: baseline; gap: 4px;
@@ -2029,13 +2049,14 @@ body.bdp-scrolled .bdp-sticky-bar { display: none !important; }
 }
 
 /* ── Boat Details accordion ───────────────────────────────────
-   v=112: REVERTED v=110/111. Real BT's `.accordion-details-section`
-   uses bg #f5f9ff, br 8px, padding 20px 16px. */
+   v=114: added `border-bottom: 1px solid #ededed` per real BT's
+   `.accordion-details-section` probe (bb: 1px solid #ededed). */
 .bdp-details-section {
   background: #f5f9ff;
   border-radius: 8px;
   padding: 20px 16px;
   margin: 24px 0;
+  border-bottom: 1px solid #ededed;
 }
 .bdp-details-h2 {
   font-size: 20px;
@@ -2080,8 +2101,13 @@ body.bdp-scrolled .bdp-sticky-bar { display: none !important; }
   transition: transform 200ms ease;
 }
 .bdp-accordion[open] .accordion-chevron { transform: rotate(-135deg); }
+/* v=114: real BT's Description inner card (`.accordion-details-items`)
+   is white bg with 8px radius and `padding: 0 16px`, sitting on the
+   light-blue `.bdp-details-section` parent. */
 .accordion-body {
-  padding: 0 22px 18px;
+  background: #fff;
+  border-radius: 8px;
+  padding: 0 16px 18px;
   font-size: 14px;
   color: var(--bt-text);
   line-height: 1.55;

--- a/deploy/sim_envs/mantis_boattrader/app/templates/base.html
+++ b/deploy/sim_envs/mantis_boattrader/app/templates/base.html
@@ -9,7 +9,7 @@
      (San Francisco on macOS, Segoe UI on Windows). Loading Roboto Medium
      from Google Fonts makes our text render heavier than real BT, so we
      match by NOT loading Roboto and letting the system fallback render. #}
-  <link rel="stylesheet" href="/static/app.css?v=120" />
+  <link rel="stylesheet" href="/static/app.css?v=121" />
   <meta name="description" content="{% block description %}Buy and sell new & used boats. Find boats, yachts, sailboats, fishing boats, pontoons, and more.{% endblock %}" />
 </head>
 <body class="bt-body">

--- a/deploy/sim_envs/mantis_boattrader/app/templates/base.html
+++ b/deploy/sim_envs/mantis_boattrader/app/templates/base.html
@@ -9,7 +9,7 @@
      (San Francisco on macOS, Segoe UI on Windows). Loading Roboto Medium
      from Google Fonts makes our text render heavier than real BT, so we
      match by NOT loading Roboto and letting the system fallback render. #}
-  <link rel="stylesheet" href="/static/app.css?v=109" />
+  <link rel="stylesheet" href="/static/app.css?v=112" />
   <meta name="description" content="{% block description %}Buy and sell new & used boats. Find boats, yachts, sailboats, fishing boats, pontoons, and more.{% endblock %}" />
 </head>
 <body class="bt-body">

--- a/deploy/sim_envs/mantis_boattrader/app/templates/base.html
+++ b/deploy/sim_envs/mantis_boattrader/app/templates/base.html
@@ -9,7 +9,7 @@
      (San Francisco on macOS, Segoe UI on Windows). Loading Roboto Medium
      from Google Fonts makes our text render heavier than real BT, so we
      match by NOT loading Roboto and letting the system fallback render. #}
-  <link rel="stylesheet" href="/static/app.css?v=124" />
+  <link rel="stylesheet" href="/static/app.css?v=125" />
   <meta name="description" content="{% block description %}Buy and sell new & used boats. Find boats, yachts, sailboats, fishing boats, pontoons, and more.{% endblock %}" />
 </head>
 <body class="bt-body">

--- a/deploy/sim_envs/mantis_boattrader/app/templates/base.html
+++ b/deploy/sim_envs/mantis_boattrader/app/templates/base.html
@@ -9,7 +9,7 @@
      (San Francisco on macOS, Segoe UI on Windows). Loading Roboto Medium
      from Google Fonts makes our text render heavier than real BT, so we
      match by NOT loading Roboto and letting the system fallback render. #}
-  <link rel="stylesheet" href="/static/app.css?v=115" />
+  <link rel="stylesheet" href="/static/app.css?v=116" />
   <meta name="description" content="{% block description %}Buy and sell new & used boats. Find boats, yachts, sailboats, fishing boats, pontoons, and more.{% endblock %}" />
 </head>
 <body class="bt-body">

--- a/deploy/sim_envs/mantis_boattrader/app/templates/base.html
+++ b/deploy/sim_envs/mantis_boattrader/app/templates/base.html
@@ -9,7 +9,7 @@
      (San Francisco on macOS, Segoe UI on Windows). Loading Roboto Medium
      from Google Fonts makes our text render heavier than real BT, so we
      match by NOT loading Roboto and letting the system fallback render. #}
-  <link rel="stylesheet" href="/static/app.css?v=114" />
+  <link rel="stylesheet" href="/static/app.css?v=115" />
   <meta name="description" content="{% block description %}Buy and sell new & used boats. Find boats, yachts, sailboats, fishing boats, pontoons, and more.{% endblock %}" />
 </head>
 <body class="bt-body">

--- a/deploy/sim_envs/mantis_boattrader/app/templates/base.html
+++ b/deploy/sim_envs/mantis_boattrader/app/templates/base.html
@@ -9,7 +9,7 @@
      (San Francisco on macOS, Segoe UI on Windows). Loading Roboto Medium
      from Google Fonts makes our text render heavier than real BT, so we
      match by NOT loading Roboto and letting the system fallback render. #}
-  <link rel="stylesheet" href="/static/app.css?v=131" />
+  <link rel="stylesheet" href="/static/app.css?v=132" />
   <meta name="description" content="{% block description %}Buy and sell new & used boats. Find boats, yachts, sailboats, fishing boats, pontoons, and more.{% endblock %}" />
 </head>
 <body class="bt-body">

--- a/deploy/sim_envs/mantis_boattrader/app/templates/base.html
+++ b/deploy/sim_envs/mantis_boattrader/app/templates/base.html
@@ -9,7 +9,7 @@
      (San Francisco on macOS, Segoe UI on Windows). Loading Roboto Medium
      from Google Fonts makes our text render heavier than real BT, so we
      match by NOT loading Roboto and letting the system fallback render. #}
-  <link rel="stylesheet" href="/static/app.css?v=107" />
+  <link rel="stylesheet" href="/static/app.css?v=109" />
   <meta name="description" content="{% block description %}Buy and sell new & used boats. Find boats, yachts, sailboats, fishing boats, pontoons, and more.{% endblock %}" />
 </head>
 <body class="bt-body">

--- a/deploy/sim_envs/mantis_boattrader/app/templates/base.html
+++ b/deploy/sim_envs/mantis_boattrader/app/templates/base.html
@@ -9,7 +9,7 @@
      (San Francisco on macOS, Segoe UI on Windows). Loading Roboto Medium
      from Google Fonts makes our text render heavier than real BT, so we
      match by NOT loading Roboto and letting the system fallback render. #}
-  <link rel="stylesheet" href="/static/app.css?v=116" />
+  <link rel="stylesheet" href="/static/app.css?v=117" />
   <meta name="description" content="{% block description %}Buy and sell new & used boats. Find boats, yachts, sailboats, fishing boats, pontoons, and more.{% endblock %}" />
 </head>
 <body class="bt-body">

--- a/deploy/sim_envs/mantis_boattrader/app/templates/base.html
+++ b/deploy/sim_envs/mantis_boattrader/app/templates/base.html
@@ -9,7 +9,7 @@
      (San Francisco on macOS, Segoe UI on Windows). Loading Roboto Medium
      from Google Fonts makes our text render heavier than real BT, so we
      match by NOT loading Roboto and letting the system fallback render. #}
-  <link rel="stylesheet" href="/static/app.css?v=127" />
+  <link rel="stylesheet" href="/static/app.css?v=128" />
   <meta name="description" content="{% block description %}Buy and sell new & used boats. Find boats, yachts, sailboats, fishing boats, pontoons, and more.{% endblock %}" />
 </head>
 <body class="bt-body">

--- a/deploy/sim_envs/mantis_boattrader/app/templates/base.html
+++ b/deploy/sim_envs/mantis_boattrader/app/templates/base.html
@@ -9,7 +9,7 @@
      (San Francisco on macOS, Segoe UI on Windows). Loading Roboto Medium
      from Google Fonts makes our text render heavier than real BT, so we
      match by NOT loading Roboto and letting the system fallback render. #}
-  <link rel="stylesheet" href="/static/app.css?v=132" />
+  <link rel="stylesheet" href="/static/app.css?v=133" />
   <meta name="description" content="{% block description %}Buy and sell new & used boats. Find boats, yachts, sailboats, fishing boats, pontoons, and more.{% endblock %}" />
 </head>
 <body class="bt-body">

--- a/deploy/sim_envs/mantis_boattrader/app/templates/base.html
+++ b/deploy/sim_envs/mantis_boattrader/app/templates/base.html
@@ -9,7 +9,7 @@
      (San Francisco on macOS, Segoe UI on Windows). Loading Roboto Medium
      from Google Fonts makes our text render heavier than real BT, so we
      match by NOT loading Roboto and letting the system fallback render. #}
-  <link rel="stylesheet" href="/static/app.css?v=122" />
+  <link rel="stylesheet" href="/static/app.css?v=123" />
   <meta name="description" content="{% block description %}Buy and sell new & used boats. Find boats, yachts, sailboats, fishing boats, pontoons, and more.{% endblock %}" />
 </head>
 <body class="bt-body">

--- a/deploy/sim_envs/mantis_boattrader/app/templates/base.html
+++ b/deploy/sim_envs/mantis_boattrader/app/templates/base.html
@@ -9,7 +9,7 @@
      (San Francisco on macOS, Segoe UI on Windows). Loading Roboto Medium
      from Google Fonts makes our text render heavier than real BT, so we
      match by NOT loading Roboto and letting the system fallback render. #}
-  <link rel="stylesheet" href="/static/app.css?v=128" />
+  <link rel="stylesheet" href="/static/app.css?v=129" />
   <meta name="description" content="{% block description %}Buy and sell new & used boats. Find boats, yachts, sailboats, fishing boats, pontoons, and more.{% endblock %}" />
 </head>
 <body class="bt-body">

--- a/deploy/sim_envs/mantis_boattrader/app/templates/base.html
+++ b/deploy/sim_envs/mantis_boattrader/app/templates/base.html
@@ -9,7 +9,7 @@
      (San Francisco on macOS, Segoe UI on Windows). Loading Roboto Medium
      from Google Fonts makes our text render heavier than real BT, so we
      match by NOT loading Roboto and letting the system fallback render. #}
-  <link rel="stylesheet" href="/static/app.css?v=129" />
+  <link rel="stylesheet" href="/static/app.css?v=130" />
   <meta name="description" content="{% block description %}Buy and sell new & used boats. Find boats, yachts, sailboats, fishing boats, pontoons, and more.{% endblock %}" />
 </head>
 <body class="bt-body">

--- a/deploy/sim_envs/mantis_boattrader/app/templates/base.html
+++ b/deploy/sim_envs/mantis_boattrader/app/templates/base.html
@@ -9,7 +9,7 @@
      (San Francisco on macOS, Segoe UI on Windows). Loading Roboto Medium
      from Google Fonts makes our text render heavier than real BT, so we
      match by NOT loading Roboto and letting the system fallback render. #}
-  <link rel="stylesheet" href="/static/app.css?v=126" />
+  <link rel="stylesheet" href="/static/app.css?v=127" />
   <meta name="description" content="{% block description %}Buy and sell new & used boats. Find boats, yachts, sailboats, fishing boats, pontoons, and more.{% endblock %}" />
 </head>
 <body class="bt-body">

--- a/deploy/sim_envs/mantis_boattrader/app/templates/base.html
+++ b/deploy/sim_envs/mantis_boattrader/app/templates/base.html
@@ -9,7 +9,7 @@
      (San Francisco on macOS, Segoe UI on Windows). Loading Roboto Medium
      from Google Fonts makes our text render heavier than real BT, so we
      match by NOT loading Roboto and letting the system fallback render. #}
-  <link rel="stylesheet" href="/static/app.css?v=112" />
+  <link rel="stylesheet" href="/static/app.css?v=114" />
   <meta name="description" content="{% block description %}Buy and sell new & used boats. Find boats, yachts, sailboats, fishing boats, pontoons, and more.{% endblock %}" />
 </head>
 <body class="bt-body">

--- a/deploy/sim_envs/mantis_boattrader/app/templates/base.html
+++ b/deploy/sim_envs/mantis_boattrader/app/templates/base.html
@@ -9,7 +9,7 @@
      (San Francisco on macOS, Segoe UI on Windows). Loading Roboto Medium
      from Google Fonts makes our text render heavier than real BT, so we
      match by NOT loading Roboto and letting the system fallback render. #}
-  <link rel="stylesheet" href="/static/app.css?v=123" />
+  <link rel="stylesheet" href="/static/app.css?v=124" />
   <meta name="description" content="{% block description %}Buy and sell new & used boats. Find boats, yachts, sailboats, fishing boats, pontoons, and more.{% endblock %}" />
 </head>
 <body class="bt-body">

--- a/deploy/sim_envs/mantis_boattrader/app/templates/base.html
+++ b/deploy/sim_envs/mantis_boattrader/app/templates/base.html
@@ -9,7 +9,7 @@
      (San Francisco on macOS, Segoe UI on Windows). Loading Roboto Medium
      from Google Fonts makes our text render heavier than real BT, so we
      match by NOT loading Roboto and letting the system fallback render. #}
-  <link rel="stylesheet" href="/static/app.css?v=121" />
+  <link rel="stylesheet" href="/static/app.css?v=122" />
   <meta name="description" content="{% block description %}Buy and sell new & used boats. Find boats, yachts, sailboats, fishing boats, pontoons, and more.{% endblock %}" />
 </head>
 <body class="bt-body">

--- a/deploy/sim_envs/mantis_boattrader/app/templates/base.html
+++ b/deploy/sim_envs/mantis_boattrader/app/templates/base.html
@@ -9,7 +9,7 @@
      (San Francisco on macOS, Segoe UI on Windows). Loading Roboto Medium
      from Google Fonts makes our text render heavier than real BT, so we
      match by NOT loading Roboto and letting the system fallback render. #}
-  <link rel="stylesheet" href="/static/app.css?v=104" />
+  <link rel="stylesheet" href="/static/app.css?v=107" />
   <meta name="description" content="{% block description %}Buy and sell new & used boats. Find boats, yachts, sailboats, fishing boats, pontoons, and more.{% endblock %}" />
 </head>
 <body class="bt-body">

--- a/deploy/sim_envs/mantis_boattrader/app/templates/base.html
+++ b/deploy/sim_envs/mantis_boattrader/app/templates/base.html
@@ -9,7 +9,7 @@
      (San Francisco on macOS, Segoe UI on Windows). Loading Roboto Medium
      from Google Fonts makes our text render heavier than real BT, so we
      match by NOT loading Roboto and letting the system fallback render. #}
-  <link rel="stylesheet" href="/static/app.css?v=117" />
+  <link rel="stylesheet" href="/static/app.css?v=120" />
   <meta name="description" content="{% block description %}Buy and sell new & used boats. Find boats, yachts, sailboats, fishing boats, pontoons, and more.{% endblock %}" />
 </head>
 <body class="bt-body">

--- a/deploy/sim_envs/mantis_boattrader/app/templates/base.html
+++ b/deploy/sim_envs/mantis_boattrader/app/templates/base.html
@@ -9,7 +9,7 @@
      (San Francisco on macOS, Segoe UI on Windows). Loading Roboto Medium
      from Google Fonts makes our text render heavier than real BT, so we
      match by NOT loading Roboto and letting the system fallback render. #}
-  <link rel="stylesheet" href="/static/app.css?v=130" />
+  <link rel="stylesheet" href="/static/app.css?v=131" />
   <meta name="description" content="{% block description %}Buy and sell new & used boats. Find boats, yachts, sailboats, fishing boats, pontoons, and more.{% endblock %}" />
 </head>
 <body class="bt-body">

--- a/deploy/sim_envs/mantis_boattrader/app/templates/base.html
+++ b/deploy/sim_envs/mantis_boattrader/app/templates/base.html
@@ -9,7 +9,7 @@
      (San Francisco on macOS, Segoe UI on Windows). Loading Roboto Medium
      from Google Fonts makes our text render heavier than real BT, so we
      match by NOT loading Roboto and letting the system fallback render. #}
-  <link rel="stylesheet" href="/static/app.css?v=125" />
+  <link rel="stylesheet" href="/static/app.css?v=126" />
   <meta name="description" content="{% block description %}Buy and sell new & used boats. Find boats, yachts, sailboats, fishing boats, pontoons, and more.{% endblock %}" />
 </head>
 <body class="bt-body">

--- a/deploy/sim_envs/mantis_boattrader/app/templates/boat_detail.html
+++ b/deploy/sim_envs/mantis_boattrader/app/templates/boat_detail.html
@@ -206,7 +206,14 @@
       {% endif %}{# /if false (v=107 hide bdp-dealership-card) #}
     {% endif %}
 
-    {# ─── Get pre-qualified card (always last in the right rail) ─── #}
+    {# v=123: `.prequal-card` ("Get pre-qualified in minutes" with
+       3 bullets + Get-Pre-Qualified button) HIDDEN in the right rail.
+       Real BT probe of `.summary-section` shows only contact-card
+       contents; no prequal mini-card after the contact form. The
+       same prequal content is already present inside the loan calc
+       section so removing here doesn't lose any UX. Wrapped in
+       `{% if false %}` to keep markup as reference. #}
+    {% if false %}
     <div class="prequal-card">
       <h3 class="prequal-card-heading">Get pre-qualified in minutes</h3>
       <ul class="prequal-bullets">
@@ -216,6 +223,7 @@
       </ul>
       <a href="/boat-loans/" class="btn-secondary btn-block prequal-btn">Get Pre-Qualified</a>
     </div>
+    {% endif %}
   </aside>
 
 {# ─── Top stats strip (8 cells in a 4-col × 2-row grid) ──────── #}

--- a/deploy/sim_envs/mantis_boattrader/app/templates/boat_detail.html
+++ b/deploy/sim_envs/mantis_boattrader/app/templates/boat_detail.html
@@ -41,6 +41,13 @@
   </div>
 </div>
 
+{# v=111: real BT wraps the BDP body in a `.boat-details-gradient` div
+   that applies a subtle `linear-gradient(180deg, #f7f7f7, transparent
+   20%)` page background — soft grey fade at the top of the BDP that
+   transitions to transparent by 20% down. Sections inside this
+   wrapper render directly on the gradient (no card tints). #}
+<div class="boat-details boat-details-gradient">
+
 {# v=105: `.bdp-nav-row` removed — the breadcrumb + Back/Next links
    are now inside the always-sticky `.next-previous` bar, matching
    real BT's layout (no separate page-header nav row). #}
@@ -269,6 +276,7 @@
   <div class="owners-card-grid">
     <div class="owners-card-text">
       <h2 class="owners-card-heading">
+        <span class="sparkle-icon" aria-hidden="true">✦</span>
         What Owners Say<span class="info-tip" title="Generated from owner reviews and editorial sources">ⓘ</span>
       </h2>
       <p class="owners-card-paragraph">{{ boat.what_owners_say }}</p>
@@ -509,4 +517,6 @@
 
 
 </div>  {# ─── close .bdp-grid — page ends here; footer follows ── #}
+
+</div>  {# ─── close .boat-details.boat-details-gradient (v=111) ── #}
 {% endblock %}

--- a/deploy/sim_envs/mantis_boattrader/app/templates/boat_detail.html
+++ b/deploy/sim_envs/mantis_boattrader/app/templates/boat_detail.html
@@ -141,8 +141,13 @@
         <h3 class="dealer-card-heading">Contact Private Seller</h3>
         <form class="dealer-lead-form" method="post" action="/boat/{{ boat.slug }}/contact" data-testid="dealer-lead-form">
           <input type="text" name="name" placeholder="First &amp; Last Name" required class="lead-input" />
-          <input type="email" name="email" placeholder="Your Email" required class="lead-input" />
-          <input type="tel" name="phone" placeholder="Your Phone" class="lead-input" />
+          {# v=124: restored Email + Phone split-half row to match real
+             BT's .lead-form-basic__body layout (Name full-width, Email
+             + Phone side-by-side at 163px each in a 334px form). #}
+          <div class="lead-row">
+            <input type="email" name="email" placeholder="Your Email" required class="lead-input" />
+            <input type="tel" name="phone" placeholder="Your Phone" class="lead-input" />
+          </div>
           <button type="submit" class="btn-primary btn-block contact-seller-btn srp-apply-now-button" data-testid="contact-seller-submit">Contact Seller</button>
         </form>
         <div class="private-seller-phone-row" data-testid="phone-row">
@@ -168,8 +173,11 @@
         <a href="tel:{{ dealer.phone }}" class="dealer-card-subline dealer-card-phone">{{ dealer.phone }}</a>
         <form class="dealer-lead-form" method="post" action="/boat/{{ boat.slug }}/contact" data-testid="dealer-lead-form">
           <input type="text" name="name" placeholder="First &amp; Last Name" required class="lead-input" />
-          <input type="email" name="email" placeholder="Your Email" required class="lead-input" />
-          <input type="tel" name="phone" placeholder="Your Phone" class="lead-input" />
+          {# v=124: Email + Phone split row (matches real BT layout). #}
+          <div class="lead-row">
+            <input type="email" name="email" placeholder="Your Email" required class="lead-input" />
+            <input type="tel" name="phone" placeholder="Your Phone" class="lead-input" />
+          </div>
           <textarea name="message" rows="3" class="lead-textarea" placeholder="I'm interested in your {{ boat.year }} {{ boat.make }} {{ boat.model }}. Please contact me with more information."></textarea>
           <button type="submit" class="btn-primary btn-block contact-seller-btn srp-apply-now-button" data-testid="contact-seller-submit">Contact Seller</button>
         </form>

--- a/deploy/sim_envs/mantis_boattrader/app/templates/boat_detail.html
+++ b/deploy/sim_envs/mantis_boattrader/app/templates/boat_detail.html
@@ -104,20 +104,20 @@
        span entirely. #}
     <h1 class="bdp-title">{{ boat.title }}<span class="bdp-length"> | {{ boat.length_ft|int }}'</span></h1>
     <p class="bdp-location">{{ boat.city }}, {{ boat.state }} {{ boat.zip }}</p>
+    {# v=131: simplified price + monthly to match real BT exactly.
+       Real BT renders price (20/700 #333) inline-right with monthly
+       estimate (18/400) on the same row — no "Own this boat for /
+       Customize" wrapper text. Monthly is just the bare amount. #}
     <div class="bdp-price-block" data-testid="price-block">
       <p class="bdp-price">
         <strong>{{ boat.display_price }}</strong>
+        {% if boat.monthly_price %}
+          <a href="#loan-calculator" class="bdp-monthly-est">{{ boat.display_monthly|replace('*','')|replace('/mo','') }}</a>
+        {% endif %}
         {% if boat.price_drop_amount %}
           <span class="bdp-price-drop"><span class="bdp-price-drop-arrow">↓</span>{{ boat.price_drop_amount|replace('-','') }}</span>
         {% endif %}
       </p>
-      {% if boat.monthly_price %}
-        <p class="bdp-own-line">
-          <a href="#loan-calculator" class="bdp-own-link">Own this boat for {{ boat.display_monthly|replace('*','') }}</a>
-          <span class="info-tip" title="Estimated payment">ⓘ</span>
-          <a href="#loan-calculator" class="bdp-customize-link">Customize</a>
-        </p>
-      {% endif %}
     </div>
     {# v=117: simplified to match real BT's `.listing-engagement-
        indicators` exactly: just "Views | Saves", 12/400 #757575

--- a/deploy/sim_envs/mantis_boattrader/app/templates/boat_detail.html
+++ b/deploy/sim_envs/mantis_boattrader/app/templates/boat_detail.html
@@ -16,36 +16,36 @@
   </a>
 </section>
 
-{# ─── Sticky boat header bar (shows on scroll).
-   Matches real BT: breadcrumb stays in the sticky row, NOT the
-   title/price line — that lives only in the right-rail summary. ── #}
-<div class="bdp-sticky-bar" data-testid="bdp-sticky-bar">
-  <div class="bdp-sticky-bar-inner">
-    <a href="/boats/" class="bdp-back">‹ Search</a>
-    <nav class="breadcrumb sticky-breadcrumb" aria-label="Breadcrumb">
+{# ─── `.next-previous` always-sticky bar (v=105) — matches real BT
+   pattern exactly: 54px tall, bg #f7f7f7, sticky top:0, z:110,
+   contains Back-to-Search + listing name/price/location + Next Boat
+   link. Always visible on BDP, sticks to top on scroll. Replaces the
+   old `.bdp-sticky-bar` which only appeared after 320px scroll. ── #}
+<div class="next-previous" data-testid="bdp-sticky-bar">
+  <a href="/boats/" class="next-previous-button next-previous-back">‹ Back to Search</a>
+  <div class="next-previous-info-container">
+    <nav class="breadcrumb next-previous-breadcrumb" aria-label="Breadcrumb">
       <a href="/">Home</a> / <a href="/boats/">Boats For Sale</a> /
       <a href="/boats/?fuel_type=Diesel">Power</a> /
       <a href="/boats/?type={{ boat.boat_type|urlencode }}">{{ boat.boat_type }}</a> /
       <a href="/boats/?make={{ boat.make|urlencode }}">{{ boat.make }}</a>
     </nav>
-    <div class="sticky-actions">
-      {% if next_boat %}<a href="/boat/{{ next_boat.slug }}/" class="bdp-next">Next Boat</a>{% endif %}
-      <a href="#contact" class="btn-primary sticky-contact-btn">Contact Seller</a>
+    <div class="next-previous-info">
+      <span class="next-previous-listing-name">{{ boat.title }}</span>
+      <span class="next-previous-listing-price">{{ boat.display_price }}</span>
+      <span class="next-previous-listing-loc">{{ boat.city }}, {{ boat.state }} {{ boat.zip }}</span>
     </div>
+  </div>
+  <div class="next-previous-actions">
+    <button type="button" class="next-previous-save" aria-label="Save listing">♡ Save</button>
+    {% if not boat.is_owner_listed %}<span class="next-previous-offered-by">Offered By: <strong>{{ dealer.name }}</strong></span>{% endif %}
+    {% if next_boat %}<a href="/boat/{{ next_boat.slug }}/" class="next-previous-button next-previous-next">Next Boat ›</a>{% endif %}
   </div>
 </div>
 
-{# ─── Breadcrumb row ─────────────────────────────────────────── #}
-<div class="bdp-nav-row">
-  <a href="/boats/" class="bdp-back">‹ Search</a>
-  <nav class="breadcrumb" aria-label="Breadcrumb">
-    <a href="/">Home</a> / <a href="/boats/">Boats For Sale</a> /
-    <a href="/boats/?fuel_type=Diesel">Power</a> /
-    <a href="/boats/?type={{ boat.boat_type|urlencode }}">{{ boat.boat_type }}</a> /
-    <a href="/boats/?make={{ boat.make|urlencode }}">{{ boat.make }}</a>
-  </nav>
-  {% if next_boat %}<a href="/boat/{{ next_boat.slug }}/" class="bdp-next">Next Boat ›</a>{% endif %}
-</div>
+{# v=105: `.bdp-nav-row` removed — the breadcrumb + Back/Next links
+   are now inside the always-sticky `.next-previous` bar, matching
+   real BT's layout (no separate page-header nav row). #}
 
 {% if lead_confirmation %}
 <div class="lead-confirm" data-testid="lead-confirmation">
@@ -93,7 +93,11 @@
       {% for badge in boat.badges %}<span class="listing-tag listing-tag-{{ badge|lower|replace(' ','-') }}">{{ badge }}</span>{% endfor %}
       </div>
     {% endif %}
-    <h1 class="bdp-title">{{ boat.title }}</h1>
+    {# v=107: H1 + sibling length-suffix SPAN to match real BT exactly.
+       Real BT renders `<h1>Year Make Model</h1><span>| <len>'</span>`
+       inline, both 20/700 #333. v=104 over-corrected by removing the
+       span entirely. #}
+    <h1 class="bdp-title">{{ boat.title }}<span class="bdp-length"> | {{ boat.length_ft|int }}'</span></h1>
     <p class="bdp-location">{{ boat.city }}, {{ boat.state }} {{ boat.zip }}</p>
     <div class="bdp-price-block" data-testid="price-block">
       <p class="bdp-price">
@@ -121,70 +125,58 @@
     </ul>
 
     {# ─── Contact card (owner vs dealer/sponsored) ──────────────
-       v=104: "Meet Your Seller" H2 above the contact card matches
-       real BT's pattern (same heading for both seller types). #}
-    <h2 class="meet-your-seller-h2">Meet Your Seller</h2>
+       v=105: removed "Meet Your Seller" H2 — real BT does not show
+       one above the contact card on either dealer or private listings.
+       Contact heading is H3 18/500 #303030 matching real BT. #}
     {% if boat.is_owner_listed %}
+      {# v=107: real BT private lead form: just Name/Email/Phone (no
+         message textarea, no Show Phone button by default). Show Phone
+         retained as cookie-gated interaction surface for agent training. #}
       <div class="bdp-private-seller-card" id="contact" data-testid="private-seller-card">
-        <div class="private-seller-tag">Private Seller</div>
-        <h2 class="dealer-card-heading">Contact {{ boat.owner_name }}, the owner</h2>
-        <p class="private-seller-note">
-          This boat is being sold directly by the owner. Boat Trader does not verify
-          private-seller listings — please ask for a survey, title, and registration before purchase.
-        </p>
+        <h3 class="dealer-card-heading">Contact Private Seller</h3>
+        <form class="dealer-lead-form" method="post" action="/boat/{{ boat.slug }}/contact" data-testid="dealer-lead-form">
+          <input type="text" name="name" placeholder="First &amp; Last Name" required class="lead-input" />
+          <input type="email" name="email" placeholder="Your Email" required class="lead-input" />
+          <input type="tel" name="phone" placeholder="Your Phone" class="lead-input" />
+          <button type="submit" class="btn-primary btn-block contact-seller-btn srp-apply-now-button" data-testid="contact-seller-submit">Contact Seller</button>
+        </form>
         <div class="private-seller-phone-row" data-testid="phone-row">
           {% set show_phone = request.cookies.get('bt_show_phone_' ~ boat.id) == '1' %}
           {% if show_phone %}
             <img class="phone-svg" src="/assets/phone/{{ boat.slug }}.svg?_t={{ boat.id }}" alt="Phone number" data-testid="phone-svg" />
-            <span class="phone-note">Call between 9am – 6pm local time.</span>
           {% else %}
             <form method="post" action="/boat/{{ boat.slug }}/show-phone">
-              <button type="submit" class="btn-secondary show-phone-btn" data-testid="show-phone-btn"><svg class="ico-phone" viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z"/></svg> Show Phone Number</button>
+              <button type="submit" class="btn-secondary btn-block show-phone-btn" data-testid="show-phone-btn"><svg class="ico-phone" viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z"/></svg> Show Phone Number</button>
             </form>
-            <span class="phone-note">The seller's number is hidden until you confirm you're a buyer.</span>
           {% endif %}
         </div>
-        <form class="dealer-lead-form" method="post" action="/boat/{{ boat.slug }}/contact" data-testid="dealer-lead-form">
-          <input type="text" name="name" placeholder="First &amp; Last Name" required class="lead-input" />
-          <div class="lead-row">
-            <input type="email" name="email" placeholder="Your Email" required class="lead-input" />
-            <input type="tel" name="phone" placeholder="Your Phone" class="lead-input" />
-          </div>
-          <textarea name="message" rows="3" class="lead-textarea" placeholder="Hi {{ boat.owner_name }}, I'm interested in your {{ boat.year }} {{ boat.make }} {{ boat.model }}. Is it still available?"></textarea>
-          <button type="submit" class="btn-primary btn-block contact-seller-btn srp-apply-now-button" data-testid="contact-seller-submit">Email Seller</button>
-        </form>
       </div>
     {% else %}
+      {# v=107: dealer card — salesperson H3 + dealer name+city + phone
+         sublines INSIDE the contact card (matches real BT pattern).
+         Separate `.bdp-dealership-card` deleted since real BT integrates
+         dealer info here instead of below. #}
       <div class="bdp-dealer-card" id="contact" data-testid="dealer-card">
         {% set _sp_idx = (boat.id|length + boat.year) % 6 %}
-        <h2 class="dealer-card-heading">Contact {{ ['Michael Mandery','Jennifer Cole','Marcus Webb','Elena Patel','Tom Hartwell','Priya Shah'][_sp_idx] }}</h2>
-        <div class="dealer-card-meta">
-          <div class="dealer-headshot" aria-label="Salesperson headshot">
-            <svg viewBox="0 0 60 60" xmlns="http://www.w3.org/2000/svg" width="60" height="60">
-              <defs><linearGradient id="hs{{ _sp_idx }}" x1="0" x2="0" y1="0" y2="1"><stop offset="0" stop-color="#9bbcdb"/><stop offset="1" stop-color="#3a6a93"/></linearGradient></defs>
-              <rect width="60" height="60" rx="30" fill="url(#hs{{ _sp_idx }})"/>
-              <circle cx="30" cy="24" r="11" fill="#f2e3c8"/>
-              <path d="M8 60 Q 30 36 52 60 Z" fill="#f2e3c8"/>
-            </svg>
-          </div>
-          <address class="dealer-address">
-            {{ dealer.name }}<br/>
-            <a href="tel:{{ dealer.phone }}" class="dealer-phone"><svg class="ico-phone" viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z"/></svg> {{ dealer.phone }}</a>
-          </address>
-        </div>
+        <h3 class="dealer-card-heading">Contact {{ ['Michael Mandery','Jennifer Cole','Marcus Webb','Elena Patel','Tom Hartwell','Priya Shah'][_sp_idx] }}</h3>
+        <p class="dealer-card-subline dealer-card-name">{{ dealer.name }} - {{ dealer.city }}</p>
+        <a href="tel:{{ dealer.phone }}" class="dealer-card-subline dealer-card-phone">{{ dealer.phone }}</a>
         <form class="dealer-lead-form" method="post" action="/boat/{{ boat.slug }}/contact" data-testid="dealer-lead-form">
           <input type="text" name="name" placeholder="First &amp; Last Name" required class="lead-input" />
-          <div class="lead-row">
-            <input type="email" name="email" placeholder="Your Email" required class="lead-input" />
-            <input type="tel" name="phone" placeholder="Your Phone" class="lead-input" />
-          </div>
+          <input type="email" name="email" placeholder="Your Email" required class="lead-input" />
+          <input type="tel" name="phone" placeholder="Your Phone" class="lead-input" />
           <textarea name="message" rows="3" class="lead-textarea" placeholder="I'm interested in your {{ boat.year }} {{ boat.make }} {{ boat.model }}. Please contact me with more information."></textarea>
           <button type="submit" class="btn-primary btn-block contact-seller-btn srp-apply-now-button" data-testid="contact-seller-submit">Contact Seller</button>
-          <a href="tel:{{ dealer.phone }}" class="btn-secondary btn-block call-btn"><svg class="ico-phone" viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z"/></svg> Call</a>
         </form>
       </div>
 
-      {# Separate dealership card with logo + address + active/sold stats. #}
+      {# v=107: `.bdp-dealership-card` (right-rail logo + stats block)
+         hidden — real BT does not render a separate dealership card in
+         the right rail; dealer identity is conveyed via the contact card
+         + the `.next-previous-offered-by` tag in the sticky bar. The
+         block below is wrapped in `{% if false %}` so it stays in the
+         template for reference but is never rendered. #}
+      {% if false %}
       <div class="bdp-dealership-card" data-testid="dealership-card">
         <div class="dealership-logo-wrap">
           <div class="dealership-logo">
@@ -206,6 +198,7 @@
         </div>
         <a href="https://www.{{ dealer.name|lower|replace(' ','-')|replace(',','')|replace('--','-') }}.com" class="visit-seller-link dealership-link" target="_blank" rel="nofollow">Visit Seller Website ↗</a>
       </div>
+      {% endif %}{# /if false (v=107 hide bdp-dealership-card) #}
     {% endif %}
 
     {# ─── Get pre-qualified card (always last in the right rail) ─── #}
@@ -278,9 +271,7 @@
   <div class="owners-card-grid">
     <div class="owners-card-text">
       <h2 class="owners-card-heading">
-        <span class="sparkle-icon" aria-hidden="true">✦</span>
-        What Owners Say
-        <span class="info-tip" title="Generated from owner reviews and editorial sources">ⓘ</span>
+        What Owners Say<span class="info-tip" title="Generated from owner reviews and editorial sources">ⓘ</span>
       </h2>
       <p class="owners-card-paragraph">{{ boat.what_owners_say }}</p>
     </div>
@@ -310,7 +301,9 @@
         {% for para in boat.description %}<p>{{ para }}</p>{% endfor %}
       </div>
       {% if boat.description_features %}
-        <h3 class="bdp-feature-h3">Key Features</h3>
+        {# v=105: removed "Key Features" H3 — real BT doesn't render
+           this heading on probed dealer or private listings. List
+           content kept as part of the Description body. #}
         <ul class="bdp-feature-list">
           {% for f in boat.description_features %}<li>{{ f }}</li>{% endfor %}
         </ul>
@@ -346,6 +339,13 @@
         <div><dt>Fuel Capacity</dt><dd>{{ boat.fuel_capacity_gal }} gal</dd></div>
         <div><dt>Fresh Water Capacity</dt><dd>{{ (boat.length_ft * 1.2)|int }} gal</dd></div>
       </dl>
+      {# v=105: Accommodations H4 — present on real BT BDP under
+         Measurements. Sandbox derives berth count from length. #}
+      <h4 class="accordion-subhead">Accommodations</h4>
+      <dl class="spec-grid">
+        <div><dt>Number of Cabins</dt><dd>{{ ((boat.length_ft - 14) // 8)|int if boat.length_ft > 22 else 1 }}</dd></div>
+        <div><dt>Number of Berths</dt><dd>{{ (boat.capacity_people // 2)|int if boat.capacity_people else 2 }}</dd></div>
+      </dl>
     </div>
   </details>
 
@@ -368,7 +368,7 @@
 
   <details class="bdp-accordion">
     <summary>
-      <h3 class="accordion-title">More Details</h3>
+      <h4 class="accordion-title">More Details</h4>
       <span class="accordion-chevron"></span>
     </summary>
     <div class="accordion-body">
@@ -385,7 +385,7 @@
 
   <details class="bdp-accordion">
     <summary>
-      <h3 class="accordion-title">Location</h3>
+      <h4 class="accordion-title">Location</h4>
       <span class="accordion-chevron"></span>
     </summary>
     <div class="accordion-body">
@@ -447,43 +447,19 @@
   </div>
 </section>
 
-{# ─── Listed By / enhanced dealer card (left column) ─────────── #}
-{% if not boat.is_owner_listed %}
-<section class="bdp-listed-by enhanced-seller-details-card" data-testid="listed-by">
-  <h2 class="bdp-listed-by-h2">Listed By</h2>
-  <div class="enhanced-seller-details-card-container">
-    <div class="enhanced-seller-card-left">
-      <div class="enhanced-dealer-logo">
-        <span class="logo-mark">{{ dealer.logo_initial }}</span>
-        <span class="logo-name">{{ dealer.name|upper }}</span>
-      </div>
-      <h3 class="enhanced-dealer-name">{{ dealer.name }}</h3>
-      <p class="enhanced-dealer-address">
-        <a href="#">{{ dealer.address }}, {{ dealer.city }}, {{ dealer.state }}, {{ dealer.zip }}</a>
-      </p>
-      <p class="enhanced-dealer-phone"><a href="tel:{{ dealer.phone }}"><svg class="ico-phone" viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z"/></svg> {{ dealer.phone }}</a></p>
-      <a href="#" class="enhanced-dealer-link">Visit Seller Website</a>
-    </div>
-    <div class="enhanced-seller-card-right">
-      <p class="trusted-partner enhanced-trusted">Trusted Boat Trader Partner | <strong>{{ dealer.trusted_partner_label }}</strong></p>
-      <div class="enhanced-stat-row">
-        <div class="enhanced-stat-num">{{ dealer.active_listings }}</div>
-        <div class="enhanced-stat-label">Active listings</div>
-      </div>
-      <div class="enhanced-stat-row">
-        <div class="enhanced-stat-num">{{ "{:,}".format(dealer.sold_listings) }}</div>
-        <div class="enhanced-stat-label">Sold listings</div>
-      </div>
-    </div>
-  </div>
-</section>
+{# v=105: `.bdp-listed-by` section deleted — real BT does not render
+   a separate "Listed By" section on either dealer or private listings.
+   Dealer identity is conveyed via the contact card + the
+   `.next-previous` sticky bar's "Offered By: <dealer>" tag. #}
 
 {# ─── More From This Dealer — horizontally scrolling carousel
    matching real boattrader: image-only cards (no heart/badge/contact),
    visible scrollbar, › next button on right, "More Boats from this
-   Dealer" link at the bottom. ────────────────────────────────── #}
+   Dealer" link at the bottom. v=105: H2 → H4 to match real BT
+   (heading tag is H4 with carousel-special color #414d4a). ── #}
+{% if not boat.is_owner_listed %}
 <section class="bdp-more-from-dealer" data-testid="more-from-dealer">
-  <h2 class="more-from-dealer-h2">More From This Dealer</h2>
+  <h4 class="more-from-dealer-h2">More From This Dealer</h4>
   <div class="more-from-dealer-rail-wrap">
     <div class="more-from-dealer-rail" role="region" aria-label="More from this dealer">
       {% for b in similar[:8] %}
@@ -501,23 +477,13 @@
   </div>
   <a href="#" class="more-from-dealer-link">More Boats from this Dealer</a>
 </section>
-{% else %}
-<section class="bdp-listed-by" data-testid="listed-by-private">
-  <h2 class="bdp-listed-by-h2">Listed By</h2>
-  <div class="listed-by-card listed-by-private">
-    <div class="listed-by-logo private">{{ boat.owner_name[0] }}</div>
-    <div class="listed-by-body">
-      <h3 class="listed-by-dealer">{{ boat.owner_name }}</h3>
-      <p class="listed-by-address">Private Seller · {{ boat.city }}, {{ boat.state }}</p>
-      <p class="listed-by-private-note">Listed for <strong>{{ boat.listed_days_ago }} days</strong>. Not a verified dealer.</p>
-    </div>
-  </div>
-</section>
 {% endif %}
+{# v=105: private-seller Listed By section removed — real BT does not
+   render a separate Listed By block on private listings either. #}
 
-{# ─── Still have a question? ────────────────────────────────── #}
+{# ─── Still have a question? (v=105: H2 → H3 24/700 #303030 per real BT) #}
 <section class="bdp-question-card" data-testid="still-have-question">
-  <h2 class="question-card-h2">Still have a question?</h2>
+  <h3 class="question-card-h2">Still have a question?</h3>
   <span class="question-card-rule" aria-hidden="true"></span>
   <p>Get answers, schedule a visit to see the boat, or find a good time for a sea trial.</p>
   <p>Take the next step and contact the seller.</p>

--- a/deploy/sim_envs/mantis_boattrader/app/templates/boat_detail.html
+++ b/deploy/sim_envs/mantis_boattrader/app/templates/boat_detail.html
@@ -22,24 +22,22 @@
    link. Always visible on BDP, sticks to top on scroll. Replaces the
    old `.bdp-sticky-bar` which only appeared after 320px scroll. ── #}
 <div class="next-previous" data-testid="bdp-sticky-bar">
-  <a href="/boats/" class="next-previous-button next-previous-back">‹ Back to Search</a>
-  <div class="next-previous-info-container">
+  {# v=109: inner wrapper constrains content to max-width 1400px with
+     80px side margins, matching real BT's layout. At 1600px viewport
+     this places "‹ Search" at x≈100 (20px bar padding + 80px wrapper
+     margin), not at x≈25 as v=108 had. #}
+  <div class="next-previous-inner">
+    <a href="/boats/" class="next-previous-button next-previous-back">‹ Search</a>
     <nav class="breadcrumb next-previous-breadcrumb" aria-label="Breadcrumb">
       <a href="/">Home</a> / <a href="/boats/">Boats For Sale</a> /
       <a href="/boats/?fuel_type=Diesel">Power</a> /
       <a href="/boats/?type={{ boat.boat_type|urlencode }}">{{ boat.boat_type }}</a> /
       <a href="/boats/?make={{ boat.make|urlencode }}">{{ boat.make }}</a>
     </nav>
-    <div class="next-previous-info">
-      <span class="next-previous-listing-name">{{ boat.title }}</span>
-      <span class="next-previous-listing-price">{{ boat.display_price }}</span>
-      <span class="next-previous-listing-loc">{{ boat.city }}, {{ boat.state }} {{ boat.zip }}</span>
+    <div class="next-previous-actions">
+      {% if prev_boat %}<a href="/boat/{{ prev_boat.slug }}/" class="next-previous-button next-previous-prev">Previous Boat</a>{% endif %}
+      {% if next_boat %}<a href="/boat/{{ next_boat.slug }}/" class="next-previous-button next-previous-next">Next Boat</a>{% endif %}
     </div>
-  </div>
-  <div class="next-previous-actions">
-    <button type="button" class="next-previous-save" aria-label="Save listing">♡ Save</button>
-    {% if not boat.is_owner_listed %}<span class="next-previous-offered-by">Offered By: <strong>{{ dealer.name }}</strong></span>{% endif %}
-    {% if next_boat %}<a href="/boat/{{ next_boat.slug }}/" class="next-previous-button next-previous-next">Next Boat ›</a>{% endif %}
   </div>
 </div>
 

--- a/deploy/sim_envs/mantis_boattrader/app/templates/boat_detail.html
+++ b/deploy/sim_envs/mantis_boattrader/app/templates/boat_detail.html
@@ -169,7 +169,9 @@
       <div class="bdp-dealer-card" id="contact" data-testid="dealer-card">
         {% set _sp_idx = (boat.id|length + boat.year) % 6 %}
         <h3 class="dealer-card-heading">Contact {{ ['Michael Mandery','Jennifer Cole','Marcus Webb','Elena Patel','Tom Hartwell','Priya Shah'][_sp_idx] }}</h3>
-        <p class="dealer-card-subline dealer-card-name">{{ dealer.name }} - {{ dealer.city }}</p>
+        {# v=125: "Verified Broker" label above dealer name matches real BT pattern. #}
+        <span class="dealer-card-verified">Verified Broker</span>
+        <p class="dealer-card-subline dealer-card-name">{{ dealer.name }}</p>
         <a href="tel:{{ dealer.phone }}" class="dealer-card-subline dealer-card-phone">{{ dealer.phone }}</a>
         <form class="dealer-lead-form" method="post" action="/boat/{{ boat.slug }}/contact" data-testid="dealer-lead-form">
           <input type="text" name="name" placeholder="First &amp; Last Name" required class="lead-input" />

--- a/deploy/sim_envs/mantis_boattrader/app/templates/boat_detail.html
+++ b/deploy/sim_envs/mantis_boattrader/app/templates/boat_detail.html
@@ -119,15 +119,15 @@
         </p>
       {% endif %}
     </div>
-    <ul class="bdp-engagement-row">
-      <li class="engagement-item"><span class="ico" aria-hidden="true"><svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg></span> <strong>{{ boat.views }}</strong> Views</li>
-      <li class="engagement-item"><span class="ico" aria-hidden="true"><svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></span> <strong>{{ boat.saves }}</strong> Save{% if boat.saves != 1 %}s{% endif %}</li>
-      <li class="engagement-item"><span class="ico" aria-hidden="true"><svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg></span>
-        {% if boat.listed_days_ago <= 7 %}New to Market
-        {% elif boat.listed_days_ago <= 30 %}Listed {{ boat.listed_days_ago }} days ago
-        {% else %}Listed {{ (boat.listed_days_ago / 30)|int }} months ago{% endif %}
-      </li>
-    </ul>
+    {# v=117: simplified to match real BT's `.listing-engagement-
+       indicators` exactly: just "Views | Saves", 12/400 #757575
+       with a 1×12px #dee2e3 vertical divider. No icons, no
+       Listed/days-ago row. Container padding 11px 0 (was 12px 0 14px). #}
+    <div class="bdp-engagement-row listing-engagement-indicators" data-testid="engagement-indicators">
+      <div class="engagement-item listing-engagement-indicators__item"><strong>{{ boat.views }}</strong> Views</div>
+      <span class="listing-engagement-indicators__divider" aria-hidden="true"></span>
+      <div class="engagement-item listing-engagement-indicators__item"><strong>{{ boat.saves }}</strong> Save{% if boat.saves != 1 %}s{% endif %}</div>
+    </div>
 
     {# ─── Contact card (owner vs dealer/sponsored) ──────────────
        v=105: removed "Meet Your Seller" H2 — real BT does not show

--- a/deploy/sim_envs/mantis_boattrader/app/templates/boat_detail.html
+++ b/deploy/sim_envs/mantis_boattrader/app/templates/boat_detail.html
@@ -412,7 +412,14 @@
   </a>
 </section>
 
-{# ─── Loan Calculator ──────────────────────────────────────── #}
+{# ─── Loan Calculator (v=120: redesigned to match real BT) ────
+     LEFT pane (white bg): 5 stacked fields — Loan Type, Year,
+     Purchase Price, Down Payment, Loan Term (Months) defaulting
+     to 240. RIGHT pane (light blue #f5f9ff bg): centered heading
+     + huge monthly payment + TOTAL LOAN AMOUNT line + divider +
+     See Important Disclosure link. Removed APR display, 180 MONTHS
+     caption, Get-Pre-Qualified button, pre-qualified bullets per
+     user real-BT screenshot. #}
 <section class="bdp-loan-card" id="loan-calculator" data-testid="loan-calculator">
   <div class="loan-card-grid">
     <div class="loan-form">
@@ -430,24 +437,15 @@
       <label class="loan-field"><span>Down Payment</span>
         <input type="text" class="filter-input" value="${{ ((boat.price or 0) * 0.10)|int }}" />
       </label>
-      <label class="loan-field"><span>Credit Score (FICO)</span>
-        <select class="filter-select"><option>800-850</option><option>740-799</option><option>670-739</option></select>
+      <label class="loan-field"><span>Loan Term (Months)</span>
+        <input type="text" class="filter-input" value="240" />
       </label>
     </div>
     <div class="loan-preview">
       <h3 class="loan-preview-heading">Here is what your monthly payment might look like:</h3>
-      <p class="loan-apr"><strong>{{ '%.2f'|format(7.49 if boat.condition == 'new' else 8.24) }}%</strong> APR</p>
       <p class="loan-payment">{{ boat.display_monthly|replace('/mo*','')|replace('/mo','') if boat.display_monthly else '$—' }}</p>
-      <p class="loan-total">TOTAL LOAN AMOUNT <strong>${{ ((boat.price or 0) * 0.90)|int }}</strong></p>
-      <p class="loan-term"><strong>180</strong> MONTHS</p>
-      <a href="/boat-loans/" class="btn-secondary loan-prequal-btn">Get Pre-Qualified</a>
+      <p class="loan-total">TOTAL LOAN AMOUNT <strong>${{ "{:,}".format(((boat.price or 0) * 0.90)|int) }}</strong></p>
       <hr class="loan-divider" />
-      <h4 class="loan-bullets-heading">Get pre-qualified in minutes</h4>
-      <ul class="prequal-bullets">
-        <li><span class="prequal-check">✓</span> We'll compare over 15 lenders to get you the best rate &amp; terms</li>
-        <li><span class="prequal-check">✓</span> Customized financing to meet your needs</li>
-        <li><span class="prequal-check">✓</span> Over 25 years of marine lending experience</li>
-      </ul>
       <a href="#" class="loan-disclosure-link">See Important Disclosure<sup>3</sup></a>
     </div>
   </div>

--- a/deploy/sim_envs/mantis_boattrader/app/templates/boat_detail.html
+++ b/deploy/sim_envs/mantis_boattrader/app/templates/boat_detail.html
@@ -185,13 +185,10 @@
         </form>
       </div>
 
-      {# v=107: `.bdp-dealership-card` (right-rail logo + stats block)
-         hidden — real BT does not render a separate dealership card in
-         the right rail; dealer identity is conveyed via the contact card
-         + the `.next-previous-offered-by` tag in the sticky bar. The
-         block below is wrapped in `{% if false %}` so it stays in the
-         template for reference but is never rendered. #}
-      {% if false %}
+      {# v=130: RESTORED right-rail dealership card after re-probing
+         real BT — the .enhanced-business-card-wrapper at y=858 inside
+         .summary-section contains the dealer address + Trusted Partner
+         info. v=107's hide was based on a wrong measurement. #}
       <div class="bdp-dealership-card" data-testid="dealership-card">
         <div class="dealership-logo-wrap">
           <div class="dealership-logo">
@@ -213,7 +210,7 @@
         </div>
         <a href="https://www.{{ dealer.name|lower|replace(' ','-')|replace(',','')|replace('--','-') }}.com" class="visit-seller-link dealership-link" target="_blank" rel="nofollow">Visit Seller Website ↗</a>
       </div>
-      {% endif %}{# /if false (v=107 hide bdp-dealership-card) #}
+      {# v=130: end of restored .bdp-dealership-card block #}
     {% endif %}
 
     {# v=123: `.prequal-card` ("Get pre-qualified in minutes" with

--- a/tests/sim_envs/mantis_boattrader/test_filter_panel_fidelity.py
+++ b/tests/sim_envs/mantis_boattrader/test_filter_panel_fidelity.py
@@ -683,10 +683,10 @@ def test_bdp_no_listed_by_section(bdp_html):
     assert 'bdp-listed-by-h2' not in bdp_html
 
 
-def test_bdp_no_sparkle_on_what_owners_say(bdp_html):
-    """v=105: real BT renders "What Owners Say" without the ✦
-    sparkle prefix. Sandbox's decorative ✦ removed."""
-    # The owners-card-heading should not contain a sparkle-icon span
+def test_bdp_has_sparkle_on_what_owners_say(bdp_html):
+    """v=112: REVERTED v=105's removal. Real BT renders "What Owners
+    Say" WITH the ✦ sparkle prefix (per user screenshot 2026-05-24).
+    v=105 wrongly removed it; v=112 restored it."""
     import re
     m = re.search(
         r'<h2 class="owners-card-heading">.*?</h2>',
@@ -694,8 +694,8 @@ def test_bdp_no_sparkle_on_what_owners_say(bdp_html):
         re.DOTALL,
     )
     assert m, "owners-card-heading H2 missing"
-    assert 'sparkle-icon' not in m.group(0)
-    assert '✦' not in m.group(0)
+    assert 'sparkle-icon' in m.group(0), "sparkle-icon span missing from heading"
+    assert '✦' in m.group(0), "✦ glyph missing from heading"
 
 
 def test_bdp_no_key_features_heading(bdp_html):

--- a/tests/sim_envs/mantis_boattrader/test_filter_panel_fidelity.py
+++ b/tests/sim_envs/mantis_boattrader/test_filter_panel_fidelity.py
@@ -610,23 +610,26 @@ def test_bdp_has_next_previous_sticky_bar(bdp_html):
     assert 'class="next-previous-button next-previous-back"' in bdp_html
 
 
-def test_bdp_next_previous_has_breadcrumb_and_info(bdp_html):
-    """v=105: sticky bar contains both the breadcrumb nav AND the
-    listing name/price/location info row."""
+def test_bdp_next_previous_has_breadcrumb(bdp_html):
+    """v=108: sticky bar contains the breadcrumb nav only. (v=105/106
+    initially included a listing-name/price/location row beneath the
+    breadcrumb, but re-comparison with the real BT screenshot showed
+    that data is NOT visible in the sticky-bar row — only the
+    breadcrumb sits in the middle.)"""
     assert 'class="breadcrumb next-previous-breadcrumb"' in bdp_html
-    assert 'class="next-previous-info"' in bdp_html
-    assert 'next-previous-listing-name' in bdp_html
-    assert 'next-previous-listing-price' in bdp_html
-    assert 'next-previous-listing-loc' in bdp_html
+    # The listing-info row from v=105 should NOT be present anymore
+    assert 'next-previous-info"' not in bdp_html
+    assert 'next-previous-listing-name' not in bdp_html
 
 
-def test_bdp_next_previous_info_container_is_column_flex(base_css):
-    """v=106: `.next-previous-info-container` uses flex-direction:
-    column so the breadcrumb sits on top row and the listing info
-    sits on bottom row, matching real BT (NOT smashed onto one line
-    as v=105 first shipped)."""
-    block = _rule_block(base_css, ".next-previous-info-container {")
-    assert "flex-direction: column" in block
+def test_bdp_next_previous_actions_only_prev_next(bdp_html):
+    """v=108: real BT sticky bar's right action group has ONLY
+    "Previous Boat" + "Next Boat" links. No Save button, no
+    "Offered By" text."""
+    assert 'next-previous-prev' in bdp_html or 'next-previous-next' in bdp_html
+    # Removed in v=108: Save button and Offered-By tag
+    assert 'next-previous-save' not in bdp_html
+    assert 'next-previous-offered-by' not in bdp_html
 
 
 def test_bdp_no_legacy_nav_row(base_css):

--- a/tests/sim_envs/mantis_boattrader/test_filter_panel_fidelity.py
+++ b/tests/sim_envs/mantis_boattrader/test_filter_panel_fidelity.py
@@ -737,6 +737,42 @@ def test_bdp_dealer_card_has_inline_sublines(bdp_html):
     assert 'class="dealer-card-subline dealer-card-phone"' in bdp_html
 
 
+def test_bdp_engagement_row_simplified_to_views_saves(bdp_html):
+    """v=117: engagement row simplified to plain "Views | Saves"
+    matching real BT's `.listing-engagement-indicators`. Removed
+    icons, removed "Listed days ago" row, added 1×12px #dee2e3
+    vertical divider span."""
+    assert 'listing-engagement-indicators' in bdp_html
+    assert 'listing-engagement-indicators__item' in bdp_html
+    assert 'listing-engagement-indicators__divider' in bdp_html
+    # Pull engagement row from <div class="bdp-engagement-row…"> to
+    # the matching </div> by counting open/close tags.
+    import re
+    start_match = re.search(r'<div class="bdp-engagement-row[^"]*"', bdp_html)
+    assert start_match, "engagement row container not found"
+    start = start_match.start()
+    # Naive depth-counter from `start`:
+    depth = 0
+    i = start
+    while i < len(bdp_html):
+        if bdp_html[i:i+4] == '<div':
+            depth += 1
+            i += 4
+        elif bdp_html[i:i+6] == '</div>':
+            depth -= 1
+            i += 6
+            if depth == 0:
+                break
+        else:
+            i += 1
+    block = bdp_html[start:i]
+    assert '<svg' not in block, "engagement row should have no icons"
+    assert 'Listed ' not in block and 'New to Market' not in block, \
+        "Listed/New-to-Market row should be removed"
+    assert 'Views' in block
+    assert 'Save' in block
+
+
 def test_bdp_dealership_card_not_rendered(bdp_html):
     """v=107: the separate `.bdp-dealership-card` (right-rail logo +
     active/sold stats block) is wrapped in `{% if false %}` and not

--- a/tests/sim_envs/mantis_boattrader/test_filter_panel_fidelity.py
+++ b/tests/sim_envs/mantis_boattrader/test_filter_panel_fidelity.py
@@ -773,13 +773,18 @@ def test_bdp_engagement_row_simplified_to_views_saves(bdp_html):
     assert 'Save' in block
 
 
-def test_bdp_dealership_card_not_rendered(bdp_html):
-    """v=107: the separate `.bdp-dealership-card` (right-rail logo +
-    active/sold stats block) is wrapped in `{% if false %}` and not
-    rendered — real BT does not have a separate dealership card in
-    the right rail."""
-    assert 'class="bdp-dealership-card"' not in bdp_html
-    assert 'dealership-stat-num' not in bdp_html
+def test_bdp_dealership_card_rendered(bdp_html):
+    """v=130 (REVERTED v=107): the right-rail `.bdp-dealership-card` IS
+    rendered after re-probe — real BT's `.summary-section` contains
+    an `.enhanced-business-card-wrapper` at y=858 with dealer address
+    + Trusted Partner info. v=107's hide was based on a wrong probe.
+
+    Only renders on dealer (not owner) listings, so skip if the
+    fixture chose an owner listing."""
+    if 'bdp-private-seller-card' in bdp_html:
+        return  # owner listing — dealership card N/A
+    assert 'class="bdp-dealership-card"' in bdp_html
+    assert 'dealership-stat-num' in bdp_html
 
 
 def _details_block(html: str, anchor: str) -> str:

--- a/tests/sim_envs/mantis_boattrader/test_filter_panel_fidelity.py
+++ b/tests/sim_envs/mantis_boattrader/test_filter_panel_fidelity.py
@@ -509,23 +509,28 @@ def bdp_html(client) -> str:
     return r2.text
 
 
-def test_bdp_h1_has_no_length_suffix(bdp_html):
-    """v=104: real BT BDP H1 is just "Year Make Model" — no length
-    suffix like sandbox's old "| 16'". Removed in v=104."""
-    # H1 should not contain the bdp-length span anymore
-    assert 'class="bdp-length"' not in bdp_html
-    # H1 should not contain a vertical bar followed by a length unit
+def test_bdp_h1_has_length_suffix_span(bdp_html):
+    """v=107: real BT BDP renders the length as a sibling SPAN right
+    after H1 (not appended inside H1), styled 20/700 #333. v=104's
+    removal was based on a stale measurement — re-probed real BT
+    dealer + private listings both show the span. Sandbox restored
+    it as a SPAN child of H1 (visually identical, simpler markup)."""
+    assert 'class="bdp-length"' in bdp_html
+    # Length suffix should match the pattern "| <N>'"
     import re
-    h1_match = re.search(r'<h1[^>]*>([^<]+)</h1>', bdp_html)
-    assert h1_match, "no h1 found"
-    h1_text = h1_match.group(1)
-    assert "| " not in h1_text, f"H1 still has length suffix: {h1_text!r}"
+    assert re.search(r'<span class="bdp-length">\s*\|\s*\d+\'', bdp_html), \
+        "bdp-length span missing the '| <N>'' pattern"
 
 
-def test_bdp_has_meet_your_seller_heading(bdp_html):
-    """v=104: H2 "Meet Your Seller" sits above the contact card on both
-    private and dealer listings — matches real BT's pattern."""
-    assert '<h2 class="meet-your-seller-h2">Meet Your Seller</h2>' in bdp_html
+def test_bdp_has_no_meet_your_seller_heading(bdp_html):
+    """v=107 (was v=104): real BT BDP does NOT render a "Meet Your
+    Seller" H2 above the contact card on either dealer or private
+    listings — re-probed against 2024 Catalina 355 (dealer) and 2015
+    Pioneer 197 Sportfish (private) and both go straight to the
+    contact heading. v=104 added it based on a stale measurement;
+    v=107 removed it again."""
+    assert 'meet-your-seller-h2' not in bdp_html
+    assert 'Meet Your Seller' not in bdp_html
 
 
 def test_owner_highlights_is_h2(bdp_html):
@@ -590,6 +595,152 @@ def _rule_block(css: str, selector_line: str) -> str:
     end = css.find("}", idx)
     assert end > idx
     return css[idx:end + 1]
+
+
+# ── v=105..v=107 BDP exact-mirror tests ────────────────────────────
+# Each test below pins one of the structural changes from the
+# 2026-05-24 BDP re-probe of real boattrader (dealer 2024 Catalina
+# 355 + private 2015 Pioneer 197 Sportfish at 1440x900).
+
+def test_bdp_has_next_previous_sticky_bar(bdp_html):
+    """v=105: `.next-previous` always-sticky bar replaces the old
+    320px-scroll-triggered `.bdp-sticky-bar`. Real BT renders it at
+    position:sticky top:0, 54px tall, bg #f7f7f7, z:110."""
+    assert 'class="next-previous"' in bdp_html
+    assert 'class="next-previous-button next-previous-back"' in bdp_html
+
+
+def test_bdp_next_previous_has_breadcrumb_and_info(bdp_html):
+    """v=105: sticky bar contains both the breadcrumb nav AND the
+    listing name/price/location info row."""
+    assert 'class="breadcrumb next-previous-breadcrumb"' in bdp_html
+    assert 'class="next-previous-info"' in bdp_html
+    assert 'next-previous-listing-name' in bdp_html
+    assert 'next-previous-listing-price' in bdp_html
+    assert 'next-previous-listing-loc' in bdp_html
+
+
+def test_bdp_next_previous_info_container_is_column_flex(base_css):
+    """v=106: `.next-previous-info-container` uses flex-direction:
+    column so the breadcrumb sits on top row and the listing info
+    sits on bottom row, matching real BT (NOT smashed onto one line
+    as v=105 first shipped)."""
+    block = _rule_block(base_css, ".next-previous-info-container {")
+    assert "flex-direction: column" in block
+
+
+def test_bdp_no_legacy_nav_row(base_css):
+    """v=105: `.bdp-nav-row` (the duplicate breadcrumb + Back/Next
+    block above the gallery) is hidden — its contents now live inside
+    `.next-previous`."""
+    assert ".bdp-nav-row { display: none" in base_css
+
+
+def test_bdp_more_details_is_h4(bdp_html):
+    """v=105: real BT renders "More Details" as H4 16/700 (NOT H3)."""
+    assert '<h4 class="accordion-title">More Details</h4>' in bdp_html
+    assert '<h3 class="accordion-title">More Details</h3>' not in bdp_html
+
+
+def test_bdp_location_accordion_is_h4(bdp_html):
+    """v=105: real BT renders "Location" as H4 16/700 (NOT H3)."""
+    assert '<h4 class="accordion-title">Location</h4>' in bdp_html
+    assert '<h3 class="accordion-title">Location</h3>' not in bdp_html
+
+
+def test_bdp_has_accommodations_subhead(bdp_html):
+    """v=105: real BT renders an "Accommodations" H4 14/700 subhead
+    under the Measurements accordion alongside Dimensions/Weights/Tanks."""
+    assert '<h4 class="accordion-subhead">Accommodations</h4>' in bdp_html
+
+
+def test_bdp_still_have_a_question_is_h3(bdp_html):
+    """v=105: real BT renders "Still have a question?" as H3 24/700
+    #303030 (NOT H2 as sandbox previously had)."""
+    assert '<h3 class="question-card-h2">Still have a question?</h3>' in bdp_html
+    assert '<h2 class="question-card-h2">Still have a question?</h2>' not in bdp_html
+
+
+def test_bdp_more_from_dealer_is_h4(bdp_html):
+    """v=105: real BT renders "More From This Dealer" as H4 20/700
+    with the carousel-special color #414d4a (NOT H2)."""
+    # The page only includes this section for dealer listings, but
+    # the fixture used by `bdp_html` may pick either type. Skip if
+    # the section isn't rendered (private listing path)."""
+    if "more-from-dealer-h2" not in bdp_html:
+        return  # private listing — section absent by design
+    assert '<h4 class="more-from-dealer-h2">More From This Dealer</h4>' in bdp_html
+    assert '<h2 class="more-from-dealer-h2">' not in bdp_html
+
+
+def test_bdp_no_listed_by_section(bdp_html):
+    """v=105: the entire "Listed By" section deleted — real BT does
+    not render a separate Listed By block on either listing type."""
+    assert 'bdp-listed-by' not in bdp_html
+    assert 'bdp-listed-by-h2' not in bdp_html
+
+
+def test_bdp_no_sparkle_on_what_owners_say(bdp_html):
+    """v=105: real BT renders "What Owners Say" without the ✦
+    sparkle prefix. Sandbox's decorative ✦ removed."""
+    # The owners-card-heading should not contain a sparkle-icon span
+    import re
+    m = re.search(
+        r'<h2 class="owners-card-heading">.*?</h2>',
+        bdp_html,
+        re.DOTALL,
+    )
+    assert m, "owners-card-heading H2 missing"
+    assert 'sparkle-icon' not in m.group(0)
+    assert '✦' not in m.group(0)
+
+
+def test_bdp_no_key_features_heading(bdp_html):
+    """v=105: "Key Features" H3 removed — real BT doesn't render this
+    heading on probed listings. The feature list <ul> kept as part
+    of the Description body."""
+    assert 'bdp-feature-h3' not in bdp_html
+    assert '>Key Features<' not in bdp_html
+
+
+def test_bdp_dealer_card_heading_is_h3(bdp_html):
+    """v=105/107: contact card heading is H3 18/500 (was H2 20/700).
+    Dealer cards use the salesperson name, private cards use
+    "Contact Private Seller"."""
+    import re
+    h3_match = re.search(
+        r'<h3 class="dealer-card-heading">(Contact [^<]+)</h3>',
+        bdp_html,
+    )
+    assert h3_match, "dealer-card-heading H3 not found"
+    heading = h3_match.group(1)
+    # Either "Contact Private Seller" or "Contact <FirstName LastName>"
+    assert (
+        heading == "Contact Private Seller"
+        or re.match(r"^Contact [A-Z][a-z]+ [A-Z][a-z]+$", heading)
+    ), f"unexpected heading: {heading!r}"
+    # H2 dealer-card-heading should not exist anymore
+    assert '<h2 class="dealer-card-heading">' not in bdp_html
+
+
+def test_bdp_dealer_card_has_inline_sublines(bdp_html):
+    """v=107: dealer card renders dealer name + city as a subline
+    paragraph and dealer phone as a subline link directly under the
+    salesperson H3 (matches real BT pattern). Skip on private listing
+    fixture (those listings don't have a dealer)."""
+    if "bdp-private-seller-card" in bdp_html:
+        return  # private listing path doesn't have dealer sublines
+    assert 'class="dealer-card-subline dealer-card-name"' in bdp_html
+    assert 'class="dealer-card-subline dealer-card-phone"' in bdp_html
+
+
+def test_bdp_dealership_card_not_rendered(bdp_html):
+    """v=107: the separate `.bdp-dealership-card` (right-rail logo +
+    active/sold stats block) is wrapped in `{% if false %}` and not
+    rendered — real BT does not have a separate dealership card in
+    the right rail."""
+    assert 'class="bdp-dealership-card"' not in bdp_html
+    assert 'dealership-stat-num' not in bdp_html
 
 
 def _details_block(html: str, anchor: str) -> str:


### PR DESCRIPTION
## Summary

Multi-session BDP exact-mirror pass on the `mantis_boattrader` sim env, pulling the boat-detail-page layout from ~v=104 to byte-near-exact match with real `boattrader.com`. **29 deploys, 28 commits**, driven by user screenshot feedback (~half the rounds) + autonomous Chrome MCP structural probes (~half).

Branch: `worktree-bdp-exact-mirror`
Iteration log: `deploy/sim_envs/mantis_boattrader/FIDELITY.md` (v=105 → v=133 entries)

### Notable structural fixes

**Sticky bar (`.next-previous`)** — replaces the old `.bdp-sticky-bar` (320px-scroll-triggered):
- Always-sticky top:0, full-viewport bleed (`width: 100vw; margin-left: calc(-50vw + 50%)`)
- Inner wrapper `max-width: 1400px; margin: 0 80px`
- Contents: `‹ Search` / breadcrumb (12/400 #616161) / Previous Boat / Next Boat

**Heading hierarchy aligned to real BT:**
- More Details / Location: H3 → H4 (16/700)
- Accommodations H4 added under Measurements
- More From This Dealer H2 → H4 (20/700 #414d4a)
- Still-have-a-question H2 → H3 (24/700 #303030)
- Dealer contact card H2 → H3 (18/500 #1a2022)
- Owners-card sparkle ✦ restored after v=110/111 whitewash
- Meet-Your-Seller H2 + Listed-By section + Key-Features H3 deleted (not in real BT)

**Layout root-cause fix (v=128):**
- `.bdp-grid-stack` was inheriting `gap: 80px` from `.bdp-grid`, becoming row-gap between every section (80-116px whitespace ghosts). Added `row-gap: 0`.

**Column widths exactly match real BT (v=129):**
- Gallery 890px + 76px gap + summary 400px + 34px right margin = 1400px

**Cards:**
- Owners / Boat Details / More From Dealer cards: `#f5f9ff` bg, border 1px #ededed, br 8px (was white-washed in v=110/111, reverted v=112)
- Description (Boat Details body): white nested card inside the #f5f9ff parent
- Right rail dealership card restored (v=130 — v=107's hide was a wrong probe)
- Engagement row simplified to "Views | Saves" with 1×12 #dee2e3 divider
- Lead form: Name → Email + Phone split row → Submit, all transparent inputs

**Loan calculator redesigned (v=120):**
- Loan Term (Months) field replaces Credit Score (FICO)
- Right pane: huge `$monthly` (64/700) + TOTAL LOAN AMOUNT + divider + See Important Disclosure (removed APR display, 180 MONTHS caption, Get-Pre-Qualified button, bullets)

**Contact Seller submit button (v=133):**
- Solid dark-navy pill (`#082F4C`, white 16/700, full-width) — was white-outline leaking from SRP defaults

### Verification

- **83 fidelity tests passing** (16 new for v=105-117 added during this session)
- Sandbox: `https://8080-014f48ab-eeb1-4ca5-947e-42e169d1fcc8.daytonaproxy01.net/boat/2021-crestliner-vt-18-10000396/?daytona_preview_token=<rotating>`
- Token rotates per sandbox restart; see `FIDELITY.md` for current.

### Memory captured (for future agents)

- `feedback_bdp_grid_stack_inherited_gap.md` — the v=128 root cause
- `feedback_daytona_patch_exec_504_files_still_deploy.md` — the recurring 504 on uvicorn-restart `process.exec` that returns failed but the deploy actually succeeded
- `project_boattrader_bdp_exact_mirror_session_2026_05_24.md` — session retrospective
- `reference_sim_env_verifier_inventory.md` — oracle + mutation-log inventory across all 4 sim envs

## Test plan

- [ ] Reload deployed sandbox URL and confirm visual parity with `boattrader.com/boat/<slug>/`
- [ ] `pytest tests/sim_envs/mantis_boattrader/` → 83 passing
- [ ] Spot-check: sticky bar matches "‹ Search / breadcrumb / Previous Boat / Next Boat" pattern
- [ ] Spot-check: right rail summary 400px wide with full-width dark-navy "Contact Seller" submit
- [ ] Spot-check: bottom sections (More-From-Dealer → Still-have-a-question → Other Services) sit close together (no 80px row-gap ghost)
- [ ] Spot-check: Loan calculator shows Loan Term field + huge $monthly preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)