### PR TITLE
feat(plan-evolution): Phase 1 — rewrite_url recovery action

### DIFF
--- a/src/mantis_agent/agentic_recovery.py
+++ b/src/mantis_agent/agentic_recovery.py
@@ -224,6 +224,7 @@ def analyse_failure_and_recover(
     model: str = "claude-haiku-4-5-20251001",
     prior_hints: list[str] | None = None,
     page_context: dict | None = None,
+    env: Any = None,
 ) -> RecoveryDecision | None:
     """Ask Claude to analyse a step failure and pick a recovery mode.
 
@@ -283,26 +284,65 @@ def analyse_failure_and_recover(
         does NOT track budgets — it just performs the analysis when
         invoked.
     """
-    # Plan-evolution Phase 0 (#704): a `bad_url:<subclass>` failure means
+    # Plan-evolution Phase 1 (#705): a `bad_url:<subclass>` failure means
     # the navigate step landed somewhere unusable (DNS error, 404,
-    # wrong domain, soft-404). The four existing recovery modes
-    # (add_hint / edit_step / insert_steps) won't help — they're for
-    # element-level drift, not URL-level drift. Phase 1 (#705) will
-    # add a `rewrite_url` mode that runs pattern_transform → page_links
-    # → web_search before deciding. Until then, short-circuit to halt
-    # with a structured reason so we don't burn a Claude tool call on
-    # a failure class we can't fix.
+    # wrong domain, soft-404). Run the URL-rewrite sources in cheapness
+    # order (pattern_transform, then page_links if env supports CDP).
+    # If a candidate emerges, dispatch as an `edit_step` decision
+    # rewriting the navigate intent + params.url; the existing
+    # step_recovery dispatcher merges the params and the navigate
+    # handler picks up the new URL on retry. If no candidate emerges,
+    # halt cleanly with the structured reason so result.json + Augur
+    # show what was tried.
+    #
+    # `blocked` subclass is filtered upstream (handled by
+    # external_pause / CF challenge paths) and never reaches this point.
     fd_lc = (failure_data or "").lower()
     if fd_lc.startswith("bad_url:") or fd_lc.startswith("bad_url="):
+        from .gym.url_recovery import propose_url_rewrites
         subclass = (failure_data or "").split(":", 1)[-1].split("=", 1)[-1].strip()
+        failed_url = _extract_failed_url_from_step(step, page_context or {})
+        report = propose_url_rewrites(
+            failed_url=failed_url,
+            failure_subclass=subclass,
+            intent_text=getattr(step, "intent", "") or "",
+            env=env,
+        )
+        if report.proposals:
+            best = report.proposals[0]
+            logger.warning(
+                "agentic_recovery: bad_url subclass=%s → rewrite_url "
+                "source=%s confidence=%.2f new_url=%s (notes=%s)",
+                subclass, best.source, best.confidence,
+                best.new_url[:120], best.notes,
+            )
+            return RecoveryDecision(
+                mode="edit_step",
+                edited_step={
+                    "intent": _rewrite_intent_url(
+                        getattr(step, "intent", "") or "",
+                        failed_url,
+                        best.new_url,
+                    ),
+                    "params": {"url": best.new_url},
+                },
+                reasoning=(
+                    f"rewrite_url:{best.source} {failed_url} → {best.new_url} "
+                    f"(confidence={best.confidence:.2f}; {best.notes})"
+                ),
+            )
+
         logger.warning(
-            "agentic_recovery: bad_url subclass=%s — Phase 0 routes to halt "
-            "(rewrite_url lands in #705)",
-            subclass,
+            "agentic_recovery: bad_url subclass=%s — no rewrite_url candidates "
+            "(sources_tried=%s sources_skipped=%s); halting cleanly",
+            subclass, report.sources_tried, report.sources_skipped,
         )
         return RecoveryDecision(
             mode="halt",
-            reasoning=f"bad_url:{subclass} — no rewrite_url recovery yet (#705)",
+            reasoning=(
+                f"bad_url:{subclass} — rewrite_url found no candidates "
+                f"(tried {','.join(report.sources_tried)})"
+            ),
         )
 
     api_key = api_key or os.environ.get("ANTHROPIC_API_KEY", "")
@@ -498,6 +538,51 @@ def _format_plan_context(steps: list[str]) -> str:
     if not steps:
         return "  (this is the first step that failed)"
     return "\n".join(f"  [{i}] {s[:100]}" for i, s in enumerate(steps))
+
+
+# ── plan-evolution Phase 1 helpers ───────────────────────────────────
+
+import re as _re  # noqa: E402 — keep heavy imports up top, plain re here
+
+
+_URL_RE = _re.compile(r'https?://[^\s"]+')
+
+
+def _extract_failed_url_from_step(step: Any, page_context: dict) -> str:
+    """Find the URL the navigate step tried to load.
+
+    Order: step.params['url'] > URL match in step.intent > page_context
+    ['current_url']. Returns "" only if every source is empty (shouldn't
+    happen for a bad_url failure; defensive).
+    """
+    params = getattr(step, "params", None) or {}
+    params_url = str(params.get("url", "") or "").strip()
+    if params_url:
+        m = _URL_RE.search(params_url)
+        if m:
+            return m.group(0)
+        if params_url.startswith("http"):
+            return params_url
+    intent = getattr(step, "intent", "") or ""
+    m = _URL_RE.search(intent)
+    if m:
+        return m.group(0)
+    return str(page_context.get("current_url", "") or "").strip()
+
+
+def _rewrite_intent_url(intent: str, old_url: str, new_url: str) -> str:
+    """Swap old_url → new_url inside the intent prose, preserving the rest.
+
+    When the intent doesn't literally contain old_url (the decomposer
+    paraphrased), returns the intent unchanged — params.url is the
+    authoritative source for the navigate handler anyway. The intent
+    rewrite is for log readability + future audit.
+    """
+    if not intent or not old_url or old_url == new_url:
+        return intent
+    if old_url in intent:
+        return intent.replace(old_url, new_url)
+    return intent
 
 
 def _format_page_context(page: dict) -> str:

--- a/src/mantis_agent/gym/step_recovery.py
+++ b/src/mantis_agent/gym/step_recovery.py
@@ -1095,6 +1095,12 @@ class StepRecoveryPolicy:
                 model=recovery_model,
                 prior_hints=prior_hints,
                 page_context=page_ctx,
+                # Plan-evolution Phase 1 (#705): page_links source needs
+                # CDP access to read links off the currently-loaded page.
+                # The local impl + RemoteComputerImpl both expose
+                # ``cdp_evaluate``; the source degrades silently when
+                # env is None or lacks the method.
+                env=getattr(runner, "env", None),
             )
         if decision is None:
             # #431: even though analyse_failure_and_recover already logs

--- a/src/mantis_agent/gym/url_recovery.py
+++ b/src/mantis_agent/gym/url_recovery.py
@@ -1,0 +1,362 @@
+"""URL rewrite recovery sources — plan-evolution Phase 1 (#705).
+
+Consumed by :func:`mantis_agent.agentic_recovery.analyse_failure_and_recover`
+when a navigate step fails with ``failure_class='bad_url'``. Each source
+emits zero or more :class:`RewriteProposal` candidates; the recovery loop
+picks the highest-confidence proposal and returns an ``edit_step``
+RecoveryDecision that rewrites the step's intent + ``params.url``.
+
+Phase 1 ships two sources (web_search deferred):
+
+1. ``pattern_transform`` (~free) — pure-Python rule set for common URL
+   drifts (slug normalisation, trailing slash, case folding). Confidence
+   0.6 — pattern matches but doesn't validate semantic correctness.
+
+2. ``page_links`` (~$0.001) — read ``a[href]`` from the currently-loaded
+   page (homepage / last good page) via CDP; score by text overlap with
+   the failed step's intent + the original URL's path tokens. Confidence
+   0.7 — page-derived but heuristic.
+
+Phase 1 does NOT validate proposals (no HEAD-200 check). A bad proposal
+fails the next navigate, the recovery budget eventually exhausts, and
+the run halts cleanly. Validation lands in Phase 2 (#706) once we have
+real production data on how often pattern_transform produces invalid
+URLs.
+
+CUA-purity: ``page_links`` reads DOM only to *propose alternative URLs*.
+The brain still has to navigate to the proposal and verify visually —
+the URL is action-target, not grounding-derivation. See
+``feedback_cua_no_dom_access.md`` for the boundary.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+from typing import Any, Literal
+from urllib.parse import urlparse, urlunparse
+
+from .url_health import _normalize_netloc, expand_expected_domains
+
+logger = logging.getLogger(__name__)
+
+RewriteSource = Literal["pattern_transform", "page_links"]
+
+
+@dataclass
+class RewriteProposal:
+    """A candidate URL rewrite + provenance.
+
+    Recovery picks the highest-confidence proposal; ties broken by
+    source order (pattern_transform before page_links).
+    """
+
+    new_url: str
+    source: RewriteSource
+    confidence: float           # 0.0–1.0
+    notes: str = ""             # short human-readable rationale
+    matched_link_text: str = "" # populated by page_links only
+
+
+@dataclass
+class _PageLink:
+    text: str
+    href: str
+
+
+# ── pattern_transform ────────────────────────────────────────────────
+
+
+def _pattern_transform(failed_url: str) -> list[RewriteProposal]:
+    """Generate URL variants via common drift patterns.
+
+    Each rule emits at most one proposal. Caller dedupes by `new_url`
+    in the assembly step (multiple rules may converge on the same
+    transform).
+    """
+    parsed = urlparse(failed_url)
+    if not parsed.scheme or not parsed.netloc:
+        return []
+
+    proposals: list[RewriteProposal] = []
+    path = parsed.path or "/"
+
+    # Rule 1: trailing slash flip. /boats/by-owner ↔ /boats/by-owner/
+    if path.endswith("/") and len(path) > 1:
+        alt_path = path.rstrip("/")
+        proposals.append(_make_proposal(
+            parsed, alt_path,
+            notes="strip-trailing-slash",
+        ))
+    elif not path.endswith("/") and "/" in path:
+        proposals.append(_make_proposal(
+            parsed, path + "/",
+            notes="add-trailing-slash",
+        ))
+
+    # Rule 2: hyphen ↔ slash in slug. /boats/state-fl/ ↔ /boats/state/fl/
+    # Apply only when the path contains a hyphen-joined slug that LOOKS
+    # like two tokens (lowercase + 2-char state code is a strong tell on
+    # marketplace plans; keep the rule conservative to avoid spurious
+    # transforms on /style-guide etc.).
+    for m in re.finditer(r"/([a-z]+)-([a-z]{2})(/|$)", path):
+        before = path[: m.start()]
+        after = path[m.end() - 1 :]  # keep trailing / or ""
+        transformed = f"{before}/{m.group(1)}/{m.group(2)}{after}"
+        if transformed != path:
+            proposals.append(_make_proposal(
+                parsed, transformed,
+                notes=f"slug-split:{m.group(1)}-{m.group(2)}",
+            ))
+        # And the reverse: /state/fl ↔ /state-fl
+    for m in re.finditer(r"/([a-z]+)/([a-z]{2})(/|$)", path):
+        before = path[: m.start()]
+        after = path[m.end() - 1 :]
+        transformed = f"{before}/{m.group(1)}-{m.group(2)}{after}"
+        if transformed != path:
+            proposals.append(_make_proposal(
+                parsed, transformed,
+                notes=f"slug-merge:{m.group(1)}-{m.group(2)}",
+            ))
+
+    # Rule 3: drop www. or add www. — covers domain-level drift where
+    # the canonical host moved between bare and www variants.
+    netloc_no_port = parsed.netloc.split(":", 1)[0]
+    port_suffix = ""
+    if ":" in parsed.netloc:
+        port_suffix = ":" + parsed.netloc.split(":", 1)[1]
+    if netloc_no_port.startswith("www."):
+        alt = parsed._replace(netloc=netloc_no_port[4:] + port_suffix)
+        proposals.append(RewriteProposal(
+            new_url=urlunparse(alt),
+            source="pattern_transform",
+            confidence=0.55,
+            notes="strip-www",
+        ))
+    else:
+        alt = parsed._replace(netloc="www." + netloc_no_port + port_suffix)
+        proposals.append(RewriteProposal(
+            new_url=urlunparse(alt),
+            source="pattern_transform",
+            confidence=0.55,
+            notes="add-www",
+        ))
+
+    # Rule 4: case-fold query params. ?param=Value → ?param=value
+    if parsed.query and parsed.query != parsed.query.lower():
+        alt = parsed._replace(query=parsed.query.lower())
+        proposals.append(RewriteProposal(
+            new_url=urlunparse(alt),
+            source="pattern_transform",
+            confidence=0.5,
+            notes="lower-query",
+        ))
+
+    # Dedupe by new_url, preserving first occurrence (highest confidence
+    # since we appended in confidence order).
+    seen: set[str] = set()
+    deduped: list[RewriteProposal] = []
+    for p in proposals:
+        if p.new_url == failed_url or p.new_url in seen:
+            continue
+        seen.add(p.new_url)
+        deduped.append(p)
+    return deduped
+
+
+def _make_proposal(
+    parsed: Any, new_path: str, *, notes: str, confidence: float = 0.6,
+) -> RewriteProposal:
+    """Build a proposal that swaps just the path component."""
+    new_url = urlunparse(parsed._replace(path=new_path))
+    return RewriteProposal(
+        new_url=new_url,
+        source="pattern_transform",
+        confidence=confidence,
+        notes=notes,
+    )
+
+
+# ── page_links ────────────────────────────────────────────────────────
+
+
+_LINK_EXTRACT_JS = (
+    "Array.from(document.querySelectorAll('a[href]'))"
+    ".slice(0, 200)"
+    ".map(a => ({text: (a.innerText || a.title || a.ariaLabel || '').trim().slice(0, 120), "
+    "href: a.href}))"
+    ".filter(l => l.href && l.href.startsWith('http'))"
+)
+
+
+def _page_links(
+    env: Any,
+    failed_url: str,
+    intent_text: str,
+    *,
+    max_links: int = 200,
+    min_score: float = 0.25,
+) -> list[RewriteProposal]:
+    """Scan the currently-loaded page for links that match the intent.
+
+    Degrades silently when env doesn't expose `cdp_evaluate` — many
+    test envs and the local CLI fallback don't have CDP wired.
+    """
+    cdp = getattr(env, "cdp_evaluate", None)
+    if not callable(cdp):
+        return []
+
+    try:
+        raw = cdp(_LINK_EXTRACT_JS)
+    except Exception as exc:  # noqa: BLE001 — best-effort
+        logger.debug("page_links cdp_evaluate raised: %s", exc)
+        return []
+
+    links = _coerce_links(raw, max_links=max_links)
+    if not links:
+        return []
+
+    expected = expand_expected_domains(failed_url)
+    intent_tokens = _tokenize(intent_text)
+    failed_tokens = _tokenize(_url_to_text(failed_url))
+    target_tokens = intent_tokens | failed_tokens
+    if not target_tokens:
+        return []
+
+    scored: list[tuple[float, _PageLink]] = []
+    for link in links:
+        link_netloc = _normalize_netloc(urlparse(link.href).netloc)
+        if expected and link_netloc not in expected:
+            # Off-domain link — skip. We don't follow cross-site
+            # redirects from this source.
+            continue
+        link_tokens = _tokenize(link.text) | _tokenize(_url_to_text(link.href))
+        if not link_tokens:
+            continue
+        overlap = len(target_tokens & link_tokens)
+        score = overlap / max(len(target_tokens), 1)
+        if score >= min_score and link.href != failed_url:
+            scored.append((score, link))
+
+    if not scored:
+        return []
+    scored.sort(key=lambda t: -t[0])
+
+    # Top 3 — confidence scales with score (0.5–0.75 range).
+    proposals: list[RewriteProposal] = []
+    for score, link in scored[:3]:
+        confidence = round(min(0.75, 0.5 + score * 0.25), 3)
+        proposals.append(RewriteProposal(
+            new_url=link.href,
+            source="page_links",
+            confidence=confidence,
+            notes=f"score={score:.2f}",
+            matched_link_text=link.text[:80],
+        ))
+    return proposals
+
+
+def _coerce_links(raw: Any, *, max_links: int) -> list[_PageLink]:
+    if not isinstance(raw, list):
+        return []
+    out: list[_PageLink] = []
+    for entry in raw[:max_links]:
+        if not isinstance(entry, dict):
+            continue
+        href = str(entry.get("href", "") or "").strip()
+        text = str(entry.get("text", "") or "").strip()
+        if href:
+            out.append(_PageLink(text=text, href=href))
+    return out
+
+
+# Common stopwords that hurt overlap scoring for URL-shaped strings
+# (most marketplace URLs include `boats`, `by-owner`, etc. that aren't
+# discriminating enough to drive a rewrite).
+_STOPWORDS: frozenset[str] = frozenset({
+    "http", "https", "www", "com", "org", "net",
+    "the", "a", "an", "to", "for", "in", "of", "and", "or",
+    "navigate", "go", "open", "visit", "page", "url",
+})
+
+
+def _tokenize(text: str) -> set[str]:
+    """Lowercase + alphanumeric word split + stopword strip.
+
+    Keeps tokens ≥ 2 chars to avoid noise from single-char fragments.
+    """
+    if not text:
+        return set()
+    raw = re.findall(r"[a-z0-9]+", text.lower())
+    return {t for t in raw if len(t) >= 2 and t not in _STOPWORDS}
+
+
+def _url_to_text(url: str) -> str:
+    """Path + query tokens, hyphen / slash / underscore replaced with space."""
+    parsed = urlparse(url)
+    parts = [parsed.path or "", parsed.query or ""]
+    return " ".join(parts).replace("-", " ").replace("/", " ").replace("_", " ")
+
+
+# ── orchestrator ──────────────────────────────────────────────────────
+
+
+@dataclass
+class UrlRecoveryReport:
+    """Surface what each source produced — used in logs + result.json."""
+
+    proposals: list[RewriteProposal] = field(default_factory=list)
+    sources_tried: list[str] = field(default_factory=list)
+    sources_skipped: dict[str, str] = field(default_factory=dict)
+
+
+def propose_url_rewrites(
+    *,
+    failed_url: str,
+    failure_subclass: str,
+    intent_text: str = "",
+    env: Any = None,
+) -> UrlRecoveryReport:
+    """Run all sources, return ordered proposals + diagnostic report.
+
+    Sources run in cheapness order; results are merged + sorted by
+    confidence DESC. Empty proposal list means no source found a
+    candidate — caller halts.
+
+    Args:
+        failed_url: The URL the navigate step tried to load.
+        failure_subclass: `dns` / `not_found` / `wrong_domain` /
+            `soft_404` — informs which sources are worth running.
+            `blocked` is filtered upstream (handled by external_pause).
+        intent_text: The plan step's intent prose; used by page_links
+            for relevance scoring.
+        env: Optional `GymEnvironment` for sources that need CDP
+            (page_links). Absent → page_links skipped silently.
+    """
+    report = UrlRecoveryReport()
+
+    if failure_subclass == "dns":
+        # DNS failure → no page loaded → page_links can't run; pattern
+        # transforms are the only useful source.
+        report.sources_tried.append("pattern_transform")
+        report.proposals.extend(_pattern_transform(failed_url))
+        report.sources_skipped["page_links"] = "dns_no_page_loaded"
+    else:
+        # not_found / wrong_domain / soft_404 — both sources useful.
+        report.sources_tried.append("pattern_transform")
+        report.proposals.extend(_pattern_transform(failed_url))
+
+        report.sources_tried.append("page_links")
+        page_proposals = _page_links(env, failed_url, intent_text)
+        if not page_proposals and not callable(getattr(env, "cdp_evaluate", None)):
+            report.sources_skipped["page_links"] = "env_lacks_cdp_evaluate"
+        report.proposals.extend(page_proposals)
+
+    # Sort by confidence DESC; ties broken by source preference
+    # (pattern_transform before page_links per spec).
+    source_order = {"pattern_transform": 0, "page_links": 1}
+    report.proposals.sort(
+        key=lambda p: (-p.confidence, source_order.get(p.source, 99))
+    )
+    return report

--- a/tests/test_agentic_recovery.py
+++ b/tests/test_agentic_recovery.py
@@ -321,7 +321,7 @@ def test_step_recovery_passes_page_context_to_agentic_recovery(monkeypatch) -> N
 
     def _capture(*, step, failure_data, screenshot, plan_context,
                  attempts, model=None, api_key="", prior_hints=None,
-                 page_context=None):
+                 page_context=None, env=None):
         captured["page_context"] = page_context
         return None
 
@@ -485,7 +485,7 @@ def test_no_state_change_submit_uses_opus_model() -> None:
 
     def _capture(*, step, failure_data, screenshot, plan_context,
                  attempts, model=None, api_key="", prior_hints=None,
-                 page_context=None):
+                 page_context=None, env=None):
         captured["model"] = model
         captured["page_context"] = page_context
         return None  # short-circuit; we only care about the model arg.
@@ -926,7 +926,7 @@ def test_recovery_runs_tab_blur_traversal_on_no_state_change_submit() -> None:
 
     def _capture(*, step, failure_data, screenshot, plan_context,
                  attempts, model=None, api_key="", prior_hints=None,
-                 page_context=None):
+                 page_context=None, env=None):
         captured["screenshot"] = screenshot
         return None  # short-circuit; we only care about the pre-call sequence.
 

--- a/tests/test_url_recovery.py
+++ b/tests/test_url_recovery.py
@@ -1,0 +1,458 @@
+"""Tests for url_recovery — plan-evolution Phase 1 (#705).
+
+Covers the two sources (pattern_transform + page_links) + the
+orchestrator + the agentic_recovery integration that turns proposals
+into ``edit_step`` decisions.
+
+Web search is out of scope for Phase 1 per the implementation decision.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from mantis_agent.gym.url_recovery import (
+    RewriteProposal,
+    _coerce_links,
+    _page_links,
+    _pattern_transform,
+    _tokenize,
+    propose_url_rewrites,
+)
+
+
+# ── _tokenize ─────────────────────────────────────────────────────────
+
+
+def test_tokenize_strips_stopwords_and_short_tokens() -> None:
+    out = _tokenize("Navigate to the boats by-owner page")
+    # 'navigate', 'to', 'the', 'page' are stopwords. 'by' is 2 chars
+    # and not in the stopword list (intentional — too aggressive a
+    # filter risks dropping real path tokens). 'boats' + 'by' + 'owner'
+    # survive.
+    assert out == {"boats", "by", "owner"}
+
+
+def test_tokenize_drops_single_char_tokens() -> None:
+    """A 1-char token from a hyphen split shouldn't survive."""
+    out = _tokenize("a-good-test")
+    assert "a" not in out
+    assert "good" in out
+    assert "test" in out
+
+
+def test_tokenize_empty_returns_empty() -> None:
+    assert _tokenize("") == set()
+    assert _tokenize("the a to of") == set()
+
+
+# ── _pattern_transform ────────────────────────────────────────────────
+
+
+def test_pattern_transform_trailing_slash() -> None:
+    out = _pattern_transform("https://boattrader.com/boats/by-owner")
+    new_urls = {p.new_url for p in out}
+    assert "https://boattrader.com/boats/by-owner/" in new_urls
+
+
+def test_pattern_transform_strip_trailing_slash() -> None:
+    out = _pattern_transform("https://boattrader.com/boats/by-owner/")
+    new_urls = {p.new_url for p in out}
+    assert "https://boattrader.com/boats/by-owner" in new_urls
+
+
+def test_pattern_transform_slug_split_state() -> None:
+    """`/boats/state-fl/` → `/boats/state/fl/` is the canonical rule."""
+    out = _pattern_transform("https://boattrader.com/boats/state-fl/")
+    new_urls = {p.new_url for p in out}
+    assert "https://boattrader.com/boats/state/fl/" in new_urls
+
+
+def test_pattern_transform_slug_merge() -> None:
+    """Reverse: `/state/fl/` → `/state-fl/`."""
+    out = _pattern_transform("https://boattrader.com/boats/state/fl/")
+    new_urls = {p.new_url for p in out}
+    assert "https://boattrader.com/boats/state-fl/" in new_urls
+
+
+def test_pattern_transform_www_strip_and_add() -> None:
+    out_no_www = _pattern_transform("https://boattrader.com/")
+    assert any(p.new_url == "https://www.boattrader.com/" for p in out_no_www)
+
+    out_www = _pattern_transform("https://www.boattrader.com/")
+    assert any(p.new_url == "https://boattrader.com/" for p in out_www)
+
+
+def test_pattern_transform_case_fold_query() -> None:
+    out = _pattern_transform("https://example.com/page?Param=Value")
+    new_urls = {p.new_url for p in out}
+    assert "https://example.com/page?param=value" in new_urls
+
+
+def test_pattern_transform_skips_own_url() -> None:
+    """No proposal should equal the input URL."""
+    failed = "https://boattrader.com/"
+    out = _pattern_transform(failed)
+    assert all(p.new_url != failed for p in out)
+
+
+def test_pattern_transform_no_scheme_returns_empty() -> None:
+    assert _pattern_transform("/no/scheme") == []
+    assert _pattern_transform("") == []
+
+
+def test_pattern_transform_confidence_in_range() -> None:
+    out = _pattern_transform("https://boattrader.com/boats/state-fl/")
+    for p in out:
+        assert 0.0 <= p.confidence <= 1.0
+        assert p.source == "pattern_transform"
+
+
+def test_pattern_transform_dedupes_proposals() -> None:
+    """Multiple rules converging on the same URL emit only once."""
+    out = _pattern_transform("https://boattrader.com/x")
+    new_urls = [p.new_url for p in out]
+    assert len(new_urls) == len(set(new_urls))
+
+
+# ── _page_links ───────────────────────────────────────────────────────
+
+
+def test_page_links_skips_when_env_lacks_cdp() -> None:
+    env = MagicMock(spec=[])  # no cdp_evaluate attribute
+    assert _page_links(env, "https://example.com/typo", "navigate") == []
+
+
+def test_page_links_skips_when_cdp_raises() -> None:
+    env = MagicMock()
+    env.cdp_evaluate.side_effect = RuntimeError("CDP unreachable")
+    assert _page_links(env, "https://example.com/typo", "navigate") == []
+
+
+def test_page_links_filters_off_domain() -> None:
+    """Cross-site links don't get proposed."""
+    env = MagicMock()
+    env.cdp_evaluate.return_value = [
+        {"text": "Sign in", "href": "https://accounts.google.com/signin"},
+        {"text": "Boats by owner", "href": "https://boattrader.com/boats/by-owner/"},
+    ]
+    out = _page_links(env, "https://boattrader.com/x", "Find boats by owner")
+    new_urls = {p.new_url for p in out}
+    assert "https://accounts.google.com/signin" not in new_urls
+    assert "https://boattrader.com/boats/by-owner/" in new_urls
+
+
+def test_page_links_scores_by_token_overlap() -> None:
+    env = MagicMock()
+    env.cdp_evaluate.return_value = [
+        {"text": "Unrelated link", "href": "https://boattrader.com/something-else/"},
+        {"text": "Boats by owner FL", "href": "https://boattrader.com/boats/by-owner/"},
+    ]
+    out = _page_links(env, "https://boattrader.com/x", "boats owner florida")
+    # The matching link should rank first.
+    assert out
+    assert out[0].new_url == "https://boattrader.com/boats/by-owner/"
+    assert out[0].source == "page_links"
+    assert "score=" in out[0].notes
+
+
+def test_page_links_skips_self_referential_proposals() -> None:
+    """A link pointing at the same failed URL isn't a useful proposal."""
+    env = MagicMock()
+    failed = "https://boattrader.com/boats/state-fl/"
+    env.cdp_evaluate.return_value = [
+        {"text": "Boats in FL", "href": failed},
+    ]
+    out = _page_links(env, failed, "boats florida")
+    assert all(p.new_url != failed for p in out)
+
+
+def test_page_links_returns_empty_on_malformed_cdp_payload() -> None:
+    env = MagicMock()
+    env.cdp_evaluate.return_value = "not a list"
+    assert _page_links(env, "https://example.com/", "navigate") == []
+
+
+def test_page_links_caps_to_top_3() -> None:
+    env = MagicMock()
+    # 5 matching links — should clip to 3 proposals
+    env.cdp_evaluate.return_value = [
+        {"text": f"Boats by owner {i}", "href": f"https://boattrader.com/boats/{i}"}
+        for i in range(5)
+    ]
+    out = _page_links(env, "https://boattrader.com/x", "boats owner")
+    assert len(out) <= 3
+
+
+# ── _coerce_links ─────────────────────────────────────────────────────
+
+
+def test_coerce_links_filters_non_dict_entries() -> None:
+    raw = [{"text": "ok", "href": "https://x.com"}, "junk", None, {"href": ""}]
+    out = _coerce_links(raw, max_links=10)
+    assert len(out) == 1
+    assert out[0].href == "https://x.com"
+
+
+def test_coerce_links_caps_at_max() -> None:
+    raw = [{"text": f"t{i}", "href": f"https://x.com/{i}"} for i in range(500)]
+    out = _coerce_links(raw, max_links=10)
+    assert len(out) == 10
+
+
+# ── propose_url_rewrites orchestrator ─────────────────────────────────
+
+
+def test_propose_dns_uses_pattern_transform_only() -> None:
+    """DNS failure → no page loaded → page_links should be skipped."""
+    env = MagicMock()
+    env.cdp_evaluate.return_value = [{"text": "Home", "href": "https://x.com/"}]
+    report = propose_url_rewrites(
+        failed_url="https://boattrader.com/boats/state-fl/",
+        failure_subclass="dns",
+        intent_text="navigate to florida boats",
+        env=env,
+    )
+    assert "pattern_transform" in report.sources_tried
+    assert "page_links" not in report.sources_tried
+    assert "dns_no_page_loaded" in report.sources_skipped.get("page_links", "")
+    # CDP wasn't even consulted
+    env.cdp_evaluate.assert_not_called()
+
+
+def test_propose_not_found_runs_both_sources() -> None:
+    env = MagicMock()
+    env.cdp_evaluate.return_value = [
+        {"text": "Boats by owner", "href": "https://boattrader.com/boats/by-owner/"},
+    ]
+    report = propose_url_rewrites(
+        failed_url="https://boattrader.com/boats/typo/",
+        failure_subclass="not_found",
+        intent_text="boats by owner",
+        env=env,
+    )
+    assert "pattern_transform" in report.sources_tried
+    assert "page_links" in report.sources_tried
+
+
+def test_propose_sorts_by_confidence_desc() -> None:
+    report = propose_url_rewrites(
+        failed_url="https://boattrader.com/boats/state-fl/",
+        failure_subclass="not_found",
+        intent_text="boats",
+        env=None,  # page_links skipped silently
+    )
+    if len(report.proposals) >= 2:
+        confidences = [p.confidence for p in report.proposals]
+        assert confidences == sorted(confidences, reverse=True)
+
+
+def test_propose_logs_env_lacking_cdp() -> None:
+    """When env doesn't support CDP, page_links is marked skipped."""
+    env_no_cdp = MagicMock(spec=[])
+    report = propose_url_rewrites(
+        failed_url="https://boattrader.com/boats/state-fl/",
+        failure_subclass="wrong_domain",
+        intent_text="boats",
+        env=env_no_cdp,
+    )
+    assert "env_lacks_cdp_evaluate" in report.sources_skipped.get("page_links", "")
+
+
+def test_propose_empty_when_no_sources_match() -> None:
+    """Garbage URL + no env → pattern_transform empty + page_links skipped."""
+    report = propose_url_rewrites(
+        failed_url="garbage-not-a-url",
+        failure_subclass="dns",
+        intent_text="",
+        env=None,
+    )
+    assert report.proposals == []
+
+
+# ── agentic_recovery integration ──────────────────────────────────────
+
+
+def _stub_step(intent: str = "", params: dict | None = None):
+    s = MagicMock()
+    s.intent = intent
+    s.params = params or {}
+    s.type = "navigate"
+    return s
+
+
+def test_agentic_recovery_emits_edit_step_for_bad_url_with_proposal() -> None:
+    """End-to-end: bad_url failure with a pattern_transform-recoverable
+    URL → recovery returns an `edit_step` decision rewriting params.url."""
+    from mantis_agent import agentic_recovery as ar
+
+    step = _stub_step(
+        intent="Navigate to https://boattrader.com/boats/state-fl/ to find listings",
+        params={"url": "https://boattrader.com/boats/state-fl/"},
+    )
+    decision = ar.analyse_failure_and_recover(
+        step=step,
+        failure_data="bad_url:not_found",
+        screenshot=None,
+        plan_context=[],
+        attempts=1,
+        env=None,
+    )
+    assert decision is not None
+    assert decision.mode == "edit_step"
+    assert "url" in decision.edited_step.get("params", {})
+    new_url = decision.edited_step["params"]["url"]
+    assert new_url != "https://boattrader.com/boats/state-fl/"
+    assert "rewrite_url:pattern_transform" in decision.reasoning
+
+
+def test_agentic_recovery_rewrites_intent_when_url_literal() -> None:
+    """When the failed URL appears verbatim in intent prose, the rewrite
+    replaces it so logs are coherent."""
+    from mantis_agent import agentic_recovery as ar
+
+    failed = "https://boattrader.com/boats/state-fl/"
+    step = _stub_step(
+        intent=f"Navigate to {failed} to find listings",
+        params={"url": failed},
+    )
+    decision = ar.analyse_failure_and_recover(
+        step=step,
+        failure_data="bad_url:not_found",
+        screenshot=None,
+        plan_context=[],
+        attempts=1,
+        env=None,
+    )
+    assert decision is not None and decision.mode == "edit_step"
+    new_url = decision.edited_step["params"]["url"]
+    assert failed not in decision.edited_step["intent"]
+    assert new_url in decision.edited_step["intent"]
+
+
+def test_agentic_recovery_halts_when_no_proposal() -> None:
+    """Garbage URL → no proposals → halt with structured reason."""
+    from mantis_agent import agentic_recovery as ar
+
+    step = _stub_step(
+        intent="Navigate to this thing",
+        params={"url": "garbage-not-a-url"},
+    )
+    decision = ar.analyse_failure_and_recover(
+        step=step,
+        failure_data="bad_url:dns",
+        screenshot=None,
+        plan_context=[],
+        attempts=1,
+        env=None,
+    )
+    assert decision is not None
+    assert decision.mode == "halt"
+    assert "rewrite_url found no candidates" in decision.reasoning
+
+
+def test_agentic_recovery_uses_page_links_when_env_available() -> None:
+    """When env has cdp_evaluate, page_links is consulted alongside pattern."""
+    from mantis_agent import agentic_recovery as ar
+
+    env = MagicMock()
+    env.cdp_evaluate.return_value = [
+        {"text": "Boats by owner Florida",
+         "href": "https://boattrader.com/boats/state/fl/by-owner/"},
+    ]
+    step = _stub_step(
+        intent="Navigate to https://boattrader.com/boats/state-fl/by-owner/",
+        params={"url": "https://boattrader.com/boats/state-fl/by-owner/"},
+    )
+    decision = ar.analyse_failure_and_recover(
+        step=step,
+        failure_data="bad_url:wrong_domain",
+        screenshot=None,
+        plan_context=[],
+        attempts=1,
+        env=env,
+    )
+    assert decision is not None and decision.mode == "edit_step"
+    # CDP was consulted at least once
+    env.cdp_evaluate.assert_called()
+
+
+def test_agentic_recovery_falls_through_for_non_bad_url() -> None:
+    """Other failure_class blobs are NOT short-circuited; they go to
+    Claude (or, without an API key, return None)."""
+    import os
+    from mantis_agent import agentic_recovery as ar
+
+    # No API key set — should return None (legacy halt fallback)
+    saved = os.environ.pop("ANTHROPIC_API_KEY", None)
+    try:
+        step = _stub_step(intent="click the Save button", params={})
+        decision = ar.analyse_failure_and_recover(
+            step=step,
+            failure_data="no_state_change:click",
+            screenshot=None,
+            plan_context=[],
+            attempts=1,
+            env=None,
+        )
+        assert decision is None  # would have hit Claude path
+    finally:
+        if saved is not None:
+            os.environ["ANTHROPIC_API_KEY"] = saved
+
+
+# ── RewriteProposal dataclass ────────────────────────────────────────
+
+
+def test_rewrite_proposal_fields() -> None:
+    p = RewriteProposal(
+        new_url="https://x.com/",
+        source="pattern_transform",
+        confidence=0.6,
+        notes="strip-www",
+    )
+    assert p.new_url == "https://x.com/"
+    assert p.source == "pattern_transform"
+    assert p.confidence == 0.6
+    assert p.matched_link_text == ""
+
+
+# ── helpers in agentic_recovery ──────────────────────────────────────
+
+
+def test_extract_failed_url_from_step_prefers_params_url() -> None:
+    from mantis_agent.agentic_recovery import _extract_failed_url_from_step
+    step = _stub_step(
+        intent="navigate to https://intent-url.com/",
+        params={"url": "https://params-url.com/path"},
+    )
+    assert _extract_failed_url_from_step(step, {}) == "https://params-url.com/path"
+
+
+def test_extract_failed_url_from_step_falls_back_to_intent() -> None:
+    from mantis_agent.agentic_recovery import _extract_failed_url_from_step
+    step = _stub_step(intent="Open https://intent-url.com/page", params={})
+    assert _extract_failed_url_from_step(step, {}) == "https://intent-url.com/page"
+
+
+def test_extract_failed_url_from_step_falls_back_to_page_context() -> None:
+    from mantis_agent.agentic_recovery import _extract_failed_url_from_step
+    step = _stub_step(intent="navigate somewhere", params={})
+    assert _extract_failed_url_from_step(
+        step, {"current_url": "https://ctx-url.com/"}
+    ) == "https://ctx-url.com/"
+
+
+def test_rewrite_intent_url_swaps_literal() -> None:
+    from mantis_agent.agentic_recovery import _rewrite_intent_url
+    out = _rewrite_intent_url(
+        "Navigate to https://old.com/ and click", "https://old.com/", "https://new.com/"
+    )
+    assert out == "Navigate to https://new.com/ and click"
+
+
+def test_rewrite_intent_url_unchanged_when_url_not_literal() -> None:
+    from mantis_agent.agentic_recovery import _rewrite_intent_url
+    intent = "Navigate to the listings page"
+    out = _rewrite_intent_url(intent, "https://x.com/", "https://y.com/")
+    assert out == intent


### PR DESCRIPTION
## Summary

Phase 1 of #703. Adds the URL-rewrite recovery action that consumes the structured `failure_class='bad_url'` signal shipped in Phase 0 (#708) and turns it into an `edit_step` `RecoveryDecision` rewriting the navigate step's intent + `params.url`. The existing step_recovery dispatcher applies the edit; the navigate handler picks up the new URL on retry.

**Per scoping decision: web_search source deferred.** Two sources land in this PR.

**Canonical spec:** [`docs/reference/plan-evolution.md` § Phase 1](https://github.com/mercurialsolo/mantis/blob/main/docs/reference/plan-evolution.md)

## Sources (in cheapness order)

| Source | Cost | Confidence | Notes |
|---|---|---|---|
| `pattern_transform` | ~free | 0.5–0.6 | Pure-Python rule set: trailing slash, hyphen↔slash slug, www-strip/add, query case fold |
| `page_links` | ~$0.001 | 0.5–0.75 | CDP-evaluates `a[href]` from the loaded page, scores by token overlap. Degrades silently when env lacks `cdp_evaluate` |
| ~~`web_search`~~ | ~~~$0.005~~ | — | Deferred per scoping decision |

## Wiring

- `src/mantis_agent/gym/url_recovery.py` (new): `RewriteProposal` dataclass + `propose_url_rewrites()` orchestrator. DNS subclass skips `page_links` (no page loaded); other subclasses run both sources. Proposals sorted by confidence DESC, ties broken by source order.
- `src/mantis_agent/agentic_recovery.py`: Phase 0 halt short-circuit replaced. On `bad_url:<subclass>` failure, call `propose_url_rewrites`, pick the highest-confidence proposal, return `RecoveryDecision(mode='edit_step', edited_step={'intent': ..., 'params': {'url': ...}})`. No new dispatcher path — `edit_step` is already wired in `step_recovery.py`.
- `analyse_failure_and_recover` gains optional `env` kwarg; `step_recovery.py` plumbs `runner.env` through so `page_links` can call CDP.
- `_extract_failed_url_from_step` + `_rewrite_intent_url` helpers in `agentic_recovery.py`.

## What's NOT in this PR

- **Persistence** — rewrites apply to the running plan but don't survive run terminate. Phase 2 (#706) adds the store + promotion gate.
- **Web search source** — deferred. Easy follow-up: add `_web_search()` to `url_recovery.py` + a tool-use call in `agentic_recovery._call_recovery_tool`.
- **HEAD-200 validation** — proposals are emitted unverified. A bad rewrite fails the retry, recovery budget exhausts, run halts cleanly. Validation lands when we have production data on miss rates.

## Acceptance

- [x] Pattern-transform rules generate the canonical drift variants (test cases match the spec's examples: `/boats/state-fl/` ↔ `/boats/state/fl/`, trailing-slash flip, www-strip).
- [x] `page_links` scores by intent + URL-path token overlap; off-domain links filtered.
- [x] `page_links` degrades silently when env lacks CDP (test mocks, local-CLI fallback).
- [x] End-to-end: a `bad_url:not_found` failure with a pattern-recoverable URL produces an `edit_step` decision rewriting both intent and params.
- [x] When no proposal emerges, recovery halts cleanly with structured reason (sources tried + sources skipped) instead of looping.
- [x] Other failure_class blobs are NOT short-circuited; they still flow to Claude as before.
- [ ] Boattrader smoke run with a deliberately munged URL recovers via `pattern_transform` within one extra step. **To validate after merge** via the same Modal-redeploy + script-rerun workflow used for Phase 0.

## Test plan

- [x] `.venv/bin/python -m pytest tests/test_url_recovery.py` — 38 passed
- [x] `.venv/bin/python -m pytest tests/test_agentic_recovery.py tests/test_url_health.py tests/test_navigate_handler.py tests/test_failure_class.py` — 99 passed (no regressions)
- [x] `ruff check` clean
- [ ] CI green (mkdocs / ruff / pytest 1-4)

## Dependencies

- Built on Phase 0 (#704) which merged as #708. The `bad_url:<subclass>` failure signal this PR consumes is shipped there.

Closes #705

🤖 Generated with [Claude Code](https://claude.com/claude-code)