### PR TITLE
feat(boattrader/oracles): BT02 knowledge + BT03 policy graders

### DIFF
--- a/deploy/sim_envs/mantis_boattrader/app/oracles/__init__.py
+++ b/deploy/sim_envs/mantis_boattrader/app/oracles/__init__.py
@@ -29,13 +29,19 @@ from __future__ import annotations
 from typing import Any, Callable
 
 from .. import db
-from . import bt01_lead_capture_filtered_search
+from . import (
+    bt01_lead_capture_filtered_search,
+    bt02_spec_lookup_engine,
+    bt03_byowner_phone_reveal,
+)
 
 GraderFn = Callable[..., dict[str, Any]]
 
 
 GRADERS: dict[str, GraderFn] = {
     "BT01_lead_capture_filtered_search": bt01_lead_capture_filtered_search.grade,
+    "BT02_spec_lookup_engine": bt02_spec_lookup_engine.grade,
+    "BT03_byowner_phone_reveal": bt03_byowner_phone_reveal.grade,
 }
 
 

--- a/deploy/sim_envs/mantis_boattrader/app/oracles/bt02_spec_lookup_engine.py
+++ b/deploy/sim_envs/mantis_boattrader/app/oracles/bt02_spec_lookup_engine.py
@@ -1,0 +1,146 @@
+"""BT02_spec_lookup_engine — submit a lead on a Caterpillar-powered boat.
+
+Task contract
+-------------
+
+The agent must find a boat whose engine is made by **Caterpillar** and
+submit the dealer contact form on it with a non-empty name + email.
+
+This is a *knowledge* task, not a *capability* one: ``engine_make`` is a
+spec-sheet field, **not** a listing-page facet/filter. There is no
+``?engine_make=Caterpillar`` query the agent can lean on — it has to open
+listings and read the spec block to learn which boats qualify. That is
+exactly the regime where an S0 retrieval rung wins: once the agent (or a
+prior run) has learned "boat X is Caterpillar-powered / the engine spec
+lives here", caching that anchor short-circuits the lookup. A fresh agent
+with no memory has to re-discover it every time.
+
+The catalog has 82 Caterpillar-powered boats at seed=42 (76 at seed=7),
+so at least one qualifying target always exists; the grader never depends
+on a hand-counted per-seed id.
+
+Grader
+------
+
+Reads ``store.leads`` and ``store.boats_by_id`` (mirrors BT01):
+
+* **Hit set**: leads whose boat is Caterpillar-powered, carrying a
+  non-empty ``name`` and an email-shaped ``email``.
+* **Miss set**: leads on boats with any other engine make (collateral).
+* **Malformed set**: leads on a qualifying boat but with a blank
+  name / non-email email — the agent reached the right boat but didn't
+  submit a real-shaped payload.
+* **Pass condition**: ``len(hits) >= 1`` AND ``len(misses) == 0`` AND
+  ``len(malformed) == 0``.
+* **Score**: F1 over (precision, recall), precision = hits /
+  (hits + misses + malformed), recall = 1 if hits >= 1 else 0. 4 dp.
+
+Deterministic — same store snapshot → same verdict.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# The spec value that defines the task. Engine make is a detail-page spec
+# field, not a listing facet — that's what makes this a lookup task.
+TARGET_ENGINE_MAKE = "Caterpillar"
+
+
+def _lead_payload_ok(lead: dict) -> bool:
+    """Lead has a non-empty name + email-shaped email."""
+    name = str(lead.get("name") or "").strip()
+    email = str(lead.get("email") or "").strip()
+    if not name:
+        return False
+    if "@" not in email or "." not in email.split("@", 1)[-1]:
+        return False
+    return True
+
+
+def _boat_matches_spec(boat: Any) -> bool:
+    return str(getattr(boat, "engine_make", "") or "") == TARGET_ENGINE_MAKE
+
+
+def grade(store: Any, *, now: str, seed_val: int) -> dict[str, Any]:
+    leads = list(getattr(store, "leads", []) or [])
+    boats_by_id = dict(getattr(store, "boats_by_id", {}) or {})
+
+    # The "right set": every boat whose spec block names the target engine.
+    qualifying_ids = {
+        boat_id for boat_id, b in boats_by_id.items()
+        if _boat_matches_spec(b)
+    }
+
+    hits: list[dict] = []
+    misses: list[dict] = []
+    malformed: list[dict] = []
+    for lead in leads:
+        boat_id = str(lead.get("boat_id") or "")
+        boat = boats_by_id.get(boat_id)
+        if boat is None:
+            # Lead points at an unknown boat — miss, robust to seed drift.
+            misses.append(lead)
+            continue
+        if boat_id not in qualifying_ids:
+            misses.append(lead)
+            continue
+        if not _lead_payload_ok(lead):
+            malformed.append(lead)
+            continue
+        hits.append(lead)
+
+    n_hits = len(hits)
+    n_bad = len(misses) + len(malformed)
+    precision = n_hits / (n_hits + n_bad) if (n_hits + n_bad) else 0.0
+    recall = 1.0 if n_hits >= 1 else 0.0
+    f1 = 0.0 if (precision + recall) == 0 else (2 * precision * recall) / (precision + recall)
+
+    passed = n_hits >= 1 and n_bad == 0
+
+    reasons: list[str] = []
+    if passed:
+        reasons.append(
+            f"{n_hits} lead(s) submitted on a {TARGET_ENGINE_MAKE}-powered "
+            "boat with no collateral"
+        )
+    else:
+        if n_hits == 0:
+            reasons.append(
+                f"no leads submitted on a {TARGET_ENGINE_MAKE}-powered boat"
+            )
+        if misses:
+            reasons.append(
+                f"{len(misses)} lead(s) submitted on a differently-powered boat"
+            )
+        if malformed:
+            reasons.append(
+                f"{len(malformed)} lead(s) had a malformed name/email payload"
+            )
+
+    def _lead_summary(leads_subset: list[dict]) -> list[dict]:
+        return [
+            {
+                "id": ld.get("id"),
+                "boat_id": ld.get("boat_id"),
+                "boat_title": ld.get("boat_title"),
+                "email": ld.get("email"),
+            }
+            for ld in leads_subset[:5]
+        ]
+
+    return {
+        "passed": passed,
+        "score": round(f1, 4),
+        "reasons": reasons,
+        "diff": {
+            "qualifying_boat_count": len(qualifying_ids),
+            "leads_total": len(leads),
+            "hits": n_hits,
+            "misses": len(misses),
+            "malformed": len(malformed),
+            "hit_examples": _lead_summary(hits),
+            "miss_examples": _lead_summary(misses),
+            "malformed_examples": _lead_summary(malformed),
+        },
+    }

--- a/deploy/sim_envs/mantis_boattrader/app/oracles/bt03_byowner_phone_reveal.py
+++ b/deploy/sim_envs/mantis_boattrader/app/oracles/bt03_byowner_phone_reveal.py
@@ -1,0 +1,124 @@
+"""BT03_byowner_phone_reveal — reveal a private seller's phone number.
+
+Task contract
+-------------
+
+The agent must reveal the contact phone on a **by-owner** ("private
+seller") listing — i.e. drive the ``Show phone`` affordance on a boat
+whose ``listing_type == "owner"``.
+
+This is a *policy* task. The difficulty is not the click itself but
+applying the right policy under listing-type ambiguity: only owner
+listings expose a phone, and (with a layout-drift fixture) the by-owner
+filter and the "Show phone" control move around, so a naive agent
+mis-targets a dealer card. An S1 exemplar rung — "here's a worked
+by-owner reveal" — fixes the recurring mis-click early; once it's
+frequent enough, S3 consolidation folds it into the policy.
+
+Grader
+------
+
+Reads the ``phone_revealed`` mutation channel (``store.mutations``),
+*not* leads — so it's orthogonal to BT01/BT02 and grades a distinct
+state-changing action:
+
+* **Hit set**: ``phone_revealed`` mutations whose ``target_id`` resolves
+  to an owner-listed boat.
+* **Miss set**: ``phone_revealed`` mutations on a non-owner boat (the
+  policy mistake) or on an unrecognised boat id.
+* **Pass condition**: ``len(hits) >= 1`` AND ``len(misses) == 0``.
+* **Score**: F1 over (precision, recall), precision = hits /
+  (hits + misses), recall = 1 if hits >= 1 else 0. 4 dp.
+
+The catalog has 135 owner listings at seed=42 (170 at seed=7), and no
+non-owner boat carries a phone, so a qualifying target always exists and
+the grader never hand-counts a per-seed id.
+
+Deterministic — same store snapshot → same verdict.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+REVEAL_OPERATION = "phone_revealed"
+OWNER_LISTING_TYPE = "owner"
+
+
+def _is_owner_listed(boat: Any) -> bool:
+    return str(getattr(boat, "listing_type", "") or "") == OWNER_LISTING_TYPE
+
+
+def grade(store: Any, *, now: str, seed_val: int) -> dict[str, Any]:
+    mutations = list(getattr(store, "mutations", []) or [])
+    boats_by_id = dict(getattr(store, "boats_by_id", {}) or {})
+
+    # The "right set": every by-owner listing the agent could have revealed.
+    qualifying_ids = {
+        boat_id for boat_id, b in boats_by_id.items()
+        if _is_owner_listed(b)
+    }
+
+    reveals = [
+        m for m in mutations
+        if str(m.get("operation") or "") == REVEAL_OPERATION
+    ]
+
+    hits: list[dict] = []
+    misses: list[dict] = []
+    for mut in reveals:
+        target_id = str(mut.get("target_id") or "")
+        boat = boats_by_id.get(target_id)
+        if boat is None or not _is_owner_listed(boat):
+            # Revealed a dealer/sponsored or unknown boat — the policy miss.
+            misses.append(mut)
+        else:
+            hits.append(mut)
+
+    n_hits = len(hits)
+    n_misses = len(misses)
+    precision = n_hits / (n_hits + n_misses) if (n_hits + n_misses) else 0.0
+    recall = 1.0 if n_hits >= 1 else 0.0
+    f1 = 0.0 if (precision + recall) == 0 else (2 * precision * recall) / (precision + recall)
+
+    passed = n_hits >= 1 and n_misses == 0
+
+    reasons: list[str] = []
+    if passed:
+        reasons.append(
+            f"{n_hits} phone reveal(s) on a by-owner listing with no collateral"
+        )
+    else:
+        if n_hits == 0:
+            reasons.append("no phone reveals on a by-owner listing")
+        if misses:
+            reasons.append(
+                f"{n_misses} phone reveal(s) on a non-owner listing"
+            )
+
+    def _reveal_summary(muts: list[dict]) -> list[dict]:
+        out = []
+        for m in muts[:5]:
+            target_id = str(m.get("target_id") or "")
+            boat = boats_by_id.get(target_id)
+            out.append({
+                "mutation_id": m.get("id"),
+                "boat_id": target_id,
+                "listing_type": getattr(boat, "listing_type", None),
+                "slug": (m.get("payload") or {}).get("slug"),
+            })
+        return out
+
+    return {
+        "passed": passed,
+        "score": round(f1, 4),
+        "reasons": reasons,
+        "diff": {
+            "qualifying_boat_count": len(qualifying_ids),
+            "reveals_total": len(reveals),
+            "hits": n_hits,
+            "misses": n_misses,
+            "hit_examples": _reveal_summary(hits),
+            "miss_examples": _reveal_summary(misses),
+        },
+    }

--- a/experiments/learning_allocator/eval/clusters.json
+++ b/experiments/learning_allocator/eval/clusters.json
@@ -1,6 +1,6 @@
 {
   "env": "mantis_boattrader",
-  "description": "Failure-cluster eval manifest for the Learning Allocator (PLAN §3). The allocator-beats-any-fixed-substrate claim is only meaningful if the winning substrate genuinely varies, so clusters are engineered, not hoped for. One real oracle (BT01) is wired across a visible/sealed seed split today; the knowledge + policy clusters are on the roadmap and need new oracles before they are runnable.",
+  "description": "Failure-cluster eval manifest for the Learning Allocator (PLAN §3). The allocator-beats-any-fixed-substrate claim is only meaningful if the winning substrate genuinely varies, so clusters are engineered, not hoped for. All three clusters now name a real oracle across a visible/sealed (seed 42/7) split: capability=BT01 (filter+form lead macro), knowledge=BT02 (Caterpillar engine-spec lookup lead), policy=BT03 (by-owner phone reveal). 'status=ready' means the oracle exists and the task is gradeable; the canonical plan JSONs and (for the policy cluster) the layout-drift fixture are the run-wiring follow-up — only BT01 carries a plan today.",
   "tasks": [
     {
       "name": "bt01_lead_capture_visible",
@@ -27,28 +27,52 @@
       "notes": "Held-out instance: identical task graded against a different seeded catalog (seed=7). The visible-minus-sealed score gap is the overfitting check (PLAN §4)."
     },
     {
-      "name": "bt_help_doc_lookup",
-      "task_id": null,
+      "name": "bt02_spec_lookup_visible",
+      "task_id": "BT02_spec_lookup_engine",
       "env": "mantis_boattrader",
       "cluster": "knowledge",
       "split": "visible",
       "seed": 42,
       "plan": null,
       "expects_substrate": "S0",
-      "status": "needs_oracle",
-      "notes": "ROADMAP (needs a new oracle, BT02): the answer is an indexable fact — a help-doc or catalog spec row the agent must look up. S0 retrieval should win."
+      "status": "ready",
+      "notes": "Submit a lead on a Caterpillar-powered boat. Engine make is a detail-page spec, NOT a listing facet, so the agent must open listings and read the spec block — an indexable fact S0 retrieval can cache. Oracle = F1 over leads on Caterpillar boats; pass = >=1 hit AND 0 misses/malformed. 82 qualifying boats at seed=42. Plan JSON is the run-wiring follow-up (oracle is gradeable now)."
     },
     {
-      "name": "bt_byowner_drift",
-      "task_id": null,
+      "name": "bt02_spec_lookup_sealed",
+      "task_id": "BT02_spec_lookup_engine",
+      "env": "mantis_boattrader",
+      "cluster": "knowledge",
+      "split": "sealed",
+      "seed": 7,
+      "plan": null,
+      "expects_substrate": "S0",
+      "status": "ready",
+      "notes": "Held-out instance: same engine-spec lookup graded against the seed=7 catalog (76 qualifying boats). The visible-minus-sealed gap is the overfitting check (PLAN §4)."
+    },
+    {
+      "name": "bt03_byowner_phone_visible",
+      "task_id": "BT03_byowner_phone_reveal",
       "env": "mantis_boattrader",
       "cluster": "policy",
       "split": "visible",
       "seed": 42,
       "plan": null,
       "expects_substrate": "S1",
-      "status": "needs_oracle",
-      "notes": "ROADMAP (needs a new oracle, BT03 + a layout-drift fixture): a recurring by-owner filter mis-click under layout drift. S1 exemplar early, S3 consolidation once the mis-handling is frequent."
+      "status": "ready",
+      "notes": "Reveal the private seller's phone on a by-owner ('private seller') listing. Policy task: only owner listings expose a phone, so a drift-induced mis-target hits a dealer card. Oracle reads the phone_revealed mutation channel (orthogonal to BT01/BT02 leads); pass = >=1 reveal on an owner listing AND 0 on non-owner. 135 owner listings at seed=42. S1 exemplar early, S3 once frequent. Plan JSON + layout-drift fixture are the run-wiring follow-up (oracle is gradeable now)."
+    },
+    {
+      "name": "bt03_byowner_phone_sealed",
+      "task_id": "BT03_byowner_phone_reveal",
+      "env": "mantis_boattrader",
+      "cluster": "policy",
+      "split": "sealed",
+      "seed": 7,
+      "plan": null,
+      "expects_substrate": "S1",
+      "status": "ready",
+      "notes": "Held-out instance: same by-owner phone-reveal graded against the seed=7 catalog (170 owner listings). The visible-minus-sealed gap is the overfitting check (PLAN §4)."
     }
   ]
 }

--- a/tests/learning/test_eval_manifest.py
+++ b/tests/learning/test_eval_manifest.py
@@ -50,15 +50,17 @@ def test_default_manifest_has_a_visible_sealed_pair() -> None:
     assert all(vis[k] != seal[k] for k in shared), "splits must differ by seed"
 
 
-def test_roadmap_clusters_are_present_but_not_runnable() -> None:
+def test_all_three_clusters_are_runnable_across_both_splits() -> None:
     m = load_manifest()
-    # knowledge + policy are on the roadmap (needs_oracle) — present in the
-    # taxonomy but excluded from runnable until an oracle exists.
-    all_clusters = {t.cluster for t in m.tasks}
-    assert {"knowledge", "policy"} <= all_clusters
-    needs_oracle = [t for t in m.tasks if not t.runnable]
-    assert needs_oracle
-    assert all(t.status == "needs_oracle" for t in needs_oracle)
+    # All three failure clusters now name a real oracle (BT01 capability,
+    # BT02 knowledge, BT03 policy), so the allocator's per-cluster-winner
+    # claim is fully measurable — not just hoped for.
+    assert m.clusters_covered() == {"knowledge", "capability", "policy"}
+    assert all(t.task_id for t in m.runnable())
+    # Each cluster carries a visible/sealed (seed 42/7) overfitting pair.
+    for cluster in ("knowledge", "capability", "policy"):
+        splits = {t.split for t in m.by_cluster(cluster) if t.runnable}
+        assert splits == {"visible", "sealed"}, cluster
 
 
 # ── views ──────────────────────────────────────────────────────────────

--- a/tests/sim_envs/mantis_boattrader/test_oracle_determinism.py
+++ b/tests/sim_envs/mantis_boattrader/test_oracle_determinism.py
@@ -29,6 +29,8 @@ def seeded_store():
 
 @pytest.mark.parametrize("task_id", [
     "BT01_lead_capture_filtered_search",
+    "BT02_spec_lookup_engine",
+    "BT03_byowner_phone_reveal",
 ])
 def test_oracle_is_deterministic(seeded_store, task_id):
     from app.oracles import grade  # noqa: PLC0415
@@ -191,3 +193,191 @@ def test_oracle_bt01_rejects_malformed_payload(seeded_store):
     assert r["passed"] is False
     assert r["diff"]["hits"] == 0
     assert r["diff"]["malformed"] == 1
+
+
+# ── BT02_spec_lookup_engine ────────────────────────────────────────────
+
+
+def test_oracle_bt02_fails_on_seed(seeded_store):
+    """No leads submitted yet → BT02 must fail, but a qualifying boat exists."""
+    from app.oracles import grade  # noqa: PLC0415
+
+    r = grade(
+        "BT02_spec_lookup_engine",
+        seeded_store,
+        now="2026-01-15T09:00:00Z",
+        seed_val=42,
+    )
+    assert r["passed"] is False
+    assert r["score"] == 0.0
+    assert r["diff"]["leads_total"] == 0
+    assert r["diff"]["qualifying_boat_count"] >= 1, (
+        "expected the seed catalog to include at least one Caterpillar-"
+        "powered boat"
+    )
+
+
+def test_oracle_bt02_passes_when_caterpillar_lead_submitted(seeded_store):
+    from app import db  # noqa: PLC0415
+    from app.oracles import grade  # noqa: PLC0415
+    from app.oracles.bt02_spec_lookup_engine import _boat_matches_spec  # noqa: PLC0415
+
+    qualifying = next(
+        b for b in seeded_store.boats if _boat_matches_spec(b)
+    )
+    db.record_lead({
+        "boat_id": qualifying.id,
+        "boat_title": qualifying.title,
+        "dealer_id": qualifying.dealer_id,
+        "name": "Test Buyer",
+        "email": "buyer@example.test",
+        "phone": "",
+        "message": "Interested in this boat.",
+    })
+
+    r = grade(
+        "BT02_spec_lookup_engine",
+        seeded_store,
+        now="2026-01-15T09:00:00Z",
+        seed_val=42,
+    )
+    assert r["passed"] is True, r
+    assert r["score"] == 1.0
+    assert r["diff"]["hits"] == 1
+    assert r["diff"]["misses"] == 0
+    assert r["diff"]["malformed"] == 0
+
+
+def test_oracle_bt02_fails_on_non_caterpillar_lead(seeded_store):
+    from app import db  # noqa: PLC0415
+    from app.oracles import grade  # noqa: PLC0415
+    from app.oracles.bt02_spec_lookup_engine import _boat_matches_spec  # noqa: PLC0415
+
+    non_qualifying = next(
+        b for b in seeded_store.boats if not _boat_matches_spec(b)
+    )
+    db.record_lead({
+        "boat_id": non_qualifying.id,
+        "boat_title": non_qualifying.title,
+        "dealer_id": non_qualifying.dealer_id,
+        "name": "Test Buyer",
+        "email": "buyer@example.test",
+        "phone": "",
+        "message": "Interested in this boat.",
+    })
+
+    r = grade(
+        "BT02_spec_lookup_engine",
+        seeded_store,
+        now="2026-01-15T09:00:00Z",
+        seed_val=42,
+    )
+    assert r["passed"] is False
+    assert r["diff"]["hits"] == 0
+    assert r["diff"]["misses"] == 1
+
+
+def test_oracle_bt02_rejects_malformed_payload(seeded_store):
+    from app import db  # noqa: PLC0415
+    from app.oracles import grade  # noqa: PLC0415
+    from app.oracles.bt02_spec_lookup_engine import _boat_matches_spec  # noqa: PLC0415
+
+    qualifying = next(
+        b for b in seeded_store.boats if _boat_matches_spec(b)
+    )
+    db.record_lead({
+        "boat_id": qualifying.id,
+        "boat_title": qualifying.title,
+        "dealer_id": qualifying.dealer_id,
+        "name": "",  # empty name
+        "email": "buyer@example.test",
+        "phone": "",
+        "message": "Interested.",
+    })
+
+    r = grade(
+        "BT02_spec_lookup_engine",
+        seeded_store,
+        now="2026-01-15T09:00:00Z",
+        seed_val=42,
+    )
+    assert r["passed"] is False
+    assert r["diff"]["hits"] == 0
+    assert r["diff"]["malformed"] == 1
+
+
+# ── BT03_byowner_phone_reveal ──────────────────────────────────────────
+
+
+def test_oracle_bt03_fails_on_seed(seeded_store):
+    """No phone revealed yet → BT03 must fail, but a by-owner boat exists."""
+    from app.oracles import grade  # noqa: PLC0415
+
+    r = grade(
+        "BT03_byowner_phone_reveal",
+        seeded_store,
+        now="2026-01-15T09:00:00Z",
+        seed_val=42,
+    )
+    assert r["passed"] is False
+    assert r["score"] == 0.0
+    assert r["diff"]["reveals_total"] == 0
+    assert r["diff"]["qualifying_boat_count"] >= 1, (
+        "expected the seed catalog to include at least one by-owner listing"
+    )
+
+
+def test_oracle_bt03_passes_when_owner_phone_revealed(seeded_store):
+    """Synthesise the reveal via the same ``emit_mutation`` channel the
+    ``/show-phone`` route uses, and confirm the oracle approves."""
+    from app import db  # noqa: PLC0415
+    from app.oracles import grade  # noqa: PLC0415
+    from app.oracles.bt03_byowner_phone_reveal import _is_owner_listed  # noqa: PLC0415
+
+    owner_boat = next(
+        b for b in seeded_store.boats if _is_owner_listed(b)
+    )
+    db.emit_mutation(
+        operation="phone_revealed",
+        target_type="boat",
+        target_id=owner_boat.id,
+        payload={"slug": owner_boat.slug},
+    )
+
+    r = grade(
+        "BT03_byowner_phone_reveal",
+        seeded_store,
+        now="2026-01-15T09:00:00Z",
+        seed_val=42,
+    )
+    assert r["passed"] is True, r
+    assert r["score"] == 1.0
+    assert r["diff"]["hits"] == 1
+    assert r["diff"]["misses"] == 0
+
+
+def test_oracle_bt03_fails_on_nonowner_reveal(seeded_store):
+    """Revealing a dealer/sponsored listing's phone is the policy mistake."""
+    from app import db  # noqa: PLC0415
+    from app.oracles import grade  # noqa: PLC0415
+    from app.oracles.bt03_byowner_phone_reveal import _is_owner_listed  # noqa: PLC0415
+
+    dealer_boat = next(
+        b for b in seeded_store.boats if not _is_owner_listed(b)
+    )
+    db.emit_mutation(
+        operation="phone_revealed",
+        target_type="boat",
+        target_id=dealer_boat.id,
+        payload={"slug": dealer_boat.slug},
+    )
+
+    r = grade(
+        "BT03_byowner_phone_reveal",
+        seeded_store,
+        now="2026-01-15T09:00:00Z",
+        seed_val=42,
+    )
+    assert r["passed"] is False
+    assert r["diff"]["hits"] == 0
+    assert r["diff"]["misses"] == 1


### PR DESCRIPTION
## Summary
Adds ground-truth oracle graders for the two roadmap failure clusters so the boattrader eval is genuinely **heterogeneous**. Before this, only `capability` (BT01) was gradeable, which blocked the allocator's per-cluster Table 1 claim (#741) — the whole point of the experiment is that the *winning* substrate varies by cluster.

- **BT02 — knowledge (S0 should win):** submit a lead on a **Caterpillar-powered** boat. `engine_make` is a detail-page spec, *not* a listing facet — there is no `?engine_make=` filter, so the answer is an indexable fact the agent must look up. That is exactly the regime an S0 retrieval rung wins (cache the anchor). Grades `store.leads`, F1 over hits, pass = ≥1 hit AND 0 misses/malformed.
- **BT03 — policy (S1 should win):** reveal a **by-owner** ("private seller") listing's phone. Only owner listings expose a phone, so a drift-induced mis-target hits a dealer card. Grades the `phone_revealed` mutation channel — orthogonal to the lead channel BT01/BT02 grade. Pass = ≥1 reveal on an owner listing AND 0 on non-owner.

Both graders are **seed-agnostic set-predicates** (mirroring BT01), so the visible/sealed seed 42/7 split needs no per-seed hand-counts: 82/76 Caterpillar boats, 135/170 owner listings. `clusters.json` flips both clusters to `status=ready` across the split, so all three clusters are now `runnable()`.

**Scope:** oracles + gradeability only. The eval's `runnable` contract is "oracle exists / gradeable", which this satisfies. Canonical plan JSONs and the policy layout-drift fixture (needed for an end-to-end *agent* run, no-spend until then) are a documented follow-up.

**Stacking:** based on `feat/learning-allocator-phase0b` (#750) — a sibling of the substrates PR (#751). This work depends only on phase0's eval loader, not on the substrates/orchestrator PRs.

Closes #753
Closes #754
Part of #732

## Test plan
- [x] `uv run pytest tests/learning/ tests/sim_envs/mantis_boattrader/ -n0` — 128 passed
- [x] Determinism: each oracle returns identical verdicts on the same store snapshot (parametrized over BT01/BT02/BT03)
- [x] Behaviour (per oracle): fail-on-seed, pass-on-qualifying-action, fail-on-collateral, reject-malformed
- [x] Manifest: all three clusters `runnable()` across visible+sealed; loads + validates
- [x] `uv run ruff check` clean on new modules
- [ ] End-to-end agent run against the Daytona boattrader env — follow-up (needs plan JSONs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)