### PR TITLE
feat(learning): Phase-2 experiment runner — offline Table 1 / Fig 1 harness

### DIFF
--- a/experiments/learning_allocator/runner.py
+++ b/experiments/learning_allocator/runner.py
@@ -1,0 +1,590 @@
+"""Phase-2 experiment runner — turn the bandit loop into Table 1 / Fig 1.
+
+The orchestrator (:mod:`mantis_agent.learning.orchestrator`) drives *one*
+policy through the eval. The paper's headline result is a *comparison*: the
+Learning Allocator against every fixed-substrate baseline under one budget
+(PLAN §4). This module is that comparison harness — it builds the baseline
+and learner policies, runs each over the same eval tasks, and renders the
+two artifacts #741 asks for:
+
+* **Table 1** — per policy: sealed oracle score, score-per-dollar, and the
+  visible−sealed overfitting gap.
+* **Fig 1** — per policy: running oracle score vs cumulative dollars, so the
+  allocator's "more competence per dollar" curve is plottable above the
+  fixed rungs.
+
+Policies (PLAN §4 baselines), each a :class:`MyopicAllocator` over a chosen
+slice of the ladder:
+
+* ``frozen``   — base agent, no learning (a single no-op rung).
+* ``S0_only``  — retrieval/hint overlay only.
+* ``S1_only``  — exemplar replay only.
+* ``allocator``— the learner, choosing across S0+S1 (our policy).
+
+``oracle_allocator`` (the upper-reference / headroom) is **derived** post
+hoc — per task, the best oracle score any fixed policy achieved — not run as
+its own policy.
+
+Two run modes, one code path:
+
+* **Offline** (this PR, no spend) — outcomes are baked into the
+  ``run_result`` dict and scored by :func:`offline_reward_fn`. Used by the
+  unit tests and the ``--out`` demo to exercise the whole pipeline and the
+  renderers with no env boots and no Modal/Daytona calls.
+* **Live** (the spend boundary, a follow-up) — a ``run_fn`` that submits each
+  plan to the Modal CUA server against the Daytona boattrader env (no
+  proxies) and a ``reward_fn`` left at its default
+  (:func:`~mantis_agent.learning.reward.reward_from_run`, which calls the
+  env's ``/__env__/oracle``). That adapter lands when we cross the spend
+  line; this module deliberately ships only the no-spend half.
+
+Run the offline demo (synthetic — validates wiring, NOT agent data)::
+
+    uv run python -m experiments.learning_allocator.runner --out /tmp/la
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+from dataclasses import dataclass, field
+from pathlib import Path
+from random import Random
+from typing import Any
+
+from mantis_agent.learning.allocator import MyopicAllocator
+from mantis_agent.learning.eval import EvalTask, load_manifest
+from mantis_agent.learning.orchestrator import (
+    Phase2Orchestrator,
+    Phase2Report,
+    TaskOutcome,
+)
+from mantis_agent.learning.reward import (
+    DEFAULT_LAMBDA,
+    RewardRecord,
+    compute_reward,
+    cost_channel,
+    proxy_channel,
+)
+from mantis_agent.learning.substrates.base import (
+    Durability,
+    SubstrateContext,
+    SubstrateResult,
+)
+from mantis_agent.learning.substrates.exemplar import ExemplarSubstrate
+from mantis_agent.learning.substrates.retrieval import RetrievalSubstrate
+
+# Policy → the substrate roles it may choose among. "frozen" is the base
+# agent with no learning, modelled as a single no-op rung.
+FROZEN = "frozen"
+S0 = "S0_retrieval"
+S1 = "S1_exemplar"
+
+POLICY_SUBSTRATES: dict[str, tuple[str, ...]] = {
+    "frozen": (FROZEN,),
+    "S0_only": (S0,),
+    "S1_only": (S1,),
+    "allocator": (S0, S1),
+}
+
+# The fixed-substrate policies whose per-task best defines the oracle-allocator
+# upper bound. The learner ("allocator") is excluded — it is what the upper
+# bound is a reference *for*.
+FIXED_POLICIES: tuple[str, ...] = ("frozen", "S0_only", "S1_only")
+
+
+# ── frozen rung ─────────────────────────────────────────────────────────────
+
+
+class NoOpSubstrate:
+    """The ``frozen`` baseline: a rung that never acts, at zero cost.
+
+    Lets the base (non-learning) agent ride the exact same loop as the
+    learning policies — the allocator "chooses" it, ``apply`` overlays
+    nothing, and the run reflects the frozen agent's own competence. Without
+    this, ``frozen`` would need a separate code path; with it, every policy
+    is just a different substrate slice.
+    """
+
+    durability = Durability.EPHEMERAL
+
+    def __init__(self, *, name: str = FROZEN) -> None:
+        self.name = name
+
+    def cost_estimate(self, context: SubstrateContext) -> float:  # noqa: ARG002
+        return 0.0
+
+    def apply(self, context: SubstrateContext) -> SubstrateResult:  # noqa: ARG002
+        return SubstrateResult(
+            substrate=self.name,
+            applied=False,
+            dollars_spent=0.0,
+            durability=self.durability,
+            notes="frozen baseline — no learning applied",
+        )
+
+    def observe(
+        self, context: SubstrateContext, result: SubstrateResult, reward: float,
+    ) -> None:  # noqa: ARG002
+        return None
+
+
+# ── offline reward channel ──────────────────────────────────────────────────
+
+
+def offline_reward_fn(
+    *,
+    env_url: str,  # noqa: ARG001 — kept for reward_fn signature parity
+    admin_token: str,  # noqa: ARG001
+    task_id: str,
+    run_result: dict[str, Any],
+    lam: float = DEFAULT_LAMBDA,
+) -> RewardRecord:
+    """Score a run from outcomes baked into ``run_result`` — no oracle call.
+
+    The live channel (:func:`reward_from_run`) hits the env's oracle over
+    HTTP. Offline, the ground-truth verdict is carried *in* the run_result
+    (``oracle_score`` / ``oracle_passed``); the proxy verdict and dollar cost
+    are read from the same dict by the shared channel readers. Same arithmetic
+    (:func:`compute_reward`), no network — so the loop runs with zero spend.
+    """
+    return compute_reward(
+        task_id=task_id,
+        oracle_score=float(run_result.get("oracle_score", 0.0) or 0.0),
+        oracle_passed=bool(run_result.get("oracle_passed", False)),
+        proxy_verdict=proxy_channel(run_result),
+        dollars=cost_channel(run_result),
+        lam=lam,
+    )
+
+
+# ── policy assembly ─────────────────────────────────────────────────────────
+
+
+def build_substrate(role: str, *, hint_store: Any = None, trace_dir: Any = None):
+    """Instantiate one substrate by role name."""
+    if role == FROZEN:
+        return NoOpSubstrate()
+    if role == S0:
+        return RetrievalSubstrate(hint_store)
+    if role == S1:
+        # trace_dir may be None in offline runs — ExemplarSubstrate then finds
+        # no corpus and simply applies nothing, which is the correct frozen-ish
+        # behaviour for a cold start.
+        return ExemplarSubstrate(trace_dir or Path("/nonexistent-trace-dir"))
+    raise ValueError(f"unknown substrate role: {role!r}")
+
+
+def build_policy_allocator(
+    policy: str,
+    *,
+    hint_store: Any = None,
+    trace_dir: Any = None,
+    epsilon: float = 0.1,
+    rng: Random | None = None,
+    lam: float = DEFAULT_LAMBDA,
+) -> MyopicAllocator:
+    """Build the :class:`MyopicAllocator` for a named policy."""
+    roles = POLICY_SUBSTRATES.get(policy)
+    if roles is None:
+        raise ValueError(f"unknown policy: {policy!r}")
+    substrates = [
+        build_substrate(r, hint_store=hint_store, trace_dir=trace_dir)
+        for r in roles
+    ]
+    return MyopicAllocator(substrates, lam=lam, epsilon=epsilon, rng=rng)
+
+
+@dataclass
+class ExperimentResult:
+    """Everything the renderers need: one report per policy + split metadata."""
+
+    reports: dict[str, Phase2Report] = field(default_factory=dict)
+    split_of: dict[str, str] = field(default_factory=dict)
+    seed_of: dict[str, int] = field(default_factory=dict)
+    cluster_of: dict[str, str] = field(default_factory=dict)
+    budget: float = 0.0
+    rounds: int = 1
+
+
+def run_experiment(
+    *,
+    tasks: list[EvalTask],
+    run_fn,
+    reward_fn=None,
+    env_url: str = "",
+    admin_token: str = "",
+    budget: float = 50.0,
+    rounds: int = 1,
+    epsilon: float = 0.1,
+    seed: int = 0,
+    policies: tuple[str, ...] = tuple(POLICY_SUBSTRATES),
+    hint_store: Any = None,
+    trace_dir: Any = None,
+    start_url: str = "",
+) -> ExperimentResult:
+    """Run every policy over ``tasks`` under an identical budget and collect.
+
+    Each policy gets its own allocator and its own fresh budget ``B`` (the
+    paper runs all learning policies under the *same* budget, separately).
+    ``run_fn`` / ``reward_fn`` are injected so this is spend-agnostic: offline
+    tests pass canned ones, the live wiring passes the Modal-submit pair.
+    """
+    result = ExperimentResult(budget=budget, rounds=rounds)
+    for t in tasks:
+        result.split_of[t.name] = t.split
+        result.seed_of[t.name] = t.seed
+        result.cluster_of[t.name] = t.cluster
+
+    for policy in policies:
+        # Per-policy RNG keeps each policy deterministic yet decorrelated.
+        # Seed with a string — Random hashes str/bytes stably (sha512), unlike
+        # the builtin hash() which is per-process randomized.
+        rng = Random(f"{seed}:{policy}")
+        allocator = build_policy_allocator(
+            policy, hint_store=hint_store, trace_dir=trace_dir,
+            epsilon=epsilon, rng=rng,
+        )
+        orch = Phase2Orchestrator(
+            allocator=allocator,
+            run_fn=run_fn,
+            env_url=env_url,
+            admin_token=admin_token,
+            budget=budget,
+            reward_fn=reward_fn,
+            start_url=start_url,
+        )
+        result.reports[policy] = orch.run(tasks, rounds=rounds)
+    return result
+
+
+# ── analysis: Table 1 + the oracle-allocator upper bound ────────────────────
+
+
+def _graded(report: Phase2Report) -> list[TaskOutcome]:
+    return [o for o in report.outcomes if not o.skipped and o.reward_record]
+
+
+def _safe_div(num: float, den: float) -> float:
+    return num / den if den else 0.0
+
+
+@dataclass
+class Table1Row:
+    """One policy's row in Table 1 (PLAN §5)."""
+
+    policy: str
+    sealed_score: float       # mean oracle score on the sealed split
+    visible_score: float      # mean oracle score on the visible split
+    visible_minus_sealed: float  # the overfitting gap
+    score_per_dollar: float   # total oracle score / total dollars
+    total_dollars: float
+    n_runs: int
+
+
+def build_table1(result: ExperimentResult) -> list[Table1Row]:
+    """Per-policy Table 1 rows, plus the derived ``oracle_allocator`` row."""
+    rows = [_policy_row(name, rep, result) for name, rep in result.reports.items()]
+    oracle_row = _oracle_allocator_row(result)
+    if oracle_row is not None:
+        rows.append(oracle_row)
+    return rows
+
+
+def _policy_row(
+    policy: str, report: Phase2Report, result: ExperimentResult,
+) -> Table1Row:
+    visible, sealed = [], []
+    total_score = 0.0
+    total_dollars = 0.0
+    for o in _graded(report):
+        score = o.reward_record.oracle_score
+        total_score += score
+        total_dollars += float(o.dollars or 0.0)
+        if result.split_of.get(o.task_name) == "sealed":
+            sealed.append(score)
+        else:
+            visible.append(score)
+    sealed_mean = _mean(sealed)
+    visible_mean = _mean(visible)
+    return Table1Row(
+        policy=policy,
+        sealed_score=round(sealed_mean, 4),
+        visible_score=round(visible_mean, 4),
+        visible_minus_sealed=round(visible_mean - sealed_mean, 4),
+        score_per_dollar=round(_safe_div(total_score, total_dollars), 4),
+        total_dollars=round(total_dollars, 4),
+        n_runs=len(_graded(report)),
+    )
+
+
+def _oracle_allocator_row(result: ExperimentResult) -> Table1Row | None:
+    """Upper bound: per task, the best (oracle_score, dollars) any fixed
+    policy got. The headroom the learner is chasing."""
+    # task_name -> (best_score, dollars_at_best)
+    best: dict[str, tuple[float, float]] = {}
+    for policy in FIXED_POLICIES:
+        report = result.reports.get(policy)
+        if not report:
+            continue
+        for o in _graded(report):
+            score = o.reward_record.oracle_score
+            dollars = float(o.dollars or 0.0)
+            cur = best.get(o.task_name)
+            # Prefer higher score; on a tie prefer the cheaper run.
+            if cur is None or score > cur[0] or (score == cur[0] and dollars < cur[1]):
+                best[o.task_name] = (score, dollars)
+    if not best:
+        return None
+
+    visible, sealed = [], []
+    total_score = 0.0
+    total_dollars = 0.0
+    for name, (score, dollars) in best.items():
+        total_score += score
+        total_dollars += dollars
+        if result.split_of.get(name) == "sealed":
+            sealed.append(score)
+        else:
+            visible.append(score)
+    sealed_mean = _mean(sealed)
+    visible_mean = _mean(visible)
+    return Table1Row(
+        policy="oracle_allocator",
+        sealed_score=round(sealed_mean, 4),
+        visible_score=round(visible_mean, 4),
+        visible_minus_sealed=round(visible_mean - sealed_mean, 4),
+        score_per_dollar=round(_safe_div(total_score, total_dollars), 4),
+        total_dollars=round(total_dollars, 4),
+        n_runs=len(best),
+    )
+
+
+def _mean(xs: list[float]) -> float:
+    return sum(xs) / len(xs) if xs else 0.0
+
+
+# ── analysis: Fig 1 series ──────────────────────────────────────────────────
+
+
+@dataclass
+class Fig1Point:
+    index: int
+    cum_dollars: float
+    running_mean_oracle: float
+
+
+def fig1_series(report: Phase2Report) -> list[Fig1Point]:
+    """Running-mean oracle score vs cumulative dollars, in decision order.
+
+    The x-axis is *cumulative dollars* (the paper's Fig 1, not steps); the
+    y-axis is the agent's competence so far (running mean oracle score). A
+    learner that buys competence efficiently rises left of the fixed rungs.
+    """
+    points: list[Fig1Point] = []
+    cum_dollars = 0.0
+    score_sum = 0.0
+    n = 0
+    for o in _graded(report):
+        n += 1
+        cum_dollars += float(o.dollars or 0.0)
+        score_sum += o.reward_record.oracle_score
+        points.append(Fig1Point(
+            index=n,
+            cum_dollars=round(cum_dollars, 4),
+            running_mean_oracle=round(score_sum / n, 4),
+        ))
+    return points
+
+
+# ── writers ─────────────────────────────────────────────────────────────────
+
+_SYNTHETIC_BANNER = (
+    "# SOURCE=offline-demo — SYNTHETIC outcomes for pipeline validation. "
+    "NOT agent data. Real results require the live Modal/Daytona run."
+)
+
+
+def write_results(
+    result: ExperimentResult, out_dir: str | Path, *, banner: str = _SYNTHETIC_BANNER,
+) -> dict[str, Path]:
+    """Write results.tsv + table1.tsv + fig1.tsv under ``out_dir``.
+
+    ``banner`` is stamped as the first commented line of every file so an
+    offline-demo run can never be mistaken for real agent data.
+    """
+    out = Path(out_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    paths = {
+        "results": out / "results.tsv",
+        "table1": out / "table1.tsv",
+        "fig1": out / "fig1.tsv",
+    }
+    _write_outcomes_tsv(paths["results"], result, banner)
+    _write_table1_tsv(paths["table1"], build_table1(result), banner)
+    _write_fig1_tsv(paths["fig1"], result, banner)
+    return paths
+
+
+def _write_outcomes_tsv(path: Path, result: ExperimentResult, banner: str) -> None:
+    cols = [
+        "policy", "task_name", "task_id", "cluster", "split", "seed",
+        "substrate", "oracle_score", "oracle_passed", "proxy_verdict",
+        "dollars", "reward", "false_pass", "false_fail", "skipped", "note",
+    ]
+    with path.open("w", newline="") as fh:
+        fh.write(banner + "\n")
+        w = csv.writer(fh, delimiter="\t")
+        w.writerow(cols)
+        for policy, report in result.reports.items():
+            for o in report.outcomes:
+                rr = o.reward_record
+                w.writerow([
+                    policy, o.task_name, o.task_id, o.cluster,
+                    result.split_of.get(o.task_name, ""),
+                    result.seed_of.get(o.task_name, ""),
+                    o.substrate or "",
+                    rr.oracle_score if rr else "",
+                    rr.oracle_passed if rr else "",
+                    rr.proxy_verdict if rr else "",
+                    o.dollars if o.dollars is not None else "",
+                    o.reward if o.reward is not None else "",
+                    rr.false_pass if rr else "",
+                    rr.false_fail if rr else "",
+                    o.skipped, o.note,
+                ])
+
+
+def _write_table1_tsv(path: Path, rows: list[Table1Row], banner: str) -> None:
+    cols = [
+        "policy", "sealed_score", "visible_score", "visible_minus_sealed",
+        "score_per_dollar", "total_dollars", "n_runs",
+    ]
+    with path.open("w", newline="") as fh:
+        fh.write(banner + "\n")
+        w = csv.writer(fh, delimiter="\t")
+        w.writerow(cols)
+        for r in rows:
+            w.writerow([
+                r.policy, r.sealed_score, r.visible_score,
+                r.visible_minus_sealed, r.score_per_dollar,
+                r.total_dollars, r.n_runs,
+            ])
+
+
+def _write_fig1_tsv(path: Path, result: ExperimentResult, banner: str) -> None:
+    with path.open("w", newline="") as fh:
+        fh.write(banner + "\n")
+        w = csv.writer(fh, delimiter="\t")
+        w.writerow(["policy", "index", "cum_dollars", "running_mean_oracle"])
+        for policy, report in result.reports.items():
+            for p in fig1_series(report):
+                w.writerow([policy, p.index, p.cum_dollars, p.running_mean_oracle])
+
+
+def format_table1(rows: list[Table1Row]) -> str:
+    """Render Table 1 as a fixed-width text table for stdout."""
+    header = (
+        f"{'policy':<18} {'sealed':>8} {'visible':>8} {'vis−seal':>9} "
+        f"{'score/$':>9} {'$total':>8} {'n':>4}"
+    )
+    lines = [header, "-" * len(header)]
+    for r in rows:
+        lines.append(
+            f"{r.policy:<18} {r.sealed_score:>8.4f} {r.visible_score:>8.4f} "
+            f"{r.visible_minus_sealed:>9.4f} {r.score_per_dollar:>9.4f} "
+            f"{r.total_dollars:>8.4f} {r.n_runs:>4d}"
+        )
+    return "\n".join(lines)
+
+
+# ── offline demo (synthetic — wiring validation only) ───────────────────────
+
+# Synthetic per-(cluster, substrate-role) outcomes encoding the PLAN §3
+# heterogeneity: knowledge→S0 wins, capability/policy→S1 wins, frozen loses
+# everywhere. ONLY for validating the harness end-to-end with no spend; these
+# numbers are invented, not measured.
+_DEMO_PROFILE: dict[tuple[str, str], dict[str, Any]] = {
+    ("knowledge", FROZEN): {"oracle_score": 0.0, "oracle_passed": False, "verdict": "fail", "cost": 0.40},
+    ("knowledge", S0):     {"oracle_score": 0.9, "oracle_passed": True,  "verdict": "pass", "cost": 0.42},
+    ("knowledge", S1):     {"oracle_score": 0.4, "oracle_passed": False, "verdict": "partial", "cost": 0.45},
+    ("capability", FROZEN): {"oracle_score": 0.1, "oracle_passed": False, "verdict": "fail", "cost": 0.50},
+    ("capability", S0):     {"oracle_score": 0.4, "oracle_passed": False, "verdict": "partial", "cost": 0.52},
+    ("capability", S1):     {"oracle_score": 0.8, "oracle_passed": True,  "verdict": "pass", "cost": 0.55},
+    ("policy", FROZEN): {"oracle_score": 0.0, "oracle_passed": False, "verdict": "fail", "cost": 0.45},
+    ("policy", S0):     {"oracle_score": 0.3, "oracle_passed": False, "verdict": "fail", "cost": 0.46},
+    ("policy", S1):     {"oracle_score": 0.85, "oracle_passed": True, "verdict": "pass", "cost": 0.50},
+}
+
+
+def make_demo_run_fn(cluster_of: dict[str, str]):
+    """A deterministic offline ``run_fn`` for the synthetic demo.
+
+    Looks the outcome up by the task's cluster and the substrate the
+    allocator applied, returning the ``run_result`` shape the offline reward
+    channel reads. Pure — no network, no spend.
+    """
+
+    def run_fn(task: EvalTask, plan: Any, result: SubstrateResult) -> dict:  # noqa: ARG001
+        cluster = cluster_of.get(task.name, task.cluster)
+        profile = _DEMO_PROFILE.get((cluster, result.substrate))
+        if profile is None:
+            profile = {"oracle_score": 0.0, "oracle_passed": False, "verdict": "fail", "cost": 0.4}
+        return {
+            "oracle_score": profile["oracle_score"],
+            "oracle_passed": profile["oracle_passed"],
+            "dynamic_verification_summary": {"verdict": profile["verdict"]},
+            "costs": {"total": profile["cost"]},
+        }
+
+    return run_fn
+
+
+def run_offline_demo(
+    *, rounds: int = 3, budget: float = 50.0, epsilon: float = 0.1, seed: int = 0,
+) -> ExperimentResult:
+    """Run the whole comparison offline on synthetic outcomes (no spend)."""
+    tasks = load_manifest().runnable()
+    cluster_of = {t.name: t.cluster for t in tasks}
+    return run_experiment(
+        tasks=tasks,
+        run_fn=make_demo_run_fn(cluster_of),
+        reward_fn=offline_reward_fn,
+        budget=budget,
+        rounds=rounds,
+        epsilon=epsilon,
+        seed=seed,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Phase-2 Learning Allocator runner (offline demo).",
+    )
+    parser.add_argument("--out", default="", help="dir to write results TSVs (optional)")
+    parser.add_argument("--rounds", type=int, default=3)
+    parser.add_argument("--budget", type=float, default=50.0)
+    parser.add_argument("--epsilon", type=float, default=0.1)
+    parser.add_argument("--seed", type=int, default=0)
+    args = parser.parse_args(argv)
+
+    print(
+        "Learning Allocator — Phase-2 OFFLINE DEMO (synthetic outcomes).\n"
+        "This validates the runner wiring + renderers with NO spend. Real\n"
+        "Table 1 / Fig 1 require the live Modal/Daytona run (spend boundary).\n"
+    )
+    result = run_offline_demo(
+        rounds=args.rounds, budget=args.budget,
+        epsilon=args.epsilon, seed=args.seed,
+    )
+    print(format_table1(build_table1(result)))
+    if args.out:
+        paths = write_results(result, args.out)
+        print("\nwrote (SYNTHETIC):")
+        for label, p in paths.items():
+            print(f"  {label:<8} {p}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/mantis_agent/learning/orchestrator.py
+++ b/src/mantis_agent/learning/orchestrator.py
@@ -25,6 +25,13 @@ env boots and no spend**:
 * ``plan_loader(task) -> plan`` — returns the in-process plan object S0
   overlays grounding hints onto (and that ``run_fn`` submits). Optional:
   without it S0 simply finds nothing to overlay and S1 still runs.
+* ``reward_fn(*, env_url, admin_token, task_id, run_result, lam)`` — scores
+  a finished run into a :class:`~mantis_agent.learning.reward.RewardRecord`.
+  Defaults to the live :func:`~mantis_agent.learning.reward.reward_from_run`
+  (which calls the env's oracle over HTTP). Injecting it lets the experiment
+  runner drive the loop fully offline — outcomes baked into ``run_result``
+  rather than read from a live env — so Table 1 / Fig 1 can be produced and
+  the renderers exercised with no env boots and no spend.
 
 The experiment wiring that supplies the real Modal-submit ``run_fn`` lives
 under ``experiments/learning_allocator/`` — that is the only spend
@@ -51,6 +58,9 @@ RunFn = Callable[[EvalTask, Any, SubstrateResult], dict]
 PlanLoader = Callable[[EvalTask], Any]
 # Map a task to the plan_signature that keys the hint / exemplar stores.
 PlanSigFn = Callable[[EvalTask], str]
+# Score a finished run into a RewardRecord. Defaults to reward_from_run (live
+# oracle over HTTP); injectable so the loop can run fully offline.
+RewardFn = Callable[..., RewardRecord]
 
 
 @dataclass
@@ -101,6 +111,7 @@ class Phase2Orchestrator:
         budget: float,
         plan_loader: PlanLoader | None = None,
         plan_signature_fn: PlanSigFn | None = None,
+        reward_fn: RewardFn | None = None,
         start_url: str = "",
         lam: float = DEFAULT_LAMBDA,
     ) -> None:
@@ -114,6 +125,7 @@ class Phase2Orchestrator:
         self.start_url = start_url
         self._plan_loader = plan_loader
         self._plan_sig = plan_signature_fn or _default_plan_signature
+        self._reward_fn = reward_fn
         self.outcomes: list[TaskOutcome] = []
 
     # ── per-task ────────────────────────────────────────────────────────
@@ -153,7 +165,10 @@ class Phase2Orchestrator:
 
         run_result = self.run_fn(task, plan, substrate_result)
 
-        record = reward_from_run(
+        # Default resolves the module global at call time so existing tests
+        # that monkeypatch ``orchestrator.reward_from_run`` keep working.
+        reward_fn = self._reward_fn or reward_from_run
+        record = reward_fn(
             env_url=self.env_url,
             admin_token=self.admin_token,
             task_id=task.task_id or task.name,
@@ -240,6 +255,7 @@ __all__ = [
     "RunFn",
     "PlanLoader",
     "PlanSigFn",
+    "RewardFn",
     "TaskOutcome",
     "Phase2Report",
     "Phase2Orchestrator",

--- a/tests/learning/test_runner.py
+++ b/tests/learning/test_runner.py
@@ -1,0 +1,299 @@
+"""Tests for the Phase-2 experiment runner.
+
+All offline: the loop is driven by an injected ``run_fn`` (canned
+``run_result`` dicts) + :func:`offline_reward_fn` (ground truth baked into
+the result), so nothing here boots an env or spends a cent. They cover the
+no-op ``frozen`` rung, the offline reward channel, policy assembly, the
+Table 1 / Fig 1 derivations + writers, and an end-to-end demo asserting the
+allocator learns the per-cluster winner.
+"""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+import pytest
+
+from mantis_agent.learning.eval import EvalTask
+from mantis_agent.learning.substrates.base import Durability, SubstrateContext
+
+from experiments.learning_allocator.runner import (
+    FROZEN,
+    POLICY_SUBSTRATES,
+    S0,
+    S1,
+    NoOpSubstrate,
+    build_policy_allocator,
+    build_table1,
+    fig1_series,
+    offline_reward_fn,
+    run_experiment,
+    run_offline_demo,
+    write_results,
+)
+
+# ── tasks ────────────────────────────────────────────────────────────────
+
+
+def _ctx() -> SubstrateContext:
+    return SubstrateContext(task_id="T", cluster="knowledge", budget_remaining=10.0)
+
+
+def _tasks() -> list[EvalTask]:
+    """Two clusters × visible/sealed — enough to exercise the split logic."""
+    return [
+        EvalTask(name="k_vis", cluster="knowledge", split="visible", seed=42,
+                 task_id="K", status="ready"),
+        EvalTask(name="k_seal", cluster="knowledge", split="sealed", seed=7,
+                 task_id="K", status="ready"),
+        EvalTask(name="c_vis", cluster="capability", split="visible", seed=42,
+                 task_id="C", status="ready"),
+        EvalTask(name="c_seal", cluster="capability", split="sealed", seed=7,
+                 task_id="C", status="ready"),
+    ]
+
+
+# ── NoOpSubstrate (frozen) ───────────────────────────────────────────────
+
+
+def test_noop_substrate_applies_nothing_at_zero_cost() -> None:
+    sub = NoOpSubstrate()
+    assert sub.name == FROZEN
+    assert sub.cost_estimate(_ctx()) == 0.0
+    res = sub.apply(_ctx())
+    assert res.applied is False
+    assert res.dollars_spent == 0.0
+    assert res.durability == Durability.EPHEMERAL
+    # observe is a no-op and must not raise
+    assert sub.observe(_ctx(), res, 1.0) is None
+
+
+# ── offline reward channel ───────────────────────────────────────────────
+
+
+def test_offline_reward_reads_ground_truth_from_run_result() -> None:
+    rr = offline_reward_fn(
+        env_url="", admin_token="", task_id="K",
+        run_result={
+            "oracle_score": 0.9,
+            "oracle_passed": True,
+            "dynamic_verification_summary": {"verdict": "pass"},
+            "costs": {"total": 0.5},
+        },
+        lam=0.1,
+    )
+    assert rr.oracle_score == 0.9
+    assert rr.oracle_passed is True
+    assert rr.proxy_verdict == "pass"
+    assert rr.dollars == 0.5
+    # reward = oracle − λ·dollars = 0.9 − 0.1·0.5 = 0.85
+    assert rr.reward == pytest.approx(0.85)
+
+
+def test_offline_reward_flags_false_pass() -> None:
+    # proxy says pass, oracle says fail → false_pass for attribution noise.
+    rr = offline_reward_fn(
+        env_url="", admin_token="", task_id="K",
+        run_result={
+            "oracle_score": 0.0, "oracle_passed": False,
+            "dynamic_verification_summary": {"verdict": "pass"},
+            "costs": {"total": 0.2},
+        },
+    )
+    assert rr.false_pass is True
+    assert rr.false_fail is False
+
+
+# ── policy assembly ──────────────────────────────────────────────────────
+
+
+def test_build_policy_allocator_substrate_sets() -> None:
+    assert [s.name for s in build_policy_allocator("frozen").substrates] == [FROZEN]
+    assert [s.name for s in build_policy_allocator("S0_only").substrates] == [S0]
+    assert [s.name for s in build_policy_allocator("S1_only").substrates] == [S1]
+    assert {s.name for s in build_policy_allocator("allocator").substrates} == {S0, S1}
+
+
+def test_build_policy_allocator_rejects_unknown() -> None:
+    with pytest.raises(ValueError, match="unknown policy"):
+        build_policy_allocator("nonsense")
+
+
+def test_policy_substrates_cover_paper_baselines() -> None:
+    assert set(POLICY_SUBSTRATES) == {"frozen", "S0_only", "S1_only", "allocator"}
+
+
+# ── run_experiment ───────────────────────────────────────────────────────
+
+
+def _const_run_fn(score: float, dollars: float, verdict: str = "pass"):
+    def run_fn(task, plan, result):  # noqa: ARG001
+        return {
+            "oracle_score": score, "oracle_passed": score >= 0.5,
+            "dynamic_verification_summary": {"verdict": verdict},
+            "costs": {"total": dollars},
+        }
+    return run_fn
+
+
+def test_run_experiment_runs_every_policy() -> None:
+    result = run_experiment(
+        tasks=_tasks(), run_fn=_const_run_fn(0.8, 0.1),
+        reward_fn=offline_reward_fn, budget=100.0, rounds=1, epsilon=0.0,
+    )
+    assert set(result.reports) == set(POLICY_SUBSTRATES)
+    # split metadata captured for every task
+    assert result.split_of["k_seal"] == "sealed"
+    assert result.cluster_of["c_vis"] == "capability"
+    for rep in result.reports.values():
+        assert rep.n_runs == len(_tasks())
+
+
+def test_run_experiment_is_reproducible() -> None:
+    kw = dict(tasks=_tasks(), run_fn=_const_run_fn(0.7, 0.2),
+              reward_fn=offline_reward_fn, budget=100.0, rounds=2, seed=11)
+    a = run_experiment(**kw)
+    b = run_experiment(**kw)
+    assert (build_table1(a)[0].score_per_dollar
+            == build_table1(b)[0].score_per_dollar)
+
+
+# ── Table 1 ──────────────────────────────────────────────────────────────
+
+
+def test_build_table1_has_a_row_per_policy_plus_oracle() -> None:
+    result = run_experiment(
+        tasks=_tasks(), run_fn=_const_run_fn(0.8, 0.1),
+        reward_fn=offline_reward_fn, budget=100.0, epsilon=0.0,
+    )
+    policies = {r.policy for r in build_table1(result)}
+    assert policies == set(POLICY_SUBSTRATES) | {"oracle_allocator"}
+
+
+def test_table1_visible_minus_sealed_gap() -> None:
+    # Visible tasks score 1.0, sealed tasks score 0.0 → gap of 1.0 exactly.
+    def split_run_fn(task, plan, result):  # noqa: ARG001
+        score = 1.0 if task.split == "visible" else 0.0
+        return {"oracle_score": score, "oracle_passed": score > 0.5,
+                "dynamic_verification_summary": {"verdict": "pass"},
+                "costs": {"total": 0.1}}
+
+    result = run_experiment(
+        tasks=_tasks(), run_fn=split_run_fn,
+        reward_fn=offline_reward_fn, budget=100.0, epsilon=0.0,
+    )
+    frozen = next(r for r in build_table1(result) if r.policy == "frozen")
+    assert frozen.visible_score == pytest.approx(1.0)
+    assert frozen.sealed_score == pytest.approx(0.0)
+    assert frozen.visible_minus_sealed == pytest.approx(1.0)
+
+
+def test_table1_score_per_dollar() -> None:
+    result = run_experiment(
+        tasks=_tasks(), run_fn=_const_run_fn(0.8, 0.2),
+        reward_fn=offline_reward_fn, budget=100.0, epsilon=0.0,
+    )
+    row = next(r for r in build_table1(result) if r.policy == "S0_only")
+    # 4 runs × score 0.8 / (4 × $0.2) = 3.2 / 0.8 = 4.0
+    assert row.score_per_dollar == pytest.approx(4.0)
+    assert row.total_dollars == pytest.approx(0.8)
+
+
+def test_oracle_allocator_is_upper_bound() -> None:
+    # frozen always 0.2, S0 0.9 on knowledge / 0.1 on capability, S1 the
+    # mirror. The oracle-allocator picks the per-task best, so its sealed
+    # score must be >= every fixed policy's sealed score.
+    def het_run_fn(task, plan, result):  # noqa: ARG001
+        table = {
+            (FROZEN, "knowledge"): 0.2, (FROZEN, "capability"): 0.2,
+            (S0, "knowledge"): 0.9, (S0, "capability"): 0.1,
+            (S1, "knowledge"): 0.1, (S1, "capability"): 0.9,
+        }
+        score = table.get((result.substrate, task.cluster), 0.0)
+        return {"oracle_score": score, "oracle_passed": score >= 0.5,
+                "dynamic_verification_summary": {"verdict": "pass"},
+                "costs": {"total": 0.1}}
+
+    result = run_experiment(
+        tasks=_tasks(), run_fn=het_run_fn,
+        reward_fn=offline_reward_fn, budget=100.0, epsilon=0.0,
+    )
+    rows = {r.policy: r for r in build_table1(result)}
+    oracle = rows["oracle_allocator"].sealed_score
+    for fixed in ("frozen", "S0_only", "S1_only"):
+        assert oracle >= rows[fixed].sealed_score - 1e-9
+
+
+# ── Fig 1 ────────────────────────────────────────────────────────────────
+
+
+def test_fig1_series_cumulative_dollars_monotonic() -> None:
+    result = run_experiment(
+        tasks=_tasks(), run_fn=_const_run_fn(0.6, 0.15),
+        reward_fn=offline_reward_fn, budget=100.0, epsilon=0.0,
+    )
+    series = fig1_series(result.reports["allocator"])
+    assert len(series) == len(_tasks())
+    cum = [p.cum_dollars for p in series]
+    assert cum == sorted(cum)  # non-decreasing
+    assert series[-1].cum_dollars == pytest.approx(0.15 * len(_tasks()))
+    # constant score → running mean stays at 0.6
+    assert series[-1].running_mean_oracle == pytest.approx(0.6)
+
+
+# ── writers ──────────────────────────────────────────────────────────────
+
+
+def test_write_results_emits_stamped_parseable_tsv(tmp_path: Path) -> None:
+    result = run_experiment(
+        tasks=_tasks(), run_fn=_const_run_fn(0.8, 0.1),
+        reward_fn=offline_reward_fn, budget=100.0, epsilon=0.0,
+    )
+    paths = write_results(result, tmp_path)
+    assert set(paths) == {"results", "table1", "fig1"}
+
+    for p in paths.values():
+        lines = p.read_text().splitlines()
+        # First line is the synthetic-source banner so demo output can never
+        # be mistaken for real data.
+        assert lines[0].startswith("# SOURCE=offline-demo")
+
+    # table1.tsv parses and carries every policy row + the oracle bound.
+    with paths["table1"].open() as fh:
+        next(fh)  # banner
+        rows = list(csv.DictReader(fh, delimiter="\t"))
+    policies = {r["policy"] for r in rows}
+    assert policies == set(POLICY_SUBSTRATES) | {"oracle_allocator"}
+
+
+# ── end-to-end demo ──────────────────────────────────────────────────────
+
+
+def test_offline_demo_allocator_learns_per_cluster_winner() -> None:
+    # The synthetic demo encodes knowledge→S0, capability→S1, policy→S1.
+    # After enough rounds the allocator's value table must rank the expected
+    # winner above the loser in each cluster — the heterogeneity the whole
+    # experiment hinges on.
+    result = run_offline_demo(rounds=8, budget=500.0, epsilon=0.1, seed=3)
+    vt = result.reports["allocator"].value_table
+
+    def val(cluster: str, sub: str) -> float:
+        return vt.get((cluster, sub), (float("-inf"), 0))[0]
+
+    assert val("knowledge", S0) > val("knowledge", S1)
+    assert val("capability", S1) > val("capability", S0)
+    assert val("policy", S1) > val("policy", S0)
+
+
+def test_offline_demo_allocator_beats_frozen_on_sealed() -> None:
+    result = run_offline_demo(rounds=8, budget=500.0, epsilon=0.1, seed=3)
+    rows = {r.policy: r for r in build_table1(result)}
+    assert rows["allocator"].sealed_score > rows["frozen"].sealed_score
+
+
+def test_run_offline_demo_covers_all_runnable_tasks() -> None:
+    result = run_offline_demo(rounds=1, budget=500.0)
+    # Six runnable tasks in the shipped manifest (3 clusters × 2 splits).
+    assert result.reports["frozen"].n_runs == 6
+    assert set(result.cluster_of.values()) == {"knowledge", "capability", "policy"}


### PR DESCRIPTION
## Summary

The no-spend **Phase-2 comparison harness** that produces the paper's Table 1 / Fig 1 — runs entirely offline so the whole pipeline + renderers are validated with **no env boots and no spend**. The live Modal/Daytona run that produces *real* agent data is a follow-up gated on the spend boundary (tracked in #741).

- **`experiments/learning_allocator/runner.py`** — runs the four policies (`frozen` / `S0_only` / `S1_only` / `allocator`) over the eval manifest, each with its own fresh budget. Outcomes are injected via `run_fn`; scoring goes through `offline_reward_fn` (ground truth baked into `run_result`, no oracle HTTP). Derives:
  - **Table 1** — score-per-dollar, visible−sealed generalisation gap, and an `oracle_allocator` per-task-best **upper bound**.
  - **Fig 1** — running-mean oracle vs cumulative dollars.
  - TSV writers + a fixed-width stdout renderer. **Every output file is banner-stamped `SOURCE=offline-demo — SYNTHETIC`** so demo output can never be mistaken for real results.
- **`src/mantis_agent/learning/orchestrator.py`** — adds a `reward_fn` injection seam (resolved at call time, so the existing `monkeypatch(reward_from_run)` tests keep working) so the loop can be driven fully offline.
- **`tests/learning/test_runner.py`** — 17 offline tests; the end-to-end demo asserts the allocator learns the per-cluster winner (`knowledge→S0`, `capability→S1`, `policy→S1`) and beats `frozen` on sealed tasks.

### Offline demo (synthetic — wiring check, NOT agent data)

```
policy               sealed  visible  vis−seal   score/$   $total    n
----------------------------------------------------------------------
frozen               0.0333   0.0333    0.0000    0.0741  10.8000   24
S0_only              0.5333   0.5333    0.0000    1.1429  11.2000   24
S1_only              0.6833   0.6833    0.0000    1.3667  12.0000   24
allocator            0.7750   0.7708   -0.0042    1.5868  11.6900   24
oracle_allocator     0.8500   0.8500    0.0000    1.7347   2.9400    6
```

The allocator beats every fixed single-substrate policy and approaches the oracle upper bound — the heterogeneity the experiment hinges on.

## What this is NOT

This produces **synthetic** outcomes to validate wiring. Real Table 1 / Fig 1 require the live spend-gated run (Modal CUA + Daytona boattrader, **no proxies**) — that's the next PR. Part of #741 (left open until real results land).

## Test plan

- [x] `uv run pytest tests/learning/ -n0 -q` — 108 passed (17 new + existing suite)
- [x] `uv run ruff check` clean on all touched files
- [x] `uv run python -m experiments.learning_allocator.runner --out /tmp/la` — demo runs end-to-end, TSVs banner-stamped
- [ ] Live Modal/Daytona run (follow-up, spend boundary — #741)

🤖 Generated with [Claude Code](https://claude.com/claude-code)