### PR TITLE
feat(computer-plane): wire run_claude_cua onto the Phase-1 RPC seam (#698)

### DIFF
--- a/deploy/modal/modal_cua_server.py
+++ b/deploy/modal/modal_cua_server.py
@@ -771,7 +771,7 @@ def _run_holo3_executor(
         try:
             from mantis_agent.brain_claude import ClaudeBrain
             claude_fallback_brain = ClaudeBrain(
-                model=str(task_suite.get("_claude_fallback_model") or "claude-sonnet-4-20250514"),
+                model=str(task_suite.get("_claude_fallback_model") or "claude-sonnet-4-6"),
                 thinking_budget=2048,
                 screen_size=(1280, 720),
             )
@@ -1452,7 +1452,7 @@ def _run_holo3_executor(
         ):
             try:
                 from mantis_agent.brain_claude import ClaudeBrain as _CB
-                task_brain = _CB(model="claude-sonnet-4-20250514", thinking_budget=2048, screen_size=(1280, 720))
+                task_brain = _CB(model="claude-sonnet-4-6", thinking_budget=2048, screen_size=(1280, 720))
                 task_brain.load()
                 print("  Using Claude Sonnet for setup (hybrid mode)")
                 runner = GymRunner(brain=task_brain, env=_env, max_steps=task_max_steps,
@@ -1787,7 +1787,7 @@ def _run_claude_executor(
     max_steps: int = 30,
     max_retries: int = 2,
     frames_per_inference: int = 2,
-    claude_model: str = "claude-sonnet-4-20250514",
+    claude_model: str = "claude-sonnet-4-6",
     thinking_budget: int = 2048,
     viewer: bool = False,
     profile_dir: str = "",
@@ -1888,7 +1888,7 @@ def _run_claude_executor(
     memory=8192,
     cpu=4,
 )
-def run_claude_cua(task_file_contents: str, claude_model: str = "claude-sonnet-4-20250514", **kwargs) -> dict:
+def run_claude_cua(task_file_contents: str, claude_model: str = "claude-sonnet-4-6", **kwargs) -> dict:
     """Claude CUA executor (no GPU — API-based inference, Chrome + xdotool only)."""
     kwargs.pop("cua_model", None)
     return _run_claude_executor(task_file_contents, claude_model=claude_model, **kwargs)
@@ -3107,7 +3107,7 @@ def main(
     inputs: str = "",
     session_name: str = "",
     max_listings: int = 50,
-    claude_model: str = "claude-sonnet-4-20250514",
+    claude_model: str = "claude-sonnet-4-6",
     thinking_budget: int = 2048,
     workers: int = 1,
     viewer: bool = False,
@@ -3142,7 +3142,7 @@ def main(
 
     Models: evocua-8b, evocua-32b, opencua-32b, opencua-72b, holo3, fara, gemma4-cua, claude
     Parallel: --workers 5   (auto fan-out looped tasks across N GPUs)
-    Claude options: --claude-model claude-sonnet-4-20250514 --thinking-budget 2048
+    Claude options: --claude-model claude-sonnet-4-6 --thinking-budget 2048
     Viewer: --viewer   (live web viewer via modal.forward tunnel)
     Learning: --learn --learn-samples 5   (build site playbook from N samples)
     Verification: --verify   (enable step verification during execution)

--- a/deploy/modal/modal_cua_server.py
+++ b/deploy/modal/modal_cua_server.py
@@ -1739,6 +1739,48 @@ claude_executor_image = (
 )
 
 
+def _resolve_claude_computer_plane_config():
+    """Build the `ComputerPlaneConfig` for `run_claude_cua`.
+
+    Reads `MANTIS_COMPUTER_PLANE_BACKEND` (default `local`). When set
+    to `modal`, resolves the `computer_plane` Modal function's web URL
+    if `MANTIS_COMPUTER_PLANE_URL` isn't explicitly set in the secret
+    — keeps the rollback story to a single env-var edit.
+
+    Returns `None` on `local` so the call site can rely on `setup_env`'s
+    env-var-driven default path (and tests that monkeypatch `setup_env`
+    don't need to know about this helper).
+    """
+    backend = (os.environ.get("MANTIS_COMPUTER_PLANE_BACKEND") or "local").strip().lower()
+    if backend == "local":
+        return None
+    from mantis_agent.gym.computer_client import ComputerPlaneConfig
+
+    base_url = (os.environ.get("MANTIS_COMPUTER_PLANE_URL") or "").strip()
+    if not base_url and backend == "modal":
+        try:
+            base_url = modal.Function.from_name(APP_NAME, "computer_plane").get_web_url()
+        except Exception as exc:  # noqa: BLE001 — print at WARNING via Modal
+            # Modal suppresses INFO/DEBUG (see
+            # `feedback_warning_level_for_modal_observability.md`); use
+            # print so the diagnostic survives `modal app logs`.
+            print(
+                f"  WARNING: Failed to resolve computer_plane web URL "
+                f"via Modal SDK ({exc}); set MANTIS_COMPUTER_PLANE_URL "
+                f"explicitly in the secret."
+            )
+            base_url = ""
+    enable_cdp = (os.environ.get("MANTIS_COMPUTER_PLANE_ENABLE_CDP") or "").strip().lower() in (
+        "1", "true", "yes", "on",
+    )
+    return ComputerPlaneConfig(
+        backend=backend,  # type: ignore[arg-type]
+        remote_base_url=base_url or None,
+        remote_auth_token=(os.environ.get("MANTIS_COMPUTER_PLANE_TOKEN") or "").strip() or None,
+        enable_cdp=enable_cdp,
+    )
+
+
 def _run_claude_executor(
     task_file_contents: str,
     plan_inputs: dict[str, str] | None = None,
@@ -1755,6 +1797,11 @@ def _run_claude_executor(
 
     No GPU needed — inference is via API. Only needs Chrome + xdotool.
     Trajectories are saved for potential distillation training.
+
+    Phase-1 migration target (#698): set
+    `MANTIS_COMPUTER_PLANE_BACKEND=modal` in the Modal secret to flip
+    this executor onto the remote computer plane. Default `local`
+    keeps the in-process behavior; rollback is a single secret edit.
     """
     from datetime import datetime, timezone
 
@@ -1797,6 +1844,7 @@ def _run_claude_executor(
             f.write(json.dumps(traj_entry) + "\n")
 
     # ── Env + viewer ──
+    computer_plane_config = _resolve_claude_computer_plane_config()
     env, proxy_proc, proxy_diag = setup_env(
         base_url=task_suite.get("base_url", ""),
         run_id=run_id, session_name=session_name,
@@ -1808,6 +1856,8 @@ def _run_claude_executor(
         proxy_disabled=bool(task_suite.get("_proxy_disabled", False)),
         extra_http_headers=task_suite.get("_browser_extra_headers") or None,
         profile_dir=profile_dir,
+        computer_plane_config=computer_plane_config,
+        executor_name="run_claude_cua",
     )
     viewer_ctx, viewer_event_bus, _viewer_url = setup_viewer(viewer, proxy_diag=proxy_diag)
 
@@ -2751,8 +2801,18 @@ computer_plane_image = (
     memory=8192,
     cpu=4.0,
     scaledown_window=600,
+    # The ASGI app holds the active session in process-local state
+    # (`ComputerAgentState._state.session`). With more than one
+    # replica, the brain's second request fans out to a different
+    # container which has no session and 401s — the failure mode the
+    # prior holo3 smoke surfaced. Phase 2 (#699) lifts this via
+    # per-session `.spawn()`; for Phase 1 we hard-pin to a single
+    # container and turn up per-container concurrency so the brain's
+    # parallel screenshot + xdotool calls still don't queue serially.
+    min_containers=1,
+    max_containers=1,
 )
-@modal.concurrent(max_inputs=1)  # one session per container; brain plane fans out
+@modal.concurrent(max_inputs=64)
 @modal.asgi_app()
 def computer_plane():
     """Computer Plane RPC server — Xvfb + Chrome + xdotool over HTTPS.
@@ -2760,21 +2820,25 @@ def computer_plane():
     Exposes the wire contract defined in
     ``mantis_agent.gym.computer_wire``:
 
-      * POST /session/init    — bind tenant/profile/run, launch Xvfb + Chrome
-      * POST /session/close   — SIGTERM Chrome, stop Xvfb
-      * POST /screenshot      — base64 PNG + viewport metadata
-      * POST /xdotool         — argv with step_id (LRU dedup, TTL=30s)
-      * POST /cdp             — opt-in, off by default
-      * GET  /health          — liveness + last-action timestamp
+      * POST /session/init      — bind tenant/profile/run, launch Xvfb + Chrome
+      * POST /session/close     — SIGTERM Chrome, stop Xvfb
+      * POST /screenshot        — base64 PNG + viewport metadata
+      * POST /xdotool           — argv with step_id (LRU dedup, TTL=30s)
+      * POST /cdp               — opt-in, off by default
+      * POST /cdp_click_at_point — SoM-anchored click via CDP (opt-in)
+      * GET  /current_url       — active tab URL
+      * GET  /cdp_count_pages   — open Chrome tabs (page-type)
+      * GET  /health            — liveness + last-action timestamp
 
     Phase 1 rollout (#698): brain executors call this via
     ``RemoteComputerImpl`` once ``ComputerPlaneConfig.backend='modal'``
     is set on the executor (with ``remote_base_url`` pointing at this
     function's web URL — resolve via
     ``modal.Function.from_name('mantis-cua-server', 'computer_plane').get_web_url()``).
-
-    Until then this function is built but unused, so deploys validate
-    that the image builds without affecting the local-in-process path.
+    The Claude executor flip is the first migration target; flip via
+    `modal secret create --from-dotenv` after setting
+    ``MANTIS_COMPUTER_PLANE_BACKEND=modal`` in the dotenv. Rollback by
+    re-pushing with ``local``.
     """
     from mantis_agent.server.computer_agent import build_app
     return build_app()

--- a/src/mantis_agent/gym/computer_wire.py
+++ b/src/mantis_agent/gym/computer_wire.py
@@ -25,6 +25,15 @@ class SessionInitRequest(BaseModel):
     Idempotent on `run_id`: a second init for the same `run_id` returns the
     existing session token. Different `run_id` against an active session is
     a 409.
+
+    `start_url` and `profile_dir` are forwarded to the remote
+    `XdotoolGymEnv` so the brain plane controls the initial navigation
+    and the on-volume profile path (paths must live under `/data/...`
+    — the brain and computer plane share the same Modal Volume).
+
+    `extra_http_headers` is forwarded to Chrome via CDP for sites that
+    need a persistent header (e.g. Daytona preview-warning bypass, see
+    `feedback_daytona_preview_warning_bypass.md`).
     """
 
     tenant_id: str
@@ -34,6 +43,9 @@ class SessionInitRequest(BaseModel):
     chrome_flags: list[str] = Field(default_factory=list)
     enable_cdp: bool = False
     viewport: tuple[int, int] = (1280, 720)
+    start_url: str = "about:blank"
+    profile_dir: str | None = None
+    extra_http_headers: dict[str, str] | None = None
 
 
 class SessionInitResponse(BaseModel):
@@ -104,3 +116,46 @@ class HealthResponse(BaseModel):
     ok: bool
     last_action_ms: int | None = None
     session_token: str | None = None
+
+
+class CurrentUrlResponse(BaseModel):
+    """Active tab URL — proxies `XdotoolGymEnv.current_url`.
+
+    Step handlers (and `task_loop`'s final-URL bookkeeping) read this
+    directly, so the remote impl must answer the same shape. Empty
+    string when no page has loaded yet.
+    """
+
+    url: str
+
+
+class CdpClickAtPointRequest(BaseModel):
+    """Forward `XdotoolGymEnv.cdp_click_at_point` over the wire.
+
+    `via_pointer=True` discriminates the `cdp_click_via_pointer` variant
+    (DOM `pointerdown`/`pointerup` rather than `mousedown`/`mouseup`)
+    which some sites need to register interaction. Single endpoint to
+    keep the server surface tight.
+    """
+
+    x: int
+    y: int
+    button: Literal["left", "middle", "right"] = "left"
+    click_count: int = 1
+    via_pointer: bool = False
+    step_id: str
+
+
+class CdpClickAtPointResponse(BaseModel):
+    ok: bool
+    error: str | None = None
+
+
+class CdpCountPagesResponse(BaseModel):
+    """Number of open Chrome targets (#582 — defensive count).
+
+    Used by the click handler to detect "click opened a new tab"
+    transitions.
+    """
+
+    count: int

--- a/src/mantis_agent/gym/remote_computer_impl.py
+++ b/src/mantis_agent/gym/remote_computer_impl.py
@@ -44,6 +44,10 @@ from .computer_client import ComputerClient
 from .computer_wire import (
     CDPRequest,
     CDPResponse,
+    CdpClickAtPointRequest,
+    CdpClickAtPointResponse,
+    CdpCountPagesResponse,
+    CurrentUrlResponse,
     ScreenshotRequest,
     ScreenshotResponse,
     SessionCloseRequest,
@@ -86,6 +90,11 @@ class RemoteComputerImpl(ComputerClient):
         proxy_server: str = "",
         chrome_flags: list[str] | None = None,
         request_timeout_seconds: float = _DEFAULT_HTTP_TIMEOUT,
+        # Honored — forwarded to the remote `SessionInitRequest` so the
+        # remote Chrome lands at the right page on the right on-volume
+        # profile with the brain-supplied header set.
+        profile_dir: str | None = None,
+        extra_http_headers: dict[str, str] | None = None,
         # The following kwargs are accepted for parity with
         # XdotoolGymEnv.__init__ but unused server-side (computer plane
         # manages its own lifecycle).
@@ -93,7 +102,6 @@ class RemoteComputerImpl(ComputerClient):
         display: str | None = None,  # noqa: ARG002
         settle_time: float = 1.5,  # noqa: ARG002
         human_speed: bool = False,  # noqa: ARG002
-        profile_dir: str = "/data/chrome-profile",  # noqa: ARG002
         save_screenshots: str = "",  # noqa: ARG002
         cdp_port: int = 9222,  # noqa: ARG002
         reuse_session: bool = False,  # noqa: ARG002
@@ -109,6 +117,8 @@ class RemoteComputerImpl(ComputerClient):
         self._proxy_server = proxy_server
         self._chrome_flags = chrome_flags or []
         self._timeout = request_timeout_seconds
+        self._profile_dir = profile_dir
+        self._extra_http_headers = extra_http_headers or None
         self._session_token: str | None = None
 
         self.screenshot_latency = LatencyTracker("screenshot")
@@ -179,6 +189,39 @@ class RemoteComputerImpl(ComputerClient):
         assert last_exc is not None
         raise last_exc
 
+    def _get(self, path: str) -> dict[str, Any]:
+        """GET with bounded retry on transient 5xx — mirrors `_post`.
+
+        Used by the read-only proxies (`/current_url`, `/cdp_count_pages`)
+        where there's nothing to serialize.
+        """
+        last_exc: Exception | None = None
+        for attempt in range(_MAX_RETRIES + 1):
+            try:
+                resp = requests.get(
+                    self._url(path),
+                    headers=self._headers(),
+                    timeout=self._timeout,
+                )
+                if resp.status_code < 400:
+                    return resp.json()
+                if 400 <= resp.status_code < 500:
+                    raise RuntimeError(
+                        f"computer-plane {path} returned {resp.status_code}: {resp.text[:200]}"
+                    )
+                last_exc = RuntimeError(
+                    f"computer-plane {path} returned {resp.status_code}: {resp.text[:200]}"
+                )
+            except requests.RequestException as exc:
+                last_exc = exc
+            if attempt < _MAX_RETRIES:
+                backoff = _RETRY_BACKOFF_SECONDS[
+                    min(attempt, len(_RETRY_BACKOFF_SECONDS) - 1)
+                ]
+                time.sleep(backoff)
+        assert last_exc is not None
+        raise last_exc
+
     # ── wire contract surface (used by tests + advanced callers) ────
 
     def session_init(self) -> SessionInitResponse:
@@ -190,6 +233,9 @@ class RemoteComputerImpl(ComputerClient):
             chrome_flags=self._chrome_flags,
             enable_cdp=self._enable_cdp,
             viewport=self._viewport,
+            start_url=self._start_url,
+            profile_dir=self._profile_dir,
+            extra_http_headers=self._extra_http_headers,
         )
         payload = self._post(
             "/session/init", req.model_dump(), include_session=False
@@ -278,6 +324,11 @@ class RemoteComputerImpl(ComputerClient):
     def close(self) -> None:
         self.session_close()
 
+    def shutdown(self) -> None:
+        """Alias for `close` — matches `XdotoolGymEnv.shutdown` which the
+        lifecycle code in `run_executor_lifecycle` calls."""
+        self.close()
+
     @property
     def screen_size(self) -> tuple[int, int]:
         return self._viewport
@@ -287,6 +338,175 @@ class RemoteComputerImpl(ComputerClient):
             "screenshot": self.screenshot_latency.summary(),
             "xdotool": self.xdotool_latency.summary(),
         }
+
+    # ── XdotoolGymEnv-compatibility surface ─────────────────────────
+    #
+    # Step handlers and the runner reach past `GymEnvironment` ABC into
+    # concrete `XdotoolGymEnv` methods. The migration's correctness
+    # rests on these proxies returning the same shapes the local impl
+    # does — every divergence becomes a brain-side crash at runtime.
+
+    def screenshot(self) -> Image.Image:
+        """PIL Image matching `XdotoolGymEnv.screenshot()` shape.
+
+        Handlers call `env.screenshot()` (not `env._capture()`) for the
+        ad-hoc post-action verify; same image bytes as
+        `_screenshot_observation()` so callers can mix the two.
+        """
+        return self._screenshot_observation().screenshot  # type: ignore[return-value]
+
+    def _capture(self) -> GymObservation:
+        """Alias for `_screenshot_observation` — some handlers poke at
+        the private name directly (mirrors `XdotoolGymEnv._capture`).
+        """
+        return self._screenshot_observation()
+
+    @property
+    def current_url(self) -> str:
+        """Active Chrome tab URL via `/current_url`. Empty string when
+        no page has loaded yet — never `None`, matching the local impl.
+        """
+        if not self._session_token:
+            self.session_init()
+        try:
+            payload = self._get("/current_url")
+            return CurrentUrlResponse.model_validate(payload).url or ""
+        except Exception as exc:  # noqa: BLE001 — observability, never fatal
+            logger.warning("RemoteComputerImpl.current_url failed: %s", exc)
+            return ""
+
+    def cdp_evaluate(self, expression: str) -> Any:
+        """Run a JS expression via the remote `/cdp` Runtime.evaluate.
+
+        Returns the unwrapped value (any JSON-serializable type) or
+        `None` on failure — matches `XdotoolGymEnv.cdp_evaluate`'s
+        contract. Requires `enable_cdp=True` on this session (raises
+        `RuntimeError` otherwise — caller treats absent CDP as
+        feature-not-available).
+        """
+        if not self._enable_cdp:
+            raise RuntimeError(
+                "RemoteComputerImpl.cdp_evaluate called but enable_cdp=False"
+            )
+        if not self._session_token:
+            self.session_init()
+        sid = f"step-{secrets.token_hex(8)}"
+        req = CDPRequest(expression=expression, await_promise=False, step_id=sid)
+        try:
+            payload = self._post("/cdp", req.model_dump())
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("RemoteComputerImpl.cdp_evaluate raised: %s", exc)
+            return None
+        resp = CDPResponse.model_validate(payload)
+        if resp.returncode != 0:
+            return None
+        import json as _json
+        try:
+            value = _json.loads(resp.result_json or "{}")
+        except _json.JSONDecodeError:
+            return None
+        # `Runtime.evaluate` returns `{result: {type, value}}`; unwrap
+        # to mirror `XdotoolGymEnv.cdp_evaluate`.
+        return (value.get("result") or {}).get("value") if isinstance(value, dict) else None
+
+    def cdp_click_at_point(self, x: int, y: int) -> bool:
+        """SoM-anchored click via remote `/cdp_click_at_point`.
+
+        Returns the server's `ok` flag — `True` iff an element was found
+        at (x, y) and the synthetic click was dispatched.
+        """
+        return self._remote_click(x, y, via_pointer=False)
+
+    def cdp_click_via_pointer(self, x: int, y: int) -> bool:
+        """Real-pointer click via `Input.dispatchMouseEvent`.
+
+        Same endpoint as `cdp_click_at_point` with `via_pointer=True`;
+        needed when sites gate on `isTrusted=true` (#audit batch).
+        """
+        return self._remote_click(x, y, via_pointer=True)
+
+    def _remote_click(self, x: int, y: int, *, via_pointer: bool) -> bool:
+        if not self._enable_cdp:
+            raise RuntimeError(
+                "RemoteComputerImpl click via CDP requires enable_cdp=True"
+            )
+        if not self._session_token:
+            self.session_init()
+        sid = f"step-{secrets.token_hex(8)}"
+        req = CdpClickAtPointRequest(
+            x=int(x), y=int(y), via_pointer=via_pointer, step_id=sid,
+        )
+        try:
+            payload = self._post(
+                "/cdp_click_at_point", req.model_dump(), step_id_for_retry=sid,
+            )
+        except Exception as exc:  # noqa: BLE001 — fall back like the local impl
+            logger.debug("RemoteComputerImpl click failed: %s", exc)
+            return False
+        return bool(CdpClickAtPointResponse.model_validate(payload).ok)
+
+    def _chrome_offset_px(self) -> int:
+        """Chrome chrome-offset (outerHeight - innerHeight) via CDP.
+
+        Used by callers translating screen coords to viewport coords.
+        Returns 0 when CDP is unavailable, matching the local impl.
+        """
+        try:
+            value = self.cdp_evaluate(
+                "Math.max(0, window.outerHeight - window.innerHeight)"
+            )
+        except Exception:  # noqa: BLE001
+            return 0
+        try:
+            return int(value) if value is not None else 0
+        except (TypeError, ValueError):
+            return 0
+
+    def cdp_count_pages(self) -> int:
+        """Number of open Chrome `type=page` tabs whose URL isn't a
+        system page — proxies `/cdp_count_pages`. Returns 0 on failure.
+        """
+        if not self._session_token:
+            self.session_init()
+        try:
+            payload = self._get("/cdp_count_pages")
+            return int(CdpCountPagesResponse.model_validate(payload).count)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("RemoteComputerImpl.cdp_count_pages failed: %s", exc)
+            return 0
+
+    def cdp_history_back(self, *, settle_seconds: float = 1.5) -> bool:
+        """Navigate back via `window.history.back()` over CDP — verifies
+        the URL changed within `settle_seconds`. Mirrors
+        `XdotoolGymEnv.cdp_history_back`.
+        """
+        if not self._enable_cdp:
+            return False
+        url_before = self.current_url or ""
+        try:
+            self.cdp_evaluate("window.history.back()")
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("cdp_history_back dispatch failed: %s", exc)
+            return False
+        deadline = time.time() + max(0.1, settle_seconds)
+        while time.time() < deadline:
+            time.sleep(0.1)
+            try:
+                url_after = self.current_url or ""
+            except Exception:  # noqa: BLE001
+                url_after = ""
+            if url_after and url_after != url_before:
+                return True
+        return False
+
+    def capture_browser_state(self) -> dict[str, Any]:
+        """Stub matching `XdotoolGymEnv.capture_browser_state` shape.
+
+        Full browser-state capture is brain-side bookkeeping; the
+        remote doesn't own it. Returning `{}` keeps call sites that
+        spread the result safe.
+        """
+        return {}
 
     # ── helpers ──────────────────────────────────────────────────────
 

--- a/src/mantis_agent/server/computer_agent.py
+++ b/src/mantis_agent/server/computer_agent.py
@@ -38,6 +38,10 @@ from fastapi import FastAPI, Header, HTTPException
 from ..gym.computer_wire import (
     CDPRequest,
     CDPResponse,
+    CdpClickAtPointRequest,
+    CdpClickAtPointResponse,
+    CdpCountPagesResponse,
+    CurrentUrlResponse,
     HealthResponse,
     ScreenshotRequest,
     ScreenshotResponse,
@@ -137,25 +141,52 @@ def _require_session(session_token: str | None) -> _Session:
     return s
 
 
+def _resolve_profile_dir(req: SessionInitRequest) -> str:
+    """Resolve the on-volume profile dir the remote Chrome will use.
+
+    Brain-side `profile_dir` strings reach us as-is. Both planes mount
+    the same `osworld-data` Modal Volume at `/data`, so paths under
+    `/data/...` are shared transparently. Reject anything else loudly
+    rather than silently writing a profile into the container's
+    ephemeral filesystem (which evaporates with the container).
+    """
+    requested = (req.profile_dir or "").strip()
+    if requested:
+        if not requested.startswith("/data/"):
+            raise HTTPException(
+                400,
+                f"profile_dir must live under /data/ (got {requested!r}); "
+                "brain and computer plane share /data via the same Modal Volume",
+            )
+        return requested
+    return f"/data/chrome-profile/{req.tenant_id}__{req.profile_id}"
+
+
 def _new_xdotool_env(req: SessionInitRequest) -> Any:
     """Construct + start the Xvfb / Chrome stack for this session.
 
     Goes through `make_computer_client(ComputerPlaneConfig())` so the
     server-side wiring uses the same factory the brain plane uses — keeps
     the impl honest about being a `ComputerClient`.
+
+    Forwards the brain-supplied `start_url`, `profile_dir`, and
+    `extra_http_headers` so the remote Chrome lands at the right page
+    on the right profile with the right header set (CF preview-warning
+    bypass, etc.).
     """
     from ..gym.computer_client import ComputerPlaneConfig, make_computer_client
 
-    profile_dir = f"/data/chrome-profile/{req.tenant_id}__{req.profile_id}"
+    profile_dir = _resolve_profile_dir(req)
     env = make_computer_client(
         ComputerPlaneConfig(),
-        start_url="about:blank",
+        start_url=req.start_url,
         viewport=req.viewport,
         browser="google-chrome",
         proxy_server=req.proxy_server or "",
         profile_dir=profile_dir,
+        extra_http_headers=req.extra_http_headers or None,
     )
-    env.reset(task="computer_plane_session", start_url="about:blank")
+    env.reset(task="computer_plane_session", start_url=req.start_url)
     return env
 
 
@@ -315,6 +346,86 @@ def build_app() -> FastAPI:
             )
         except Exception as exc:  # noqa: BLE001 — bubble as 5xx
             raise HTTPException(500, f"cdp_evaluate failed: {exc}") from exc
+
+    @app.get("/current_url", response_model=CurrentUrlResponse)
+    def current_url(
+        x_mantis_session: str | None = Header(default=None),
+    ) -> CurrentUrlResponse:
+        """Active Chrome tab URL.
+
+        Step handlers (`claude_step`, `navigate_back`, the runner's
+        final-URL bookkeeping) read this. Empty string when no page has
+        loaded yet — never `None`, so brain-side `.lower()` chains stay
+        safe.
+        """
+        s = _require_session(x_mantis_session)
+        s.touch()
+        try:
+            url = s.env.current_url or ""
+        except Exception as exc:  # noqa: BLE001 — observability only
+            logger.warning("current_url read failed: %s", exc)
+            url = ""
+        return CurrentUrlResponse(url=url)
+
+    @app.post("/cdp_click_at_point", response_model=CdpClickAtPointResponse)
+    def cdp_click_at_point(
+        req: CdpClickAtPointRequest,
+        x_mantis_session: str | None = Header(default=None),
+    ) -> CdpClickAtPointResponse:
+        """SoM-anchored click via CDP — single endpoint covers both
+        `cdp_click_at_point` (`el.click()`) and `cdp_click_via_pointer`
+        (`Input.dispatchMouseEvent`) variants. `via_pointer=True` picks
+        the latter; needed when sites gate on `isTrusted` (#audit batch
+        ok-but-no-state-change).
+
+        Honors the session dedup LRU on `step_id` like `/xdotool` does —
+        retries with the same id no-op rather than double-clicking.
+        """
+        s = _require_session(x_mantis_session)
+        if not s.enable_cdp:
+            raise HTTPException(403, "CDP disabled for this session")
+
+        # Reuse the xdotool dedup table — `step_id` is unique per
+        # logical step regardless of which dispatch path the brain
+        # chose, so cross-path dedup is safe.
+        cached = s.lookup_dedup(req.step_id)
+        if cached is not None:
+            s.touch()
+            return CdpClickAtPointResponse(ok=cached.returncode == 0)
+        try:
+            if req.via_pointer:
+                ok = bool(s.env.cdp_click_via_pointer(req.x, req.y))
+            else:
+                ok = bool(s.env.cdp_click_at_point(req.x, req.y))
+        except Exception as exc:  # noqa: BLE001 — bubble as 5xx
+            raise HTTPException(500, f"cdp_click_at_point failed: {exc}") from exc
+        # Stash a stub XdotoolResponse for the dedup table — only the
+        # returncode field is consulted on cache hit.
+        s.remember_dedup(
+            req.step_id,
+            XdotoolResponse(stdout="", stderr="", returncode=0 if ok else 1),
+        )
+        s.touch()
+        return CdpClickAtPointResponse(ok=ok)
+
+    @app.get("/cdp_count_pages", response_model=CdpCountPagesResponse)
+    def cdp_count_pages(
+        x_mantis_session: str | None = Header(default=None),
+    ) -> CdpCountPagesResponse:
+        """Count of Chrome `type=page` tabs whose URL isn't a system
+        page — used by the click handler to detect new-tab opens.
+
+        Returns `0` on any CDP failure (per `XdotoolGymEnv.cdp_count_pages`'s
+        contract); caller treats `0` as "couldn't check".
+        """
+        s = _require_session(x_mantis_session)
+        s.touch()
+        try:
+            count = int(s.env.cdp_count_pages())
+        except Exception as exc:  # noqa: BLE001 — observability only
+            logger.warning("cdp_count_pages read failed: %s", exc)
+            count = 0
+        return CdpCountPagesResponse(count=count)
 
     return app
 

--- a/src/mantis_agent/task_loop.py
+++ b/src/mantis_agent/task_loop.py
@@ -122,6 +122,40 @@ def diagnose_proxy_egress(proxy_server: str, *, timeout: float = 8.0) -> dict[st
         return {"error": f"{type(exc).__name__}: {str(exc)[:120]}"}
 
 
+def _computer_plane_config_from_env(
+    executor_name: str | None = None,
+) -> "ComputerPlaneConfig":
+    """Build a `ComputerPlaneConfig` from `MANTIS_COMPUTER_PLANE_*` env vars.
+
+    Defaults match production today: `backend="local"`. Lets the brain
+    container flip a single executor onto the Phase-1 remote plane via
+    a one-secret edit without touching call sites:
+
+    * `MANTIS_COMPUTER_PLANE_BACKEND` — `local` (default) | `modal`
+    * `MANTIS_COMPUTER_PLANE_URL` — remote base URL (required for
+      `modal`); typically resolved at executor boot via
+      `modal.Function.from_name("mantis-cua-server", "computer_plane").get_web_url()`.
+    * `MANTIS_COMPUTER_PLANE_TOKEN` — `Authorization: Bearer ...`
+    * `MANTIS_COMPUTER_PLANE_ENABLE_CDP` — `1`/`true` to opt in
+      (off by default per the wire-contract CUA-purity constraint).
+    """
+    from .gym.computer_client import ComputerPlaneConfig
+
+    backend_env = (os.environ.get("MANTIS_COMPUTER_PLANE_BACKEND") or "local").strip().lower()
+    if backend_env not in ("local", "modal", "e2b", "daytona"):
+        backend_env = "local"
+    enable_cdp = (os.environ.get("MANTIS_COMPUTER_PLANE_ENABLE_CDP") or "").strip().lower() in (
+        "1", "true", "yes", "on",
+    )
+    cfg = ComputerPlaneConfig(
+        backend=backend_env,  # type: ignore[arg-type]
+        remote_base_url=(os.environ.get("MANTIS_COMPUTER_PLANE_URL") or "").strip() or None,
+        remote_auth_token=(os.environ.get("MANTIS_COMPUTER_PLANE_TOKEN") or "").strip() or None,
+        enable_cdp=enable_cdp,
+    )
+    return cfg.resolve_for_executor(executor_name)
+
+
 def setup_env(
     *,
     base_url: str,
@@ -141,6 +175,8 @@ def setup_env(
     save_screenshots_dir: str = "/data/screenshots",
     reuse_session: bool = False,
     extra_http_headers: dict[str, str] | None = None,
+    computer_plane_config: "ComputerPlaneConfig | None" = None,
+    executor_name: str | None = None,
 ) -> tuple[Any, Any, dict[str, Any]]:
     """Set up proxy + computer-plane env.
 
@@ -148,20 +184,31 @@ def setup_env(
     in #697 (Computer Plane Phase 0) is the only construction path. The
     returned env is always a ``ComputerClient`` — today that resolves to
     ``LocalXdotoolImpl`` (a ``XdotoolGymEnv`` subclass with latency
-    instrumentation); Phase 1 swaps in ``RemoteComputerImpl`` per
-    ``ComputerPlaneConfig``.
+    instrumentation) by default; Phase 1 swaps in ``RemoteComputerImpl``
+    when the config flips to ``backend="modal"``.
 
     Args:
         proxy_disabled: When True, skip the upstream proxy entirely. Use for
             test/internal sites that don't need bot-detection bypass and
             shouldn't depend on the residential proxy's availability.
+        computer_plane_config: Explicit config. Default reads
+            ``MANTIS_COMPUTER_PLANE_*`` env vars via
+            :func:`_computer_plane_config_from_env`. The ``backend="modal"``
+            path skips the local Xvfb spawn (the remote container owns
+            Xvfb + Chrome).
+        executor_name: When set, the env-derived config is consulted
+            for a per-executor override before resolving the backend
+            (e.g. ``run_claude_cua`` flips to ``modal`` while GPU
+            executors stay ``local``).
 
     Returns ``(env, proxy_proc_or_None, proxy_diag)`` where ``proxy_diag``
     is the ipinfo egress probe (``{"ip", "city", "region", ...}`` on
     success, ``{"disabled": True}`` when proxy is off, ``{"error": ...}``
     when the probe failed).
     """
-    from .gym.computer_client import ComputerPlaneConfig, make_computer_client
+    from .gym.computer_client import make_computer_client
+
+    cfg = computer_plane_config or _computer_plane_config_from_env(executor_name)
 
     if proxy_disabled:
         proxy = None
@@ -186,7 +233,10 @@ def setup_env(
     # uses, so we surface the IP Cloudflare sees.
     proxy_diag = diagnose_proxy_egress(proxy_server)
 
-    if start_xvfb and display:
+    # Local Xvfb only when the env actually runs in-process. The remote
+    # computer plane owns its own Xvfb; spawning a brain-side one would
+    # both waste a CPU and break DISPLAY clobbering on shared executors.
+    if cfg.backend == "local" and start_xvfb and display:
         subprocess.Popen(
             ["Xvfb", display, "-screen", "0", f"{viewport[0]}x{viewport[1]}x24", "-ac", "-nolisten", "tcp"],
             stdout=subprocess.DEVNULL,
@@ -205,14 +255,21 @@ def setup_env(
         "save_screenshots": f"{save_screenshots_dir}/{session_name}_{run_id}",
         "reuse_session": reuse_session,
     }
-    if display:
+    if display and cfg.backend == "local":
         env_kwargs["display"] = display
     if profile_dir:
         env_kwargs["profile_dir"] = profile_dir
     if extra_http_headers:
         env_kwargs["extra_http_headers"] = extra_http_headers
+    if cfg.backend != "local":
+        # `RemoteComputerImpl` binds its session to (tenant, profile,
+        # run); surface the brain-side identifiers so the remote can
+        # honor profile reuse + the per-profile lock in Phase 2.
+        env_kwargs.setdefault("tenant_id", session_name)
+        env_kwargs.setdefault("profile_id", session_name)
+        env_kwargs.setdefault("run_id", run_id)
 
-    env = make_computer_client(ComputerPlaneConfig(), **env_kwargs)
+    env = make_computer_client(cfg, **env_kwargs)
     return env, proxy_proc, proxy_diag
 
 

--- a/src/mantis_agent/task_loop.py
+++ b/src/mantis_agent/task_loop.py
@@ -15,9 +15,12 @@ import time
 import traceback
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Any, Callable
+from typing import TYPE_CHECKING, Any, Callable
 
 from .server_utils import build_proxy_config, resolve_proxy_server
+
+if TYPE_CHECKING:
+    from .gym.computer_client import ComputerPlaneConfig
 
 logger = logging.getLogger(__name__)
 

--- a/tests/test_computer_agent_server.py
+++ b/tests/test_computer_agent_server.py
@@ -306,3 +306,213 @@ def test_cdp_200_when_enabled(
     body = r.json()
     assert body["returncode"] == 0
     assert '"value": 100' in body["result_json"]
+
+
+# ── session-init forwarding ──────────────────────────────────────────
+
+
+def test_session_init_forwards_start_url_profile_dir_extra_headers(
+    monkeypatch: pytest.MonkeyPatch,
+    fake_env: MagicMock,
+) -> None:
+    """The new fields must reach `_new_xdotool_env` — the brain plane
+    relies on them to land Chrome at the right page on the right
+    profile with the right header set (`extra_http_headers` for
+    Daytona preview-warning bypass etc.).
+    """
+    from mantis_agent.server import computer_agent as ca
+
+    ca._state.session = None
+    captured: dict[str, Any] = {}
+
+    def _capture(req: Any) -> MagicMock:
+        captured["start_url"] = req.start_url
+        captured["profile_dir"] = req.profile_dir
+        captured["extra_http_headers"] = req.extra_http_headers
+        return fake_env
+
+    monkeypatch.setattr(ca, "_new_xdotool_env", _capture)
+    client = TestClient(ca.build_app())
+
+    r = client.post(
+        "/session/init",
+        json={
+            "tenant_id": "acme",
+            "profile_id": "p1",
+            "run_id": "r1",
+            "viewport": [1280, 720],
+            "start_url": "https://target.example/start",
+            "profile_dir": "/data/chrome-profile/acme__p1",
+            "extra_http_headers": {"X-Test": "1"},
+        },
+    )
+    assert r.status_code == 200
+    assert captured["start_url"] == "https://target.example/start"
+    assert captured["profile_dir"] == "/data/chrome-profile/acme__p1"
+    assert captured["extra_http_headers"] == {"X-Test": "1"}
+
+
+def test_resolve_profile_dir_rejects_paths_outside_data_volume() -> None:
+    """Off-volume `profile_dir` would silently write to the container's
+    ephemeral filesystem and evaporate. Fail loud server-side."""
+    from fastapi import HTTPException
+
+    from mantis_agent.server.computer_agent import (
+        _resolve_profile_dir,
+    )
+    from mantis_agent.gym.computer_wire import SessionInitRequest
+
+    req = SessionInitRequest(
+        tenant_id="t",
+        profile_id="p",
+        run_id="r",
+        profile_dir="/tmp/bad",
+    )
+    with pytest.raises(HTTPException) as exc:
+        _resolve_profile_dir(req)
+    assert exc.value.status_code == 400
+
+
+def test_resolve_profile_dir_defaults_when_unset() -> None:
+    from mantis_agent.server.computer_agent import _resolve_profile_dir
+    from mantis_agent.gym.computer_wire import SessionInitRequest
+
+    req = SessionInitRequest(tenant_id="acme", profile_id="p1", run_id="r1")
+    assert _resolve_profile_dir(req) == "/data/chrome-profile/acme__p1"
+
+
+# ── current_url ──────────────────────────────────────────────────────
+
+
+def test_current_url_returns_active_tab_url(
+    client: TestClient,
+    init_payload: dict[str, Any],
+    fake_env: MagicMock,
+) -> None:
+    fake_env.current_url = "https://example.com/leads"
+    tok = client.post("/session/init", json=init_payload).json()["session_token"]
+    r = client.get("/current_url", headers={"X-Mantis-Session": tok})
+    assert r.status_code == 200
+    assert r.json() == {"url": "https://example.com/leads"}
+
+
+def test_current_url_returns_empty_string_on_env_failure(
+    client: TestClient,
+    init_payload: dict[str, Any],
+    fake_env: MagicMock,
+) -> None:
+    type(fake_env).current_url = property(
+        lambda _self: (_ for _ in ()).throw(RuntimeError("CDP off")),
+    )
+    tok = client.post("/session/init", json=init_payload).json()["session_token"]
+    r = client.get("/current_url", headers={"X-Mantis-Session": tok})
+    # Reset to keep other tests sane.
+    del type(fake_env).current_url
+    assert r.status_code == 200
+    assert r.json() == {"url": ""}
+
+
+def test_current_url_requires_session_header(client: TestClient) -> None:
+    r = client.get("/current_url")
+    assert r.status_code == 401
+
+
+# ── cdp_click_at_point ───────────────────────────────────────────────
+
+
+def test_cdp_click_at_point_403_when_disabled(
+    client: TestClient, init_payload: dict[str, Any]
+) -> None:
+    tok = client.post("/session/init", json=init_payload).json()["session_token"]
+    r = client.post(
+        "/cdp_click_at_point",
+        json={"x": 1, "y": 2, "via_pointer": False, "step_id": "s"},
+        headers={"X-Mantis-Session": tok},
+    )
+    assert r.status_code == 403
+
+
+def test_cdp_click_at_point_dispatches_env_method(
+    client: TestClient,
+    init_payload: dict[str, Any],
+    fake_env: MagicMock,
+) -> None:
+    init_payload = dict(init_payload, enable_cdp=True)
+    fake_env.cdp_click_at_point.return_value = True
+    tok = client.post("/session/init", json=init_payload).json()["session_token"]
+    r = client.post(
+        "/cdp_click_at_point",
+        json={"x": 100, "y": 200, "via_pointer": False, "step_id": "s1"},
+        headers={"X-Mantis-Session": tok},
+    )
+    assert r.status_code == 200
+    assert r.json()["ok"] is True
+    fake_env.cdp_click_at_point.assert_called_once_with(100, 200)
+    fake_env.cdp_click_via_pointer.assert_not_called()
+
+
+def test_cdp_click_at_point_via_pointer_picks_pointer_method(
+    client: TestClient,
+    init_payload: dict[str, Any],
+    fake_env: MagicMock,
+) -> None:
+    init_payload = dict(init_payload, enable_cdp=True)
+    fake_env.cdp_click_via_pointer.return_value = True
+    tok = client.post("/session/init", json=init_payload).json()["session_token"]
+    r = client.post(
+        "/cdp_click_at_point",
+        json={"x": 50, "y": 60, "via_pointer": True, "step_id": "s2"},
+        headers={"X-Mantis-Session": tok},
+    )
+    assert r.status_code == 200
+    assert r.json()["ok"] is True
+    fake_env.cdp_click_via_pointer.assert_called_once_with(50, 60)
+    fake_env.cdp_click_at_point.assert_not_called()
+
+
+def test_cdp_click_at_point_dedup_on_repeated_step_id(
+    client: TestClient,
+    init_payload: dict[str, Any],
+    fake_env: MagicMock,
+) -> None:
+    init_payload = dict(init_payload, enable_cdp=True)
+    fake_env.cdp_click_at_point.return_value = True
+    tok = client.post("/session/init", json=init_payload).json()["session_token"]
+    body = {"x": 1, "y": 2, "via_pointer": False, "step_id": "step-dedup"}
+    headers = {"X-Mantis-Session": tok}
+    client.post("/cdp_click_at_point", json=body, headers=headers)
+    client.post("/cdp_click_at_point", json=body, headers=headers)
+    # Second call must not invoke the env method again.
+    assert fake_env.cdp_click_at_point.call_count == 1
+
+
+# ── cdp_count_pages ──────────────────────────────────────────────────
+
+
+def test_cdp_count_pages_returns_int(
+    client: TestClient,
+    init_payload: dict[str, Any],
+    fake_env: MagicMock,
+) -> None:
+    fake_env.cdp_count_pages.return_value = 3
+    tok = client.post("/session/init", json=init_payload).json()["session_token"]
+    r = client.get("/cdp_count_pages", headers={"X-Mantis-Session": tok})
+    assert r.status_code == 200
+    assert r.json() == {"count": 3}
+
+
+def test_cdp_count_pages_returns_zero_on_env_failure(
+    client: TestClient,
+    init_payload: dict[str, Any],
+    fake_env: MagicMock,
+) -> None:
+    fake_env.cdp_count_pages.side_effect = RuntimeError("CDP socket dead")
+    tok = client.post("/session/init", json=init_payload).json()["session_token"]
+    r = client.get("/cdp_count_pages", headers={"X-Mantis-Session": tok})
+    assert r.status_code == 200
+    assert r.json() == {"count": 0}
+
+
+def test_cdp_count_pages_requires_session_header(client: TestClient) -> None:
+    r = client.get("/cdp_count_pages")
+    assert r.status_code == 401

--- a/tests/test_remote_computer_impl.py
+++ b/tests/test_remote_computer_impl.py
@@ -451,8 +451,6 @@ def test_current_url_proxies_get_current_url() -> None:
 
 
 def test_current_url_swallows_failure_and_returns_empty_string() -> None:
-    fake = _FakeServer()
-
     def _failing_get(*_a: Any, **_kw: Any) -> _Resp:
         raise requests.ConnectTimeout("nope")
 

--- a/tests/test_remote_computer_impl.py
+++ b/tests/test_remote_computer_impl.py
@@ -47,6 +47,11 @@ class _FakeServer:
         self.screenshot_image_b64 = screenshot_image_b64 or _png_b64()
         self.session_token = "tok-abc"
         self.dedup_returncode_overrides: dict[str, int] = {}
+        # Proxied-env state — flipped by individual tests as needed.
+        self.current_url = "https://example.com/start"
+        self.page_count = 1
+        self.cdp_click_ok = True
+        self.cdp_result_json = '{"result": {"value": 42}}'
 
     def __call__(
         self,
@@ -101,8 +106,28 @@ class _FakeServer:
                 },
             )
         if path == "/cdp":
-            return _Resp(200, {"result_json": "{}", "returncode": 0})
+            return _Resp(200, {"result_json": self.cdp_result_json, "returncode": 0})
+        if path == "/cdp_click_at_point":
+            return _Resp(200, {"ok": self.cdp_click_ok, "error": None})
         return _Resp(404, {}, text=f"no handler for {path}")
+
+    def get(
+        self,
+        url: str,
+        headers: dict[str, str] | None = None,
+        timeout: float | None = None,
+    ) -> _Resp:
+        """Sibling of `__call__` for GET endpoints (`/current_url`,
+        `/cdp_count_pages`). Recorded with the same `self.calls` shape
+        as POSTs so assertions can grep paths uniformly.
+        """
+        path = "/" + url.split("/", 3)[-1] if url.count("/") >= 3 else url
+        self.calls.append({"path": path, "json": None, "headers": headers or {}})
+        if path == "/current_url":
+            return _Resp(200, {"url": self.current_url})
+        if path == "/cdp_count_pages":
+            return _Resp(200, {"count": self.page_count})
+        return _Resp(404, {}, text=f"no GET handler for {path}")
 
 
 def _png_b64(size: tuple[int, int] = (16, 16)) -> str:
@@ -364,3 +389,199 @@ def test_latency_report_aggregates_screenshot_and_xdotool() -> None:
     assert report["screenshot"]["count"] == 3
     # Each CLICK is 2 xdotool calls → 4 across the two steps.
     assert report["xdotool"]["count"] == 4
+
+
+# ── XdotoolGymEnv-compatibility surface ──────────────────────────────
+
+
+def test_session_init_forwards_start_url_profile_dir_extra_headers() -> None:
+    fake = _FakeServer()
+    env = RemoteComputerImpl(
+        base_url="https://x",
+        start_url="https://target.example/landing",
+        profile_dir="/data/chrome-profile/t__p",
+        extra_http_headers={"X-Daytona-Skip-Preview-Warning": "true"},
+    )
+    with patch("requests.post", side_effect=fake):
+        env.session_init()
+    init_call = next(c for c in fake.calls if c["path"] == "/session/init")
+    assert init_call["json"]["start_url"] == "https://target.example/landing"
+    assert init_call["json"]["profile_dir"] == "/data/chrome-profile/t__p"
+    assert init_call["json"]["extra_http_headers"] == {
+        "X-Daytona-Skip-Preview-Warning": "true",
+    }
+
+
+def test_screenshot_returns_pil_image_with_same_bytes_as_observation() -> None:
+    fake = _FakeServer()
+    env = RemoteComputerImpl(base_url="https://x")
+    with patch("requests.post", side_effect=fake):
+        env.reset(task="t")
+        img_direct = env.screenshot()
+        obs = env._capture()
+    assert img_direct.size == (16, 16)
+    assert obs.screenshot.size == (16, 16)
+
+
+def test_shutdown_calls_session_close() -> None:
+    fake = _FakeServer()
+    env = RemoteComputerImpl(base_url="https://x")
+    with patch("requests.post", side_effect=fake):
+        env.reset(task="t")
+        env.shutdown()
+    assert env._session_token is None
+    assert any(c["path"] == "/session/close" for c in fake.calls)
+
+
+def test_capture_browser_state_is_empty_stub() -> None:
+    env = RemoteComputerImpl(base_url="https://x")
+    assert env.capture_browser_state() == {}
+
+
+def test_current_url_proxies_get_current_url() -> None:
+    fake = _FakeServer()
+    fake.current_url = "https://example.com/leads?owner=true"
+    env = RemoteComputerImpl(base_url="https://x")
+    with patch("requests.post", side_effect=fake), patch(
+        "requests.get", side_effect=fake.get
+    ):
+        env.reset(task="t")
+        url = env.current_url
+    assert url == "https://example.com/leads?owner=true"
+
+
+def test_current_url_swallows_failure_and_returns_empty_string() -> None:
+    fake = _FakeServer()
+
+    def _failing_get(*_a: Any, **_kw: Any) -> _Resp:
+        raise requests.ConnectTimeout("nope")
+
+    env = RemoteComputerImpl(base_url="https://x")
+    env._session_token = "tok"  # skip init
+    with patch("requests.get", side_effect=_failing_get), patch(
+        "mantis_agent.gym.remote_computer_impl.time.sleep", lambda *_: None
+    ):
+        assert env.current_url == ""
+
+
+def test_cdp_evaluate_disabled_raises() -> None:
+    env = RemoteComputerImpl(base_url="https://x")
+    with pytest.raises(RuntimeError, match="enable_cdp=False"):
+        env.cdp_evaluate("window.scrollY")
+
+
+def test_cdp_evaluate_unwraps_runtime_evaluate_result_value() -> None:
+    fake = _FakeServer()
+    fake.cdp_result_json = '{"result": {"type": "number", "value": 1234}}'
+    env = RemoteComputerImpl(base_url="https://x", enable_cdp=True)
+    with patch("requests.post", side_effect=fake):
+        env.reset(task="t")
+        out = env.cdp_evaluate("window.scrollY")
+    assert out == 1234
+
+
+def test_cdp_evaluate_returns_none_on_undefined_result() -> None:
+    fake = _FakeServer()
+    fake.cdp_result_json = "{}"  # mirrors JS `undefined`
+    env = RemoteComputerImpl(base_url="https://x", enable_cdp=True)
+    with patch("requests.post", side_effect=fake):
+        env.reset(task="t")
+        assert env.cdp_evaluate("nothing") is None
+
+
+def test_chrome_offset_px_uses_cdp_evaluate() -> None:
+    fake = _FakeServer()
+    fake.cdp_result_json = '{"result": {"value": 95}}'
+    env = RemoteComputerImpl(base_url="https://x", enable_cdp=True)
+    with patch("requests.post", side_effect=fake):
+        env.reset(task="t")
+        assert env._chrome_offset_px() == 95
+
+
+def test_cdp_click_at_point_proxies_endpoint() -> None:
+    fake = _FakeServer()
+    fake.cdp_click_ok = True
+    env = RemoteComputerImpl(base_url="https://x", enable_cdp=True)
+    with patch("requests.post", side_effect=fake):
+        env.reset(task="t")
+        assert env.cdp_click_at_point(100, 200) is True
+    click_calls = [c for c in fake.calls if c["path"] == "/cdp_click_at_point"]
+    assert len(click_calls) == 1
+    payload = click_calls[0]["json"]
+    assert payload["x"] == 100 and payload["y"] == 200
+    assert payload["via_pointer"] is False
+
+
+def test_cdp_click_via_pointer_sets_via_pointer_flag() -> None:
+    fake = _FakeServer()
+    env = RemoteComputerImpl(base_url="https://x", enable_cdp=True)
+    with patch("requests.post", side_effect=fake):
+        env.reset(task="t")
+        env.cdp_click_via_pointer(300, 400)
+    click_calls = [c for c in fake.calls if c["path"] == "/cdp_click_at_point"]
+    assert click_calls[0]["json"]["via_pointer"] is True
+
+
+def test_cdp_click_requires_enable_cdp() -> None:
+    env = RemoteComputerImpl(base_url="https://x")
+    with pytest.raises(RuntimeError, match="enable_cdp=True"):
+        env.cdp_click_at_point(1, 2)
+
+
+def test_cdp_count_pages_proxies_get_endpoint() -> None:
+    fake = _FakeServer()
+    fake.page_count = 3
+    env = RemoteComputerImpl(base_url="https://x")
+    with patch("requests.post", side_effect=fake), patch(
+        "requests.get", side_effect=fake.get
+    ):
+        env.reset(task="t")
+        assert env.cdp_count_pages() == 3
+
+
+def test_cdp_count_pages_returns_zero_on_failure() -> None:
+    def _bad_get(*_a: Any, **_kw: Any) -> _Resp:
+        raise requests.ConnectionError("nope")
+
+    env = RemoteComputerImpl(base_url="https://x")
+    env._session_token = "tok"
+    with patch("requests.get", side_effect=_bad_get), patch(
+        "mantis_agent.gym.remote_computer_impl.time.sleep", lambda *_: None
+    ):
+        assert env.cdp_count_pages() == 0
+
+
+def test_cdp_history_back_returns_true_on_url_change() -> None:
+    fake = _FakeServer()
+    fake.cdp_result_json = "{}"  # `history.back()` returns undefined
+    urls = iter(["https://example.com/before", "https://example.com/after"])
+
+    def _get(url: str, **_kw: Any) -> _Resp:
+        path = "/" + url.split("/", 3)[-1] if url.count("/") >= 3 else url
+        fake.calls.append({"path": path, "json": None, "headers": {}})
+        if path == "/current_url":
+            return _Resp(200, {"url": next(urls)})
+        return _Resp(404, {})
+
+    env = RemoteComputerImpl(base_url="https://x", enable_cdp=True)
+    with patch("requests.post", side_effect=fake), patch(
+        "requests.get", side_effect=_get
+    ), patch("mantis_agent.gym.remote_computer_impl.time.sleep", lambda *_: None):
+        env.reset(task="t")
+        assert env.cdp_history_back(settle_seconds=0.5) is True
+
+
+def test_cdp_history_back_returns_false_when_url_unchanged() -> None:
+    fake = _FakeServer()
+    env = RemoteComputerImpl(base_url="https://x", enable_cdp=True)
+    with patch("requests.post", side_effect=fake), patch(
+        "requests.get", side_effect=fake.get
+    ), patch("mantis_agent.gym.remote_computer_impl.time.sleep", lambda *_: None):
+        env.reset(task="t")
+        # `fake.current_url` is constant → no change → returns False.
+        assert env.cdp_history_back(settle_seconds=0.3) is False
+
+
+def test_cdp_history_back_returns_false_when_cdp_disabled() -> None:
+    env = RemoteComputerImpl(base_url="https://x")
+    assert env.cdp_history_back() is False

--- a/tests/test_setup_env_backend_flip.py
+++ b/tests/test_setup_env_backend_flip.py
@@ -18,7 +18,6 @@ no code change on the call sites. These tests pin three properties:
 from __future__ import annotations
 
 from typing import Any
-from unittest.mock import patch
 
 import pytest
 

--- a/tests/test_setup_env_backend_flip.py
+++ b/tests/test_setup_env_backend_flip.py
@@ -1,0 +1,244 @@
+"""Tests for the `MANTIS_COMPUTER_PLANE_BACKEND` flip plumbed through
+`task_loop.setup_env`.
+
+Phase 1 (#698) acceptance requires the flip be a one-secret edit with
+no code change on the call sites. These tests pin three properties:
+
+  1. Default config returns a `LocalXdotoolImpl` — production today
+     keeps working unchanged when the env var is absent.
+  2. `backend="modal"` returns a `RemoteComputerImpl` and forwards
+     `start_url` / `profile_dir` / `extra_http_headers` into the
+     impl so the remote `SessionInitRequest` carries them.
+  3. The local Xvfb subprocess is NOT spawned when the env runs in a
+     remote backend — its display lives on the computer-plane
+     container, so a brain-side `Xvfb` would clobber `DISPLAY` and
+     also waste a CPU.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from mantis_agent.gym.computer_client import ComputerPlaneConfig
+from mantis_agent.gym.local_xdotool_impl import LocalXdotoolImpl
+from mantis_agent.gym.remote_computer_impl import RemoteComputerImpl
+from mantis_agent.task_loop import _computer_plane_config_from_env, setup_env
+
+
+@pytest.fixture(autouse=True)
+def _disable_proxy_egress_probe(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The probe hits ipinfo.io over HTTP — short-circuit so tests are
+    network-free."""
+    monkeypatch.setattr(
+        "mantis_agent.task_loop.diagnose_proxy_egress",
+        lambda *_a, **_kw: {"disabled": True},
+    )
+
+
+@pytest.fixture(autouse=True)
+def _no_real_xvfb(monkeypatch: pytest.MonkeyPatch) -> list[list[str]]:
+    """Capture every `subprocess.Popen` invocation from setup_env so
+    tests can assert whether Xvfb was actually spawned."""
+    spawns: list[list[str]] = []
+
+    class _FakeProc:
+        pass
+
+    def _popen(argv: list[str], **_kw: Any) -> _FakeProc:
+        spawns.append(argv)
+        return _FakeProc()
+
+    monkeypatch.setattr(
+        "mantis_agent.task_loop.subprocess.Popen", _popen
+    )
+    return spawns
+
+
+@pytest.fixture()
+def _local_no_chrome(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stop `LocalXdotoolImpl.__init__` from spawning Chrome under tests
+    that exercise the `local` factory branch — only the type matters
+    for the assertions."""
+    monkeypatch.setattr(
+        "mantis_agent.task_loop.build_proxy_config", lambda **_kw: None
+    )
+    monkeypatch.setattr(
+        "mantis_agent.task_loop.resolve_proxy_server", lambda _p: ("", None)
+    )
+
+
+# ── env-var → config ────────────────────────────────────────────────
+
+
+def test_config_from_env_defaults_to_local(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("MANTIS_COMPUTER_PLANE_BACKEND", raising=False)
+    cfg = _computer_plane_config_from_env()
+    assert cfg.backend == "local"
+    assert cfg.remote_base_url is None
+
+
+def test_config_from_env_modal_reads_url_and_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MANTIS_COMPUTER_PLANE_BACKEND", "modal")
+    monkeypatch.setenv("MANTIS_COMPUTER_PLANE_URL", "https://cp.example/")
+    monkeypatch.setenv("MANTIS_COMPUTER_PLANE_TOKEN", "tok-xyz")
+    monkeypatch.setenv("MANTIS_COMPUTER_PLANE_ENABLE_CDP", "1")
+    cfg = _computer_plane_config_from_env()
+    assert cfg.backend == "modal"
+    assert cfg.remote_base_url == "https://cp.example/"
+    assert cfg.remote_auth_token == "tok-xyz"
+    assert cfg.enable_cdp is True
+
+
+def test_config_from_env_unknown_backend_falls_back_to_local(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MANTIS_COMPUTER_PLANE_BACKEND", "lambda")
+    cfg = _computer_plane_config_from_env()
+    assert cfg.backend == "local"
+
+
+# ── setup_env: default path ─────────────────────────────────────────
+
+
+def test_setup_env_default_returns_local_xdotool_impl(
+    monkeypatch: pytest.MonkeyPatch,
+    _local_no_chrome: None,
+    _no_real_xvfb: list[list[str]],
+) -> None:
+    monkeypatch.delenv("MANTIS_COMPUTER_PLANE_BACKEND", raising=False)
+
+    env, _proxy, _diag = setup_env(
+        base_url="https://example.com",
+        run_id="r1",
+        session_name="sn",
+        proxy_disabled=True,
+        display=":99",
+        start_xvfb=True,
+    )
+    assert isinstance(env, LocalXdotoolImpl)
+    # Default = local backend → Xvfb spawned by setup_env.
+    assert any(argv[0] == "Xvfb" for argv in _no_real_xvfb)
+
+
+# ── setup_env: modal-backend path ───────────────────────────────────
+
+
+def test_setup_env_modal_backend_returns_remote_computer_impl(
+    monkeypatch: pytest.MonkeyPatch,
+    _no_real_xvfb: list[list[str]],
+) -> None:
+    monkeypatch.setattr(
+        "mantis_agent.task_loop.build_proxy_config", lambda **_kw: None
+    )
+    monkeypatch.setattr(
+        "mantis_agent.task_loop.resolve_proxy_server", lambda _p: ("", None)
+    )
+    cfg = ComputerPlaneConfig(
+        backend="modal",
+        remote_base_url="https://cp.example",
+    )
+
+    env, _proxy, _diag = setup_env(
+        base_url="https://target.example",
+        run_id="r1",
+        session_name="sn",
+        proxy_disabled=True,
+        display=":99",
+        start_xvfb=True,
+        computer_plane_config=cfg,
+    )
+    assert isinstance(env, RemoteComputerImpl)
+    assert env._start_url == "https://target.example"
+    # CRITICAL: remote backend must NOT spawn a brain-side Xvfb. The
+    # remote container owns its own display; clobbering DISPLAY locally
+    # would also break colocated executors during the migration window.
+    assert not any(argv[0] == "Xvfb" for argv in _no_real_xvfb)
+
+
+def test_setup_env_modal_backend_forwards_session_identity(
+    monkeypatch: pytest.MonkeyPatch,
+    _no_real_xvfb: list[list[str]],
+) -> None:
+    """`RemoteComputerImpl` binds its session to (tenant, profile, run).
+    setup_env must surface the brain-side identifiers so the remote can
+    honor the per-profile lock and the run-scoped idempotency.
+    """
+    monkeypatch.setattr(
+        "mantis_agent.task_loop.build_proxy_config", lambda **_kw: None
+    )
+    monkeypatch.setattr(
+        "mantis_agent.task_loop.resolve_proxy_server", lambda _p: ("", None)
+    )
+    cfg = ComputerPlaneConfig(
+        backend="modal", remote_base_url="https://cp.example"
+    )
+    env, _proxy, _diag = setup_env(
+        base_url="https://x",
+        run_id="r-42",
+        session_name="claude_cua",
+        proxy_disabled=True,
+        computer_plane_config=cfg,
+    )
+    assert isinstance(env, RemoteComputerImpl)
+    assert env._run_id == "r-42"
+    assert env._tenant_id == "claude_cua"
+    assert env._profile_id == "claude_cua"
+
+
+def test_setup_env_modal_backend_forwards_extra_http_headers(
+    monkeypatch: pytest.MonkeyPatch,
+    _no_real_xvfb: list[list[str]],
+) -> None:
+    monkeypatch.setattr(
+        "mantis_agent.task_loop.build_proxy_config", lambda **_kw: None
+    )
+    monkeypatch.setattr(
+        "mantis_agent.task_loop.resolve_proxy_server", lambda _p: ("", None)
+    )
+    cfg = ComputerPlaneConfig(
+        backend="modal", remote_base_url="https://cp.example"
+    )
+    env, _proxy, _diag = setup_env(
+        base_url="https://x",
+        run_id="r1",
+        session_name="sn",
+        proxy_disabled=True,
+        extra_http_headers={"X-Daytona-Skip-Preview-Warning": "true"},
+        computer_plane_config=cfg,
+    )
+    assert isinstance(env, RemoteComputerImpl)
+    assert env._extra_http_headers == {
+        "X-Daytona-Skip-Preview-Warning": "true",
+    }
+
+
+def test_setup_env_modal_backend_via_env_var_alone(
+    monkeypatch: pytest.MonkeyPatch,
+    _no_real_xvfb: list[list[str]],
+) -> None:
+    """The Phase-1 rollback story rests on this: a single secret edit
+    flips behavior without touching call sites."""
+    monkeypatch.setattr(
+        "mantis_agent.task_loop.build_proxy_config", lambda **_kw: None
+    )
+    monkeypatch.setattr(
+        "mantis_agent.task_loop.resolve_proxy_server", lambda _p: ("", None)
+    )
+    monkeypatch.setenv("MANTIS_COMPUTER_PLANE_BACKEND", "modal")
+    monkeypatch.setenv("MANTIS_COMPUTER_PLANE_URL", "https://cp.example")
+
+    env, _proxy, _diag = setup_env(
+        base_url="https://x",
+        run_id="r1",
+        session_name="sn",
+        proxy_disabled=True,
+        display=":99",
+        start_xvfb=True,
+    )
+    assert isinstance(env, RemoteComputerImpl)
+    assert env._base_url == "https://cp.example"


### PR DESCRIPTION
## Summary

Carries the Phase-1 follow-up work begun on the (now stale) unmerged
`feat/computer-plane-holo3-flip` branch, retargeted at `run_claude_cua`
— the executor #698 explicitly named as the first migration target
("0 GPU, easiest, biggest cost win"). Default behavior is unchanged
(`backend=local`); the flip is opt-in via `MANTIS_COMPUTER_PLANE_BACKEND=modal`
in the Modal secret, so rollback is a single-secret edit.

Refs #696, #698.

## What this PR adds

### Wire / server / client extensions on top of #698

- `computer_wire.py` — `SessionInitRequest` gains `start_url`,
  `profile_dir`, `extra_http_headers`. New models: `CurrentUrlResponse`,
  `CdpClickAtPointRequest/Response`, `CdpCountPagesResponse`.
- `server/computer_agent.py` — honors the new init fields and rejects
  off-volume `profile_dir` server-side (a brain-side typo would
  otherwise silently write into the container's ephemeral filesystem
  and evaporate). Adds `/current_url`, `/cdp_click_at_point`,
  `/cdp_count_pages` endpoints.
- `gym/remote_computer_impl.py` — full `XdotoolGymEnv`-compat surface
  step handlers reach for: `screenshot()`, `current_url`,
  `cdp_evaluate`, `cdp_click_at_point`, `cdp_click_via_pointer`,
  `_chrome_offset_px`, `cdp_count_pages`, `cdp_history_back`,
  `shutdown`, `_capture`, `capture_browser_state`. Without these
  every step handler crashes at the first `env.screenshot()` call.
  Forwards `start_url`/`profile_dir`/`extra_http_headers` into the
  remote `SessionInitRequest`.

### Brain-side wiring

- `task_loop.setup_env` grows `computer_plane_config` + an
  `_computer_plane_config_from_env()` helper that reads
  `MANTIS_COMPUTER_PLANE_BACKEND`, `MANTIS_COMPUTER_PLANE_URL`,
  `MANTIS_COMPUTER_PLANE_TOKEN`, `MANTIS_COMPUTER_PLANE_ENABLE_CDP`.
  Local Xvfb is only spawned on `backend=local` — the remote
  container owns its own display, and a brain-side Xvfb would
  clobber `DISPLAY`.
- `deploy/modal/modal_cua_server.py`:
  - `_run_claude_executor` reads `MANTIS_COMPUTER_PLANE_BACKEND` and
    lazy-resolves the remote URL via `modal.Function.from_name(...)`.
  - `computer_plane` is pinned to `min_containers=1,
    max_containers=1` and `concurrent(max_inputs=64)` — the prior
    holo3 smoke surfaced 401s when session state sharded across
    replicas. Phase 2 (#699) will lift this via per-session
    `.spawn()`.
- **`fix(claude-cua): bump default model to claude-sonnet-4-6`** —
  the Claude-CUA executor was the last holdout pinning
  `claude-sonnet-4-20250514`, which 400s on the `computer_20251124`
  tool type the brain emits. Bumped to match the rest of the tree
  (`grounding.py`, `extractor.py`, baseten runtime, cost-meter
  rates, etc.). Caught during the Modal verification below.

## Tests

89/89 green in the focused worktree:

```
tests/test_remote_computer_impl.py       36 passed
tests/test_computer_agent_server.py      27 passed
tests/test_setup_env_backend_flip.py      8 passed
tests/test_computer_client_factory.py    18 passed
```

## Modal verification (2026-06-07)

Deployed this branch on top of `mantis-cua-server` with
`MANTIS_COMPUTER_PLANE_BACKEND=modal`, submitted a 1-task lu.ma
extract via the legacy `tasks[]` shape (the canonical boattrader
script uses `_micro_plan` which the Claude executor doesn't process —
see `feedback_cua_model_holo3_vs_claude_shape.md`; that gap is a
separate fix).

Phase-1 RPC fired end-to-end:

```
POST /session/init   -> 200 OK   (6.63 s — first Chrome boot)
POST /screenshot     -> 200 OK   (451 ms first / ~270 ms steady-state)
POST /screenshot     -> 200 OK   × N (one per step)
POST /session/close  -> 200 OK
```

Per-step screenshot p50 sits inside the #698 budget. The task itself
exposed the model/tool-type 400 fixed by the second commit on this
branch.

`.env` was reverted and production redeployed from `main` after the
smoke; nothing is left flipped to `modal`.

## Out of scope (deferred)

- Migrating `run_holo3`, `run_fara`, `run_gemma4_cua`, EvoCUA tiers
  — same flip pattern but each is its own smoke + verify cycle.
- Slimming the brain image (drop Xvfb/Chrome/xdotool layers from
  `claude_executor_image`) — keep redundantly until the flip is
  proven in prod for a full weekly cycle.
- Per-session `.spawn()` model + E2B/Daytona backends — Phase 2 (#699).
- Closing the Claude `_micro_plan` shape gap so the boattrader micro
  script can drive `cua_model=claude` end-to-end — pre-existing
  divergence, separate PR.

## Test plan

- [ ] Focused suite green in CI (xdist matrix)
- [ ] Reviewers: skim `task_loop.setup_env` plumbing — only the
      `backend=local` branch should be reachable from production
      until someone sets the new env vars on a Modal secret.
- [ ] Reviewers: confirm `min_containers=1,max_containers=1` on
      `computer_plane` is acceptable as a Phase-1 interim (Phase-2
      issue #699 owns the multi-container story).

🤖 Generated with [Claude Code](https://claude.com/claude-code)