### PR TITLE
feat(learning): S0/S1 substrate adapters + myopic bandit allocator (P2)

### DIFF
--- a/src/mantis_agent/learning/__init__.py
+++ b/src/mantis_agent/learning/__init__.py
@@ -9,12 +9,18 @@ The package has these parts, added across the phased plan:
     substrates/   the uniform action space (the ladder S0→S3)   — P0/P2/P3/P4
     reward.py     dual reward channels (oracle vs proxy)         — P0  (live)
     eval.py       the heterogeneous failure-cluster eval         — P0  (live)
-    allocator.py  the myopic contextual-bandit allocator         — P2
+    allocator.py  the myopic contextual-bandit allocator         — P2  (live)
 
-The substrate interface, reward channels, and eval scaffold are present; the
-concrete rungs and the allocator land in the P2–P4 PRs.
+The interface, reward channels, eval scaffold, the S0/S1 rungs, and the
+allocator are present; the S2/S3 rungs land in the P3–P4 PRs.
 """
 
+from .allocator import (
+    AllocationRecord,
+    MyopicAllocator,
+    SubstrateChoice,
+    ValueEstimate,
+)
 from .eval import EvalManifest, EvalTask, load_manifest
 from .reward import (
     DEFAULT_LAMBDA,
@@ -28,6 +34,8 @@ from .substrates.base import (
     SubstrateContext,
     SubstrateResult,
 )
+from .substrates.exemplar import ExemplarSubstrate
+from .substrates.retrieval import RetrievalSubstrate
 
 __all__ = [
     # substrates
@@ -35,6 +43,13 @@ __all__ = [
     "LearningSubstrate",
     "SubstrateContext",
     "SubstrateResult",
+    "RetrievalSubstrate",
+    "ExemplarSubstrate",
+    # allocator
+    "MyopicAllocator",
+    "SubstrateChoice",
+    "AllocationRecord",
+    "ValueEstimate",
     # reward
     "DEFAULT_LAMBDA",
     "RewardRecord",

--- a/src/mantis_agent/learning/allocator.py
+++ b/src/mantis_agent/learning/allocator.py
@@ -1,0 +1,266 @@
+"""The myopic contextual-bandit allocator (PLAN §5).
+
+The decision layer that makes "continual improvement" a *budget-constrained
+choice* rather than a fixed pipeline. On each task it scores every
+affordable rung of the substrate ladder (S0→S3) with one currency —
+``R = Δscore − λ·cost`` — picks one, applies it, then folds the realised
+reward back into a per-``(cluster, substrate)`` value estimate.
+
+It is deliberately **myopic** (the paper's framing): a one-step contextual
+bandit, not a planner. The "context" is the task's failure cluster
+(``knowledge`` | ``capability`` | ``policy``); the "arms" are the
+substrates. Two properties the experiment leans on fall out of this design:
+
+* **Beats any fixed substrate** — because the value table is per-cluster,
+  the allocator can learn S0 wins ``knowledge`` while S2 wins
+  ``capability``, which no single fixed rung can match (Table 1 / Fig 1).
+* **Tracks non-stationarity** — :attr:`timeline` records every decision in
+  order, so the drift of the winning rung as the agent matures is directly
+  plottable (Fig 2).
+
+Exploration is ε-greedy with an *explore-unknown-first* warm-up: until a
+``(cluster, substrate)`` cell has been tried once, it is preferred over
+exploitation, so every affordable rung gets at least one real pull before
+the bandit settles. Ties (equal value, or the all-zero warm-up) break
+toward the cheaper, more reversible rung — the durability ordering the
+ladder is built on.
+"""
+
+from __future__ import annotations
+
+import random
+from collections import Counter
+from dataclasses import dataclass
+
+from .reward import DEFAULT_LAMBDA
+from .substrates.base import (
+    Durability,
+    LearningSubstrate,
+    SubstrateContext,
+    SubstrateResult,
+)
+
+# Cheaper / more reversible first. Used to break value ties (and to order
+# the warm-up over untried arms) toward the bottom of the ladder.
+_DURABILITY_RANK: dict[Durability, int] = {
+    Durability.EPHEMERAL: 0,
+    Durability.SESSION: 1,
+    Durability.POLICY: 2,
+    Durability.WEIGHTS: 3,
+}
+
+
+@dataclass
+class ValueEstimate:
+    """Running mean reward for one ``(cluster, substrate)`` cell."""
+
+    count: int = 0
+    mean: float = 0.0
+
+    def update(self, reward: float) -> None:
+        self.count += 1
+        # Incremental mean — no need to retain the sample history.
+        self.mean += (reward - self.mean) / self.count
+
+
+@dataclass
+class AllocationRecord:
+    """One decision the allocator made — the unit of :attr:`timeline`."""
+
+    index: int
+    cluster: str
+    substrate: str
+    reason: str  # "explore" | "exploit" | "explore-unknown"
+    value_estimate: float
+    cost_estimate: float
+
+
+@dataclass
+class SubstrateChoice:
+    """The rung the allocator picked, plus why — returned by :meth:`choose`."""
+
+    substrate: LearningSubstrate
+    value_estimate: float
+    cost_estimate: float
+    reason: str
+
+    @property
+    def name(self) -> str:
+        return self.substrate.name
+
+
+class MyopicAllocator:
+    """ε-greedy contextual bandit over the substrate ladder.
+
+    Construct with the rungs to choose among; the allocator keeps a value
+    table keyed on ``(cluster, substrate.name)`` and updated through
+    :meth:`observe`. ``rng`` is injectable so tests are deterministic.
+    """
+
+    def __init__(
+        self,
+        substrates: list[LearningSubstrate],
+        *,
+        lam: float = DEFAULT_LAMBDA,
+        epsilon: float = 0.1,
+        rng: random.Random | None = None,
+    ) -> None:
+        if not substrates:
+            raise ValueError("MyopicAllocator needs at least one substrate")
+        self.substrates = list(substrates)
+        self._by_name = {s.name: s for s in self.substrates}
+        if len(self._by_name) != len(self.substrates):
+            raise ValueError("substrate names must be unique")
+        self.lam = float(lam)
+        self.epsilon = float(epsilon)
+        self._rng = rng or random.Random()
+        self._values: dict[tuple[str, str], ValueEstimate] = {}
+        self._timeline: list[AllocationRecord] = []
+        self._n = 0
+
+    # ── value table ─────────────────────────────────────────────────────
+
+    @staticmethod
+    def _key(cluster: str | None, name: str) -> tuple[str, str]:
+        return (cluster or "", name)
+
+    def value_of(self, cluster: str | None, name: str) -> float:
+        v = self._values.get(self._key(cluster, name))
+        return v.mean if v else 0.0
+
+    def count_of(self, cluster: str | None, name: str) -> int:
+        v = self._values.get(self._key(cluster, name))
+        return v.count if v else 0
+
+    # ── choice ──────────────────────────────────────────────────────────
+
+    def _affordable(
+        self, context: SubstrateContext,
+    ) -> list[tuple[LearningSubstrate, float]]:
+        """Rungs whose cost estimate fits the remaining budget."""
+        out: list[tuple[LearningSubstrate, float]] = []
+        for s in self.substrates:
+            cost = float(s.cost_estimate(context))
+            if cost <= context.budget_remaining + 1e-9:
+                out.append((s, cost))
+        return out
+
+    def choose(self, context: SubstrateContext) -> SubstrateChoice | None:
+        """Pick a rung for ``context``. ``None`` when nothing is affordable.
+
+        ε-greedy with explore-unknown-first warm-up. Records the decision
+        on :attr:`timeline` either way.
+        """
+        affordable = self._affordable(context)
+        if not affordable:
+            return None
+        cluster = context.cluster or ""
+
+        if self._rng.random() < self.epsilon:
+            substrate, cost = self._rng.choice(affordable)
+            reason = "explore"
+        else:
+            untried = [
+                (s, c) for (s, c) in affordable
+                if self.count_of(cluster, s.name) == 0
+            ]
+            pool = untried or affordable
+            reason = "explore-unknown" if untried else "exploit"
+            substrate, cost = min(pool, key=lambda item: self._rank(cluster, item))
+
+        value = self.value_of(cluster, substrate.name)
+        self._n += 1
+        self._timeline.append(
+            AllocationRecord(
+                index=self._n,
+                cluster=cluster,
+                substrate=substrate.name,
+                reason=reason,
+                value_estimate=value,
+                cost_estimate=cost,
+            )
+        )
+        return SubstrateChoice(substrate, value, cost, reason)
+
+    def _rank(
+        self, cluster: str, item: tuple[LearningSubstrate, float],
+    ) -> tuple[float, int, float, str]:
+        """Sort key for the greedy pick — ``min`` over this picks the
+        winner. Highest value first (negated), then the cheaper / more
+        reversible rung on a tie. For untried arms every value is 0.0, so
+        the warm-up falls through to the durability + cost ordering."""
+        substrate, cost = item
+        value = self.value_of(cluster, substrate.name)
+        durability = getattr(substrate, "durability", Durability.EPHEMERAL)
+        return (-value, _DURABILITY_RANK.get(durability, 0), cost, substrate.name)
+
+    def allocate(
+        self, context: SubstrateContext,
+    ) -> tuple[SubstrateChoice, SubstrateResult] | None:
+        """Choose a rung *and* apply it — the orchestrator's one-call path.
+
+        Returns the ``(choice, result)`` pair, or ``None`` when nothing was
+        affordable. The caller runs the plan, scores the reward channels,
+        then hands the reward back via :meth:`observe`.
+        """
+        choice = self.choose(context)
+        if choice is None:
+            return None
+        result = choice.substrate.apply(context)
+        return choice, result
+
+    # ── update ──────────────────────────────────────────────────────────
+
+    def observe(
+        self,
+        context: SubstrateContext,
+        substrate_name: str,
+        reward: float,
+        *,
+        result: SubstrateResult | None = None,
+    ) -> None:
+        """Fold a realised reward into the value table and the rung itself.
+
+        ``reward`` is the combined-currency ``R = Δscore − λ·cost`` the
+        reward channels produced (see :mod:`mantis_agent.learning.reward`).
+        """
+        key = self._key(context.cluster, substrate_name)
+        self._values.setdefault(key, ValueEstimate()).update(float(reward))
+        substrate = self._by_name.get(substrate_name)
+        if substrate is not None and result is not None:
+            substrate.observe(context, result, float(reward))
+
+    # ── reporting (Table 1 / Fig 1 / Fig 2) ─────────────────────────────
+
+    def value_table(self) -> dict[tuple[str, str], tuple[float, int]]:
+        """``(cluster, substrate) -> (mean_reward, n)`` — the Table 1 grid."""
+        return {k: (v.mean, v.count) for k, v in self._values.items()}
+
+    def selection_counts(self, cluster: str | None = None) -> Counter:
+        """How often each substrate was chosen (optionally within a cluster)."""
+        counts: Counter = Counter()
+        for record in self._timeline:
+            if cluster is None or record.cluster == cluster:
+                counts[record.substrate] += 1
+        return counts
+
+    def selection_distribution(self, cluster: str | None = None) -> dict[str, float]:
+        """:meth:`selection_counts` normalised to fractions — Fig 1's bars."""
+        counts = self.selection_counts(cluster)
+        total = sum(counts.values())
+        if not total:
+            return {}
+        return {name: n / total for name, n in counts.items()}
+
+    @property
+    def timeline(self) -> list[AllocationRecord]:
+        """Every decision in order — the raw signal for Fig 2."""
+        return list(self._timeline)
+
+
+__all__ = [
+    "ValueEstimate",
+    "AllocationRecord",
+    "SubstrateChoice",
+    "MyopicAllocator",
+]

--- a/src/mantis_agent/learning/substrates/__init__.py
+++ b/src/mantis_agent/learning/substrates/__init__.py
@@ -4,12 +4,12 @@ Each adapter wraps an existing Mantis mechanism behind the uniform
 :class:`~mantis_agent.learning.substrates.base.LearningSubstrate` protocol so
 the allocator can compare them with one currency:
 
-    retrieval.py      S0  hint_memory / grounding_cache    (LIVE)
-    exemplar.py       S1  trace_exporter + replay          (replay TO BUILD)
+    retrieval.py      S0  hint_memory overlay              (LIVE)
+    exemplar.py       S1  trace_exporter + replay          (LIVE)
     skill.py          S2  graph/learner + playbook         (PARTIAL)
     consolidation.py  S3  rollout_collector + distill      (NEVER RUN)
 
-Only :mod:`base` exists today; the adapters land per the P2–P4 issues.
+S0 and S1 land in the P2 PR; S2/S3 land per the P3–P4 issues.
 """
 
 from .base import (
@@ -18,10 +18,14 @@ from .base import (
     SubstrateContext,
     SubstrateResult,
 )
+from .exemplar import ExemplarSubstrate
+from .retrieval import RetrievalSubstrate
 
 __all__ = [
     "Durability",
     "LearningSubstrate",
     "SubstrateContext",
     "SubstrateResult",
+    "RetrievalSubstrate",
+    "ExemplarSubstrate",
 ]

--- a/src/mantis_agent/learning/substrates/exemplar.py
+++ b/src/mantis_agent/learning/substrates/exemplar.py
@@ -1,0 +1,152 @@
+"""S1 — exemplar replay substrate (the session-durable rung).
+
+One rung up from retrieval: instead of a single grounding anchor, replay
+a whole *successful step* the agent took on this plan before — its intent,
+the action that worked, the outcome it produced — so the brain can pattern-
+match against a known-good example. It reads the trace files
+:class:`~mantis_agent.gym.trace_exporter.TraceExporter` already writes and
+labels them with the existing
+:class:`~mantis_agent.gym.trace_labeller.TraceLabeller`, keeping only the
+steps the labeller marks ``positive``.
+
+Why this is S1 (PLAN §3):
+
+* **Cheap** — labelling is pure heuristics over local JSON, no model call,
+  so :meth:`cost_estimate` is ``0.0``. It sits above S0 only on the
+  *durability* axis, not on cost.
+* **Session-durable** — an exemplar persists for the life of the trace
+  corpus (a session / deploy), longer than S0's single-task hint but not
+  baked into a reusable macro (that's S2) or weights (S3). Hence
+  :class:`Durability.SESSION`.
+
+The retrieval is deliberately minimal: group positive steps by
+``plan_signature`` and hand back the top-N for the plan about to run. The
+trace exporter writes ``plan_signature`` at the top level but the labeller
+drops it, so we read the raw JSON once and label it in-memory rather than
+going through ``label_trace_file`` (which would re-read and lose the key).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+from ...gym.trace_labeller import TraceLabeller
+from .base import Durability, SubstrateContext, SubstrateResult
+
+logger = logging.getLogger(__name__)
+
+
+class ExemplarSubstrate:
+    """S1 — replay positive-labelled steps from prior runs of the same plan.
+
+    ``trace_dir`` points at the corpus
+    :class:`~mantis_agent.gym.trace_exporter.TraceExporter` writes
+    (``$MANTIS_TRACE_EXPORT_DIR``); layout is ``<tenant>/<run_id>.json``,
+    so the index globs ``**/*.json``. The index is built lazily on first
+    :meth:`apply` and cached; call :meth:`refresh` after new traces land
+    (e.g. between eval rounds) to rebuild it.
+    """
+
+    durability = Durability.SESSION
+
+    def __init__(
+        self,
+        trace_dir: str | Path,
+        *,
+        labeller: TraceLabeller | None = None,
+        name: str = "S1_exemplar",
+        max_exemplars: int = 5,
+    ) -> None:
+        self.trace_dir = Path(trace_dir)
+        self.labeller = labeller or TraceLabeller()
+        self.name = name
+        self.max_exemplars = max(1, int(max_exemplars))
+        # plan_signature -> list of exemplar dicts. None ⇒ not built yet.
+        self._index: dict[str, list[dict]] | None = None
+
+    # ── index ───────────────────────────────────────────────────────────
+
+    def refresh(self) -> None:
+        """Rebuild the exemplar index from the trace corpus on disk."""
+        self._index = self._build_index()
+
+    def _ensure_index(self) -> dict[str, list[dict]]:
+        if self._index is None:
+            self._index = self._build_index()
+        return self._index
+
+    def _build_index(self) -> dict[str, list[dict]]:
+        index: dict[str, list[dict]] = {}
+        if not self.trace_dir.is_dir():
+            return index
+        for path in sorted(self.trace_dir.glob("**/*.json")):
+            if not path.is_file():
+                continue
+            try:
+                raw = json.loads(path.read_text())
+            except (json.JSONDecodeError, OSError) as exc:
+                logger.warning("exemplar: skipping %s (%s)", path, exc)
+                continue
+            plan_sig = str(raw.get("plan_signature", "") or "")
+            if not plan_sig:
+                continue
+            labelled = self.labeller.label_trace(raw)
+            for step in labelled.steps:
+                if step.label != "positive":
+                    continue
+                index.setdefault(plan_sig, []).append({
+                    "intent": step.intent,
+                    "type": step.type,
+                    "last_action": step.last_action,
+                    "observed_outcome": step.observed_outcome,
+                    "label_reason": step.label_reason,
+                    "source_run": labelled.run_id,
+                })
+        return index
+
+    # ── substrate protocol ──────────────────────────────────────────────
+
+    def cost_estimate(self, context: SubstrateContext) -> float:  # noqa: ARG002
+        """Always free — labelling is heuristic, no model call."""
+        return 0.0
+
+    def apply(self, context: SubstrateContext) -> SubstrateResult:
+        plan_signature = str(context.extras.get("plan_signature", "") or "")
+        if not plan_signature:
+            return SubstrateResult(
+                substrate=self.name,
+                applied=False,
+                dollars_spent=0.0,
+                durability=self.durability,
+                notes="no plan_signature in context.extras — cannot retrieve exemplars",
+            )
+
+        exemplars = self._ensure_index().get(plan_signature, [])[: self.max_exemplars]
+        return SubstrateResult(
+            substrate=self.name,
+            applied=bool(exemplars),
+            dollars_spent=0.0,
+            durability=self.durability,
+            delta_artifacts={
+                "exemplars": exemplars,
+                "plan_signature": plan_signature,
+            },
+            notes=(
+                f"replaying {len(exemplars)} positive exemplar(s)"
+                if exemplars
+                else "no positive exemplars for this plan"
+            ),
+        )
+
+    def observe(
+        self, context: SubstrateContext, result: SubstrateResult, reward: float,
+    ) -> None:
+        """No-op — exemplar *capture* happens via trace export downstream;
+        the index is rebuilt from disk by :meth:`refresh`, not from the
+        allocator's reward signal."""
+        return None
+
+
+__all__ = ["ExemplarSubstrate"]

--- a/src/mantis_agent/learning/substrates/retrieval.py
+++ b/src/mantis_agent/learning/substrates/retrieval.py
@@ -1,0 +1,100 @@
+"""S0 — retrieval / context substrate (the cheapest rung).
+
+The bottom of the ladder: stamp grounding hints the agent already learned
+onto the plan before it runs, so the brain re-uses a known visual anchor
+instead of re-discovering it from pixels. It wraps the trajectory hint
+memory (``gym/hint_memory.py``) — specifically :func:`apply_hint_overlay`,
+which had no caller until now.
+
+Why this is S0 (PLAN §3, the ``knowledge`` cluster's expected winner):
+
+* **Cheapest** — overlaying a stored anchor is a dict lookup. No model
+  call, no network, so :meth:`cost_estimate` is ``0.0``.
+* **Most reversible** — the effect is one ``preferred_target_description``
+  hint on the current plan and nothing else; it evaporates when the run
+  ends. That is :class:`Durability.EPHEMERAL`.
+
+CUA purity (``feedback_cua_no_dom_access.md``): the hints this rung
+replays are visual anchors Holo3 *saw* (``elv_text`` strings, screen
+offsets), never DOM selectors — that invariant is enforced upstream in
+``hint_memory`` and inherited here unchanged.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ...gym.hint_memory import HintStore, NullHintStore, apply_hint_overlay
+from .base import Durability, SubstrateContext, SubstrateResult
+
+
+class RetrievalSubstrate:
+    """S0 — overlay stored grounding anchors onto the plan about to run.
+
+    The substrate carries the :class:`HintStore` backend (dependency-
+    injected so tests use an in-memory store and prod uses the disk /
+    Modal-dict one). Per-task specifics arrive through
+    ``context.extras``:
+
+    * ``plan`` — the live plan object whose steps get the overlay. Absent
+      in a pure cost-probe; present when the allocator actually applies
+      this rung. We never read it in :meth:`cost_estimate`.
+    * ``plan_signature`` — the 12-char plan hash that keys the store.
+    * ``start_url`` — seeds the URL-pattern axis of the hint key.
+    """
+
+    durability = Durability.EPHEMERAL
+
+    def __init__(
+        self, store: HintStore | None = None, *, name: str = "S0_retrieval",
+    ) -> None:
+        # NullHintStore default keeps the rung safe to construct with no
+        # backend wired — apply() then simply finds nothing to overlay.
+        self.store: HintStore = store or NullHintStore()
+        self.name = name
+
+    def cost_estimate(self, context: SubstrateContext) -> float:  # noqa: ARG002
+        """Always free — a hint overlay is a store read, no model call."""
+        return 0.0
+
+    def apply(self, context: SubstrateContext) -> SubstrateResult:
+        plan: Any = context.extras.get("plan")
+        plan_signature = str(context.extras.get("plan_signature", "") or "")
+        start_url = str(context.extras.get("start_url", "") or "")
+
+        if plan is None or not plan_signature:
+            return SubstrateResult(
+                substrate=self.name,
+                applied=False,
+                dollars_spent=0.0,
+                durability=self.durability,
+                notes="no plan / plan_signature in context.extras — nothing to overlay",
+            )
+
+        n = apply_hint_overlay(
+            plan, store=self.store, plan_signature=plan_signature, start_url=start_url,
+        )
+        return SubstrateResult(
+            substrate=self.name,
+            applied=n > 0,
+            dollars_spent=0.0,
+            durability=self.durability,
+            delta_artifacts={"hints_applied": n, "plan_signature": plan_signature},
+            notes=(
+                f"overlaid {n} grounding hint(s)"
+                if n
+                else "no matching anchors in store"
+            ),
+        )
+
+    def observe(
+        self, context: SubstrateContext, result: SubstrateResult, reward: float,
+    ) -> None:
+        """No-op — hint *recording* is the run executor's job (it writes
+        anchors back to the store on step success, see
+        ``hint_memory.record_hint_if_eligible``). The allocator's reward
+        signal doesn't feed this rung's internal state."""
+        return None
+
+
+__all__ = ["RetrievalSubstrate"]

--- a/tests/learning/test_allocator.py
+++ b/tests/learning/test_allocator.py
@@ -1,0 +1,286 @@
+"""Tests for the myopic contextual-bandit allocator.
+
+The allocator is the piece that makes the paper's central claim testable —
+that a budget-aware bandit beats any *fixed* substrate by learning a
+*per-cluster* winner. The tests pin the mechanics the experiment depends
+on: deterministic warm-up coverage, per-cluster value isolation, budget
+filtering, durability tie-breaks, and the selection-distribution / timeline
+reporting that Fig 1 + Fig 2 read.
+
+Fake substrates stand in for the real rungs so no env boots; the bandit
+logic is what's under test, not the adapters (those have their own suites).
+"""
+
+from __future__ import annotations
+
+import random
+
+import pytest
+
+from mantis_agent.learning.allocator import (
+    MyopicAllocator,
+    ValueEstimate,
+)
+from mantis_agent.learning.substrates.base import (
+    Durability,
+    SubstrateContext,
+    SubstrateResult,
+)
+
+
+class FakeSubstrate:
+    """Minimal LearningSubstrate with controllable cost + durability."""
+
+    def __init__(
+        self,
+        name: str,
+        *,
+        cost: float = 0.0,
+        durability: Durability = Durability.EPHEMERAL,
+    ) -> None:
+        self.name = name
+        self._cost = cost
+        self.durability = durability
+        self.observed: list[float] = []
+
+    def cost_estimate(self, context: SubstrateContext) -> float:  # noqa: ARG002
+        return self._cost
+
+    def apply(self, context: SubstrateContext) -> SubstrateResult:  # noqa: ARG002
+        return SubstrateResult(
+            substrate=self.name, applied=True,
+            dollars_spent=self._cost, durability=self.durability,
+        )
+
+    def observe(self, context, result, reward: float) -> None:  # noqa: ARG002
+        self.observed.append(reward)
+
+
+def _ctx(cluster: str = "capability", *, budget: float = 100.0) -> SubstrateContext:
+    return SubstrateContext(task_id="t", cluster=cluster, budget_remaining=budget)
+
+
+def _greedy(substrates, **kw) -> MyopicAllocator:
+    # epsilon=0 ⇒ deterministic; no random exploration branch.
+    return MyopicAllocator(substrates, epsilon=0.0, **kw)
+
+
+# ── construction guards ────────────────────────────────────────────────
+
+
+def test_requires_at_least_one_substrate() -> None:
+    with pytest.raises(ValueError, match="at least one"):
+        MyopicAllocator([])
+
+
+def test_rejects_duplicate_names() -> None:
+    with pytest.raises(ValueError, match="unique"):
+        MyopicAllocator([FakeSubstrate("S0"), FakeSubstrate("S0")])
+
+
+# ── warm-up: every affordable arm tried once before exploitation ───────
+
+
+def test_warmup_tries_each_arm_once_in_ladder_order() -> None:
+    s0 = FakeSubstrate("S0", durability=Durability.EPHEMERAL)
+    s1 = FakeSubstrate("S1", durability=Durability.SESSION)
+    alloc = _greedy([s1, s0])  # deliberately out of order
+
+    picks = []
+    for _ in range(2):
+        choice = alloc.choose(_ctx())
+        picks.append(choice.name)
+        alloc.observe(_ctx(), choice.name, 0.0)
+
+    # Untried arms are explored cheapest/most-reversible first ⇒ S0 then S1.
+    assert picks == ["S0", "S1"]
+    assert all(p == "explore-unknown" for p in
+               [r.reason for r in alloc.timeline])
+
+
+# ── exploitation: highest per-cluster value wins ───────────────────────
+
+
+def test_exploit_picks_highest_value_arm() -> None:
+    s0, s1 = FakeSubstrate("S0"), FakeSubstrate("S1", durability=Durability.SESSION)
+    alloc = _greedy([s0, s1])
+    # Prime both as tried, with S1 the better arm in this cluster.
+    alloc.observe(_ctx(), "S0", 0.1)
+    alloc.observe(_ctx(), "S1", 0.9)
+
+    choice = alloc.choose(_ctx())
+
+    assert choice.name == "S1"
+    assert choice.reason == "exploit"
+    assert choice.value_estimate == pytest.approx(0.9)
+
+
+def test_value_is_per_cluster_not_global() -> None:
+    # The contextual claim: the same arm can win one cluster and lose another.
+    s0, s1 = FakeSubstrate("S0"), FakeSubstrate("S1", durability=Durability.SESSION)
+    alloc = _greedy([s0, s1])
+    # knowledge: S0 strong, S1 weak.
+    alloc.observe(_ctx("knowledge"), "S0", 1.0)
+    alloc.observe(_ctx("knowledge"), "S1", 0.0)
+    # capability: reversed.
+    alloc.observe(_ctx("capability"), "S0", 0.0)
+    alloc.observe(_ctx("capability"), "S1", 1.0)
+
+    assert alloc.choose(_ctx("knowledge")).name == "S0"
+    assert alloc.choose(_ctx("capability")).name == "S1"
+
+
+# ── budget gating ──────────────────────────────────────────────────────
+
+
+def test_budget_filters_unaffordable_arms() -> None:
+    cheap = FakeSubstrate("S0", cost=0.0)
+    pricey = FakeSubstrate("S3", cost=3.0, durability=Durability.WEIGHTS)
+    alloc = _greedy([cheap, pricey])
+
+    # Budget below the pricey rung ⇒ it's never an option.
+    choice = alloc.choose(_ctx(budget=0.5))
+    assert choice.name == "S0"
+
+
+def test_choose_returns_none_when_nothing_affordable() -> None:
+    pricey = FakeSubstrate("S3", cost=3.0, durability=Durability.WEIGHTS)
+    alloc = _greedy([pricey])
+    assert alloc.choose(_ctx(budget=0.0)) is None
+
+
+def test_free_arm_affordable_at_zero_budget() -> None:
+    free = FakeSubstrate("S0", cost=0.0)
+    alloc = _greedy([free])
+    assert alloc.choose(_ctx(budget=0.0)).name == "S0"
+
+
+# ── tie-breaking ───────────────────────────────────────────────────────
+
+
+def test_ties_break_toward_lower_durability() -> None:
+    # Two free arms, both untried (value 0) ⇒ prefer the more reversible.
+    ephem = FakeSubstrate("S0", durability=Durability.EPHEMERAL)
+    weighty = FakeSubstrate("S3", durability=Durability.WEIGHTS)
+    alloc = _greedy([weighty, ephem])
+    assert alloc.choose(_ctx()).name == "S0"
+
+
+# ── observe / value table ──────────────────────────────────────────────
+
+
+def test_observe_updates_running_mean() -> None:
+    alloc = _greedy([FakeSubstrate("S0")])
+    for r in (1.0, 0.0, 1.0):
+        alloc.observe(_ctx(), "S0", r)
+    assert alloc.value_of("capability", "S0") == pytest.approx(2 / 3)
+    assert alloc.count_of("capability", "S0") == 3
+
+
+def test_observe_forwards_reward_to_substrate() -> None:
+    s0 = FakeSubstrate("S0")
+    alloc = _greedy([s0])
+    result = s0.apply(_ctx())
+    alloc.observe(_ctx(), "S0", 0.7, result=result)
+    assert s0.observed == [0.7]
+
+
+def test_observe_without_result_skips_substrate_hook() -> None:
+    s0 = FakeSubstrate("S0")
+    alloc = _greedy([s0])
+    alloc.observe(_ctx(), "S0", 0.7)  # no result ⇒ table updates, hook skipped
+    assert s0.observed == []
+    assert alloc.value_of("capability", "S0") == pytest.approx(0.7)
+
+
+def test_value_table_reports_mean_and_count() -> None:
+    alloc = _greedy([FakeSubstrate("S0")])
+    alloc.observe(_ctx("knowledge"), "S0", 0.5)
+    alloc.observe(_ctx("knowledge"), "S0", 0.5)
+    table = alloc.value_table()
+    assert table[("knowledge", "S0")] == (pytest.approx(0.5), 2)
+
+
+# ── allocate (choose + apply) ──────────────────────────────────────────
+
+
+def test_allocate_chooses_and_applies() -> None:
+    s0 = FakeSubstrate("S0")
+    alloc = _greedy([s0])
+    choice, result = alloc.allocate(_ctx())
+    assert choice.name == "S0"
+    assert result.applied is True
+    assert result.substrate == "S0"
+
+
+def test_allocate_returns_none_when_nothing_affordable() -> None:
+    alloc = _greedy([FakeSubstrate("S3", cost=9.0)])
+    assert alloc.allocate(_ctx(budget=0.0)) is None
+
+
+# ── reporting: Fig 1 (distribution) + Fig 2 (timeline) ─────────────────
+
+
+def test_selection_distribution_normalises() -> None:
+    s0, s1 = FakeSubstrate("S0"), FakeSubstrate("S1", durability=Durability.SESSION)
+    alloc = _greedy([s0, s1])
+    # Warm-up then settle: 1×S0, 1×S1, then exploit S0 (give it the edge).
+    for name, reward in (("S0", 1.0), ("S1", 0.0)):
+        c = alloc.choose(_ctx())
+        alloc.observe(_ctx(), c.name, reward)
+    for _ in range(2):
+        c = alloc.choose(_ctx())
+        alloc.observe(_ctx(), c.name, 1.0)
+
+    dist = alloc.selection_distribution()
+    assert sum(dist.values()) == pytest.approx(1.0)
+    # 4 picks total, S0 chosen 3× (warm-up + 2 exploits), S1 once.
+    assert dist["S0"] == pytest.approx(0.75)
+    assert dist["S1"] == pytest.approx(0.25)
+
+
+def test_selection_distribution_is_per_cluster() -> None:
+    alloc = _greedy([FakeSubstrate("S0")])
+    alloc.choose(_ctx("knowledge"))
+    alloc.choose(_ctx("capability"))
+    assert alloc.selection_distribution("knowledge") == {"S0": 1.0}
+    assert alloc.selection_counts("knowledge")["S0"] == 1
+
+
+def test_timeline_records_every_decision() -> None:
+    alloc = _greedy([FakeSubstrate("S0"), FakeSubstrate("S1",
+                     durability=Durability.SESSION)])
+    alloc.choose(_ctx())
+    alloc.choose(_ctx("knowledge"))
+    tl = alloc.timeline
+    assert len(tl) == 2
+    assert [r.index for r in tl] == [1, 2]
+    assert tl[0].cluster == "capability"
+    assert tl[1].cluster == "knowledge"
+
+
+def test_empty_distribution_before_any_choice() -> None:
+    alloc = _greedy([FakeSubstrate("S0")])
+    assert alloc.selection_distribution() == {}
+
+
+# ── exploration branch ─────────────────────────────────────────────────
+
+
+def test_epsilon_one_always_explores() -> None:
+    s0, s1 = FakeSubstrate("S0"), FakeSubstrate("S1", durability=Durability.SESSION)
+    alloc = MyopicAllocator([s0, s1], epsilon=1.0, rng=random.Random(0))
+    choice = alloc.choose(_ctx())
+    assert choice.reason == "explore"
+    assert choice.name in {"S0", "S1"}
+
+
+# ── ValueEstimate unit ─────────────────────────────────────────────────
+
+
+def test_value_estimate_incremental_mean() -> None:
+    v = ValueEstimate()
+    for r in (1.0, 0.0, 1.0, 0.0):
+        v.update(r)
+    assert v.count == 4
+    assert v.mean == pytest.approx(0.5)

--- a/tests/learning/test_exemplar_substrate.py
+++ b/tests/learning/test_exemplar_substrate.py
@@ -1,0 +1,181 @@
+"""Tests for the S1 exemplar substrate.
+
+The substrate indexes the trace corpus the ``TraceExporter`` writes and
+replays positive-labelled steps. These build real trace JSON on disk (the
+exporter's schema) and assert the labeller's positive/negative split flows
+through into the retrieved exemplars.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from mantis_agent.learning.substrates import ExemplarSubstrate
+from mantis_agent.learning.substrates.base import (
+    Durability,
+    LearningSubstrate,
+    SubstrateContext,
+)
+
+PLAN_SIG = "planABC123456"
+
+
+def _trace(plan_sig: str, *, run_id: str, steps: list[dict]) -> dict:
+    return {
+        "schema_version": 2,
+        "run_id": run_id,
+        "tenant_id": "",
+        "plan_signature": plan_sig,
+        "status": "completed",
+        "steps": steps,
+    }
+
+
+def _positive(idx: int, intent: str = "apply used filter") -> dict:
+    # success + a non-empty observed_outcome ⇒ labeller marks 'positive'.
+    return {
+        "step_index": idx,
+        "intent": intent,
+        "type": "click",
+        "success": True,
+        "data": "",
+        "observed_outcome": "filter applied",
+        "predicted_outcome": "filter should apply",
+        "last_action": {"action_type": "click", "params": {"x": 1, "y": 2}},
+    }
+
+
+def _negative(idx: int) -> dict:
+    return {
+        "step_index": idx,
+        "intent": "submit broken form",
+        "type": "click",
+        "success": False,
+        "data": "",
+        "observed_outcome": "",
+        "predicted_outcome": "",
+        "last_action": None,
+    }
+
+
+def _write(dir_: Path, trace: dict, *, tenant: str = "__shared__") -> Path:
+    # Mirror the exporter layout: <dir>/<tenant>/<run_id>.json.
+    out = dir_ / tenant / f"{trace['run_id']}.json"
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(trace))
+    return out
+
+
+def _ctx(plan_signature: str = PLAN_SIG) -> SubstrateContext:
+    return SubstrateContext(
+        task_id="BT01", cluster="capability",
+        extras={"plan_signature": plan_signature},
+    )
+
+
+# ── protocol / cheap-path invariants ───────────────────────────────────
+
+
+def test_conforms_to_substrate_protocol(tmp_path) -> None:
+    assert isinstance(ExemplarSubstrate(tmp_path), LearningSubstrate)
+
+
+def test_durability_is_session(tmp_path) -> None:
+    assert ExemplarSubstrate(tmp_path).durability is Durability.SESSION
+
+
+def test_cost_estimate_is_free(tmp_path) -> None:
+    assert ExemplarSubstrate(tmp_path).cost_estimate(_ctx()) == 0.0
+
+
+def test_missing_trace_dir_is_empty_not_error(tmp_path) -> None:
+    sub = ExemplarSubstrate(tmp_path / "does-not-exist")
+    res = sub.apply(_ctx())
+    assert res.applied is False
+
+
+# ── apply / retrieval ───────────────────────────────────────────────────
+
+
+def test_apply_returns_only_positive_exemplars(tmp_path) -> None:
+    _write(tmp_path, _trace(PLAN_SIG, run_id="run1",
+                            steps=[_positive(0), _negative(1)]))
+    sub = ExemplarSubstrate(tmp_path)
+
+    res = sub.apply(_ctx())
+
+    assert res.applied is True
+    exemplars = res.delta_artifacts["exemplars"]
+    assert len(exemplars) == 1  # the negative step is filtered out
+    assert exemplars[0]["intent"] == "apply used filter"
+    assert exemplars[0]["observed_outcome"] == "filter applied"
+    assert exemplars[0]["source_run"] == "run1"
+
+
+def test_apply_unknown_plan_is_not_applied(tmp_path) -> None:
+    _write(tmp_path, _trace(PLAN_SIG, run_id="run1", steps=[_positive(0)]))
+    sub = ExemplarSubstrate(tmp_path)
+
+    res = sub.apply(_ctx(plan_signature="some-other-plan"))
+
+    assert res.applied is False
+    assert res.delta_artifacts["exemplars"] == []
+
+
+def test_apply_without_plan_signature_is_not_applied(tmp_path) -> None:
+    sub = ExemplarSubstrate(tmp_path)
+    res = sub.apply(SubstrateContext(task_id="t", extras={}))
+    assert res.applied is False
+    assert "cannot retrieve" in res.notes
+
+
+def test_max_exemplars_caps_the_result(tmp_path) -> None:
+    steps = [_positive(i, intent=f"step {i}") for i in range(5)]
+    _write(tmp_path, _trace(PLAN_SIG, run_id="run1", steps=steps))
+    sub = ExemplarSubstrate(tmp_path, max_exemplars=2)
+
+    res = sub.apply(_ctx())
+
+    assert len(res.delta_artifacts["exemplars"]) == 2
+
+
+def test_exemplars_aggregate_across_runs(tmp_path) -> None:
+    _write(tmp_path, _trace(PLAN_SIG, run_id="run1", steps=[_positive(0)]))
+    _write(tmp_path, _trace(PLAN_SIG, run_id="run2", steps=[_positive(0)]))
+    sub = ExemplarSubstrate(tmp_path)
+
+    res = sub.apply(_ctx())
+
+    runs = {e["source_run"] for e in res.delta_artifacts["exemplars"]}
+    assert runs == {"run1", "run2"}
+
+
+def test_refresh_picks_up_new_traces(tmp_path) -> None:
+    sub = ExemplarSubstrate(tmp_path)
+    # Index built (lazily) against an empty dir.
+    assert sub.apply(_ctx()).applied is False
+
+    _write(tmp_path, _trace(PLAN_SIG, run_id="run1", steps=[_positive(0)]))
+    # Stale cache still misses until we refresh.
+    assert sub.apply(_ctx()).applied is False
+    sub.refresh()
+    assert sub.apply(_ctx()).applied is True
+
+
+def test_corrupt_trace_is_skipped(tmp_path) -> None:
+    _write(tmp_path, _trace(PLAN_SIG, run_id="good", steps=[_positive(0)]))
+    bad = tmp_path / "__shared__" / "bad.json"
+    bad.write_text("{ not valid json")
+    sub = ExemplarSubstrate(tmp_path)
+
+    res = sub.apply(_ctx())
+
+    # The good trace still indexes; the corrupt file is logged + skipped.
+    assert res.applied is True
+    assert len(res.delta_artifacts["exemplars"]) == 1
+
+
+def test_observe_is_noop(tmp_path) -> None:
+    sub = ExemplarSubstrate(tmp_path)
+    assert sub.observe(_ctx(), sub.apply(_ctx()), 1.0) is None

--- a/tests/learning/test_retrieval_substrate.py
+++ b/tests/learning/test_retrieval_substrate.py
@@ -1,0 +1,126 @@
+"""Tests for the S0 retrieval substrate.
+
+The substrate wraps ``hint_memory.apply_hint_overlay``, so these exercise
+the *real* overlay against an in-memory hint store rather than mocking it —
+a stored anchor must actually land on the plan's step as a
+``preferred_target_description`` hint.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from mantis_agent.gym.hint_memory import (
+    HintRecord,
+    InMemoryHintStore,
+    hint_key_for,
+)
+from mantis_agent.learning.substrates import RetrievalSubstrate
+from mantis_agent.learning.substrates.base import (
+    Durability,
+    LearningSubstrate,
+    SubstrateContext,
+)
+
+PLAN_SIG = "plansig12345"
+URL = "https://www.boattrader.com/boat/1986-marine-trader/"
+
+
+def _step(intent: str = "click Show More", step_type: str = "click"):
+    # apply_hint_overlay reads .type / .intent and writes .hints in place.
+    return SimpleNamespace(type=step_type, intent=intent, hints=None)
+
+
+def _ctx(plan=None, *, plan_signature: str = PLAN_SIG, start_url: str = URL):
+    extras = {"plan_signature": plan_signature, "start_url": start_url}
+    if plan is not None:
+        extras["plan"] = plan
+    return SubstrateContext(task_id="BT01", cluster="knowledge", extras=extras)
+
+
+def _store_with_anchor(step, *, anchor: str = "Show More") -> InMemoryHintStore:
+    store = InMemoryHintStore()
+    key = hint_key_for(PLAN_SIG, step, URL)
+    store.add(key, HintRecord(anchor_text=anchor, confidence=1.0))
+    return store
+
+
+# ── protocol / cheap-path invariants ───────────────────────────────────
+
+
+def test_conforms_to_substrate_protocol() -> None:
+    assert isinstance(RetrievalSubstrate(), LearningSubstrate)
+
+
+def test_durability_is_ephemeral() -> None:
+    assert RetrievalSubstrate().durability is Durability.EPHEMERAL
+
+
+def test_cost_estimate_is_free() -> None:
+    # A store read costs nothing — the bandit must rank this rung at $0.
+    assert RetrievalSubstrate().cost_estimate(_ctx()) == 0.0
+
+
+def test_default_store_is_safe_to_construct() -> None:
+    # No backend wired ⇒ NullHintStore ⇒ apply finds nothing, never raises.
+    sub = RetrievalSubstrate()
+    res = sub.apply(_ctx(plan=SimpleNamespace(steps=[_step()])))
+    assert res.applied is False
+
+
+# ── apply ───────────────────────────────────────────────────────────────
+
+
+def test_apply_overlays_a_stored_anchor() -> None:
+    step = _step()
+    plan = SimpleNamespace(steps=[step])
+    sub = RetrievalSubstrate(_store_with_anchor(step))
+
+    res = sub.apply(_ctx(plan=plan))
+
+    assert res.applied is True
+    assert res.delta_artifacts["hints_applied"] == 1
+    assert res.dollars_spent == 0.0
+    # The overlay actually mutated the plan step.
+    assert step.hints["preferred_target_description"] == "Show More"
+
+
+def test_apply_without_plan_is_not_applied() -> None:
+    # Pure cost-probe path: no live plan handle ⇒ nothing to overlay.
+    res = RetrievalSubstrate(InMemoryHintStore()).apply(_ctx())
+    assert res.applied is False
+    assert "nothing to overlay" in res.notes
+
+
+def test_apply_without_plan_signature_is_not_applied() -> None:
+    plan = SimpleNamespace(steps=[_step()])
+    res = RetrievalSubstrate(InMemoryHintStore()).apply(_ctx(plan=plan, plan_signature=""))
+    assert res.applied is False
+
+
+def test_apply_with_empty_store_is_not_applied() -> None:
+    plan = SimpleNamespace(steps=[_step()])
+    res = RetrievalSubstrate(InMemoryHintStore()).apply(_ctx(plan=plan))
+    assert res.applied is False
+    assert res.delta_artifacts["hints_applied"] == 0
+
+
+def test_apply_does_not_overwrite_operator_hint() -> None:
+    step = _step()
+    step.hints = {"preferred_target_description": "operator choice"}
+    plan = SimpleNamespace(steps=[step])
+    sub = RetrievalSubstrate(_store_with_anchor(step, anchor="stored anchor"))
+
+    sub.apply(_ctx(plan=plan))
+
+    # Operator-authored hint wins; the store is a fallback, not an override.
+    assert step.hints["preferred_target_description"] == "operator choice"
+
+
+# ── observe ─────────────────────────────────────────────────────────────
+
+
+def test_observe_is_noop() -> None:
+    sub = RetrievalSubstrate()
+    # Must not raise — recording happens in the run executor, not here.
+    assert sub.observe(_ctx(), sub.apply(_ctx()), 1.0) is None


### PR DESCRIPTION
## Summary

Phase-2 of the Learning Allocator — the no-spend decision layer. Three pieces, all unit-tested with mocks/in-memory fixtures (no env boots, no Modal/Daytona spend):

- **S0 `RetrievalSubstrate`** (`substrates/retrieval.py`) — wraps `hint_memory.apply_hint_overlay`, which had no caller until now. Stamps stored visual grounding anchors onto the plan before it runs. `cost_estimate=0.0`, `Durability.EPHEMERAL`.
- **S1 `ExemplarSubstrate`** (`substrates/exemplar.py`) — indexes the `TraceExporter` corpus, labels each trace via `TraceLabeller`, and replays the `positive`-labelled steps keyed by `plan_signature`. `cost_estimate=0.0`, `Durability.SESSION`. (Exemplar replay was previously unbuilt.)
- **`MyopicAllocator`** (`allocator.py`) — ε-greedy contextual bandit over the ladder, value table keyed per `(cluster, substrate)`. Budget-gated, durability-tie-broken, with an explore-unknown-first warm-up so every affordable rung is pulled once before exploitation. Exposes `value_table()` / `selection_distribution()` / `timeline` for the paper's Table 1 + Fig 1/2.

Why per-cluster value matters: it's what lets the allocator learn S0 wins `knowledge` while S2 wins `capability` — the "beats any fixed substrate" claim no single rung can match.

## Test plan
- [x] `uv run pytest tests/learning/ -n0` → 79 passed (36 prior + 43 new)
- [x] `uv run ruff check src/mantis_agent/learning/ tests/learning/` → clean
- [x] S0 suite drives the *real* `apply_hint_overlay` against an in-memory store (not mocked)
- [x] S1 suite builds real trace JSON on disk in the exporter's schema
- [x] Import-surface smoke test: `MyopicAllocator([RetrievalSubstrate(), ExemplarSubstrate(...)])` allocates end-to-end

Stacked on #750 (Phase 0b). Closes #738, #739, #740.

🤖 Generated with [Claude Code](https://claude.com/claude-code)