### PR TITLE
feat(hint-memory): ModalDictHintStore — cross-worker shared backend (Phase 1b)

### DIFF
--- a/src/mantis_agent/gym/hint_memory.py
+++ b/src/mantis_agent/gym/hint_memory.py
@@ -280,6 +280,40 @@ def hint_key_for(
     )
 
 
+# ── Record (de)serialization (shared by the persistent backends) ────
+
+
+def _record_to_dict(r: HintRecord) -> dict:
+    """JSON-serializable form of a :class:`HintRecord`. Shared by the
+    disk and modal.Dict backends so their on-the-wire shape can't drift."""
+    return {
+        "anchor_text": r.anchor_text,
+        "anchor_xy_offset": list(r.anchor_xy_offset),
+        "viewport_stage": r.viewport_stage,
+        "confidence": r.confidence,
+        "recorded_at": r.recorded_at,
+        "source_url": r.source_url,
+    }
+
+
+def _record_from_dict(r: object) -> HintRecord | None:
+    """Inverse of :func:`_record_to_dict`. Returns ``None`` for anything
+    malformed so callers can drop it without aborting the whole load."""
+    if not isinstance(r, dict):
+        return None
+    try:
+        return HintRecord(
+            anchor_text=str(r.get("anchor_text", "") or ""),
+            anchor_xy_offset=tuple(r.get("anchor_xy_offset") or (0, 0))[:2],
+            viewport_stage=int(r.get("viewport_stage", 0) or 0),
+            confidence=float(r.get("confidence", 0.0) or 0.0),
+            recorded_at=float(r.get("recorded_at", 0.0) or 0.0),
+            source_url=str(r.get("source_url", "") or ""),
+        )
+    except Exception:  # noqa: BLE001 — drop malformed record
+        return None
+
+
 # ── DiskHintStore (Phase 1b) — tenant-scoped persistence ────────────
 
 
@@ -361,21 +395,10 @@ class DiskHintStore:
         for bucket_key, records in (raw or {}).items():
             if not isinstance(records, list):
                 continue
-            parsed: list[HintRecord] = []
-            for r in records:
-                if not isinstance(r, dict):
-                    continue
-                try:
-                    parsed.append(HintRecord(
-                        anchor_text=str(r.get("anchor_text", "") or ""),
-                        anchor_xy_offset=tuple(r.get("anchor_xy_offset") or (0, 0))[:2],
-                        viewport_stage=int(r.get("viewport_stage", 0) or 0),
-                        confidence=float(r.get("confidence", 0.0) or 0.0),
-                        recorded_at=float(r.get("recorded_at", 0.0) or 0.0),
-                        source_url=str(r.get("source_url", "") or ""),
-                    ))
-                except Exception:  # noqa: BLE001 — drop malformed record
-                    continue
+            parsed = [
+                rec for rec in (_record_from_dict(r) for r in records)
+                if rec is not None
+            ]
             if parsed:
                 buckets[str(bucket_key)] = parsed
         return buckets
@@ -383,19 +406,10 @@ class DiskHintStore:
     def _save(self, plan_signature: str, buckets: dict[str, list[HintRecord]]) -> None:
         path = self._file_for(plan_signature)
         os.makedirs(os.path.dirname(path), exist_ok=True)
-        serializable: dict[str, list[dict]] = {}
-        for bucket_key, records in buckets.items():
-            serializable[bucket_key] = [
-                {
-                    "anchor_text": r.anchor_text,
-                    "anchor_xy_offset": list(r.anchor_xy_offset),
-                    "viewport_stage": r.viewport_stage,
-                    "confidence": r.confidence,
-                    "recorded_at": r.recorded_at,
-                    "source_url": r.source_url,
-                }
-                for r in records
-            ]
+        serializable: dict[str, list[dict]] = {
+            bucket_key: [_record_to_dict(r) for r in records]
+            for bucket_key, records in buckets.items()
+        }
         tmp_path = f"{path}.tmp.{os.getpid()}.{int(time.time() * 1000)}"
         with open(tmp_path, "w") as f:
             json.dump(serializable, f, indent=2)
@@ -464,6 +478,165 @@ class DiskHintStore:
         for plan_sig in self.list_plan_signatures():
             buckets = self._load(plan_sig)
             for bk, records in buckets.items():
+                intent_hash, _, url_pattern = bk.partition("|")
+                key = HintKey(
+                    plan_signature=plan_sig,
+                    intent_hash=intent_hash,
+                    url_pattern=url_pattern,
+                )
+                for r in records:
+                    yield (key, r)
+
+
+# ── ModalDictHintStore (Phase 1b) — cross-worker shared backend ─────
+
+
+class ModalDictHintStore:
+    """``modal.Dict``-backed `HintStore` shared across fan-out workers.
+
+    Where :class:`DiskHintStore` persists across *deploys* on a volume,
+    this backend is shared across the *workers of one deploy* through a
+    ``modal.Dict``: a recording made by the Phase-1 fan-out worker is
+    visible to the Phase-2 worker (and to the next run) immediately,
+    without waiting for a volume write/read cycle. This is the backend
+    the Learning Allocator's S0 retrieval rung reads/writes in prod so
+    its effect actually reaches the remote run.
+
+    Layout — one entry per ``(tenant_id, plan_signature)``::
+
+        "<tenant>/<plan_signature>"  →  {"<intent>|<url_pattern>": [record-dict, …]}
+
+    Tenant isolation is by key prefix, so one ``modal.Dict`` per deploy
+    serves every tenant without cross-talk. Bucket / LRU semantics match
+    :class:`DiskHintStore` (cap ``max_per_key``, newest-first ``get``).
+
+    The backing object is dependency-injected (anything with
+    ``get`` / ``__setitem__`` / ``keys``) so tests pass a plain ``dict``
+    and prod passes a ``modal.Dict`` via :meth:`from_name`. Every access
+    is best-effort: a store fault logs a warning and degrades to "no
+    hints", never breaking a run. We never call ``len()`` on the backing
+    object — ``modal.Dict`` raises ``TypeError`` on ``len()``
+    (see ``feedback_modal_dict_no_len``); :meth:`size` iterates ``keys()``.
+    """
+
+    def __init__(
+        self, backing: object, *, tenant_id: str, max_per_key: int = 10,
+    ) -> None:
+        if not tenant_id:
+            raise ValueError("ModalDictHintStore requires a non-empty tenant_id")
+        self._d = backing
+        self._tenant_id = tenant_id
+        self.max_per_key = max(1, int(max_per_key))
+
+    @classmethod
+    def from_name(
+        cls, dict_name: str, *, tenant_id: str,
+        max_per_key: int = 10, create_if_missing: bool = True,
+    ) -> "ModalDictHintStore":
+        """Build against a named ``modal.Dict``. ``modal`` is imported
+        lazily so this module stays importable off-Modal (tests use the
+        plain-``dict`` constructor instead)."""
+        import modal  # noqa: PLC0415 — lazy so the module imports without modal
+
+        backing = modal.Dict.from_name(dict_name, create_if_missing=create_if_missing)
+        return cls(backing, tenant_id=tenant_id, max_per_key=max_per_key)
+
+    # ── key + I/O ──
+
+    def _entry_key(self, plan_signature: str) -> str:
+        return (
+            f"{_sanitize_scope(self._tenant_id)}/"
+            f"{_sanitize_scope(plan_signature)}"
+        )
+
+    def _load(self, plan_signature: str) -> dict[str, list[HintRecord]]:
+        try:
+            raw = self._d.get(self._entry_key(plan_signature))  # type: ignore[attr-defined]
+        except Exception as exc:  # noqa: BLE001 — store fault ≠ run fault
+            logger.warning(
+                "ModalDictHintStore: read failed tenant=%s plan=%s (%s)",
+                self._tenant_id, plan_signature, exc,
+            )
+            return {}
+        if not isinstance(raw, dict):
+            return {}
+        buckets: dict[str, list[HintRecord]] = {}
+        for bucket_key, records in raw.items():
+            if not isinstance(records, list):
+                continue
+            parsed = [
+                rec for rec in (_record_from_dict(r) for r in records)
+                if rec is not None
+            ]
+            if parsed:
+                buckets[str(bucket_key)] = parsed
+        return buckets
+
+    def _save(self, plan_signature: str, buckets: dict[str, list[HintRecord]]) -> None:
+        serializable = {
+            bucket_key: [_record_to_dict(r) for r in records]
+            for bucket_key, records in buckets.items()
+        }
+        try:
+            self._d[self._entry_key(plan_signature)] = serializable  # type: ignore[index]
+        except Exception as exc:  # noqa: BLE001 — store fault ≠ run fault
+            logger.warning(
+                "ModalDictHintStore: write failed tenant=%s plan=%s (%s)",
+                self._tenant_id, plan_signature, exc,
+            )
+
+    @staticmethod
+    def _bucket_key(key: HintKey) -> str:
+        return f"{key.intent_hash}|{key.url_pattern}"
+
+    # ── HintStore protocol ──
+
+    def add(self, key: HintKey, record: HintRecord) -> None:
+        if not key.plan_signature:
+            return
+        buckets = self._load(key.plan_signature)
+        bucket = buckets.setdefault(self._bucket_key(key), [])
+        bucket.append(record)
+        if len(bucket) > self.max_per_key:
+            bucket.pop(0)
+        self._save(key.plan_signature, buckets)
+
+    def get(self, key: HintKey) -> list[HintRecord]:
+        if not key.plan_signature:
+            return []
+        buckets = self._load(key.plan_signature)
+        # Newest-first for the injection side's pick-top-N lookup.
+        return list(reversed(buckets.get(self._bucket_key(key), [])))
+
+    def size(self) -> int:
+        """Total record count for this tenant. Iterates ``keys()`` rather
+        than ``len()`` — ``modal.Dict`` has no ``__len__``."""
+        prefix = f"{_sanitize_scope(self._tenant_id)}/"
+        total = 0
+        for k in self._tenant_entry_keys(prefix):
+            try:
+                raw = self._d.get(k)  # type: ignore[attr-defined]
+            except Exception:  # noqa: BLE001
+                continue
+            if not isinstance(raw, dict):
+                continue
+            total += sum(len(v) for v in raw.values() if isinstance(v, list))
+        return total
+
+    # ── inspector surface ──
+
+    def _tenant_entry_keys(self, prefix: str) -> list[str]:
+        try:
+            return [str(k) for k in self._d.keys() if str(k).startswith(prefix)]  # type: ignore[attr-defined]
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("ModalDictHintStore: keys() failed (%s)", exc)
+            return []
+
+    def iter_records(self) -> Iterable[tuple[HintKey, HintRecord]]:
+        prefix = f"{_sanitize_scope(self._tenant_id)}/"
+        for k in self._tenant_entry_keys(prefix):
+            plan_sig = k[len(prefix):]
+            for bk, records in self._load(plan_sig).items():
                 intent_hash, _, url_pattern = bk.partition("|")
                 key = HintKey(
                     plan_signature=plan_sig,

--- a/tests/test_hint_memory_phase1b.py
+++ b/tests/test_hint_memory_phase1b.py
@@ -22,6 +22,7 @@ from mantis_agent.gym.hint_memory import (
     HintKey,
     HintRecord,
     InMemoryHintStore,
+    ModalDictHintStore,
     NullHintStore,
     apply_hint_overlay,
     extract_anchor_from_env,
@@ -157,6 +158,154 @@ def test_disk_store_iter_records(temp_dir: str) -> None:
     assert len(pairs) == 2
     texts = sorted(r.anchor_text for _, r in pairs)
     assert texts == ["A", "B"]
+
+
+# ── ModalDictHintStore ───────────────────────────────────────────────
+
+
+class _FakeModalDict:
+    """Stand-in for ``modal.Dict``: dict-like (get / __setitem__ / keys)
+    but raises on ``len()`` exactly as the real one does, so size() can't
+    cheat with ``len()``. One instance is shared across stores to mirror
+    the cross-worker / multi-tenant single-Dict deploy."""
+
+    def __init__(self) -> None:
+        self._inner: dict = {}
+
+    def get(self, key, default=None):
+        return self._inner.get(key, default)
+
+    def __setitem__(self, key, value) -> None:
+        self._inner[key] = value
+
+    def keys(self):
+        return list(self._inner.keys())
+
+    def __len__(self):  # noqa: D105
+        raise TypeError("modal.Dict has no __len__")
+
+
+def test_modal_store_requires_tenant_id() -> None:
+    with pytest.raises(ValueError, match="non-empty tenant_id"):
+        ModalDictHintStore({}, tenant_id="")
+
+
+def test_modal_store_round_trips_single_record() -> None:
+    store = ModalDictHintStore(_FakeModalDict(), tenant_id="acme")
+    key = HintKey(plan_signature="sig1", intent_hash="ih1", url_pattern="x.com/y")
+    store.add(key, HintRecord(
+        anchor_text="Show More", anchor_xy_offset=(120, 540),
+        viewport_stage=1, confidence=0.8, source_url="https://x.com/y/123",
+    ))
+    out = store.get(key)
+    assert len(out) == 1
+    assert out[0].anchor_text == "Show More"
+    assert out[0].anchor_xy_offset == (120, 540)
+    assert out[0].viewport_stage == 1
+    assert out[0].confidence == 0.8
+
+
+def test_modal_store_lru_evicts_oldest_at_cap() -> None:
+    store = ModalDictHintStore(_FakeModalDict(), tenant_id="acme", max_per_key=3)
+    key = HintKey(plan_signature="sig1", intent_hash="ih1", url_pattern="x.com/y")
+    for i in range(5):
+        store.add(key, HintRecord(anchor_text=f"Anchor {i}", confidence=0.5))
+    out = store.get(key)
+    assert [r.anchor_text for r in out] == ["Anchor 4", "Anchor 3", "Anchor 2"]
+
+
+def test_modal_store_tenant_isolation_in_one_dict() -> None:
+    """Two tenants share ONE backing Dict; key-prefix keeps them apart."""
+    backing = _FakeModalDict()
+    s1 = ModalDictHintStore(backing, tenant_id="customerA")
+    s2 = ModalDictHintStore(backing, tenant_id="customerB")
+    key = HintKey(plan_signature="sig1", intent_hash="ih1", url_pattern="x.com/y")
+
+    s1.add(key, HintRecord(anchor_text="A-only", confidence=0.9))
+    assert [r.anchor_text for r in s1.get(key)] == ["A-only"]
+    assert s2.get(key) == []  # B sees nothing
+
+    s2.add(key, HintRecord(anchor_text="B-only", confidence=0.9))
+    assert [r.anchor_text for r in s2.get(key)] == ["B-only"]
+    assert [r.anchor_text for r in s1.get(key)] == ["A-only"]  # A unaffected
+
+
+def test_modal_store_keys_isolated_within_tenant() -> None:
+    store = ModalDictHintStore(_FakeModalDict(), tenant_id="acme")
+    k1 = HintKey(plan_signature="sig1", intent_hash="ih1", url_pattern="x.com/a")
+    k2 = HintKey(plan_signature="sig1", intent_hash="ih2", url_pattern="x.com/a")
+    store.add(k1, HintRecord(anchor_text="A"))
+    store.add(k2, HintRecord(anchor_text="B"))
+    assert [r.anchor_text for r in store.get(k1)] == ["A"]
+    assert [r.anchor_text for r in store.get(k2)] == ["B"]
+
+
+def test_modal_store_size_iterates_keys_not_len() -> None:
+    """size() must count via keys() — _FakeModalDict raises on len()."""
+    store = ModalDictHintStore(_FakeModalDict(), tenant_id="acme")
+    store.add(HintKey(plan_signature="s1", intent_hash="i1", url_pattern="x"),
+              HintRecord(anchor_text="a"))
+    store.add(HintKey(plan_signature="s1", intent_hash="i2", url_pattern="x"),
+              HintRecord(anchor_text="b"))
+    store.add(HintKey(plan_signature="s2", intent_hash="i1", url_pattern="x"),
+              HintRecord(anchor_text="c"))
+    assert store.size() == 3  # no TypeError from len()
+
+
+def test_modal_store_size_excludes_other_tenants() -> None:
+    backing = _FakeModalDict()
+    a = ModalDictHintStore(backing, tenant_id="A")
+    b = ModalDictHintStore(backing, tenant_id="B")
+    a.add(HintKey(plan_signature="s", intent_hash="i", url_pattern="x"),
+          HintRecord(anchor_text="a"))
+    b.add(HintKey(plan_signature="s", intent_hash="i", url_pattern="x"),
+          HintRecord(anchor_text="b"))
+    assert a.size() == 1
+    assert b.size() == 1
+
+
+def test_modal_store_no_op_on_empty_plan_signature() -> None:
+    store = ModalDictHintStore(_FakeModalDict(), tenant_id="acme")
+    key = HintKey(plan_signature="", intent_hash="ih1", url_pattern="x")
+    store.add(key, HintRecord(anchor_text="X"))
+    assert store.get(key) == []
+    assert store.size() == 0
+
+
+def test_modal_store_get_missing_returns_empty() -> None:
+    store = ModalDictHintStore(_FakeModalDict(), tenant_id="acme")
+    key = HintKey(plan_signature="never", intent_hash="ih", url_pattern="x")
+    assert store.get(key) == []
+
+
+def test_modal_store_iter_records() -> None:
+    store = ModalDictHintStore(_FakeModalDict(), tenant_id="acme")
+    k = HintKey(plan_signature="sig", intent_hash="ih", url_pattern="x")
+    store.add(k, HintRecord(anchor_text="A"))
+    store.add(k, HintRecord(anchor_text="B"))
+    pairs = list(store.iter_records())
+    assert sorted(r.anchor_text for _, r in pairs) == ["A", "B"]
+
+
+def test_modal_store_read_fault_degrades_to_empty() -> None:
+    """A backing that raises on read must yield no hints, not crash."""
+
+    class _Exploding:
+        def get(self, key, default=None):  # noqa: ARG002
+            raise RuntimeError("modal.Dict down")
+
+        def __setitem__(self, key, value) -> None:  # noqa: ARG002
+            raise RuntimeError("modal.Dict down")
+
+        def keys(self):
+            raise RuntimeError("modal.Dict down")
+
+    store = ModalDictHintStore(_Exploding(), tenant_id="acme")
+    key = HintKey(plan_signature="sig", intent_hash="ih", url_pattern="x")
+    # add swallows the write fault, get/size degrade to empty — no raise.
+    store.add(key, HintRecord(anchor_text="X"))
+    assert store.get(key) == []
+    assert store.size() == 0
 
 
 # ── extract_anchor_from_env ──────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds **`ModalDictHintStore`** — the `modal.Dict`-backed `HintStore` the Protocol + module docstring have named as "Phase 1b" since #643/#670, but which never existed. This is the backend the **Learning Allocator's S0 retrieval rung** needs so its effect can actually reach the *remote* Modal run (today S0 only mutates an in-process plan the remote run never sees).

- **Cross-worker, intra-deploy sharing**: where `DiskHintStore` persists across *deploys* on a volume, this shares anchors across the *workers of one deploy* via a `modal.Dict` — a hint recorded by the Phase-1 fan-out worker is visible to the Phase-2 worker (and the next run) immediately, no volume round-trip.
- **Layout mirrors `DiskHintStore`**: one entry per `(tenant, plan_signature)` → `{intent|url_pattern: [record]}`, LRU at `max_per_key`, newest-first `get`. Tenant isolation is by **key prefix**, so one `Dict` per deploy serves every tenant without cross-talk.
- **Injected backing**: the store takes any dict-like (`get`/`__setitem__`/`keys`) — a plain `dict` in tests, a `modal.Dict` via `ModalDictHintStore.from_name(...)` (lazy `import modal`) in prod. So the module stays importable off-Modal and the unit tests need no Modal.
- **Best-effort throughout**: a store fault logs a warning and degrades to "no hints", never breaking a run. `size()` iterates `keys()` — `modal.Dict` raises `TypeError` on `len()` (`feedback_modal_dict_no_len`), and a regression test enforces this via a fake that raises on `__len__`.
- **Shared serialization**: factors `HintRecord` (de)serialization into `_record_to_dict` / `_record_from_dict`, reused by the disk + modal backends so their wire shape can't drift. `DiskHintStore` refactored onto them (covered by existing round-trip/LRU/corrupt-file tests).

## Not in this PR (next)

Wiring the **Modal run path** to construct the store, set `runner._hint_store` (so the existing `record_hint_if_eligible` hook fires) and call `apply_hint_overlay` pre-flight — gated on a submit flag so `frozen` vs `S0` differ. Then the live BT01-only run_fn adapter. Part of #741.

## Test plan

- [x] `uv run pytest tests/test_hint_memory_phase1b.py tests/test_hint_memory_643.py -n0 -q` — 65 passed (11 new ModalDictHintStore tests: round-trip, LRU, single-Dict tenant isolation, size-via-keys-not-len, read-fault degradation)
- [x] `uv run pytest tests/test_recovery_hints.py tests/test_decomposer_runtime_hints.py tests/learning/ -n0 -q` — 198 total passed (DiskHintStore refactor regression-free)
- [x] `uv run ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)