### PR TITLE
feat(extractor): per-plan extractor_model override for A/B testing

### DIFF
--- a/deploy/modal/modal_cua_server.py
+++ b/deploy/modal/modal_cua_server.py
@@ -801,7 +801,16 @@ def _run_holo3_executor(
         from mantis_agent.graph.objective import ObjectiveSpec
         objective = ObjectiveSpec.from_dict(objective_data)
         schema = ExtractionSchema.from_objective(objective)
-    extractor = ClaudeExtractor(schema=schema)
+    # Per-plan extractor model override — A/B-able from the submit
+    # payload via `build_micro_suite(extractor_model=...)`. Empty
+    # falls through to ClaudeExtractor's default. Print so operators
+    # see which side of the A/B each container is on.
+    extractor_model = str(task_suite.get("_extractor_model", "") or "")
+    extractor_kwargs: dict = {"schema": schema}
+    if extractor_model:
+        extractor_kwargs["model"] = extractor_model
+        print(f"  Extractor: model={extractor_model} (A/B override)")
+    extractor = ClaudeExtractor(**extractor_kwargs)
     # #416 follow-up: the live-viewer's screen-capture thread reads
     # ``os.environ["DISPLAY"]`` (via mss) but ``setup_env`` doesn't
     # propagate that into the executor process's environ — the env

--- a/src/mantis_agent/server_utils.py
+++ b/src/mantis_agent/server_utils.py
@@ -1129,6 +1129,7 @@ def build_micro_suite(
     pagination_url_template: str = "",
     plan_hash: str = "",
     plan_evolution_scope_id: str = "",
+    extractor_model: str = "",
 ) -> dict[str, Any]:
     """Build a task_suite dict for micro-intent execution.
 
@@ -1195,6 +1196,14 @@ def build_micro_suite(
         # the same plan on the same profile accumulate learning. Each
         # tenant + profile gets its own store entry naturally.
         suite["_plan_evolution_scope_id"] = resolved_profile
+
+    # A/B-able extractor model — empty defaults to ClaudeExtractor's
+    # built-in default (currently claude-sonnet-4-6). Operators set
+    # this to claude-haiku-4-5-20251001 to measure the cost / quality
+    # tradeoff. Per-plan so different plans on the same deployment can
+    # pick independently.
+    if extractor_model:
+        suite["_extractor_model"] = extractor_model
 
     if objective:
         suite["_objective"] = objective

--- a/tests/test_server_utils.py
+++ b/tests/test_server_utils.py
@@ -588,6 +588,23 @@ def test_build_micro_suite_skips_scope_default_when_no_plan_hash():
     assert "_plan_evolution_scope_id" not in suite
 
 
+def test_build_micro_suite_carries_extractor_model_when_set():
+    """A/B-able extractor model — overrides ClaudeExtractor's default
+    when set, absent when empty (preserves back-compat)."""
+    steps = [{"intent": "nav", "type": "navigate"}]
+    suite = build_micro_suite(
+        steps, "example.com",
+        extractor_model="claude-haiku-4-5-20251001",
+    )
+    assert suite["_extractor_model"] == "claude-haiku-4-5-20251001"
+
+
+def test_build_micro_suite_omits_extractor_model_when_empty():
+    steps = [{"intent": "nav", "type": "navigate"}]
+    suite = build_micro_suite(steps, "example.com")
+    assert "_extractor_model" not in suite
+
+
 # ── #341: profile_id / workflow_id split ─────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Pivots from prompt-cache cost reduction (won't fire below Anthropic's 1024-token minimum — see #714 retrospective) to swapping the extractor model entirely. Haiku 4.5 is ~50% the cost of \`claude-sonnet-4-6\` and may match quality on the boattrader lead-extraction shape — worth A/B-ing.

## Wiring

- \`build_micro_suite(extractor_model=\"\")\` — new kwarg. When set, stamps \`_extractor_model\` on the suite. Empty preserves current behavior.
- \`modal_cua_server._run_holo3_executor\` — reads \`_extractor_model\` off the suite and passes to \`ClaudeExtractor(model=...)\`. Prints \`Extractor: model=X (A/B override)\` so operators can see which side of the A/B each container is on.
- Local-side boattrader script reads \`MANTIS_EXTRACTOR_MODEL\` env var.

## A/B usage

\`\`\`bash
# Run A — current default (sonnet-4-6)
MANTIS_API_TOKEN=... uv run python scripts/run_boattrader_urlnav_with_proxy.py

# Run B — Haiku 4.5 override
MANTIS_API_TOKEN=... MANTIS_EXTRACTOR_MODEL=claude-haiku-4-5-20251001 \\
    uv run python scripts/run_boattrader_urlnav_with_proxy.py
\`\`\`

References #675, #714

🤖 Generated with [Claude Code](https://claude.com/claude-code)