### PR TITLE
fix(step-recovery): soft-advance failed non-required gate instead of halting

### DIFF
--- a/src/mantis_agent/gym/step_recovery.py
+++ b/src/mantis_agent/gym/step_recovery.py
@@ -428,7 +428,7 @@ class StepRecoveryPolicy:
                 halt_reason=f"required_failed:{step.type}",
             )
 
-        # ── gate: anti-bot one-shot retry then halt ─────────────────────
+        # ── gate: anti-bot one-shot retry, then soft-advance ────────────
         if step.gate:
             gate_data = step_result.data or ""
             gate_retry_key = f"gate_retry_{step_index}"
@@ -450,12 +450,23 @@ class StepRecoveryPolicy:
                 return RecoveryOutcome(
                     halt=False, step_index=step_index, halt_reason="gate_retry",
                 )
-            logger_.error(
-                f"  [{step_index}] GATE FAILED: {step.verify[:60]} — HALTING"
+            # A gate that reaches here is always required=False: a
+            # *required* gate is handled by the required branch above
+            # (retry-budget then halt) and never falls through. So this is
+            # a soft checkpoint, not a setup precondition — e.g. the
+            # decomposer auto-promotes any extract_data step whose intent
+            # reads like verification ("verify"/"confirm" the confirmation
+            # banner) to gate=True without marking it required (issue #244),
+            # so a post-submit banner check on a boat the agent legitimately
+            # declined (no submit → no banner) lands here. Halting the whole
+            # run on that is wrong: advance past the checkpoint so the
+            # surrounding loop can try the next listing.
+            logger_.warning(
+                f"  [{step_index}] soft gate failed (not required) — advancing: {step.verify[:60]}"
             )
-            print(f"  HALT: Gate verification '{step.verify[:50]}' failed. Setup incomplete.")
             return RecoveryOutcome(
-                halt=True, step_index=step_index, halt_reason="gate_failed",
+                halt=False, step_index=step_index + 1,
+                halt_reason="gate_failed_soft",
             )
 
         # ── per-type recovery ───────────────────────────────────────────

--- a/tests/test_step_recovery_policy.py
+++ b/tests/test_step_recovery_policy.py
@@ -139,7 +139,36 @@ def test_gate_failure_with_antibot_keyword_retries_navigate_once(monkeypatch):
     runner._execute_navigate.assert_called_once_with(plan.steps[0], 0)
 
 
-def test_gate_failure_without_antibot_keyword_halts(monkeypatch):
+def test_required_gate_takes_required_path_not_gate_path(monkeypatch):
+    # A step that is BOTH required and gate is handled by the required
+    # branch (retry-budget → halt), never the gate branch. This invariant
+    # is what makes the gate branch's unconditional soft-advance correct.
+    monkeypatch.setattr("mantis_agent.gym.step_recovery.time.sleep", lambda *_: None)
+    runner = _runner_stub()
+    policy = StepRecoveryPolicy(runner)
+
+    outcome = policy.handle_failure(
+        step=MicroIntent(
+            intent="x", type="extract_data", gate=True, verify="ok", required=True
+        ),
+        step_result=_result(data="some other failure mode"),
+        plan=_plan("navigate", "extract_data"),
+        step_index=1,
+        step_retry_counts={},
+        loop_counters={},
+        max_retries=2,
+        listings_on_page=0,
+    )
+    assert outcome.halt is False
+    assert outcome.halt_reason == "required_retry:extract_data:1"
+
+
+def test_soft_gate_failure_advances_instead_of_halting(monkeypatch):
+    # A non-required gate (the decomposer auto-promotes verification-intent
+    # extract_data steps to gate=True without marking them required, issue
+    # #244). Failing it — e.g. a post-submit confirmation-banner check on a
+    # boat the agent legitimately declined — must advance the loop, not halt
+    # the whole run.
     monkeypatch.setattr("mantis_agent.gym.step_recovery.time.sleep", lambda *_: None)
     runner = _runner_stub()
     policy = StepRecoveryPolicy(runner)
@@ -154,8 +183,9 @@ def test_gate_failure_without_antibot_keyword_halts(monkeypatch):
         max_retries=2,
         listings_on_page=0,
     )
-    assert outcome.halt is True
-    assert outcome.halt_reason == "gate_failed"
+    assert outcome.halt is False
+    assert outcome.step_index == 2
+    assert outcome.halt_reason == "gate_failed_soft"
 
 
 # ── navigate ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- A `extract_data` step whose intent reads like verification (e.g. "confirm the lead-submitted banner") is auto-promoted to `gate=True` by the decomposer **without** being marked `required` (issue #244).
- The old gate branch in `StepRecoveryPolicy` **halted the entire run** when such a gate failed. That is wrong inside a surrounding loop: when the agent legitimately declines a non-matching listing (no submit → no confirmation banner), the post-submit gate fails and the whole run dies instead of trying the next listing.
- Control-flow invariant: a *required* gate never reaches this branch — the `if step.required:` branch above always returns (retry-budget → halt). So any gate that falls through is by construction a **soft checkpoint**, not a setup precondition. We now advance past it (`gate_failed_soft`) so the loop continues.

This restores issue #244's "reroute, not fatal" intent for auto-promoted verification gates. The anti-bot one-shot navigate-retry on the gate branch is preserved unchanged.

## Test plan
- [x] `tests/test_step_recovery_policy.py` — 32 pass, `ruff check` clean
- [x] New `test_soft_gate_failure_advances_instead_of_halting`: non-required gate failure → `halt=False`, `step_index` advances, `halt_reason="gate_failed_soft"`
- [x] New `test_required_gate_takes_required_path_not_gate_path`: documents the invariant (required+gate → required path, never the gate path)
- [x] Existing `test_gate_failure_with_antibot_keyword_retries_navigate_once` unchanged and passing
- [ ] End-to-end Modal verification (BT02 frozen-vs-S0 rerun) — exercised together with the sim-env fidelity PR at the next gated live run

🤖 Generated with [Claude Code](https://claude.com/claude-code)