### PR TITLE
fix(step-recovery): scroll already at document bottom counts as success

### DIFF
--- a/src/mantis_agent/gym/step_recovery.py
+++ b/src/mantis_agent/gym/step_recovery.py
@@ -313,6 +313,31 @@ class StepRecoveryPolicy:
                         except Exception:
                             return -1.0  # sentinel — can't read
 
+                    def _read_dist_from_bottom() -> float:
+                        # px between the current scroll position and the
+                        # document bottom. 0 (≤ tol) ⇒ already at the
+                        # bottom; large ⇒ real content still below the
+                        # fold. Same provenance carve-out as _read_scroll_y:
+                        # this is post-action verification of layout
+                        # metrics to decide whether the plan's
+                        # "scroll to bottom" intent is *already satisfied*,
+                        # not DOM-derived grounding of a click target
+                        # (feedback_cua_no_dom_access.md). -1.0 = can't read.
+                        try:
+                            v = cdp_eval(
+                                "(function(){"
+                                "var se=document.scrollingElement"
+                                "||document.documentElement;"
+                                "var y=window.scrollY||se.scrollTop||0;"
+                                "var ih=window.innerHeight||0;"
+                                "var sh=se.scrollHeight"
+                                "||document.body.scrollHeight||0;"
+                                "return Math.max(0, sh-(y+ih));})()"
+                            )
+                            return float(v) if v is not None else -1.0
+                        except Exception:
+                            return -1.0  # sentinel — can't read
+
                     pre_y = _read_scroll_y()
                     # Multi-prong scroll dispatch — covers three
                     # browser scroll mechanisms in one CDP call so we
@@ -370,11 +395,41 @@ class StepRecoveryPolicy:
                                 halt=False, step_index=step_index + 1,
                                 halt_reason="scroll_cdp_fallback",
                             )
+                        # Δ<50px is ambiguous: either (a) we're already at
+                        # the document bottom — the plan's "scroll to
+                        # bottom" intent is *satisfied*, there's simply
+                        # nowhere further to go, so advancing is correct;
+                        # or (b) an overflow:hidden / sub-element scroller
+                        # ate the event and real content still sits below
+                        # the fold — a genuine failure that should keep
+                        # burning the retry budget. Disambiguate via the
+                        # document's own scroll metrics: scrollY+innerHeight
+                        # within tol of scrollHeight ⇒ case (a). Without
+                        # this, a required scroll-to-bottom step on a page
+                        # shorter than the brain expects (e.g. BoatTrader
+                        # by-owner detail pages) halts the whole run one
+                        # step short of the reveal it was scrolling toward.
+                        AT_BOTTOM_TOL = 96.0
+                        dist = _read_dist_from_bottom()
+                        if 0.0 <= dist <= AT_BOTTOM_TOL:
+                            logger_.warning(
+                                f"  [{step_index}] scroll brain_loop_exhausted "
+                                f"x{attempt} — CDP fallback fired, scrollY "
+                                f"{pre_y:.0f} → {post_y:.0f} (Δ<50px) but "
+                                f"document bottom is {dist:.0f}px away "
+                                f"(≤{AT_BOTTOM_TOL:.0f}px tol); scroll-to-bottom "
+                                f"intent satisfied, advancing"
+                            )
+                            return RecoveryOutcome(
+                                halt=False, step_index=step_index + 1,
+                                halt_reason="scroll_reached_bottom",
+                            )
                         logger_.warning(
                             f"  [{step_index}] scroll brain_loop_exhausted "
                             f"x{attempt} — CDP fallback fired but scrollY "
-                            f"{pre_y:.0f} → {post_y:.0f} (Δ<50px; page bottom "
-                            f"or sub-element scroller); continuing retry budget"
+                            f"{pre_y:.0f} → {post_y:.0f} (Δ<50px) and document "
+                            f"bottom is {dist:.0f}px away (sub-element scroller "
+                            f"or content below fold); continuing retry budget"
                         )
                         # Fall through to the normal retry path below.
 

--- a/tests/test_step_recovery_policy.py
+++ b/tests/test_step_recovery_policy.py
@@ -532,18 +532,20 @@ def test_required_scroll_brain_loop_second_attempt_cdp_fallback_advances(monkeyp
     assert any("KeyboardEvent" in c for c in cdp_calls)
 
 
-def test_required_scroll_brain_loop_cdp_fires_but_scrollY_unchanged_continues_retry(monkeypatch):
-    """When CDP scrollBy fires but window.scrollY doesn't move (page
-    already at bottom, overflow:hidden, sub-element scroller capturing
-    events), the fallback falls through to the normal retry budget
-    rather than falsely advancing."""
+def test_required_scroll_brain_loop_cdp_fires_but_content_below_fold_continues_retry(monkeypatch):
+    """When CDP scrollBy fires, window.scrollY doesn't move, AND the
+    document still has real content below the fold (overflow:hidden or a
+    sub-element scroller eating the event), the fallback falls through to
+    the normal retry budget rather than falsely advancing."""
     monkeypatch.setattr("mantis_agent.gym.step_recovery.time.sleep", lambda *_: None)
     runner = _runner_stub()
-    # scrollY stays at 0 before and after.
+    # scrollY pinned at 0 before/after; 1500px still below the fold.
     def _cdp(expr):
         if "scrollBy" in expr or "KeyboardEvent" in expr:
             return None
-        return 0.0  # always return 0 for scrollY reads
+        if "scrollHeight" in expr:
+            return 1500.0  # distance-from-bottom: content remains below
+        return 0.0  # scrollY reads
     runner.env.cdp_evaluate.side_effect = _cdp
 
     policy = StepRecoveryPolicy(runner)
@@ -558,9 +560,43 @@ def test_required_scroll_brain_loop_cdp_fires_but_scrollY_unchanged_continues_re
         listings_on_page=0,
     )
     # Fall-through: regular retry path returns required_retry, NOT
-    # scroll_cdp_fallback.
+    # scroll_reached_bottom.
     assert outcome.halt is False
     assert outcome.halt_reason.startswith("required_retry:scroll")
+
+
+def test_required_scroll_brain_loop_already_at_document_bottom_advances(monkeypatch):
+    """When CDP scrollBy can't move because the page is already at the
+    document bottom (scrollY + innerHeight ≈ scrollHeight), the
+    scroll-to-bottom intent is satisfied — advance instead of burning
+    the retry budget down to a HALT one step short of the next step.
+    This is the BoatTrader by-owner detail-page case: a short page the
+    brain keeps trying to scroll past its own bottom."""
+    monkeypatch.setattr("mantis_agent.gym.step_recovery.time.sleep", lambda *_: None)
+    runner = _runner_stub()
+    # scrollY pinned at 3345 before/after (page bottom); 0px remaining.
+    def _cdp(expr):
+        if "scrollBy" in expr or "KeyboardEvent" in expr:
+            return None
+        if "scrollHeight" in expr:
+            return 0.0  # distance-from-bottom: already at the end
+        return 3345.0  # scrollY reads (unchanged → not "moved")
+    runner.env.cdp_evaluate.side_effect = _cdp
+
+    policy = StepRecoveryPolicy(runner)
+    outcome = policy.handle_failure(
+        step=MicroIntent(intent="Scroll to bottom", type="scroll", required=True),
+        step_result=_result(failure_class="brain_loop_exhausted"),
+        plan=_plan("scroll"),
+        step_index=0,
+        step_retry_counts={0: 1},
+        loop_counters={},
+        max_retries=2,
+        listings_on_page=0,
+    )
+    assert outcome.halt is False
+    assert outcome.step_index == 1  # advance to the next step
+    assert outcome.halt_reason == "scroll_reached_bottom"
 
 
 def test_required_scroll_brain_loop_first_attempt_retries_normally(monkeypatch):


### PR DESCRIPTION
## Summary
- A required `scroll` step that exhausts the brain loop falls to the CDP multi-prong fallback. When the fallback can't move the viewport (Δ<50px), the old code always fell through to the retry budget and eventually **HALTED the run** — even when the page was simply *already at its document bottom* and the "scroll to bottom" intent was satisfied.
- Δ<50px is now disambiguated via the document's own scroll metrics: `scrollHeight - (scrollY + innerHeight) ≤ 96px` ⇒ we're at the bottom ⇒ advance (`scroll_reached_bottom`); otherwise (sub-element scroller / content still below the fold) keep burning the retry budget exactly as before.
- The new `_read_dist_from_bottom()` CDP read is post-action verification of layout metrics, **not** DOM-derived grounding of a click target — same CUA-purity carve-out as the existing `_read_scroll_y()`.

### Why
A required scroll-to-bottom step on a page shorter than the brain expects (surfaced on BoatTrader by-owner detail pages) halted the whole run one step short of the step it was scrolling toward. This generalizes to any short page where the brain over-estimates scrollable height.

## Test plan
- [x] `tests/test_step_recovery_policy.py` — 33/33 green
- [x] New `..._already_at_document_bottom_advances` (dist=0 ⇒ `step_index+1`, `scroll_reached_bottom`)
- [x] Renamed `..._content_below_fold_continues_retry` (dist=1500 ⇒ stays on the `required_retry:scroll` path)
- [x] Deployed to `mantis-cua-server`; a re-run advanced past the previously-halting scroll step

🤖 Generated with [Claude Code](https://claude.com/claude-code)