### PR TITLE
feat(learning): Phase-2 orchestrator — bandit control loop

### DIFF
--- a/src/mantis_agent/learning/__init__.py
+++ b/src/mantis_agent/learning/__init__.py
@@ -22,6 +22,11 @@ from .allocator import (
     ValueEstimate,
 )
 from .eval import EvalManifest, EvalTask, load_manifest
+from .orchestrator import (
+    Phase2Orchestrator,
+    Phase2Report,
+    TaskOutcome,
+)
 from .reward import (
     DEFAULT_LAMBDA,
     RewardRecord,
@@ -59,4 +64,8 @@ __all__ = [
     "EvalManifest",
     "EvalTask",
     "load_manifest",
+    # orchestrator
+    "Phase2Orchestrator",
+    "Phase2Report",
+    "TaskOutcome",
 ]

--- a/src/mantis_agent/learning/orchestrator.py
+++ b/src/mantis_agent/learning/orchestrator.py
@@ -1,0 +1,246 @@
+"""Phase-2 orchestrator — the bandit control loop that produces the data.
+
+Ties the four Phase-0/2 pieces into one budget-constrained run:
+
+    eval manifest  →  allocator.allocate  →  run the plan  →  dual reward
+         ↑                                                        │
+         └──────────────── allocator.observe ←───────────────────┘
+
+For each runnable eval task it asks the :class:`MyopicAllocator` to pick a
+substrate, applies it, executes the plan, scores the run through both
+reward channels (oracle + proxy + cost via
+:func:`~mantis_agent.learning.reward.reward_from_run`), and folds the
+realised reward back into the bandit. A single hard budget ``B`` is
+decremented by each run's realised dollar cost — the paper's budget
+constraint — and scheduling stops when it runs dry.
+
+Two I/O seams are injected so the whole loop is unit-testable with **no
+env boots and no spend**:
+
+* ``run_fn(task, plan, substrate_result) -> run_result`` — executes the
+  (possibly substrate-modified) plan and returns the result dict the
+  reward channels read (``dynamic_verification_summary.verdict`` +
+  ``costs.total``). In production this submits to the Modal CUA server
+  against the Daytona boattrader env; in tests it returns a canned dict.
+* ``plan_loader(task) -> plan`` — returns the in-process plan object S0
+  overlays grounding hints onto (and that ``run_fn`` submits). Optional:
+  without it S0 simply finds nothing to overlay and S1 still runs.
+
+The experiment wiring that supplies the real Modal-submit ``run_fn`` lives
+under ``experiments/learning_allocator/`` — that is the only spend
+boundary; this module never calls Modal or Daytona itself.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass, field
+from typing import Any
+
+from .allocator import MyopicAllocator
+from .eval import EvalTask
+from .reward import DEFAULT_LAMBDA, RewardRecord, reward_from_run
+from .substrates.base import SubstrateContext, SubstrateResult
+
+logger = logging.getLogger(__name__)
+
+# Execute a plan and return the run_result dict reward_from_run consumes.
+RunFn = Callable[[EvalTask, Any, SubstrateResult], dict]
+# Load the in-process plan object for a task (the thing S0 overlays onto).
+PlanLoader = Callable[[EvalTask], Any]
+# Map a task to the plan_signature that keys the hint / exemplar stores.
+PlanSigFn = Callable[[EvalTask], str]
+
+
+@dataclass
+class TaskOutcome:
+    """One task's trip through the loop — the row behind every data point."""
+
+    task_name: str
+    task_id: str
+    cluster: str
+    substrate: str | None = None
+    reward: float | None = None
+    dollars: float | None = None
+    reward_record: RewardRecord | None = None
+    substrate_result: SubstrateResult | None = None
+    skipped: bool = False
+    note: str = ""
+
+
+@dataclass
+class Phase2Report:
+    """The eval's collected output — Table 1 / Fig 1 + attribution tallies."""
+
+    outcomes: list[TaskOutcome] = field(default_factory=list)
+    value_table: dict[tuple[str, str], tuple[float, int]] = field(default_factory=dict)
+    selection_distribution: dict[str, float] = field(default_factory=dict)
+    budget_start: float = 0.0
+    budget_spent: float = 0.0
+    n_runs: int = 0
+    n_skipped: int = 0
+    false_passes: int = 0
+    false_fails: int = 0
+
+    @property
+    def budget_remaining(self) -> float:
+        return self.budget_start - self.budget_spent
+
+
+class Phase2Orchestrator:
+    """Drives the allocator over the eval under a hard dollar budget."""
+
+    def __init__(
+        self,
+        *,
+        allocator: MyopicAllocator,
+        run_fn: RunFn,
+        env_url: str,
+        admin_token: str,
+        budget: float,
+        plan_loader: PlanLoader | None = None,
+        plan_signature_fn: PlanSigFn | None = None,
+        start_url: str = "",
+        lam: float = DEFAULT_LAMBDA,
+    ) -> None:
+        self.allocator = allocator
+        self.run_fn = run_fn
+        self.env_url = env_url
+        self.admin_token = admin_token
+        self.budget_start = float(budget)
+        self.budget_remaining = float(budget)
+        self.lam = float(lam)
+        self.start_url = start_url
+        self._plan_loader = plan_loader
+        self._plan_sig = plan_signature_fn or _default_plan_signature
+        self.outcomes: list[TaskOutcome] = []
+
+    # ── per-task ────────────────────────────────────────────────────────
+
+    def _context(self, task: EvalTask, plan: Any) -> SubstrateContext:
+        extras: dict[str, Any] = {
+            "plan_signature": self._plan_sig(task),
+            "start_url": self.start_url,
+        }
+        if plan is not None:
+            extras["plan"] = plan
+        return SubstrateContext(
+            task_id=task.task_id or task.name,
+            cluster=task.cluster,
+            budget_remaining=self.budget_remaining,
+            extras=extras,
+        )
+
+    def run_task(self, task: EvalTask) -> TaskOutcome:
+        """Allocate → run → reward → observe for one task.
+
+        Skips (cheaply, no spend) when the task isn't runnable, the budget
+        is exhausted, or the allocator finds nothing affordable.
+        """
+        if not task.runnable:
+            return self._skip(task, "task not runnable (no oracle / not ready)")
+        if self.budget_remaining <= 0.0:
+            return self._skip(task, "budget exhausted")
+
+        plan = self._plan_loader(task) if self._plan_loader else None
+        context = self._context(task, plan)
+
+        allocated = self.allocator.allocate(context)
+        if allocated is None:
+            return self._skip(task, "no affordable substrate")
+        choice, substrate_result = allocated
+
+        run_result = self.run_fn(task, plan, substrate_result)
+
+        record = reward_from_run(
+            env_url=self.env_url,
+            admin_token=self.admin_token,
+            task_id=task.task_id or task.name,
+            run_result=run_result,
+            lam=self.lam,
+        )
+
+        # Realised cost = the run's dollars plus whatever the substrate
+        # spent applying itself (0 for S0/S1, nonzero once S2/S3 land).
+        spent = float(record.dollars) + float(substrate_result.dollars_spent)
+        self.budget_remaining -= spent
+
+        self.allocator.observe(
+            context, choice.name, record.reward, result=substrate_result,
+        )
+
+        outcome = TaskOutcome(
+            task_name=task.name,
+            task_id=task.task_id or task.name,
+            cluster=task.cluster,
+            substrate=choice.name,
+            reward=record.reward,
+            dollars=record.dollars,
+            reward_record=record,
+            substrate_result=substrate_result,
+        )
+        self.outcomes.append(outcome)
+        logger.info(
+            "[phase2] %s cluster=%s substrate=%s reward=%.3f $=%.3f budget_left=%.3f",
+            task.name, task.cluster, choice.name, record.reward,
+            record.dollars, self.budget_remaining,
+        )
+        return outcome
+
+    def _skip(self, task: EvalTask, note: str) -> TaskOutcome:
+        outcome = TaskOutcome(
+            task_name=task.name,
+            task_id=task.task_id or task.name,
+            cluster=task.cluster,
+            skipped=True,
+            note=note,
+        )
+        self.outcomes.append(outcome)
+        return outcome
+
+    # ── driver ──────────────────────────────────────────────────────────
+
+    def run(
+        self, tasks: Iterable[EvalTask], *, rounds: int = 1,
+    ) -> Phase2Report:
+        """Run ``rounds`` passes over ``tasks`` and return the report.
+
+        Repeating passes is how the bandit accumulates per-cluster
+        evidence: round 1 is mostly warm-up exploration, later rounds let
+        exploitation settle so Fig 2's selection drift becomes visible.
+        """
+        task_list = list(tasks)
+        for _ in range(max(1, int(rounds))):
+            for task in task_list:
+                self.run_task(task)
+        return self.report()
+
+    def report(self) -> Phase2Report:
+        graded = [o for o in self.outcomes if not o.skipped and o.reward_record]
+        return Phase2Report(
+            outcomes=list(self.outcomes),
+            value_table=self.allocator.value_table(),
+            selection_distribution=self.allocator.selection_distribution(),
+            budget_start=self.budget_start,
+            budget_spent=self.budget_start - self.budget_remaining,
+            n_runs=len(graded),
+            n_skipped=sum(1 for o in self.outcomes if o.skipped),
+            false_passes=sum(1 for o in graded if o.reward_record.false_pass),
+            false_fails=sum(1 for o in graded if o.reward_record.false_fail),
+        )
+
+
+def _default_plan_signature(task: EvalTask) -> str:
+    """Fallback plan signature: the task's plan name, else its id / name."""
+    return task.plan or task.task_id or task.name
+
+
+__all__ = [
+    "RunFn",
+    "PlanLoader",
+    "PlanSigFn",
+    "TaskOutcome",
+    "Phase2Report",
+    "Phase2Orchestrator",
+]

--- a/tests/learning/test_orchestrator.py
+++ b/tests/learning/test_orchestrator.py
@@ -1,0 +1,314 @@
+"""Tests for the Phase-2 orchestrator (the bandit control loop).
+
+The loop's two I/O seams — ``run_fn`` (the Modal/Daytona submit) and the
+oracle call inside ``reward_from_run`` — are injected / monkeypatched, so
+these run with no env boots and no spend. Most tests stub
+``reward_from_run`` to drive reward + cost deterministically; one drives
+the *real* reward path with only ``grade_run`` mocked, to catch wiring
+bugs. One more exercises the real S0 overlay end-to-end through the loop.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from mantis_agent.gym.grading import GradingResult
+from mantis_agent.gym.hint_memory import (
+    HintRecord,
+    InMemoryHintStore,
+    hint_key_for,
+)
+from mantis_agent.learning import orchestrator as O
+from mantis_agent.learning import reward as R
+from mantis_agent.learning.allocator import MyopicAllocator
+from mantis_agent.learning.eval import EvalTask
+from mantis_agent.learning.substrates.base import (
+    Durability,
+    SubstrateContext,
+    SubstrateResult,
+)
+from mantis_agent.learning.substrates.retrieval import RetrievalSubstrate
+
+PLAN_SIG = "sig123456789"
+START_URL = "https://www.boattrader.com/boat/x/"
+
+
+# ── fakes ───────────────────────────────────────────────────────────────
+
+
+class FakeSub:
+    def __init__(
+        self, name: str, *, cost: float = 0.0,
+        durability: Durability = Durability.EPHEMERAL,
+    ) -> None:
+        self.name = name
+        self._cost = cost
+        self.durability = durability
+        self.observed: list[float] = []
+
+    def cost_estimate(self, context: SubstrateContext) -> float:  # noqa: ARG002
+        return self._cost
+
+    def apply(self, context: SubstrateContext) -> SubstrateResult:  # noqa: ARG002
+        return SubstrateResult(
+            substrate=self.name, applied=True,
+            dollars_spent=self._cost, durability=self.durability,
+            delta_artifacts={"tag": self.name},
+        )
+
+    def observe(self, context, result, reward: float) -> None:  # noqa: ARG002
+        self.observed.append(reward)
+
+
+def _task(
+    name: str = "bt01_visible", *, task_id: str = "BT01",
+    cluster: str = "capability", status: str = "ready",
+) -> EvalTask:
+    return EvalTask(
+        name=name, cluster=cluster, split="visible", seed=42,
+        task_id=task_id, status=status, plan="boattrader_scrape",
+    )
+
+
+def _stub_reward(monkeypatch, **defaults):
+    """Stub orchestrator.reward_from_run to read the run_result dict.
+
+    run_result may carry ``reward`` / ``costs.total`` / ``false_pass`` /
+    ``false_fail`` to drive the loop deterministically.
+    """
+
+    def fake(*, env_url, admin_token, task_id, run_result, lam):  # noqa: ARG001
+        return R.RewardRecord(
+            task_id=task_id,
+            oracle_score=run_result.get("oracle_score", 0.0),
+            oracle_passed=run_result.get("oracle_passed", False),
+            proxy_verdict=run_result.get("verdict", "unknown"),
+            proxy_score=0.0,
+            dollars=run_result.get("costs", {}).get("total", defaults.get("dollars", 0.0)),
+            reward=run_result.get("reward", defaults.get("reward", 0.0)),
+            false_pass=run_result.get("false_pass", False),
+            false_fail=run_result.get("false_fail", False),
+        )
+
+    monkeypatch.setattr(O, "reward_from_run", fake)
+
+
+def _orch(allocator, run_fn, *, budget=100.0, **kw) -> O.Phase2Orchestrator:
+    return O.Phase2Orchestrator(
+        allocator=allocator, run_fn=run_fn,
+        env_url="https://env.example", admin_token="tok",
+        budget=budget, start_url=START_URL, **kw,
+    )
+
+
+# ── basic loop ──────────────────────────────────────────────────────────
+
+
+def test_runs_task_and_records_outcome(monkeypatch) -> None:
+    _stub_reward(monkeypatch)
+    sub = FakeSub("S0")
+    alloc = MyopicAllocator([sub], epsilon=0.0)
+    calls = []
+
+    def run_fn(task, plan, result):
+        calls.append((task.name, result.substrate))
+        return {"reward": 0.7, "costs": {"total": 0.2}}
+
+    orch = _orch(alloc, run_fn)
+    outcome = orch.run_task(_task())
+
+    assert outcome.skipped is False
+    assert outcome.substrate == "S0"
+    assert outcome.reward == 0.7
+    assert outcome.dollars == 0.2
+    assert calls == [("bt01_visible", "S0")]
+    # reward folded back into the bandit
+    assert sub.observed == [0.7]
+    assert alloc.value_of("capability", "S0") == pytest.approx(0.7)
+
+
+def test_skips_non_runnable_task(monkeypatch) -> None:
+    _stub_reward(monkeypatch)
+    alloc = MyopicAllocator([FakeSub("S0")], epsilon=0.0)
+    ran = []
+    orch = _orch(alloc, lambda *a: ran.append(a) or {})
+
+    outcome = orch.run_task(_task(status="needs_oracle", task_id=""))
+
+    assert outcome.skipped is True
+    assert "not runnable" in outcome.note
+    assert ran == []  # run_fn never called
+
+
+def test_no_affordable_substrate_skips(monkeypatch) -> None:
+    _stub_reward(monkeypatch)
+    pricey = FakeSub("S3", cost=3.0, durability=Durability.WEIGHTS)
+    alloc = MyopicAllocator([pricey], epsilon=0.0)
+    orch = _orch(alloc, lambda *a: {}, budget=0.5)  # >0 so the budget guard passes
+
+    outcome = orch.run_task(_task())
+
+    assert outcome.skipped is True
+    assert "no affordable substrate" in outcome.note
+
+
+# ── budget ──────────────────────────────────────────────────────────────
+
+
+def test_budget_decrements_by_realised_cost(monkeypatch) -> None:
+    _stub_reward(monkeypatch)
+    alloc = MyopicAllocator([FakeSub("S0")], epsilon=0.0)
+    orch = _orch(alloc, lambda *a: {"reward": 1.0, "costs": {"total": 0.3}}, budget=1.0)
+
+    orch.run_task(_task())
+
+    assert orch.budget_remaining == pytest.approx(0.7)
+
+
+def test_budget_exhaustion_skips_remaining(monkeypatch) -> None:
+    _stub_reward(monkeypatch)
+    alloc = MyopicAllocator([FakeSub("S0")], epsilon=0.0)
+    # First run costs the whole budget; the second task must be skipped.
+    orch = _orch(alloc, lambda *a: {"reward": 1.0, "costs": {"total": 1.0}}, budget=1.0)
+
+    first = orch.run_task(_task("t1"))
+    second = orch.run_task(_task("t2"))
+
+    assert first.skipped is False
+    assert second.skipped is True
+    assert "budget exhausted" in second.note
+
+
+# ── substrate delta threading ───────────────────────────────────────────
+
+
+def test_run_fn_receives_substrate_delta(monkeypatch) -> None:
+    _stub_reward(monkeypatch)
+    alloc = MyopicAllocator([FakeSub("S1", durability=Durability.SESSION)], epsilon=0.0)
+    seen = {}
+
+    def run_fn(task, plan, result):
+        seen["delta"] = result.delta_artifacts
+        return {"reward": 0.5, "costs": {"total": 0.1}}
+
+    _orch(alloc, run_fn).run_task(_task())
+
+    assert seen["delta"] == {"tag": "S1"}
+
+
+def test_s0_overlay_fires_through_the_loop(monkeypatch) -> None:
+    # End-to-end: a stored anchor lands on the plan step the loop submits.
+    _stub_reward(monkeypatch)
+    step = SimpleNamespace(type="click", intent="click Show More", hints=None)
+    plan = SimpleNamespace(steps=[step])
+
+    store = InMemoryHintStore()
+    store.add(
+        hint_key_for(PLAN_SIG, step, START_URL),
+        HintRecord(anchor_text="Show More", confidence=1.0),
+    )
+    alloc = MyopicAllocator([RetrievalSubstrate(store)], epsilon=0.0)
+
+    submitted = {}
+
+    def run_fn(task, plan_arg, result):
+        submitted["plan"] = plan_arg
+        submitted["applied"] = result.applied
+        return {"reward": 1.0, "costs": {"total": 0.2}}
+
+    orch = _orch(
+        alloc, run_fn,
+        plan_loader=lambda task: plan,
+        plan_signature_fn=lambda task: PLAN_SIG,
+    )
+    orch.run_task(_task())
+
+    # The real overlay mutated the plan step, and run_fn got that same plan.
+    assert step.hints["preferred_target_description"] == "Show More"
+    assert submitted["plan"] is plan
+    assert submitted["applied"] is True
+
+
+# ── driver + report ─────────────────────────────────────────────────────
+
+
+def test_rounds_repeats_passes(monkeypatch) -> None:
+    _stub_reward(monkeypatch)
+    sub = FakeSub("S0")
+    alloc = MyopicAllocator([sub], epsilon=0.0)
+    orch = _orch(alloc, lambda *a: {"reward": 0.5, "costs": {"total": 0.1}})
+
+    report = orch.run([_task()], rounds=3)
+
+    assert report.n_runs == 3
+    assert alloc.count_of("capability", "S0") == 3
+
+
+def test_report_aggregates_value_table_and_distribution(monkeypatch) -> None:
+    _stub_reward(monkeypatch)
+    s0 = FakeSub("S0")
+    s1 = FakeSub("S1", durability=Durability.SESSION)
+    alloc = MyopicAllocator([s0, s1], epsilon=0.0)
+    orch = _orch(alloc, lambda *a: {"reward": 0.6, "costs": {"total": 0.1}})
+
+    report = orch.run([_task()], rounds=2)
+
+    # Warm-up tried both rungs once across the two rounds.
+    assert ("capability", "S0") in report.value_table
+    assert ("capability", "S1") in report.value_table
+    assert sum(report.selection_distribution.values()) == pytest.approx(1.0)
+    assert report.n_runs == 2
+    assert report.budget_spent == pytest.approx(0.2)
+
+
+def test_report_counts_false_pass_and_fail(monkeypatch) -> None:
+    _stub_reward(monkeypatch)
+    alloc = MyopicAllocator([FakeSub("S0")], epsilon=0.0)
+    orch = _orch(alloc, lambda *a: {"reward": 0.0, "costs": {"total": 0.1},
+                                    "false_pass": True})
+
+    report = orch.run([_task()])
+
+    assert report.false_passes == 1
+    assert report.false_fails == 0
+
+
+def test_run_skips_non_runnable_in_batch(monkeypatch) -> None:
+    _stub_reward(monkeypatch)
+    alloc = MyopicAllocator([FakeSub("S0")], epsilon=0.0)
+    orch = _orch(alloc, lambda *a: {"reward": 0.5, "costs": {"total": 0.1}})
+
+    report = orch.run([_task("ok"), _task("road", status="needs_oracle", task_id="")])
+
+    assert report.n_runs == 1
+    assert report.n_skipped == 1
+
+
+# ── real reward path (only grade_run mocked) ────────────────────────────
+
+
+def test_full_reward_path_with_mocked_oracle(monkeypatch) -> None:
+    # No reward_from_run stub — exercise the real arithmetic + cost channel,
+    # mocking only the live oracle call.
+    def fake_grade(env_url, admin_token, task_id, **kw):  # noqa: ARG001
+        return GradingResult(task_id=task_id, passed=True, score=0.9, reasons=["ok"])
+
+    monkeypatch.setattr(R, "grade_run", fake_grade)
+
+    alloc = MyopicAllocator([FakeSub("S0")], epsilon=0.0)
+    orch = _orch(
+        alloc,
+        lambda *a: {"dynamic_verification_summary": {"verdict": "pass"},
+                    "costs": {"total": 1.0}},
+        budget=5.0,
+    )
+
+    outcome = orch.run_task(_task())
+
+    # reward = oracle_score − λ·dollars = 0.9 − 0.1·1.0 = 0.8
+    assert outcome.reward == pytest.approx(0.8)
+    assert outcome.dollars == pytest.approx(1.0)
+    assert orch.budget_remaining == pytest.approx(4.0)
+    assert alloc.value_of("capability", "S0") == pytest.approx(0.8)


### PR DESCRIPTION
## Summary

The Phase-2 control loop that turns the allocator + reward channels into the data-producing run. Stacked on #751 (S0/S1 substrates + allocator).

For each runnable eval task it: asks the `MyopicAllocator` to pick a substrate, applies it, runs the (possibly overlaid) plan, scores the run through both reward channels (oracle + proxy + cost), folds the realised reward back into the bandit, and decrements a single hard dollar budget `B` — stopping when it runs dry.

Two I/O seams are **injected** so the whole loop is unit-testable with **no env boots and no spend**:
- `run_fn(task, plan, substrate_result) -> run_result` — submits the plan and returns the dict the reward channels read (`dynamic_verification_summary.verdict` + `costs.total`). In production this is the Modal CUA submit; in tests it returns a canned dict.
- `plan_loader(task) -> plan` — the in-process plan object S0 overlays grounding hints onto (and that `run_fn` submits). Optional.

The Modal-submit wiring (the only spend boundary) intentionally stays **out of this module** under `experiments/` — this never calls Modal or Daytona itself.

## What's here
- `orchestrator.py` — `Phase2Orchestrator` (`run_task` / `run` / `report`), `TaskOutcome`, `Phase2Report`.
- `test_orchestrator.py` — 12 tests: basic loop, skip paths (non-runnable / budget exhausted / no affordable substrate), budget decrement by realised cost, substrate-delta threading, **real S0 overlay end-to-end through the loop**, rounds/report aggregation, false-pass/fail tallies, and the **real reward arithmetic with only the live oracle mocked** (`reward = oracle − λ·dollars`).

## Test plan
- [x] `uv run pytest tests/learning/ -n0 -q` → 91 passed
- [x] `uv run ruff check src/mantis_agent/learning/ tests/learning/` → clean
- [ ] Live Phase-2 run (Daytona boattrader, no proxies) → produces the partial Table 1 + Fig 1 that closes #741. **Gated on a spend decision — not in this PR.**

Part of #741.

🤖 Generated with [Claude Code](https://claude.com/claude-code)