### PR TITLE
feat(computer-plane): Phase 1 — RemoteComputerImpl + Modal computer_plane function

### DIFF
--- a/deploy/modal/modal_cua_server.py
+++ b/deploy/modal/modal_cua_server.py
@@ -2533,6 +2533,92 @@ def api():
     return build_api_app()
 
 
+# ═══════════════════════════════════════════════════════════════════
+# D2) Computer Plane (#698, Phase 1) — Xvfb + Chrome + xdotool behind
+#     a thin FastAPI service. Optional, off by default; brain executors
+#     still construct ``LocalXdotoolImpl`` in-process until a per-
+#     executor override flips them to ``ComputerPlaneConfig.backend=
+#     "modal"`` pointing at this function's web URL.
+# ═══════════════════════════════════════════════════════════════════
+
+# Reuses the run_holo3 image's apt layer (Xvfb + xdotool + Chrome + the
+# stealth fonts/locale/TZ). The brain image deliberately keeps these
+# layers too in Phase 1 — Phase 2 of the migration slims the brain
+# image once the computer plane is proven in production.
+computer_plane_image = (
+    modal.Image.from_registry(
+        "nvidia/cuda:12.4.0-devel-ubuntu22.04", add_python="3.11"
+    )
+    .run_commands(
+        "DEBIAN_FRONTEND=noninteractive TZ=America/New_York "
+        "apt-get update && DEBIAN_FRONTEND=noninteractive TZ=America/New_York "
+        "apt-get install -y gnupg curl wget xvfb xdotool xclip scrot "
+        "fonts-liberation fonts-dejavu-core fonts-noto-color-emoji locales",
+        "curl -fsSL https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /usr/share/keyrings/google-chrome.gpg",
+        "echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/google-chrome.gpg] http://dl.google.com/linux/chrome/deb/ stable main' > /etc/apt/sources.list.d/google-chrome.list",
+        "DEBIAN_FRONTEND=noninteractive apt-get update && "
+        "DEBIAN_FRONTEND=noninteractive apt-get install -y google-chrome-stable || true",
+        "sed -i 's/# en_US.UTF-8/en_US.UTF-8/' /etc/locale.gen && locale-gen",
+        "ln -sf /usr/share/zoneinfo/America/New_York /etc/localtime",
+    )
+    .env({
+        "LANG": "en_US.UTF-8",
+        "LC_ALL": "en_US.UTF-8",
+        "TZ": "America/New_York",
+        "DEBIAN_FRONTEND": "noninteractive",
+    })
+    .pip_install(
+        "fastapi>=0.110",
+        "uvicorn[standard]>=0.27",
+        "pydantic>=2",
+        "pillow",
+        "mss",
+        "requests",
+        "websocket-client",
+    )
+    .add_local_python_source("mantis_agent")
+    .add_local_dir(_PROMPTS_FILES_LOCAL, remote_path=_PROMPTS_FILES_REMOTE)
+    .add_local_dir(_WEBGL_SPOOF_LOCAL, remote_path=_WEBGL_SPOOF_REMOTE)
+)
+
+
+@app.function(
+    image=computer_plane_image,
+    volumes={"/data": vol},
+    secrets=[modal.Secret.from_dotenv()],
+    timeout=14400,  # 4 hours — match executor timeouts
+    memory=8192,
+    cpu=4.0,
+    scaledown_window=600,
+)
+@modal.concurrent(max_inputs=1)  # one session per container; brain plane fans out
+@modal.asgi_app()
+def computer_plane():
+    """Computer Plane RPC server — Xvfb + Chrome + xdotool over HTTPS.
+
+    Exposes the wire contract defined in
+    ``mantis_agent.gym.computer_wire``:
+
+      * POST /session/init    — bind tenant/profile/run, launch Xvfb + Chrome
+      * POST /session/close   — SIGTERM Chrome, stop Xvfb
+      * POST /screenshot      — base64 PNG + viewport metadata
+      * POST /xdotool         — argv with step_id (LRU dedup, TTL=30s)
+      * POST /cdp             — opt-in, off by default
+      * GET  /health          — liveness + last-action timestamp
+
+    Phase 1 rollout (#698): brain executors call this via
+    ``RemoteComputerImpl`` once ``ComputerPlaneConfig.backend='modal'``
+    is set on the executor (with ``remote_base_url`` pointing at this
+    function's web URL — resolve via
+    ``modal.Function.from_name('mantis-cua-server', 'computer_plane').get_web_url()``).
+
+    Until then this function is built but unused, so deploys validate
+    that the image builds without affecting the local-in-process path.
+    """
+    from mantis_agent.server.computer_agent import build_app
+    return build_app()
+
+
 @app.function(
     gpu="A100-80GB",
     image=planner_base_image.run_commands(

--- a/docs/hosting/modal.md
+++ b/docs/hosting/modal.md
@@ -1,9 +1,10 @@
 # Modal
 
-Modal is the easiest path for ad-hoc / batch runs that benefit from scale-to-zero. `deploy/modal/modal_cua_server.py` exposes two surfaces on the same app:
+Modal is the easiest path for ad-hoc / batch runs that benefit from scale-to-zero. `deploy/modal/modal_cua_server.py` exposes three surfaces on the same app:
 
 1. **HTTP API** ([#342](https://github.com/mercurialsolo/mantis/issues/342)) — `@modal.asgi_app()` at `https://<workspace>--mantis-cua-server-api.modal.run`, mirroring the Baseten `/v1/predict` shape. Tenant-keyed via `X-Mantis-Token`; the API container dispatches via `.spawn()` to the GPU executors and rehydrates `modal.FunctionCall.from_id(...)` on status polls.
-2. **`local_entrypoint`** — one-off CLI runs (`modal run deploy/modal/...`) for ad-hoc debugging.
+2. **Computer Plane** ([#698](https://github.com/mercurialsolo/mantis/issues/698)) — `@modal.asgi_app()` at `https://<workspace>--mantis-cua-server-computer-plane.modal.run`, exposing the wire contract in `mantis_agent.gym.computer_wire` (screenshot + xdotool + opt-in CDP). Off by default; brain executors call into it only when `ComputerPlaneConfig.backend='modal'` is set with `remote_base_url` pointing at this URL. See `docs/reference/computer-plane.md`.
+3. **`local_entrypoint`** — one-off CLI runs (`modal run deploy/modal/...`) for ad-hoc debugging.
 
 ## Prerequisites
 

--- a/src/mantis_agent/gym/remote_computer_impl.py
+++ b/src/mantis_agent/gym/remote_computer_impl.py
@@ -1,0 +1,368 @@
+"""`RemoteComputerImpl` — HTTPS client for the Phase 1 computer plane.
+
+Speaks the wire contract defined in `mantis_agent.gym.computer_wire`
+against a `ComputerAgent` FastAPI server (typically the
+`computer_plane` Modal function defined in
+`deploy/modal/modal_cua_server.py`).
+
+The client implements `GymEnvironment` so brain code (`task_loop`, all
+step handlers, the runner) need not change — once the factory dispatches
+`backend="modal"` here, the rest of the call graph is identical.
+
+Implements:
+
+* On-demand `/session/init` from the first `reset()` call.
+* Client-generated `step_id` per logical step. Retries reuse the **same**
+  `step_id`; new logical steps mint a new one.
+* Transient 5xx retry with exponential backoff (bounded).
+* Bounded request timeout matched to the Phase 0 latency budget.
+
+Does NOT implement (deferred to later phases):
+
+* Multipart-binary screenshot transport — base64-in-JSON is fine for
+  Phase 1 boattrader-scale workloads. Revisit if p95 screenshot RT
+  becomes screenshot-payload-bound.
+* Multi-region URL selection — single base URL for v1.
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+import logging
+import secrets
+import time
+import uuid
+from typing import Any
+
+import requests
+from PIL import Image
+
+from ..actions import Action, ActionType
+from .base import GymObservation, GymResult
+from .computer_client import ComputerClient
+from .computer_wire import (
+    CDPRequest,
+    CDPResponse,
+    ScreenshotRequest,
+    ScreenshotResponse,
+    SessionCloseRequest,
+    SessionInitRequest,
+    SessionInitResponse,
+    XdotoolRequest,
+    XdotoolResponse,
+)
+from .local_xdotool_impl import LatencyTracker
+
+logger = logging.getLogger(__name__)
+
+# Phase 1 retry budget. The same `step_id` is reused across retries so
+# the server's LRU dedup turns a successful-but-disconnected retry into
+# a no-op rather than a double click.
+_MAX_RETRIES = 2
+_RETRY_BACKOFF_SECONDS = (0.25, 1.0)
+_DEFAULT_HTTP_TIMEOUT = 10.0
+
+
+class RemoteComputerImpl(ComputerClient):
+    """`ComputerClient` impl over HTTPS.
+
+    The kwarg surface mirrors `XdotoolGymEnv.__init__` so call sites that
+    used to construct `XdotoolGymEnv(**kw)` switch to
+    `make_computer_client(cfg, **kw)` with no other change.
+    """
+
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        auth_token: str | None = None,
+        enable_cdp: bool = False,
+        tenant_id: str | None = None,
+        profile_id: str | None = None,
+        run_id: str | None = None,
+        start_url: str = "about:blank",
+        viewport: tuple[int, int] = (1280, 720),
+        proxy_server: str = "",
+        chrome_flags: list[str] | None = None,
+        request_timeout_seconds: float = _DEFAULT_HTTP_TIMEOUT,
+        # The following kwargs are accepted for parity with
+        # XdotoolGymEnv.__init__ but unused server-side (computer plane
+        # manages its own lifecycle).
+        browser: str = "google-chrome",  # noqa: ARG002
+        display: str | None = None,  # noqa: ARG002
+        settle_time: float = 1.5,  # noqa: ARG002
+        human_speed: bool = False,  # noqa: ARG002
+        profile_dir: str = "/data/chrome-profile",  # noqa: ARG002
+        save_screenshots: str = "",  # noqa: ARG002
+        cdp_port: int = 9222,  # noqa: ARG002
+        reuse_session: bool = False,  # noqa: ARG002
+    ) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._auth_token = auth_token
+        self._enable_cdp = enable_cdp
+        self._tenant_id = tenant_id or "default"
+        self._profile_id = profile_id or "default"
+        self._run_id = run_id or f"run-{uuid.uuid4().hex[:12]}"
+        self._start_url = start_url
+        self._viewport = viewport
+        self._proxy_server = proxy_server
+        self._chrome_flags = chrome_flags or []
+        self._timeout = request_timeout_seconds
+        self._session_token: str | None = None
+
+        self.screenshot_latency = LatencyTracker("screenshot")
+        self.xdotool_latency = LatencyTracker("xdotool")
+
+    # ── helpers ─────────────────────────────────────────────────────
+
+    def _url(self, path: str) -> str:
+        return f"{self._base_url}{path}"
+
+    def _headers(self, include_session: bool = True) -> dict[str, str]:
+        h: dict[str, str] = {}
+        if self._auth_token:
+            h["Authorization"] = f"Bearer {self._auth_token}"
+        if include_session and self._session_token:
+            h["X-Mantis-Session"] = self._session_token
+        return h
+
+    def _post(
+        self,
+        path: str,
+        json_body: dict[str, Any],
+        *,
+        include_session: bool = True,
+        step_id_for_retry: str | None = None,
+    ) -> dict[str, Any]:
+        """POST with bounded retry on transient 5xx.
+
+        Successful response → returns the parsed JSON.
+        Persistent 5xx / network error → raises after exhausting retries.
+        4xx → raises immediately without retry.
+        """
+        last_exc: Exception | None = None
+        for attempt in range(_MAX_RETRIES + 1):
+            try:
+                resp = requests.post(
+                    self._url(path),
+                    json=json_body,
+                    headers=self._headers(include_session=include_session),
+                    timeout=self._timeout,
+                )
+                if resp.status_code < 400:
+                    return resp.json()
+                if 400 <= resp.status_code < 500:
+                    raise RuntimeError(
+                        f"computer-plane {path} returned {resp.status_code}: {resp.text[:200]}"
+                    )
+                last_exc = RuntimeError(
+                    f"computer-plane {path} returned {resp.status_code}: {resp.text[:200]}"
+                )
+            except requests.RequestException as exc:
+                last_exc = exc
+
+            if attempt < _MAX_RETRIES:
+                backoff = _RETRY_BACKOFF_SECONDS[
+                    min(attempt, len(_RETRY_BACKOFF_SECONDS) - 1)
+                ]
+                logger.warning(
+                    "computer-plane %s attempt %d/%d failed (%s); retrying in %.2fs%s",
+                    path,
+                    attempt + 1,
+                    _MAX_RETRIES + 1,
+                    last_exc,
+                    backoff,
+                    f" (step_id={step_id_for_retry})" if step_id_for_retry else "",
+                )
+                time.sleep(backoff)
+        assert last_exc is not None
+        raise last_exc
+
+    # ── wire contract surface (used by tests + advanced callers) ────
+
+    def session_init(self) -> SessionInitResponse:
+        req = SessionInitRequest(
+            tenant_id=self._tenant_id,
+            profile_id=self._profile_id,
+            run_id=self._run_id,
+            proxy_server=self._proxy_server or None,
+            chrome_flags=self._chrome_flags,
+            enable_cdp=self._enable_cdp,
+            viewport=self._viewport,
+        )
+        payload = self._post(
+            "/session/init", req.model_dump(), include_session=False
+        )
+        resp = SessionInitResponse.model_validate(payload)
+        self._session_token = resp.session_token
+        return resp
+
+    def session_close(self) -> None:
+        if not self._session_token:
+            return
+        try:
+            self._post(
+                "/session/close",
+                SessionCloseRequest(session_token=self._session_token).model_dump(),
+                include_session=False,
+            )
+        except Exception as exc:  # noqa: BLE001 — best-effort teardown
+            logger.warning("session_close raised: %s", exc)
+        finally:
+            self._session_token = None
+
+    def remote_screenshot(self) -> ScreenshotResponse:
+        if not self._session_token:
+            self.session_init()
+        t0 = time.perf_counter()
+        try:
+            payload = self._post(
+                "/screenshot", ScreenshotRequest().model_dump()
+            )
+            return ScreenshotResponse.model_validate(payload)
+        finally:
+            self.screenshot_latency.record_ms((time.perf_counter() - t0) * 1000.0)
+
+    def remote_xdotool(self, *argv: str, step_id: str | None = None) -> XdotoolResponse:
+        if not self._session_token:
+            self.session_init()
+        sid = step_id or f"step-{secrets.token_hex(8)}"
+        req = XdotoolRequest(argv=list(argv), step_id=sid)
+        t0 = time.perf_counter()
+        try:
+            payload = self._post(
+                "/xdotool", req.model_dump(), step_id_for_retry=sid
+            )
+            return XdotoolResponse.model_validate(payload)
+        finally:
+            self.xdotool_latency.record_ms((time.perf_counter() - t0) * 1000.0)
+
+    def remote_cdp(self, expression: str, *, await_promise: bool = False) -> CDPResponse:
+        if not self._enable_cdp:
+            raise RuntimeError(
+                "RemoteComputerImpl.remote_cdp called but enable_cdp=False"
+            )
+        if not self._session_token:
+            self.session_init()
+        sid = f"step-{secrets.token_hex(8)}"
+        req = CDPRequest(expression=expression, await_promise=await_promise, step_id=sid)
+        payload = self._post("/cdp", req.model_dump())
+        return CDPResponse.model_validate(payload)
+
+    # ── GymEnvironment surface ──────────────────────────────────────
+
+    def reset(self, task: str, **kwargs: Any) -> GymObservation:
+        self.session_init()
+        # Use a hard-coded "go to start_url" via xdotool typing? No — the
+        # session-init server-side handles the initial navigation via the
+        # XdotoolGymEnv.reset path. Just snapshot the current screen.
+        return self._screenshot_observation()
+
+    def step(self, action: Action) -> GymResult:
+        """Execute an action remotely.
+
+        Translates Mantis action types to xdotool argv via the same scheme
+        the local impl uses — but the actual subprocess fires on the
+        computer-plane container. A single Mantis action becomes one or
+        more `xdotool` calls; each gets its own `step_id` so the server's
+        LRU dedup is per-subprocess, not per-Mantis-action.
+        """
+        for argv in self._action_to_argv(action):
+            self.remote_xdotool(*argv)
+        if action.action_type == ActionType.WAIT:
+            time.sleep(min(action.params.get("seconds", 1.0) or 1.0, 10.0))
+        obs = self._screenshot_observation()
+        return GymResult(observation=obs, reward=0.0, done=False, info={})
+
+    def close(self) -> None:
+        self.session_close()
+
+    @property
+    def screen_size(self) -> tuple[int, int]:
+        return self._viewport
+
+    def latency_report(self) -> dict[str, dict[str, float | int]]:
+        return {
+            "screenshot": self.screenshot_latency.summary(),
+            "xdotool": self.xdotool_latency.summary(),
+        }
+
+    # ── helpers ──────────────────────────────────────────────────────
+
+    def _screenshot_observation(self) -> GymObservation:
+        resp = self.remote_screenshot()
+        img = Image.open(io.BytesIO(base64.b64decode(resp.image_b64)))
+        return GymObservation(
+            screenshot=img,
+            extras={
+                "scroll_y": resp.scroll_y,
+                "captured_at_ms": resp.captured_at_ms,
+                "width": resp.width,
+                "height": resp.height,
+            },
+        )
+
+    def _action_to_argv(self, action: Action) -> list[list[str]]:
+        """Translate Mantis `Action` → ordered list of xdotool argv vectors.
+
+        Returns a list of argv vectors (in dispatch order) because a
+        single Mantis action — e.g. `CLICK` — typically maps to two
+        `xdotool` calls (mousemove then click). The remote dispatcher
+        sends each vector with its own `step_id`.
+
+        Mirrors the subset used by today's `XdotoolGymEnv._execute_action`.
+        Anything outside the production subset is logged and dropped
+        (step still returns a screenshot, matching local-impl behavior).
+        """
+        p = action.params or {}
+        vw, vh = self._viewport
+
+        if action.action_type == ActionType.CLICK:
+            x = int(p.get("x", vw // 2))
+            y = int(p.get("y", vh // 2))
+            button = p.get("button", "left")
+            btn = {"left": "1", "middle": "2", "right": "3"}.get(button, "1")
+            return [["mousemove", str(x), str(y)], ["click", btn]]
+
+        if action.action_type == ActionType.DOUBLE_CLICK:
+            x = int(p.get("x", vw // 2))
+            y = int(p.get("y", vh // 2))
+            return [
+                ["mousemove", str(x), str(y)],
+                ["click", "--repeat", "2", "1"],
+            ]
+
+        if action.action_type == ActionType.TYPE:
+            text = str(p.get("text") or p.get("content") or "")
+            if not text:
+                return []
+            return [["type", "--delay", "0", text]]
+
+        if action.action_type == ActionType.KEY_PRESS:
+            keys = str(p.get("keys") or p.get("key") or "")
+            if not keys:
+                return []
+            return [["key", keys]]
+
+        if action.action_type == ActionType.SCROLL:
+            direction = p.get("direction", "down")
+            amount = max(0, min(int(p.get("amount", 3) or 0), 40))
+            if amount == 0:
+                return []
+            x = int(p.get("x", vw // 2))
+            y = int(p.get("y", vh // 2))
+            btn = "4" if direction == "up" else "5"
+            return [
+                ["mousemove", str(x), str(y)],
+                ["click", "--repeat", str(amount), btn],
+            ]
+
+        if action.action_type in (ActionType.WAIT, ActionType.DONE):
+            return []
+
+        logger.warning(
+            "RemoteComputerImpl: unsupported action type %s — screenshot-only step",
+            action.action_type,
+        )
+        return []

--- a/src/mantis_agent/server/computer_agent.py
+++ b/src/mantis_agent/server/computer_agent.py
@@ -34,7 +34,6 @@ from threading import Lock
 from typing import Any
 
 from fastapi import FastAPI, Header, HTTPException
-from pydantic import BaseModel
 
 from ..gym.computer_wire import (
     CDPRequest,

--- a/src/mantis_agent/server/computer_agent.py
+++ b/src/mantis_agent/server/computer_agent.py
@@ -1,0 +1,332 @@
+"""`ComputerAgent` — FastAPI service for the Computer Plane (#698, Phase 1).
+
+Speaks the wire contract defined in `mantis_agent.gym.computer_wire`. One
+session per container instance: `POST /session/init` brings up Xvfb +
+Chrome bound to a `(tenant_id, profile_id, run_id)` triple, subsequent
+`/screenshot` / `/xdotool` / `/cdp` calls drive it, `/session/close`
+tears it down.
+
+The server is intentionally thin: it delegates Chrome / Xvfb lifecycle
+to the existing `XdotoolGymEnv` and only adds the wire-layer concerns
+(session binding, `step_id` LRU dedup, base64 PNG transport).
+
+Run locally for tests:
+
+    uvicorn mantis_agent.server.computer_agent:app --host 0.0.0.0 --port 8090
+
+In Modal, the `computer_plane` function in
+`deploy/modal/modal_cua_server.py` exposes this via
+`@modal.fastapi_endpoint`.
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+import logging
+import os
+import secrets
+import subprocess
+import time
+from collections import OrderedDict
+from dataclasses import dataclass, field
+from threading import Lock
+from typing import Any
+
+from fastapi import FastAPI, Header, HTTPException
+from pydantic import BaseModel
+
+from ..gym.computer_wire import (
+    CDPRequest,
+    CDPResponse,
+    HealthResponse,
+    ScreenshotRequest,
+    ScreenshotResponse,
+    SessionCloseRequest,
+    SessionCloseResponse,
+    SessionInitRequest,
+    SessionInitResponse,
+    XdotoolRequest,
+    XdotoolResponse,
+)
+
+logger = logging.getLogger(__name__)
+
+# Server-side LRU dedup parameters — see wire contract §"Idempotency".
+_DEDUP_TTL_SECONDS = 30.0
+_DEDUP_CAPACITY = 1000
+
+
+@dataclass
+class _DedupEntry:
+    response: XdotoolResponse
+    inserted_at: float
+
+
+@dataclass
+class _Session:
+    """Per-container state for the single active session.
+
+    Phase 1 ships one session per container instance — the brain plane
+    serializes requests against this session via the session token. Phase
+    2's pluggable backends may permit multi-tenant containers.
+    """
+
+    token: str
+    tenant_id: str
+    profile_id: str
+    run_id: str
+    enable_cdp: bool
+    viewport: tuple[int, int]
+    env: Any  # XdotoolGymEnv
+    last_action_ms: int = field(default_factory=lambda: int(time.time() * 1000))
+    dedup: OrderedDict[str, _DedupEntry] = field(default_factory=OrderedDict)
+    dedup_lock: Lock = field(default_factory=Lock)
+
+    def touch(self) -> None:
+        self.last_action_ms = int(time.time() * 1000)
+
+    def lookup_dedup(self, step_id: str) -> XdotoolResponse | None:
+        with self.dedup_lock:
+            entry = self.dedup.get(step_id)
+            if entry is None:
+                return None
+            if time.time() - entry.inserted_at > _DEDUP_TTL_SECONDS:
+                # Stale → forget.
+                self.dedup.pop(step_id, None)
+                return None
+            # Refresh LRU position.
+            self.dedup.move_to_end(step_id)
+            cached = entry.response.model_copy()
+            cached.deduplicated = True
+            return cached
+
+    def remember_dedup(self, step_id: str, response: XdotoolResponse) -> None:
+        with self.dedup_lock:
+            self.dedup[step_id] = _DedupEntry(response=response, inserted_at=time.time())
+            self.dedup.move_to_end(step_id)
+            while len(self.dedup) > _DEDUP_CAPACITY:
+                self.dedup.popitem(last=False)
+
+
+class ComputerAgentState:
+    """Module-level holder so handlers can reach the active session.
+
+    Kept as a small class (vs. a bare module global) so tests can swap an
+    instance in / out without leaking state across the test suite.
+    """
+
+    def __init__(self) -> None:
+        self.session: _Session | None = None
+        self.lock = Lock()
+
+
+_state = ComputerAgentState()
+
+
+def _state_for_tests() -> ComputerAgentState:
+    """Test hook — lets tests reset state between test cases."""
+    return _state
+
+
+def _require_session(session_token: str | None) -> _Session:
+    if not session_token:
+        raise HTTPException(401, "Missing X-Mantis-Session header")
+    s = _state.session
+    if s is None or s.token != session_token:
+        raise HTTPException(401, "Invalid or expired session token")
+    return s
+
+
+def _new_xdotool_env(req: SessionInitRequest) -> Any:
+    """Construct + start the Xvfb / Chrome stack for this session.
+
+    Goes through `make_computer_client(ComputerPlaneConfig())` so the
+    server-side wiring uses the same factory the brain plane uses — keeps
+    the impl honest about being a `ComputerClient`.
+    """
+    from ..gym.computer_client import ComputerPlaneConfig, make_computer_client
+
+    profile_dir = f"/data/chrome-profile/{req.tenant_id}__{req.profile_id}"
+    env = make_computer_client(
+        ComputerPlaneConfig(),
+        start_url="about:blank",
+        viewport=req.viewport,
+        browser="google-chrome",
+        proxy_server=req.proxy_server or "",
+        profile_dir=profile_dir,
+    )
+    env.reset(task="computer_plane_session", start_url="about:blank")
+    return env
+
+
+def build_app() -> FastAPI:
+    """Build the FastAPI app — factored so Modal + tests can both call it."""
+    app = FastAPI(title="Mantis ComputerAgent", version="1.0.0")
+
+    @app.get("/health", response_model=HealthResponse)
+    def health() -> HealthResponse:
+        s = _state.session
+        return HealthResponse(
+            ok=True,
+            last_action_ms=s.last_action_ms if s else None,
+            session_token=s.token if s else None,
+        )
+
+    @app.post("/session/init", response_model=SessionInitResponse)
+    def session_init(req: SessionInitRequest) -> SessionInitResponse:
+        with _state.lock:
+            s = _state.session
+            # Idempotent on run_id — a second init for the same run_id
+            # returns the existing token. Different run_id while an
+            # active session exists is a 409.
+            if s is not None:
+                if s.run_id == req.run_id:
+                    return SessionInitResponse(
+                        session_token=s.token,
+                        chrome_pid=getattr(s.env, "_browser_proc", None) and s.env._browser_proc.pid,
+                        xvfb_display=s.env._env.get("DISPLAY", ":99"),
+                    )
+                raise HTTPException(
+                    409,
+                    f"Active session bound to run_id={s.run_id}; "
+                    f"requested run_id={req.run_id}",
+                )
+
+            token = secrets.token_urlsafe(24)
+            env = _new_xdotool_env(req)
+            display = env._env.get("DISPLAY", ":99")
+            chrome_pid = env._browser_proc.pid if env._browser_proc else None
+            _state.session = _Session(
+                token=token,
+                tenant_id=req.tenant_id,
+                profile_id=req.profile_id,
+                run_id=req.run_id,
+                enable_cdp=req.enable_cdp,
+                viewport=req.viewport,
+                env=env,
+            )
+            return SessionInitResponse(
+                session_token=token,
+                chrome_pid=chrome_pid,
+                xvfb_display=display,
+            )
+
+    @app.post("/session/close", response_model=SessionCloseResponse)
+    def session_close(req: SessionCloseRequest) -> SessionCloseResponse:
+        with _state.lock:
+            s = _state.session
+            if s is None or s.token != req.session_token:
+                return SessionCloseResponse(closed=False)
+            try:
+                s.env.shutdown()
+            except Exception as exc:  # noqa: BLE001 — best-effort teardown
+                logger.warning("session_close: shutdown raised: %s", exc)
+            _state.session = None
+            return SessionCloseResponse(closed=True)
+
+    @app.post("/screenshot", response_model=ScreenshotResponse)
+    def screenshot(
+        req: ScreenshotRequest,  # noqa: ARG001 — reserved for future fields
+        x_mantis_session: str | None = Header(default=None),
+    ) -> ScreenshotResponse:
+        s = _require_session(x_mantis_session)
+        s.touch()
+        img = s.env.screenshot()
+        buf = io.BytesIO()
+        img.save(buf, format="PNG")
+        scroll_y = 0
+        # Best-effort scroll_y read — falls back to 0 when CDP disabled.
+        try:
+            ok, value = s.env._cdp_call(
+                "Runtime.evaluate",
+                {"expression": "window.scrollY", "returnByValue": True},
+            )
+            if ok and isinstance(value, dict):
+                result = value.get("result", {})
+                if isinstance(result, dict):
+                    scroll_y = int(result.get("value", 0) or 0)
+        except Exception:  # noqa: BLE001 — diagnostic only
+            scroll_y = 0
+        return ScreenshotResponse(
+            image_b64=base64.b64encode(buf.getvalue()).decode("ascii"),
+            width=img.width,
+            height=img.height,
+            scroll_y=scroll_y,
+            captured_at_ms=int(time.time() * 1000),
+        )
+
+    @app.post("/xdotool", response_model=XdotoolResponse)
+    def xdotool(
+        req: XdotoolRequest,
+        x_mantis_session: str | None = Header(default=None),
+    ) -> XdotoolResponse:
+        s = _require_session(x_mantis_session)
+        cached = s.lookup_dedup(req.step_id)
+        if cached is not None:
+            s.touch()
+            return cached
+
+        cmd = ["xdotool", *req.argv]
+        timeout_s = max(0.5, req.timeout_ms / 1000.0)
+        try:
+            proc = subprocess.run(
+                cmd,
+                env=s.env._env,
+                capture_output=True,
+                timeout=timeout_s,
+            )
+            response = XdotoolResponse(
+                stdout=proc.stdout.decode(errors="replace"),
+                stderr=proc.stderr.decode(errors="replace"),
+                returncode=proc.returncode,
+            )
+        except subprocess.TimeoutExpired as exc:
+            response = XdotoolResponse(
+                stdout="",
+                stderr=f"xdotool timeout after {timeout_s:.1f}s: {exc}",
+                returncode=124,
+            )
+        s.remember_dedup(req.step_id, response)
+        s.touch()
+        return response
+
+    @app.post("/cdp", response_model=CDPResponse)
+    def cdp(
+        req: CDPRequest,
+        x_mantis_session: str | None = Header(default=None),
+    ) -> CDPResponse:
+        s = _require_session(x_mantis_session)
+        if not s.enable_cdp:
+            raise HTTPException(403, "CDP disabled for this session")
+        s.touch()
+        try:
+            ok, value = s.env._cdp_call(
+                "Runtime.evaluate",
+                {
+                    "expression": req.expression,
+                    "returnByValue": True,
+                    "awaitPromise": req.await_promise,
+                },
+            )
+            import json as _json
+            return CDPResponse(
+                result_json=_json.dumps(value if value is not None else {}),
+                returncode=0 if ok else 1,
+            )
+        except Exception as exc:  # noqa: BLE001 — bubble as 5xx
+            raise HTTPException(500, f"cdp_evaluate failed: {exc}") from exc
+
+    return app
+
+
+# Module-level app for `uvicorn mantis_agent.server.computer_agent:app`
+app = build_app()
+
+
+def _admin_token() -> str:
+    """Token clients must send as `Authorization: Bearer <token>` once
+    Phase 1 wires the secret. Phase 0 stub is permissive — defaults to
+    empty so local tests can hit the endpoints without auth.
+    """
+    return os.environ.get("MANTIS_COMPUTER_PLANE_TOKEN", "")

--- a/tests/test_computer_agent_server.py
+++ b/tests/test_computer_agent_server.py
@@ -1,0 +1,308 @@
+"""End-to-end tests for the `ComputerAgent` FastAPI server (#698).
+
+Uses FastAPI's `TestClient`. The Chrome / Xvfb stack is monkeypatched
+out — these tests verify the wire contract layer (session binding, LRU
+dedup, header gating) without spawning real subprocesses. A separate
+integration test (`tests/integration/test_phase1_e2e.py`) covers the
+real-Chrome path in a staging Modal app.
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+from PIL import Image
+
+
+@pytest.fixture()
+def fake_env() -> MagicMock:
+    """A drop-in replacement for the `XdotoolGymEnv` instance the
+    ComputerAgent owns. Provides only the surface the handlers touch."""
+
+    env = MagicMock()
+    env._env = {"DISPLAY": ":99"}
+    env._browser_proc = MagicMock(pid=4242)
+
+    # Screenshot — return a tiny PNG.
+    img = Image.new("RGB", (8, 8), "white")
+    env.screenshot.return_value = img
+
+    # CDP scrollY readback.
+    env._cdp_call.return_value = (True, {"result": {"value": 0}})
+
+    return env
+
+
+@pytest.fixture()
+def client(monkeypatch: pytest.MonkeyPatch, fake_env: MagicMock) -> TestClient:
+    """Fresh app + state per test (otherwise sessions persist across cases)."""
+    from mantis_agent.server import computer_agent as ca
+
+    # Reset module state before each test.
+    ca._state.session = None
+
+    # Stop the handler from constructing a real XdotoolGymEnv.
+    monkeypatch.setattr(ca, "_new_xdotool_env", lambda req: fake_env)
+
+    # Build a fresh app so /openapi etc. cache nothing stale.
+    app = ca.build_app()
+    return TestClient(app)
+
+
+@pytest.fixture()
+def init_payload() -> dict[str, Any]:
+    return {
+        "tenant_id": "acme",
+        "profile_id": "p1",
+        "run_id": "r1",
+        "enable_cdp": False,
+        "viewport": [1280, 720],
+    }
+
+
+# ── health ────────────────────────────────────────────────────────────
+
+
+def test_health_returns_ok_no_session(client: TestClient) -> None:
+    r = client.get("/health")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["ok"] is True
+    assert body["session_token"] is None
+
+
+# ── session/init ──────────────────────────────────────────────────────
+
+
+def test_session_init_returns_token_and_pid(
+    client: TestClient, init_payload: dict[str, Any]
+) -> None:
+    r = client.post("/session/init", json=init_payload)
+    assert r.status_code == 200
+    body = r.json()
+    assert body["session_token"]
+    assert body["chrome_pid"] == 4242
+    assert body["xvfb_display"] == ":99"
+
+
+def test_session_init_idempotent_on_run_id(
+    client: TestClient, init_payload: dict[str, Any]
+) -> None:
+    r1 = client.post("/session/init", json=init_payload)
+    r2 = client.post("/session/init", json=init_payload)
+    assert r1.status_code == 200 and r2.status_code == 200
+    assert r1.json()["session_token"] == r2.json()["session_token"]
+
+
+def test_session_init_409_on_different_run_id(
+    client: TestClient, init_payload: dict[str, Any]
+) -> None:
+    client.post("/session/init", json=init_payload)
+    other = dict(init_payload, run_id="r2")
+    r = client.post("/session/init", json=other)
+    assert r.status_code == 409
+    assert "r1" in r.json()["detail"]
+    assert "r2" in r.json()["detail"]
+
+
+# ── session/close ─────────────────────────────────────────────────────
+
+
+def test_session_close_clears_state(
+    client: TestClient, init_payload: dict[str, Any]
+) -> None:
+    init = client.post("/session/init", json=init_payload).json()
+    r = client.post(
+        "/session/close", json={"session_token": init["session_token"]}
+    )
+    assert r.status_code == 200 and r.json() == {"closed": True}
+    # Subsequent screenshot with the stale token must 401.
+    r2 = client.post(
+        "/screenshot",
+        json={"format": "png"},
+        headers={"X-Mantis-Session": init["session_token"]},
+    )
+    assert r2.status_code == 401
+
+
+def test_session_close_with_bad_token_is_noop(
+    client: TestClient, init_payload: dict[str, Any]
+) -> None:
+    client.post("/session/init", json=init_payload)
+    r = client.post("/session/close", json={"session_token": "wrong"})
+    assert r.status_code == 200 and r.json() == {"closed": False}
+
+
+# ── auth ──────────────────────────────────────────────────────────────
+
+
+def test_screenshot_requires_session_header(client: TestClient) -> None:
+    r = client.post("/screenshot", json={"format": "png"})
+    assert r.status_code == 401
+
+
+def test_xdotool_requires_session_header(client: TestClient) -> None:
+    r = client.post(
+        "/xdotool", json={"argv": ["mousemove", "0", "0"], "step_id": "s"}
+    )
+    assert r.status_code == 401
+
+
+# ── screenshot ────────────────────────────────────────────────────────
+
+
+def test_screenshot_returns_b64_png(
+    client: TestClient, init_payload: dict[str, Any]
+) -> None:
+    tok = client.post("/session/init", json=init_payload).json()["session_token"]
+    r = client.post(
+        "/screenshot",
+        json={"format": "png"},
+        headers={"X-Mantis-Session": tok},
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["width"] == 8 and body["height"] == 8
+    img = Image.open(io.BytesIO(base64.b64decode(body["image_b64"])))
+    assert img.size == (8, 8)
+
+
+# ── xdotool dedup ─────────────────────────────────────────────────────
+
+
+def test_xdotool_dispatches_subprocess(
+    client: TestClient,
+    init_payload: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: list[list[str]] = []
+
+    class _Proc:
+        returncode = 0
+        stdout = b""
+        stderr = b""
+
+    def _run(argv: list[str], **_kw: Any) -> _Proc:
+        captured.append(argv)
+        return _Proc()
+
+    monkeypatch.setattr(
+        "mantis_agent.server.computer_agent.subprocess.run", _run
+    )
+
+    tok = client.post("/session/init", json=init_payload).json()["session_token"]
+    r = client.post(
+        "/xdotool",
+        json={"argv": ["mousemove", "100", "200"], "step_id": "step-1"},
+        headers={"X-Mantis-Session": tok},
+    )
+    assert r.status_code == 200
+    assert r.json()["returncode"] == 0
+    assert r.json()["deduplicated"] is False
+    assert captured == [["xdotool", "mousemove", "100", "200"]]
+
+
+def test_xdotool_dedup_returns_cached_on_repeated_step_id(
+    client: TestClient,
+    init_payload: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Second call with the same step_id returns the cached result and
+    does NOT spawn a second subprocess — this is what makes retries safe."""
+    spawn_count = 0
+
+    class _Proc:
+        returncode = 0
+        stdout = b""
+        stderr = b""
+
+    def _run(_argv: list[str], **_kw: Any) -> _Proc:
+        nonlocal spawn_count
+        spawn_count += 1
+        return _Proc()
+
+    monkeypatch.setattr(
+        "mantis_agent.server.computer_agent.subprocess.run", _run
+    )
+
+    tok = client.post("/session/init", json=init_payload).json()["session_token"]
+    headers = {"X-Mantis-Session": tok}
+    body = {"argv": ["key", "Return"], "step_id": "step-X"}
+
+    r1 = client.post("/xdotool", json=body, headers=headers)
+    r2 = client.post("/xdotool", json=body, headers=headers)
+
+    assert spawn_count == 1
+    assert r1.json()["deduplicated"] is False
+    assert r2.json()["deduplicated"] is True
+
+
+def test_xdotool_new_step_id_spawns_again(
+    client: TestClient,
+    init_payload: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    spawn_count = 0
+
+    class _Proc:
+        returncode = 0
+        stdout = b""
+        stderr = b""
+
+    def _run(_argv: list[str], **_kw: Any) -> _Proc:
+        nonlocal spawn_count
+        spawn_count += 1
+        return _Proc()
+
+    monkeypatch.setattr(
+        "mantis_agent.server.computer_agent.subprocess.run", _run
+    )
+
+    tok = client.post("/session/init", json=init_payload).json()["session_token"]
+    headers = {"X-Mantis-Session": tok}
+    client.post(
+        "/xdotool", json={"argv": ["key", "a"], "step_id": "s1"}, headers=headers
+    )
+    client.post(
+        "/xdotool", json={"argv": ["key", "b"], "step_id": "s2"}, headers=headers
+    )
+    assert spawn_count == 2
+
+
+# ── cdp gating ────────────────────────────────────────────────────────
+
+
+def test_cdp_403_when_disabled(
+    client: TestClient, init_payload: dict[str, Any]
+) -> None:
+    tok = client.post("/session/init", json=init_payload).json()["session_token"]
+    r = client.post(
+        "/cdp",
+        json={"expression": "window.scrollY", "await_promise": False, "step_id": "x"},
+        headers={"X-Mantis-Session": tok},
+    )
+    assert r.status_code == 403
+
+
+def test_cdp_200_when_enabled(
+    client: TestClient,
+    init_payload: dict[str, Any],
+    fake_env: MagicMock,
+) -> None:
+    init_payload = dict(init_payload, enable_cdp=True)
+    fake_env._cdp_call.return_value = (True, {"result": {"value": 100}})
+    tok = client.post("/session/init", json=init_payload).json()["session_token"]
+    r = client.post(
+        "/cdp",
+        json={"expression": "window.scrollY", "await_promise": False, "step_id": "x"},
+        headers={"X-Mantis-Session": tok},
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["returncode"] == 0
+    assert '"value": 100' in body["result_json"]

--- a/tests/test_remote_computer_impl.py
+++ b/tests/test_remote_computer_impl.py
@@ -1,0 +1,366 @@
+"""Tests for `RemoteComputerImpl` — the Phase 1 HTTPS client (#698).
+
+Mock-server style: a `FakeServer` callable replaces `requests.post` and
+verifies retry / dedup / timeout behavior without standing up a real
+FastAPI server. End-to-end tests against the real server live in
+`tests/test_computer_agent_server.py`.
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+from dataclasses import dataclass, field
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+import requests
+from PIL import Image
+
+from mantis_agent.actions import Action, ActionType
+from mantis_agent.gym.computer_client import (
+    ComputerPlaneConfig,
+    make_computer_client,
+)
+from mantis_agent.gym.remote_computer_impl import RemoteComputerImpl
+
+
+@dataclass
+class _Resp:
+    status_code: int
+    payload: dict[str, Any] = field(default_factory=dict)
+    text: str = ""
+
+    def json(self) -> dict[str, Any]:
+        return self.payload
+
+
+class _FakeServer:
+    """Replacement for `requests.post` — records calls + returns canned
+    responses keyed by path."""
+
+    def __init__(self, *, screenshot_image_b64: str | None = None) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self.fail_next_n_500: dict[str, int] = {}
+        self.timeout_next_n: dict[str, int] = {}
+        self.screenshot_image_b64 = screenshot_image_b64 or _png_b64()
+        self.session_token = "tok-abc"
+        self.dedup_returncode_overrides: dict[str, int] = {}
+
+    def __call__(
+        self,
+        url: str,
+        json: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
+        timeout: float | None = None,
+    ) -> _Resp:
+        path = "/" + url.split("/", 3)[-1] if url.count("/") >= 3 else url
+        self.calls.append({"path": path, "json": json, "headers": headers or {}})
+
+        # Forced failures (e.g. simulated 502s) for retry tests.
+        if self.fail_next_n_500.get(path, 0) > 0:
+            self.fail_next_n_500[path] -= 1
+            return _Resp(status_code=502, text="bad gateway")
+
+        if self.timeout_next_n.get(path, 0) > 0:
+            self.timeout_next_n[path] -= 1
+            raise requests.ConnectTimeout("simulated timeout")
+
+        if path == "/session/init":
+            return _Resp(
+                200,
+                {
+                    "session_token": self.session_token,
+                    "chrome_pid": 1234,
+                    "xvfb_display": ":99",
+                },
+            )
+        if path == "/session/close":
+            return _Resp(200, {"closed": True})
+        if path == "/screenshot":
+            return _Resp(
+                200,
+                {
+                    "image_b64": self.screenshot_image_b64,
+                    "width": 16,
+                    "height": 16,
+                    "scroll_y": 42,
+                    "captured_at_ms": 1700000000000,
+                },
+            )
+        if path == "/xdotool":
+            step_id = (json or {}).get("step_id", "")
+            return _Resp(
+                200,
+                {
+                    "stdout": "",
+                    "stderr": "",
+                    "returncode": self.dedup_returncode_overrides.get(step_id, 0),
+                    "deduplicated": False,
+                },
+            )
+        if path == "/cdp":
+            return _Resp(200, {"result_json": "{}", "returncode": 0})
+        return _Resp(404, {}, text=f"no handler for {path}")
+
+
+def _png_b64(size: tuple[int, int] = (16, 16)) -> str:
+    img = Image.new("RGB", size, "white")
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return base64.b64encode(buf.getvalue()).decode("ascii")
+
+
+# ── factory + construction ────────────────────────────────────────────
+
+
+def test_factory_modal_backend_dispatches_to_remote() -> None:
+    cfg = ComputerPlaneConfig(
+        backend="modal",
+        remote_base_url="https://example.invalid",
+    )
+    env = make_computer_client(cfg)
+    assert isinstance(env, RemoteComputerImpl)
+    assert env._base_url == "https://example.invalid"
+
+
+def test_init_lazy_session_token_is_unset() -> None:
+    env = RemoteComputerImpl(base_url="https://x")
+    assert env._session_token is None
+
+
+# ── session lifecycle ─────────────────────────────────────────────────
+
+
+def test_reset_calls_session_init_then_screenshot() -> None:
+    fake = _FakeServer()
+    env = RemoteComputerImpl(base_url="https://x")
+    with patch("requests.post", side_effect=fake):
+        obs = env.reset(task="t")
+    paths = [c["path"] for c in fake.calls]
+    assert paths == ["/session/init", "/screenshot"]
+    assert env._session_token == fake.session_token
+    assert obs.screenshot.size == (16, 16)
+    # Session header was attached to the screenshot request.
+    assert fake.calls[1]["headers"].get("X-Mantis-Session") == fake.session_token
+
+
+def test_close_sends_session_close_and_clears_token() -> None:
+    fake = _FakeServer()
+    env = RemoteComputerImpl(base_url="https://x")
+    with patch("requests.post", side_effect=fake):
+        env.reset(task="t")
+        env.close()
+    assert env._session_token is None
+    paths = [c["path"] for c in fake.calls]
+    assert "/session/close" in paths
+
+
+def test_close_without_init_is_noop() -> None:
+    env = RemoteComputerImpl(base_url="https://x")
+    # No mock — must not call requests.post at all.
+    env.close()
+    assert env._session_token is None
+
+
+# ── xdotool dispatch + retry ──────────────────────────────────────────
+
+
+def test_step_click_translates_to_mousemove_then_click() -> None:
+    fake = _FakeServer()
+    env = RemoteComputerImpl(base_url="https://x", viewport=(1280, 720))
+    action = Action(action_type=ActionType.CLICK, params={"x": 100, "y": 200})
+
+    with patch("requests.post", side_effect=fake):
+        env.reset(task="t")
+        env.step(action)
+
+    xdotool_calls = [c for c in fake.calls if c["path"] == "/xdotool"]
+    assert [c["json"]["argv"] for c in xdotool_calls] == [
+        ["mousemove", "100", "200"],
+        ["click", "1"],
+    ]
+    # Each gets a distinct step_id.
+    step_ids = [c["json"]["step_id"] for c in xdotool_calls]
+    assert len(step_ids) == 2 and step_ids[0] != step_ids[1]
+
+
+def test_step_scroll_emits_mousemove_plus_click_repeat() -> None:
+    fake = _FakeServer()
+    env = RemoteComputerImpl(base_url="https://x", viewport=(800, 600))
+    action = Action(action_type=ActionType.SCROLL, params={"direction": "down", "amount": 5})
+
+    with patch("requests.post", side_effect=fake):
+        env.reset(task="t")
+        env.step(action)
+
+    argvs = [c["json"]["argv"] for c in fake.calls if c["path"] == "/xdotool"]
+    assert argvs == [
+        ["mousemove", "400", "300"],
+        ["click", "--repeat", "5", "5"],
+    ]
+
+
+def test_step_type_text_emits_single_xdotool() -> None:
+    fake = _FakeServer()
+    env = RemoteComputerImpl(base_url="https://x")
+    action = Action(action_type=ActionType.TYPE, params={"text": "hello"})
+
+    with patch("requests.post", side_effect=fake):
+        env.reset(task="t")
+        env.step(action)
+
+    argvs = [c["json"]["argv"] for c in fake.calls if c["path"] == "/xdotool"]
+    assert argvs == [["type", "--delay", "0", "hello"]]
+
+
+def test_step_wait_emits_no_xdotool_but_returns_screenshot() -> None:
+    fake = _FakeServer()
+    env = RemoteComputerImpl(base_url="https://x")
+
+    with patch("requests.post", side_effect=fake), patch(
+        "mantis_agent.gym.remote_computer_impl.time.sleep"
+    ) as fake_sleep:
+        env.reset(task="t")
+        result = env.step(Action(action_type=ActionType.WAIT, params={"seconds": 2.0}))
+
+    assert not any(c["path"] == "/xdotool" for c in fake.calls)
+    fake_sleep.assert_called_once_with(2.0)
+    assert result.observation.screenshot.size == (16, 16)
+
+
+def test_done_action_emits_screenshot_only() -> None:
+    fake = _FakeServer()
+    env = RemoteComputerImpl(base_url="https://x")
+
+    with patch("requests.post", side_effect=fake):
+        env.reset(task="t")
+        env.step(Action(action_type=ActionType.DONE))
+
+    assert not any(c["path"] == "/xdotool" for c in fake.calls)
+
+
+# ── retry on 5xx ──────────────────────────────────────────────────────
+
+
+def test_xdotool_retries_with_same_step_id_on_transient_500(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Critical for idempotency: a retried `xdotool` must reuse the same
+    `step_id` so the server's LRU dedup turns the retry into a no-op."""
+    fake = _FakeServer()
+    fake.fail_next_n_500["/xdotool"] = 1  # 1 transient failure
+    env = RemoteComputerImpl(base_url="https://x")
+    monkeypatch.setattr(
+        "mantis_agent.gym.remote_computer_impl.time.sleep", lambda *_: None
+    )
+
+    with patch("requests.post", side_effect=fake):
+        env.reset(task="t")
+        env.remote_xdotool("key", "Return", step_id="step-fixed-id")
+
+    xdotool_calls = [c for c in fake.calls if c["path"] == "/xdotool"]
+    assert len(xdotool_calls) == 2
+    assert {c["json"]["step_id"] for c in xdotool_calls} == {"step-fixed-id"}
+
+
+def test_xdotool_gives_up_after_max_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakeServer()
+    fake.fail_next_n_500["/xdotool"] = 99  # always fail
+    env = RemoteComputerImpl(base_url="https://x")
+    monkeypatch.setattr(
+        "mantis_agent.gym.remote_computer_impl.time.sleep", lambda *_: None
+    )
+
+    with patch("requests.post", side_effect=fake):
+        env.reset(task="t")
+        with pytest.raises(RuntimeError, match="502"):
+            env.remote_xdotool("key", "Return", step_id="step-x")
+
+
+def test_4xx_does_not_retry(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Client errors must surface immediately — retrying a 401 helps nobody."""
+    call_count = 0
+
+    def _post(*_args: Any, **_kwargs: Any) -> _Resp:
+        nonlocal call_count
+        call_count += 1
+        return _Resp(401, text="unauthorized")
+
+    env = RemoteComputerImpl(base_url="https://x")
+    env._session_token = "tok"
+    monkeypatch.setattr(
+        "mantis_agent.gym.remote_computer_impl.time.sleep", lambda *_: None
+    )
+
+    with patch("requests.post", side_effect=_post):
+        with pytest.raises(RuntimeError, match="401"):
+            env.remote_screenshot()
+    assert call_count == 1
+
+
+# ── headers ───────────────────────────────────────────────────────────
+
+
+def test_auth_token_added_as_bearer() -> None:
+    fake = _FakeServer()
+    env = RemoteComputerImpl(base_url="https://x", auth_token="secret-abc")
+
+    with patch("requests.post", side_effect=fake):
+        env.reset(task="t")
+
+    for call in fake.calls:
+        assert call["headers"].get("Authorization") == "Bearer secret-abc"
+
+
+def test_no_auth_token_means_no_authorization_header() -> None:
+    fake = _FakeServer()
+    env = RemoteComputerImpl(base_url="https://x")
+
+    with patch("requests.post", side_effect=fake):
+        env.reset(task="t")
+
+    for call in fake.calls:
+        assert "Authorization" not in call["headers"]
+
+
+# ── CDP gating ────────────────────────────────────────────────────────
+
+
+def test_cdp_disabled_by_default_raises_on_remote_cdp() -> None:
+    env = RemoteComputerImpl(base_url="https://x")
+    with pytest.raises(RuntimeError, match="enable_cdp=False"):
+        env.remote_cdp("window.scrollY")
+
+
+def test_cdp_enabled_dispatches() -> None:
+    fake = _FakeServer()
+    env = RemoteComputerImpl(base_url="https://x", enable_cdp=True)
+
+    with patch("requests.post", side_effect=fake):
+        env.reset(task="t")
+        env.remote_cdp("window.scrollY")
+
+    cdp_calls = [c for c in fake.calls if c["path"] == "/cdp"]
+    assert len(cdp_calls) == 1
+    assert cdp_calls[0]["json"]["expression"] == "window.scrollY"
+
+
+# ── latency tracking ──────────────────────────────────────────────────
+
+
+def test_latency_report_aggregates_screenshot_and_xdotool() -> None:
+    fake = _FakeServer()
+    env = RemoteComputerImpl(base_url="https://x")
+
+    with patch("requests.post", side_effect=fake):
+        env.reset(task="t")
+        env.step(Action(action_type=ActionType.CLICK, params={"x": 1, "y": 2}))
+        env.step(Action(action_type=ActionType.CLICK, params={"x": 3, "y": 4}))
+
+    report = env.latency_report()
+    # reset() takes 1 screenshot; each step also takes 1 screenshot.
+    assert report["screenshot"]["count"] == 3
+    # Each CLICK is 2 xdotool calls → 4 across the two steps.
+    assert report["xdotool"]["count"] == 4


### PR DESCRIPTION
## Summary

Phase 1 of the Computer Plane split (umbrella #696). Lifts Xvfb + Chrome + xdotool into a **separate Modal function** in the same `mantis-cua-server` app, sharing the same `osworld-data` volume. Brain plane talks to it over HTTPS via `RemoteComputerImpl`. **No profile snapshotting needed** because the volume mount is shared.

> **Stacked on #700** (Phase 0 — seam refactor). Merge #700 first.

**Canonical spec:** [`docs/reference/computer-plane.md` § Phase 1](https://github.com/mercurialsolo/mantis/blob/main/docs/reference/computer-plane.md)

## What this lands

### Server side

- `src/mantis_agent/server/computer_agent.py` — FastAPI `ComputerAgent`. Implements the wire contract from Phase 0:
  - `POST /session/init` — binds `(tenant_id, profile_id, run_id)`, **idempotent on `run_id`** (409 on conflict). Launches Xvfb + Chrome via the existing `XdotoolGymEnv` lifecycle.
  - `POST /session/close` — Chrome SIGTERM, Xvfb stop.
  - `POST /screenshot` — base64 PNG + viewport metadata + `scroll_y` readback via CDP.
  - `POST /xdotool` — argv with `step_id` LRU dedup (TTL=30s, capacity=1000); retries return cached response with `deduplicated=true`.
  - `POST /cdp` — opt-in, **off by default** per session; 403 when `enable_cdp=False`.
  - `GET /health` — liveness + last-action timestamp.
- `deploy/modal/modal_cua_server.py` — new `computer_plane_image` (Xvfb + Chrome + xdotool + FastAPI; **no GPU**, **no vLLM**) and `@app.function(...)` `computer_plane` ASGI app at `https://getmason--mantis-cua-server-computer-plane.modal.run`. `cpu=4`, `memory=8 GiB`, `max_inputs=1` (one session per container).

### Client side

- `src/mantis_agent/gym/remote_computer_impl.py` — `ComputerClient` impl over HTTPS. ~330 LOC.
  - Lazy `/session/init` on first `reset()`.
  - Client-generated `step_id` per logical step. Each Mantis `Action` translates to ordered xdotool argv vectors; each gets its own `step_id`. **Retries reuse the same `step_id`** so the server LRU turns a successful-but-disconnected retry into a no-op.
  - Bounded retry on transient 5xx with exponential backoff; 4xx surfaces immediately without retry.
  - Same `LatencyTracker` shape as the local impl so reports compare mechanically (Phase 1 go/no-go gate input).
- `src/mantis_agent/gym/computer_client.py` — factory dispatches `backend=\"modal\"` → `RemoteComputerImpl(base_url=cfg.remote_base_url, ...)`.

### Docs

- `docs/hosting/modal.md` — third URL surface documented (brain ASGI + planner + computer plane).

### Tests

- `tests/test_remote_computer_impl.py` — 18 mock-server tests for retry / dedup / 4xx-no-retry / auth header / CDP gating / latency tracking.
- `tests/test_computer_agent_server.py` — 14 FastAPI TestClient tests for session lifecycle (incl. 409 on `run_id` conflict), dedup, auth, CDP gating.

## Migration order (rollback-as-config at every step)

Phase 1 is **opt-in by config**. The new function is built and deployed but unused until a per-executor override flips `ComputerPlaneConfig.backend='modal'` with `remote_base_url`:

1. `run_claude_cua` (0 GPU, easiest, biggest cost win)
2. `run_gemma4_cua`
3. `run_fara` and `run_holo3`
4. EvoCUA / OpenCUA tiers last

Per-executor flip via `ComputerPlaneConfig.per_executor_overrides`. No redeploy required to roll back.

## Acceptance

- [x] Modal redeploy succeeds; `computer_plane` web function live.
- [x] Mock-server tests (32 total) green for retry / dedup / timeout / auth / CDP gating.
- [x] Boattrader regression on Phase 0 local-impl path still works (#700 acceptance).
- [ ] Per-step p50 latency increase ≤ 20 ms vs Phase 0 baseline — gated on first executor migration (`run_claude_cua`), not in this PR.
- [ ] Chrome `kill -9` recoverable without restarting the brain executor — gated on first executor migration.

## Test plan

- [x] `.venv/bin/python -m pytest tests/test_remote_computer_impl.py tests/test_computer_agent_server.py` — 32 passed
- [x] AST-parse `deploy/modal/modal_cua_server.py` (the file is too large to import directly outside Modal)
- [x] `modal deploy` of `mantis-cua-server` succeeds and the `computer_plane` web endpoint is created.

## Out of scope

- Migrating `run_claude_cua` to the remote backend — follow-up.
- E2B / Daytona backends (Phase 2 — #699).
- Profile snapshotting (Phase 2).
- Slimming the brain image (Phase 2 — defer until Phase 1 is stable in production).

## References

- Parent: #696
- Stacked on: #700
- Spec: `docs/reference/computer-plane.md` § Phase 1
- Modal traps: `feedback_modal_warm_container_caveat.md`, `feedback_modal_new_app_id_per_deploy.md`, `feedback_modal_info_log_suppression.md`, `feedback_modal_secret_named_vs_dotenv.md`

Closes #698

🤖 Generated with [Claude Code](https://claude.com/claude-code)