### PR TITLE
feat(augur): env-gated capture_logprobs=True + Anthropic logprob mapping (closes #687)

### DIFF
--- a/src/mantis_agent/observability/augur.py
+++ b/src/mantis_agent/observability/augur.py
@@ -180,6 +180,28 @@ def is_verbose() -> bool:
     return flag in {"1", "true", "yes", "on"}
 
 
+def should_capture_logprobs() -> bool:
+    """Whether to open DebugSession with ``capture_logprobs=True``.
+
+    Gated by ``MANTIS_CAPTURE_LOGPROBS`` — off by default in
+    production because:
+
+    * Capture roughly doubles the OpenAI / Anthropic response payload
+      size when the vendor actually returns logprobs.
+    * Most production runs don't need the per-token data; only
+      training-data generation runs do.
+
+    Set ``MANTIS_CAPTURE_LOGPROBS=1`` on the runtime to enable. The
+    flag rides on the session — once a session is open with
+    ``capture_logprobs=True``, every modelio record the SDK writes on
+    close carries ``response.logprobs = []`` (empty list) when the
+    vendor didn't surface logprobs, so downstream consumers can tell
+    "requested but vendor returned nothing" from "not requested".
+    """
+    flag = os.environ.get("MANTIS_CAPTURE_LOGPROBS", "").strip().lower()
+    return flag in {"1", "true", "yes", "on"}
+
+
 def default_out_dir(run_id: str) -> Path:
     """Resolve the per-run bundle directory.
 
@@ -510,6 +532,16 @@ class AugurAdapter:
                 dsn=dsn if dsn is not None else (os.environ.get("AUGUR_DSN") or None),
                 tags=tags,
             )
+            # #687 (augur-sdk 0.5.0+): per-token logprob capture is
+            # opt-in via ``MANTIS_CAPTURE_LOGPROBS=1``. When on, the
+            # SDK writes ``response.logprobs = []`` on every modelio
+            # record by default; the modelio mapper (#689 +
+            # observability/modelio.py) stamps the canonical
+            # ``[{token, logprob, ...}]`` shape when the vendor
+            # returned logprobs. Off by default in production —
+            # capture roughly doubles vendor response payload size.
+            if should_capture_logprobs():
+                session_kwargs["capture_logprobs"] = True
             # augur-sdk 0.1.14+ ships ``branch_context=`` on DebugSession;
             # 0.2.1 documents the ``mode`` resolution. Mantis fan-out
             # partitions pass ``branch_context`` to label sessions under
@@ -549,17 +581,18 @@ class AugurAdapter:
             try:
                 session = DebugSession(**session_kwargs)
             except TypeError as exc:
-                # SDK predates 0.6.0 → ``group_id`` / ``task_spec``
-                # aren't accepted. Drop the 0.6.0 kwargs and retry —
-                # preserves the production path on older pins.
+                # SDK predates 0.5.0/0.6.0 → ``capture_logprobs`` /
+                # ``group_id`` / ``task_spec`` aren't accepted. Drop
+                # the new kwargs and retry — preserves the production
+                # path on older pins.
                 stripped = [
-                    k for k in ("group_id", "task_spec")
+                    k for k in ("group_id", "task_spec", "capture_logprobs")
                     if k in session_kwargs
                 ]
                 if stripped:
                     if _verbose:
                         logger.warning(
-                            "AugurAdapter init: SDK rejected 0.6.0 "
+                            "AugurAdapter init: SDK rejected new "
                             "kwargs %s (%s) — retrying without them",
                             stripped, exc,
                         )

--- a/src/mantis_agent/observability/modelio.py
+++ b/src/mantis_agent/observability/modelio.py
@@ -210,6 +210,26 @@ def record_anthropic_modelio(
         response_block["stop_reason"] = stop_reason
     if usage:
         response_block["usage"] = usage
+    # #687 (augur-sdk 0.5.0+): when the vendor returns logprobs on the
+    # response, map them through the SDK's canonical extractor and
+    # stamp on ``response.logprobs``. Returns ``None`` when the
+    # response didn't carry logprobs (Anthropic Messages API today
+    # doesn't surface them on most call paths). The session-level
+    # ``capture_logprobs=True`` opt-in still gates the empty-vs-absent
+    # semantics: when the flag is on AND the vendor returned nothing,
+    # the SDK writes ``response.logprobs = []`` so downstream
+    # consumers can distinguish "requested but vendor returned
+    # nothing" from "not requested" (absent / null).
+    try:
+        from augur_sdk import ModelApiAdapterBase
+        logprobs = ModelApiAdapterBase.extract_logprobs_from_response(response_json)
+        if logprobs is not None:
+            response_block["logprobs"] = logprobs
+    except Exception:  # noqa: BLE001 — observability never fatal
+        # Pre-0.5.0 SDK, import failed, or extractor raised.
+        # Leave logprobs unset; the session-level opt-in still
+        # controls whether the SDK writes ``[]`` on close.
+        pass
 
     record: dict[str, Any] = {
         "schema_version": "0.1",

--- a/tests/test_augur_capture_logprobs_687.py
+++ b/tests/test_augur_capture_logprobs_687.py
@@ -133,6 +133,25 @@ def test_adapter_retries_without_capture_logprobs_on_TypeError(
 # ── record_anthropic_modelio stamps response.logprobs ──────────────
 
 
+# These tests exercise the real ``record_anthropic_modelio`` mapper,
+# which imports ``augur_sdk.ModelApiAdapterBase`` to call
+# ``extract_logprobs_from_response``. CI doesn't install the
+# ``observability`` extra (.github/workflows/test.yml installs
+# dev + server + orchestrator + metrics only), so ``augur_sdk``
+# isn't on the path there and the silent ImportError inside the
+# mapper would leave ``response.logprobs`` unstamped. Skip when the
+# SDK genuinely isn't installed; the env-flag + adapter-forward
+# tests above still run because they patch ``augur_mod.DebugSession``
+# directly without touching the real SDK.
+import importlib.util  # noqa: E402
+
+_HAS_AUGUR_SDK = importlib.util.find_spec("augur_sdk") is not None
+
+
+@pytest.mark.skipif(
+    not _HAS_AUGUR_SDK,
+    reason="augur-sdk not installed (CI runs without the observability extra)",
+)
 def test_record_anthropic_modelio_stamps_logprobs_when_vendor_returns_them():
     """SDK extractor returns logprobs list → mapper stamps it on
     response.logprobs for the augur bundle."""
@@ -167,6 +186,10 @@ def test_record_anthropic_modelio_stamps_logprobs_when_vendor_returns_them():
     assert lp[0]["token"] == "hel"
 
 
+@pytest.mark.skipif(
+    not _HAS_AUGUR_SDK,
+    reason="augur-sdk not installed (CI runs without the observability extra)",
+)
 def test_record_anthropic_modelio_omits_logprobs_when_vendor_returned_none():
     """Vendor didn't return logprobs (typical Anthropic Messages
     today) → SDK extractor returns None → field absent from the
@@ -191,6 +214,10 @@ def test_record_anthropic_modelio_omits_logprobs_when_vendor_returned_none():
     assert "logprobs" not in record["response"]
 
 
+@pytest.mark.skipif(
+    not _HAS_AUGUR_SDK,
+    reason="augur-sdk not installed (CI runs without the observability extra)",
+)
 def test_record_anthropic_modelio_swallows_extractor_exception():
     """SDK extractor raised (corrupt response shape, schema drift) →
     mapper continues without logprobs. Telemetry never breaks the

--- a/tests/test_augur_capture_logprobs_687.py
+++ b/tests/test_augur_capture_logprobs_687.py
@@ -1,0 +1,222 @@
+"""#687 — env-gated ``capture_logprobs=True`` on the DebugSession.
+
+augur-sdk 0.5.0+ added ``DebugSession(capture_logprobs=True)`` and
+``ModelApiAdapterBase.extract_logprobs_from_response`` for capturing
+per-token vendor logprobs at runtime. Without these, future DPO /
+PPO / GRPO trainers must recompute logprobs from the trajectory —
+expensive and lossy.
+
+This PR wires:
+
+* ``MANTIS_CAPTURE_LOGPROBS=1`` env flag (off by default in
+  production — capture roughly doubles vendor response payload size).
+* ``AugurAdapter.__init__`` forwards ``capture_logprobs=True`` to
+  ``DebugSession`` when the flag is on. Pre-0.5.0 SDKs that reject
+  the kwarg get retried without it (best-effort observability).
+* ``observability/modelio.record_anthropic_modelio`` extracts the
+  vendor's logprobs via the SDK's canonical helper and stamps them
+  on ``response.logprobs``. The session's ``capture_logprobs=True``
+  flag then governs the empty-vs-absent semantics in the bundle.
+
+Contract pinned here:
+
+* ``should_capture_logprobs()`` reads ``MANTIS_CAPTURE_LOGPROBS`` and
+  returns ``True`` for ``1/true/yes/on``; ``False`` otherwise.
+* ``AugurAdapter`` forwards ``capture_logprobs=True`` when the flag
+  is on; omits the kwarg when off.
+* TypeError on the kwarg → retry strips it (production-path
+  preservation for pre-0.5.0 pins).
+* ``record_anthropic_modelio`` calls the SDK extractor and stamps
+  ``response.logprobs`` when the vendor returned them; leaves the
+  field absent otherwise (the session-level flag controls the
+  empty-list default).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import mantis_agent.observability.augur as augur_mod
+from mantis_agent.observability.augur import (
+    AugurAdapter,
+    should_capture_logprobs,
+)
+from mantis_agent.observability.modelio import (
+    ModelIOContext,
+    record_anthropic_modelio,
+)
+
+
+@pytest.fixture
+def force_augur_available(monkeypatch):
+    monkeypatch.delenv("MANTIS_AUGUR_DISABLED", raising=False)
+    monkeypatch.setattr(augur_mod, "_AUGUR_AVAILABLE", True)
+    monkeypatch.setattr(
+        augur_mod, "CaptureMode", lambda v=None: f"capture_mode:{v}",
+    )
+
+
+# ── should_capture_logprobs env-flag parsing ───────────────────────
+
+
+@pytest.mark.parametrize(
+    "flag,expected",
+    [
+        ("1", True), ("true", True), ("TRUE", True), ("on", True), ("yes", True),
+        ("0", False), ("false", False), ("", False), ("no", False), ("off", False),
+    ],
+)
+def test_should_capture_logprobs_parses_env(monkeypatch, flag, expected):
+    monkeypatch.setenv("MANTIS_CAPTURE_LOGPROBS", flag)
+    assert should_capture_logprobs() is expected
+
+
+def test_should_capture_logprobs_default_off(monkeypatch):
+    """Production default: env unset → off (capture has cost)."""
+    monkeypatch.delenv("MANTIS_CAPTURE_LOGPROBS", raising=False)
+    assert should_capture_logprobs() is False
+
+
+# ── AugurAdapter forwards capture_logprobs to DebugSession ─────────
+
+
+def test_adapter_forwards_capture_logprobs_when_flag_on(
+    force_augur_available, monkeypatch,
+):
+    """``MANTIS_CAPTURE_LOGPROBS=1`` → ``DebugSession(capture_logprobs=True)``."""
+    monkeypatch.setenv("MANTIS_CAPTURE_LOGPROBS", "1")
+    fake_session = MagicMock()
+    fake_session._stream = None
+    debug_session_cls = MagicMock(return_value=fake_session)
+    with patch.object(augur_mod, "DebugSession", debug_session_cls):
+        AugurAdapter(run_id="r", tenant_id="t", session_name="s")
+    debug_session_cls.assert_called_once()
+    kwargs = debug_session_cls.call_args.kwargs
+    assert kwargs["capture_logprobs"] is True
+
+
+def test_adapter_omits_capture_logprobs_when_flag_off(
+    force_augur_available, monkeypatch,
+):
+    """Env unset → kwarg not forwarded (production default)."""
+    monkeypatch.delenv("MANTIS_CAPTURE_LOGPROBS", raising=False)
+    fake_session = MagicMock()
+    fake_session._stream = None
+    debug_session_cls = MagicMock(return_value=fake_session)
+    with patch.object(augur_mod, "DebugSession", debug_session_cls):
+        AugurAdapter(run_id="r", tenant_id="t", session_name="s")
+    assert "capture_logprobs" not in debug_session_cls.call_args.kwargs
+
+
+def test_adapter_retries_without_capture_logprobs_on_TypeError(
+    force_augur_available, monkeypatch,
+):
+    """Pre-0.5.0 SDK rejects the kwarg → retry strips it; session
+    still opens (logprob capture silently degrades but bundle works)."""
+    monkeypatch.setenv("MANTIS_CAPTURE_LOGPROBS", "1")
+    fake_session = MagicMock()
+    fake_session._stream = None
+    debug_session_cls = MagicMock(side_effect=[
+        TypeError("got unexpected keyword 'capture_logprobs'"),
+        fake_session,
+    ])
+    with patch.object(augur_mod, "DebugSession", debug_session_cls):
+        a = AugurAdapter(run_id="r", tenant_id="t", session_name="s")
+    assert debug_session_cls.call_count == 2
+    assert "capture_logprobs" in debug_session_cls.call_args_list[0].kwargs
+    assert "capture_logprobs" not in debug_session_cls.call_args_list[1].kwargs
+    assert a._session is fake_session
+
+
+# ── record_anthropic_modelio stamps response.logprobs ──────────────
+
+
+def test_record_anthropic_modelio_stamps_logprobs_when_vendor_returns_them():
+    """SDK extractor returns logprobs list → mapper stamps it on
+    response.logprobs for the augur bundle."""
+    fake_augur = MagicMock()
+    fake_augur.active = True
+    fake_augur.record_modelio = MagicMock()
+    ctx = ModelIOContext(augur=fake_augur, layer="model", step_index=2)
+
+    # Anthropic-shape response with logprobs.
+    response_json = {
+        "content": [
+            {"type": "text", "text": "hello",
+             "logprobs": [
+                 {"token": "hel", "logprob": -0.5},
+                 {"token": "lo", "logprob": -1.2},
+             ]},
+        ],
+        "stop_reason": "end_turn",
+        "usage": {"input_tokens": 10, "output_tokens": 2},
+    }
+    record_anthropic_modelio(
+        request_payload={"model": "claude-3-5-sonnet", "messages": []},
+        response_json=response_json,
+        duration_ms=100,
+        ctx=ctx,
+    )
+    fake_augur.record_modelio.assert_called_once()
+    record = fake_augur.record_modelio.call_args.args[0]
+    assert "logprobs" in record["response"]
+    lp = record["response"]["logprobs"]
+    assert isinstance(lp, list)
+    assert lp[0]["token"] == "hel"
+
+
+def test_record_anthropic_modelio_omits_logprobs_when_vendor_returned_none():
+    """Vendor didn't return logprobs (typical Anthropic Messages
+    today) → SDK extractor returns None → field absent from the
+    record. The session-level capture_logprobs flag still governs
+    the empty-list default at session close."""
+    fake_augur = MagicMock()
+    fake_augur.active = True
+    fake_augur.record_modelio = MagicMock()
+    ctx = ModelIOContext(augur=fake_augur, layer="model", step_index=0)
+    response_json = {
+        "content": [{"type": "text", "text": "no logprobs here"}],
+        "stop_reason": "end_turn",
+    }
+    record_anthropic_modelio(
+        request_payload={"model": "claude-3-5-sonnet", "messages": []},
+        response_json=response_json,
+        duration_ms=100,
+        ctx=ctx,
+    )
+    fake_augur.record_modelio.assert_called_once()
+    record = fake_augur.record_modelio.call_args.args[0]
+    assert "logprobs" not in record["response"]
+
+
+def test_record_anthropic_modelio_swallows_extractor_exception():
+    """SDK extractor raised (corrupt response shape, schema drift) →
+    mapper continues without logprobs. Telemetry never breaks the
+    run; the rest of the modelio record still lands."""
+    fake_augur = MagicMock()
+    fake_augur.active = True
+    fake_augur.record_modelio = MagicMock()
+    ctx = ModelIOContext(augur=fake_augur, layer="model", step_index=0)
+    response_json = {"content": [{"type": "text", "text": "x"}]}
+
+    # Patch the SDK extractor at the import site to raise.
+    import augur_sdk as sdk_mod
+    real_extractor = sdk_mod.ModelApiAdapterBase.extract_logprobs_from_response
+    with patch.object(
+        sdk_mod.ModelApiAdapterBase, "extract_logprobs_from_response",
+        side_effect=RuntimeError("extractor blew up"),
+    ):
+        record_anthropic_modelio(
+            request_payload={"model": "claude-3-5-sonnet", "messages": []},
+            response_json=response_json,
+            duration_ms=100,
+            ctx=ctx,
+        )
+    # record_modelio still called; record has no logprobs key.
+    fake_augur.record_modelio.assert_called_once()
+    record = fake_augur.record_modelio.call_args.args[0]
+    assert "logprobs" not in record["response"]
+    # Restore.
+    sdk_mod.ModelApiAdapterBase.extract_logprobs_from_response = real_extractor


### PR DESCRIPTION
## Summary

augur-sdk 0.5.0+ shipped per-token logprob capture surfaces — ``DebugSession(capture_logprobs=True)`` and ``ModelApiAdapterBase.extract_logprobs_from_response``. Without wiring these, future DPO/PPO/GRPO training has to recompute logprobs from the trajectory (expensive + lossy when the vendor actually surfaced them but the bundle dropped them).

Three pieces:

| Surface | Where | Notes |
|---|---|---|
| ``MANTIS_CAPTURE_LOGPROBS`` env flag | ``observability/augur.should_capture_logprobs()`` | Off by default in production (payload size); training-data runs flip it on |
| Adapter forwards ``capture_logprobs=True`` | ``AugurAdapter.__init__`` → ``DebugSession`` | Pre-0.5.0 SDK pins reject the kwarg → retry strips it (best-effort) |
| Vendor logprobs → modelio record | ``observability/modelio.record_anthropic_modelio`` | Maps via SDK's canonical extractor; stamps ``response.logprobs`` when vendor returned them |

## Depends on #689

Without modelio records landing in the first place, ``capture_logprobs`` has nothing to attach to. PR #691 (#689) lands the runner-level ``publish_modelio_context`` that raises coverage from 1.3% → near-100%. This PR completes the chain.

## Empty-vs-absent semantics

augur-sdk's contract: when ``capture_logprobs=True`` on the session AND the producer doesn't stamp anything, the SDK writes ``response.logprobs = []`` on bundle close. Consumers read this to distinguish "requested but vendor returned nothing" from "not requested" (absent / null).

This PR's mapper stamps the canonical ``[{token, logprob, ...}]`` shape when the vendor returned logprobs. Empty list fallback is the SDK's responsibility — no producer change needed.

## Test plan

- [x] 17 new tests in ``test_augur_capture_logprobs_687.py``:
  - env-flag parsing matrix (1, true, on, yes / 0, false, off, no, unset)
  - Adapter forwards / omits capture_logprobs based on flag
  - TypeError on the kwarg → retry strips (pre-0.5.0 SDK)
  - record_anthropic_modelio stamps response.logprobs when vendor returned them
  - Omits field when vendor returned nothing
  - SDK extractor exceptions are swallowed (telemetry never fatal)
- [x] 145 augur+executor+recovery tests pass
- [x] ``ruff check`` clean

Closes #687.

🤖 Generated with [Claude Code](https://claude.com/claude-code)