### PR TITLE
feat(hint-memory): Modal-path backend selection — frozen / S0 / disk

### DIFF
--- a/deploy/modal/modal_cua_server.py
+++ b/deploy/modal/modal_cua_server.py
@@ -1095,22 +1095,40 @@ def _run_holo3_executor(
         # ``<tenant>__<workflow>`` shape from the API container's
         # acquire_profile_lock) so customer A's anchors can never leak
         # into customer B's runs.
+        #
+        # The backend is suite-driven (``build_hint_store``): the
+        # Learning Allocator steers it per trial via ``_hint_store_disabled``
+        # (frozen → NullHintStore, no overlay/record) and
+        # ``_hint_store_dict_name`` (S0 retrieval → a shared modal.Dict so
+        # anchors accumulate across workers + runs). Absent both flags it
+        # stays the production DiskHintStore.
         try:
             from mantis_agent.gym.hint_memory import (
-                DiskHintStore, apply_hint_overlay,
+                apply_hint_overlay, build_hint_store,
             )
             hint_tenant = str(task_suite.get("_profile_id", "") or "") or "default"
-            micro_runner._hint_store = DiskHintStore(tenant_id=hint_tenant)
+            micro_runner._hint_store = build_hint_store(
+                task_suite, tenant_id=hint_tenant,
+            )
             applied = apply_hint_overlay(
                 micro_plan,
                 store=micro_runner._hint_store,
                 plan_signature=plan_signature,
                 start_url=str(task_suite.get("base_url", "") or ""),
             )
+            store_kind = type(micro_runner._hint_store).__name__
             if applied:
                 print(
-                    f"  Hint-memory: tenant={hint_tenant} "
+                    f"  Hint-memory[{store_kind}]: tenant={hint_tenant} "
                     f"plan_sig={plan_signature[:12]} applied={applied} hints"
+                )
+            elif store_kind != "DiskHintStore":
+                # Surface the allocator-steered backend (frozen / S0) even
+                # when nothing overlaid — e.g. first run of a fresh shared
+                # store — so the selection is greppable in Modal logs.
+                print(
+                    f"  Hint-memory[{store_kind}]: tenant={hint_tenant} "
+                    f"plan_sig={plan_signature[:12]} (no overlay yet)"
                 )
         except Exception as exc:  # noqa: BLE001 — never block executor
             print(f"  WARNING: hint memory init failed (recording disabled): {exc}")

--- a/src/mantis_agent/gym/hint_memory.py
+++ b/src/mantis_agent/gym/hint_memory.py
@@ -38,7 +38,7 @@ import re
 import time
 from collections import OrderedDict
 from dataclasses import dataclass, field
-from typing import Iterable, Protocol
+from typing import Callable, Iterable, Protocol
 
 logger = logging.getLogger(__name__)
 
@@ -801,3 +801,61 @@ def apply_hint_overlay(
             best.confidence,
         )
     return applied
+
+
+# ── Modal-path store factory ────────────────────────────────────────
+
+
+def build_hint_store(
+    task_suite: object, *,
+    tenant_id: str,
+    modal_dict_factory: Callable[[str], object] | None = None,
+) -> HintStore:
+    """Pick the `HintStore` backend for a Modal micro-run from suite metadata.
+
+    The Modal dispatcher (``modal_cua_server``) calls this once before
+    ``MicroPlanRunner.run`` to choose the backend the run overlays from
+    and records into. Selection (first match wins):
+
+    * ``_hint_store_disabled`` truthy → :class:`NullHintStore`. The run
+      neither overlays nor records — the Learning Allocator's *frozen*
+      policy (cold-start behaviour, no improvement applied).
+    * ``_hint_store_dict_name`` non-empty → :class:`ModalDictHintStore`
+      against that named ``modal.Dict``: a cross-worker shared store the
+      Learning Allocator's *S0 retrieval* rung accumulates anchors in,
+      so its effect reaches sibling workers and later runs immediately.
+    * otherwise → :class:`DiskHintStore` keyed by ``tenant_id`` — today's
+      production default (per-tenant JSON on the ``/data`` volume).
+
+    ``modal_dict_factory`` is a test seam: when given, it's called with
+    the dict name to build the backing object (tests pass one returning a
+    plain dict), bypassing the lazy ``modal`` import inside
+    :meth:`ModalDictHintStore.from_name`.
+
+    Never raises. A ``modal.Dict`` open failure degrades to the
+    production :class:`DiskHintStore`; an empty ``tenant_id`` (shouldn't
+    happen on the Modal path, but DiskHintStore forbids it) degrades to
+    :class:`NullHintStore`. A malformed suite can never break a run.
+    """
+    suite = task_suite if isinstance(task_suite, dict) else {}
+
+    if bool(suite.get("_hint_store_disabled")):
+        return NullHintStore()
+
+    dict_name = str(suite.get("_hint_store_dict_name", "") or "").strip()
+    if dict_name:
+        try:
+            if modal_dict_factory is not None:
+                return ModalDictHintStore(
+                    modal_dict_factory(dict_name), tenant_id=tenant_id,
+                )
+            return ModalDictHintStore.from_name(dict_name, tenant_id=tenant_id)
+        except Exception as exc:  # noqa: BLE001 — never break a run
+            logger.warning(
+                "build_hint_store: ModalDictHintStore(%s) open failed (%s); "
+                "falling back to DiskHintStore", dict_name, exc,
+            )
+
+    if not tenant_id:
+        return NullHintStore()
+    return DiskHintStore(tenant_id=tenant_id)

--- a/tests/test_hint_memory_phase1b.py
+++ b/tests/test_hint_memory_phase1b.py
@@ -25,6 +25,7 @@ from mantis_agent.gym.hint_memory import (
     ModalDictHintStore,
     NullHintStore,
     apply_hint_overlay,
+    build_hint_store,
     extract_anchor_from_env,
     hint_key_for,
     record_hint_if_eligible,
@@ -306,6 +307,95 @@ def test_modal_store_read_fault_degrades_to_empty() -> None:
     store.add(key, HintRecord(anchor_text="X"))
     assert store.get(key) == []
     assert store.size() == 0
+
+
+# ── build_hint_store (Modal-path backend factory) ────────────────────
+
+
+def _fake_dict_factory():
+    """Mimic ``modal.Dict.from_name``: same name → same backing object, so
+    two workers naming the same dict share state."""
+    pool: dict[str, _FakeModalDict] = {}
+
+    def _for(name: str) -> _FakeModalDict:
+        return pool.setdefault(name, _FakeModalDict())
+
+    return _for
+
+
+def test_build_hint_store_default_returns_disk() -> None:
+    """No allocator flags → today's production DiskHintStore."""
+    store = build_hint_store({}, tenant_id="acme")
+    assert isinstance(store, DiskHintStore)
+
+
+def test_build_hint_store_disabled_returns_null() -> None:
+    """``_hint_store_disabled`` → frozen policy (NullHintStore)."""
+    store = build_hint_store({"_hint_store_disabled": True}, tenant_id="acme")
+    assert isinstance(store, NullHintStore)
+
+
+def test_build_hint_store_dict_name_returns_modal() -> None:
+    """``_hint_store_dict_name`` → ModalDictHintStore over that named Dict."""
+    store = build_hint_store(
+        {"_hint_store_dict_name": "la-hints"}, tenant_id="acme",
+        modal_dict_factory=_fake_dict_factory(),
+    )
+    assert isinstance(store, ModalDictHintStore)
+    key = HintKey(plan_signature="sig", intent_hash="ih", url_pattern="x")
+    store.add(key, HintRecord(anchor_text="A"))
+    assert [r.anchor_text for r in store.get(key)] == ["A"]
+
+
+def test_build_hint_store_disabled_takes_precedence_over_dict_name() -> None:
+    """Frozen wins when both flags are present (first match in the ladder)."""
+    store = build_hint_store(
+        {"_hint_store_disabled": True, "_hint_store_dict_name": "la-hints"},
+        tenant_id="acme", modal_dict_factory=_fake_dict_factory(),
+    )
+    assert isinstance(store, NullHintStore)
+
+
+def test_build_hint_store_empty_tenant_returns_null() -> None:
+    """No flags + empty tenant → NullHintStore (DiskHintStore forbids it)."""
+    store = build_hint_store({}, tenant_id="")
+    assert isinstance(store, NullHintStore)
+
+
+def test_build_hint_store_non_dict_suite_returns_disk() -> None:
+    """A malformed (non-dict) suite degrades to the production default."""
+    store = build_hint_store(None, tenant_id="acme")
+    assert isinstance(store, DiskHintStore)
+
+
+def test_build_hint_store_modal_open_failure_falls_back_to_disk() -> None:
+    """A modal.Dict open fault must not break the run — fall back to disk."""
+
+    def _boom(_name: str):
+        raise RuntimeError("modal.Dict.from_name unavailable")
+
+    store = build_hint_store(
+        {"_hint_store_dict_name": "la-hints"}, tenant_id="acme",
+        modal_dict_factory=_boom,
+    )
+    assert isinstance(store, DiskHintStore)
+
+
+def test_build_hint_store_shared_dict_name_is_cross_worker() -> None:
+    """Two workers naming the same Dict see each other's anchors — the
+    property the live S0 rung depends on."""
+    factory = _fake_dict_factory()
+    s1 = build_hint_store(
+        {"_hint_store_dict_name": "la-run-1"}, tenant_id="t",
+        modal_dict_factory=factory,
+    )
+    s2 = build_hint_store(
+        {"_hint_store_dict_name": "la-run-1"}, tenant_id="t",
+        modal_dict_factory=factory,
+    )
+    key = HintKey(plan_signature="sig", intent_hash="ih", url_pattern="x")
+    s1.add(key, HintRecord(anchor_text="cross-worker"))
+    assert [r.anchor_text for r in s2.get(key)] == ["cross-worker"]
 
 
 # ── extract_anchor_from_env ──────────────────────────────────────────


### PR DESCRIPTION
## Summary

Wires the Modal micro-run dispatcher to choose its `HintStore` backend
from suite metadata, so the **Learning Allocator** can steer the
trajectory-memory effect of a *remote* CUA run on a per-trial basis.
This is the integration that makes the `ModalDictHintStore` backend
(#757, merged) actually reachable from a live run.

A new `build_hint_store(task_suite, *, tenant_id, modal_dict_factory=None)`
factory in `gym/hint_memory.py` resolves the backend (first match wins):

| suite flag | backend | allocator policy |
|---|---|---|
| `_hint_store_disabled` truthy | `NullHintStore` (no overlay, no record) | **frozen** (cold-start) |
| `_hint_store_dict_name` set | `ModalDictHintStore` over that shared `modal.Dict` | **S0 retrieval** (anchors accumulate across workers + runs) |
| neither | `DiskHintStore(tenant_id)` | unchanged production default |

`modal_cua_server` swaps its hardcoded `DiskHintStore` construction for
`build_hint_store(...)` and logs the selected backend kind, so
frozen-vs-S0 selection is greppable in Modal logs. The factory never
raises: a `modal.Dict` open fault degrades to disk; an empty tenant
degrades to no-op — a malformed suite can't break a run.

No spend in this PR — pure wiring + unit tests with a fake `modal.Dict`.

## Note

Supersedes #758, which GitHub auto-closed when its stacked base branch
(#757) was deleted on merge. Same commit (a098e3d), now based directly
on `main` with #757 already landed.

## Test plan

- [x] `uv run pytest tests/test_hint_memory_phase1b.py -n0` — 48 passed (8 new `build_hint_store` cases: frozen, S0, disk default, precedence, empty-tenant, non-dict suite, open-failure fallback, cross-worker shared dict)
- [x] `uv run ruff check` clean on all three files
- [x] `py_compile` of `modal_cua_server.py`
- [ ] Live verification deferred to the BT01 smoke run (spend-gated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)