### PR TITLE
fix(observability): close instrumentation gap on intent_rewriter + plan_decomposer

### DIFF
--- a/src/mantis_agent/gym/intent_rewriter.py
+++ b/src/mantis_agent/gym/intent_rewriter.py
@@ -220,6 +220,17 @@ def propose_rewrite(
         logger.warning("intent_rewriter: response body was not valid JSON")
         return None
 
+    # Per-source cost attribution — without this, intent_rewriter's
+    # Opus-rate calls land in costs.claude aggregate but NEVER in the
+    # claude_cost_by_path meter. On failure-heavy runs the rewriter
+    # fires many times per failed step (often the single biggest
+    # uninstrumented spender). Tag as "intent_rewriter".
+    try:
+        from ..observability.claude_cost_meter import record_from_response
+        record_from_response(source="intent_rewriter", model=model, response_json=body)
+    except Exception:  # noqa: BLE001 — telemetry never breaks the rewriter
+        pass
+
     for block in body.get("content", []):
         if block.get("type") == "text":
             text = (block.get("text") or "").strip()

--- a/src/mantis_agent/plan_decomposer.py
+++ b/src/mantis_agent/plan_decomposer.py
@@ -995,6 +995,15 @@ class PlanDecomposer:
         if resp.status_code != 200:
             raise RuntimeError(f"Decompose API error: {resp.status_code} {resp.text[:200]}")
 
+        # Per-source cost attribution — decompose fires once per run on
+        # an Opus-rate model. Without this it shows up in costs.claude
+        # but not in claude_cost_by_path. Tag as "decompose".
+        try:
+            from .observability.claude_cost_meter import record_from_response
+            record_from_response(source="decompose", model=self.model, response_json=resp.json())
+        except Exception:  # noqa: BLE001 — telemetry never breaks decomposition
+            pass
+
         # #523 PR B-2 — capture this call as a modelio record when an
         # upstream caller has published a layer context (planner). Silent
         # no-op otherwise (default path until the wrap fires in PR B-2-


### PR DESCRIPTION
## Summary
Per-source `claude_cost_by_path` meter was missing two Anthropic callsites that contribute materially to `costs.claude` on real runs. Closes the gap on the two biggest uninstrumented spenders observed in today's PR #770 validation work.

## Evidence
Miami pre-warm smoke (run `20260602_233403_3c6ac7ba`):

| Bucket | Value |
|---|---|
| `costs.total` | **$1.152** |
| `costs.claude` (framework aggregate) | ~$0.6-0.8 (estimated) |
| `claude_cost_by_path.totals.cost_usd` | **$0.167** |
| **Unattributed Claude $** | **~$0.4-0.6 (~50-85% gap)** |

After this fix, the meter will additionally capture:

- **`intent_rewriter`** — defaults to `claude-opus-4-7`, fires on every failed step retry. On click-failure-heavy runs we observed 28+ ClaudeGrounding refinements per page, and each upstream rewrite call hits the same opus rate. Likely the single biggest contributor to the unattributed bulk in click-loop runs.
- **`decompose`** — fires once per submission at opus rates. Small per-run but persistently missed.

Both record with `try/except` around the meter import so a future telemetry breakage cannot break the rewriter or decomposer paths.

## Other uninstrumented callsites (out of scope here)
Audited during PR but not wired — either config-dependent or out of boattrader's hot path:

- `verification/step_verifier.py:129` — config-dependent
- `gym/claude_director.py:176` — only when Claude director is selected as brain
- `brain_claude.py:181` (`query`) — only when `cua_model=claude`
- `objective.py`, `graph/*`, `recipes/marketplace_planner/*` — outside boattrader path entirely

If a future plan turns one of these into a hot path, add a follow-up patch with the same shape.

## Test plan
- [ ] Smoke a $1 boattrader run on Baseten and confirm `claude_cost_by_path.by_path` now contains `intent_rewriter::...` and `decompose::...` entries on a run that exercises them.
- [ ] Compare `claude_cost_by_path.totals.cost_usd` to `costs.claude` — the gap should shrink from ~50% to under ~10% on the boattrader plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)