### PR TITLE
feat(plan-evolution): Phase 0 — URL health classifier + bad_url failure_class

### DIFF
--- a/src/mantis_agent/agentic_recovery.py
+++ b/src/mantis_agent/agentic_recovery.py
@@ -283,6 +283,28 @@ def analyse_failure_and_recover(
         does NOT track budgets — it just performs the analysis when
         invoked.
     """
+    # Plan-evolution Phase 0 (#704): a `bad_url:<subclass>` failure means
+    # the navigate step landed somewhere unusable (DNS error, 404,
+    # wrong domain, soft-404). The four existing recovery modes
+    # (add_hint / edit_step / insert_steps) won't help — they're for
+    # element-level drift, not URL-level drift. Phase 1 (#705) will
+    # add a `rewrite_url` mode that runs pattern_transform → page_links
+    # → web_search before deciding. Until then, short-circuit to halt
+    # with a structured reason so we don't burn a Claude tool call on
+    # a failure class we can't fix.
+    fd_lc = (failure_data or "").lower()
+    if fd_lc.startswith("bad_url:") or fd_lc.startswith("bad_url="):
+        subclass = (failure_data or "").split(":", 1)[-1].split("=", 1)[-1].strip()
+        logger.warning(
+            "agentic_recovery: bad_url subclass=%s — Phase 0 routes to halt "
+            "(rewrite_url lands in #705)",
+            subclass,
+        )
+        return RecoveryDecision(
+            mode="halt",
+            reasoning=f"bad_url:{subclass} — no rewrite_url recovery yet (#705)",
+        )
+
     api_key = api_key or os.environ.get("ANTHROPIC_API_KEY", "")
     if not api_key:
         logger.warning(

--- a/src/mantis_agent/gym/checkpoint.py
+++ b/src/mantis_agent/gym/checkpoint.py
@@ -129,12 +129,17 @@ class StepResult:
     # ``failure_class`` is one of the keys documented in
     # :mod:`~.failure_class` (cf_challenge / nav_timeout / http_4xx /
     # http_5xx / selector_miss / extractor_error / budget_exceeded /
-    # unknown). ``final_url`` and ``page_title`` snapshot the browser at
-    # the moment of failure so post-mortems land in result.json instead
-    # of Modal logs. All three are empty on success.
+    # bad_url / unknown). ``final_url`` and ``page_title`` snapshot the
+    # browser at the moment of failure so post-mortems land in
+    # result.json instead of Modal logs. All four are empty on success.
     failure_class: str = ""
     final_url: str = ""
     page_title: str = ""
+    # Plan-evolution Phase 0 (#704): when ``failure_class == 'bad_url'``,
+    # this carries the structured subclass from :mod:`~.url_health`
+    # (``dns`` / ``not_found`` / ``wrong_domain`` / ``soft_404`` /
+    # ``blocked``). Empty for every other failure_class and on success.
+    failure_subclass: str = ""
 
     # #508 structured extraction passthrough. When the step ran a
     # schema-driven ``extract_data`` and produced a viable row, the
@@ -151,7 +156,7 @@ class StepResult:
     _PERSISTED: ClassVar[tuple[str, ...]] = (
         "step_index", "intent", "success", "data", "steps_used", "duration", "reversed",
         "skip", "skip_reason", "executor_backend",
-        "failure_class", "final_url", "page_title",
+        "failure_class", "final_url", "page_title", "failure_subclass",
         "extracted_fields",
     )
 

--- a/src/mantis_agent/gym/failure_class.py
+++ b/src/mantis_agent/gym/failure_class.py
@@ -33,6 +33,10 @@ Classes (stay small on purpose — anything not matched lands in
   (Phase B) is the right response.
 * ``extractor_error`` — Claude extractor failed or returned empty.
 * ``budget_exceeded`` — cost / time / context budget tripped.
+* ``bad_url`` — post-navigate URL health check failed. Carries a
+  subclass (``dns`` / ``not_found`` / ``wrong_domain`` / ``soft_404`` /
+  ``blocked``) in :attr:`StepResult.failure_subclass`. See
+  :mod:`~.url_health` for the classifier. Plan-evolution Phase 0 (#704).
 * ``unknown`` — no rule matched (caller should still surface ``data``).
 
 The classifier is pure-functional and runs in microseconds — it lives
@@ -72,6 +76,13 @@ _DATA_RULES: tuple[tuple[str, tuple[str, ...]], ...] = (
     # ``verify_post_click_navigation`` returns ``kind=wrong_target``;
     # rule below catches the substring on legacy result.json.
     ("wrong_target", ("wrong_target",)),
+    # Plan-evolution Phase 0 (#704): structured URL-failure class.
+    # Set by the navigate handler via `url_health.classify` when the
+    # post-navigate state is non-`ok`. The subclass (`dns` / `not_found`
+    # / `wrong_domain` / `soft_404` / `blocked`) is carried on the
+    # StepResult separately; this rule only catches the `bad_url:`
+    # prefix in legacy `data` blobs.
+    ("bad_url", ("bad_url:", "bad_url=")),
     ("cf_challenge", ("error 403", "403 forbidden", "cloudflare", "verify you are human")),
     ("http_4xx", ("error 404", "404", "error 401", "error 410", "error 4")),
     ("http_5xx", ("error 5", "502", "503", "504", "internal server error")),

--- a/src/mantis_agent/gym/step_handlers/navigate.py
+++ b/src/mantis_agent/gym/step_handlers/navigate.py
@@ -38,6 +38,7 @@ from typing import TYPE_CHECKING
 
 from ...actions import Action, ActionType
 from .. import adaptive_settle
+from .. import url_health
 from ..checkpoint import StepResult
 from ..step_context import StepContext
 
@@ -124,6 +125,46 @@ class NavigateHandler:
             adaptive_settle.settle_after_action(env, max_seconds=wait_seconds)
             env.step(Action(action_type=ActionType.KEY_PRESS, params={"keys": "Home"}))
             adaptive_settle.settle_after_action(env, max_seconds=2.0)
+
+            # Plan-evolution Phase 0 (#704): classify post-navigate URL
+            # health BEFORE arming the scanner. A bad_url here means
+            # nothing downstream will work — emit a structured failure
+            # so #705's rewrite_url recovery action has a clean trigger.
+            # The `blocked` subclass defers to existing CF / external-
+            # pause handling (which runs from the runner's scan loop)
+            # so we don't fight it here.
+            #
+            # Skip entirely when the env doesn't expose a real
+            # `current_url` (test mocks, embed surfaces without CDP) —
+            # we can't tell health from nothing, and silence here is
+            # the conservative choice. Real Modal / local Chrome envs
+            # always return a string.
+            cur_url, page_title, body_snippet = url_health.read_page_signals(env)
+            expected = url_health.expand_expected_domains(url)
+            if not cur_url:
+                subclass = "ok"
+            else:
+                subclass = url_health.classify(
+                    current_url=cur_url,
+                    expected_domains=expected,
+                    page_title=page_title,
+                    page_body_text=body_snippet,
+                )
+            if subclass not in ("ok", "blocked"):
+                logger.warning(
+                    "  [navigate] url_health=%s requested=%s landed=%s title=%r",
+                    subclass, url, cur_url, page_title[:60],
+                )
+                return StepResult(
+                    step_index=index,
+                    intent=step.intent,
+                    success=False,
+                    data=f"bad_url:{subclass}",
+                    failure_class="bad_url",
+                    failure_subclass=subclass,
+                    final_url=cur_url,
+                    page_title=page_title,
+                )
 
             # Anchor the results scan state to this URL.
             if scanner is not None:

--- a/src/mantis_agent/gym/url_health.py
+++ b/src/mantis_agent/gym/url_health.py
@@ -1,0 +1,232 @@
+"""URL health classifier — Phase 0 of #703 plan-evolution.
+
+Pure-functional classifier that maps `(current_url, expected_url,
+expected_domains, page_title)` into a small fixed vocabulary so the
+recovery loop sees a clean signal instead of inferring URL drift from
+pixels.
+
+The classifier is intentionally narrow — Phase 0 is observability only.
+Phase 1 (#705) adds the matching `rewrite_url` recovery action that
+consumes these subclasses; Phase 2 (#706) persists what works.
+
+Subclasses (small on purpose — anything not matched is `ok`):
+
+* `ok` — `current_url` is in `expected_domains` and isn't a known
+  error template. The default; emitted when nothing went wrong.
+* `dns` — Chrome's own error page. `current_url` starts with
+  `chrome-error://` or is empty after a navigate. Means the request
+  never reached an origin server (bad domain, no network).
+* `wrong_domain` — navigation completed but landed on a domain that
+  isn't in the plan's expected set. Catches redirects to login walls
+  on different domains, account-suspension redirects, accidental
+  cross-site redirects.
+* `not_found` — origin returned a 404-shaped page. Detected via page
+  title heuristics (no Chrome-side HTTP status is available without
+  CDP `Network.responseReceived`; the heuristic catches the common
+  cases without that plumbing).
+* `soft_404` — 200 OK with `current_url` matching the expected
+  domain, but page content matches "this page no longer exists" /
+  "page not found" / "couldn't find what you were looking for"
+  patterns. Harder than 404 because the URL looks fine.
+* `blocked` — Cloudflare / WAF interstitial. Detected by the same
+  title markers as `failure_class.cf_challenge` so the two paths
+  don't fight. Phase 0 reports it but defers to the existing CF /
+  external-pause handling; the rewrite layer doesn't try to "rewrite"
+  around a CF block.
+
+The classifier runs on the failure path so it can't pull heavy imports.
+Pure Python, no I/O, microseconds.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+from urllib.parse import urlparse
+
+UrlHealthSubclass = Literal[
+    "ok",
+    "dns",
+    "not_found",
+    "wrong_domain",
+    "soft_404",
+    "blocked",
+]
+
+
+# Same set as failure_class._CF_TITLE_MARKERS — kept in sync so
+# url_health.classify and failure_class.classify agree about CF.
+_BLOCKED_TITLE_MARKERS: tuple[str, ...] = (
+    "just a moment",
+    "performing security verification",
+    "checking your browser",
+    "verifying you are human",
+    "verify you are human",
+    "attention required",
+)
+
+# Title patterns that indicate the origin returned a "page not found"
+# template. Lowercased substring match. Conservative — we'd rather
+# under-classify than mis-classify a real page as 404.
+_NOT_FOUND_TITLE_MARKERS: tuple[str, ...] = (
+    "404",
+    "page not found",
+    "not found",
+    "page doesn't exist",
+    "page does not exist",
+    "page no longer exists",
+    "this page isn't available",
+    "this page isn't here",
+)
+
+# Title patterns that indicate a soft-404: the URL resolved (200 OK),
+# stayed on the expected domain, but the page content says "we don't
+# have what you asked for". Some sites use this instead of a real 404
+# for missing resources.
+_SOFT_404_BODY_MARKERS: tuple[str, ...] = (
+    "we couldn't find",
+    "we could not find",
+    "no results found",
+    "nothing matches",
+    "page is no longer available",
+    "this listing is no longer available",
+    "this item is no longer available",
+)
+
+
+def _normalize_netloc(netloc: str) -> str:
+    """Strip leading `www.`, lowercase, drop port. Comparison-friendly."""
+    if not netloc:
+        return ""
+    nl = netloc.lower().split(":", 1)[0]
+    if nl.startswith("www."):
+        nl = nl[4:]
+    return nl
+
+
+def expand_expected_domains(start_url: str) -> set[str]:
+    """Derive the expected-domain set from a plan's start_url.
+
+    Returns the normalised netloc + common subdomain variants the plan
+    is likely to land on (e.g. `www.` ↔ bare, `m.` mobile). Callers can
+    extend this with site-specific aliases via Phase 1's SiteConfig.
+    """
+    parsed = urlparse(start_url)
+    netloc = _normalize_netloc(parsed.netloc)
+    if not netloc:
+        return set()
+    return {netloc, f"www.{netloc}", f"m.{netloc}"}
+
+
+def classify(
+    *,
+    current_url: str,
+    expected_domains: set[str],
+    page_title: str = "",
+    page_body_text: str = "",
+) -> UrlHealthSubclass:
+    """Map browser state → URL-health subclass.
+
+    Args:
+        current_url: `env.current_url` after a navigate step.
+        expected_domains: set of normalised netlocs the plan considers
+            valid landings. Use :func:`expand_expected_domains` to
+            derive from a single start_url, or pass an explicit set
+            for multi-domain plans.
+        page_title: `document.title` at failure time. Lowercased for
+            matching.
+        page_body_text: A short slice of visible body text for soft-404
+            detection. Optional — many callers don't have it and the
+            classifier degrades gracefully.
+
+    Returns:
+        One of `UrlHealthSubclass`. `ok` means no URL-health problem
+        was detected; the caller may still find other failures via
+        :func:`failure_class.classify`.
+    """
+    # DNS / Chrome-error / empty URL — the navigate didn't reach an
+    # origin. Highest-priority signal.
+    if not current_url or current_url.startswith("chrome-error://"):
+        return "dns"
+
+    title_lc = (page_title or "").lower()
+
+    # Blocked (CF / WAF) takes precedence over wrong_domain because CF
+    # serves its interstitial under the requested domain — we shouldn't
+    # claim "wrong_domain" when the request actually reached the right
+    # origin but got intercepted.
+    if any(m in title_lc for m in _BLOCKED_TITLE_MARKERS):
+        return "blocked"
+
+    parsed = urlparse(current_url)
+    current_netloc = _normalize_netloc(parsed.netloc)
+    expected_norm = {_normalize_netloc(d) for d in expected_domains if d}
+
+    # Wrong-domain: navigated outside the expected set. Skips the
+    # not_found / soft_404 checks because those are domain-relative.
+    if expected_norm and current_netloc and current_netloc not in expected_norm:
+        return "wrong_domain"
+
+    # 404-shaped title — the page itself self-identifies as missing.
+    if any(m in title_lc for m in _NOT_FOUND_TITLE_MARKERS):
+        return "not_found"
+
+    # Soft-404 — title looks fine but body says "we don't have this".
+    body_lc = (page_body_text or "").lower()
+    if body_lc and any(m in body_lc for m in _SOFT_404_BODY_MARKERS):
+        return "soft_404"
+
+    return "ok"
+
+
+def read_page_signals(env) -> tuple[str, str, str]:
+    """Best-effort `(current_url, title, body_snippet)` for the classifier.
+
+    Mirrors :func:`failure_class.read_failure_context` but also pulls a
+    short body slice for soft-404 detection. Returns empty strings on
+    any failure — the classifier degrades gracefully.
+
+    The body snippet is the first 2 KB of visible text — enough for
+    soft-404 marker matching without blowing prompt budgets if anything
+    downstream logs it.
+    """
+    url = ""
+    title = ""
+    body = ""
+
+    try:
+        raw_url = getattr(env, "current_url", "") or ""
+    except Exception:  # noqa: BLE001 — best-effort
+        raw_url = ""
+    # Defensive cast — test mocks return MagicMock for unconfigured
+    # attributes. Treat anything non-string as "we don't know" rather
+    # than coercing into a false-positive bad_url classification.
+    url = raw_url if isinstance(raw_url, str) else ""
+
+    cdp_eval = getattr(env, "cdp_evaluate", None)
+    if callable(cdp_eval):
+        try:
+            t = cdp_eval("document.title || ''")
+            if isinstance(t, str):
+                title = t
+        except Exception:  # noqa: BLE001
+            title = ""
+        try:
+            b = cdp_eval(
+                "(document.body && document.body.innerText || '').slice(0, 2048)"
+            )
+            if isinstance(b, str):
+                body = b
+        except Exception:  # noqa: BLE001
+            body = ""
+
+    # Fallback: Playwright `page.title()` for CLI runs that don't have
+    # a `cdp_evaluate` method.
+    if not title:
+        page = getattr(env, "_page", None) or getattr(env, "page", None)
+        if page is not None and not callable(page):
+            try:
+                title = page.title() or ""
+            except Exception:  # noqa: BLE001
+                title = ""
+
+    return url, title, body

--- a/tests/test_url_health.py
+++ b/tests/test_url_health.py
@@ -1,0 +1,338 @@
+"""Tests for url_health — plan-evolution Phase 0 (#704).
+
+Pure-Python classifier; no real browser / env needed. Covers each
+documented subclass + the helper functions.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from mantis_agent.gym.url_health import (
+    classify,
+    expand_expected_domains,
+    read_page_signals,
+)
+
+
+# ── helpers ───────────────────────────────────────────────────────────
+
+
+def test_expand_expected_domains_strips_www_and_adds_variants() -> None:
+    domains = expand_expected_domains("https://www.boattrader.com/boats/state-fl/")
+    assert "boattrader.com" in domains
+    assert "www.boattrader.com" in domains
+    assert "m.boattrader.com" in domains
+
+
+def test_expand_expected_domains_handles_bare_domain() -> None:
+    domains = expand_expected_domains("https://example.com/path")
+    assert "example.com" in domains
+    assert "www.example.com" in domains
+
+
+def test_expand_expected_domains_empty_for_no_netloc() -> None:
+    assert expand_expected_domains("about:blank") == set()
+    assert expand_expected_domains("") == set()
+
+
+# ── classifier: dns ───────────────────────────────────────────────────
+
+
+def test_classify_dns_on_chrome_error() -> None:
+    assert classify(
+        current_url="chrome-error://chromewebdata/",
+        expected_domains={"example.com"},
+    ) == "dns"
+
+
+def test_classify_dns_on_empty_url() -> None:
+    """Some Chrome failure modes leave current_url empty."""
+    assert classify(current_url="", expected_domains={"example.com"}) == "dns"
+
+
+# ── classifier: blocked (CF / WAF) ────────────────────────────────────
+
+
+def test_classify_blocked_on_cf_title() -> None:
+    assert classify(
+        current_url="https://boattrader.com/boats/",
+        expected_domains={"boattrader.com"},
+        page_title="Just a moment...",
+    ) == "blocked"
+
+
+def test_classify_blocked_precedes_wrong_domain() -> None:
+    """CF interstitial under the requested domain is `blocked`, not
+    `wrong_domain` — we did reach the right origin."""
+    assert classify(
+        current_url="https://challenges.cloudflare.com/...",
+        expected_domains={"boattrader.com"},
+        page_title="Just a moment...",
+    ) == "blocked"
+
+
+# ── classifier: wrong_domain ──────────────────────────────────────────
+
+
+def test_classify_wrong_domain_on_external_redirect() -> None:
+    assert classify(
+        current_url="https://accounts.google.com/signin",
+        expected_domains={"boattrader.com", "www.boattrader.com"},
+        page_title="Sign in - Google Accounts",
+    ) == "wrong_domain"
+
+
+def test_classify_ok_when_landed_on_www_variant() -> None:
+    """Plan starts at bare domain; landed on www. should be OK."""
+    assert classify(
+        current_url="https://www.boattrader.com/boats/state-fl/",
+        expected_domains=expand_expected_domains("https://boattrader.com/boats/"),
+        page_title="Boat Trader - FL",
+    ) == "ok"
+
+
+def test_classify_ok_when_landed_on_mobile_variant() -> None:
+    assert classify(
+        current_url="https://m.boattrader.com/boats/",
+        expected_domains=expand_expected_domains("https://boattrader.com/"),
+    ) == "ok"
+
+
+# ── classifier: not_found ─────────────────────────────────────────────
+
+
+def test_classify_not_found_on_404_title() -> None:
+    assert classify(
+        current_url="https://boattrader.com/boats/nonexistent/",
+        expected_domains={"boattrader.com"},
+        page_title="404 - Page Not Found - Boat Trader",
+    ) == "not_found"
+
+
+def test_classify_not_found_on_generic_not_found_title() -> None:
+    assert classify(
+        current_url="https://boattrader.com/boats/typo/",
+        expected_domains={"boattrader.com"},
+        page_title="Page not found",
+    ) == "not_found"
+
+
+# ── classifier: soft_404 ──────────────────────────────────────────────
+
+
+def test_classify_soft_404_on_no_results_body() -> None:
+    """200 OK, right domain, body says 'we couldn't find'."""
+    assert classify(
+        current_url="https://boattrader.com/boats/state-fl-typo/",
+        expected_domains={"boattrader.com"},
+        page_title="Boat Trader",
+        page_body_text="We couldn't find any boats matching your search.",
+    ) == "soft_404"
+
+
+def test_classify_soft_404_on_no_listings() -> None:
+    assert classify(
+        current_url="https://boattrader.com/boat/expired-listing-id/",
+        expected_domains={"boattrader.com"},
+        page_title="Boat Trader",
+        page_body_text="This listing is no longer available.",
+    ) == "soft_404"
+
+
+# ── classifier: ok ────────────────────────────────────────────────────
+
+
+def test_classify_ok_on_healthy_page() -> None:
+    assert classify(
+        current_url="https://boattrader.com/boats/state-fl/by-owner/",
+        expected_domains={"boattrader.com"},
+        page_title="Boats by owner in Florida - Boat Trader",
+        page_body_text="Showing 1-25 of 1247 boats",
+    ) == "ok"
+
+
+def test_classify_ok_when_no_expected_domains_provided() -> None:
+    """When the caller can't provide expected_domains, we don't claim
+    wrong_domain — only the title-based subclasses still apply."""
+    assert classify(
+        current_url="https://any-domain.com/page",
+        expected_domains=set(),
+        page_title="Welcome",
+    ) == "ok"
+
+
+# ── precedence ────────────────────────────────────────────────────────
+
+
+def test_dns_beats_blocked() -> None:
+    """An empty URL is dns even if title would match blocked markers."""
+    assert classify(
+        current_url="",
+        expected_domains={"example.com"},
+        page_title="Just a moment...",
+    ) == "dns"
+
+
+def test_wrong_domain_skips_not_found_check() -> None:
+    """wrong_domain returns before not_found heuristics run."""
+    assert classify(
+        current_url="https://other-site.com/page-not-found",
+        expected_domains={"boattrader.com"},
+        page_title="404 Not Found",
+    ) == "wrong_domain"
+
+
+# ── read_page_signals helper ──────────────────────────────────────────
+
+
+def test_read_page_signals_via_cdp_evaluate() -> None:
+    env = MagicMock()
+    env.current_url = "https://boattrader.com/boats/"
+    env.cdp_evaluate.side_effect = ["My Title", "Body content here"]
+
+    url, title, body = read_page_signals(env)
+    assert url == "https://boattrader.com/boats/"
+    assert title == "My Title"
+    assert body == "Body content here"
+
+
+def test_read_page_signals_returns_empty_when_cdp_missing() -> None:
+    env = MagicMock(spec=["current_url"])
+    env.current_url = "https://example.com/"
+    url, title, body = read_page_signals(env)
+    assert url == "https://example.com/"
+    assert title == ""
+    assert body == ""
+
+
+def test_read_page_signals_falls_back_to_playwright_page() -> None:
+    """Local-CLI Playwright env doesn't have cdp_evaluate but has page.title().
+
+    Uses a plain class (not MagicMock) because `read_page_signals` checks
+    `not callable(page)` to distinguish a Page instance from a bound
+    method; MagicMock is always callable so it fails that gate.
+    """
+
+    class _FakePage:
+        def title(self) -> str:
+            return "Playwright Title"
+
+    class _FakeEnv:
+        current_url = "https://example.com/"
+        _page = _FakePage()
+
+    url, title, _body = read_page_signals(_FakeEnv())
+    assert url == "https://example.com/"
+    assert title == "Playwright Title"
+
+
+def test_read_page_signals_swallows_env_exceptions() -> None:
+    """Best-effort — any exception returns empty string for that field."""
+    env = MagicMock()
+    # current_url access raises
+    type(env).current_url = property(
+        lambda self: (_ for _ in ()).throw(RuntimeError("boom"))
+    )
+    env.cdp_evaluate.side_effect = RuntimeError("dead pipe")
+    url, title, body = read_page_signals(env)
+    assert url == ""
+    assert title == ""
+    assert body == ""
+
+
+# ── agentic_recovery short-circuit ────────────────────────────────────
+
+
+def test_agentic_recovery_routes_bad_url_to_halt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Phase 0 invariant: bad_url failures never hit the Claude tool —
+    they short-circuit to halt with a structured reason."""
+    from mantis_agent import agentic_recovery as ar
+
+    # Ensure the function would otherwise try to make the API call.
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "fake-key-not-used")
+
+    decision = ar.analyse_failure_and_recover(
+        step=MagicMock(intent="navigate to boattrader", type="navigate", params={}),
+        failure_data="bad_url:wrong_domain",
+        screenshot=None,
+        plan_context=[],
+        attempts=1,
+    )
+    assert decision is not None
+    assert decision.mode == "halt"
+    assert "wrong_domain" in decision.reasoning
+
+
+def test_agentic_recovery_short_circuit_each_subclass(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from mantis_agent import agentic_recovery as ar
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "fake-key-not-used")
+
+    for subclass in ("dns", "not_found", "wrong_domain", "soft_404"):
+        decision = ar.analyse_failure_and_recover(
+            step=MagicMock(intent="navigate", type="navigate", params={}),
+            failure_data=f"bad_url:{subclass}",
+            screenshot=None,
+            plan_context=[],
+            attempts=1,
+        )
+        assert decision is not None and decision.mode == "halt", (
+            f"subclass={subclass} should halt"
+        )
+        assert subclass in decision.reasoning
+
+
+# ── failure_class integration ─────────────────────────────────────────
+
+
+def test_failure_class_recognises_bad_url_prefix() -> None:
+    from mantis_agent.gym.failure_class import classify as fc_classify
+    assert fc_classify("bad_url:wrong_domain") == "bad_url"
+    assert fc_classify("bad_url:dns") == "bad_url"
+    assert fc_classify("bad_url=not_found") == "bad_url"
+
+
+def test_failure_class_legacy_classes_still_work() -> None:
+    """Adding bad_url didn't disturb the existing rules."""
+    from mantis_agent.gym.failure_class import classify as fc_classify
+    assert fc_classify("no_state_change", page_title="") == "no_state_change"
+    assert fc_classify("cloudflare interstitial detected") == "cf_challenge"
+    assert fc_classify("", page_title="Just a moment...") == "cf_challenge"
+
+
+# ── StepResult round-trip ─────────────────────────────────────────────
+
+
+def test_step_result_persists_failure_subclass() -> None:
+    """The new failure_subclass field survives to_dict/from_dict."""
+    from mantis_agent.gym.checkpoint import StepResult
+
+    r = StepResult(
+        step_index=0,
+        intent="navigate",
+        success=False,
+        failure_class="bad_url",
+        failure_subclass="wrong_domain",
+        final_url="https://other-site.com/",
+        page_title="Sign in",
+    )
+    d = r.to_dict()
+    assert d["failure_class"] == "bad_url"
+    assert d["failure_subclass"] == "wrong_domain"
+
+    r2 = StepResult.from_dict(d)
+    assert r2.failure_class == "bad_url"
+    assert r2.failure_subclass == "wrong_domain"
+    assert r2.final_url == "https://other-site.com/"
+
+
+def test_step_result_failure_subclass_defaults_empty() -> None:
+    from mantis_agent.gym.checkpoint import StepResult
+    r = StepResult(step_index=0, intent="x", success=True)
+    assert r.failure_subclass == ""


### PR DESCRIPTION
## Summary

Phase 0 of #703. Ships the URL health classifier + structured `failure_class='bad_url'` emission so the existing recovery loop sees a clean signal. **No new recovery action yet** — that's Phase 1 (#705). Phase 0 is observability: surfaces URL-drift incidence in result.json + Augur for sizing the actual fix.

**Canonical spec:** [`docs/reference/plan-evolution.md` § Phase 0](https://github.com/mercurialsolo/mantis/blob/main/docs/reference/plan-evolution.md)

## What this lands

- `src/mantis_agent/gym/url_health.py` — pure-functional classifier with subclasses:
  - `ok` — landed where expected
  - `dns` — `chrome-error://` or empty URL (Chrome failed to navigate)
  - `wrong_domain` — landed on a domain not in the expected set
  - `not_found` — 404-shaped title
  - `soft_404` — 200 OK + right domain + "we couldn't find this" body
  - `blocked` — CF / WAF interstitial (defers to existing handling)
- Helpers `expand_expected_domains(start_url)` + `read_page_signals(env)` (defensive — returns empty strings for non-string env attrs so test mocks don't trip false positives).
- `failure_class.py` — adds `bad_url` to the enum + prefix matcher for legacy `data` blobs starting with `bad_url:<subclass>`.
- `StepResult.failure_subclass: str` — new persisted field carrying the subclass; empty for non-`bad_url` failures.
- `step_handlers/navigate.py` — hooks `url_health.classify` after the post-navigate settle. On non-ok / non-blocked subclass, emits `StepResult(success=False, failure_class='bad_url', failure_subclass=<value>)`. Skipped when env has no real `current_url` (test mocks).
- `agentic_recovery.py` — short-circuits `bad_url:` failures to `RecoveryDecision(mode='halt')` without a Claude tool call. The four existing recovery modes (add_hint / edit_step / insert_steps) don't help URL-level drift; Phase 1 (#705) will replace this short-circuit with the `rewrite_url` mode.

## Acceptance

- [x] **Zero behaviour change for runs that have a working URL.** All 116 tests across touched modules (navigate_handler, failure_class, checkpoint, agentic_recovery) pass unchanged.
- [x] Every navigate step now classifies URL health post-settle; non-ok subclass surfaces as structured `failure_class='bad_url'` in `StepResult` instead of being inferred from prose.
- [x] Augur per-step events include `failure_class` / `failure_subclass` for downstream sizing of the actual fix.
- [x] 28 new tests in `test_url_health.py` cover each subclass + precedence + mock-env compatibility + failure_class integration + StepResult round-trip + agentic_recovery short-circuit.
- [x] Lint clean (`ruff check`).

## Out of scope

- Recovery action (Phase 1 — #705) — `rewrite_url` mode with pattern_transform / page_links / web_search sources.
- Persistence (Phase 2 — #706) — plan evolution store + pre-flight overlay.
- Generalising to selectors / labels (Phase 3 — #707).

## Test plan

- [x] `.venv/bin/python -m pytest tests/test_url_health.py` — 28 passed
- [x] `.venv/bin/python -m pytest tests/test_navigate_handler.py tests/test_failure_class.py tests/test_checkpoint_module.py tests/test_checkpoint_manager.py tests/test_agentic_recovery.py` — 88 passed (no regressions)
- [x] `ruff check` clean
- [ ] CI green (mkdocs / ruff / pytest 1-4)

Closes #704

🤖 Generated with [Claude Code](https://claude.com/claude-code)