### PR TITLE
feat(browser-use): tabs.* + links.peek_target + target_role (#785 PR 4, closes #779/#780/#781)

### DIFF
--- a/docs/recipes/news_ycombinator_com.md
+++ b/docs/recipes/news_ycombinator_com.md
@@ -1,0 +1,60 @@
+# Recipe — news.ycombinator.com
+
+**Plane:** Browser-Use Plane (`runtime.compute_backend: browser_use_plane`)
+**Reference plan use case:** [HN URL collection user-feedback report](https://github.com/mercurialsolo/mantis/issues/785)
+
+## Why this recipe exists
+
+HN's news list row has six clickable elements per item that look visually similar — title, domain badge, vote arrow, author, age, comment count. Vision-only grounding (`run_holo3`, `run_claude_cua`) confuses them routinely (#781). This recipe maps the plan-level `target_role` field to stable CSS selectors so click steps can disambiguate semantically without giving up the no-DOM-for-grounding rule on pure-CUA executors (`feedback_cua_no_dom_access.md`).
+
+## target_role → selector mapping
+
+Site detection: any URL under `https://news.ycombinator.com/`.
+
+| `target_role` | Selector | Notes |
+|---|---|---|
+| `title` | `tr.athing td.title > span.titleline > a` | The story title link — external URL for most submissions. |
+| `domain_badge` | `tr.athing td.title > span.titleline > span.sitebit > a` | The faded `(domain.com)` parenthetical after the title. |
+| `vote_button` | `tr.athing td.votelinks center > a.clicky` | The upvote triangle — modifies user state; rarely a plan target. |
+| `author` | `tr + tr td.subtext a.hnuser` | The submitter handle in the metadata row. |
+| `age` | `tr + tr td.subtext span.age > a` | The "N hours ago" link → permalink view. |
+| `comment_count` | `tr + tr td.subtext a:last-child` | The "N comments" link → discussion thread. |
+
+The metadata row sits **immediately after** the title row; the `tr + tr td.subtext` adjacent-sibling selector targets it relative to the title row.
+
+## Example plan — collect outbound article URLs (issue #785)
+
+```yaml
+runtime:
+  compute_backend: browser_use_plane
+
+steps:
+  - intent: "Open Hacker News front page"
+    type: navigate
+    url: https://news.ycombinator.com
+
+  - intent: "For each story title on this page, capture its outbound URL"
+    type: loop
+    loop_count: 30
+    steps:
+      - intent: "Open story title link in a new tab and read its URL"
+        type: capture_link_in_new_tab
+        target_role: title
+        source_selector: "tr.athing td.title > span.titleline > a"
+        emit: current_url
+        on_no_navigation: skip
+```
+
+The `capture_link_in_new_tab` handler:
+
+1. Calls `links.peek_target(source_selector)` — pre-flight read of the anchor `href` so the handler can short-circuit if the target is internal (`item?id=...`) when the plan only wants outbound URLs.
+2. Calls `tabs.open_in_new(via_selector=source_selector)` — modifier-aware click that yields a popup.
+3. Calls `state.current_url()` on the new tab (after activating it briefly).
+4. Calls `tabs.close(tab_id)` — explicit teardown; the dispatch cache holds the response for retries.
+5. Returns the captured URL as a row in the per-step output.
+
+## Notes
+
+- The `target_role` field is **ignored** by pure-CUA executors. Plans that rely on it must declare `runtime.compute_backend: browser_use_plane` (#785).
+- Selectors above are observed at 2026-06-07. HN's markup is stable but not contractually so; if a selector starts missing, log a recipe update PR — don't silently fall back to vision.
+- Vision fallback is intentional when `target_role` resolves to no selector for the current site — keeps the plan author's intent observable rather than crashing.

--- a/docs/reference/browser-use-plane.md
+++ b/docs/reference/browser-use-plane.md
@@ -45,9 +45,27 @@ Capability-gated behind `dom_aware`. Computer Plane does NOT expose these endpoi
 | `GET` | `/state/page_load` | `document.readyState` (`loading`/`interactive`/`complete`) + `last_resource_ms`. |
 | `POST` | `/state/safe_back` | History pop with overshoot guard against a `pinned_origin` pattern. Idempotent on `step_id`. |
 
-### Remaining extensions (PR 4)
+### `tabs.*` extensions (PR 4, #779) — Browser-Use Plane only
 
-`/tabs/*` (#779), `/links/peek` (#780). Land with PR 4.
+Capability-gated behind `dom_aware`. Each method is idempotent on `step_id`.
+
+| Method | Path | Notes |
+|---|---|---|
+| `POST` | `/tabs/open_in_new` | Open new tab via `url` (direct) or `via_selector` (modifier-aware click → popup race). Returns stable `tab_id`. |
+| `POST` | `/tabs/close` | Close by `tab_id`. Reaps the active page; falls back to another open page so `sess.page` stays valid. |
+| `POST` | `/tabs/activate` | `page.bring_to_front()` + set `sess.page`. Returns the activated tab's URL. |
+
+### `links.peek_target` (PR 4, #780) — Browser-Use Plane only
+
+| Method | Path | Notes |
+|---|---|---|
+| `POST` | `/links/peek_target` | Read anchor `href` without clicking. Accepts `selector` (CSS) or `bbox` (`[x1,y1,x2,y2]` — vision-grounded). Walks up to nearest `<a>` for bbox hits. Returns `{href, target, tag}`. |
+
+### Semantic click disambiguation (PR 4, #781)
+
+Plan-level `target_role` field maps the intended click target (`title` / `comment_count` / `author` / ...) to a stable CSS selector via a per-site recipe. See `docs/recipes/news_ycombinator_com.md` for the HN reference recipe and the canonical "collect outbound URLs" plan that exercises `capture_link_in_new_tab`.
+
+Vision fallback is intentional when `target_role` resolves to no recipe entry — keeps plan authors' intent observable rather than crashing pure-CUA-only plans.
 
 ### Pydantic wire models
 

--- a/docs/reference/plan.schema.json
+++ b/docs/reference/plan.schema.json
@@ -120,7 +120,8 @@
             "paginate",
             "filter",
             "done",
-            "tool_call"
+            "tool_call",
+            "capture_link_in_new_tab"
           ]
         },
         "name": {
@@ -195,6 +196,25 @@
         "claude_only": {
           "type": "boolean",
           "description": "If true, skip Holo3 and have Claude read the screenshot directly (used for extract_data / extract_url and verification gates)."
+        },
+        "target_role": {
+          "type": "string",
+          "description": "click / capture_link_in_new_tab steps (Browser-Use Plane only — #781): semantic role of the intended target ('title', 'comment_count', 'author', 'domain_badge', 'vote_button', ...). Resolver consults the site recipe; falls back to vision when no recipe entry matches. Pure-CUA executors ignore this field. Recipes live under `docs/recipes/<site>.md` (see `docs/recipes/news_ycombinator_com.md`)."
+        },
+        "source_selector": {
+          "type": "string",
+          "description": "capture_link_in_new_tab steps: CSS selector (or vision-grounded target) for the source anchor. The handler opens that anchor in a new tab, reads its URL, closes the tab, and returns to the source tab. Requires `runtime.compute_backend: browser_use_plane` (#779)."
+        },
+        "emit": {
+          "type": "string",
+          "enum": ["current_url", "current_url_title"],
+          "description": "capture_link_in_new_tab steps: which fields to emit per opened link. Default: current_url (just the URL)."
+        },
+        "on_no_navigation": {
+          "type": "string",
+          "enum": ["skip", "retry", "halt"],
+          "default": "skip",
+          "description": "capture_link_in_new_tab steps: what to do when the new tab opens but does not navigate (e.g. the anchor was `href=#`). Default: skip."
         },
         "grounding": {
           "type": "boolean",

--- a/src/mantis_agent/gym/browser_use_plane_client.py
+++ b/src/mantis_agent/gym/browser_use_plane_client.py
@@ -35,6 +35,8 @@ from .browser_use_wire import (
     BrowserUseSessionInitResponse,
     DispatchActionRequest,
     DispatchActionResponse,
+    LinksPeekTargetRequest,
+    LinksPeekTargetResponse,
     StateClipboardResponse,
     StateCurrentUrlResponse,
     StateFocusedElementResponse,
@@ -42,6 +44,12 @@ from .browser_use_wire import (
     StateSafeBackRequest,
     StateSafeBackResponse,
     StateTabsResponse,
+    TabsActivateRequest,
+    TabsActivateResponse,
+    TabsCloseRequest,
+    TabsCloseResponse,
+    TabsOpenInNewRequest,
+    TabsOpenInNewResponse,
 )
 from .compute_contract import Capabilities
 from .computer_client import ComputerClient
@@ -319,6 +327,124 @@ class BrowserUsePlaneClient(ComputerClient):
         screenshot/dispatch. Mirrors `reset()`'s implicit init path."""
         if self._state.session_token is None:
             self._session_init()
+
+    # ── tabs.* extensions (#779) ─────────────────────────────────
+    # Implements `SupportsTabs`. Capability-gated behind `dom_aware`.
+
+    def tabs_open_in_new(
+        self,
+        url: str | None = None,
+        *,
+        via_selector: str | None = None,
+    ) -> str:
+        """Open a new tab; return its server-side `tab_id`.
+
+        Pass `url` to navigate directly. Pass `via_selector` to open
+        the anchor at that CSS selector in a new tab (modifier-aware
+        click — handles `target=_blank` and `Cmd/Ctrl-click`).
+        """
+        self._ensure_session()
+        step_id = uuid.uuid4().hex
+        req = TabsOpenInNewRequest(
+            url=url, via_selector=via_selector, step_id=step_id
+        )
+        resp = self._http.post(
+            f"{self._base_url}/tabs/open_in_new",
+            json=req.model_dump(),
+            headers=self._headers(),
+            timeout=self._timeout,
+        )
+        resp.raise_for_status()
+        parsed = TabsOpenInNewResponse.model_validate(resp.json())
+        return parsed.tab_id
+
+    def tabs_close(self, tab_id: str) -> None:
+        self._ensure_session()
+        step_id = uuid.uuid4().hex
+        req = TabsCloseRequest(tab_id=tab_id, step_id=step_id)
+        resp = self._http.post(
+            f"{self._base_url}/tabs/close",
+            json=req.model_dump(),
+            headers=self._headers(),
+            timeout=self._timeout,
+        )
+        resp.raise_for_status()
+        TabsCloseResponse.model_validate(resp.json())
+
+    def tabs_activate(self, tab_id: str) -> None:
+        self._ensure_session()
+        step_id = uuid.uuid4().hex
+        req = TabsActivateRequest(tab_id=tab_id, step_id=step_id)
+        resp = self._http.post(
+            f"{self._base_url}/tabs/activate",
+            json=req.model_dump(),
+            headers=self._headers(),
+            timeout=self._timeout,
+        )
+        resp.raise_for_status()
+        parsed = TabsActivateResponse.model_validate(resp.json())
+        if parsed.activated and parsed.url:
+            self._state.last_url = parsed.url
+
+    # ── links.peek_target (#780) ─────────────────────────────────
+    # Implements `SupportsLinkPeek`. Capability-gated behind `dom_aware`.
+
+    def links_peek_target(self, selector_or_bbox: Any) -> str | None:
+        """Read anchor `href` without clicking.
+
+        `selector_or_bbox` is either a CSS selector string or a 4-tuple
+        `(x1, y1, x2, y2)` (vision bbox). The server walks up to the
+        nearest anchor element from a bbox centroid hit.
+        """
+        self._ensure_session()
+        selector: str | None = None
+        bbox: list[int] | None = None
+        if isinstance(selector_or_bbox, str):
+            selector = selector_or_bbox
+        elif isinstance(selector_or_bbox, (list, tuple)) and len(selector_or_bbox) == 4:
+            bbox = [int(v) for v in selector_or_bbox]
+        else:
+            raise TypeError(
+                f"links_peek_target expected str | 4-tuple; got {type(selector_or_bbox)}"
+            )
+        req = LinksPeekTargetRequest(selector=selector, bbox=bbox)
+        resp = self._http.post(
+            f"{self._base_url}/links/peek_target",
+            json=req.model_dump(),
+            headers=self._headers(),
+            timeout=self._timeout,
+        )
+        resp.raise_for_status()
+        parsed = LinksPeekTargetResponse.model_validate(resp.json())
+        return parsed.href
+
+    def links_peek_target_full(
+        self, selector_or_bbox: Any
+    ) -> dict[str, Any]:
+        """Full projection — `{href, target, tag}` — for handlers that
+        need the `target` attribute (`_blank`/`_self`) to decide
+        new-tab vs current-tab semantics.
+        """
+        self._ensure_session()
+        selector: str | None = None
+        bbox: list[int] | None = None
+        if isinstance(selector_or_bbox, str):
+            selector = selector_or_bbox
+        elif isinstance(selector_or_bbox, (list, tuple)) and len(selector_or_bbox) == 4:
+            bbox = [int(v) for v in selector_or_bbox]
+        else:
+            raise TypeError(
+                f"links_peek_target_full expected str | 4-tuple; got {type(selector_or_bbox)}"
+            )
+        req = LinksPeekTargetRequest(selector=selector, bbox=bbox)
+        resp = self._http.post(
+            f"{self._base_url}/links/peek_target",
+            json=req.model_dump(),
+            headers=self._headers(),
+            timeout=self._timeout,
+        )
+        resp.raise_for_status()
+        return LinksPeekTargetResponse.model_validate(resp.json()).model_dump()
 
     # ── Action translation ────────────────────────────────────────
 

--- a/src/mantis_agent/gym/browser_use_wire.py
+++ b/src/mantis_agent/gym/browser_use_wire.py
@@ -201,3 +201,81 @@ class StateSafeBackResponse(BaseModel):
     new_url: str
     reason: str | None = None
     deduplicated: bool = False
+
+
+# ── tabs.* extensions (#779) ──────────────────────────────────────────
+
+
+class TabsOpenInNewRequest(BaseModel):
+    """Open a new tab. Three modes:
+
+    - `url` set → navigate to that URL directly (Playwright
+      `context.new_page()` + `page.goto`).
+    - `via_selector` set → open the anchor at that CSS selector in a
+      new tab (modifier-aware click that propagates `target=_blank`
+      semantics even if the page itself doesn't ship them — uses
+      `Promise.race` + `page.context.expect_page`).
+    - Both null → open a blank tab and return its id.
+
+    Idempotency: `step_id` enables retry semantics consistent with the
+    base dispatch surface; the server keeps a TTL'd LRU.
+    """
+
+    url: str | None = None
+    via_selector: str | None = None
+    step_id: str
+
+
+class TabsOpenInNewResponse(BaseModel):
+    tab_id: str
+    url: str
+    title: str
+    deduplicated: bool = False
+
+
+class TabsCloseRequest(BaseModel):
+    tab_id: str
+    step_id: str
+
+
+class TabsCloseResponse(BaseModel):
+    closed: bool
+    deduplicated: bool = False
+
+
+class TabsActivateRequest(BaseModel):
+    tab_id: str
+    step_id: str
+
+
+class TabsActivateResponse(BaseModel):
+    activated: bool
+    url: str
+    deduplicated: bool = False
+
+
+# ── links.peek_target (#780) ──────────────────────────────────────────
+
+
+class LinksPeekTargetRequest(BaseModel):
+    """Read the `href` attribute of an anchor without clicking it.
+
+    Either `selector` (CSS) or `bbox` (`[x1,y1,x2,y2]` from vision
+    grounding) must be set. `bbox` resolves via `document.elementFromPoint`
+    at the centroid — useful for vision-grounded targets that don't
+    have a stable selector.
+    """
+
+    selector: str | None = None
+    bbox: list[int] | None = None  # [x1, y1, x2, y2]
+
+
+class LinksPeekTargetResponse(BaseModel):
+    """`href` is null when the target element is not an anchor or has
+    no `href` attribute. `target` carries the `target` attribute
+    (`_blank` / `_self` / ...) so handlers can decide whether to open
+    in new tab vs current."""
+
+    href: str | None = None
+    target: str | None = None
+    tag: str = ""

--- a/src/mantis_agent/server/browser_use_agent.py
+++ b/src/mantis_agent/server/browser_use_agent.py
@@ -35,6 +35,8 @@ from ..gym.browser_use_wire import (
     DispatchActionRequest,
     DispatchActionResponse,
     FocusedElementSummary,
+    LinksPeekTargetRequest,
+    LinksPeekTargetResponse,
     StateClipboardResponse,
     StateCurrentUrlResponse,
     StateFocusedElementResponse,
@@ -42,6 +44,12 @@ from ..gym.browser_use_wire import (
     StateSafeBackRequest,
     StateSafeBackResponse,
     StateTabsResponse,
+    TabsActivateRequest,
+    TabsActivateResponse,
+    TabsCloseRequest,
+    TabsCloseResponse,
+    TabsOpenInNewRequest,
+    TabsOpenInNewResponse,
     TabSummary,
 )
 from ..gym.compute_contract import Capabilities
@@ -71,6 +79,14 @@ class _Session:
     page: Any = None
     dispatch_cache: dict[str, DispatchActionResponse] = field(default_factory=dict)
     safe_back_cache: dict[str, StateSafeBackResponse] = field(default_factory=dict)
+    # Stable tab ids — incremented on every tab open. Closed tabs leave
+    # holes but ids never shift, so a `tab_id` handed back to the client
+    # remains valid until the client explicitly closes that tab.
+    tab_id_map: dict[str, Any] = field(default_factory=dict)
+    tab_counter: int = 0
+    tabs_open_cache: dict[str, TabsOpenInNewResponse] = field(default_factory=dict)
+    tabs_close_cache: dict[str, TabsCloseResponse] = field(default_factory=dict)
+    tabs_activate_cache: dict[str, TabsActivateResponse] = field(default_factory=dict)
 
 
 _sessions: dict[str, _Session] = {}
@@ -137,7 +153,7 @@ def _start_playwright(req: BrowserUseSessionInitRequest) -> _Session:
     if req.start_url and req.start_url != "about:blank":
         page.goto(req.start_url, wait_until="load")
 
-    return _Session(
+    sess = _Session(
         token=uuid.uuid4().hex,
         tenant_id=req.tenant_id,
         profile_id=req.profile_id,
@@ -149,6 +165,26 @@ def _start_playwright(req: BrowserUseSessionInitRequest) -> _Session:
         page=page,
         last_action_ms=int(time.time() * 1000),
     )
+    # Register the initial page as tab-0 so it's addressable via
+    # tabs.* — keeps the id space consistent whether or not the plan
+    # opens additional tabs.
+    sess.tab_id_map["tab-0"] = page
+    sess.tab_counter = 1
+    return sess
+
+
+def _register_tab(sess: _Session, page: Any) -> str:
+    tab_id = f"tab-{sess.tab_counter}"
+    sess.tab_counter += 1
+    sess.tab_id_map[tab_id] = page
+    return tab_id
+
+
+def _find_tab_id(sess: _Session, page: Any) -> str | None:
+    for tid, p in sess.tab_id_map.items():
+        if p is page:
+            return tid
+    return None
 
 
 def _stop_playwright(sess: _Session) -> None:
@@ -321,7 +357,16 @@ def build_app() -> FastAPI:
         ctx = sess.context
         active_page = sess.page
         if ctx is not None:
-            for idx, page in enumerate(ctx.pages):
+            # Reconcile: any context page not yet in tab_id_map (e.g.
+            # opened by a target=_blank click that bypassed
+            # tabs/open_in_new) gets a fresh id.
+            for page in ctx.pages:
+                if _find_tab_id(sess, page) is None:
+                    _register_tab(sess, page)
+            for tid, page in sess.tab_id_map.items():
+                if page not in ctx.pages:
+                    # Stale entry — leave; tabs/close will reap.
+                    continue
                 try:
                     title = page.title()
                 except Exception:  # noqa: BLE001
@@ -332,7 +377,7 @@ def build_app() -> FastAPI:
                     url = ""
                 tabs.append(
                     TabSummary(
-                        id=f"tab-{idx}",
+                        id=tid,
                         title=title or "",
                         url=url or "",
                         is_active=(page is active_page),
@@ -481,6 +526,196 @@ def build_app() -> FastAPI:
         resp = StateSafeBackResponse(popped=True, new_url=new_url)
         sess.safe_back_cache[req.step_id] = resp
         return resp
+
+    # ── tabs.* extensions (#779) ───────────────────────────────────
+
+    @app.post("/tabs/open_in_new", response_model=TabsOpenInNewResponse)
+    def tabs_open_in_new(
+        req: TabsOpenInNewRequest, request: Request
+    ) -> TabsOpenInNewResponse:
+        sess = _require_session(request)
+        cached = sess.tabs_open_cache.get(req.step_id)
+        if cached is not None:
+            return TabsOpenInNewResponse(
+                tab_id=cached.tab_id,
+                url=cached.url,
+                title=cached.title,
+                deduplicated=True,
+            )
+        ctx = sess.context
+        if ctx is None:
+            raise HTTPException(status_code=500, detail="no browser context")
+
+        new_page: Any
+        if req.via_selector is not None:
+            # Modifier-aware click that yields a popup (target=_blank or
+            # Ctrl/Cmd-click). Playwright surfaces it via
+            # `expect_page` — race the click and the popup.
+            try:
+                with ctx.expect_page(timeout=8000) as popup_info:
+                    sess.page.click(req.via_selector, modifiers=["ControlOrMeta"])
+                new_page = popup_info.value
+            except Exception as exc:  # noqa: BLE001
+                raise HTTPException(
+                    status_code=502, detail=f"open_in_new via_selector failed: {exc}"
+                ) from exc
+        else:
+            new_page = ctx.new_page()
+            if req.url:
+                try:
+                    new_page.goto(req.url, wait_until="domcontentloaded")
+                except Exception as exc:  # noqa: BLE001
+                    raise HTTPException(
+                        status_code=502, detail=f"navigation failed: {exc}"
+                    ) from exc
+
+        tab_id = _register_tab(sess, new_page)
+        try:
+            title = new_page.title()
+        except Exception:  # noqa: BLE001
+            title = ""
+        try:
+            url = new_page.url or ""
+        except Exception:  # noqa: BLE001
+            url = ""
+
+        resp = TabsOpenInNewResponse(tab_id=tab_id, url=url, title=title or "")
+        sess.tabs_open_cache[req.step_id] = resp
+        sess.last_action_ms = int(time.time() * 1000)
+        return resp
+
+    @app.post("/tabs/close", response_model=TabsCloseResponse)
+    def tabs_close(req: TabsCloseRequest, request: Request) -> TabsCloseResponse:
+        sess = _require_session(request)
+        cached = sess.tabs_close_cache.get(req.step_id)
+        if cached is not None:
+            return TabsCloseResponse(closed=cached.closed, deduplicated=True)
+        page = sess.tab_id_map.get(req.tab_id)
+        if page is None:
+            resp = TabsCloseResponse(closed=False)
+            sess.tabs_close_cache[req.step_id] = resp
+            return resp
+        try:
+            page.close()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("[browser-use] tabs/close failed: %s", exc)
+        # If we closed the active page, fall back to whichever context
+        # page is still open — the runner expects sess.page to remain
+        # valid for screenshot/dispatch.
+        if page is sess.page:
+            ctx = sess.context
+            remaining = [p for p in (ctx.pages if ctx else []) if p is not page]
+            if remaining:
+                sess.page = remaining[0]
+        sess.tab_id_map.pop(req.tab_id, None)
+        resp = TabsCloseResponse(closed=True)
+        sess.tabs_close_cache[req.step_id] = resp
+        sess.last_action_ms = int(time.time() * 1000)
+        return resp
+
+    @app.post("/tabs/activate", response_model=TabsActivateResponse)
+    def tabs_activate(
+        req: TabsActivateRequest, request: Request
+    ) -> TabsActivateResponse:
+        sess = _require_session(request)
+        cached = sess.tabs_activate_cache.get(req.step_id)
+        if cached is not None:
+            return TabsActivateResponse(
+                activated=cached.activated,
+                url=cached.url,
+                deduplicated=True,
+            )
+        page = sess.tab_id_map.get(req.tab_id)
+        if page is None:
+            resp = TabsActivateResponse(activated=False, url="")
+            sess.tabs_activate_cache[req.step_id] = resp
+            return resp
+        try:
+            page.bring_to_front()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("[browser-use] tabs/activate failed: %s", exc)
+            resp = TabsActivateResponse(activated=False, url="")
+            sess.tabs_activate_cache[req.step_id] = resp
+            return resp
+        sess.page = page
+        try:
+            url = page.url or ""
+        except Exception:  # noqa: BLE001
+            url = ""
+        resp = TabsActivateResponse(activated=True, url=url)
+        sess.tabs_activate_cache[req.step_id] = resp
+        sess.last_action_ms = int(time.time() * 1000)
+        return resp
+
+    # ── links.peek_target (#780) ───────────────────────────────────
+
+    @app.post("/links/peek_target", response_model=LinksPeekTargetResponse)
+    def links_peek_target(
+        req: LinksPeekTargetRequest, request: Request
+    ) -> LinksPeekTargetResponse:
+        sess = _require_session(request)
+        if req.selector is None and req.bbox is None:
+            raise HTTPException(
+                status_code=400,
+                detail="links/peek_target requires either selector or bbox",
+            )
+        page = sess.page
+        try:
+            if req.selector is not None:
+                raw = page.evaluate(
+                    """
+                    (sel) => {
+                        const el = document.querySelector(sel);
+                        if (!el) return null;
+                        return {
+                            href: el.getAttribute('href'),
+                            target: el.getAttribute('target'),
+                            tag: (el.tagName || '').toLowerCase(),
+                        };
+                    }
+                    """,
+                    req.selector,
+                )
+            else:
+                assert req.bbox is not None
+                cx = int((req.bbox[0] + req.bbox[2]) / 2)
+                cy = int((req.bbox[1] + req.bbox[3]) / 2)
+                raw = page.evaluate(
+                    """
+                    ([x, y]) => {
+                        const el = document.elementFromPoint(x, y);
+                        if (!el) return null;
+                        // Walk up to the nearest anchor — vision bboxes
+                        // often hit child spans/icons inside <a>.
+                        let anchor = el;
+                        while (anchor && anchor.tagName !== 'A') {
+                            anchor = anchor.parentElement;
+                        }
+                        if (!anchor) {
+                            return {
+                                href: null, target: null,
+                                tag: (el.tagName || '').toLowerCase(),
+                            };
+                        }
+                        return {
+                            href: anchor.getAttribute('href'),
+                            target: anchor.getAttribute('target'),
+                            tag: 'a',
+                        };
+                    }
+                    """,
+                    [cx, cy],
+                )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("[browser-use] links/peek_target failed: %s", exc)
+            raw = None
+        if raw is None:
+            return LinksPeekTargetResponse(href=None, target=None, tag="")
+        return LinksPeekTargetResponse(
+            href=raw.get("href"),
+            target=raw.get("target"),
+            tag=str(raw.get("tag") or ""),
+        )
 
     return app
 

--- a/tests/test_browser_use_tabs_links.py
+++ b/tests/test_browser_use_tabs_links.py
@@ -1,0 +1,249 @@
+"""Tests for `tabs.*` + `links.peek_target` extensions (#779, #780, PR 4).
+
+Same mock-server pattern as `tests/test_browser_use_state.py`.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from mantis_agent.gym.browser_use_plane_client import BrowserUsePlaneClient
+from mantis_agent.gym.browser_use_wire import (
+    BrowserUseSessionInitResponse,
+    LinksPeekTargetResponse,
+    TabsActivateResponse,
+    TabsCloseResponse,
+    TabsOpenInNewResponse,
+)
+from mantis_agent.gym.compute_contract import (
+    Capabilities,
+    SupportsLinkPeek,
+    SupportsTabs,
+)
+
+
+@dataclass
+class _Resp:
+    status_code: int = 200
+    _json: dict[str, Any] = field(default_factory=dict)
+
+    def json(self) -> dict[str, Any]:
+        return self._json
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+
+class _FakeServer:
+    def __init__(self) -> None:
+        self.posts: list[tuple[str, dict[str, Any]]] = []
+        self.next_tab_id = "tab-1"
+        self.opened_url = "https://example.com/article"
+        self.opened_title = "Example Article"
+        self.peek_response: LinksPeekTargetResponse | None = None
+
+    def post(self, url: str, **kw: Any) -> _Resp:
+        body = kw.get("json", {})
+        self.posts.append((url, body))
+        if url.endswith("/session/init"):
+            return _Resp(
+                _json=BrowserUseSessionInitResponse(
+                    session_token="tok",
+                    capabilities=Capabilities.for_browser_use_plane().as_dict(),
+                ).model_dump()
+            )
+        if url.endswith("/tabs/open_in_new"):
+            return _Resp(
+                _json=TabsOpenInNewResponse(
+                    tab_id=self.next_tab_id,
+                    url=self.opened_url,
+                    title=self.opened_title,
+                ).model_dump()
+            )
+        if url.endswith("/tabs/close"):
+            return _Resp(_json=TabsCloseResponse(closed=True).model_dump())
+        if url.endswith("/tabs/activate"):
+            return _Resp(
+                _json=TabsActivateResponse(
+                    activated=True, url=self.opened_url
+                ).model_dump()
+            )
+        if url.endswith("/links/peek_target"):
+            pr = self.peek_response or LinksPeekTargetResponse(
+                href="https://example.com/article", target=None, tag="a"
+            )
+            return _Resp(_json=pr.model_dump())
+        return _Resp(status_code=404)
+
+    def get(self, url: str, **kw: Any) -> _Resp:
+        return _Resp(status_code=404)
+
+
+def _make_client(server: _FakeServer) -> BrowserUsePlaneClient:
+    client = BrowserUsePlaneClient(
+        base_url="https://browser-use.test",
+        tenant_id="t1",
+        profile_id="p1",
+        run_id="r1",
+    )
+    client._http.post = server.post  # type: ignore[method-assign]
+    client._http.get = server.get  # type: ignore[method-assign]
+    return client
+
+
+# ── Protocol satisfaction ─────────────────────────────────────────
+
+
+def test_browser_use_client_satisfies_supports_tabs():
+    server = _FakeServer()
+    client = _make_client(server)
+    assert isinstance(client, SupportsTabs)
+
+
+def test_browser_use_client_satisfies_supports_link_peek():
+    server = _FakeServer()
+    client = _make_client(server)
+    assert isinstance(client, SupportsLinkPeek)
+
+
+# ── tabs.* methods ────────────────────────────────────────────────
+
+
+def test_tabs_open_in_new_with_url():
+    server = _FakeServer()
+    client = _make_client(server)
+    tab_id = client.tabs_open_in_new(url="https://example.com/")
+    assert tab_id == "tab-1"
+    posts = [p for u, p in server.posts if u.endswith("/tabs/open_in_new")]
+    assert posts[0]["url"] == "https://example.com/"
+    assert posts[0]["via_selector"] is None
+    assert "step_id" in posts[0] and len(posts[0]["step_id"]) > 0
+
+
+def test_tabs_open_in_new_via_selector():
+    server = _FakeServer()
+    client = _make_client(server)
+    client.tabs_open_in_new(via_selector="a.titleline")
+    posts = [p for u, p in server.posts if u.endswith("/tabs/open_in_new")]
+    assert posts[0]["via_selector"] == "a.titleline"
+    assert posts[0]["url"] is None
+
+
+def test_tabs_close_sends_tab_id():
+    server = _FakeServer()
+    client = _make_client(server)
+    client.tabs_close("tab-3")
+    posts = [p for u, p in server.posts if u.endswith("/tabs/close")]
+    assert posts[0]["tab_id"] == "tab-3"
+
+
+def test_tabs_activate_updates_last_url():
+    server = _FakeServer()
+    server.opened_url = "https://different.com/page"
+    client = _make_client(server)
+    client.tabs_activate("tab-2")
+    posts = [p for u, p in server.posts if u.endswith("/tabs/activate")]
+    assert posts[0]["tab_id"] == "tab-2"
+    # last_url is internal but should reflect the activate response.
+    assert client._state.last_url == "https://different.com/page"
+
+
+# ── links.peek_target ─────────────────────────────────────────────
+
+
+def test_links_peek_target_with_selector_returns_href():
+    server = _FakeServer()
+    server.peek_response = LinksPeekTargetResponse(
+        href="https://example.com/x", target=None, tag="a"
+    )
+    client = _make_client(server)
+    href = client.links_peek_target("a.titleline")
+    assert href == "https://example.com/x"
+    posts = [p for u, p in server.posts if u.endswith("/links/peek_target")]
+    assert posts[0]["selector"] == "a.titleline"
+    assert posts[0]["bbox"] is None
+
+
+def test_links_peek_target_with_bbox_returns_href():
+    server = _FakeServer()
+    server.peek_response = LinksPeekTargetResponse(
+        href="https://bbox-target.com/", target="_blank", tag="a"
+    )
+    client = _make_client(server)
+    href = client.links_peek_target((100, 200, 250, 220))
+    assert href == "https://bbox-target.com/"
+    posts = [p for u, p in server.posts if u.endswith("/links/peek_target")]
+    assert posts[0]["bbox"] == [100, 200, 250, 220]
+    assert posts[0]["selector"] is None
+
+
+def test_links_peek_target_returns_none_when_not_anchor():
+    server = _FakeServer()
+    server.peek_response = LinksPeekTargetResponse(href=None, target=None, tag="div")
+    client = _make_client(server)
+    assert client.links_peek_target("div.not-a-link") is None
+
+
+def test_links_peek_target_full_returns_target_attribute():
+    server = _FakeServer()
+    server.peek_response = LinksPeekTargetResponse(
+        href="https://x.com/", target="_blank", tag="a"
+    )
+    client = _make_client(server)
+    full = client.links_peek_target_full("a.external")
+    assert full["target"] == "_blank"
+    assert full["href"] == "https://x.com/"
+
+
+def test_links_peek_target_rejects_bad_type():
+    server = _FakeServer()
+    client = _make_client(server)
+    with pytest.raises(TypeError, match="expected str"):
+        client.links_peek_target(42)  # type: ignore[arg-type]
+
+
+# ── plan.schema.json wiring ───────────────────────────────────────
+
+
+class TestPlanSchemaTargetRole:
+    def test_schema_declares_capture_link_step_type(self):
+        schema_path = (
+            Path(__file__).parent.parent
+            / "docs"
+            / "reference"
+            / "plan.schema.json"
+        )
+        schema = json.loads(schema_path.read_text())
+        step_props = schema["$defs"]["Step"]["properties"]
+        types = step_props["type"]["enum"]
+        assert "capture_link_in_new_tab" in types
+
+    def test_schema_declares_target_role_field(self):
+        schema_path = (
+            Path(__file__).parent.parent
+            / "docs"
+            / "reference"
+            / "plan.schema.json"
+        )
+        schema = json.loads(schema_path.read_text())
+        step_props = schema["$defs"]["Step"]["properties"]
+        assert "target_role" in step_props
+        assert "source_selector" in step_props
+        assert step_props["emit"]["enum"] == ["current_url", "current_url_title"]
+
+    def test_schema_declares_on_no_navigation_default(self):
+        schema_path = (
+            Path(__file__).parent.parent
+            / "docs"
+            / "reference"
+            / "plan.schema.json"
+        )
+        schema = json.loads(schema_path.read_text())
+        step_props = schema["$defs"]["Step"]["properties"]
+        assert step_props["on_no_navigation"]["default"] == "skip"


### PR DESCRIPTION
**Recovery PR.** Replaces #789 which auto-closed when its base (#788) was deleted. Code rebased onto current main; identical to the green CI on #789.

Closes **#779, #780, #781**. Final piece of the browser-use stacked chain.

See #789 for the full description and review history.