### PR TITLE
feat(compute): unified ComputeClient contract foundation (#785 PR 1)

### DIFF
--- a/docs/reference/compute-client.md
+++ b/docs/reference/compute-client.md
@@ -1,0 +1,151 @@
+# Compute Client — unified contract across both planes
+
+**Status:** Foundation (PR 1 of #785). PR 2 wires the toggle through the executor; PRs 3-4 add the extension surface on Browser-Use Plane.
+**Owners:** TBD
+**Tracks issue:** #785 (browser-use epic)
+
+## Summary
+
+Mantis runs **two compute planes**:
+
+- **Computer Plane** (#696) — Xvfb + Chrome + xdotool. CUA-pure: screenshot + key/mouse only. Stealth-capable.
+- **Browser-Use Plane** (#785) — Chrome under Playwright/CDP-native control. DOM-aware: `state.*`, `tabs.*`, `links.*` extensions.
+
+Both planes implement the **same `ComputeClient` base contract**. Plane selection is a runtime flag (`compute_backend`), not a fork in the brain plane or handler set. DOM verbs are **capability-gated extensions** advertised at `session_init` and enforced via a per-executor `CapabilityAllowlist`.
+
+This document is the umbrella spec. Plane-specific docs:
+
+- `docs/reference/computer-plane.md` — Computer Plane (existing).
+- `docs/reference/browser-use-plane.md` — Browser-Use Plane (lands with PR 2).
+
+## Goals
+
+1. **Single contract.** A plan + handler set drives either plane. Switching is `compute_backend: computer_plane | browser_use_plane` at submit time.
+2. **Capability gating.** DOM-aware extensions are advertised at `session_init` and only consumed by handlers whose executor allowlist permits them. Pure-CUA executors fail loud if they consume an extension — quiet degradation is explicitly avoided (`feedback_cua_no_dom_access.md`).
+3. **Uniform profile + proxy contracts.** Same `(tenant_id, profile_id)` identity on both planes. Same `ProxyConfig` accepted at `session_init`. Storage is per-plane.
+
+## Non-goals
+
+- **Cross-plane profile handoff.** v1 ships per-plane profiles; cross-plane handoff (package → release → mount) is a deferred follow-up gated on real demand (#785).
+- **Stealth parity across planes.** Browser-Use Plane on CF-protected sites is not a v1 requirement; pure-CUA on Computer Plane stays the path for stealth-sensitive harvesting.
+- **Shared persistent volume across planes.** Forces same-region/provider; ruled out unless mid-plan plane-switching becomes a hot path.
+
+## Two-plane layout
+
+```
+                  ┌─────────────────────────┐
+                  │      Brain Plane        │
+                  │  (executors + handlers) │
+                  └────────┬────────────────┘
+                           │  one ComputeClient contract
+              ┌────────────┴────────────┐
+              │                         │
+              ▼                         ▼
+   ┌──────────────────────┐   ┌──────────────────────┐
+   │   Computer Plane     │   │  Browser-Use Plane   │
+   │   (CUA-pure)         │   │  (DOM-aware)         │
+   │                      │   │                      │
+   │  Xvfb + Chrome +     │   │  Playwright / CDP-   │
+   │  xdotool             │   │  native Chrome       │
+   │                      │   │                      │
+   │  capabilities:       │   │  capabilities:       │
+   │    dom_aware=False   │   │    dom_aware=True    │
+   │    stealth=True      │   │    stealth=False(v1) │
+   └──────────────────────┘   └──────────────────────┘
+```
+
+## Base surface (both planes implement)
+
+| Method | Notes |
+|---|---|
+| `session_init(profile_id, proxy_config)` → `(token, Capabilities)` | Bind tenant + profile + run. Advertises capabilities. |
+| `session_close(token)` | Tear down. |
+| `screenshot()` → `(png, viewport)` | PNG + scroll_y + captured_at_ms. |
+| `dispatch(action)` | Uniform action verb — click(x,y) / key / type / scroll. Each plane translates to its native primitive (xdotool on Computer Plane, Playwright `page.mouse`/`keyboard` on Browser-Use Plane). |
+| `health()` | Liveness + last-action timestamp. |
+
+The base surface is enforced by the umbrella. Adding a Computer-Plane-only verb that isn't a no-op stub on Browser-Use Plane breaks the toggle promise — file a separate issue if a divergence is genuinely needed.
+
+## Extension surface (Browser-Use Plane only, capability-gated)
+
+| Verb | Issue | Capability |
+|---|---|---|
+| `state.current_url()`, `state.tabs()`, `state.focused_element()`, `state.clipboard()`, `state.page_load()` | #778 | `dom_aware` |
+| `tabs.open_in_new()`, `tabs.close()`, `tabs.activate()` | #779 | `dom_aware` |
+| `links.peek_target(selector)` | #780 | `dom_aware` |
+
+Computer Plane's client refuses these methods at the contract level. Handlers gate on `isinstance(client, SupportsBrowserState)` AND `allowlist.enforce("dom_aware")` BEFORE each call.
+
+## Capabilities
+
+`Capabilities` (`src/mantis_agent/gym/compute_contract.py`) is a frozen dataclass advertised at `session_init`:
+
+```python
+@dataclass(frozen=True)
+class Capabilities:
+    dom_aware: bool = False
+    stealth: bool = True
+    supports_cdp: bool = False
+    backend: ComputeBackend = ComputeBackend.COMPUTER_PLANE
+```
+
+Computer Plane returns `Capabilities.for_computer_plane(enable_cdp=...)`. Browser-Use Plane returns `Capabilities.for_browser_use_plane()`. On the wire, `Capabilities` is serialized as a dict in `SessionInitResponse.capabilities` (Phase-0/Phase-1 servers that don't populate the field are interpreted as Computer-Plane CUA-pure via `SessionInitResponse.resolved_capabilities()`).
+
+## CapabilityAllowlist
+
+`CapabilityAllowlist` is the enforcement seam. It is **per-executor**, configured at startup, and immutable for the lifetime of a run.
+
+```python
+# Pure-CUA executor: NO DOM-aware extensions.
+allowlist = CapabilityAllowlist.pure_cua(executor="run_holo3")
+
+# Browser-use executor: DOM-aware extensions OK.
+allowlist = CapabilityAllowlist.browser_use(executor="run_browser_use_claude")
+
+# Inside a handler:
+allowlist.enforce("dom_aware")  # raises CapabilityNotAllowed for pure-CUA executors
+```
+
+Consuming a non-allowed capability raises `CapabilityNotAllowed`. Fail-loud is deliberate — quiet degradation is what `feedback_cua_no_dom_access` warns against.
+
+## `compute_backend` selection
+
+A plan declares which plane it runs on under its `runtime` block:
+
+```yaml
+runtime:
+  compute_backend: computer_plane     # default — Xvfb + Chrome + xdotool, CUA-pure
+  # or
+  compute_backend: browser_use_plane  # Playwright/CDP-native, DOM-aware extensions
+```
+
+The same field is also accepted as a submission-time argument (HTTP body / CLI flag). Precedence — highest wins:
+
+1. **Plan `runtime.compute_backend`** (the plan author's choice — most local; HN URL-harvest plans set `browser_use_plane`).
+2. **Submission-time `compute_backend`** (operator override — e.g. running an existing plan on the other plane for A/B).
+3. **Global default — `computer_plane`** (Xvfb + xdotool stays the path for stealth-sensitive harvesting; pure-CUA is the safe default).
+
+The wiring through executor + client factory lands in PR 2. At session start, the executor's `CapabilityAllowlist` is checked against the advertised `Capabilities`; mismatched runs fail fast at that boundary (not mid-plan).
+
+### When to pick which
+
+| Pick `computer_plane` if … | Pick `browser_use_plane` if … |
+|---|---|
+| Target site is CF-protected / Turnstile-fronted | Plan needs DOM-aware reads (`state.current_url`, tab management) |
+| Plan works with screenshot + key/mouse only | Plan needs to read anchor href before click |
+| You don't know — leave it out (default is `computer_plane`) | List page has visually-similar links (semantic role disambiguation) |
+
+## What lands in PR 1 vs later
+
+| PR | What |
+|---|---|
+| **PR 1 (this)** | Contract types — `Capabilities`, `ComputeBackend`, `CapabilityAllowlist`, extension `Protocol`s, `CapabilityNotAllowed`. Wire-model `SessionInitResponse.capabilities` field (additive). Umbrella docs. **No behavior change.** |
+| PR 2 | Browser-Use Plane scaffold — Playwright host + `BrowserUsePlaneClient` base impl + `compute_backend` toggle wired through executor + allowlist enforcement. |
+| PR 3 | `state.*` extensions on Browser-Use Plane (#778). |
+| PR 4 | `tabs.*` + `links.*` + `target_role` (#779, #780, #781). |
+
+## References
+
+- Epic: #785 (browser-use support)
+- Sibling spec: `docs/reference/computer-plane.md` (#696)
+- Memory anchors: `feedback_cua_no_dom_access.md`, `feedback_browser_infra_rpc_surface.md`, `project_user_feedback_hn_url_collection_2026_06_07.md`

--- a/docs/reference/computer-plane.md
+++ b/docs/reference/computer-plane.md
@@ -4,6 +4,13 @@
 **Owners:** TBD
 **Tracks issue:** TBD (this doc is the canonical spec; the GitHub issue points at it)
 
+> Computer Plane is one of two compute planes under the unified
+> `ComputeClient` contract — see `docs/reference/compute-client.md`
+> (#785). It advertises `Capabilities(dom_aware=False, stealth=True)`
+> at `session_init`. The DOM-aware extensions (`state.*`, `tabs.*`,
+> `links.*`) ship on Browser-Use Plane only; Computer Plane refuses
+> them at the contract level. Pure-CUA — by design.
+
 ## Summary
 
 Today Mantis runs the brain (Holo3 / Claude / OpenCUA / Fara / Gemma4), the task loop, the step handlers, Xvfb, and Chrome **inside one Modal function invocation**. The Chrome profile lives on `modal.Volume("osworld-data")` mounted at `/data`. Brain ↔ environment calls are in-process Python.

--- a/docs/reference/plan.schema.json
+++ b/docs/reference/plan.schema.json
@@ -59,6 +59,12 @@
           "type": "integer",
           "minimum": 1,
           "description": "Per-run wall-clock ceiling in minutes. The runner halts when exceeded."
+        },
+        "compute_backend": {
+          "type": "string",
+          "enum": ["computer_plane", "browser_use_plane"],
+          "default": "computer_plane",
+          "description": "Which compute plane runs this plan. Default ``computer_plane`` (Xvfb + Chrome + xdotool, CUA-pure, stealth-capable — #696). Set ``browser_use_plane`` for plans that need DOM-aware reads (current URL, tab management, link-target peek, semantic click roles — #785). Plan-level value overrides submission-time defaults; absent in the plan, the submitter's default is used, then the global default ``computer_plane``. Pure-CUA stays the path for stealth-sensitive sites — Browser-Use Plane does NOT promise CF/Turnstile parity at v1."
         }
       }
     },

--- a/src/mantis_agent/gym/__init__.py
+++ b/src/mantis_agent/gym/__init__.py
@@ -13,18 +13,34 @@ Architecture:
 """
 
 from .base import GymEnvironment, GymObservation, GymResult
+from .compute_contract import (
+    Capabilities,
+    CapabilityAllowlist,
+    CapabilityNotAllowed,
+    ComputeBackend,
+    SupportsBrowserState,
+    SupportsLinkPeek,
+    SupportsTabs,
+)
 from .plans import Plan, load_plan, load_text_plan, save_plan, get_missing_inputs, text_to_yaml
 from .playwright_env import PlaywrightGymEnv
 from .runner import GymRunner
 from .workflow_runner import WorkflowRunner, LoopConfig, IterationResult
 
 __all__ = [
+    "Capabilities",
+    "CapabilityAllowlist",
+    "CapabilityNotAllowed",
+    "ComputeBackend",
     "GymEnvironment",
     "GymObservation",
     "GymResult",
     "GymRunner",
     "Plan",
     "PlaywrightGymEnv",
+    "SupportsBrowserState",
+    "SupportsLinkPeek",
+    "SupportsTabs",
     "get_missing_inputs",
     "load_plan",
     "load_text_plan",

--- a/src/mantis_agent/gym/compute_contract.py
+++ b/src/mantis_agent/gym/compute_contract.py
@@ -1,0 +1,202 @@
+"""Unified `ComputeClient` contract — umbrella over both compute planes.
+
+Mantis runs two compute planes (#785):
+
+- **Computer Plane** (#696) — Xvfb + Chrome + xdotool; CUA-pure. The historical
+  Mantis runtime; today's `ComputerClient` lives here. `dom_aware=False`.
+- **Browser-Use Plane** — Chrome under Playwright/CDP-native control;
+  DOM-aware. `dom_aware=True`.
+
+Both planes implement the **base surface** (session_init, screenshot,
+dispatch, health). DOM verbs (`state.*`, `tabs.*`, `links.*`) ship only on
+Browser-Use Plane and are **capability-gated** behind the `dom_aware`
+capability advertised at `session_init`.
+
+The brain plane reads the advertised `Capabilities` from session_init and
+cross-checks against a per-executor `CapabilityAllowlist`. Consuming a
+capability not on the allowlist raises `CapabilityNotAllowed` — this is the
+enforcement seam that prevents pure-CUA executors (Holo3, Claude vision)
+from silently consuming DOM-aware reads even when wired to Browser-Use
+Plane (`feedback_cua_no_dom_access.md`).
+
+This module defines the contract types only. PR 2 wires `compute_backend`
+plumbing through the executor and adds the Browser-Use Plane client. See
+`docs/reference/compute-client.md` for the umbrella spec.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, replace
+from enum import Enum
+from typing import Any, Protocol, runtime_checkable
+
+
+class ComputeBackend(str, Enum):
+    """Which plane a `ComputeClient` instance targets."""
+
+    COMPUTER_PLANE = "computer_plane"
+    BROWSER_USE_PLANE = "browser_use_plane"
+
+
+@dataclass(frozen=True)
+class Capabilities:
+    """Capabilities a `ComputeClient` advertises at `session_init`.
+
+    Defaults match Computer Plane (the historical Mantis runtime): no DOM
+    reads, stealth-capable via Xvfb + xdotool, CDP off unless explicitly
+    enabled.
+
+    Browser-Use Plane returns `dom_aware=True, stealth=False` at v1 — the
+    epic (#785) explicitly defers CF/Turnstile parity on that plane.
+    """
+
+    dom_aware: bool = False
+    stealth: bool = True
+    supports_cdp: bool = False
+    backend: ComputeBackend = ComputeBackend.COMPUTER_PLANE
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "dom_aware": self.dom_aware,
+            "stealth": self.stealth,
+            "supports_cdp": self.supports_cdp,
+            "backend": self.backend.value,
+        }
+
+    @classmethod
+    def for_computer_plane(cls, *, enable_cdp: bool = False) -> "Capabilities":
+        return cls(
+            dom_aware=False,
+            stealth=True,
+            supports_cdp=enable_cdp,
+            backend=ComputeBackend.COMPUTER_PLANE,
+        )
+
+    @classmethod
+    def for_browser_use_plane(cls) -> "Capabilities":
+        # v1: Browser-Use Plane uses Playwright/CDP-native control. Stealth
+        # parity on CF-protected sites is an explicit non-goal at v1
+        # (#785). supports_cdp=True because Playwright IS CDP under the
+        # hood — but the capability matters for handlers that gate on it.
+        return cls(
+            dom_aware=True,
+            stealth=False,
+            supports_cdp=True,
+            backend=ComputeBackend.BROWSER_USE_PLANE,
+        )
+
+
+class CapabilityNotAllowed(RuntimeError):
+    """Raised when an executor consumes a capability not on its allowlist.
+
+    The capability allowlist is configured per-executor at startup; this
+    prevents a pure-CUA executor wired to Browser-Use Plane from silently
+    starting to consume DOM-aware reads. The fail-loud behavior is
+    deliberate — quiet degradation is what `feedback_cua_no_dom_access`
+    explicitly warns against.
+    """
+
+    def __init__(self, capability: str, executor: str | None = None) -> None:
+        self.capability = capability
+        self.executor = executor
+        msg = f"capability {capability!r} not allowed"
+        if executor:
+            msg += f" for executor {executor!r}"
+        super().__init__(msg)
+
+
+@dataclass(frozen=True)
+class CapabilityAllowlist:
+    """Per-executor capability allowlist.
+
+    Used by handlers and the runner to gate consumption of advertised
+    capabilities. Configured at executor startup; immutable for the
+    lifetime of a run.
+
+    `dom_aware` is the load-bearing entry — it is the one that, if leaked
+    into a pure-CUA executor, silently changes the grounding model.
+    """
+
+    allowed: frozenset[str] = field(default_factory=frozenset)
+    executor: str | None = None
+
+    def enforce(self, capability: str) -> None:
+        """Raise `CapabilityNotAllowed` if `capability` is not on the list.
+
+        Call this BEFORE consuming a capability-gated extension verb. The
+        caller's job is to either degrade (skip the verb) or halt (let the
+        exception propagate up to the runner).
+        """
+        if capability not in self.allowed:
+            raise CapabilityNotAllowed(capability, self.executor)
+
+    def allows(self, capability: str) -> bool:
+        """Non-raising query — for handlers that want to degrade silently."""
+        return capability in self.allowed
+
+    def with_added(self, *capabilities: str) -> "CapabilityAllowlist":
+        return replace(self, allowed=self.allowed | frozenset(capabilities))
+
+    @classmethod
+    def pure_cua(cls, executor: str | None = None) -> "CapabilityAllowlist":
+        """Allowlist for pure-CUA executors: NO DOM-aware extensions.
+
+        This is the canonical pure-CUA posture. Handlers consuming DOM
+        verbs against this allowlist will raise.
+        """
+        return cls(allowed=frozenset(), executor=executor)
+
+    @classmethod
+    def browser_use(cls, executor: str | None = None) -> "CapabilityAllowlist":
+        """Allowlist for browser-use executors: DOM-aware extensions OK."""
+        return cls(
+            allowed=frozenset({"dom_aware", "supports_cdp"}),
+            executor=executor,
+        )
+
+
+# Extension protocols — implemented by Browser-Use Plane only. Capability-
+# gated behind `dom_aware`. Handlers consuming these should runtime-check
+# with `isinstance(client, SupportsBrowserState)` AND enforce the
+# allowlist BEFORE the call.
+
+
+@runtime_checkable
+class SupportsBrowserState(Protocol):
+    """`state.*` extensions — browser-state reads (#778).
+
+    Implemented by Browser-Use Plane. Capability-gated behind `dom_aware`.
+    """
+
+    def state_current_url(self) -> str: ...
+    def state_tabs(self) -> list[dict[str, Any]]: ...
+    def state_focused_element(self) -> dict[str, Any] | None: ...
+    def state_clipboard(self) -> str: ...
+    def state_page_load(self) -> str: ...
+
+
+@runtime_checkable
+class SupportsTabs(Protocol):
+    """`tabs.*` extensions — tab management (#779)."""
+
+    def tabs_open_in_new(self, url: str | None = None) -> str: ...
+    def tabs_close(self, tab_id: str) -> None: ...
+    def tabs_activate(self, tab_id: str) -> None: ...
+
+
+@runtime_checkable
+class SupportsLinkPeek(Protocol):
+    """`links.*` extensions — read anchor href without committing the click (#780)."""
+
+    def links_peek_target(self, selector_or_bbox: Any) -> str | None: ...
+
+
+__all__ = [
+    "Capabilities",
+    "CapabilityAllowlist",
+    "CapabilityNotAllowed",
+    "ComputeBackend",
+    "SupportsBrowserState",
+    "SupportsLinkPeek",
+    "SupportsTabs",
+]

--- a/src/mantis_agent/gym/computer_wire.py
+++ b/src/mantis_agent/gym/computer_wire.py
@@ -10,6 +10,13 @@ The surface is intentionally CUA-pure: `screenshot` + `xdotool(argv)` are
 required; `cdp_evaluate` / `cdp_click_at_point` are opt-in per executor
 (`enable_cdp=false` default). No DOM-aware verbs. See
 `feedback_browser_infra_rpc_surface.md`.
+
+`SessionInitResponse` carries a `capabilities` field (added under #785's
+unified `ComputeClient` contract). Computer Plane advertises a pure-CUA
+posture (`dom_aware=False, stealth=True`). Browser-Use Plane (PR 2)
+advertises `dom_aware=True`. The brain plane gates DOM-aware extension
+verbs on this advertised capability + a per-executor allowlist — see
+`compute_contract.CapabilityAllowlist`.
 """
 
 from __future__ import annotations
@@ -17,6 +24,8 @@ from __future__ import annotations
 from typing import Literal
 
 from pydantic import BaseModel, Field
+
+from .compute_contract import Capabilities, ComputeBackend
 
 
 class SessionInitRequest(BaseModel):
@@ -52,6 +61,31 @@ class SessionInitResponse(BaseModel):
     session_token: str
     chrome_pid: int | None = None
     xvfb_display: str
+    # Added under #785 unified ComputeClient contract. Serialized as a
+    # plain dict (not the dataclass) so pydantic round-trips JSON cleanly
+    # across the wire. Omitted by older backends — consumers treat None
+    # as the legacy Computer-Plane default (`Capabilities.for_computer_plane()`).
+    capabilities: dict[str, object] | None = None
+
+    def resolved_capabilities(self) -> Capabilities:
+        """Return advertised `Capabilities`, defaulting to Computer Plane.
+
+        Older Phase-0/Phase-1 servers don't populate the field; treating
+        `None` as Computer-Plane CUA-pure preserves backwards compat.
+        """
+        if self.capabilities is None:
+            return Capabilities.for_computer_plane()
+        backend_value = self.capabilities.get("backend", ComputeBackend.COMPUTER_PLANE.value)
+        try:
+            backend = ComputeBackend(backend_value)
+        except ValueError:
+            backend = ComputeBackend.COMPUTER_PLANE
+        return Capabilities(
+            dom_aware=bool(self.capabilities.get("dom_aware", False)),
+            stealth=bool(self.capabilities.get("stealth", True)),
+            supports_cdp=bool(self.capabilities.get("supports_cdp", False)),
+            backend=backend,
+        )
 
 
 class SessionCloseRequest(BaseModel):

--- a/tests/test_compute_contract.py
+++ b/tests/test_compute_contract.py
@@ -1,0 +1,217 @@
+"""Tests for the unified `ComputeClient` contract types (#785, PR 1)."""
+
+from __future__ import annotations
+
+import pytest
+
+from mantis_agent.gym.compute_contract import (
+    Capabilities,
+    CapabilityAllowlist,
+    CapabilityNotAllowed,
+    ComputeBackend,
+    SupportsBrowserState,
+    SupportsLinkPeek,
+    SupportsTabs,
+)
+from mantis_agent.gym.computer_wire import SessionInitResponse
+
+
+class TestCapabilities:
+    def test_default_is_computer_plane_pure_cua(self):
+        cap = Capabilities()
+        assert cap.dom_aware is False
+        assert cap.stealth is True
+        assert cap.supports_cdp is False
+        assert cap.backend is ComputeBackend.COMPUTER_PLANE
+
+    def test_for_computer_plane_default(self):
+        cap = Capabilities.for_computer_plane()
+        assert cap.dom_aware is False
+        assert cap.stealth is True
+        assert cap.supports_cdp is False
+        assert cap.backend is ComputeBackend.COMPUTER_PLANE
+
+    def test_for_computer_plane_with_cdp(self):
+        cap = Capabilities.for_computer_plane(enable_cdp=True)
+        assert cap.supports_cdp is True
+        # CDP-on does NOT make a computer-plane client DOM-aware.
+        assert cap.dom_aware is False
+
+    def test_for_browser_use_plane_v1_posture(self):
+        cap = Capabilities.for_browser_use_plane()
+        assert cap.dom_aware is True
+        # v1 explicit non-goal — see #785.
+        assert cap.stealth is False
+        assert cap.supports_cdp is True
+        assert cap.backend is ComputeBackend.BROWSER_USE_PLANE
+
+    def test_as_dict_round_trip_keys(self):
+        cap = Capabilities.for_browser_use_plane()
+        d = cap.as_dict()
+        assert d["dom_aware"] is True
+        assert d["backend"] == "browser_use_plane"
+
+    def test_frozen(self):
+        cap = Capabilities()
+        with pytest.raises((AttributeError, Exception)):
+            cap.dom_aware = True  # type: ignore[misc]
+
+
+class TestCapabilityAllowlist:
+    def test_pure_cua_blocks_dom_aware(self):
+        allowlist = CapabilityAllowlist.pure_cua(executor="run_holo3")
+        with pytest.raises(CapabilityNotAllowed) as exc_info:
+            allowlist.enforce("dom_aware")
+        assert exc_info.value.capability == "dom_aware"
+        assert exc_info.value.executor == "run_holo3"
+
+    def test_browser_use_admits_dom_aware(self):
+        allowlist = CapabilityAllowlist.browser_use(executor="run_browser_use")
+        # Should not raise.
+        allowlist.enforce("dom_aware")
+
+    def test_allows_non_raising_query(self):
+        pure = CapabilityAllowlist.pure_cua()
+        assert pure.allows("dom_aware") is False
+        browser = CapabilityAllowlist.browser_use()
+        assert browser.allows("dom_aware") is True
+
+    def test_with_added_is_immutable_copy(self):
+        base = CapabilityAllowlist.pure_cua(executor="x")
+        extended = base.with_added("dom_aware")
+        assert base.allows("dom_aware") is False
+        assert extended.allows("dom_aware") is True
+        # Executor identity preserved.
+        assert extended.executor == "x"
+
+    def test_capability_not_allowed_carries_context(self):
+        err = CapabilityNotAllowed("dom_aware", executor="run_holo3")
+        assert "dom_aware" in str(err)
+        assert "run_holo3" in str(err)
+
+    def test_capability_not_allowed_without_executor(self):
+        err = CapabilityNotAllowed("dom_aware")
+        assert "dom_aware" in str(err)
+
+
+class TestSessionInitResponseCapabilities:
+    def test_legacy_response_resolves_to_computer_plane(self):
+        # Phase-0/Phase-1 servers don't populate the field.
+        resp = SessionInitResponse(
+            session_token="t",
+            xvfb_display=":99",
+        )
+        cap = resp.resolved_capabilities()
+        assert cap.dom_aware is False
+        assert cap.backend is ComputeBackend.COMPUTER_PLANE
+
+    def test_browser_use_response_resolves_correctly(self):
+        resp = SessionInitResponse(
+            session_token="t",
+            xvfb_display=":99",
+            capabilities=Capabilities.for_browser_use_plane().as_dict(),
+        )
+        cap = resp.resolved_capabilities()
+        assert cap.dom_aware is True
+        assert cap.backend is ComputeBackend.BROWSER_USE_PLANE
+        assert cap.supports_cdp is True
+
+    def test_unknown_backend_falls_back_to_computer_plane(self):
+        # Defensive: an older client receiving a future backend label
+        # should not crash — degrade to pure-CUA defaults.
+        resp = SessionInitResponse(
+            session_token="t",
+            xvfb_display=":99",
+            capabilities={"backend": "future_plane_xyz", "dom_aware": True},
+        )
+        cap = resp.resolved_capabilities()
+        assert cap.backend is ComputeBackend.COMPUTER_PLANE
+
+
+class TestPlanSchemaComputeBackend:
+    """Plan-level `runtime.compute_backend` lands in PR 1 (schema only).
+
+    Default = `computer_plane`. PR 2 wires the resolved value through the
+    executor + client factory.
+    """
+
+    def test_schema_declares_compute_backend_enum(self):
+        import json
+        from pathlib import Path
+
+        schema_path = (
+            Path(__file__).parent.parent
+            / "docs"
+            / "reference"
+            / "plan.schema.json"
+        )
+        schema = json.loads(schema_path.read_text())
+        runtime_props = schema["$defs"]["Runtime"]["properties"]
+        assert "compute_backend" in runtime_props
+        field = runtime_props["compute_backend"]
+        assert set(field["enum"]) == {"computer_plane", "browser_use_plane"}
+        assert field["default"] == "computer_plane"
+
+    def test_schema_accepts_plan_with_compute_backend(self):
+        # Validates that a plan declaring browser_use_plane is well-formed
+        # under the schema, without needing the full jsonschema validator
+        # — just checks the shape matches the documented field.
+        plan = {
+            "steps": [{"intent": "Go to HN", "type": "navigate"}],
+            "runtime": {
+                "compute_backend": "browser_use_plane",
+            },
+        }
+        # Sanity: the runtime block accepts the field.
+        assert plan["runtime"]["compute_backend"] == "browser_use_plane"
+
+
+class TestExtensionProtocols:
+    """Protocols are `runtime_checkable` so handlers can dispatch on shape."""
+
+    def test_minimal_class_satisfies_browser_state(self):
+        class FakeClient:
+            def state_current_url(self) -> str:
+                return "https://example.com"
+
+            def state_tabs(self) -> list[dict]:
+                return []
+
+            def state_focused_element(self) -> dict | None:
+                return None
+
+            def state_clipboard(self) -> str:
+                return ""
+
+            def state_page_load(self) -> str:
+                return "complete"
+
+        assert isinstance(FakeClient(), SupportsBrowserState)
+
+    def test_missing_method_fails_protocol_check(self):
+        class IncompleteClient:
+            def state_current_url(self) -> str:
+                return ""
+            # Missing the other state.* methods.
+
+        assert not isinstance(IncompleteClient(), SupportsBrowserState)
+
+    def test_tabs_protocol_shape(self):
+        class FakeTabs:
+            def tabs_open_in_new(self, url=None) -> str:
+                return "tab-1"
+
+            def tabs_close(self, tab_id: str) -> None:
+                pass
+
+            def tabs_activate(self, tab_id: str) -> None:
+                pass
+
+        assert isinstance(FakeTabs(), SupportsTabs)
+
+    def test_link_peek_protocol_shape(self):
+        class FakePeek:
+            def links_peek_target(self, selector_or_bbox) -> str | None:
+                return "https://example.com"
+
+        assert isinstance(FakePeek(), SupportsLinkPeek)


### PR DESCRIPTION
## Summary

Foundation for the browser-use epic (#785). Lands the umbrella contract that **both compute planes** will implement — no behavior change today; PRs 2-4 wire the toggle through executor + add the Browser-Use Plane.

- `Capabilities` dataclass + `ComputeBackend` enum.
- `CapabilityAllowlist` + `CapabilityNotAllowed` — per-executor enforcement seam. Pure-CUA executors fail loud if they consume a DOM-aware extension; quiet degradation is what `feedback_cua_no_dom_access` warns against.
- `SupportsBrowserState` / `SupportsTabs` / `SupportsLinkPeek` `runtime_checkable` Protocols — the extension surface PR 3-4 will implement on Browser-Use Plane.
- `SessionInitResponse.capabilities` wire field (additive; legacy responses resolve to Computer-Plane CUA-pure defaults via `resolved_capabilities()`).
- **Plan-level `runtime.compute_backend` in `plan.schema.json`** — default `computer_plane`; `browser_use_plane` opts in to the DOM-aware path. Precedence: plan-level > submission-time > global default `computer_plane`.
- `docs/reference/compute-client.md` — umbrella spec covering both planes, capability gating, plane selection, when to pick which.
- `docs/reference/computer-plane.md` — header note linking to umbrella.

## Why this PR is safe

- All new types live in a new module (`compute_contract.py`); existing imports unchanged.
- `SessionInitResponse.capabilities` is `Optional` and serialized as a plain dict — Phase-0/Phase-1 servers that don't populate it are interpreted as Computer-Plane defaults.
- `plan.schema.json` is `additionalProperties: true` everywhere; existing plans without `runtime.compute_backend` keep validating.
- No call site consumes the new types yet — PR 2 starts the wiring.

## Test plan

- [x] `tests/test_compute_contract.py` — 21 tests covering Capabilities defaults, allowlist enforcement, protocol shape, plan-schema field shape, legacy `SessionInitResponse` round-trip.
- [x] Existing `tests/test_computer_client_factory.py` + `tests/test_remote_computer_impl.py` still pass (36 tests).
- [ ] PR 2 lands the executor-side allowlist enforcement; this PR only declares the types.

## Refs

- Epic #785 — Browser-Use support (DOM-aware companion path)
- Sibling spec: docs/reference/computer-plane.md (#696)
- User feedback that triggered the epic: `project_user_feedback_hn_url_collection_2026_06_07.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)