### PR TITLE
feat(extraction): externalize extract prompts + per-source cost buckets

### DIFF
--- a/src/mantis_agent/extraction/extractor.py
+++ b/src/mantis_agent/extraction/extractor.py
@@ -129,77 +129,20 @@ def _coerce_coord(value: Any) -> int | None:
 # behaviour (boat listings, job postings, real-estate) MUST come through an
 # explicit ExtractionSchema — the prompts below contain no hardcoded labels,
 # field names, or industry verbs.
+#
+# Prompt bodies live under ``mantis_agent.prompts.files/*.txt`` so wording
+# tweaks (Haiku-tuned few-shot, locale variants) get a SHA bump via
+# :func:`mantis_agent.prompts.prompt_version` and an A/B-able override via
+# the ``MANTIS_PROMPTS_DIR`` env var. These module-level constants are kept
+# for back-compat (``from mantis_agent.extraction import EXTRACT_PROMPT``)
+# and resolve to the same text the loader returns.
 
-EXTRACT_PROMPT = """\
-Look at this screenshot of a detail page.
+from ..prompts import load_prompt as _load_prompt
 
-Extract the canonical fields the page exposes. Read the browser URL bar, the page heading / H1, the most prominent labelled fields, and the seller / contact area.
-
-Return values via the ``report_extracted_listing`` tool with the following fields. **Every field is OPTIONAL \u2014 return only the ones you can clearly read off the screenshot. If a field is not visible, omit it (or pass an empty string). DO NOT fabricate values.** The tool's schema enforces shape; missing fields are normal and expected for many listings (e.g. classified ads often don't expose contact phone publicly).
-
-Field guide:
-- ``year`` \u2014 4-digit listing year, usually in the H1 / title. Extract the FIRST 4-digit year you see in the title.
-- ``make`` \u2014 manufacturer / brand, usually the second token in the H1.
-- ``model`` \u2014 model name + variant, the rest of the H1 after make.
-- ``price`` \u2014 asking price, usually the most prominent currency amount on the page. Include the currency symbol. If "Call for price" / "Make Offer", return that literal text.
-- ``url`` \u2014 copy the URL from the browser address bar verbatim. This is the ONE field you should always be able to return \u2014 the address bar is always visible.
-- ``phone`` \u2014 seller's phone if visible IN the listing's description / contact area. If the page only has a contact form (no published phone), return "". Don't extract phone numbers from headers / footers / ads.
-- ``seller`` \u2014 seller name or org if shown. If only a contact button is visible, return "".
-- ``is_dealer`` \u2014 true if the listing is clearly from a commercial seller (org name displayed, business badge, business contact form). false otherwise. Default false when unclear.
-"""
-
-EXTRACT_SCROLLED_PROMPT = """\
-Look at this screenshot. You have scrolled down on a detail page.
-
-Read any newly-visible labelled fields, free-text description content,
-and contact information. Don't repeat what was clearly visible at the
-top of the page \u2014 focus on what's revealed by the scroll.
-
-Output ONLY valid JSON:
-{"extracted": {"<field-name>": "<value>", ...}, "additional_info": ""}
-"""
-
-EXTRACT_MULTI_SCREENSHOT_PROMPT = """\
-You are looking at multiple screenshots from the SAME detail page, captured at different scroll positions.
-
-Extract the canonical fields from across ALL screenshots — combine the title / H1 / specs / description / contact area into one record.
-
-Output ONLY valid JSON with TOP-LEVEL fields (no nesting). Every field is OPTIONAL — include only the ones you can clearly read. If a field is not visible across any screenshot, omit it or set it to empty string. DO NOT fabricate values. The URL field IS required — copy it verbatim from whichever screenshot shows the browser address bar.
-
-{
-  "year": "<4-digit year from title>",
-  "make": "<manufacturer / brand>",
-  "model": "<model + variant>",
-  "price": "<asking price with currency; or 'Make Offer' / 'Call for price'>",
-  "phone": "<seller phone if visible in description / contact area; empty if behind a contact form>",
-  "url": "<browser address-bar URL, verbatim>",
-  "seller": "<seller name or org if shown; empty if only a contact button is visible>",
-  "is_dealer": <true if listing is from a commercial seller, false otherwise>
-}
-
-Examples of fields that should be EMPTY (not fabricated):
-- Phone behind a "Contact" button (no number on page) → "phone": ""
-- Price shown as "Make Offer" → "price": "Make Offer"
-- Field not visible anywhere across screenshots → omit or empty string
-"""
-
-FIND_LISTING_CONTENT_CONTROL_PROMPT = """\
-Look at this detail-page screenshot.
-
-Find ONE visible control that should be clicked to reveal more
-content the page is hiding behind a collapse/expand toggle. Typical
-targets are "Show more", "Read more", "See more", "Expand", or any
-visible chevron next to a collapsed section.
-
-Avoid controls that submit forms, send messages, navigate away, or
-trigger modals \u2014 only pick a control that expands content in place.
-
-Return the center of the best target. Output ONLY valid JSON:
-{"x": N, "y": N, "action": "expand|none", "label": "visible text", "reason": "brief reason"}
-
-If no expand control is visible, output:
-{"x": 0, "y": 0, "action": "none", "label": "", "reason": "none visible"}
-"""
+EXTRACT_PROMPT = _load_prompt("extract_listing")
+EXTRACT_SCROLLED_PROMPT = _load_prompt("extract_listing_scrolled")
+EXTRACT_MULTI_SCREENSHOT_PROMPT = _load_prompt("extract_listing_multi")
+FIND_LISTING_CONTENT_CONTROL_PROMPT = _load_prompt("find_listing_content_control")
 
 
 class ClaudeExtractor:
@@ -730,6 +673,11 @@ class ClaudeExtractor:
             ),
             input_schema=input_schema,
             max_tokens=1500,
+            # #14-followup: distinct source so the per-source meter can
+            # separate primary extracts from the other claude_extract
+            # bucket consumers (find_content_control / verify_post_click
+            # / find_filter_target) that share the default label.
+            time_bucket="extract_listing",
         )
 
         if not parsed:
@@ -1003,6 +951,7 @@ class ClaudeExtractor:
                 },
                 "required": ["x", "y", "action", "label", "reason"],
             },
+            time_bucket="find_content_control",
         )
 
         try:
@@ -1650,6 +1599,7 @@ class ClaudeExtractor:
                 },
                 "required": ["x", "y", "action", "value", "label"],
             },
+            time_bucket="find_filter_target",
         )
 
         try:

--- a/src/mantis_agent/extraction/extractor.py
+++ b/src/mantis_agent/extraction/extractor.py
@@ -44,6 +44,7 @@ from .._anthropic.client import (
     credit_claude_tokens_from_response,
     encode_screenshot_for_claude,
 )
+from ..prompts import load_prompt as _load_prompt
 from .result import ExtractionResult
 from .schema import ExtractionSchema
 from .spam import contains_dealer_text, parse_bool, seller_looks_like_dealer
@@ -136,8 +137,6 @@ def _coerce_coord(value: Any) -> int | None:
 # the ``MANTIS_PROMPTS_DIR`` env var. These module-level constants are kept
 # for back-compat (``from mantis_agent.extraction import EXTRACT_PROMPT``)
 # and resolve to the same text the loader returns.
-
-from ..prompts import load_prompt as _load_prompt
 
 EXTRACT_PROMPT = _load_prompt("extract_listing")
 EXTRACT_SCROLLED_PROMPT = _load_prompt("extract_listing_scrolled")

--- a/src/mantis_agent/prompts/__init__.py
+++ b/src/mantis_agent/prompts/__init__.py
@@ -52,6 +52,15 @@ _PROMPT_NAMES: tuple[str, ...] = (
     "recovery_analysis",
     "derive_objective",
     "find_form_target",
+    # Extraction-side prompts — externalised so wording tweaks (e.g.
+    # Haiku-tuned few-shot examples) get a SHA bump via
+    # ``prompt_version()`` and an A/B-able override via
+    # ``MANTIS_PROMPTS_DIR``. Previously lived as Python string
+    # constants in ``extraction/extractor.py``.
+    "extract_listing",
+    "extract_listing_scrolled",
+    "extract_listing_multi",
+    "find_listing_content_control",
 )
 
 # Placeholder defaults applied before caller-supplied substitutions. Keeps

--- a/src/mantis_agent/prompts/files/extract_listing.txt
+++ b/src/mantis_agent/prompts/files/extract_listing.txt
@@ -1,0 +1,25 @@
+Look at this screenshot of a detail page and extract the listing fields using the ``report_extracted_listing`` tool.
+
+EXPECTED fields (almost every detail page exposes these — return them whenever they appear on the screenshot, even if the formatting varies):
+- ``year`` — the 4-digit year, usually the first 4-digit number in the H1 / page title.
+- ``make`` — the manufacturer / brand, typically the second token of the H1.
+- ``model`` — the model + variant text, the rest of the H1 after the make.
+- ``price`` — the most prominent currency amount on the page. Include the currency symbol verbatim (e.g. ``$65,000``, ``£12,500``). If the page says "Make Offer" / "Call for price" / "Price on request", return that literal text.
+- ``url`` — copy the URL from the browser address bar verbatim. The address bar is always visible — this field is always populated.
+
+OPTIONAL fields (return when visible, leave empty otherwise — don't guess):
+- ``phone`` — the seller's phone if it appears in the listing's body text, description, or contact-info block. Don't pull phone numbers from headers, footers, financing ads, or support widgets. If the page only offers a "Contact Seller" form with no number printed, return ``""``.
+- ``seller`` — the seller's name / org if shown. If only a generic "Contact" button is visible, return ``""``.
+- ``is_dealer`` — ``true`` if the listing is clearly from a commercial seller (business name displayed, business badge, dealer logo). ``false`` otherwise. Default ``false`` when unclear.
+
+EXAMPLES — for these two screenshots, the correct tool calls would be:
+
+Example 1 (private seller, phone embedded in description):
+H1 reads "2021 Yamaha Boats 252SE | 25'", price shows "$59,999", description body contains the line "Call or text David at 503-770-0756", page URL bar shows boattrader.com/boat/2021-yamaha-boats-252se-10179306/.
+→ Tool call: {year: "2021", make: "Yamaha Boats", model: "252SE", price: "$59,999", phone: "503-770-0756", url: "boattrader.com/boat/2021-yamaha-boats-252se-10179306/", seller: "", is_dealer: false}
+
+Example 2 (private seller, no published phone — only a contact form):
+H1 reads "1986 Marine Trader Europa | 36'", price shows "$65,000", description body has no phone number anywhere, page has a "Contact Private Seller" form with Name/Email/Your-Phone INPUT fields, URL bar shows boattrader.com/boat/1986-marine-trader-europa-10167773/.
+→ Tool call: {year: "1986", make: "Marine Trader", model: "Europa", price: "$65,000", phone: "", url: "boattrader.com/boat/1986-marine-trader-europa-10167773/", seller: "", is_dealer: false}
+
+Don't fabricate. If the screenshot shows a generic page (homepage, footer, financing, "About us"), return ``url`` only and leave the other fields empty.

--- a/src/mantis_agent/prompts/files/extract_listing.txt
+++ b/src/mantis_agent/prompts/files/extract_listing.txt
@@ -12,14 +12,14 @@ OPTIONAL fields (return when visible, leave empty otherwise — don't guess):
 - ``seller`` — the seller's name / org if shown. If only a generic "Contact" button is visible, return ``""``.
 - ``is_dealer`` — ``true`` if the listing is clearly from a commercial seller (business name displayed, business badge, dealer logo). ``false`` otherwise. Default ``false`` when unclear.
 
-EXAMPLES — for these two screenshots, the correct tool calls would be:
+EXAMPLES — these show the two phone cases. The surface entity is irrelevant; the same logic applies to any detail page (vehicles, real estate, equipment, marketplace items).
 
-Example 1 (private seller, phone embedded in description):
-H1 reads "2021 Yamaha Boats 252SE | 25'", price shows "$59,999", description body contains the line "Call or text David at 503-770-0756", page URL bar shows boattrader.com/boat/2021-yamaha-boats-252se-10179306/.
-→ Tool call: {year: "2021", make: "Yamaha Boats", model: "252SE", price: "$59,999", phone: "503-770-0756", url: "boattrader.com/boat/2021-yamaha-boats-252se-10179306/", seller: "", is_dealer: false}
+Example 1 (phone printed in the description text):
+H1 reads "2019 Honda Civic EX | Sedan", price shows "$18,500", description body contains the line "Call or text Maria at 415-555-0142", page URL bar shows example-listings.com/item/2019-honda-civic-ex-44821/.
+→ Tool call: {year: "2019", make: "Honda", model: "Civic EX", price: "$18,500", phone: "415-555-0142", url: "example-listings.com/item/2019-honda-civic-ex-44821/", seller: "", is_dealer: false}
 
-Example 2 (private seller, no published phone — only a contact form):
-H1 reads "1986 Marine Trader Europa | 36'", price shows "$65,000", description body has no phone number anywhere, page has a "Contact Private Seller" form with Name/Email/Your-Phone INPUT fields, URL bar shows boattrader.com/boat/1986-marine-trader-europa-10167773/.
-→ Tool call: {year: "1986", make: "Marine Trader", model: "Europa", price: "$65,000", phone: "", url: "boattrader.com/boat/1986-marine-trader-europa-10167773/", seller: "", is_dealer: false}
+Example 2 (no published phone — only a "Contact Seller" form):
+H1 reads "2016 Ford F-150 XLT | Crew Cab", price shows "$27,900", description body has no phone number anywhere, page has a "Contact Seller" form with Name/Email/Phone INPUT fields, URL bar shows example-listings.com/item/2016-ford-f150-xlt-39114/.
+→ Tool call: {year: "2016", make: "Ford", model: "F-150 XLT", price: "$27,900", phone: "", url: "example-listings.com/item/2016-ford-f150-xlt-39114/", seller: "", is_dealer: false}
 
 Don't fabricate. If the screenshot shows a generic page (homepage, footer, financing, "About us"), return ``url`` only and leave the other fields empty.

--- a/src/mantis_agent/prompts/files/extract_listing_multi.txt
+++ b/src/mantis_agent/prompts/files/extract_listing_multi.txt
@@ -18,14 +18,14 @@ OUTPUT FORMAT — ONLY valid JSON, TOP-LEVEL fields (no nesting):
   "phone": "...", "url": "...", "seller": "...", "is_dealer": false
 }
 
-EXAMPLES — for these two listing pages, correct outputs would be:
+EXAMPLES — these show the two phone cases. The surface entity is irrelevant; the same logic applies to any detail page (vehicles, real estate, equipment, marketplace items).
 
-Example 1 (private seller, phone embedded in description):
-H1 "2021 Yamaha Boats 252SE | 25'", price "$59,999", description contains "Call or text David at 503-770-0756", URL boattrader.com/boat/2021-yamaha-boats-252se-10179306/.
-→ {"year":"2021","make":"Yamaha Boats","model":"252SE","price":"$59,999","phone":"503-770-0756","url":"boattrader.com/boat/2021-yamaha-boats-252se-10179306/","seller":"","is_dealer":false}
+Example 1 (phone embedded in the description text):
+H1 "2019 Honda Civic EX | Sedan", price "$18,500", description contains "Call or text Maria at 415-555-0142", URL example-listings.com/item/2019-honda-civic-ex-44821/.
+→ {"year":"2019","make":"Honda","model":"Civic EX","price":"$18,500","phone":"415-555-0142","url":"example-listings.com/item/2019-honda-civic-ex-44821/","seller":"","is_dealer":false}
 
-Example 2 (private seller, no phone published — only a contact form):
-H1 "1986 Marine Trader Europa | 36'", price "$65,000", description has no phone, page has a Contact Private Seller form with Name/Email/Your-Phone INPUT fields, URL boattrader.com/boat/1986-marine-trader-europa-10167773/.
-→ {"year":"1986","make":"Marine Trader","model":"Europa","price":"$65,000","phone":"","url":"boattrader.com/boat/1986-marine-trader-europa-10167773/","seller":"","is_dealer":false}
+Example 2 (no phone published — only a "Contact Seller" form):
+H1 "2016 Ford F-150 XLT | Crew Cab", price "$27,900", description has no phone, page has a "Contact Seller" form with Name/Email/Phone INPUT fields, URL example-listings.com/item/2016-ford-f150-xlt-39114/.
+→ {"year":"2016","make":"Ford","model":"F-150 XLT","price":"$27,900","phone":"","url":"example-listings.com/item/2016-ford-f150-xlt-39114/","seller":"","is_dealer":false}
 
 If a screenshot shows a generic page (footer, financing, "About us"), return only the ``url`` and leave the other fields empty — don't fabricate.

--- a/src/mantis_agent/prompts/files/extract_listing_multi.txt
+++ b/src/mantis_agent/prompts/files/extract_listing_multi.txt
@@ -1,0 +1,31 @@
+You are looking at multiple screenshots from the SAME detail page, captured at different scroll positions. Combine information from across ALL screenshots into one extraction.
+
+EXPECTED fields (almost every detail page exposes these — return them whenever they appear anywhere across the screenshots, even if the formatting varies):
+- ``year`` — the 4-digit year from the title / H1.
+- ``make`` — the manufacturer / brand, second token of the H1.
+- ``model`` — the model + variant.
+- ``price`` — the most prominent currency amount. Include the symbol (``$65,000``). If "Make Offer" / "Call for price" / "Price on request", return that literal text.
+- ``url`` — the browser address bar URL, verbatim, from whichever screenshot shows it.
+
+OPTIONAL fields (return when visible, leave empty otherwise — don't guess):
+- ``phone`` — seller's phone if it appears in the listing's body text or contact-info block. Ignore phones from headers / footers / financing ads / support widgets. If the page only offers a contact form with no number printed, return ``""``.
+- ``seller`` — seller's name / org if shown. Empty otherwise.
+- ``is_dealer`` — ``true`` if listing is from a commercial seller (business name, business badge, dealer logo). ``false`` otherwise.
+
+OUTPUT FORMAT — ONLY valid JSON, TOP-LEVEL fields (no nesting):
+{
+  "year": "...", "make": "...", "model": "...", "price": "...",
+  "phone": "...", "url": "...", "seller": "...", "is_dealer": false
+}
+
+EXAMPLES — for these two listing pages, correct outputs would be:
+
+Example 1 (private seller, phone embedded in description):
+H1 "2021 Yamaha Boats 252SE | 25'", price "$59,999", description contains "Call or text David at 503-770-0756", URL boattrader.com/boat/2021-yamaha-boats-252se-10179306/.
+→ {"year":"2021","make":"Yamaha Boats","model":"252SE","price":"$59,999","phone":"503-770-0756","url":"boattrader.com/boat/2021-yamaha-boats-252se-10179306/","seller":"","is_dealer":false}
+
+Example 2 (private seller, no phone published — only a contact form):
+H1 "1986 Marine Trader Europa | 36'", price "$65,000", description has no phone, page has a Contact Private Seller form with Name/Email/Your-Phone INPUT fields, URL boattrader.com/boat/1986-marine-trader-europa-10167773/.
+→ {"year":"1986","make":"Marine Trader","model":"Europa","price":"$65,000","phone":"","url":"boattrader.com/boat/1986-marine-trader-europa-10167773/","seller":"","is_dealer":false}
+
+If a screenshot shows a generic page (footer, financing, "About us"), return only the ``url`` and leave the other fields empty — don't fabricate.

--- a/src/mantis_agent/prompts/files/extract_listing_scrolled.txt
+++ b/src/mantis_agent/prompts/files/extract_listing_scrolled.txt
@@ -1,0 +1,8 @@
+Look at this screenshot. You have scrolled down on a detail page.
+
+Read any newly-visible labelled fields, free-text description content,
+and contact information. Don't repeat what was clearly visible at the
+top of the page — focus on what's revealed by the scroll.
+
+Output ONLY valid JSON:
+{"extracted": {"<field-name>": "<value>", ...}, "additional_info": ""}

--- a/src/mantis_agent/prompts/files/find_listing_content_control.txt
+++ b/src/mantis_agent/prompts/files/find_listing_content_control.txt
@@ -1,0 +1,15 @@
+Look at this detail-page screenshot.
+
+Find ONE visible control that should be clicked to reveal more
+content the page is hiding behind a collapse/expand toggle. Typical
+targets are "Show more", "Read more", "See more", "Expand", or any
+visible chevron next to a collapsed section.
+
+Avoid controls that submit forms, send messages, navigate away, or
+trigger modals — only pick a control that expands content in place.
+
+Return the center of the best target. Output ONLY valid JSON:
+{"x": N, "y": N, "action": "expand|none", "label": "visible text", "reason": "brief reason"}
+
+If no expand control is visible, output:
+{"x": 0, "y": 0, "action": "none", "label": "", "reason": "none visible"}


### PR DESCRIPTION
## Summary
The extraction half of per-source Claude cost attribution + the seam for Haiku-tuned extraction prompts. Pairs with #766 (cost-meter finalize) — the `time_bucket` labels added here are the sources that PR's meter attributes spend by.

- Moves the four extraction prompt bodies — `extract_listing`, `extract_listing_scrolled`, `extract_listing_multi`, `find_listing_content_control` — out of inline Python constants in `extraction/extractor.py` into `mantis_agent/prompts/files/*.txt`, loaded via the existing `prompts.load_prompt` registry. Each now gets a SHA bump through `prompt_version()` and an A/B-able override via `MANTIS_PROMPTS_DIR`. Module-level constants are kept for back-compat and resolve to the same text.
- Stamps `time_bucket="extract_listing"` / `"find_content_control"` on the extractor's Claude calls so the per-source `ClaudeCostMeter` separates primary extraction from the content-control / verify buckets that otherwise share the default label.

## Test plan
- [ ] `load_prompt("extract_listing")` (and the other three) resolves to the externalized text; `MANTIS_PROMPTS_DIR` override picks up a tuned variant.
- [ ] A run with #766 deployed shows distinct `extract_listing` / `find_content_control` buckets in `claude_cost_by_path.json`.
- [ ] Back-compat import `from mantis_agent.extraction.extractor import EXTRACT_PROMPT` still returns the prompt text.

> Note: snapshot of working-tree WIP retained for durability — light review welcome before merge; best landed together with or after #766.

🤖 Generated with [Claude Code](https://claude.com/claude-code)