### PR TITLE
fix(xdotool): poll CDP debug port instead of racing a fixed sleep

### DIFF
--- a/src/mantis_agent/gym/xdotool_env.py
+++ b/src/mantis_agent/gym/xdotool_env.py
@@ -343,7 +343,16 @@ class XdotoolGymEnv(GymEnvironment):
             cmd, env=self._env,
             stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
         )
-        time.sleep(3)
+        # Wait for Chrome to actually bind its CDP debug port before the
+        # stealth-inject + header-session calls below. A fixed ``time.sleep(3)``
+        # raced the cold-container cold-start: on a freshly-scheduled Modal
+        # container Chrome can take >3s to bind ``--remote-debugging-port``, so
+        # ``/json/list`` returned ECONNREFUSED and the persistent header seam
+        # never opened — which drops the Daytona consent cookie, so the sim env
+        # renders its consent overlay (read as a blocked page by the click
+        # handler's find_all pre-scan → page_blocked halt → 0 leads). Poll the
+        # port instead of guessing a settle time.
+        self._wait_for_cdp_ready()
         logger.info(f"Browser started: {self._browser_cmd} → {url}")
 
         # #539: register CDP stealth patches BEFORE any runner-triggered
@@ -373,6 +382,43 @@ class XdotoolGymEnv(GymEnvironment):
         # open for the browser's lifetime. See ``_open_header_session``.
         if self._extra_http_headers:
             self._open_header_session()
+
+    def _wait_for_cdp_ready(self, deadline_s: float = 15.0) -> bool:
+        """Block until Chrome's CDP HTTP endpoint answers, or ``deadline_s``.
+
+        Returns ``True`` once ``http://127.0.0.1:{cdp_port}/json/version``
+        responds 200 (the standard "DevTools is up" probe). Best-effort: on
+        timeout logs a WARNING and returns ``False`` so the caller still
+        proceeds (the stealth + header-session calls are each independently
+        best-effort), but the poll gives a cold-start Chrome the time it needs
+        to bind the debug port rather than racing a fixed sleep. A floor of one
+        short sleep also lets the launch tab map under Xvfb on the warm path.
+        """
+        import urllib.error
+        import urllib.request
+
+        time.sleep(0.5)
+        deadline = time.time() + deadline_s
+        attempt = 0
+        while time.time() < deadline:
+            attempt += 1
+            try:
+                with urllib.request.urlopen(
+                    f"http://127.0.0.1:{self._cdp_port}/json/version",
+                    timeout=2,
+                ) as resp:
+                    if getattr(resp, "status", 200) == 200:
+                        logger.info("CDP endpoint ready after %d attempt(s)", attempt)
+                        return True
+            except (urllib.error.URLError, OSError):
+                pass
+            time.sleep(0.5)
+        logger.warning(
+            "CDP endpoint not ready after %.0fs (port %s) — stealth + header "
+            "session may fall through to the blocked interstitial",
+            deadline_s, self._cdp_port,
+        )
+        return False
 
     def _open_header_session(self) -> None:
         """Hold a persistent Network-enabled CDP session that applies

--- a/tests/test_xdotool_cdp_ready.py
+++ b/tests/test_xdotool_cdp_ready.py
@@ -1,0 +1,109 @@
+"""Regression tests for the CDP-readiness poll that replaced the blind
+``time.sleep(3)`` after Chrome launch.
+
+The pre-fix bug: ``_launch_browser`` slept a fixed 3s then immediately ran the
+CDP stealth-inject + persistent-header-session calls. On a cold Modal
+container Chrome can take >3s to bind ``--remote-debugging-port``, so the
+header seam's ``urlopen('/json/list')`` got ECONNREFUSED, the seam never
+opened, the Daytona consent cookie was dropped, and the boattrader sim env
+rendered its consent overlay — which the click handler's find_all pre-scan
+reads as a blocked page → ``page_blocked`` halt → 0 leads. Surfaced on the
+BT02 frozen smoke 2026-06-01 (both tasks scored 0.0 / fail at $0 cost).
+
+The fix: ``_wait_for_cdp_ready`` polls ``/json/version`` until it answers (up
+to a deadline) before the CDP calls, so a slow cold-start is absorbed instead
+of raced against a fixed sleep.
+"""
+
+from __future__ import annotations
+
+import urllib.error
+
+import pytest
+
+from mantis_agent.gym import xdotool_env
+from mantis_agent.gym.xdotool_env import XdotoolGymEnv
+
+
+class _FakeResp:
+    """Minimal stand-in for the ``urlopen`` context-manager response."""
+
+    def __init__(self, status: int = 200) -> None:
+        self.status = status
+
+    def __enter__(self) -> "_FakeResp":
+        return self
+
+    def __exit__(self, *exc: object) -> bool:
+        return False
+
+
+def _make_env(cdp_port: int = 9222) -> XdotoolGymEnv:
+    env = XdotoolGymEnv.__new__(XdotoolGymEnv)
+    env._cdp_port = cdp_port
+    return env
+
+
+@pytest.fixture
+def fake_clock(monkeypatch: pytest.MonkeyPatch) -> dict[str, float]:
+    """Drive ``time`` from a fake clock so the poll loop never really sleeps.
+
+    ``sleep(s)`` advances the clock by ``s``; ``time()`` reads it. This makes
+    the deadline arithmetic deterministic and instant.
+    """
+    clock = {"t": 1000.0}
+    monkeypatch.setattr(xdotool_env.time, "time", lambda: clock["t"])
+    monkeypatch.setattr(
+        xdotool_env.time, "sleep", lambda s: clock.__setitem__("t", clock["t"] + s)
+    )
+    return clock
+
+
+def test_cdp_ready_returns_true_immediately_when_port_up(
+    fake_clock: dict[str, float], monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Warm path: the port answers on the first probe."""
+    calls = {"n": 0}
+
+    def _urlopen(url: str, timeout: float = 2):
+        calls["n"] += 1
+        assert "/json/version" in url
+        return _FakeResp(200)
+
+    monkeypatch.setattr("urllib.request.urlopen", _urlopen)
+
+    assert _make_env()._wait_for_cdp_ready() is True
+    assert calls["n"] == 1
+
+
+def test_cdp_ready_polls_through_cold_start_refusals(
+    fake_clock: dict[str, float], monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The race scenario: the port refuses twice, then comes up — the poll
+    absorbs the cold-start instead of giving up like the fixed sleep did."""
+    calls = {"n": 0}
+
+    def _urlopen(url: str, timeout: float = 2):
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise urllib.error.URLError(ConnectionRefusedError(111, "refused"))
+        return _FakeResp(200)
+
+    monkeypatch.setattr("urllib.request.urlopen", _urlopen)
+
+    assert _make_env()._wait_for_cdp_ready() is True
+    assert calls["n"] == 3  # two refusals absorbed, third succeeded
+
+
+def test_cdp_ready_gives_up_after_deadline(
+    fake_clock: dict[str, float], monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If the port never comes up, return False (best-effort) rather than
+    block forever — the caller's CDP calls are independently best-effort."""
+
+    def _urlopen(url: str, timeout: float = 2):
+        raise urllib.error.URLError(ConnectionRefusedError(111, "refused"))
+
+    monkeypatch.setattr("urllib.request.urlopen", _urlopen)
+
+    assert _make_env()._wait_for_cdp_ready(deadline_s=3.0) is False


### PR DESCRIPTION
## Summary
Replaces the fixed `time.sleep(3)` after Chrome launch with a poll of Chrome's CDP HTTP endpoint, fixing a cold-start race on freshly-scheduled Modal containers.

- On a cold container Chrome can take >3s to bind `--remote-debugging-port`, so `/json/list` returned ECONNREFUSED and the persistent header seam never opened — which drops the Daytona consent cookie, so the sim env renders its consent overlay (read as a blocked page by the click handler's pre-scan → `page_blocked` halt → 0 leads).
- New `_wait_for_cdp_ready(deadline_s=15.0)` polls `http://127.0.0.1:{cdp_port}/json/version` (0.5s floor + 0.5s intervals), returns `True` on HTTP 200, logs a WARNING and returns `False` on timeout (best-effort: the caller still proceeds, since the stealth + header-session calls are each independently best-effort).

## Test plan
- [x] `tests/test_xdotool_cdp_ready.py` — 3 unit tests (ready / cold-then-ready / timeout-warns), all pass.
- [ ] Modal cold-start run confirms the header seam opens and no `page_blocked` halt on the sim env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)