### PR TITLE
BT03 live-smoke hardening: lead-form suppression + submit/poll retry + xdotool cold-start cookie

### DIFF
--- a/deploy/sim_envs/mantis_boattrader/app/templates/boat_detail.html
+++ b/deploy/sim_envs/mantis_boattrader/app/templates/boat_detail.html
@@ -142,35 +142,43 @@
          message textarea, no Show Phone button by default). Show Phone
          retained as cookie-gated interaction surface for agent training. #}
       <div class="bdp-private-seller-card" id="contact" data-testid="private-seller-card">
+        {% set show_phone = request.cookies.get('bt_show_phone_' ~ boat.id) == '1' %}
+        {% set contact_started = request.cookies.get('bt_contact_start_' ~ boat.id) == '1' %}
+        {% set gate_pending = boat.reveal_gated and not show_phone and not contact_started %}
         <h3 class="dealer-card-heading">Contact Private Seller</h3>
-        <form class="dealer-lead-form" method="post" action="/boat/{{ boat.slug }}/contact" data-testid="dealer-lead-form">
-          <input type="text" name="name" placeholder="First &amp; Last Name" required class="lead-input" />
-          {# v=124: restored Email + Phone split-half row to match real
-             BT's .lead-form-basic__body layout (Name full-width, Email
-             + Phone side-by-side at 163px each in a 334px form). #}
-          <div class="lead-row">
-            <input type="email" name="email" placeholder="Your Email" required class="lead-input" />
-            <input type="tel" name="phone" placeholder="Your Phone" class="lead-input" />
-          </div>
-          <button type="submit" class="btn-primary btn-block contact-seller-btn srp-apply-now-button" data-testid="contact-seller-submit">Contact Seller</button>
-        </form>
+        {% if gate_pending %}
+          {# BT03 action-OMISSION gate (BT03_REVEAL_GATE): the seller requires a
+             "start contact request" before the number is shown. While the gate is
+             pending we LEAD with this prerequisite and SUPPRESS the Name/Email/Phone
+             lead form — otherwise the lead form's prominent "Contact Seller" submit
+             out-competes the prerequisite for the agent's click (a live 2-arm smoke
+             showed the S1 arm filling the lead form instead of starting the contact
+             request, which collapsed the discriminator). The base plan omits contact-
+             start entirely, so a frozen agent skips straight to the "Show Phone Number"
+             control in the phone-row below and the server (no bt_contact_start cookie)
+             reveals nothing — recall miss. The S1 injection seam inserts a contact-
+             start click ahead of the reveal, satisfying the gate so the unchanged
+             reveal fires. Only the POST sets the cookie; no number is exposed here.
+             Once started the gate clears and the standard lead form returns (it never
+             blocks grounding the reveal). #}
+          <form method="post" action="/boat/{{ boat.slug }}/contact-start" class="bdp-contact-start-form">
+            <button type="submit" class="btn-primary btn-block contact-start-btn" data-testid="contact-start-btn">Start contact request</button>
+          </form>
+          <p class="bdp-contact-start-note">Private seller — start a contact request to view the phone number.</p>
+        {% else %}
+          <form class="dealer-lead-form" method="post" action="/boat/{{ boat.slug }}/contact" data-testid="dealer-lead-form">
+            <input type="text" name="name" placeholder="First &amp; Last Name" required class="lead-input" />
+            {# v=124: restored Email + Phone split-half row to match real
+               BT's .lead-form-basic__body layout (Name full-width, Email
+               + Phone side-by-side at 163px each in a 334px form). #}
+            <div class="lead-row">
+              <input type="email" name="email" placeholder="Your Email" required class="lead-input" />
+              <input type="tel" name="phone" placeholder="Your Phone" class="lead-input" />
+            </div>
+            <button type="submit" class="btn-primary btn-block contact-seller-btn srp-apply-now-button" data-testid="contact-seller-submit">Contact Seller</button>
+          </form>
+        {% endif %}
         <div class="private-seller-phone-row" data-testid="phone-row">
-          {% set show_phone = request.cookies.get('bt_show_phone_' ~ boat.id) == '1' %}
-          {% set contact_started = request.cookies.get('bt_contact_start_' ~ boat.id) == '1' %}
-          {% if boat.reveal_gated and not show_phone and not contact_started %}
-            {# BT03 action-OMISSION gate (BT03_REVEAL_GATE): the seller requires a
-               "start contact request" before the number is shown. The base plan
-               omits this prerequisite, so a frozen agent goes straight to Show
-               Phone Number below and the server (no bt_contact_start cookie)
-               reveals nothing — recall miss. The S1 injection seam inserts this
-               step ahead of the reveal, satisfying the gate so the unchanged
-               reveal fires. Only the POST sets the cookie; no number is exposed
-               here. Hidden once started so it never blocks grounding the reveal. #}
-            <form method="post" action="/boat/{{ boat.slug }}/contact-start">
-              <button type="submit" class="bdp-contact-start-link" data-testid="contact-start-btn">Start contact request</button>
-            </form>
-            <p class="bdp-contact-start-note">Private seller — start a contact request to view the phone number.</p>
-          {% endif %}
           {% if show_phone %}
             <img class="phone-svg" src="/assets/phone/{{ boat.slug }}.svg?_t={{ boat.id }}" alt="Phone number" data-testid="phone-svg" />
           {% elif boat.reveal_drift %}

--- a/experiments/learning_allocator/eval/bt03_gated_inject_exemplar.json
+++ b/experiments/learning_allocator/eval/bt03_gated_inject_exemplar.json
@@ -1,13 +1,16 @@
 [
   {
     "type": "click",
-    "intent": "Start the contact request to unlock the seller's phone number — click the 'Start contact request' button in the Contact Private Seller block",
+    "intent": "Single-click the prominent primary button labelled 'Start contact request' in the 'Contact Private Seller' block — it sits directly above the gray note 'Private seller — start a contact request to view the phone number'. This is a ONE-CLICK action that starts the contact request and unlocks the hidden phone number. Just click the 'Start contact request' button; do not type anything.",
     "inject_before": "Reveal the hidden phone number via the Show Phone Number control",
     "required": false,
     "grounding": true,
     "params": {},
+    "hints": {
+      "preferred_target_description": "the prominent full-width primary button labelled 'Start contact request' in the Contact Private Seller block, sitting directly above the gray note text 'start a contact request to view the phone number'"
+    },
     "last_action": {"action_type": "click"},
-    "observed_outcome": "the contact request started and the Show Phone Number control unlocked, so clicking it then exposed the seller's phone",
+    "observed_outcome": "clicking the 'Start contact request' button started the contact request and unlocked the Show Phone Number control, so the subsequent reveal exposed the seller's phone number",
     "source_run": "bt03-gated-contact-start-seed42"
   }
 ]

--- a/experiments/learning_allocator/live_runner.py
+++ b/experiments/learning_allocator/live_runner.py
@@ -337,6 +337,10 @@ class LiveRunFn:
     # URL-encodes to ``%7Bstate_code%7D`` → an empty results page.
     state_code: str = "fl"
     poll_interval_s: float = 15.0
+    # Upper bound on how long to keep retrying a submit that fails to even reach
+    # Modal (DNS/connect blip). Only connection-establishment errors retry — see
+    # :meth:`_submit` — so this never risks a double-submit.
+    submit_retry_seconds: float = 90.0
     post_fn: PostFn = _default_post
     pull_cost_fn: PullCostFn = _default_pull_cost
     decompose_fn: DecomposeFn = _default_decompose
@@ -377,7 +381,7 @@ class LiveRunFn:
             "detached": True,
             **runtime,
         }
-        status, resp = self.post_fn("/v1/predict", body)
+        status, resp = self._submit(body, workflow_id)
         if status != 200:
             return self._failed_result(f"submit HTTP {status}: {resp}", workflow_id)
 
@@ -491,15 +495,82 @@ class LiveRunFn:
 
     # ── poll + verdict ─────────────────────────────────────────────────
 
+    def _submit(
+        self, body: dict[str, Any], workflow_id: str,
+    ) -> tuple[int | None, dict[str, Any]]:
+        """POST the detached run, retrying ONLY connection-establishment failures.
+
+        A submit that fails before the request leaves the machine — DNS
+        resolution or TCP connect, surfaced by ``requests`` as
+        ``ConnectionError`` — provably never reached Modal, so re-POSTing the
+        SAME ``workflow_id`` cannot start a second GPU run. These transient
+        local blips (a laptop wifi/DNS hiccup) otherwise propagate out of the
+        orchestrator and crash the WHOLE matrix at the submit boundary, which
+        strands any spend already incurred by earlier arms — exactly the loss
+        the time-bounded retry in :meth:`_poll` was added to prevent, but on
+        the *submit* leg.
+
+        A ``ReadTimeout`` (or any other ``RequestException``) is NOT retried:
+        the request may have landed and started a billable run, so a blind
+        re-POST could double-spend. Those fail soft — the arm is recorded as a
+        failed submit and the matrix moves on, never crashing and never
+        double-submitting.
+        """
+        deadline = time.time() + self.submit_retry_seconds
+        attempt = 0
+        while True:
+            attempt += 1
+            try:
+                return self.post_fn("/v1/predict", body)
+            except requests.exceptions.ConnectionError as exc:
+                if time.time() >= deadline:
+                    return None, {
+                        "_submit_error": f"connection failed after {attempt} "
+                        f"attempt(s) over {self.submit_retry_seconds:.0f}s: {exc!r}"
+                    }
+                print(
+                    f"[submit] WARNING: connect failed ({exc!r}); workflow "
+                    f"{workflow_id} never reached Modal (no spend) — retrying "
+                    f"after {self.poll_interval_s:.0f}s",
+                    file=sys.stderr, flush=True,
+                )
+                time.sleep(self.poll_interval_s)
+            except requests.RequestException as exc:
+                # Ambiguous: the request may have reached Modal and started a
+                # run. Do NOT retry (double-spend risk) — fail the arm soft.
+                return None, {
+                    "_submit_error": f"submit raised {type(exc).__name__} "
+                    f"(not retried — may have landed): {exc!r}"
+                }
+
     def _poll(self, run_id: str) -> tuple[str, str]:
-        """Poll ``action=status`` until terminal; return (status, halt_reason)."""
+        """Poll ``action=status`` until terminal; return (status, halt_reason).
+
+        A transient network error on a single status poll (e.g. the 120s read
+        timeout seen when the web fn briefly stalls or cold-starts) must NOT
+        abort an in-flight GPU run: the run keeps executing on Modal regardless
+        of whether one poll round-trips. Swallow ``RequestException`` and keep
+        polling until the deadline — the loop is already time-bounded, so a
+        genuinely stuck status endpoint still terminates at ``poll_timeout``
+        rather than crashing the whole matrix mid-arm and losing the spend.
+        """
         if not run_id:
             return "failed", "no_run_id"
         deadline = time.time() + 60 * self.max_time_minutes + 120
         while time.time() < deadline:
-            _, resp = self.post_fn(
-                "/v1/predict", {"action": "status", "run_id": run_id},
-            )
+            try:
+                _, resp = self.post_fn(
+                    "/v1/predict", {"action": "status", "run_id": run_id},
+                )
+            except requests.RequestException as exc:
+                print(
+                    f"[poll] WARNING: status poll failed ({exc!r}); run "
+                    f"{run_id} continues on Modal — retrying after "
+                    f"{self.poll_interval_s:.0f}s",
+                    file=sys.stderr, flush=True,
+                )
+                time.sleep(self.poll_interval_s)
+                continue
             st = str(resp.get("status") or "")
             if st in _TERMINAL:
                 return st, str(resp.get("halt_reason") or "")

--- a/src/mantis_agent/gym/xdotool_env.py
+++ b/src/mantis_agent/gym/xdotool_env.py
@@ -337,7 +337,17 @@ class XdotoolGymEnv(GymEnvironment):
             cmd.append(f"--load-extension={_stealth_ext_dir}")
         if self._proxy_server:
             cmd.append(f"--proxy-server={self._proxy_server}")
-        cmd.append(url)
+        # When extra request headers are configured (canonically a sim-env
+        # consent Cookie like ``bt_cookie_consent``), the first document fetch
+        # must wait until the persistent header session is open AND the cookie
+        # is seeded into the jar. Launching Chrome with the real URL here fetches
+        # it immediately — before ``_open_header_session`` and with an empty jar
+        # — so the cookie-gated consent overlay renders and find_all reads it as
+        # ``page_blocked`` (the SRP never reaches the vision classifier as a real
+        # listings page). Launch to about:blank and defer the real navigation to
+        # after the header/cookie setup below, via the cookie-seeding path.
+        _defer_nav = bool(self._extra_http_headers and url and url != "about:blank")
+        cmd.append("about:blank" if _defer_nav else url)
 
         self._browser_proc = subprocess.Popen(
             cmd, env=self._env,
@@ -382,6 +392,16 @@ class XdotoolGymEnv(GymEnvironment):
         # open for the browser's lifetime. See ``_open_header_session``.
         if self._extra_http_headers:
             self._open_header_session()
+
+        # Deferred cold-start navigation (see ``_defer_nav`` above). The header
+        # session is now live and ``_navigate_running_browser`` seeds the consent
+        # cookie into the jar via ``Network.setCookie`` *before* ``Page.navigate``
+        # — so the first real document (e.g. the by-owner SRP) loads without the
+        # cookie-gated consent overlay, and the stealth patches registered just
+        # above apply to it. Launching to about:blank kept that first fetch from
+        # racing ahead with an empty jar.
+        if _defer_nav:
+            self._navigate_running_browser(url)
 
     def _wait_for_cdp_ready(self, deadline_s: float = 15.0) -> bool:
         """Block until Chrome's CDP HTTP endpoint answers, or ``deadline_s``.

--- a/tests/learning/test_live_runner.py
+++ b/tests/learning/test_live_runner.py
@@ -348,6 +348,145 @@ def test_submit_failure_yields_failed_result_without_spend(tmp_path: Path) -> No
     assert all(b.get("action") != "status" for _, b in poster.calls)
 
 
+def test_poll_survives_transient_status_timeout(tmp_path: Path) -> None:
+    """A transient network error on ONE status poll must not abort the run: the
+    GPU job keeps executing on Modal regardless of whether a single poll
+    round-trips, so ``_poll`` swallows the ``RequestException`` and keeps polling
+    until a terminal status. Regression for a live smoke that crashed the whole
+    matrix mid-arm on a 120s status read-timeout, losing the spend."""
+    import requests as _requests
+
+    class FlakyStatusPoster(FakePoster):
+        def __init__(self) -> None:
+            super().__init__(statuses=["succeeded"])
+            self.timed_out_once = False
+
+        def __call__(self, path: str, body: dict) -> tuple[int, dict]:
+            if body.get("action") == "status" and not self.timed_out_once:
+                self.timed_out_once = True
+                raise _requests.exceptions.ReadTimeout("status read timed out")
+            return super().__call__(path, body)
+
+    poster = FlakyStatusPoster()
+    run = _make(tmp_path, poster, FakeDecomposer())
+
+    terminal, halt = run._poll("run-1")
+
+    assert terminal == "succeeded"  # recovered past the transient timeout
+    assert poster.timed_out_once is True  # the swallow path was exercised
+
+
+def test_poll_returns_timeout_when_status_never_terminal(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """A status endpoint that *persistently* raises still ends at the deadline
+    bound (``poll_timeout``) rather than spinning forever — the swallow path must
+    keep re-checking the deadline, not bypass it. A fake clock advances past the
+    deadline right after the first swallow so the bound (not a real 120s wait)
+    terminates the loop."""
+    import requests as _requests
+    import experiments.learning_allocator.live_runner as lr
+
+    class AlwaysTimeoutPoster(FakePoster):
+        def __call__(self, path: str, body: dict) -> tuple[int, dict]:
+            if body.get("action") == "status":
+                raise _requests.exceptions.ConnectTimeout("never answers")
+            return super().__call__(path, body)
+
+    run = _make(tmp_path, AlwaysTimeoutPoster(), FakeDecomposer())
+    # ticks: deadline-calc, first loop-check (enter), post-swallow check (exit).
+    ticks = iter([0.0, 0.0, 1e9])
+    monkeypatch.setattr(lr.time, "time", lambda: next(ticks, 1e9))
+
+    terminal, halt = run._poll("run-1")
+
+    assert terminal == "halted"
+    assert halt == "poll_timeout"
+
+
+def test_submit_retries_connection_error_then_succeeds(tmp_path: Path) -> None:
+    """A submit that fails to even reach Modal (DNS/connect — ``ConnectionError``)
+    is safe to re-POST: the request never left the machine, so the same
+    ``workflow_id`` cannot start a second run. The retry must transparently
+    succeed once connectivity returns rather than crash the matrix."""
+    import requests as _requests
+
+    class FlakyConnectPoster(FakePoster):
+        def __init__(self) -> None:
+            super().__init__()
+            self.failed_once = False
+
+        def __call__(self, path: str, body: dict) -> tuple[int, dict]:
+            if "task_suite" in body and not self.failed_once:
+                self.failed_once = True
+                raise _requests.exceptions.ConnectionError("dns resolution failed")
+            return super().__call__(path, body)
+
+    poster = FlakyConnectPoster()
+    run = _make(tmp_path, poster, FakeDecomposer())
+
+    status, resp = run._submit({"task_suite": {}}, "wf-1")
+
+    assert status == 200
+    assert resp["run_id"] == "run-1"
+    assert poster.failed_once is True
+
+
+def test_submit_gives_up_after_connection_deadline(tmp_path: Path) -> None:
+    """A persistent connection failure is bounded: once the retry deadline
+    passes, the arm fails SOFT (``status is None`` → recorded as a failed submit)
+    rather than crashing the whole matrix and stranding earlier-arm spend."""
+    import requests as _requests
+
+    class AlwaysConnErrPoster(FakePoster):
+        def __init__(self) -> None:
+            super().__init__()
+            self.attempts = 0
+
+        def __call__(self, path: str, body: dict) -> tuple[int, dict]:
+            if "task_suite" in body:
+                self.attempts += 1
+                raise _requests.exceptions.ConnectionError("dns still down")
+            return super().__call__(path, body)
+
+    poster = AlwaysConnErrPoster()
+    run = _make(tmp_path, poster, FakeDecomposer())
+    run.submit_retry_seconds = 0.0  # deadline immediately past → one try, then give up
+
+    status, resp = run._submit({"task_suite": {}}, "wf-1")
+
+    assert status is None
+    assert poster.attempts == 1
+    assert "connection failed" in resp["_submit_error"]
+
+
+def test_submit_failsoft_on_readtimeout_without_retry(tmp_path: Path) -> None:
+    """A ``ReadTimeout`` at submit is AMBIGUOUS — the request may have landed and
+    started a billable run — so it must NOT be retried (double-spend risk). It
+    fails soft after exactly one attempt, surfacing the error for a human."""
+    import requests as _requests
+
+    class ReadTimeoutPoster(FakePoster):
+        def __init__(self) -> None:
+            super().__init__()
+            self.attempts = 0
+
+        def __call__(self, path: str, body: dict) -> tuple[int, dict]:
+            if "task_suite" in body:
+                self.attempts += 1
+                raise _requests.exceptions.ReadTimeout("response lost — may have landed")
+            return super().__call__(path, body)
+
+    poster = ReadTimeoutPoster()
+    run = _make(tmp_path, poster, FakeDecomposer())
+
+    status, resp = run._submit({"task_suite": {}}, "wf-1")
+
+    assert status is None
+    assert poster.attempts == 1  # NOT retried
+    assert "ReadTimeout" in resp["_submit_error"]
+
+
 def test_plan_decomposed_once_with_substituted_placeholders(
     tmp_path: Path,
 ) -> None:

--- a/tests/sim_envs/mantis_boattrader/test_bt03_reveal_gate.py
+++ b/tests/sim_envs/mantis_boattrader/test_bt03_reveal_gate.py
@@ -99,28 +99,40 @@ def test_bt03_qualifying_set_unchanged(monkeypatch):
 # ── rendered layout (TestClient) ─────────────────────────────────────────
 
 
-def test_gated_owner_page_shows_prereq_and_reveal(monkeypatch):
-    """Gate-on: the owner page renders the "start contact request" prerequisite AND
-    the unchanged, verbatim-labelled reveal control — no masked teaser (the gate is
-    not the drift). The prerequisite is the step the base plan omits; the reveal is
-    what fires once the gate is satisfied."""
+def test_gated_owner_page_leads_with_prereq_and_suppresses_lead_form(monkeypatch):
+    """Gate-on: the owner page LEADS with the "start contact request" prerequisite as a
+    prominent primary button and renders the unchanged, verbatim-labelled reveal control
+    — no masked teaser (the gate is not the drift). While the gate is pending the
+    Name/Email/Phone lead form is SUPPRESSED: its prominent "Contact Seller" submit is the
+    attractor that out-competed the injected prerequisite click and collapsed a live 2-arm
+    smoke (S1 filled the form instead of starting the contact request). The prerequisite is
+    the step the base plan omits; the reveal is what fires once the gate is satisfied."""
     boat = _an_owner(monkeypatch, gate=True)
     with _client() as c:
         html = c.get(f"/boat/{boat.slug}/").text
     assert 'data-testid="private-seller-card"' in html, "not an owner detail page"
-    # The omitted prerequisite — present, groundable, POSTs to contact-start.
+    # The omitted prerequisite — present, groundable, POSTs to contact-start…
     assert 'data-testid="contact-start-btn"' in html
     assert f"/boat/{boat.slug}/contact-start" in html
     assert "Start contact request" in html
+    # …and it LEADS as a prominent primary button, not a muted link, so the injected
+    # S1 click has an unambiguous dominant target.
+    assert "btn-primary btn-block contact-start-btn" in html
+    # The competing lead form is suppressed while the gate is pending — removing the
+    # attractor is the whole point of this layout.
+    assert 'data-testid="dealer-lead-form"' not in html, "lead form not suppressed while gate pending"
+    assert 'data-testid="contact-seller-submit"' not in html, "lead-form submit leaked while gate pending"
     # The reveal survives verbatim; gate is orthogonal to the masked-teaser drift.
     assert 'data-testid="show-phone-btn"' in html
     assert "Show Phone Number" in html
     assert 'data-testid="seller-phone-inline"' not in html
 
 
-def test_started_contact_hides_prereq_keeps_reveal(monkeypatch):
+def test_started_contact_hides_prereq_restores_lead_form_keeps_reveal(monkeypatch):
     """Once the contact request is started the prerequisite control disappears so it
-    never blocks grounding the reveal — but the reveal itself stays present."""
+    never blocks grounding the reveal — the reveal itself stays present, and the standard
+    Name/Email/Phone lead form RETURNS (it only hid while the gate was pending, so this
+    layout is invisible to ungated and post-gate states)."""
     boat = _an_owner(monkeypatch, gate=True)
     with _client() as c:
         c.post(f"/boat/{boat.slug}/contact-start", follow_redirects=False)
@@ -128,6 +140,8 @@ def test_started_contact_hides_prereq_keeps_reveal(monkeypatch):
     assert 'data-testid="contact-start-btn"' not in html, "prereq not hidden once started"
     assert 'data-testid="show-phone-btn"' in html, "reveal control vanished"
     assert "Show Phone Number" in html
+    # The lead form returns once the gate clears.
+    assert 'data-testid="dealer-lead-form"' in html, "lead form did not return after contact-start"
 
 
 # ── gate behaviour: the mutation is what the oracle grades ────────────────
@@ -169,6 +183,8 @@ def test_gate_off_show_phone_reveals_directly(monkeypatch):
         c.post(f"/boat/{boat.slug}/show-phone", follow_redirects=False)
         svg = c.get(f"/assets/phone/{boat.slug}.svg")
     assert 'data-testid="contact-start-btn"' not in html, "prereq leaked into gate-off"
+    # No gate pending → the standard lead form renders (the suppression is gate-only).
+    assert 'data-testid="dealer-lead-form"' in html, "lead form missing on an ungated owner page"
     reveals = _reveals()
     assert len(reveals) == 1, f"stock reveal did not fire (got {len(reveals)})"
     assert reveals[0]["target_id"] == boat.id

--- a/tests/test_xdotool_env_navigate.py
+++ b/tests/test_xdotool_env_navigate.py
@@ -267,3 +267,112 @@ def test_navigate_running_browser_empty_url_is_noop(env_with_cdp_recorder) -> No
     # CDP request and Chrome will no-op. We assert behavior is consistent.
     # If a future refactor adds an empty-string guard, update this test.
     assert len(cdp_calls) <= 1
+
+
+# ── cold-start launch ordering ─────────────────────────────────────────
+#
+# The companion bug to the navigate fix above: on a *fresh* browser start,
+# ``_start_browser`` launched Chrome with the target URL on the command line,
+# so the first document (e.g. the by-owner SRP) was fetched *immediately* —
+# before ``_open_header_session`` opened and with an empty cookie jar. The
+# sim-env consent cookie was never seeded (``Network.setExtraHTTPHeaders``
+# drops a ``Cookie`` header; only ``Network.setCookie`` populates the jar, and
+# that runs inside ``_navigate_running_browser``, which the cold-start path
+# never called). The consent overlay rendered and ``find_all_listings`` read
+# it as ``page_blocked`` on every retry. Fix: when extra headers are present,
+# launch to about:blank and defer the real navigation through the cookie-
+# seeding path once the header session is live.
+
+
+def _make_start_browser_env(tmp_path, *, extra_headers):
+    env = XdotoolGymEnv.__new__(XdotoolGymEnv)
+    env._viewport = (1280, 800)
+    env._proxy_server = None
+    env._settle_time = 0.0
+    env._env = {}
+    env._browser_proc = None
+    env._browser_cmd = "chromium-browser"
+    env._cdp_port = 9222
+    env._profile_dir = str(tmp_path / "profile")
+    env._extra_http_headers = extra_headers
+    return env
+
+
+@pytest.fixture
+def start_browser_recorder(monkeypatch: pytest.MonkeyPatch):
+    """Stub out the real browser launch + CDP so ``_start_browser`` runs in
+    process. Records the Popen argv, deferred-navigation URLs, and the order of
+    header-session vs navigation events."""
+    popen_cmds: list[list[str]] = []
+    nav_urls: list[str] = []
+    events: list[str] = []
+
+    class _FakeProc:
+        def poll(self):
+            return None
+
+    def _fake_popen(cmd, **kwargs):
+        popen_cmds.append(cmd)
+        events.append("popen")
+        return _FakeProc()
+
+    monkeypatch.setattr("mantis_agent.gym.xdotool_env.subprocess.Popen", _fake_popen)
+    monkeypatch.setattr("mantis_agent.gym.xdotool_env.time.sleep", lambda *_: None)
+    monkeypatch.setattr(XdotoolGymEnv, "_wait_for_cdp_ready", lambda self, *a, **k: True)
+    monkeypatch.setattr(XdotoolGymEnv, "_cdp_call", lambda self, *a, **k: (True, {}))
+    monkeypatch.setattr(
+        "mantis_agent.gym.cdp_stealth.inject_stealth_patches", lambda *a, **k: None
+    )
+    monkeypatch.setattr(
+        "mantis_agent.gym.cdp_stealth.apply_ua_override", lambda *a, **k: None
+    )
+
+    def _fake_open_header_session(self):
+        events.append("header_session")
+
+    def _fake_navigate(self, url):
+        events.append("navigate")
+        nav_urls.append(url)
+
+    monkeypatch.setattr(XdotoolGymEnv, "_open_header_session", _fake_open_header_session)
+    monkeypatch.setattr(XdotoolGymEnv, "_navigate_running_browser", _fake_navigate)
+    return popen_cmds, nav_urls, events
+
+
+def test_start_browser_defers_nav_when_extra_headers_present(
+    start_browser_recorder, tmp_path,
+) -> None:
+    """Cold start WITH extra headers (sim-env consent Cookie): launch to
+    about:blank and defer the real navigation until after the header session
+    opens, so the first SRP fetch carries the seeded cookie rather than racing
+    ahead with an empty jar (→ consent banner → page_blocked)."""
+    popen_cmds, nav_urls, events = start_browser_recorder
+    env = _make_start_browser_env(
+        tmp_path, extra_headers={"Cookie": "bt_cookie_consent=decline"}
+    )
+
+    target = "https://8080-abc.daytonaproxy01.net/boats/state-fl/by-owner/"
+    env._start_browser(target)
+
+    # Launched to about:blank, NOT the real URL.
+    assert popen_cmds[0][-1] == "about:blank"
+    assert target not in popen_cmds[0]
+    # Real navigation deferred to the cookie-seeding path.
+    assert nav_urls == [target]
+    # Ordering: header session opened BEFORE the deferred navigation.
+    assert events.index("header_session") < events.index("navigate")
+
+
+def test_start_browser_launches_url_directly_without_extra_headers(
+    start_browser_recorder, tmp_path,
+) -> None:
+    """No extra headers (ordinary runs): unchanged behavior — Chrome launches
+    straight to the URL and no deferred CDP navigation is issued."""
+    popen_cmds, nav_urls, events = start_browser_recorder
+    env = _make_start_browser_env(tmp_path, extra_headers=None)
+
+    target = "https://example.com/page"
+    env._start_browser(target)
+
+    assert popen_cmds[0][-1] == target
+    assert nav_urls == []  # no deferred navigation


### PR DESCRIPTION
## Summary

Three thematically related changes hardening the live BT03 reveal-drift smoke. Bundled because they share a root: each on its own can collapse a 2-arm live run mid-spend.

### 1. `feat(sim-env)` — suppress BT03 lead form while reveal gate pending

The prominent Name/Email/Phone "Contact Seller" submit out-competed the injected "Start contact request" click — a live 2-arm smoke caught S1 filling the lead form instead of starting the contact request, which collapsed the discriminator. Lead with the contact-start prerequisite as a primary button and suppress the competing lead form until the gate clears. Exemplar hint sharpened so the S1 inject targets the prominent button unambiguously.

### 2. `feat(la)` — time-bounded submit/poll retry in `live_runner`

Two transient-network classes were crashing the whole matrix mid-arm and stranding spend already incurred by earlier arms:

- Submit `ConnectionError` (request never left the machine — safe to re-POST the same `workflow_id`) retries until a configurable deadline, then fails soft.
- Submit `ReadTimeout` (ambiguous — may have landed) does NOT retry; fails soft after one attempt to avoid double-spend.
- Status-poll `RequestException` is swallowed; the GPU run keeps executing on Modal, and the existing `poll_timeout` bound still terminates a genuinely stuck endpoint.

### 3. `fix(xdotool)` — defer cold-start nav until cookie jar is seeded

When extra HTTP headers are configured (canonically a sim-env consent Cookie like `bt_cookie_consent`), launching Chrome with the real URL on the command line fetches the first document immediately — before `_open_header_session` and with an empty jar — so the cookie-gated consent overlay renders and `find_all_listings` reads it as `page_blocked` on every retry. Launch to `about:blank` in that case and defer the real navigation through `_navigate_running_browser` once the header session is live (which seeds the cookie via `Network.setCookie` before `Page.navigate`).

## Test plan

- [x] `pytest tests/sim_envs/mantis_boattrader/test_bt03_reveal_gate.py tests/learning/test_live_runner.py tests/test_xdotool_env_navigate.py` — 55 passed locally
- [x] `ruff check` clean on touched files
- [ ] Full CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)