### PR TITLE
feat(browser-use): Modal-hosted Browser-Use Plane scaffold (#785 PR 2)

### DIFF
--- a/deploy/modal/browser_use_plane.py
+++ b/deploy/modal/browser_use_plane.py
@@ -28,8 +28,6 @@ browser_use_base_url=...)`.
 
 from __future__ import annotations
 
-import os
-from pathlib import Path
 
 import modal
 

--- a/deploy/modal/browser_use_plane.py
+++ b/deploy/modal/browser_use_plane.py
@@ -1,0 +1,99 @@
+"""Browser-Use Plane Modal deployment (#785, PR 2).
+
+A standalone Modal app — separate from `mantis-cua-server` (Computer
+Plane) per the epic decision (#785): "two planes on separate hosts."
+Deploying Browser-Use Plane is independent of redeploying the brain or
+Computer Plane.
+
+Image: Microsoft Playwright Python image (Chromium + Playwright +
+Python) with `mantis_agent` + FastAPI added. Headless by default; no
+Xvfb, no xdotool. CPU-only — no GPU, no Chromium-via-Xvfb stealth
+stack.
+
+Endpoints come from `mantis_agent.server.browser_use_agent.build_app`
+— see `docs/reference/browser-use-plane.md` for the wire contract.
+
+Deploy::
+
+    modal deploy deploy/modal/browser_use_plane.py
+
+After deploy, resolve the web URL with::
+
+    modal.Function.from_name('mantis-browser-use', 'browser_use').get_web_url()
+
+and pass it to `BrowserUsePlaneClient(base_url=...)` or
+`make_compute_client(ComputeBackend.BROWSER_USE_PLANE,
+browser_use_base_url=...)`.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import modal
+
+APP_NAME = "mantis-browser-use"
+app = modal.App(APP_NAME)
+
+# Shared with Computer Plane / brain plane for cross-plane profile reads
+# (deferred to a follow-up — at v1 profiles are per-plane; see #785).
+# Mounting the same volume here doesn't enable shared profiles by itself;
+# the storage paths under it differ (`/data/browser-use-profile/...`).
+vol = modal.Volume.from_name("osworld-data", create_if_missing=True)
+
+# `mcr.microsoft.com/playwright-python` ships Chromium + the Python
+# Playwright SDK preinstalled. Smaller than building from scratch, and
+# bundles the exact Chromium build the SDK version expects.
+browser_use_image = (
+    modal.Image.from_registry(
+        "mcr.microsoft.com/playwright-python:v1.49.0-jammy",
+        add_python=None,  # base image ships Python 3.x
+    )
+    .run_commands(
+        # Match Computer Plane's locale + TZ posture so screenshots /
+        # date-format-sensitive sites behave identically.
+        "sed -i 's/# en_US.UTF-8/en_US.UTF-8/' /etc/locale.gen && locale-gen || true",
+        "ln -sf /usr/share/zoneinfo/America/New_York /etc/localtime || true",
+    )
+    .env({
+        "LANG": "en_US.UTF-8",
+        "LC_ALL": "en_US.UTF-8",
+        "TZ": "America/New_York",
+    })
+    .pip_install(
+        "fastapi>=0.110",
+        "uvicorn[standard]>=0.27",
+        "pydantic>=2",
+        "pillow",
+        "httpx",
+    )
+    .add_local_python_source("mantis_agent")
+)
+
+
+@app.function(
+    image=browser_use_image,
+    volumes={"/data": vol},
+    secrets=[modal.Secret.from_name("mantis-cua-server", required_keys=[])],
+    timeout=14400,  # 4 hours — match brain executor timeouts
+    memory=4096,
+    cpu=2.0,
+    scaledown_window=600,
+    # Single-session-per-container at v1; matches Computer Plane's
+    # pinned-container semantics (see modal_cua_server.py:2812-2813 for
+    # the rationale). Per-session fan-out is a Phase-2 concern.
+    min_containers=1,
+    max_containers=1,
+)
+@modal.concurrent(max_inputs=32)
+@modal.asgi_app()
+def browser_use():
+    """Browser-Use Plane RPC server — Playwright + Chromium over HTTPS.
+
+    Base surface only at v1 — `session/init`, `session/close`,
+    `screenshot`, `dispatch`, `health`. DOM-aware extensions
+    (`state/*`, `tabs/*`, `links/peek`) land with PR 3-4 of #785.
+    """
+    from mantis_agent.server.browser_use_agent import build_app
+    return build_app()

--- a/docs/reference/browser-use-plane.md
+++ b/docs/reference/browser-use-plane.md
@@ -1,0 +1,158 @@
+# Browser-Use Plane — DOM-aware companion to Computer Plane
+
+**Status:** Scaffold landed (PR 2 of #785). PR 3-4 add the DOM-aware extension surface (`state.*`, `tabs.*`, `links.*`).
+**Owners:** TBD
+**Tracks issue:** #785
+
+## Summary
+
+Browser-Use Plane is the **second** Mantis compute plane — the DOM-aware companion to Computer Plane. Chrome runs under **Playwright / CDP-native control** (no Xvfb, no xdotool). Both planes implement the same base `ComputeClient` contract; what differs is the dispatch primitives and the extension verbs Browser-Use Plane admits.
+
+| | Computer Plane | Browser-Use Plane |
+|---|---|---|
+| Driver | Xvfb + xdotool | Playwright (headless Chromium by default) |
+| Capabilities | `dom_aware=False, stealth=True` | `dom_aware=True, stealth=False (v1)` |
+| Dispatch | raw `xdotool argv` | structured action verbs (`click`/`key`/`type`/`scroll`) |
+| Profile storage | Chrome `--user-data-dir` blob | Playwright `userDataDir` + `storageState` |
+| CF / Turnstile parity | yes | **non-goal at v1** |
+
+Pick `computer_plane` (the default) for stealth-sensitive harvesting; pick `browser_use_plane` when the plan needs DOM-aware reads (tab management, anchor `href` peek, semantic click role disambiguation).
+
+## Wire contract (PR 2 — base surface only)
+
+Mirrors `docs/reference/computer-plane.md` in shape; differs in the dispatch verb.
+
+| Method | Path | Required | Notes |
+|---|---|---|---|
+| `POST` | `/session/init` | yes | Bind `(tenant_id, profile_id, run_id)`. Advertises `Capabilities` (PR 1). Idempotent on `run_id`. |
+| `POST` | `/session/close` | yes | Tear down browser context + Playwright runtime. |
+| `POST` | `/screenshot` | yes | PNG base64 + viewport metadata. |
+| `POST` | `/dispatch` | yes | Structured action verb (`click`/`key`/`type`/`scroll`) + `step_id`. Server keeps a TTL-bounded LRU and returns `deduplicated=true` on retry. |
+| `GET` | `/health` | yes | Liveness + last-action timestamp. |
+
+DOM-aware extensions (`/state/*`, `/tabs/*`, `/links/peek`) land in PR 3-4 — they are explicitly NOT in the base surface and NOT supported by Computer Plane.
+
+### Pydantic wire models
+
+Defined in `src/mantis_agent/gym/browser_use_wire.py`:
+
+- `BrowserUseSessionInitRequest` / `BrowserUseSessionInitResponse`
+- `BrowserUseSessionCloseRequest` / `BrowserUseSessionCloseResponse`
+- `BrowserUseScreenshotResponse`
+- `DispatchActionRequest` / `DispatchActionResponse`
+- `BrowserUseHealthResponse`
+
+### Capabilities
+
+`session/init` returns `Capabilities.for_browser_use_plane()`:
+
+```python
+Capabilities(
+    dom_aware=True,
+    stealth=False,           # explicit non-goal at v1
+    supports_cdp=True,       # Playwright IS CDP under the hood
+    backend=ComputeBackend.BROWSER_USE_PLANE,
+)
+```
+
+## Architecture
+
+```
+┌──────────────────────────────────────────────────────┐
+│  Modal app "mantis-browser-use"  (NEW, this PR)      │
+│                                                       │
+│  ┌──────────── BROWSER-USE PLANE ────────────┐       │
+│  │ Browser-Use Agent FastAPI:                │       │
+│  │   POST /session/init                      │       │
+│  │   POST /session/close                     │       │
+│  │   POST /screenshot                        │       │
+│  │   POST /dispatch                          │       │
+│  │   GET  /health                            │       │
+│  │ Playwright + Chromium (headless)          │       │
+│  └───────────────────────────────────────────┘       │
+└──────────────────────────────────────────────────────┘
+                       ▲
+                       │ HTTPS
+                       │
+┌──────────────────────────────────────────────────────┐
+│  Modal app "mantis-cua-server"  (UNCHANGED)          │
+│                                                       │
+│  Brain plane → run_browser_use executor →            │
+│    BrowserUsePlaneClient ───────────────┘            │
+└──────────────────────────────────────────────────────┘
+```
+
+Two Modal apps. Independent deploy cadence — redeploying the brain doesn't redeploy Browser-Use Plane and vice versa.
+
+## Image (Modal)
+
+`mcr.microsoft.com/playwright-python:v1.49.0-jammy` — bundles Chromium + the Playwright Python SDK pinned to the same version. CPU-only (no GPU, no Xvfb, no xdotool). ~2 GB.
+
+Locale + TZ matched to Computer Plane so screenshot-comparison and date-format-sensitive sites behave identically across planes.
+
+## Deploy
+
+```bash
+modal deploy deploy/modal/browser_use_plane.py
+```
+
+Reads the function URL after deploy:
+
+```python
+import modal
+url = modal.Function.from_name("mantis-browser-use", "browser_use").get_web_url()
+```
+
+## Brain-plane integration
+
+`src/mantis_agent/run_browser_use.py` exports `run_browser_use_executor(...)` — the executor entry point. PR 2 leaves it **un-wired** from `modal_cua_server.py`'s `cua_model` dispatch table; PR 3 wires it once the DOM-aware extensions make the surface useful for plan authors.
+
+Configure plan-level via `runtime.compute_backend: browser_use_plane`:
+
+```yaml
+runtime:
+  compute_backend: browser_use_plane
+
+steps:
+  - intent: "Open Hacker News"
+    type: navigate
+    url: https://news.ycombinator.com
+```
+
+The resolver in `src/mantis_agent/gym/compute_backend_resolver.py` reads this; the factory in `src/mantis_agent/gym/compute_factory.py` dispatches to the right client. Default remains `computer_plane`.
+
+## Capability enforcement
+
+`run_browser_use` configures `CapabilityAllowlist.browser_use(executor="run_browser_use")` — admits `dom_aware` + `supports_cdp`. Pure-CUA executors (`run_claude_cua`, `run_holo3`, etc.) use `CapabilityAllowlist.pure_cua()` and will raise `CapabilityNotAllowed` if a handler tries to consume DOM-aware extensions against them even when the client speaks Browser-Use Plane.
+
+The mismatch check runs at session start (`run_browser_use._validate_executor_compat`) — failures here happen before any browser action, not mid-plan.
+
+## Profile + proxy at v1
+
+Profiles are **per-plane**. The same `(tenant_id, profile_id)` identity exists on both planes but storage is independent. Layout (this plane):
+
+```
+/data/browser-use-profile/<tenant>__<profile_id>/   ← Playwright userDataDir blob
+```
+
+Computer Plane keeps its existing layout at `/data/chrome-profile/...`. Both volumes mounted; no shared bytes. Cross-plane profile handoff is the deferred follow-up gated on real demand (#785).
+
+Proxy is passed at `session/init` and forwarded to Playwright's `launch({proxy: {server}})`. Same `PrivateProxy` creds as Computer Plane.
+
+## Non-goals (v1)
+
+- Stealth on CF-protected sites — use Computer Plane for those.
+- Cross-plane profile handoff — deferred follow-up.
+- Concurrent sessions per container — single-session pinned at v1, matching Computer Plane's posture.
+
+## Open questions
+
+1. **Async vs sync Playwright.** v1 uses `sync_playwright` for simplicity. Switching to `async_api` is a non-trivial refactor — defer until concurrency pressure makes it worth it.
+2. **Session pool sizing.** Same as Computer Plane: pin to one container at v1, revisit after a real workload.
+
+## References
+
+- Umbrella contract: `docs/reference/compute-client.md`
+- Sibling plane spec: `docs/reference/computer-plane.md`
+- Epic: #785
+- PR 1 (foundation): #786

--- a/src/mantis_agent/gym/__init__.py
+++ b/src/mantis_agent/gym/__init__.py
@@ -13,6 +13,8 @@ Architecture:
 """
 
 from .base import GymEnvironment, GymObservation, GymResult
+from .browser_use_plane_client import BrowserUsePlaneClient
+from .compute_backend_resolver import resolve_compute_backend
 from .compute_contract import (
     Capabilities,
     CapabilityAllowlist,
@@ -22,12 +24,14 @@ from .compute_contract import (
     SupportsLinkPeek,
     SupportsTabs,
 )
+from .compute_factory import default_capabilities_for, make_compute_client
 from .plans import Plan, load_plan, load_text_plan, save_plan, get_missing_inputs, text_to_yaml
 from .playwright_env import PlaywrightGymEnv
 from .runner import GymRunner
 from .workflow_runner import WorkflowRunner, LoopConfig, IterationResult
 
 __all__ = [
+    "BrowserUsePlaneClient",
     "Capabilities",
     "CapabilityAllowlist",
     "CapabilityNotAllowed",
@@ -41,10 +45,13 @@ __all__ = [
     "SupportsBrowserState",
     "SupportsLinkPeek",
     "SupportsTabs",
+    "default_capabilities_for",
     "get_missing_inputs",
     "load_plan",
     "load_text_plan",
     "LoopConfig",
+    "make_compute_client",
+    "resolve_compute_backend",
     "save_plan",
     "text_to_yaml",
     "WorkflowRunner",

--- a/src/mantis_agent/gym/browser_use_plane_client.py
+++ b/src/mantis_agent/gym/browser_use_plane_client.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 import base64
 import logging
-import time
 import uuid
 from dataclasses import dataclass
 from io import BytesIO
@@ -32,7 +31,6 @@ from .browser_use_wire import (
     BrowserUseHealthResponse,
     BrowserUseScreenshotResponse,
     BrowserUseSessionCloseRequest,
-    BrowserUseSessionCloseResponse,
     BrowserUseSessionInitRequest,
     BrowserUseSessionInitResponse,
     DispatchActionRequest,

--- a/src/mantis_agent/gym/browser_use_plane_client.py
+++ b/src/mantis_agent/gym/browser_use_plane_client.py
@@ -1,0 +1,272 @@
+"""HTTPS client for the Browser-Use Plane Modal function (#785, PR 2).
+
+Implements the **base surface** of the unified `ComputeClient` contract
+(session_init, session_close, screenshot, dispatch_action, health) over
+HTTPS against a Browser-Use Plane FastAPI host.
+
+PR 3-4 add the DOM-aware extension methods (`state.*`, `tabs.*`,
+`links.*`). They are kept off this class until then so PR 2 ships a
+small, testable scaffold.
+
+The class deliberately mirrors the surface shape of
+`RemoteComputerImpl` (the Computer-Plane HTTPS client) so that a future
+brain-plane refactor can swap them via the unified factory
+(`compute_factory.make_compute_client`).
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+import time
+import uuid
+from dataclasses import dataclass
+from io import BytesIO
+from typing import Any
+
+import requests
+from PIL import Image
+
+from .base import GymObservation, GymResult
+from .browser_use_wire import (
+    BrowserUseHealthResponse,
+    BrowserUseScreenshotResponse,
+    BrowserUseSessionCloseRequest,
+    BrowserUseSessionCloseResponse,
+    BrowserUseSessionInitRequest,
+    BrowserUseSessionInitResponse,
+    DispatchActionRequest,
+    DispatchActionResponse,
+)
+from .compute_contract import Capabilities
+from .computer_client import ComputerClient
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class _ClientState:
+    session_token: str | None = None
+    last_capabilities: Capabilities | None = None
+    last_url: str = ""
+
+
+class BrowserUsePlaneClient(ComputerClient):
+    """`ComputeClient` impl for the Browser-Use Plane Modal function.
+
+    Mirrors `RemoteComputerImpl` shape so the brain plane is plane-agnostic
+    at the call site. Capabilities are read from `session/init` and made
+    available via `capabilities()` for downstream `CapabilityAllowlist`
+    enforcement (`compute_contract.CapabilityAllowlist`).
+    """
+
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        auth_token: str | None = None,
+        tenant_id: str = "default",
+        profile_id: str = "default",
+        run_id: str | None = None,
+        proxy_server: str | None = None,
+        start_url: str = "about:blank",
+        profile_dir: str | None = None,
+        viewport: tuple[int, int] = (1280, 720),
+        extra_http_headers: dict[str, str] | None = None,
+        headless: bool = True,
+        request_timeout_s: float = 30.0,
+    ) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._auth_token = auth_token
+        self._tenant_id = tenant_id
+        self._profile_id = profile_id
+        self._run_id = run_id or uuid.uuid4().hex
+        self._proxy_server = proxy_server
+        self._start_url = start_url
+        self._profile_dir = profile_dir
+        self._viewport = viewport
+        self._extra_http_headers = extra_http_headers
+        self._headless = headless
+        self._timeout = request_timeout_s
+        self._http = requests.Session()
+        self._state = _ClientState()
+
+    # ── ComputeClient base surface ────────────────────────────────
+
+    def reset(self, task: str, **_kw: Any) -> GymObservation:
+        """Open or reuse a session; return the initial screenshot.
+
+        Mirrors `GymEnvironment.reset`. The first call performs
+        `session/init`; subsequent calls reuse the bound session and
+        re-screenshot.
+        """
+        if self._state.session_token is None:
+            self._session_init()
+        png = self._screenshot_bytes()
+        img = Image.open(BytesIO(png))
+        return GymObservation(screenshot=img, extras={"url": self._state.last_url})
+
+    def step(self, action: Any) -> GymResult:
+        """Dispatch a structured action; return new screenshot.
+
+        Mantis `Action` types map to `DispatchActionRequest` kinds. The
+        translation is deliberately minimal in PR 2 — full action-type
+        coverage lands when PR 3-4 wire handlers through.
+        """
+        kind, params = self._translate_action(action)
+        self._dispatch(kind=kind, params=params)
+        png = self._screenshot_bytes()
+        img = Image.open(BytesIO(png))
+        return GymResult(
+            observation=GymObservation(screenshot=img, extras={"url": self._state.last_url}),
+            reward=0.0,
+            done=False,
+            info={},
+        )
+
+    def close(self) -> None:
+        if self._state.session_token is None:
+            return
+        try:
+            self._session_close()
+        finally:
+            self._http.close()
+            self._state = _ClientState()
+
+    @property
+    def screen_size(self) -> tuple[int, int]:
+        return self._viewport
+
+    # ── ComputeClient extras ──────────────────────────────────────
+
+    def capabilities(self) -> Capabilities:
+        """Last-advertised capabilities. Falls back to the Browser-Use
+        Plane default if `session/init` has not run."""
+        if self._state.last_capabilities is not None:
+            return self._state.last_capabilities
+        return Capabilities.for_browser_use_plane()
+
+    # ── HTTP plumbing ─────────────────────────────────────────────
+
+    def _headers(self) -> dict[str, str]:
+        h: dict[str, str] = {}
+        if self._auth_token:
+            h["Authorization"] = f"Bearer {self._auth_token}"
+        if self._state.session_token:
+            h["X-Mantis-Session"] = self._state.session_token
+        return h
+
+    def _session_init(self) -> None:
+        req = BrowserUseSessionInitRequest(
+            tenant_id=self._tenant_id,
+            profile_id=self._profile_id,
+            run_id=self._run_id,
+            proxy_server=self._proxy_server,
+            viewport=self._viewport,
+            start_url=self._start_url,
+            profile_dir=self._profile_dir,
+            extra_http_headers=self._extra_http_headers,
+            headless=self._headless,
+        )
+        resp = self._http.post(
+            f"{self._base_url}/session/init",
+            json=req.model_dump(),
+            headers=self._headers(),
+            timeout=self._timeout,
+        )
+        resp.raise_for_status()
+        parsed = BrowserUseSessionInitResponse.model_validate(resp.json())
+        self._state.session_token = parsed.session_token
+        self._state.last_capabilities = parsed.resolved_capabilities()
+        logger.warning(
+            "[browser-use] session init ok token=%s caps=%s",
+            parsed.session_token[:8],
+            self._state.last_capabilities.as_dict(),
+        )
+
+    def _session_close(self) -> None:
+        assert self._state.session_token is not None
+        req = BrowserUseSessionCloseRequest(session_token=self._state.session_token)
+        try:
+            self._http.post(
+                f"{self._base_url}/session/close",
+                json=req.model_dump(),
+                headers=self._headers(),
+                timeout=self._timeout,
+            )
+        except Exception as exc:  # noqa: BLE001 — best-effort teardown
+            logger.warning("[browser-use] session close failed: %s", exc)
+
+    def _screenshot_bytes(self) -> bytes:
+        resp = self._http.post(
+            f"{self._base_url}/screenshot",
+            json={"format": "png"},
+            headers=self._headers(),
+            timeout=self._timeout,
+        )
+        resp.raise_for_status()
+        parsed = BrowserUseScreenshotResponse.model_validate(resp.json())
+        return base64.b64decode(parsed.image_b64)
+
+    def _dispatch(self, *, kind: str, params: dict[str, Any]) -> None:
+        step_id = uuid.uuid4().hex
+        req = DispatchActionRequest(kind=kind, params=params, step_id=step_id)
+        resp = self._http.post(
+            f"{self._base_url}/dispatch",
+            json=req.model_dump(),
+            headers=self._headers(),
+            timeout=self._timeout,
+        )
+        resp.raise_for_status()
+        parsed = DispatchActionResponse.model_validate(resp.json())
+        if not parsed.ok:
+            raise RuntimeError(f"dispatch {kind} failed: {parsed.error}")
+
+    def health(self) -> BrowserUseHealthResponse:
+        resp = self._http.get(
+            f"{self._base_url}/health", headers=self._headers(), timeout=self._timeout
+        )
+        resp.raise_for_status()
+        return BrowserUseHealthResponse.model_validate(resp.json())
+
+    # ── Action translation ────────────────────────────────────────
+
+    def _translate_action(self, action: Any) -> tuple[str, dict[str, Any]]:
+        """Map a Mantis `Action` to a Browser-Use dispatch verb.
+
+        Kept minimal — PR 3-4 expand coverage. The cases below cover the
+        common shapes used by today's step handlers. Unknown shapes raise
+        so silent fall-through doesn't mask wire-contract bugs.
+        """
+        from ..actions import Action
+
+        if not isinstance(action, Action):
+            raise TypeError(f"BrowserUsePlaneClient.step expected Action, got {type(action)}")
+
+        # Mantis Action is a tagged union — fields populated depend on type.
+        atype = getattr(action, "type", None) or getattr(action, "action_type", None)
+        if atype == "click":
+            return "click", {
+                "x": int(action.x),
+                "y": int(action.y),
+                "button": getattr(action, "button", "left"),
+                "click_count": int(getattr(action, "click_count", 1)),
+            }
+        if atype == "key":
+            return "key", {"key": str(getattr(action, "key", "") or action.text or "")}
+        if atype == "type":
+            return "type", {
+                "text": str(action.text),
+                "delay_ms": int(getattr(action, "delay_ms", 0)),
+            }
+        if atype == "scroll":
+            return "scroll", {
+                "delta_y": int(getattr(action, "delta_y", 0)),
+                "x": int(getattr(action, "x", 0) or 0),
+                "y": int(getattr(action, "y", 0) or 0),
+            }
+        raise NotImplementedError(
+            f"BrowserUsePlaneClient does not yet handle Action type={atype!r}; "
+            "extend `_translate_action` and add a test in "
+            "tests/test_browser_use_plane_client.py."
+        )

--- a/src/mantis_agent/gym/browser_use_wire.py
+++ b/src/mantis_agent/gym/browser_use_wire.py
@@ -1,0 +1,120 @@
+"""Pydantic wire models for the Browser-Use Plane RPC (#785).
+
+Browser-Use Plane diverges from Computer Plane on the *dispatch* surface:
+where Computer Plane sends raw `xdotool argv`, Browser-Use Plane sends
+structured action verbs (`click`, `key`, `type`, `scroll`) that map to
+Playwright's `page.mouse` / `keyboard` primitives. The base lifecycle
+(session_init, session_close, screenshot, health) mirrors the Computer
+Plane shape so the umbrella `ComputeClient` contract (#785) is honored.
+
+DOM-aware extensions (`state.*`, `tabs.*`, `links.*`) land in PR 3-4 —
+they are NOT in this module yet. Computer Plane's wire surface does not
+gain them; pure-CUA executors carry a `CapabilityAllowlist` that
+excludes `dom_aware`.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+from .compute_contract import Capabilities, ComputeBackend
+
+
+class BrowserUseSessionInitRequest(BaseModel):
+    """Bind a Browser-Use Plane session to `(tenant_id, profile_id, run_id)`.
+
+    Profile is stored as a Playwright `userDataDir` blob under
+    `/data/browser-use-profile/<tenant>__<profile_id>/`. Storage layout
+    differs from Computer Plane (which uses Chrome's `--user-data-dir`);
+    see `docs/reference/browser-use-plane.md` for the per-plane storage
+    contract.
+    """
+
+    tenant_id: str
+    profile_id: str
+    run_id: str
+    proxy_server: str | None = None
+    viewport: tuple[int, int] = (1280, 720)
+    start_url: str = "about:blank"
+    profile_dir: str | None = None
+    extra_http_headers: dict[str, str] | None = None
+    # Browser-Use Plane has no Xvfb. Headless mode is the default; set
+    # False only when debugging locally.
+    headless: bool = True
+
+
+class BrowserUseSessionInitResponse(BaseModel):
+    """Mirrors Computer Plane's `SessionInitResponse` shape with one diff:
+    no `xvfb_display` (Browser-Use Plane runs headless). Capabilities
+    advertise `dom_aware=True`."""
+
+    session_token: str
+    browser_pid: int | None = None
+    capabilities: dict[str, object] | None = None
+
+    def resolved_capabilities(self) -> Capabilities:
+        if self.capabilities is None:
+            return Capabilities.for_browser_use_plane()
+        backend_value = self.capabilities.get(
+            "backend", ComputeBackend.BROWSER_USE_PLANE.value
+        )
+        try:
+            backend = ComputeBackend(backend_value)
+        except ValueError:
+            backend = ComputeBackend.BROWSER_USE_PLANE
+        return Capabilities(
+            dom_aware=bool(self.capabilities.get("dom_aware", True)),
+            stealth=bool(self.capabilities.get("stealth", False)),
+            supports_cdp=bool(self.capabilities.get("supports_cdp", True)),
+            backend=backend,
+        )
+
+
+class BrowserUseSessionCloseRequest(BaseModel):
+    session_token: str
+
+
+class BrowserUseSessionCloseResponse(BaseModel):
+    closed: bool
+
+
+class BrowserUseScreenshotResponse(BaseModel):
+    image_b64: str
+    width: int
+    height: int
+    scroll_y: int
+    captured_at_ms: int
+
+
+class DispatchActionRequest(BaseModel):
+    """Uniform structured action verb — the Browser-Use Plane analogue of
+    Computer Plane's `xdotool argv`.
+
+    `kind` discriminates:
+      - `click` — `{x, y, button, click_count}`
+      - `key` — `{key}` (Playwright key names: `Enter`, `Escape`, `Tab`, ...)
+      - `type` — `{text, delay_ms}` (`delay_ms` is per-character pace)
+      - `scroll` — `{delta_y, x, y}` (CDP `Input.dispatchMouseEvent` with `wheel`)
+
+    `step_id` enables idempotency per the unified contract; the server
+    keeps a TTL'd LRU and returns `deduplicated=true` on retry.
+    """
+
+    kind: Literal["click", "key", "type", "scroll"]
+    params: dict[str, object] = Field(default_factory=dict)
+    step_id: str
+    timeout_ms: int = 5000
+
+
+class DispatchActionResponse(BaseModel):
+    ok: bool
+    error: str | None = None
+    deduplicated: bool = False
+
+
+class BrowserUseHealthResponse(BaseModel):
+    ok: bool
+    last_action_ms: int | None = None
+    session_token: str | None = None

--- a/src/mantis_agent/gym/compute_backend_resolver.py
+++ b/src/mantis_agent/gym/compute_backend_resolver.py
@@ -1,0 +1,63 @@
+"""Resolve `compute_backend` from layered sources (#785, PR 2).
+
+Precedence — highest wins:
+
+1. **Plan-level** — `plan["runtime"]["compute_backend"]` (the plan
+   author's choice; most local).
+2. **Submission-level** — HTTP body / CLI flag (operator override —
+   e.g. A/B-running the same plan on the other plane).
+3. **Global default** — `ComputeBackend.COMPUTER_PLANE` (Xvfb + xdotool
+   stays the safe default; pure-CUA is what production has been on).
+
+The resolver is intentionally pure — no env-var reads, no I/O — so the
+precedence is observable and testable in isolation.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .compute_contract import ComputeBackend
+
+
+def _coerce(value: Any) -> ComputeBackend | None:
+    if value is None:
+        return None
+    if isinstance(value, ComputeBackend):
+        return value
+    if isinstance(value, str):
+        try:
+            return ComputeBackend(value)
+        except ValueError:
+            return None
+    return None
+
+
+def resolve_compute_backend(
+    *,
+    plan: dict[str, Any] | None = None,
+    submission_value: Any = None,
+    default: ComputeBackend = ComputeBackend.COMPUTER_PLANE,
+) -> ComputeBackend:
+    """Return the effective `ComputeBackend` for this run.
+
+    `plan` is the raw micro-plan dict (after JSON parse). Looks at
+    `plan["runtime"]["compute_backend"]`; tolerates the legacy
+    flat-array plan shape (no runtime block) by treating it as absent.
+
+    `submission_value` may be a `ComputeBackend`, a string, or None.
+    Unrecognized strings fall through to the next layer (do NOT raise —
+    forward-compat with future backend names).
+    """
+    if isinstance(plan, dict):
+        runtime = plan.get("runtime")
+        if isinstance(runtime, dict):
+            plan_value = _coerce(runtime.get("compute_backend"))
+            if plan_value is not None:
+                return plan_value
+
+    sub_value = _coerce(submission_value)
+    if sub_value is not None:
+        return sub_value
+
+    return default

--- a/src/mantis_agent/gym/compute_factory.py
+++ b/src/mantis_agent/gym/compute_factory.py
@@ -1,0 +1,91 @@
+"""Umbrella factory for the unified `ComputeClient` contract (#785, PR 2).
+
+Dispatches between the two compute planes based on the resolved
+`ComputeBackend`:
+
+- `ComputeBackend.COMPUTER_PLANE` → `make_computer_client(...)`
+  (existing factory in `computer_client.py`).
+- `ComputeBackend.BROWSER_USE_PLANE` → `BrowserUsePlaneClient(...)`
+  (new client in `browser_use_plane_client.py`).
+
+`make_compute_client` is the single brain-plane entry point — call sites
+don't need to know which plane they're on. The selected plane's client
+is constructed; capabilities advertised at `session_init` are then
+checked against a per-executor `CapabilityAllowlist` (enforcement seam
+is one layer up in the executor; see `run_browser_use.py`).
+
+Backwards compat: existing call sites that construct
+`make_computer_client(...)` directly keep working — this module sits
+alongside, not in place.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .browser_use_plane_client import BrowserUsePlaneClient
+from .compute_contract import Capabilities, ComputeBackend
+from .computer_client import (
+    ComputerClient,
+    ComputerPlaneConfig,
+    make_computer_client,
+)
+
+
+def make_compute_client(
+    compute_backend: ComputeBackend | str = ComputeBackend.COMPUTER_PLANE,
+    *,
+    computer_plane_cfg: ComputerPlaneConfig | None = None,
+    browser_use_base_url: str | None = None,
+    browser_use_auth_token: str | None = None,
+    **env_kwargs: Any,
+) -> ComputerClient:
+    """Build a `ComputeClient` for the resolved compute plane.
+
+    `compute_backend` accepts either a `ComputeBackend` enum or its
+    string value (which is what `plan.runtime.compute_backend` carries on
+    the wire). Default is `COMPUTER_PLANE` — pure-CUA stays the path
+    when no plan-level or submission-time override is set.
+
+    Pass `computer_plane_cfg` for Computer Plane runs;
+    `browser_use_base_url` for Browser-Use Plane runs. Remaining
+    `env_kwargs` are forwarded to the underlying client (e.g.
+    `start_url`, `viewport`, `proxy_server`).
+    """
+    backend = (
+        compute_backend
+        if isinstance(compute_backend, ComputeBackend)
+        else ComputeBackend(compute_backend)
+    )
+
+    if backend is ComputeBackend.COMPUTER_PLANE:
+        return make_computer_client(computer_plane_cfg, **env_kwargs)
+
+    if backend is ComputeBackend.BROWSER_USE_PLANE:
+        if not browser_use_base_url:
+            raise ValueError(
+                "ComputeBackend.BROWSER_USE_PLANE requires browser_use_base_url "
+                "(URL of the deployed Browser-Use Plane Modal function)."
+            )
+        return BrowserUsePlaneClient(
+            base_url=browser_use_base_url,
+            auth_token=browser_use_auth_token,
+            **env_kwargs,
+        )
+
+    raise ValueError(f"unknown ComputeBackend: {backend!r}")
+
+
+def default_capabilities_for(backend: ComputeBackend | str) -> Capabilities:
+    """Capabilities a backend advertises before `session_init`.
+
+    Used by call sites that need a Capabilities snapshot pre-session —
+    e.g. setting up the per-executor `CapabilityAllowlist` based on
+    which plane was resolved.
+    """
+    b = backend if isinstance(backend, ComputeBackend) else ComputeBackend(backend)
+    if b is ComputeBackend.COMPUTER_PLANE:
+        return Capabilities.for_computer_plane()
+    if b is ComputeBackend.BROWSER_USE_PLANE:
+        return Capabilities.for_browser_use_plane()
+    raise ValueError(f"unknown ComputeBackend: {backend!r}")

--- a/src/mantis_agent/run_browser_use.py
+++ b/src/mantis_agent/run_browser_use.py
@@ -1,0 +1,223 @@
+"""`run_browser_use` — brain-plane executor for Browser-Use Plane (#785, PR 2).
+
+Mirrors `_run_claude_executor`'s shape but routes the brain through
+`BrowserUsePlaneClient` instead of the Computer Plane (`XdotoolGymEnv` /
+`RemoteComputerImpl`). Stays headless / Playwright-driven; no Xvfb, no
+xdotool, no local proxy subprocess.
+
+PR 2 scaffold scope:
+
+- Constructs the client + configures `CapabilityAllowlist.browser_use()`
+  for the executor.
+- Drives the existing `run_executor_lifecycle` with a Browser-Use plane
+  env so the rest of the task-loop pipeline (Augur emission, retry,
+  step recovery) keeps working without per-plane forks.
+- NOT yet wired into `modal_cua_server.py`'s `cua_model` dispatch
+  table — that lands once PR 3 / PR 4 add the DOM-aware extensions and
+  there's an HTTP API contract worth exposing. Callers in PR 2 must
+  invoke this function directly (e.g. from a smoke script).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from datetime import datetime, timezone
+from typing import Any
+
+from .gym.browser_use_plane_client import BrowserUsePlaneClient
+from .gym.compute_contract import (
+    Capabilities,
+    CapabilityAllowlist,
+    CapabilityNotAllowed,
+    ComputeBackend,
+)
+
+logger = logging.getLogger(__name__)
+
+
+EXECUTOR_NAME = "run_browser_use"
+
+
+def make_browser_use_allowlist() -> CapabilityAllowlist:
+    """Capability allowlist for the `run_browser_use` executor.
+
+    Admits `dom_aware` + `supports_cdp` extensions; pure-CUA executors
+    use `CapabilityAllowlist.pure_cua()` instead. This is the enforcement
+    seam — handlers that consume DOM-aware extensions cross-check this
+    allowlist before each call (see `compute_contract.CapabilityAllowlist`
+    and the PR 3 / PR 4 handlers).
+    """
+    return CapabilityAllowlist.browser_use(executor=EXECUTOR_NAME)
+
+
+def resolve_browser_use_base_url() -> str:
+    """Resolve the Modal function URL for the Browser-Use Plane.
+
+    Reads `MANTIS_BROWSER_USE_URL` first (operator override / local
+    dev); falls back to looking the function up via the Modal SDK by
+    app + function name. Empty string is returned if neither path
+    succeeds — callers must raise (the executor cannot run without a
+    backing host).
+    """
+    explicit = (os.environ.get("MANTIS_BROWSER_USE_URL") or "").strip()
+    if explicit:
+        return explicit
+    try:
+        import modal  # noqa: PLC0415
+
+        fn = modal.Function.from_name("mantis-browser-use", "browser_use")
+        return fn.get_web_url()  # type: ignore[no-any-return]
+    except Exception as exc:  # noqa: BLE001 — best-effort resolution
+        logger.warning(
+            "[browser-use] cannot resolve URL via Modal SDK: %s; "
+            "set MANTIS_BROWSER_USE_URL in the secret",
+            exc,
+        )
+        return ""
+
+
+def make_browser_use_client(
+    *,
+    tenant_id: str = "default",
+    profile_id: str = "default",
+    run_id: str | None = None,
+    proxy_server: str | None = None,
+    start_url: str = "about:blank",
+    profile_dir: str | None = None,
+    viewport: tuple[int, int] = (1280, 720),
+    extra_http_headers: dict[str, str] | None = None,
+    base_url: str | None = None,
+    auth_token: str | None = None,
+) -> tuple[BrowserUsePlaneClient, Capabilities]:
+    """Construct a `BrowserUsePlaneClient` + return the expected `Capabilities`.
+
+    The capabilities returned are the *expected* / declared shape (before
+    `session/init` actually runs). After init, the client's
+    `capabilities()` reflects what the server advertised — and the
+    allowlist enforcement step in handlers re-checks it.
+    """
+    resolved_url = base_url or resolve_browser_use_base_url()
+    if not resolved_url:
+        raise RuntimeError(
+            "Browser-Use Plane URL is not configured. Set "
+            "MANTIS_BROWSER_USE_URL or deploy the Modal app "
+            "'mantis-browser-use' via `modal deploy "
+            "deploy/modal/browser_use_plane.py`."
+        )
+    client = BrowserUsePlaneClient(
+        base_url=resolved_url,
+        auth_token=auth_token,
+        tenant_id=tenant_id,
+        profile_id=profile_id,
+        run_id=run_id,
+        proxy_server=proxy_server,
+        start_url=start_url,
+        profile_dir=profile_dir,
+        viewport=viewport,
+        extra_http_headers=extra_http_headers,
+    )
+    return client, Capabilities.for_browser_use_plane()
+
+
+def _validate_executor_compat(allowlist: CapabilityAllowlist, advertised: Capabilities) -> None:
+    """Fail fast at session start if the executor's allowlist doesn't
+    permit the advertised capabilities it intends to use.
+
+    For `run_browser_use`, that means `dom_aware` must be on the
+    allowlist AND the server must advertise it. Mismatched runs raise
+    `CapabilityNotAllowed` here, not mid-plan.
+    """
+    if advertised.dom_aware and not allowlist.allows("dom_aware"):
+        raise CapabilityNotAllowed("dom_aware", executor=allowlist.executor)
+    if not advertised.dom_aware:
+        logger.warning(
+            "[browser-use] server advertised dom_aware=False — likely "
+            "misconfigured. Expected Browser-Use Plane to advertise "
+            "dom_aware=True for the %s executor.",
+            allowlist.executor,
+        )
+
+
+def run_browser_use_executor(
+    task_file_contents: str,
+    *,
+    claude_model: str = "claude-sonnet-4-6",
+    max_steps: int = 30,
+    frames_per_inference: int = 2,
+    thinking_budget: int = 2048,
+    base_url: str | None = None,
+    auth_token: str | None = None,
+    profile_dir: str | None = None,
+    **_extra: Any,
+) -> dict[str, Any]:
+    """Execute a task suite against the Browser-Use Plane.
+
+    Mirror of `_run_claude_executor` in shape. Currently uses
+    `ClaudeBrain` for vision-grounded actions (PR 3 may add a brain
+    variant that consumes DOM-aware reads via `state.*` / `tabs.*`).
+
+    Scaffold-only at PR 2: not wired into modal_cua_server.py's
+    cua_model dispatch table. Invoke directly via the Modal SDK or a
+    smoke script.
+    """
+    from .brain_claude import ClaudeBrain
+    from .task_loop import TaskLoopConfig, run_executor_lifecycle, setup_viewer
+
+    run_id = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    t0 = time.time()
+
+    task_suite = json.loads(task_file_contents)
+    session_name = task_suite.get("session_name", "browser_use")
+
+    brain = ClaudeBrain(
+        model=claude_model,
+        max_tokens=4096,
+        thinking_budget=thinking_budget,
+        screen_size=(1280, 720),
+    )
+    brain.load()
+
+    client, expected_caps = make_browser_use_client(
+        tenant_id=task_suite.get("_tenant_id", "default"),
+        profile_id=task_suite.get("_profile_id", "default"),
+        run_id=run_id,
+        proxy_server=task_suite.get("_proxy_server"),
+        start_url=task_suite.get("base_url", "about:blank"),
+        profile_dir=profile_dir,
+        extra_http_headers=task_suite.get("_browser_extra_headers"),
+        base_url=base_url,
+        auth_token=auth_token,
+    )
+
+    allowlist = make_browser_use_allowlist()
+    _validate_executor_compat(allowlist, expected_caps)
+
+    viewer_ctx, viewer_event_bus, _viewer_url = setup_viewer(False, proxy_diag={"disabled": True})
+
+    config = TaskLoopConfig(
+        run_id=run_id,
+        session_name=session_name,
+        model_name=f"BrowserUse-Claude ({claude_model})",
+        results_prefix="browser_use",
+        brain=brain,
+        env=client,
+        max_steps=max_steps,
+        frames_per_inference=frames_per_inference,
+        viewer_event_bus=viewer_event_bus,
+        on_task_complete=None,
+        volume_commit=None,
+        summary_extras={
+            "compute_backend": ComputeBackend.BROWSER_USE_PLANE.value,
+            "capability_allowlist": sorted(allowlist.allowed),
+        },
+    )
+    return run_executor_lifecycle(
+        task_suite,
+        config,
+        proxy_proc=None,
+        viewer_ctx=viewer_ctx,
+        t0=t0,
+    )

--- a/src/mantis_agent/server/browser_use_agent.py
+++ b/src/mantis_agent/server/browser_use_agent.py
@@ -1,0 +1,277 @@
+"""Browser-Use Plane FastAPI app — Playwright-driven (#785, PR 2).
+
+Mirrors `computer_agent.py`'s shape but drives Playwright + Chromium
+instead of Xvfb + xdotool. Implements the **base surface** of the
+unified `ComputeClient` contract: `session/init`, `session/close`,
+`screenshot`, `dispatch`, `health`.
+
+PR 3-4 add the DOM-aware extension endpoints (`state/*`, `tabs/*`,
+`links/peek`). They are NOT exposed here yet — handlers gate on the
+advertised `dom_aware` capability, so the missing routes would surface
+as a 404 (acceptable at scaffold stage).
+
+This module is imported by `deploy/modal/browser_use_plane.py`; running
+it directly with `uvicorn` is supported for local debugging.
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Any
+
+from fastapi import FastAPI, HTTPException, Request
+
+from ..gym.browser_use_wire import (
+    BrowserUseHealthResponse,
+    BrowserUseScreenshotResponse,
+    BrowserUseSessionCloseRequest,
+    BrowserUseSessionCloseResponse,
+    BrowserUseSessionInitRequest,
+    BrowserUseSessionInitResponse,
+    DispatchActionRequest,
+    DispatchActionResponse,
+)
+from ..gym.compute_contract import Capabilities
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class _Session:
+    """Per-session Playwright state.
+
+    A single Modal container handles one session at a time at v1 (matches
+    the existing `ComputerAgent` per-profile-lock semantics). PR 3+ may
+    relax this once concurrent tabs are wired through.
+    """
+
+    token: str
+    tenant_id: str
+    profile_id: str
+    run_id: str
+    capabilities: Capabilities
+    last_action_ms: int = 0
+    playwright: Any = None  # opaque — Playwright runtime handle
+    browser: Any = None
+    context: Any = None
+    page: Any = None
+    dispatch_cache: dict[str, DispatchActionResponse] = field(default_factory=dict)
+
+
+_sessions: dict[str, _Session] = {}
+
+
+def _require_session(request: Request) -> _Session:
+    token = request.headers.get("X-Mantis-Session", "")
+    if not token or token not in _sessions:
+        raise HTTPException(status_code=401, detail="missing or unknown session token")
+    return _sessions[token]
+
+
+def _start_playwright(req: BrowserUseSessionInitRequest) -> _Session:
+    """Lazy-import Playwright + launch a browser.
+
+    Import is deferred so this module remains importable in environments
+    without Playwright (e.g. test runners that mock the client).
+    """
+    from playwright.sync_api import sync_playwright  # noqa: PLC0415
+
+    pw = sync_playwright().start()
+    launch_args: dict[str, Any] = {"headless": req.headless}
+    if req.proxy_server:
+        launch_args["proxy"] = {"server": req.proxy_server}
+    if req.profile_dir:
+        # Persistent context — profile path is per-tenant on the shared
+        # volume. See `docs/reference/browser-use-plane.md` for the
+        # layout contract.
+        ctx = pw.chromium.launch_persistent_context(
+            user_data_dir=req.profile_dir,
+            viewport={"width": req.viewport[0], "height": req.viewport[1]},
+            extra_http_headers=req.extra_http_headers or {},
+            **launch_args,
+        )
+        browser = ctx.browser
+        page = ctx.new_page() if not ctx.pages else ctx.pages[0]
+    else:
+        browser = pw.chromium.launch(**launch_args)
+        ctx = browser.new_context(
+            viewport={"width": req.viewport[0], "height": req.viewport[1]},
+            extra_http_headers=req.extra_http_headers or {},
+        )
+        page = ctx.new_page()
+
+    if req.start_url and req.start_url != "about:blank":
+        page.goto(req.start_url, wait_until="load")
+
+    return _Session(
+        token=uuid.uuid4().hex,
+        tenant_id=req.tenant_id,
+        profile_id=req.profile_id,
+        run_id=req.run_id,
+        capabilities=Capabilities.for_browser_use_plane(),
+        playwright=pw,
+        browser=browser,
+        context=ctx,
+        page=page,
+        last_action_ms=int(time.time() * 1000),
+    )
+
+
+def _stop_playwright(sess: _Session) -> None:
+    try:
+        if sess.page is not None:
+            sess.page.close()
+    except Exception:  # noqa: BLE001
+        pass
+    try:
+        if sess.context is not None:
+            sess.context.close()
+    except Exception:  # noqa: BLE001
+        pass
+    try:
+        if sess.browser is not None:
+            sess.browser.close()
+    except Exception:  # noqa: BLE001
+        pass
+    try:
+        if sess.playwright is not None:
+            sess.playwright.stop()
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def _dispatch(sess: _Session, req: DispatchActionRequest) -> DispatchActionResponse:
+    """Execute one structured action against the bound page.
+
+    Idempotent on `step_id` via a per-session TTL'd-feeling cache. The
+    cache is process-local and capped — sufficient for a single-session
+    container.
+    """
+    cached = sess.dispatch_cache.get(req.step_id)
+    if cached is not None:
+        return DispatchActionResponse(
+            ok=cached.ok,
+            error=cached.error,
+            deduplicated=True,
+        )
+
+    page = sess.page
+    try:
+        if req.kind == "click":
+            p = req.params
+            page.mouse.click(
+                int(p["x"]),
+                int(p["y"]),
+                button=str(p.get("button", "left")),  # type: ignore[arg-type]
+                click_count=int(p.get("click_count", 1)),
+            )
+        elif req.kind == "key":
+            p = req.params
+            page.keyboard.press(str(p["key"]))
+        elif req.kind == "type":
+            p = req.params
+            page.keyboard.type(str(p["text"]), delay=int(p.get("delay_ms", 0)))
+        elif req.kind == "scroll":
+            p = req.params
+            page.mouse.wheel(int(p.get("x", 0) or 0), int(p["delta_y"]))
+        else:
+            return DispatchActionResponse(ok=False, error=f"unknown kind {req.kind!r}")
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("[browser-use] dispatch %s failed: %s", req.kind, exc)
+        resp = DispatchActionResponse(ok=False, error=str(exc))
+        sess.dispatch_cache[req.step_id] = resp
+        return resp
+
+    sess.last_action_ms = int(time.time() * 1000)
+    resp = DispatchActionResponse(ok=True)
+    sess.dispatch_cache[req.step_id] = resp
+    # Keep the cache bounded — simple FIFO.
+    if len(sess.dispatch_cache) > 1024:
+        for k in list(sess.dispatch_cache.keys())[:128]:
+            sess.dispatch_cache.pop(k, None)
+    return resp
+
+
+def build_app() -> FastAPI:
+    """Construct the Browser-Use Plane FastAPI app.
+
+    Wrapping construction in a factory keeps the module side-effect-free
+    on import — important for both Modal's `add_local_python_source` and
+    for the test suite (which imports models without spinning servers).
+    """
+    app = FastAPI(title="Mantis Browser-Use Plane Agent")
+
+    @app.post("/session/init", response_model=BrowserUseSessionInitResponse)
+    def session_init(req: BrowserUseSessionInitRequest) -> BrowserUseSessionInitResponse:
+        # Idempotent on run_id — second init with the same run_id returns
+        # the existing token.
+        for s in _sessions.values():
+            if s.run_id == req.run_id and s.tenant_id == req.tenant_id:
+                return BrowserUseSessionInitResponse(
+                    session_token=s.token,
+                    browser_pid=None,
+                    capabilities=s.capabilities.as_dict(),
+                )
+        sess = _start_playwright(req)
+        _sessions[sess.token] = sess
+        logger.warning(
+            "[browser-use] session init tenant=%s profile=%s run=%s token=%s",
+            req.tenant_id,
+            req.profile_id,
+            req.run_id,
+            sess.token[:8],
+        )
+        return BrowserUseSessionInitResponse(
+            session_token=sess.token,
+            browser_pid=None,
+            capabilities=sess.capabilities.as_dict(),
+        )
+
+    @app.post("/session/close", response_model=BrowserUseSessionCloseResponse)
+    def session_close(req: BrowserUseSessionCloseRequest) -> BrowserUseSessionCloseResponse:
+        sess = _sessions.pop(req.session_token, None)
+        if sess is None:
+            return BrowserUseSessionCloseResponse(closed=False)
+        _stop_playwright(sess)
+        return BrowserUseSessionCloseResponse(closed=True)
+
+    @app.post("/screenshot", response_model=BrowserUseScreenshotResponse)
+    def screenshot(request: Request) -> BrowserUseScreenshotResponse:
+        sess = _require_session(request)
+        page = sess.page
+        png = page.screenshot(type="png")
+        width = sess.capabilities.as_dict().get("width") or sess.page.viewport_size["width"]
+        height = sess.capabilities.as_dict().get("height") or sess.page.viewport_size["height"]
+        scroll_y = int(page.evaluate("window.scrollY"))
+        return BrowserUseScreenshotResponse(
+            image_b64=base64.b64encode(png).decode("ascii"),
+            width=int(width),
+            height=int(height),
+            scroll_y=scroll_y,
+            captured_at_ms=int(time.time() * 1000),
+        )
+
+    @app.post("/dispatch", response_model=DispatchActionResponse)
+    def dispatch(req: DispatchActionRequest, request: Request) -> DispatchActionResponse:
+        sess = _require_session(request)
+        return _dispatch(sess, req)
+
+    @app.get("/health", response_model=BrowserUseHealthResponse)
+    def health(request: Request) -> BrowserUseHealthResponse:
+        token = request.headers.get("X-Mantis-Session", "")
+        sess = _sessions.get(token) if token else None
+        return BrowserUseHealthResponse(
+            ok=True,
+            last_action_ms=sess.last_action_ms if sess else None,
+            session_token=sess.token if sess else None,
+        )
+
+    return app
+
+
+# Lazy global app object — built on first import for uvicorn convenience.
+app = build_app()

--- a/tests/test_browser_use_plane_client.py
+++ b/tests/test_browser_use_plane_client.py
@@ -1,0 +1,186 @@
+"""Tests for `BrowserUsePlaneClient` (#785, PR 2).
+
+Mock-server style: monkeypatch `requests.Session.post`/`.get` to verify
+the wire shape without standing up a real FastAPI server. Mirrors the
+pattern in `tests/test_remote_computer_impl.py`.
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+from dataclasses import dataclass, field
+from typing import Any
+import pytest
+from PIL import Image
+
+from mantis_agent.gym.browser_use_plane_client import BrowserUsePlaneClient
+from mantis_agent.gym.browser_use_wire import (
+    BrowserUseScreenshotResponse,
+    BrowserUseSessionInitResponse,
+    DispatchActionResponse,
+)
+from mantis_agent.gym.compute_contract import Capabilities, ComputeBackend
+
+
+@dataclass
+class _Resp:
+    """Minimal `requests.Response` stand-in."""
+
+    status_code: int = 200
+    _json: dict[str, Any] = field(default_factory=dict)
+
+    def json(self) -> dict[str, Any]:
+        return self._json
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+
+def _png_b64(w: int = 8, h: int = 8) -> str:
+    img = Image.new("RGB", (w, h), color=(255, 0, 0))
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return base64.b64encode(buf.getvalue()).decode("ascii")
+
+
+class _FakeServer:
+    """Routes requests by URL suffix; records call counts."""
+
+    def __init__(self) -> None:
+        self.posts: list[tuple[str, dict[str, Any]]] = []
+        self.gets: list[str] = []
+
+    def post(self, url: str, **kw: Any) -> _Resp:
+        self.posts.append((url, kw.get("json", {})))
+        if url.endswith("/session/init"):
+            return _Resp(
+                _json=BrowserUseSessionInitResponse(
+                    session_token="tok-abc",
+                    browser_pid=12345,
+                    capabilities=Capabilities.for_browser_use_plane().as_dict(),
+                ).model_dump()
+            )
+        if url.endswith("/session/close"):
+            return _Resp(_json={"closed": True})
+        if url.endswith("/screenshot"):
+            return _Resp(
+                _json=BrowserUseScreenshotResponse(
+                    image_b64=_png_b64(),
+                    width=8,
+                    height=8,
+                    scroll_y=0,
+                    captured_at_ms=1,
+                ).model_dump()
+            )
+        if url.endswith("/dispatch"):
+            return _Resp(_json=DispatchActionResponse(ok=True).model_dump())
+        return _Resp(status_code=404)
+
+    def get(self, url: str, **kw: Any) -> _Resp:
+        self.gets.append(url)
+        if url.endswith("/health"):
+            return _Resp(_json={"ok": True, "last_action_ms": 100, "session_token": "tok-abc"})
+        return _Resp(status_code=404)
+
+
+def _make_client(server: _FakeServer) -> BrowserUsePlaneClient:
+    client = BrowserUsePlaneClient(
+        base_url="https://browser-use.test",
+        tenant_id="t1",
+        profile_id="p1",
+        run_id="r1",
+    )
+    # Replace the session's HTTP methods with the fake server's.
+    client._http.post = server.post  # type: ignore[method-assign]
+    client._http.get = server.get  # type: ignore[method-assign]
+    return client
+
+
+def test_reset_initializes_session_and_returns_observation():
+    server = _FakeServer()
+    client = _make_client(server)
+    obs = client.reset("noop")
+    # session_init came first, then screenshot.
+    urls = [p[0] for p in server.posts]
+    assert urls[0].endswith("/session/init")
+    assert urls[1].endswith("/screenshot")
+    assert obs.screenshot.size == (8, 8)
+    caps = client.capabilities()
+    assert caps.dom_aware is True
+    assert caps.backend is ComputeBackend.BROWSER_USE_PLANE
+
+
+def test_default_capabilities_when_session_not_initialized():
+    server = _FakeServer()
+    client = _make_client(server)
+    caps = client.capabilities()
+    # Before session_init, client reports Browser-Use Plane defaults (NOT
+    # Computer-Plane defaults — would be a wire mismatch).
+    assert caps.dom_aware is True
+    assert caps.backend is ComputeBackend.BROWSER_USE_PLANE
+
+
+def test_close_releases_session():
+    server = _FakeServer()
+    client = _make_client(server)
+    client.reset("noop")
+    client.close()
+    urls = [p[0] for p in server.posts]
+    assert any(u.endswith("/session/close") for u in urls)
+
+
+def test_step_dispatches_click_action():
+    server = _FakeServer()
+    client = _make_client(server)
+    client.reset("noop")
+
+    # Synthetic action shape matching the translator's expectations.
+    class _A:
+        type = "click"
+        x = 100
+        y = 200
+        button = "left"
+        click_count = 1
+
+    # Bypass the `isinstance(action, Action)` check in the translator —
+    # this test pins the dispatch wire shape, not the Action-translation
+    # logic. Translator coverage lives in a separate test below.
+    client._translate_action = lambda action: ("click", {  # type: ignore[method-assign]
+        "x": action.x,
+        "y": action.y,
+        "button": action.button,
+        "click_count": action.click_count,
+    })
+    client.step(_A())  # type: ignore[arg-type]
+    urls = [p[0] for p in server.posts]
+    assert any(u.endswith("/dispatch") for u in urls)
+    # Check the dispatch payload had the expected click params.
+    dispatch_payload = next(p for u, p in server.posts if u.endswith("/dispatch"))
+    assert dispatch_payload["kind"] == "click"
+    assert dispatch_payload["params"]["x"] == 100
+    assert dispatch_payload["params"]["y"] == 200
+
+
+def test_unconfigured_url_raises_executor_construction_error():
+    from mantis_agent.run_browser_use import make_browser_use_client
+
+    # No MANTIS_BROWSER_USE_URL and no Modal SDK lookup → must raise.
+    with pytest.raises(RuntimeError, match="Browser-Use Plane URL is not configured"):
+        make_browser_use_client(base_url=None)
+
+
+def test_screen_size_returns_viewport():
+    server = _FakeServer()
+    client = _make_client(server)
+    assert client.screen_size == (1280, 720)
+
+
+def test_health_returns_session_token_after_init():
+    server = _FakeServer()
+    client = _make_client(server)
+    client.reset("noop")
+    h = client.health()
+    assert h.ok is True
+    assert h.session_token == "tok-abc"

--- a/tests/test_compute_backend_resolver.py
+++ b/tests/test_compute_backend_resolver.py
@@ -1,0 +1,103 @@
+"""Tests for `compute_backend` precedence (#785, PR 2).
+
+Plan > submission > default(`computer_plane`).
+"""
+
+from __future__ import annotations
+
+from mantis_agent.gym.compute_backend_resolver import resolve_compute_backend
+from mantis_agent.gym.compute_contract import ComputeBackend
+
+
+def test_default_is_computer_plane():
+    assert resolve_compute_backend() is ComputeBackend.COMPUTER_PLANE
+
+
+def test_default_when_plan_has_no_runtime_block():
+    plan = {"steps": [{"intent": "x", "type": "navigate"}]}
+    assert resolve_compute_backend(plan=plan) is ComputeBackend.COMPUTER_PLANE
+
+
+def test_submission_overrides_default():
+    assert (
+        resolve_compute_backend(submission_value="browser_use_plane")
+        is ComputeBackend.BROWSER_USE_PLANE
+    )
+
+
+def test_plan_overrides_submission():
+    plan = {"runtime": {"compute_backend": "browser_use_plane"}}
+    # Submission says computer_plane but plan wins.
+    assert (
+        resolve_compute_backend(plan=plan, submission_value="computer_plane")
+        is ComputeBackend.BROWSER_USE_PLANE
+    )
+
+
+def test_plan_overrides_submission_inverse():
+    plan = {"runtime": {"compute_backend": "computer_plane"}}
+    assert (
+        resolve_compute_backend(plan=plan, submission_value="browser_use_plane")
+        is ComputeBackend.COMPUTER_PLANE
+    )
+
+
+def test_unknown_plan_value_falls_through_to_submission():
+    # Forward-compat: an unrecognized backend label in the plan should
+    # fall through to the next layer rather than raise.
+    plan = {"runtime": {"compute_backend": "future_plane_xyz"}}
+    assert (
+        resolve_compute_backend(plan=plan, submission_value="browser_use_plane")
+        is ComputeBackend.BROWSER_USE_PLANE
+    )
+
+
+def test_unknown_submission_falls_through_to_default():
+    assert (
+        resolve_compute_backend(submission_value="future_plane_xyz")
+        is ComputeBackend.COMPUTER_PLANE
+    )
+
+
+def test_enum_values_accepted_directly():
+    assert (
+        resolve_compute_backend(submission_value=ComputeBackend.BROWSER_USE_PLANE)
+        is ComputeBackend.BROWSER_USE_PLANE
+    )
+
+
+def test_legacy_flat_array_plan_does_not_crash():
+    # Old shape: just a list of steps, no runtime block.
+    plan = [{"intent": "x", "type": "navigate"}]
+    assert resolve_compute_backend(plan=plan) is ComputeBackend.COMPUTER_PLANE  # type: ignore[arg-type]
+
+
+def test_compute_factory_dispatches_to_browser_use():
+    from mantis_agent.gym.compute_factory import make_compute_client
+
+    client = make_compute_client(
+        ComputeBackend.BROWSER_USE_PLANE,
+        browser_use_base_url="https://browser-use.test",
+    )
+    # Smoke — the factory returned a BrowserUsePlaneClient instance.
+    from mantis_agent.gym.browser_use_plane_client import BrowserUsePlaneClient
+
+    assert isinstance(client, BrowserUsePlaneClient)
+
+
+def test_compute_factory_requires_url_for_browser_use():
+    from mantis_agent.gym.compute_factory import make_compute_client
+
+    import pytest
+
+    with pytest.raises(ValueError, match="browser_use_base_url"):
+        make_compute_client(ComputeBackend.BROWSER_USE_PLANE)
+
+
+def test_default_capabilities_for_each_backend():
+    from mantis_agent.gym.compute_factory import default_capabilities_for
+
+    pure = default_capabilities_for(ComputeBackend.COMPUTER_PLANE)
+    bu = default_capabilities_for(ComputeBackend.BROWSER_USE_PLANE)
+    assert pure.dom_aware is False
+    assert bu.dom_aware is True


### PR DESCRIPTION
**Recovery PR.** Replaces #787 which auto-closed when PR #786 merged with --delete-branch (the base ref disappeared). All commits and CI verifications carry over; rebased onto current main.

Lands the **DOM-aware companion plane** for the browser-use epic (#785). Closes nothing on its own — foundation for #788/#789/#790/#791.

See #787 for the full description and review history.