### PR TITLE
feat(hint-memory): Phase 1b — DiskHintStore + recording/injection hooks + tenant isolation

### DIFF
--- a/deploy/modal/modal_cua_server.py
+++ b/deploy/modal/modal_cua_server.py
@@ -1024,6 +1024,40 @@ def _run_holo3_executor(
                 f"plan_hash={micro_runner._plan_hash}"
             )
 
+        # Trajectory hint memory (#643 / #670). Tenant-scoped disk store
+        # at /data/hints/<tenant_id>/<plan_signature>.json. Producer
+        # side: ``run_executor._record_hint_memory`` reads ``_hint_store``
+        # off the runner after every step success. Consumer side: the
+        # holo3 step handler reads ``preferred_target_description`` from
+        # ``step.hints`` (stamped by ``apply_hint_overlay`` pre-flight
+        # below).
+        #
+        # Tenant id is the profile_id (which already carries the
+        # ``<tenant>__<workflow>`` shape from the API container's
+        # acquire_profile_lock) so customer A's anchors can never leak
+        # into customer B's runs.
+        try:
+            from mantis_agent.gym.hint_memory import (
+                DiskHintStore, apply_hint_overlay,
+            )
+            hint_tenant = str(task_suite.get("_profile_id", "") or "") or "default"
+            micro_runner._hint_store = DiskHintStore(tenant_id=hint_tenant)
+            applied = apply_hint_overlay(
+                micro_plan,
+                store=micro_runner._hint_store,
+                plan_signature=plan_signature,
+                start_url=str(task_suite.get("base_url", "") or ""),
+            )
+            if applied:
+                print(
+                    f"  Hint-memory: tenant={hint_tenant} "
+                    f"plan_sig={plan_signature[:12]} applied={applied} hints"
+                )
+        except Exception as exc:  # noqa: BLE001 — never block executor
+            print(f"  WARNING: hint memory init failed (recording disabled): {exc}")
+            from mantis_agent.gym.hint_memory import NullHintStore
+            micro_runner._hint_store = NullHintStore()
+
         # #627: bind a cross-worker shared seen-URL set from the suite
         # metadata. Modal orchestrator sets ``_fanout_seen_dict_name``
         # before spawning; workers re-attach to the same modal.Dict by

--- a/src/mantis_agent/cli.py
+++ b/src/mantis_agent/cli.py
@@ -137,6 +137,84 @@ def cmd_plan_overlay_list(args: argparse.Namespace) -> int:
     return EXIT_OK
 
 
+def cmd_plan_hints_show(args: argparse.Namespace) -> int:
+    """``mantis plan hints show`` — dump stored hint anchors for a plan.
+
+    Useful for validating the recording side fired as expected:
+
+      MANTIS_HINT_MEMORY_DIR=/tmp/hints \\
+      mantis plan hints show --tenant-id default__boattrader-urlnav-stable \\
+                             --plan-signature deadbeef1234
+    """
+    from .gym.hint_memory import DiskHintStore, HintKey
+
+    store = DiskHintStore(tenant_id=args.tenant_id)
+    buckets = store._load(args.plan_signature)  # type: ignore[attr-defined]
+
+    if args.json:
+        out: dict[str, list[dict]] = {}
+        for bk, recs in buckets.items():
+            out[bk] = [
+                {
+                    "anchor_text": r.anchor_text,
+                    "anchor_xy_offset": list(r.anchor_xy_offset),
+                    "viewport_stage": r.viewport_stage,
+                    "confidence": r.confidence,
+                    "recorded_at": r.recorded_at,
+                    "source_url": r.source_url,
+                }
+                for r in recs
+            ]
+        print(json.dumps(out, indent=2))
+        return EXIT_OK
+
+    if not buckets:
+        print(
+            f"(no hints stored for tenant_id={args.tenant_id!r} "
+            f"plan_signature={args.plan_signature!r})"
+        )
+        return EXIT_OK
+
+    print(f"tenant_id:        {args.tenant_id}")
+    print(f"plan_signature:   {args.plan_signature}")
+    print(f"buckets:          {len(buckets)}")
+    print(f"total records:    {sum(len(r) for r in buckets.values())}")
+    print()
+    for bk, recs in sorted(buckets.items()):
+        intent_hash, _, url_pattern = bk.partition("|")
+        # Reconstruct a HintKey for display.
+        HintKey(
+            plan_signature=args.plan_signature,
+            intent_hash=intent_hash,
+            url_pattern=url_pattern,
+        )
+        print(f"  intent_hash={intent_hash} url_pattern={url_pattern} ({len(recs)} records)")
+        for i, r in enumerate(reversed(recs)):  # newest first
+            print(
+                f"    [{i}] anchor={r.anchor_text!r}  "
+                f"xy={r.anchor_xy_offset}  stage={r.viewport_stage}  "
+                f"conf={r.confidence:.2f}"
+            )
+            if r.source_url:
+                print(f"         source: {r.source_url[:120]}")
+        print()
+    return EXIT_OK
+
+
+def cmd_plan_hints_list(args: argparse.Namespace) -> int:
+    """``mantis plan hints list`` — list plan_signatures stored for a tenant."""
+    from .gym.hint_memory import DiskHintStore
+
+    store = DiskHintStore(tenant_id=args.tenant_id)
+    sigs = store.list_plan_signatures()
+    if not sigs:
+        print(f"(no plans stored for tenant_id={args.tenant_id!r})")
+        return EXIT_OK
+    for s in sigs:
+        print(s)
+    return EXIT_OK
+
+
 def cmd_plan_validate(args: argparse.Namespace) -> int:
     """``mantis plan validate <path>`` — run :class:`PlanValidator` on a JSON plan.
 
@@ -1830,6 +1908,43 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Workflow identifier to list plans for.",
     )
     overlay_list.set_defaults(func=cmd_plan_overlay_list)
+
+    # ── hint-memory: inspect trajectory hint store (#643 / #670) ──
+    hints_cmd = plan_sub.add_parser(
+        "hints",
+        help="Inspect or seed the trajectory hint memory store (#643). "
+             "Reads /data/hints/<tenant_id>/<plan_signature>.json "
+             "(override the root via MANTIS_HINT_MEMORY_DIR).",
+    )
+    hints_sub = hints_cmd.add_subparsers(dest="hints_command", required=True)
+
+    hints_show = hints_sub.add_parser(
+        "show",
+        help="Dump the stored hint anchors for a (tenant_id, plan_signature) pair.",
+    )
+    hints_show.add_argument(
+        "--tenant-id", required=True,
+        help="Tenant id the hint store is scoped to.",
+    )
+    hints_show.add_argument(
+        "--plan-signature", required=True,
+        help="Plan signature (matches MicroPlan.plan_signature / suite._plan_signature).",
+    )
+    hints_show.add_argument(
+        "--json", action="store_true",
+        help="Emit raw JSON instead of human-formatted lines.",
+    )
+    hints_show.set_defaults(func=cmd_plan_hints_show)
+
+    hints_list = hints_sub.add_parser(
+        "list",
+        help="List plan_signatures with stored hints for a tenant.",
+    )
+    hints_list.add_argument(
+        "--tenant-id", required=True,
+        help="Tenant id to list plans for.",
+    )
+    hints_list.set_defaults(func=cmd_plan_hints_list)
 
     # ── cua: pure Holo3 pass-through (no decomposition, no Claude) ──
     cua = sub.add_parser(

--- a/src/mantis_agent/gym/hint_memory.py
+++ b/src/mantis_agent/gym/hint_memory.py
@@ -31,7 +31,9 @@ DOM CONTAINS.
 from __future__ import annotations
 
 import hashlib
+import json
 import logging
+import os
 import re
 import time
 from collections import OrderedDict
@@ -276,3 +278,353 @@ def hint_key_for(
         intent_hash=intent_hash_for(step),
         url_pattern=url_pattern_for(url),
     )
+
+
+# ── DiskHintStore (Phase 1b) — tenant-scoped persistence ────────────
+
+
+def _hint_store_root() -> str:
+    """Where DiskHintStore persists. Env-overridable for tests."""
+    return os.environ.get(
+        "MANTIS_HINT_MEMORY_DIR",
+        os.path.join(
+            os.environ.get("MANTIS_DATA_DIR", "/data"), "hints",
+        ),
+    )
+
+
+def _sanitize_scope(s: str) -> str:
+    """Filesystem-safe id. Mirrors the convention used by
+    ``server_utils.safe_state_key`` so tenant + plan paths align."""
+    return "".join(c if c.isalnum() or c in "_-." else "_" for c in s)[:120] or "_"
+
+
+class DiskHintStore:
+    """JSON-on-volume `HintStore` with **per-tenant isolation**.
+
+    Layout::
+
+        /data/hints/<tenant_id>/<plan_signature>.json
+
+    Tenant isolation is structural — different tenants can't see each
+    other's anchors even when running the same plan. Same plan on the
+    same tenant accumulates across deploys.
+
+    The in-memory bucket semantics (LRU at ``max_per_key`` records) are
+    preserved per (intent_hash, url_pattern) pair inside each plan file.
+
+    Concurrency: atomic write via tmpfile + ``os.replace``. Concurrent
+    workers race on the write — last-writer-wins. Acceptable for Phase 1b
+    because:
+
+    * The recording side appends one record per step success, and the
+      record's value is the same shape across workers for the same
+      (key) — so a lost write at most delays accumulation by one run.
+    * The injection side reads at run start (single load); subsequent
+      writes during the run don't affect that snapshot.
+
+    Phase 2 may upgrade to SQLite if multi-region writes start producing
+    visible drift. Phase 2 may also add a Modal Dict overlay so workers
+    in the SAME run share writes immediately (today they only see each
+    other's writes on the NEXT run).
+    """
+
+    def __init__(self, *, tenant_id: str, max_per_key: int = 10) -> None:
+        if not tenant_id:
+            raise ValueError("DiskHintStore requires a non-empty tenant_id")
+        self._tenant_id = tenant_id
+        self.max_per_key = max(1, int(max_per_key))
+
+    # ── path helpers ──
+
+    def _tenant_dir(self) -> str:
+        return os.path.join(_hint_store_root(), _sanitize_scope(self._tenant_id))
+
+    def _file_for(self, plan_signature: str) -> str:
+        return os.path.join(
+            self._tenant_dir(), f"{_sanitize_scope(plan_signature)}.json",
+        )
+
+    # ── I/O ──
+
+    def _load(self, plan_signature: str) -> dict[str, list[HintRecord]]:
+        path = self._file_for(plan_signature)
+        try:
+            with open(path) as f:
+                raw = json.load(f)
+        except FileNotFoundError:
+            return {}
+        except Exception as exc:  # noqa: BLE001 — corrupt store → start fresh
+            logger.warning("DiskHintStore: load failed %s (%s)", path, exc)
+            return {}
+        buckets: dict[str, list[HintRecord]] = {}
+        for bucket_key, records in (raw or {}).items():
+            if not isinstance(records, list):
+                continue
+            parsed: list[HintRecord] = []
+            for r in records:
+                if not isinstance(r, dict):
+                    continue
+                try:
+                    parsed.append(HintRecord(
+                        anchor_text=str(r.get("anchor_text", "") or ""),
+                        anchor_xy_offset=tuple(r.get("anchor_xy_offset") or (0, 0))[:2],
+                        viewport_stage=int(r.get("viewport_stage", 0) or 0),
+                        confidence=float(r.get("confidence", 0.0) or 0.0),
+                        recorded_at=float(r.get("recorded_at", 0.0) or 0.0),
+                        source_url=str(r.get("source_url", "") or ""),
+                    ))
+                except Exception:  # noqa: BLE001 — drop malformed record
+                    continue
+            if parsed:
+                buckets[str(bucket_key)] = parsed
+        return buckets
+
+    def _save(self, plan_signature: str, buckets: dict[str, list[HintRecord]]) -> None:
+        path = self._file_for(plan_signature)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        serializable: dict[str, list[dict]] = {}
+        for bucket_key, records in buckets.items():
+            serializable[bucket_key] = [
+                {
+                    "anchor_text": r.anchor_text,
+                    "anchor_xy_offset": list(r.anchor_xy_offset),
+                    "viewport_stage": r.viewport_stage,
+                    "confidence": r.confidence,
+                    "recorded_at": r.recorded_at,
+                    "source_url": r.source_url,
+                }
+                for r in records
+            ]
+        tmp_path = f"{path}.tmp.{os.getpid()}.{int(time.time() * 1000)}"
+        with open(tmp_path, "w") as f:
+            json.dump(serializable, f, indent=2)
+        os.replace(tmp_path, path)
+
+    @staticmethod
+    def _bucket_key(key: HintKey) -> str:
+        """Compound key within a single plan file. Plan_signature lives
+        in the filename; bucket key is intent_hash + url_pattern."""
+        return f"{key.intent_hash}|{key.url_pattern}"
+
+    # ── HintStore protocol ──
+
+    def add(self, key: HintKey, record: HintRecord) -> None:
+        if not key.plan_signature:
+            return
+        buckets = self._load(key.plan_signature)
+        bk = self._bucket_key(key)
+        bucket = buckets.setdefault(bk, [])
+        bucket.append(record)
+        if len(bucket) > self.max_per_key:
+            bucket.pop(0)
+        try:
+            self._save(key.plan_signature, buckets)
+        except Exception as exc:  # noqa: BLE001 — store failure must
+            # never break a run. Silent on the hot path; the recording
+            # side calls this best-effort.
+            logger.warning(
+                "DiskHintStore: save failed for tenant=%s plan=%s (%s)",
+                self._tenant_id, key.plan_signature, exc,
+            )
+
+    def get(self, key: HintKey) -> list[HintRecord]:
+        if not key.plan_signature:
+            return []
+        buckets = self._load(key.plan_signature)
+        bucket = buckets.get(self._bucket_key(key), [])
+        # Newest-first for the injection side's pick-top-N lookup.
+        return list(reversed(bucket))
+
+    def size(self) -> int:
+        """Total record count across this tenant's plans."""
+        td = self._tenant_dir()
+        if not os.path.isdir(td):
+            return 0
+        total = 0
+        for name in os.listdir(td):
+            if not name.endswith(".json"):
+                continue
+            plan_sig = name[:-5]
+            buckets = self._load(plan_sig)
+            for bucket in buckets.values():
+                total += len(bucket)
+        return total
+
+    # ── inspector surface ──
+
+    def list_plan_signatures(self) -> list[str]:
+        """Plan signatures with stored hints for this tenant."""
+        td = self._tenant_dir()
+        if not os.path.isdir(td):
+            return []
+        return sorted(f[:-5] for f in os.listdir(td) if f.endswith(".json"))
+
+    def iter_records(self) -> Iterable[tuple[HintKey, HintRecord]]:
+        for plan_sig in self.list_plan_signatures():
+            buckets = self._load(plan_sig)
+            for bk, records in buckets.items():
+                intent_hash, _, url_pattern = bk.partition("|")
+                key = HintKey(
+                    plan_signature=plan_sig,
+                    intent_hash=intent_hash,
+                    url_pattern=url_pattern,
+                )
+                for r in records:
+                    yield (key, r)
+
+
+# ── Recording-side adapter ──────────────────────────────────────────
+
+
+# Step types that exercise grounding heavily — recording fires only for
+# these. Other types (navigate, navigate_back, wait, done) don't ground
+# from screenshot pixels, so there's nothing useful to record.
+GROUNDING_STEP_TYPES: frozenset[str] = frozenset({
+    "click", "claude_click", "detect_visible",
+})
+
+
+def extract_anchor_from_env(env: object) -> tuple[str, tuple[int, int]] | None:
+    """Read the most recent SoM-click diagnostic off the env.
+
+    XdotoolGymEnv stashes ``_last_som_diag`` after each ``cdp_click_at_point``
+    call (see ``feedback_cua_cdp_post_action_verify.md`` for the
+    provenance contract). The diagnostic carries ``elv_text`` (the
+    visible text label Holo3 anchored to) and the click coordinates.
+
+    Returns ``(anchor_text, (x, y))`` when a usable diagnostic exists,
+    ``None`` when there's nothing to record. Callers treat ``None`` as
+    "skip recording" — typical when the click went through xdotool only
+    (no CDP verification path) or when the env doesn't expose
+    ``_last_som_diag`` (test mocks).
+    """
+    diag = getattr(env, "_last_som_diag", None)
+    if not isinstance(diag, dict):
+        return None
+    anchor = str(diag.get("elv_text") or "").strip()
+    if not anchor:
+        return None
+    try:
+        x = int(diag.get("x", 0))
+        y = int(diag.get("y", 0))
+    except (TypeError, ValueError):
+        x, y = 0, 0
+    return (anchor[:200], (x, y))
+
+
+def record_hint_if_eligible(
+    *,
+    store: HintStore,
+    plan_signature: str,
+    step: object,
+    step_type: str,
+    success: bool,
+    env: object,
+    confidence: float = 1.0,
+) -> HintRecord | None:
+    """Producer-side gate + record.
+
+    Fires only when:
+      * The step type is in :data:`GROUNDING_STEP_TYPES`
+      * The step succeeded
+      * ``store`` isn't the :class:`NullHintStore`
+      * The env exposed a usable SoM anchor
+
+    Returns the recorded :class:`HintRecord` on success, ``None`` when
+    any gate rejected. Never raises — best-effort throughout.
+    """
+    if isinstance(store, NullHintStore):
+        return None
+    if not success or step_type not in GROUNDING_STEP_TYPES:
+        return None
+    if not plan_signature:
+        return None
+    anchor_pair = extract_anchor_from_env(env)
+    if anchor_pair is None:
+        return None
+    anchor_text, anchor_xy = anchor_pair
+
+    url = ""
+    try:
+        url = str(getattr(env, "current_url", "") or "")
+    except Exception:  # noqa: BLE001
+        url = ""
+
+    try:
+        key = hint_key_for(plan_signature, step, url)
+        record = HintRecord(
+            anchor_text=anchor_text,
+            anchor_xy_offset=anchor_xy,
+            viewport_stage=int(getattr(env, "_viewport_stage", 0) or 0),
+            confidence=float(confidence),
+            source_url=url[:200],
+        )
+        store.add(key, record)
+        logger.warning(
+            "  [hint-memory] recorded anchor=%r step_type=%s plan=%s url_pattern=%s",
+            anchor_text[:60], step_type, plan_signature[:8], key.url_pattern,
+        )
+        return record
+    except Exception as exc:  # noqa: BLE001 — store failure ≠ run failure
+        logger.debug("record_hint_if_eligible raised: %s", exc)
+        return None
+
+
+# ── Injection-side function ─────────────────────────────────────────
+
+
+def apply_hint_overlay(
+    plan: object, *,
+    store: HintStore,
+    plan_signature: str,
+    start_url: str = "",
+) -> int:
+    """Pre-flight: stamp ``preferred_target_description`` on every
+    grounding-bearing step that has a stored anchor.
+
+    Returns the count of steps that received a hint. ``0`` when the
+    store is empty or no eligible step matched.
+
+    Called by the dispatcher BEFORE ``MicroPlanRunner.run()`` so the
+    brain prompt sees the hint on the first attempt instead of
+    re-discovering the anchor from pixels.
+
+    Mutates ``plan.steps[i].hints`` in place — preserves existing hint
+    keys, only sets ``preferred_target_description`` (and
+    ``preferred_target_viewport_stage`` when known) when absent. We
+    don't overwrite operator-authored hints; the store is a fallback,
+    not an override.
+    """
+    if isinstance(store, NullHintStore) or not plan_signature:
+        return 0
+
+    applied = 0
+    for step in getattr(plan, "steps", []) or []:
+        step_type = str(getattr(step, "type", "") or "")
+        if step_type not in GROUNDING_STEP_TYPES:
+            continue
+        key = hint_key_for(plan_signature, step, start_url)
+        records = store.get(key)
+        if not records:
+            continue
+        # Top record by confidence × recency (store returns newest-first).
+        best = max(records, key=lambda r: (r.confidence, r.recorded_at))
+        if best.confidence < 0.3:
+            continue
+        hints = dict(getattr(step, "hints", None) or {})
+        # Don't overwrite operator-authored hints.
+        if "preferred_target_description" not in hints:
+            hints["preferred_target_description"] = best.anchor_text
+        if "preferred_target_viewport_stage" not in hints and best.viewport_stage:
+            hints["preferred_target_viewport_stage"] = best.viewport_stage
+        step.hints = hints
+        applied += 1
+        logger.warning(
+            "  [hint-overlay] step type=%s intent=%r ← anchor=%r (conf=%.2f)",
+            step_type,
+            str(getattr(step, "intent", "") or "")[:60],
+            best.anchor_text[:60],
+            best.confidence,
+        )
+    return applied

--- a/src/mantis_agent/gym/run_executor.py
+++ b/src/mantis_agent/gym/run_executor.py
@@ -436,8 +436,40 @@ class RunExecutor:
                 costs_before=costs_before_step,
             )
 
+            # #643 / #670: trajectory hint memory recording side. Fires
+            # only on success + grounding-bearing step + when the runner
+            # carries a HintStore (set by the dispatcher). Best-effort —
+            # store failures must never block a run. Sees the SoM
+            # diagnostic (``env._last_som_diag``) the click handler
+            # stashed via CDP verification.
+            self._record_hint_memory(step, step_result)
+
         self._finalize(plan, state)
         return state.results
+
+    def _record_hint_memory(self, step: Any, step_result: Any) -> None:
+        """Producer side of the trajectory hint memory (#643 Phase 1b).
+
+        Cheap gate: only fires on success + grounding-bearing step
+        types + when a HintStore is wired. NullHintStore (the default)
+        short-circuits inside :func:`record_hint_if_eligible`.
+        """
+        runner = self.parent
+        store = getattr(runner, "_hint_store", None)
+        if store is None:
+            return
+        try:
+            from .hint_memory import record_hint_if_eligible
+            record_hint_if_eligible(
+                store=store,
+                plan_signature=str(getattr(runner, "plan_signature", "") or ""),
+                step=step,
+                step_type=str(getattr(step, "type", "") or ""),
+                success=bool(getattr(step_result, "success", False)),
+                env=getattr(runner, "env", None),
+            )
+        except Exception as exc:  # noqa: BLE001 — never break the run
+            logger.debug("hint_memory recording raised: %s", exc)
 
     _COST_KEYS_FOR_DELTA: tuple[str, ...] = (
         "gpu_seconds",

--- a/src/mantis_agent/gym/step_handlers/holo3.py
+++ b/src/mantis_agent/gym/step_handlers/holo3.py
@@ -166,6 +166,22 @@ def _build_scoped_task(step: "MicroIntent", runner: Any, step_index: int) -> str
     layout = str(hints.get("layout") or "").strip()
     if layout:
         target_lines.append(f"  layout: {layout}")
+    # #643 / #670 — trajectory hint memory injection. When the dispatcher
+    # found a stored anchor from a prior successful run of THIS step on
+    # THIS plan + URL pattern, surface it as the strongest signal in the
+    # Target hints section. The brain treats it as a viewport bias — the
+    # anchor is visual text it can re-find on the current screenshot,
+    # not a coordinate.
+    preferred = str(hints.get("preferred_target_description") or "").strip()
+    if preferred:
+        target_lines.append(f"  preferred_target: {preferred}")
+    preferred_stage = hints.get("preferred_target_viewport_stage")
+    if preferred_stage is not None:
+        try:
+            stage_int = int(preferred_stage)
+            target_lines.append(f"  preferred_target_at_scroll_stage: {stage_int}")
+        except (TypeError, ValueError):
+            pass
     if target_lines:
         sections.append("Target hints:\n" + "\n".join(target_lines))
 

--- a/tests/test_hint_memory_phase1b.py
+++ b/tests/test_hint_memory_phase1b.py
@@ -1,0 +1,403 @@
+"""Tests for trajectory hint memory Phase 1b (#670 / #643).
+
+Covers:
+- DiskHintStore: tenant isolation, atomic writes, round-trip, LRU eviction
+- record_hint_if_eligible: gating (step type, success, anchor presence)
+- apply_hint_overlay: stamps hints only on grounding steps, preserves operator hints
+- holo3 prompt builder includes the new preferred_target field
+- Recording hook in run_executor fires through to the store
+"""
+
+from __future__ import annotations
+
+import os
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from mantis_agent.gym.hint_memory import (
+    DiskHintStore,
+    GROUNDING_STEP_TYPES,
+    HintKey,
+    HintRecord,
+    InMemoryHintStore,
+    NullHintStore,
+    apply_hint_overlay,
+    extract_anchor_from_env,
+    hint_key_for,
+    record_hint_if_eligible,
+)
+
+
+@pytest.fixture()
+def temp_dir(monkeypatch: pytest.MonkeyPatch, tmp_path) -> str:
+    monkeypatch.setenv("MANTIS_HINT_MEMORY_DIR", str(tmp_path))
+    return str(tmp_path)
+
+
+def _step(intent: str = "click Show More", type_: str = "click", hints: dict | None = None):
+    s = SimpleNamespace(intent=intent, type=type_, params={}, hints=hints or {})
+    return s
+
+
+# ── DiskHintStore ────────────────────────────────────────────────────
+
+
+def test_disk_store_requires_tenant_id(temp_dir: str) -> None:
+    with pytest.raises(ValueError, match="non-empty tenant_id"):
+        DiskHintStore(tenant_id="")
+
+
+def test_disk_store_round_trips_single_record(temp_dir: str) -> None:
+    store = DiskHintStore(tenant_id="acme")
+    key = HintKey(plan_signature="sig1", intent_hash="ih1", url_pattern="x.com/y")
+    record = HintRecord(
+        anchor_text="Show More", anchor_xy_offset=(120, 540),
+        viewport_stage=1, confidence=0.8, source_url="https://x.com/y/123",
+    )
+    store.add(key, record)
+    out = store.get(key)
+    assert len(out) == 1
+    assert out[0].anchor_text == "Show More"
+    assert out[0].anchor_xy_offset == (120, 540)
+    assert out[0].viewport_stage == 1
+    assert out[0].confidence == 0.8
+
+
+def test_disk_store_lru_evicts_oldest_at_cap(temp_dir: str) -> None:
+    store = DiskHintStore(tenant_id="acme", max_per_key=3)
+    key = HintKey(plan_signature="sig1", intent_hash="ih1", url_pattern="x.com/y")
+    for i in range(5):
+        store.add(key, HintRecord(anchor_text=f"Anchor {i}", confidence=0.5))
+    out = store.get(key)
+    assert len(out) == 3
+    # Newest first — Anchor 4 → 3 → 2 (oldest two evicted)
+    texts = [r.anchor_text for r in out]
+    assert texts == ["Anchor 4", "Anchor 3", "Anchor 2"]
+
+
+def test_disk_store_tenant_isolation(temp_dir: str) -> None:
+    """Different tenants writing the same key must not see each other."""
+    s1 = DiskHintStore(tenant_id="customerA")
+    s2 = DiskHintStore(tenant_id="customerB")
+    key = HintKey(plan_signature="sig1", intent_hash="ih1", url_pattern="x.com/y")
+
+    s1.add(key, HintRecord(anchor_text="A-only", confidence=0.9))
+    assert [r.anchor_text for r in s1.get(key)] == ["A-only"]
+    # s2 sees nothing
+    assert s2.get(key) == []
+
+    s2.add(key, HintRecord(anchor_text="B-only", confidence=0.9))
+    assert [r.anchor_text for r in s2.get(key)] == ["B-only"]
+    # s1 still doesn't see B's
+    assert [r.anchor_text for r in s1.get(key)] == ["A-only"]
+
+
+def test_disk_store_keys_isolated_within_tenant(temp_dir: str) -> None:
+    store = DiskHintStore(tenant_id="acme")
+    k1 = HintKey(plan_signature="sig1", intent_hash="ih1", url_pattern="x.com/a")
+    k2 = HintKey(plan_signature="sig1", intent_hash="ih2", url_pattern="x.com/a")
+    store.add(k1, HintRecord(anchor_text="A"))
+    store.add(k2, HintRecord(anchor_text="B"))
+    assert [r.anchor_text for r in store.get(k1)] == ["A"]
+    assert [r.anchor_text for r in store.get(k2)] == ["B"]
+
+
+def test_disk_store_size_counts_across_buckets(temp_dir: str) -> None:
+    store = DiskHintStore(tenant_id="acme")
+    store.add(HintKey(plan_signature="s1", intent_hash="i1", url_pattern="x"),
+              HintRecord(anchor_text="a"))
+    store.add(HintKey(plan_signature="s1", intent_hash="i2", url_pattern="x"),
+              HintRecord(anchor_text="b"))
+    store.add(HintKey(plan_signature="s2", intent_hash="i1", url_pattern="x"),
+              HintRecord(anchor_text="c"))
+    assert store.size() == 3
+
+
+def test_disk_store_no_op_on_empty_plan_signature(temp_dir: str) -> None:
+    store = DiskHintStore(tenant_id="acme")
+    key = HintKey(plan_signature="", intent_hash="ih1", url_pattern="x")
+    store.add(key, HintRecord(anchor_text="A"))
+    assert store.get(key) == []
+
+
+def test_disk_store_corrupt_file_starts_fresh(temp_dir: str) -> None:
+    store = DiskHintStore(tenant_id="acme")
+    # Manually create a malformed file
+    tenant_dir = os.path.join(temp_dir, "acme")
+    os.makedirs(tenant_dir, exist_ok=True)
+    with open(os.path.join(tenant_dir, "sig1.json"), "w") as f:
+        f.write("not json at all")
+    key = HintKey(plan_signature="sig1", intent_hash="ih1", url_pattern="x")
+    # Should not raise; should return empty
+    assert store.get(key) == []
+    # And should be writable after corruption
+    store.add(key, HintRecord(anchor_text="recovered"))
+    assert [r.anchor_text for r in store.get(key)] == ["recovered"]
+
+
+def test_disk_store_list_plan_signatures(temp_dir: str) -> None:
+    store = DiskHintStore(tenant_id="acme")
+    store.add(HintKey(plan_signature="sigA", intent_hash="i", url_pattern="x"),
+              HintRecord(anchor_text="a"))
+    store.add(HintKey(plan_signature="sigB", intent_hash="i", url_pattern="x"),
+              HintRecord(anchor_text="b"))
+    sigs = store.list_plan_signatures()
+    assert "sigA" in sigs
+    assert "sigB" in sigs
+
+
+def test_disk_store_iter_records(temp_dir: str) -> None:
+    store = DiskHintStore(tenant_id="acme")
+    k = HintKey(plan_signature="sig", intent_hash="ih", url_pattern="x")
+    store.add(k, HintRecord(anchor_text="A"))
+    store.add(k, HintRecord(anchor_text="B"))
+    pairs = list(store.iter_records())
+    assert len(pairs) == 2
+    texts = sorted(r.anchor_text for _, r in pairs)
+    assert texts == ["A", "B"]
+
+
+# ── extract_anchor_from_env ──────────────────────────────────────────
+
+
+def test_extract_anchor_returns_none_without_diag() -> None:
+    env = MagicMock(spec=[])  # no _last_som_diag
+    assert extract_anchor_from_env(env) is None
+
+
+def test_extract_anchor_returns_none_on_empty_elv_text() -> None:
+    env = SimpleNamespace(_last_som_diag={"elv_text": "", "x": 100, "y": 200})
+    assert extract_anchor_from_env(env) is None
+
+
+def test_extract_anchor_returns_text_and_xy() -> None:
+    env = SimpleNamespace(_last_som_diag={
+        "elv_text": "Show More", "x": 542, "y": 678,
+    })
+    out = extract_anchor_from_env(env)
+    assert out == ("Show More", (542, 678))
+
+
+def test_extract_anchor_truncates_long_text() -> None:
+    env = SimpleNamespace(_last_som_diag={
+        "elv_text": "x" * 500, "x": 0, "y": 0,
+    })
+    out = extract_anchor_from_env(env)
+    assert out is not None
+    assert len(out[0]) == 200
+
+
+# ── record_hint_if_eligible ──────────────────────────────────────────
+
+
+def test_record_skipped_for_null_store() -> None:
+    """Cheap short-circuit when store is the NullHintStore."""
+    env = SimpleNamespace(
+        _last_som_diag={"elv_text": "OK", "x": 0, "y": 0},
+        current_url="https://x.com/y",
+    )
+    record = record_hint_if_eligible(
+        store=NullHintStore(), plan_signature="sig", step=_step(),
+        step_type="click", success=True, env=env,
+    )
+    assert record is None
+
+
+def test_record_skipped_on_failure() -> None:
+    env = SimpleNamespace(
+        _last_som_diag={"elv_text": "OK", "x": 0, "y": 0},
+        current_url="https://x.com/y",
+    )
+    record = record_hint_if_eligible(
+        store=InMemoryHintStore(), plan_signature="sig", step=_step(),
+        step_type="click", success=False, env=env,
+    )
+    assert record is None
+
+
+def test_record_skipped_for_non_grounding_step_type() -> None:
+    env = SimpleNamespace(
+        _last_som_diag={"elv_text": "OK", "x": 0, "y": 0},
+        current_url="https://x.com/y",
+    )
+    record = record_hint_if_eligible(
+        store=InMemoryHintStore(), plan_signature="sig", step=_step(),
+        step_type="navigate", success=True, env=env,
+    )
+    assert record is None
+
+
+def test_record_skipped_when_anchor_missing() -> None:
+    """Step succeeded but no SoM anchor was captured — skip silently."""
+    env = SimpleNamespace(_last_som_diag=None, current_url="https://x.com/y")
+    record = record_hint_if_eligible(
+        store=InMemoryHintStore(), plan_signature="sig", step=_step(),
+        step_type="click", success=True, env=env,
+    )
+    assert record is None
+
+
+def test_record_fires_for_grounding_step_with_anchor() -> None:
+    store = InMemoryHintStore()
+    env = SimpleNamespace(
+        _last_som_diag={"elv_text": "Show More", "x": 542, "y": 678},
+        current_url="https://boattrader.com/boat/1986-marine/",
+    )
+    record = record_hint_if_eligible(
+        store=store, plan_signature="sig1", step=_step("click Show More", "click"),
+        step_type="click", success=True, env=env,
+    )
+    assert record is not None
+    assert record.anchor_text == "Show More"
+    # Stored in the right key bucket
+    key = hint_key_for("sig1", _step("click Show More", "click"),
+                      "https://boattrader.com/boat/1986-marine/")
+    out = store.get(key)
+    assert len(out) == 1
+    assert out[0].anchor_text == "Show More"
+
+
+def test_record_handles_each_grounding_step_type() -> None:
+    """All step types in GROUNDING_STEP_TYPES are eligible."""
+    env = SimpleNamespace(
+        _last_som_diag={"elv_text": "X", "x": 0, "y": 0},
+        current_url="https://x.com/y",
+    )
+    for step_type in GROUNDING_STEP_TYPES:
+        store = InMemoryHintStore()
+        record_hint_if_eligible(
+            store=store, plan_signature="sig", step=_step("x", step_type),
+            step_type=step_type, success=True, env=env,
+        )
+        assert store.size() == 1, f"{step_type} should record"
+
+
+# ── apply_hint_overlay ───────────────────────────────────────────────
+
+
+def test_apply_overlay_no_op_when_store_empty() -> None:
+    plan = SimpleNamespace(steps=[_step("click X", "click")])
+    n = apply_hint_overlay(plan, store=InMemoryHintStore(), plan_signature="sig")
+    assert n == 0
+    assert plan.steps[0].hints == {}
+
+
+def test_apply_overlay_skips_non_grounding_steps() -> None:
+    """Stored hint exists but step type is navigate → not applied."""
+    store = InMemoryHintStore()
+    step = _step("navigate to X", "navigate")
+    key = hint_key_for("sig", step, "https://x.com/y")
+    store.add(key, HintRecord(anchor_text="Anchor X", confidence=0.9))
+
+    plan = SimpleNamespace(steps=[step])
+    n = apply_hint_overlay(
+        plan, store=store, plan_signature="sig", start_url="https://x.com/y",
+    )
+    assert n == 0
+    assert plan.steps[0].hints == {}
+
+
+def test_apply_overlay_stamps_preferred_target() -> None:
+    store = InMemoryHintStore()
+    step = _step("click Show More", "click")
+    key = hint_key_for("sig", step, "https://x.com/y")
+    store.add(key, HintRecord(
+        anchor_text="Show More", viewport_stage=2, confidence=0.85,
+    ))
+
+    plan = SimpleNamespace(steps=[step])
+    n = apply_hint_overlay(
+        plan, store=store, plan_signature="sig", start_url="https://x.com/y",
+    )
+    assert n == 1
+    assert plan.steps[0].hints["preferred_target_description"] == "Show More"
+    assert plan.steps[0].hints["preferred_target_viewport_stage"] == 2
+
+
+def test_apply_overlay_preserves_operator_hints() -> None:
+    """When operator already authored preferred_target_description, the
+    overlay must NOT overwrite."""
+    store = InMemoryHintStore()
+    step = _step("click Show More", "click", hints={
+        "preferred_target_description": "Operator override",
+        "region": "footer",
+    })
+    key = hint_key_for("sig", step, "https://x.com/y")
+    store.add(key, HintRecord(anchor_text="Stored anchor", confidence=0.9))
+
+    plan = SimpleNamespace(steps=[step])
+    apply_hint_overlay(
+        plan, store=store, plan_signature="sig", start_url="https://x.com/y",
+    )
+    # Operator value wins
+    assert plan.steps[0].hints["preferred_target_description"] == "Operator override"
+    # Existing other hints preserved
+    assert plan.steps[0].hints["region"] == "footer"
+
+
+def test_apply_overlay_skips_low_confidence_records() -> None:
+    store = InMemoryHintStore()
+    step = _step("click X", "click")
+    key = hint_key_for("sig", step, "https://x.com/y")
+    store.add(key, HintRecord(anchor_text="Low conf", confidence=0.1))
+
+    plan = SimpleNamespace(steps=[step])
+    n = apply_hint_overlay(
+        plan, store=store, plan_signature="sig", start_url="https://x.com/y",
+    )
+    assert n == 0
+
+
+def test_apply_overlay_picks_highest_confidence() -> None:
+    store = InMemoryHintStore()
+    step = _step("click X", "click")
+    key = hint_key_for("sig", step, "https://x.com/y")
+    store.add(key, HintRecord(anchor_text="Old", confidence=0.5))
+    store.add(key, HintRecord(anchor_text="New high conf", confidence=0.95))
+
+    plan = SimpleNamespace(steps=[step])
+    apply_hint_overlay(
+        plan, store=store, plan_signature="sig", start_url="https://x.com/y",
+    )
+    assert plan.steps[0].hints["preferred_target_description"] == "New high conf"
+
+
+def test_apply_overlay_no_op_on_empty_plan_signature() -> None:
+    store = InMemoryHintStore()
+    key = HintKey(plan_signature="sig", intent_hash="ih", url_pattern="x")
+    store.add(key, HintRecord(anchor_text="A", confidence=0.9))
+    plan = SimpleNamespace(steps=[_step("click X", "click")])
+    n = apply_hint_overlay(plan, store=store, plan_signature="")
+    assert n == 0
+
+
+# ── Holo3 prompt integration ─────────────────────────────────────────
+
+
+def test_holo3_prompt_includes_preferred_target() -> None:
+    """The holo3 prompt builder must surface preferred_target_description
+    in the Target hints section so the brain actually sees the stored anchor."""
+    from mantis_agent.gym.step_handlers.holo3 import _build_scoped_task as build_search_prompt
+
+    step = _step("click Show More", "click", hints={
+        "preferred_target_description": "Show More button below Description",
+    })
+    runner = SimpleNamespace()
+    prompt = build_search_prompt(step, runner, step_index=0)
+    assert "preferred_target" in prompt
+    assert "Show More button below Description" in prompt
+
+
+def test_holo3_prompt_includes_viewport_stage() -> None:
+    from mantis_agent.gym.step_handlers.holo3 import _build_scoped_task as build_search_prompt
+
+    step = _step("click X", "click", hints={
+        "preferred_target_description": "X",
+        "preferred_target_viewport_stage": 2,
+    })
+    runner = SimpleNamespace()
+    prompt = build_search_prompt(step, runner, step_index=0)
+    assert "preferred_target_at_scroll_stage" in prompt
+    assert "2" in prompt


### PR DESCRIPTION
## Summary

Closes #670 / completes #643 Phase 1b. Builds on the foundation (types, key derivation, NullHintStore + InMemoryHintStore) shipped in #665. Result: grounding-heavy steps (\`click Show More\`, ad-hoc reveal toggles, custom widgets) **learn from successful runs** and re-apply the anchor on subsequent runs of the same plan + URL pattern.

The full loop is now live: a successful click → SoM diag captured → anchor persisted → next run with same plan_signature + intent_hash + url_pattern reads the anchor as \`preferred_target_description\` → Holo3's grounding pass uses it as a viewport bias.

## Per-client isolation (answer to the design question)

\`DiskHintStore\` keys storage by \`tenant_id\` —

\`\`\`
/data/hints/<tenant_id>/<plan_signature>.json
\`\`\`

Customer A's anchors **structurally cannot** leak into customer B's runs. The Modal executor uses \`task_suite['_profile_id']\` (which already carries the \`<tenant>__<workflow>\` shape from the API container's profile lock) as the tenant key. Same pattern as the plan-evolution store landed in #710.

## What this lands

### Store
- \`gym/hint_memory.py\`:
  - \`DiskHintStore\` — tenant-scoped JSON-on-volume. Atomic writes (tmpfile + rename), corrupt-store recovery, LRU eviction at \`max_per_key\` per (intent_hash, url_pattern) bucket. Inspector surface (\`list_plan_signatures\`, \`iter_records\`, \`size\`).
  - \`extract_anchor_from_env(env)\` — reads \`env._last_som_diag\` (stashed by \`XdotoolGymEnv.cdp_click_at_point\` post-action CDP verify) → returns \`(anchor_text, (x, y))\` or None.
  - \`record_hint_if_eligible(...)\` — producer-side gate + record. Fires only on success + grounding step type + non-empty anchor. Short-circuits on NullHintStore. Never raises.
  - \`apply_hint_overlay(plan, *, store, plan_signature, start_url)\` — consumer-side pre-flight. Stamps \`preferred_target_description\` + \`preferred_target_viewport_stage\` on grounding steps that have a stored anchor. **Preserves operator-authored hints** (never overwrites). Picks highest-confidence record.
  - \`GROUNDING_STEP_TYPES = {\"click\", \"claude_click\", \"detect_visible\"}\` — single source of truth.

### Wiring
- \`gym/run_executor.py\`: \`_record_hint_memory(step, step_result)\` called from the main loop right after \`_emit_augur_step\`. Reads \`runner._hint_store\` (None disables — preserves legacy callers).
- \`gym/step_handlers/holo3.py\`: prompt builder surfaces \`preferred_target\` (+ \`preferred_target_at_scroll_stage\` when known) in the Target hints section so the brain sees the anchor on the **first attempt** instead of re-discovering it from pixels.
- \`deploy/modal/modal_cua_server.py\`: \`_run_holo3_executor\` constructs \`DiskHintStore(tenant_id=profile_id)\`, stamps on the runner, calls \`apply_hint_overlay\` pre-flight, prints \`Hint-memory: tenant=X plan_sig=Y applied=N hints\` when injection fires.

### CLI inspector
\`mantis plan hints show / list\` — mirrors the plan-overlay CLI shape from #710. Lets operators validate the recording side cheaply via direct seeding instead of burning Modal runs.

\`\`\`
$ mantis plan hints list --tenant-id default__boattrader-urlnav-stable
bda88bb5

$ mantis plan hints show --tenant-id default__boattrader-urlnav-stable --plan-signature bda88bb5
tenant_id:        default__boattrader-urlnav-stable
plan_signature:   bda88bb5
buckets:          1
total records:    2

  intent_hash=abc123def456 url_pattern=boattrader.com/boat (2 records)
    [0] anchor='Description'  xy=(120, 410)  stage=1  conf=0.70
         source: https://boattrader.com/boat/2002-mainship-pilot/
    [1] anchor='Show More'  xy=(540, 678)  stage=2  conf=0.85
         source: https://boattrader.com/boat/1985-bertram-54/
\`\`\`

## What's NOT in this PR

- **ModalDictHintStore** — cross-worker, in-deploy. The disk store already gives cross-deploy persistence (workers in the same fan-out run see each other's writes on the *next* run, not the current one). A modal.Dict overlay is a small follow-up if same-run sharing matters.
- **Confidence decay over time** — Phase 2 in the spec. Today \`apply_hint_overlay\` picks the highest-confidence record; an older 0.9 will always beat a newer 0.6. Decay handles drift.
- **URL pattern specialization per recipe** — Phase 2 in the spec. Today uses \`<registrable-host>/<first-path-segment>\` (\`boattrader.com/boat\`); marketplace_listings could specialize to include make/model.

## Test plan

- [x] \`.venv/bin/python -m pytest tests/test_hint_memory_phase1b.py\` — 29 passed
- [x] \`.venv/bin/python -m pytest tests/test_hint_memory_phase1b.py tests/test_hint_memory_643.py tests/test_navigate_handler.py tests/test_plan_evolution_store.py\` — 87 passed (no regressions)
- [x] \`ruff check\` clean
- [x] CLI inspector smoke-tested with seeded data
- [ ] CI green (mkdocs / ruff / pytest 1-4)

## Dependencies

- Built on #665 (Phase 1 foundation — types + key derivation + InMemoryHintStore). Already on main.

Closes #670
References #643

🤖 Generated with [Claude Code](https://claude.com/claude-code)