### PR TITLE
feat(plan-evolution): production wiring for Phase 2 store

### DIFF
--- a/deploy/modal/modal_cua_server.py
+++ b/deploy/modal/modal_cua_server.py
@@ -984,6 +984,9 @@ def _run_holo3_executor(
             on_checkpoint=vol.commit,
             max_cost=task_suite.get("_max_cost", 10.0),
             max_time_minutes=task_suite.get("_max_time_minutes", 180),
+            # Plan-evolution Phase 2 (#706) attrs are stamped AFTER
+            # construction (the runner doesn't accept them as kwargs).
+            # See the block below.
             # #657 PR 2: per-domain SiteConfig resolved from suite.
             # None means "use runner default" (preserves legacy
             # behaviour for callers that pre-build a suite without
@@ -1001,6 +1004,25 @@ def _run_holo3_executor(
             max_recoveries_per_run=task_suite.get("_max_recoveries_per_run"),
             max_recoveries_per_step=task_suite.get("_max_recoveries_per_step"),
         )
+
+        # Plan-evolution Phase 2 (#706): stamp the plan_hash + scope_id
+        # the recovery layer needs to record candidates and the
+        # micro_runner needs at terminal to finalize promotion gates.
+        # Empty strings disable persistence (no-op for legacy callers
+        # that don't pass plan_hash through build_micro_suite).
+        micro_runner._plan_hash = str(task_suite.get("_plan_hash", "") or "")
+        micro_runner._workflow_id = str(
+            task_suite.get("_plan_evolution_scope_id", "")
+            or task_suite.get("_profile_id", "")
+            or task_suite.get("_workflow_id", "")
+            or ""
+        )
+        micro_runner._applied_plan_rewrites = []
+        if micro_runner._plan_hash and micro_runner._workflow_id:
+            print(
+                f"  Plan-evolution: scope={micro_runner._workflow_id} "
+                f"plan_hash={micro_runner._plan_hash}"
+            )
 
         # #627: bind a cross-worker shared seen-URL set from the suite
         # metadata. Modal orchestrator sets ``_fanout_seen_dict_name``

--- a/src/mantis_agent/plan_decomposer.py
+++ b/src/mantis_agent/plan_decomposer.py
@@ -229,6 +229,14 @@ class MicroPlan:
     # mentions a URL with a page indicator, OR set programmatically
     # by a future enhancer step that probes the site.
     pagination_url_template: str = ""
+    # Plan-evolution Phase 2 (#706): stable hash of (prompt_version +
+    # source_plan). Populated by :meth:`PlanDecomposer.decompose_text`
+    # (and the cache-load path) so downstream callers can key the
+    # plan-evolution store on a single field without re-deriving the
+    # hash. Empty when the plan was constructed directly (e.g. tests,
+    # CLI dry-run) — the plan-evolution layer treats empty as "no
+    # store interaction" so legacy callers see no change.
+    plan_hash: str = ""
 
     def summary(self) -> str:
         shape_tag = f" [{','.join(self.shapes)}]" if self.shapes else ""
@@ -874,7 +882,9 @@ class PlanDecomposer:
                     cached_steps = cached
                     cached_shapes = []
                     cached_template = ""
-                plan = MicroPlan(source_plan=plan_text, domain=domain)
+                plan = MicroPlan(
+                    source_plan=plan_text, domain=domain, plan_hash=plan_hash,
+                )
                 plan.shapes = self._normalize_shapes(cached_shapes)
                 if "{base}" in cached_template and "{n}" in cached_template:
                     plan.pagination_url_template = cached_template
@@ -984,7 +994,9 @@ class PlanDecomposer:
                 f"Decomposer returned unexpected JSON type: {type(parsed).__name__}"
             )
 
-        plan = MicroPlan(source_plan=plan_text, domain=domain)
+        plan = MicroPlan(
+            source_plan=plan_text, domain=domain, plan_hash=plan_hash,
+        )
         plan.shapes = self._normalize_shapes(shapes_raw)
         # Only accept the template when it contains both placeholders;
         # otherwise it's malformed and the orchestrator will reject it

--- a/src/mantis_agent/server_utils.py
+++ b/src/mantis_agent/server_utils.py
@@ -1127,6 +1127,8 @@ def build_micro_suite(
     max_recoveries_per_step: int | None = None,
     loop_groups: list[dict[str, Any]] | None = None,
     pagination_url_template: str = "",
+    plan_hash: str = "",
+    plan_evolution_scope_id: str = "",
 ) -> dict[str, Any]:
     """Build a task_suite dict for micro-intent execution.
 
@@ -1179,6 +1181,21 @@ def build_micro_suite(
         "_micro_plan": micro_plan_steps,
         "tasks": [],
     }
+    # Plan-evolution Phase 2 (#706): hash of the authored plan +
+    # stable scope id for the persistence store. Both default to
+    # empty — when empty, the executor never touches the store
+    # (legacy callers preserved). Production callers (the boattrader
+    # submit script, API integrations) set both.
+    if plan_hash:
+        suite["_plan_hash"] = plan_hash
+    if plan_evolution_scope_id:
+        suite["_plan_evolution_scope_id"] = plan_evolution_scope_id
+    elif plan_hash:
+        # Sensible default: use the profile_id as the scope so runs of
+        # the same plan on the same profile accumulate learning. Each
+        # tenant + profile gets its own store entry naturally.
+        suite["_plan_evolution_scope_id"] = resolved_profile
+
     if objective:
         suite["_objective"] = objective
     # #560: ``None`` means "let the runner apply DEFAULT_BRAIN_BUDGET_CAPS".

--- a/tests/test_server_utils.py
+++ b/tests/test_server_utils.py
@@ -546,6 +546,46 @@ def test_build_micro_suite_structure():
     assert suite["_micro_plan"] == steps
     assert suite["tasks"] == []
     assert suite["_checkpoint_path"].endswith("my_key.json")
+    # Plan-evolution Phase 2 (#706): fields absent when not passed.
+    assert "_plan_hash" not in suite
+    assert "_plan_evolution_scope_id" not in suite
+
+
+def test_build_micro_suite_carries_plan_hash_and_scope():
+    """When plan_hash is supplied, the suite carries both fields so the
+    Modal executor can stamp them on the runner."""
+    steps = [{"intent": "nav", "type": "navigate"}]
+    suite = build_micro_suite(
+        steps, "example.com",
+        profile_id="alice",
+        plan_hash="abc12345",
+        plan_evolution_scope_id="alice-stable",
+    )
+    assert suite["_plan_hash"] == "abc12345"
+    assert suite["_plan_evolution_scope_id"] == "alice-stable"
+
+
+def test_build_micro_suite_scope_defaults_to_profile_when_plan_hash_set():
+    """Sensible default: when plan_hash is supplied but scope is not,
+    use the resolved profile_id so runs of the same plan on the same
+    profile accumulate learning."""
+    steps = [{"intent": "nav", "type": "navigate"}]
+    suite = build_micro_suite(
+        steps, "example.com",
+        profile_id="alice", workflow_id="run-xyz",
+        plan_hash="abc12345",
+    )
+    assert suite["_plan_evolution_scope_id"] == "alice"
+
+
+def test_build_micro_suite_skips_scope_default_when_no_plan_hash():
+    """No plan_hash → no scope_id either (the store is the only consumer)."""
+    steps = [{"intent": "nav", "type": "navigate"}]
+    suite = build_micro_suite(
+        steps, "example.com", profile_id="alice",
+        plan_evolution_scope_id="",
+    )
+    assert "_plan_evolution_scope_id" not in suite
 
 
 # ── #341: profile_id / workflow_id split ─────────────────────────────


### PR DESCRIPTION
## Summary

Closes the loop opened by #710. The persistence + promotion gate landed there, but no production caller populated `plan_hash` or `workflow_id`, so the store stayed empty. This PR threads both fields through the dispatch path — `MicroPlan` → `build_micro_suite` → suite carry → Modal executor → `MicroPlanRunner` attrs.

## Wiring

- **`MicroPlan.plan_hash: str = ""`** — new field. `PlanDecomposer.decompose_text` populates it on both the LLM-call and cache-load paths. Empty for plans constructed directly (tests, CLI dry-run).
- **`build_micro_suite(plan_hash="", plan_evolution_scope_id="")`** — new kwargs. When supplied, the suite carries `_plan_hash` + `_plan_evolution_scope_id`. When `plan_hash` is set but scope is not, defaults to the resolved `profile_id` so runs of the same plan on the same profile accumulate learning.
- **`modal_cua_server.py:_run_holo3_executor`** — stamps `micro_runner._plan_hash` + `micro_runner._workflow_id` (= the scope) immediately after construction; resets `_applied_plan_rewrites = []`. Empty values disable persistence (legacy callers preserved). Prints a `Plan-evolution: scope=X plan_hash=Y` diagnostic when both are set.
- **Local-side boattrader script** (gitignored per repo memory) calls `apply_plan_overlay` post-decompose and passes both new kwargs to `build_micro_suite`. The new client-side log line `[plan-overlay] no promoted rewrites for workflow_id='...' plan_hash='...'` (or the applied-rewrites variant when promoted entries exist) is visible per run.

## E2E validation

Deployed + ran the canonical boattrader plan on the warm `boattrader-urlnav-stable` profile:

| | |
|---|---|
| Status | `halted/time_cap` at 30 min (script-imposed cap) |
| Leads | **7 viable** from 64 steps |
| Cost | **$0.33/lead** ($2.28 total) — within baseline band ($0.30–$0.36) |
| Client log | `[plan-overlay] no promoted rewrites for workflow_id='boattrader-urlnav-stable' plan_hash='bda88bb5'` ✓ |
| Store state | Empty (correct — no `bad_url` failures fired on this healthy run) |
| Regressions | None |

The full persistence loop will fire automatically the moment a real `bad_url:<subclass>` event occurs in production:
1. Recovery picks a `rewrite_url` proposal
2. `record_rewrite_candidate` stores it as `candidate`
3. Run terminal triggers `finalize_run_outcomes` (success/failure split)
4. After 3 consecutive successes, candidate → `promoted`
5. Next run's `apply_plan_overlay` swaps the URL pre-flight

## Tests

- 4 new in `test_server_utils.py` lock the suite-field shape: fields absent when not passed, both stamped when supplied, scope defaults to `profile_id` when only `plan_hash` is supplied.
- 205 tests pass across all touched modules (Phase 0/1/2 + server_utils + agentic_recovery + navigate_handler + url_recovery + url_health + plan_evolution_store).
- `ruff check` clean.

## Out of scope

- **CLI inspector access to the Modal `/data` volume** — for inspecting the store, the CLI inspector needs to run inside a Modal container or have the volume mounted locally. The CLI works (smoke-tested in #710); a future enhancement could ship a `modal volume get` wrapper or expose the store via a small HTTP endpoint.
- **Phase 3 (#707)** — generalising beyond URLs + site-scope rewrites. Blocked per spec until 2+ weeks of Phase 2 production data calibrates the auto-promotion threshold.

## Test plan

- [x] `.venv/bin/python -m pytest tests/test_server_utils.py tests/test_plan_evolution_store.py tests/test_url_recovery.py tests/test_url_health.py tests/test_agentic_recovery.py` — 205 passed
- [x] `ruff check` clean
- [x] Modal redeploy succeeds (16s deploy time)
- [x] Boattrader E2E: client log shows `[plan-overlay]` line; run produces leads at parity with baseline
- [ ] CI green (mkdocs / ruff / pytest 1-4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)