### PR TITLE
feat(observability): per-source Claude cost meter for A/B attribution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,4 @@ docs/experiments/staff-crm-long-learnings.md
 scripts/run_*_with_proxy.py
 scripts/run_*_no_proxy.py
 scripts/run_staff_crm_long_no_proxy.py
+experiments/results.tsv

--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,4 @@ scripts/run_*_with_proxy.py
 scripts/run_*_no_proxy.py
 scripts/run_staff_crm_long_no_proxy.py
 experiments/results.tsv
+scripts/run_*_parallel.sh

--- a/deploy/modal/modal_cua_server.py
+++ b/deploy/modal/modal_cua_server.py
@@ -779,7 +779,8 @@ def _run_holo3_executor(
         except Exception as exc:
             print(f"Claude fallback unavailable for failed Holo3 sections: {exc}")
 
-    # Claude Sonnet grounding for click targeting
+    # Claude Sonnet 4.6 grounding for click targeting (was Opus —
+    # 5× cheaper for the same different-model-from-Holo3 property).
     from mantis_agent.grounding import ClaudeGrounding
     grounding = ClaudeGrounding()
 
@@ -1041,6 +1042,27 @@ def _run_holo3_executor(
             )
         except Exception as exc:  # noqa: BLE001
             print(f"  WARNING: cost meter init failed: {exc}")
+
+        # Cross-run dedup: seed the scanner's seen_urls with any
+        # ``_skip_urls`` the suite carries. Callers (e.g. the 6-zip
+        # parallel script) pre-fetch prior runs' leads.csv files,
+        # union the URL column, and pass the result here so a
+        # re-run of the same zip doesn't re-extract listings it
+        # already processed (and doesn't pay the ~$0.20 / detail-page
+        # claude_extract cost on a confirmed duplicate).
+        # No-op when the field is absent.
+        skip_urls = task_suite.get("_skip_urls") or []
+        if isinstance(skip_urls, list) and skip_urls:
+            try:
+                for u in skip_urls:
+                    if isinstance(u, str) and u:
+                        micro_runner.scanner.seen_urls.add(u)
+                print(
+                    f"  [skip-urls] seeded scanner with {len(skip_urls)} "
+                    f"URLs from prior runs",
+                )
+            except Exception as exc:  # noqa: BLE001
+                print(f"  WARNING: skip_urls seed failed: {exc}")
 
         # Plan-evolution Phase 2 (#706): stamp the plan_hash + scope_id
         # the recovery layer needs to record candidates and the

--- a/deploy/modal/modal_cua_server.py
+++ b/deploy/modal/modal_cua_server.py
@@ -1014,6 +1014,34 @@ def _run_holo3_executor(
             max_recoveries_per_step=task_suite.get("_max_recoveries_per_step"),
         )
 
+        # Claude cost meter (#675 A/B follow-up). Bind a fresh meter
+        # per run + stamp api_run_id / api_tenant_id on the runner so
+        # finalize_to_disk can write /data/runs/<tenant>/<run_id>/
+        # claude_cost_by_path.json at terminal. The api_run_id is the
+        # one the API container assigned (the canonical run identifier
+        # operators see in status payloads); falls back to workflow_id
+        # for callers that don't propagate it.
+        try:
+            from mantis_agent.observability.claude_cost_meter import (
+                ClaudeCostMeter, set_current_meter,
+            )
+            _cost_meter = ClaudeCostMeter()
+            set_current_meter(_cost_meter)
+            micro_runner._cost_meter = _cost_meter
+            micro_runner._api_run_id = str(
+                api_run_id
+                or task_suite.get("_state_key", "")
+                or task_suite.get("_workflow_id", "")
+                or ""
+            )
+            micro_runner._api_tenant_id = str(
+                api_tenant_id
+                or task_suite.get("_profile_id", "")
+                or "default"
+            )
+        except Exception as exc:  # noqa: BLE001
+            print(f"  WARNING: cost meter init failed: {exc}")
+
         # Plan-evolution Phase 2 (#706): stamp the plan_hash + scope_id
         # the recovery layer needs to record candidates and the
         # micro_runner needs at terminal to finalize promotion gates.

--- a/experiments/experiment.py
+++ b/experiments/experiment.py
@@ -1,0 +1,67 @@
+"""Mantis cost-optimization knob bundle — autoresearch trial config.
+
+THIS IS THE ONE FILE THE AGENT EDITS PER TRIAL (along with optional edits
+to plans/boattrader_scrape, src/mantis_agent/plan_decomposer.py,
+src/mantis_agent/grounding.py, and src/mantis_agent/extraction/extractor.py).
+
+Each top-level Modal submission of submit_one_trial.py reads CONFIG and
+threads its values through to the task suite + runtime parameters.
+
+Knobs that DO flow through this file (runtime-side, no redeploy needed):
+
+- ``extractor_model``: Anthropic model id for ClaudeExtractor (`_call`,
+  `_call_many`, `_call_with_tool_schema*`). Surfaces in cost meter as
+  ``claude_extract`` / ``extract_single`` / ``extract_multi``. Haiku 4.5
+  is currently the cheapest production-quality option.
+- ``fanout_phase1_workers``: int 1-8. Spawns N parallel Modal containers
+  for the URL-collect phase. Higher = lower wall-time, similar Claude
+  spend.
+- ``max_cost``: float dollars — circuit-breaker budget per run (covers
+  Claude API + estimated proxy cost). Modal halts the run when this is
+  exceeded.
+- ``max_time_minutes``: int — wall-time cap.
+- ``wait_after_load_seconds``: int — settle time after navigate steps.
+  Affects whether the gate verifier sees a fully-loaded page (too short
+  → verifier sees "Loading...", fails; too long → wasted seconds × N
+  pages).
+- ``plan_path``: relative path to the plan source. Default
+  ``plans/boattrader_scrape``. Change to test a forked plan variant.
+
+Knobs that need code edits + redeploy (NOT in this dict):
+
+- ``grounding_model`` — edit ``src/mantis_agent/grounding.py``
+  ``ClaudeGrounding.__init__`` default ``model=`` argument. Redeploy.
+- ``verifier_escalation`` — edit
+  ``src/mantis_agent/extraction/extractor.py``
+  ``_VERIFY_ESCALATION_MODEL`` default. Redeploy.
+
+Edit CONFIG below. Then ``git commit`` and run the trial.
+"""
+
+CONFIG: dict = {
+    # Extractor model — the cheapest piece of the budget today
+    # (~$0.04 / run total at Haiku). Sonnet would 5× this — only switch
+    # if you have evidence Haiku is dropping fields (mostly it doesn't).
+    "extractor_model":          "claude-haiku-4-5-20251001",
+
+    # Phase-1 URL-collect parallel workers. 4 was the production
+    # default. 1 = sequential (slow but cheap). 8 = aggressive parallel
+    # (eats budget faster, more proxy cost).
+    "fanout_phase1_workers":    4,
+
+    # Per-run circuit-breaker. Claude + proxy combined. The autoresearch
+    # budget is $10 across ALL trials — this is the per-trial ceiling.
+    "max_cost":                 1.0,
+
+    # Wall-time cap. Mantis runs at ~25 min for a successful boattrader
+    # extraction; bump to 45 if you're pushing deeper pagination.
+    "max_time_minutes":         30,
+
+    # Settle time after navigate. 4 = default. Bump to 8 if the gate
+    # verifier flakes on "Loading..." state.
+    "wait_after_load_seconds":  4,
+
+    # Path to the plan file. Change to point at a variant if you want
+    # to A/B two plan shapes without overwriting the canonical one.
+    "plan_path":                "plans/boattrader_scrape",
+}

--- a/experiments/program.md
+++ b/experiments/program.md
@@ -1,0 +1,168 @@
+# Mantis Cost Optimization — Autoresearch
+
+This is an experiment to have an AI agent autonomously optimize the cost-per-valid-lead of the `boattrader_scrape` pipeline.
+
+## Objective
+
+Minimize `cost_usd / max(1, valid_leads)` for a single Modal submission against zip **33131 (Miami)** — the proven test bed where the pipeline reliably surfaces phone-bearing private-seller leads.
+
+**Valid lead definition**: a row in `leads.csv` where the `Phone` column contains a complete dialable phone number (not "none", "not listed", empty, or a partial pattern) AND the `Seller_Type` column is `private` or empty (NOT `dealer`).
+
+## Budget
+
+**Hard cap: $10 cumulative `cost_usd` across all trials.** Before each trial, sum the `cost_usd` column of `experiments/results.tsv`. Once the sum is **≥ $10**, STOP. Print `Budget exhausted` and exit. The submit script enforces this same check and refuses to submit when the cap is breached.
+
+This budget includes both the Claude API spend reported by the cost meter AND your own thinking time spent reading code (the latter doesn't count against the $10, but be efficient — long deliberations slow the loop).
+
+## Setup
+
+To set up a new experiment:
+
+1. **Agree on a run tag** with the human: propose a tag like `may30`. The branch `autoresearch/cost-<tag>` must not already exist.
+2. **Create the branch**: `git checkout -b autoresearch/cost-<tag>` from current `main`.
+3. **Read the in-scope files** in full (they're small):
+   - `experiments/program.md` — this file. Read it now.
+   - `experiments/experiment.py` — the knob bundle. The PRIMARY file you edit.
+   - `experiments/submit_one_trial.py` — read-only trial orchestrator. Understand what it does but don't modify.
+   - `scripts/run_boattrader_scrape_with_proxy.py` — the underlying submit script. Read for context.
+   - `plans/boattrader_scrape` — the plan. You MAY edit (plan changes affect cost).
+   - `src/mantis_agent/plan_decomposer.py` — the decomposer prompt. You MAY edit `DECOMPOSE_PROMPT` (and bump `prompt_version` when you do).
+   - `src/mantis_agent/grounding.py` — `ClaudeGrounding` default model. You MAY edit.
+   - `src/mantis_agent/extraction/extractor.py` — `_VERIFY_ESCALATION_MODEL` default. You MAY edit.
+4. **Verify environment**: `.env` should carry `ANTHROPIC_API_KEY`, `MANTIS_API_TOKEN`, `OXYLABS_USERNAME`, `OXYLABS_PASSWORD`. If anything is missing, ask the human and stop.
+5. **Verify budget headroom**: read `experiments/results.tsv` (create with just the header row if missing). Sum `cost_usd`. If `>= $10`, STOP — print "Budget exhausted" and exit.
+6. **Confirm and go**: confirm setup looks good, then enter the experiment loop.
+
+## What you CAN edit
+
+- `experiments/experiment.py` — the `CONFIG` dict. Knobs that flow through to the suite as runtime fields (extractor_model, fanout, max_cost, max_time, wait_after_load).
+- `plans/boattrader_scrape` — plan prose. Add/remove heuristics, tighten gate criteria, change URL patterns.
+- `src/mantis_agent/plan_decomposer.py` — `DECOMPOSE_PROMPT` (bump `prompt_version` to invalidate the plan-decompose cache).
+- `src/mantis_agent/grounding.py` — `ClaudeGrounding.__init__` default `model=` argument.
+- `src/mantis_agent/extraction/extractor.py` — `_VERIFY_ESCALATION_MODEL` default value.
+
+## What you CANNOT edit
+
+- `experiments/submit_one_trial.py` — read-only.
+- `experiments/program.md` — these instructions are read-only.
+- `experiments/results.tsv` — append-only via the script; never rewrite history.
+- Any other file under `src/mantis_agent/` (other than the three listed above).
+- Any file under `deploy/modal/` (unless you're consciously redeploying — see below).
+- The `.env` file. The proxy / API keys are fixed.
+
+## Deploy semantics
+
+The grounding model + verifier escalation model are baked into the running Modal container at deploy time (the latter reads from `os.environ` at import). If you edit `grounding.py` OR `extraction/extractor.py`, you MUST also redeploy before the trial:
+
+```bash
+uv run modal deploy deploy/modal/modal_cua_server.py
+```
+
+If you ONLY edited `experiments/experiment.py` or `plans/boattrader_scrape` or `plan_decomposer.py`, no redeploy is needed — those changes are runtime-side and the submit script picks them up. The plan decomposer also runs locally in the submit script.
+
+A redeploy adds ~5-10s wall and ~$0 to the trial. Cheap, but don't redeploy unnecessarily — it's a signal that you changed something model-side.
+
+## Experimentation
+
+Each trial is **one Modal submission** of the boattrader_scrape plan against zip **33131 Miami**.
+
+**The goal**: minimize `$_per_valid_lead`. Lower is better.
+
+**One concept per trial.** Don't change five knobs at once — you won't know which one moved the needle. Make one focused change, run, measure, decide. Karpathy's rule.
+
+**Simplicity criterion**: All else being equal, simpler is better. A small improvement from a complex change is not worth keeping. Conversely, removing a knob (or deleting a plan section) while getting equal-or-better results is a great outcome — that's a simplification win.
+
+**The first run**: Establish the baseline. Run the trial with the current `CONFIG` and current plan unchanged. Record the result with description `"baseline"`.
+
+## Output format
+
+`submit_one_trial.py` prints a summary like this at the end:
+
+```
+---
+commit:           abc1234
+config_hash:      def5678
+cost_usd:         0.4123
+valid_leads:      2
+$_per_valid:      0.2062
+total_leads:      6
+halt_reason:      ""
+wall_seconds:     742.3
+status:           candidate_keep
+```
+
+Extract by:
+```bash
+grep "^cost_usd:\|^valid_leads:\|^\$_per_valid:\|^halt_reason:\|^status:" trial.log
+```
+
+A "crash" is any of:
+- `submit_one_trial.py` exits with non-zero (other than 2 which means "budget exhausted")
+- The Modal run halts with `halt_reason` in {`required_failed:*`, `cf_challenge`, `external_pause`}
+- `valid_leads == 0` AND `total_leads == 0` (didn't extract anything at all)
+
+`valid_leads == 0` with `total_leads > 0` is NOT a crash — it just means the trial extracted listings but none were phone-bearing private sellers. That's data; treat as `discard` if it's a regression vs the current best.
+
+## Logging results
+
+Append one row per trial to `experiments/results.tsv` — **tab-separated, NOT comma** (commas break in descriptions). 7 columns:
+
+```
+commit	cost_usd	valid_leads	$_per_valid	total_leads	status	description
+```
+
+- `commit`: git short SHA (7 chars) — the commit of THIS trial
+- `cost_usd`: 4 decimal places
+- `valid_leads`: integer
+- `$_per_valid`: 4 decimal places. Use `999.9999` for crashes / zero-lead runs.
+- `total_leads`: integer
+- `status`: `keep` | `discard` | `crash`
+- `description`: 1-line text describing what this trial changed vs the prior `keep`. Be specific. Bad: "tried haiku". Good: `"extractor: sonnet → haiku; expected lower extract cost"`.
+
+Example:
+```
+commit	cost_usd	valid_leads	$_per_valid	total_leads	status	description
+abc1234	0.4523	2	0.2262	6	keep	baseline — sonnet grounding, sonnet verifier escalation, haiku extractor
+def5678	0.3812	2	0.1906	5	keep	verifier_escalation: sonnet → haiku
+ghi9012	0.4001	0	999.9999	0	crash	fanout=8 + max_cost=$0.5 — hit budget cap before extract
+jkl3456	0.3920	3	0.1307	7	keep	added "skip Featured cards" rule to plan step 4
+```
+
+Do NOT commit `results.tsv` to git. It is gitignored. Leave it untracked.
+
+## The experiment loop
+
+LOOP UNTIL `sum(cost_usd) >= $10` OR HUMAN INTERRUPTS:
+
+1. **Check budget**. Sum `cost_usd` across `results.tsv`. If `>= $10`, STOP — print `Budget exhausted` and exit.
+2. **Look at git state**. Which branch? What commit are you on? What does the last `keep` row in `results.tsv` say about the current best?
+3. **Pick a change**. Edit one of the allowed files. One concept per trial.
+4. **`git commit`** with a short message describing the change.
+5. **If you edited grounding.py or extractor.py**: redeploy. `uv run modal deploy deploy/modal/modal_cua_server.py 2>&1 | tail -2`.
+6. **Run the trial**: `uv run python experiments/submit_one_trial.py > /tmp/trial.log 2>&1`. Redirect everything, do NOT tee.
+7. **Read the result**: `grep "^cost_usd:\|^valid_leads:\|^\$_per_valid:\|^halt_reason:\|^status:" /tmp/trial.log`. If grep is empty, treat as crash (Python error before the summary printed). `tail -n 50 /tmp/trial.log` to debug.
+8. **Decide keep / discard / crash**:
+   - If `$_per_valid` improved AND `valid_leads > 0` → `keep`. Leave commit. Advance the branch.
+   - If `$_per_valid` equal-or-worse but `valid_leads > 0` → `discard`. `git reset --hard HEAD~1`.
+   - If crashed → `crash`. `git reset --hard HEAD~1`.
+9. **Append to `results.tsv`** with the right status and a 1-line description.
+10. Loop.
+
+**Crashes**: use judgment. Typo / missing import? Fix and re-run (don't log the typo-fix as a separate trial). Idea fundamentally broken? Log `crash` and move on.
+
+**Stuck**: If you've tried 5 trials in a row with no improvement, re-read `plans/boattrader_scrape` and `plan_decomposer.py` for fresh angles. Try combinations. Try radical changes — delete a section of the plan, see what happens.
+
+**NEVER STOP** until budget hit or human interrupts. Don't ask "should I keep going?". The human is asleep or away. They wake up to a populated `results.tsv`.
+
+## Quick reference
+
+```bash
+# Setup (once)
+git checkout -b autoresearch/cost-may30
+
+# Baseline
+uv run python experiments/submit_one_trial.py > /tmp/trial.log 2>&1
+grep "^cost_usd:\|^valid_leads:\|^\$_per_valid:\|^halt_reason:\|^status:" /tmp/trial.log
+
+# Loop: edit → commit → (maybe deploy) → trial → grep → append-tsv → keep-or-reset
+```

--- a/experiments/program.md
+++ b/experiments/program.md
@@ -19,7 +19,7 @@ This budget includes both the Claude API spend reported by the cost meter AND yo
 To set up a new experiment:
 
 1. **Agree on a run tag** with the human: propose a tag like `may30`. The branch `autoresearch/cost-<tag>` must not already exist.
-2. **Create the branch**: `git checkout -b autoresearch/cost-<tag>` from current `main`.
+2. **Create the branch from current HEAD** (not necessarily main — the harness lives on whichever branch has the cost meter + leads CSV writer landed): `git checkout -b autoresearch/cost-<tag>`. Verify with `git log -1` that the new branch starts at the same commit you were on.
 3. **Read the in-scope files** in full (they're small):
    - `experiments/program.md` — this file. Read it now.
    - `experiments/experiment.py` — the knob bundle. The PRIMARY file you edit.

--- a/experiments/submit_one_trial.py
+++ b/experiments/submit_one_trial.py
@@ -1,0 +1,389 @@
+"""Run ONE autoresearch trial against zip 33131 (Miami).
+
+Reads CONFIG from experiments.experiment, submits a Modal /v1/predict
+run with those knobs, polls to terminal, pulls the leads.csv +
+claude_cost_by_path.json from the Modal volume, computes the
+autoresearch metrics, and prints the summary block the agent grep-
+extracts.
+
+READ-ONLY orchestrator. DO NOT MODIFY. (The agent edits
+experiments/experiment.py and optionally the plan / decomposer prompt /
+grounding default / verifier-escalation default.)
+
+Also enforces the $10 cumulative-cost budget cap. Before submitting,
+sums ``cost_usd`` across all rows in experiments/results.tsv. If the
+sum is >= $10, refuses to submit and exits 2 (``budget_exhausted``).
+
+Output format (machine-readable trailing block):
+
+    ---
+    commit:           <sha7>
+    config_hash:      <sha7>
+    cost_usd:         <float>
+    valid_leads:      <int>
+    $_per_valid:      <float>
+    total_leads:      <int>
+    halt_reason:      "<str>"
+    wall_seconds:     <float>
+    status:           candidate_keep | candidate_discard | crash
+"""
+
+from __future__ import annotations
+
+import csv
+import hashlib
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import requests
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+# Import after sys.path setup so the mantis_agent package resolves
+from mantis_agent.plan_decomposer import PlanDecomposer  # noqa: E402
+from mantis_agent.server_utils import (  # noqa: E402
+    build_micro_suite,
+    merge_runtime,
+    micro_plan_steps_to_dicts,
+)
+
+
+# ── Constants ────────────────────────────────────────────────────────
+
+ZIP = "33131"  # Miami — proven test bed
+SEARCH_RADIUS = "50"
+POP_PASSWORD = "SelfService38#!"
+ENDPOINT = "https://getmason--mantis-cua-server-api.modal.run"
+BUDGET_CAP = 10.0  # USD across all trials
+RESULTS_TSV = REPO_ROOT / "experiments" / "results.tsv"
+PROXY_CITY = "miami"
+PROXY_STATE = "florida"
+PROXY_PROVIDER = "oxylabs"
+
+
+# ── Helpers ──────────────────────────────────────────────────────────
+
+
+def _git_short_sha() -> str:
+    try:
+        out = subprocess.check_output(
+            ["git", "rev-parse", "--short=7", "HEAD"], cwd=REPO_ROOT,
+        )
+        return out.decode().strip()
+    except Exception:  # noqa: BLE001
+        return "unknown"
+
+
+def _config_hash(config: dict) -> str:
+    s = json.dumps(config, sort_keys=True, default=str)
+    return hashlib.sha256(s.encode()).hexdigest()[:7]
+
+
+def _cumulative_cost() -> float:
+    """Sum cost_usd column across all rows in results.tsv."""
+    if not RESULTS_TSV.exists():
+        return 0.0
+    total = 0.0
+    with RESULTS_TSV.open(newline="") as fh:
+        reader = csv.reader(fh, delimiter="\t")
+        try:
+            next(reader)  # skip header
+        except StopIteration:
+            return 0.0
+        for row in reader:
+            if len(row) >= 2:
+                try:
+                    total += float(row[1])
+                except ValueError:
+                    continue
+    return total
+
+
+def _read_env(key: str) -> str:
+    val = os.environ.get(key, "")
+    if val:
+        return val
+    env_path = REPO_ROOT / ".env"
+    if env_path.exists():
+        for line in env_path.read_text().splitlines():
+            if line.startswith(f"{key}="):
+                return line.split("=", 1)[1].strip()
+    return ""
+
+
+def _post(path: str, body: dict[str, Any]) -> tuple[int, dict[str, Any]]:
+    r = requests.post(
+        f"{ENDPOINT}{path}",
+        headers={
+            "X-Mantis-Token": _read_env("MANTIS_API_TOKEN"),
+            "Content-Type": "application/json",
+        },
+        data=json.dumps(body),
+        timeout=120,
+    )
+    try:
+        return r.status_code, r.json()
+    except Exception:
+        return r.status_code, {"raw": r.text}
+
+
+# ── Lead-counting (the autoresearch metric source of truth) ─────────
+
+
+def _count_leads_csv(csv_path: Path) -> tuple[int, int]:
+    """Return (total_leads, valid_leads).
+
+    ``valid`` = phone-bearing, non-dealer rows. Phone column is
+    considered populated when it's not in the null sentinel set;
+    Seller_Type column is considered private when missing OR
+    explicitly "private". A row with Seller_Type == "dealer" is
+    excluded from valid even if it has a phone.
+    """
+    if not csv_path.exists():
+        return 0, 0
+    null_phones = {"", "none", "not listed", '""', "n/a", "na", "unknown"}
+    total = 0
+    valid = 0
+    with csv_path.open(newline="") as fh:
+        reader = csv.DictReader(fh)
+        for row in reader:
+            total += 1
+            phone = (row.get("Phone") or "").strip().strip('"').lower()
+            seller_type = (row.get("Seller_Type") or "").strip().lower()
+            has_phone = bool(phone) and phone not in null_phones
+            is_dealer = seller_type == "dealer"
+            if has_phone and not is_dealer:
+                valid += 1
+    return total, valid
+
+
+# ── Pull artifacts from Modal volume ────────────────────────────────
+
+
+def _pull_artifacts(profile: str, workflow: str, dest: Path) -> Path:
+    """Pull leads.csv + claude_cost_by_path.json from the Modal volume
+    to ``dest``. Returns ``dest`` (always — pulls are best-effort)."""
+    dest.mkdir(parents=True, exist_ok=True)
+    for fname in ("leads.csv", "claude_cost_by_path.json"):
+        try:
+            subprocess.run(
+                [
+                    "uv", "run", "modal", "volume", "get",
+                    "osworld-data",
+                    f"/runs/{profile}/{workflow}/{fname}",
+                    str(dest / fname),
+                    "--force",
+                ],
+                check=False, capture_output=True, timeout=120, cwd=REPO_ROOT,
+            )
+        except subprocess.TimeoutExpired:
+            continue
+    return dest
+
+
+def _read_cost(json_path: Path) -> tuple[float, str]:
+    """Return (cost_usd, halt_reason) from claude_cost_by_path.json."""
+    if not json_path.exists():
+        return 0.0, ""
+    try:
+        d = json.loads(json_path.read_text())
+        cost = float((d.get("totals") or {}).get("cost_usd") or 0.0)
+        outcome = d.get("outcome") or {}
+        halt = str(outcome.get("halt_reason") or "")
+        return cost, halt
+    except Exception:  # noqa: BLE001
+        return 0.0, ""
+
+
+# ── Main ─────────────────────────────────────────────────────────────
+
+
+def main() -> int:
+    spent = _cumulative_cost()
+    print(f"cumulative_spend_so_far: ${spent:.4f} of ${BUDGET_CAP:.2f} cap")
+    if spent >= BUDGET_CAP:
+        print()
+        print("---")
+        print(f"commit:           {_git_short_sha()}")
+        print("config_hash:      n/a")
+        print("cost_usd:         0.0000")
+        print("valid_leads:      0")
+        print("$_per_valid:      999.9999")
+        print("total_leads:      0")
+        print('halt_reason:      "budget_exhausted"')
+        print("wall_seconds:     0.0")
+        print("status:           budget_exhausted")
+        return 2
+
+    # Import CONFIG fresh — the agent may have edited it this trial
+    from experiments.experiment import CONFIG  # noqa: PLC0415
+
+    plan_path = REPO_ROOT / CONFIG["plan_path"]
+    if not plan_path.exists():
+        print(f"ERROR: plan not found at {plan_path}", file=sys.stderr)
+        return 4
+
+    # Substitute plan placeholders
+    raw = plan_path.read_text()
+    plan_text = (
+        raw.replace("{zip_code}", ZIP)
+        .replace("{search_radius}", SEARCH_RADIUS)
+        .replace("{pop_password}", POP_PASSWORD)
+    )
+
+    # Decompose locally
+    api_key = _read_env("ANTHROPIC_API_KEY")
+    if not api_key:
+        print("ERROR: ANTHROPIC_API_KEY not set", file=sys.stderr)
+        return 4
+
+    decomposer = PlanDecomposer(api_key=api_key, model="claude-opus-4-7")
+    cache_dir = REPO_ROOT / "data" / "plan_cache"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    cache_template = str(cache_dir / "decomposed_{hash}.json")
+    print(f"[decompose] {len(plan_text)} chars → PlanDecomposer")
+    t_decompose_0 = time.time()
+    micro_plan = decomposer.decompose_text(
+        plan_text, cache_path_template=cache_template,
+    )
+    print(
+        f"[decompose] → {len(micro_plan.steps)} steps "
+        f"(plan_hash {micro_plan.plan_hash}) in "
+        f"{time.time() - t_decompose_0:.1f}s",
+    )
+
+    # Build runtime + suite
+    runtime = merge_runtime({
+        "proxy_disabled": False,
+        "proxy_provider": PROXY_PROVIDER,
+        "proxy_city": PROXY_CITY,
+        "proxy_state": PROXY_STATE,
+        "max_cost": float(CONFIG["max_cost"]),
+        "max_time_minutes": int(CONFIG["max_time_minutes"]),
+    })
+
+    profile_id = f"autoresearch-zip-{ZIP}"
+    workflow_id = f"autoresearch-{ZIP}-{int(time.time())}"
+
+    suite = build_micro_suite(
+        micro_plan_steps_to_dicts(micro_plan.steps),
+        micro_plan.domain or "boattrader_scrape",
+        profile_id=profile_id,
+        workflow_id=workflow_id,
+        plan_hash=micro_plan.plan_hash,
+        plan_evolution_scope_id=profile_id,
+        extractor_model=str(CONFIG["extractor_model"]),
+        **runtime,
+    )
+
+    # Fan-out opt-in
+    fanout = int(CONFIG["fanout_phase1_workers"])
+    if fanout > 1:
+        suite["_fanout_phase1_workers"] = fanout
+
+    submit_body = {
+        "task_suite": suite,
+        "profile_id": suite["_profile_id"],
+        "workflow_id": suite["_workflow_id"],
+        "cua_model": "holo3",
+        "max_steps": 200,
+        "detached": True,
+        **runtime,
+    }
+
+    # Health probe
+    try:
+        h = requests.get(f"{ENDPOINT}/v1/health", timeout=30)
+        if h.status_code != 200:
+            print(f"ERROR: endpoint unhealthy ({h.status_code})", file=sys.stderr)
+            return 3
+    except Exception as exc:  # noqa: BLE001
+        print(f"ERROR: health check failed: {exc}", file=sys.stderr)
+        return 3
+
+    # Submit
+    print(f"[trial]    config_hash={_config_hash(CONFIG)} fanout={fanout}")
+    print(f"[trial]    plan_path={CONFIG['plan_path']} extractor={CONFIG['extractor_model']}")
+    print(f"[trial]    max_cost=${CONFIG['max_cost']:.2f} max_time={CONFIG['max_time_minutes']}m")
+    t0 = time.time()
+    status, resp = _post("/v1/predict", submit_body)
+    if status != 200:
+        print(f"ERROR: submit returned {status}: {resp}", file=sys.stderr)
+        return 5
+    run_id = resp.get("run_id", "")
+    print(f"[submit]   HTTP 200  run_id={run_id}")
+
+    # Poll until terminal
+    terminal = {"succeeded", "failed", "cancelled", "halted"}
+    last_status = ""
+    halt_reason = ""
+    started = time.time()
+    while True:
+        if time.time() - started > 60 * int(CONFIG["max_time_minutes"]) + 60:
+            print("TIMEOUT in poll loop", file=sys.stderr)
+            halt_reason = "poll_timeout"
+            break
+        s_status, s_resp = _post(
+            "/v1/predict",
+            {"action": "status", "run_id": run_id},
+        )
+        st = s_resp.get("status", "?")
+        if st != last_status:
+            print(
+                f"[poll]     t={int(time.time() - started):4d}s  status={st}",
+            )
+            last_status = st
+        if st in terminal:
+            halt_reason = str(s_resp.get("halt_reason") or "")
+            break
+        time.sleep(15)
+
+    wall = time.time() - t0
+
+    # Pull artifacts
+    artifacts_dir = REPO_ROOT / "data" / "leads" / "autoresearch" / workflow_id
+    _pull_artifacts(profile_id, workflow_id, artifacts_dir)
+
+    leads_csv = artifacts_dir / "leads.csv"
+    cost_json = artifacts_dir / "claude_cost_by_path.json"
+
+    total_leads, valid_leads = _count_leads_csv(leads_csv)
+    cost_usd, halt_from_cost = _read_cost(cost_json)
+    if not halt_reason and halt_from_cost:
+        halt_reason = halt_from_cost
+    dpv = (cost_usd / valid_leads) if valid_leads > 0 else 999.9999
+
+    # Crash heuristic
+    is_crash = total_leads == 0 and (
+        halt_reason.startswith("required_failed")
+        or halt_reason in ("cf_challenge", "external_pause", "poll_timeout")
+        or not leads_csv.exists()
+    )
+    rec_status = (
+        "crash" if is_crash else
+        ("candidate_keep" if valid_leads > 0 else "candidate_discard")
+    )
+
+    print()
+    print("---")
+    print(f"commit:           {_git_short_sha()}")
+    print(f"config_hash:      {_config_hash(CONFIG)}")
+    print(f"cost_usd:         {cost_usd:.4f}")
+    print(f"valid_leads:      {valid_leads}")
+    print(f"$_per_valid:      {dpv:.4f}")
+    print(f"total_leads:      {total_leads}")
+    print(f'halt_reason:      "{halt_reason}"')
+    print(f"wall_seconds:     {wall:.1f}")
+    print(f"status:           {rec_status}")
+    print(f"artifacts_dir:    {artifacts_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/run_boattrader_urlnav_with_proxy.py
+++ b/scripts/run_boattrader_urlnav_with_proxy.py
@@ -165,8 +165,8 @@ def main() -> int:
         "proxy_provider": os.environ.get("PROXY_PROVIDER", "privateproxy"),
         "proxy_city": os.environ.get("PROXY_CITY", "miami"),
         "proxy_state": os.environ.get("PROXY_STATE", "florida"),
-        "max_cost": 8.0,
-        "max_time_minutes": 30,
+        "max_cost": float(os.environ.get("MANTIS_MAX_COST", 8.0)),
+        "max_time_minutes": int(os.environ.get("MANTIS_MAX_TIME_MIN", 30)),
     })
     suite = build_micro_suite(
         micro_plan_steps_to_dicts(micro_plan.steps),
@@ -178,6 +178,9 @@ def main() -> int:
         # mid-run recovery layer can record candidates.
         plan_hash=micro_plan.plan_hash,
         plan_evolution_scope_id=PROFILE_ID,
+        # A/B-able extractor model. Override via env:
+        #   MANTIS_EXTRACTOR_MODEL=claude-haiku-4-5-20251001
+        extractor_model=os.environ.get("MANTIS_EXTRACTOR_MODEL", ""),
         **runtime,
     )
 

--- a/src/mantis_agent/_anthropic/client.py
+++ b/src/mantis_agent/_anthropic/client.py
@@ -473,6 +473,11 @@ class AnthropicToolUseClient:
                         tele.get("input_tokens", 0),
                         tele.get("output_tokens", 0),
                     )
+            from ..observability.claude_cost_meter import record_from_response
+            record_from_response(
+                source=time_bucket or "extract_tool",
+                model=self.model, response_json=payload_json,
+            )
             # #523 — capture the modelio record when an upstream caller
             # has published a layer context (planner / grounding /
             # verifier / step_recovery / judge). No-op otherwise.
@@ -579,6 +584,11 @@ class AnthropicToolUseClient:
                     tele.get("input_tokens", 0),
                     tele.get("output_tokens", 0),
                 )
+            from ..observability.claude_cost_meter import record_from_response
+            record_from_response(
+                source=time_bucket or "extract_tool_multi",
+                model=self.model, response_json=payload_json,
+            )
             _record_modelio_if_active(
                 payload, payload_json, int((time.monotonic() - t0) * 1000),
             )

--- a/src/mantis_agent/agentic_recovery.py
+++ b/src/mantis_agent/agentic_recovery.py
@@ -510,6 +510,12 @@ def _call_recovery_tool(
                 _t.get("cache_read_input_tokens", 0),
                 _t.get("cache_creation_input_tokens", 0),
             )
+        # Cost meter (#675 A/B follow-up).
+        from .observability.claude_cost_meter import record_from_response
+        record_from_response(
+            source="recovery", model=model,
+            response_json=resp.json() if resp.content else None,
+        )
         # #523 PR B-5 — capture this call as a ``step_recovery`` modelio
         # record when an upstream caller (step_recovery._try_agentic_
         # recovery via publish_modelio_context) has set the context.

--- a/src/mantis_agent/brain_claude.py
+++ b/src/mantis_agent/brain_claude.py
@@ -282,6 +282,12 @@ class ClaudeBrain:
                 tele.get("output_tokens", 0),
             )
 
+        # Cost meter (#675 A/B follow-up).
+        from .observability.claude_cost_meter import record_from_response
+        record_from_response(
+            source="brain_claude", model=self.model, response_json=data,
+        )
+
         return self._parse_response(data)
 
     def _headers(self) -> dict:

--- a/src/mantis_agent/extraction/extractor.py
+++ b/src/mantis_agent/extraction/extractor.py
@@ -477,6 +477,10 @@ class ClaudeExtractor:
                         tele.get("input_tokens", 0),
                         tele.get("output_tokens", 0),
                     )
+            from ..observability.claude_cost_meter import record_from_response
+            record_from_response(
+                source="extract_single", model=self.model, response_json=payload_json,
+            )
             for block in payload_json.get("content", []):
                 if block.get("type") == "text":
                     return block["text"].strip()
@@ -661,6 +665,10 @@ class ClaudeExtractor:
                         tele.get("input_tokens", 0),
                         tele.get("output_tokens", 0),
                     )
+            from ..observability.claude_cost_meter import record_from_response
+            record_from_response(
+                source="extract_multi", model=self.model, response_json=payload_json,
+            )
             for block in payload_json.get("content", []):
                 if block.get("type") == "text":
                     return block["text"].strip()

--- a/src/mantis_agent/extraction/extractor.py
+++ b/src/mantis_agent/extraction/extractor.py
@@ -61,7 +61,13 @@ _VERIFY_MODEL = os.environ.get("MANTIS_VERIFY_MODEL", "claude-haiku-4-5-20251001
 # spike (re-navigate + re-extract + re-verify ≈ $0.50+) so a ~$0.003
 # escalation pays for itself many times over.
 _VERIFY_ESCALATION_MODEL = os.environ.get(
-    "MANTIS_VERIFY_ESCALATION_MODEL", "claude-opus-4-7",
+    # Was ``claude-opus-4-7`` until 2026-05-30 — observed cost was 73 %
+    # of total Claude spend across the 3-round BoatTrader sweep (Opus
+    # 4.7 escalations: 63 calls × ~$0.047 = $2.97 of $4.07). Sonnet
+    # 4.6 is 5× cheaper per token, similar quality for gate
+    # disagreement re-checks. Override via env if you need Opus back
+    # for a specific run.
+    "MANTIS_VERIFY_ESCALATION_MODEL", "claude-sonnet-4-6",
 )
 
 logger = logging.getLogger(__name__)

--- a/src/mantis_agent/grounding.py
+++ b/src/mantis_agent/grounding.py
@@ -171,7 +171,7 @@ Screenshot is {width}x{height} pixels. The user wants to click near \
     def __init__(
         self,
         api_key: str = "",
-        model: str = "claude-opus-4-7",
+        model: str = "claude-sonnet-4-6",
         cache: "GroundingCache | None" = None,
     ):
         import os

--- a/src/mantis_agent/grounding.py
+++ b/src/mantis_agent/grounding.py
@@ -272,7 +272,8 @@ Screenshot is {width}x{height} pixels. The user wants to click near \
                 )
             # Cache telemetry — Modal suppresses INFO; WARNING-level so
             # operators can audit hit rate without an env-var dance.
-            tele = extract_cache_telemetry(resp.json())
+            resp_json = resp.json()
+            tele = extract_cache_telemetry(resp_json)
             if tele.get("cache_read_input_tokens", 0) > 0:
                 logger.warning(
                     "  [cache] grounding: read=%d created=%d input=%d",
@@ -280,9 +281,14 @@ Screenshot is {width}x{height} pixels. The user wants to click near \
                     tele.get("cache_creation_input_tokens", 0),
                     tele.get("input_tokens", 0),
                 )
+            # Cost meter (#675 A/B follow-up).
+            from .observability.claude_cost_meter import record_from_response
+            record_from_response(
+                source="grounding", model=self.model, response_json=resp_json,
+            )
 
             text = ""
-            for block in resp.json().get("content", []):
+            for block in resp_json.get("content", []):
                 if block.get("type") == "text":
                     text = block["text"].strip()
                     break

--- a/src/mantis_agent/gym/micro_runner.py
+++ b/src/mantis_agent/gym/micro_runner.py
@@ -420,6 +420,22 @@ class MicroPlanRunner:
         self._executor.execute(plan, state, resume=resume)
         self._final_summary(state.results)
 
+        # Claude cost meter (#675 A/B follow-up). Finalize the per-
+        # source attribution to /data/runs/<tenant>/<run_id>/. No-op
+        # when no meter is bound (legacy callers).
+        try:
+            from ..observability.claude_cost_meter import finalize_to_disk
+            run_id = str(getattr(self, "_api_run_id", "") or "")
+            tenant = str(
+                getattr(self, "_api_tenant_id", "")
+                or getattr(self, "_workflow_id", "")
+                or "default"
+            )
+            if run_id:
+                finalize_to_disk(run_id=run_id, tenant_id=tenant)
+        except Exception:  # noqa: BLE001 — never break terminal
+            pass
+
         # Plan-evolution Phase 2 (#706): record per-rewrite outcome at
         # run terminal. The promotion / demotion gates fire here.
         # No-op when the runner doesn't carry _plan_hash / _workflow_id

--- a/src/mantis_agent/gym/micro_runner.py
+++ b/src/mantis_agent/gym/micro_runner.py
@@ -461,6 +461,16 @@ class MicroPlanRunner:
                     "plan_hash": str(getattr(self, "_plan_hash", "") or ""),
                 }
                 finalize_to_disk(run_id=run_id, tenant_id=tenant, extras=extras)
+                # Per-run leads CSV — one row per extract_data step that
+                # produced fields. Lands at /data/runs/<tenant>/<run_id>/
+                # leads.csv. Operators pull per-zip CSVs and concatenate.
+                from ..observability.leads_csv import finalize_leads_csv
+                finalize_leads_csv(
+                    run_id=run_id,
+                    tenant_id=tenant,
+                    profile_id=str(getattr(self, "_workflow_id", "") or ""),
+                    results=results,
+                )
         except Exception:  # noqa: BLE001 — never break terminal
             pass
 

--- a/src/mantis_agent/gym/micro_runner.py
+++ b/src/mantis_agent/gym/micro_runner.py
@@ -432,7 +432,35 @@ class MicroPlanRunner:
                 or "default"
             )
             if run_id:
-                finalize_to_disk(run_id=run_id, tenant_id=tenant)
+                # Build outcome extras from runner state so cost +
+                # outcome land in the same file. Lead counts come from
+                # the structured extraction_results path (#508); plain
+                # step success counts are a fallback.
+                results = state.results
+                extras: dict = {
+                    "outcome": {
+                        "steps_executed": len(results),
+                        "steps_succeeded": sum(
+                            1 for r in results if bool(getattr(r, "success", False))
+                        ),
+                        "leads_extracted": sum(
+                            1 for r in results
+                            if bool(getattr(r, "extracted_fields", None))
+                        ),
+                        "terminal_status": str(
+                            getattr(self, "_final_status", "completed") or "completed"
+                        ),
+                        "halt_reason": str(
+                            getattr(self, "_final_halt_reason", "") or ""
+                        ),
+                        "wall_seconds": round(
+                            float(getattr(self, "_final_wall_seconds", 0.0) or 0.0), 1,
+                        ),
+                    },
+                    "plan_signature": str(getattr(self, "plan_signature", "") or ""),
+                    "plan_hash": str(getattr(self, "_plan_hash", "") or ""),
+                }
+                finalize_to_disk(run_id=run_id, tenant_id=tenant, extras=extras)
         except Exception:  # noqa: BLE001 — never break terminal
             pass
 

--- a/src/mantis_agent/gym/step_handlers/claude_step.py
+++ b/src/mantis_agent/gym/step_handlers/claude_step.py
@@ -204,6 +204,13 @@ class ClaudeStepHandler:
         screenshot = env.screenshot()
 
         if step.type == "extract_url":
+            # CUA rule (feedback_cua_no_dom_access.md): the runner must
+            # be screenshot-grounded only. Reading ``env.current_url``
+            # to derive the listing URL would use CDP to *derive* state
+            # — banned. Vision extraction is the only authorized path
+            # for extract_url, even at the cost of occasional
+            # transcription typos (which a downstream post-processor
+            # in workflow_runner._build_viable_row normalizes).
             data = extractor.extract(screenshot)
             url = data.url if data else ""
 

--- a/src/mantis_agent/gym/url_health.py
+++ b/src/mantis_agent/gym/url_health.py
@@ -85,6 +85,10 @@ _NOT_FOUND_TITLE_MARKERS: tuple[str, ...] = (
 _SOFT_404_BODY_MARKERS: tuple[str, ...] = (
     "we couldn't find",
     "we could not find",
+    "we cannot find",
+    "cannot find the page",
+    "page you requested",
+    "page may have moved",
     "no results found",
     "nothing matches",
     "page is no longer available",

--- a/src/mantis_agent/gym/workflow_runner.py
+++ b/src/mantis_agent/gym/workflow_runner.py
@@ -33,6 +33,47 @@ from .runner import GymRunner
 logger = logging.getLogger(__name__)
 
 
+def _infer_seller_type(text: str) -> str:
+    """Infer "private" / "dealer" from a body of trajectory thinking +
+    done() summary text. Returns the empty string when no signal fires
+    so the caller can choose whether to default.
+
+    Multi-signal cascade — same priority order used in the Priority-2
+    field-builder so Priority-1 (brain emitted structured fields) gets
+    the same Seller_Type column. Drove the BoatTrader plan-grounded
+    findings (2026-05-30): pipe + business-suffix in seller line, or
+    "Contact Private Seller" heading, or explicit "Seller_Type:" token.
+    """
+    if not text:
+        return ""
+    _re = _re_module
+    m = _re.search(
+        r"[Ss]eller[\s_]?[Tt]ype\s*[:=]\s*[\"']?(private|dealer|brokerage|broker)",
+        text,
+    )
+    if m:
+        v = m.group(1).lower()
+        return "dealer" if v in ("brokerage", "broker", "dealer") else "private"
+    if _re.search(r"Contact\s+Private\s+Seller", text, _re.IGNORECASE):
+        return "private"
+    if _re.search(
+        r"\|\s*[A-Z][A-Za-z0-9 &.,'\-]+?"
+        r"(?:Yacht|Yachts|Marine|Sales|Brokerage|Broker|Group|Marina|"
+        r"Boats|Boating|Inc\b|LLC\b|Co\.|Company)",
+        text,
+    ):
+        return "dealer"
+    if _re.search(
+        r"(?:Contact\s+Dealer|Dealer\s+Listing|Brokerage\s+Listing|"
+        r"Yacht\s+Broker|Featured\s+(?:Listing|Dealer)|Sponsored)",
+        text, _re.IGNORECASE,
+    ):
+        return "dealer"
+    if _re.search(r"/by-owner/", text):
+        return "private"
+    return ""
+
+
 def _extract_url_latest(trajectory: list, year: str = "") -> str | None:
     """Extract the most recent listing URL from a trajectory.
 
@@ -1302,6 +1343,30 @@ class WorkflowRunner:
                     # because the convention prefix was missing.
                     if not summary.lstrip().startswith("VIABLE"):
                         summary = "VIABLE | " + summary
+                    # Backfill Seller_Type when the brain's done() summary
+                    # doesn't include it. Priority 1 short-circuits before
+                    # Priority 2's field-builder runs, so Seller_Type was
+                    # silently missing from every lead the brain emitted
+                    # structured-style. Reapply the same 5-signal cascade
+                    # against the full trajectory thinking text.
+                    if "Seller_Type" not in summary:
+                        all_thinking = " ".join(
+                            str(s.thinking or "") for s in result.trajectory
+                        )
+                        st = _infer_seller_type(summary + " " + all_thinking)
+                        if st:
+                            summary += f" | Seller_Type: {st}"
+                    # Normalize the well-known BoatTrader vision-typo
+                    # ``boatrader.com`` (missing the second ``t``) to the
+                    # canonical host. The brain reads the URL from the
+                    # address bar visually and occasionally drops a
+                    # character; CDP-read URLs at the extract_url level
+                    # already use the canonical host, but the brain's
+                    # done()-summary URL was a separate transcription so
+                    # we patch it here as a final safety net.
+                    summary = _re.sub(
+                        r"\bboatrader\.com\b", "boattrader.com", summary,
+                    )
                     return summary
 
         # Priority 2: Build structured data from thinking text
@@ -1342,6 +1407,70 @@ class WorkflowRunner:
             url = _extract_url_latest(trajectory, year=extracted_year)
             if url:
                 parts.append(f"URL: {url}")
+
+            # Seller_Type — "private" | "dealer" — multi-signal detection.
+            # On BoatTrader the canonical hallmarks (verified on-site
+            # 2026-05-30) are:
+            #   - "Contact Private Seller" heading → private
+            #   - "Contact Dealer" / "Contact <Business>" heading → dealer
+            #   - Location line "City, ST ZIP | Business Name" → dealer
+            #     (pipe + business name suffix)
+            #   - Bare "City, ST ZIP" (no pipe) → private
+            #   - "Featured" / "Sponsored" badge in card area → dealer
+            # We try each signal in priority order and emit the first hit.
+            seller_type: str | None = None
+            # 1. Explicit "Seller_Type: dealer" / "Seller_Type: private"
+            #    if the brain wrote it.
+            m = _re.search(
+                r"[Ss]eller[\s_]?[Tt]ype\s*[:=]\s*[\"']?(private|dealer|brokerage|broker)",
+                search_text,
+            )
+            if m:
+                st = m.group(1).lower()
+                seller_type = "dealer" if st in ("brokerage", "broker", "dealer") else "private"
+            # 2. "Contact Private Seller" → private (BoatTrader canonical).
+            if seller_type is None and _re.search(
+                r"Contact\s+Private\s+Seller", search_text, _re.IGNORECASE,
+            ):
+                seller_type = "private"
+            # 3. Pipe + business-suffix pattern in seller line.
+            if seller_type is None and _re.search(
+                r"\|\s*[A-Z][A-Za-z0-9 &.,'\-]+?"
+                r"(?:Yacht|Yachts|Marine|Sales|Brokerage|Broker|Group|"
+                r"Marina|Boats|Boating|Inc\b|LLC\b|Co\.|Company)",
+                search_text,
+            ):
+                seller_type = "dealer"
+            # 4. Generic dealer keyword in seller-info / contact area.
+            #    Conservative — only trip when accompanied by a contact
+            #    cue so we don't false-positive on stray text elsewhere
+            #    on the page.
+            if seller_type is None and _re.search(
+                r"(?:Contact\s+Dealer|Dealer\s+Listing|Brokerage\s+Listing|"
+                r"Yacht\s+Broker|Featured\s+(?:Listing|Dealer)|Sponsored)",
+                search_text, _re.IGNORECASE,
+            ):
+                seller_type = "dealer"
+            # 5. Default to private when the URL came from the
+            #    by-owner filter (the search-page filter we navigate
+            #    to). Without this default, "no signal" leaves the
+            #    column empty even though the agent took the private
+            #    path and just didn't surface the hallmark in
+            #    thinking text. Empty < weak default; downstream
+            #    consumers can still verify against the URL.
+            if seller_type is None and _re.search(r"/by-owner/", search_text):
+                seller_type = "private"
+            if seller_type:
+                parts.append(f"Seller_Type: {seller_type}")
+
+            # Seller_Name — Name near phone or "Contact <Name>" / "Ask
+            # for <Name>" / signature in description.
+            name_match = _re.search(
+                r"(?:Contact|Ask for|Call|Signed|sincerely,?)\s+([A-Z][a-zA-Z]+(?:\s+[A-Z][a-zA-Z]+)?)",
+                search_text,
+            )
+            if name_match:
+                parts.append(f"Seller_Name: {name_match.group(1)}")
 
             if parts:
                 return "VIABLE | " + " | ".join(parts)

--- a/src/mantis_agent/observability/claude_cost_meter.py
+++ b/src/mantis_agent/observability/claude_cost_meter.py
@@ -60,17 +60,20 @@ class ModelRates:
 # `_UNKNOWN` rates (set to the highest-billed model so cost estimates
 # err on the cautious side).
 MODEL_RATES: dict[str, ModelRates] = {
+    # Rates are per-TOKEN (Anthropic publishes per-million-token rates;
+    # we store divided by 1e6 so estimate_cost can multiply by raw
+    # token counts). Public USD rates as of 2026-05-29.
     "claude-opus-4-7": ModelRates(
-        input=15.0 / 1000, output=75.0 / 1000,
-        cache_read=1.5 / 1000, cache_creation=18.75 / 1000,
+        input=15.0 / 1_000_000, output=75.0 / 1_000_000,
+        cache_read=1.5 / 1_000_000, cache_creation=18.75 / 1_000_000,
     ),
     "claude-sonnet-4-6": ModelRates(
-        input=3.0 / 1000, output=15.0 / 1000,
-        cache_read=0.3 / 1000, cache_creation=3.75 / 1000,
+        input=3.0 / 1_000_000, output=15.0 / 1_000_000,
+        cache_read=0.3 / 1_000_000, cache_creation=3.75 / 1_000_000,
     ),
     "claude-haiku-4-5": ModelRates(
-        input=0.8 / 1000, output=4.0 / 1000,
-        cache_read=0.08 / 1000, cache_creation=1.0 / 1000,
+        input=0.8 / 1_000_000, output=4.0 / 1_000_000,
+        cache_read=0.08 / 1_000_000, cache_creation=1.0 / 1_000_000,
     ),
 }
 _UNKNOWN_RATES = MODEL_RATES["claude-opus-4-7"]  # conservative

--- a/src/mantis_agent/observability/claude_cost_meter.py
+++ b/src/mantis_agent/observability/claude_cost_meter.py
@@ -272,9 +272,16 @@ def _sanitize(s: str) -> str:
 def finalize_to_disk(
     *, meter: ClaudeCostMeter | None = None,
     run_id: str, tenant_id: str,
+    extras: dict[str, Any] | None = None,
 ) -> str:
     """Write the meter snapshot to disk. Returns the written path, or
     empty string when nothing was written (no meter / no run_id).
+
+    ``extras`` is merged into the top-level JSON so callers can record
+    run-outcome metadata alongside the cost breakdown — leads counted,
+    steps executed, halt reason, model used. Keeps the meter purely
+    about Claude spend while letting cost / outcome live in one file
+    operators can pull with a single ``modal volume get``.
 
     Best-effort: errors are logged at DEBUG and swallowed — the run
     terminal must never fail because of cost-meter I/O.
@@ -287,6 +294,11 @@ def finalize_to_disk(
         return ""
     snapshot["run_id"] = run_id
     snapshot["tenant_id"] = tenant_id
+    if extras:
+        # extras keys win over snapshot keys when they collide. Lets
+        # callers override e.g. ``run_id`` if they have a more
+        # authoritative identifier than what was passed.
+        snapshot.update(extras)
     path = _output_path(tenant_id=tenant_id, run_id=run_id)
     try:
         os.makedirs(os.path.dirname(path), exist_ok=True)

--- a/src/mantis_agent/observability/claude_cost_meter.py
+++ b/src/mantis_agent/observability/claude_cost_meter.py
@@ -1,0 +1,302 @@
+"""Per-source Claude cost attribution for one run.
+
+Companion to :mod:`time_meter` but for tokens + cost instead of wall
+time. Lets operators answer "where did my $X of Claude spend go?"
+after a run — separated by source (brain, grounding, extraction-
+single, extraction-multi, recovery, verify) and model.
+
+Pattern: thread-local current meter, set at the runner's entry point,
+read by every Claude HTTP call site, finalised to disk at run
+terminal. Best-effort throughout — never blocks the run.
+
+Output path on the production volume::
+
+    /data/runs/<tenant_id>/<run_id>/claude_cost_by_path.json
+
+Schema::
+
+    {
+      "run_id": "20260529_...",
+      "tenant_id": "default__ab-haiku-...",
+      "totals": {"input": 12345, "output": 678, "cost_usd": 0.42},
+      "by_path": {
+        "brain_claude": {...},
+        "grounding": {...},
+        "extract_multi": {...},
+        ...
+      }
+    }
+"""
+
+from __future__ import annotations
+
+import contextvars
+import json
+import logging
+import os
+import threading
+from dataclasses import dataclass
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+# ── Cost model — rough per-1K-token rates in USD ─────────────────────
+
+
+@dataclass(frozen=True)
+class ModelRates:
+    """Per-1K-token USD rates. Anthropic prices their models per
+    million tokens; we store per-1K for ergonomic multiplication."""
+
+    input: float
+    output: float
+    cache_read: float
+    cache_creation: float
+
+
+# Conservative defaults — match Anthropic's public pricing as of
+# 2026-05-29. When a model name doesn't match here, falls back to the
+# `_UNKNOWN` rates (set to the highest-billed model so cost estimates
+# err on the cautious side).
+MODEL_RATES: dict[str, ModelRates] = {
+    "claude-opus-4-7": ModelRates(
+        input=15.0 / 1000, output=75.0 / 1000,
+        cache_read=1.5 / 1000, cache_creation=18.75 / 1000,
+    ),
+    "claude-sonnet-4-6": ModelRates(
+        input=3.0 / 1000, output=15.0 / 1000,
+        cache_read=0.3 / 1000, cache_creation=3.75 / 1000,
+    ),
+    "claude-haiku-4-5": ModelRates(
+        input=0.8 / 1000, output=4.0 / 1000,
+        cache_read=0.08 / 1000, cache_creation=1.0 / 1000,
+    ),
+}
+_UNKNOWN_RATES = MODEL_RATES["claude-opus-4-7"]  # conservative
+
+
+def rates_for(model: str) -> ModelRates:
+    """Per-1K-token rates for ``model``; falls back to Opus rates on
+    unknown names so cost estimates never under-report."""
+    if model in MODEL_RATES:
+        return MODEL_RATES[model]
+    # Handle versioned names — e.g. claude-haiku-4-5-20251001 matches
+    # claude-haiku-4-5; claude-sonnet-4-6-20260201 matches sonnet-4-6.
+    for known in MODEL_RATES:
+        if model.startswith(known) or known.startswith(model):
+            return MODEL_RATES[known]
+    return _UNKNOWN_RATES
+
+
+def estimate_cost(
+    *, model: str, input_tokens: int, output_tokens: int,
+    cache_read_tokens: int = 0, cache_creation_tokens: int = 0,
+) -> float:
+    """USD cost estimate for a single response. ``input_tokens``
+    excludes the cache_read portion (Anthropic reports them
+    separately); the helper sums them with their respective rates."""
+    r = rates_for(model)
+    return (
+        input_tokens * r.input
+        + output_tokens * r.output
+        + cache_read_tokens * r.cache_read
+        + cache_creation_tokens * r.cache_creation
+    )
+
+
+# ── Accumulator ──────────────────────────────────────────────────────
+
+
+@dataclass
+class PathStats:
+    """Aggregated counters for one (source, model) bucket."""
+
+    calls: int = 0
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_read_tokens: int = 0
+    cache_creation_tokens: int = 0
+    cost_usd: float = 0.0
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "calls": self.calls,
+            "input_tokens": self.input_tokens,
+            "output_tokens": self.output_tokens,
+            "cache_read_tokens": self.cache_read_tokens,
+            "cache_creation_tokens": self.cache_creation_tokens,
+            "cost_usd": round(self.cost_usd, 6),
+        }
+
+
+class ClaudeCostMeter:
+    """Single-run accumulator. Thread-safe append; finalise once.
+
+    Source labels (free-form strings — used as JSON keys):
+
+    - ``brain_claude`` — Claude as the executor brain (``cua_model=claude``)
+    - ``grounding`` — ClaudeGrounding refining click coords
+    - ``extract_multi`` — ClaudeExtractor `_call_many` (the boattrader
+      detail-page extraction hot path)
+    - ``extract_single`` — ClaudeExtractor `_call` (single-screenshot
+      extracts; find_listings / content_control / fields)
+    - ``extract_tool`` — ClaudeExtractor `_call_with_tool_schema*`
+    - ``verify`` — Haiku verifier gate
+    - ``verify_escalation`` — Opus escalation on Haiku verifier fail
+    - ``recovery`` — agentic_recovery's tool_use call
+    - ``planner`` — PlanDecomposer's one-shot decompose call
+    - other — any caller passing a custom bucket
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        # buckets[(source, model)] = PathStats
+        self._buckets: dict[tuple[str, str], PathStats] = {}
+
+    def record(
+        self,
+        *, source: str, model: str,
+        input_tokens: int = 0, output_tokens: int = 0,
+        cache_read_tokens: int = 0, cache_creation_tokens: int = 0,
+    ) -> None:
+        if not source or not model:
+            return
+        cost = estimate_cost(
+            model=model, input_tokens=input_tokens, output_tokens=output_tokens,
+            cache_read_tokens=cache_read_tokens,
+            cache_creation_tokens=cache_creation_tokens,
+        )
+        key = (source, model)
+        with self._lock:
+            bucket = self._buckets.get(key)
+            if bucket is None:
+                bucket = PathStats()
+                self._buckets[key] = bucket
+            bucket.calls += 1
+            bucket.input_tokens += int(input_tokens)
+            bucket.output_tokens += int(output_tokens)
+            bucket.cache_read_tokens += int(cache_read_tokens)
+            bucket.cache_creation_tokens += int(cache_creation_tokens)
+            bucket.cost_usd += cost
+
+    def snapshot(self) -> dict[str, Any]:
+        """Read-only view of the current accumulator state."""
+        with self._lock:
+            by_path: dict[str, dict[str, Any]] = {}
+            tot_input = tot_output = tot_read = tot_creation = 0
+            tot_cost = 0.0
+            for (source, model), stats in self._buckets.items():
+                label = source if model == "unknown" else f"{source}::{model}"
+                by_path[label] = {**stats.to_dict(), "source": source, "model": model}
+                tot_input += stats.input_tokens
+                tot_output += stats.output_tokens
+                tot_read += stats.cache_read_tokens
+                tot_creation += stats.cache_creation_tokens
+                tot_cost += stats.cost_usd
+            return {
+                "totals": {
+                    "input_tokens": tot_input,
+                    "output_tokens": tot_output,
+                    "cache_read_tokens": tot_read,
+                    "cache_creation_tokens": tot_creation,
+                    "cost_usd": round(tot_cost, 6),
+                    "calls": sum(b.calls for b in self._buckets.values()),
+                },
+                "by_path": by_path,
+            }
+
+
+# ── Thread-local current meter ───────────────────────────────────────
+
+
+_current: contextvars.ContextVar[ClaudeCostMeter | None] = contextvars.ContextVar(
+    "mantis_claude_cost_meter", default=None,
+)
+
+
+def set_current_meter(meter: ClaudeCostMeter | None) -> None:
+    """Bind ``meter`` as the active accumulator. Call once at runner
+    entry; the call sites pick it up via :func:`current_meter`."""
+    _current.set(meter)
+
+
+def current_meter() -> ClaudeCostMeter | None:
+    return _current.get()
+
+
+def record_from_response(
+    *, source: str, model: str, response_json: dict[str, Any] | None,
+) -> None:
+    """Convenience: pull tokens from an Anthropic response and credit
+    the current meter. No-op when no meter is bound or response is
+    malformed."""
+    meter = _current.get()
+    if meter is None or not isinstance(response_json, dict):
+        return
+    usage = response_json.get("usage") or {}
+    if not isinstance(usage, dict):
+        return
+    try:
+        meter.record(
+            source=source, model=model,
+            input_tokens=int(usage.get("input_tokens", 0) or 0),
+            output_tokens=int(usage.get("output_tokens", 0) or 0),
+            cache_read_tokens=int(usage.get("cache_read_input_tokens", 0) or 0),
+            cache_creation_tokens=int(usage.get("cache_creation_input_tokens", 0) or 0),
+        )
+    except (TypeError, ValueError):
+        return
+
+
+# ── Persistence ──────────────────────────────────────────────────────
+
+
+def _output_path(*, tenant_id: str, run_id: str) -> str:
+    """Production layout: /data/runs/<tenant>/<run_id>/claude_cost_by_path.json.
+
+    Env-overridable for tests."""
+    root = os.environ.get("MANTIS_RUN_ARTIFACTS_DIR", "/data/runs")
+    safe_tenant = _sanitize(tenant_id) or "default"
+    safe_run = _sanitize(run_id) or "unknown"
+    return os.path.join(root, safe_tenant, safe_run, "claude_cost_by_path.json")
+
+
+def _sanitize(s: str) -> str:
+    return "".join(c if c.isalnum() or c in "_-." else "_" for c in (s or ""))[:120]
+
+
+def finalize_to_disk(
+    *, meter: ClaudeCostMeter | None = None,
+    run_id: str, tenant_id: str,
+) -> str:
+    """Write the meter snapshot to disk. Returns the written path, or
+    empty string when nothing was written (no meter / no run_id).
+
+    Best-effort: errors are logged at DEBUG and swallowed — the run
+    terminal must never fail because of cost-meter I/O.
+    """
+    meter = meter or current_meter()
+    if meter is None or not run_id:
+        return ""
+    snapshot = meter.snapshot()
+    if snapshot["totals"]["calls"] == 0:
+        return ""
+    snapshot["run_id"] = run_id
+    snapshot["tenant_id"] = tenant_id
+    path = _output_path(tenant_id=tenant_id, run_id=run_id)
+    try:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        tmp_path = f"{path}.tmp.{os.getpid()}"
+        with open(tmp_path, "w") as f:
+            json.dump(snapshot, f, indent=2, sort_keys=True)
+        os.replace(tmp_path, path)
+        logger.warning(
+            "  [cost-meter] wrote %s: %d calls, $%.4f total",
+            path, snapshot["totals"]["calls"],
+            snapshot["totals"]["cost_usd"],
+        )
+        return path
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("claude_cost_meter finalize failed: %s", exc)
+        return ""

--- a/src/mantis_agent/observability/leads_csv.py
+++ b/src/mantis_agent/observability/leads_csv.py
@@ -1,0 +1,180 @@
+"""Per-run lead CSV writer.
+
+Walks the micro-runner's terminal step results and writes one row per
+lead to::
+
+    /data/runs/<tenant_id>/<run_id>/leads.csv
+
+Two extraction-shape paths are supported (use whichever the step
+produced):
+
+1. **Structured ``extracted_fields``** — schema-keyed dict produced by
+   the listings-flow extract_data path (claude_step.py:475). Each
+   key/value becomes a CSV column.
+
+2. **Pipe-delimited ``VIABLE | k: v | ...`` string in ``data``** — the
+   canonical row format produced by the marketplace recipe's deep-
+   extraction path (see ListingDedup._VIABLE_PREFIX). Parsed back into
+   a flat dict so the columns are equivalent between paths.
+
+Without the second path, the writer misses every lead the marketplace
+recipe produces — the lead-counter in ``run_reporter`` reads
+``r.data``, so an empty CSV next to a "3 viable leads" log line is a
+wiring gap, not zero leads.
+
+Columns are the union of all field keys seen in the run, with
+``step_index``, ``step_intent``, ``final_url``, and ``viable`` prepended
+for traceability. ``run_id`` and ``profile_id`` are included so multi-
+run CSVs (one per zip / proxy geo / model variant) can be concatenated
+later with ``pandas.concat`` or shell ``cat``.
+
+Best-effort throughout — errors are swallowed at DEBUG and the run
+terminal never fails because of CSV I/O.
+"""
+
+from __future__ import annotations
+
+import csv
+import logging
+import os
+import re
+from typing import Any, Iterable
+
+logger = logging.getLogger(__name__)
+
+
+_FIXED_HEAD_COLS = (
+    "run_id",
+    "profile_id",
+    "step_index",
+    "step_intent",
+    "final_url",
+    "viable",
+)
+
+
+_VIABLE_PREFIX = "VIABLE"
+# Match "Field: value" pairs from "VIABLE | Year: 2022 | Make: Bayliner | ..."
+_KV_PAIR_RE = re.compile(r"([A-Za-z][A-Za-z0-9 _]*?)\s*:\s*([^|]*?)(?=\s*\||$)")
+
+
+def _parse_viable_row(data: str) -> dict[str, Any]:
+    """Parse a marketplace-recipe VIABLE row into a {field: value} dict.
+
+    Input shape (canonical, from ListingDedup):
+        "VIABLE | Year: 2022 | Make: Bayliner | Model: T22CC | URL: ... | Phone: 555-..."
+    Returns:
+        {"Year": "2022", "Make": "Bayliner", ...} — keys preserved as-is
+        from the source row. Empty dict on parse failure.
+    """
+    if not data or not data.startswith(_VIABLE_PREFIX):
+        return {}
+    out: dict[str, Any] = {}
+    for m in _KV_PAIR_RE.finditer(data):
+        key = m.group(1).strip()
+        if not key or key.upper() == _VIABLE_PREFIX:
+            continue
+        out[key] = m.group(2).strip()
+    return out
+
+
+def _sanitize(s: str) -> str:
+    return "".join(c if c.isalnum() or c in "_-." else "_" for c in (s or ""))[:120]
+
+
+def _output_path(*, tenant_id: str, run_id: str) -> str:
+    root = os.environ.get("MANTIS_RUN_ARTIFACTS_DIR", "/data/runs")
+    safe_tenant = _sanitize(tenant_id) or "default"
+    safe_run = _sanitize(run_id) or "unknown"
+    return os.path.join(root, safe_tenant, safe_run, "leads.csv")
+
+
+def _rows_from_results(
+    results: Iterable[Any], *, run_id: str, profile_id: str,
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for r in results:
+        # Path 1: structured extracted_fields (listings-flow extract_data)
+        fields = getattr(r, "extracted_fields", None)
+        # Path 2: pipe-delimited VIABLE row in data (marketplace recipe)
+        data = getattr(r, "data", None) or ""
+        viable_fields: dict[str, Any] = {}
+        if isinstance(data, str) and data.startswith(_VIABLE_PREFIX):
+            viable_fields = _parse_viable_row(data)
+        # Skip this step if neither path produced fields
+        has_fields = bool(fields) if isinstance(fields, dict) else False
+        if not has_fields and not viable_fields:
+            continue
+        row: dict[str, Any] = {
+            "run_id": run_id,
+            "profile_id": profile_id,
+            "step_index": getattr(r, "step_index", ""),
+            "step_intent": (getattr(r, "intent", "") or "")[:200],
+            "final_url": getattr(r, "final_url", "") or "",
+            "viable": bool(viable_fields),
+        }
+        # Merge both — extracted_fields keys win on overlap (they're
+        # schema-typed, viable parse is regex-best-effort).
+        merged: dict[str, Any] = {}
+        for k, v in viable_fields.items():
+            merged[str(k)] = v
+        if isinstance(fields, dict):
+            for k, v in fields.items():
+                if isinstance(v, (str, int, float, bool)) or v is None:
+                    merged[str(k)] = v
+                else:
+                    merged[str(k)] = repr(v)
+        row.update(merged)
+        rows.append(row)
+    return rows
+
+
+def finalize_leads_csv(
+    *, run_id: str, tenant_id: str, profile_id: str,
+    results: Iterable[Any],
+) -> str:
+    """Write one CSV row per step with non-empty ``extracted_fields``.
+
+    Returns the path written, or empty string when there's nothing to
+    write (no run_id, no extracting steps). Idempotent: rewrites the
+    same path on each call.
+    """
+    if not run_id:
+        return ""
+    rows = _rows_from_results(
+        results, run_id=run_id, profile_id=profile_id or "",
+    )
+    # Always emit a CSV at run terminal — even when no leads landed —
+    # so operators see the writer ran. Empty-result file has just the
+    # fixed header columns (run_id / profile_id / step_index / etc.),
+    # which is enough to confirm the artifact path is correct and lets
+    # downstream tooling treat "no leads" as a valid outcome instead of
+    # a missing file.
+
+    extra_cols: list[str] = []
+    seen: set[str] = set(_FIXED_HEAD_COLS)
+    for row in rows:
+        for k in row:
+            if k not in seen:
+                seen.add(k)
+                extra_cols.append(k)
+    fieldnames = list(_FIXED_HEAD_COLS) + extra_cols
+
+    path = _output_path(tenant_id=tenant_id, run_id=run_id)
+    try:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        tmp_path = f"{path}.tmp.{os.getpid()}"
+        with open(tmp_path, "w", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=fieldnames, extrasaction="ignore")
+            writer.writeheader()
+            for row in rows:
+                writer.writerow(row)
+        os.replace(tmp_path, path)
+        logger.warning(
+            "  [leads-csv] wrote %s: %d lead rows, %d columns",
+            path, len(rows), len(fieldnames),
+        )
+        return path
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("leads_csv finalize failed: %s", exc)
+        return ""

--- a/src/mantis_agent/plan_decomposer.py
+++ b/src/mantis_agent/plan_decomposer.py
@@ -385,10 +385,21 @@ Plans MUST be organized into sections. Each section has a purpose and a gate:
    - For form-only flows, end with an extract_data step that verifies the right
      page/state was reached (URL, header, and any read-back of the values just set)
    - If the gate FAILS, the entire pipeline HALTS — do not proceed
-   - Example listings gate: "Verify page heading shows the expected filters and a
-     reasonable result count"
-   - Example form gate: "Verify the page shows the just-saved record with the
-     updated values"
+   - GATE INTENTS MUST ASSERT POSITIVE EVIDENCE OF PROGRESS (not absence of error
+     text). A 404 page, an empty-results page, a CF challenge, a paywall, and an
+     expired-login redirect all share one trait: the thing the plan came here for
+     is not visible. Forcing the gate to name the artifact catches every one of
+     those without enumerating them. Per shape:
+       LISTINGS: "Verify ≥1 listing card with a price and a title is visible AND
+                  filter pills show <expected filters>"
+       FORM:     "Verify the form fields are populated with the values that were
+                  just submitted (read each value back from the visible page)"
+       WORKFLOW: "Verify the target <record/page section> is visible with
+                  <expected attribute>" (e.g. "the Acme lead row shows status=Qualified")
+       INSPECT:  "Verify the specific value <X> for <field> is rendered on the page"
+     Never accept generic chrome (footer links, nav menus, filter widgets in the
+     sidebar) as evidence the page is the expected results page — those render on
+     error pages too.
 
 2. EXTRACTION section (listings flows only — depends on setup gate passing):
    - Click → URL → scroll → extract → re-navigate or back → loop
@@ -400,6 +411,12 @@ Plans MUST be organized into sections. Each section has a purpose and a gate:
    - If any content section is collapsed, the extraction step must expand it first.
    - Prefer safe reveal controls (Show more, Read more, See details, View …,
      Expand). Never use generic contact / lead-generation forms.
+   - REVEAL CONTROLS MUST BE required=false. "Show more" / "Read more" /
+     "See details" / "View" / "Expand" steps are best-effort — many
+     listings show the content unconditionally after scroll, so requiring
+     a click halts the run on listings where the control doesn't exist.
+     Mark these steps required=false so the extract_data step that
+     follows can still run on either page state.
 
 3. PAGINATION section (listings flows only — depends on extraction):
    - Paginate → loop back to extraction
@@ -672,6 +689,39 @@ RULES:
       frontier critic propose a different recovery instead. Default
       to emitting fallback_url unless the source explicitly warns
       about URL-stripping or SPA-only state.
+    • `hints.preferred_target_description` — explicit description
+      of WHAT the click should target, used to bias visual grounding
+      toward a specific element when the brain's coarse pick is
+      ambiguous. Emit this whenever the source plan distinguishes
+      one clickable region from another in the same card / row /
+      tile and explicitly names which to hit.
+        Source: "click the boat TITLE TEXT (year + make + model
+                 line) — NOT the photo, which opens a gallery overlay"
+        → hints={"preferred_target_description": "boat title text —
+                                                   year + make + model line"}
+        Source: "click the row's record name (left column), not the
+                 status badge or action menu"
+        → hints={"preferred_target_description": "record name in
+                                                   the leftmost column"}
+        Source: "click the article headline link, not the
+                 thumbnail image"
+        → hints={"preferred_target_description": "article headline
+                                                   text link"}
+      Use whenever the source plan ELIMINATES alternatives ("click X,
+      not Y") — that elimination is itself a hint the grounding
+      model needs. Without it, the executor brain often picks the
+      largest visible target (usually a photo), which lands clicks
+      inside image carousels or other modal overlays instead of
+      navigating to the intended detail page.
+    • `hints.wait_after_load_seconds` — extra settle time the runner
+      should wait after this step before treating the page as ready
+      for the next action. Use when the source plan says the page is
+      JS-heavy, SPA-mounted, or lazy-loaded.
+        Source: "navigate to the dashboard and wait for the data
+                 grid to populate"
+        → hints={"wait_after_load_seconds": 8}
+      Default settle is ~4s; only emit for steps that explicitly
+      need more.
 - The "reverse" field must be a CUA-executable instruction
 - Set section="setup", section="extraction", or section="pagination"
 - Set required=true for all setup/filter/form steps (this is the default)
@@ -860,7 +910,7 @@ class PlanDecomposer:
             domain = m.group(1)
 
         # Check cache — include prompt version in hash to invalidate on schema changes
-        prompt_version = "v32_pagination_url_template_neutral"  # Bump this when DECOMPOSE_PROMPT changes
+        prompt_version = "v35_preferred_target_description_hints"  # Bump this when DECOMPOSE_PROMPT changes
         plan_hash = hashlib.md5(f"{prompt_version}:{plan_text}".encode()).hexdigest()[:8]
         cache_path = (
             cache_path_template.replace("{hash}", plan_hash)
@@ -919,7 +969,7 @@ class PlanDecomposer:
 
         request_body = {
             "model": self.model,
-            "max_tokens": 4096,
+            "max_tokens": 16384,
             "messages": [{"role": "user", "content": prompt}],
         }
         t0 = time.monotonic()

--- a/src/mantis_agent/recipes/marketplace_planner/planner.py
+++ b/src/mantis_agent/recipes/marketplace_planner/planner.py
@@ -162,14 +162,49 @@ PHONE NUMBER EXTRACTION RULES:
 - Phones are typically buried DEEP in listing pages: 5-6 scrolls below photos/gallery
 - Include explicit scrolling instructions: "scroll(direction='down', amount=5) AGGRESSIVELY \
   past the photo gallery to reach Description/Seller Notes where phone numbers appear"
-- If Description, Seller Notes, More Details, or Additional Equipment is collapsed, click \
-  a safe expander such as "Show more", "Read more", "See more", or a section chevron before reading
+- If Description, Seller Notes, More Details, Additional Equipment, About This Boat, Notes, \
+  or Comments is collapsed, click EVERY safe expander you see — "Show more", "Read more", \
+  "See more", "See details", "View more", "Expand", or a section chevron — before reading. \
+  Multiple sections may be collapsed; expand them all
 - Also inspect safe phone reveal controls such as "Show phone", "View phone", or "Call"
-- Phone formats to look for: (305)555-1234, 786-555-1234, 305.555.5678, +1-555-0123, +44 20 7946 0958, 10+ digit numbers
-- NOT phone numbers: prices ($45,000), years (2020), zip codes (33101), model numbers
-- Do NOT click "Contact Seller" or "Request Info" buttons — they open popup forms, not phone numbers
-- If only a generic "Contact Seller" form is visible after checking expanded text and safe phone \
-  reveal controls, report "Phone: none" and move on
+
+WHERE TO LOOK — TRY ALL OF THESE (sellers hide phones in many places):
+  * Inside the Description prose, including the closing line: "Call 555-1234 for details"
+  * The More Details section, especially custom-text fields
+  * "Owner contact" or "Seller info" sub-blocks below the price
+  * Phone numbers PAINTED ON BOAT PHOTOS (some sellers stencil the number on the hull as a \
+    "For Sale" sign — read the photo's pixels if a number is visible in the image)
+  * Marketing watermarks in the gallery photos that read "Call XXX-XXX-XXXX"
+  * Email signatures: "John, john@x.com, 555-1234"
+
+PHONE FORMATS — RECOGNIZE OBFUSCATED AND UNUSUAL VARIANTS:
+- Standard US: (305)555-1234, 305-555-1234, 305.555.1234, 305 555 1234
+- Run-together: 3055551234 (10 consecutive digits)
+- With US country code: +1 305-555-1234, 1-305-555-1234, 1.305.555.1234
+- Heavily spaced anti-scraper: "3 0 5 5 5 5 1 2 3 4" or "305 - 555 - 1234" with extra spaces
+- Dashed-out for spam protection: "305-555-1XX4" — REJECT only if partial; full numbers count
+- Letters mixed in marketing format: "1-800-CALL-NOW" (treat as phone if it's a real toll-free)
+- Digits spelled out in prose: "call me at five five five one two three four" — \
+  reconstruct only when ALL 7-10 digits are spelled out unambiguously in sequence
+- International: +44 20 7946 0958, +52 55 1234 5678, +1 (305) 555-1234, etc.
+- Country code with parens: "+1 (305) 555-1234"
+- Lowercased "tel:" prefix: "tel:3055551234" — strip the prefix, take the number
+- "(c)" / "(m)" / "(h)" suffixes for cell/mobile/home: take the number, drop the suffix
+- ANY sequence that looks like a dialable number (7-15 digits when normalized) counts
+
+NOT phone numbers (always reject these):
+- Prices ($45,000 — has a dollar sign; never a phone)
+- Years (2020, 1997 — only 4 digits)
+- Zip codes (33101 — only 5 digits, may be near a city name)
+- Model numbers (T22CC, 4087 Aft Cabin)
+- VIN / HIN (hull ID) numbers — long alphanumeric, not pure digits
+- Length/beam dimensions ("22.5 ft" — has units)
+
+DECISION RULE:
+- If you found ANY dialable number using ANY of the patterns above, report it as the phone
+- Do NOT click "Contact Seller" or "Request Info" buttons — they open popup forms, not phones
+- If after expanding all collapsibles AND scanning all photo text AND checking every section \
+  you find NO dialable number, report "Phone: none"
 - ALWAYS report phone: "Phone: 305-555-1234" or "Phone: none" — never omit the field
 
 OUTPUT FORMAT — exact format for done() calls with realistic examples

--- a/tests/test_claude_cost_meter.py
+++ b/tests/test_claude_cost_meter.py
@@ -27,32 +27,33 @@ def temp_runs_dir(monkeypatch: pytest.MonkeyPatch, tmp_path) -> str:
 
 
 def test_rates_for_known_models() -> None:
-    assert rates_for("claude-opus-4-7").input == 0.015
-    assert rates_for("claude-sonnet-4-6").input == 0.003
-    assert rates_for("claude-haiku-4-5-20251001").input == 0.0008
+    # Rates are per-TOKEN (Anthropic per-Mtok rates / 1e6).
+    assert rates_for("claude-opus-4-7").input == 15.0 / 1_000_000
+    assert rates_for("claude-sonnet-4-6").input == 3.0 / 1_000_000
+    assert rates_for("claude-haiku-4-5-20251001").input == 0.8 / 1_000_000
 
 
 def test_rates_for_versioned_haiku_falls_back_to_base() -> None:
     """Versioned model names match by prefix."""
     rates = rates_for("claude-haiku-4-5-20260201")
-    assert rates.input == 0.0008  # haiku rate
+    assert rates.input == 0.8 / 1_000_000  # haiku rate
 
 
 def test_rates_for_unknown_model_uses_opus_conservative() -> None:
     """Unknown model → conservative (Opus) so cost never under-reports."""
-    assert rates_for("claude-future-x").input == 0.015
+    assert rates_for("claude-future-x").input == 15.0 / 1_000_000
 
 
 def test_estimate_cost_combines_input_output_cache() -> None:
-    # Haiku-4-5: input 0.0008/Mtok, output 0.004/Mtok,
-    # cache_read 0.00008/Mtok, cache_creation 0.001/Mtok
+    # Haiku-4-5: input $0.80/Mtok, output $4/Mtok,
+    # cache_read $0.08/Mtok, cache_creation $1/Mtok
     cost = estimate_cost(
         model="claude-haiku-4-5-20251001",
-        input_tokens=1000, output_tokens=100,
-        cache_read_tokens=5000, cache_creation_tokens=0,
+        input_tokens=1_000_000, output_tokens=100_000,
+        cache_read_tokens=5_000_000, cache_creation_tokens=0,
     )
-    # 1000 * 0.0008 + 100 * 0.004 + 5000 * 0.00008
-    expected = 0.8 + 0.4 + 0.4
+    # 1Mtok * $0.80 + 100Ktok * $4 + 5Mtok * $0.08
+    expected = 0.80 + 0.40 + 0.40
     assert abs(cost - expected) < 1e-6
 
 

--- a/tests/test_claude_cost_meter.py
+++ b/tests/test_claude_cost_meter.py
@@ -1,0 +1,220 @@
+"""Tests for the Claude cost meter — per-source attribution. (#675 follow-up)"""
+
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+
+from mantis_agent.observability.claude_cost_meter import (
+    ClaudeCostMeter,
+    estimate_cost,
+    finalize_to_disk,
+    rates_for,
+    record_from_response,
+    set_current_meter,
+)
+
+
+@pytest.fixture()
+def temp_runs_dir(monkeypatch: pytest.MonkeyPatch, tmp_path) -> str:
+    monkeypatch.setenv("MANTIS_RUN_ARTIFACTS_DIR", str(tmp_path))
+    return str(tmp_path)
+
+
+# ── cost model ───────────────────────────────────────────────────────
+
+
+def test_rates_for_known_models() -> None:
+    assert rates_for("claude-opus-4-7").input == 0.015
+    assert rates_for("claude-sonnet-4-6").input == 0.003
+    assert rates_for("claude-haiku-4-5-20251001").input == 0.0008
+
+
+def test_rates_for_versioned_haiku_falls_back_to_base() -> None:
+    """Versioned model names match by prefix."""
+    rates = rates_for("claude-haiku-4-5-20260201")
+    assert rates.input == 0.0008  # haiku rate
+
+
+def test_rates_for_unknown_model_uses_opus_conservative() -> None:
+    """Unknown model → conservative (Opus) so cost never under-reports."""
+    assert rates_for("claude-future-x").input == 0.015
+
+
+def test_estimate_cost_combines_input_output_cache() -> None:
+    # Haiku-4-5: input 0.0008/Mtok, output 0.004/Mtok,
+    # cache_read 0.00008/Mtok, cache_creation 0.001/Mtok
+    cost = estimate_cost(
+        model="claude-haiku-4-5-20251001",
+        input_tokens=1000, output_tokens=100,
+        cache_read_tokens=5000, cache_creation_tokens=0,
+    )
+    # 1000 * 0.0008 + 100 * 0.004 + 5000 * 0.00008
+    expected = 0.8 + 0.4 + 0.4
+    assert abs(cost - expected) < 1e-6
+
+
+# ── accumulator ──────────────────────────────────────────────────────
+
+
+def test_meter_records_call() -> None:
+    meter = ClaudeCostMeter()
+    meter.record(
+        source="brain_claude", model="claude-sonnet-4-6",
+        input_tokens=1000, output_tokens=200,
+    )
+    snap = meter.snapshot()
+    assert snap["totals"]["calls"] == 1
+    assert snap["totals"]["input_tokens"] == 1000
+    assert snap["totals"]["output_tokens"] == 200
+    assert snap["totals"]["cost_usd"] > 0
+
+
+def test_meter_accumulates_across_calls() -> None:
+    meter = ClaudeCostMeter()
+    for _ in range(5):
+        meter.record(
+            source="extract_multi", model="claude-sonnet-4-6",
+            input_tokens=500, output_tokens=50,
+        )
+    snap = meter.snapshot()
+    assert snap["totals"]["calls"] == 5
+    assert snap["totals"]["input_tokens"] == 2500
+    assert snap["totals"]["output_tokens"] == 250
+
+
+def test_meter_separates_by_source_and_model() -> None:
+    """Two sources + two models = four buckets."""
+    meter = ClaudeCostMeter()
+    meter.record(source="brain_claude", model="claude-opus-4-7",
+                 input_tokens=100, output_tokens=10)
+    meter.record(source="brain_claude", model="claude-sonnet-4-6",
+                 input_tokens=100, output_tokens=10)
+    meter.record(source="extract_multi", model="claude-sonnet-4-6",
+                 input_tokens=100, output_tokens=10)
+    snap = meter.snapshot()
+    # 3 distinct (source, model) tuples
+    assert len(snap["by_path"]) == 3
+
+
+def test_meter_ignores_empty_source_or_model() -> None:
+    meter = ClaudeCostMeter()
+    meter.record(source="", model="claude-opus-4-7", input_tokens=100)
+    meter.record(source="brain_claude", model="", input_tokens=100)
+    assert meter.snapshot()["totals"]["calls"] == 0
+
+
+# ── record_from_response ─────────────────────────────────────────────
+
+
+def test_record_from_response_no_op_without_meter() -> None:
+    """Bound meter is None → no-op (doesn't raise)."""
+    set_current_meter(None)
+    record_from_response(
+        source="brain_claude", model="claude-sonnet-4-6",
+        response_json={"usage": {"input_tokens": 100}},
+    )
+
+
+def test_record_from_response_pulls_usage_fields() -> None:
+    meter = ClaudeCostMeter()
+    set_current_meter(meter)
+    try:
+        record_from_response(
+            source="extract_multi", model="claude-sonnet-4-6",
+            response_json={
+                "usage": {
+                    "input_tokens": 1000,
+                    "output_tokens": 200,
+                    "cache_read_input_tokens": 500,
+                    "cache_creation_input_tokens": 0,
+                },
+            },
+        )
+        snap = meter.snapshot()
+        bucket = next(iter(snap["by_path"].values()))
+        assert bucket["input_tokens"] == 1000
+        assert bucket["output_tokens"] == 200
+        assert bucket["cache_read_tokens"] == 500
+    finally:
+        set_current_meter(None)
+
+
+def test_record_from_response_swallows_malformed_response() -> None:
+    meter = ClaudeCostMeter()
+    set_current_meter(meter)
+    try:
+        record_from_response(
+            source="brain_claude", model="claude-opus-4-7",
+            response_json=None,
+        )
+        record_from_response(
+            source="brain_claude", model="claude-opus-4-7",
+            response_json={"usage": "not a dict"},
+        )
+        assert meter.snapshot()["totals"]["calls"] == 0
+    finally:
+        set_current_meter(None)
+
+
+# ── finalize_to_disk ─────────────────────────────────────────────────
+
+
+def test_finalize_writes_json_at_canonical_path(temp_runs_dir: str) -> None:
+    meter = ClaudeCostMeter()
+    meter.record(
+        source="brain_claude", model="claude-sonnet-4-6",
+        input_tokens=1000, output_tokens=100,
+    )
+    path = finalize_to_disk(
+        meter=meter, run_id="run_xyz", tenant_id="acme",
+    )
+    assert path
+    assert os.path.exists(path)
+    with open(path) as f:
+        data = json.load(f)
+    assert data["run_id"] == "run_xyz"
+    assert data["tenant_id"] == "acme"
+    assert data["totals"]["calls"] == 1
+    assert "brain_claude::claude-sonnet-4-6" in data["by_path"]
+
+
+def test_finalize_no_op_when_no_calls(temp_runs_dir: str) -> None:
+    """Empty meter → no file written (avoid empty-file noise)."""
+    meter = ClaudeCostMeter()
+    path = finalize_to_disk(
+        meter=meter, run_id="empty_run", tenant_id="acme",
+    )
+    assert path == ""
+
+
+def test_finalize_no_op_without_run_id(temp_runs_dir: str) -> None:
+    meter = ClaudeCostMeter()
+    meter.record(source="x", model="claude-opus-4-7", input_tokens=10)
+    assert finalize_to_disk(meter=meter, run_id="", tenant_id="acme") == ""
+
+
+def test_finalize_uses_current_meter_by_default(temp_runs_dir: str) -> None:
+    meter = ClaudeCostMeter()
+    meter.record(source="brain", model="claude-sonnet-4-6", input_tokens=10)
+    set_current_meter(meter)
+    try:
+        path = finalize_to_disk(run_id="run_default", tenant_id="acme")
+        assert path
+    finally:
+        set_current_meter(None)
+
+
+def test_path_includes_sanitized_tenant_and_run_id(temp_runs_dir: str) -> None:
+    """Slashes / spaces in tenant_id or run_id are sanitized — no directory escape."""
+    meter = ClaudeCostMeter()
+    meter.record(source="x", model="claude-opus-4-7", input_tokens=10)
+    path = finalize_to_disk(
+        meter=meter,
+        run_id="../escape/attempt",
+        tenant_id="../../bad/tenant",
+    )
+    # File must land under temp_runs_dir, never outside it
+    assert path.startswith(temp_runs_dir)

--- a/tests/test_claude_cost_meter.py
+++ b/tests/test_claude_cost_meter.py
@@ -208,6 +208,32 @@ def test_finalize_uses_current_meter_by_default(temp_runs_dir: str) -> None:
         set_current_meter(None)
 
 
+def test_finalize_merges_extras(temp_runs_dir: str) -> None:
+    """Extras dict is merged at the top level so cost + outcome share
+    one file. Useful for landing leads + steps + halt reason alongside
+    cost in a single artifact."""
+    meter = ClaudeCostMeter()
+    meter.record(source="x", model="claude-opus-4-7", input_tokens=10)
+    path = finalize_to_disk(
+        meter=meter, run_id="r1", tenant_id="acme",
+        extras={
+            "outcome": {
+                "leads_extracted": 7,
+                "steps_executed": 58,
+                "terminal_status": "halted",
+                "halt_reason": "budget_cap",
+            },
+            "plan_hash": "bda88bb5",
+        },
+    )
+    with open(path) as f:
+        data = json.load(f)
+    assert data["outcome"]["leads_extracted"] == 7
+    assert data["outcome"]["steps_executed"] == 58
+    assert data["outcome"]["terminal_status"] == "halted"
+    assert data["plan_hash"] == "bda88bb5"
+
+
 def test_path_includes_sanitized_tenant_and_run_id(temp_runs_dir: str) -> None:
     """Slashes / spaces in tenant_id or run_id are sanitized — no directory escape."""
     meter = ClaudeCostMeter()

--- a/tests/test_extractor_tool_use_migration.py
+++ b/tests/test_extractor_tool_use_migration.py
@@ -179,12 +179,15 @@ def test_verify_gate_opts_into_cache_tools() -> None:
 
 
 def test_verify_gate_uses_haiku_default_model() -> None:
-    """#421 §2: the verify client defaults to Haiku 4.5; the
-    escalation client defaults to Opus 4.7. Operators can pin
-    either via env, but the constructor defaults must be stable."""
+    """#421 §2: the verify client defaults to Haiku 4.5; the escalation
+    client defaults to Sonnet 4.6 (was Opus 4.7 — flipped in PR #724
+    after the 3-round boattrader sweep showed Opus escalations
+    accounted for 73 % of total Claude spend at ~$0.047 per call).
+    Operators can pin either via env, but the constructor defaults
+    must be stable."""
     extractor = ClaudeExtractor(api_key="dummy")
     assert extractor._verify_client.model == "claude-haiku-4-5-20251001"
-    assert extractor._verify_escalation_client.model == "claude-opus-4-7"
+    assert extractor._verify_escalation_client.model == "claude-sonnet-4-6"
 
 
 # ── find_filter_target ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes the attribution gap that made #719 / #721 / #722 / #723's A/B validation inconclusive. The cache + extractor-model PRs all shipped infrastructure, but Modal log rotation hid the diagnostic prints and per-call cost couldn't be tied back to specific code paths.

This PR writes a per-run JSON to \`/data/runs/<tenant>/<run_id>/claude_cost_by_path.json\` that survives log rotation. Operators can answer \"where did my \$X of Claude spend go?\" after every run.

## New module

\`mantis_agent/observability/claude_cost_meter.py\`:
- \`ClaudeCostMeter\` — thread-safe accumulator keyed by (source, model)
- \`MODEL_RATES\` — per-1K-token USD rates for Opus / Sonnet / Haiku (matches Anthropic public pricing, conservative Opus fallback for unknown names)
- \`estimate_cost\` — sums input + output + cache_read + cache_creation
- \`set_current_meter\` / \`current_meter\` — contextvar-backed binding so callers don't have to thread the meter through
- \`record_from_response\` — pulls usage fields from any Anthropic response; no-op when no meter bound or response malformed
- \`finalize_to_disk\` — writes the snapshot at run terminal; sanitizes tenant_id + run_id for path safety

## Sources tagged

| Source label | Where it fires |
|---|---|
| \`brain_claude\` | Claude as executor brain (\`cua_model=claude\`) |
| \`grounding\` | ClaudeGrounding refining click coords |
| \`extract_multi\` | ClaudeExtractor \`_call_many\` (boattrader detail-page extraction hot path) |
| \`extract_single\` | ClaudeExtractor \`_call\` |
| \`extract_tool\` / \`extract_tool_multi\` | Shared tool-use client (single + multi screenshot) |
| \`recovery\` | agentic_recovery's tool_use call |

## Wiring

- Every Claude HTTP call site appends \`record_from_response(source, model, response_json)\` alongside existing telemetry — no behavior change.
- \`micro_runner.run()\` terminal calls \`finalize_to_disk\` after the Plan-evolution finalize hook, so cost lands even on \`time_cap\` / \`budget_cap\` halts.
- \`modal_cua_server._run_holo3_executor\` binds a fresh meter + stamps \`_api_run_id\` + \`_api_tenant_id\` on the runner so finalize knows where to write.

## Expected output

\`\`\`json
{
  \"run_id\": \"20260529_051236_9464045f\",
  \"tenant_id\": \"default__ab-haiku-1780031553\",
  \"totals\": {\"input_tokens\": 12345, \"output_tokens\": 678, \"cost_usd\": 0.42, \"calls\": 47},
  \"by_path\": {
    \"grounding::claude-opus-4-7\": {\"calls\": 12, \"input_tokens\": 3000, \"cost_usd\": 0.045, ...},
    \"extract_multi::claude-haiku-4-5\": {\"calls\": 8, \"input_tokens\": 6000, \"cost_usd\": 0.013, ...},
    \"recovery::claude-haiku-4-5\": {\"calls\": 1, ...}
  }
}
\`\`\`

## Tests

- 16 new in \`tests/test_claude_cost_meter.py\` — model rates, accumulator, record_from_response, finalize, sanitization, no-op cases
- 46 tests pass across the combined cache + cost-meter suite
- \`ruff check\` clean

## Next: A/B rerun with attribution

Once this lands + deploys, the haiku-vs-sonnet A/B becomes definitive — pull the JSON from each run and diff the by_path totals.

References #675, #714

🤖 Generated with [Claude Code](https://claude.com/claude-code)