### PR TITLE
feat(learning): Phase 0b — dual reward channels + failure-cluster eval

### DIFF
--- a/experiments/learning_allocator/eval/clusters.json
+++ b/experiments/learning_allocator/eval/clusters.json
@@ -1,0 +1,54 @@
+{
+  "env": "mantis_boattrader",
+  "description": "Failure-cluster eval manifest for the Learning Allocator (PLAN §3). The allocator-beats-any-fixed-substrate claim is only meaningful if the winning substrate genuinely varies, so clusters are engineered, not hoped for. One real oracle (BT01) is wired across a visible/sealed seed split today; the knowledge + policy clusters are on the roadmap and need new oracles before they are runnable.",
+  "tasks": [
+    {
+      "name": "bt01_lead_capture_visible",
+      "task_id": "BT01_lead_capture_filtered_search",
+      "env": "mantis_boattrader",
+      "cluster": "capability",
+      "split": "visible",
+      "seed": 42,
+      "plan": "boattrader_scrape",
+      "expects_substrate": "S2",
+      "status": "ready",
+      "notes": "Multi-step macro: apply condition=used + make=Sea Ray + price_max=200000, click a matching listing, submit a clean dealer lead. Oracle = F1 over qualifying leads; pass = >=1 hit AND 0 misses. Capability gap: the base agent fumbles the multi-step filter+form macro."
+    },
+    {
+      "name": "bt01_lead_capture_sealed",
+      "task_id": "BT01_lead_capture_filtered_search",
+      "env": "mantis_boattrader",
+      "cluster": "capability",
+      "split": "sealed",
+      "seed": 7,
+      "plan": "boattrader_scrape",
+      "expects_substrate": "S2",
+      "status": "ready",
+      "notes": "Held-out instance: identical task graded against a different seeded catalog (seed=7). The visible-minus-sealed score gap is the overfitting check (PLAN §4)."
+    },
+    {
+      "name": "bt_help_doc_lookup",
+      "task_id": null,
+      "env": "mantis_boattrader",
+      "cluster": "knowledge",
+      "split": "visible",
+      "seed": 42,
+      "plan": null,
+      "expects_substrate": "S0",
+      "status": "needs_oracle",
+      "notes": "ROADMAP (needs a new oracle, BT02): the answer is an indexable fact — a help-doc or catalog spec row the agent must look up. S0 retrieval should win."
+    },
+    {
+      "name": "bt_byowner_drift",
+      "task_id": null,
+      "env": "mantis_boattrader",
+      "cluster": "policy",
+      "split": "visible",
+      "seed": 42,
+      "plan": null,
+      "expects_substrate": "S1",
+      "status": "needs_oracle",
+      "notes": "ROADMAP (needs a new oracle, BT03 + a layout-drift fixture): a recurring by-owner filter mis-click under layout drift. S1 exemplar early, S3 consolidation once the mis-handling is frequent."
+    }
+  ]
+}

--- a/src/mantis_agent/learning/__init__.py
+++ b/src/mantis_agent/learning/__init__.py
@@ -4,15 +4,24 @@ An adaptation of *"The Learning Allocator: Continual Agent Improvement as
 Budget-Constrained Substrate Selection"* to the Mantis CUA testbed. See
 ``experiments/learning_allocator/PLAN.md`` for the full design.
 
-The package has three parts, added across the phased plan:
+The package has these parts, added across the phased plan:
 
     substrates/   the uniform action space (the ladder S0→S3)   — P0/P2/P3/P4
-    reward.py     dual reward channels (oracle vs proxy)         — P0
+    reward.py     dual reward channels (oracle vs proxy)         — P0  (live)
+    eval.py       the heterogeneous failure-cluster eval         — P0  (live)
     allocator.py  the myopic contextual-bandit allocator         — P2
 
-Today only the substrate interface (``substrates/base.py``) is present.
+The substrate interface, reward channels, and eval scaffold are present; the
+concrete rungs and the allocator land in the P2–P4 PRs.
 """
 
+from .eval import EvalManifest, EvalTask, load_manifest
+from .reward import (
+    DEFAULT_LAMBDA,
+    RewardRecord,
+    compute_reward,
+    reward_from_run,
+)
 from .substrates.base import (
     Durability,
     LearningSubstrate,
@@ -21,8 +30,18 @@ from .substrates.base import (
 )
 
 __all__ = [
+    # substrates
     "Durability",
     "LearningSubstrate",
     "SubstrateContext",
     "SubstrateResult",
+    # reward
+    "DEFAULT_LAMBDA",
+    "RewardRecord",
+    "compute_reward",
+    "reward_from_run",
+    # eval
+    "EvalManifest",
+    "EvalTask",
+    "load_manifest",
 ]

--- a/src/mantis_agent/learning/eval.py
+++ b/src/mantis_agent/learning/eval.py
@@ -1,0 +1,163 @@
+"""Heterogeneous failure-cluster eval — engineered substrate heterogeneity.
+
+The allocator-beats-any-fixed-substrate claim is only meaningful if the best
+substrate genuinely *varies* across tasks. We don't hope for that — we engineer
+it, by binning tasks into three clusters (PLAN §3):
+
+    knowledge   — the answer is an indexable fact     → S0 (retrieval) should win
+    capability  — needs a multi-step macro            → S2 (skill synth) should win
+    policy      — recurring mis-handling under drift   → S1 early, S3 once frequent
+
+Each task names a real oracle ``task_id`` and a seeded env. The sealed/visible
+split (the overfitting check, PLAN §4) is by **seed**: the same task graded
+against a different seeded DB is a held-out instance. ``runnable`` filters to
+tasks whose oracle exists today — the manifest also carries roadmap entries
+(``status="needs_oracle"``) so the structure is honest about what is and isn't
+measurable yet.
+
+The manifest data lives next to the experiment, not in the package:
+``experiments/learning_allocator/eval/clusters.json``.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+CLUSTERS = ("knowledge", "capability", "policy")
+SPLITS = ("visible", "sealed")
+STATUSES = ("ready", "needs_oracle")
+
+# experiments/learning_allocator/eval/clusters.json, relative to the repo root
+# (this file is src/mantis_agent/learning/eval.py → up 4 to the repo root).
+DEFAULT_MANIFEST_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "experiments"
+    / "learning_allocator"
+    / "eval"
+    / "clusters.json"
+)
+
+
+@dataclass(frozen=True)
+class EvalTask:
+    """One row of the failure-cluster eval.
+
+    ``task_id`` is the oracle id (``None`` until an oracle is built).
+    ``expects_substrate`` is the *hypothesis* — which rung should win this
+    cluster — not a constraint; the experiment is what confirms or falsifies it.
+    """
+
+    name: str
+    cluster: str
+    split: str
+    seed: int
+    env: str = "mantis_boattrader"
+    task_id: str | None = None
+    plan: str | None = None
+    expects_substrate: str = ""
+    status: str = "needs_oracle"
+    notes: str = ""
+
+    @property
+    def runnable(self) -> bool:
+        """True when this task can actually be graded today."""
+        return self.status == "ready" and bool(self.task_id)
+
+
+@dataclass
+class EvalManifest:
+    """The set of failure-cluster tasks + convenience views over it."""
+
+    env: str
+    tasks: list[EvalTask] = field(default_factory=list)
+    description: str = ""
+
+    def by_cluster(self, cluster: str) -> list[EvalTask]:
+        return [t for t in self.tasks if t.cluster == cluster]
+
+    def by_split(self, split: str) -> list[EvalTask]:
+        return [t for t in self.tasks if t.split == split]
+
+    def visible(self) -> list[EvalTask]:
+        return self.by_split("visible")
+
+    def sealed(self) -> list[EvalTask]:
+        return self.by_split("sealed")
+
+    def runnable(self) -> list[EvalTask]:
+        """Tasks whose oracle exists — the subset measurable right now."""
+        return [t for t in self.tasks if t.runnable]
+
+    def clusters_covered(self) -> set[str]:
+        """Clusters that have at least one runnable task."""
+        return {t.cluster for t in self.runnable()}
+
+
+def _validate(task: EvalTask) -> None:
+    if task.cluster not in CLUSTERS:
+        raise ValueError(
+            f"task {task.name!r}: unknown cluster {task.cluster!r} "
+            f"(expected one of {CLUSTERS})"
+        )
+    if task.split not in SPLITS:
+        raise ValueError(
+            f"task {task.name!r}: unknown split {task.split!r} "
+            f"(expected one of {SPLITS})"
+        )
+    if task.status not in STATUSES:
+        raise ValueError(
+            f"task {task.name!r}: unknown status {task.status!r} "
+            f"(expected one of {STATUSES})"
+        )
+    if task.status == "ready" and not task.task_id:
+        raise ValueError(
+            f"task {task.name!r}: status 'ready' but no task_id — a runnable "
+            f"task must name an oracle"
+        )
+
+
+def load_manifest(path: str | Path | None = None) -> EvalManifest:
+    """Load + validate the failure-cluster manifest from JSON.
+
+    Fails fast with a descriptive error on an unknown cluster/split/status —
+    a typo in the manifest should not silently drop a task from the eval.
+    """
+    p = Path(path) if path is not None else DEFAULT_MANIFEST_PATH
+    raw: dict[str, Any] = json.loads(p.read_text())
+
+    tasks: list[EvalTask] = []
+    for entry in raw.get("tasks", []):
+        task = EvalTask(
+            name=entry["name"],
+            cluster=entry["cluster"],
+            split=entry["split"],
+            seed=int(entry["seed"]),
+            env=entry.get("env", raw.get("env", "mantis_boattrader")),
+            task_id=entry.get("task_id"),
+            plan=entry.get("plan"),
+            expects_substrate=entry.get("expects_substrate", ""),
+            status=entry.get("status", "needs_oracle"),
+            notes=entry.get("notes", ""),
+        )
+        _validate(task)
+        tasks.append(task)
+
+    return EvalManifest(
+        env=raw.get("env", "mantis_boattrader"),
+        tasks=tasks,
+        description=raw.get("description", ""),
+    )
+
+
+__all__ = [
+    "CLUSTERS",
+    "SPLITS",
+    "STATUSES",
+    "DEFAULT_MANIFEST_PATH",
+    "EvalTask",
+    "EvalManifest",
+    "load_manifest",
+]

--- a/src/mantis_agent/learning/reward.py
+++ b/src/mantis_agent/learning/reward.py
@@ -1,0 +1,197 @@
+"""Dual reward channels — the Mantis advantage over the paper's testbed.
+
+The Learning Allocator paper has a noisy reward (ASR-attributed success) but
+*no ground truth to measure the noise against*. Mantis ships both:
+
+* an expensive **accurate oracle** — the sim-env mutation-log grader, reached
+  via ``GET /__env__/oracle?task_id=<id>`` (``gym.grading.grade_run``). It reads
+  server DB state, not the agent transcript, so it is the ground truth.
+* a cheap **noisy proxy** — the LLM verifier (``DynamicPlanVerifier``), whose
+  verdict rides on a completed run's ``dynamic_verification_summary``.
+
+Pairing the two lets us do two things the paper cannot:
+
+1. **Quantify partial observability** — log oracle verdict vs proxy verdict per
+   task → false-pass / false-fail rates (the Fig P / PRM training data).
+2. **Score the reward** the allocator optimises: ``R = oracle_score − λ·cost``,
+   cost in dollars from the run's cost meter.
+
+This module is deliberately split into *pure* combinators (testable without a
+network) and thin *channel readers* that pull each signal from its source.
+``reward_from_run`` ties them together for a completed run.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from ..gym.grading import GradingResult, grade_run
+
+# Cost coefficient λ in ``R = oracle_score − λ·cost``. A tunable knob, not a
+# law: at λ=0.1 a dollar of spend is worth 0.1 of oracle score (scores live in
+# 0..1), so a ~$1 run trades against a 0.1 score gain. Sweeping λ is what the
+# budget-frontier figure (Fig 4) does; this is the default working point.
+DEFAULT_LAMBDA = 0.1
+
+# Map the proxy's categorical verdict onto the oracle's 0..1 scale so the two
+# channels are comparable. ``partial`` is the verifier hedging — half credit.
+_PROXY_SCORE: dict[str, float] = {
+    "pass": 1.0,
+    "partial": 0.5,
+    "fail": 0.0,
+    "unknown": 0.0,
+}
+
+
+def proxy_score(verdict: str | None) -> float:
+    """Map a proxy verdict (``pass``/``partial``/``fail``) to a 0..1 score."""
+    return _PROXY_SCORE.get((verdict or "unknown").strip().lower(), 0.0)
+
+
+@dataclass
+class RewardRecord:
+    """One task's dual-channel reward + the paired labels for noise analysis.
+
+    ``reward`` is the *absolute* working reward ``oracle_score − λ·dollars``.
+    The allocator turns this into the paper's ``Δscore − λ·cost`` by
+    subtracting a frozen-baseline record's ``oracle_score`` — kept out of here
+    so this stays a pure per-run measurement.
+    """
+
+    task_id: str
+    oracle_score: float
+    oracle_passed: bool
+    proxy_verdict: str
+    proxy_score: float
+    dollars: float
+    reward: float
+    # Attribution-noise labels (proxy vs ground truth) — feed Fig P / the PRM.
+    false_pass: bool  # proxy said pass, oracle says the task failed
+    false_fail: bool  # proxy said fail, oracle says the task passed
+    oracle_error: str | None = None
+    notes: str = ""
+    extras: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        from dataclasses import asdict
+
+        return asdict(self)
+
+
+def compute_reward(
+    *,
+    task_id: str,
+    oracle_score: float,
+    oracle_passed: bool,
+    proxy_verdict: str | None,
+    dollars: float,
+    lam: float = DEFAULT_LAMBDA,
+    oracle_error: str | None = None,
+    extras: dict[str, Any] | None = None,
+) -> RewardRecord:
+    """Combine the two channels + cost into a :class:`RewardRecord` (pure).
+
+    No network, no run-result parsing — just the arithmetic and the
+    paired-label bookkeeping. The channel readers below feed this.
+    """
+    verdict = (proxy_verdict or "unknown").strip().lower()
+    p_score = proxy_score(verdict)
+    reward = oracle_score - lam * dollars
+
+    false_pass = verdict == "pass" and not oracle_passed
+    false_fail = verdict == "fail" and oracle_passed
+
+    return RewardRecord(
+        task_id=task_id,
+        oracle_score=round(float(oracle_score), 4),
+        oracle_passed=bool(oracle_passed),
+        proxy_verdict=verdict,
+        proxy_score=p_score,
+        dollars=round(float(dollars), 4),
+        reward=round(reward, 4),
+        false_pass=false_pass,
+        false_fail=false_fail,
+        oracle_error=oracle_error,
+        extras=extras or {},
+    )
+
+
+# ── Channel readers ────────────────────────────────────────────────────────
+
+
+def oracle_channel(env_url: str, admin_token: str, task_id: str) -> GradingResult:
+    """Ground-truth channel: grade the env's DB state via the oracle endpoint.
+
+    Thin wrapper over :func:`gym.grading.grade_run` — kept here so callers in
+    the learning package have one import surface and so the live oracle call
+    is trivially swappable in tests.
+    """
+    return grade_run(env_url, admin_token, task_id)
+
+
+def proxy_channel(run_result: dict[str, Any]) -> str:
+    """Noisy channel: pull the LLM-verifier verdict off a completed run.
+
+    Reads ``run_result["dynamic_verification_summary"]["verdict"]``. Returns
+    ``"unknown"`` when the run carried no verifier summary (e.g. verification
+    disabled) rather than guessing.
+    """
+    summary = run_result.get("dynamic_verification_summary") or {}
+    if not isinstance(summary, dict):
+        return "unknown"
+    verdict = summary.get("verdict")
+    return str(verdict).strip().lower() if verdict else "unknown"
+
+
+def cost_channel(run_result: dict[str, Any]) -> float:
+    """Cost channel: total dollars for the run from its cost meter.
+
+    Reads ``run_result["costs"]["total"]``. Returns ``0.0`` when absent.
+    """
+    costs = run_result.get("costs") or {}
+    if not isinstance(costs, dict):
+        return 0.0
+    try:
+        return float(costs.get("total") or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def reward_from_run(
+    *,
+    env_url: str,
+    admin_token: str,
+    task_id: str,
+    run_result: dict[str, Any],
+    lam: float = DEFAULT_LAMBDA,
+) -> RewardRecord:
+    """End-to-end per-run reward: grade the env, read proxy + cost off the run.
+
+    The oracle is queried live (DB ground truth); the proxy verdict and dollar
+    cost are read from the already-returned ``run_result`` dict (the
+    ``build_micro_result`` payload from the Modal CUA server).
+    """
+    graded = oracle_channel(env_url, admin_token, task_id)
+    return compute_reward(
+        task_id=task_id,
+        oracle_score=graded.score,
+        oracle_passed=graded.passed,
+        proxy_verdict=proxy_channel(run_result),
+        dollars=cost_channel(run_result),
+        lam=lam,
+        oracle_error=graded.error,
+        extras={"oracle_reasons": graded.reasons, "oracle_diff": graded.diff},
+    )
+
+
+__all__ = [
+    "DEFAULT_LAMBDA",
+    "RewardRecord",
+    "proxy_score",
+    "compute_reward",
+    "oracle_channel",
+    "proxy_channel",
+    "cost_channel",
+    "reward_from_run",
+]

--- a/tests/learning/test_eval_manifest.py
+++ b/tests/learning/test_eval_manifest.py
@@ -1,0 +1,121 @@
+"""Tests for the failure-cluster eval manifest loader + views.
+
+The default manifest (``experiments/learning_allocator/eval/clusters.json``)
+is loaded as-is so the shipped data stays valid; synthetic manifests exercise
+the validation and the runnable/sealed filters.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from mantis_agent.learning.eval import (
+    CLUSTERS,
+    EvalManifest,
+    EvalTask,
+    load_manifest,
+)
+
+
+# ── the shipped manifest ───────────────────────────────────────────────
+
+
+def test_default_manifest_loads_and_validates() -> None:
+    m = load_manifest()
+    assert isinstance(m, EvalManifest)
+    assert m.env == "mantis_boattrader"
+    assert len(m.tasks) >= 1
+
+
+def test_default_manifest_has_a_runnable_capability_task() -> None:
+    m = load_manifest()
+    runnable = m.runnable()
+    assert runnable, "expected at least one runnable task in the shipped manifest"
+    assert all(t.task_id for t in runnable)
+    # BT01 is the wired oracle today.
+    assert any(t.task_id == "BT01_lead_capture_filtered_search" for t in runnable)
+
+
+def test_default_manifest_has_a_visible_sealed_pair() -> None:
+    m = load_manifest()
+    assert m.visible(), "expected a visible split"
+    assert m.sealed(), "expected a sealed split (the overfitting check)"
+    # visible and sealed should differ by seed for the same task_id.
+    vis = {t.task_id: t.seed for t in m.visible() if t.task_id}
+    seal = {t.task_id: t.seed for t in m.sealed() if t.task_id}
+    shared = set(vis) & set(seal)
+    assert shared, "expected a task present in both splits"
+    assert all(vis[k] != seal[k] for k in shared), "splits must differ by seed"
+
+
+def test_roadmap_clusters_are_present_but_not_runnable() -> None:
+    m = load_manifest()
+    # knowledge + policy are on the roadmap (needs_oracle) — present in the
+    # taxonomy but excluded from runnable until an oracle exists.
+    all_clusters = {t.cluster for t in m.tasks}
+    assert {"knowledge", "policy"} <= all_clusters
+    needs_oracle = [t for t in m.tasks if not t.runnable]
+    assert needs_oracle
+    assert all(t.status == "needs_oracle" for t in needs_oracle)
+
+
+# ── views ──────────────────────────────────────────────────────────────
+
+
+def _manifest() -> EvalManifest:
+    return EvalManifest(
+        env="mantis_boattrader",
+        tasks=[
+            EvalTask(name="a", cluster="capability", split="visible", seed=42,
+                     task_id="BT01", status="ready"),
+            EvalTask(name="b", cluster="capability", split="sealed", seed=7,
+                     task_id="BT01", status="ready"),
+            EvalTask(name="c", cluster="knowledge", split="visible", seed=42,
+                     status="needs_oracle"),
+        ],
+    )
+
+
+def test_by_cluster_and_split_views() -> None:
+    m = _manifest()
+    assert len(m.by_cluster("capability")) == 2
+    assert len(m.by_cluster("knowledge")) == 1
+    assert len(m.visible()) == 2
+    assert len(m.sealed()) == 1
+
+
+def test_runnable_excludes_needs_oracle() -> None:
+    m = _manifest()
+    assert {t.name for t in m.runnable()} == {"a", "b"}
+    assert m.clusters_covered() == {"capability"}
+
+
+# ── validation ─────────────────────────────────────────────────────────
+
+
+def test_load_rejects_unknown_cluster(tmp_path) -> None:
+    bad = tmp_path / "bad.json"
+    bad.write_text(json.dumps({
+        "env": "mantis_boattrader",
+        "tasks": [{"name": "x", "cluster": "nonsense", "split": "visible",
+                   "seed": 42, "status": "needs_oracle"}],
+    }))
+    with pytest.raises(ValueError, match="unknown cluster"):
+        load_manifest(bad)
+
+
+def test_load_rejects_ready_without_task_id(tmp_path) -> None:
+    bad = tmp_path / "bad.json"
+    bad.write_text(json.dumps({
+        "env": "mantis_boattrader",
+        "tasks": [{"name": "x", "cluster": "capability", "split": "visible",
+                   "seed": 42, "status": "ready"}],
+    }))
+    with pytest.raises(ValueError, match="no task_id"):
+        load_manifest(bad)
+
+
+def test_known_clusters_constant() -> None:
+    assert CLUSTERS == ("knowledge", "capability", "policy")

--- a/tests/learning/test_reward.py
+++ b/tests/learning/test_reward.py
@@ -1,0 +1,188 @@
+"""Tests for the dual reward channels (oracle vs proxy + cost).
+
+The pure combinators are tested directly; the live oracle call inside
+``reward_from_run`` is exercised with ``grade_run`` monkeypatched, so no env
+boots.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mantis_agent.gym.grading import GradingResult
+from mantis_agent.learning import reward as R
+
+
+# ── proxy_score ────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "verdict,expected",
+    [
+        ("pass", 1.0),
+        ("PASS", 1.0),
+        ("partial", 0.5),
+        ("fail", 0.0),
+        ("unknown", 0.0),
+        (None, 0.0),
+        ("garbage", 0.0),
+    ],
+)
+def test_proxy_score_mapping(verdict, expected) -> None:
+    assert R.proxy_score(verdict) == expected
+
+
+# ── compute_reward arithmetic ──────────────────────────────────────────
+
+
+def test_reward_is_score_minus_lambda_cost() -> None:
+    rec = R.compute_reward(
+        task_id="t",
+        oracle_score=0.8,
+        oracle_passed=True,
+        proxy_verdict="pass",
+        dollars=2.0,
+        lam=0.1,
+    )
+    # 0.8 − 0.1*2.0 = 0.6
+    assert rec.reward == 0.6
+    assert rec.oracle_score == 0.8
+    assert rec.proxy_score == 1.0
+    assert rec.dollars == 2.0
+
+
+def test_default_lambda_used_when_unspecified() -> None:
+    rec = R.compute_reward(
+        task_id="t",
+        oracle_score=1.0,
+        oracle_passed=True,
+        proxy_verdict="pass",
+        dollars=1.0,
+    )
+    assert rec.reward == round(1.0 - R.DEFAULT_LAMBDA * 1.0, 4)
+
+
+# ── attribution-noise labels (the Fig P signal) ────────────────────────
+
+
+def test_false_pass_when_proxy_optimistic() -> None:
+    # proxy says pass, oracle says the task failed → false pass
+    rec = R.compute_reward(
+        task_id="t",
+        oracle_score=0.0,
+        oracle_passed=False,
+        proxy_verdict="pass",
+        dollars=0.5,
+    )
+    assert rec.false_pass is True
+    assert rec.false_fail is False
+
+
+def test_false_fail_when_proxy_pessimistic() -> None:
+    # proxy says fail, oracle says it passed → false fail
+    rec = R.compute_reward(
+        task_id="t",
+        oracle_score=1.0,
+        oracle_passed=True,
+        proxy_verdict="fail",
+        dollars=0.5,
+    )
+    assert rec.false_fail is True
+    assert rec.false_pass is False
+
+
+def test_agreement_sets_no_noise_flags() -> None:
+    rec = R.compute_reward(
+        task_id="t",
+        oracle_score=1.0,
+        oracle_passed=True,
+        proxy_verdict="pass",
+        dollars=0.0,
+    )
+    assert rec.false_pass is False
+    assert rec.false_fail is False
+
+
+def test_partial_verdict_is_not_a_clean_pass_or_fail() -> None:
+    # 'partial' is the verifier hedging — it should not trip either label.
+    rec = R.compute_reward(
+        task_id="t",
+        oracle_score=0.0,
+        oracle_passed=False,
+        proxy_verdict="partial",
+        dollars=0.0,
+    )
+    assert rec.false_pass is False
+    assert rec.false_fail is False
+    assert rec.proxy_score == 0.5
+
+
+# ── channel readers ────────────────────────────────────────────────────
+
+
+def test_proxy_channel_reads_verdict() -> None:
+    run = {"dynamic_verification_summary": {"verdict": "Pass"}}
+    assert R.proxy_channel(run) == "pass"
+
+
+def test_proxy_channel_missing_summary_is_unknown() -> None:
+    assert R.proxy_channel({}) == "unknown"
+    assert R.proxy_channel({"dynamic_verification_summary": None}) == "unknown"
+    assert R.proxy_channel({"dynamic_verification_summary": {}}) == "unknown"
+
+
+def test_cost_channel_reads_total() -> None:
+    assert R.cost_channel({"costs": {"total": 1.23}}) == 1.23
+
+
+def test_cost_channel_absent_is_zero() -> None:
+    assert R.cost_channel({}) == 0.0
+    assert R.cost_channel({"costs": None}) == 0.0
+    assert R.cost_channel({"costs": {"total": None}}) == 0.0
+
+
+# ── reward_from_run (oracle mocked) ────────────────────────────────────
+
+
+def test_reward_from_run_ties_channels_together(monkeypatch) -> None:
+    def fake_grade(env_url, admin_token, task_id, **kw):
+        return GradingResult(
+            task_id=task_id, passed=True, score=0.9, reasons=["ok"], diff={"hits": 3}
+        )
+
+    monkeypatch.setattr(R, "grade_run", fake_grade)
+
+    run_result = {
+        "dynamic_verification_summary": {"verdict": "pass"},
+        "costs": {"total": 1.0},
+    }
+    rec = R.reward_from_run(
+        env_url="https://env.example",
+        admin_token="tok",
+        task_id="BT01_lead_capture_filtered_search",
+        run_result=run_result,
+        lam=0.1,
+    )
+    assert rec.oracle_score == 0.9
+    assert rec.oracle_passed is True
+    assert rec.proxy_verdict == "pass"
+    assert rec.dollars == 1.0
+    assert rec.reward == round(0.9 - 0.1 * 1.0, 4)
+    assert rec.extras["oracle_diff"] == {"hits": 3}
+
+
+def test_reward_from_run_surfaces_oracle_error(monkeypatch) -> None:
+    def fake_grade(env_url, admin_token, task_id, **kw):
+        return GradingResult(task_id=task_id, error="oracle network error")
+
+    monkeypatch.setattr(R, "grade_run", fake_grade)
+
+    rec = R.reward_from_run(
+        env_url="https://env.example",
+        admin_token="tok",
+        task_id="BT01_lead_capture_filtered_search",
+        run_result={"costs": {"total": 0.2}},
+    )
+    assert rec.oracle_error == "oracle network error"
+    assert rec.oracle_score == 0.0
+    assert rec.proxy_verdict == "unknown"


### PR DESCRIPTION
## Summary
Phase 0b of the **Learning Allocator on Mantis** epic (#732). Lands the two remaining P0 deliverables — the reward signal the allocator optimises and the eval it runs on.

> Stacked on #749 (Phase 0a). Base branch is `feat/learning-allocator-phase0`; will retarget to `main` once #749 merges.

### `reward.py` — dual reward channels (Mantis's edge over the paper)
The paper has a noisy reward but no ground truth to measure the noise against. Mantis has both:
- **oracle** (ground truth): `grade_run` → F1 `score` + `passed`, reading server DB state.
- **proxy** (cheap, noisy): the LLM verifier's `dynamic_verification_summary.verdict`.
- **cost**: `costs.total` USD off the run.

Computes `R = oracle_score − λ·cost` and the **false-pass / false-fail** labels that feed the attribution-noise study (Fig P) and the PRM (#736/#737). Pure combinators + thin channel readers; the live oracle call is monkeypatched in tests.

### `eval.py` + `eval/clusters.json` — failure-cluster eval scaffold
- The **knowledge / capability / policy** cluster taxonomy (PLAN §3).
- A seed-based **visible/sealed split** — the overfitting check (PLAN §4).
- A validating loader (fails fast on a bad cluster/split/status).
- **BT01** wired as the capability cluster across a visible (seed 42) / sealed (seed 7) pair.
- The knowledge + policy clusters are carried as `needs_oracle` roadmap entries — they need new graders (BT02/BT03) before Phase 3's Table 2 (#743). The manifest is self-documenting about what's measurable today.

## Test plan
- [x] `uv run pytest tests/learning/ -n0` — 36 passed
- [x] `uv run ruff check src/mantis_agent/learning/ tests/learning/` — clean
- [ ] CI green

Part of #732. Closes #734. Closes #735.

🤖 Generated with [Claude Code](https://claude.com/claude-code)