### PR TITLE
feat(learning): Learning Allocator Phase 0a — substrate interface + plan

### DIFF
--- a/experiments/learning_allocator/PLAN.md
+++ b/experiments/learning_allocator/PLAN.md
@@ -1,0 +1,174 @@
+# The Learning Allocator on Mantis — Experiment Plan
+
+Adaptation of *"The Learning Allocator: Continual Agent Improvement as
+Budget-Constrained Substrate Selection"* to the Mantis CUA testbed.
+
+Status: draft v0.1. Tracked by the `[EPIC] Learning Allocator on Mantis`
+task and its children. Not peer reviewed.
+
+---
+
+## 0. Thesis — what we adopt, what we adapt
+
+**Adopt (the paper's durable core):**
+
+- Continual improvement = **substrate selection** under a compute budget,
+  not a single fixed learning mechanism.
+- A cost/durability-ordered **substrate ladder** S0 → S3.
+- Reward `R = Δscore − λ·cost`; hard budget `B`.
+- The two properties that make the problem *meta*: **partial observability**
+  (true competence is never observed, only a noisy estimate) and
+  **non-stationarity** (the value of each substrate shifts as the agent matures).
+- The tractable instance: a **myopic contextual-bandit** allocator.
+
+**Adapt for Mantis (the deltas that make this a worthwhile testbed):**
+
+1. **Domain is visual CUA, not voice.** The noisy-attribution channel is
+   *vision misperception + layout drift + LLM-verifier self-disagreement*
+   instead of ASR error. Mantis therefore tests the paper's **general** claim
+   as a **second vertical** — it does *not* test the voice/ASR headline.
+2. **Dual reward with ground truth — the key upgrade.** Mantis ships BOTH an
+   expensive accurate **oracle** (the sim-env mutation-log grader) AND a cheap
+   noisy **proxy** (the LLM verifier). The voice domain has a noisy reward but
+   *no ground truth to measure the noise against*. Here we can (a) **quantify**
+   the partial observability the paper can only assume (§3.2), and (b) **train
+   the PRM the paper leaves stubbed** (§3.4). This is the single biggest reason
+   to run the experiment on Mantis.
+3. **S2 is reframed.** Mantis synthesizes *plans / skills / playbooks*, not
+   Python tools. S2 = **skill/macro synthesis** (GraphLearner + playbook
+   auto-generation), not tool synthesis. We state this reframing explicitly.
+
+---
+
+## 1. Substrate ladder mapped to Mantis
+
+| Rung | Paper substrate | Mantis module(s) | Status today |
+|---|---|---|---|
+| **S0** | Retrieval / context | `gym/hint_memory.py`, `grounding_cache.py`, `curriculum/` | **LIVE** (called from `run_executor.py`) |
+| **S1** | Exemplar | `gym/trace_exporter.py` → `gym/trace_labeller.py` → exemplar store | collection **LIVE**, inference-time replay **TO BUILD** |
+| **S2** | Tool synth → **skill/macro synth** | `graph/learner.py`, `recipes/`, `verification/playbook.py` | **PARTIAL** (synthesizes plans, not tools — reframe) |
+| **S3** | Weight consolidation | `training/rollout_collector.py` → `training/train_holo3_distill.py` | **SCAFFOLDED, NEVER RUN** (zero checkpoints, placeholder model names) |
+
+Ordering by cost is **measured**, not assumed: hint cache (≈free, reversible)
+< exemplar replay (cheap) < skill synthesis (moderate Claude cost) <
+distillation (expensive, durable). Cost per rung comes from `gym/cost_meter.py`
++ `observability/claude_cost_meter.py`.
+
+---
+
+## 2. Reward model (the Mantis advantage)
+
+- **Sealed oracle benchmark (ground truth):** `/__env__/oracle` + per-task
+  mutation-log graders in `deploy/sim_envs/*/app/oracles/`. Reads server DB
+  state, not the agent transcript.
+- **Cheap online proxy (noisy):** the LLM verifier —
+  `extraction/extractor.verify_gate`, `verification/step_verifier.py`,
+  `gym/failure_class.py`.
+- **Reward:** `R = Δ(oracle score) − λ·cost`, cost in dollars from the meters
+  above.
+- **Partial observability is literally measurable:** log oracle verdict vs
+  proxy verdict per step → false-pass / false-fail rates → PRM training data.
+
+---
+
+## 3. Heterogeneous eval, by construction
+
+The central claim (allocator beats any fixed substrate) is only meaningful if
+the best substrate genuinely varies. We construct three failure clusters in the
+white-box envs — we control the fixtures, so the heterogeneity is engineered,
+not hoped for:
+
+- **Knowledge gap** — the task answer is an indexable fact (a help-doc or
+  catalog row the agent must look up). **S0 should win.**
+- **Capability gap** — the task needs a multi-step macro the base agent fumbles
+  but a synthesized skill nails. **S2 should win.**
+- **Policy gap** — a recurring mis-handling (e.g. wrong-target click on a
+  drifting layout). **S1 early, S3 once frequent.**
+
+Envs: `mantis_crm` + `mantis_shop` for Phase 2–3; add `mantis_helpdesk` for a
+generalization check. Sealed/visible split via seeded DB; rotate the sealed set
+periodically. `failure_class.py` provides a starting *mechanical* signal, but
+clusters are defined at the **task** level, not by mechanical class.
+
+---
+
+## 4. Baselines & protocol
+
+- **Frozen** agent (lower reference).
+- **Fixed-substrate** policies: S0-only, S1-only, S2-only, S3-only.
+- **Learning Allocator** (ours).
+- **Oracle-allocator** — best substrate per signal (upper reference / headroom).
+
+All learning policies run under an **identical compute budget** `B`; report
+mean ± variance across seeds. Report the **visible − sealed** gap as the
+overfitting check.
+
+---
+
+## 5. Metrics & artifacts (Mantis-ified paper tables)
+
+- **Table 1** — sealed score, score/compute, visible−sealed, per policy.
+- **Table 2** — improvement-per-dollar, substrate × failure-cluster
+  (off-diagonal structure = premise holds; a flat matrix falsifies it).
+- **Fig 1** — oracle score vs **cumulative dollars** (not steps); allocator
+  tracking the oracle above all fixed substrates. *Headline.*
+- **Fig 2** — allocator selection distribution over time (shift
+  exemplar→skill→consolidation = the non-stationarity justification).
+- **Fig 3** — Table 2 heatmap.
+- **Fig 4** — budget frontier (final sealed score vs `B`).
+- **Fig 5** — visible vs sealed paired bars (overfitting check).
+- **Fig P (beyond the paper)** — proxy-vs-oracle calibration / attribution
+  noise per cluster; the PRM result.
+
+**Minimum reportable set** if compute compresses: Fig 1 + Fig 3 + Table 1
+(sealed column) + Fig P.
+
+---
+
+## 6. Phased plan (de-risked, cheap-first)
+
+| Phase | Goal | Why this order |
+|---|---|---|
+| **0 Foundations** | uniform substrate interface; failure-cluster eval; dual-reward wiring | nothing runs without the action space + a heterogeneous eval |
+| **1 Reward/PRM grounding** | measure oracle-vs-proxy noise; fit the PRM | cheapest, highest value-per-$, de-risks every later reward estimate |
+| **2 Two live substrates + allocator MVP** | S0 + S1 behind the interface; myopic bandit; partial Table 1 + Fig 1 | first real result using only LIVE substrates |
+| **3 S2 skill-synthesis substrate** | add S2; Table 2 off-diagonal | proves the heterogeneity premise |
+| **4 S3 weight consolidation** | **actually run** the distillation loop; full Table 1/2 + Fig 2 | the repo's long-deferred piece; the only path to the full 4-rung claim |
+| **5 Analysis & write-up** | overfitting/frontier/variance; second-vertical write-up | turns runs into the paper section |
+
+---
+
+## 7. Honest gating & risks
+
+- **S3 is the only rung never run in this repo** (zero checkpoints, placeholder
+  model names). Phases 0–3 produce a real **partial** result without it; the
+  **full** 4-substrate claim is gated on Phase 4 actually succeeding.
+- **Still single-domain.** This strengthens the paper as a *second* vertical;
+  it does not validate the voice/ASR claim.
+- **"Builds its own benchmark"** risk (paper §6) is mitigated by the sealed
+  split + oracle upper bound + determinism already tested in
+  `tests/sim_envs/*/test_oracle_determinism.py`.
+- The myopic bandit ignores **sequencing** — most importantly *when to
+  consolidate* (wait for enough exemplars before promoting to S3). Named as the
+  bandit→full-POMDP gap, not hidden.
+
+---
+
+## 8. File targets (where code lands)
+
+```
+src/mantis_agent/learning/
+  allocator.py                 # the myopic contextual bandit
+  reward.py                    # oracle + proxy reward, PRM
+  substrates/
+    base.py                    # LearningSubstrate protocol + SubstrateResult
+    retrieval.py               # S0  (wraps hint_memory / grounding_cache)
+    exemplar.py                # S1  (wraps trace_exporter + replay)
+    skill.py                   # S2  (wraps graph/learner + playbook)
+    consolidation.py           # S3  (wraps training/rollout_collector + distill)
+experiments/learning_allocator/
+  eval/                        # failure-cluster manifests + sealed split
+  results/                     # results.tsv, figures
+  WRITEUP.md                   # second-vertical paper section
+tests/learning/                # interface + bandit unit tests
+```

--- a/src/mantis_agent/learning/__init__.py
+++ b/src/mantis_agent/learning/__init__.py
@@ -1,0 +1,28 @@
+"""The Learning Allocator — budget-constrained substrate selection.
+
+An adaptation of *"The Learning Allocator: Continual Agent Improvement as
+Budget-Constrained Substrate Selection"* to the Mantis CUA testbed. See
+``experiments/learning_allocator/PLAN.md`` for the full design.
+
+The package has three parts, added across the phased plan:
+
+    substrates/   the uniform action space (the ladder S0→S3)   — P0/P2/P3/P4
+    reward.py     dual reward channels (oracle vs proxy)         — P0
+    allocator.py  the myopic contextual-bandit allocator         — P2
+
+Today only the substrate interface (``substrates/base.py``) is present.
+"""
+
+from .substrates.base import (
+    Durability,
+    LearningSubstrate,
+    SubstrateContext,
+    SubstrateResult,
+)
+
+__all__ = [
+    "Durability",
+    "LearningSubstrate",
+    "SubstrateContext",
+    "SubstrateResult",
+]

--- a/src/mantis_agent/learning/substrates/__init__.py
+++ b/src/mantis_agent/learning/substrates/__init__.py
@@ -1,0 +1,27 @@
+"""Substrate adapters — the rungs of the ladder S0→S3.
+
+Each adapter wraps an existing Mantis mechanism behind the uniform
+:class:`~mantis_agent.learning.substrates.base.LearningSubstrate` protocol so
+the allocator can compare them with one currency:
+
+    retrieval.py      S0  hint_memory / grounding_cache    (LIVE)
+    exemplar.py       S1  trace_exporter + replay          (replay TO BUILD)
+    skill.py          S2  graph/learner + playbook         (PARTIAL)
+    consolidation.py  S3  rollout_collector + distill      (NEVER RUN)
+
+Only :mod:`base` exists today; the adapters land per the P2–P4 issues.
+"""
+
+from .base import (
+    Durability,
+    LearningSubstrate,
+    SubstrateContext,
+    SubstrateResult,
+)
+
+__all__ = [
+    "Durability",
+    "LearningSubstrate",
+    "SubstrateContext",
+    "SubstrateResult",
+]

--- a/src/mantis_agent/learning/substrates/base.py
+++ b/src/mantis_agent/learning/substrates/base.py
@@ -1,0 +1,133 @@
+"""The uniform action space the Learning Allocator chooses over.
+
+Continual improvement, in the Learning Allocator framing, is a
+budget-constrained choice over a *ladder* of learning mechanisms ordered
+by cost and durability:
+
+    S0 retrieval / context   — cheap, reversible, lasts one task
+    S1 exemplar replay       — cheap, lasts a session
+    S2 skill / macro synth    — moderate, becomes reusable policy
+    S3 weight consolidation  — expensive, baked into the model
+
+The allocator must score every rung with the *same* currency
+(``R = Δscore − λ·cost``) before paying, then actually pay for the one it
+picks. That only works if every rung presents the same four-method shape.
+This module defines that shape — :class:`LearningSubstrate` — plus the
+two value types that cross the boundary (:class:`SubstrateContext` in,
+:class:`SubstrateResult` out) and the :class:`Durability` axis that orders
+the ladder. The concrete rungs live in sibling modules
+(``retrieval.py`` … ``consolidation.py``) and wrap mechanisms that already
+exist in the repo; they are added per the P2–P4 issues.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Protocol, runtime_checkable
+
+
+class Durability(str, Enum):
+    """How long a substrate's effect persists — the ladder's vertical axis.
+
+    Ordered cheapest/most-reversible first. The allocator uses durability
+    both to break cost ties (prefer the reversible rung when scores match)
+    and to justify the non-stationarity claim: as the agent matures the
+    optimal rung drifts *down* this list (ephemeral hint → durable weights).
+    """
+
+    EPHEMERAL = "ephemeral"   # S0: applies to the current task only
+    SESSION = "session"       # S1: persists within a run / session
+    POLICY = "policy"         # S2: a reusable macro across tasks
+    WEIGHTS = "weights"       # S3: consolidated into model parameters
+
+
+@dataclass
+class SubstrateContext:
+    """Read-only snapshot the allocator hands a substrate when it picks it.
+
+    A substrate reads this to decide *what* to retrieve / replay / synthesize
+    / distill. It is deliberately small and free of live handles — the
+    cost-estimate path must stay cheap enough to call for every candidate
+    rung on every task.
+    """
+
+    task_id: str
+    cluster: str | None = None
+    """Failure cluster this task belongs to: ``knowledge`` | ``capability``
+    | ``policy``. Drives which rung is expected to win (see PLAN §3)."""
+
+    failure_signal: dict[str, Any] = field(default_factory=dict)
+    """Coarse signal about the recurring failure (e.g. a ``failure_class``
+    tag, the offending step index, a layout-drift hint)."""
+
+    budget_remaining: float = 0.0
+    """Dollars left in the hard budget ``B``. A substrate may decline (return
+    an un-applied result) when its cost would blow the remaining budget."""
+
+    extras: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class SubstrateResult:
+    """The outcome of applying one substrate to one task.
+
+    ``delta_artifacts`` is whatever the substrate produced — a hint string,
+    an exemplar trace id, a synthesized playbook, a checkpoint path. The
+    allocator treats it opaquely; the run executor knows how to consume it.
+    ``applied=False`` means the substrate chose not to act (nothing to
+    retrieve, budget too tight) — distinct from acting and failing, and it
+    should incur ~no cost.
+    """
+
+    substrate: str
+    applied: bool
+    dollars_spent: float = 0.0
+    durability: Durability = Durability.EPHEMERAL
+    delta_artifacts: dict[str, Any] = field(default_factory=dict)
+    notes: str = ""
+
+
+@runtime_checkable
+class LearningSubstrate(Protocol):
+    """One rung of the cost/durability-ordered ladder S0→S3.
+
+    The allocator needs exactly four things from a rung: a stable
+    :attr:`name` to key its value estimates on, a *cheap* :meth:`cost_estimate`
+    so the bandit can score ``R = Δscore − λ·cost`` before paying,
+    :meth:`apply` to actually spend compute and produce a delta, and
+    :meth:`observe` to fold the realised reward back into whatever internal
+    state the rung keeps. Keeping the surface this small is what lets a
+    free hint cache and an expensive distillation run be compared head to
+    head by the same bandit.
+    """
+
+    name: str
+
+    def cost_estimate(self, context: SubstrateContext) -> float:
+        """Expected dollar cost of applying this substrate to ``context``.
+
+        Must be cheap — no network or model calls. The allocator invokes it
+        for every candidate rung on every task to rank them before paying.
+        """
+        ...
+
+    def apply(self, context: SubstrateContext) -> SubstrateResult:
+        """Spend compute and produce a delta artifact — the expensive call.
+
+        Invoked only for the rung the allocator chose. Implementations should
+        return ``applied=False`` (cheaply) rather than raise when there is
+        nothing to do for this ``context``.
+        """
+        ...
+
+    def observe(
+        self, context: SubstrateContext, result: SubstrateResult, reward: float
+    ) -> None:
+        """Fold the realised reward back in — the online-update hook.
+
+        Called after the run executor consumes ``result`` and the reward
+        channels score it. Stateless rungs may no-op; rungs that maintain
+        their own caches or value estimates update them here.
+        """
+        ...

--- a/tests/learning/test_substrate_interface.py
+++ b/tests/learning/test_substrate_interface.py
@@ -1,0 +1,127 @@
+"""Contract tests for the LearningSubstrate interface.
+
+These pin the shape the allocator depends on: a substrate is anything that
+carries a ``name`` and round-trips ``cost_estimate → apply → observe``. We
+verify the contract with a recording fake rather than a live rung, so the
+interface can be exercised before any real substrate exists.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from mantis_agent.learning import (
+    Durability,
+    LearningSubstrate,
+    SubstrateContext,
+    SubstrateResult,
+)
+
+
+@dataclass
+class RecordingSubstrate:
+    """Minimal in-memory rung that records what the allocator did to it.
+
+    Implements the :class:`LearningSubstrate` protocol structurally (no
+    inheritance) — which is exactly how the real adapters are written.
+    """
+
+    name: str = "mock"
+    unit_cost: float = 0.05
+    durability: Durability = Durability.EPHEMERAL
+    observed: list[tuple[str, float]] = field(default_factory=list)
+
+    def cost_estimate(self, context: SubstrateContext) -> float:
+        return self.unit_cost
+
+    def apply(self, context: SubstrateContext) -> SubstrateResult:
+        # Decline cheaply when the budget can't cover the spend.
+        if context.budget_remaining < self.unit_cost:
+            return SubstrateResult(
+                substrate=self.name, applied=False, notes="budget too tight"
+            )
+        return SubstrateResult(
+            substrate=self.name,
+            applied=True,
+            dollars_spent=self.unit_cost,
+            durability=self.durability,
+            delta_artifacts={"hint": f"for {context.task_id}"},
+        )
+
+    def observe(
+        self, context: SubstrateContext, result: SubstrateResult, reward: float
+    ) -> None:
+        self.observed.append((context.task_id, reward))
+
+
+def _ctx(**kw: Any) -> SubstrateContext:
+    base: dict[str, Any] = {"task_id": "bt01-0", "budget_remaining": 1.0}
+    base.update(kw)
+    return SubstrateContext(**base)
+
+
+def test_recording_substrate_satisfies_protocol() -> None:
+    sub = RecordingSubstrate()
+    # runtime_checkable Protocol — structural typing, no base class needed.
+    assert isinstance(sub, LearningSubstrate)
+
+
+def test_cost_estimate_is_cheap_scalar() -> None:
+    sub = RecordingSubstrate(unit_cost=0.05)
+    cost = sub.cost_estimate(_ctx())
+    assert isinstance(cost, float)
+    assert cost == 0.05
+
+
+def test_apply_produces_a_result_with_spend_and_artifacts() -> None:
+    sub = RecordingSubstrate(unit_cost=0.05)
+    result = sub.apply(_ctx(task_id="bt01-7"))
+    assert result.applied is True
+    assert result.substrate == "mock"
+    assert result.dollars_spent == 0.05
+    assert result.delta_artifacts == {"hint": "for bt01-7"}
+
+
+def test_apply_declines_when_budget_too_tight() -> None:
+    sub = RecordingSubstrate(unit_cost=0.50)
+    result = sub.apply(_ctx(budget_remaining=0.10))
+    assert result.applied is False
+    assert result.dollars_spent == 0.0  # declining costs nothing
+    assert "budget" in result.notes
+
+
+def test_observe_folds_reward_back_in() -> None:
+    sub = RecordingSubstrate()
+    ctx = _ctx(task_id="bt01-3")
+    result = sub.apply(ctx)
+    sub.observe(ctx, result, reward=0.42)
+    assert sub.observed == [("bt01-3", 0.42)]
+
+
+def test_substrate_result_defaults_are_conservative() -> None:
+    # A bare result is un-applied-cost-free-ephemeral: the safe default a
+    # rung returns when it has nothing to contribute.
+    r = SubstrateResult(substrate="s0", applied=False)
+    assert r.dollars_spent == 0.0
+    assert r.durability is Durability.EPHEMERAL
+    assert r.delta_artifacts == {}
+    assert r.notes == ""
+
+
+def test_substrate_context_defaults() -> None:
+    ctx = SubstrateContext(task_id="t")
+    assert ctx.cluster is None
+    assert ctx.failure_signal == {}
+    assert ctx.budget_remaining == 0.0
+    assert ctx.extras == {}
+
+
+def test_durability_orders_cheapest_first() -> None:
+    order = list(Durability)
+    assert order == [
+        Durability.EPHEMERAL,
+        Durability.SESSION,
+        Durability.POLICY,
+        Durability.WEIGHTS,
+    ]


### PR DESCRIPTION
## Summary
First release of the **Learning Allocator on Mantis** initiative (epic #732) — adapting *"The Learning Allocator: Continual Agent Improvement as Budget-Constrained Substrate Selection"* to Mantis as a second (visual) vertical.

This PR lands the **Phase 0 foundation**: the uniform action space the allocator will choose over, plus the full experiment plan.

- **`experiments/learning_allocator/PLAN.md`** — the design doc (adopt/adapt thesis, substrate ladder, dual-reward model, heterogeneous eval, phased plan, honest gating).
- **`src/mantis_agent/learning/substrates/base.py`** — `LearningSubstrate` protocol (`name` / `cost_estimate` / `apply` / `observe`), `SubstrateContext`, `SubstrateResult`, and the `Durability` axis (S0→S3).
- **`tests/learning/`** — 8 contract tests pinning the interface via a recording fake.

The four concrete rungs (retrieval/exemplar/skill/consolidation) wrap mechanisms that already exist in the repo and land in the P2–P4 PRs.

## Why this shape
The allocator must score a free hint cache and an expensive distillation run with the *same* currency (`R = Δscore − λ·cost`) before paying. That only works if every rung presents the same four-method surface — this PR defines that surface and nothing more.

## Test plan
- [x] `uv run pytest tests/learning/ -n0` — 8 passed
- [x] `uv run ruff check src/mantis_agent/learning/ tests/learning/` — clean
- [ ] CI green

Part of #732. Closes #733.

🤖 Generated with [Claude Code](https://claude.com/claude-code)