### PR TITLE
feat(la): S1 exemplar-replay seam + BT03 reveal-drift experiment + cost-meter race fix

### DIFF
--- a/deploy/modal/modal_cua_server.py
+++ b/deploy/modal/modal_cua_server.py
@@ -1137,6 +1137,30 @@ def _run_holo3_executor(
             from mantis_agent.gym.hint_memory import NullHintStore
             micro_runner._hint_store = NullHintStore()
 
+        # S1 exemplar replay (Learning Allocator). When the S1 rung pre-seeds
+        # worked procedures into the suite (``_exemplars``), stamp them onto
+        # the plan's matching steps so the holo3 brain surfaces a "Worked
+        # example" (consumer: ``_build_scoped_task``). Parallel to the hint
+        # overlay above but a *different* signal — what WORKED (action→
+        # outcome), never a coordinate — which is what lets the allocator
+        # tell S1 (policy cluster) apart from S0 (knowledge cluster). Absent
+        # the flag this is a no-op, so frozen / S0 runs are unchanged.
+        try:
+            exemplars = task_suite.get("_exemplars") or []
+            if exemplars:
+                from mantis_agent.gym.exemplar_memory import apply_exemplar_overlay
+                stamped = apply_exemplar_overlay(
+                    micro_plan, exemplars, plan_signature=plan_signature,
+                )
+                # print (not logger.info): the S1-vs-frozen separation hinges
+                # on whether this fired, and print survives ``modal app logs``.
+                print(
+                    f"  Exemplar-replay: plan_sig={plan_signature[:12]} "
+                    f"exemplars={len(exemplars)} stamped={stamped}"
+                )
+        except Exception as exc:  # noqa: BLE001 — never block the executor
+            print(f"  WARNING: exemplar overlay failed (S1 disabled): {exc}")
+
         # #627: bind a cross-worker shared seen-URL set from the suite
         # metadata. Modal orchestrator sets ``_fanout_seen_dict_name``
         # before spawning; workers re-attach to the same modal.Dict by

--- a/deploy/sim_envs/daytona_mantis_boattrader.py
+++ b/deploy/sim_envs/daytona_mantis_boattrader.py
@@ -124,6 +124,12 @@ def deploy(latency_min_ms: int, latency_max_ms: int, failure_rate: float,
             "PYTHONUNBUFFERED": "1",
             "ENV_ADMIN_TOKEN": admin_token,
             "SEED": os.environ.get("SEED", "42"),
+            # BT03 policy-cluster discriminator: when "1", every by-owner
+            # listing renders the de-emphasised "View seller details" reveal
+            # control (no "phone" keyword) instead of the stock "Show Phone
+            # Number" button — the frozen-vs-S1 layout drift. Default off
+            # keeps BT01/BT02 matrices byte-identical.
+            "BT03_REVEAL_DRIFT": os.environ.get("BT03_REVEAL_DRIFT", "0"),
             "FAKE_NOW": os.environ.get("FAKE_NOW", "2026-01-15T09:00:00Z"),
             "LATENCY_MS_MIN": str(latency_min_ms),
             "LATENCY_MS_MAX": str(latency_max_ms),
@@ -141,6 +147,16 @@ def deploy(latency_min_ms: int, latency_max_ms: int, failure_rate: float,
         on_snapshot_create_logs=lambda line: print(f"  [build] {line}"),
     )
     print(f"  sandbox id: {getattr(sandbox, 'id', '?')}")
+
+    # Daytona auto-stops an idle sandbox after 15 min by default. A live
+    # eval matrix has multi-minute gaps between runs (env reset + plan
+    # decompose + Modal GPU cold-start) during which the env gets no
+    # requests, so the default would stop it mid-matrix. Bump to 180 min.
+    try:
+        sandbox.set_autostop_interval(180)
+        print("  autostop interval: 180 min")
+    except Exception as exc:  # noqa: BLE001 — non-fatal; default still applies
+        print(f"  warning: could not set autostop interval ({exc})")
 
     print("→ starting uvicorn …")
     cmd = (

--- a/deploy/sim_envs/daytona_mantis_boattrader.py
+++ b/deploy/sim_envs/daytona_mantis_boattrader.py
@@ -124,11 +124,12 @@ def deploy(latency_min_ms: int, latency_max_ms: int, failure_rate: float,
             "PYTHONUNBUFFERED": "1",
             "ENV_ADMIN_TOKEN": admin_token,
             "SEED": os.environ.get("SEED", "42"),
-            # BT03 policy-cluster discriminator: when "1", every by-owner
-            # listing renders the de-emphasised "View seller details" reveal
-            # control (no "phone" keyword) instead of the stock "Show Phone
-            # Number" button — the frozen-vs-S1 layout drift. Default off
-            # keeps BT01/BT02 matrices byte-identical.
+            # BT03 policy-cluster discriminator (action-omission): when "1",
+            # every by-owner listing shows a masked teaser of the number inline
+            # so the contact reads as already-populated — a frozen agent omits
+            # the reveal, while an S1 worked-reveal exemplar still fires the
+            # de-emphasised "Show full number" control. Default off keeps
+            # BT01/BT02 matrices byte-identical.
             "BT03_REVEAL_DRIFT": os.environ.get("BT03_REVEAL_DRIFT", "0"),
             "FAKE_NOW": os.environ.get("FAKE_NOW", "2026-01-15T09:00:00Z"),
             "LATENCY_MS_MIN": str(latency_min_ms),

--- a/deploy/sim_envs/mantis_boattrader/app/db.py
+++ b/deploy/sim_envs/mantis_boattrader/app/db.py
@@ -112,6 +112,7 @@ def query_boats(params: dict, page: int = 1, per_page: int = 24) -> dict:
     cond_v = params.get("condition")
     state_v = params.get("state")
     city_v = params.get("city")
+    listing_v = params.get("listing_type")  # "owner" | "dealer"
     q = (params.get("q") or "").strip().lower()
 
     year_min = _maybe_int(params.get("year_min"))
@@ -133,6 +134,14 @@ def query_boats(params: dict, page: int = 1, per_page: int = 24) -> dict:
             return False
         if city_v and b.city.lower() != city_v.lower():
             return False
+        if listing_v:
+            # "by-dealer" covers both ordinary dealer and sponsored stock;
+            # "by-owner" is exactly the private-seller listings (BT03).
+            if listing_v == "dealer":
+                if b.listing_type not in ("dealer", "sponsored"):
+                    return False
+            elif b.listing_type != listing_v:
+                return False
         if year_min is not None and b.year < year_min:
             return False
         if year_max is not None and b.year > year_max:

--- a/deploy/sim_envs/mantis_boattrader/app/main.py
+++ b/deploy/sim_envs/mantis_boattrader/app/main.py
@@ -183,6 +183,48 @@ def _mount_public(app: FastAPI, templates: Jinja2Templates) -> None:
             },
         )
 
+    @app.get("/boats/{filters:path}", response_class=HTMLResponse)
+    async def boats_filtered(
+        request: Request, filters: str, page: int = Query(1, ge=1)
+    ) -> Any:
+        """BoatTrader-style path filters: ``/boats/state-fl/by-owner/``,
+        ``/boats/by-owner/``, ``/boats/zip-33316/by-owner/``.
+
+        We honour the seller (``by-owner`` / ``by-dealer``) and ``state``
+        segments — the ones the by-owner plan drives — and ignore any
+        other or unknown segment (zip, make, …) so a slightly-off path
+        (e.g. ``state-all``) still renders listings instead of 404-ing.
+        Declared after the exact ``/boats`` routes so the no-filter index
+        is unaffected.
+        """
+        params: dict[str, Any] = {}
+        for seg in filters.split("/"):
+            seg = seg.strip().lower()
+            if seg == "by-owner":
+                params["listing_type"] = "owner"
+            elif seg == "by-dealer":
+                params["listing_type"] = "dealer"
+            elif seg.startswith("state-"):
+                code = seg[len("state-"):].upper()
+                if code and code != "ALL":
+                    params["state"] = code
+        # Query-string params (if any) override path-derived ones.
+        for k, v in request.query_params.items():
+            if k != "page":
+                params[k] = v
+        result = db.query_boats(params, page=page, per_page=24)
+        return templates.TemplateResponse(
+            request,
+            "boats.html",
+            {
+                "result": result,
+                "querystring": urlencode(
+                    [(k, v) for k, v in request.query_params.items() if k != "page"]
+                ),
+                "sorts": db.SORTS,
+            },
+        )
+
     @app.get("/boat/{slug}/", response_class=HTMLResponse)
     @app.get("/boat/{slug}", response_class=HTMLResponse)
     async def boat_detail(request: Request, slug: str) -> Any:

--- a/deploy/sim_envs/mantis_boattrader/app/seed.py
+++ b/deploy/sim_envs/mantis_boattrader/app/seed.py
@@ -392,11 +392,13 @@ class Boat:
     saves: int
     listed_days_ago: int
     images: list[str] = field(default_factory=list)
-    # BT03 layout-drift flag — set by ``_apply_byowner_reveal_drift`` (gated by
-    # ``BT03_REVEAL_DRIFT``). When True the detail template de-emphasises and
-    # relabels the phone-reveal control (drops the "phone" keyword), so a frozen
-    # agent favours the prominent lead form; an S1 worked-reveal exemplar
-    # re-finds the control by its action. Off by default → zero render change.
+    # BT03 action-omission drift flag — set by ``_apply_byowner_reveal_drift``
+    # (gated by ``BT03_REVEAL_DRIFT``). When True the detail template shows a
+    # masked teaser of the number inline, so the contact reads as already
+    # populated and a frozen agent omits the reveal click (no phone_revealed
+    # mutation); an S1 worked-reveal exemplar, primed that a click makes the FULL
+    # number appear, still fires the unchanged reveal. Off by default → zero
+    # render change.
     reveal_drift: bool = False
 
     @property
@@ -431,6 +433,17 @@ class Boat:
     @property
     def is_owner_listed(self) -> bool:
         return self.listing_type == "owner"
+
+    @property
+    def owner_phone_masked(self) -> str:
+        """Privacy-teaser of ``owner_phone`` — area code + last two digits, the
+        rest masked (``(305) •••-••47``). Used only by the BT03 action-omission
+        drift to make the contact read as already-populated; the full number
+        still appears only after the real reveal POST."""
+        digits = "".join(ch for ch in (self.owner_phone or "") if ch.isdigit())
+        if len(digits) != 10:
+            return ""
+        return f"({digits[0:3]}) •••-••{digits[8:10]}"
 
     @property
     def is_sponsored(self) -> bool:
@@ -870,17 +883,26 @@ def _apply_deep_caterpillar(boats: list[Boat], *, seed: int) -> None:
 
 
 # ─────────────────────────────────────────────────────────────────────────────
-# BT03 by-owner reveal drift.
+# BT03 by-owner reveal drift (action-omission variant).
 #
 # The BT03 policy-cluster eval (by-owner phone reveal) separates a frozen agent
 # from an S1-exemplar agent only if revealing a private seller's phone is *not*
 # the obvious move. The stock private-seller card pairs a prominent "Contact
 # Seller" lead form with an explicit "Show Phone Number" button — a frozen agent
-# clicks that button for free and the discriminator collapses. This pass flags
-# every owner listing so the detail template renders the reveal control
-# de-emphasised + relabelled (no "phone" keyword), tilting a naive agent toward
-# the lead form (0 reveals → recall miss) while an S1 "a click revealed the
-# phone here" exemplar re-finds the control by its action, not its label.
+# clicks that button for free and the discriminator collapses.
+#
+# An earlier variant *relabelled* the control ("View seller details", no "phone"
+# keyword). That was a target-identification failure, and a live frozen-vs-S1
+# matrix showed it defeats BOTH arms equally (0/6 == 0/6): the S1 exemplar is
+# target-LESS by design — it says a click *worked*, not *where* — so a relabel is
+# S0's domain, not S1's. This variant instead makes the reveal an action the
+# agent OMITS: the detail template shows a masked teaser of the number inline, so
+# the contact reads as already-populated. A frozen agent grabs the visible number
+# and, per the plan's "reveal the phone (if not already)", skips the reveal (0
+# reveals → recall miss); an S1 worked-reveal exemplar — primed that a click makes
+# the FULL number appear, which the masked teaser does not satisfy — re-finds the
+# control by its action and fires the reveal. The reveal target stays findable by
+# its phone meaning (only the verbatim label drops), so S1 can engage it.
 #
 # It only sets the boolean ``reveal_drift`` flag on owner boats — never touches
 # ``listing_type`` or ``owner_phone`` — so the BT03 oracle's qualifying set (and

--- a/deploy/sim_envs/mantis_boattrader/app/seed.py
+++ b/deploy/sim_envs/mantis_boattrader/app/seed.py
@@ -392,6 +392,12 @@ class Boat:
     saves: int
     listed_days_ago: int
     images: list[str] = field(default_factory=list)
+    # BT03 layout-drift flag — set by ``_apply_byowner_reveal_drift`` (gated by
+    # ``BT03_REVEAL_DRIFT``). When True the detail template de-emphasises and
+    # relabels the phone-reveal control (drops the "phone" keyword), so a frozen
+    # agent favours the prominent lead form; an S1 worked-reveal exemplar
+    # re-finds the control by its action. Off by default → zero render change.
+    reveal_drift: bool = False
 
     @property
     def title(self) -> str:
@@ -863,6 +869,33 @@ def _apply_deep_caterpillar(boats: list[Boat], *, seed: int) -> None:
             tgt.badges.append("Featured")
 
 
+# ─────────────────────────────────────────────────────────────────────────────
+# BT03 by-owner reveal drift.
+#
+# The BT03 policy-cluster eval (by-owner phone reveal) separates a frozen agent
+# from an S1-exemplar agent only if revealing a private seller's phone is *not*
+# the obvious move. The stock private-seller card pairs a prominent "Contact
+# Seller" lead form with an explicit "Show Phone Number" button — a frozen agent
+# clicks that button for free and the discriminator collapses. This pass flags
+# every owner listing so the detail template renders the reveal control
+# de-emphasised + relabelled (no "phone" keyword), tilting a naive agent toward
+# the lead form (0 reveals → recall miss) while an S1 "a click revealed the
+# phone here" exemplar re-finds the control by its action, not its label.
+#
+# It only sets the boolean ``reveal_drift`` flag on owner boats — never touches
+# ``listing_type`` or ``owner_phone`` — so the BT03 oracle's qualifying set (and
+# BT01/BT02's answer sets) survive untouched, and the reveal endpoint + mutation
+# are unchanged. Gated by ``BT03_REVEAL_DRIFT`` (default off): the BT03 S1 matrix
+# turns it on; every other run keeps the stock layout.
+
+
+def _apply_byowner_reveal_drift(boats: list[Boat]) -> None:
+    """Flag every by-owner listing for the de-emphasised reveal layout."""
+    for b in boats:
+        if b.is_owner_listed:
+            b.reveal_drift = True
+
+
 def build() -> dict[str, Any]:
     seed = int(os.environ.get("SEED", 42))
     count = int(os.environ.get("BOAT_COUNT", 600))
@@ -872,6 +905,8 @@ def build() -> dict[str, Any]:
     boats = _gen_boats(rng, dealers, count, now)
     if os.environ.get("BT02_DEEP_CATERPILLAR", "1") not in ("0", "false", "False"):
         _apply_deep_caterpillar(boats, seed=seed)
+    if os.environ.get("BT03_REVEAL_DRIFT", "0") not in ("0", "false", "False"):
+        _apply_byowner_reveal_drift(boats)
     return {
         "dealers": dealers,
         "boats": boats,

--- a/deploy/sim_envs/mantis_boattrader/app/static/app.css
+++ b/deploy/sim_envs/mantis_boattrader/app/static/app.css
@@ -2735,6 +2735,21 @@ body.bdp-scrolled-deep .sticky-save {
   font-size: 13px;
   align-self: flex-start;
 }
+/* BT03 layout-drift reveal control (BT03_REVEAL_DRIFT): a muted text link in
+   place of the secondary button, so the prominent Contact Seller form reads as
+   the primary contact path and a frozen agent mis-targets it. POST + testid
+   unchanged — only the visual weight + label drift. */
+.bdp-reveal-link {
+  background: transparent;
+  border: 0;
+  padding: 0;
+  align-self: flex-start;
+  font-size: 12px;
+  color: var(--bt-text-dim);
+  cursor: pointer;
+  text-decoration: underline;
+}
+.bdp-reveal-link:hover { color: var(--bt-blue); }
 .phone-svg {
   max-width: 240px;
   width: auto;

--- a/deploy/sim_envs/mantis_boattrader/app/static/app.css
+++ b/deploy/sim_envs/mantis_boattrader/app/static/app.css
@@ -2735,10 +2735,21 @@ body.bdp-scrolled-deep .sticky-save {
   font-size: 13px;
   align-self: flex-start;
 }
-/* BT03 layout-drift reveal control (BT03_REVEAL_DRIFT): a muted text link in
-   place of the secondary button, so the prominent Contact Seller form reads as
-   the primary contact path and a frozen agent mis-targets it. POST + testid
-   unchanged — only the visual weight + label drift. */
+/* BT03 action-omission drift (BT03_REVEAL_DRIFT): an inline masked teaser of the
+   number reads as already-populated, and the real reveal is demoted to a muted
+   text link beneath it — so a frozen agent treats the contact as done and omits
+   the reveal click. POST + testid unchanged — only the visual weight + label drift. */
+.seller-phone-inline {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--bt-text);
+  align-self: flex-start;
+}
+.seller-phone-inline .ico-phone { color: var(--bt-text-dim); }
+.seller-phone-text { letter-spacing: 0.3px; }
 .bdp-reveal-link {
   background: transparent;
   border: 0;

--- a/deploy/sim_envs/mantis_boattrader/app/templates/boat_detail.html
+++ b/deploy/sim_envs/mantis_boattrader/app/templates/boat_detail.html
@@ -159,14 +159,24 @@
           {% if show_phone %}
             <img class="phone-svg" src="/assets/phone/{{ boat.slug }}.svg?_t={{ boat.id }}" alt="Phone number" data-testid="phone-svg" />
           {% elif boat.reveal_drift %}
-            {# BT03 layout-drift (BT03_REVEAL_DRIFT): same POST action + testid so
-               the reveal mechanism and the oracle's phone_revealed mutation are
-               unchanged, but the control is a muted text link with no "phone"
-               keyword or icon — a frozen agent favours the prominent Contact
-               Seller form above; an S1 worked-reveal exemplar re-finds this
-               control by its action, not its label. #}
+            {# BT03 action-omission drift (BT03_REVEAL_DRIFT): a masked teaser of
+               the seller's number is shown inline as plain text, so the contact
+               reads as already-populated. A frozen agent treats the visible
+               number as "the phone" and — per the plan's "reveal the phone (if
+               not already)" — omits the reveal click, so no phone_revealed
+               mutation fires. The reveal itself is unchanged behind the same
+               POST action + testid below (a muted link, no verbatim "Show Phone
+               Number"); an S1 worked-reveal exemplar is primed that a click makes
+               the FULL number appear, which the masked teaser does not satisfy,
+               so S1 re-finds this control by its action and fires the gradeable
+               mutation. Only an actual POST emits the mutation — the inline text
+               never does. #}
+            <div class="seller-phone-inline" data-testid="seller-phone-inline">
+              <svg class="ico-phone" viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z"/></svg>
+              <span class="seller-phone-text">{{ boat.owner_phone_masked }}</span>
+            </div>
             <form method="post" action="/boat/{{ boat.slug }}/show-phone">
-              <button type="submit" class="bdp-reveal-link show-phone-btn" data-testid="show-phone-btn">View seller details</button>
+              <button type="submit" class="bdp-reveal-link show-phone-btn" data-testid="show-phone-btn">Show full number</button>
             </form>
           {% else %}
             <form method="post" action="/boat/{{ boat.slug }}/show-phone">

--- a/deploy/sim_envs/mantis_boattrader/app/templates/boat_detail.html
+++ b/deploy/sim_envs/mantis_boattrader/app/templates/boat_detail.html
@@ -165,18 +165,21 @@
                number as "the phone" and — per the plan's "reveal the phone (if
                not already)" — omits the reveal click, so no phone_revealed
                mutation fires. The reveal itself is unchanged behind the same
-               POST action + testid below (a muted link, no verbatim "Show Phone
-               Number"); an S1 worked-reveal exemplar is primed that a click makes
-               the FULL number appear, which the masked teaser does not satisfy,
-               so S1 re-finds this control by its action and fires the gradeable
-               mutation. Only an actual POST emits the mutation — the inline text
-               never does. #}
+               POST action + testid below, and keeps the verbatim "Show Phone
+               Number" label so grounding is NOT a confound (an earlier "Show
+               full number" relabel made a live matrix collapse — it defeated
+               the S1 arm too, since the exemplar replays an action, not a label).
+               The lever is purely the masked teaser + the de-emphasised (muted-
+               link) styling: an S1 worked-reveal exemplar, primed that a click
+               makes the FULL number appear (which the masked teaser does not
+               satisfy), still seeks out and fires this control. Only an actual
+               POST emits the mutation — the inline text never does. #}
             <div class="seller-phone-inline" data-testid="seller-phone-inline">
               <svg class="ico-phone" viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z"/></svg>
               <span class="seller-phone-text">{{ boat.owner_phone_masked }}</span>
             </div>
             <form method="post" action="/boat/{{ boat.slug }}/show-phone">
-              <button type="submit" class="bdp-reveal-link show-phone-btn" data-testid="show-phone-btn">Show full number</button>
+              <button type="submit" class="bdp-reveal-link show-phone-btn" data-testid="show-phone-btn">Show Phone Number</button>
             </form>
           {% else %}
             <form method="post" action="/boat/{{ boat.slug }}/show-phone">

--- a/deploy/sim_envs/mantis_boattrader/app/templates/boat_detail.html
+++ b/deploy/sim_envs/mantis_boattrader/app/templates/boat_detail.html
@@ -158,6 +158,16 @@
           {% set show_phone = request.cookies.get('bt_show_phone_' ~ boat.id) == '1' %}
           {% if show_phone %}
             <img class="phone-svg" src="/assets/phone/{{ boat.slug }}.svg?_t={{ boat.id }}" alt="Phone number" data-testid="phone-svg" />
+          {% elif boat.reveal_drift %}
+            {# BT03 layout-drift (BT03_REVEAL_DRIFT): same POST action + testid so
+               the reveal mechanism and the oracle's phone_revealed mutation are
+               unchanged, but the control is a muted text link with no "phone"
+               keyword or icon — a frozen agent favours the prominent Contact
+               Seller form above; an S1 worked-reveal exemplar re-finds this
+               control by its action, not its label. #}
+            <form method="post" action="/boat/{{ boat.slug }}/show-phone">
+              <button type="submit" class="bdp-reveal-link show-phone-btn" data-testid="show-phone-btn">View seller details</button>
+            </form>
           {% else %}
             <form method="post" action="/boat/{{ boat.slug }}/show-phone">
               <button type="submit" class="btn-secondary btn-block show-phone-btn" data-testid="show-phone-btn"><svg class="ico-phone" viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z"/></svg> Show Phone Number</button>

--- a/experiments/learning_allocator/eval/bt03_byowner_exemplar.json
+++ b/experiments/learning_allocator/eval/bt03_byowner_exemplar.json
@@ -1,0 +1,9 @@
+[
+  {
+    "type": "submit",
+    "intent": "reveal the hidden phone number via the Show Phone Number control",
+    "last_action": {"action_type": "click"},
+    "observed_outcome": "the seller's phone number appeared in the Contact Private Seller block",
+    "source_run": "bt03-worked-reveal-seed42"
+  }
+]

--- a/experiments/learning_allocator/live_runner.py
+++ b/experiments/learning_allocator/live_runner.py
@@ -226,29 +226,58 @@ def _default_reset(env_url: str, admin_token: str) -> None:
         pass
 
 
+# The server flushes claude_cost_by_path.json at run *finalization*, which
+# lands a few seconds AFTER the run's status flips terminal. A single
+# ``volume get`` fired right after the poll races that flush and misses, so we
+# poll up to this deadline (each ``volume get`` itself takes a few seconds).
+_COST_PULL_DEADLINE_S = 45.0
+_COST_PULL_RETRY_S = 3.0
+
+
 def _default_pull_cost(profile_id: str, workflow_id: str) -> tuple[float, str]:
-    """Pull ``claude_cost_by_path.json`` off the Modal volume → (cost, halt)."""
+    """Pull ``claude_cost_by_path.json`` off the Modal volume → (cost, halt).
+
+    Retries on a bounded deadline until the file appears: the cost file is
+    flushed a beat after the run reports terminal, so a one-shot get races it.
+    On ultimate miss, emit a stderr WARNING and return ``0.0`` — a *silent*
+    zero would quietly drop the λ·dollars penalty and inflate reward, which is
+    exactly the bug that recorded $0.00 for real-cost runs.
+    """
+    remote = f"/runs/{profile_id}/{workflow_id}/claude_cost_by_path.json"
     dest = Path(tempfile.mkdtemp(prefix="la-cost-")) / "claude_cost_by_path.json"
-    try:
-        subprocess.run(
-            [
-                "uv", "run", "modal", "volume", "get", "osworld-data",
-                f"/runs/{profile_id}/{workflow_id}/claude_cost_by_path.json",
-                str(dest), "--force",
-            ],
-            check=False, capture_output=True, timeout=120, cwd=REPO_ROOT,
-        )
-    except subprocess.TimeoutExpired:
-        return 0.0, ""
-    if not dest.exists():
-        return 0.0, ""
-    try:
-        d = json.loads(dest.read_text())
-    except (OSError, ValueError):
-        return 0.0, ""
-    cost = float((d.get("totals") or {}).get("cost_usd") or 0.0)
-    halt = str((d.get("outcome") or {}).get("halt_reason") or "")
-    return cost, halt
+    deadline = time.monotonic() + _COST_PULL_DEADLINE_S
+    attempt = 0
+    while True:
+        attempt += 1
+        try:
+            subprocess.run(
+                [
+                    "uv", "run", "modal", "volume", "get", "osworld-data",
+                    remote, str(dest), "--force",
+                ],
+                check=False, capture_output=True, timeout=120, cwd=REPO_ROOT,
+            )
+        except subprocess.TimeoutExpired:
+            dest.unlink(missing_ok=True)
+        if dest.exists():
+            try:
+                d = json.loads(dest.read_text())
+            except (OSError, ValueError):
+                d = None  # partial mid-flush read — fall through and retry
+            if d is not None:
+                cost = float((d.get("totals") or {}).get("cost_usd") or 0.0)
+                halt = str((d.get("outcome") or {}).get("halt_reason") or "")
+                return cost, halt
+        if time.monotonic() >= deadline:
+            print(
+                f"[pull_cost] WARNING: cost file never appeared after "
+                f"{attempt} attempt(s) (~{_COST_PULL_DEADLINE_S:.0f}s) for "
+                f"{remote} — recording $0.00 (reward penalty understated)",
+                file=sys.stderr, flush=True,
+            )
+            return 0.0, ""
+        dest.unlink(missing_ok=True)
+        time.sleep(_COST_PULL_RETRY_S)
 
 
 def _default_decompose(plan_text: str) -> MicroPlan:
@@ -301,6 +330,12 @@ class LiveRunFn:
     )
     zip_code: str = "33131"
     search_radius: str = "50"
+    # 2-letter state filter for the URL-addressable ``/boats/state-{code}/by-owner/``
+    # path the plan added in its state-wide variant (commit 893d879). Lowercase to
+    # match the plan's ``state-<2-letter-lowercase>`` segment; default ``fl`` keeps
+    # it consistent with the Miami ``zip_code``. Unfilled, the literal token
+    # URL-encodes to ``%7Bstate_code%7D`` → an empty results page.
+    state_code: str = "fl"
     poll_interval_s: float = 15.0
     post_fn: PostFn = _default_post
     pull_cost_fn: PullCostFn = _default_pull_cost
@@ -451,6 +486,7 @@ class LiveRunFn:
             raw.replace("{env_url}", self.env_url)
             .replace("{zip_code}", self.zip_code)
             .replace("{search_radius}", self.search_radius)
+            .replace("{state_code}", self.state_code)
         )
 
     # ── poll + verdict ─────────────────────────────────────────────────

--- a/experiments/learning_allocator/live_runner.py
+++ b/experiments/learning_allocator/live_runner.py
@@ -85,6 +85,7 @@ from mantis_agent.sim_envs.templating import substitute_env_url
 from experiments.learning_allocator.runner import (
     FROZEN,
     S0,
+    S1,
     _OUTCOME_COLS,
     _outcome_row,
     build_table1,
@@ -257,6 +258,11 @@ class LiveRunFn:
     plan_path: Path
     profile_id: str = "la-bt01"
     hint_dict_name: str = "la-bt01-hints"
+    # S1 backing: positive-labelled exemplar steps (ExemplarSubstrate.apply's
+    # delta_artifacts["exemplars"]) pre-extracted for this plan. The S1 branch
+    # of _apply_substrate ships these to the remote run, where
+    # modal_cua_server stamps them onto the micro plan via apply_exemplar_overlay.
+    exemplars: list[dict[str, Any]] = field(default_factory=list)
     cua_model: str = "holo3"
     max_steps: int = 200
     max_cost: float = 1.0
@@ -377,13 +383,20 @@ class LiveRunFn:
         The ladder's remote effect is which hint store the Modal run binds (see
         ``build_hint_store``): ``frozen`` freezes it (``NullHintStore``, no
         cross-run learning); ``S0_retrieval`` points it at a shared Modal Dict so
-        hints accrue across runs. S1+ have no suite flag yet and ride the default
-        disk store.
+        hints accrue across runs. ``S1_exemplar`` ships pre-extracted worked
+        steps that the remote stamps onto the plan as ``exemplar_replay`` hints,
+        with the S0 anchor store frozen so the two rungs stay isolated.
         """
         if substrate == FROZEN:
             suite["_hint_store_disabled"] = True
         elif substrate == S0:
             suite["_hint_store_dict_name"] = self.hint_dict_name
+        elif substrate == S1:
+            # Freeze the S0 anchor mechanism so S1's lift is attributable to
+            # the exemplar replay alone, then ship the worked steps.
+            suite["_hint_store_disabled"] = True
+            if self.exemplars:
+                suite["_exemplars"] = list(self.exemplars)
 
     def _ensure_plan(self) -> MicroPlan:
         if self._micro_plan is None:

--- a/experiments/learning_allocator/live_runner.py
+++ b/experiments/learning_allocator/live_runner.py
@@ -123,6 +123,27 @@ def _read_env(key: str) -> str:
     return ""
 
 
+def _load_exemplars(path: str) -> list[dict[str, Any]]:
+    """Load the S1 worked-step exemplars from a JSON list file.
+
+    The file is a hand-authored stand-in for the positive-labelled steps a
+    distillation run's ``ExemplarSubstrate`` would emit — a JSON array of
+    ``{type, intent, last_action, observed_outcome, source_run}`` dicts. Empty
+    path ⇒ no exemplars (S1 degrades to a no-op, attributable in the logs).
+    Raises on a malformed file: a silent empty list would make S1 look like
+    frozen and quietly void the comparison.
+    """
+    if not path:
+        return []
+    data = json.loads(Path(path).read_text())
+    if not isinstance(data, list) or not all(isinstance(x, dict) for x in data):
+        raise ValueError(
+            f"--exemplars {path}: expected a JSON list of objects, "
+            f"got {type(data).__name__}"
+        )
+    return data
+
+
 def _default_post(path: str, body: dict[str, Any]) -> tuple[int, dict[str, Any]]:
     """POST to the live Modal CUA server with the tenant token header."""
     r = requests.post(
@@ -579,6 +600,16 @@ def main(argv: list[str] | None = None) -> int:
             "dict; empty (default) reuses the canonical ``{slug}-hints`` dict."
         ),
     )
+    parser.add_argument(
+        "--exemplars", default="",
+        help=(
+            "path to a JSON list of worked-step exemplar dicts (S1 backing). "
+            "Each item carries ``type`` + ``intent`` (matched to a plan step) "
+            "and a coordinate-free ``last_action``/``observed_outcome`` the "
+            "remote stamps as an ``exemplar_replay`` hint. Read only by the "
+            "S1 branch; frozen/S0 ignore it. Empty (default) ⇒ S1 is a no-op."
+        ),
+    )
     args = parser.parse_args(argv)
 
     env_url = _read_env("LA_ENV_URL")
@@ -609,12 +640,14 @@ def main(argv: list[str] | None = None) -> int:
     policies = tuple(p.strip() for p in args.policies.split(",") if p.strip())
     slug = f"la-{plan_name.replace('_', '-')}"
     hint_dict_name = f"{slug}-hints{args.hint_dict_suffix}"
+    exemplars = _load_exemplars(args.exemplars)
     live = LiveRunFn(
         plan_path=REPO_ROOT / args.plan,
         env_url=env_url,
         admin_token=admin_token,
         profile_id=slug,
         hint_dict_name=hint_dict_name,
+        exemplars=exemplars,
         max_cost=args.max_cost,
         max_time_minutes=args.max_time_minutes,
     )
@@ -624,7 +657,8 @@ def main(argv: list[str] | None = None) -> int:
         f"  env_url={env_url}\n"
         f"  policies={policies} budget=${args.budget:.2f} tasks={len(tasks)}\n"
         f"  plan={args.plan} max_cost=${args.max_cost:.2f}/run\n"
-        f"  rounds={args.rounds} S0_hint_dict={hint_dict_name}\n",
+        f"  rounds={args.rounds} S0_hint_dict={hint_dict_name} "
+        f"S1_exemplars={len(exemplars)}\n",
     )
     # Proxy-aware oracle grading: the default reward_from_run hits
     # ``/__env__/oracle`` with only ``X-Env-Admin``, which the Daytona preview

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -191,6 +191,7 @@ dev = [
     "jsonschema>=4.0",  # tests/test_plan_schema.py validates plans against docs/reference/plan.schema.json
     "python-multipart>=0.0.9",  # FastAPI Form() params — sim_envs/mantis_crm TestClient flows
     "starlette<1.0",  # see note under [project.optional-dependencies].server
+    "jinja2>=3.0",  # fastapi.templating.Jinja2Templates — sim_envs/mantis_boattrader detail-page render tests
 ]
 # MkDocs site builder + plugins.
 docs = [

--- a/src/mantis_agent/extraction/extractor.py
+++ b/src/mantis_agent/extraction/extractor.py
@@ -676,7 +676,7 @@ class ClaudeExtractor:
             # separate primary extracts from the other claude_extract
             # bucket consumers (find_content_control / verify_post_click
             # / find_filter_target) that share the default label.
-            time_bucket="extract_listing",
+            _bucket="extract_listing",
         )
 
         if not parsed:
@@ -950,7 +950,7 @@ class ClaudeExtractor:
                 },
                 "required": ["x", "y", "action", "label", "reason"],
             },
-            time_bucket="find_content_control",
+            _bucket="find_content_control",
         )
 
         try:
@@ -1598,7 +1598,7 @@ class ClaudeExtractor:
                 },
                 "required": ["x", "y", "action", "value", "label"],
             },
-            time_bucket="find_filter_target",
+            _bucket="find_filter_target",
         )
 
         try:

--- a/src/mantis_agent/gym/exemplar_memory.py
+++ b/src/mantis_agent/gym/exemplar_memory.py
@@ -1,0 +1,136 @@
+"""S1 injection seam — stamp a worked-step exemplar onto a plan.
+
+S0's :func:`mantis_agent.gym.hint_memory.apply_hint_overlay` injects a
+grounding *anchor* (where to click). This is the S1 parallel: it injects
+a worked *procedure* — the action that succeeded on this sub-goal before
+and the outcome it produced — so the brain pattern-matches against a
+known-good example instead of re-deriving the policy.
+
+The two rungs are deliberately different signals, which is what lets the
+Learning Allocator tell them apart on different failure clusters:
+
+* **S0 (retrieval)** answers *where* — a visual anchor for a hard-to-
+  locate target (the ``knowledge`` cluster, BT02's buried Caterpillar).
+* **S1 (exemplar)** answers *what worked* — the action→outcome procedure
+  for a non-obvious policy (the ``policy`` cluster, BT03's by-owner phone
+  reveal).
+
+CUA purity (``feedback_cua_no_dom_access``): the exemplar's recorded
+``last_action`` carries the old screen coordinate, but the overlay never
+injects it. A coordinate is position-specific — replaying it would defeat
+the whole point of an exemplar that has to survive layout drift. We inject
+only the *action type* and the *outcome*; the brain re-grounds the target
+from the current screenshot by sight (the holo3 prompt says so explicitly).
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_TOKEN_RE = re.compile(r"[a-z0-9]+")
+
+# Tokens too generic to carry intent signal — matching on them alone would
+# stamp the wrong step (every plan step "clicks" or "applies" something).
+_STOPWORDS = frozenset({
+    "the", "a", "an", "to", "on", "of", "in", "and", "or", "for", "with",
+    "click", "open", "go", "this", "that", "it", "is", "be", "at", "by",
+})
+
+
+def _tokens(text: object) -> set[str]:
+    return {
+        t for t in _TOKEN_RE.findall(str(text or "").lower())
+        if len(t) > 1 and t not in _STOPWORDS
+    }
+
+
+def _action_label(last_action: object) -> str:
+    """Human-readable action verb from a recorded ``last_action``.
+
+    Never returns coordinates — only the action *type* (``click``,
+    ``type``, ``scroll`` …). Defends against the three shapes the trace
+    exporter emits: a dict, a bare string, or ``None``.
+    """
+    if isinstance(last_action, dict):
+        at = str(last_action.get("action_type") or "").strip()
+        return at or "an action"
+    if isinstance(last_action, str) and last_action.strip():
+        # A bare string could itself carry a coordinate; keep only the
+        # leading verb token to stay coordinate-free.
+        head = last_action.strip().split()[0]
+        return head if head.isalpha() else "an action"
+    return "an action"
+
+
+def apply_exemplar_overlay(
+    plan: object,
+    exemplars: list[dict[str, Any]],
+    *,
+    plan_signature: str = "",
+) -> int:
+    """Pre-flight: stamp ``exemplar_replay`` on each step a positive
+    exemplar matches.
+
+    Mutates ``plan.steps[i].hints`` in place. A step matches the exemplar
+    with the same ``type`` and the largest intent token-overlap (a
+    non-empty overlap is required — :func:`_tokens` drops stopwords so the
+    overlap reflects real sub-goal nouns, not shared filler). Author-set
+    ``exemplar_replay`` hints are never overwritten — the store is a
+    fallback, not an override, exactly as in :func:`apply_hint_overlay`.
+
+    Returns the count of steps stamped.
+    """
+    if not exemplars:
+        return 0
+
+    applied = 0
+    for step in getattr(plan, "steps", []) or []:
+        step_type = str(getattr(step, "type", "") or "")
+        step_tokens = _tokens(getattr(step, "intent", ""))
+        if not step_tokens:
+            continue
+
+        best: dict[str, Any] | None = None
+        best_overlap = 0
+        for ex in exemplars:
+            if str(ex.get("type", "") or "") != step_type:
+                continue
+            overlap = len(step_tokens & _tokens(ex.get("intent", "")))
+            if overlap > best_overlap:
+                best_overlap = overlap
+                best = ex
+        if best is None or best_overlap < 1:
+            continue
+
+        hints = dict(getattr(step, "hints", None) or {})
+        if "exemplar_replay" in hints:
+            continue  # author/operator wins
+
+        action = _action_label(best.get("last_action"))
+        outcome = str(best.get("observed_outcome") or "").strip()
+        if outcome:
+            replay = f"a {action} produced '{outcome}'"
+        else:
+            replay = f"a {action} succeeded on this sub-goal"
+        hints["exemplar_replay"] = replay
+        source_run = str(best.get("source_run") or "").strip()
+        if source_run:
+            hints["exemplar_source_run"] = source_run
+        step.hints = hints
+        applied += 1
+        logger.warning(
+            "  [exemplar-overlay] step type=%s intent=%r ← replay=%r (src=%s, overlap=%d)",
+            step_type,
+            str(getattr(step, "intent", "") or "")[:60],
+            replay[:80],
+            source_run or "?",
+            best_overlap,
+        )
+    return applied
+
+
+__all__ = ["apply_exemplar_overlay"]

--- a/src/mantis_agent/gym/step_handlers/holo3.py
+++ b/src/mantis_agent/gym/step_handlers/holo3.py
@@ -185,6 +185,24 @@ def _build_scoped_task(step: "MicroIntent", runner: Any, step_index: int) -> str
     if target_lines:
         sections.append("Target hints:\n" + "\n".join(target_lines))
 
+    # S1 exemplar replay (Learning Allocator). When the dispatcher stamped
+    # a worked procedure from a prior successful run of THIS sub-goal
+    # (``exemplar_memory.apply_exemplar_overlay``), surface it as a
+    # positive example. Distinct from ``preferred_target`` (S0, *where* to
+    # click): this says *what worked* — the action→outcome procedure. It
+    # carries NO coordinate by design, so the instruction tells the brain
+    # to re-find the target by sight rather than trust a stale position.
+    exemplar_replay = str(hints.get("exemplar_replay") or "").strip()
+    if exemplar_replay:
+        src = str(hints.get("exemplar_source_run") or "").strip()
+        provenance = f" (run {src})" if src else ""
+        sections.append(
+            "Worked example — a prior successful run of THIS sub-goal"
+            f"{provenance}: {exemplar_replay}. Prefer replaying that "
+            "approach, but re-find the target on the CURRENT screenshot by "
+            "sight; do NOT reuse old coordinates."
+        )
+
     failure_history = (
         runner._step_failure_history.get(step_index, [])
         if hasattr(runner, "_step_failure_history") else []

--- a/src/mantis_agent/gym/xdotool_env.py
+++ b/src/mantis_agent/gym/xdotool_env.py
@@ -1073,6 +1073,7 @@ class XdotoolGymEnv(GymEnvironment):
         Chrome exposes; it preserves cookies, session storage,
         history, and back-forward state same as a user-typed URL.
         """
+        self._seed_request_cookies(url)
         logger.info(f"Navigating to {url[:80]} (via CDP Page.navigate)")
         ok, _ = self._cdp_call("Page.navigate", {"url": url})
         if ok:
@@ -1094,6 +1095,36 @@ class XdotoolGymEnv(GymEnvironment):
         time.sleep(0.3)
         self._xdotool("key", "Return")
         time.sleep(self._settle_time + 2)
+
+    def _seed_request_cookies(self, url: str) -> None:
+        """Seed cookies from an extra ``Cookie`` request header into the jar.
+
+        ``_open_header_session`` applies ``self._extra_http_headers`` via
+        ``Network.setExtraHTTPHeaders``, but Chromium's network service drops a
+        manually-set ``Cookie`` header from that path (it composes the request
+        ``Cookie`` from the cookie store, not from extra headers) while honoring
+        the custom ``x-daytona-*`` headers in the same dict. That divergence is
+        why the Daytona preview-warning bypass works yet a sim-env consent
+        cookie (e.g. ``bt_cookie_consent``) never reaches the server, so its
+        cookie-gated banner renders and ``ClaudeExtractor.find_all_listings``
+        reads the full-page overlay as ``page_blocked``. ``Network.setCookie``
+        puts the cookie in the real jar for ``url``'s host, where the network
+        stack *does* send it. No-op unless a ``Cookie`` header is present and
+        ``url`` is http(s) — so non-sim-env runs are unaffected.
+        """
+        headers = getattr(self, "_extra_http_headers", None) or {}
+        cookie_header = next(
+            (v for k, v in headers.items() if k.lower() == "cookie"), ""
+        )
+        if not cookie_header or not url.startswith(("http://", "https://")):
+            return
+        for pair in cookie_header.split(";"):
+            name, _, value = pair.strip().partition("=")
+            if name:
+                self._cdp_call(
+                    "Network.setCookie",
+                    {"url": url, "name": name, "value": value.strip()},
+                )
 
     def _type_into_omnibox(self, url: str) -> None:
         """Type ``url`` into the currently-focused omnibox via xclip

--- a/src/mantis_agent/learning/substrates/exemplar.py
+++ b/src/mantis_agent/learning/substrates/exemplar.py
@@ -32,6 +32,7 @@ import json
 import logging
 from pathlib import Path
 
+from ...gym.exemplar_memory import apply_exemplar_overlay
 from ...gym.trace_labeller import TraceLabeller
 from .base import Durability, SubstrateContext, SubstrateResult
 
@@ -124,6 +125,19 @@ class ExemplarSubstrate:
             )
 
         exemplars = self._ensure_index().get(plan_signature, [])[: self.max_exemplars]
+
+        # Mirror RetrievalSubstrate (S0): when the live plan rides in the
+        # context, stamp the worked procedure onto its matching steps so
+        # the brain actually consumes the exemplar. ``plan`` is absent in a
+        # pure cost-probe (cost_estimate path), present when the allocator
+        # truly applies this rung — same contract S0 uses for ``apply``.
+        overlaid = 0
+        plan = context.extras.get("plan")
+        if plan is not None and exemplars:
+            overlaid = apply_exemplar_overlay(
+                plan, exemplars, plan_signature=plan_signature,
+            )
+
         return SubstrateResult(
             substrate=self.name,
             applied=bool(exemplars),
@@ -131,10 +145,12 @@ class ExemplarSubstrate:
             durability=self.durability,
             delta_artifacts={
                 "exemplars": exemplars,
+                "exemplars_overlaid": overlaid,
                 "plan_signature": plan_signature,
             },
             notes=(
                 f"replaying {len(exemplars)} positive exemplar(s)"
+                f" ({overlaid} stamped onto the plan)"
                 if exemplars
                 else "no positive exemplars for this plan"
             ),

--- a/tests/learning/test_exemplar_substrate.py
+++ b/tests/learning/test_exemplar_substrate.py
@@ -179,3 +179,43 @@ def test_corrupt_trace_is_skipped(tmp_path) -> None:
 def test_observe_is_noop(tmp_path) -> None:
     sub = ExemplarSubstrate(tmp_path)
     assert sub.observe(_ctx(), sub.apply(_ctx()), 1.0) is None
+
+
+# ── plan overlay (the runtime-consumption seam) ─────────────────────────
+
+
+def test_apply_overlays_the_plan_when_present(tmp_path) -> None:
+    """When the live plan rides in context.extras, apply() stamps the
+    worked procedure onto matching steps (mirrors RetrievalSubstrate)."""
+    from types import SimpleNamespace
+
+    _write(tmp_path, _trace(
+        PLAN_SIG, run_id="run1",
+        steps=[_positive(0, intent="apply used filter")],
+    ))
+    sub = ExemplarSubstrate(tmp_path)
+    step = SimpleNamespace(intent="apply used filter", type="click", params={}, hints={})
+    plan = SimpleNamespace(steps=[step])
+
+    res = sub.apply(SubstrateContext(
+        task_id="BT01",
+        extras={"plan_signature": PLAN_SIG, "plan": plan},
+    ))
+
+    assert res.applied is True
+    assert res.delta_artifacts["exemplars_overlaid"] == 1
+    assert "exemplar_replay" in step.hints
+    assert step.hints["exemplar_source_run"] == "run1"
+
+
+def test_apply_without_plan_still_returns_exemplars(tmp_path) -> None:
+    """Cost-probe path (no plan in extras) — exemplars are returned but
+    nothing is overlaid. Backward-compatible with the pre-seam contract."""
+    _write(tmp_path, _trace(PLAN_SIG, run_id="run1", steps=[_positive(0)]))
+    sub = ExemplarSubstrate(tmp_path)
+
+    res = sub.apply(_ctx())
+
+    assert res.applied is True
+    assert res.delta_artifacts["exemplars_overlaid"] == 0
+    assert len(res.delta_artifacts["exemplars"]) == 1

--- a/tests/learning/test_live_runner.py
+++ b/tests/learning/test_live_runner.py
@@ -552,6 +552,60 @@ def test_incremental_writer_handles_skipped_outcome(tmp_path: Path) -> None:
     assert row[-2] == "True"  # skipped column
 
 
+# ── --exemplars loader (S1 backing) ──────────────────────────────────────
+
+
+def test_load_exemplars_empty_path_returns_empty() -> None:
+    # No --exemplars ⇒ S1 is a no-op (attributable in the logs), not an error.
+    assert live_runner._load_exemplars("") == []
+
+
+def test_load_exemplars_reads_json_list(tmp_path: Path) -> None:
+    p = tmp_path / "ex.json"
+    p.write_text(json.dumps([{"type": "submit", "intent": "reveal phone"}]))
+    assert live_runner._load_exemplars(str(p)) == [
+        {"type": "submit", "intent": "reveal phone"},
+    ]
+
+
+def test_load_exemplars_rejects_non_list(tmp_path: Path) -> None:
+    # A malformed file must fail loudly — a silent [] makes S1 look like frozen
+    # and voids the comparison.
+    p = tmp_path / "ex.json"
+    p.write_text(json.dumps({"type": "submit"}))
+    with pytest.raises(ValueError, match="expected a JSON list"):
+        live_runner._load_exemplars(str(p))
+
+
+def test_committed_bt03_exemplar_matches_reveal_not_lead_submit() -> None:
+    """The shipped BT03 exemplar must out-match the *reveal* submit step over
+    the *lead* submit step, or S1 stamps the wrong sub-goal. Guards the file
+    against an edit that drifts its intent tokens (matching is type + overlap).
+    """
+    from mantis_agent.gym.exemplar_memory import _tokens
+
+    path = (
+        Path(live_runner.__file__).resolve().parent
+        / "eval" / "bt03_byowner_exemplar.json"
+    )
+    exemplars = live_runner._load_exemplars(str(path))
+    assert len(exemplars) == 1
+    ex = exemplars[0]
+    assert ex["type"] == "submit"  # the decomposed reveal step is a `submit`
+    ex_tok = _tokens(ex["intent"])
+    reveal_tok = _tokens(
+        "Click the Show Phone Number button in the Contact Private Seller "
+        "area to reveal the seller phone"
+    )
+    lead_tok = _tokens(
+        "Click the Contact Seller submit button on the Contact Private "
+        "Seller form"
+    )
+    assert len(ex_tok & reveal_tok) > len(ex_tok & lead_tok), (
+        "exemplar must overlap the reveal step more than the lead-submit step"
+    )
+
+
 # ── main() preflight ─────────────────────────────────────────────────────
 
 

--- a/tests/learning/test_live_runner.py
+++ b/tests/learning/test_live_runner.py
@@ -91,7 +91,7 @@ def _fake_cost(profile_id: str, workflow_id: str) -> tuple[float, str]:  # noqa:
 def _plan_file(tmp_path: Path) -> Path:
     p = tmp_path / "plan.txt"
     p.write_text(
-        "Navigate to {env_url}/boats/.\n"
+        "Navigate to {env_url}/boats/state-{state_code}/by-owner/.\n"
         "Search boats near {zip_code} within {search_radius} miles.\n",
     )
     return p
@@ -362,6 +362,8 @@ def test_plan_decomposed_once_with_substituted_placeholders(
     assert len(decomposer.texts) == 1
     text = decomposer.texts[0]
     assert "33131" in text  # {zip_code} filled
+    assert "state-fl/by-owner" in text  # {state_code} filled (was URL-encoded %7B..%7D)
+    assert "{state_code}" not in text
     assert "https://sim.example/env" in text  # {env_url} points the nav at the sim env
     assert "{env_url}" not in text
     # Each submit gets a fresh workflow_id.
@@ -604,6 +606,46 @@ def test_committed_bt03_exemplar_matches_reveal_not_lead_submit() -> None:
     assert len(ex_tok & reveal_tok) > len(ex_tok & lead_tok), (
         "exemplar must overlap the reveal step more than the lead-submit step"
     )
+
+
+# ── _default_pull_cost: race-safe volume read ────────────────────────────
+
+
+def test_pull_cost_retries_until_file_appears(monkeypatch) -> None:
+    # The cost file is flushed a beat after the run reports terminal, so the
+    # first `volume get` misses. A one-shot read would record $0.00 (and zero
+    # the λ·dollars penalty); the retry must keep going until it lands.
+    calls = {"n": 0}
+    payload = {"totals": {"cost_usd": 0.24}, "outcome": {"halt_reason": "budget_cap"}}
+
+    def fake_run(argv, **kwargs):  # noqa: ANN001, ANN003
+        calls["n"] += 1
+        if calls["n"] >= 2:  # miss on attempt 1, land on attempt 2
+            Path(argv[7]).write_text(json.dumps(payload))
+
+    monkeypatch.setattr(live_runner.subprocess, "run", fake_run)
+    monkeypatch.setattr(live_runner.time, "sleep", lambda *_: None)
+
+    cost, halt = live_runner._default_pull_cost("prof", "wf")
+
+    assert calls["n"] == 2
+    assert cost == 0.24
+    assert halt == "budget_cap"
+
+
+def test_pull_cost_warns_and_returns_zero_on_ultimate_miss(monkeypatch, capsys) -> None:
+    # If the file never appears, the silent path must NOT stay silent — emit a
+    # stderr WARNING so an understated reward is attributable, not invisible.
+    monkeypatch.setattr(live_runner.subprocess, "run", lambda *a, **k: None)
+    monkeypatch.setattr(live_runner.time, "sleep", lambda *_: None)
+    monkeypatch.setattr(live_runner, "_COST_PULL_DEADLINE_S", 0.0)
+
+    cost, halt = live_runner._default_pull_cost("prof", "wf")
+
+    assert (cost, halt) == (0.0, "")
+    err = capsys.readouterr().err
+    assert "WARNING" in err
+    assert "prof" in err and "wf" in err
 
 
 # ── main() preflight ─────────────────────────────────────────────────────

--- a/tests/learning/test_live_runner.py
+++ b/tests/learning/test_live_runner.py
@@ -145,6 +145,28 @@ def test_s0_binds_shared_hint_dict(tmp_path: Path) -> None:
     assert "_hint_store_disabled" not in suite
 
 
+def test_s1_ships_exemplars_and_freezes_s0(tmp_path: Path) -> None:
+    # S1's lift must be attributable to the exemplar replay alone, so the S0
+    # anchor store is frozen while the worked steps ride along.
+    run = _make(tmp_path, FakePoster(), FakeDecomposer())
+    run.exemplars = [{"intent": "reveal phone", "type": "click"}]
+    suite: dict = {}
+    run._apply_substrate(suite, "S1_exemplar")
+    assert suite["_hint_store_disabled"] is True
+    assert suite["_exemplars"] == [{"intent": "reveal phone", "type": "click"}]
+    assert "_hint_store_dict_name" not in suite
+
+
+def test_s1_without_exemplars_omits_suite_key(tmp_path: Path) -> None:
+    # No pre-extracted exemplars ⇒ no _exemplars key (the remote overlay is a
+    # no-op), but S0 still frozen so the rung stays isolated.
+    run = _make(tmp_path, FakePoster(), FakeDecomposer())
+    suite: dict = {}
+    run._apply_substrate(suite, "S1_exemplar")
+    assert suite["_hint_store_disabled"] is True
+    assert "_exemplars" not in suite
+
+
 # ── end-to-end __call__ (faked I/O) ──────────────────────────────────────
 
 

--- a/tests/sim_envs/mantis_boattrader/test_bt03_reveal_drift.py
+++ b/tests/sim_envs/mantis_boattrader/test_bt03_reveal_drift.py
@@ -1,0 +1,114 @@
+"""The BT03 reveal-drift fixture must create a frozen-vs-S1 discriminator.
+
+BT03 (by-owner phone reveal) only separates a frozen agent from an S1-exemplar
+agent if revealing a private seller's phone is *not* the obvious move. The stock
+private-seller card pairs a prominent "Contact Seller" lead form with an explicit
+"Show Phone Number" button — a frozen agent clicks that button for free and the
+discriminator collapses. ``seed._apply_byowner_reveal_drift`` flags every owner
+listing so the detail page renders the reveal control de-emphasised + relabelled
+(no "phone" keyword); a frozen agent then favours the lead form (recall miss)
+while an S1 worked-reveal exemplar re-finds the control by its action.
+
+These tests pin the fixture's data shape (the flag lands only on owner boats, the
+gate toggles it, it's deterministic, the reveal target survives) and prove the
+rendered detail page actually drifts — without ever asserting a per-seed boat id.
+"""
+
+from __future__ import annotations
+
+
+def _build(monkeypatch, *, drift: bool):
+    """Fresh ``seed.build()`` with the reveal-drift gate forced on/off."""
+    from app import seed  # noqa: PLC0415
+
+    monkeypatch.setenv("BT03_REVEAL_DRIFT", "1" if drift else "0")
+    return seed.build()["boats"]
+
+
+# ── fixture data shape ───────────────────────────────────────────────────
+
+
+def test_drift_flags_every_owner_and_only_owners(monkeypatch):
+    """Gate-on flags exactly the owner listings — the reveal control only exists
+    on owner cards, so flagging a dealer/sponsored boat would be dead collateral."""
+    boats = _build(monkeypatch, drift=True)
+    owners = [b for b in boats if b.is_owner_listed]
+    assert owners, "seed produced zero owner listings"
+    assert all(b.reveal_drift for b in owners), "an owner listing was left undrifted"
+    assert not any(b.reveal_drift for b in boats if not b.is_owner_listed), (
+        "a non-owner boat was flagged for reveal drift"
+    )
+
+
+def test_gate_off_leaves_no_drift(monkeypatch):
+    """``BT03_REVEAL_DRIFT=0`` is a clean off-switch: nothing is flagged and the
+    stock "Show Phone Number" layout renders for every owner listing."""
+    boats = _build(monkeypatch, drift=False)
+    assert any(b.is_owner_listed for b in boats), "seed produced zero owner listings"
+    assert not any(b.reveal_drift for b in boats), "gate-off should flag nothing"
+
+
+def test_drift_preserves_reveal_target(monkeypatch):
+    """The drift changes how the reveal control *looks*, never whether there is a
+    phone to reveal — every flagged owner must still carry ``owner_phone``."""
+    flagged = [b for b in _build(monkeypatch, drift=True) if b.reveal_drift]
+    assert flagged, "no owner listings were flagged"
+    assert all(b.owner_phone for b in flagged), "a drifted owner lost its phone"
+
+
+def test_drift_is_deterministic(monkeypatch):
+    """Same seed → same flagged id set (the pass must not depend on iteration
+    order), so the discriminator is reproducible across runs."""
+    a = {b.id for b in _build(monkeypatch, drift=True) if b.reveal_drift}
+    b = {x.id for x in _build(monkeypatch, drift=True) if x.reveal_drift}
+    assert a and a == b, f"non-deterministic drift set ({len(a)} vs {len(b)})"
+
+
+def test_bt03_qualifying_set_unchanged(monkeypatch):
+    """The BT03 oracle grades by-owner reveals; its qualifying owner-id set must
+    be identical gate-on vs gate-off — the flag never touches ``listing_type``."""
+    on = {b.id for b in _build(monkeypatch, drift=True) if b.is_owner_listed}
+    off = {b.id for b in _build(monkeypatch, drift=False) if b.is_owner_listed}
+    assert on and on == off, "reveal drift perturbed BT03's qualifying set"
+
+
+# ── rendered layout drift (TestClient) ───────────────────────────────────
+
+
+def _client():
+    from fastapi.testclient import TestClient  # noqa: PLC0415
+
+    from app.main import create_app  # noqa: PLC0415
+
+    return TestClient(create_app())
+
+
+def _an_owner_slug(monkeypatch, *, drift: bool) -> str:
+    owners = [b for b in _build(monkeypatch, drift=drift) if b.is_owner_listed]
+    assert owners, "no owner listing to render"
+    return owners[0].slug
+
+
+def test_drifted_owner_page_hides_phone_label(monkeypatch):
+    """Gate-on: the reveal endpoint + testid survive (mechanism + oracle mutation
+    unchanged) but the phone-labelled affordance is replaced by a muted link —
+    that relabel is what makes a frozen agent mis-target the lead form."""
+    slug = _an_owner_slug(monkeypatch, drift=True)
+    with _client() as c:
+        html = c.get(f"/boat/{slug}/").text
+    assert 'data-testid="private-seller-card"' in html, "not an owner detail page"
+    assert 'data-testid="show-phone-btn"' in html
+    assert f"/boat/{slug}/show-phone" in html
+    assert "Show Phone Number" not in html
+    assert "View seller details" in html
+
+
+def test_stock_owner_page_shows_phone_label(monkeypatch):
+    """Gate-off: the owner detail page renders the explicit "Show Phone Number"
+    button — the easy path a frozen agent takes for free."""
+    slug = _an_owner_slug(monkeypatch, drift=False)
+    with _client() as c:
+        html = c.get(f"/boat/{slug}/").text
+    assert 'data-testid="private-seller-card"' in html
+    assert "Show Phone Number" in html
+    assert "View seller details" not in html

--- a/tests/sim_envs/mantis_boattrader/test_bt03_reveal_drift.py
+++ b/tests/sim_envs/mantis_boattrader/test_bt03_reveal_drift.py
@@ -4,10 +4,19 @@ BT03 (by-owner phone reveal) only separates a frozen agent from an S1-exemplar
 agent if revealing a private seller's phone is *not* the obvious move. The stock
 private-seller card pairs a prominent "Contact Seller" lead form with an explicit
 "Show Phone Number" button — a frozen agent clicks that button for free and the
-discriminator collapses. ``seed._apply_byowner_reveal_drift`` flags every owner
-listing so the detail page renders the reveal control de-emphasised + relabelled
-(no "phone" keyword); a frozen agent then favours the lead form (recall miss)
-while an S1 worked-reveal exemplar re-finds the control by its action.
+discriminator collapses.
+
+``seed._apply_byowner_reveal_drift`` flags every owner listing so the detail page
+runs the *action-omission* drift: it shows a masked teaser of the number inline,
+so the contact reads as already-populated. A frozen agent grabs the visible
+number and (per the plan's "reveal the phone if not already") omits the reveal
+click — a recall miss — while an S1 worked-reveal exemplar, primed that a click
+makes the FULL number appear (which the masked teaser does not satisfy), re-finds
+the reveal control by its action and fires it. The reveal target stays findable by
+its phone meaning; only the verbatim "Show Phone Number" label drops. (An earlier
+*relabel* variant — "View seller details" — was a target-identification failure
+that a live matrix showed defeats both arms equally, since the S1 exemplar is
+target-less by design.)
 
 These tests pin the fixture's data shape (the flag lands only on owner boats, the
 gate toggles it, it's deterministic, the reveal target survives) and prove the
@@ -89,26 +98,35 @@ def _an_owner_slug(monkeypatch, *, drift: bool) -> str:
     return owners[0].slug
 
 
-def test_drifted_owner_page_hides_phone_label(monkeypatch):
-    """Gate-on: the reveal endpoint + testid survive (mechanism + oracle mutation
-    unchanged) but the phone-labelled affordance is replaced by a muted link —
-    that relabel is what makes a frozen agent mis-target the lead form."""
+def test_drifted_owner_page_shows_inline_decoy_keeps_reveal(monkeypatch):
+    """Gate-on (action-omission): a masked teaser of the number renders inline so
+    the contact reads as already-populated, while the reveal endpoint + testid
+    survive (mechanism + oracle mutation unchanged) behind a muted, non-verbatim
+    control. The inline decoy is the reason a frozen agent omits the reveal; the
+    surviving control is what an S1 exemplar re-finds and fires."""
     slug = _an_owner_slug(monkeypatch, drift=True)
     with _client() as c:
         html = c.get(f"/boat/{slug}/").text
     assert 'data-testid="private-seller-card"' in html, "not an owner detail page"
+    # The inline masked teaser — deterministic mask infix, no per-seed digits.
+    assert 'data-testid="seller-phone-inline"' in html
+    assert ") •••-••" in html
+    # The reveal mechanism the oracle grades survives, relabelled + de-emphasised.
     assert 'data-testid="show-phone-btn"' in html
     assert f"/boat/{slug}/show-phone" in html
+    assert "Show full number" in html
+    # Neither the verbatim plan label nor the failed relabel variant is present.
     assert "Show Phone Number" not in html
-    assert "View seller details" in html
+    assert "View seller details" not in html
 
 
 def test_stock_owner_page_shows_phone_label(monkeypatch):
     """Gate-off: the owner detail page renders the explicit "Show Phone Number"
-    button — the easy path a frozen agent takes for free."""
+    button with no inline decoy — the easy path a frozen agent takes for free."""
     slug = _an_owner_slug(monkeypatch, drift=False)
     with _client() as c:
         html = c.get(f"/boat/{slug}/").text
     assert 'data-testid="private-seller-card"' in html
     assert "Show Phone Number" in html
     assert "View seller details" not in html
+    assert 'data-testid="seller-phone-inline"' not in html

--- a/tests/sim_envs/mantis_boattrader/test_bt03_reveal_drift.py
+++ b/tests/sim_envs/mantis_boattrader/test_bt03_reveal_drift.py
@@ -11,12 +11,14 @@ runs the *action-omission* drift: it shows a masked teaser of the number inline,
 so the contact reads as already-populated. A frozen agent grabs the visible
 number and (per the plan's "reveal the phone if not already") omits the reveal
 click — a recall miss — while an S1 worked-reveal exemplar, primed that a click
-makes the FULL number appear (which the masked teaser does not satisfy), re-finds
-the reveal control by its action and fires it. The reveal target stays findable by
-its phone meaning; only the verbatim "Show Phone Number" label drops. (An earlier
-*relabel* variant — "View seller details" — was a target-identification failure
-that a live matrix showed defeats both arms equally, since the S1 exemplar is
-target-less by design.)
+makes the FULL number appear (which the masked teaser does not satisfy), still
+seeks out the reveal control and fires it. The reveal target keeps the verbatim
+"Show Phone Number" label (matching the plan + exemplar); the *only* drift is the
+inline masked teaser plus de-emphasised (muted-link) styling. The lever is recall,
+not target-identification. (Two earlier *relabel* variants — "View seller details"
+and "Show full number" — each dropped the label and each made a live matrix
+collapse, defeating BOTH arms equally: the S1 exemplar replays an action, not a
+label, so a relabel it can't ground breaks S1 just as it breaks frozen.)
 
 These tests pin the fixture's data shape (the flag lands only on owner boats, the
 gate toggles it, it's deterministic, the reveal target survives) and prove the
@@ -101,9 +103,9 @@ def _an_owner_slug(monkeypatch, *, drift: bool) -> str:
 def test_drifted_owner_page_shows_inline_decoy_keeps_reveal(monkeypatch):
     """Gate-on (action-omission): a masked teaser of the number renders inline so
     the contact reads as already-populated, while the reveal endpoint + testid
-    survive (mechanism + oracle mutation unchanged) behind a muted, non-verbatim
-    control. The inline decoy is the reason a frozen agent omits the reveal; the
-    surviving control is what an S1 exemplar re-finds and fires."""
+    survive (mechanism + oracle mutation unchanged) behind a muted but *verbatim*-
+    labelled control. The inline decoy is the reason a frozen agent omits the
+    reveal; the surviving control is what an S1 exemplar re-finds and fires."""
     slug = _an_owner_slug(monkeypatch, drift=True)
     with _client() as c:
         html = c.get(f"/boat/{slug}/").text
@@ -111,12 +113,15 @@ def test_drifted_owner_page_shows_inline_decoy_keeps_reveal(monkeypatch):
     # The inline masked teaser — deterministic mask infix, no per-seed digits.
     assert 'data-testid="seller-phone-inline"' in html
     assert ") •••-••" in html
-    # The reveal mechanism the oracle grades survives, relabelled + de-emphasised.
+    # The reveal mechanism the oracle grades survives — verbatim label retained,
+    # only the styling is de-emphasised (muted link, not a prominent button), so
+    # grounding is NOT a confound. The lever is purely the teaser + de-emphasis.
     assert 'data-testid="show-phone-btn"' in html
     assert f"/boat/{slug}/show-phone" in html
-    assert "Show full number" in html
-    # Neither the verbatim plan label nor the failed relabel variant is present.
-    assert "Show Phone Number" not in html
+    assert "Show Phone Number" in html
+    assert "bdp-reveal-link" in html
+    # Neither failed relabel variant is present — the label is NOT the lever.
+    assert "Show full number" not in html
     assert "View seller details" not in html
 
 
@@ -130,3 +135,5 @@ def test_stock_owner_page_shows_phone_label(monkeypatch):
     assert "Show Phone Number" in html
     assert "View seller details" not in html
     assert 'data-testid="seller-phone-inline"' not in html
+    # Stock uses the prominent button styling, never the muted drift-link.
+    assert "bdp-reveal-link" not in html

--- a/tests/sim_envs/mantis_boattrader/test_byowner_path_filter.py
+++ b/tests/sim_envs/mantis_boattrader/test_byowner_path_filter.py
@@ -1,0 +1,95 @@
+"""BoatTrader-style ``/boats/<path-filters>/`` routing must resolve, not 404.
+
+Real BoatTrader narrows listings through URL *path* segments
+(``/boats/state-fl/by-owner/``) rather than a querystring, and the
+BT03 by-owner plan was hardened to drive that scheme. The sim env
+originally served only ``/boats/?query`` — so the plan's
+``/boats/state-<code>/by-owner/`` navigation 404'd before the agent
+ever reached an owner detail page, turning a genuine reveal-under-drift
+failure into a navigation artifact.
+
+These tests pin the path-filter route: the by-owner segment selects
+exactly the private-seller listings, the state segment narrows by
+location, a slightly-off ``state-all`` still renders (graceful) instead
+of 404-ing, and the bare ``/boats/`` index is unaffected.
+"""
+
+from __future__ import annotations
+
+import re
+
+
+def _client():
+    from fastapi.testclient import TestClient  # noqa: PLC0415
+
+    from app.main import create_app  # noqa: PLC0415
+
+    return TestClient(create_app())
+
+
+def _slugs(html: str) -> list[str]:
+    return list(dict.fromkeys(re.findall(r"/boat/([a-z0-9\-]+)/", html)))
+
+
+def _listing_types(slugs: list[str]) -> set[str]:
+    from app import db  # noqa: PLC0415
+
+    out: set[str] = set()
+    for sl in slugs:
+        b = db.boat_by_slug(sl)
+        if b is not None:
+            out.add(b.listing_type)
+    return out
+
+
+def test_state_all_by_owner_resolves(monkeypatch):
+    """The exact path the live frozen run hit (``state-all`` → all states,
+    by-owner) must return 200, not the 404 that stranded the agent at step 4."""
+    monkeypatch.setenv("SEED", "42")
+    with _client() as c:
+        r = c.get("/boats/state-all/by-owner/")
+    assert r.status_code == 200, f"state-all/by-owner 404'd again: {r.status_code}"
+    assert _slugs(r.text), "by-owner page rendered no listings"
+
+
+def test_by_owner_returns_only_owner_listings(monkeypatch):
+    """``by-owner`` selects exactly the private-seller listings — a dealer or
+    sponsored card leaking in would let the agent mis-target a non-reveal page."""
+    monkeypatch.setenv("SEED", "42")
+    with _client() as c:
+        slugs = _slugs(c.get("/boats/by-owner/").text)
+    assert slugs, "by-owner page rendered no listings"
+    assert _listing_types(slugs) == {"owner"}, "non-owner listing leaked onto by-owner"
+
+
+def test_by_dealer_excludes_owner_listings(monkeypatch):
+    """The mirror filter: ``by-dealer`` must never surface an owner listing."""
+    monkeypatch.setenv("SEED", "42")
+    with _client() as c:
+        slugs = _slugs(c.get("/boats/by-dealer/").text)
+    assert slugs, "by-dealer page rendered no listings"
+    assert "owner" not in _listing_types(slugs), "owner listing leaked onto by-dealer"
+
+
+def test_state_segment_narrows_by_location(monkeypatch):
+    """``state-fl`` constrains to Florida — the page must carry FL owner boats
+    and no out-of-state listing."""
+    monkeypatch.setenv("SEED", "42")
+    from app import db  # noqa: PLC0415
+
+    with _client() as c:
+        slugs = _slugs(c.get("/boats/state-fl/by-owner/").text)
+    assert slugs, "FL by-owner page rendered no listings"
+    states = {db.boat_by_slug(s).state for s in slugs}
+    assert states == {"FL"}, f"state-fl leaked other states: {states}"
+
+
+def test_bare_boats_index_unaffected(monkeypatch):
+    """The exact ``/boats/`` index must still render the unfiltered catalog
+    (owner + dealer + sponsored) — the path route is declared after it."""
+    monkeypatch.setenv("SEED", "42")
+    with _client() as c:
+        slugs = _slugs(c.get("/boats/").text)
+    assert slugs, "index rendered no listings"
+    # The unfiltered first page should not be owner-only.
+    assert _listing_types(slugs) - {"owner"}, "index collapsed to owner-only"

--- a/tests/test_exemplar_overlay.py
+++ b/tests/test_exemplar_overlay.py
@@ -1,0 +1,226 @@
+"""S1 exemplar injection seam — ``apply_exemplar_overlay``.
+
+The S1 substrate (``learning/substrates/exemplar.py``) indexes positive
+steps from prior runs but, until this seam, nothing *consumed* them at
+runtime — unlike S0, whose ``apply_hint_overlay`` stamps a grounding
+anchor onto the plan. ``apply_exemplar_overlay`` is the S1 parallel: it
+stamps a PROCEDURAL ``exemplar_replay`` hint (the action that worked →
+the outcome it produced) onto the matching step.
+
+CUA purity (``feedback_cua_no_dom_access`` / ``feedback_tab_walk_label_matcher``):
+the injected signal is what WORKED, never a stale coordinate. The brain
+re-grounds the target from the current screenshot — so the hint must not
+leak the exemplar's recorded x/y.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from mantis_agent.gym.exemplar_memory import apply_exemplar_overlay
+
+
+def _step(intent: str, type_: str = "click", hints: dict | None = None):
+    return SimpleNamespace(intent=intent, type=type_, params={}, hints=hints or {})
+
+
+def _exemplar(
+    intent: str,
+    *,
+    type_: str = "click",
+    outcome: str = "phone revealed",
+    action: dict | None = None,
+    source_run: str = "run1",
+) -> dict:
+    # Same shape ExemplarSubstrate.apply() emits in delta_artifacts.
+    return {
+        "intent": intent,
+        "type": type_,
+        "last_action": action if action is not None else {
+            "action_type": "click", "params": {"x": 412, "y": 663},
+        },
+        "observed_outcome": outcome,
+        "label_reason": "success + non-empty outcome",
+        "source_run": source_run,
+    }
+
+
+# ── nothing to do ───────────────────────────────────────────────────────
+
+
+def test_empty_exemplars_stamps_nothing():
+    plan = SimpleNamespace(steps=[_step("reveal phone on owner listing")])
+    assert apply_exemplar_overlay(plan, []) == 0
+    assert plan.steps[0].hints == {}
+
+
+def test_no_steps_is_safe():
+    plan = SimpleNamespace(steps=[])
+    assert apply_exemplar_overlay(plan, [_exemplar("reveal phone")]) == 0
+
+
+# ── matching ────────────────────────────────────────────────────────────
+
+
+def test_matching_exemplar_stamps_replay_hint():
+    step = _step("reveal phone on owner listing")
+    plan = SimpleNamespace(steps=[step])
+
+    n = apply_exemplar_overlay(
+        plan, [_exemplar("reveal phone on owner listing")],
+    )
+
+    assert n == 1
+    assert "exemplar_replay" in step.hints
+    assert step.hints["exemplar_source_run"] == "run1"
+
+
+def test_replay_hint_is_procedural_action_and_outcome():
+    step = _step("reveal phone on owner listing")
+    plan = SimpleNamespace(steps=[step])
+    apply_exemplar_overlay(plan, [_exemplar("reveal phone on owner listing")])
+
+    replay = step.hints["exemplar_replay"].lower()
+    assert "click" in replay              # the action_type that worked
+    assert "phone revealed" in replay     # the outcome it produced
+
+
+def test_replay_hint_never_leaks_coordinates():
+    """CUA purity: the worked-step's recorded x/y must NOT appear in the
+    injected hint. S1 conveys the procedure; the brain re-grounds by sight."""
+    step = _step("reveal phone on owner listing")
+    plan = SimpleNamespace(steps=[step])
+    apply_exemplar_overlay(
+        plan,
+        [_exemplar(
+            "reveal phone on owner listing",
+            action={"action_type": "click", "params": {"x": 412, "y": 663}},
+        )],
+    )
+    replay = step.hints["exemplar_replay"]
+    assert "412" not in replay
+    assert "663" not in replay
+
+
+def test_type_mismatch_does_not_match():
+    step = _step("reveal phone on owner listing", type_="extract_data")
+    plan = SimpleNamespace(steps=[step])
+
+    n = apply_exemplar_overlay(
+        plan, [_exemplar("reveal phone on owner listing", type_="click")],
+    )
+
+    assert n == 0
+    assert "exemplar_replay" not in step.hints
+
+
+def test_no_intent_overlap_does_not_match():
+    step = _step("apply length filter")
+    plan = SimpleNamespace(steps=[step])
+
+    n = apply_exemplar_overlay(
+        plan, [_exemplar("reveal phone on owner listing")],
+    )
+
+    assert n == 0
+    assert "exemplar_replay" not in step.hints
+
+
+def test_best_intent_overlap_wins():
+    step = _step("reveal phone on owner listing")
+    plan = SimpleNamespace(steps=[step])
+    weak = _exemplar("reveal something", outcome="weak", source_run="weak")
+    strong = _exemplar(
+        "reveal phone on owner listing", outcome="phone revealed", source_run="strong",
+    )
+
+    apply_exemplar_overlay(plan, [weak, strong])
+
+    assert step.hints["exemplar_source_run"] == "strong"
+    assert "phone revealed" in step.hints["exemplar_replay"].lower()
+
+
+def test_each_step_gets_its_own_match():
+    s1 = _step("apply used filter")
+    s2 = _step("reveal phone on owner listing")
+    plan = SimpleNamespace(steps=[s1, s2])
+
+    n = apply_exemplar_overlay(plan, [
+        _exemplar("apply used filter", outcome="filter applied", source_run="a"),
+        _exemplar("reveal phone on owner listing", outcome="phone revealed", source_run="b"),
+    ])
+
+    assert n == 2
+    assert s1.hints["exemplar_source_run"] == "a"
+    assert s2.hints["exemplar_source_run"] == "b"
+
+
+# ── author hints win ────────────────────────────────────────────────────
+
+
+def test_existing_replay_hint_not_overwritten():
+    step = _step(
+        "reveal phone on owner listing",
+        hints={"exemplar_replay": "operator override"},
+    )
+    plan = SimpleNamespace(steps=[step])
+
+    n = apply_exemplar_overlay(
+        plan, [_exemplar("reveal phone on owner listing")],
+    )
+
+    assert n == 0
+    assert step.hints["exemplar_replay"] == "operator override"
+
+
+def test_preserves_unrelated_hints():
+    step = _step("reveal phone on owner listing", hints={"region": "card"})
+    plan = SimpleNamespace(steps=[step])
+    apply_exemplar_overlay(plan, [_exemplar("reveal phone on owner listing")])
+    assert step.hints["region"] == "card"
+    assert "exemplar_replay" in step.hints
+
+
+# ── outcome-less exemplar still injects the action ──────────────────────
+
+
+def test_outcome_less_exemplar_still_stamps_action():
+    step = _step("reveal phone on owner listing")
+    plan = SimpleNamespace(steps=[step])
+    apply_exemplar_overlay(
+        plan, [_exemplar("reveal phone on owner listing", outcome="")],
+    )
+    assert "exemplar_replay" in step.hints
+    assert "click" in step.hints["exemplar_replay"].lower()
+
+
+# ── brain surfacing (holo3 prompt) ──────────────────────────────────────
+
+
+def test_holo3_prompt_surfaces_exemplar_replay():
+    """The stamped ``exemplar_replay`` must reach the brain prompt as a
+    'Worked example' section, with the don't-reuse-coordinates guardrail."""
+    from mantis_agent.gym.step_handlers.holo3 import _build_scoped_task
+
+    step = _step(
+        "reveal phone on owner listing",
+        hints={
+            "exemplar_replay": "a click produced 'phone revealed'",
+            "exemplar_source_run": "run42",
+        },
+    )
+    prompt = _build_scoped_task(step, SimpleNamespace(), step_index=0)
+
+    assert "Worked example" in prompt
+    assert "a click produced 'phone revealed'" in prompt
+    assert "run42" in prompt
+    # CUA guardrail — the brain must re-ground by sight, not replay coords.
+    assert "do NOT reuse old coordinates" in prompt
+
+
+def test_holo3_prompt_omits_section_when_no_exemplar():
+    from mantis_agent.gym.step_handlers.holo3 import _build_scoped_task
+
+    step = _step("reveal phone on owner listing")
+    prompt = _build_scoped_task(step, SimpleNamespace(), step_index=0)
+    assert "Worked example" not in prompt

--- a/tests/test_xdotool_env_navigate.py
+++ b/tests/test_xdotool_env_navigate.py
@@ -194,6 +194,68 @@ def test_type_into_omnibox_xdotool_fallback_when_xclip_unavailable(
     assert "https://example.com" in type_calls[0]
 
 
+def test_navigate_seeds_cookie_header_into_jar_before_page_navigate(
+    env_with_cdp_recorder,
+) -> None:
+    """A ``Cookie`` extra-header is seeded via ``Network.setCookie`` *before*
+    ``Page.navigate``.
+
+    ``Network.setExtraHTTPHeaders`` silently drops a manually-set ``Cookie``
+    header, so a sim-env consent cookie never reaches the server and its
+    banner renders (read as ``page_blocked`` by ``find_all_listings``).
+    Putting the cookie in the real jar — scoped to the target URL, and set
+    before the navigation so the first load carries it — fixes that.
+    """
+    env, cdp_calls = env_with_cdp_recorder
+    env._extra_http_headers = {  # type: ignore[attr-defined]
+        "x-daytona-preview-token": "tok",
+        "Cookie": "bt_cookie_consent=decline",
+    }
+
+    env._navigate_running_browser("https://8080-abc.daytonaproxy01.net/boats")
+
+    # setCookie must precede Page.navigate (jar populated before the load).
+    assert cdp_calls[0][0] == "Network.setCookie"
+    assert cdp_calls[0][1] == {
+        "url": "https://8080-abc.daytonaproxy01.net/boats",
+        "name": "bt_cookie_consent",
+        "value": "decline",
+    }
+    assert cdp_calls[1][0] == "Page.navigate"
+
+
+def test_navigate_seeds_every_cookie_in_a_multi_value_header(
+    env_with_cdp_recorder,
+) -> None:
+    """A multi-cookie header yields one ``Network.setCookie`` per pair."""
+    env, cdp_calls = env_with_cdp_recorder
+    env._extra_http_headers = {  # type: ignore[attr-defined]
+        "Cookie": "bt_cookie_consent=decline; session=xyz",
+    }
+
+    env._navigate_running_browser("https://example.com/")
+
+    set_cookies = [p for m, p in cdp_calls if m == "Network.setCookie"]
+    assert {c["name"]: c["value"] for c in set_cookies} == {
+        "bt_cookie_consent": "decline",
+        "session": "xyz",
+    }
+
+
+def test_navigate_without_cookie_header_skips_setcookie(
+    env_with_cdp_recorder,
+) -> None:
+    """No ``Cookie`` header → no ``Network.setCookie`` (non-sim-env runs are
+    unaffected; only ``Page.navigate`` fires)."""
+    env, cdp_calls = env_with_cdp_recorder
+    env._extra_http_headers = {"x-daytona-preview-token": "tok"}  # type: ignore[attr-defined]
+
+    env._navigate_running_browser("https://example.com/page")
+
+    assert all(method != "Network.setCookie" for method, _ in cdp_calls)
+    assert cdp_calls[0][0] == "Page.navigate"
+
+
 def test_navigate_running_browser_empty_url_is_noop(env_with_cdp_recorder) -> None:
     """Defensive: empty URL must not call Page.navigate (would 400)."""
     env, cdp_calls = env_with_cdp_recorder

--- a/uv.lock
+++ b/uv.lock
@@ -1478,6 +1478,7 @@ client = [
 ]
 dev = [
     { name = "httpx" },
+    { name = "jinja2" },
     { name = "jsonschema" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -1558,6 +1559,7 @@ requires-dist = [
     { name = "fastapi", marker = "extra == 'viewer'", specifier = ">=0.100" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.24" },
     { name = "hud-python", marker = "extra == 'hud'", specifier = ">=0.5.34" },
+    { name = "jinja2", marker = "extra == 'dev'", specifier = ">=3.0" },
     { name = "jsonschema", marker = "extra == 'dev'", specifier = ">=4.0" },
     { name = "mantis-agent", extras = ["orchestrator", "server", "local-cua", "viewer", "gpu", "hud", "observability"], marker = "extra == 'full'" },
     { name = "mkdocs", marker = "extra == 'docs'", specifier = ">=1.6" },


### PR DESCRIPTION
## Summary
Lands the S1 exemplar-replay consumption seam and the BT03 reveal-drift experiment, plus three fixes surfaced while running it live.

- **S1 exemplar-replay seam** — `apply_exemplar_overlay` injection, `ExemplarSubstrate.apply` plan mutation + brain surfacing, and `live_runner` + Modal server wiring (target-less "what worked" replay).
- **BT03 reveal-drift fixture** — by-owner phone-reveal drift (`BT03_REVEAL_DRIFT`) with a masked inline teaser + verbatim "Show Phone Number" reveal control, oracle on the `phone_revealed` mutation, and by-owner path filters.
- **cost-meter race fix** — `_default_pull_cost` now retries on a bounded deadline instead of recording a silent `$0.00` when the cost file is still flushing (which zeroed the λ·dollars reward penalty). +2 regression tests.
- **cookie-seed before navigate** — seed `Cookie`-header cookies into the jar via `Network.setCookie` so a sim-env consent cookie reaches the server (else its banner reads as `page_blocked`). +3 tests.
- **jinja2 dev dep** — declares the dep the boattrader app's `Jinja2Templates` use needs; fixes the failing CI shard.

## Result note (BT03 discriminator)
The reveal-drift was designed so a frozen agent omits the reveal and S1 re-fires it. Live de-confounded verification (verbatim label) showed **frozen FIRES the verbatim reveal** (oracle 1.0) — so the discriminator's necessary "frozen omits" precondition fails, and BT03-as-single-screen-reveal does **not** separate frozen from S1. The seam + fixture land as reusable infrastructure and a documented negative result, not as a working discriminator.

## Test plan
- [x] tests/learning/, tests/sim_envs/mantis_boattrader/, xdotool navigate tests green locally (293 passed)
- [ ] CI green on all shards