### PR TITLE
feat(learning): Daytona-proxy + consent-cookie productionization for BT02 live runs

### DIFF
--- a/experiments/learning_allocator/live_runner.py
+++ b/experiments/learning_allocator/live_runner.py
@@ -62,7 +62,15 @@ from typing import Any
 
 import requests
 
+from mantis_agent.gym.grading import grade_run
 from mantis_agent.learning.eval import EvalTask, load_manifest
+from mantis_agent.learning.reward import (
+    DEFAULT_LAMBDA,
+    RewardRecord,
+    compute_reward,
+    cost_channel,
+    proxy_channel,
+)
 from mantis_agent.learning.substrates.base import SubstrateResult
 from mantis_agent.plan_decomposer import MicroPlan, PlanDecomposer
 from mantis_agent.server_utils import (
@@ -127,6 +135,46 @@ def _default_post(path: str, body: dict[str, Any]) -> tuple[int, dict[str, Any]]
         return r.status_code, {"raw": r.text}
 
 
+def _daytona_proxy_headers() -> dict[str, str]:
+    """Proxy headers every request to the Daytona-served sim env needs.
+
+    The sandbox is fronted by ``*.daytonaproxy01.net``, whose preview proxy
+    (a) shows a "Preview - Warning" interstitial to real-browser User-Agents
+    unless ``X-Daytona-Skip-Preview-Warning`` is set, and (b) 307s to an Auth0
+    wall unless the per-sandbox ``x-daytona-preview-token`` is presented. BOTH
+    are required on EVERY request — browser navigations *and* the admin
+    reset/oracle calls alike. The token rotates per sandbox and is read from
+    the env (never hard-coded — this repo is public). Empty token → skip the
+    token header so a direct (non-Daytona) env still works.
+    """
+    hdr = {"X-Daytona-Skip-Preview-Warning": "true"}
+    token = _read_env("LA_ENV_PREVIEW_TOKEN")
+    if token:
+        hdr["x-daytona-preview-token"] = token
+    return hdr
+
+
+def _default_browser_headers() -> dict[str, str]:
+    """Headers applied to every *browser* request on the remote run.
+
+    Two concerns, both sim-env-specific:
+
+    * the Daytona proxy headers (see :func:`_daytona_proxy_headers`) — without
+      the preview token the CUA browser 307s to Auth0 and never reaches the
+      boats page;
+    * a pre-seeded ``bt_cookie_consent`` cookie. The sim env renders a OneTrust
+      cookie-consent banner on first visit (fresh Modal profile → no consent
+      cookie → banner every run). The listings pre-scan
+      (``ClaudeExtractor.find_all_listings``) reads that full-page overlay as a
+      consent/sign-in wall and halts ``page_blocked`` *before* the brain can
+      dismiss it. The server gates the banner on the cookie's mere presence, so
+      seeding it suppresses the banner; ``decline`` is the privacy-preserving
+      choice. Eval-only noise removal — the banner would block FROZEN and S0
+      equally, so it adds nothing but variance to the substrate comparison.
+    """
+    return {**_daytona_proxy_headers(), "Cookie": "bt_cookie_consent=decline"}
+
+
 def _default_reset(env_url: str, admin_token: str) -> None:
     """Reset the sim env to a clean, deterministically-reseeded state.
 
@@ -137,11 +185,15 @@ def _default_reset(env_url: str, admin_token: str) -> None:
     catalog from the fixed ``SEED`` (same boats, so S0's cross-run hints stay
     valid). Best-effort: a reset failure must not crash the run loop, so it is
     swallowed the way ``grade_run`` swallows oracle errors.
+
+    ``/__env__/reset`` is an admin route *behind* the Daytona preview proxy, so
+    it needs the proxy headers in addition to ``X-Env-Admin`` — without them the
+    POST 307s to the proxy auth wall and the reset silently no-ops.
     """
     try:
         requests.post(
             f"{env_url.rstrip('/')}/__env__/reset",
-            headers={"X-Env-Admin": admin_token},
+            headers={"X-Env-Admin": admin_token, **_daytona_proxy_headers()},
             timeout=30,
         )
     except requests.RequestException:
@@ -208,15 +260,13 @@ class LiveRunFn:
     extractor_model: str = "claude-haiku-4-5-20251001"
     env_url: str = ""
     admin_token: str = ""
-    # Request headers applied to every browser request on the remote run.
-    # Default carries the Daytona preview-proxy skip header: the sim env is
-    # served behind ``*.daytonaproxy01.net``, which shows a "Preview -
-    # Warning" interstitial to real-browser User-Agents (which the Modal
-    # runner forces via the stealth UA override). Without this the CUA
-    # browser never reaches the boats page → 0 leads. Set to ``{}`` for a
-    # direct (non-Daytona) env.
+    # Request headers applied to every browser request on the remote run —
+    # Daytona proxy headers (skip-warning + preview token) plus a pre-seeded
+    # cookie-consent choice that suppresses the sim env's OneTrust banner.
+    # See :func:`_default_browser_headers`. Set to ``{}`` for a direct
+    # (non-Daytona) env with no consent banner.
     browser_extra_headers: dict[str, str] = field(
-        default_factory=lambda: {"X-Daytona-Skip-Preview-Warning": "true"}
+        default_factory=_default_browser_headers
     )
     zip_code: str = "33131"
     search_radius: str = "50"
@@ -497,10 +547,33 @@ def main(argv: list[str] | None = None) -> int:
         f"  policies={policies} budget=${args.budget:.2f} tasks={len(tasks)}\n"
         f"  plan={args.plan} max_cost=${args.max_cost:.2f}/run\n",
     )
+    # Proxy-aware oracle grading: the default reward_from_run hits
+    # ``/__env__/oracle`` with only ``X-Env-Admin``, which the Daytona preview
+    # proxy 307s to its auth wall (→ HTML, not JSON → every run graded
+    # oracle-error). This closure is reward_from_run with the proxy headers
+    # threaded onto the oracle GET; the arithmetic is identical.
+    oracle_hdr = _daytona_proxy_headers()
+
+    def _proxied_reward_fn(
+        *, env_url: str, admin_token: str, task_id: str,
+        run_result: dict[str, Any], lam: float = DEFAULT_LAMBDA,
+    ) -> RewardRecord:
+        graded = grade_run(env_url, admin_token, task_id, extra_headers=oracle_hdr)
+        return compute_reward(
+            task_id=task_id,
+            oracle_score=graded.score,
+            oracle_passed=graded.passed,
+            proxy_verdict=proxy_channel(run_result),
+            dollars=cost_channel(run_result),
+            lam=lam,
+            oracle_error=graded.error,
+            extras={"oracle_reasons": graded.reasons, "oracle_diff": graded.diff},
+        )
+
     result = run_experiment(
         tasks=tasks,
         run_fn=live,
-        reward_fn=None,  # live oracle via reward_from_run
+        reward_fn=_proxied_reward_fn,  # live oracle, proxy-header aware
         env_url=env_url,
         admin_token=admin_token,
         budget=args.budget,

--- a/src/mantis_agent/gym/grading.py
+++ b/src/mantis_agent/gym/grading.py
@@ -54,6 +54,7 @@ def grade_run(
     task_id: str,
     *,
     timeout_s: float = 30.0,
+    extra_headers: dict[str, str] | None = None,
 ) -> GradingResult:
     """Hit ``GET <env_url>/__env__/oracle?task_id=<task_id>`` with the admin token.
 
@@ -61,6 +62,12 @@ def grade_run(
     failures populate ``error`` so the run record always reflects what
     happened. This is the right shape for benchmarks: a flaky network
     should not lose the rest of the run record.
+
+    ``extra_headers`` are merged onto the request (``X-Env-Admin`` still
+    set first). A sim env served behind a preview proxy (e.g. Daytona's
+    ``*.daytonaproxy01.net``) needs the proxy's skip-warning + preview-token
+    headers on *every* request, including this admin oracle call, or the GET
+    307s to the proxy's auth wall and the body comes back as HTML, not JSON.
     """
     if not env_url:
         return GradingResult(
@@ -75,7 +82,8 @@ def grade_run(
 
     base = env_url.rstrip("/")
     url = f"{base}/__env__/oracle?task_id={quote(task_id)}"
-    req = Request(url, headers={"X-Env-Admin": admin_token})
+    headers = {"X-Env-Admin": admin_token, **(extra_headers or {})}
+    req = Request(url, headers=headers)
     try:
         with urlopen(req, timeout=timeout_s) as resp:  # noqa: S310 — env URL only
             body = resp.read().decode("utf-8")

--- a/tests/learning/test_live_runner.py
+++ b/tests/learning/test_live_runner.py
@@ -17,6 +17,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from mantis_agent.learning.reward import cost_channel, proxy_channel
 from mantis_agent.learning.substrates.base import SubstrateResult
 from mantis_agent.plan_decomposer import MicroIntent, MicroPlan
@@ -177,18 +179,45 @@ def test_submit_body_has_no_proxy_and_frozen_flag(tmp_path: Path) -> None:
     assert body["detached"] is True
 
 
-def test_suite_carries_daytona_skip_header_by_default(tmp_path: Path) -> None:
-    # The sim env sits behind the Daytona preview proxy, which blocks the
-    # runner's browser-UA requests with an interstitial unless this header
-    # rides every request. The suite must carry it so modal_cua_server's
-    # setup_env opens the persistent header session.
+def test_suite_carries_daytona_proxy_and_consent_headers_by_default(
+    tmp_path: Path, monkeypatch: "pytest.MonkeyPatch",
+) -> None:
+    # The sim env sits behind the Daytona preview proxy: every browser request
+    # needs the skip-warning header (suppresses the UA interstitial) AND the
+    # per-sandbox preview token (else a 307 to Auth0). It also pre-seeds the
+    # cookie-consent cookie so the OneTrust banner — which the listings
+    # pre-scan reads as a consent wall → page_blocked — never renders. The
+    # suite must carry all three so modal_cua_server's setup_env opens the
+    # persistent header session with them.
+    monkeypatch.setenv("LA_ENV_PREVIEW_TOKEN", "tok-xyz")
     poster = FakePoster(statuses=["succeeded"], result_envelope={})
     run = _make(tmp_path, poster, FakeDecomposer())
 
     run(_task(seed=42), None, _result("frozen"))
 
     headers = poster.submit_bodies[0]["task_suite"]["_browser_extra_headers"]
-    assert headers == {"X-Daytona-Skip-Preview-Warning": "true"}
+    assert headers == {
+        "X-Daytona-Skip-Preview-Warning": "true",
+        "x-daytona-preview-token": "tok-xyz",
+        "Cookie": "bt_cookie_consent=decline",
+    }
+
+
+def test_suite_omits_preview_token_when_env_unset(
+    tmp_path: Path, monkeypatch: "pytest.MonkeyPatch",
+) -> None:
+    # No LA_ENV_PREVIEW_TOKEN (e.g. a direct env or an un-exported shell) → the
+    # token header is dropped, but the skip + consent headers still ride.
+    monkeypatch.delenv("LA_ENV_PREVIEW_TOKEN", raising=False)
+    poster = FakePoster(statuses=["succeeded"], result_envelope={})
+    run = _make(tmp_path, poster, FakeDecomposer())
+
+    run(_task(seed=42), None, _result("frozen"))
+
+    headers = poster.submit_bodies[0]["task_suite"]["_browser_extra_headers"]
+    assert "x-daytona-preview-token" not in headers
+    assert headers["X-Daytona-Skip-Preview-Warning"] == "true"
+    assert headers["Cookie"] == "bt_cookie_consent=decline"
 
 
 def test_empty_browser_headers_omits_suite_key(tmp_path: Path) -> None:

--- a/tests/test_grading.py
+++ b/tests/test_grading.py
@@ -32,6 +32,7 @@ def _free_port() -> int:
 class _OracleHandler(BaseHTTPRequestHandler):
     response: dict = {"passed": True, "score": 1.0, "reasons": ["ok"], "diff": {}}
     admin_token = "trusted"
+    last_headers: dict = {}
 
     def log_message(self, fmt, *args):  # noqa: ANN001, A002
         return  # silence test log
@@ -42,6 +43,7 @@ class _OracleHandler(BaseHTTPRequestHandler):
             self.send_response(404)
             self.end_headers()
             return
+        _OracleHandler.last_headers = dict(self.headers)
         if self.headers.get("X-Env-Admin") != self.admin_token:
             self.send_response(401)
             self.send_header("Content-Type", "application/json")
@@ -108,6 +110,27 @@ def test_wrong_admin_token_yields_error_not_raise(oracle_server):
     assert result.passed is False
     assert result.error is not None
     assert "401" in result.error
+
+
+def test_extra_headers_are_sent_with_oracle_call(oracle_server):
+    """Proxy headers (e.g. Daytona skip-warning + preview token) must ride
+    along on the oracle GET so a preview-proxied sim env returns JSON, not its
+    auth-wall HTML. ``X-Env-Admin`` is still set."""
+    url, token = oracle_server
+    result = grade_run(
+        url, token, "T08_proxy",
+        extra_headers={
+            "X-Daytona-Skip-Preview-Warning": "true",
+            "x-daytona-preview-token": "tok-abc",
+        },
+    )
+    assert result.error is None
+    assert result.passed is True
+    sent = _OracleHandler.last_headers
+    # http.server normalises header names to title-case.
+    assert sent.get("X-Daytona-Skip-Preview-Warning") == "true"
+    assert sent.get("X-Daytona-Preview-Token") == "tok-abc"
+    assert sent.get("X-Env-Admin") == token
 
 
 def test_connection_failure_yields_error_not_raise():


### PR DESCRIPTION
## Summary
- Productionizes the Daytona-proxy access model into the live-runner code path so the frozen-vs-S0 BT02 matrix can actually run end-to-end. Three concerns, all sim-env-specific and eval-only:
  - **Preview token everywhere.** `_daytona_proxy_headers()` adds `x-daytona-preview-token` (read from `LA_ENV_PREVIEW_TOKEN`, never hard-coded — public repo) alongside the existing `X-Daytona-Skip-Preview-Warning`. Both ride **every** request — browser navigations *and* the admin `/__env__/reset` + `/__env__/oracle` calls — else the request 307s to the proxy's Auth0 wall.
  - **Consent cookie.** `_default_browser_headers()` pre-seeds `Cookie: bt_cookie_consent=decline`. The sim env renders a OneTrust banner on first visit (fresh Modal profile → no cookie → banner every run); the listings pre-scan (`ClaudeExtractor.find_all_listings`) reads that full-page overlay as a consent wall and halts `page_blocked` *before* the brain can act. The server gates the banner on the cookie's mere presence, so seeding it suppresses the banner server-side. `decline` is the privacy-preserving choice. The banner blocks FROZEN and S0 equally, so removing it only removes variance from the substrate comparison.
  - **Proxy-aware oracle.** `grade_run` gains a generic, backward-compatible `extra_headers` kwarg; `main()` threads the proxy headers onto the oracle GET via a `reward_from_run` closure (arithmetic unchanged). Without it every run grades oracle-error (HTML auth wall, not JSON).

## Test plan
- [x] `tests/test_grading.py::test_extra_headers_are_sent_with_oracle_call` — proxy headers + `X-Env-Admin` ride the oracle GET (title-cased by `http.server`).
- [x] `tests/learning/test_live_runner.py` — `test_suite_carries_daytona_proxy_and_consent_headers_by_default` (all three headers present when `LA_ENV_PREVIEW_TOKEN` set) + `test_suite_omits_preview_token_when_env_unset` (token dropped, skip+consent still ride).
- [x] Full suite: 135 passed, ruff-clean.
- [x] **Live BT02 GPU smoke** (run_id `20260601_014817_0122490f`): consent cookie rode the persistent CDP header seam; BT02 produced a clean Caterpillar lead — oracle `passed=true score=1.0 hits=1 misses=0 malformed=0` (lead-00001 on boat-00429 "2023 Grady-White Canyon 366"). Terminal `budget_cap` (normal for this scrape loop after producing leads).

🤖 Generated with [Claude Code](https://claude.com/claude-code)