### PR TITLE
feat(observability): per-source Claude cost attribution end-to-end

### DIFF
--- a/deploy/baseten/holo3/config.yaml
+++ b/deploy/baseten/holo3/config.yaml
@@ -12,6 +12,7 @@ build_commands:
   - git clone --depth 1 --branch b8948 https://github.com/ggerganov/llama.cpp /opt/llama.cpp  # SHA 42401c72b8d239240ed0fb37694d29ac33b3bc4f
   - ln -sf /usr/local/cuda/lib64/stubs/libcuda.so /usr/lib/x86_64-linux-gnu/libcuda.so.1 && ldconfig
   - cd /opt/llama.cpp && cmake -B build -DGGML_CUDA=ON -DGGML_NATIVE=OFF -DGGML_AMX_TILE=OFF -DGGML_AMX_INT8=OFF -DGGML_AMX_BF16=OFF -DCMAKE_CUDA_ARCHITECTURES="80;90" -DLLAMA_BUILD_TESTS=OFF -DLLAMA_BUILD_EXAMPLES=OFF -DLLAMA_BUILD_SERVER=ON && cmake --build build --target llama-server --config Release -j$(nproc)
+  - mkdir -p /workspace/mantis-data && ln -snf /workspace/mantis-data /data
 docker_server:
   start_command: bash -lc "PYTHONPATH=/packages MANTIS_MODEL=holo3 MANTIS_LLAMA_PORT=18080 MANTIS_DATA_DIR=/workspace/mantis-data MANTIS_REPO_ROOT=/packages MANTIS_MAX_RUNTIME_MINUTES=240 MANTIS_MAX_COST_USD=75 MANTIS_MAX_STEPS_PER_PLAN=500 MANTIS_CONTEXT_SIZE=32768 uvicorn mantis_agent.baseten_server:app --host 0.0.0.0 --port 8000 --timeout-keep-alive 300"
   server_port: 8000

--- a/src/mantis_agent/baseten_server/routes.py
+++ b/src/mantis_agent/baseten_server/routes.py
@@ -307,6 +307,13 @@ _ARTIFACT_ALLOWLIST: dict[str, str] = {
     "extracted_rows.csv": "text/csv",
     "extracted_rows.json": "application/json",
     "result.json": "application/json",
+    # Per-source Claude cost breakdown — observability.claude_cost_meter
+    # mirrors this to run_dir at finalize so persist_run_artifacts can
+    # expose it. Lets callers see real per-source dollar splits
+    # (extract_single / extract_multi / brain_claude / grounding /
+    # recovery / extract_tool) instead of the single aggregate the
+    # ``costs.claude`` total field gives.
+    "claude_cost_by_path.json": "application/json",
 }
 
 

--- a/src/mantis_agent/baseten_server/runtime.py
+++ b/src/mantis_agent/baseten_server/runtime.py
@@ -1074,7 +1074,7 @@ class BasetenCUARuntime:
 
         data_root = _data_root()
         session_name = task_suite.get("session_name", "baseten_cua")
-        return setup_env(
+        env, proxy_proc, _proxy_diag = setup_env(
             base_url=task_suite.get("base_url", ""),
             run_id=run_id,
             session_name=session_name,
@@ -1087,6 +1087,7 @@ class BasetenCUARuntime:
             save_screenshots_dir=str(data_root / "screenshots"),
             reuse_session=reuse_session,
         )
+        return env, proxy_proc
 
     def _maybe_start_live_viewer(
         self, payload: dict[str, Any], run_id: str, env: Any = None,
@@ -1499,7 +1500,17 @@ class BasetenCUARuntime:
                     from mantis_agent.graph.objective import ObjectiveSpec
                     objective = ObjectiveSpec.from_dict(objective_data)
                     schema = ExtractionSchema.from_objective(objective)
-            extractor = ClaudeExtractor(schema=schema)
+            # Honor _extractor_model from the suite (set via
+            # build_micro_suite ← MANTIS_EXTRACTOR_MODEL env var on the
+            # caller). Without this, ClaudeExtractor always uses its
+            # hardcoded default (claude-sonnet-4-6) and the cheaper
+            # Haiku extraction never lands — the suite field is silently
+            # ignored. Empty string keeps the legacy default.
+            _extractor_model = str(task_suite.get("_extractor_model") or "").strip()
+            if _extractor_model:
+                extractor = ClaudeExtractor(model=_extractor_model, schema=schema)
+            else:
+                extractor = ClaudeExtractor(schema=schema)
             resume_state = bool(task_suite.get("_resume_state", False))
             checkpoint_path = task_suite.get("_checkpoint_path")
             if not checkpoint_path:
@@ -1551,6 +1562,16 @@ class BasetenCUARuntime:
                 extraction_cache=cache,
                 routing_policy=routing_policy,
             )
+            # Cost-meter finalize gate: ``micro_runner.run`` calls
+            # ``finalize_to_disk(run_id=self._api_run_id, tenant_id=...)``
+            # only when ``_api_run_id`` is truthy. Without these attrs
+            # the per-source cost JSON never lands on disk and the new
+            # artifact-side instrumentation has nothing to expose.
+            # ``tenant_id`` here is just a path-sanitization scope for
+            # the meter (not auth) — workflow_id is a stable enough
+            # bucket on Baseten where the API token is per-tenant.
+            runner._api_run_id = run_id
+            runner._api_tenant_id = workflow_id or session_name or "default"
             # #344: default ``request_user_input`` host tool. Brains that
             # emit ``Action(TOOL_CALL, name="request_user_input")`` get a
             # paused-run snapshot on the first call, and the staged
@@ -1579,20 +1600,43 @@ class BasetenCUARuntime:
             # the payload. ``runner.resume(...)`` replays the recorded
             # steps and continues from the paused step.
             resume_blob = payload.get("_resume_pause_state")
-            if resume_blob is not None:
-                pause_state_obj = (
-                    PauseState.from_dict(resume_blob)
-                    if isinstance(resume_blob, dict) else resume_blob
-                )
-                runner_result = runner.resume(
-                    pause_state_obj,
-                    user_input=payload.get("_resume_user_input"),
-                    plan=micro_plan,
-                )
-            else:
-                runner_result = runner.run_with_status(
-                    micro_plan, resume=resume_state,
-                )
+            # Bind a fresh per-source ClaudeCostMeter for this run.
+            # ``record_from_response`` (called from brain_claude /
+            # extractor / grounding / agentic_recovery / _anthropic.
+            # client) pulls the active meter via ``current_meter()``,
+            # which reads the ContextVar this binds. Without this
+            # binding every record_from_response is a silent no-op and
+            # the per-source cost JSON never accumulates anything to
+            # write. The ContextVar shape means concurrent runs in the
+            # same process get isolated meters automatically; on
+            # Baseten predict_concurrency=1 anyway.
+            from mantis_agent.observability.claude_cost_meter import (
+                ClaudeCostMeter as _ClaudeCostMeter,
+                set_current_meter as _set_current_meter,
+            )
+            run_cost_meter = _ClaudeCostMeter()
+            _set_current_meter(run_cost_meter)
+            try:
+                if resume_blob is not None:
+                    pause_state_obj = (
+                        PauseState.from_dict(resume_blob)
+                        if isinstance(resume_blob, dict) else resume_blob
+                    )
+                    runner_result = runner.resume(
+                        pause_state_obj,
+                        user_input=payload.get("_resume_user_input"),
+                        plan=micro_plan,
+                    )
+                else:
+                    runner_result = runner.run_with_status(
+                        micro_plan, resume=resume_state,
+                    )
+            finally:
+                # ``micro_runner.run`` itself calls finalize_to_disk via
+                # current_meter() once it returns, so we keep the bind
+                # active across the call AND clear it afterwards to
+                # avoid leaking across runs in the same container.
+                _set_current_meter(None)
             step_results = runner_result.steps
             if cache is not None:
                 try:

--- a/src/mantis_agent/observability/claude_cost_meter.py
+++ b/src/mantis_agent/observability/claude_cost_meter.py
@@ -311,7 +311,27 @@ def finalize_to_disk(
             path, snapshot["totals"]["calls"],
             snapshot["totals"]["cost_usd"],
         )
-        return path
     except Exception as exc:  # noqa: BLE001
         logger.debug("claude_cost_meter finalize failed: %s", exc)
         return ""
+    # Mirror to the run_dir layout the Baseten/Modal artifact server
+    # uses (``<MANTIS_DATA_DIR>/runs/<run_id>/claude_cost_by_path.json``)
+    # so ``persist_run_artifacts`` can expose it via /v1/runs/<id>/
+    # artifacts/<name>. Without this, the only on-disk copy lives under
+    # the tenant-prefixed path (``<root>/<tenant>/<run_id>/``) which the
+    # artifact endpoint doesn't search. Best-effort: failure to mirror
+    # doesn't fail finalization.
+    try:
+        root = os.environ.get("MANTIS_DATA_DIR", os.environ.get("MANTIS_RUN_ARTIFACTS_DIR", "/data"))
+        safe_run = _sanitize(run_id) or "unknown"
+        mirror_dir = os.path.join(root, "runs", safe_run)
+        os.makedirs(mirror_dir, exist_ok=True)
+        mirror_path = os.path.join(mirror_dir, "claude_cost_by_path.json")
+        if os.path.abspath(mirror_path) != os.path.abspath(path):
+            tmp_mirror = f"{mirror_path}.tmp.{os.getpid()}"
+            with open(tmp_mirror, "w") as f:
+                json.dump(snapshot, f, indent=2, sort_keys=True)
+            os.replace(tmp_mirror, mirror_path)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("claude_cost_meter mirror to run_dir failed: %s", exc)
+    return path

--- a/src/mantis_agent/server_utils.py
+++ b/src/mantis_agent/server_utils.py
@@ -653,6 +653,30 @@ def persist_run_artifacts(
             "download_url": f"{url_prefix}/{run_id}/artifacts/leads.csv",
         })
 
+    # claude_cost_by_path.json — per-source LLM cost breakdown the
+    # observability.claude_cost_meter mirrors into run_dir at finalize.
+    # Exposing it as an artifact lets callers see real numbers per
+    # source (extract_single / extract_multi / brain_claude / grounding /
+    # recovery / extract_tool) instead of inferring from time_breakdown.
+    # We also inline the JSON contents into ``result["claude_cost_by_path"]``
+    # so callers can read the breakdown directly from action=result
+    # without depending on the artifact-download endpoint (whose path
+    # resolution diverges between persist_run_artifacts' write location
+    # `<root>/runs/<id>/` and the routes.py read location
+    # `<root>/tenants/<tenant>/runs/<id>/` — a pre-existing path bug).
+    cost_path = run_dir / "claude_cost_by_path.json"
+    if cost_path.exists() and cost_path.stat().st_size > 0:
+        file_artifacts.append({
+            "name": "claude_cost_by_path.json",
+            "kind": "file",
+            "mime_type": "application/json",
+            "download_url": f"{url_prefix}/{run_id}/artifacts/claude_cost_by_path.json",
+        })
+        try:
+            result["claude_cost_by_path"] = json.loads(cost_path.read_text())
+        except Exception:
+            pass
+
     inline = result.get("artifacts") or []
     structured = next(
         (a for a in inline if a.get("kind") == "structured_data" and a.get("name") == "extracted_rows"),


### PR DESCRIPTION
## Summary
Lands per-source Claude cost attribution so each run emits a `claude_cost_by_path.json` breakdown (brain / extractor / grounding / agentic-recovery) that survives to disk and is exposed via the artifact + read APIs.

- **runtime.py** — bind a fresh per-run `ClaudeCostMeter` via the `current_meter()` ContextVar across `runner.run_with_status` / `runner.resume` (try/finally clears it); set `runner._api_run_id` / `_api_tenant_id` so `finalize_to_disk` actually fires; honor `_extractor_model` from the suite so the cheaper Haiku extraction path can land (was silently ignored → always Sonnet default).
- **claude_cost_meter.py** — `finalize_to_disk` mirrors the per-path breakdown to the run dir as `claude_cost_by_path.json`.
- **server_utils.py** — `persist_run_artifacts` writes the file artifact and inlines `result["claude_cost_by_path"]`.
- **routes.py** — add `claude_cost_by_path.json` to the read allow-list.
- **config.yaml** — `/data` → `/workspace/mantis-data` symlink so the file persists across the Baseten container boundary.

Without the ContextVar bind every `record_from_response` was a silent no-op; without the `_api_run_id` gate the JSON never landed on disk. This wires the existing meter end-to-end.

## Test plan
- [ ] Baseten redeploy (`--no-cache`, unique `--deployment-name`) and confirm a run emits `claude_cost_by_path.json` with non-zero per-source buckets.
- [ ] Confirm `_extractor_model` from the suite is honored (Haiku extraction lands, not Sonnet default).
- [ ] Confirm the artifact is readable via the routes allow-list and the file persists via the `/data` symlink.

🤖 Generated with [Claude Code](https://claude.com/claude-code)