### PR TITLE
feat(trace): structured per-step trace envelope (closes #783)

### DIFF
--- a/src/mantis_agent/gym/step_trace.py
+++ b/src/mantis_agent/gym/step_trace.py
@@ -1,0 +1,232 @@
+"""Structured per-step trace envelope (#783).
+
+Extends what `TraceExporter` writes today (`StepResult` -> JSON) with
+the fields the HN URL-collection user report (#785) called out as
+missing for triage:
+
+- before / after URL
+- screenshot pre / post (paths, not bytes)
+- vision-grounding target (description + bbox)
+- actual click coordinates
+- dispatch payload (xdotool argv on Computer Plane, structured verb
+  on Browser-Use Plane)
+- step verifier verdict (pass / fail / demoted)
+- retry count + last retry reason
+- emitted rows / outputs
+
+The envelope is per-step. Runners attach one to each `StepResult`
+they emit; `TraceExporter` serializes it inline when present. Handlers
+that don't populate the envelope just leave the fields empty —
+backwards-compatible with today's exports.
+
+Storage layout (when `MANTIS_TRACE_EXPORT_DIR` is set):
+
+    $MANTIS_TRACE_EXPORT_DIR/<tenant>/<run_id>.json
+        — contains step_envelope blocks inline
+    $MANTIS_TRACE_EXPORT_DIR/<tenant>/<run_id>/<step>_pre.png
+    $MANTIS_TRACE_EXPORT_DIR/<tenant>/<run_id>/<step>_post.png
+        — written when `MANTIS_TRACE_INCLUDE_SCREENSHOTS=1`
+        — `_pre` only when the envelope actually carries a pre-action shot
+
+Companion HTTP / CLI surface lands in PR 7 (`/v1/runs/{id}/trace`,
+`mantis trace <run_id>`).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class GroundingTarget:
+    """Vision-grounded click target — what the brain *aimed* at."""
+
+    description: str = ""
+    bbox: tuple[int, int, int, int] | None = None  # (x1, y1, x2, y2)
+    confidence: float | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "description": self.description,
+            "bbox": list(self.bbox) if self.bbox else None,
+            "confidence": self.confidence,
+        }
+
+
+@dataclass
+class DispatchRecord:
+    """The actual action that was dispatched to the compute plane.
+
+    `kind` discriminates: Computer Plane → `xdotool` with `argv`;
+    Browser-Use Plane → `click` / `key` / `type` / `scroll` with
+    structured `params`. CDP escape hatches use `cdp`.
+    """
+
+    kind: str = ""  # "xdotool" | "click" | "key" | "type" | "scroll" | "cdp"
+    argv: list[str] = field(default_factory=list)
+    params: dict[str, Any] = field(default_factory=dict)
+    coordinates: tuple[int, int] | None = None  # (x, y) when applicable
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "kind": self.kind,
+            "argv": list(self.argv),
+            "params": dict(self.params),
+            "coordinates": list(self.coordinates) if self.coordinates else None,
+        }
+
+
+@dataclass
+class VerifierVerdict:
+    """Outcome of the step's verification gate.
+
+    `status` is one of:
+      - `pass` — verifier confirmed expected outcome.
+      - `fail` — verifier rejected; step counted as a failure.
+      - `demoted` — verifier failed but `required=False`, so we
+        continued (see `feedback_critic_gate_truthy_fail`).
+      - `skipped` — no verifier configured.
+    """
+
+    status: str = "skipped"  # pass | fail | demoted | skipped
+    reason: str = ""
+    raw_verifier_output: str = ""
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "status": self.status,
+            "reason": self.reason,
+            "raw_verifier_output": self.raw_verifier_output,
+        }
+
+
+@dataclass
+class StepTraceEnvelope:
+    """Per-step structured trace data.
+
+    Attached to a `StepResult` via the `record_step_trace` helper.
+    Empty envelopes (default-constructed) are semantically equivalent
+    to "no envelope" — `TraceExporter` skips empty blocks to avoid
+    bloating the JSON.
+    """
+
+    # URLs around the action.
+    url_before: str = ""
+    url_after: str = ""
+
+    # Screenshot artifacts. Stored as paths in the export dir, not
+    # bytes — keeps the JSON readable and the binary on disk.
+    screenshot_pre_path: str = ""
+    screenshot_post_path: str = ""
+
+    # What the brain wanted vs what got dispatched.
+    grounding: GroundingTarget | None = None
+    dispatch: DispatchRecord | None = None
+
+    # How verification + retry played out.
+    verifier: VerifierVerdict | None = None
+    retry_count: int = 0
+    retry_reason: str = ""
+
+    # What the step emitted to downstream (rows / leads / extracted
+    # data). The runner's `step.data` is the source of truth; this
+    # field carries a stable projection (e.g. row count, first row
+    # sample) so a trace consumer doesn't have to parse plan-specific
+    # blobs.
+    emitted_count: int = 0
+    emitted_sample: dict[str, Any] = field(default_factory=dict)
+
+    def is_empty(self) -> bool:
+        return (
+            not self.url_before
+            and not self.url_after
+            and not self.screenshot_pre_path
+            and not self.screenshot_post_path
+            and self.grounding is None
+            and self.dispatch is None
+            and self.verifier is None
+            and self.retry_count == 0
+            and not self.retry_reason
+            and self.emitted_count == 0
+            and not self.emitted_sample
+        )
+
+    def as_dict(self) -> dict[str, Any]:
+        d: dict[str, Any] = {
+            "url_before": self.url_before,
+            "url_after": self.url_after,
+            "screenshot_pre_path": self.screenshot_pre_path,
+            "screenshot_post_path": self.screenshot_post_path,
+            "retry_count": self.retry_count,
+            "retry_reason": self.retry_reason,
+            "emitted_count": self.emitted_count,
+            "emitted_sample": dict(self.emitted_sample),
+        }
+        if self.grounding is not None:
+            d["grounding"] = self.grounding.as_dict()
+        if self.dispatch is not None:
+            d["dispatch"] = self.dispatch.as_dict()
+        if self.verifier is not None:
+            d["verifier"] = self.verifier.as_dict()
+        return d
+
+
+# ── In-process collector ────────────────────────────────────────────
+
+
+@dataclass
+class StepTraceCollector:
+    """Accumulates per-step envelopes for one run.
+
+    Runners hold a single instance and the step handlers `record()`
+    into it. `envelopes_by_step_index` is the source of truth — the
+    `TraceExporter._step_to_dict` patch reads from here to merge the
+    extra fields into the exported JSON.
+    """
+
+    run_id: str = ""
+    envelopes_by_step_index: dict[int, StepTraceEnvelope] = field(default_factory=dict)
+
+    def record(self, step_index: int, envelope: StepTraceEnvelope) -> None:
+        # Last write wins per step_index. Handlers may call `record`
+        # multiple times during a step (e.g. once after grounding,
+        # again after verifier) — caller should merge into a single
+        # envelope per call, or call `update` (below).
+        self.envelopes_by_step_index[step_index] = envelope
+
+    def update(self, step_index: int, **fields: Any) -> StepTraceEnvelope:
+        """Merge fields into the envelope at `step_index`, creating
+        one if absent. Convenience for handlers that record bits as
+        they go (URL on entry, dispatch on action, verifier on gate)."""
+        env = self.envelopes_by_step_index.setdefault(
+            step_index, StepTraceEnvelope()
+        )
+        for k, v in fields.items():
+            if hasattr(env, k):
+                setattr(env, k, v)
+        return env
+
+    def get(self, step_index: int) -> StepTraceEnvelope | None:
+        return self.envelopes_by_step_index.get(step_index)
+
+    def as_dict_by_index(self) -> dict[str, dict[str, Any]]:
+        """Project to the export-friendly dict (string-keyed for JSON).
+        Skips empty envelopes — `TraceExporter` does not need entries
+        that carry no information beyond what `StepResult` already has.
+        """
+        out: dict[str, dict[str, Any]] = {}
+        for idx, env in self.envelopes_by_step_index.items():
+            if env.is_empty():
+                continue
+            out[str(idx)] = env.as_dict()
+        return out
+
+
+__all__ = [
+    "DispatchRecord",
+    "GroundingTarget",
+    "StepTraceCollector",
+    "StepTraceEnvelope",
+    "VerifierVerdict",
+]

--- a/src/mantis_agent/gym/trace_exporter.py
+++ b/src/mantis_agent/gym/trace_exporter.py
@@ -48,6 +48,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from .checkpoint import StepResult
+from .step_trace import StepTraceCollector
 
 if TYPE_CHECKING:
     from .micro_runner import MicroPlanRunner
@@ -55,11 +56,13 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-SCHEMA_VERSION: int = 2
+SCHEMA_VERSION: int = 3
 """``v1`` was the initial export shape (PR #194). ``v2`` (PR for #155
-step 5) adds the optional top-level ``variant`` field for
-shadow-deploy attribution. ``v1`` consumers can still read ``v2`` —
-they just ignore the new key."""
+step 5) added the optional top-level ``variant`` field for
+shadow-deploy attribution. ``v3`` (PR for #783) adds an optional
+``envelope`` block per step carrying the structured per-step trace
+fields (URLs, grounding, dispatch, verifier, retries, emitted rows).
+Older consumers can still read ``v3`` — they ignore the new key."""
 
 ENV_DIR: str = "MANTIS_TRACE_EXPORT_DIR"
 ENV_INCLUDE_SCREENSHOTS: str = "MANTIS_TRACE_INCLUDE_SCREENSHOTS"
@@ -73,6 +76,27 @@ def _action_to_dict(action: Any) -> dict[str, Any] | None:
         "action_type": getattr(getattr(action, "action_type", None), "value", ""),
         "params": dict(getattr(action, "params", {}) or {}),
     }
+
+
+def _serialize_steps(
+    results: list[StepResult],
+    step_traces: "StepTraceCollector | None",
+) -> list[dict[str, Any]]:
+    """Serialize each step, merging in its `StepTraceEnvelope` if present.
+
+    The envelope rides as a sibling key on the step dict (`envelope`)
+    so v2 consumers that only read the canonical fields still work
+    (additive — #783 schema_version bump = v3).
+    """
+    out: list[dict[str, Any]] = []
+    envelopes = step_traces.envelopes_by_step_index if step_traces else {}
+    for s in results:
+        block = _step_to_dict(s)
+        env = envelopes.get(s.step_index) if envelopes else None
+        if env is not None and not env.is_empty():
+            block["envelope"] = env.as_dict()
+        out.append(block)
+    return out
 
 
 def _step_to_dict(step: StepResult) -> dict[str, Any]:
@@ -127,6 +151,7 @@ class TraceExporter:
         results: list[StepResult],
         *,
         status: str,
+        step_traces: "StepTraceCollector | None" = None,
     ) -> str | None:
         """Write a trace file when the exporter is enabled. No-op otherwise.
 
@@ -137,7 +162,7 @@ class TraceExporter:
         if not self.enabled:
             return None
         try:
-            return self._write(runner, results, status=status)
+            return self._write(runner, results, status=status, step_traces=step_traces)
         except Exception as exc:  # noqa: BLE001 — telemetry never breaks runs
             logger.warning("trace export failed: %s", exc)
             return None
@@ -148,6 +173,7 @@ class TraceExporter:
         results: list[StepResult],
         *,
         status: str,
+        step_traces: "StepTraceCollector | None" = None,
     ) -> str:
         tenant_id = (getattr(runner, "tenant_id", "") or "").strip() or "__shared__"
         run_id = (
@@ -188,7 +214,7 @@ class TraceExporter:
                 "total": round(total, 4),
             },
             "step_count": len(results),
-            "steps": [_step_to_dict(s) for s in results],
+            "steps": _serialize_steps(results, step_traces),
         }
 
         out = base / f"{run_id}.json"

--- a/tests/test_step_trace.py
+++ b/tests/test_step_trace.py
@@ -4,13 +4,9 @@ integration (#783, PR 6)."""
 from __future__ import annotations
 
 import json
-import os
-import tempfile
 from pathlib import Path
-from typing import Any
 from unittest.mock import MagicMock
 
-import pytest
 
 from mantis_agent.gym.step_trace import (
     DispatchRecord,
@@ -176,7 +172,6 @@ def _make_step_result(step_index: int = 0, intent: str = "x"):
 def test_exporter_merges_envelope_into_step_block():
     from mantis_agent.gym.trace_exporter import (
         SCHEMA_VERSION,
-        TraceExporter,
         _serialize_steps,
     )
 

--- a/tests/test_step_trace.py
+++ b/tests/test_step_trace.py
@@ -1,0 +1,274 @@
+"""Tests for `StepTraceEnvelope` + `StepTraceCollector` + TraceExporter
+integration (#783, PR 6)."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from mantis_agent.gym.step_trace import (
+    DispatchRecord,
+    GroundingTarget,
+    StepTraceCollector,
+    StepTraceEnvelope,
+    VerifierVerdict,
+)
+
+
+# ── GroundingTarget / DispatchRecord / VerifierVerdict ────────────
+
+
+def test_grounding_target_serializes_bbox_as_list():
+    g = GroundingTarget(description="story title", bbox=(10, 20, 100, 40), confidence=0.92)
+    d = g.as_dict()
+    assert d["bbox"] == [10, 20, 100, 40]
+    assert d["confidence"] == 0.92
+
+
+def test_grounding_target_handles_no_bbox():
+    g = GroundingTarget(description="vague")
+    assert g.as_dict()["bbox"] is None
+
+
+def test_dispatch_record_xdotool_shape():
+    d = DispatchRecord(
+        kind="xdotool",
+        argv=["mousemove", "100", "200", "click", "1"],
+        coordinates=(100, 200),
+    )
+    blob = d.as_dict()
+    assert blob["kind"] == "xdotool"
+    assert blob["argv"] == ["mousemove", "100", "200", "click", "1"]
+    assert blob["coordinates"] == [100, 200]
+
+
+def test_dispatch_record_browser_use_shape():
+    d = DispatchRecord(kind="click", params={"x": 100, "y": 200, "button": "left"})
+    blob = d.as_dict()
+    assert blob["kind"] == "click"
+    assert blob["params"]["x"] == 100
+
+
+def test_verifier_verdict_default_skipped():
+    v = VerifierVerdict()
+    assert v.status == "skipped"
+
+
+def test_verifier_verdict_demoted_carries_reason():
+    v = VerifierVerdict(status="demoted", reason="critic disagreed; required=False")
+    assert v.as_dict()["status"] == "demoted"
+    assert "critic" in v.as_dict()["reason"]
+
+
+# ── StepTraceEnvelope ────────────────────────────────────────────
+
+
+def test_envelope_default_is_empty():
+    env = StepTraceEnvelope()
+    assert env.is_empty() is True
+
+
+def test_envelope_with_url_is_not_empty():
+    env = StepTraceEnvelope(url_before="https://x.com/")
+    assert env.is_empty() is False
+
+
+def test_envelope_with_only_grounding_not_empty():
+    env = StepTraceEnvelope(grounding=GroundingTarget(description="x"))
+    assert env.is_empty() is False
+
+
+def test_envelope_serializes_all_optional_blocks():
+    env = StepTraceEnvelope(
+        url_before="https://hn.com/",
+        url_after="https://example.com/article",
+        screenshot_pre_path="/run/abc/0001_pre.png",
+        screenshot_post_path="/run/abc/0001_post.png",
+        grounding=GroundingTarget(description="title link", bbox=(10, 20, 100, 40)),
+        dispatch=DispatchRecord(kind="click", coordinates=(50, 30)),
+        verifier=VerifierVerdict(status="pass"),
+        retry_count=1,
+        retry_reason="no_state_change",
+        emitted_count=1,
+        emitted_sample={"url": "https://example.com/article"},
+    )
+    d = env.as_dict()
+    assert d["url_before"] == "https://hn.com/"
+    assert d["grounding"]["description"] == "title link"
+    assert d["dispatch"]["kind"] == "click"
+    assert d["verifier"]["status"] == "pass"
+    assert d["emitted_count"] == 1
+
+
+# ── StepTraceCollector ───────────────────────────────────────────
+
+
+def test_collector_record_and_get():
+    c = StepTraceCollector(run_id="r1")
+    env = StepTraceEnvelope(url_before="https://x.com/")
+    c.record(3, env)
+    assert c.get(3) is env
+    assert c.get(99) is None
+
+
+def test_collector_update_merges_fields():
+    c = StepTraceCollector(run_id="r1")
+    c.update(0, url_before="https://hn.com/")
+    c.update(0, url_after="https://example.com/")
+    c.update(0, retry_count=2, retry_reason="dispatch_5xx")
+    env = c.get(0)
+    assert env is not None
+    assert env.url_before == "https://hn.com/"
+    assert env.url_after == "https://example.com/"
+    assert env.retry_count == 2
+    assert env.retry_reason == "dispatch_5xx"
+
+
+def test_collector_update_with_unknown_field_is_ignored():
+    c = StepTraceCollector(run_id="r1")
+    c.update(0, url_before="https://x.com/", nonexistent_field="ignored")
+    env = c.get(0)
+    assert env is not None
+    assert env.url_before == "https://x.com/"
+    # Unknown field should not be set as an attribute.
+    assert not hasattr(env, "nonexistent_field")
+
+
+def test_collector_as_dict_skips_empty_envelopes():
+    c = StepTraceCollector(run_id="r1")
+    c.record(0, StepTraceEnvelope())  # empty
+    c.record(1, StepTraceEnvelope(url_before="https://x.com/"))
+    out = c.as_dict_by_index()
+    assert "0" not in out
+    assert "1" in out
+    assert out["1"]["url_before"] == "https://x.com/"
+
+
+def test_collector_as_dict_keys_are_strings():
+    c = StepTraceCollector(run_id="r1")
+    c.record(5, StepTraceEnvelope(url_before="x"))
+    out = c.as_dict_by_index()
+    assert "5" in out
+    assert 5 not in out  # type: ignore[operator]
+
+
+# ── TraceExporter integration ────────────────────────────────────
+
+
+def _make_step_result(step_index: int = 0, intent: str = "x"):
+    """Build a minimal `StepResult` shape that `_step_to_dict` accepts."""
+    from mantis_agent.gym.checkpoint import StepResult
+
+    return StepResult(
+        step_index=step_index,
+        intent=intent,
+        success=True,
+        data="",
+    )
+
+
+def test_exporter_merges_envelope_into_step_block():
+    from mantis_agent.gym.trace_exporter import (
+        SCHEMA_VERSION,
+        TraceExporter,
+        _serialize_steps,
+    )
+
+    assert SCHEMA_VERSION >= 3
+    step = _make_step_result(step_index=0, intent="navigate")
+    collector = StepTraceCollector(run_id="r1")
+    collector.update(
+        0,
+        url_before="https://hn.com/",
+        url_after="https://hn.com/news",
+        dispatch=DispatchRecord(kind="click", coordinates=(50, 30)),
+        verifier=VerifierVerdict(status="pass"),
+        emitted_count=1,
+    )
+    out = _serialize_steps([step], collector)
+    assert len(out) == 1
+    assert "envelope" in out[0]
+    assert out[0]["envelope"]["url_before"] == "https://hn.com/"
+    assert out[0]["envelope"]["dispatch"]["kind"] == "click"
+
+
+def test_exporter_omits_envelope_block_when_empty():
+    from mantis_agent.gym.trace_exporter import _serialize_steps
+
+    step = _make_step_result(step_index=0, intent="navigate")
+    collector = StepTraceCollector(run_id="r1")
+    collector.record(0, StepTraceEnvelope())
+    out = _serialize_steps([step], collector)
+    assert "envelope" not in out[0]
+
+
+def test_exporter_omits_envelope_block_when_no_collector():
+    from mantis_agent.gym.trace_exporter import _serialize_steps
+
+    step = _make_step_result(step_index=0, intent="navigate")
+    out = _serialize_steps([step], None)
+    assert "envelope" not in out[0]
+
+
+def test_exporter_round_trip_end_to_end(tmp_path: Path, monkeypatch):
+    """Drive `maybe_export` with a step_traces argument; verify the
+    JSON on disk carries the envelope block."""
+    from mantis_agent.gym.trace_exporter import TraceExporter
+
+    monkeypatch.setenv("MANTIS_TRACE_EXPORT_DIR", str(tmp_path))
+    exporter = TraceExporter.from_env()
+    assert exporter.enabled is True
+
+    runner = MagicMock()
+    runner.tenant_id = "t1"
+    runner.run_key = "run-001"
+    runner.session_name = "test"
+    runner.plan_signature = "abcd"
+    runner.shadow_variant = ""
+    runner._final_status = "complete"
+    runner._run_start = 1000.0
+    runner._cost_totals = lambda: (0.0, 0.0, 0.0, 0.0)
+
+    step = _make_step_result(step_index=0, intent="navigate")
+    collector = StepTraceCollector(run_id="run-001")
+    collector.update(0, url_before="https://hn.com/", emitted_count=3)
+
+    out_path = exporter.maybe_export(
+        runner, [step], status="complete", step_traces=collector
+    )
+    assert out_path is not None
+    payload = json.loads(Path(out_path).read_text())
+    assert payload["schema_version"] == 3
+    assert payload["steps"][0]["envelope"]["url_before"] == "https://hn.com/"
+    assert payload["steps"][0]["envelope"]["emitted_count"] == 3
+
+
+def test_exporter_no_step_traces_kwarg_still_works_legacy(tmp_path: Path, monkeypatch):
+    """Backwards compat: legacy callers don't pass step_traces."""
+    from mantis_agent.gym.trace_exporter import TraceExporter
+
+    monkeypatch.setenv("MANTIS_TRACE_EXPORT_DIR", str(tmp_path))
+    exporter = TraceExporter.from_env()
+
+    runner = MagicMock()
+    runner.tenant_id = "t1"
+    runner.run_key = "run-002"
+    runner.session_name = "legacy"
+    runner.plan_signature = ""
+    runner.shadow_variant = ""
+    runner._final_status = "complete"
+    runner._run_start = 1000.0
+    runner._cost_totals = lambda: (0.0, 0.0, 0.0, 0.0)
+
+    step = _make_step_result(step_index=0, intent="navigate")
+    out_path = exporter.maybe_export(runner, [step], status="complete")
+    assert out_path is not None
+    payload = json.loads(Path(out_path).read_text())
+    # Legacy path: no envelope in the step blocks.
+    assert "envelope" not in payload["steps"][0]


### PR DESCRIPTION
## Summary

**Closes #783.** Lands the structured per-step trace fields the HN URL-collection user report flagged as missing for triage. Extends the existing `TraceExporter` JSON with an inline `envelope` block per step. Branched off `main` — independent of the browser-use chain.

## What's in the envelope

| Field | Purpose |
|---|---|
| `url_before` / `url_after` | What the step navigated from/to |
| `screenshot_pre_path` / `screenshot_post_path` | File refs to PNG pair (not embedded bytes) |
| `grounding` | What the brain aimed at — description + bbox + confidence |
| `dispatch` | What was actually dispatched — `xdotool argv` (Computer Plane) OR structured verb (Browser-Use Plane) OR CDP. Includes coordinates |
| `verifier` | Verification verdict — `pass` / `fail` / `demoted` / `skipped` + reason + raw output (catches the `critic_gate_truthy_fail` trap) |
| `retry_count` / `retry_reason` | Recovery history per step |
| `emitted_count` / `emitted_sample` | Projection of `step.data` so trace consumers don't parse plan-specific shapes |

## Plumbing

- `SCHEMA_VERSION` bumped 2 → 3 (additive — v2 consumers still parse v3).
- `TraceExporter.maybe_export` gains optional `step_traces=StepTraceCollector` kwarg. Legacy callers omit it — backwards-compatible.
- Empty envelopes dropped to keep JSON tight.

## What's NOT wired

- **Per-handler envelope population.** Step handlers each need 5-10 lines to push their grounding/dispatch/verifier observations into the collector. Kept out of PR 6 so this PR stays additive — the data structure + exporter integration land first, the handler-side calls follow in a focused follow-up.
- **`/v1/runs/{id}/trace` HTTP endpoint + `mantis trace <id>` CLI.** Land with PR 7 (run lifecycle).

## Tests

20 new (`tests/test_step_trace.py`):
- `GroundingTarget` / `DispatchRecord` / `VerifierVerdict` serialization
- Envelope `is_empty()` correctness + full-shape `as_dict`
- Collector `record`/`update`/`get`/`as_dict_by_index`
- Unknown-field tolerance on `update()`
- TraceExporter merges envelope when collector passed; omits when empty OR no collector
- End-to-end round-trip via `maybe_export` writing JSON to tmp
- Legacy `maybe_export(...)` call (no step_traces kwarg) still works

74 chain tests + 94 trace-related tests across the repo green.

## Refs

- Closes #783
- Sibling issues: #782 (PR 5), #784 (PR 7)
- Memory: `feedback_critic_gate_truthy_fail.md`, `feedback_verify_from_production_logs.md`, `project_user_feedback_hn_url_collection_2026_06_07.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)