### PR TITLE
test(augur): pin end-to-end group_id propagation to step traces (closes #685)

### DIFF
--- a/tests/test_augur_group_id_step_propagation_685.py
+++ b/tests/test_augur_group_id_step_propagation_685.py
@@ -1,0 +1,106 @@
+"""#685 — verify ``step.group_id`` propagates from session to step traces.
+
+augur-sdk 0.6.0's contract: when ``DebugSession(group_id=X)`` is set
+at session open, the SDK auto-stamps ``step.group_id = X`` on every
+recorded step trace. PR #681 (closes #680) wired the mantis side:
+
+* Orchestrator stamps ``_fanout_group_id`` on the suite envelope.
+* Modal worker entrypoint pulls it back onto
+  ``MicroRunner._fanout_group_id``.
+* ``RunExecutor`` forwards as ``AugurAdapter(group_id=...)``.
+* ``AugurAdapter.__init__`` forwards to ``DebugSession(group_id=...)``.
+* SDK's ``record_step`` reads ``self._group_id`` and stamps
+  ``step["group_id"]`` (augur-sdk 0.6.0+ line 451-452).
+
+This test pins the end-to-end: open AugurAdapter with group_id,
+record a step, close, read the bundle, assert step.group_id ==
+expected.
+
+Without this pinned, an SDK change (e.g. moving the propagation to
+``set_group_id()`` only, removing the constructor-time propagation,
+renaming the schema field) would silently break GRPO sibling
+correlation in ``/runs/sample`` without any mantis-side regression
+test catching it.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from mantis_agent.observability.augur import AugurAdapter
+
+
+def _stub_step_result(*, step_index: int = 0):
+    return SimpleNamespace(
+        step_index=step_index, intent=f"step{step_index}",
+        success=True,
+        verdict=SimpleNamespace(kind="ok", reason="", confidence=1.0),
+        data="", failure_class="", last_action=None, duration=0.0,
+        page_title="", executor_backend="som", reasoning="",
+    )
+
+
+def test_group_id_lands_on_step_trace():
+    """End-to-end: open adapter with group_id → record_step →
+    close → bundle's step trace carries the group_id."""
+    with tempfile.TemporaryDirectory() as tmp:
+        a = AugurAdapter(
+            run_id="685_e2e", tenant_id="t", session_name="s",
+            out_dir=tmp, group_id="fanout-parent-685",
+        )
+        if not a.active:
+            pytest.skip("AugurAdapter inactive — SDK not installed")
+        a.record_step(step_result=_stub_step_result(step_index=0))
+        a.close()
+
+        trace = json.loads((Path(tmp) / "trace.json").read_text())
+        steps = trace.get("steps", [])
+        assert steps, "No steps in trace.json"
+        # SDK auto-propagates session.group_id → every step.
+        assert steps[0]["group_id"] == "fanout-parent-685"
+
+
+def test_group_id_omitted_when_session_opened_without_it():
+    """No ``group_id=`` on the adapter → step trace doesn't carry
+    one. Confirms the propagation is conditional (production non-
+    fanout runs don't pollute the bundle with a synthetic id)."""
+    with tempfile.TemporaryDirectory() as tmp:
+        a = AugurAdapter(
+            run_id="685_no_group", tenant_id="t", session_name="s",
+            out_dir=tmp,  # no group_id
+        )
+        if not a.active:
+            pytest.skip("AugurAdapter inactive")
+        a.record_step(step_result=_stub_step_result(step_index=0))
+        a.close()
+
+        trace = json.loads((Path(tmp) / "trace.json").read_text())
+        steps = trace.get("steps", [])
+        assert steps, "No steps in trace.json"
+        assert steps[0].get("group_id") is None
+
+
+def test_group_id_propagates_across_multiple_steps():
+    """Every step carries the same group_id — not just the first
+    (the SDK's auto-stamp fires per record_step call)."""
+    with tempfile.TemporaryDirectory() as tmp:
+        a = AugurAdapter(
+            run_id="685_multi", tenant_id="t", session_name="s",
+            out_dir=tmp, group_id="fanout-parent-685",
+        )
+        if not a.active:
+            pytest.skip("AugurAdapter inactive")
+        for i in range(3):
+            a.record_step(step_result=_stub_step_result(step_index=i))
+        a.close()
+
+        trace = json.loads((Path(tmp) / "trace.json").read_text())
+        steps = trace.get("steps", [])
+        assert len(steps) >= 3
+        group_ids = [s.get("group_id") for s in steps[:3]]
+        assert group_ids == ["fanout-parent-685"] * 3


### PR DESCRIPTION
## Summary

#685 was filed to verify PR #681's ``group_id`` wiring actually lands on step traces. Investigation traced the path:

```
AugurAdapter(group_id="X")
  → DebugSession(group_id="X")  [SDK constructor stores _group_id]
  → record_step(trace)
  → SDK.record_step: if self._group_id and "group_id" not in step:
        step["group_id"] = self._group_id  (lines 451-452, 531-532 in 0.6.1)
  → step.group_id == "X" on bundle close ✓
```

Verified end-to-end against the installed augur-sdk 0.6.1: a step trace recorded with ``group_id="fanout-parent-685"`` lands in ``steps/0001.json`` with ``"group_id": "fanout-parent-685"``.

## Why pin this with tests

A future SDK refactor that moves group_id propagation off the constructor path (e.g. ``set_group_id`` only, removing the auto-stamp from ``record_step``) would silently break GRPO sibling correlation in ``/runs/sample`` without any regression test catching it.

## Test plan

- [x] 3 new tests in ``test_augur_group_id_step_propagation_685.py``:
  - ``test_group_id_lands_on_step_trace`` — happy path, one step
  - ``test_group_id_omitted_when_session_opened_without_it`` — production non-fanout runs don't carry a synthetic id
  - ``test_group_id_propagates_across_multiple_steps`` — every step in the trace carries the same id

No production code change needed — #681's wiring already works.

Closes #685.

🤖 Generated with [Claude Code](https://claude.com/claude-code)