### PR TITLE
feat(augur): task_spec on children + captured_versions per step (closes #683, #684)

### DIFF
--- a/deploy/modal/modal_cua_server.py
+++ b/deploy/modal/modal_cua_server.py
@@ -1038,6 +1038,17 @@ def _run_holo3_executor(
             task_suite.get("_fanout_group_id", "") or ""
         ) or None
 
+        # #683: forward the orchestrator-composed ``task_spec`` so the
+        # child Phase-1 / Phase-2 worker session opens with the same
+        # canonical task definition. The trajectory buffer's
+        # task_spec_ids filter matches against child bundles too —
+        # without this hop the parent row is the only one with a
+        # task_spec_id.
+        _ts = task_suite.get("_fanout_task_spec")
+        micro_runner._fanout_task_spec = (
+            dict(_ts) if isinstance(_ts, dict) and _ts else None
+        )
+
         # #638 axis 2 follow-up: derive a short worker tag from the
         # fan-out branch_id so per-step log lines can be greppable per-
         # worker in the interleaved orchestrator stdout. The branch_id

--- a/src/mantis_agent/gym/fanout_runner.py
+++ b/src/mantis_agent/gym/fanout_runner.py
@@ -1511,6 +1511,14 @@ def run_fanout_dispatch(
     # in the Augur viewer keys on the same field that already drives
     # branch_context.parent_run_id grouping.
     task_suite["_fanout_group_id"] = fanout_parent_run_id
+    # #683: also stamp the composed task_spec onto the suite so every
+    # child Phase-1 / Phase-2 worker can open its DebugSession with
+    # the same canonical task definition the orchestrator surfaces.
+    # Without this, the trajectory buffer's task_spec_ids filter has
+    # nothing to match on child bundles (only the parent row carries
+    # the task_spec) and ``same_task_divergent_outcomes`` preference
+    # mining starves.
+    task_suite["_fanout_task_spec"] = task_spec
     with open_orchestrator_session(
         run_id=fanout_parent_run_id,
         session_name=session_name,

--- a/src/mantis_agent/gym/micro_runner.py
+++ b/src/mantis_agent/gym/micro_runner.py
@@ -288,6 +288,13 @@ class MicroPlanRunner:
         # separate attr so a future loop with non-parent rollouts can
         # set group_id alone.
         self._fanout_group_id: str | None = None
+        # #683 (augur-sdk 0.6.0): canonical task_spec composed by the
+        # orchestrator and propagated through the suite envelope.
+        # ``None`` for non-fanout runs so AugurAdapter opens without
+        # the kwarg and the per-step trajectory buffer reads it from
+        # the bundle without needing the trainer to join on the
+        # parent's metadata.
+        self._fanout_task_spec: dict | None = None
         self._active_checkpoint_context = None
         self._pre_step_snapshot, self._final_status = None, "running"
         # #audit item 4: halt_reason last set by ``_persist`` — read by

--- a/src/mantis_agent/gym/run_executor.py
+++ b/src/mantis_agent/gym/run_executor.py
@@ -303,6 +303,20 @@ class RunExecutor:
             # as separate hook so a future GRPO loop with rollouts
             # that don't share a parent can set group_id alone).
             group_id=getattr(runner, "_fanout_group_id", None),
+            # #683 (augur-sdk 0.6.0): canonical TaskSpec on every
+            # child session so the trajectory buffer's task_spec_ids
+            # filter matches against child bundles too. Orchestrator
+            # composes the spec from suite metadata; the Modal worker
+            # entrypoint plumbs it onto ``_fanout_task_spec``. ``None``
+            # for non-fanout runs — AugurAdapter omits the kwarg.
+            task_spec=getattr(runner, "_fanout_task_spec", None),
+            # #684 (augur-sdk 0.6.0): brain model name for the
+            # per-step ``captured_versions.model`` stamp. The session
+            # tag still carries it (existing #542 behaviour); this is
+            # the typed field the policy registry / training surface
+            # consumes. Read once at AugurAdapter open so we don't
+            # snapshot a swapped brain mid-run.
+            brain_model_name=model_name,
         )
 
         if not runner._results_base_url and plan.steps:

--- a/src/mantis_agent/observability/augur.py
+++ b/src/mantis_agent/observability/augur.py
@@ -452,9 +452,16 @@ class AugurAdapter:
         extra_tags: dict[str, str] | None = None,
         branch_context: dict | None = None,
         group_id: str | None = None,
+        task_spec: dict | None = None,
+        brain_model_name: str | None = None,
     ) -> None:
         self._session: Any = None
         self._emitted_event_count: int = 0
+        # #684: stash the brain's model name once at adapter open so
+        # every step's ``set_step_versions`` call can stamp the typed
+        # ``captured_versions.model`` field without re-reading from
+        # the (possibly swapped) brain instance mid-run.
+        self._brain_model_name: str = str(brain_model_name or "")
         # #659: per-step-index emission counter — used by
         # :meth:`_build_step_trace` to mint a unique ``step_id`` for
         # each emission even when the same plan ``step_index`` fires
@@ -533,19 +540,31 @@ class AugurAdapter:
             # raise TypeError on unknown kwargs.
             if group_id:
                 session_kwargs["group_id"] = str(group_id)
+            # #683 (augur-sdk 0.6.0): forward the canonical TaskSpec
+            # so the trajectory buffer's task_spec_ids filter matches
+            # against child bundles too. Same TypeError fallback as
+            # group_id for pre-0.6.0 pins.
+            if task_spec:
+                session_kwargs["task_spec"] = dict(task_spec)
             try:
                 session = DebugSession(**session_kwargs)
             except TypeError as exc:
-                # SDK predates 0.6.0 → ``group_id`` isn't accepted.
-                # Drop the 0.6.0 kwarg and retry — preserves the
-                # production path on older pins.
-                if "group_id" in session_kwargs:
+                # SDK predates 0.6.0 → ``group_id`` / ``task_spec``
+                # aren't accepted. Drop the 0.6.0 kwargs and retry —
+                # preserves the production path on older pins.
+                stripped = [
+                    k for k in ("group_id", "task_spec")
+                    if k in session_kwargs
+                ]
+                if stripped:
                     if _verbose:
                         logger.warning(
-                            "AugurAdapter init: SDK rejected group_id "
-                            "(%s) — retrying without it", exc,
+                            "AugurAdapter init: SDK rejected 0.6.0 "
+                            "kwargs %s (%s) — retrying without them",
+                            stripped, exc,
                         )
-                    session_kwargs.pop("group_id", None)
+                    for k in stripped:
+                        session_kwargs.pop(k, None)
                     session = DebugSession(**session_kwargs)
                 else:
                     raise
@@ -744,6 +763,16 @@ class AugurAdapter:
             self._maybe_stamp_loop_detected(
                 augur_index, getattr(step_result, "failure_class", ""),
             )
+            # #684 (augur-sdk 0.6.0): stamp captured_versions per step
+            # so the policy registry can deduplicate runs by model +
+            # grounder + code revision. Without this, the registry
+            # collapses every run to the same policy signature.
+            self._maybe_stamp_step_versions(
+                augur_index,
+                executor_backend=str(
+                    getattr(step_result, "executor_backend", "") or "",
+                ),
+            )
         except Exception as exc:  # noqa: BLE001
             # Verbose deploys want this visible; production stays at debug.
             if is_verbose():
@@ -763,6 +792,48 @@ class AugurAdapter:
         "hard_loop",
         "soft_loop",
     })
+
+    def _maybe_stamp_step_versions(
+        self, augur_index: int, *, executor_backend: str,
+    ) -> None:
+        """Stamp ``captured_versions.model`` + ``.grounder`` +
+        ``.code_git_sha`` for this step via the augur-sdk 0.6.0
+        ``set_step_versions`` API (#684).
+
+        Without this, every mantis bundle hashes to the same policy
+        signature in ``/registry/policies`` — the registry can't
+        distinguish Holo3 vs Claude-driven runs, different grounder
+        backends (SoM vs vision), or code revisions.
+
+        Silently no-ops when the SDK predates 0.6.0 (no
+        ``set_step_versions`` method) or the session is inactive.
+        ``executor_backend`` is read off the per-step ``StepResult``
+        and maps directly to the augur ``grounder`` enum
+        (``som`` / ``vision`` / ``plan``).
+        """
+        versions_fn = getattr(self._session, "set_step_versions", None)
+        if not callable(versions_fn):
+            return
+        kwargs: dict[str, Any] = {"step_index": augur_index}
+        if self._brain_model_name:
+            kwargs["model"] = self._brain_model_name
+        if executor_backend:
+            kwargs["grounder"] = executor_backend
+        git_sha = os.environ.get("MANTIS_GIT_SHA", "").strip()
+        if git_sha:
+            kwargs["code_git_sha"] = git_sha
+        # Only call when we have at least one field beyond step_index
+        # — empty stamps would land an empty captured_versions
+        # block on the trace without adding signal.
+        if len(kwargs) <= 1:
+            return
+        try:
+            versions_fn(**kwargs)
+        except Exception as exc:  # noqa: BLE001
+            if is_verbose():
+                logger.warning(
+                    "AugurAdapter.set_step_versions failed: %r", exc,
+                )
 
     def _maybe_stamp_loop_detected(
         self, augur_index: int, failure_class: Any,

--- a/tests/test_augur_adopt_task_spec_children_683.py
+++ b/tests/test_augur_adopt_task_spec_children_683.py
@@ -1,0 +1,301 @@
+"""#683 + #684 — producer-side adoption of augur-sdk 0.6.0 per-step fields.
+
+Three discrete additions on top of #680 / #681 (Phase A):
+
+* ``AugurAdapter(task_spec=...)`` forwards to ``DebugSession(task_spec=...)``
+  so child fan-out sessions carry the canonical task definition the
+  trajectory buffer filters on (#683).
+* ``AugurAdapter(brain_model_name=...)`` is stashed at adapter open and
+  stamped on every step via ``session.set_step_versions(step_index,
+  model=, grounder=, code_git_sha=)`` (#684). Without this, the policy
+  registry collapses every run to one signature.
+* ``run_fanout_dispatch`` stamps ``_fanout_task_spec`` on the suite so
+  the Modal worker entrypoint can pull it back and pass to the child
+  ``AugurAdapter``.
+
+Contract pinned here:
+
+* TypeError on the new kwargs strips them AND retries cleanly
+  (best-effort observability — never break the run for missing
+  metadata fields).
+* ``set_step_versions`` is called when the SDK has the method AND we
+  have at least one field beyond step_index. The empty-fields case
+  skips the call to avoid landing empty captured_versions blocks.
+* Children read ``_fanout_task_spec`` off the suite envelope same as
+  ``_fanout_group_id``.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import mantis_agent.observability.augur as augur_mod
+from mantis_agent.gym.fanout_runner import run_fanout_dispatch
+from mantis_agent.observability.augur import AugurAdapter
+from mantis_agent.plan_decomposer import MicroIntent, MicroPlan, PlanDecomposer
+
+
+@pytest.fixture
+def force_augur_available(monkeypatch):
+    """Same shape as the #680 fixture — flip ``_AUGUR_AVAILABLE``
+    and stub ``CaptureMode`` so adapter init's pre-DebugSession
+    helpers don't crash on CI runners that lack the SDK."""
+    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
+    monkeypatch.setattr(augur_mod, "_AUGUR_AVAILABLE", True)
+    monkeypatch.setattr(
+        augur_mod, "CaptureMode", lambda v=None: f"capture_mode:{v}",
+    )
+
+
+# ── AugurAdapter forwards task_spec to DebugSession (#683) ─────────
+
+
+def test_augur_adapter_forwards_task_spec_to_debug_session(force_augur_available):
+    """``AugurAdapter(task_spec=...)`` → ``DebugSession(task_spec=...)``."""
+    fake_session = MagicMock()
+    fake_session._stream = None
+    debug_session_cls = MagicMock(return_value=fake_session)
+    spec = {"task_spec_id": "boattrader.com.boattrader_scrape_urlnav.v1"}
+    with patch.object(augur_mod, "DebugSession", debug_session_cls):
+        AugurAdapter(
+            run_id="child-rid", tenant_id="t", session_name="s",
+            task_spec=spec,
+        )
+    debug_session_cls.assert_called_once()
+    forwarded = debug_session_cls.call_args.kwargs["task_spec"]
+    assert forwarded == spec
+    # The adapter forwards a dict COPY (defensive) — mutating the
+    # original after AugurAdapter() returns mustn't poison the bundle.
+    assert forwarded is not spec
+
+
+def test_augur_adapter_retries_without_task_spec_on_TypeError(force_augur_available):
+    """Pre-0.6.0 SDKs reject ``task_spec=`` → retry strips it."""
+    fake_session = MagicMock()
+    fake_session._stream = None
+    debug_session_cls = MagicMock(side_effect=[
+        TypeError("got unexpected keyword 'task_spec'"),
+        fake_session,
+    ])
+    with patch.object(augur_mod, "DebugSession", debug_session_cls):
+        a = AugurAdapter(
+            run_id="r", tenant_id="t", session_name="s",
+            task_spec={"task_spec_id": "x.v1"},
+        )
+    assert debug_session_cls.call_count == 2
+    assert "task_spec" in debug_session_cls.call_args_list[0].kwargs
+    assert "task_spec" not in debug_session_cls.call_args_list[1].kwargs
+    assert a._session is fake_session
+
+
+def test_augur_adapter_retries_strips_both_kwargs_on_TypeError(force_augur_available):
+    """When both ``group_id`` and ``task_spec`` are passed, a single
+    TypeError on the new kwargs strips BOTH and retries once."""
+    fake_session = MagicMock()
+    fake_session._stream = None
+    debug_session_cls = MagicMock(side_effect=[
+        TypeError("got unexpected keyword 'task_spec'"),
+        fake_session,
+    ])
+    with patch.object(augur_mod, "DebugSession", debug_session_cls):
+        AugurAdapter(
+            run_id="r", tenant_id="t", session_name="s",
+            group_id="g", task_spec={"task_spec_id": "x.v1"},
+        )
+    assert debug_session_cls.call_count == 2
+    first = debug_session_cls.call_args_list[0].kwargs
+    assert "group_id" in first and "task_spec" in first
+    retry = debug_session_cls.call_args_list[1].kwargs
+    assert "group_id" not in retry and "task_spec" not in retry
+
+
+def test_augur_adapter_omits_task_spec_when_caller_omits(force_augur_available):
+    """No ``task_spec=`` arg → kwarg not forwarded to DebugSession.
+    (Production single-runner sessions shouldn't carry a task_spec
+    they didn't earn.)"""
+    fake_session = MagicMock()
+    fake_session._stream = None
+    debug_session_cls = MagicMock(return_value=fake_session)
+    with patch.object(augur_mod, "DebugSession", debug_session_cls):
+        AugurAdapter(run_id="r", tenant_id="t", session_name="s")
+    assert "task_spec" not in debug_session_cls.call_args.kwargs
+
+
+# ── set_step_versions stamping (#684) ──────────────────────────────
+
+
+def _stub_step_result(*, step_index: int, executor_backend: str = "som"):
+    return SimpleNamespace(
+        step_index=step_index, intent=f"step{step_index}",
+        success=True, verdict=SimpleNamespace(kind="ok", reason="", confidence=1.0),
+        data="", failure_class="", last_action=None, duration=0.0,
+        page_title="", executor_backend=executor_backend, reasoning="",
+    )
+
+
+def test_record_step_stamps_model_grounder_git_sha(tmp_path, monkeypatch):
+    """``record_step`` calls ``session.set_step_versions`` with model,
+    grounder, code_git_sha — the policy registry's signature inputs."""
+    monkeypatch.setenv("MANTIS_GIT_SHA", "abc1234")
+    a = AugurAdapter(
+        run_id="versions_test", tenant_id="t", session_name="s",
+        out_dir=tmp_path, brain_model_name="Holo3-35B-A3B",
+    )
+    if not a.active:
+        pytest.skip("AugurAdapter inactive")
+    a._session = MagicMock()
+    a._session.record_step = MagicMock()
+    a._session.record_step_iteration = MagicMock()
+    a._session.set_step_versions = MagicMock()
+    a._session.set_loop_detected = MagicMock()
+    a.record_step(step_result=_stub_step_result(step_index=2, executor_backend="som"))
+    a._session.set_step_versions.assert_called_once_with(
+        step_index=3, model="Holo3-35B-A3B", grounder="som", code_git_sha="abc1234",
+    )
+
+
+def test_record_step_omits_step_versions_when_no_signal(tmp_path, monkeypatch):
+    """No brain_model_name + no executor_backend + no git_sha → skip
+    the ``set_step_versions`` call (empty captured_versions on the
+    trace is useless noise)."""
+    monkeypatch.delenv("MANTIS_GIT_SHA", raising=False)
+    a = AugurAdapter(
+        run_id="versions_test", tenant_id="t", session_name="s",
+        out_dir=tmp_path,  # no brain_model_name
+    )
+    if not a.active:
+        pytest.skip("AugurAdapter inactive")
+    a._session = MagicMock()
+    a._session.record_step = MagicMock()
+    a._session.set_step_versions = MagicMock()
+    a.record_step(step_result=_stub_step_result(step_index=2, executor_backend=""))
+    a._session.set_step_versions.assert_not_called()
+
+
+def test_record_step_step_versions_no_op_on_pre_06_sdk(tmp_path):
+    """SDKs without ``set_step_versions`` → method lookup misses,
+    stamp is skipped, step trace still recorded."""
+    a = AugurAdapter(
+        run_id="versions_test", tenant_id="t", session_name="s",
+        out_dir=tmp_path, brain_model_name="x",
+    )
+    if not a.active:
+        pytest.skip("AugurAdapter inactive")
+    # spec=[...] strips ``set_step_versions`` from the mock — matches
+    # the pre-0.6.0 SDK surface.
+    a._session = MagicMock(spec=["record_step"])
+    a._session.record_step = MagicMock()
+    a.record_step(step_result=_stub_step_result(step_index=2))
+    a._session.record_step.assert_called_once()
+
+
+def test_record_step_stamps_only_present_fields(tmp_path, monkeypatch):
+    """Partial inputs (model set, grounder + git_sha absent) → kwargs
+    forwarded omit the absent fields entirely instead of stamping
+    empty strings."""
+    monkeypatch.delenv("MANTIS_GIT_SHA", raising=False)
+    a = AugurAdapter(
+        run_id="versions_test", tenant_id="t", session_name="s",
+        out_dir=tmp_path, brain_model_name="Holo3-35B-A3B",
+    )
+    if not a.active:
+        pytest.skip("AugurAdapter inactive")
+    a._session = MagicMock()
+    a._session.record_step = MagicMock()
+    a._session.set_step_versions = MagicMock()
+    a.record_step(step_result=_stub_step_result(step_index=2, executor_backend=""))
+    a._session.set_step_versions.assert_called_once_with(
+        step_index=3, model="Holo3-35B-A3B",
+    )
+
+
+# ── run_fanout_dispatch stamps _fanout_task_spec on suite (#683) ───
+
+
+def _make_eligible_suite() -> dict:
+    plan = MicroPlan(domain="boattrader.com")
+    plan.steps = [
+        MicroIntent(
+            intent="Navigate", type="navigate", section="setup",
+            params={"url": "https://www.boattrader.com/boats/by-owner/"},
+        ),
+        MicroIntent(intent="Click card", type="click", section="extraction"),
+        MicroIntent(intent="Read URL", type="extract_url", section="extraction"),
+        MicroIntent(intent="Scroll", type="scroll", section="extraction"),
+        MicroIntent(intent="Extract", type="extract_data", section="extraction"),
+        MicroIntent(intent="Back", type="navigate_back", section="extraction"),
+        MicroIntent(
+            intent="Inner loop", type="loop", section="extraction",
+            loop_target=1, loop_count=40,
+        ),
+    ]
+    PlanDecomposer._classify_loop_groups(plan)
+    return {
+        "session_name": "x",
+        "_plan_name": "boattrader_scrape_urlnav",
+        "_plan_signature": "bt-test-sig",
+        "_site_config": {"domain": "boattrader.com"},
+        "_fanout_phase1_workers": 1,
+        "_micro_plan": [
+            {
+                "intent": s.intent, "type": s.type, "section": s.section,
+                "params": dict(s.params or {}),
+                "loop_target": s.loop_target, "loop_count": s.loop_count,
+                "claude_only": s.claude_only, "gate": s.gate,
+                "required": s.required, "grounding": s.grounding,
+                "verify": s.verify, "reverse": s.reverse,
+                "budget": s.budget, "hints": dict(s.hints or {}),
+            }
+            for s in plan.steps
+        ],
+        "_loop_groups": [
+            {
+                "loop_step_idx": g.loop_step_idx,
+                "body_range": list(g.body_range),
+                "shape": g.shape,
+            }
+            for g in plan.loop_groups
+        ],
+    }
+
+
+def _make_executor_stub():
+    handle_p1 = MagicMock()
+    handle_p1.get.return_value = {
+        "viable": 0, "leads_with_phone": 0, "leads": [],
+        "collected_urls": ["https://x/d/1"], "shared_seen_hits": 0,
+    }
+    handle_p2 = MagicMock()
+    handle_p2.get.return_value = {
+        "viable": 1, "leads_with_phone": 0,
+        "leads": [{"url": "https://x/d/1"}], "shared_seen_hits": 0,
+    }
+    executor = MagicMock()
+    executor.spawn.side_effect = [handle_p1, handle_p2]
+    return executor
+
+
+def test_run_fanout_dispatch_stamps_task_spec_on_suite(force_augur_available):
+    """``_fanout_task_spec`` lands on the suite dict so the Modal
+    worker entrypoint can plumb it onto ``MicroRunner._fanout_task_spec``."""
+    fake_ctx = MagicMock()
+    fake_ctx.__enter__ = MagicMock(return_value=MagicMock())
+    fake_ctx.__exit__ = MagicMock(return_value=False)
+    stub = MagicMock()
+    stub.open_orchestrator = MagicMock(return_value=fake_ctx)
+    suite = _make_eligible_suite()
+    with patch.object(augur_mod, "DebugSession", stub):
+        run_fanout_dispatch(
+            suite,
+            executor_fn=_make_executor_stub(),
+            model="holo3", claude_model="",
+            max_steps=10, workers=1,
+            fanout_parent_run_id="fanout-683",
+        )
+    assert "_fanout_task_spec" in suite
+    spec = suite["_fanout_task_spec"]
+    assert spec["task_class"] == "boattrader.com"
+    assert spec["task_spec_id"] == "boattrader.com.boattrader_scrape_urlnav.v1"


### PR DESCRIPTION
## Summary

Producer-side adoption hops for the upstream "what's left on mantis" audit:

| # | Surface | Without this | With this |
|---|---|---|---|
| #683 | ``task_spec`` on **child** fanout sessions | trajectory buffer's ``task_spec_ids`` filter starves; preference UI's ``same_task_divergent_outcomes`` strategy has nothing to match | every child Phase-1 / Phase-2 worker carries the same canonical TaskSpec the orchestrator surfaces |
| #684 | per-step ``captured_versions.model`` / ``.grounder`` / ``.code_git_sha`` via ``set_step_versions`` | 133 production runs hash to one policy signature in ``/registry/policies`` | each step's typed captured_versions identifies model (Holo3-35B-A3B / Claude-…) + grounder (SoM / vision / plan) + commit |

Both hops are "one-line producer-side change" per the upstream audit.

## Implementation

**task_spec child propagation** mirrors the ``_fanout_group_id`` shape PR #681 established:

```
run_fanout_dispatch (orchestrator)
  → task_suite["_fanout_task_spec"] = composed_spec
modal_cua_server worker entrypoint
  → micro_runner._fanout_task_spec = task_suite["_fanout_task_spec"]
RunExecutor
  → AugurAdapter(task_spec=runner._fanout_task_spec, ...)
AugurAdapter.__init__
  → DebugSession(task_spec=..., group_id=..., ...)
    [retries without on TypeError for pre-0.6.0 SDKs]
```

**captured_versions** is per-step. ``RunExecutor`` reads ``brain.model_name`` once and passes to ``AugurAdapter(brain_model_name=...)``. Each ``record_step`` call invokes a new ``_maybe_stamp_step_versions`` helper that forwards ``model`` / ``grounder`` / ``code_git_sha`` via ``session.set_step_versions(...)``. ``grounder`` reads off ``StepResult.executor_backend``; ``code_git_sha`` from ``MANTIS_GIT_SHA`` env (already set on production containers).

## Backwards compatibility

Same TypeError retry pattern PR #681 already established — pre-0.6.0 SDK pins silently degrade. ``set_step_versions`` is dispatched via ``getattr`` so older SDK shapes skip the call cleanly.

When no field beyond ``step_index`` is available, the stamp is skipped entirely so the bundle doesn't carry empty ``captured_versions`` blocks.

## Out of scope

- **#685** group_id step-trace verification — likely already works via SDK auto-propagation (per 0.6.0 docs: "group_id auto-propagates to every recorded step"). Needs a verbose Modal rerun to confirm; no code change expected.
- **#686** subgoals_completed at Phase-1/Phase-2 boundaries — separate scope, Phase C of #680.
- **#687** capture_logprobs — env-gated training-data quality, Phase B of #680.

## Test plan

- [x] ``tests/test_augur_adopt_task_spec_children_683.py`` — 9 new tests
- [x] All 90 augur-related tests pass
- [x] ``ruff check`` clean
- [ ] Modal redeploy + boattrader rerun with ``MANTIS_AUGUR_VERBOSE=1`` — confirm child bundles carry ``task_spec.task_spec_id`` AND each step carries ``captured_versions.model="Holo3-35B-A3B"`` + ``.grounder=<som|vision|plan>``

Closes #683, #684.

🤖 Generated with [Claude Code](https://claude.com/claude-code)