### PR TITLE
feat(learning): live BT02 enablement — browser extra-headers seam + JSON plan load

### DIFF
--- a/deploy/modal/modal_cua_server.py
+++ b/deploy/modal/modal_cua_server.py
@@ -535,6 +535,7 @@ def _run_executor(
         proxy_provider=str(task_suite.get("_proxy_provider") or ""),
         proxy_country=str(task_suite.get("_proxy_country") or ""),
         proxy_disabled=bool(task_suite.get("_proxy_disabled", False)),
+        extra_http_headers=task_suite.get("_browser_extra_headers") or None,
         profile_dir=profile_dir,
     )
     viewer_ctx, viewer_event_bus, _viewer_url = setup_viewer(viewer, proxy_diag=proxy_diag)
@@ -793,6 +794,7 @@ def _run_holo3_executor(
         proxy_provider=str(task_suite.get("_proxy_provider") or ""),
         proxy_country=str(task_suite.get("_proxy_country") or ""),
         proxy_disabled=bool(task_suite.get("_proxy_disabled", False)),
+        extra_http_headers=task_suite.get("_browser_extra_headers") or None,
         profile_dir=profile_dir,
     )
     from mantis_agent.extraction import ClaudeExtractor, ExtractionSchema
@@ -1608,6 +1610,7 @@ def _run_gemma4_cua_executor(
         proxy_provider=str(task_suite.get("_proxy_provider") or ""),
         proxy_country=str(task_suite.get("_proxy_country") or ""),
         proxy_disabled=bool(task_suite.get("_proxy_disabled", False)),
+        extra_http_headers=task_suite.get("_browser_extra_headers") or None,
         profile_dir=profile_dir,
     )
     viewer_ctx, viewer_event_bus, _viewer_url = setup_viewer(viewer, proxy_diag=proxy_diag)
@@ -1779,6 +1782,7 @@ def _run_claude_executor(
         proxy_provider=str(task_suite.get("_proxy_provider") or ""),
         proxy_country=str(task_suite.get("_proxy_country") or ""),
         proxy_disabled=bool(task_suite.get("_proxy_disabled", False)),
+        extra_http_headers=task_suite.get("_browser_extra_headers") or None,
         profile_dir=profile_dir,
     )
     viewer_ctx, viewer_event_bus, _viewer_url = setup_viewer(viewer, proxy_diag=proxy_diag)

--- a/experiments/learning_allocator/live_runner.py
+++ b/experiments/learning_allocator/live_runner.py
@@ -11,7 +11,9 @@ module is that adapter.
 plan to the **Modal CUA server** running against the **Daytona boattrader sim
 env** — no proxies (the sandbox URL is reached directly). For each call it:
 
-* decomposes the plan once (memoised across every task and policy),
+* loads the plan once, memoised across every task and policy — a ``.json``
+  plan is a pre-decomposed micro-plan loaded directly (the deterministic,
+  guard-carrying path); any other extension is decomposed via the LLM,
 * builds a micro-suite with a fresh ``workflow_id`` and maps the allocator's
   chosen substrate onto the remote hint-store backend flags (``frozen`` →
   frozen / ``NullHintStore``; ``S0_retrieval`` → a Modal-Dict hint store shared
@@ -68,6 +70,7 @@ from mantis_agent.server_utils import (
     merge_runtime,
     micro_plan_steps_to_dicts,
 )
+from mantis_agent.sim_envs.templating import substitute_env_url
 
 from experiments.learning_allocator.runner import (
     FROZEN,
@@ -205,6 +208,16 @@ class LiveRunFn:
     extractor_model: str = "claude-haiku-4-5-20251001"
     env_url: str = ""
     admin_token: str = ""
+    # Request headers applied to every browser request on the remote run.
+    # Default carries the Daytona preview-proxy skip header: the sim env is
+    # served behind ``*.daytonaproxy01.net``, which shows a "Preview -
+    # Warning" interstitial to real-browser User-Agents (which the Modal
+    # runner forces via the stealth UA override). Without this the CUA
+    # browser never reaches the boats page → 0 leads. Set to ``{}`` for a
+    # direct (non-Daytona) env.
+    browser_extra_headers: dict[str, str] = field(
+        default_factory=lambda: {"X-Daytona-Skip-Preview-Warning": "true"}
+    )
     zip_code: str = "33131"
     search_radius: str = "50"
     poll_interval_s: float = 15.0
@@ -297,6 +310,10 @@ class LiveRunFn:
             extractor_model=self.extractor_model,
             **runtime,
         )
+        if self.browser_extra_headers:
+            # Read by modal_cua_server's setup_env call sites → xdotool_env's
+            # persistent header session (applied to every browser request).
+            suite["_browser_extra_headers"] = dict(self.browser_extra_headers)
         self._apply_substrate(suite, substrate)
         return suite
 
@@ -316,8 +333,27 @@ class LiveRunFn:
 
     def _ensure_plan(self) -> MicroPlan:
         if self._micro_plan is None:
-            self._micro_plan = self.decompose_fn(self._plan_text())
+            if self.plan_path.suffix.lower() == ".json":
+                self._micro_plan = self._load_json_plan()
+            else:
+                self._micro_plan = self.decompose_fn(self._plan_text())
         return self._micro_plan
+
+    def _load_json_plan(self) -> MicroPlan:
+        """Load a pre-decomposed micro-plan JSON directly — no decompose call.
+
+        Mirrors ``cli.py``'s plan-format dispatch (``_looks_like_text_plan``): a
+        ``.json`` plan is an already-decomposed micro-plan, so the LLM
+        decomposer is bypassed entirely (a deterministic, hand-authored plan
+        must not be re-paraphrased — e.g. the conditional ``detect_visible``
+        guard the decomposer flattens). ``{{ENV_URL}}`` is substituted with the
+        live sim-env URL via the repo's standard JSON-plan templating so the nav
+        steps reach the sandbox directly (the text path uses its own
+        ``{env_url}`` token). ``decompose_fn`` is unused on this branch.
+        """
+        payload = json.loads(self.plan_path.read_text())
+        payload = substitute_env_url(payload, self.env_url)
+        return MicroPlan.from_dict(payload)
 
     def _plan_text(self) -> str:
         """Plan text with placeholders filled. ``{env_url}`` points the nav at the
@@ -386,12 +422,14 @@ _LIVE_BANNER = (
 
 
 def tasks_for_plan(plan_name: str) -> list[EvalTask]:
-    """Runnable eval tasks wired to ``plan_name`` (a live submit decomposes that
-    plan). Matching on the basename keeps ``plans/foo`` and a bare ``foo`` equal."""
-    base = Path(plan_name).name
+    """Runnable eval tasks wired to ``plan_name``. Matching on the *stem* keeps
+    ``plans/foo``, a bare ``foo``, and ``foo.json`` equal — clusters.json names
+    the logical plan (``bt02_spec_lookup``) while the on-disk file may carry a
+    ``.json`` suffix (a pre-decomposed micro-plan)."""
+    stem = Path(plan_name).stem
     return [
         t for t in load_manifest().runnable()
-        if t.plan and Path(t.plan).name == base
+        if t.plan and Path(t.plan).stem == stem
     ]
 
 
@@ -427,7 +465,11 @@ def main(argv: list[str] | None = None) -> int:
         )
         return 2
 
-    plan_name = Path(args.plan).name
+    # Stem (drop any ``.json`` suffix) so the profile slug and task wiring stay
+    # clean for a pre-decomposed plan: ``plans/bt02_spec_lookup.json`` →
+    # ``bt02_spec_lookup`` → slug ``la-bt02-spec-lookup`` and a clusters.json
+    # match. ``plan_path`` below keeps the full suffixed path for reading.
+    plan_name = Path(args.plan).stem
     tasks = tasks_for_plan(plan_name)
     if not tasks:
         print(

--- a/src/mantis_agent/gym/xdotool_env.py
+++ b/src/mantis_agent/gym/xdotool_env.py
@@ -97,6 +97,7 @@ class XdotoolGymEnv(GymEnvironment):
         save_screenshots: str = "",
         cdp_port: int = 9222,
         reuse_session: bool = False,
+        extra_http_headers: dict[str, str] | None = None,
     ):
         self._start_url = start_url
         self._viewport = viewport
@@ -121,6 +122,16 @@ class XdotoolGymEnv(GymEnvironment):
         # ``XdotoolGymEnv.shutdown`` exists for the cache to force-close
         # the underlying processes when the container is recycled.
         self._reuse_session = reuse_session
+
+        # Optional request headers applied to EVERY browser request via a
+        # persistent Network-enabled CDP session (see ``_start_browser``).
+        # Default ``None`` = no-op, so production CF runs are unaffected.
+        # The only caller that sets this is the Learning Allocator live
+        # runner, which injects ``X-Daytona-Skip-Preview-Warning: true`` to
+        # get past the Daytona preview proxy's interstitial on the sim env.
+        self._extra_http_headers = extra_http_headers or None
+        self._header_ws = None  # persistent CDP ws holding the header
+        self._header_ws_thread = None
 
         self._xvfb_proc = None
         self._browser_proc = None
@@ -353,6 +364,115 @@ class XdotoolGymEnv(GymEnvironment):
             apply_ua_override(self._cdp_call)
         except Exception as exc:  # noqa: BLE001 — never fatal
             logger.debug("CDP stealth inject/UA-override raised at startup: %s", exc)
+
+        # Persistent request-header session (no-op unless configured).
+        # MUST come after the stealth block: a one-shot CDP header set
+        # reverts the instant its ws detaches (CDP overrides are
+        # session-scoped), so a header that has to survive runner-driven
+        # navigations AND in-page link clicks needs ONE ws that stays
+        # open for the browser's lifetime. See ``_open_header_session``.
+        if self._extra_http_headers:
+            self._open_header_session()
+
+    def _open_header_session(self) -> None:
+        """Hold a persistent Network-enabled CDP session that applies
+        ``self._extra_http_headers`` to every page request.
+
+        Why persistent: ``Network.setExtraHTTPHeaders`` is session-scoped —
+        it reverts the moment the ws detaches. The one-shot ``_cdp_call``
+        pattern therefore can't carry a header across the runner's later
+        ``Page.navigate`` calls, and certainly not across in-page link
+        clicks / ``location.href`` pagination (which no CDP call drives at
+        all). A single ws that enables Network, sets the header, and stays
+        open covers ALL of those request paths until the browser closes.
+
+        ``Network.enable`` is mandatory first — ``setExtraHTTPHeaders``
+        silently no-ops (returns ``{}`` but applies nothing) without it.
+
+        Best-effort: any failure leaves ``self._header_ws`` ``None`` and is
+        logged at WARNING (the header is the only thing past the Daytona
+        preview interstitial, so a silent miss would be hard to diagnose).
+        """
+        try:
+            import json as _json
+            import threading
+            import urllib.request
+            try:
+                import websocket  # websocket-client package
+            except ImportError:
+                logger.warning(
+                    "extra_http_headers set but websocket-client missing — "
+                    "header session not opened"
+                )
+                return
+            with urllib.request.urlopen(
+                f"http://127.0.0.1:{self._cdp_port}/json/list",
+                timeout=2,
+            ) as resp:
+                tabs = _json.loads(resp.read().decode())
+            # Unlike _cdp_call we DON'T skip about:blank — at startup the
+            # only page target is the launch tab (about:blank), and that
+            # is exactly the session we need to hold.
+            ws_url: str | None = None
+            for tab in tabs:
+                if tab.get("type") == "page" and tab.get("webSocketDebuggerUrl"):
+                    ws_url = tab["webSocketDebuggerUrl"]
+                    break
+            if not ws_url:
+                logger.warning("header session: no page target to attach to")
+                return
+            ws = websocket.create_connection(ws_url, timeout=5)
+            ws.settimeout(5)
+
+            def _send(method: str, params: dict[str, Any]) -> None:
+                req_id = int(time.time() * 1e6) % 1_000_000
+                ws.send(_json.dumps({"id": req_id, "method": method, "params": params}))
+                for _ in range(40):
+                    decoded = _json.loads(ws.recv())
+                    if decoded.get("id") == req_id:
+                        return
+
+            _send("Network.enable", {})
+            _send("Network.setExtraHTTPHeaders", {"headers": self._extra_http_headers})
+            self._header_ws = ws
+            # Daemon drain: Chrome streams Network.* events on this ws once
+            # enabled; if we never read them the socket buffer fills and the
+            # connection wedges. The thread just discards everything and
+            # exits when the ws closes (recv raises).
+            ws.settimeout(None)
+
+            def _drain() -> None:
+                try:
+                    while True:
+                        ws.recv()
+                except Exception:  # noqa: BLE001 — ws closed / shutdown
+                    pass
+
+            t = threading.Thread(target=_drain, daemon=True)
+            t.start()
+            self._header_ws_thread = t
+            # WARNING (not INFO): this seam is load-bearing for the Daytona
+            # sim-env run and Modal suppresses INFO in production logs, so a
+            # visible confirmation is the only way to tell the session opened
+            # vs. silently fell through to the blocked interstitial.
+            logger.warning(
+                "persistent header session open: %s",
+                list(self._extra_http_headers.keys()),
+            )
+        except Exception as exc:  # noqa: BLE001 — never fatal to a run
+            logger.warning("header session setup failed: %s", exc)
+            self._header_ws = None
+
+    def _close_header_session(self) -> None:
+        """Close the persistent header ws (reverts the header). Idempotent."""
+        ws = self._header_ws
+        self._header_ws = None
+        self._header_ws_thread = None
+        if ws is not None:
+            try:
+                ws.close()
+            except Exception:  # noqa: BLE001 — best-effort teardown
+                pass
 
     # ── Screenshot ──────────────────────────────────────────────────
 
@@ -1068,6 +1188,8 @@ class XdotoolGymEnv(GymEnvironment):
         The container-scoped cache calls this at recycle time so reused
         processes don't leak across container lifetimes.
         """
+        self._close_header_session()
+
         if self._browser_proc:
             self._browser_proc.terminate()
             try:

--- a/src/mantis_agent/task_loop.py
+++ b/src/mantis_agent/task_loop.py
@@ -140,6 +140,7 @@ def setup_env(
     profile_dir: str = "",
     save_screenshots_dir: str = "/data/screenshots",
     reuse_session: bool = False,
+    extra_http_headers: dict[str, str] | None = None,
 ) -> tuple[Any, Any, dict[str, Any]]:
     """Set up proxy + computer-plane env.
 
@@ -208,6 +209,8 @@ def setup_env(
         env_kwargs["display"] = display
     if profile_dir:
         env_kwargs["profile_dir"] = profile_dir
+    if extra_http_headers:
+        env_kwargs["extra_http_headers"] = extra_http_headers
 
     env = make_computer_client(ComputerPlaneConfig(), **env_kwargs)
     return env, proxy_proc, proxy_diag

--- a/tests/learning/test_live_runner.py
+++ b/tests/learning/test_live_runner.py
@@ -14,6 +14,7 @@ pin the behaviours that would silently corrupt a live run or leak spend:
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 from mantis_agent.learning.reward import cost_channel, proxy_channel
@@ -176,6 +177,32 @@ def test_submit_body_has_no_proxy_and_frozen_flag(tmp_path: Path) -> None:
     assert body["detached"] is True
 
 
+def test_suite_carries_daytona_skip_header_by_default(tmp_path: Path) -> None:
+    # The sim env sits behind the Daytona preview proxy, which blocks the
+    # runner's browser-UA requests with an interstitial unless this header
+    # rides every request. The suite must carry it so modal_cua_server's
+    # setup_env opens the persistent header session.
+    poster = FakePoster(statuses=["succeeded"], result_envelope={})
+    run = _make(tmp_path, poster, FakeDecomposer())
+
+    run(_task(seed=42), None, _result("frozen"))
+
+    headers = poster.submit_bodies[0]["task_suite"]["_browser_extra_headers"]
+    assert headers == {"X-Daytona-Skip-Preview-Warning": "true"}
+
+
+def test_empty_browser_headers_omits_suite_key(tmp_path: Path) -> None:
+    # A direct (non-Daytona) env clears the default → no header key, so the
+    # remote env's header session stays a no-op (production CF runs path).
+    poster = FakePoster(statuses=["succeeded"], result_envelope={})
+    run = _make(tmp_path, poster, FakeDecomposer())
+    run.browser_extra_headers = {}
+
+    run(_task(seed=42), None, _result("frozen"))
+
+    assert "_browser_extra_headers" not in poster.submit_bodies[0]["task_suite"]
+
+
 class FakeReset:
     """Records env resets so ordering against the submit can be asserted."""
 
@@ -290,6 +317,104 @@ def test_plan_decomposed_once_with_substituted_placeholders(
     wf0 = poster.submit_bodies[0]["workflow_id"]
     wf1 = poster.submit_bodies[1]["workflow_id"]
     assert wf0 != wf1
+
+
+# ── .json pre-decomposed plan path (no decompose, no spend) ──────────────
+
+
+def _json_plan_file(tmp_path: Path) -> Path:
+    """A minimal pre-decomposed micro-plan with a vision guard + {{ENV_URL}}."""
+    p = tmp_path / "bt02_spec_lookup.json"
+    p.write_text(json.dumps({
+        "domain": "boattrader_scrape",
+        "shapes": ["listings", "form"],
+        "steps": [
+            {
+                "index": 0, "type": "navigate",
+                "intent": "Navigate to {{ENV_URL}}/boats/",
+                "params": {"url": "{{ENV_URL}}/boats/", "wait_after_load_seconds": 8},
+                "section": "setup", "required": True,
+            },
+            {
+                "index": 1, "type": "detect_visible",
+                "intent": "Is the engine make exactly Caterpillar?",
+                "out_var": "is_caterpillar",
+                "params": {"out_var": "is_caterpillar"},
+                "hints": {"out_var": "is_caterpillar"},
+                "claude_only": True, "section": "extraction", "required": False,
+            },
+            {
+                "index": 2, "type": "submit",
+                "intent": "Click Contact Seller to send the inquiry",
+                "params": {"label": "Contact Seller", "kind": "button"},
+                "guard": "is_caterpillar",
+                "hints": {"guard": "is_caterpillar"},
+                "section": "extraction", "required": False,
+            },
+        ],
+    }))
+    return p
+
+
+def test_json_plan_loads_directly_without_decompose(tmp_path: Path) -> None:
+    decomposer = FakeDecomposer()
+    poster = FakePoster(statuses=["succeeded"], result_envelope={})
+    run = LiveRunFn(
+        plan_path=_json_plan_file(tmp_path),
+        env_url="https://sim.example/env",
+        post_fn=poster,
+        pull_cost_fn=_fake_cost,
+        decompose_fn=decomposer,
+        poll_interval_s=0.0,
+    )
+
+    run(_task(seed=42), None, _result("frozen"))
+
+    # A .json plan is already decomposed — the LLM decomposer never runs
+    # (the deterministic guard must not be re-paraphrased away).
+    assert decomposer.texts == []
+    steps = poster.submit_bodies[0]["task_suite"]["_micro_plan"]
+    # {{ENV_URL}} is substituted with the live sim-env URL on the nav step.
+    assert steps[0]["params"]["url"] == "https://sim.example/env/boats/"
+    assert "{{ENV_URL}}" not in json.dumps(steps)
+    # The conditional guard the decomposer would flatten survives verbatim,
+    # both at top level (read by the suite builder) and in hints (the
+    # runner's triple-fallback resolution).
+    assert steps[1]["type"] == "detect_visible"
+    assert steps[1]["out_var"] == "is_caterpillar"
+    assert steps[2]["guard"] == "is_caterpillar"
+    assert steps[2]["hints"]["guard"] == "is_caterpillar"
+
+
+def test_json_plan_memoised_across_submits(tmp_path: Path) -> None:
+    poster = FakePoster(statuses=["succeeded"], result_envelope={})
+    run = LiveRunFn(
+        plan_path=_json_plan_file(tmp_path),
+        env_url="https://sim.example/env",
+        post_fn=poster,
+        pull_cost_fn=_fake_cost,
+        decompose_fn=FakeDecomposer(),
+        poll_interval_s=0.0,
+    )
+
+    run(_task(seed=42), None, _result("frozen"))
+    run(_task(seed=7), None, _result("S0_retrieval"))
+
+    # One load shared across both submits, each with a fresh workflow_id.
+    wf0 = poster.submit_bodies[0]["workflow_id"]
+    wf1 = poster.submit_bodies[1]["workflow_id"]
+    assert wf0 != wf1
+    assert poster.submit_bodies[0]["task_suite"]["_hint_store_disabled"] is True
+    assert poster.submit_bodies[1]["task_suite"]["_hint_store_dict_name"]
+
+
+def test_tasks_for_plan_matches_json_suffix_by_stem() -> None:
+    """clusters.json names the logical plan (``bt02_spec_lookup``); the on-disk
+    file may be ``bt02_spec_lookup.json``. Both must select the same tasks."""
+    bare = {t.name for t in live_runner.tasks_for_plan("bt02_spec_lookup")}
+    suffixed = {t.name for t in live_runner.tasks_for_plan("plans/bt02_spec_lookup.json")}
+    assert bare == suffixed
+    assert "bt02_spec_lookup_visible" in suffixed
 
 
 def test_credential_not_hardcoded_in_source() -> None:


### PR DESCRIPTION
## Summary

Two coupled changes that together let a **live BT02 frozen run** reach the
Daytona boattrader sim env and execute a pre-decomposed plan. Both were
exercised end-to-end by Modal run `20260531_231042` ($0.14): the CUA browser
navigated **real boat detail pages** (`/boat/2023-beneteau-oceanis-40.1-…`),
no `page_blocked`.

### Browser extra-HTTP-headers seam (generic, gated)
- `XdotoolGymEnv` gains an optional `extra_http_headers` ctor arg. When set, it
  opens a **persistent** Network-enabled CDP session and holds
  `Network.setExtraHTTPHeaders` open for the browser's lifetime, so the headers
  ride **every** request — runner-driven navigations *and* in-page link clicks /
  pagination alike (a one-shot CDP set reverts on ws detach). No-op when unset,
  so production Cloudflare runs are unaffected; degrades gracefully if
  `websocket-client` is missing.
- `task_loop.setup_env` and the 4 `modal_cua_server` `setup_env` call sites
  thread `_browser_extra_headers` (read from the task suite) through.

### `live_runner`
- `browser_extra_headers` defaults to the Daytona preview-proxy skip header
  (`X-Daytona-Skip-Preview-Warning: true`). The sandbox sits behind
  `*.daytonaproxy01.net`, which shows a "Preview - Warning" interstitial to the
  real-browser UA the Modal runner forces — without the header the browser never
  reaches the boats page (0 leads). Set `{}` for a direct env.
- `.json` plans load as **pre-decomposed micro-plans** (no LLM decompose), with
  `{{ENV_URL}}` substituted via the standard JSON-plan templating; task/profile
  wiring matches on the plan **stem** so `bt02_spec_lookup.json` maps to the
  `bt02_spec_lookup` cluster task.

## Validation
- `tests/learning/test_live_runner.py` — 18 pass (incl. the suite-carries-header
  and JSON-plan-load cases).
- Live: Modal run navigated real Daytona pages past the preview warning. The
  header session itself is empirically validated (it needs a live CDP endpoint,
  so it has no unit test).

## Follow-up (not this PR)
That same run collected **0 leads** for a reason **independent of this seam**:
the `bt02_spec_lookup` plan strands the agent on a detail page when its loop
re-enters the per-listing click step, and `critic-frontier` halts. Tracked
separately; the frozen-vs-S0 matrix is gated on that plan-nav fix.

## Test plan
- [ ] CI green (pytest 3.11 / 3.12)
- [ ] Confirm no behavior change on existing gym paths (the seam is gated on `extra_http_headers`, default `None`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)