### PR TITLE
feat(augur): publish model-layer modelio context at runner step boundary (closes #689)

### DIFF
--- a/src/mantis_agent/gym/run_executor.py
+++ b/src/mantis_agent/gym/run_executor.py
@@ -944,9 +944,26 @@ class RunExecutor:
         # runner orchestration outside any helper falls into
         # ``overhead`` automatically via :meth:`TimeMeter.breakdown`.
         from . import time_meter as _tm
+        # #689 — publish a default ``model`` modelio context for the
+        # duration of every step's execute. Any LLM call made inside
+        # (extractor, brain's action decision, form-targeting Claude)
+        # records a ``modelio/<step:04d>-model-<seq>.json`` entry
+        # without each call site needing its own wrapper. Critic,
+        # verifier, and step_recovery sub-paths already publish their
+        # own contexts deeper — contextvar nesting reapplies their
+        # layer for the inner block, then reverts to ``model`` on the
+        # way out. Reads ``_augur`` off the runner; the helper is a
+        # no-op when the adapter is inactive (Augur disabled / SDK
+        # missing), so this wrapper is free in those cases.
+        from ..observability.modelio import publish_modelio_context
         try:
-            with _tm.publish_dispatch(meter, state.step_index):
-                step_result = runner._execute_step(effective_step, state.step_index)
+            with publish_modelio_context(
+                getattr(runner, "_augur", None),
+                layer="model",
+                step_index=state.step_index,
+            ):
+                with _tm.publish_dispatch(meter, state.step_index):
+                    step_result = runner._execute_step(effective_step, state.step_index)
         finally:
             runner._active_checkpoint_context = None
         if step_result.screenshot_png is None:

--- a/tests/test_modelio_coverage_689.py
+++ b/tests/test_modelio_coverage_689.py
@@ -1,0 +1,237 @@
+"""#689 — runner-level ``publish_modelio_context`` default.
+
+Coverage of ``session.record_modelio()`` was sparse (1.3% on the
+staffai tenant) because most LLM call sites didn't have an outer
+``publish_modelio_context`` wrapping them. Step handlers and helpers
+that already published contexts (form-targeting → grounding,
+step_recovery → step_recovery, runner verify → verifier) were the
+exceptions; the bulk of model-decision LLM calls (extractor,
+brain's action call) fell through with no context published, so the
+client-side capture hook in ``_anthropic/client._record_modelio_if_active``
+short-circuited on ``current_modelio_context() is None``.
+
+The fix: ``RunExecutor._dispatch_step`` now wraps every
+``_execute_step`` invocation in ``publish_modelio_context(layer="model",
+step_index=...)`` as the DEFAULT layer for the step's duration. Step
+handlers that have a more specific layer (form-targeting →
+``grounding``, verifier path → ``verifier``) override via contextvar
+nesting; the outer ``model`` reverts on the way out.
+
+Contract pinned here:
+
+* ``_dispatch_step`` publishes ``model`` modelio context around
+  ``_execute_step``.
+* The publish is a no-op when ``runner._augur`` is None / inactive
+  (Augur disabled / SDK missing).
+* Inner-scope overrides win — a step handler that publishes
+  ``grounding`` sees ``grounding`` for its inner Anthropic calls; the
+  outer ``model`` reasserts after the handler returns.
+* Exception in the step body still resets the contextvar (the
+  context manager's ``finally`` honors the contract).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import mantis_agent.observability.modelio as modelio_mod
+from mantis_agent.observability.modelio import (
+    current_modelio_context,
+    publish_modelio_context,
+)
+
+
+@pytest.fixture
+def fake_augur():
+    """Mock AugurAdapter that the helper accepts (active=True)."""
+    augur = MagicMock()
+    augur.active = True
+    return augur
+
+
+# ── publish_modelio_context nesting semantics ──────────────────────
+
+
+def test_publish_default_then_inner_override_then_revert(fake_augur):
+    """Outer ``model`` + inner ``grounding`` → reads ``grounding``
+    inside the inner block, reverts to ``model`` after."""
+    with publish_modelio_context(fake_augur, layer="model", step_index=2):
+        ctx = current_modelio_context()
+        assert ctx is not None
+        assert ctx.layer == "model"
+        assert ctx.step_index == 2
+        with publish_modelio_context(fake_augur, layer="grounding", step_index=2):
+            inner = current_modelio_context()
+            assert inner.layer == "grounding"
+        # After inner exits, outer context restores.
+        again = current_modelio_context()
+        assert again.layer == "model"
+
+
+def test_publish_resets_on_exception(fake_augur):
+    """Exception inside the ``with`` block still resets the
+    contextvar — no leak between steps."""
+    assert current_modelio_context() is None
+    try:
+        with publish_modelio_context(fake_augur, layer="model", step_index=0):
+            raise RuntimeError("step blew up")
+    except RuntimeError:
+        pass
+    # Contextvar must have reset even though the body raised.
+    assert current_modelio_context() is None
+
+
+def test_publish_unknown_layer_logs_and_skips(monkeypatch, caplog, fake_augur):
+    """Unknown layer string → WARN logged, yield without setting
+    context. Catches typos in call sites at dev time."""
+    import logging
+    caplog.set_level(logging.WARNING, logger=modelio_mod.logger.name)
+    with publish_modelio_context(fake_augur, layer="not-a-layer", step_index=0):
+        # No context published since layer was rejected.
+        assert current_modelio_context() is None
+    assert any("unknown layer" in r.message for r in caplog.records)
+
+
+def test_publish_inactive_augur_yields_without_context():
+    """``augur=None`` or inactive → yield without setting context
+    (telemetry never breaks the run)."""
+    with publish_modelio_context(None, layer="model", step_index=0):
+        assert current_modelio_context() is None
+    inactive = MagicMock()
+    inactive.active = False
+    with publish_modelio_context(inactive, layer="model", step_index=0):
+        assert current_modelio_context() is None
+
+
+# ── RunExecutor wraps _execute_step with layer="model" ─────────────
+
+
+def test_dispatch_step_publishes_model_context(fake_augur):
+    """``RunExecutor._dispatch_step`` wraps ``_execute_step`` in a
+    ``publish_modelio_context(layer="model")`` block so any deep
+    Anthropic call inside lands as ``model`` modelio.
+
+    Asserted by patching ``publish_modelio_context`` at the import
+    site (run_executor.py imports it locally inside the function)
+    and confirming it's invoked with the expected layer + step_index.
+    """
+    # Import sites in run_executor: ``from ..observability.modelio
+    # import publish_modelio_context`` is local-in-function, so the
+    # patch target is ``modelio_mod.publish_modelio_context`` (the
+    # source-of-truth module) since the local rebind picks it up at
+    # call time, not module load.
+    seen: list[tuple[Any, str, int | None]] = []
+
+    real_publish = publish_modelio_context
+
+    def _spy(augur, *, layer, step_index=None):
+        seen.append((augur, layer, step_index))
+        return real_publish(augur, layer=layer, step_index=step_index)
+
+    # Build a minimal RunExecutor enough to exercise the publish path.
+    from mantis_agent.gym.run_executor import RunExecutor, RunState
+
+    runner = MagicMock()
+    runner._augur = fake_augur
+    runner._active_checkpoint_context = None
+    runner.pending_form_labels = []
+    runner._latest_preview_result = None
+    runner.env = MagicMock()
+    runner._last_known_url = ""
+    runner._pre_step_snapshot = None
+    runner.time_meter = None
+    # ``_execute_step`` returns a stub StepResult.
+    fake_result = MagicMock()
+    fake_result.screenshot_png = b"png"
+    fake_result.success = True
+    runner._execute_step = MagicMock(return_value=fake_result)
+
+    plan = MagicMock()
+    plan.steps = []
+    state = RunState(checkpoint=MagicMock(), results=[], step_index=2,
+                     loop_counters={}, listings_on_page=set())
+    step = MagicMock()
+    step.type = "click"
+    step.verify = ""
+
+    executor = RunExecutor.__new__(RunExecutor)
+    executor.parent = runner
+    # Patch dependencies that _dispatch_step calls.
+    with patch.object(modelio_mod, "publish_modelio_context", side_effect=_spy), \
+         patch("mantis_agent.gym.run_executor._pending_form_labels", return_value=[]), \
+         patch("mantis_agent.gym.run_executor.reset_grounding_trace_stashes"), \
+         patch("mantis_agent.gym.run_executor._maybe_run_reversibility_gate"), \
+         patch("mantis_agent.gym.run_executor.step_snapshot.capture", return_value=MagicMock()), \
+         patch("mantis_agent.gym.run_executor._read_env_url", return_value=""):
+        # Suppress the inner time_meter.publish_dispatch since it's
+        # not the contract under test.
+        import mantis_agent.gym.time_meter as _tm
+        with patch.object(_tm, "publish_dispatch", side_effect=publish_modelio_context):
+            executor._dispatch_step(plan, state, step)
+
+    # At least one call with layer="model" and step_index=2
+    model_calls = [
+        (a, layer, s) for (a, layer, s) in seen if layer == "model"
+    ]
+    assert any(s == 2 for (_, _, s) in model_calls), (
+        f"Expected a model-layer publish at step_index=2 in {seen!r}"
+    )
+
+
+def test_dispatch_step_passes_runner_augur_to_publish(fake_augur):
+    """The publish call forwards ``runner._augur`` so the contextvar
+    knows which adapter to attach LLM records to. Critical because
+    fan-out workers each have their own AugurAdapter — wrong augur =
+    records land on the wrong session."""
+    seen: list[Any] = []
+
+    def _spy(augur, *, layer, step_index=None):
+        seen.append(augur)
+        return publish_modelio_context(augur, layer=layer, step_index=step_index)
+
+    from mantis_agent.gym.run_executor import RunExecutor, RunState
+
+    runner = MagicMock()
+    runner._augur = fake_augur
+    runner._active_checkpoint_context = None
+    runner.pending_form_labels = []
+    runner._latest_preview_result = None
+    runner.env = MagicMock()
+    runner._last_known_url = ""
+    runner._pre_step_snapshot = None
+    runner.time_meter = None
+    fake_result = MagicMock()
+    fake_result.screenshot_png = b"png"
+    fake_result.success = True
+    runner._execute_step = MagicMock(return_value=fake_result)
+
+    plan = MagicMock()
+    plan.steps = []
+    state = RunState(checkpoint=MagicMock(), results=[], step_index=0,
+                     loop_counters={}, listings_on_page=set())
+    step = MagicMock()
+    step.type = "click"
+    step.verify = ""
+
+    executor = RunExecutor.__new__(RunExecutor)
+    executor.parent = runner
+    with patch.object(modelio_mod, "publish_modelio_context", side_effect=_spy), \
+         patch("mantis_agent.gym.run_executor._pending_form_labels", return_value=[]), \
+         patch("mantis_agent.gym.run_executor.reset_grounding_trace_stashes"), \
+         patch("mantis_agent.gym.run_executor._maybe_run_reversibility_gate"), \
+         patch("mantis_agent.gym.run_executor.step_snapshot.capture", return_value=MagicMock()), \
+         patch("mantis_agent.gym.run_executor._read_env_url", return_value=""):
+        import mantis_agent.gym.time_meter as _tm
+        with patch.object(_tm, "publish_dispatch", side_effect=publish_modelio_context):
+            executor._dispatch_step(plan, state, step)
+
+    assert fake_augur in seen, (
+        f"Expected runner._augur ({fake_augur!r}) to be passed to "
+        f"publish_modelio_context; saw {seen!r}"
+    )
+
+
+# Imports needed for the spy assertions above to read 'Any' type-tag.
+from typing import Any  # noqa: E402

--- a/tests/test_modelio_coverage_689.py
+++ b/tests/test_modelio_coverage_689.py
@@ -1,8 +1,8 @@
 """#689 — runner-level ``publish_modelio_context`` default.
 
-Coverage of ``session.record_modelio()`` was sparse (1.3% on the
-staffai tenant) because most LLM call sites didn't have an outer
-``publish_modelio_context`` wrapping them. Step handlers and helpers
+Coverage of ``session.record_modelio()`` was sparse (1.3% across
+recent production runs) because most LLM call sites didn't have an
+outer ``publish_modelio_context`` wrapping them. Step handlers and helpers
 that already published contexts (form-targeting → grounding,
 step_recovery → step_recovery, runner verify → verifier) were the
 exceptions; the bulk of model-decision LLM calls (extractor,


### PR DESCRIPTION
## Summary

``record_modelio()`` coverage was sparse — **1.3% on the staffai tenant** (2 of 149 runs carried a ``modelio/`` directory). The plumbing already existed (``publish_modelio_context`` contextmanager + client-side capture hook in ``_anthropic/client._record_modelio_if_active``), but no caller published a ``model``-layer context around the main LLM call sites. Only form-targeting (``grounding``), step_recovery (``step_recovery``), and the runner-verify helpers (``verifier``) had published contexts.

## Fix

``RunExecutor._dispatch_step`` now wraps every ``_execute_step`` invocation in ``publish_modelio_context(layer="model", step_index=...)`` as the DEFAULT layer. Any Anthropic call made during the step's execution (extractor, brain's action decision, ad-hoc Claude tool calls) lands as ``model`` modelio without a per-call-site wrapper. Step handlers with a more specific layer override via contextvar nesting — form-targeting's ``grounding``, verifier path's ``verifier``, step_recovery's ``step_recovery`` — and the outer ``model`` reverts on the way out.

## Why this is the right hook

| Surface | Wrap | Effect |
|---|---|---|
| Runner step boundary (this PR) | ``model`` (default) | Every LLM call inside the step lands as ``model`` unless overridden |
| ``step_handlers/form.py`` (existing) | ``grounding`` (inner) | Form-targeting Claude calls land as ``grounding`` |
| ``_runner_helpers.py`` verifier path (existing) | ``verifier`` (inner) | Verifier calls land as ``verifier`` |
| ``step_recovery.py`` (existing) | ``step_recovery`` (inner) | Recovery LLM calls land as ``step_recovery`` |

Contextvar nesting is the standard Python idiom; the inner wraps win for the duration of their with-block and revert on exit. No call site needs to know about its parent's published layer.

## This is the prerequisite for #687

``capture_logprobs=True`` depends on modelio records existing in the first place — without coverage, even per-token probabilities can't be stamped. With this PR's wrap landing, #687 can follow with the env-flag opt-in path.

## Out of scope

- **``judge`` layer** for async ``judge_decisions[]`` entries — judge calls happen post-run, not inside the step loop. Separate ticket.
- **Holo3 (local) modelio capture** — the local llama-server path doesn't share the ``_record_modelio_if_active`` hook. Mantis runs that use Holo3 for grounding still need a client-side capture hook on that path. Vast majority of production runs use Claude for at least extraction + verifier, so the model+grounding+verifier coverage this PR unlocks already raises the floor dramatically.

## Test plan

- [x] 6 new tests in ``test_modelio_coverage_689.py``:
  - Outer ``model`` + inner ``grounding`` override + revert semantics
  - Exception inside the with block still resets contextvar
  - Unknown layer logs WARN + skips
  - augur=None / inactive → no-op
  - ``_dispatch_step`` publishes a ``model``-layer context per step
  - ``_dispatch_step`` passes ``runner._augur`` (correct adapter for fan-out workers)
- [x] 134 augur + executor + recovery tests pass
- [x] ``ruff check`` clean

Closes #689.

🤖 Generated with [Claude Code](https://claude.com/claude-code)