### PR TITLE
feat(learning): live Phase-2 run_fn — Modal+Daytona spend adapter (PR-4)

### DIFF
--- a/experiments/learning_allocator/eval/clusters.json
+++ b/experiments/learning_allocator/eval/clusters.json
@@ -1,6 +1,6 @@
 {
   "env": "mantis_boattrader",
-  "description": "Failure-cluster eval manifest for the Learning Allocator (PLAN §3). The allocator-beats-any-fixed-substrate claim is only meaningful if the winning substrate genuinely varies, so clusters are engineered, not hoped for. All three clusters now name a real oracle across a visible/sealed (seed 42/7) split: capability=BT01 (filter+form lead macro), knowledge=BT02 (Caterpillar engine-spec lookup lead), policy=BT03 (by-owner phone reveal). 'status=ready' means the oracle exists and the task is gradeable; the canonical plan JSONs and (for the policy cluster) the layout-drift fixture are the run-wiring follow-up — only BT01 carries a plan today.",
+  "description": "Failure-cluster eval manifest for the Learning Allocator (PLAN §3). The allocator-beats-any-fixed-substrate claim is only meaningful if the winning substrate genuinely varies, so clusters are engineered, not hoped for. All three clusters name a real oracle across a visible/sealed (seed 42/7) split: capability=BT01 (filter+form lead macro), knowledge=BT02 (Caterpillar engine-spec lookup lead), policy=BT03 (by-owner phone reveal). 'status=ready' means the oracle exists and the task is gradeable. Live run-wiring (the 'plan' field): BT02 -> 'bt02_spec_lookup' and BT03 -> 'boattrader_scrape' (both retargeted to the high-fidelity sim env, reached directly with no proxy); the frozen-vs-S0 discriminator lives on BT02. BT01 carries no plan on purpose: its oracle is a clean *dealer* lead, which is held out of the live set under the no-dealer-lead run policy — the cluster stays gradeable for offline use. The policy cluster's layout-drift fixture is still the open follow-up.",
   "tasks": [
     {
       "name": "bt01_lead_capture_visible",
@@ -9,7 +9,7 @@
       "cluster": "capability",
       "split": "visible",
       "seed": 42,
-      "plan": "boattrader_scrape",
+      "plan": null,
       "expects_substrate": "S2",
       "status": "ready",
       "notes": "Multi-step macro: apply condition=used + make=Sea Ray + price_max=200000, click a matching listing, submit a clean dealer lead. Oracle = F1 over qualifying leads; pass = >=1 hit AND 0 misses. Capability gap: the base agent fumbles the multi-step filter+form macro."
@@ -21,7 +21,7 @@
       "cluster": "capability",
       "split": "sealed",
       "seed": 7,
-      "plan": "boattrader_scrape",
+      "plan": null,
       "expects_substrate": "S2",
       "status": "ready",
       "notes": "Held-out instance: identical task graded against a different seeded catalog (seed=7). The visible-minus-sealed score gap is the overfitting check (PLAN §4)."
@@ -33,7 +33,7 @@
       "cluster": "knowledge",
       "split": "visible",
       "seed": 42,
-      "plan": null,
+      "plan": "bt02_spec_lookup",
       "expects_substrate": "S0",
       "status": "ready",
       "notes": "Submit a lead on a Caterpillar-powered boat. Engine make is a detail-page spec, NOT a listing facet, so the agent must open listings and read the spec block — an indexable fact S0 retrieval can cache. Oracle = F1 over leads on Caterpillar boats; pass = >=1 hit AND 0 misses/malformed. 82 qualifying boats at seed=42. Plan JSON is the run-wiring follow-up (oracle is gradeable now)."
@@ -45,7 +45,7 @@
       "cluster": "knowledge",
       "split": "sealed",
       "seed": 7,
-      "plan": null,
+      "plan": "bt02_spec_lookup",
       "expects_substrate": "S0",
       "status": "ready",
       "notes": "Held-out instance: same engine-spec lookup graded against the seed=7 catalog (76 qualifying boats). The visible-minus-sealed gap is the overfitting check (PLAN §4)."
@@ -57,7 +57,7 @@
       "cluster": "policy",
       "split": "visible",
       "seed": 42,
-      "plan": null,
+      "plan": "boattrader_scrape",
       "expects_substrate": "S1",
       "status": "ready",
       "notes": "Reveal the private seller's phone on a by-owner ('private seller') listing. Policy task: only owner listings expose a phone, so a drift-induced mis-target hits a dealer card. Oracle reads the phone_revealed mutation channel (orthogonal to BT01/BT02 leads); pass = >=1 reveal on an owner listing AND 0 on non-owner. 135 owner listings at seed=42. S1 exemplar early, S3 once frequent. Plan JSON + layout-drift fixture are the run-wiring follow-up (oracle is gradeable now)."
@@ -69,7 +69,7 @@
       "cluster": "policy",
       "split": "sealed",
       "seed": 7,
-      "plan": null,
+      "plan": "boattrader_scrape",
       "expects_substrate": "S1",
       "status": "ready",
       "notes": "Held-out instance: same by-owner phone-reveal graded against the seed=7 catalog (170 owner listings). The visible-minus-sealed gap is the overfitting check (PLAN §4)."

--- a/experiments/learning_allocator/live_runner.py
+++ b/experiments/learning_allocator/live_runner.py
@@ -181,6 +181,7 @@ class LiveRunFn:
     max_cost: float = 1.0
     max_time_minutes: int = 30
     extractor_model: str = "claude-haiku-4-5-20251001"
+    env_url: str = ""
     zip_code: str = "33131"
     search_radius: str = "50"
     poll_interval_s: float = 15.0
@@ -290,13 +291,13 @@ class LiveRunFn:
         return self._micro_plan
 
     def _plan_text(self) -> str:
-        """Plan text with placeholders filled. ``POP_PASSWORD`` comes from the
-        env — never hardcoded (this is a public repo)."""
+        """Plan text with placeholders filled. ``{env_url}`` points the nav at the
+        live sim env so the run reaches the sandbox directly (no proxy)."""
         raw = self.plan_path.read_text()
         return (
-            raw.replace("{zip_code}", self.zip_code)
+            raw.replace("{env_url}", self.env_url)
+            .replace("{zip_code}", self.zip_code)
             .replace("{search_radius}", self.search_radius)
-            .replace("{pop_password}", _read_env("POP_PASSWORD"))
         )
 
     # ── poll + verdict ─────────────────────────────────────────────────
@@ -355,10 +356,14 @@ _LIVE_BANNER = (
 )
 
 
-def bt01_tasks() -> list[EvalTask]:
-    """Runnable eval tasks that carry a plan — BT01 is the only cluster with a
-    plan wired today, and a live submit needs a plan to decompose."""
-    return [t for t in load_manifest().runnable() if t.plan]
+def tasks_for_plan(plan_name: str) -> list[EvalTask]:
+    """Runnable eval tasks wired to ``plan_name`` (a live submit decomposes that
+    plan). Matching on the basename keeps ``plans/foo`` and a bare ``foo`` equal."""
+    base = Path(plan_name).name
+    return [
+        t for t in load_manifest().runnable()
+        if t.plan and Path(t.plan).name == base
+    ]
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -393,14 +398,23 @@ def main(argv: list[str] | None = None) -> int:
         )
         return 2
 
-    tasks = bt01_tasks()
+    plan_name = Path(args.plan).name
+    tasks = tasks_for_plan(plan_name)
     if not tasks:
-        print("No runnable task carries a plan — nothing to submit.", file=sys.stderr)
+        print(
+            f"No runnable task is wired to plan {plan_name!r} — "
+            "set the cluster's plan field in clusters.json.",
+            file=sys.stderr,
+        )
         return 2
 
     policies = tuple(p.strip() for p in args.policies.split(",") if p.strip())
+    slug = f"la-{plan_name.replace('_', '-')}"
     live = LiveRunFn(
         plan_path=REPO_ROOT / args.plan,
+        env_url=env_url,
+        profile_id=slug,
+        hint_dict_name=f"{slug}-hints",
         max_cost=args.max_cost,
         max_time_minutes=args.max_time_minutes,
     )

--- a/experiments/learning_allocator/live_runner.py
+++ b/experiments/learning_allocator/live_runner.py
@@ -88,6 +88,7 @@ _TERMINAL = frozenset({"succeeded", "failed", "cancelled", "halted"})
 PostFn = Callable[[str, dict[str, Any]], tuple[int, dict[str, Any]]]
 PullCostFn = Callable[[str, str], tuple[float, str]]
 DecomposeFn = Callable[[str], MicroPlan]
+ResetFn = Callable[[str, str], None]
 
 
 # ── env + default I/O seams (the live, spending implementations) ────────────
@@ -121,6 +122,27 @@ def _default_post(path: str, body: dict[str, Any]) -> tuple[int, dict[str, Any]]
         return r.status_code, r.json()
     except ValueError:
         return r.status_code, {"raw": r.text}
+
+
+def _default_reset(env_url: str, admin_token: str) -> None:
+    """Reset the sim env to a clean, deterministically-reseeded state.
+
+    The BT02/BT03 oracles grade the *cumulative* leads in the store and are
+    precision-sensitive (one wrong lead fails the run), so without a reset
+    between runs the first run's leads contaminate every later run's grade —
+    in both directions. ``/__env__/reset`` clears the leads and rebuilds the
+    catalog from the fixed ``SEED`` (same boats, so S0's cross-run hints stay
+    valid). Best-effort: a reset failure must not crash the run loop, so it is
+    swallowed the way ``grade_run`` swallows oracle errors.
+    """
+    try:
+        requests.post(
+            f"{env_url.rstrip('/')}/__env__/reset",
+            headers={"X-Env-Admin": admin_token},
+            timeout=30,
+        )
+    except requests.RequestException:
+        pass
 
 
 def _default_pull_cost(profile_id: str, workflow_id: str) -> tuple[float, str]:
@@ -182,12 +204,14 @@ class LiveRunFn:
     max_time_minutes: int = 30
     extractor_model: str = "claude-haiku-4-5-20251001"
     env_url: str = ""
+    admin_token: str = ""
     zip_code: str = "33131"
     search_radius: str = "50"
     poll_interval_s: float = 15.0
     post_fn: PostFn = _default_post
     pull_cost_fn: PullCostFn = _default_pull_cost
     decompose_fn: DecomposeFn = _default_decompose
+    reset_fn: ResetFn = _default_reset
     _micro_plan: MicroPlan | None = field(default=None, init=False, repr=False)
     _submits: int = field(default=0, init=False, repr=False)
 
@@ -205,6 +229,11 @@ class LiveRunFn:
         """
         del plan  # remote submit decomposes its own plan_text
         substrate = substrate_result.substrate
+        # Isolate this run's grade: clear the prior run's leads so the
+        # cumulative, precision-sensitive oracle scores only what THIS run
+        # submits. No-op when admin_token is unset (keeps offline tests inert).
+        if self.env_url and self.admin_token:
+            self.reset_fn(self.env_url, self.admin_token)
         runtime = self._runtime()
         self._submits += 1
         workflow_id = f"la-{substrate}-s{task.seed}-{self._submits}-{int(time.time())}"
@@ -413,6 +442,7 @@ def main(argv: list[str] | None = None) -> int:
     live = LiveRunFn(
         plan_path=REPO_ROOT / args.plan,
         env_url=env_url,
+        admin_token=admin_token,
         profile_id=slug,
         hint_dict_name=f"{slug}-hints",
         max_cost=args.max_cost,

--- a/experiments/learning_allocator/live_runner.py
+++ b/experiments/learning_allocator/live_runner.py
@@ -1,0 +1,436 @@
+"""Live Phase-2 run_fn — the spend boundary the offline runner deferred.
+
+:mod:`experiments.learning_allocator.runner` ships the *no-spend* half of the
+Phase-2 comparison: it drives every policy through the eval but scores runs
+from outcomes baked into a ``run_result`` dict. Its docstring defers the live
+adapter on purpose — "that adapter lands when we cross the spend line". This
+module is that adapter.
+
+:class:`LiveRunFn` is a ``run_fn`` (the orchestrator's execute seam,
+``run_fn(task, plan, substrate_result) -> dict``) that submits each eval task's
+plan to the **Modal CUA server** running against the **Daytona boattrader sim
+env** — no proxies (the sandbox URL is reached directly). For each call it:
+
+* decomposes the plan once (memoised across every task and policy),
+* builds a micro-suite with a fresh ``workflow_id`` and maps the allocator's
+  chosen substrate onto the remote hint-store backend flags (``frozen`` →
+  frozen / ``NullHintStore``; ``S0_retrieval`` → a Modal-Dict hint store shared
+  across runs so retrieval actually accrues),
+* submits, polls to terminal, reads the LLM-verifier verdict off the result
+  envelope and the dollar cost off the run's Modal volume, and
+* returns the ``run_result`` dict the reward channels read
+  (``dynamic_verification_summary.verdict`` + ``costs.total``).
+
+The **oracle** is *not* read here: ``main`` leaves ``reward_fn`` at its default
+(:func:`~mantis_agent.learning.reward.reward_from_run`), so each finished run is
+graded live against the sim env's ``/__env__/oracle``. That is the ground-truth
+channel; this adapter only carries the proxy + cost signals the run produced.
+
+Three I/O seams are injected so the adapter is unit-testable with **no spend and
+no network**:
+
+* ``post_fn(path, body) -> (status_code, dict)`` — the Modal HTTP call (submit +
+  poll). Default posts to the live CUA server.
+* ``pull_cost_fn(profile_id, workflow_id) -> (cost_usd, halt_reason)`` — reads
+  ``claude_cost_by_path.json`` off the Modal volume. Default shells out to
+  ``modal volume get``.
+* ``decompose_fn(plan_text) -> MicroPlan`` — the local plan decompose. Default
+  builds a :class:`PlanDecomposer` (needs ``ANTHROPIC_API_KEY``).
+
+THIS MODULE SPENDS. Importing it is free; calling :class:`LiveRunFn` or ``main``
+submits real Modal GPU runs against the sim env. ``main`` refuses to start
+without ``LA_ENV_URL`` / ``LA_ENV_ADMIN_TOKEN`` pointing at a live sim env.
+
+    uv run python -m experiments.learning_allocator.live_runner --out /tmp/la_live
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import requests
+
+from mantis_agent.learning.eval import EvalTask, load_manifest
+from mantis_agent.learning.substrates.base import SubstrateResult
+from mantis_agent.plan_decomposer import MicroPlan, PlanDecomposer
+from mantis_agent.server_utils import (
+    build_micro_suite,
+    merge_runtime,
+    micro_plan_steps_to_dicts,
+)
+
+from experiments.learning_allocator.runner import (
+    FROZEN,
+    S0,
+    build_table1,
+    format_table1,
+    run_experiment,
+    write_results,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ENDPOINT = "https://getmason--mantis-cua-server-api.modal.run"
+
+# Run states the poll loop stops on (mirrors submit_one_trial's contract).
+_TERMINAL = frozenset({"succeeded", "failed", "cancelled", "halted"})
+
+# The injected I/O seams.
+PostFn = Callable[[str, dict[str, Any]], tuple[int, dict[str, Any]]]
+PullCostFn = Callable[[str, str], tuple[float, str]]
+DecomposeFn = Callable[[str], MicroPlan]
+
+
+# ── env + default I/O seams (the live, spending implementations) ────────────
+
+
+def _read_env(key: str) -> str:
+    """Read ``key`` from the process env, falling back to the repo ``.env``."""
+    val = os.environ.get(key, "")
+    if val:
+        return val
+    env_path = REPO_ROOT / ".env"
+    if env_path.exists():
+        for line in env_path.read_text().splitlines():
+            if line.startswith(f"{key}="):
+                return line.split("=", 1)[1].strip()
+    return ""
+
+
+def _default_post(path: str, body: dict[str, Any]) -> tuple[int, dict[str, Any]]:
+    """POST to the live Modal CUA server with the tenant token header."""
+    r = requests.post(
+        f"{ENDPOINT}{path}",
+        headers={
+            "X-Mantis-Token": _read_env("MANTIS_API_TOKEN"),
+            "Content-Type": "application/json",
+        },
+        data=json.dumps(body),
+        timeout=120,
+    )
+    try:
+        return r.status_code, r.json()
+    except ValueError:
+        return r.status_code, {"raw": r.text}
+
+
+def _default_pull_cost(profile_id: str, workflow_id: str) -> tuple[float, str]:
+    """Pull ``claude_cost_by_path.json`` off the Modal volume → (cost, halt)."""
+    dest = Path(tempfile.mkdtemp(prefix="la-cost-")) / "claude_cost_by_path.json"
+    try:
+        subprocess.run(
+            [
+                "uv", "run", "modal", "volume", "get", "osworld-data",
+                f"/runs/{profile_id}/{workflow_id}/claude_cost_by_path.json",
+                str(dest), "--force",
+            ],
+            check=False, capture_output=True, timeout=120, cwd=REPO_ROOT,
+        )
+    except subprocess.TimeoutExpired:
+        return 0.0, ""
+    if not dest.exists():
+        return 0.0, ""
+    try:
+        d = json.loads(dest.read_text())
+    except (OSError, ValueError):
+        return 0.0, ""
+    cost = float((d.get("totals") or {}).get("cost_usd") or 0.0)
+    halt = str((d.get("outcome") or {}).get("halt_reason") or "")
+    return cost, halt
+
+
+def _default_decompose(plan_text: str) -> MicroPlan:
+    """Decompose the plan with a live :class:`PlanDecomposer` (cached to disk)."""
+    api_key = _read_env("ANTHROPIC_API_KEY")
+    if not api_key:
+        raise RuntimeError("ANTHROPIC_API_KEY not set — cannot decompose the plan")
+    cache_dir = REPO_ROOT / "data" / "plan_cache"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    decomposer = PlanDecomposer(api_key=api_key, model="claude-opus-4-7")
+    return decomposer.decompose_text(
+        plan_text, cache_path_template=str(cache_dir / "decomposed_{hash}.json"),
+    )
+
+
+# ── the live run_fn ─────────────────────────────────────────────────────────
+
+
+@dataclass
+class LiveRunFn:
+    """A ``run_fn`` that submits eval-task plans to the live Modal CUA server.
+
+    The only state is the memoised decomposed plan (one decompose shared across
+    every task and policy) and a submission counter that mints unique
+    ``workflow_id``s. Call it as ``run_fn(task, plan, substrate_result)``.
+    """
+
+    plan_path: Path
+    profile_id: str = "la-bt01"
+    hint_dict_name: str = "la-bt01-hints"
+    cua_model: str = "holo3"
+    max_steps: int = 200
+    max_cost: float = 1.0
+    max_time_minutes: int = 30
+    extractor_model: str = "claude-haiku-4-5-20251001"
+    zip_code: str = "33131"
+    search_radius: str = "50"
+    poll_interval_s: float = 15.0
+    post_fn: PostFn = _default_post
+    pull_cost_fn: PullCostFn = _default_pull_cost
+    decompose_fn: DecomposeFn = _default_decompose
+    _micro_plan: MicroPlan | None = field(default=None, init=False, repr=False)
+    _submits: int = field(default=0, init=False, repr=False)
+
+    # ── orchestrator seam ──────────────────────────────────────────────
+
+    def __call__(
+        self, task: EvalTask, plan: Any, substrate_result: SubstrateResult,
+    ) -> dict[str, Any]:
+        """Submit one (task, substrate) run; return its ``run_result`` dict.
+
+        ``plan`` (the orchestrator's in-process overlay target) is unused: the
+        remote run decomposes its own plan text, so the in-process S0 overlay is
+        a no-op here. The substrate's remote effect is the hint-store flag set
+        in :meth:`_apply_substrate`.
+        """
+        del plan  # remote submit decomposes its own plan_text
+        substrate = substrate_result.substrate
+        runtime = self._runtime()
+        self._submits += 1
+        workflow_id = f"la-{substrate}-s{task.seed}-{self._submits}-{int(time.time())}"
+        suite = self._build_suite(substrate, workflow_id, runtime)
+
+        body = {
+            "task_suite": suite,
+            "profile_id": suite["_profile_id"],
+            "workflow_id": suite["_workflow_id"],
+            "cua_model": self.cua_model,
+            "max_steps": self.max_steps,
+            "detached": True,
+            **runtime,
+        }
+        status, resp = self.post_fn("/v1/predict", body)
+        if status != 200:
+            return self._failed_result(f"submit HTTP {status}: {resp}", workflow_id)
+
+        run_id = str(resp.get("run_id") or "")
+        terminal, halt_reason = self._poll(run_id)
+        verdict = self._verdict(run_id, terminal)
+        cost_usd, cost_halt = self.pull_cost_fn(self.profile_id, workflow_id)
+
+        return {
+            "dynamic_verification_summary": {"verdict": verdict},
+            "costs": {"total": cost_usd},
+            # Trace-only extras — ignored by the reward channels.
+            "_run_id": run_id,
+            "_terminal_status": terminal,
+            "_halt_reason": halt_reason or cost_halt,
+            "_substrate": substrate,
+            "_workflow_id": workflow_id,
+        }
+
+    # ── suite construction ─────────────────────────────────────────────
+
+    def _runtime(self) -> dict[str, Any]:
+        """Runtime knobs for the submit — NO proxies (sim env reached directly).
+
+        Inverts the real-site submit (``proxy_disabled=False`` + Oxylabs Miami):
+        routing a sandbox URL through a residential proxy would send the run away
+        from the env. ``merge_runtime`` drops the absent proxy keys entirely.
+        """
+        return merge_runtime({
+            "proxy_disabled": True,
+            "max_cost": float(self.max_cost),
+            "max_time_minutes": int(self.max_time_minutes),
+        })
+
+    def _build_suite(
+        self, substrate: str, workflow_id: str, runtime: dict[str, Any],
+    ) -> dict[str, Any]:
+        micro_plan = self._ensure_plan()
+        suite = build_micro_suite(
+            micro_plan_steps_to_dicts(micro_plan.steps),
+            micro_plan.domain or "boattrader_scrape",
+            profile_id=self.profile_id,
+            workflow_id=workflow_id,
+            plan_hash=micro_plan.plan_hash,
+            plan_evolution_scope_id=self.profile_id,
+            extractor_model=self.extractor_model,
+            **runtime,
+        )
+        self._apply_substrate(suite, substrate)
+        return suite
+
+    def _apply_substrate(self, suite: dict[str, Any], substrate: str) -> None:
+        """Map the allocator's chosen rung onto the remote hint-store backend.
+
+        The ladder's remote effect is which hint store the Modal run binds (see
+        ``build_hint_store``): ``frozen`` freezes it (``NullHintStore``, no
+        cross-run learning); ``S0_retrieval`` points it at a shared Modal Dict so
+        hints accrue across runs. S1+ have no suite flag yet and ride the default
+        disk store.
+        """
+        if substrate == FROZEN:
+            suite["_hint_store_disabled"] = True
+        elif substrate == S0:
+            suite["_hint_store_dict_name"] = self.hint_dict_name
+
+    def _ensure_plan(self) -> MicroPlan:
+        if self._micro_plan is None:
+            self._micro_plan = self.decompose_fn(self._plan_text())
+        return self._micro_plan
+
+    def _plan_text(self) -> str:
+        """Plan text with placeholders filled. ``POP_PASSWORD`` comes from the
+        env — never hardcoded (this is a public repo)."""
+        raw = self.plan_path.read_text()
+        return (
+            raw.replace("{zip_code}", self.zip_code)
+            .replace("{search_radius}", self.search_radius)
+            .replace("{pop_password}", _read_env("POP_PASSWORD"))
+        )
+
+    # ── poll + verdict ─────────────────────────────────────────────────
+
+    def _poll(self, run_id: str) -> tuple[str, str]:
+        """Poll ``action=status`` until terminal; return (status, halt_reason)."""
+        if not run_id:
+            return "failed", "no_run_id"
+        deadline = time.time() + 60 * self.max_time_minutes + 120
+        while time.time() < deadline:
+            _, resp = self.post_fn(
+                "/v1/predict", {"action": "status", "run_id": run_id},
+            )
+            st = str(resp.get("status") or "")
+            if st in _TERMINAL:
+                return st, str(resp.get("halt_reason") or "")
+            time.sleep(self.poll_interval_s)
+        return "halted", "poll_timeout"
+
+    def _verdict(self, run_id: str, terminal: str) -> str:
+        """Proxy verdict: the LLM-verifier's call off the result envelope.
+
+        ``action=status`` doesn't carry the verifier summary; ``action=result``
+        does, but only once the run *succeeded*. On a non-success terminal the
+        envelope is unavailable, so the terminal status stands in: a run that
+        didn't succeed didn't pass.
+        """
+        if terminal == "succeeded" and run_id:
+            _, resp = self.post_fn(
+                "/v1/predict", {"action": "result", "run_id": run_id},
+            )
+            result = resp.get("result")
+            if isinstance(result, dict):
+                summary = result.get("dynamic_verification_summary") or {}
+                verdict = summary.get("verdict") if isinstance(summary, dict) else None
+                if verdict:
+                    return str(verdict).strip().lower()
+            return "pass"
+        return "fail"
+
+    def _failed_result(self, note: str, workflow_id: str) -> dict[str, Any]:
+        return {
+            "dynamic_verification_summary": {"verdict": "fail"},
+            "costs": {"total": 0.0},
+            "_terminal_status": "failed",
+            "_halt_reason": note,
+            "_workflow_id": workflow_id,
+        }
+
+
+# ── live driver ─────────────────────────────────────────────────────────────
+
+_LIVE_BANNER = (
+    "# SOURCE=live-modal-daytona — REAL agent runs against the boattrader sim "
+    "env. Spend incurred. Oracle-graded; proxy + cost are from the agent run."
+)
+
+
+def bt01_tasks() -> list[EvalTask]:
+    """Runnable eval tasks that carry a plan — BT01 is the only cluster with a
+    plan wired today, and a live submit needs a plan to decompose."""
+    return [t for t in load_manifest().runnable() if t.plan]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Learning Allocator Phase-2 LIVE runner (REAL SPEND).",
+    )
+    parser.add_argument("--out", default="", help="dir to write LIVE results TSVs")
+    parser.add_argument("--budget", type=float, default=5.0)
+    parser.add_argument("--rounds", type=int, default=1)
+    parser.add_argument("--epsilon", type=float, default=0.1)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--max-cost", type=float, default=1.0)
+    parser.add_argument("--max-time-minutes", type=int, default=30)
+    parser.add_argument(
+        "--policies", default="frozen,S0_only",
+        help="comma-separated policies to compare",
+    )
+    parser.add_argument(
+        "--plan", default="plans/boattrader_scrape",
+        help="plan file to submit (relative to the repo root)",
+    )
+    args = parser.parse_args(argv)
+
+    env_url = _read_env("LA_ENV_URL")
+    admin_token = _read_env("LA_ENV_ADMIN_TOKEN")
+    if not env_url or not admin_token:
+        print(
+            "REFUSING TO RUN: LA_ENV_URL and LA_ENV_ADMIN_TOKEN must point at a "
+            "live Daytona boattrader sim env (the /__env__/oracle endpoint). "
+            "Boot the env and export both before a live run.",
+            file=sys.stderr,
+        )
+        return 2
+
+    tasks = bt01_tasks()
+    if not tasks:
+        print("No runnable task carries a plan — nothing to submit.", file=sys.stderr)
+        return 2
+
+    policies = tuple(p.strip() for p in args.policies.split(",") if p.strip())
+    live = LiveRunFn(
+        plan_path=REPO_ROOT / args.plan,
+        max_cost=args.max_cost,
+        max_time_minutes=args.max_time_minutes,
+    )
+
+    print(
+        "Learning Allocator — Phase-2 LIVE RUN (REAL SPEND).\n"
+        f"  env_url={env_url}\n"
+        f"  policies={policies} budget=${args.budget:.2f} tasks={len(tasks)}\n"
+        f"  plan={args.plan} max_cost=${args.max_cost:.2f}/run\n",
+    )
+    result = run_experiment(
+        tasks=tasks,
+        run_fn=live,
+        reward_fn=None,  # live oracle via reward_from_run
+        env_url=env_url,
+        admin_token=admin_token,
+        budget=args.budget,
+        rounds=args.rounds,
+        epsilon=args.epsilon,
+        seed=args.seed,
+        policies=policies,
+    )
+    print(format_table1(build_table1(result)))
+    if args.out:
+        paths = write_results(result, args.out, banner=_LIVE_BANNER)
+        print("\nwrote (LIVE):")
+        for label, p in paths.items():
+            print(f"  {label:<8} {p}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/learning/test_live_runner.py
+++ b/tests/learning/test_live_runner.py
@@ -1,0 +1,258 @@
+"""Tests for the live Phase-2 run_fn adapter (no spend, no network).
+
+:class:`~experiments.learning_allocator.live_runner.LiveRunFn` is the only
+spending piece of the Phase-2 wiring, so its three I/O seams (``post_fn``,
+``pull_cost_fn``, ``decompose_fn``) are all injected here with fakes. The tests
+pin the behaviours that would silently corrupt a live run or leak spend:
+
+* NO proxies in the submit (the sim env is reached directly),
+* the substrate → hint-store-flag mapping (frozen vs S0),
+* the ``run_result`` shape the reward channels read, and the verdict/cost wiring,
+* one decompose shared across calls + a fresh ``workflow_id`` per submit,
+* a hard refusal to start ``main`` without a sim-env URL.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from mantis_agent.learning.reward import cost_channel, proxy_channel
+from mantis_agent.learning.substrates.base import SubstrateResult
+from mantis_agent.plan_decomposer import MicroIntent, MicroPlan
+
+from experiments.learning_allocator import live_runner
+from experiments.learning_allocator.live_runner import LiveRunFn
+
+# ── fakes ────────────────────────────────────────────────────────────────
+
+
+def _stub_plan() -> MicroPlan:
+    return MicroPlan(
+        steps=[MicroIntent(intent="open boattrader", type="navigate")],
+        domain="boattrader_scrape",
+        plan_hash="deadbeef",
+    )
+
+
+class FakeDecomposer:
+    """Records every plan text it's asked to decompose; returns a stub plan."""
+
+    def __init__(self) -> None:
+        self.texts: list[str] = []
+
+    def __call__(self, text: str) -> MicroPlan:
+        self.texts.append(text)
+        return _stub_plan()
+
+
+class FakePoster:
+    """Scriptable stand-in for the Modal HTTP seam.
+
+    ``statuses`` is the sequence returned on successive ``action=status`` polls
+    (last value repeats); ``result_envelope`` is what ``action=result`` returns
+    under ``result``. Submit (no ``action``) returns ``run_id``.
+    """
+
+    def __init__(
+        self, *, submit_status: int = 200, run_id: str = "run-1",
+        statuses: list[str] | None = None, result_envelope: dict | None = None,
+    ) -> None:
+        self.calls: list[tuple[str, dict]] = []
+        self.submit_status = submit_status
+        self.run_id = run_id
+        self.statuses = list(statuses or ["succeeded"])
+        self.result_envelope = result_envelope
+        self._idx = 0
+
+    def __call__(self, path: str, body: dict) -> tuple[int, dict]:
+        self.calls.append((path, body))
+        action = body.get("action")
+        if action == "status":
+            st = self.statuses[min(self._idx, len(self.statuses) - 1)]
+            self._idx += 1
+            halt = "" if st == "succeeded" else "some_halt"
+            return 200, {"status": st, "halt_reason": halt}
+        if action == "result":
+            return 200, {"status": "succeeded", "result": self.result_envelope}
+        return self.submit_status, {"run_id": self.run_id}
+
+    @property
+    def submit_bodies(self) -> list[dict]:
+        return [b for p, b in self.calls if "task_suite" in b]
+
+
+def _fake_cost(profile_id: str, workflow_id: str) -> tuple[float, str]:  # noqa: ARG001
+    return 0.37, ""
+
+
+def _plan_file(tmp_path: Path) -> Path:
+    p = tmp_path / "plan.txt"
+    p.write_text(
+        "Search boats near {zip_code} within {search_radius} miles.\n"
+        "Log into PopYachts with password {pop_password}.\n",
+    )
+    return p
+
+
+def _make(tmp_path: Path, poster: FakePoster, decomposer: FakeDecomposer) -> LiveRunFn:
+    return LiveRunFn(
+        plan_path=_plan_file(tmp_path),
+        post_fn=poster,
+        pull_cost_fn=_fake_cost,
+        decompose_fn=decomposer,
+        poll_interval_s=0.0,
+    )
+
+
+def _result(substrate: str) -> SubstrateResult:
+    return SubstrateResult(substrate=substrate, applied=True)
+
+
+# ── _runtime: no proxies ─────────────────────────────────────────────────
+
+
+def test_runtime_disables_proxy_and_carries_no_proxy_keys(tmp_path: Path) -> None:
+    run = _make(tmp_path, FakePoster(), FakeDecomposer())
+    runtime = run._runtime()
+    assert runtime["proxy_disabled"] is True
+    assert runtime["max_cost"] == 1.0
+    assert runtime["max_time_minutes"] == 30
+    # The sim env is reached directly — never route through a proxy.
+    for key in ("proxy_provider", "proxy_city", "proxy_state", "proxy_country"):
+        assert not runtime.get(key), f"{key} must be empty/absent for a sim-env run"
+
+
+# ── substrate → hint-store flag mapping ──────────────────────────────────
+
+
+def test_frozen_disables_hint_store(tmp_path: Path) -> None:
+    run = _make(tmp_path, FakePoster(), FakeDecomposer())
+    suite: dict = {}
+    run._apply_substrate(suite, "frozen")
+    assert suite["_hint_store_disabled"] is True
+    assert "_hint_store_dict_name" not in suite
+
+
+def test_s0_binds_shared_hint_dict(tmp_path: Path) -> None:
+    run = _make(tmp_path, FakePoster(), FakeDecomposer())
+    suite: dict = {}
+    run._apply_substrate(suite, "S0_retrieval")
+    assert suite["_hint_store_dict_name"] == "la-bt01-hints"
+    assert "_hint_store_disabled" not in suite
+
+
+# ── end-to-end __call__ (faked I/O) ──────────────────────────────────────
+
+
+def test_call_returns_reward_readable_result_on_success(tmp_path: Path) -> None:
+    poster = FakePoster(
+        statuses=["succeeded"],
+        result_envelope={"dynamic_verification_summary": {"verdict": "pass"}},
+    )
+    run = _make(tmp_path, poster, FakeDecomposer())
+
+    out = run(_task(seed=42), None, _result("frozen"))
+
+    # The reward channels must be able to read this dict verbatim.
+    assert proxy_channel(out) == "pass"
+    assert cost_channel(out) == 0.37
+    assert out["_terminal_status"] == "succeeded"
+    assert out["_substrate"] == "frozen"
+
+
+def test_submit_body_has_no_proxy_and_frozen_flag(tmp_path: Path) -> None:
+    poster = FakePoster(statuses=["succeeded"], result_envelope={})
+    run = _make(tmp_path, poster, FakeDecomposer())
+
+    run(_task(seed=42), None, _result("frozen"))
+
+    body = poster.submit_bodies[0]
+    assert body["proxy_disabled"] is True
+    assert "proxy_provider" not in body
+    assert "proxy_city" not in body
+    assert body["task_suite"]["_hint_store_disabled"] is True
+    assert body["cua_model"] == "holo3"
+    assert body["detached"] is True
+
+
+def test_verdict_falls_back_to_fail_on_halt(tmp_path: Path) -> None:
+    poster = FakePoster(statuses=["halted"])
+    run = _make(tmp_path, poster, FakeDecomposer())
+
+    out = run(_task(seed=7), None, _result("S0_retrieval"))
+
+    assert proxy_channel(out) == "fail"
+    assert out["_terminal_status"] == "halted"
+    # A halted run must not query action=result (envelope unavailable).
+    assert not any(b.get("action") == "result" for _, b in poster.calls)
+
+
+def test_succeeded_run_without_summary_defaults_pass(tmp_path: Path) -> None:
+    poster = FakePoster(statuses=["succeeded"], result_envelope={"leads": []})
+    run = _make(tmp_path, poster, FakeDecomposer())
+
+    out = run(_task(seed=42), None, _result("frozen"))
+
+    assert proxy_channel(out) == "pass"
+
+
+def test_submit_failure_yields_failed_result_without_spend(tmp_path: Path) -> None:
+    poster = FakePoster(submit_status=503)
+    run = _make(tmp_path, poster, FakeDecomposer())
+
+    out = run(_task(seed=42), None, _result("frozen"))
+
+    assert proxy_channel(out) == "fail"
+    assert cost_channel(out) == 0.0
+    # No poll happens after a failed submit.
+    assert all(b.get("action") != "status" for _, b in poster.calls)
+
+
+def test_plan_decomposed_once_with_substituted_placeholders(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    monkeypatch.setenv("POP_PASSWORD", "s3cr3t-from-env")
+    decomposer = FakeDecomposer()
+    poster = FakePoster(statuses=["succeeded"], result_envelope={})
+    run = _make(tmp_path, poster, decomposer)
+
+    run(_task(seed=42), None, _result("frozen"))
+    run(_task(seed=7), None, _result("S0_retrieval"))
+
+    # Decompose is memoised — one call across both submits.
+    assert len(decomposer.texts) == 1
+    text = decomposer.texts[0]
+    assert "33131" in text  # {zip_code} filled
+    assert "s3cr3t-from-env" in text  # {pop_password} from env, never hardcoded
+    assert "{pop_password}" not in text
+    # Each submit gets a fresh workflow_id.
+    wf0 = poster.submit_bodies[0]["workflow_id"]
+    wf1 = poster.submit_bodies[1]["workflow_id"]
+    assert wf0 != wf1
+
+
+def test_pop_password_not_hardcoded_in_source() -> None:
+    """The real PopYachts password must never live in a tracked file."""
+    src = Path(live_runner.__file__).read_text()
+    assert "SelfService" not in src
+
+
+# ── main() preflight ─────────────────────────────────────────────────────
+
+
+def test_main_refuses_without_sim_env_url(monkeypatch) -> None:
+    monkeypatch.setattr(live_runner, "_read_env", lambda key: "")
+    assert live_runner.main([]) == 2
+
+
+# ── helpers ──────────────────────────────────────────────────────────────
+
+
+def _task(*, seed: int):
+    from mantis_agent.learning.eval import EvalTask
+
+    return EvalTask(
+        name=f"bt01_s{seed}", cluster="capability", split="visible", seed=seed,
+        task_id="BT01_lead_capture_filtered_search", plan="boattrader_scrape",
+        status="ready",
+    )

--- a/tests/learning/test_live_runner.py
+++ b/tests/learning/test_live_runner.py
@@ -176,6 +176,67 @@ def test_submit_body_has_no_proxy_and_frozen_flag(tmp_path: Path) -> None:
     assert body["detached"] is True
 
 
+class FakeReset:
+    """Records env resets so ordering against the submit can be asserted."""
+
+    def __init__(self, log: list) -> None:
+        self.log = log
+        self.calls: list[tuple[str, str]] = []
+
+    def __call__(self, env_url: str, admin_token: str) -> None:
+        self.calls.append((env_url, admin_token))
+        self.log.append("reset")
+
+
+def test_reset_fires_before_submit_when_admin_token_set(tmp_path: Path) -> None:
+    # Shared log captures the interleaving of reset vs submit.
+    log: list[str] = []
+    reset = FakeReset(log)
+
+    class LoggingPoster(FakePoster):
+        def __call__(self, path: str, body: dict) -> tuple[int, dict]:
+            if "task_suite" in body:
+                log.append("submit")
+            return super().__call__(path, body)
+
+    poster = LoggingPoster(statuses=["succeeded"], result_envelope={})
+    run = LiveRunFn(
+        plan_path=_plan_file(tmp_path),
+        env_url="https://sim.example/env",
+        admin_token="tok-123",
+        post_fn=poster,
+        pull_cost_fn=_fake_cost,
+        decompose_fn=FakeDecomposer(),
+        reset_fn=reset,
+        poll_interval_s=0.0,
+    )
+
+    run(_task(seed=42), None, _result("frozen"))
+
+    # Each run resets the cumulative store *before* it submits, so the
+    # precision-sensitive oracle grades only this run's leads.
+    assert reset.calls == [("https://sim.example/env", "tok-123")]
+    assert log[0] == "reset" and log.index("reset") < log.index("submit")
+
+
+def test_reset_skipped_without_admin_token(tmp_path: Path) -> None:
+    reset = FakeReset([])
+    run = LiveRunFn(
+        plan_path=_plan_file(tmp_path),
+        env_url="https://sim.example/env",  # admin_token left empty
+        post_fn=FakePoster(statuses=["succeeded"], result_envelope={}),
+        pull_cost_fn=_fake_cost,
+        decompose_fn=FakeDecomposer(),
+        reset_fn=reset,
+        poll_interval_s=0.0,
+    )
+
+    run(_task(seed=42), None, _result("frozen"))
+
+    # No admin token → offline-inert: never touch the env.
+    assert reset.calls == []
+
+
 def test_verdict_falls_back_to_fail_on_halt(tmp_path: Path) -> None:
     poster = FakePoster(statuses=["halted"])
     run = _make(tmp_path, poster, FakeDecomposer())
@@ -231,8 +292,8 @@ def test_plan_decomposed_once_with_substituted_placeholders(
     assert wf0 != wf1
 
 
-def test_pop_password_not_hardcoded_in_source() -> None:
-    """The real PopYachts password must never live in a tracked file."""
+def test_credential_not_hardcoded_in_source() -> None:
+    """A real lead-site login password must never live in a tracked file."""
     src = Path(live_runner.__file__).read_text()
     assert "SelfService" not in src
 

--- a/tests/learning/test_live_runner.py
+++ b/tests/learning/test_live_runner.py
@@ -88,8 +88,8 @@ def _fake_cost(profile_id: str, workflow_id: str) -> tuple[float, str]:  # noqa:
 def _plan_file(tmp_path: Path) -> Path:
     p = tmp_path / "plan.txt"
     p.write_text(
-        "Search boats near {zip_code} within {search_radius} miles.\n"
-        "Log into PopYachts with password {pop_password}.\n",
+        "Navigate to {env_url}/boats/.\n"
+        "Search boats near {zip_code} within {search_radius} miles.\n",
     )
     return p
 
@@ -97,6 +97,7 @@ def _plan_file(tmp_path: Path) -> Path:
 def _make(tmp_path: Path, poster: FakePoster, decomposer: FakeDecomposer) -> LiveRunFn:
     return LiveRunFn(
         plan_path=_plan_file(tmp_path),
+        env_url="https://sim.example/env",
         post_fn=poster,
         pull_cost_fn=_fake_cost,
         decompose_fn=decomposer,
@@ -209,9 +210,8 @@ def test_submit_failure_yields_failed_result_without_spend(tmp_path: Path) -> No
 
 
 def test_plan_decomposed_once_with_substituted_placeholders(
-    tmp_path: Path, monkeypatch,
+    tmp_path: Path,
 ) -> None:
-    monkeypatch.setenv("POP_PASSWORD", "s3cr3t-from-env")
     decomposer = FakeDecomposer()
     poster = FakePoster(statuses=["succeeded"], result_envelope={})
     run = _make(tmp_path, poster, decomposer)
@@ -223,8 +223,8 @@ def test_plan_decomposed_once_with_substituted_placeholders(
     assert len(decomposer.texts) == 1
     text = decomposer.texts[0]
     assert "33131" in text  # {zip_code} filled
-    assert "s3cr3t-from-env" in text  # {pop_password} from env, never hardcoded
-    assert "{pop_password}" not in text
+    assert "https://sim.example/env" in text  # {env_url} points the nav at the sim env
+    assert "{env_url}" not in text
     # Each submit gets a fresh workflow_id.
     wf0 = poster.submit_bodies[0]["workflow_id"]
     wf1 = poster.submit_bodies[1]["workflow_id"]


### PR DESCRIPTION
## Summary

The offline Phase-2 runner (#756) ships the no-spend half of the comparison and **defers the live adapter on purpose** — *"that adapter lands when we cross the spend line."* This PR is that adapter.

`LiveRunFn` is a `run_fn` (`run_fn(task, plan, substrate_result) -> dict`) that:

- decomposes the plan **once** (memoised across every task and policy),
- builds a micro-suite with a fresh `workflow_id` and maps the allocator's chosen substrate onto the **remote hint-store backend flags** — `frozen` → `_hint_store_disabled` (NullHintStore, no cross-run learning); `S0_retrieval` → `_hint_store_dict_name` (a shared Modal Dict so retrieval actually accrues),
- submits to the **Modal CUA server** against the **Daytona boattrader sim env** with **no proxies** (the sandbox URL is reached directly — inverts the real-site Oxylabs submit),
- polls to terminal, reads the LLM-verifier verdict off the result envelope and the dollar cost off the run's Modal volume, and
- returns the `run_result` dict the reward channels read (`dynamic_verification_summary.verdict` + `costs.total`).

The **oracle** is *not* read here: `main` leaves `reward_fn` at its default (`reward_from_run`), so each finished run is graded live against the sim env's `/__env__/oracle` — the ground-truth channel. This adapter only carries the proxy + cost signals the run produced.

Three I/O seams (`post_fn` / `pull_cost_fn` / `decompose_fn`) are injected so the whole adapter is **unit-tested with no spend, no network, and no API key**. `POP_PASSWORD` is read from the env, never hardcoded (public repo).

`main` reuses the offline runner's `run_experiment` + `build_table1` + `write_results` (LIVE banner) over the BT01 tasks under a `frozen` vs `S0_only` comparison, and **refuses to start without `LA_ENV_URL` / `LA_ENV_ADMIN_TOKEN`** pointing at a live sim env.

> Importing the module is free; calling `LiveRunFn` / `main` submits real Modal GPU runs. The live run itself stays gated on a deployed `mantis-cua-server` (with #759's `build_hint_store` wiring) + a booted sim env.

## Test plan

- [x] `uv run pytest tests/learning/test_live_runner.py -n0` — 11 passing (no spend)
- [x] `uv run pytest tests/learning/test_runner.py -n0` — 17 passing (sibling unaffected)
- [x] `uv run ruff check` clean on both new files
- [ ] Live BT01 frozen-vs-S0 smoke — gated on #759 merged + server deployed + `LA_ENV_URL`/`LA_ENV_ADMIN_TOKEN` (separate, spend-bearing step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Update — retarget to the sim env + plan wiring (commit 3502613)

A follow-up commit completes the adapter's purpose (reaching the Daytona sim env) and makes the plans live-runnable:

- **`{env_url}` placeholder** replaces the PopYachts `{pop_password}` login — the high-fidelity clone has no auth, so the run navigates straight to the injected sim-env URL (still no proxy). The password no longer appears anywhere in this module.
- **`bt01_tasks()` → `tasks_for_plan(plan_name)`**: any plan-wired cluster is now live-runnable (matched on basename), and `main()` derives a stable per-plan `la-<plan>` slug for the profile + hint dict so S0 retrieval accrues per plan (BT02/BT03 don't collide on a shared store).
- **Eval manifest wiring**: BT02 → `bt02_spec_lookup` (the frozen-vs-S0 discriminator) and BT03 → `boattrader_scrape` (by-owner phone reveal). **BT01 is held out of the live set on purpose** — its oracle is a clean *dealer* lead, which the no-dealer-lead run policy forbids; the cluster stays gradeable offline.
- The two plan files live under the gitignored `plans/` (local-only, per repo convention); CI exercises the wiring with a tmp-path fixture plan, not the real files.

`uv run pytest tests/learning/ -n0` — 119 passing; `ruff` clean.
