### PR TITLE
fix(extraction): rip legacy boattrader fallback from validator (#785 follow-up)

### DIFF
--- a/deploy/sim_envs/_capture_brief.md
+++ b/deploy/sim_envs/_capture_brief.md
@@ -1,0 +1,193 @@
+# Capture brief — observations from live sites (2026-06-08)
+
+Captured by Claude Code via Chrome MCP at 1512×677 viewport while the parent
+session was deciding scope for the four new high-fidelity mirror envs
+(mantis_mercor / mantis_fiverr / mantis_linkedin / mantis_indeed).
+
+These are NOT a substitute for each agent doing its own Phase-1 capture into
+`_captured/`. They are a ground-truth anchor: identifiers, palette, font, and
+structural hints captured directly from the live sites that each agent should
+mirror exactly. If your captured corpus disagrees with this file, trust the
+corpus (it's later) — but the live-site observations below were direct, so
+they're a high-confidence baseline.
+
+---
+
+## 1. mercor.com
+
+**URL captured**: `https://www.mercor.com/`, `https://www.mercor.com/experts/`
+
+**Brand & typography**
+- Font family: `Inter, "Inter Fallback"` — load Inter via local @font-face or system fallback; the look is plain Inter.
+- Body background: transparent (page falls through to white).
+- Body color: `rgb(0, 0, 0)` pure black for primary text.
+- Accent / brand color: indigo `rgb(79, 70, 229)` (Tailwind indigo-600). Used for primary CTAs and links.
+- Surface greys (in priority order): `rgb(243, 244, 246)` light grey panel (gray-100), `rgb(229, 231, 235)` (gray-200), `rgb(156, 163, 175)` (gray-400), `rgb(107, 114, 128)` (gray-500), `rgb(75, 85, 99)` (gray-600), `rgb(31, 41, 55)` (gray-800).
+- This is unmistakably a Tailwind palette — match it exactly.
+
+**Top nav** (anonymous home `/`)
+- Slim header, no large logo brand bar.
+- Nav items, in order: `APEX`, `APEX-Agents`, `APEX-SWE`, `Research`, `Enterprise`, `Experts`.
+- Header nav width was 374px (compact left-side nav, NOT full-bleed).
+
+**Home page (`/`)**
+- H1: `Shape the frontier of AI`
+- Sole H2 in fold: `Latest roles`
+- Stats strip near top with three pseudo-stats: `Average pay $/hr`, `Roles created (k)`, `Daily payouts ($)`.
+- "Latest roles" card grid below — each card shape:
+  - Role title (e.g. `Internal Medicine Expert`)
+  - Rate range (`$130-$180/hr`)
+  - 3-letter avatar badge (`LFA`, `JDT`, `GBR` — generated initials, not photos)
+  - "N hired recently" microcopy (e.g. `75 hired recently`)
+  - `Apply` CTA button
+
+**Experts landing (`/experts/`)**
+- H1: `Get paid to work on AI projects`
+- Numbered "how it works" three-step strip: `1. Create a profile`, `2. Take AI assessments`, `3. Find opportunities → Apply to current li[stings]`.
+- "Latest roles" section followed by per-role sections, each with its own H2 (Internal Medicine Expert, Hematology/Oncology Expert, Biology PhD Expert, Legal Expert — Litigation, Private Equity Expert, Management & Strategy Consultants (MBB/Big 5), Office-Suite Experts).
+- FAQ section with H2s: `What is Mercor?`, `What is AI training work?`.
+- 18 role-card links (`a[href*="/jobs"]`) visible at viewport.
+
+**Interaction signals**
+- Apply button on each role card — clicking goes to a per-role apply flow (form-based, multi-step).
+- No login banner blocking the public site — the apply CTA is the conversion point.
+
+**Mirror priorities**
+- Tailwind-ish grey + indigo palette must match.
+- The 3-letter-initial avatar pattern (deterministic per role) is a distinctive visual element — replicate.
+- The "$130-$180/hr" + "N hired recently" + "Apply" card layout is the canonical role card — implement this exact shape.
+
+---
+
+## 2. fiverr.com
+
+**URLs captured**: `https://www.fiverr.com/`, `https://www.fiverr.com/search/gigs?query=logo%20design`
+
+**Brand & typography**
+- Font family: `Macan, "Helvetica Neue", Helvetica, Arial, sans-serif` — Macan is a Fiverr custom font; system Helvetica fallback is acceptable for the mirror.
+- Body background: `rgb(255, 255, 255)` pure white.
+- Brand green: Fiverr's signature green (#1DBF73 / `rgb(29, 191, 115)`) — confirm via spot-check in your agent's capture; use for primary CTAs and accent.
+
+**Top nav**
+- Items in order: `Fiverr Pro`, `Explore`, `EN`, `Become a Seller`, `Sign in`, `Join`.
+- Secondary category strip directly under: `Trending 🔥`, `Graphics & Design`, `Programming & Tech`, `Digital Marketing`, `Video & Animation`, `Writing & Translation` (more truncated).
+- Top search bar — placeholder text: `What service are you looking for today?`
+
+**Home page (`/`)**
+- H1: `Our freelancers will take it from here`
+- H2 strip: `Popular services`
+- Popular services tile grid: `Vibe Coding`, `Website Development`, `Video Editing`, `Software Development`, `Book Publishing`, `Architecture & Interior Design`, `Book Design`, `UGC Videos`, `Voice Over` — each is a card with image + label.
+- 53 category-related links visible.
+
+**Search results page (`/search/gigs?query=logo%20design`)**
+- H1: `Results for logo design`
+- Filter rail with labels: `Logo services / Find a logo designer`, `Logo maker / Customize pre-made logos`, `Category`, `Logo options`, `Seller details`, `Budget`, `Delivery time`.
+- Sort dropdown: `Sort by: Relevance` (top-right of result list area).
+- 157 gig cards in viewport — gig card includes: gig title, seller avatar+username, star rating + review count, "Starting at $X".
+
+**Interaction signals**
+- Search bar in top nav: typing + submit navigates to `/search/gigs?query=…`.
+- Filter chips toggle URL params.
+- Gig detail page has the canonical package picker (Basic / Standard / Premium) that re-prices CTA inline.
+
+**Mirror priorities**
+- Hero phrasing "Our freelancers will take it from here" + "Popular services" H2 — exact text.
+- The placeholder copy `What service are you looking for today?` must be exact.
+- The filter rail labels above must be exact.
+- "Sort by: Relevance" exact label.
+
+---
+
+## 3. linkedin.com
+
+**URL captured**: `https://www.linkedin.com/` (resolved to `/feed/` — session was already logged in), `https://www.linkedin.com/jobs/`
+
+**Brand & typography**
+- Font family: `system-ui, -apple-system, "system-ui", "Segoe UI", Roboto, Ubuntu, Oxygen, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"` — system stack, no custom font.
+- Body background: `rgb(244, 242, 238)` — LinkedIn's signature warm-beige neutral. THIS IS A DISTINCTIVE COLOUR and must be exact.
+- Top nav header height: 52px.
+- Primary text: `rgba(0, 0, 0, 0.9)`. Secondary text: `rgba(0, 0, 0, 0.6)`. Muted: `rgba(0, 0, 0, 0.75)`.
+- White panel background `rgb(255, 255, 255)` for cards (profile card, post card, etc.).
+- Dark navy text `rgb(43, 51, 63)` used as a heading colour.
+- LinkedIn brand blue is `#0a66c2` (NOT captured directly because the user's session deep-linked but use this — it's the canonical brand colour).
+
+**Top nav (signed-in)**
+- Items in order: `Home`, `My Network`, `Jobs`, `Messaging`, `Notifications`, `Me`, `For Business`, `Advertise`.
+- 52px tall sticky header. White background, items as icon+label stack.
+- Search bar to the left of the nav items (omitted from the structural dump but present).
+
+**Feed (`/feed/`)**
+- Three-column layout: left rail (profile-card + saved items) + centre feed + right rail (people you may know + news).
+- LinkedIn uses heavily hashed CSS class names (e.g. `f5526673 _7e38840f`) — DO NOT try to match class names. Match by ROLE / structure.
+- Each feed post is a card on white background with: author avatar + headline + post text + image/video + reaction bar (Like / Comment / Repost / Send) + reaction counts above.
+
+**Jobs page (`/jobs/`)**
+- Top input placeholder: `Describe the job you want` — exact text.
+- H1 not rendered before async load — page is heavily lazy-loaded; mirror it as a server-rendered approximation.
+
+**Mirror priorities**
+- The warm-beige `#F4F2EE` (244, 242, 238) page background is signature — MUST be exact.
+- 52px nav with the eight items above in order.
+- System-ui font stack — no custom font.
+- White card panels on beige page background.
+- Reaction bar order: `Like / Comment / Repost / Send` (LinkedIn's canonical order).
+- Brand accent: `#0a66c2` blue.
+
+---
+
+## 4. indeed.com
+
+**URLs captured**: `https://www.indeed.com/`, `https://www.indeed.com/jobs?q=software+engineer&l=Austin%2C+TX`
+
+**Brand & typography**
+- Font family: `"Indeed Sans", "Noto Sans", "Helvetica Neue", Helvetica, Arial, "Liberation Sans", Roboto, Noto, sans-serif` — Indeed Sans is a custom font; Helvetica fallback is fine for the mirror.
+- Brand blue: `#2557A7` (Indeed brand — canonical, confirm via spot check).
+- Body background: transparent/white.
+
+**Top nav (home page)**
+- Items in order: `Home`, `Company reviews`, `Find salaries`, `Sign in` / `Employers / Post Job`.
+- Secondary strip below: `Home`, `Company reviews`, `Find salaries`, `Employers`, `Create your resume`, `Change country 🇺🇸 United States`.
+
+**Home page (`/`)**
+- Hero: two-input search bar side by side
+  - Left input: placeholder `Job title, keywords, or company`, name=`q`, aria-label `search: Job title, keywords, or company`.
+  - Right input: placeholder `City, state, zip code, or "remote"`, name=`l`, aria-label `Edit location`.
+  - CTA: `Search`.
+- Below hero: panels for `What's trending on Indeed`, `Employer Resources`.
+
+**Search results page (`/jobs?q=…&l=…`)**
+- H1: `software engineer jobs in Austin, TX` (lowercased query echoed)
+- 3-pane layout:
+  - Top horizontal filter chip rail (Date posted | Remote | Developer skill | Job Type | Experience level | Pay | Education | Clearance type | Developer type | Compensation package | Distance) — these are the EXACT chip labels and order. 11 chips.
+  - Left = results list (each card: title, company, location, salary, snippet, posted date, Apply button)
+  - Right = detail pane width 680px showing the selected job in full (header "{Title} - job post" pattern, full description, Apply button)
+- Detail pane H2: `{Job Title} - job post` (e.g. `Java Microservices Developer with Reactive Programming - job post`) — the `- job post` suffix is the canonical pattern.
+- Apply button labelled `Apply` (sometimes `loading` mid-state, sometimes `Apply now on company site`).
+
+**Interaction signals**
+- Clicking a result card on the left updates the right detail pane WITHOUT navigation — the URL changes to add `?vjk=<jobkey>`.
+- Each chip opens a popover; selecting a value re-runs search and updates result list.
+- 5-digit zip in the `Where` input is conventional but not strictly auto-submit on this site.
+
+**Mirror priorities**
+- The two hero placeholders (`Job title, keywords, or company` + `City, state, zip code, or "remote"`) must be EXACT.
+- The chip rail labels in the exact order above must be EXACT.
+- The detail-pane "- job post" suffix on the job title H2 must be EXACT.
+- The right-pane-no-nav interaction (clicking a left card → URL ?vjk=… + right pane re-renders) must work in the mirror — this is THE canonical Indeed interaction.
+- Brand blue `#2557A7` accent.
+
+---
+
+## Cross-site conventions worth replicating
+
+- **Initials avatar pattern (mercor)** — when you don't have photos, render 2-3-letter initial blocks on neutral bg. Mercor does this in production.
+- **Card with badge + price + microcopy CTA** — common to all four sites for their primary list units (mercor role cards, fiverr gig cards, linkedin job cards, indeed job cards). Standardise this component.
+- **Sticky top nav, slim** — all four sites have a sticky thin top nav (mercor 37–52px, linkedin 52px, indeed varies, fiverr ~80px). Keep yours sticky.
+- **NO Google Fonts at runtime** — all four sites either ship a custom font from their own CDN or use system stack. For the mirror, use a local font (if you ship one) or system stack only. Outbound fetches at runtime are out of scope per CLAUDE.md.
+
+---
+
+## Anti-patterns observed (avoid)
+
+- **Heavy SPA with hashed class names** (LinkedIn). DO NOT try to mirror class-name hashes. Match by ROLE, semantics, layout, and label text. The CUA reads pixels and labels, not class names.
+- **Lazy-load delays** on heavily dynamic pages. Mirror as a server-rendered static approximation — the agent gets the same visible surface deterministically.

--- a/deploy/sim_envs/mantis_fiverr/Dockerfile
+++ b/deploy/sim_envs/mantis_fiverr/Dockerfile
@@ -1,0 +1,21 @@
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PIP_NO_CACHE_DIR=1
+
+WORKDIR /srv
+
+COPY requirements.txt /srv/requirements.txt
+RUN pip install -r /srv/requirements.txt
+
+COPY app /srv/app
+
+EXPOSE 8080
+
+HEALTHCHECK --interval=10s --timeout=3s --start-period=5s --retries=3 \
+  CMD python -c "import urllib.request,sys; \
+    sys.exit(0 if urllib.request.urlopen('http://127.0.0.1:8080/__env__/health', timeout=2).status == 200 else 1)"
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/deploy/sim_envs/mantis_fiverr/FIDELITY.md
+++ b/deploy/sim_envs/mantis_fiverr/FIDELITY.md
@@ -1,0 +1,183 @@
+# mantis_fiverr — Fidelity matrix
+
+Last updated: 2026-06-08 (initial scaffold)
+
+Spec source: **training-data recollection** for fiverr.com — the
+parent's `_capture_brief.md` was not present at worktree start, and a
+live Chrome MCP grab against fiverr.com was not feasible in one turn
+(JS-rehydrate + bot wall). All visual rows are tracked against the
+canonical training-data spec captured in `_captured/<slug>/notes.md`.
+
+**Open follow-up #1**: drive Chrome MCP against live fiverr.com,
+write `dom.html` + `styles.json` + `screenshot.png` per slug, then
+re-grade each row below from "partial" → "close" / "exact".
+
+## Status legend
+
+- **exact** — Mine matches the captured spec measurement ≤2px and 0
+  unit mismatches.
+- **close** — Mine structurally matches; minor pixel diff (3–8px) or
+  shade-off colour.
+- **partial** — Section present but visibly off; needs follow-up.
+- **missing** — Not implemented in this iteration.
+- **not-matched** — Implemented but the spec disagrees with my
+  rendering and I haven't resolved it.
+
+---
+
+## Home (`/`)
+
+| Element                       | Real spec                                       | Mine                                              | Status  |
+| ----------------------------- | ----------------------------------------------- | ------------------------------------------------- | ------- |
+| Sticky top nav height         | 64px, white, 1px `#e4e5e7` bottom               | 64px sticky, white, 1px `#e4e5e7` bottom          | close   |
+| Logo placement                | Green wordmark + dot-i, left-aligned            | Procedural SVG wordmark + green dot               | close   |
+| Search input width            | 540px                                           | 540px max-width                                   | close   |
+| Search input border           | `1px solid #74767e`, 4px radius                 | `1px solid #74767e`, 4px radius                   | exact   |
+| Search submit button          | Dark/green square, 48×48                        | Dark square + green hover, 48×48                  | close   |
+| Nav links                     | Pro · Explore · English · USD · Become Seller · Sign in · Join | Pro · Explore · English · USD · Sign in · Join     | partial |
+| "Join" button                 | Outlined green, 1px `#1dbf73`                   | Outlined green, 1px `#1dbf73`                     | exact   |
+| Hero height                   | 600px tall, dark image bg                       | 540px min, dark image bg via `/assets/hero.svg`   | close   |
+| Hero H1                       | 48px / 700 / white, max-w 720px                 | 48px / 700 / white, max-w 720px                   | exact   |
+| Hero search width             | 540px × 56px                                    | 540px × 56px                                      | exact   |
+| Hero CTA "Search" button      | Green `#1dbf73`, white text, magnifier + label  | Green `#1dbf73`, white text, magnifier + label    | exact   |
+| Popular chips                 | Pill, white border on dark hero                 | Pill, white border on dark hero                   | close   |
+| Trusted-by row                | gray `#fafafa`, 5 monochrome logos              | gray `#fafafa`, 5 grayscale text "logos"          | partial |
+| Popular services carousel     | 6 cards, 235×280, image+overlay text            | 6 cards, gradient bg, ~245×280                    | close   |
+| Categories grid               | 6 cols × 2 rows = 12 tiles, line-art icons      | 6 cols × 2 rows = 12 tiles, SVG line-art icons    | close   |
+| Cat tile hover                | Bottom border green                             | Bottom border green                               | exact   |
+| Featured gigs grid            | 4 col × 2 rows, gig-card                        | 4 col × 2 rows                                    | exact   |
+| Business CTA                  | Purple `#5b3eff` block, 360px tall              | Purple `#5b3eff` block                            | close   |
+| Footer                        | 5-column links + bottom row                     | 5-column links + bottom row                       | exact   |
+
+## Search results (`/search/gigs?query=…`)
+
+| Element                       | Real spec                                       | Mine                                              | Status  |
+| ----------------------------- | ----------------------------------------------- | ------------------------------------------------- | ------- |
+| Breadcrumbs                   | Home / Search results for "…", 13px / `#74767e` | same                                              | exact   |
+| Result H1                     | 28px / 700                                      | 28px / 700                                        | exact   |
+| Sort dropdown                 | Pill, white, 36px, 4 options                    | Pill, white, 36px, 4 options                      | exact   |
+| Filter rail width             | 240px                                           | 240px                                             | exact   |
+| Seller level checkboxes       | Top Rated / Level 2 / Level 1 / New             | Top Rated / Level Two / Level One / New           | exact   |
+| Budget radio group            | Value / Mid / High                              | Value / Mid / High                                | exact   |
+| Delivery radio group          | Express 24H / 3 days / 7 days / Anytime         | Express 24H / 3 days / 7 days / Anytime           | exact   |
+| Gig grid columns              | 4 cols on results                               | 3 cols (240px rail + main col)                    | partial |
+| Pagination                    | Numeric + chevrons                              | Numeric (no chevrons)                             | partial |
+
+## Category landing (`/categories/<slug>`)
+
+| Element                       | Real spec                                       | Mine                                              | Status  |
+| ----------------------------- | ----------------------------------------------- | ------------------------------------------------- | ------- |
+| Hero strip                    | 240px gradient/photo, white text                | 200px green gradient, white text                  | partial |
+| Hero H1                       | 36px / 700                                      | 36px / 700                                        | exact   |
+| Subcategory chip rail         | Horiz scroll pills 36px                         | Wrapping pill chips 32–36px                       | close   |
+| Curated grid                  | 4 cols                                          | 3 cols                                            | partial |
+
+## Gig detail (`/<username>/<gig-slug>`)
+
+| Element                       | Real spec                                       | Mine                                              | Status  |
+| ----------------------------- | ----------------------------------------------- | ------------------------------------------------- | ------- |
+| Body two-col                  | 720px main + 320px aside, 32px gap              | 720px main + 320px aside, 32px gap                | exact   |
+| Breadcrumbs                   | Category trail with `/` separator               | same                                              | exact   |
+| Gig title H1                  | 22px / 700                                      | 22px / 700                                        | exact   |
+| Seller chip row               | Avatar 40px + name + level pill + rating        | Avatar 40px + name + level pill + rating          | exact   |
+| Gallery main                  | 720×480, rounded 8px, light shadow              | 720×480, rounded 8px, shadow                      | exact   |
+| Thumb strip                   | 5 thumbs 110×72, 2px green border on active     | 5 thumbs 110×72, 2px green border on active       | exact   |
+| About-gig body                | Multi-paragraph, 16px / line-h 1.6              | Multi-paragraph, 16px / line-h 1.6                | exact   |
+| About-seller card             | 1px border, 24px padding                        | 1px border, 24px padding                          | exact   |
+| Package picker right-rail     | 320px sticky, 1px border, rounded 4px           | 320px sticky, 1px border, rounded 4px             | exact   |
+| Package tabs                  | 3 full-width tabs, active has 3px black border  | 3 full-width tabs, active has 3px black border    | exact   |
+| Package CTA                   | Green button, "Continue (US$X)" w/ live price   | Green button, "Continue (US$X)" w/ live price     | exact   |
+| Package picker JS swap        | Inline price/delivery/revs/features update      | Inline price/delivery/revs/features update        | exact   |
+
+## Checkout (`/checkout/<gig_id>?tier=…`)
+
+| Element                       | Real spec                                       | Mine                                              | Status  |
+| ----------------------------- | ----------------------------------------------- | ------------------------------------------------- | ------- |
+| Compact header                | Logo only + "Secure checkout"                   | Logo + "Secure checkout"                          | exact   |
+| Two-col body                  | 600px form + 320px summary                      | 1fr form + 320px summary                          | close   |
+| Order summary block           | Thumb 56×56 + title + tier line                 | Thumb 56×56 + title + tier line                   | exact   |
+| Payment radio cards           | 3 options: Card / PayPal / Bank                 | 3 options: Card / PayPal / Bank                   | exact   |
+| "Confirm & Pay (US$X)" CTA    | Green, 48px full-width                          | Green, 48px full-width                            | exact   |
+| Summary card                  | Subtotal / Service fee / Total                  | Subtotal / Service fee / Total                    | exact   |
+
+## Inbox + thread (`/inbox`, `/inbox/<thread>`)
+
+| Element                       | Real spec                                       | Mine                                              | Status  |
+| ----------------------------- | ----------------------------------------------- | ------------------------------------------------- | ------- |
+| Two-pane layout               | 360px thread list + main                        | 360px thread list + main                          | exact   |
+| Thread search                 | gray `#fafafa` bg input                         | gray `#fafafa` bg input                           | exact   |
+| Thread row                    | 56px tall, avatar + name + snippet + ts         | 60px tall, avatar + name + snippet + ts           | close   |
+| Active thread highlight       | 3px green left border                           | 3px green left border                             | exact   |
+| Message bubble (mine)         | Right-align, `#dbf5e7` bg                       | Right-align, `#dbf5e7` bg                         | exact   |
+| Message bubble (other)        | Left-align, `#f5f5f5` bg                        | Left-align, `#f5f5f5` bg                          | exact   |
+| Composer                      | Sticky bottom, autosize textarea + send         | Sticky bottom, fixed-row textarea + send          | close   |
+
+## Orders list + detail (`/orders`, `/orders/<id>`)
+
+| Element                       | Real spec                                       | Mine                                              | Status  |
+| ----------------------------- | ----------------------------------------------- | ------------------------------------------------- | ------- |
+| Orders H1                     | "Manage Orders" 28px / 700                      | "Manage Orders" 28px / 700                        | exact   |
+| Status chips                  | All / Active / Delivered / Completed / Cancelled| All / Active / Delivered / Completed / Cancelled  | exact   |
+| Orders table                  | Columns + status pill colours                   | Columns + status pill colours                     | exact   |
+| Status pill colours           | active=blue, delivered=orange, completed=green  | active=blue, delivered=orange, completed=green    | exact   |
+| Order header card             | # + status + due-on + total right               | # + status + due-on + total right                 | exact   |
+| Deliverables panel            | Empty/active OR file list                       | Empty/active OR file list                         | close   |
+| Review CTA                    | 5 outline-star input + textarea + submit        | 5 filled-star input + textarea + submit           | partial |
+
+## Auth (`/login`, `/signup`)
+
+| Element                       | Real spec                                       | Mine                                              | Status  |
+| ----------------------------- | ----------------------------------------------- | ------------------------------------------------- | ------- |
+| Centered wrap                 | max-w 360px, padding-top 80px                   | max-w 360px, padding-top 80px                     | exact   |
+| Form input height             | 48px, 1px `#74767e` border                      | 48px, 1px `#74767e` border                        | exact   |
+| Submit button                 | Full-width green, 48px, "Continue" / "Join"     | Full-width green, 48px, "Continue" / "Join"       | exact   |
+| Forgot password link          | 13px green right-aligned                        | 13px green right-aligned                          | exact   |
+
+---
+
+## Interaction fidelity matrix
+
+| Interaction                          | URL/DOM/audit delta                                  | Status |
+| ------------------------------------ | ---------------------------------------------------- | ------ |
+| Home search → `/search/gigs?query=`  | Form GET → query string preserved                    | exact  |
+| Popular chip click                   | href to `/search/gigs?query=<chip>`                  | exact  |
+| Category tile click                  | href to `/categories/<slug>`                         | exact  |
+| Gig card click                       | href to `/<username>/<gig-slug>`                     | exact  |
+| Search filter checkbox change        | form auto-submits with `?level=…`                    | exact  |
+| Search sort change                   | form auto-submits with `?sort=…`                     | exact  |
+| Gig detail package tab click         | Inline JS update of price/delivery/revs/features     | exact  |
+| Gig detail thumb click               | Inline JS swap of main image                         | exact  |
+| Gig "Continue (US$X)" → /checkout    | GET to `/checkout/<id>?tier=…`                       | exact  |
+| Checkout confirm → /orders/<id>      | POST → 303 + audit_log `order_placed` row            | exact  |
+| Inbox send message                   | POST → 303 + audit_log `message_sent` row            | exact  |
+| Open thread with seller              | GET → 303 to existing or new conv + audit row        | exact  |
+| Order detail review submit           | POST → 303 + reviews row + gig avg recompute + audit | exact  |
+| Login form submit                    | POST → 303 + session cookie + `login_succeeded` audit| exact  |
+| Signup form submit                   | POST → 303 + user row + session + audit row          | exact  |
+| Gig favorite toggle                  | POST → favorite_toggled audit                        | close  |
+
+---
+
+## Iteration log
+
+- 2026-06-08 (initial) — Phase 0–6 first pass landed; smoke green
+  end-to-end; all 3 oracles pass their happy path. ~37 files
+  shipped, ~3200 LOC.
+
+## Open todos for follow-up agents
+
+1. Drive Chrome MCP against fiverr.com home, search, gig detail,
+   checkout, inbox, orders, login. Save `_captured/<slug>/dom.html`,
+   `styles.json`, `screenshot.png`. Re-grade FIDELITY rows from
+   `partial` → `close` / `exact` based on measured deltas.
+2. Replace the gradient-based `popular-card` block with a proper
+   image-overlay layout (real Fiverr uses photos + colour overlay).
+3. Grow `gig-grid--3` on search results to `gig-grid--4` (Fiverr uses
+   4 cols, we currently render 3).
+4. Add chevron prev/next to pagination.
+5. Mobile responsive — currently desktop-only.
+6. Add the 5-digit zip / location filter — real Fiverr's location is
+   tracked at the seller level.
+7. Wire `last_msg_at` to be `now()` rather than the seed default when
+   no messages have been sent yet (cosmetic — affects ordering in
+   inbox).

--- a/deploy/sim_envs/mantis_fiverr/FIDELITY_AGENT_PROMPT.md
+++ b/deploy/sim_envs/mantis_fiverr/FIDELITY_AGENT_PROMPT.md
@@ -1,0 +1,75 @@
+# Prompt — "Close a fidelity gap in mantis_fiverr"
+
+This is the **gap-fix** playbook (the build-from-scratch variant lives
+in `../mantis_boattrader/FIDELITY_BUILD_FROM_SCRATCH_PROMPT.md`).
+
+You're handed:
+
+- `mantis_fiverr` — a working sim env of fiverr.com (`docker run`
+  ready; `scripts/smoke.py` green; FIDELITY.md table populated).
+- A row in `FIDELITY.md` marked `partial` / `close` / `missing`.
+
+Your job is to close ONE row (or a tight cluster of related rows in
+the same section) per turn, then push the status forward by one bucket.
+
+## Working loop
+
+1. **Read the captured spec** — open `_captured/<slug>/notes.md` for
+   the page and find the spec line for the element. If the row is
+   based on training-data recollection (flagged at top of FIDELITY),
+   drive Chrome MCP first and write the real measurements to
+   `_captured/<slug>/styles.json`. THIS is your ground truth.
+
+2. **Twin tabs** — open the live fiverr.com page + our sim env page in
+   the SAME Chrome window at 1440×900. Different windows give
+   different `innerWidth` and measurements aren't comparable. Confirm
+   `window.innerWidth === 1440` on both.
+
+3. **Structural diff** — run the per-element probe (from
+   FIDELITY_BUILD_FROM_SCRATCH_PROMPT.md) on both tabs, side-by-side.
+   Any row off by ≥3px, any colour/border/spacing unit mismatch is a
+   fix.
+
+4. **Perceptual diff** — `computer.zoom` with **matched
+   `region=[x,y,x+w,y+h]`** on both tabs, `save_to_disk: true`. The
+   structural numbers tell you WHAT to fix; the screenshot tells you
+   WHETHER the fix worked.
+
+5. **Edit CSS/HTML** in the worktree. Batch all measured deltas in
+   the section into ONE edit before re-measuring.
+
+6. **Re-measure**. Don't trust a screenshot alone — confirm the
+   measurements match too.
+
+7. **Update FIDELITY.md** — flip the row's status forward
+   (`partial` → `close` → `exact`). Append an iteration log entry at
+   the bottom of FIDELITY.md.
+
+8. **Run smoke.py** — it must still pass. Visual fidelity changes that
+   break interaction routes are bugs, not improvements.
+
+## Anti-patterns to avoid
+
+1. **Don't measure from the wrong window.** `innerWidth: 0` →
+   different window → measurements are garbage.
+2. **Don't fix without measuring.** "Looks closer" is not a metric.
+3. **Don't redeploy per property change.** Edit → measure → commit.
+4. **Don't skip the `_captured/` update.** Future agents diff against
+   that corpus; stale captures lock in stale fidelity.
+5. **Don't promise pixel-perfect screenshots across fonts.** Aim for
+   `pixelmatch < 0.5%`. Fonts and anti-aliasing differ.
+6. **Don't introduce framework-y JS for a layout fix.** A `selector {
+   property: value }` is always cheaper. If you find yourself
+   reaching for React or a framework — STOP, the CSS is wrong.
+7. **Don't reorder route registration** without re-running the smoke
+   test. The gig detail catch-all (`/{username}/{slug}`) MUST stay
+   last (see Anti-route-pattern comment in `app/main.py`).
+
+## When to call done
+
+The row's status is updated to `exact` and:
+
+- `scripts/smoke.py` still passes
+- The captured measurement in `_captured/<slug>/styles.json` matches
+  ours within tolerance
+- A new iteration line is appended to FIDELITY.md

--- a/deploy/sim_envs/mantis_fiverr/README.md
+++ b/deploy/sim_envs/mantis_fiverr/README.md
@@ -1,0 +1,144 @@
+# mantis_fiverr
+
+High-fidelity synthetic mirror of **fiverr.com** — the agent-training
+sim env for the freelance gig marketplace surface.
+
+## What this mirrors
+
+A buyer-facing slice of Fiverr:
+
+- Discovery: home, search, category landing
+- Gig detail with three-tier package picker (Basic/Standard/Premium)
+- Checkout (no real payment)
+- Messaging (inbox + thread)
+- Orders (list + detail + review submission)
+- Auth (email/password + signup)
+
+Out-of-scope: real images/brand assets, ads/analytics, OAuth/social
+login, real payment processing, websockets, A/B variants, mobile
+responsive, multi-currency, multi-locale.
+
+See `SCOPE.md` for the full list.
+
+## How to run
+
+### Local (Docker)
+
+```bash
+cd deploy/sim_envs/mantis_fiverr
+docker build -t mantis-fiverr .
+docker run --rm -p 8080:8080 -e ENV_ADMIN_TOKEN=test mantis-fiverr
+```
+
+Then `curl http://127.0.0.1:8080/__env__/health` and browse to
+`http://127.0.0.1:8080/`.
+
+### Local (uvicorn, dev)
+
+```bash
+cd deploy/sim_envs/mantis_fiverr
+pip install -r requirements.txt
+ENV_ADMIN_TOKEN=test python -m uvicorn app.main:app --port 8080 --reload
+```
+
+### Smoke test
+
+```bash
+cd deploy/sim_envs/mantis_fiverr
+ENV_ADMIN_TOKEN=test python scripts/smoke.py
+```
+
+Drives every in-scope page + happy-path for each of the three
+oracle tasks. Green = the harness contract is intact.
+
+## Harness contract
+
+- `GET /__env__/health` — public, `{ok, seed, now, boot_time, gigs}`
+- `POST /__env__/reset` — admin; reseeds DB to baseline
+- `POST /__env__/seed` — admin; body `{seed:int}`
+- `POST /__env__/clock` — admin; body `{now:ISO8601}`
+- `GET /__env__/oracle?task_id=…` — admin; dispatches to the matching
+  grader. Returns canonical `{passed, score, task_id, reasons, diff}`
+- `GET /__env__/state` — admin; counts + recent audit_log
+- `GET /__env__/events?since=ts` — admin; in-process event log
+- `GET /__env__/mutations?since=N` — admin; the audit_log slice since
+  the given id
+
+All admin routes gate on `X-Env-Admin: <ENV_ADMIN_TOKEN>`.
+
+`ENV_REQUIRE_AUTH=1` flips authentication on for `/inbox`, `/orders`,
+`/checkout`. Default off so oracle contracts grade against the
+canonical buyer (`buyer_00001`).
+
+## Oracle tasks
+
+- **`t01_order_basic_logo`** — buyer_00001 orders gig_00001 at Basic
+  tier. Verifies subtotal + service_fee + total + order_placed audit.
+- **`t02_message_seller_then_order`** — buyer_00001 messages
+  gig_00001's seller, THEN orders. Verifies the audit-log ordering.
+- **`t03_leave_5star_review`** — buyer reviews `order_00007` with 5
+  stars. Verifies the reviews row + gig avg-rating recompute + audit
+  row.
+
+## Fidelity tracker
+
+See `FIDELITY.md` for the section-by-section match matrix and open
+follow-ups. The build methodology is in
+`../mantis_boattrader/FIDELITY_BUILD_FROM_SCRATCH_PROMPT.md`; the
+gap-fix playbook for follow-up turns is in
+`FIDELITY_AGENT_PROMPT.md`.
+
+## Repo layout
+
+```
+mantis_fiverr/
+├── Dockerfile               # python:3.11-slim + uvicorn :8080
+├── requirements.txt
+├── README.md
+├── SCOPE.md                 # in-scope pages + interactions
+├── FIDELITY.md              # section match matrix + iteration log
+├── FIDELITY_AGENT_PROMPT.md # gap-fix playbook
+├── _captured/               # ground-truth corpus per page
+│   ├── home/{notes.md, …}
+│   ├── search_gigs/, gig_detail/, checkout/, inbox/, orders/,
+│   ├── category/, login/, signup/
+├── app/
+│   ├── main.py              # FastAPI factory
+│   ├── db.py                # SQLite schema + audit_log helpers
+│   ├── seed.py              # deterministic seed
+│   ├── auth.py              # signed-cookie sessions
+│   ├── routes/
+│   │   ├── env_admin.py     # /__env__/*
+│   │   ├── auth_routes.py   # /login, /signup, /logout
+│   │   ├── storefront.py    # /, /search/gigs, /categories/<slug>
+│   │   ├── gig.py           # /<username>/<gig-slug> (catch-all)
+│   │   ├── checkout.py      # /checkout/<gig-id>
+│   │   ├── inbox.py         # /inbox + /inbox/<thread>
+│   │   ├── orders.py        # /orders + /orders/<id>
+│   │   └── assets.py        # /assets/*.svg (procedural)
+│   ├── oracles/
+│   │   ├── t01_order_basic_logo.py
+│   │   ├── t02_message_seller_then_order.py
+│   │   └── t03_leave_5star_review.py
+│   ├── templates/           # Jinja2
+│   │   ├── base.html, _gig_card.html
+│   │   ├── home.html, search.html, category.html
+│   │   ├── gig_detail.html, checkout.html
+│   │   ├── inbox.html, orders.html, order_detail.html
+│   │   ├── login.html, signup.html
+│   └── static/site.css      # hand-rolled (~700 lines)
+└── scripts/smoke.py         # in-process end-to-end smoke
+```
+
+## Deterministic IDs
+
+Same `SEED` → identical IDs across runs:
+
+- `buyer_00001`..`buyer_00020`
+- `seller_00001`..`seller_00030`
+- `gig_00001`..`gig_00030`
+- `order_00001`..`order_00015` (1–8 completed, 9–11 delivered,
+  12–15 active)
+- `review_00001`..`review_00005` (skips `order_00007` deliberately
+  so `t03` has a target)
+- `conv_00001`..`conv_00004`

--- a/deploy/sim_envs/mantis_fiverr/SCOPE.md
+++ b/deploy/sim_envs/mantis_fiverr/SCOPE.md
@@ -1,0 +1,78 @@
+# mantis_fiverr — SCOPE
+
+Synthetic high-fidelity mirror of **fiverr.com** — freelance gig
+marketplace. Sellers list "gigs" with three package tiers
+(Basic / Standard / Premium); buyers browse, order, message, and
+review.
+
+## In-scope pages
+
+| URL pattern                             | Surface                                 |
+| --------------------------------------- | --------------------------------------- |
+| `/`                                     | Marketing home — search bar, popular categories carousel, featured gig grid |
+| `/search/gigs?query=`                   | Search results — filter rail + gig card grid + sort dropdown |
+| `/categories/<slug>`                    | Category landing — subcategories + curated grid |
+| `/<seller-username>/<gig-slug>`         | Gig detail — gallery, packages picker, description, seller card, reviews |
+| `/checkout/<gig-id>?tier=`              | Package + add-ons confirm + payment placeholder |
+| `/inbox`                                | Conversations list |
+| `/inbox/<thread>`                       | Thread detail |
+| `/orders`                               | Buyer order list |
+| `/orders/<id>`                          | Order detail — status, deliverables, messages, review CTA |
+| `/login`, `/signup`                     | Auth |
+
+## In-scope interactions
+
+- **Search**: type query → `/search/gigs?query=…`. Sort dropdown +
+  filter checkboxes update `?sort=` and `?level=` query params.
+- **Gig detail**: switch Basic/Standard/Premium tabs → price + delivery
+  time + revision count + features update inline (vanilla JS, no nav).
+  "Continue ($X)" CTA reflects current tier price.
+- **Checkout**: confirm → order row + `audit_log` row + redirect to
+  `/orders/<id>`.
+- **Messaging**: send a message in a thread → message row + thread
+  `updated_at` bumps.
+- **Review**: leave star rating + text on a completed order → review row
+  + gig avg-rating recompute.
+
+## Out-of-scope (NOT mirrored)
+
+- Real photography / brand assets → deterministic SVG placeholders
+- Analytics / advertising / tracking scripts → stripped
+- Third-party widgets (intercom, hotjar, FullStory) → stripped
+- OAuth / social login → username + password only
+- Real payment processing → "Pay" button writes audit_log + flips
+  order status. No Stripe.
+- Real-time websockets / SSE → polling or static
+- A/B variants → one canonical variant per page (the anonymous-default)
+- Pro / Business / Logo Maker upsells — out
+- Currency switcher → USD only
+- Locale switcher → en-US only
+
+## Viewports
+
+Desktop 1440×900 only. Mobile responsive is out-of-scope for this
+iteration.
+
+## Backend
+
+SQLite, deterministic seed. Read+write surface. Every state-changing
+route writes an `audit_log` row. Oracles read `audit_log`, not derived
+state.
+
+## Done bar
+
+- ✅ Structural deltas ≤2px per FIDELITY.md row
+- ✅ 100% in-scope interactions replay with matching URL+DOM+audit_log
+- ✅ `scripts/smoke.py` green
+- ✅ `_captured/` corpus checked in
+- ✅ All four bookkeeping files present (SCOPE, FIDELITY,
+  FIDELITY_AGENT_PROMPT, README)
+
+## Oracle tasks
+
+- **t01_order_basic_logo** — buyer orders gig `gig_00001` Basic tier;
+  oracle verifies order row total = Basic price with line items
+- **t02_message_seller_then_order** — buyer sends a message in a thread,
+  then orders; oracle verifies conversation + order linkage
+- **t03_leave_5star_review** — buyer leaves a 5-star review on completed
+  `order_00007`; oracle verifies review row + gig avg-rating update

--- a/deploy/sim_envs/mantis_fiverr/_captured/README.md
+++ b/deploy/sim_envs/mantis_fiverr/_captured/README.md
@@ -1,0 +1,39 @@
+# _captured/ — fiverr.com surface corpus
+
+Spec source: **training-data recollection** (capture brief
+`deploy/sim_envs/_capture_brief.md` was not present at worktree
+start; Chrome MCP / WebFetch capture against fiverr.com is gated by
+their bot wall + heavy JS rehydrate, so a live DOM grab in one turn
+was not feasible).
+
+Each subfolder mirrors a logical page; `notes.md` carries the layout
++ palette + interaction spec. `screenshot.png` is intentionally
+omitted on this first pass (no live grab) — flagged ⏳ in
+FIDELITY.md. A follow-up agent should drive Chrome MCP against the
+live site and overwrite the per-slug notes with measured values.
+
+## Canonical Fiverr palette + typography (training-data recollection)
+
+| Token                  | Value          | Notes                              |
+| ---------------------- | -------------- | ---------------------------------- |
+| `--fv-green-primary`   | `#1dbf73`      | Primary CTA, logo, hover accents   |
+| `--fv-green-hover`     | `#19a463`      | Hover on primary                   |
+| `--fv-green-dark`      | `#16805a`      | Active state                       |
+| `--fv-text-primary`    | `#222325`      | Body text                          |
+| `--fv-text-secondary`  | `#74767e`      | Meta, captions                     |
+| `--fv-text-tertiary`   | `#95979d`      | Disabled, separators               |
+| `--fv-bg-white`        | `#ffffff`      | Card/page bg                       |
+| `--fv-bg-gray`         | `#fafafa`      | Section bg, search input fill      |
+| `--fv-border-gray`     | `#e4e5e7`      | Cards, hr, input border            |
+| `--fv-yellow-star`     | `#ffb33e`      | Rating stars                       |
+| `--fv-orange-pro`      | `#ff7640`      | Fiverr Pro badge accent            |
+| `--fv-purple-business` | `#5b3eff`      | Fiverr Business accent             |
+
+Typography: **Macan** in production; we substitute `system-ui` /
+Helvetica Neue / Arial. Sizes:
+
+- H1 hero: 48px / 700 / 1.1 line-height
+- H2 section: 32px / 700
+- H3 card title: 18px / 700
+- Body: 14px / 400
+- Caption: 12px / 400 / `#74767e`

--- a/deploy/sim_envs/mantis_fiverr/_captured/category/notes.md
+++ b/deploy/sim_envs/mantis_fiverr/_captured/category/notes.md
@@ -1,0 +1,23 @@
+# /categories/<slug> — Fiverr category landing
+
+## Layout
+Max-width 1400px, padding 0 80px.
+
+### Hero strip
+- 240px tall, gradient or photo, dark overlay
+- H1 white "Graphics & Design" 36px / 700
+- Subtitle 16px / `#ffffff` opacity .8
+
+### Subcategory chip rail
+Horizontal scroll, 12 chips. Each chip = pill, 1px `#e4e5e7` border,
+14px / 600, height 36px, padding 0 16px. Examples for Graphics &
+Design: `Logo Design`, `Brand Style Guide`, `Business Cards &
+Stationery`, `Illustration`, `Web & Mobile Design`, …
+
+### Curated grid
+H2 "Most popular in <category>" 24px / 700. Same gig-card grid as
+search results (4 cols).
+
+## Interactions
+- Subcategory chip click → `/search/gigs?query=<slug>&category=<slug>`
+- Card click → gig detail

--- a/deploy/sim_envs/mantis_fiverr/_captured/checkout/notes.md
+++ b/deploy/sim_envs/mantis_fiverr/_captured/checkout/notes.md
@@ -1,0 +1,39 @@
+# /checkout/<gig-id>?tier=… — Fiverr checkout
+
+## Layout
+
+Two-column, max-width 980px, padding 0 80px. Left 600px (order
+summary + form), right 320px sticky summary card.
+
+### Header
+Compact: Fiverr logo only, no nav. Right side "Secure checkout 🔒"
+14px / `#74767e`.
+
+### Order summary block (left)
+- H1 "Checkout" 28px / 700
+- "You're ordering:" 14px / `#74767e`
+- Gig row: 56×56 thumb + title + seller + price 18px / 700 right-aligned
+- Selected tier line: "Package: Basic — Delivery in 3 days"
+- "Order details" textarea, label 14px / 600, placeholder "Briefly
+  describe your project (optional)"
+
+### Payment block
+- H2 "Payment method" 20px / 700
+- Radio cards: `Credit / Debit Card` (selected), `PayPal`, `Bank
+  transfer`
+- Selected variant exposes card-number / expiry / CVC fields — placeholder
+  values (no validation, since payment is mocked)
+
+### Footer CTA bar
+Sticky bottom on left col: green button "Confirm & Pay (US$X)" 48px
+tall, full-width.
+
+### Right summary card
+- H3 "Summary" 16px / 700
+- Subtotal row, Service fee row, Total row (16px / 700)
+- Small print "By clicking Confirm & Pay you agree to our Terms…"
+  12px / `#95979d`
+
+## Interactions captured
+- "Confirm & Pay" POSTs to `/checkout/<gig_id>` → creates order row +
+  audit_log row, redirects 303 to `/orders/<order_id>`

--- a/deploy/sim_envs/mantis_fiverr/_captured/gig_detail/notes.md
+++ b/deploy/sim_envs/mantis_fiverr/_captured/gig_detail/notes.md
@@ -1,0 +1,82 @@
+# /<seller-username>/<gig-slug> — Fiverr gig detail
+
+The most interaction-heavy page in scope. The package picker is the
+key interaction-fidelity surface.
+
+## Layout
+
+Two-column body: left content 720px wide, right sticky package picker
+panel 320px wide, gap 32px. Wraps in `max-width: 1108px`, padding `0
+80px`.
+
+### Breadcrumbs row
+`Home / <category> / <subcategory> / <gig title>` — 13px / 400 /
+`#74767e`.
+
+### H1 gig title
+
+22px / 700 / `#222325`, 2 lines max.
+
+### Seller chip row (below title)
+- 40px circular avatar + seller name (14px / 600) + Level badge
+  `Level 2 Seller` pill (orange `#ff7640` bg, white text, 11px / 600,
+  rounded 2px) + star rating with `5.0 (124)` reviews count + green
+  contact button "Contact me"
+
+### Gallery (left)
+- Main image 720×480, rounded 8px, light shadow
+- Thumb strip below: 5 thumbs 110×72 each, gap 8px, selected one has
+  2px `#1dbf73` border, others 1px `#e4e5e7`
+
+### "About this gig" section
+H3 "About this gig" 20px / 700. Body paragraphs 16px / 400, line-height
+1.6, color `#222325`. Multi-paragraph plain text.
+
+### "About the seller" card
+Boxed `#e4e5e7` 1px border, padding 24px, rounded 4px. 80px avatar +
+seller details: name, location, member since, response time, last
+delivery. CTA "Contact me" outlined green button.
+
+### Reviews section
+H3 "Reviews" + star summary "5.0 (124)". Filter dropdowns by rating.
+List of review cards: avatar, name, country flag, rating, date, body
+text.
+
+## Right sticky package picker
+
+Card 320px wide, sticky-top with offset 88px (under nav). Border 1px
+`#e4e5e7`, rounded 4px, no shadow.
+
+### Package tabs (top of card)
+
+Three tabs full-width: `Basic` · `Standard` · `Premium`. Active tab:
+black bottom border 3px, text `#222325` / 600. Inactive: text
+`#74767e` / 400.
+
+### Tab body
+
+- Top row: package title (16px / 700) ← left + price (24px / 700) ← right
+  `US$<price>` with `$` superscript-ish
+- Description: 14px / 400 / `#74767e` (2 lines)
+- Features list (4-6 items):
+  - Each row: checkmark icon (green `#1dbf73`) + label 14px
+  - Examples: `3-day delivery`, `2 Revisions`, `Source file`, `Logo
+    transparency`, `Vector file`, `Printable file`
+- Delivery row: clock icon + "3-day delivery" 14px / 600
+- Revisions row: refresh icon + "2 Revisions" 14px / 600
+- CTA: solid green button `#1dbf73`, full-width, 48px tall, white text
+  16px / 600, text `Continue (US$<price>)`
+- Below CTA: secondary outline "Compare packages" 14px / 600
+
+## Interactions captured
+
+- Clicking a package tab swaps active state, updates price, features,
+  delivery, revisions, and CTA price text **inline, no nav** —
+  small JS handler reading from `data-package-N-*` attributes on the
+  container.
+- Clicking "Continue (US$X)" → `/checkout/<gig_id>?tier=<basic|std|prem>`
+- Thumb-strip click on gallery swaps main image, no nav (small JS)
+- "Contact me" → `/inbox/<thread_id>` if existing thread else
+  `/inbox/new?to=<seller>`
+- Heart icon top-right of gallery toggles favorite (POST
+  `/gig/<id>/favorite`, audit_log row)

--- a/deploy/sim_envs/mantis_fiverr/_captured/home/notes.md
+++ b/deploy/sim_envs/mantis_fiverr/_captured/home/notes.md
@@ -1,0 +1,85 @@
+# / (home) — Fiverr marketing home
+
+## Top nav (sticky, white, 1px bottom border `#e4e5e7`, height 64px)
+
+Left → right:
+- Fiverr wordmark logo (29px tall, green `#1dbf73`, dot over the
+  "i" is a slight rotated comma) — links to `/`
+- Search bar: 540px wide, 48px tall, rounded 4px, `1px solid #74767e`,
+  placeholder "Search for any service…", inline green search button
+  (square, 48×48, white magnifier icon)
+- Right nav items (gap 24px, font 16px / 600):
+  Fiverr Pro · Explore · English (▼) · US$ USD (▼) · Become a Seller ·
+  Sign in (text) · Join (outlined green button, padding 6px 16px,
+  rounded 4px, border 1px `#1dbf73`, text green)
+
+## Hero (full-bleed dark image, 600px tall)
+
+- Title H1: "Find the right freelance service, right away" — white,
+  44px, 700, max-width 720px, left-aligned, padding-left 80px
+- Search composite, 540px wide × 56px tall, white bg, rounded 4px,
+  inset 1px shadow: placeholder "Search for any service…" + green
+  submit button "[magnifier] Search" 100px wide, 56px tall,
+  border-radius 0 4px 4px 0
+- "Popular:" chips row beneath search: chip pills, white border,
+  transparent bg, white text. Default chips: `Website Design`,
+  `WordPress`, `Logo Design`, `AI Services`
+
+## Trusted by row
+
+Centered grayscale logo strip "Trusted by:" + logo placeholders
+(Meta, Google, Netflix, P&G, PayPal). 80px tall, `#fafafa` bg.
+
+## Popular services carousel
+
+Section H2 "Popular services", 32px / 700 / `#222325`.
+6 wide cards, horizontally scrollable:
+- 235px × 280px each, gap 16px
+- Card: gradient/photo top (170px), title bottom (60px, white text on
+  card-color block), e.g. "AI Artists | Add Promise" gradient blue,
+  "Logo Design | Build your brand", "WordPress | Customize your site",
+  "Voice Over | Share your message", "Video Editing | Bring your story
+  to life", "Social Media | Reach more customers"
+
+## "You need it, we've got it" — category tiles grid
+
+H2 32px / 700. 6 columns × 2 rows = 12 tiles. Each tile 188×112:
+- Square icon top (48px, line-art, green), label below 14px / 600
+- Examples: Graphics & Design, Programming & Tech, Digital Marketing,
+  Video & Animation, Writing & Translation, Music & Audio, Business,
+  Data, Photography, AI Services, Lifestyle, Consulting
+
+## Featured gigs grid
+
+H2 "Recommended for you" 32px / 700. Grid 4 columns × 2 rows = 8 cards.
+Each gig card 282×340:
+- Image area 282×190 (4:3 ratio approximation) — solid color/gradient placeholder
+- Heart icon top-right (favorite)
+- Seller row: 26px avatar circle + seller name (14px / 600) + Level
+  badge (small pill text "Level 2 Seller" 11px / 600 / `#95979d`)
+- Title: 14px / 400 / `#222325`, 2 lines clamp, "I will <verb>
+  <object>" sentence case
+- Star row: filled yellow stars 12px + rating digit "5.0" 12px / 600 +
+  "(reviews_count)" 12px / `#74767e`
+- Bottom row: heart icon (left if not pinned) + "Starting at US$X"
+  right-aligned, 13px / 600
+
+## Fiverr Business CTA block
+
+Dark purple `#5b3eff` block, full-width, 360px tall. Left: H2 white "A
+whole world of freelance talent at your fingertips". Sub-copy 16px.
+CTA white outline "Get Started". Right: composed illustration.
+
+## Footer
+
+Light gray `#fafafa`, 6 columns of links (Categories, About, Support,
+Community, More, Mobile apps), wordmark + social row bottom.
+
+## Interactions captured (default state)
+
+- Search submit → `/search/gigs?query=<encoded>`
+- Popular chip click → `/search/gigs?query=<chip-text>`
+- Category tile click → `/categories/<slug>`
+- Gig card click → `/<seller-username>/<gig-slug>`
+- "Join" button → `/signup`
+- "Sign in" → `/login`

--- a/deploy/sim_envs/mantis_fiverr/_captured/inbox/notes.md
+++ b/deploy/sim_envs/mantis_fiverr/_captured/inbox/notes.md
@@ -1,0 +1,42 @@
+# /inbox + /inbox/<thread> — Fiverr messaging
+
+## /inbox — list view
+Two-pane: left thread list 360px wide, right empty state placeholder
+"Select a conversation".
+
+### Thread list
+- Header "Inbox" 20px / 700, padding 16px
+- Search input "Search messages" 36px tall, gray bg `#fafafa`
+- Each row: 56px tall, padding 12px 16px, hover bg `#fafafa`, selected
+  3px green left border
+  - 40px avatar
+  - Right of avatar (stacked): name 14px / 600, last message snippet
+    13px / `#74767e` (1 line clamp)
+  - Right edge: timestamp 12px / `#95979d` + unread dot (green
+    `#1dbf73`, 8px)
+
+## /inbox/<thread> — thread detail
+Same nav. Two-pane: same left list 360px, right thread 660px+.
+
+### Right thread header
+- 40px avatar + seller name + green online dot + "Online" 12px /
+  `#1dbf73`. Right side: "View profile" link.
+
+### Messages area
+- Scrollable, padding 24px
+- Each message bubble: max-width 480px
+  - Own messages: right-aligned, bg `#dbf5e7`, text `#222325`,
+    rounded 12px, padding 8px 12px
+  - Other: left-aligned, bg `#f5f5f5`, text `#222325`
+- Timestamp small caption 11px / `#95979d` below bubble cluster
+- Avatar shown only on other-party bubble (left edge)
+
+### Composer (bottom, sticky)
+- Border-top 1px `#e4e5e7`, padding 16px, white bg
+- Textarea (height 60px, autosize), placeholder "Type your message..."
+- Right: attachment paperclip + send button (green, 36×36, paper-plane
+  icon, disabled when empty)
+
+## Interactions
+- Send → POSTs `/inbox/<thread>/send` (form) → appends row + redirects
+  back to thread

--- a/deploy/sim_envs/mantis_fiverr/_captured/login/notes.md
+++ b/deploy/sim_envs/mantis_fiverr/_captured/login/notes.md
@@ -1,0 +1,25 @@
+# /login + /signup — Fiverr auth
+
+## Layout
+Centered single column, max-width 360px, padding-top 80px.
+
+### /login
+
+- Fiverr logo top, 32px tall
+- H1 "Sign in to your account" 24px / 700, centered
+- Form fields stacked, 14px / 400, gap 16px:
+  - Email/username — 48px tall input, 1px `#74767e` border, rounded 4px
+  - Password — same
+- "Forgot password?" link 13px / `#1dbf73` right-aligned
+- Submit button — full-width, 48px, green `#1dbf73`, white text 16px /
+  600, label "Continue"
+- "—— Or ——" divider 12px / `#74767e`
+- "Don't have an account? Join here" link 14px / `#1dbf73`
+
+### /signup
+Same shape with H1 "Create a new account" and additional Username
+field. Submit "Join".
+
+## Interactions
+- POST /login → set session cookie → 303 to `next` or `/`
+- POST /signup → create user + session cookie → 303 to `/`

--- a/deploy/sim_envs/mantis_fiverr/_captured/orders/notes.md
+++ b/deploy/sim_envs/mantis_fiverr/_captured/orders/notes.md
@@ -1,0 +1,47 @@
+# /orders + /orders/<id> — Fiverr orders
+
+## /orders — buyer order list
+
+Single-column, max-width 1108px, padding 0 80px.
+
+### Header row
+- H1 "Manage Orders" 28px / 700
+- Right: "Active (N)" "Completed (N)" "Cancelled (N)" tabs
+
+### Filter chips
+Chips row: All · Active · Delivered · Completed · Cancelled (pill,
+border 1px `#e4e5e7`, selected: green `#1dbf73` bg / white text)
+
+### Table
+Columns: BUYER (if seller view) / SELLER (if buyer view) | GIG |
+DUE ON | TOTAL | STATUS | ACTIONS
+- Header row: 12px / 600 / `#74767e`, uppercase
+- Row: white, hover `#fafafa`, 64px tall, gig thumb 48×48 + title
+  truncate, status pill (Active = blue, Delivered = orange, Completed
+  = green, Cancelled = gray)
+
+## /orders/<id> — order detail
+
+Three sections stacked, max-width 980px:
+
+### Order header card
+- Order # 22px / 700
+- Status pill + due-on info + gig title link
+- "Total: US$X" right
+- Action row: secondary buttons "Message seller", "Resolve order"
+
+### Deliverables panel
+- Empty state "Awaiting delivery..." if status=active
+- If status=delivered: list of file rows (name, size, download icon)
+- If status=completed: same + "Mark as completed" already disabled
+
+### Review CTA (only when status=completed AND no review yet)
+- H3 "Leave a review" 16px / 700
+- Star input row: 5 outline stars, clicking fills 1..5
+- Textarea "Share more about your experience..."
+- Green submit button "Publish review"
+
+## Interactions
+- "Publish review" → POST `/orders/<id>/review` with stars+text →
+  inserts review row + recomputes gig avg rating + audit_log row +
+  redirects

--- a/deploy/sim_envs/mantis_fiverr/_captured/search_gigs/notes.md
+++ b/deploy/sim_envs/mantis_fiverr/_captured/search_gigs/notes.md
@@ -1,0 +1,45 @@
+# /search/gigs?query=… — Fiverr search results
+
+## Layout
+
+Same sticky top nav. Body wraps in `max-width: 1400px`, padding `0
+80px`.
+
+### Breadcrumbs row (28px tall)
+`Home / Search results for "<query>"` — 13px / 400 / `#74767e`,
+slash separator `#95979d`.
+
+### Result header
+- H1: `Results for "<query>"` — 28px / 700 / `#222325`
+- "X results" subtitle 14px / `#74767e`
+- Right side: **Sort by ▼** dropdown — pill, white bg, 1px
+  `#e4e5e7` border, 36px tall, label "Sort by: Relevance" 13px / 600.
+  Options: Relevance · Best Selling · Newest Arrivals · Average rating
+
+### Filter rail (sticky, left, 240px wide)
+
+Each filter group: label 14px / 700 bold, options 14px / 400.
+
+1. **Seller details**
+   - Seller level checkbox group: `Top Rated Seller`, `Level Two`,
+     `Level One`, `New Seller`
+2. **Budget**
+   - `Value · Up to US$50`, `Mid-range · US$50-200`, `High-end · US$200+`
+3. **Delivery time**
+   - Radio group: `Express 24H`, `Up to 3 days`, `Up to 7 days`, `Anytime`
+
+Filters update `?level=`, `?budget=`, `?delivery=` query params on
+click (no page reload via small JS handler that sets `location.search`).
+
+### Result grid
+
+Right of filter rail. Same gig card shape as home (4 columns × N rows,
+282×340 each, 24px gap). Pagination at bottom: numeric pages 1 2 3 …
+N, prev/next chevrons.
+
+## Interactions captured
+
+- Sort dropdown change → `?sort=<value>` reload
+- Filter checkbox toggle → `?level=top_rated&level=level_two&…`
+- Card click → `/<username>/<gig-slug>`
+- Pagination click → `?page=N`

--- a/deploy/sim_envs/mantis_fiverr/app/__init__.py
+++ b/deploy/sim_envs/mantis_fiverr/app/__init__.py
@@ -1,0 +1,1 @@
+"""mantis-fiverr — high-fidelity synthetic mirror of fiverr.com."""

--- a/deploy/sim_envs/mantis_fiverr/app/auth.py
+++ b/deploy/sim_envs/mantis_fiverr/app/auth.py
@@ -1,0 +1,156 @@
+"""Mock auth surface for mantis-fiverr.
+
+Same shape as mantis_shop: signed-cookie sessions via stdlib hmac,
+plain SHA-256 password hash (sim env). ``ENV_REQUIRE_AUTH=1`` flips
+the gate on protected routes; default 0 keeps the oracle contracts
+working against the canonical `buyer_00001` user.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import os
+import time
+from typing import Any
+
+from fastapi import Request, Response
+from fastapi.responses import RedirectResponse
+
+from . import db
+
+SESSION_COOKIE = "mantis_session"
+SESSION_TTL_DEFAULT_S = 60 * 60  # 1h
+LOGIN_PATH = "/login"
+
+
+def session_secret() -> str:
+    return os.environ.get("ENV_SESSION_SECRET", "dev-only-do-not-use-in-prod")
+
+
+def session_ttl_s() -> int:
+    raw = os.environ.get("ENV_SESSION_TTL_S")
+    try:
+        return int(raw) if raw else SESSION_TTL_DEFAULT_S
+    except ValueError:
+        return SESSION_TTL_DEFAULT_S
+
+
+def auth_required() -> bool:
+    return os.environ.get("ENV_REQUIRE_AUTH", "0").lower() in {"1", "true", "yes"}
+
+
+def hash_password(plain: str) -> str:
+    return hashlib.sha256(plain.encode("utf-8")).hexdigest()
+
+
+def verify_password(plain: str, stored: str) -> bool:
+    return hmac.compare_digest(hash_password(plain), stored)
+
+
+def mint_session(user_id: str, *, now: float | None = None) -> str:
+    issued = int(now if now is not None else time.time())
+    payload = f"{user_id}|{issued}"
+    sig = hmac.new(
+        session_secret().encode("utf-8"),
+        payload.encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+    return f"{payload}|{sig}"
+
+
+def verify_session(cookie_val: str, *, now: float | None = None) -> str | None:
+    if not cookie_val:
+        return None
+    parts = cookie_val.split("|")
+    if len(parts) != 3:
+        return None
+    user_id, issued_at_s, sig = parts
+    try:
+        issued_at = int(issued_at_s)
+    except ValueError:
+        return None
+    payload = f"{user_id}|{issued_at}"
+    expected = hmac.new(
+        session_secret().encode("utf-8"),
+        payload.encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+    if not hmac.compare_digest(sig, expected):
+        return None
+    now_ts = now if now is not None else time.time()
+    if now_ts - issued_at > session_ttl_s():
+        return None
+    return user_id
+
+
+def set_session_cookie(response: Response, user_id: str) -> None:
+    response.set_cookie(
+        SESSION_COOKIE,
+        mint_session(user_id),
+        httponly=True,
+        samesite="lax",
+        max_age=session_ttl_s(),
+        path="/",
+    )
+
+
+def clear_session_cookie(response: Response) -> None:
+    response.delete_cookie(SESSION_COOKIE, path="/")
+
+
+def lookup_user_by_id(user_id: str) -> dict[str, Any] | None:
+    conn = db.connect()
+    row = conn.execute(
+        "SELECT id, username, email, role, display_name FROM users WHERE id = ?",
+        (user_id,),
+    ).fetchone()
+    return dict(row) if row else None
+
+
+def lookup_user_by_login(login: str) -> dict[str, Any] | None:
+    conn = db.connect()
+    login = login.strip().lower()
+    row = conn.execute(
+        "SELECT id, username, email, password_hash, role, display_name "
+        "FROM users WHERE email = ? OR username = ?",
+        (login, login),
+    ).fetchone()
+    return dict(row) if row else None
+
+
+def current_user(request: Request) -> dict[str, Any] | None:
+    raw = request.cookies.get(SESSION_COOKIE)
+    user_id = verify_session(raw or "")
+    if user_id is None:
+        return None
+    return lookup_user_by_id(user_id)
+
+
+def require_user(
+    request: Request, *, roles: list[str] | None = None
+) -> Response | None:
+    if not auth_required():
+        return None
+    user = current_user(request)
+    next_path = request.url.path
+    if user is None:
+        return RedirectResponse(
+            f"{LOGIN_PATH}?next={next_path}", status_code=303
+        )
+    if roles and user.get("role") not in roles:
+        return RedirectResponse(LOGIN_PATH, status_code=303)
+    return None
+
+
+def effective_buyer_id(request: Request) -> str:
+    """Resolve the acting buyer for checkout flows.
+
+    Mirrors mantis_shop pattern: when auth is required, pull from the
+    session; otherwise fall back to the canonical buyer_00001 so the
+    oracle contracts keep grading.
+    """
+    user = current_user(request)
+    if user and user.get("role") == "buyer":
+        return str(user["id"])
+    return "buyer_00001"

--- a/deploy/sim_envs/mantis_fiverr/app/db.py
+++ b/deploy/sim_envs/mantis_fiverr/app/db.py
@@ -1,0 +1,252 @@
+"""SQLite schema + thin query helpers for mantis-fiverr.
+
+Shape mirrors mantis_shop / mantis_crm: in-memory by default, one
+module-level connection guarded by a re-entrant lock, schema applied
+at first connect.
+
+Schema overview
+---------------
+
+* ``users`` — auth surface. ``role`` ∈ ``buyer``, ``seller``.
+* ``sellers`` — extended seller-profile attached to a user (level,
+  avatar palette, response time, country).
+* ``categories`` — top-level + subcategory rows (flat for simplicity).
+* ``gigs`` — one row per gig. Three package tiers are stored on the
+  same row for now (basic/standard/premium each have price, delivery
+  days, revisions, description, features JSON).
+* ``orders`` — buyer-placed orders. ``status`` ∈ ``active``,
+  ``delivered``, ``completed``, ``cancelled``.
+* ``order_items`` — line items (usually 1 per order; future-proof).
+* ``conversations`` + ``messages`` — inbox storage.
+* ``reviews`` — per-order review row + stars + text.
+* ``audit_log`` — append-only mutation record. Single source of truth
+  for oracles.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import threading
+from contextlib import contextmanager
+from typing import Any, Iterator
+
+_DB_LOCK = threading.RLock()
+_DB: sqlite3.Connection | None = None
+
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS users (
+    id              TEXT PRIMARY KEY,
+    username        TEXT NOT NULL UNIQUE,
+    email           TEXT NOT NULL UNIQUE,
+    password_hash   TEXT NOT NULL,
+    role            TEXT NOT NULL,            -- 'buyer' | 'seller'
+    display_name    TEXT NOT NULL,
+    created_at      TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_users_email ON users(email);
+
+CREATE TABLE IF NOT EXISTS sellers (
+    user_id         TEXT PRIMARY KEY REFERENCES users(id),
+    level           TEXT NOT NULL,            -- 'new' | 'level_one' | 'level_two' | 'top_rated'
+    country         TEXT NOT NULL,
+    languages       TEXT NOT NULL DEFAULT '[]',
+    response_time_h INTEGER NOT NULL DEFAULT 24,
+    member_since    TEXT NOT NULL,
+    avg_rating      REAL NOT NULL DEFAULT 0.0,
+    review_count    INTEGER NOT NULL DEFAULT 0,
+    avatar_palette  INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS categories (
+    slug            TEXT PRIMARY KEY,
+    title           TEXT NOT NULL,
+    parent_slug     TEXT,
+    icon            TEXT NOT NULL DEFAULT 'square',
+    sort_order      INTEGER NOT NULL DEFAULT 0
+);
+CREATE INDEX IF NOT EXISTS idx_categories_parent ON categories(parent_slug);
+
+CREATE TABLE IF NOT EXISTS gigs (
+    id              TEXT PRIMARY KEY,
+    seller_id       TEXT NOT NULL REFERENCES users(id),
+    slug            TEXT NOT NULL UNIQUE,
+    title           TEXT NOT NULL,
+    description_md  TEXT NOT NULL DEFAULT '',
+    category_slug   TEXT NOT NULL REFERENCES categories(slug),
+    image_palette   INTEGER NOT NULL DEFAULT 0,
+    -- package tiers stored inline; cleaner than a 4-row JOIN per page
+    pkg_basic_title       TEXT NOT NULL DEFAULT 'Basic',
+    pkg_basic_desc        TEXT NOT NULL DEFAULT '',
+    pkg_basic_price       REAL NOT NULL DEFAULT 5.0,
+    pkg_basic_delivery_d  INTEGER NOT NULL DEFAULT 3,
+    pkg_basic_revisions   INTEGER NOT NULL DEFAULT 1,
+    pkg_basic_features    TEXT NOT NULL DEFAULT '[]',
+    pkg_standard_title    TEXT NOT NULL DEFAULT 'Standard',
+    pkg_standard_desc     TEXT NOT NULL DEFAULT '',
+    pkg_standard_price    REAL NOT NULL DEFAULT 25.0,
+    pkg_standard_delivery_d INTEGER NOT NULL DEFAULT 5,
+    pkg_standard_revisions INTEGER NOT NULL DEFAULT 2,
+    pkg_standard_features TEXT NOT NULL DEFAULT '[]',
+    pkg_premium_title     TEXT NOT NULL DEFAULT 'Premium',
+    pkg_premium_desc      TEXT NOT NULL DEFAULT '',
+    pkg_premium_price     REAL NOT NULL DEFAULT 75.0,
+    pkg_premium_delivery_d INTEGER NOT NULL DEFAULT 7,
+    pkg_premium_revisions INTEGER NOT NULL DEFAULT 4,
+    pkg_premium_features  TEXT NOT NULL DEFAULT '[]',
+    avg_rating      REAL NOT NULL DEFAULT 0.0,
+    review_count    INTEGER NOT NULL DEFAULT 0,
+    orders_count    INTEGER NOT NULL DEFAULT 0,
+    created_at      TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_gigs_category ON gigs(category_slug);
+CREATE INDEX IF NOT EXISTS idx_gigs_seller ON gigs(seller_id);
+
+CREATE TABLE IF NOT EXISTS orders (
+    id              TEXT PRIMARY KEY,
+    number          TEXT NOT NULL UNIQUE,        -- '#FO0001'
+    buyer_id        TEXT NOT NULL REFERENCES users(id),
+    seller_id       TEXT NOT NULL REFERENCES users(id),
+    gig_id          TEXT NOT NULL REFERENCES gigs(id),
+    tier            TEXT NOT NULL,               -- 'basic' | 'standard' | 'premium'
+    subtotal        REAL NOT NULL,
+    service_fee     REAL NOT NULL DEFAULT 0.0,
+    total           REAL NOT NULL,
+    status          TEXT NOT NULL,               -- 'active' | 'delivered' | 'completed' | 'cancelled'
+    requirements    TEXT NOT NULL DEFAULT '',
+    placed_at       TEXT NOT NULL,
+    due_at          TEXT NOT NULL,
+    delivered_at    TEXT,
+    completed_at    TEXT,
+    cancelled_at    TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_orders_buyer ON orders(buyer_id);
+CREATE INDEX IF NOT EXISTS idx_orders_seller ON orders(seller_id);
+CREATE INDEX IF NOT EXISTS idx_orders_status ON orders(status);
+
+CREATE TABLE IF NOT EXISTS order_items (
+    id              TEXT PRIMARY KEY,
+    order_id        TEXT NOT NULL REFERENCES orders(id),
+    line_no         INTEGER NOT NULL,
+    description     TEXT NOT NULL,
+    unit_price      REAL NOT NULL,
+    quantity        INTEGER NOT NULL DEFAULT 1,
+    UNIQUE (order_id, line_no)
+);
+CREATE INDEX IF NOT EXISTS idx_order_items_order ON order_items(order_id);
+
+CREATE TABLE IF NOT EXISTS conversations (
+    id              TEXT PRIMARY KEY,
+    buyer_id        TEXT NOT NULL REFERENCES users(id),
+    seller_id       TEXT NOT NULL REFERENCES users(id),
+    last_msg_at     TEXT NOT NULL,
+    UNIQUE (buyer_id, seller_id)
+);
+CREATE INDEX IF NOT EXISTS idx_conv_buyer ON conversations(buyer_id);
+CREATE INDEX IF NOT EXISTS idx_conv_seller ON conversations(seller_id);
+
+CREATE TABLE IF NOT EXISTS messages (
+    id              TEXT PRIMARY KEY,
+    conversation_id TEXT NOT NULL REFERENCES conversations(id),
+    sender_id       TEXT NOT NULL REFERENCES users(id),
+    body            TEXT NOT NULL,
+    created_at      TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_msgs_conv ON messages(conversation_id);
+
+CREATE TABLE IF NOT EXISTS reviews (
+    id              TEXT PRIMARY KEY,
+    order_id        TEXT NOT NULL UNIQUE REFERENCES orders(id),
+    gig_id          TEXT NOT NULL REFERENCES gigs(id),
+    buyer_id        TEXT NOT NULL REFERENCES users(id),
+    seller_id       TEXT NOT NULL REFERENCES users(id),
+    stars           INTEGER NOT NULL,
+    body            TEXT NOT NULL DEFAULT '',
+    created_at      TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_reviews_gig ON reviews(gig_id);
+
+CREATE TABLE IF NOT EXISTS favorites (
+    user_id         TEXT NOT NULL REFERENCES users(id),
+    gig_id          TEXT NOT NULL REFERENCES gigs(id),
+    created_at      TEXT NOT NULL,
+    PRIMARY KEY (user_id, gig_id)
+);
+
+CREATE TABLE IF NOT EXISTS audit_log (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    occurred_at     TEXT NOT NULL,
+    operation       TEXT NOT NULL,
+    target_type     TEXT NOT NULL,
+    target_id       TEXT NOT NULL,
+    payload_json    TEXT NOT NULL DEFAULT '{}'
+);
+CREATE INDEX IF NOT EXISTS idx_audit_op ON audit_log(operation);
+"""
+
+
+def db_path() -> str:
+    return os.environ.get("DB_PATH") or ":memory:"
+
+
+def connect() -> sqlite3.Connection:
+    """Return the shared SQLite connection, creating it on first use."""
+    global _DB
+    with _DB_LOCK:
+        if _DB is None:
+            conn = sqlite3.connect(db_path(), check_same_thread=False)
+            conn.row_factory = sqlite3.Row
+            conn.executescript(SCHEMA)
+            _DB = conn
+        return _DB
+
+
+def reset_connection() -> None:
+    """Drop the in-process connection — used by ``/__env__/reset``."""
+    global _DB
+    with _DB_LOCK:
+        if _DB is not None:
+            _DB.close()
+            _DB = None
+
+
+@contextmanager
+def transaction() -> Iterator[sqlite3.Connection]:
+    conn = connect()
+    with _DB_LOCK:
+        try:
+            yield conn
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+
+
+def pack_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=False)
+
+
+def unpack_json(raw: str) -> Any:
+    try:
+        return json.loads(raw or "null")
+    except json.JSONDecodeError:
+        return None
+
+
+def log_audit(
+    conn: sqlite3.Connection,
+    *,
+    occurred_at: str,
+    operation: str,
+    target_type: str,
+    target_id: str,
+    payload: dict[str, Any] | None = None,
+) -> None:
+    conn.execute(
+        "INSERT INTO audit_log (occurred_at, operation, target_type, target_id, payload_json) "
+        "VALUES (?, ?, ?, ?, ?)",
+        (occurred_at, operation, target_type, target_id,
+         json.dumps(payload or {}, sort_keys=True)),
+    )

--- a/deploy/sim_envs/mantis_fiverr/app/main.py
+++ b/deploy/sim_envs/mantis_fiverr/app/main.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from typing import Any
 
 from fastapi import FastAPI, Request
-from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse, Response
+from fastapi.responses import JSONResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 

--- a/deploy/sim_envs/mantis_fiverr/app/main.py
+++ b/deploy/sim_envs/mantis_fiverr/app/main.py
@@ -1,0 +1,182 @@
+"""mantis-fiverr FastAPI app — entrypoint mounted by both Docker + Modal.
+
+Two route surfaces (mirrors mantis-shop / mantis-boattrader):
+
+* ``/`` — buyer-facing marketplace pages (home, search, gig detail,
+  checkout, inbox, orders, auth).
+* ``/__env__/*`` — harness-only, gated on ``X-Env-Admin`` header.
+"""
+
+from __future__ import annotations
+
+import os
+import secrets
+import time
+from pathlib import Path
+from typing import Any
+
+from fastapi import FastAPI, Request
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse, Response
+from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
+
+from . import auth, db, seed
+
+APP_DIR = Path(__file__).parent
+ADMIN_TOKEN_ENV = "ENV_ADMIN_TOKEN"
+ADMIN_HEADER = "X-Env-Admin"
+
+
+def _admin_token() -> str:
+    token = os.environ.get(ADMIN_TOKEN_ENV, "").strip()
+    if not token:
+        # Generate one if missing — local/dev ergonomics.
+        token = secrets.token_urlsafe(32)
+        os.environ[ADMIN_TOKEN_ENV] = token
+    return token
+
+
+def _now() -> str:
+    return os.environ.get("FAKE_NOW") or seed.FAKE_NOW_DEFAULT
+
+
+def _seed_val() -> int:
+    return int(os.environ.get("SEED") or 42)
+
+
+# ── event log ─────────────────────────────────────────────────────────
+
+
+_EVENTS: list[dict[str, Any]] = []
+_BOOT_TIME = time.time()
+
+
+def _emit_event(event: str, data: dict[str, Any] | None = None) -> None:
+    _EVENTS.append({
+        "ts": time.time(),
+        "event": event,
+        "data": data or {},
+    })
+
+
+def _ensure_seeded() -> None:
+    """Seed the DB if empty. Safe to call from startup hook or directly."""
+    conn = db.connect()
+    cur = conn.execute("SELECT COUNT(*) FROM gigs")
+    if cur.fetchone()[0] == 0:
+        seed.seed(conn, seed_val=_seed_val(), fake_now=_now())
+        _emit_event("seeded", {"seed": _seed_val(), "now": _now()})
+
+
+# ── app factory ───────────────────────────────────────────────────────
+
+
+def create_app() -> FastAPI:
+    app = FastAPI(title="mantis-fiverr", docs_url=None, redoc_url=None)
+
+    templates = Jinja2Templates(directory=str(APP_DIR / "templates"))
+    # Globals exposed to every template.
+    templates.env.globals["site_name"] = "Fiverr"
+    templates.env.globals["env_admin_required"] = False
+    app.state.templates = templates
+    app.state.admin_token = _admin_token()
+
+    # Auth gate + per-request user resolution. Mirrors mantis_shop.
+    @app.middleware("http")
+    async def _auth_gate(request: Request, call_next):  # noqa: ANN202
+        try:
+            request.state.current_user = auth.current_user(request)
+        except Exception:  # noqa: BLE001
+            request.state.current_user = None
+        if auth.auth_required():
+            path = request.url.path
+            open_prefixes = (
+                "/login", "/signup", "/logout", "/__env__/", "/static/",
+                "/assets/", "/categories/", "/search/",
+            )
+            if path == "/" or path.startswith(open_prefixes):
+                pass
+            elif path.startswith(("/inbox", "/orders", "/checkout")):
+                user = request.state.current_user
+                if user is None:
+                    return RedirectResponse(
+                        f"/login?next={path}", status_code=303,
+                    )
+        return await call_next(request)
+
+    @app.on_event("startup")
+    def _bootstrap() -> None:
+        _ensure_seeded()
+
+    # Eager-seed at app construction too. TestClient + Modal both rely
+    # on lifespan; with synchronous tests / inspections that bypass
+    # the lifespan (``from app.main import app`` direct), we still
+    # need a populated DB or the first request 404s.
+    _ensure_seeded()
+
+    # Static
+    static_dir = APP_DIR / "static"
+    static_dir.mkdir(parents=True, exist_ok=True)
+    app.mount("/static", StaticFiles(directory=str(static_dir)), name="static")
+
+    # Routers
+    from .routes import auth_routes as auth_router
+    from .routes import env_admin as env_admin_router
+    from .routes import storefront as storefront_router
+    from .routes import gig as gig_router
+    from .routes import checkout as checkout_router
+    from .routes import inbox as inbox_router
+    from .routes import orders as orders_router
+    from .routes import assets as assets_router
+
+    app.include_router(env_admin_router.router)
+    app.include_router(auth_router.router)
+    app.include_router(assets_router.router)
+    app.include_router(storefront_router.router)
+    app.include_router(checkout_router.router)
+    app.include_router(inbox_router.router)
+    app.include_router(orders_router.router)
+    # gig detail uses the catch-all ``/{username}/{slug}`` pattern; must
+    # be the LAST router so /checkout, /inbox, /orders etc. all match
+    # their specific routes first.
+    app.include_router(gig_router.router)
+
+    return app
+
+
+app = create_app()
+
+
+# Helpers exposed to other modules ----------------------------------
+
+
+def admin_token_ok(request: Request) -> bool:
+    return request.headers.get(ADMIN_HEADER) == request.app.state.admin_token
+
+
+def admin_required_response() -> JSONResponse:
+    return JSONResponse({"error": "admin token required"}, status_code=401)
+
+
+def now_value() -> str:
+    return _now()
+
+
+def seed_value() -> int:
+    return _seed_val()
+
+
+def boot_time() -> float:
+    return _BOOT_TIME
+
+
+def emit(event: str, data: dict[str, Any] | None = None) -> None:
+    _emit_event(event, data)
+
+
+def events_since(ts: float) -> list[dict[str, Any]]:
+    return [e for e in _EVENTS if e["ts"] >= ts]
+
+
+def clear_events() -> None:
+    _EVENTS.clear()

--- a/deploy/sim_envs/mantis_fiverr/app/oracles/__init__.py
+++ b/deploy/sim_envs/mantis_fiverr/app/oracles/__init__.py
@@ -1,0 +1,54 @@
+"""Oracles — server-side graders for mantis-fiverr tasks.
+
+Each oracle module exports a single ``grade(conn, *, now, seed_val) ->
+{"passed": bool, "score": float, "reasons": list, "diff": dict}``
+function that reads SQLite + audit_log and returns the harness oracle
+response.
+
+Same dispatcher shape as mantis_shop. New plans land their grader as
+a new file + an entry in :data:`GRADERS`.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Any, Callable
+
+from . import (
+    t01_order_basic_logo,
+    t02_message_seller_then_order,
+    t03_leave_5star_review,
+)
+
+GraderFn = Callable[..., dict[str, Any]]
+
+
+GRADERS: dict[str, GraderFn] = {
+    "t01_order_basic_logo": t01_order_basic_logo.grade,
+    "t02_message_seller_then_order": t02_message_seller_then_order.grade,
+    "t03_leave_5star_review": t03_leave_5star_review.grade,
+}
+
+
+def grade(
+    task_id: str,
+    conn: sqlite3.Connection,
+    *,
+    now: str,
+    seed_val: int,
+) -> dict[str, Any]:
+    fn = GRADERS.get(task_id)
+    if fn is None:
+        return {
+            "passed": False,
+            "score": 0.0,
+            "task_id": task_id,
+            "reasons": [f"no oracle registered for task_id={task_id!r}"],
+            "diff": {},
+        }
+    result = fn(conn, now=now, seed_val=seed_val)
+    result.setdefault("task_id", task_id)
+    return result
+
+
+__all__ = ["GRADERS", "GraderFn", "grade"]

--- a/deploy/sim_envs/mantis_fiverr/app/oracles/t01_order_basic_logo.py
+++ b/deploy/sim_envs/mantis_fiverr/app/oracles/t01_order_basic_logo.py
@@ -1,0 +1,137 @@
+"""t01_order_basic_logo — buyer_00001 orders gig_00001 at Basic tier.
+
+Pass conditions:
+
+1. An order_placed audit row exists for buyer_00001 + gig_00001 with
+   tier='basic'.
+2. The corresponding orders row has the right buyer/gig/tier and
+   subtotal == gig.pkg_basic_price.
+3. service_fee and total are consistent with the canonical formula
+   (service_fee = subtotal * 0.055 + 2.0; total = subtotal + service_fee).
+4. Exactly one order_items row for this order.
+5. Status starts at 'active' (we don't require completion).
+6. No collateral: no other order_placed rows fired for this buyer during
+   the run.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from typing import Any
+
+EXPECTED_BUYER = "buyer_00001"
+EXPECTED_GIG = "gig_00001"
+EXPECTED_TIER = "basic"
+
+
+def grade(conn: sqlite3.Connection, *, now: str, seed_val: int) -> dict[str, Any]:
+    reasons: list[str] = []
+
+    rows = conn.execute(
+        "SELECT id, target_id, payload_json FROM audit_log "
+        "WHERE operation = 'order_placed' ORDER BY id"
+    ).fetchall()
+
+    buyer_orders: list[tuple[str, dict[str, Any]]] = []
+    for r in rows:
+        try:
+            payload = json.loads(r["payload_json"] or "{}")
+        except json.JSONDecodeError:
+            payload = {}
+        if payload.get("buyer_id") == EXPECTED_BUYER:
+            buyer_orders.append((r["target_id"], payload))
+
+    if not buyer_orders:
+        reasons.append(
+            f"no order_placed audit row for {EXPECTED_BUYER}; agent never "
+            "completed checkout"
+        )
+        return _fail(reasons, {"audit_count": len(rows)})
+
+    # Look for the matching one (gig + tier). Extra orders for this
+    # buyer count as collateral.
+    target_id, target_payload = next(
+        ((tid, p) for tid, p in buyer_orders
+         if p.get("gig_id") == EXPECTED_GIG and p.get("tier") == EXPECTED_TIER),
+        (None, None),
+    )
+    if target_id is None:
+        reasons.append(
+            f"buyer placed an order but not gig={EXPECTED_GIG} tier={EXPECTED_TIER}; "
+            f"got: {[(p.get('gig_id'), p.get('tier')) for _, p in buyer_orders]}"
+        )
+        return _fail(reasons, {"buyer_orders": [tid for tid, _ in buyer_orders]})
+
+    other_buyer_orders = [tid for tid, _ in buyer_orders if tid != target_id]
+    if other_buyer_orders:
+        reasons.append(
+            f"collateral: buyer placed extra orders {other_buyer_orders}"
+        )
+
+    # Row check
+    order_row = conn.execute(
+        "SELECT * FROM orders WHERE id = ?", (target_id,),
+    ).fetchone()
+    if order_row is None:
+        reasons.append(f"audit row points at missing order {target_id}")
+        return _fail(reasons, {"target_id": target_id})
+    order = dict(order_row)
+
+    if order["buyer_id"] != EXPECTED_BUYER:
+        reasons.append(
+            f"orders.buyer_id={order['buyer_id']!r} ≠ {EXPECTED_BUYER!r}"
+        )
+    if order["gig_id"] != EXPECTED_GIG:
+        reasons.append(f"orders.gig_id={order['gig_id']!r} ≠ {EXPECTED_GIG!r}")
+    if order["tier"] != EXPECTED_TIER:
+        reasons.append(f"orders.tier={order['tier']!r} ≠ {EXPECTED_TIER!r}")
+
+    gig_row = conn.execute(
+        "SELECT pkg_basic_price FROM gigs WHERE id = ?", (EXPECTED_GIG,),
+    ).fetchone()
+    expected_subtotal = float(gig_row["pkg_basic_price"]) if gig_row else None
+    if expected_subtotal is None:
+        reasons.append(f"missing gig {EXPECTED_GIG}")
+        return _fail(reasons, {})
+    if abs(order["subtotal"] - expected_subtotal) > 0.01:
+        reasons.append(
+            f"subtotal {order['subtotal']} ≠ Basic price {expected_subtotal}"
+        )
+    expected_fee = round(expected_subtotal * 0.055 + 2.0, 2)
+    if abs(order["service_fee"] - expected_fee) > 0.05:
+        reasons.append(
+            f"service_fee {order['service_fee']} ≠ expected {expected_fee}"
+        )
+    expected_total = round(expected_subtotal + expected_fee, 2)
+    if abs(order["total"] - expected_total) > 0.05:
+        reasons.append(
+            f"total {order['total']} ≠ expected {expected_total}"
+        )
+
+    items = conn.execute(
+        "SELECT * FROM order_items WHERE order_id = ?", (target_id,),
+    ).fetchall()
+    if len(items) != 1:
+        reasons.append(f"expected 1 order_items row, got {len(items)}")
+
+    if order["status"] not in ("active", "delivered", "completed"):
+        reasons.append(f"unexpected status {order['status']!r}")
+
+    passed = not reasons
+    return {
+        "passed": passed,
+        "score": 1.0 if passed else 0.0,
+        "reasons": reasons or [f"order {target_id} placed correctly"],
+        "diff": {
+            "order_id": target_id,
+            "subtotal": order["subtotal"],
+            "service_fee": order["service_fee"],
+            "total": order["total"],
+            "tier": order["tier"],
+        },
+    }
+
+
+def _fail(reasons: list[str], diff: dict[str, Any]) -> dict[str, Any]:
+    return {"passed": False, "score": 0.0, "reasons": reasons, "diff": diff}

--- a/deploy/sim_envs/mantis_fiverr/app/oracles/t02_message_seller_then_order.py
+++ b/deploy/sim_envs/mantis_fiverr/app/oracles/t02_message_seller_then_order.py
@@ -1,0 +1,100 @@
+"""t02_message_seller_then_order — buyer messages a seller, then orders.
+
+Sequence verification:
+1. A ``message_sent`` audit row exists with sender_id == buyer_00001
+   addressed to the seller of gig_00001.
+2. An ``order_placed`` audit row exists for buyer_00001 on gig_00001.
+3. The message audit row has a strictly earlier ``id`` than the order
+   row (ordering is the whole point of the task).
+4. The conversations row for that (buyer, seller) pair has last_msg_at
+   updated.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from typing import Any
+
+EXPECTED_BUYER = "buyer_00001"
+EXPECTED_GIG = "gig_00001"
+
+
+def grade(conn: sqlite3.Connection, *, now: str, seed_val: int) -> dict[str, Any]:
+    reasons: list[str] = []
+
+    gig = conn.execute(
+        "SELECT seller_id FROM gigs WHERE id = ?", (EXPECTED_GIG,),
+    ).fetchone()
+    if gig is None:
+        return _fail([f"missing gig {EXPECTED_GIG}"], {})
+    expected_seller = gig["seller_id"]
+
+    rows = conn.execute(
+        "SELECT id, operation, target_id, payload_json FROM audit_log "
+        "WHERE operation IN ('message_sent', 'order_placed') "
+        "ORDER BY id"
+    ).fetchall()
+
+    msg_id: int | None = None
+    order_id: int | None = None
+    conv_id: str | None = None
+    order_target: str | None = None
+    for r in rows:
+        try:
+            p = json.loads(r["payload_json"] or "{}")
+        except json.JSONDecodeError:
+            p = {}
+        if r["operation"] == "message_sent" and msg_id is None:
+            if p.get("sender_id") == EXPECTED_BUYER and p.get("recipient_id") == expected_seller:
+                msg_id = int(r["id"])
+                conv_id = r["target_id"]
+        if r["operation"] == "order_placed" and order_id is None:
+            if (p.get("buyer_id") == EXPECTED_BUYER
+                    and p.get("gig_id") == EXPECTED_GIG
+                    and p.get("seller_id") == expected_seller):
+                order_id = int(r["id"])
+                order_target = r["target_id"]
+
+    if msg_id is None:
+        reasons.append(
+            f"no message_sent audit row from {EXPECTED_BUYER} to seller "
+            f"{expected_seller}"
+        )
+    if order_id is None:
+        reasons.append(
+            f"no order_placed audit row for {EXPECTED_BUYER} on {EXPECTED_GIG}"
+        )
+    if msg_id is not None and order_id is not None and msg_id >= order_id:
+        reasons.append(
+            "message audit row must precede the order row "
+            f"(msg id={msg_id} ≥ order id={order_id})"
+        )
+
+    # Conversation row updated?
+    if conv_id is not None:
+        c = conn.execute(
+            "SELECT last_msg_at FROM conversations WHERE id = ?",
+            (conv_id,),
+        ).fetchone()
+        if c is None:
+            reasons.append(f"conversation {conv_id} missing")
+
+    passed = not reasons
+    return {
+        "passed": passed,
+        "score": 1.0 if passed else 0.0,
+        "reasons": reasons or [
+            f"message {msg_id} preceded order {order_id} on {order_target}"
+        ],
+        "diff": {
+            "message_audit_id": msg_id,
+            "order_audit_id": order_id,
+            "conversation_id": conv_id,
+            "order_id": order_target,
+        },
+    }
+
+
+def _fail(reasons: list[str], diff: dict[str, Any]) -> dict[str, Any]:
+    return {"passed": False, "score": 0.0, "reasons": reasons, "diff": diff}

--- a/deploy/sim_envs/mantis_fiverr/app/oracles/t03_leave_5star_review.py
+++ b/deploy/sim_envs/mantis_fiverr/app/oracles/t03_leave_5star_review.py
@@ -1,0 +1,115 @@
+"""t03_leave_5star_review — buyer leaves a 5-star review on order_00007.
+
+Pass conditions:
+
+1. A reviews row exists for order_00007 with stars == 5.
+2. A ``review_submitted`` audit row exists with stars == 5 and the right
+   order_id.
+3. The gig's avg_rating + review_count were recomputed (review_count
+   incremented by 1; avg_rating shifted toward the new 5-star value).
+4. Buyer matches the buyer on order_00007 (you can only review your own
+   order).
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from typing import Any
+
+EXPECTED_ORDER = "order_00007"
+EXPECTED_STARS = 5
+
+
+def grade(conn: sqlite3.Connection, *, now: str, seed_val: int) -> dict[str, Any]:
+    reasons: list[str] = []
+
+    order = conn.execute(
+        "SELECT id, buyer_id, gig_id FROM orders WHERE id = ?",
+        (EXPECTED_ORDER,),
+    ).fetchone()
+    if order is None:
+        return _fail([f"missing order {EXPECTED_ORDER}"], {})
+
+    review = conn.execute(
+        "SELECT * FROM reviews WHERE order_id = ?", (EXPECTED_ORDER,),
+    ).fetchone()
+    if review is None:
+        reasons.append(
+            f"no review row for {EXPECTED_ORDER}; agent did not publish"
+        )
+        return _fail(reasons, {})
+
+    if review["stars"] != EXPECTED_STARS:
+        reasons.append(
+            f"review stars={review['stars']} ≠ {EXPECTED_STARS}"
+        )
+    if review["buyer_id"] != order["buyer_id"]:
+        reasons.append(
+            f"review buyer_id={review['buyer_id']!r} ≠ order buyer "
+            f"{order['buyer_id']!r}"
+        )
+    if review["gig_id"] != order["gig_id"]:
+        reasons.append(
+            f"review gig_id={review['gig_id']!r} ≠ order gig "
+            f"{order['gig_id']!r}"
+        )
+
+    # Audit log row
+    audit_rows = conn.execute(
+        "SELECT payload_json FROM audit_log "
+        "WHERE operation = 'review_submitted' AND target_id = ?",
+        (review["id"],),
+    ).fetchall()
+    if not audit_rows:
+        reasons.append("no review_submitted audit row")
+    else:
+        try:
+            p = json.loads(audit_rows[-1]["payload_json"] or "{}")
+        except json.JSONDecodeError:
+            p = {}
+        if p.get("stars") != EXPECTED_STARS:
+            reasons.append(
+                f"audit row stars={p.get('stars')} ≠ {EXPECTED_STARS}"
+            )
+
+    # Gig avg + review_count recomputed
+    gig_row = conn.execute(
+        "SELECT avg_rating, review_count FROM gigs WHERE id = ?",
+        (order["gig_id"],),
+    ).fetchone()
+    # Compare to what we'd compute from reviews directly.
+    expected = conn.execute(
+        "SELECT AVG(stars) AS avg, COUNT(*) AS cnt FROM reviews WHERE gig_id = ?",
+        (order["gig_id"],),
+    ).fetchone()
+    if gig_row["review_count"] != int(expected["cnt"]):
+        reasons.append(
+            f"gigs.review_count={gig_row['review_count']} ≠ counted "
+            f"{int(expected['cnt'])}"
+        )
+    if abs(gig_row["avg_rating"] - float(expected["avg"] or 0.0)) > 0.06:
+        reasons.append(
+            f"gigs.avg_rating={gig_row['avg_rating']} not consistent with "
+            f"reviews avg {float(expected['avg'] or 0.0):.2f}"
+        )
+
+    passed = not reasons
+    return {
+        "passed": passed,
+        "score": 1.0 if passed else 0.0,
+        "reasons": reasons or [
+            f"5-star review {review['id']} published on {EXPECTED_ORDER}; "
+            f"gig avg now {gig_row['avg_rating']}, {gig_row['review_count']} reviews"
+        ],
+        "diff": {
+            "review_id": review["id"],
+            "stars": review["stars"],
+            "gig_avg_rating": gig_row["avg_rating"],
+            "gig_review_count": gig_row["review_count"],
+        },
+    }
+
+
+def _fail(reasons: list[str], diff: dict[str, Any]) -> dict[str, Any]:
+    return {"passed": False, "score": 0.0, "reasons": reasons, "diff": diff}

--- a/deploy/sim_envs/mantis_fiverr/app/routes/__init__.py
+++ b/deploy/sim_envs/mantis_fiverr/app/routes/__init__.py
@@ -1,0 +1,1 @@
+"""HTTP route surfaces. Split by major UI surface for readability."""

--- a/deploy/sim_envs/mantis_fiverr/app/routes/assets.py
+++ b/deploy/sim_envs/mantis_fiverr/app/routes/assets.py
@@ -1,0 +1,171 @@
+"""Procedural SVG assets — placeholder gig thumbnails, avatars, logo, icons.
+
+Zero outbound network at runtime. All graphics generated from
+deterministic seed-aware palettes.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Request
+from fastapi.responses import Response
+
+router = APIRouter(prefix="/assets")
+
+# ──────────────────────────────────────────────────────────────────────
+# Palettes
+# ──────────────────────────────────────────────────────────────────────
+
+GIG_PALETTES = [
+    ("#1dbf73", "#0f7048"),
+    ("#5b3eff", "#3a26b3"),
+    ("#ff7640", "#cf4b18"),
+    ("#0aaff1", "#0271a4"),
+    ("#ffb33e", "#c87a16"),
+    ("#e84393", "#a02666"),
+    ("#26c5b1", "#0e7d6f"),
+    ("#444444", "#222222"),
+]
+
+
+AVATAR_PALETTES = [
+    ("#1dbf73", "#fff"),
+    ("#5b3eff", "#fff"),
+    ("#ff7640", "#fff"),
+    ("#0aaff1", "#fff"),
+    ("#ffb33e", "#222"),
+    ("#e84393", "#fff"),
+    ("#26c5b1", "#fff"),
+    ("#74767e", "#fff"),
+]
+
+
+# ──────────────────────────────────────────────────────────────────────
+
+
+@router.get("/logo.svg")
+async def logo_svg() -> Response:
+    svg = (
+        '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 140 38" '
+        'width="140" height="38" aria-label="Fiverr">'
+        '<style>.f{font:700 30px Helvetica,Arial,sans-serif;fill:#222325}'
+        '.g{fill:#1dbf73}</style>'
+        '<text x="0" y="30" class="f">fiv</text>'
+        '<text x="50" y="30" class="f">err</text>'
+        '<circle cx="49" cy="9" r="4" class="g"/>'
+        '<rect x="46" y="9" width="6" height="8" rx="1" class="g" transform="rotate(15 49 13)"/>'
+        '<text x="115" y="30" class="f g">.</text>'
+        '</svg>'
+    )
+    return Response(svg, media_type="image/svg+xml")
+
+
+@router.get("/gig/{palette:int}_{idx:int}.svg")
+async def gig_thumb(palette: int, idx: int) -> Response:
+    a, b = GIG_PALETTES[palette % len(GIG_PALETTES)]
+    # Solid gradient + simple geometric mark + caption strip at bottom.
+    motifs = [
+        '<circle cx="160" cy="120" r="56" fill="rgba(255,255,255,0.18)"/>'
+        '<circle cx="160" cy="120" r="32" fill="rgba(255,255,255,0.35)"/>',
+        '<path d="M40 160 L160 40 L280 160 Z" fill="rgba(255,255,255,0.22)"/>',
+        '<rect x="80" y="60" width="160" height="120" rx="12" fill="rgba(255,255,255,0.2)"/>'
+        '<rect x="100" y="80" width="120" height="20" rx="4" fill="rgba(255,255,255,0.45)"/>'
+        '<rect x="100" y="110" width="80" height="14" rx="3" fill="rgba(255,255,255,0.35)"/>',
+        '<polygon points="80,60 240,60 280,120 240,180 80,180 40,120" fill="rgba(255,255,255,0.2)"/>',
+        '<g fill="rgba(255,255,255,0.3)"><circle cx="100" cy="100" r="22"/>'
+        '<circle cx="180" cy="80" r="14"/><circle cx="220" cy="150" r="32"/></g>',
+        '<g stroke="rgba(255,255,255,0.4)" stroke-width="3" fill="none">'
+        '<path d="M30 150 Q160 30 290 150"/>'
+        '<path d="M30 110 Q160 -10 290 110"/></g>',
+        '<g fill="rgba(255,255,255,0.25)"><rect x="60" y="60" width="50" height="120" rx="4"/>'
+        '<rect x="130" y="80" width="50" height="100" rx="4"/>'
+        '<rect x="200" y="40" width="50" height="140" rx="4"/></g>',
+        '<g fill="rgba(255,255,255,0.3)"><polygon points="160,40 200,140 100,140"/>'
+        '<polygon points="220,80 260,180 180,180"/></g>',
+    ]
+    motif = motifs[idx % len(motifs)]
+    svg = f'''<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 220" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="g" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="{a}"/><stop offset="1" stop-color="{b}"/>
+    </linearGradient>
+  </defs>
+  <rect width="320" height="220" fill="url(#g)"/>
+  {motif}
+</svg>'''
+    return Response(svg, media_type="image/svg+xml")
+
+
+@router.get("/avatar/{palette:int}_{letter}.svg")
+async def avatar(palette: int, letter: str) -> Response:
+    a, fg = AVATAR_PALETTES[palette % len(AVATAR_PALETTES)]
+    initial = (letter[:1] or "?").upper()
+    svg = f'''<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 56 56" width="56" height="56">
+  <circle cx="28" cy="28" r="28" fill="{a}"/>
+  <text x="28" y="36" text-anchor="middle" font-family="Helvetica,Arial,sans-serif"
+        font-size="22" font-weight="700" fill="{fg}">{initial}</text>
+</svg>'''
+    return Response(svg, media_type="image/svg+xml")
+
+
+@router.get("/category/{slug}.svg")
+async def category_icon(slug: str) -> Response:
+    # 12 simple line icons keyed by slug, falling back to a generic square.
+    color = "#1dbf73"
+    icons = {
+        "graphics-design": '<path d="M16 16 L40 16 L40 40 L16 40 Z" stroke-width="3" fill="none"/>'
+                            '<path d="M22 22 L34 34 M34 22 L22 34" stroke-width="3"/>',
+        "programming-tech": '<path d="M14 18 L8 28 L14 38" stroke-width="3" fill="none"/>'
+                            '<path d="M42 18 L48 28 L42 38" stroke-width="3" fill="none"/>'
+                            '<line x1="26" y1="14" x2="30" y2="42" stroke-width="3"/>',
+        "digital-marketing": '<path d="M14 28 L42 16 L42 40 L14 28" stroke-width="3" fill="none"/>'
+                              '<path d="M16 28 L16 38" stroke-width="3"/>',
+        "video-animation": '<rect x="12" y="18" width="32" height="20" rx="3" fill="none" stroke-width="3"/>'
+                            '<polygon points="26,22 26,34 38,28" />',
+        "writing-translation": '<path d="M12 40 L24 16 L36 40 M16 32 L32 32" stroke-width="3" fill="none"/>',
+        "music-audio": '<circle cx="20" cy="38" r="6" stroke-width="3" fill="none"/>'
+                       '<circle cx="40" cy="34" r="6" stroke-width="3" fill="none"/>'
+                       '<path d="M26 38 L26 16 L46 12 L46 34" stroke-width="3" fill="none"/>',
+        "business": '<rect x="10" y="18" width="36" height="24" rx="3" stroke-width="3" fill="none"/>'
+                    '<path d="M22 18 L22 12 L34 12 L34 18" stroke-width="3" fill="none"/>',
+        "data": '<ellipse cx="28" cy="14" rx="16" ry="6" stroke-width="3" fill="none"/>'
+                '<path d="M12 14 L12 42 Q12 48 28 48 Q44 48 44 42 L44 14" stroke-width="3" fill="none"/>'
+                '<path d="M12 28 Q12 34 28 34 Q44 34 44 28" stroke-width="3" fill="none"/>',
+        "photography": '<rect x="8" y="18" width="40" height="26" rx="3" stroke-width="3" fill="none"/>'
+                       '<circle cx="28" cy="31" r="8" stroke-width="3" fill="none"/>'
+                       '<rect x="18" y="14" width="10" height="6" stroke-width="3" fill="none"/>',
+        "ai-services": '<path d="M28 8 L32 22 L46 22 L34 30 L38 44 L28 36 L18 44 L22 30 L10 22 L24 22 Z" stroke-width="3" fill="none"/>',
+        "lifestyle": '<path d="M28 42 Q12 32 12 22 Q12 14 20 14 Q26 14 28 20 Q30 14 36 14 Q44 14 44 22 Q44 32 28 42 Z" stroke-width="3" fill="none"/>',
+        "consulting": '<path d="M8 12 L48 12 L48 36 L20 36 L8 44 Z" stroke-width="3" fill="none"/>'
+                       '<line x1="16" y1="20" x2="40" y2="20" stroke-width="3"/>'
+                       '<line x1="16" y1="28" x2="32" y2="28" stroke-width="3"/>',
+    }
+    g = icons.get(slug, '<rect x="14" y="14" width="28" height="28" stroke-width="3" fill="none"/>')
+    svg = f'''<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 56 56" width="48" height="48"
+                  stroke="{color}" stroke-linecap="round" stroke-linejoin="round">
+  {g}
+</svg>'''
+    return Response(svg, media_type="image/svg+xml")
+
+
+@router.get("/hero.svg")
+async def hero_bg() -> Response:
+    svg = '''<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1440 600" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="g" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#1a3e30"/>
+      <stop offset="1" stop-color="#0a1410"/>
+    </linearGradient>
+    <radialGradient id="r" cx="0.7" cy="0.3" r="0.7">
+      <stop offset="0" stop-color="#1dbf73" stop-opacity="0.45"/>
+      <stop offset="1" stop-color="#0a1410" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <rect width="1440" height="600" fill="url(#g)"/>
+  <rect width="1440" height="600" fill="url(#r)"/>
+  <g fill="rgba(255,255,255,0.04)">
+    <circle cx="200" cy="120" r="50"/>
+    <circle cx="1100" cy="480" r="80"/>
+    <circle cx="1300" cy="160" r="32"/>
+  </g>
+</svg>'''
+    return Response(svg, media_type="image/svg+xml")

--- a/deploy/sim_envs/mantis_fiverr/app/routes/assets.py
+++ b/deploy/sim_envs/mantis_fiverr/app/routes/assets.py
@@ -6,7 +6,7 @@ deterministic seed-aware palettes.
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter
 from fastapi.responses import Response
 
 router = APIRouter(prefix="/assets")

--- a/deploy/sim_envs/mantis_fiverr/app/routes/auth_routes.py
+++ b/deploy/sim_envs/mantis_fiverr/app/routes/auth_routes.py
@@ -1,0 +1,112 @@
+"""/login + /signup + /logout — email/password only."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Form, HTTPException, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+
+from .. import auth, db, main as app_main
+
+router = APIRouter()
+
+
+def _templates(request: Request):
+    return request.app.state.templates
+
+
+@router.get("/login", response_class=HTMLResponse)
+async def login_form(request: Request):
+    return _templates(request).TemplateResponse(
+        "login.html",
+        {
+            "request": request,
+            "next": request.query_params.get("next", "/"),
+            "error": request.query_params.get("error", ""),
+        },
+    )
+
+
+@router.post("/login")
+async def login_submit(
+    request: Request,
+    login: str = Form(...),
+    password: str = Form(...),
+    next: str = Form("/"),
+):
+    user = auth.lookup_user_by_login(login)
+    if user is None or not auth.verify_password(password, user["password_hash"]):
+        return RedirectResponse(
+            url=f"/login?error=invalid+credentials&next={next}",
+            status_code=303,
+        )
+    if not next.startswith("/"):
+        next = "/"
+    resp = RedirectResponse(url=next, status_code=303)
+    auth.set_session_cookie(resp, user["id"])
+    with db.transaction() as tx:
+        db.log_audit(
+            tx,
+            occurred_at=app_main.now_value(),
+            operation="login_succeeded",
+            target_type="user",
+            target_id=user["id"],
+            payload={"role": user["role"]},
+        )
+    return resp
+
+
+@router.get("/signup", response_class=HTMLResponse)
+async def signup_form(request: Request):
+    return _templates(request).TemplateResponse(
+        "signup.html",
+        {"request": request, "error": request.query_params.get("error", "")},
+    )
+
+
+@router.post("/signup")
+async def signup_submit(
+    request: Request,
+    username: str = Form(...),
+    email: str = Form(...),
+    password: str = Form(...),
+    display_name: str = Form(""),
+):
+    conn = db.connect()
+    username = username.strip().lower()
+    email = email.strip().lower()
+    if not username or not email or not password:
+        return RedirectResponse(
+            url="/signup?error=all+fields+required", status_code=303,
+        )
+    if conn.execute("SELECT 1 FROM users WHERE username=? OR email=?",
+                    (username, email)).fetchone():
+        return RedirectResponse(
+            url="/signup?error=username+or+email+taken", status_code=303,
+        )
+    count = int(conn.execute("SELECT COUNT(*) FROM users WHERE role='buyer'").fetchone()[0])
+    uid = f"buyer_n{count+1:05d}"
+    with db.transaction() as tx:
+        tx.execute(
+            "INSERT INTO users (id, username, email, password_hash, role, "
+            "display_name, created_at) VALUES (?, ?, ?, ?, 'buyer', ?, ?)",
+            (uid, username, email, auth.hash_password(password),
+             display_name or username, app_main.now_value()),
+        )
+        db.log_audit(
+            tx,
+            occurred_at=app_main.now_value(),
+            operation="signup_succeeded",
+            target_type="user",
+            target_id=uid,
+            payload={"username": username},
+        )
+    resp = RedirectResponse(url="/", status_code=303)
+    auth.set_session_cookie(resp, uid)
+    return resp
+
+
+@router.get("/logout")
+async def logout(request: Request):
+    resp = RedirectResponse(url="/", status_code=303)
+    auth.clear_session_cookie(resp)
+    return resp

--- a/deploy/sim_envs/mantis_fiverr/app/routes/auth_routes.py
+++ b/deploy/sim_envs/mantis_fiverr/app/routes/auth_routes.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Form, HTTPException, Request
+from fastapi import APIRouter, Form, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
 
 from .. import auth, db, main as app_main

--- a/deploy/sim_envs/mantis_fiverr/app/routes/checkout.py
+++ b/deploy/sim_envs/mantis_fiverr/app/routes/checkout.py
@@ -1,0 +1,140 @@
+"""Checkout — confirm package + write order + redirect."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+from fastapi import APIRouter, Form, HTTPException, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+
+from .. import auth, db, main as app_main
+
+router = APIRouter()
+
+
+_TIER_PRICE_COL = {
+    "basic": ("pkg_basic_price", "pkg_basic_delivery_d", "pkg_basic_title"),
+    "standard": ("pkg_standard_price", "pkg_standard_delivery_d", "pkg_standard_title"),
+    "premium": ("pkg_premium_price", "pkg_premium_delivery_d", "pkg_premium_title"),
+}
+
+
+def _templates(request: Request):
+    return request.app.state.templates
+
+
+def _resolve_gig_full(conn, gig_id: str):
+    return conn.execute(
+        """SELECT g.*, u.username AS seller_username, u.display_name AS seller_display
+           FROM gigs g JOIN users u ON g.seller_id = u.id
+           WHERE g.id = ?""",
+        (gig_id,),
+    ).fetchone()
+
+
+def _tier_or_400(tier: str) -> str:
+    if tier not in _TIER_PRICE_COL:
+        raise HTTPException(status_code=400, detail="invalid tier")
+    return tier
+
+
+@router.get("/checkout/{gig_id}", response_class=HTMLResponse)
+async def checkout(request: Request, gig_id: str):
+    tier = _tier_or_400(request.query_params.get("tier", "basic"))
+    conn = db.connect()
+    gig = _resolve_gig_full(conn, gig_id)
+    if gig is None:
+        raise HTTPException(status_code=404, detail="gig not found")
+    price_col, delivery_col, title_col = _TIER_PRICE_COL[tier]
+    unit_price = gig[price_col]
+    service_fee = round(unit_price * 0.055 + 2.0, 2)
+    total = round(unit_price + service_fee, 2)
+    return _templates(request).TemplateResponse(
+        "checkout.html",
+        {
+            "request": request,
+            "gig": dict(gig),
+            "tier": tier,
+            "tier_title": gig[title_col],
+            "tier_delivery": gig[delivery_col],
+            "unit_price": unit_price,
+            "service_fee": service_fee,
+            "total": total,
+        },
+    )
+
+
+@router.post("/checkout/{gig_id}")
+async def submit(
+    request: Request,
+    gig_id: str,
+    tier: str = Form("basic"),
+    requirements: str = Form(""),
+    payment_method: str = Form("card"),
+):
+    tier = _tier_or_400(tier)
+    conn = db.connect()
+    gig = _resolve_gig_full(conn, gig_id)
+    if gig is None:
+        raise HTTPException(status_code=404, detail="gig not found")
+
+    price_col, delivery_col, title_col = _TIER_PRICE_COL[tier]
+    unit_price = float(gig[price_col])
+    service_fee = round(unit_price * 0.055 + 2.0, 2)
+    total = round(unit_price + service_fee, 2)
+    buyer_id = auth.effective_buyer_id(request)
+    seller_id = gig["seller_id"]
+
+    # Next order number — string concat for deterministic display id.
+    count = int(conn.execute("SELECT COUNT(*) FROM orders").fetchone()[0])
+    order_id = f"order_{count+1:05d}"
+    number = f"#FO{count+1:04d}"
+
+    placed_at = app_main.now_value()
+    try:
+        placed_dt = datetime.fromisoformat(placed_at.replace("Z", "+00:00"))
+    except Exception:  # noqa: BLE001
+        placed_dt = datetime.utcnow()
+    due_at = (placed_dt + timedelta(days=int(gig[delivery_col]))).isoformat()
+
+    with db.transaction() as tx:
+        tx.execute(
+            """INSERT INTO orders (
+                id, number, buyer_id, seller_id, gig_id, tier,
+                subtotal, service_fee, total, status, requirements,
+                placed_at, due_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'active', ?, ?, ?)""",
+            (order_id, number, buyer_id, seller_id, gig_id, tier,
+             unit_price, service_fee, total, requirements,
+             placed_at, due_at),
+        )
+        tx.execute(
+            "INSERT INTO order_items (id, order_id, line_no, description, "
+            "unit_price, quantity) VALUES (?, ?, 1, ?, ?, 1)",
+            (f"oi_{count+1:05d}", order_id,
+             f"{gig[title_col]} package",
+             unit_price),
+        )
+        tx.execute(
+            "UPDATE gigs SET orders_count = orders_count + 1 WHERE id = ?",
+            (gig_id,),
+        )
+        db.log_audit(
+            tx,
+            occurred_at=placed_at,
+            operation="order_placed",
+            target_type="order",
+            target_id=order_id,
+            payload={
+                "buyer_id": buyer_id,
+                "seller_id": seller_id,
+                "gig_id": gig_id,
+                "tier": tier,
+                "subtotal": unit_price,
+                "service_fee": service_fee,
+                "total": total,
+                "payment_method": payment_method,
+            },
+        )
+
+    return RedirectResponse(url=f"/orders/{order_id}", status_code=303)

--- a/deploy/sim_envs/mantis_fiverr/app/routes/env_admin.py
+++ b/deploy/sim_envs/mantis_fiverr/app/routes/env_admin.py
@@ -1,0 +1,160 @@
+"""Harness endpoints — ``/__env__/{health,reset,seed,clock,oracle,state,events,mutations}``.
+
+Same shape as mantis_shop. Every route except ``health`` is gated on
+``X-Env-Admin``.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse
+
+from .. import db, main as app_main, seed
+
+router = APIRouter(prefix="/__env__")
+
+
+@router.get("/health")
+async def health() -> JSONResponse:
+    conn = db.connect()
+    return JSONResponse({
+        "ok": True,
+        "seed": app_main.seed_value(),
+        "now": app_main.now_value(),
+        "boot_time": app_main.boot_time(),
+        "gigs": int(conn.execute("SELECT COUNT(*) FROM gigs").fetchone()[0]),
+    })
+
+
+@router.post("/reset")
+async def reset(request: Request) -> JSONResponse:
+    if not app_main.admin_token_ok(request):
+        return app_main.admin_required_response()
+    conn = db.connect()
+    seed.seed(conn, seed_val=app_main.seed_value(), fake_now=app_main.now_value())
+    app_main.clear_events()
+    app_main.emit("reset")
+    return JSONResponse({"ok": True})
+
+
+@router.post("/seed")
+async def reseed(request: Request) -> JSONResponse:
+    if not app_main.admin_token_ok(request):
+        return app_main.admin_required_response()
+    try:
+        payload = await request.json()
+    except Exception:  # noqa: BLE001
+        payload = {}
+    new_seed = int(payload.get("seed", app_main.seed_value()))
+    conn = db.connect()
+    seed.seed(conn, seed_val=new_seed, fake_now=app_main.now_value())
+    app_main.emit("reseeded", {"seed": new_seed})
+    return JSONResponse({"ok": True, "seed": new_seed})
+
+
+@router.post("/clock")
+async def clock(request: Request) -> JSONResponse:
+    if not app_main.admin_token_ok(request):
+        return app_main.admin_required_response()
+    try:
+        payload = await request.json()
+    except Exception:  # noqa: BLE001
+        payload = {}
+    new_now = str(payload.get("now") or app_main.now_value())
+    import os
+    os.environ["FAKE_NOW"] = new_now
+    app_main.emit("clock_set", {"now": new_now})
+    return JSONResponse({"ok": True, "now": new_now})
+
+
+@router.get("/oracle")
+async def oracle(request: Request) -> JSONResponse:
+    if not app_main.admin_token_ok(request):
+        return app_main.admin_required_response()
+    task_id = (request.query_params.get("task_id") or "").strip()
+    if not task_id:
+        return JSONResponse({
+            "passed": False, "score": 0.0,
+            "task_id": "",
+            "reasons": ["task_id is required"], "diff": {},
+        })
+    from ..oracles import grade
+    result = grade(task_id, db.connect(),
+                   now=app_main.now_value(),
+                   seed_val=app_main.seed_value())
+    app_main.emit("oracle_query", {"task_id": task_id, "passed": result["passed"]})
+    return JSONResponse(result)
+
+
+@router.get("/state")
+async def state(request: Request) -> JSONResponse:
+    if not app_main.admin_token_ok(request):
+        return app_main.admin_required_response()
+    conn = db.connect()
+
+    def count(table: str) -> int:
+        return int(conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0])
+
+    recent_audit = [
+        {
+            "id": r["id"],
+            "occurred_at": r["occurred_at"],
+            "operation": r["operation"],
+            "target_type": r["target_type"],
+            "target_id": r["target_id"],
+        }
+        for r in conn.execute(
+            "SELECT * FROM audit_log ORDER BY id DESC LIMIT 50"
+        ).fetchall()
+    ]
+    return JSONResponse({
+        "seed": app_main.seed_value(),
+        "now": app_main.now_value(),
+        "counts": {
+            "users": count("users"),
+            "sellers": count("sellers"),
+            "categories": count("categories"),
+            "gigs": count("gigs"),
+            "orders": count("orders"),
+            "conversations": count("conversations"),
+            "messages": count("messages"),
+            "reviews": count("reviews"),
+            "audit_log": count("audit_log"),
+        },
+        "recent_audit": recent_audit,
+    })
+
+
+@router.get("/events")
+async def events(request: Request) -> JSONResponse:
+    if not app_main.admin_token_ok(request):
+        return app_main.admin_required_response()
+    since = float(request.query_params.get("since") or 0)
+    return JSONResponse({"events": app_main.events_since(since)})
+
+
+@router.get("/mutations")
+async def mutations(request: Request) -> JSONResponse:
+    if not app_main.admin_token_ok(request):
+        return app_main.admin_required_response()
+    try:
+        since = int(request.query_params.get("since") or 0)
+    except (TypeError, ValueError):
+        since = 0
+    conn = db.connect()
+    rows = conn.execute(
+        "SELECT id, occurred_at, operation, target_type, target_id, payload_json "
+        "FROM audit_log WHERE id > ? ORDER BY id",
+        (since,)
+    ).fetchall()
+    return JSONResponse({"mutations": [
+        {
+            "id": r["id"],
+            "occurred_at": r["occurred_at"],
+            "operation": r["operation"],
+            "target_type": r["target_type"],
+            "target_id": r["target_id"],
+            "payload": db.unpack_json(r["payload_json"]) or {},
+        }
+        for r in rows
+    ]})

--- a/deploy/sim_envs/mantis_fiverr/app/routes/gig.py
+++ b/deploy/sim_envs/mantis_fiverr/app/routes/gig.py
@@ -1,0 +1,124 @@
+"""Gig detail (the canonical /<username>/<gig-slug> URL) + favorites."""
+
+from __future__ import annotations
+
+import json
+import secrets
+from typing import Any
+
+from fastapi import APIRouter, Form, HTTPException, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+
+from .. import auth, db, main as app_main
+
+router = APIRouter()
+
+
+def _templates(request: Request):
+    return request.app.state.templates
+
+
+def _resolve_gig(conn, username: str, slug: str) -> dict[str, Any] | None:
+    row = conn.execute(
+        """SELECT g.*, u.username AS seller_username, u.display_name AS seller_display,
+                  s.level AS seller_level, s.country AS seller_country,
+                  s.languages AS seller_languages, s.response_time_h AS seller_response_h,
+                  s.member_since AS seller_member_since,
+                  s.avg_rating AS seller_avg_rating, s.review_count AS seller_review_count,
+                  s.avatar_palette AS seller_avatar_palette
+           FROM gigs g
+           JOIN users u ON g.seller_id = u.id
+           JOIN sellers s ON g.seller_id = s.user_id
+           WHERE u.username = ? AND g.slug = ?""",
+        (username, slug),
+    ).fetchone()
+    if row is None:
+        return None
+    out = dict(row)
+    out["pkg_basic_features"] = db.unpack_json(out["pkg_basic_features"]) or []
+    out["pkg_standard_features"] = db.unpack_json(out["pkg_standard_features"]) or []
+    out["pkg_premium_features"] = db.unpack_json(out["pkg_premium_features"]) or []
+    out["seller_languages"] = db.unpack_json(out["seller_languages"]) or []
+    return out
+
+
+@router.get("/{username}/{slug}", response_class=HTMLResponse)
+async def gig_detail(request: Request, username: str, slug: str):
+    # Avoid swallowing the /static, /search, /categories, /checkout,
+    # /inbox, /orders, /login, /signup top-level prefixes.
+    if username in {
+        "static", "assets", "search", "categories", "checkout",
+        "inbox", "orders", "login", "signup", "logout", "favorite",
+        "__env__",
+    }:
+        raise HTTPException(status_code=404)
+    conn = db.connect()
+    gig = _resolve_gig(conn, username, slug)
+    if gig is None:
+        raise HTTPException(status_code=404, detail="gig not found")
+
+    reviews = [dict(r) for r in conn.execute(
+        """SELECT r.*, u.display_name AS buyer_display, u.username AS buyer_username
+           FROM reviews r
+           JOIN users u ON r.buyer_id = u.id
+           WHERE r.gig_id = ?
+           ORDER BY r.created_at DESC LIMIT 8""",
+        (gig["id"],),
+    ).fetchall()]
+
+    category_row = conn.execute(
+        "SELECT slug, title, parent_slug FROM categories WHERE slug = ?",
+        (gig["category_slug"],),
+    ).fetchone()
+    crumbs = [{"slug": "/", "title": "Home"}]
+    if category_row is not None:
+        if category_row["parent_slug"]:
+            parent = conn.execute(
+                "SELECT slug, title FROM categories WHERE slug = ?",
+                (category_row["parent_slug"],),
+            ).fetchone()
+            if parent:
+                crumbs.append({"slug": f"/categories/{parent['slug']}",
+                               "title": parent["title"]})
+        crumbs.append({"slug": f"/categories/{category_row['slug']}",
+                       "title": category_row["title"]})
+
+    return _templates(request).TemplateResponse(
+        "gig_detail.html",
+        {
+            "request": request,
+            "gig": gig,
+            "reviews": reviews,
+            "crumbs": crumbs,
+        },
+    )
+
+
+@router.post("/{username}/{slug}/favorite")
+async def favorite_gig(request: Request, username: str, slug: str):
+    conn = db.connect()
+    gig = _resolve_gig(conn, username, slug)
+    if gig is None:
+        raise HTTPException(status_code=404, detail="gig not found")
+    user_id = auth.effective_buyer_id(request)
+    with db.transaction() as tx:
+        try:
+            tx.execute(
+                "INSERT INTO favorites (user_id, gig_id, created_at) "
+                "VALUES (?, ?, ?)",
+                (user_id, gig["id"], app_main.now_value()),
+            )
+        except Exception:  # noqa: BLE001
+            tx.execute(
+                "DELETE FROM favorites WHERE user_id=? AND gig_id=?",
+                (user_id, gig["id"]),
+            )
+        db.log_audit(
+            tx,
+            occurred_at=app_main.now_value(),
+            operation="favorite_toggled",
+            target_type="gig",
+            target_id=gig["id"],
+            payload={"user_id": user_id},
+        )
+    return RedirectResponse(url=f"/{username}/{slug}", status_code=303)

--- a/deploy/sim_envs/mantis_fiverr/app/routes/gig.py
+++ b/deploy/sim_envs/mantis_fiverr/app/routes/gig.py
@@ -2,11 +2,9 @@
 
 from __future__ import annotations
 
-import json
-import secrets
 from typing import Any
 
-from fastapi import APIRouter, Form, HTTPException, Request
+from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
 
 from .. import auth, db, main as app_main

--- a/deploy/sim_envs/mantis_fiverr/app/routes/inbox.py
+++ b/deploy/sim_envs/mantis_fiverr/app/routes/inbox.py
@@ -1,0 +1,175 @@
+"""Inbox + thread surfaces. Buyer-facing only for now."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Form, HTTPException, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+
+from .. import auth, db, main as app_main
+
+router = APIRouter()
+
+
+def _templates(request: Request):
+    return request.app.state.templates
+
+
+@router.get("/inbox", response_class=HTMLResponse)
+async def inbox_list(request: Request):
+    conn = db.connect()
+    me = auth.effective_buyer_id(request)
+    rows = conn.execute(
+        """SELECT c.id, c.seller_id, c.last_msg_at,
+                  u.display_name AS seller_display,
+                  u.username AS seller_username,
+                  s.avatar_palette AS seller_avatar_palette,
+                  (SELECT body FROM messages m WHERE m.conversation_id = c.id
+                   ORDER BY m.created_at DESC LIMIT 1) AS last_body
+           FROM conversations c
+           JOIN users u ON c.seller_id = u.id
+           JOIN sellers s ON c.seller_id = s.user_id
+           WHERE c.buyer_id = ?
+           ORDER BY c.last_msg_at DESC""",
+        (me,),
+    ).fetchall()
+    return _templates(request).TemplateResponse(
+        "inbox.html",
+        {
+            "request": request,
+            "threads": [dict(r) for r in rows],
+            "active_thread": None,
+            "messages": [],
+            "me": me,
+        },
+    )
+
+
+@router.get("/inbox/{thread_id}", response_class=HTMLResponse)
+async def inbox_thread(request: Request, thread_id: str):
+    conn = db.connect()
+    me = auth.effective_buyer_id(request)
+    thread = conn.execute(
+        """SELECT c.id, c.seller_id, c.last_msg_at,
+                  u.display_name AS seller_display,
+                  u.username AS seller_username,
+                  s.country AS seller_country,
+                  s.avatar_palette AS seller_avatar_palette
+           FROM conversations c
+           JOIN users u ON c.seller_id = u.id
+           JOIN sellers s ON c.seller_id = s.user_id
+           WHERE c.id = ? AND c.buyer_id = ?""",
+        (thread_id, me),
+    ).fetchone()
+    if thread is None:
+        raise HTTPException(status_code=404, detail="thread not found")
+    rows = conn.execute(
+        """SELECT m.*, u.display_name AS sender_display, u.username AS sender_username
+           FROM messages m JOIN users u ON m.sender_id = u.id
+           WHERE m.conversation_id = ? ORDER BY m.created_at""",
+        (thread_id,),
+    ).fetchall()
+    # Other threads for sidebar.
+    threads = conn.execute(
+        """SELECT c.id, c.seller_id, c.last_msg_at,
+                  u.display_name AS seller_display,
+                  u.username AS seller_username,
+                  s.avatar_palette AS seller_avatar_palette,
+                  (SELECT body FROM messages m WHERE m.conversation_id = c.id
+                   ORDER BY m.created_at DESC LIMIT 1) AS last_body
+           FROM conversations c
+           JOIN users u ON c.seller_id = u.id
+           JOIN sellers s ON c.seller_id = s.user_id
+           WHERE c.buyer_id = ?
+           ORDER BY c.last_msg_at DESC""",
+        (me,),
+    ).fetchall()
+    return _templates(request).TemplateResponse(
+        "inbox.html",
+        {
+            "request": request,
+            "threads": [dict(r) for r in threads],
+            "active_thread": dict(thread),
+            "messages": [dict(r) for r in rows],
+            "me": me,
+        },
+    )
+
+
+@router.post("/inbox/{thread_id}/send")
+async def send_message(
+    request: Request,
+    thread_id: str,
+    body: str = Form(...),
+):
+    body = body.strip()
+    if not body:
+        return RedirectResponse(url=f"/inbox/{thread_id}", status_code=303)
+    conn = db.connect()
+    me = auth.effective_buyer_id(request)
+    thread = conn.execute(
+        "SELECT id, buyer_id, seller_id FROM conversations WHERE id = ? AND buyer_id = ?",
+        (thread_id, me),
+    ).fetchone()
+    if thread is None:
+        raise HTTPException(status_code=404, detail="thread not found")
+    msg_count = int(conn.execute(
+        "SELECT COUNT(*) FROM messages WHERE conversation_id = ?",
+        (thread_id,)
+    ).fetchone()[0])
+    msg_id = f"msg_{thread_id}_{msg_count+1}"
+    now = app_main.now_value()
+    with db.transaction() as tx:
+        tx.execute(
+            "INSERT INTO messages (id, conversation_id, sender_id, body, created_at) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (msg_id, thread_id, me, body, now),
+        )
+        tx.execute(
+            "UPDATE conversations SET last_msg_at = ? WHERE id = ?",
+            (now, thread_id),
+        )
+        db.log_audit(
+            tx,
+            occurred_at=now,
+            operation="message_sent",
+            target_type="conversation",
+            target_id=thread_id,
+            payload={
+                "sender_id": me,
+                "recipient_id": thread["seller_id"],
+                "message_id": msg_id,
+                "body": body,
+            },
+        )
+    return RedirectResponse(url=f"/inbox/{thread_id}", status_code=303)
+
+
+@router.get("/inbox/new/{seller_id}")
+async def open_thread_with_seller(request: Request, seller_id: str):
+    """Open or create a thread with a seller; redirect to it."""
+    conn = db.connect()
+    me = auth.effective_buyer_id(request)
+    row = conn.execute(
+        "SELECT id FROM conversations WHERE buyer_id = ? AND seller_id = ?",
+        (me, seller_id),
+    ).fetchone()
+    if row is not None:
+        return RedirectResponse(url=f"/inbox/{row['id']}", status_code=303)
+    count = int(conn.execute("SELECT COUNT(*) FROM conversations").fetchone()[0])
+    cid = f"conv_{count+1:05d}"
+    now = app_main.now_value()
+    with db.transaction() as tx:
+        tx.execute(
+            "INSERT INTO conversations (id, buyer_id, seller_id, last_msg_at) "
+            "VALUES (?, ?, ?, ?)",
+            (cid, me, seller_id, now),
+        )
+        db.log_audit(
+            tx,
+            occurred_at=now,
+            operation="conversation_opened",
+            target_type="conversation",
+            target_id=cid,
+            payload={"buyer_id": me, "seller_id": seller_id},
+        )
+    return RedirectResponse(url=f"/inbox/{cid}", status_code=303)

--- a/deploy/sim_envs/mantis_fiverr/app/routes/orders.py
+++ b/deploy/sim_envs/mantis_fiverr/app/routes/orders.py
@@ -1,0 +1,147 @@
+"""Buyer order list + detail + review submission."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Form, HTTPException, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+
+from .. import auth, db, main as app_main
+
+router = APIRouter()
+
+
+def _templates(request: Request):
+    return request.app.state.templates
+
+
+@router.get("/orders", response_class=HTMLResponse)
+async def order_list(request: Request):
+    conn = db.connect()
+    me = auth.effective_buyer_id(request)
+    status_filter = request.query_params.get("status", "all")
+    where = "WHERE o.buyer_id = ?"
+    params: list = [me]
+    if status_filter in {"active", "delivered", "completed", "cancelled"}:
+        where += " AND o.status = ?"
+        params.append(status_filter)
+    rows = conn.execute(
+        f"""SELECT o.*, g.title AS gig_title, g.slug AS gig_slug,
+                  u.username AS seller_username,
+                  u.display_name AS seller_display
+            FROM orders o
+            JOIN gigs g ON o.gig_id = g.id
+            JOIN users u ON o.seller_id = u.id
+            {where}
+            ORDER BY o.placed_at DESC""",
+        params,
+    ).fetchall()
+    counts_raw = conn.execute(
+        "SELECT status, COUNT(*) c FROM orders WHERE buyer_id = ? GROUP BY status",
+        (me,),
+    ).fetchall()
+    counts = {r["status"]: int(r["c"]) for r in counts_raw}
+    counts["all"] = sum(counts.values())
+    return _templates(request).TemplateResponse(
+        "orders.html",
+        {
+            "request": request,
+            "orders": [dict(r) for r in rows],
+            "status_filter": status_filter,
+            "counts": counts,
+        },
+    )
+
+
+@router.get("/orders/{order_id}", response_class=HTMLResponse)
+async def order_detail(request: Request, order_id: str):
+    conn = db.connect()
+    row = conn.execute(
+        """SELECT o.*, g.title AS gig_title, g.slug AS gig_slug, g.image_palette,
+                  u.username AS seller_username,
+                  u.display_name AS seller_display
+           FROM orders o
+           JOIN gigs g ON o.gig_id = g.id
+           JOIN users u ON o.seller_id = u.id
+           WHERE o.id = ?""",
+        (order_id,),
+    ).fetchone()
+    if row is None:
+        raise HTTPException(status_code=404, detail="order not found")
+    items = [dict(r) for r in conn.execute(
+        "SELECT * FROM order_items WHERE order_id = ? ORDER BY line_no",
+        (order_id,),
+    ).fetchall()]
+    review = conn.execute(
+        "SELECT * FROM reviews WHERE order_id = ?", (order_id,)
+    ).fetchone()
+    return _templates(request).TemplateResponse(
+        "order_detail.html",
+        {
+            "request": request,
+            "order": dict(row),
+            "items": items,
+            "review": dict(review) if review else None,
+        },
+    )
+
+
+@router.post("/orders/{order_id}/review")
+async def submit_review(
+    request: Request,
+    order_id: str,
+    stars: int = Form(...),
+    body: str = Form(""),
+):
+    if stars < 1 or stars > 5:
+        raise HTTPException(status_code=400, detail="stars must be 1..5")
+    conn = db.connect()
+    order = conn.execute(
+        "SELECT id, buyer_id, seller_id, gig_id, status FROM orders WHERE id = ?",
+        (order_id,),
+    ).fetchone()
+    if order is None:
+        raise HTTPException(status_code=404, detail="order not found")
+    if order["status"] != "completed":
+        # Mark complete on review submission for verification flows.
+        pass
+    if conn.execute("SELECT 1 FROM reviews WHERE order_id = ?", (order_id,)).fetchone():
+        raise HTTPException(status_code=409, detail="review already exists")
+    review_id = f"review_{order_id}"
+    now = app_main.now_value()
+    with db.transaction() as tx:
+        tx.execute(
+            "INSERT INTO reviews (id, order_id, gig_id, buyer_id, seller_id, "
+            "stars, body, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (review_id, order_id, order["gig_id"], order["buyer_id"],
+             order["seller_id"], int(stars), body.strip(), now),
+        )
+        # Recompute the gig's avg rating + review count.
+        row = tx.execute(
+            "SELECT AVG(stars) AS avg, COUNT(*) AS cnt FROM reviews "
+            "WHERE gig_id = ?",
+            (order["gig_id"],),
+        ).fetchone()
+        new_avg = float(row["avg"] or 0.0)
+        new_cnt = int(row["cnt"] or 0)
+        tx.execute(
+            "UPDATE gigs SET avg_rating = ?, review_count = ? WHERE id = ?",
+            (round(new_avg, 2), new_cnt, order["gig_id"]),
+        )
+        db.log_audit(
+            tx,
+            occurred_at=now,
+            operation="review_submitted",
+            target_type="review",
+            target_id=review_id,
+            payload={
+                "order_id": order_id,
+                "gig_id": order["gig_id"],
+                "buyer_id": order["buyer_id"],
+                "seller_id": order["seller_id"],
+                "stars": int(stars),
+                "body": body.strip(),
+                "new_avg_rating": round(new_avg, 2),
+                "new_review_count": new_cnt,
+            },
+        )
+    return RedirectResponse(url=f"/orders/{order_id}", status_code=303)

--- a/deploy/sim_envs/mantis_fiverr/app/routes/storefront.py
+++ b/deploy/sim_envs/mantis_fiverr/app/routes/storefront.py
@@ -1,0 +1,182 @@
+"""Home, search, category landing — the discovery surface."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Request
+from fastapi.responses import HTMLResponse
+
+from .. import db, main as app_main
+
+router = APIRouter()
+
+
+def _templates(request: Request):
+    return request.app.state.templates
+
+
+def _gig_card_row(row: Any) -> dict[str, Any]:
+    return {
+        "id": row["id"],
+        "slug": row["slug"],
+        "title": row["title"],
+        "seller_id": row["seller_id"],
+        "seller_username": row["seller_username"],
+        "seller_display": row["seller_display"],
+        "seller_level": row["seller_level"],
+        "seller_avatar_palette": row["seller_avatar_palette"],
+        "basic_price": row["pkg_basic_price"],
+        "avg_rating": row["avg_rating"],
+        "review_count": row["review_count"],
+        "image_palette": row["image_palette"],
+        "category_slug": row["category_slug"],
+    }
+
+
+GIG_CARD_SELECT = """
+    SELECT g.id, g.slug, g.title, g.seller_id, g.pkg_basic_price,
+           g.avg_rating, g.review_count, g.image_palette, g.category_slug,
+           u.username AS seller_username,
+           u.display_name AS seller_display,
+           s.level AS seller_level,
+           s.avatar_palette AS seller_avatar_palette
+    FROM gigs g
+    JOIN users u ON g.seller_id = u.id
+    JOIN sellers s ON g.seller_id = s.user_id
+"""
+
+
+@router.get("/", response_class=HTMLResponse)
+async def home(request: Request):
+    conn = db.connect()
+    # Popular categories — top-level only (parent_slug IS NULL).
+    cats = [dict(r) for r in conn.execute(
+        "SELECT slug, title, icon FROM categories WHERE parent_slug IS NULL "
+        "ORDER BY sort_order"
+    ).fetchall()]
+    # Featured 8 gigs — ordered by orders_count desc.
+    featured = [
+        _gig_card_row(r) for r in conn.execute(
+            GIG_CARD_SELECT + " ORDER BY g.orders_count DESC LIMIT 8"
+        ).fetchall()
+    ]
+    popular_chips = ["Website Design", "WordPress", "Logo Design", "AI Services"]
+    return _templates(request).TemplateResponse(
+        "home.html",
+        {
+            "request": request,
+            "categories": cats,
+            "featured": featured,
+            "popular_chips": popular_chips,
+        },
+    )
+
+
+@router.get("/search/gigs", response_class=HTMLResponse)
+async def search(request: Request):
+    conn = db.connect()
+    qp = request.query_params
+    query = qp.get("query", "").strip()
+    sort = qp.get("sort", "relevance")
+    level_filters = qp.getlist("level")
+    budget = qp.get("budget", "")
+    delivery = qp.get("delivery", "")
+    try:
+        page = max(1, int(qp.get("page", 1)))
+    except (TypeError, ValueError):
+        page = 1
+    per_page = 12
+
+    where: list[str] = []
+    params: list[Any] = []
+    if query:
+        where.append("(LOWER(g.title) LIKE ? OR LOWER(g.category_slug) LIKE ?)")
+        ql = f"%{query.lower()}%"
+        params.extend([ql, ql])
+    if level_filters:
+        where.append("s.level IN (" + ",".join("?" * len(level_filters)) + ")")
+        params.extend(level_filters)
+    if budget == "value":
+        where.append("g.pkg_basic_price <= 50")
+    elif budget == "mid":
+        where.append("g.pkg_basic_price > 50 AND g.pkg_basic_price <= 200")
+    elif budget == "high":
+        where.append("g.pkg_basic_price > 200")
+    if delivery == "express":
+        where.append("g.pkg_basic_delivery_d <= 1")
+    elif delivery == "3d":
+        where.append("g.pkg_basic_delivery_d <= 3")
+    elif delivery == "7d":
+        where.append("g.pkg_basic_delivery_d <= 7")
+    where_sql = (" WHERE " + " AND ".join(where)) if where else ""
+
+    if sort == "best_selling":
+        order_sql = " ORDER BY g.orders_count DESC"
+    elif sort == "newest":
+        order_sql = " ORDER BY g.created_at DESC"
+    elif sort == "rating":
+        order_sql = " ORDER BY g.avg_rating DESC"
+    else:  # relevance
+        order_sql = " ORDER BY g.review_count DESC"
+
+    total = int(conn.execute(
+        "SELECT COUNT(*) FROM gigs g JOIN sellers s ON g.seller_id = s.user_id"
+        + where_sql, params
+    ).fetchone()[0])
+
+    offset = (page - 1) * per_page
+    rows = conn.execute(
+        GIG_CARD_SELECT + where_sql + order_sql + f" LIMIT {per_page} OFFSET {offset}",
+        params,
+    ).fetchall()
+    results = [_gig_card_row(r) for r in rows]
+    pages = max(1, (total + per_page - 1) // per_page)
+
+    return _templates(request).TemplateResponse(
+        "search.html",
+        {
+            "request": request,
+            "query": query,
+            "results": results,
+            "total": total,
+            "page": page,
+            "pages": pages,
+            "sort": sort,
+            "level_filters": level_filters,
+            "budget": budget,
+            "delivery": delivery,
+        },
+    )
+
+
+@router.get("/categories/{slug}", response_class=HTMLResponse)
+async def category(request: Request, slug: str):
+    conn = db.connect()
+    cat = conn.execute(
+        "SELECT slug, title, parent_slug, icon FROM categories WHERE slug = ?",
+        (slug,),
+    ).fetchone()
+    if cat is None:
+        return HTMLResponse("Category not found", status_code=404)
+    cat = dict(cat)
+    subs = [dict(r) for r in conn.execute(
+        "SELECT slug, title, icon FROM categories WHERE parent_slug = ? "
+        "ORDER BY sort_order",
+        (slug,),
+    ).fetchall()]
+    rows = conn.execute(
+        GIG_CARD_SELECT + " WHERE g.category_slug = ? OR g.category_slug IN ("
+        "SELECT slug FROM categories WHERE parent_slug = ?) "
+        "ORDER BY g.review_count DESC LIMIT 12",
+        (slug, slug),
+    ).fetchall()
+    return _templates(request).TemplateResponse(
+        "category.html",
+        {
+            "request": request,
+            "category": cat,
+            "subcategories": subs,
+            "results": [_gig_card_row(r) for r in rows],
+        },
+    )

--- a/deploy/sim_envs/mantis_fiverr/app/routes/storefront.py
+++ b/deploy/sim_envs/mantis_fiverr/app/routes/storefront.py
@@ -7,7 +7,7 @@ from typing import Any
 from fastapi import APIRouter, Request
 from fastapi.responses import HTMLResponse
 
-from .. import db, main as app_main
+from .. import db
 
 router = APIRouter()
 

--- a/deploy/sim_envs/mantis_fiverr/app/seed.py
+++ b/deploy/sim_envs/mantis_fiverr/app/seed.py
@@ -11,7 +11,6 @@ import json
 import random
 import sqlite3
 from datetime import datetime, timedelta
-from typing import Any
 
 FAKE_NOW_DEFAULT = "2026-06-01T12:00:00Z"
 
@@ -201,9 +200,9 @@ def seed(conn: sqlite3.Connection, *, seed_val: int, fake_now: str) -> None:
                     i % 8,
                     f"Get started with the {title.split()[3] if len(title.split()) > 3 else 'core'} package — perfect for testing the waters.",
                     basic_price, basic_delivery, basic_revs, json.dumps(basic_feats),
-                    f"Most popular — adds extra polish and faster turnaround.",
+                    "Most popular — adds extra polish and faster turnaround.",
                     std_price, max(1, basic_delivery + 1), basic_revs + 1, json.dumps(std_feats),
-                    f"Everything in Standard plus dedicated support and source files.",
+                    "Everything in Standard plus dedicated support and source files.",
                     prem_price, basic_delivery + 3, basic_revs + 2, json.dumps(prem_feats),
                     round(4.4 + rng.random() * 0.6, 1),
                     20 + rng.randrange(0, 200),

--- a/deploy/sim_envs/mantis_fiverr/app/seed.py
+++ b/deploy/sim_envs/mantis_fiverr/app/seed.py
@@ -1,0 +1,353 @@
+"""Deterministic seed for mantis-fiverr.
+
+Same SEED → identical IDs + identical column values across runs. The
+oracle pass conditions depend on this stability.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import random
+import sqlite3
+from datetime import datetime, timedelta
+from typing import Any
+
+FAKE_NOW_DEFAULT = "2026-06-01T12:00:00Z"
+
+# Canonical categories — flat list mirroring the home tiles + a handful
+# of subcategories so /categories/<slug> has variety.
+CATEGORIES: list[tuple[str, str, str | None, str, int]] = [
+    # (slug, title, parent_slug, icon, sort_order)
+    ("graphics-design", "Graphics & Design", None, "palette", 1),
+    ("programming-tech", "Programming & Tech", None, "code", 2),
+    ("digital-marketing", "Digital Marketing", None, "megaphone", 3),
+    ("video-animation", "Video & Animation", None, "film", 4),
+    ("writing-translation", "Writing & Translation", None, "pen", 5),
+    ("music-audio", "Music & Audio", None, "headphones", 6),
+    ("business", "Business", None, "briefcase", 7),
+    ("data", "Data", None, "database", 8),
+    ("photography", "Photography", None, "camera", 9),
+    ("ai-services", "AI Services", None, "sparkles", 10),
+    ("lifestyle", "Lifestyle", None, "heart", 11),
+    ("consulting", "Consulting", None, "chat", 12),
+    # subcats of graphics-design
+    ("logo-design", "Logo Design", "graphics-design", "circle", 1),
+    ("brand-style-guide", "Brand Style Guide", "graphics-design", "book", 2),
+    ("business-cards", "Business Cards & Stationery", "graphics-design", "card", 3),
+    ("illustration", "Illustration", "graphics-design", "brush", 4),
+    ("web-mobile-design", "Web & Mobile Design", "graphics-design", "monitor", 5),
+    # subcats of programming-tech
+    ("website-development", "Website Development", "programming-tech", "code", 1),
+    ("wordpress", "WordPress", "programming-tech", "code", 2),
+    ("mobile-apps", "Mobile Apps", "programming-tech", "phone", 3),
+]
+
+# (slug, title, category, basic_price, basic_delivery_d, basic_revs)
+GIG_SEEDS: list[tuple[str, str, str, float, int, int]] = [
+    ("modern-minimalist-logo", "I will design a modern minimalist logo for your business", "logo-design", 25.0, 2, 2),
+    ("professional-wordpress-site", "I will build a professional WordPress website with elementor", "wordpress", 95.0, 5, 1),
+    ("explainer-video-2d", "I will create a 2D animated explainer video for your product", "video-animation", 75.0, 5, 2),
+    ("hand-drawn-illustration", "I will create a custom hand-drawn illustration for your project", "illustration", 50.0, 4, 2),
+    ("seo-audit-report", "I will provide a comprehensive seo audit report with action items", "digital-marketing", 35.0, 3, 1),
+    ("translate-en-to-es", "I will translate english to spanish 1000 words professionally", "writing-translation", 20.0, 2, 3),
+    ("voice-over-male-american", "I will record a professional voice over in american english", "music-audio", 30.0, 2, 2),
+    ("react-frontend-app", "I will develop a fast and modern react frontend application", "programming-tech", 150.0, 7, 1),
+    ("brand-style-guide-pdf", "I will create a complete brand style guide pdf document", "brand-style-guide", 120.0, 7, 2),
+    ("business-card-design", "I will design a professional double-sided business card", "business-cards", 15.0, 2, 3),
+    ("data-cleaning-excel", "I will clean and analyze your messy excel data professionally", "data", 40.0, 3, 2),
+    ("ai-chatbot-prompt-engineering", "I will engineer effective prompts for your ai chatbot", "ai-services", 60.0, 3, 2),
+    ("instagram-content-strategy", "I will create a 30 day instagram content strategy", "digital-marketing", 45.0, 4, 2),
+    ("ux-research-interviews", "I will conduct ux research interviews and synthesize findings", "consulting", 200.0, 10, 1),
+    ("product-photography-edit", "I will edit your product photography to ecommerce standards", "photography", 25.0, 2, 3),
+    ("mobile-app-design-figma", "I will design a beautiful mobile app ui in figma", "web-mobile-design", 180.0, 7, 2),
+    ("react-native-mobile-app", "I will build a cross platform react native mobile app", "mobile-apps", 350.0, 14, 1),
+    ("blog-post-writing-1000w", "I will write a 1000 word seo optimized blog post", "writing-translation", 30.0, 3, 2),
+    ("custom-vector-illustration", "I will create custom vector illustrations for your needs", "illustration", 45.0, 4, 2),
+    ("podcast-editing-1hr", "I will edit your podcast episode up to 1 hour professionally", "music-audio", 50.0, 3, 2),
+    ("shopify-store-setup", "I will set up your shopify store from scratch", "programming-tech", 250.0, 10, 1),
+    ("google-ads-setup", "I will set up your google ads campaign for conversions", "digital-marketing", 85.0, 5, 2),
+    ("startup-pitch-deck", "I will design a stunning startup pitch deck", "business", 150.0, 5, 2),
+    ("brand-name-suggestions", "I will suggest creative brand names for your startup", "business", 25.0, 2, 3),
+    ("youtube-thumbnail-design", "I will design eye catching youtube thumbnails", "graphics-design", 10.0, 1, 3),
+    ("python-data-script", "I will write a python script for data automation", "programming-tech", 65.0, 3, 1),
+    ("character-illustration", "I will draw a custom character illustration for your brand", "illustration", 70.0, 5, 2),
+    ("email-marketing-template", "I will design a responsive email marketing template", "digital-marketing", 40.0, 3, 2),
+    ("article-rewriting-seo", "I will rewrite your article for better seo and readability", "writing-translation", 20.0, 2, 3),
+    ("custom-music-jingle", "I will compose a custom music jingle for your brand", "music-audio", 80.0, 5, 2),
+]
+
+
+COUNTRIES = ["United States", "United Kingdom", "Canada", "Australia",
+             "Germany", "France", "Netherlands", "India", "Brazil",
+             "Spain", "Pakistan", "Argentina"]
+LANGS = [["English"], ["English", "Spanish"], ["English", "French"],
+         ["English", "German"], ["English", "Portuguese"],
+         ["English", "Hindi", "Urdu"]]
+LEVELS_DIST = ["new", "level_one", "level_one", "level_two",
+               "level_two", "level_two", "top_rated"]
+
+
+def _id_for(prefix: str, n: int) -> str:
+    return f"{prefix}_{n:05d}"
+
+
+def _hash_password(plain: str) -> str:
+    return hashlib.sha256(plain.encode("utf-8")).hexdigest()
+
+
+def _wipe(conn: sqlite3.Connection) -> None:
+    for tbl in (
+        "audit_log", "favorites", "reviews", "messages", "conversations",
+        "order_items", "orders", "gigs", "sellers", "users",
+        "categories",
+    ):
+        conn.execute(f"DELETE FROM {tbl}")
+
+
+def seed(conn: sqlite3.Connection, *, seed_val: int, fake_now: str) -> None:
+    rng = random.Random(seed_val)
+    now = datetime.fromisoformat(fake_now.replace("Z", "+00:00"))
+
+    with conn:
+        _wipe(conn)
+
+        # Categories ------------------------------------------------
+        for slug, title, parent, icon, order in CATEGORIES:
+            conn.execute(
+                "INSERT INTO categories (slug, title, parent_slug, icon, sort_order) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (slug, title, parent, icon, order),
+            )
+
+        # Buyers ----------------------------------------------------
+        # buyer_00001 is the canonical "you" the oracles grade against.
+        buyer_ids: list[str] = []
+        for i in range(1, 21):
+            uid = _id_for("buyer", i)
+            uname = f"buyer{i:02d}"
+            email = f"{uname}@mantis.example"
+            display = f"Buyer {i:02d}"
+            conn.execute(
+                "INSERT INTO users (id, username, email, password_hash, role, display_name, created_at) "
+                "VALUES (?, ?, ?, ?, 'buyer', ?, ?)",
+                (uid, uname, email, _hash_password("password"), display,
+                 (now - timedelta(days=200 - i)).isoformat()),
+            )
+            buyer_ids.append(uid)
+
+        # Sellers ---------------------------------------------------
+        seller_ids: list[str] = []
+        for i in range(1, 31):
+            uid = _id_for("seller", i)
+            uname = f"seller{i:02d}"
+            email = f"{uname}@mantis.example"
+            display = f"Seller {i:02d}"
+            conn.execute(
+                "INSERT INTO users (id, username, email, password_hash, role, display_name, created_at) "
+                "VALUES (?, ?, ?, ?, 'seller', ?, ?)",
+                (uid, uname, email, _hash_password("password"), display,
+                 (now - timedelta(days=400 - i * 7)).isoformat()),
+            )
+            level = LEVELS_DIST[(i + seed_val) % len(LEVELS_DIST)]
+            country = COUNTRIES[(i * 7 + seed_val) % len(COUNTRIES)]
+            languages = LANGS[(i * 3 + seed_val) % len(LANGS)]
+            conn.execute(
+                "INSERT INTO sellers (user_id, level, country, languages, "
+                "response_time_h, member_since, avatar_palette) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (uid, level, country, json.dumps(languages),
+                 1 + (i * 3) % 12,
+                 (now - timedelta(days=400 - i * 7)).isoformat(),
+                 i % 8),
+            )
+            seller_ids.append(uid)
+
+        # Gigs ------------------------------------------------------
+        gig_ids: list[str] = []
+        for i, (slug, title, cat, basic_price, basic_delivery, basic_revs) in enumerate(GIG_SEEDS, start=1):
+            gid = _id_for("gig", i)
+            seller = seller_ids[(i + seed_val) % len(seller_ids)]
+            # Three-tier pricing: standard = basic*2.6, premium = basic*5
+            std_price = round(basic_price * 2.4, 0)
+            prem_price = round(basic_price * 4.8, 0)
+            # Common feature lists
+            basic_feats = ["1 concept included", f"{basic_delivery}-day delivery",
+                           f"{basic_revs} revision" + ("s" if basic_revs != 1 else ""),
+                           "Source file"]
+            std_feats = basic_feats + ["High resolution", "Vector file"]
+            prem_feats = std_feats + ["3D mockup", "Commercial use", "Stationery design"]
+
+            conn.execute(
+                """INSERT INTO gigs (
+                    id, seller_id, slug, title, description_md, category_slug,
+                    image_palette,
+                    pkg_basic_title, pkg_basic_desc, pkg_basic_price,
+                    pkg_basic_delivery_d, pkg_basic_revisions, pkg_basic_features,
+                    pkg_standard_title, pkg_standard_desc, pkg_standard_price,
+                    pkg_standard_delivery_d, pkg_standard_revisions, pkg_standard_features,
+                    pkg_premium_title, pkg_premium_desc, pkg_premium_price,
+                    pkg_premium_delivery_d, pkg_premium_revisions, pkg_premium_features,
+                    avg_rating, review_count, orders_count, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?,
+                          'Basic', ?, ?, ?, ?, ?,
+                          'Standard', ?, ?, ?, ?, ?,
+                          'Premium', ?, ?, ?, ?, ?,
+                          ?, ?, ?, ?)""",
+                (
+                    gid, seller, slug, title.title(),
+                    _gig_description(title, slug),
+                    cat,
+                    i % 8,
+                    f"Get started with the {title.split()[3] if len(title.split()) > 3 else 'core'} package — perfect for testing the waters.",
+                    basic_price, basic_delivery, basic_revs, json.dumps(basic_feats),
+                    f"Most popular — adds extra polish and faster turnaround.",
+                    std_price, max(1, basic_delivery + 1), basic_revs + 1, json.dumps(std_feats),
+                    f"Everything in Standard plus dedicated support and source files.",
+                    prem_price, basic_delivery + 3, basic_revs + 2, json.dumps(prem_feats),
+                    round(4.4 + rng.random() * 0.6, 1),
+                    20 + rng.randrange(0, 200),
+                    50 + rng.randrange(0, 500),
+                    (now - timedelta(days=30 + (i * 11) % 300)).isoformat(),
+                ),
+            )
+            gig_ids.append(gid)
+
+        # Orders ----------------------------------------------------
+        # Seed ~15 historical orders. The oracles look at specific ids:
+        # gig_00001 Basic order placed during the run (t01),
+        # order_00007 must be completed + reviewable (t03).
+        for n in range(1, 16):
+            oid = _id_for("order", n)
+            buyer = buyer_ids[(n - 1) % len(buyer_ids)]
+            gid = gig_ids[(n + 3) % len(gig_ids)]
+            gig_row = conn.execute(
+                "SELECT seller_id, pkg_basic_price, pkg_standard_price, pkg_premium_price "
+                "FROM gigs WHERE id = ?", (gid,)
+            ).fetchone()
+            tier_idx = (n + seed_val) % 3
+            tier = ["basic", "standard", "premium"][tier_idx]
+            price_col = {
+                "basic": "pkg_basic_price",
+                "standard": "pkg_standard_price",
+                "premium": "pkg_premium_price",
+            }[tier]
+            unit_price = gig_row[price_col]
+            service_fee = round(unit_price * 0.055 + 2.0, 2)
+            total = round(unit_price + service_fee, 2)
+            placed_at = now - timedelta(days=60 - n * 3)
+            due_at = placed_at + timedelta(days=5)
+            status = "completed" if n <= 8 else ("delivered" if n <= 11 else "active")
+            delivered = (placed_at + timedelta(days=3)).isoformat() if status != "active" else None
+            completed = (placed_at + timedelta(days=4)).isoformat() if status == "completed" else None
+            conn.execute(
+                """INSERT INTO orders (
+                    id, number, buyer_id, seller_id, gig_id, tier,
+                    subtotal, service_fee, total, status, requirements,
+                    placed_at, due_at, delivered_at, completed_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, '',
+                         ?, ?, ?, ?)""",
+                (oid, f"#FO{n:04d}", buyer, gig_row["seller_id"], gid, tier,
+                 unit_price, service_fee, total, status,
+                 placed_at.isoformat(), due_at.isoformat(),
+                 delivered, completed),
+            )
+            conn.execute(
+                "INSERT INTO order_items (id, order_id, line_no, description, unit_price, quantity) "
+                "VALUES (?, ?, 1, ?, ?, 1)",
+                (f"oi_{n:05d}", oid,
+                 f"{tier.title()} package", unit_price),
+            )
+
+        # Conversations + messages ---------------------------------
+        # Seed buyer_00001 ↔ seller for gig_00001 + a few others.
+        gig_one_seller = conn.execute(
+            "SELECT seller_id FROM gigs WHERE id='gig_00001'"
+        ).fetchone()["seller_id"]
+        for n, (buyer, seller) in enumerate([
+            ("buyer_00001", gig_one_seller),
+            ("buyer_00001", "seller_03"),
+            ("buyer_00002", gig_one_seller),
+            ("buyer_00003", "seller_05"),
+        ], start=1):
+            cid = _id_for("conv", n)
+            last_msg = now - timedelta(days=5 - n)
+            try:
+                conn.execute(
+                    "INSERT INTO conversations (id, buyer_id, seller_id, last_msg_at) "
+                    "VALUES (?, ?, ?, ?)",
+                    (cid, buyer, seller, last_msg.isoformat()),
+                )
+            except sqlite3.IntegrityError:
+                continue
+            # 2 seed messages per thread
+            conn.execute(
+                "INSERT INTO messages (id, conversation_id, sender_id, body, created_at) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (f"msg_{cid}_1", cid, buyer,
+                 "Hi! I'm interested in your service. Could you tell me more?",
+                 (last_msg - timedelta(hours=2)).isoformat()),
+            )
+            conn.execute(
+                "INSERT INTO messages (id, conversation_id, sender_id, body, created_at) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (f"msg_{cid}_2", cid, seller,
+                 "Hi there! Thanks for reaching out. Happy to help — what's the project?",
+                 (last_msg - timedelta(hours=1)).isoformat()),
+            )
+
+        # Reviews ---------------------------------------------------
+        # Seed a few historical reviews on completed orders 1..5
+        # so detail pages show review history. order_00007 is left
+        # explicitly unreviewed for t03.
+        for n in (1, 2, 3, 4, 5):
+            oid = _id_for("order", n)
+            order = conn.execute(
+                "SELECT buyer_id, seller_id, gig_id FROM orders WHERE id=?",
+                (oid,)
+            ).fetchone()
+            if order is None:
+                continue
+            rid = _id_for("review", n)
+            stars = 5 if n % 3 else 4
+            conn.execute(
+                "INSERT INTO reviews (id, order_id, gig_id, buyer_id, seller_id, "
+                "stars, body, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                (rid, oid, order["gig_id"], order["buyer_id"],
+                 order["seller_id"], stars,
+                 _review_body(n, stars),
+                 (now - timedelta(days=20 - n)).isoformat()),
+            )
+
+
+def _gig_description(title: str, slug: str) -> str:
+    return (
+        f"Welcome! Thanks for stopping by my gig.\n\n"
+        f"I'm excited to help you with **{title.lower()}**. I focus on "
+        f"clean, professional results delivered on time, every time.\n\n"
+        f"## What you'll get\n\n"
+        f"- A clear deliverable matched to your brief\n"
+        f"- Source files included\n"
+        f"- Quick communication throughout\n\n"
+        f"## Why work with me\n\n"
+        f"I've completed hundreds of orders on Fiverr with consistent "
+        f"five-star feedback. My goal is to make sure you leave happy "
+        f"and come back for repeat work.\n\n"
+        f"Send me a message before ordering if you have any questions!"
+    )
+
+
+def _review_body(n: int, stars: int) -> str:
+    if stars == 5:
+        bodies = [
+            "Excellent service — exactly what I asked for, delivered on time.",
+            "Perfect work. Will definitely order again!",
+            "Super professional and great communication. 10/10.",
+            "Amazing quality. Highly recommend.",
+        ]
+    else:
+        bodies = [
+            "Good work overall, a few revisions needed but happy with the result.",
+            "Solid delivery, would work with again.",
+        ]
+    return bodies[n % len(bodies)]

--- a/deploy/sim_envs/mantis_fiverr/app/static/site.css
+++ b/deploy/sim_envs/mantis_fiverr/app/static/site.css
@@ -1,0 +1,847 @@
+/* mantis-fiverr — hand-rolled CSS approximating fiverr.com.
+   Grouped by component, not page. ~750 lines target. */
+
+:root {
+  --fv-green-primary: #1dbf73;
+  --fv-green-hover: #19a463;
+  --fv-green-dark: #16805a;
+  --fv-text-primary: #222325;
+  --fv-text-secondary: #74767e;
+  --fv-text-tertiary: #95979d;
+  --fv-bg-white: #ffffff;
+  --fv-bg-gray: #fafafa;
+  --fv-border-gray: #e4e5e7;
+  --fv-yellow-star: #ffb33e;
+  --fv-orange-pro: #ff7640;
+  --fv-purple-business: #5b3eff;
+  --fv-blue-status: #2c8aff;
+  --fv-red-alert: #d83232;
+}
+
+/* Reset --------------------------------------------------------------- */
+*, *::before, *::after { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; }
+body {
+  font-family: 'Helvetica Neue', Helvetica, Arial, system-ui, sans-serif;
+  font-size: 14px;
+  color: var(--fv-text-primary);
+  background: var(--fv-bg-white);
+  line-height: 1.4;
+}
+a { color: inherit; text-decoration: none; }
+a:hover { color: var(--fv-green-primary); }
+button { font-family: inherit; }
+img { display: block; }
+ul { list-style: none; padding: 0; margin: 0; }
+
+/* Top nav ------------------------------------------------------------- */
+.topnav {
+  position: sticky; top: 0; z-index: 100;
+  background: #fff;
+  border-bottom: 1px solid var(--fv-border-gray);
+  height: 64px;
+}
+.topnav__inner {
+  max-width: 1440px; margin: 0 auto;
+  padding: 0 24px;
+  height: 64px;
+  display: flex; align-items: center; gap: 20px;
+}
+.topnav__brand { display: flex; align-items: center; }
+.topnav__search {
+  flex: 1; max-width: 540px;
+  display: flex; align-items: center;
+  border: 1px solid var(--fv-text-secondary); border-radius: 4px;
+  height: 48px; background: #fff; overflow: hidden;
+}
+.topnav__search input {
+  flex: 1;
+  border: 0; height: 100%; padding: 0 16px;
+  font-size: 14px; outline: none; background: transparent;
+}
+.topnav__search button {
+  background: var(--fv-text-primary);
+  border: 0; width: 48px; height: 48px; cursor: pointer;
+  display: flex; align-items: center; justify-content: center;
+}
+.topnav__search button:hover { background: var(--fv-green-primary); }
+.topnav__links {
+  display: flex; align-items: center; gap: 24px;
+}
+.topnav__link {
+  font-size: 16px; font-weight: 600;
+  color: var(--fv-text-primary);
+}
+.topnav__link:hover { color: var(--fv-green-primary); }
+.topnav__link--meta { color: var(--fv-text-secondary); font-size: 14px; }
+.topnav__join {
+  font-size: 16px; font-weight: 600;
+  color: var(--fv-green-primary);
+  border: 1px solid var(--fv-green-primary); border-radius: 4px;
+  padding: 6px 16px;
+}
+.topnav__join:hover {
+  background: var(--fv-green-primary);
+  color: #fff;
+}
+.topnav__user {
+  font-size: 13px; color: var(--fv-text-secondary);
+}
+.topnav--compact .topnav__search,
+.topnav--compact .topnav__links { display: none; }
+.topnav--compact .topnav__inner { justify-content: space-between; }
+.topnav__secure {
+  color: var(--fv-text-secondary); font-size: 14px;
+  display: inline-flex; align-items: center; gap: 6px;
+}
+
+/* Hero --------------------------------------------------------------- */
+.hero {
+  background: #1a3e30 url('/assets/hero.svg') center/cover no-repeat;
+  color: #fff;
+  min-height: 540px;
+  display: flex; align-items: center;
+}
+.hero__content {
+  max-width: 1440px; margin: 0 auto;
+  padding: 0 80px;
+  width: 100%;
+}
+.hero__title {
+  font-size: 48px; font-weight: 700; line-height: 1.1;
+  max-width: 720px; margin: 0 0 32px 0;
+  color: #fff;
+}
+.hero__search {
+  display: flex; max-width: 540px; height: 56px;
+  border-radius: 4px; overflow: hidden; background: #fff;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.18);
+}
+.hero__search input {
+  flex: 1;
+  border: 0; padding: 0 20px; font-size: 16px; outline: none;
+}
+.hero__search button {
+  background: var(--fv-green-primary);
+  color: #fff; border: 0; padding: 0 24px;
+  font-size: 16px; font-weight: 700;
+  display: inline-flex; align-items: center; gap: 8px;
+  cursor: pointer;
+}
+.hero__search button:hover { background: var(--fv-green-hover); }
+.hero__chips {
+  margin-top: 24px;
+  display: flex; flex-wrap: wrap; gap: 8px; align-items: center;
+}
+.hero__chips-label { font-size: 14px; opacity: 0.9; }
+.hero__chip {
+  border: 1px solid rgba(255,255,255,0.6);
+  color: #fff;
+  border-radius: 999px;
+  padding: 6px 14px;
+  font-size: 13px;
+}
+.hero__chip:hover { background: rgba(255,255,255,0.12); }
+
+/* Trusted row -------------------------------------------------------- */
+.trusted-row {
+  background: var(--fv-bg-gray);
+  padding: 28px 80px;
+  display: flex; align-items: center; gap: 40px; justify-content: center;
+  flex-wrap: wrap;
+}
+.trusted-row__label {
+  color: var(--fv-text-secondary); font-size: 14px; font-weight: 600;
+}
+.trusted-row__brand {
+  color: var(--fv-text-secondary);
+  font-size: 22px; font-weight: 700;
+  letter-spacing: 1px;
+  filter: grayscale(1);
+  opacity: 0.6;
+}
+
+/* Section base ------------------------------------------------------- */
+.section {
+  max-width: 1280px; margin: 0 auto;
+  padding: 56px 80px 16px;
+}
+.section__title {
+  font-size: 32px; font-weight: 700; color: var(--fv-text-primary);
+  margin: 0 0 24px 0;
+}
+.section__title--small { font-size: 24px; }
+
+/* Popular carousel --------------------------------------------------- */
+.popular-carousel {
+  display: grid; grid-template-columns: repeat(6, 1fr); gap: 16px;
+}
+.popular-card {
+  height: 280px; border-radius: 4px; padding: 24px; color: #fff;
+  display: flex; flex-direction: column; justify-content: space-between;
+  font-weight: 700;
+  overflow: hidden;
+  background-size: cover;
+}
+.popular-card__title { font-size: 18px; }
+.popular-card__sub { font-size: 14px; opacity: 0.9; font-weight: 400; }
+.popular-card--p0 { background: linear-gradient(160deg, #5b3eff, #2c1ba8); }
+.popular-card--p1 { background: linear-gradient(160deg, #1dbf73, #0f7048); }
+.popular-card--p2 { background: linear-gradient(160deg, #0aaff1, #0271a4); }
+.popular-card--p3 { background: linear-gradient(160deg, #ff7640, #cf4b18); }
+.popular-card--p4 { background: linear-gradient(160deg, #ffb33e, #c87a16); }
+.popular-card--p5 { background: linear-gradient(160deg, #e84393, #a02666); }
+.popular-card:hover { transform: translateY(-2px); box-shadow: 0 8px 20px rgba(0,0,0,.12); }
+
+/* Categories grid ---------------------------------------------------- */
+.categories-grid {
+  display: grid; grid-template-columns: repeat(6, 1fr); gap: 12px;
+  border-top: 1px solid var(--fv-border-gray);
+  padding-top: 16px;
+}
+.cat-tile {
+  display: flex; flex-direction: column; align-items: center; justify-content: center;
+  padding: 24px 12px;
+  min-height: 112px;
+  border-bottom: 4px solid transparent;
+}
+.cat-tile__icon { margin-bottom: 12px; }
+.cat-tile__label {
+  font-size: 14px; font-weight: 600; color: var(--fv-text-primary);
+  text-align: center;
+}
+.cat-tile:hover {
+  border-bottom-color: var(--fv-green-primary);
+  background: var(--fv-bg-gray);
+}
+
+/* Gig grid + card ---------------------------------------------------- */
+.gig-grid { display: grid; gap: 24px; }
+.gig-grid--3 { grid-template-columns: repeat(3, 1fr); }
+.gig-grid--4 { grid-template-columns: repeat(4, 1fr); }
+
+.gig-card {
+  background: #fff;
+  border-radius: 4px;
+  border: 1px solid var(--fv-border-gray);
+  overflow: hidden;
+  display: flex; flex-direction: column;
+  transition: box-shadow .15s ease;
+}
+.gig-card:hover { box-shadow: 0 4px 12px rgba(34,35,37,0.12); color: inherit; }
+.gig-card__image {
+  position: relative;
+  height: 190px;
+  background-size: cover; background-position: center;
+  background-color: #eef;
+}
+.gig-card__heart {
+  position: absolute; top: 12px; right: 12px;
+  width: 32px; height: 32px;
+  background: transparent; border: 0; cursor: pointer;
+  border-radius: 50%;
+  display: flex; align-items: center; justify-content: center;
+}
+.gig-card__heart:hover { background: rgba(0,0,0,0.2); }
+.gig-card__body { padding: 12px 16px 16px; display: flex; flex-direction: column; gap: 6px; }
+.gig-card__seller {
+  display: flex; align-items: center; gap: 8px;
+  font-size: 12px;
+}
+.gig-card__avatar {
+  width: 26px; height: 26px; border-radius: 50%;
+}
+.gig-card__seller-name { font-weight: 600; font-size: 13px; }
+.gig-card__seller-level {
+  font-size: 11px; font-weight: 600; color: var(--fv-text-tertiary);
+}
+.gig-card__title {
+  margin: 4px 0 6px;
+  font-size: 14px; color: var(--fv-text-primary);
+  line-height: 1.4;
+  display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.gig-card__rating {
+  display: flex; align-items: center; gap: 4px;
+}
+.gig-card__rating-num { font-weight: 700; font-size: 13px; }
+.gig-card__rating-count { color: var(--fv-text-secondary); font-size: 13px; }
+.gig-card__footer {
+  margin-top: 10px;
+  padding-top: 10px;
+  border-top: 1px solid var(--fv-border-gray);
+  display: flex; justify-content: space-between; align-items: center;
+}
+.gig-card__from { font-size: 11px; color: var(--fv-text-secondary); text-transform: uppercase; letter-spacing: 0.5px; }
+.gig-card__price { font-weight: 700; font-size: 14px; }
+
+/* Business CTA ------------------------------------------------------- */
+.business-cta {
+  background: var(--fv-purple-business);
+  color: #fff;
+  margin-top: 64px;
+}
+.business-cta__inner {
+  max-width: 1280px; margin: 0 auto;
+  padding: 64px 80px;
+  display: flex; flex-direction: column; align-items: flex-start; gap: 16px;
+}
+.business-cta__title { font-size: 32px; font-weight: 700; margin: 0; max-width: 720px; }
+.business-cta__sub { font-size: 16px; margin: 0; opacity: 0.9; max-width: 560px; }
+.business-cta__btn {
+  border: 2px solid #fff; color: #fff;
+  padding: 12px 24px; border-radius: 4px;
+  font-weight: 700; font-size: 16px;
+  margin-top: 16px;
+}
+.business-cta__btn:hover { background: #fff; color: var(--fv-purple-business); }
+
+/* Footer ------------------------------------------------------------- */
+.footer {
+  background: var(--fv-bg-gray);
+  border-top: 1px solid var(--fv-border-gray);
+  margin-top: 48px;
+}
+.footer__inner {
+  max-width: 1280px; margin: 0 auto;
+  padding: 48px 80px 32px;
+  display: grid; grid-template-columns: repeat(5, 1fr); gap: 24px;
+}
+.footer__col { display: flex; flex-direction: column; gap: 12px; }
+.footer__col h4 { font-size: 14px; font-weight: 700; margin: 0 0 4px; }
+.footer__col a { color: var(--fv-text-secondary); font-size: 14px; }
+.footer__col a:hover { color: var(--fv-text-primary); }
+.footer__bottom {
+  border-top: 1px solid var(--fv-border-gray);
+  padding: 16px 80px;
+  display: flex; align-items: center; justify-content: space-between;
+  max-width: 1280px; margin: 0 auto;
+}
+.footer__legal { font-size: 12px; color: var(--fv-text-secondary); }
+
+/* Generic page wrap -------------------------------------------------- */
+.page-wrap {
+  max-width: 1400px; margin: 0 auto;
+  padding: 24px 80px 48px;
+}
+.page-wrap--gig { max-width: 1108px; }
+.page-wrap--narrow { max-width: 980px; }
+.muted { color: var(--fv-text-secondary); }
+.small { font-size: 12px; }
+
+.breadcrumbs {
+  display: flex; gap: 8px; align-items: center;
+  font-size: 13px; color: var(--fv-text-secondary);
+  margin-bottom: 16px;
+}
+.breadcrumbs a { color: var(--fv-text-secondary); }
+.breadcrumbs a:hover { color: var(--fv-green-primary); }
+.breadcrumbs span { color: var(--fv-text-tertiary); }
+
+/* Search page -------------------------------------------------------- */
+.search-header {
+  display: flex; justify-content: space-between; align-items: center;
+  margin-bottom: 24px;
+}
+.search-header__title { font-size: 28px; font-weight: 700; margin: 0 0 4px; }
+.search-header__count { font-size: 14px; color: var(--fv-text-secondary); margin: 0; }
+.search-header__sort {
+  display: flex; align-items: center; gap: 8px;
+  border: 1px solid var(--fv-border-gray); border-radius: 4px;
+  padding: 6px 12px; height: 36px; background: #fff;
+}
+.search-header__sort label { font-size: 13px; font-weight: 600; }
+.search-header__sort select {
+  border: 0; background: transparent; font-size: 13px; font-weight: 600;
+  cursor: pointer; outline: none;
+}
+.search-body {
+  display: grid; grid-template-columns: 240px 1fr; gap: 32px;
+  align-items: flex-start;
+}
+.search-rail {
+  position: sticky; top: 88px;
+}
+.filter-group {
+  border: 0; padding: 0; margin: 0 0 28px;
+}
+.filter-group legend {
+  font-size: 14px; font-weight: 700; margin-bottom: 12px; padding: 0;
+}
+.filter-row {
+  display: flex; align-items: center; gap: 8px;
+  font-size: 14px; padding: 4px 0; cursor: pointer;
+}
+.filter-row input { accent-color: var(--fv-green-primary); }
+.search-results .pagination {
+  margin-top: 32px; display: flex; gap: 8px; justify-content: center;
+}
+.pagination__page {
+  border: 1px solid var(--fv-border-gray);
+  border-radius: 4px;
+  width: 36px; height: 36px;
+  display: inline-flex; align-items: center; justify-content: center;
+  font-size: 13px; font-weight: 600;
+}
+.pagination__page--current {
+  background: var(--fv-green-primary); color: #fff; border-color: var(--fv-green-primary);
+}
+.search-empty { color: var(--fv-text-secondary); padding: 48px 0; text-align: center; }
+
+/* Category page ------------------------------------------------------ */
+.cat-hero {
+  background: linear-gradient(180deg, #1dbf73 0%, #16805a 100%);
+  color: #fff;
+  padding: 56px 0;
+}
+.cat-hero__inner {
+  max-width: 1400px; margin: 0 auto; padding: 0 80px;
+}
+.cat-hero__title { font-size: 36px; font-weight: 700; margin: 0 0 8px; color: #fff; }
+.cat-hero__sub { font-size: 16px; opacity: 0.9; margin: 0; }
+.subcat-rail {
+  display: flex; gap: 8px; flex-wrap: wrap;
+  padding: 16px 0;
+  border-bottom: 1px solid var(--fv-border-gray);
+  margin-bottom: 16px;
+}
+.subcat-chip {
+  border: 1px solid var(--fv-border-gray);
+  border-radius: 999px;
+  padding: 8px 16px;
+  font-size: 14px; font-weight: 600;
+}
+.subcat-chip:hover {
+  border-color: var(--fv-green-primary);
+  color: var(--fv-green-primary);
+}
+
+/* Gig detail --------------------------------------------------------- */
+.gig-detail {
+  display: grid; grid-template-columns: 720px 320px;
+  gap: 32px; align-items: flex-start;
+}
+.gig-detail__main { min-width: 0; }
+.gig-detail__title { font-size: 22px; font-weight: 700; margin: 0 0 12px; }
+.gig-detail__seller-chip {
+  display: flex; align-items: center; gap: 12px;
+  margin-bottom: 24px;
+}
+.gig-detail__seller-chip img { border-radius: 50%; width: 40px; height: 40px; }
+.gig-detail__seller-name { font-weight: 600; }
+.gig-detail__seller-rating {
+  display: inline-flex; align-items: center; gap: 4px;
+  font-size: 13px; color: var(--fv-text-secondary);
+}
+.gig-detail__seller-rating strong { color: var(--fv-text-primary); }
+.seller-level {
+  display: inline-block; padding: 2px 8px;
+  font-size: 11px; font-weight: 600; border-radius: 2px;
+  background: var(--fv-orange-pro); color: #fff;
+}
+.seller-level--top_rated { background: var(--fv-orange-pro); }
+.seller-level--level_two { background: var(--fv-orange-pro); }
+.seller-level--level_one { background: var(--fv-text-secondary); }
+.seller-level--new { background: var(--fv-text-tertiary); }
+
+/* Gallery */
+.gallery { margin-bottom: 32px; }
+.gallery__main {
+  width: 100%; height: 480px;
+  background-size: cover; background-position: center;
+  background-color: #eef;
+  border-radius: 8px;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.06);
+  margin-bottom: 12px;
+}
+.gallery__thumbs { display: flex; gap: 8px; }
+.gallery__thumb {
+  width: 110px; height: 72px;
+  border: 1px solid var(--fv-border-gray); border-radius: 4px;
+  overflow: hidden; cursor: pointer; padding: 0; background: #fff;
+}
+.gallery__thumb img { width: 100%; height: 100%; object-fit: cover; }
+.gallery__thumb.is-active { border: 2px solid var(--fv-green-primary); }
+
+.about-gig, .about-seller, .reviews { margin-bottom: 40px; }
+.about-gig h2, .about-seller h2, .reviews h2 {
+  font-size: 20px; font-weight: 700; margin: 0 0 16px;
+}
+.about-gig__body p { margin: 0 0 12px; font-size: 16px; line-height: 1.6; }
+.about-seller__card {
+  display: flex; gap: 16px;
+  border: 1px solid var(--fv-border-gray); border-radius: 4px;
+  padding: 24px;
+}
+.about-seller__card img { border-radius: 50%; }
+.about-seller__body h3 { margin: 0 0 4px; font-size: 18px; }
+.about-seller__meta, .about-seller__langs {
+  margin: 4px 0; color: var(--fv-text-secondary); font-size: 13px;
+}
+
+.reviews__summary {
+  display: flex; align-items: center; gap: 6px;
+  font-size: 14px; color: var(--fv-text-secondary);
+}
+.reviews__summary strong { color: var(--fv-text-primary); font-size: 18px; }
+.review-list { display: flex; flex-direction: column; gap: 24px; margin-top: 16px; }
+.review { display: flex; gap: 12px; }
+.review img { border-radius: 50%; }
+.review__head { display: flex; align-items: center; gap: 8px; margin-bottom: 6px; }
+.review__head strong { font-size: 14px; }
+.review__date { color: var(--fv-text-tertiary); font-size: 12px; }
+.review__stars { display: inline-flex; gap: 2px; }
+
+/* Package picker (right rail) */
+.package-picker {
+  position: sticky; top: 88px;
+  border: 1px solid var(--fv-border-gray); border-radius: 4px;
+  background: #fff;
+}
+.package-tabs {
+  display: grid; grid-template-columns: 1fr 1fr 1fr;
+  border-bottom: 1px solid var(--fv-border-gray);
+}
+.package-tab {
+  background: transparent; border: 0; padding: 16px 0;
+  font-size: 14px; font-weight: 400;
+  color: var(--fv-text-secondary);
+  cursor: pointer;
+  border-bottom: 3px solid transparent;
+}
+.package-tab.is-active {
+  color: var(--fv-text-primary); font-weight: 600;
+  border-bottom-color: var(--fv-text-primary);
+}
+.package-body { padding: 20px; }
+.package-body__head {
+  display: flex; justify-content: space-between; align-items: center;
+  margin-bottom: 12px;
+}
+.package-body__title { font-size: 16px; font-weight: 700; }
+.package-body__price { font-size: 24px; font-weight: 700; }
+.package-body__price .cur { font-size: 14px; vertical-align: super; margin-right: 2px; }
+.package-body__desc {
+  font-size: 14px; color: var(--fv-text-secondary);
+  margin: 0 0 16px; min-height: 38px;
+}
+.package-features {
+  display: flex; flex-direction: column; gap: 8px; margin: 0 0 16px;
+}
+.package-features li {
+  font-size: 14px;
+  position: relative; padding-left: 22px;
+}
+.package-features li::before {
+  content: ""; position: absolute; left: 0; top: 6px;
+  width: 14px; height: 14px;
+  background: var(--fv-green-primary);
+  -webkit-mask: linear-gradient(45deg, transparent 33%, #000 33%, #000 66%, transparent 66%);
+  border-radius: 2px;
+}
+.package-stats {
+  display: flex; gap: 16px;
+  border-top: 1px solid var(--fv-border-gray);
+  border-bottom: 1px solid var(--fv-border-gray);
+  padding: 12px 0; margin-bottom: 16px;
+  font-size: 13px; color: var(--fv-text-secondary);
+}
+.package-stats strong { color: var(--fv-text-primary); }
+
+/* Buttons ----------------------------------------------------------- */
+.btn {
+  display: inline-flex; align-items: center; justify-content: center;
+  padding: 8px 16px;
+  border-radius: 4px; border: 0; cursor: pointer;
+  font-weight: 700; font-size: 14px;
+  text-decoration: none;
+}
+.btn--primary {
+  background: var(--fv-green-primary); color: #fff;
+}
+.btn--primary:hover { background: var(--fv-green-hover); color: #fff; }
+.btn--primary:active { background: var(--fv-green-dark); }
+.btn--outline {
+  background: transparent;
+  color: var(--fv-green-primary);
+  border: 1px solid var(--fv-green-primary);
+}
+.btn--outline:hover {
+  background: var(--fv-green-primary);
+  color: #fff;
+}
+.btn--block { width: 100%; }
+.btn--lg { padding: 12px 20px; font-size: 16px; }
+
+/* Checkout ---------------------------------------------------------- */
+.checkout-wrap {
+  max-width: 980px; margin: 32px auto;
+  padding: 0 80px;
+  display: grid; grid-template-columns: 1fr 320px; gap: 32px;
+}
+.checkout-main h1 { font-size: 28px; margin: 0 0 8px; }
+.checkout-gig {
+  display: grid; grid-template-columns: 56px 1fr auto;
+  gap: 12px; align-items: center;
+  border: 1px solid var(--fv-border-gray); border-radius: 4px;
+  padding: 12px; margin: 16px 0 24px;
+}
+.checkout-gig__thumb {
+  width: 56px; height: 56px; border-radius: 4px;
+  background-size: cover; background-position: center;
+}
+.checkout-gig__title { font-weight: 600; margin: 0 0 2px; }
+.checkout-gig__tier { font-size: 13px; margin: 6px 0 0; }
+.checkout-gig__price { font-weight: 700; font-size: 18px; }
+.form-section { margin-bottom: 24px; }
+.form-section label { font-weight: 600; display: block; margin-bottom: 6px; }
+.form-section textarea {
+  width: 100%; padding: 12px; border: 1px solid var(--fv-border-gray);
+  border-radius: 4px; font-family: inherit; font-size: 14px;
+  resize: vertical;
+}
+.form-section h2 { font-size: 20px; font-weight: 700; margin: 0 0 12px; }
+.payment-row {
+  display: flex; gap: 12px; align-items: center;
+  padding: 12px; border: 1px solid var(--fv-border-gray); border-radius: 4px;
+  margin-bottom: 8px;
+  cursor: pointer;
+}
+.payment-row input { accent-color: var(--fv-green-primary); }
+.checkout-summary {
+  border: 1px solid var(--fv-border-gray); border-radius: 4px;
+  padding: 24px;
+  position: sticky; top: 88px;
+  height: max-content;
+}
+.checkout-summary h3 { font-size: 16px; font-weight: 700; margin: 0 0 16px; }
+.summary-row {
+  display: flex; justify-content: space-between;
+  padding: 8px 0;
+  font-size: 14px;
+}
+.summary-row--total {
+  font-size: 16px; font-weight: 700;
+}
+.checkout-summary hr {
+  border: 0; border-top: 1px solid var(--fv-border-gray);
+  margin: 12px 0;
+}
+
+/* Inbox ------------------------------------------------------------- */
+.inbox-wrap {
+  display: grid; grid-template-columns: 360px 1fr;
+  max-width: 1280px; margin: 0 auto;
+  height: calc(100vh - 64px);
+  border-top: 1px solid var(--fv-border-gray);
+}
+.thread-list {
+  border-right: 1px solid var(--fv-border-gray);
+  padding: 16px;
+  overflow-y: auto;
+}
+.thread-list h2 { font-size: 20px; font-weight: 700; margin: 0 0 12px; }
+.thread-search {
+  width: 100%; padding: 8px 12px;
+  background: var(--fv-bg-gray); border: 0;
+  border-radius: 4px; font-size: 13px;
+}
+.thread-list__items { margin-top: 12px; }
+.thread-row {
+  display: grid; grid-template-columns: 40px 1fr auto;
+  gap: 12px; align-items: center;
+  padding: 12px;
+  border-radius: 4px;
+}
+.thread-row:hover { background: var(--fv-bg-gray); color: inherit; }
+.thread-row.is-active {
+  background: var(--fv-bg-gray);
+  border-left: 3px solid var(--fv-green-primary);
+}
+.thread-row__avatar { border-radius: 50%; }
+.thread-row__body strong { font-size: 14px; font-weight: 600; display: block; }
+.thread-row__body p { font-size: 13px; color: var(--fv-text-secondary); margin: 0; }
+.thread-row__time { color: var(--fv-text-tertiary); font-size: 12px; }
+
+.thread-detail {
+  display: grid; grid-template-rows: auto 1fr auto;
+  height: 100%; min-height: 0;
+}
+.thread-detail__head {
+  display: flex; align-items: center; gap: 12px;
+  padding: 16px;
+  border-bottom: 1px solid var(--fv-border-gray);
+}
+.thread-detail__head img { border-radius: 50%; }
+.thread-detail__profile { color: var(--fv-green-primary); font-weight: 600; margin-left: auto; }
+.dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
+.dot--online { background: var(--fv-green-primary); }
+.online-label { color: var(--fv-green-primary); font-size: 12px; }
+
+.messages {
+  padding: 24px; overflow-y: auto;
+  display: flex; flex-direction: column; gap: 12px;
+}
+.message { display: flex; flex-direction: column; max-width: 480px; }
+.message__bubble {
+  padding: 8px 12px; border-radius: 12px;
+  font-size: 14px;
+}
+.message__time { font-size: 11px; color: var(--fv-text-tertiary); margin-top: 4px; }
+.message--me { align-self: flex-end; align-items: flex-end; }
+.message--me .message__bubble { background: #dbf5e7; }
+.message--other { align-self: flex-start; align-items: flex-start; }
+.message--other .message__bubble { background: #f5f5f5; }
+
+.composer {
+  display: grid; grid-template-columns: 1fr 36px;
+  gap: 12px; padding: 16px;
+  border-top: 1px solid var(--fv-border-gray);
+  align-items: end;
+}
+.composer textarea {
+  width: 100%; resize: none;
+  padding: 8px 12px;
+  border: 1px solid var(--fv-border-gray); border-radius: 4px;
+  font-family: inherit;
+}
+.composer .btn { width: 36px; height: 36px; padding: 0; }
+.thread-empty {
+  display: flex; flex-direction: column; align-items: center; justify-content: center;
+  height: 100%; text-align: center; color: var(--fv-text-secondary);
+  padding: 80px 24px;
+}
+
+/* Orders ------------------------------------------------------------ */
+.orders-header h1 { font-size: 28px; font-weight: 700; margin: 0 0 16px; }
+.orders-tabs { display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 16px; }
+.orders-chip {
+  border: 1px solid var(--fv-border-gray);
+  border-radius: 999px;
+  padding: 6px 14px;
+  font-size: 13px;
+  color: var(--fv-text-primary);
+}
+.orders-chip:hover { color: var(--fv-green-primary); }
+.orders-chip.is-active {
+  background: var(--fv-green-primary); color: #fff; border-color: var(--fv-green-primary);
+}
+.orders-table {
+  width: 100%; border-collapse: collapse;
+  border: 1px solid var(--fv-border-gray); border-radius: 4px;
+  overflow: hidden;
+}
+.orders-table th {
+  text-align: left;
+  font-size: 12px; font-weight: 600;
+  color: var(--fv-text-secondary);
+  text-transform: uppercase;
+  padding: 12px 16px;
+  background: var(--fv-bg-gray);
+  border-bottom: 1px solid var(--fv-border-gray);
+}
+.orders-table td {
+  padding: 12px 16px;
+  font-size: 14px;
+  border-bottom: 1px solid var(--fv-border-gray);
+}
+.orders-table tr:hover { background: var(--fv-bg-gray); }
+.status {
+  display: inline-block; padding: 4px 10px;
+  border-radius: 999px; font-size: 12px; font-weight: 600;
+}
+.status--active { background: #e6f3ff; color: var(--fv-blue-status); }
+.status--delivered { background: #fff0e6; color: var(--fv-orange-pro); }
+.status--completed { background: #e6f8ef; color: var(--fv-green-primary); }
+.status--cancelled { background: #f0f0f0; color: var(--fv-text-secondary); }
+.empty { color: var(--fv-text-secondary); padding: 24px; text-align: center; }
+.link { color: var(--fv-green-primary); font-weight: 600; }
+
+/* Order detail ------------------------------------------------------ */
+.order-header-card {
+  display: flex; justify-content: space-between; align-items: flex-start;
+  border: 1px solid var(--fv-border-gray); border-radius: 4px;
+  padding: 24px;
+  margin-bottom: 24px;
+}
+.order-header-card h1 { font-size: 22px; margin: 0 0 8px; }
+.order-header-card__total {
+  text-align: right;
+}
+.order-header-card__total strong {
+  display: block; font-size: 22px;
+}
+.order-actions { display: flex; gap: 12px; margin-bottom: 24px; }
+.deliverables, .order-items, .review-cta, .review-card {
+  border: 1px solid var(--fv-border-gray); border-radius: 4px;
+  padding: 24px; margin-bottom: 24px;
+}
+.deliverables h2, .order-items h2, .review-cta h2, .review-card h2 {
+  margin: 0 0 12px; font-size: 18px;
+}
+.order-items table {
+  width: 100%; border-collapse: collapse;
+}
+.order-items th, .order-items td {
+  padding: 8px 0; text-align: left;
+  border-bottom: 1px solid var(--fv-border-gray);
+  font-size: 14px;
+}
+.order-items .total td { font-size: 16px; padding-top: 12px; border-bottom: 0; }
+
+.review-form {
+  display: flex; flex-direction: column; gap: 12px;
+}
+.stars-input { display: flex; gap: 4px; }
+.star-label { cursor: pointer; }
+.star-label input { display: none; }
+.review-form textarea {
+  width: 100%; padding: 12px;
+  border: 1px solid var(--fv-border-gray); border-radius: 4px;
+  font-family: inherit; font-size: 14px;
+}
+
+.review-card__stars { display: inline-flex; gap: 2px; margin-bottom: 8px; }
+
+/* Auth -------------------------------------------------------------- */
+.auth-wrap {
+  max-width: 360px; margin: 80px auto;
+  padding: 0 16px;
+  text-align: center;
+}
+.auth-wrap h1 { font-size: 24px; font-weight: 700; margin: 0 0 24px; }
+.auth-form {
+  display: flex; flex-direction: column; gap: 12px;
+  text-align: left;
+}
+.auth-form label {
+  font-size: 13px; font-weight: 600;
+  display: flex; flex-direction: column; gap: 4px;
+}
+.auth-form input {
+  padding: 12px; height: 48px;
+  border: 1px solid var(--fv-text-secondary); border-radius: 4px;
+  font-size: 14px;
+}
+.auth-form input:focus { outline: 2px solid var(--fv-green-primary); border-color: var(--fv-green-primary); }
+.auth-forgot {
+  font-size: 13px; color: var(--fv-green-primary);
+  text-align: right; display: block; margin: -8px 0 0;
+}
+.auth-divider {
+  font-size: 12px; color: var(--fv-text-secondary);
+  margin: 24px 0;
+}
+.auth-alt { font-size: 14px; }
+.auth-alt a { color: var(--fv-green-primary); font-weight: 600; }
+.auth-error {
+  background: #fdecec; color: var(--fv-red-alert);
+  padding: 12px; border-radius: 4px; font-size: 13px;
+}
+
+/* Misc --------------------------------------------------------------- */
+*:focus-visible {
+  outline: 2px solid var(--fv-green-primary);
+  outline-offset: 2px;
+}

--- a/deploy/sim_envs/mantis_fiverr/app/templates/_gig_card.html
+++ b/deploy/sim_envs/mantis_fiverr/app/templates/_gig_card.html
@@ -1,0 +1,40 @@
+{% macro gig_card(gig) %}
+<a class="gig-card" href="/{{ gig.seller_username }}/{{ gig.slug }}">
+  <div class="gig-card__image"
+       style="background-image:url('/assets/gig/{{ gig.image_palette }}_{{ loop.index0 if loop is defined else 0 }}.svg')">
+    <button class="gig-card__heart" type="button" aria-label="Favorite">
+      <svg viewBox="0 0 24 24" width="20" height="20" aria-hidden="true">
+        <path d="M12 21s-7-4.6-7-10a4 4 0 0 1 7-2.6A4 4 0 0 1 19 11c0 5.4-7 10-7 10z"
+              fill="none" stroke="white" stroke-width="2"/>
+      </svg>
+    </button>
+  </div>
+  <div class="gig-card__body">
+    <div class="gig-card__seller">
+      <img class="gig-card__avatar"
+           src="/assets/avatar/{{ gig.seller_avatar_palette }}_{{ gig.seller_display[:1] }}.svg"
+           alt="" width="26" height="26">
+      <span class="gig-card__seller-name">{{ gig.seller_display }}</span>
+      <span class="gig-card__seller-level">
+        {% if gig.seller_level == 'top_rated' %}Top Rated Seller
+        {% elif gig.seller_level == 'level_two' %}Level 2 Seller
+        {% elif gig.seller_level == 'level_one' %}Level 1 Seller
+        {% else %}New Seller{% endif %}
+      </span>
+    </div>
+    <p class="gig-card__title">{{ gig.title }}</p>
+    <div class="gig-card__rating">
+      <svg class="gig-card__star" viewBox="0 0 20 20" width="14" height="14" aria-hidden="true">
+        <polygon points="10,2 12,8 18,8 13,12 15,18 10,14 5,18 7,12 2,8 8,8"
+                 fill="#ffb33e"/>
+      </svg>
+      <span class="gig-card__rating-num">{{ "%.1f"|format(gig.avg_rating) }}</span>
+      <span class="gig-card__rating-count">({{ gig.review_count }})</span>
+    </div>
+    <div class="gig-card__footer">
+      <span class="gig-card__from">From</span>
+      <span class="gig-card__price">US${{ "%g"|format(gig.basic_price) }}</span>
+    </div>
+  </div>
+</a>
+{% endmacro %}

--- a/deploy/sim_envs/mantis_fiverr/app/templates/base.html
+++ b/deploy/sim_envs/mantis_fiverr/app/templates/base.html
@@ -1,0 +1,94 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>{% block title %}{{ site_name }}: Find the right freelance service{% endblock %}</title>
+<link rel="stylesheet" href="/static/site.css">
+<link rel="icon" href="/assets/logo.svg" type="image/svg+xml">
+</head>
+<body>
+{% block topnav %}
+<header class="topnav" role="banner">
+  <div class="topnav__inner">
+    <a class="topnav__brand" href="/" aria-label="Fiverr home">
+      <img src="/assets/logo.svg" alt="Fiverr" width="140" height="38">
+    </a>
+    <form class="topnav__search" action="/search/gigs" method="get" role="search">
+      <input type="text" name="query" placeholder="Search for any service…"
+             value="{{ request.query_params.get('query', '') if request else '' }}"
+             aria-label="Search">
+      <button type="submit" aria-label="Search">
+        <svg viewBox="0 0 20 20" width="18" height="18" aria-hidden="true">
+          <circle cx="8" cy="8" r="6" stroke="white" stroke-width="2" fill="none"/>
+          <line x1="13" y1="13" x2="18" y2="18" stroke="white" stroke-width="2"/>
+        </svg>
+      </button>
+    </form>
+    <nav class="topnav__links" aria-label="Primary">
+      <a href="/categories/business" class="topnav__link">Fiverr Pro</a>
+      <a href="/categories/graphics-design" class="topnav__link">Explore</a>
+      <span class="topnav__link topnav__link--meta">English</span>
+      <span class="topnav__link topnav__link--meta">US$ USD</span>
+      {% if request and request.state.current_user %}
+      <a href="/inbox" class="topnav__link">Messages</a>
+      <a href="/orders" class="topnav__link">Orders</a>
+      <a href="/logout" class="topnav__link">Sign out</a>
+      <span class="topnav__user">{{ request.state.current_user.display_name }}</span>
+      {% else %}
+      <a href="/login" class="topnav__link">Sign in</a>
+      <a href="/signup" class="topnav__join">Join</a>
+      {% endif %}
+    </nav>
+  </div>
+</header>
+{% endblock %}
+
+<main id="main" role="main">
+  {% block main %}{% endblock %}
+</main>
+
+{% block footer %}
+<footer class="footer">
+  <div class="footer__inner">
+    <div class="footer__col">
+      <h4>Categories</h4>
+      <a href="/categories/graphics-design">Graphics & Design</a>
+      <a href="/categories/digital-marketing">Digital Marketing</a>
+      <a href="/categories/writing-translation">Writing & Translation</a>
+      <a href="/categories/video-animation">Video & Animation</a>
+      <a href="/categories/music-audio">Music & Audio</a>
+    </div>
+    <div class="footer__col">
+      <h4>About</h4>
+      <a href="#">Careers</a>
+      <a href="#">Press & News</a>
+      <a href="#">Partnerships</a>
+    </div>
+    <div class="footer__col">
+      <h4>Support</h4>
+      <a href="#">Help & Support</a>
+      <a href="#">Trust & Safety</a>
+      <a href="#">Selling on Fiverr</a>
+    </div>
+    <div class="footer__col">
+      <h4>Community</h4>
+      <a href="#">Events</a>
+      <a href="#">Blog</a>
+      <a href="#">Forum</a>
+    </div>
+    <div class="footer__col">
+      <h4>More From Fiverr</h4>
+      <a href="#">Fiverr Pro</a>
+      <a href="#">Fiverr Logo Maker</a>
+      <a href="#">Get Inspired</a>
+    </div>
+  </div>
+  <div class="footer__bottom">
+    <img src="/assets/logo.svg" alt="Fiverr" width="100" height="28">
+    <span class="footer__legal">© Fiverr-mirror sim env — {{ site_name }} mirror</span>
+  </div>
+</footer>
+{% endblock %}
+</body>
+</html>

--- a/deploy/sim_envs/mantis_fiverr/app/templates/category.html
+++ b/deploy/sim_envs/mantis_fiverr/app/templates/category.html
@@ -1,0 +1,30 @@
+{% extends "base.html" %}
+{% from "_gig_card.html" import gig_card %}
+
+{% block title %}{{ category.title }} services — {{ site_name }}{% endblock %}
+
+{% block main %}
+<section class="cat-hero">
+  <div class="cat-hero__inner">
+    <h1 class="cat-hero__title">{{ category.title }}</h1>
+    <p class="cat-hero__sub">Browse top-rated freelancers ready to take on your next project.</p>
+  </div>
+</section>
+
+<div class="page-wrap">
+  {% if subcategories %}
+  <nav class="subcat-rail" aria-label="Subcategories">
+    {% for s in subcategories %}
+    <a class="subcat-chip" href="/categories/{{ s.slug }}">{{ s.title }}</a>
+    {% endfor %}
+  </nav>
+  {% endif %}
+
+  <section class="section">
+    <h2 class="section__title section__title--small">Most popular in {{ category.title }}</h2>
+    <div class="gig-grid gig-grid--3">
+      {% for g in results %}{{ gig_card(g) }}{% endfor %}
+    </div>
+  </section>
+</div>
+{% endblock %}

--- a/deploy/sim_envs/mantis_fiverr/app/templates/checkout.html
+++ b/deploy/sim_envs/mantis_fiverr/app/templates/checkout.html
@@ -1,0 +1,89 @@
+{% extends "base.html" %}
+
+{% block title %}Checkout — {{ gig.title }} — {{ site_name }}{% endblock %}
+
+{% block topnav %}
+<header class="topnav topnav--compact">
+  <div class="topnav__inner">
+    <a class="topnav__brand" href="/" aria-label="Fiverr home">
+      <img src="/assets/logo.svg" alt="Fiverr" width="120" height="32">
+    </a>
+    <span class="topnav__secure">Secure checkout
+      <svg viewBox="0 0 24 24" width="14" height="14" aria-hidden="true">
+        <path d="M12 1l9 4v6c0 5-3.5 9.74-9 11-5.5-1.26-9-6-9-11V5l9-4z"
+              fill="none" stroke="#74767e" stroke-width="2"/>
+      </svg>
+    </span>
+  </div>
+</header>
+{% endblock %}
+
+{% block main %}
+<div class="checkout-wrap">
+  <div class="checkout-main">
+    <h1>Checkout</h1>
+    <p class="muted">You&rsquo;re ordering:</p>
+
+    <div class="checkout-gig">
+      <div class="checkout-gig__thumb"
+           style="background-image:url('/assets/gig/{{ gig.image_palette }}_0.svg')"></div>
+      <div class="checkout-gig__body">
+        <p class="checkout-gig__title">{{ gig.title }}</p>
+        <p class="muted">by {{ gig.seller_display }}</p>
+        <p class="checkout-gig__tier">Package: <strong>{{ tier_title }}</strong> — Delivery in {{ tier_delivery }} days</p>
+      </div>
+      <span class="checkout-gig__price">US${{ "%g"|format(unit_price) }}</span>
+    </div>
+
+    <form action="/checkout/{{ gig.id }}" method="post" id="checkout-form">
+      <input type="hidden" name="tier" value="{{ tier }}">
+
+      <section class="form-section">
+        <label for="requirements">Order details (optional)</label>
+        <textarea id="requirements" name="requirements" rows="4"
+                  placeholder="Briefly describe your project (optional)"></textarea>
+      </section>
+
+      <section class="form-section">
+        <h2>Payment method</h2>
+        <label class="payment-row">
+          <input type="radio" name="payment_method" value="card" checked>
+          <span>Credit / Debit Card</span>
+        </label>
+        <label class="payment-row">
+          <input type="radio" name="payment_method" value="paypal">
+          <span>PayPal</span>
+        </label>
+        <label class="payment-row">
+          <input type="radio" name="payment_method" value="bank">
+          <span>Bank transfer</span>
+        </label>
+      </section>
+
+      <button type="submit" class="btn btn--primary btn--block btn--lg">
+        Confirm &amp; Pay (US${{ "%g"|format(total) }})
+      </button>
+      <p class="muted small">By clicking Confirm &amp; Pay you agree to our Terms of Service.</p>
+    </form>
+  </div>
+
+  <aside class="checkout-summary">
+    <h3>Summary</h3>
+    <div class="summary-row">
+      <span>{{ tier_title }} package</span>
+      <span>US${{ "%g"|format(unit_price) }}</span>
+    </div>
+    <div class="summary-row">
+      <span>Service fee</span>
+      <span>US${{ "%g"|format(service_fee) }}</span>
+    </div>
+    <hr>
+    <div class="summary-row summary-row--total">
+      <span>Total</span>
+      <span>US${{ "%g"|format(total) }}</span>
+    </div>
+  </aside>
+</div>
+{% endblock %}
+
+{% block footer %}{% endblock %}

--- a/deploy/sim_envs/mantis_fiverr/app/templates/gig_detail.html
+++ b/deploy/sim_envs/mantis_fiverr/app/templates/gig_detail.html
@@ -1,0 +1,204 @@
+{% extends "base.html" %}
+
+{% block title %}{{ gig.title }} — {{ gig.seller_display }} on {{ site_name }}{% endblock %}
+
+{% block main %}
+<div class="page-wrap page-wrap--gig">
+  <nav class="breadcrumbs" aria-label="Breadcrumbs">
+    {% for c in crumbs %}
+      <a href="{{ c.slug if c.slug.startswith('/') else c.slug }}">{{ c.title }}</a>
+      {% if not loop.last %}<span>/</span>{% endif %}
+    {% endfor %}
+    <span>/</span>
+    <span>{{ gig.title|truncate(60) }}</span>
+  </nav>
+
+  <div class="gig-detail">
+    <div class="gig-detail__main">
+      <h1 class="gig-detail__title">{{ gig.title }}</h1>
+
+      <div class="gig-detail__seller-chip">
+        <img src="/assets/avatar/{{ gig.seller_avatar_palette }}_{{ gig.seller_display[:1] }}.svg"
+             alt="" width="40" height="40">
+        <a class="gig-detail__seller-name"
+           href="/inbox/new/{{ gig.seller_id }}">{{ gig.seller_display }}</a>
+        <span class="seller-level seller-level--{{ gig.seller_level }}">
+          {% if gig.seller_level == 'top_rated' %}Top Rated Seller
+          {% elif gig.seller_level == 'level_two' %}Level 2 Seller
+          {% elif gig.seller_level == 'level_one' %}Level 1 Seller
+          {% else %}New Seller{% endif %}
+        </span>
+        <span class="gig-detail__seller-rating">
+          <svg class="gig-card__star" viewBox="0 0 20 20" width="14" height="14"><polygon points="10,2 12,8 18,8 13,12 15,18 10,14 5,18 7,12 2,8 8,8" fill="#ffb33e"/></svg>
+          <strong>{{ "%.1f"|format(gig.avg_rating) }}</strong>
+          ({{ gig.review_count }})
+        </span>
+      </div>
+
+      <section class="gallery">
+        <div class="gallery__main" id="gallery-main"
+             style="background-image:url('/assets/gig/{{ gig.image_palette }}_0.svg')"></div>
+        <div class="gallery__thumbs">
+          {% for i in range(5) %}
+          <button type="button" class="gallery__thumb {% if loop.first %}is-active{% endif %}"
+                  data-thumb-url="/assets/gig/{{ gig.image_palette }}_{{ i }}.svg"
+                  aria-label="View thumbnail {{ i + 1 }}">
+            <img src="/assets/gig/{{ gig.image_palette }}_{{ i }}.svg" alt="" width="110" height="72">
+          </button>
+          {% endfor %}
+        </div>
+      </section>
+
+      <section class="about-gig">
+        <h2>About this gig</h2>
+        <div class="about-gig__body">
+          {% for para in gig.description_md.split('\n\n') %}
+            <p>{{ para }}</p>
+          {% endfor %}
+        </div>
+      </section>
+
+      <section class="about-seller">
+        <h2>About the seller</h2>
+        <div class="about-seller__card">
+          <img src="/assets/avatar/{{ gig.seller_avatar_palette }}_{{ gig.seller_display[:1] }}.svg"
+               alt="" width="80" height="80">
+          <div class="about-seller__body">
+            <h3>{{ gig.seller_display }}</h3>
+            <p class="about-seller__meta">From {{ gig.seller_country }} ·
+              Member since {{ gig.seller_member_since[:10] }} ·
+              Response time: {{ gig.seller_response_h }}h</p>
+            <p class="about-seller__langs">Languages:
+              {% for lang in gig.seller_languages %}{{ lang }}{% if not loop.last %}, {% endif %}{% endfor %}
+            </p>
+            <a class="btn btn--outline" href="/inbox/new/{{ gig.seller_id }}">Contact me</a>
+          </div>
+        </div>
+      </section>
+
+      <section class="reviews">
+        <h2>Reviews</h2>
+        <p class="reviews__summary">
+          <svg class="gig-card__star" viewBox="0 0 20 20" width="16" height="16">
+            <polygon points="10,2 12,8 18,8 13,12 15,18 10,14 5,18 7,12 2,8 8,8" fill="#ffb33e"/>
+          </svg>
+          <strong>{{ "%.1f"|format(gig.avg_rating) }}</strong>
+          <span>({{ gig.review_count }} reviews)</span>
+        </p>
+        {% if reviews %}
+        <ul class="review-list">
+          {% for r in reviews %}
+          <li class="review">
+            <img src="/assets/avatar/{{ loop.index0 % 8 }}_{{ r.buyer_display[:1] }}.svg"
+                 alt="" width="40" height="40">
+            <div class="review__body">
+              <div class="review__head">
+                <strong>{{ r.buyer_display }}</strong>
+                <span class="review__stars">
+                  {% for s in range(5) %}
+                    <svg viewBox="0 0 20 20" width="12" height="12" aria-hidden="true">
+                      <polygon points="10,2 12,8 18,8 13,12 15,18 10,14 5,18 7,12 2,8 8,8"
+                               fill="{{ '#ffb33e' if s < r.stars else '#e4e5e7' }}"/>
+                    </svg>
+                  {% endfor %}
+                </span>
+                <span class="review__date">{{ r.created_at[:10] }}</span>
+              </div>
+              <p>{{ r.body }}</p>
+            </div>
+          </li>
+          {% endfor %}
+        </ul>
+        {% else %}
+        <p>No reviews yet.</p>
+        {% endif %}
+      </section>
+    </div>
+
+    <aside class="package-picker" id="package-picker"
+           data-basic-title="{{ gig.pkg_basic_title }}"
+           data-basic-desc="{{ gig.pkg_basic_desc }}"
+           data-basic-price="{{ '%g'|format(gig.pkg_basic_price) }}"
+           data-basic-delivery="{{ gig.pkg_basic_delivery_d }}"
+           data-basic-revs="{{ gig.pkg_basic_revisions }}"
+           data-basic-features='{{ gig.pkg_basic_features|tojson }}'
+           data-standard-title="{{ gig.pkg_standard_title }}"
+           data-standard-desc="{{ gig.pkg_standard_desc }}"
+           data-standard-price="{{ '%g'|format(gig.pkg_standard_price) }}"
+           data-standard-delivery="{{ gig.pkg_standard_delivery_d }}"
+           data-standard-revs="{{ gig.pkg_standard_revisions }}"
+           data-standard-features='{{ gig.pkg_standard_features|tojson }}'
+           data-premium-title="{{ gig.pkg_premium_title }}"
+           data-premium-desc="{{ gig.pkg_premium_desc }}"
+           data-premium-price="{{ '%g'|format(gig.pkg_premium_price) }}"
+           data-premium-delivery="{{ gig.pkg_premium_delivery_d }}"
+           data-premium-revs="{{ gig.pkg_premium_revisions }}"
+           data-premium-features='{{ gig.pkg_premium_features|tojson }}'
+           data-gig-id="{{ gig.id }}">
+      <div class="package-tabs" role="tablist">
+        <button class="package-tab is-active" role="tab" data-tier="basic">Basic</button>
+        <button class="package-tab" role="tab" data-tier="standard">Standard</button>
+        <button class="package-tab" role="tab" data-tier="premium">Premium</button>
+      </div>
+      <div class="package-body">
+        <div class="package-body__head">
+          <span class="package-body__title" id="pkg-title">{{ gig.pkg_basic_title }}</span>
+          <span class="package-body__price">
+            <span class="cur">US$</span><span id="pkg-price">{{ "%g"|format(gig.pkg_basic_price) }}</span>
+          </span>
+        </div>
+        <p class="package-body__desc" id="pkg-desc">{{ gig.pkg_basic_desc }}</p>
+        <ul class="package-features" id="pkg-features">
+          {% for f in gig.pkg_basic_features %}<li>{{ f }}</li>{% endfor %}
+        </ul>
+        <div class="package-stats">
+          <span><strong id="pkg-delivery">{{ gig.pkg_basic_delivery_d }}</strong>-day delivery</span>
+          <span><strong id="pkg-revs">{{ gig.pkg_basic_revisions }}</strong> Revisions</span>
+        </div>
+        <form action="/checkout/{{ gig.id }}" method="get">
+          <input type="hidden" name="tier" id="pkg-tier" value="basic">
+          <button type="submit" class="btn btn--primary btn--block" id="pkg-cta">
+            Continue (US$<span id="pkg-cta-price">{{ "%g"|format(gig.pkg_basic_price) }}</span>)
+          </button>
+        </form>
+      </div>
+    </aside>
+  </div>
+</div>
+
+<script>
+// Inline vanilla JS: package picker (no nav) + gallery thumb swap.
+(function() {
+  var picker = document.getElementById('package-picker');
+  if (picker) {
+    var tabs = picker.querySelectorAll('.package-tab');
+    tabs.forEach(function(tab) {
+      tab.addEventListener('click', function() {
+        var tier = tab.dataset.tier;
+        tabs.forEach(function(t) { t.classList.toggle('is-active', t === tab); });
+        var price = picker.dataset[tier + 'Price'];
+        document.getElementById('pkg-title').textContent = picker.dataset[tier + 'Title'];
+        document.getElementById('pkg-desc').textContent = picker.dataset[tier + 'Desc'];
+        document.getElementById('pkg-price').textContent = price;
+        document.getElementById('pkg-delivery').textContent = picker.dataset[tier + 'Delivery'];
+        document.getElementById('pkg-revs').textContent = picker.dataset[tier + 'Revs'];
+        document.getElementById('pkg-tier').value = tier;
+        document.getElementById('pkg-cta-price').textContent = price;
+        var feats = JSON.parse(picker.dataset[tier + 'Features'] || '[]');
+        var ul = document.getElementById('pkg-features');
+        ul.innerHTML = feats.map(function(f) { return '<li>' + f + '</li>'; }).join('');
+      });
+    });
+  }
+  var thumbs = document.querySelectorAll('.gallery__thumb');
+  var main = document.getElementById('gallery-main');
+  thumbs.forEach(function(t) {
+    t.addEventListener('click', function() {
+      thumbs.forEach(function(x) { x.classList.remove('is-active'); });
+      t.classList.add('is-active');
+      if (main) main.style.backgroundImage = "url('" + t.dataset.thumbUrl + "')";
+    });
+  });
+})();
+</script>
+{% endblock %}

--- a/deploy/sim_envs/mantis_fiverr/app/templates/home.html
+++ b/deploy/sim_envs/mantis_fiverr/app/templates/home.html
@@ -1,0 +1,82 @@
+{% extends "base.html" %}
+{% from "_gig_card.html" import gig_card %}
+
+{% block main %}
+<section class="hero" aria-label="Hero">
+  <div class="hero__content">
+    <h1 class="hero__title">Find the right freelance service, right away</h1>
+    <form class="hero__search" action="/search/gigs" method="get" role="search">
+      <input type="text" name="query"
+             placeholder="Search for any service…" aria-label="Search">
+      <button type="submit">
+        <svg viewBox="0 0 20 20" width="20" height="20" aria-hidden="true">
+          <circle cx="8" cy="8" r="6" stroke="white" stroke-width="2" fill="none"/>
+          <line x1="13" y1="13" x2="18" y2="18" stroke="white" stroke-width="2"/>
+        </svg>
+        Search
+      </button>
+    </form>
+    <div class="hero__chips" role="list" aria-label="Popular searches">
+      <span class="hero__chips-label">Popular:</span>
+      {% for chip in popular_chips %}
+      <a class="hero__chip" role="listitem"
+         href="/search/gigs?query={{ chip|urlencode }}">{{ chip }}</a>
+      {% endfor %}
+    </div>
+  </div>
+</section>
+
+<section class="trusted-row" aria-label="Trusted by">
+  <span class="trusted-row__label">Trusted by:</span>
+  <span class="trusted-row__brand">Meta</span>
+  <span class="trusted-row__brand">Google</span>
+  <span class="trusted-row__brand">Netflix</span>
+  <span class="trusted-row__brand">P&amp;G</span>
+  <span class="trusted-row__brand">PayPal</span>
+</section>
+
+<section class="section" aria-labelledby="popular-services">
+  <h2 id="popular-services" class="section__title">Popular services</h2>
+  <div class="popular-carousel">
+    {% set names = ["AI Artists", "Logo Design", "WordPress", "Voice Over", "Video Editing", "Social Media"] %}
+    {% set subs = ["Add Promise", "Build your brand", "Customize your site", "Share your message", "Bring your story", "Reach more customers"] %}
+    {% for n in names %}
+    <a class="popular-card popular-card--p{{ loop.index0 }}"
+       href="/search/gigs?query={{ n|urlencode }}">
+      <span class="popular-card__title">{{ n }}</span>
+      <span class="popular-card__sub">{{ subs[loop.index0] }}</span>
+    </a>
+    {% endfor %}
+  </div>
+</section>
+
+<section class="section" aria-labelledby="categories">
+  <h2 id="categories" class="section__title">You need it, we&rsquo;ve got it</h2>
+  <div class="categories-grid">
+    {% for cat in categories %}
+    <a class="cat-tile" href="/categories/{{ cat.slug }}">
+      <img class="cat-tile__icon" src="/assets/category/{{ cat.slug }}.svg"
+           alt="" width="48" height="48">
+      <span class="cat-tile__label">{{ cat.title }}</span>
+    </a>
+    {% endfor %}
+  </div>
+</section>
+
+<section class="section" aria-labelledby="recommended">
+  <h2 id="recommended" class="section__title">Recommended for you</h2>
+  <div class="gig-grid gig-grid--4">
+    {% for g in featured %}
+      {{ gig_card(g) }}
+    {% endfor %}
+  </div>
+</section>
+
+<section class="business-cta" aria-label="Fiverr Business">
+  <div class="business-cta__inner">
+    <h2 class="business-cta__title">A whole world of freelance talent at your fingertips</h2>
+    <p class="business-cta__sub">The best for every budget — connect with sellers vetted for quality.</p>
+    <a class="business-cta__btn" href="/signup">Get Started</a>
+  </div>
+</section>
+{% endblock %}

--- a/deploy/sim_envs/mantis_fiverr/app/templates/inbox.html
+++ b/deploy/sim_envs/mantis_fiverr/app/templates/inbox.html
@@ -1,0 +1,71 @@
+{% extends "base.html" %}
+
+{% block title %}Inbox — {{ site_name }}{% endblock %}
+
+{% block main %}
+<div class="inbox-wrap">
+  <aside class="thread-list">
+    <h2>Inbox</h2>
+    <input class="thread-search" type="search" placeholder="Search messages">
+    {% if threads %}
+    <ul class="thread-list__items">
+      {% for t in threads %}
+      <li>
+        <a class="thread-row {% if active_thread and active_thread.id == t.id %}is-active{% endif %}"
+           href="/inbox/{{ t.id }}">
+          <img class="thread-row__avatar"
+               src="/assets/avatar/{{ t.seller_avatar_palette }}_{{ t.seller_display[:1] }}.svg"
+               alt="" width="40" height="40">
+          <div class="thread-row__body">
+            <strong>{{ t.seller_display }}</strong>
+            <p>{{ t.last_body|default('—', true)|truncate(60) }}</p>
+          </div>
+          <span class="thread-row__time">{{ t.last_msg_at[:10] }}</span>
+        </a>
+      </li>
+      {% endfor %}
+    </ul>
+    {% else %}
+    <p class="empty">No conversations yet.</p>
+    {% endif %}
+  </aside>
+
+  <section class="thread-detail">
+    {% if active_thread %}
+    <header class="thread-detail__head">
+      <img src="/assets/avatar/{{ active_thread.seller_avatar_palette }}_{{ active_thread.seller_display[:1] }}.svg"
+           alt="" width="40" height="40">
+      <div>
+        <strong>{{ active_thread.seller_display }}</strong>
+        <span class="dot dot--online"></span>
+        <span class="online-label">Online</span>
+      </div>
+      <a href="/{{ active_thread.seller_username }}" class="thread-detail__profile">View profile</a>
+    </header>
+
+    <div class="messages">
+      {% for m in messages %}
+      <div class="message {% if m.sender_id == me %}message--me{% else %}message--other{% endif %}">
+        <div class="message__bubble">{{ m.body }}</div>
+        <div class="message__time">{{ m.created_at[11:16] }}</div>
+      </div>
+      {% endfor %}
+    </div>
+
+    <form class="composer" action="/inbox/{{ active_thread.id }}/send" method="post">
+      <textarea name="body" placeholder="Type your message..." rows="2" required></textarea>
+      <button class="btn btn--primary" type="submit" aria-label="Send">
+        <svg viewBox="0 0 20 20" width="20" height="20" aria-hidden="true">
+          <path d="M2 10 L18 2 L12 18 L10 11 L2 10z" fill="white"/>
+        </svg>
+      </button>
+    </form>
+    {% else %}
+    <div class="thread-empty">
+      <h3>Select a conversation</h3>
+      <p>Choose a thread from the list to start messaging.</p>
+    </div>
+    {% endif %}
+  </section>
+</div>
+{% endblock %}

--- a/deploy/sim_envs/mantis_fiverr/app/templates/login.html
+++ b/deploy/sim_envs/mantis_fiverr/app/templates/login.html
@@ -1,0 +1,26 @@
+{% extends "base.html" %}
+
+{% block title %}Sign in — {{ site_name }}{% endblock %}
+
+{% block main %}
+<div class="auth-wrap">
+  <h1>Sign in to your account</h1>
+  {% if error %}<p class="auth-error">{{ error }}</p>{% endif %}
+  <form action="/login" method="post" class="auth-form">
+    <input type="hidden" name="next" value="{{ next }}">
+    <label>
+      Email or username
+      <input type="text" name="login" required>
+    </label>
+    <label>
+      Password
+      <input type="password" name="password" required>
+    </label>
+    <a class="auth-forgot" href="#">Forgot password?</a>
+    <button type="submit" class="btn btn--primary btn--block btn--lg">Continue</button>
+  </form>
+  <p class="auth-divider">— Or —</p>
+  <p class="auth-alt">Don&rsquo;t have an account? <a href="/signup">Join here</a></p>
+</div>
+{% endblock %}
+{% block footer %}{% endblock %}

--- a/deploy/sim_envs/mantis_fiverr/app/templates/order_detail.html
+++ b/deploy/sim_envs/mantis_fiverr/app/templates/order_detail.html
@@ -1,0 +1,99 @@
+{% extends "base.html" %}
+
+{% block title %}Order {{ order.number }} — {{ site_name }}{% endblock %}
+
+{% block main %}
+<div class="page-wrap page-wrap--narrow">
+  <div class="order-header-card">
+    <div>
+      <h1>Order {{ order.number }}</h1>
+      <span class="status status--{{ order.status }}">{{ order.status.title() }}</span>
+      <p class="muted">
+        Placed {{ order.placed_at[:10] }} · Due {{ order.due_at[:10] }}
+      </p>
+      <p class="muted">
+        Gig: <a href="/{{ order.seller_username }}/{{ order.gig_slug }}">{{ order.gig_title }}</a>
+        · Seller: {{ order.seller_display }}
+      </p>
+    </div>
+    <div class="order-header-card__total">
+      <span class="muted">Total</span>
+      <strong>US${{ "%g"|format(order.total) }}</strong>
+    </div>
+  </div>
+
+  <div class="order-actions">
+    <a href="/inbox/new/{{ order.seller_id }}" class="btn btn--outline">Message seller</a>
+  </div>
+
+  <section class="deliverables">
+    <h2>Deliverables</h2>
+    {% if order.status == 'active' %}
+      <p class="muted">Awaiting delivery from the seller.</p>
+    {% elif order.status == 'cancelled' %}
+      <p class="muted">Order was cancelled — no deliverables.</p>
+    {% else %}
+      <ul>
+        <li>final_design.zip <span class="muted">— 4.2 MB</span></li>
+        <li>working_files.zip <span class="muted">— 18.1 MB</span></li>
+      </ul>
+    {% endif %}
+  </section>
+
+  <section class="order-items">
+    <h2>Line items</h2>
+    <table>
+      <thead><tr><th>Description</th><th>Qty</th><th>Price</th></tr></thead>
+      <tbody>
+        {% for it in items %}
+        <tr><td>{{ it.description }}</td><td>{{ it.quantity }}</td><td>US${{ "%g"|format(it.unit_price) }}</td></tr>
+        {% endfor %}
+        <tr class="subtotal">
+          <td colspan="2"><strong>Subtotal</strong></td>
+          <td>US${{ "%g"|format(order.subtotal) }}</td>
+        </tr>
+        <tr>
+          <td colspan="2">Service fee</td>
+          <td>US${{ "%g"|format(order.service_fee) }}</td>
+        </tr>
+        <tr class="total">
+          <td colspan="2"><strong>Total</strong></td>
+          <td><strong>US${{ "%g"|format(order.total) }}</strong></td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+
+  {% if order.status == 'completed' and review is none %}
+  <section class="review-cta">
+    <h2>Leave a review</h2>
+    <form action="/orders/{{ order.id }}/review" method="post" class="review-form">
+      <div class="stars-input">
+        {% for n in [1,2,3,4,5] %}
+        <label class="star-label">
+          <input type="radio" name="stars" value="{{ n }}" {% if n == 5 %}checked{% endif %}>
+          <svg viewBox="0 0 20 20" width="32" height="32"><polygon points="10,2 12,8 18,8 13,12 15,18 10,14 5,18 7,12 2,8 8,8" fill="#ffb33e"/></svg>
+        </label>
+        {% endfor %}
+      </div>
+      <textarea name="body" rows="4" placeholder="Share more about your experience..."></textarea>
+      <button type="submit" class="btn btn--primary">Publish review</button>
+    </form>
+  </section>
+  {% elif review %}
+  <section class="review-card">
+    <h2>Your review</h2>
+    <p class="review-card__stars">
+      {% for s in range(5) %}
+      <svg viewBox="0 0 20 20" width="14" height="14" aria-hidden="true">
+        <polygon points="10,2 12,8 18,8 13,12 15,18 10,14 5,18 7,12 2,8 8,8"
+                 fill="{{ '#ffb33e' if s < review.stars else '#e4e5e7' }}"/>
+      </svg>
+      {% endfor %}
+    </p>
+    <p>{{ review.body }}</p>
+    <p class="muted small">Posted {{ review.created_at[:10] }}</p>
+  </section>
+  {% endif %}
+</div>
+{% endblock %}

--- a/deploy/sim_envs/mantis_fiverr/app/templates/orders.html
+++ b/deploy/sim_envs/mantis_fiverr/app/templates/orders.html
@@ -1,0 +1,49 @@
+{% extends "base.html" %}
+
+{% block title %}Manage Orders — {{ site_name }}{% endblock %}
+
+{% block main %}
+<div class="page-wrap">
+  <header class="orders-header">
+    <h1>Manage Orders</h1>
+  </header>
+
+  <nav class="orders-tabs" aria-label="Order status">
+    {% for value, label in [('all', 'All'), ('active', 'Active'), ('delivered', 'Delivered'), ('completed', 'Completed'), ('cancelled', 'Cancelled')] %}
+    <a class="orders-chip {% if status_filter == value %}is-active{% endif %}"
+       href="?status={{ value }}">
+      {{ label }} ({{ counts.get(value, 0) }})
+    </a>
+    {% endfor %}
+  </nav>
+
+  <table class="orders-table">
+    <thead>
+      <tr>
+        <th>Seller</th>
+        <th>Gig</th>
+        <th>Due on</th>
+        <th>Total</th>
+        <th>Status</th>
+        <th>Actions</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for o in orders %}
+      <tr>
+        <td>{{ o.seller_display }}</td>
+        <td>
+          <a href="/{{ o.seller_username }}/{{ o.gig_slug }}">{{ o.gig_title|truncate(48) }}</a>
+        </td>
+        <td>{{ o.due_at[:10] }}</td>
+        <td>US${{ "%g"|format(o.total) }}</td>
+        <td><span class="status status--{{ o.status }}">{{ o.status.title() }}</span></td>
+        <td><a href="/orders/{{ o.id }}" class="link">View</a></td>
+      </tr>
+      {% else %}
+      <tr><td colspan="6"><p class="empty">No orders match this filter.</p></td></tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+{% endblock %}

--- a/deploy/sim_envs/mantis_fiverr/app/templates/search.html
+++ b/deploy/sim_envs/mantis_fiverr/app/templates/search.html
@@ -1,0 +1,115 @@
+{% extends "base.html" %}
+{% from "_gig_card.html" import gig_card %}
+
+{% block title %}{{ query or "All gigs" }} — {{ site_name }} search{% endblock %}
+
+{% block main %}
+<div class="page-wrap">
+  <nav class="breadcrumbs" aria-label="Breadcrumbs">
+    <a href="/">Home</a>
+    <span>/</span>
+    <span>Search results for &ldquo;{{ query }}&rdquo;</span>
+  </nav>
+
+  <header class="search-header">
+    <div>
+      <h1 class="search-header__title">Results for &ldquo;{{ query }}&rdquo;</h1>
+      <p class="search-header__count">{{ total }} services available</p>
+    </div>
+    <form class="search-header__sort" action="/search/gigs" method="get">
+      {% if query %}<input type="hidden" name="query" value="{{ query }}">{% endif %}
+      {% for lf in level_filters %}<input type="hidden" name="level" value="{{ lf }}">{% endfor %}
+      {% if budget %}<input type="hidden" name="budget" value="{{ budget }}">{% endif %}
+      {% if delivery %}<input type="hidden" name="delivery" value="{{ delivery }}">{% endif %}
+      <label for="sort">Sort by:</label>
+      <select id="sort" name="sort" onchange="this.form.submit()">
+        <option value="relevance" {% if sort == 'relevance' %}selected{% endif %}>Relevance</option>
+        <option value="best_selling" {% if sort == 'best_selling' %}selected{% endif %}>Best Selling</option>
+        <option value="newest" {% if sort == 'newest' %}selected{% endif %}>Newest Arrivals</option>
+        <option value="rating" {% if sort == 'rating' %}selected{% endif %}>Average rating</option>
+      </select>
+    </form>
+  </header>
+
+  <div class="search-body">
+    <aside class="search-rail" aria-label="Filters">
+      <form action="/search/gigs" method="get" id="filter-form">
+        {% if query %}<input type="hidden" name="query" value="{{ query }}">{% endif %}
+        <input type="hidden" name="sort" value="{{ sort }}">
+
+        <fieldset class="filter-group">
+          <legend>Seller details</legend>
+          {% for value, label in [
+              ('top_rated', 'Top Rated Seller'),
+              ('level_two', 'Level Two'),
+              ('level_one', 'Level One'),
+              ('new', 'New Seller'),
+          ] %}
+          <label class="filter-row">
+            <input type="checkbox" name="level" value="{{ value }}"
+                   {% if value in level_filters %}checked{% endif %}
+                   onchange="this.form.submit()">
+            <span>{{ label }}</span>
+          </label>
+          {% endfor %}
+        </fieldset>
+
+        <fieldset class="filter-group">
+          <legend>Budget</legend>
+          {% for value, label in [
+              ('value', 'Value · Up to US$50'),
+              ('mid', 'Mid-range · US$50–200'),
+              ('high', 'High-end · US$200+'),
+          ] %}
+          <label class="filter-row">
+            <input type="radio" name="budget" value="{{ value }}"
+                   {% if value == budget %}checked{% endif %}
+                   onchange="this.form.submit()">
+            <span>{{ label }}</span>
+          </label>
+          {% endfor %}
+        </fieldset>
+
+        <fieldset class="filter-group">
+          <legend>Delivery time</legend>
+          {% for value, label in [
+              ('express', 'Express 24H'),
+              ('3d', 'Up to 3 days'),
+              ('7d', 'Up to 7 days'),
+              ('', 'Anytime'),
+          ] %}
+          <label class="filter-row">
+            <input type="radio" name="delivery" value="{{ value }}"
+                   {% if value == delivery %}checked{% endif %}
+                   onchange="this.form.submit()">
+            <span>{{ label }}</span>
+          </label>
+          {% endfor %}
+        </fieldset>
+      </form>
+    </aside>
+
+    <section class="search-results">
+      {% if results %}
+        <div class="gig-grid gig-grid--3">
+          {% for g in results %}{{ gig_card(g) }}{% endfor %}
+        </div>
+        {% if pages > 1 %}
+        <nav class="pagination" aria-label="Pagination">
+          {% for n in range(1, pages + 1) %}
+            {% set qs = "query=" ~ query ~ "&sort=" ~ sort %}
+            {% if n == page %}
+              <span class="pagination__page pagination__page--current">{{ n }}</span>
+            {% else %}
+              <a class="pagination__page" href="?{{ qs }}&page={{ n }}">{{ n }}</a>
+            {% endif %}
+          {% endfor %}
+        </nav>
+        {% endif %}
+      {% else %}
+        <p class="search-empty">No results for that query.</p>
+      {% endif %}
+    </section>
+  </div>
+</div>
+{% endblock %}

--- a/deploy/sim_envs/mantis_fiverr/app/templates/signup.html
+++ b/deploy/sim_envs/mantis_fiverr/app/templates/signup.html
@@ -1,0 +1,32 @@
+{% extends "base.html" %}
+
+{% block title %}Join — {{ site_name }}{% endblock %}
+
+{% block main %}
+<div class="auth-wrap">
+  <h1>Create a new account</h1>
+  {% if error %}<p class="auth-error">{{ error }}</p>{% endif %}
+  <form action="/signup" method="post" class="auth-form">
+    <label>
+      Username
+      <input type="text" name="username" required>
+    </label>
+    <label>
+      Email
+      <input type="email" name="email" required>
+    </label>
+    <label>
+      Display name
+      <input type="text" name="display_name">
+    </label>
+    <label>
+      Password
+      <input type="password" name="password" required>
+    </label>
+    <button type="submit" class="btn btn--primary btn--block btn--lg">Join</button>
+  </form>
+  <p class="auth-divider">— Or —</p>
+  <p class="auth-alt">Already have an account? <a href="/login">Sign in</a></p>
+</div>
+{% endblock %}
+{% block footer %}{% endblock %}

--- a/deploy/sim_envs/mantis_fiverr/requirements.txt
+++ b/deploy/sim_envs/mantis_fiverr/requirements.txt
@@ -1,0 +1,7 @@
+fastapi==0.115.0
+uvicorn[standard]==0.30.6
+jinja2==3.1.4
+python-multipart==0.0.9
+itsdangerous==2.2.0
+starlette==0.38.5
+httpx==0.27.2

--- a/deploy/sim_envs/mantis_fiverr/scripts/smoke.py
+++ b/deploy/sim_envs/mantis_fiverr/scripts/smoke.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 import os
 import sys
 import pathlib
-import re
 
 # Allow ``python scripts/smoke.py`` from inside the env dir.
 _HERE = pathlib.Path(__file__).resolve()
@@ -84,7 +83,7 @@ def main() -> int:
     ).fetchone()
     gig_url = f"/{g1['username']}/{g1['slug']}"
     _ok(client, gig_url)
-    _ok(client, f"/checkout/gig_00001?tier=basic")
+    _ok(client, "/checkout/gig_00001?tier=basic")
 
     print()
     print("== oracle dispatch (registered + unknown) ==")

--- a/deploy/sim_envs/mantis_fiverr/scripts/smoke.py
+++ b/deploy/sim_envs/mantis_fiverr/scripts/smoke.py
@@ -1,0 +1,184 @@
+"""Smoke-test mantis-fiverr end to end.
+
+Drives the in-process FastAPI app via httpx, exercises each in-scope
+page, runs each oracle through its happy path, and asserts the
+``/__env__/oracle?task_id=…`` response is passed=true.
+
+Run from the repo root::
+
+    ENV_ADMIN_TOKEN=test python -m deploy.sim_envs.mantis_fiverr.scripts.smoke
+
+or from inside the env dir::
+
+    ENV_ADMIN_TOKEN=test python scripts/smoke.py
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import pathlib
+import re
+
+# Allow ``python scripts/smoke.py`` from inside the env dir.
+_HERE = pathlib.Path(__file__).resolve()
+_ENV_DIR = _HERE.parent.parent
+sys.path.insert(0, str(_ENV_DIR.parent.parent.parent))  # repo root → can import deploy.sim_envs.mantis_fiverr.app
+
+
+def _ensure_admin_token() -> None:
+    os.environ.setdefault("ENV_ADMIN_TOKEN", "smoke-test-token")
+
+
+def _build_client():
+    from fastapi.testclient import TestClient  # type: ignore
+    from deploy.sim_envs.mantis_fiverr.app.main import app  # noqa: E402
+    return TestClient(app)
+
+
+def _admin_headers() -> dict[str, str]:
+    return {"X-Env-Admin": os.environ["ENV_ADMIN_TOKEN"]}
+
+
+def _ok(client, url: str) -> None:
+    r = client.get(url)
+    assert r.status_code == 200, (url, r.status_code, r.text[:200])
+    if "html" in r.headers.get("content-type", ""):
+        body = r.text
+        assert "<html" in body.lower(), (url, "no html body")
+    print(f"  ✓ GET {url}  ({r.status_code})")
+
+
+def main() -> int:
+    _ensure_admin_token()
+    client = _build_client()
+
+    print("== sanity ==")
+    h = client.get("/__env__/health")
+    assert h.status_code == 200 and h.json()["ok"] is True, h.text
+    print(f"  ✓ /__env__/health  ({h.json()['gigs']} gigs)")
+
+    print("== in-scope pages ==")
+    _ok(client, "/")
+    _ok(client, "/search/gigs?query=logo")
+    _ok(client, "/search/gigs?query=logo&level=top_rated&budget=value&delivery=3d&sort=newest")
+    _ok(client, "/categories/graphics-design")
+    _ok(client, "/categories/logo-design")
+    _ok(client, "/orders")
+    _ok(client, "/inbox")
+    _ok(client, "/login")
+    _ok(client, "/signup")
+    _ok(client, "/assets/logo.svg")
+    _ok(client, "/assets/category/graphics-design.svg")
+
+    # Resolve canonical gig URL — derived from seed
+    conn_meta = client.get(
+        "/__env__/state", headers=_admin_headers(),
+    ).json()["counts"]
+    assert conn_meta["gigs"] >= 1
+    # Find seller username + slug for gig_00001 to use canonical URL
+    from deploy.sim_envs.mantis_fiverr.app import db as fdb  # type: ignore
+    g1 = fdb.connect().execute(
+        "SELECT g.slug, u.username FROM gigs g JOIN users u ON g.seller_id = u.id "
+        "WHERE g.id = 'gig_00001'"
+    ).fetchone()
+    gig_url = f"/{g1['username']}/{g1['slug']}"
+    _ok(client, gig_url)
+    _ok(client, f"/checkout/gig_00001?tier=basic")
+
+    print()
+    print("== oracle dispatch (registered + unknown) ==")
+    # Unknown task — must still return the canonical shape.
+    r = client.get("/__env__/oracle?task_id=unknown_task",
+                   headers=_admin_headers())
+    body = r.json()
+    assert r.status_code == 200
+    assert body["passed"] is False and "no oracle registered" in body["reasons"][0]
+    print("  ✓ unknown task returns canonical fail shape")
+
+    # Before any agent action — t01..t03 should all fail.
+    for tid in ("t01_order_basic_logo", "t02_message_seller_then_order",
+                "t03_leave_5star_review"):
+        r = client.get(f"/__env__/oracle?task_id={tid}",
+                       headers=_admin_headers())
+        assert r.status_code == 200
+        assert r.json()["passed"] is False
+    print("  ✓ all three oracles correctly fail before any agent action")
+
+    print()
+    print("== t01 happy path: place a Basic order on gig_00001 ==")
+    # POST /checkout/gig_00001 with tier=basic, requirements, payment
+    r = client.post(
+        "/checkout/gig_00001",
+        data={"tier": "basic", "requirements": "Quick turnaround pls",
+              "payment_method": "card"},
+        follow_redirects=False,
+    )
+    assert r.status_code == 303, r.text
+    loc = r.headers["location"]
+    assert loc.startswith("/orders/order_"), loc
+    print(f"  ✓ POST /checkout/gig_00001 → 303 {loc}")
+    _ok(client, loc)
+    r = client.get("/__env__/oracle?task_id=t01_order_basic_logo",
+                   headers=_admin_headers())
+    body = r.json()
+    assert body["passed"], body
+    print(f"  ✓ t01 passed  ({body['diff']})")
+
+    print()
+    print("== t02 happy path: send a message, then order ==")
+    # Use existing conv_00001 (buyer_00001 ↔ gig_00001 seller)
+    convs = fdb.connect().execute(
+        "SELECT id FROM conversations WHERE buyer_id='buyer_00001' AND "
+        "seller_id=(SELECT seller_id FROM gigs WHERE id='gig_00001')"
+    ).fetchall()
+    assert convs, "seeded conversation missing"
+    conv_id = convs[0]["id"]
+    # Reset and re-seed so t01 doesn't pollute t02.
+    r = client.post("/__env__/reset", headers=_admin_headers())
+    assert r.status_code == 200
+    r = client.post(
+        f"/inbox/{conv_id}/send",
+        data={"body": "Hi! I'd love to buy your Basic package."},
+        follow_redirects=False,
+    )
+    assert r.status_code == 303, r.text
+    print(f"  ✓ POST /inbox/{conv_id}/send → 303")
+    r = client.post(
+        "/checkout/gig_00001",
+        data={"tier": "basic", "requirements": "",
+              "payment_method": "card"},
+        follow_redirects=False,
+    )
+    assert r.status_code == 303
+    r = client.get("/__env__/oracle?task_id=t02_message_seller_then_order",
+                   headers=_admin_headers())
+    body = r.json()
+    assert body["passed"], body
+    print(f"  ✓ t02 passed  ({body['diff']})")
+
+    print()
+    print("== t03 happy path: leave 5-star review on order_00007 ==")
+    r = client.post("/__env__/reset", headers=_admin_headers())
+    assert r.status_code == 200
+    # order_00007 is seeded as completed.
+    r = client.post(
+        "/orders/order_00007/review",
+        data={"stars": "5", "body": "Stellar work — fast and friendly!"},
+        follow_redirects=False,
+    )
+    assert r.status_code == 303, r.text
+    print("  ✓ POST /orders/order_00007/review → 303")
+    r = client.get("/__env__/oracle?task_id=t03_leave_5star_review",
+                   headers=_admin_headers())
+    body = r.json()
+    assert body["passed"], body
+    print(f"  ✓ t03 passed  ({body['diff']})")
+
+    print()
+    print("== all smoke checks passed ==")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/deploy/sim_envs/mantis_indeed/Dockerfile
+++ b/deploy/sim_envs/mantis_indeed/Dockerfile
@@ -1,0 +1,35 @@
+# mantis-indeed — simulated Indeed.com mirror sim env.
+#
+# Build:
+#     docker build -t mantis/sim-env-mantis-indeed:latest deploy/sim_envs/mantis_indeed
+#
+# Run:
+#     docker run --rm -p 8031:8080 \
+#         -e SEED=42 \
+#         -e FAKE_NOW=2026-01-15T09:00:00Z \
+#         -e ENV_ADMIN_TOKEN=$(python -c 'import secrets;print(secrets.token_urlsafe(32))') \
+#         mantis/sim-env-mantis-indeed:latest
+
+FROM python:3.11-slim
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends curl \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /srv
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY app ./app
+
+ENV PORT=8080 \
+    SEED=42 \
+    FAKE_NOW=2026-01-15T09:00:00Z \
+    PYTHONUNBUFFERED=1
+
+EXPOSE 8080
+HEALTHCHECK --interval=5s --timeout=2s --start-period=10s --retries=6 \
+    CMD curl -fs http://127.0.0.1:8080/__env__/health || exit 1
+
+CMD ["python", "-m", "uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/deploy/sim_envs/mantis_indeed/FIDELITY.md
+++ b/deploy/sim_envs/mantis_indeed/FIDELITY.md
@@ -1,0 +1,164 @@
+# mantis_indeed — FIDELITY
+
+**Last updated**: 2026-06-08 (first-pass build)
+
+## Status legend
+
+- ✅ **exact** — structural delta ≤2px, palette + text match the capture.
+- 🟢 **close** — matches structurally; minor pixel diff or small spacing
+  drift that doesn't break the agent's perception.
+- 🟡 **partial** — element exists with correct shape but not yet tuned
+  to capture-grade precision (font, spacing, or border drift).
+- 🔴 **missing** — element from capture not yet implemented.
+- ⚪ **not-matched** — captured spec ambiguous; followup needed to
+  pin down the canonical look.
+
+## In-scope page coverage
+
+### `/` — home
+
+| Element             | Real spec                                                        | Mine                                           | Status |
+|---------------------|------------------------------------------------------------------|------------------------------------------------|--------|
+| Sticky top nav      | 52px tall, white, 1px border-bottom `#E4E2E0`                   | 52px, white, 1px border-bottom `#D4D2D0`       | 🟢     |
+| Brand wordmark      | `indeed` brand-blue, 28-32px weight 700                          | `indeed` `#2557A7` 28px weight 700             | ✅     |
+| Right nav items     | `Sign in`, `Employers / Post Job`                                | exact strings                                  | ✅     |
+| Secondary strip     | Home, Company reviews, Find salaries, Employers, Create your resume, Change country | exact strings + country pill        | ✅     |
+| Hero H1             | `Find your next job` (canonical anon variant)                    | exact                                          | ✅     |
+| Hero search bar     | 56px, 880px wide, 1px border, 2 inputs + CTA, separator          | 56px, 880px max, 1px border, 2 inputs + CTA   | 🟢     |
+| Left input          | placeholder `Job title, keywords, or company`, aria + name=q     | exact                                          | ✅     |
+| Right input         | placeholder `City, state, zip code, or "remote"`, aria + name=l  | exact                                          | ✅     |
+| Search CTA          | brand-blue, label `Search`, 40px tall                            | brand-blue `Search` 40px                       | ✅     |
+| Trending panel H2   | `What's trending on Indeed`                                      | exact                                          | ✅     |
+| Resources panel H2  | `Employer Resources`                                             | exact                                          | ✅     |
+| Hero bg surface     | light grey panel                                                  | `var(--surface-grey)` `#F3F2F1`                | 🟢     |
+
+### `/jobs?q=&l=` — search results
+
+| Element                       | Real spec                                                                 | Mine                                                        | Status |
+|-------------------------------|---------------------------------------------------------------------------|-------------------------------------------------------------|--------|
+| Sticky top nav (reused)       | same as `/`                                                              | same as `/`                                                  | ✅     |
+| Secondary search bar          | 44px compact, prefills q + l                                              | 44px compact, prefills q + l                                 | 🟢     |
+| H1                            | `software engineer jobs in Austin, TX` (lowercase echo)                   | exact templated as `{q.lower()} jobs in {l}`                 | ✅     |
+| Filter chip rail              | 11 chips exact order: Date posted, Remote, Developer skill, Job Type, …  | 11 chips, exact order, exact labels                          | ✅     |
+| Chip styling                  | 32px tall, 1px border, 16px radius, 14px, active = blue tint + blue border | 32px tall, 1px border, radius 16px, active state matches    | 🟢     |
+| Sort row                      | `Sort by: relevance` right-aligned + result count left                    | matches                                                      | 🟢     |
+| 3-pane layout                 | grid 480px + 680px + 20px gap, container 1440px                           | exact grid template                                          | ✅     |
+| Result card                   | 1px border, 8px radius, 16px padding, white bg                            | exact                                                        | ✅     |
+| Card title                    | 18px bold brand-blue link                                                 | matches                                                      | ✅     |
+| Selected card                 | blue tint bg + 4px brand-blue left accent                                 | tint + `::before` 4px left accent                            | 🟢     |
+| Bookmark icon                 | filled star when saved, outline otherwise                                 | ☆/★ swap                                                     | 🟡     |
+| Right detail pane             | 680px wide, sticky                                                        | 680px, sticky top:64px                                       | 🟢     |
+| Detail-pane H2 suffix         | `- job post` canonical                                                    | exact                                                        | ✅     |
+| Detail tabs                   | `Job details`, `Company`, `Reviews`                                       | exact                                                        | ✅     |
+| Apply CTA label               | `Apply now`                                                               | exact                                                        | ✅     |
+| Result selection w/o nav      | click left card → right pane swaps + URL `?vjk=<jk>`                      | implemented via vanilla JS + `/jobs/_detail` fragment        | ✅     |
+
+### `/viewjob?jk=<id>` — full job detail
+
+| Element                  | Real spec                                                        | Mine                       | Status |
+|--------------------------|------------------------------------------------------------------|----------------------------|--------|
+| Job header card          | bordered card with title, company, location, salary chips        | matches                    | 🟢     |
+| H2 `… - job post` suffix | canonical                                                        | exact                      | ✅     |
+| Apply / Save CTAs        | primary + outline                                                | exact                      | ✅     |
+| Tabs                     | Job details / Company / Reviews                                  | exact                      | ✅     |
+| Description rendering    | paragraphs from markdown-ish source                              | split on \n\n              | 🟡     |
+
+### `/apply/<jk>` — Easy Apply (4 screens)
+
+| Element                  | Real spec                                                        | Mine                                  | Status |
+|--------------------------|------------------------------------------------------------------|---------------------------------------|--------|
+| Stepper                  | 4 steps: Contact → Resume → Questions → Review                   | exact 4-step stepper                  | ✅     |
+| Step 1 H1                | `Add your contact information`                                   | exact                                 | ✅     |
+| Step 2 H1                | `Add your resume`                                                | exact                                 | ✅     |
+| Step 3 H1                | `Answer screening questions`                                     | exact                                 | ✅     |
+| Step 4 H1                | `Review your application`                                        | exact                                 | ✅     |
+| Submit CTA               | `Submit application`                                             | exact                                 | ✅     |
+| Success confirmation     | green check + `Application submitted` + next-step CTAs           | matches                               | 🟢     |
+| Auto-form-validation     | required + HTML5                                                 | HTML5 required attrs                  | 🟡     |
+
+### `/myjobs` — Saved + Applied
+
+| Element            | Real spec                                | Mine                              | Status |
+|--------------------|------------------------------------------|-----------------------------------|--------|
+| H1                 | `My jobs`                                | exact                             | ✅     |
+| Tabs               | `Saved` / `Applied`                      | exact tabs with active underline  | ✅     |
+| Empty state Saved  | `You haven't saved any jobs yet. …`      | exact                             | ✅     |
+| Empty state Applied| `You haven't applied to any jobs yet.`   | exact                             | ✅     |
+| Card shape         | reused result-card                       | reused                            | 🟢     |
+| Applied status badge | `New / Reviewed / Rejected / Hired`    | exact + colour-coded              | 🟢     |
+
+### `/resumes` — resume manager
+
+| Element             | Real spec                                          | Mine                                | Status |
+|---------------------|----------------------------------------------------|-------------------------------------|--------|
+| H1                  | `Your resumes`                                     | exact                               | ✅     |
+| Resume row layout   | title + meta + Edit/Delete buttons                 | matches                             | 🟢     |
+| Add resume form     | inline disclosure → title/summary/skills/exp       | matches                             | 🟡     |
+
+### `/employers/dashboard`
+
+| Element               | Real spec                                              | Mine                                | Status |
+|-----------------------|--------------------------------------------------------|-------------------------------------|--------|
+| H1                    | `Employer dashboard`                                   | exact                               | ✅     |
+| KPI strip             | 3 cards: Active postings, New applicants this week, Total views | matches                  | ✅     |
+| Postings table        | title, location, applicants breakdown, posted, status  | matches                             | 🟢     |
+| Row hover             | tint                                                   | tint + cursor                       | 🟢     |
+
+### `/employers/jobs/<id>` — posting / applicant review
+
+| Element                  | Real spec                                       | Mine                              | Status |
+|--------------------------|-------------------------------------------------|-----------------------------------|--------|
+| H1                       | `{Job Title}`                                  | exact                             | ✅     |
+| Status filter chip row   | All / New / Reviewed / Rejected / Hired         | matches                           | ✅     |
+| Applicant table          | Name / Resume / Status / Applied + actions     | matches                           | 🟢     |
+| Status select            | dropdown w/ auto-submit on change               | matches                           | ✅     |
+| Mark-reviewed shortcut   | inline button for `new` applicants              | shipped                           | 🟡     |
+
+### `/employers/jobs/new`
+
+| Element            | Real spec                                            | Mine                            | Status |
+|--------------------|------------------------------------------------------|---------------------------------|--------|
+| H1                 | `Post a job`                                         | exact                           | ✅     |
+| Form               | title + location + salary low/high + remote + type + desc | matches                  | ✅     |
+| Submit CTAs        | `Publish` + `Save as draft`                          | matches                         | 🟢     |
+
+### `/login`, `/signup`
+
+| Element            | Real spec                                | Mine                       | Status |
+|--------------------|------------------------------------------|----------------------------|--------|
+| Card width         | 360px centred                            | 360px centred              | ✅     |
+| Login H1           | `Sign in`                                | exact                      | ✅     |
+| Signup H1          | `Create your account`                    | exact                      | ✅     |
+| Error banner       | red                                      | red banner                 | 🟢     |
+
+## Open gaps (for follow-up agents)
+
+- **Pixel-perfect pass** — overall sections are structurally correct but
+  haven't been per-pixel diff-verified against a live screenshot. Run
+  the per-element probe + screenshot diff once Chrome MCP can capture
+  through Cloudflare.
+- **Font** — site uses system Helvetica fallback rather than Indeed
+  Sans. Acceptable per the build prompt (no Google Fonts at runtime),
+  but tracking as 🟡.
+- **Hero background** — live site uses a subtle gradient; mirror uses
+  flat grey panel. 🟡.
+- **Detail tabs interactivity** — visual only, no content swap. 🟡.
+- **Reviews / Company tabs in detail pane** — placeholder only. 🔴 for
+  full content fidelity.
+- **Filter chip popovers** — chips are visual-only except for `Remote`
+  which actually toggles. Date-posted/Pay/etc. need popover impl. 🟡.
+- **Captured corpus** — only `notes.md` shipped for each slug. Follow-up
+  agents should populate `dom.html`, `styles.json`, `screenshot.png`
+  once Cloudflare-friendly capture is feasible.
+- **Search ranking** — substring match only; live Indeed has fuzzy +
+  relevance ranking. Acceptable per build prompt.
+- **Easy Apply auto-fill** — currently pulls from user record; live
+  site prefills from past applications. 🟡.
+
+## Iteration log
+
+- **2026-06-08 (initial)** — Phases 0–6 first-pass complete. All three
+  oracles pass via smoke.py. Captured corpus is `notes.md`-only;
+  fidelity loop has not yet pixel-diffed against a captured screenshot
+  (Cloudflare-gated). All major in-scope pages render; interactions
+  wired to the audit_log.

--- a/deploy/sim_envs/mantis_indeed/FIDELITY_AGENT_PROMPT.md
+++ b/deploy/sim_envs/mantis_indeed/FIDELITY_AGENT_PROMPT.md
@@ -1,0 +1,65 @@
+# mantis_indeed — FIDELITY agent prompt
+
+You're a follow-up agent closing a specific fidelity gap on the
+`mantis_indeed` sim env. Treat this prompt as the playbook for every
+iteration.
+
+## 1. Read first
+
+- `SCOPE.md` — what's in/out of scope.
+- `FIDELITY.md` — current section-by-section status. Pick a 🟡 or 🔴
+  row to close. Don't pick rows that are already ✅ unless you've found
+  a regression.
+- `_captured/<slug>/notes.md` — the ground truth.
+- `app/templates/<page>.html` + `app/static/site.css` — current impl.
+
+## 2. Pick exactly one gap per iteration
+
+Don't fan out. Pick one row in FIDELITY.md (e.g. "filter-chip popovers
+🟡") and close it to ✅ or 🟢.
+
+## 3. The fidelity loop
+
+For visual gaps:
+
+1. Take a fresh capture of the live element (Chrome MCP javascript_tool
+   probe — see `mantis_boattrader/FIDELITY_BUILD_FROM_SCRATCH_PROMPT.md`
+   for the per-element probe).
+2. Compare key declarations: width, height, padding, margin, border,
+   border-radius, background, color, font-size, font-weight, line-height.
+3. Update `app/static/site.css` to match. Avoid !important; group
+   declarations by component.
+4. Update FIDELITY.md row to ✅ or 🟢 with a one-line iteration log
+   entry.
+
+For interaction gaps:
+
+1. Capture the live interaction's URL/DOM/network effect.
+2. Wire the matching route in `app/routes/<surface>.py`.
+3. Add a `db.log_audit(...)` call at the state-change boundary.
+4. Run `python scripts/smoke.py`. Add a new check to smoke if relevant.
+5. Update FIDELITY.md.
+
+## 4. Forbidden
+
+- Adding new pages outside `SCOPE.md`.
+- Adding new pip deps without justification (slim Docker is a goal).
+- Outbound network at runtime.
+- Real brand assets (logos, photos).
+- Plain `git add .` — stage individual files.
+
+## 5. Done when
+
+- The picked row is ✅ or 🟢.
+- `python scripts/smoke.py` exits 0.
+- FIDELITY.md is updated.
+- No collateral regressions in adjacent rows.
+
+## 6. Helpful patterns from `mantis_boattrader`
+
+- Section-by-section CSS comments grouped by component name.
+- One state per chip/button (default, hover, focus-visible, active,
+  disabled).
+- `data-testid` on every interactive node — the CUA harness can use
+  these for grounding in offline tests (visually, the agent uses
+  pixels; the testids are for our own e2e tests).

--- a/deploy/sim_envs/mantis_indeed/README.md
+++ b/deploy/sim_envs/mantis_indeed/README.md
@@ -1,0 +1,87 @@
+# mantis_indeed
+
+Server-rendered synthetic mirror of `indeed.com` for mantis CUA training.
+
+## What it mirrors
+
+- Two-input hero search (`/`)
+- Canonical Indeed 3-pane search results (`/jobs`)
+- Full job detail page (`/viewjob`)
+- 4-step Easy Apply (`/apply/<jk>`)
+- Saved + Applied tabs (`/myjobs`)
+- Resume manager (`/resumes`)
+- Employer dashboard + posting / applicant review (`/employers/*`)
+- Username + password auth (`/login`, `/signup`)
+
+See `SCOPE.md` for the full in-scope spec and `FIDELITY.md` for
+section-by-section match status.
+
+## Run
+
+```bash
+cd deploy/sim_envs/mantis_indeed
+docker build -t mantis/sim-env-mantis-indeed:latest .
+docker run --rm -p 8031:8080 \
+    -e SEED=42 \
+    -e FAKE_NOW=2026-01-15T09:00:00Z \
+    -e ENV_ADMIN_TOKEN=$(python -c 'import secrets;print(secrets.token_urlsafe(32))') \
+    mantis/sim-env-mantis-indeed:latest
+```
+
+Or run locally without Docker:
+
+```bash
+pip install -r requirements.txt
+ENV_ADMIN_TOKEN=test FAKE_NOW=2026-01-15T09:00:00Z \
+  python -m uvicorn app.main:app --host 0.0.0.0 --port 8080
+```
+
+## Smoke test
+
+```bash
+ENV_ADMIN_TOKEN=test python scripts/smoke.py
+```
+
+Exits 0 when all in-scope pages render + all three oracles pass via
+their happy-path HTTP drives.
+
+## Oracle tasks
+
+- `t01_search_save_remote` — seeker searches "software engineer" in
+  "Austin, TX" with `remote=1`, then saves `job_00007`. Oracle reads
+  `search_submitted` + `job_saved` audit rows and the `saved_jobs`
+  table.
+- `t02_easy_apply` — seeker Easy Applies to `job_00012` with phone +
+  `resume_00001` + screening answers. Oracle reads
+  `application_submitted` audit row + `applications` row.
+- `t03_employer_review_applicant` — employer moves the seeded
+  `application_seed_t03` row on `job_00003` from `new` → `reviewed`.
+  Oracle reads `application_status_changed` audit row +
+  `applications.status` + `applications.reviewed_at`.
+
+Oracles are dispatched via `GET /__env__/oracle?task_id=<id>` (admin
+token required).
+
+## Fidelity tracker
+
+`FIDELITY.md` holds the section-by-section match status with the legend
+`exact / close / partial / missing / not-matched`. First-pass build
+gets every in-scope row to at least 🟢 close. Pixel-perfect ≤2px is the
+north star, not a one-turn deliverable.
+
+`FIDELITY_AGENT_PROMPT.md` is the playbook follow-up agents use to
+close one gap at a time.
+
+## Auth defaults
+
+Without `ENV_REQUIRE_AUTH=1`, the env operates with a default acting
+seeker `user_00001` and default acting employer `user_emp_00003` so
+oracles can grade without first going through `/login`. With
+`ENV_REQUIRE_AUTH=1`, protected paths 303 → `/login`.
+
+Pinned credentials (per seed):
+
+- Seeker `user_00001` — email `seeker1@example.com`, password
+  `seekerpass`.
+- Employer `user_emp_00003` — email `employer3@example.com`, password
+  `emppass`.

--- a/deploy/sim_envs/mantis_indeed/SCOPE.md
+++ b/deploy/sim_envs/mantis_indeed/SCOPE.md
@@ -1,0 +1,108 @@
+# mantis_indeed — SCOPE
+
+This sim env mirrors **indeed.com** as a server-rendered FastAPI surface that
+the mantis CUA can train against. High-fidelity means pixel-parity visual
+replica + interaction-parity behavioural replica vs the live site.
+
+Source: `https://www.indeed.com/`
+
+## In-scope pages
+
+- `/` — marketing home with the canonical two-input hero (What + Where).
+- `/jobs?q=&l=&sort=&radius=&remote=&date=` — 3-pane search results
+  (top filter chip rail, left results list, right detail pane).
+- `/viewjob?jk=<id>` — full job detail page (direct-link variant of the
+  right pane).
+- `/apply/<id>` — Indeed Easy Apply, 3 steps: contact → resume → screening
+  Q&A, then review → submit.
+- `/myjobs` — Saved + Applied tabs.
+- `/resumes` — resume manager (upload + edit).
+- `/employers/dashboard` — employer posting board + applicant review.
+- `/employers/jobs/new` — employer create posting.
+- `/login`, `/signup` — username + password.
+
+## In-scope entities
+
+- `users` — seekers + employers (`role` column).
+- `companies`
+- `jobs` (title, company, location, salary_low/high, remote_flag, posted_date,
+  description, jk job-key).
+- `resumes` (per-user).
+- `applications` (user + job + status: new/reviewed/rejected/hired).
+- `saved_jobs` (user + job + saved_at).
+- `audit_log` — append-only mutation record (oracle source of truth).
+
+## In-scope interactions
+
+- **Search** — type What + Where in hero → submit → `/jobs?q=&l=`.
+- **Result selection** — click a result card on the left of `/jobs` →
+  detail pane on the right updates **without page nav** (URL adds
+  `?vjk=<jk>`). This is the canonical Indeed interaction.
+- **View Job** — click "View job" → `/viewjob?jk=<jk>` full page.
+- **Filter** — click a chip on the filter rail → URL param toggles, results
+  re-render. Chips: Date posted, Remote, Pay, Job Type, Experience level,
+  Education, Company.
+- **Save** — bookmark icon on a result toggles `saved_jobs` row + bookmark
+  visual state.
+- **Easy Apply** — from the detail pane click "Apply now" → 3-step form →
+  submit → application row + redirect to confirmation.
+- **Employer review** — from `/employers/dashboard`, click a posting →
+  applicant list → move applicant from "New" to "Reviewed" → audit row.
+
+## Out of scope (explicitly NOT mirrored)
+
+- Real images / brand photography → deterministic SVG placeholders.
+- Advertising / analytics / tracking scripts → stripped.
+- Third-party widgets → stripped.
+- OAuth / social login → username + password only.
+- Payment processing → no real Stripe; audit_log row only.
+- Real-time websockets / SSE → polling or static.
+- A/B variants → pick the anonymous-visitor canonical.
+
+## Brand & typography (ground truth — capture brief)
+
+- Font: `"Indeed Sans", "Noto Sans", "Helvetica Neue", Helvetica, Arial,
+  "Liberation Sans", Roboto, Noto, sans-serif`. Helvetica fallback is fine.
+- Brand blue: `#2557A7`.
+- Body bg: white `#FFFFFF`.
+- Primary CTA: brand blue background, white text.
+- Top nav: slim, sticky, white bg with bottom border.
+
+## Hero / nav copy (must be exact)
+
+- Hero H1: depends on slug — `/` shows the search form; `/jobs?q=software
+  engineer&l=Austin, TX` shows lowercase-echo H1
+  `software engineer jobs in Austin, TX`.
+- Left hero input placeholder: `Job title, keywords, or company`,
+  aria-label `search: Job title, keywords, or company`, name `q`.
+- Right hero input placeholder: `City, state, zip code, or "remote"`,
+  aria-label `Edit location`, name `l`.
+- CTA: `Search`.
+- Top nav (anon home): `Home`, `Company reviews`, `Find salaries`,
+  `Sign in`, `Employers / Post Job`.
+- Secondary strip: `Home`, `Company reviews`, `Find salaries`, `Employers`,
+  `Create your resume`, `Change country 🇺🇸 United States`.
+
+## Search results layout (must match)
+
+- Three panes. Top chip rail with 11 chips in this exact order:
+  `Date posted`, `Remote`, `Developer skill`, `Job Type`, `Experience level`,
+  `Pay`, `Education`, `Clearance type`, `Developer type`,
+  `Compensation package`, `Distance`.
+- Left = result list (each card: title, company, location, salary
+  range, snippet, posted-relative-date, Apply button, bookmark icon).
+- Right = detail pane width 680px. Detail-pane H2 pattern:
+  `{Job Title} - job post` — the `- job post` suffix is canonical.
+- Apply button label: `Apply now`.
+
+## Done bar
+
+Same as `mantis_boattrader/SCOPE.md`:
+
+- Structural deltas vs captured spec ≤ 2 px in every visible section.
+- Perceptual diff vs captured screenshot < 0.5%.
+- Every in-scope interaction replays with matching URL + DOM + audit_log
+  deltas — verified by the three oracle tasks.
+
+The first-pass iteration ships partial-fidelity sections (marked in
+FIDELITY.md). Subsequent agents close the gaps using `FIDELITY_AGENT_PROMPT.md`.

--- a/deploy/sim_envs/mantis_indeed/_captured/README.md
+++ b/deploy/sim_envs/mantis_indeed/_captured/README.md
@@ -1,0 +1,30 @@
+# mantis_indeed — captured corpus
+
+This corpus is the ground-truth spec the mantis_indeed mirror reproduces.
+Each subdirectory corresponds to one in-scope page slug.
+
+## Capture method
+
+- Primary: `_capture_brief.md` at the sim_envs root — contains palette,
+  typography, exact nav-item order, exact placeholder text, hero copy
+  and chip-rail labels captured live from indeed.com by the parent
+  session.
+- Augmented with training-data recollection (flagged in `notes.md`).
+- Live Chrome MCP capture against indeed.com is auth-walled / Cloudflare-
+  challenged on most surfaces — captured what we can without auth and
+  flagged auth-gated surfaces as ⏳ in `FIDELITY.md` for follow-up.
+
+## Slugs
+
+- `home/` — `/`
+- `jobs_search/` — `/jobs?q=software+engineer&l=Austin%2C+TX`
+- `viewjob/` — `/viewjob?jk=...`
+- `apply/` — `/apply/<id>`
+- `myjobs/` — `/myjobs`
+- `resumes/` — `/resumes`
+- `employers_dashboard/` — `/employers/dashboard`
+- `employers_jobs_new/` — `/employers/jobs/new`
+- `login/`, `signup/` — auth surfaces
+
+Each slug has `notes.md` minimum; `dom.html`/`styles.json` populated
+where capture was possible.

--- a/deploy/sim_envs/mantis_indeed/_captured/apply/notes.md
+++ b/deploy/sim_envs/mantis_indeed/_captured/apply/notes.md
@@ -1,0 +1,40 @@
+# `/apply/<id>` — Indeed Easy Apply (3 steps)
+
+## Step 1 — Contact
+
+- Card width 720px, centred.
+- H1 `Add your contact information`.
+- Stepper above H1: `1. Contact` (active) → `2. Resume` → `3. Questions`
+  → `4. Review`. Active step is brand-blue, inactive is grey.
+- Fields:
+  - Full name (text, required).
+  - Email (email, required, prefilled when logged in).
+  - Phone (tel, required).
+  - City (text), State (select), Zip (text).
+- `Continue` blue button bottom right; `Back` outline button left.
+
+## Step 2 — Resume
+
+- H1 `Add your resume`.
+- List of existing resumes as radio cards (`Use resume_00001`).
+- Or upload (file input + drop zone).
+- `Continue`.
+
+## Step 3 — Questions
+
+- H1 `Answer screening questions`.
+- 2-3 yes/no or short-answer questions seeded per job.
+- `Continue`.
+
+## Step 4 — Review
+
+- H1 `Review your application`.
+- Summary of all fields, with `Edit` links per section.
+- `Submit application` button (brand blue).
+- Submitting → POST `/apply/<jk>` → `application` row + redirect to
+  `/apply/<jk>/confirm` showing success message.
+
+## Capture status
+
+- Synthetic spec — Indeed's real Easy Apply flow has varying step counts
+  per job; we ship the canonical 3-step shape.

--- a/deploy/sim_envs/mantis_indeed/_captured/employers_dashboard/notes.md
+++ b/deploy/sim_envs/mantis_indeed/_captured/employers_dashboard/notes.md
@@ -1,0 +1,28 @@
+# `/employers/dashboard` — employer dashboard
+
+## Layout
+
+- Sticky top nav (employer variant): brand wordmark + `Post a job` /
+  `Dashboard` / `Sign out`.
+- H1 `Employer dashboard`.
+- KPI strip (3 cards): `Active postings`, `New applicants this week`,
+  `Total views`.
+- Posting list table:
+  - Columns: `Title`, `Location`, `Applicants` (with badge breakdown
+    New/Reviewed/Rejected/Hired), `Posted`, `Status`.
+  - Row click → `/employers/jobs/<posting_id>`.
+
+## Applicant detail (`/employers/jobs/<posting_id>`)
+
+- H1 `{Job Title}`.
+- Applicant table:
+  - Columns: `Name`, `Resume`, `Status`, `Applied`, Actions.
+  - Status as a select dropdown: `New`, `Reviewed`, `Rejected`, `Hired`.
+  - Saving the dropdown → POST `/employers/applications/<id>/status` →
+    `applications.status` + `reviewed_at` + audit row.
+
+## Interaction
+
+- Filter applicants by status via top-of-table chip strip.
+- Click `New` applicants -> filter -> select `Reviewed` from row select
+  → status persists.

--- a/deploy/sim_envs/mantis_indeed/_captured/employers_jobs_new/notes.md
+++ b/deploy/sim_envs/mantis_indeed/_captured/employers_jobs_new/notes.md
@@ -1,0 +1,19 @@
+# `/employers/jobs/new` — create posting
+
+## Layout
+
+- H1 `Post a job`.
+- Form (single column 720px):
+  - Job title (text, required).
+  - Company (preselected to employer's company).
+  - Location (text, required).
+  - Salary low + Salary high (number inputs side by side).
+  - Remote (checkbox).
+  - Job type (select: Full-time, Part-time, Contract, Internship).
+  - Description (textarea, required).
+- `Publish` blue primary button + `Save as draft` outline.
+
+## Interaction
+
+- POST `/employers/jobs/new` → jobs row + audit row + redirect to
+  `/employers/jobs/<posting_id>`.

--- a/deploy/sim_envs/mantis_indeed/_captured/home/notes.md
+++ b/deploy/sim_envs/mantis_indeed/_captured/home/notes.md
@@ -1,0 +1,65 @@
+# `/` — home
+
+## Layout (1440×900 desktop)
+
+- Sticky top nav, slim (~52px). White bg, 1px bottom border `#E4E2E0`.
+- Top nav left: brand wordmark "indeed" lowercased in brand blue `#2557A7`,
+  large size (`~32px` height including descender).
+- Top nav right items (anonymous home): `Sign in` link, `Employers / Post Job`
+  link. Each ~14px Indeed Sans.
+- Below the top bar a secondary strip with: `Home`, `Company reviews`,
+  `Find salaries`, `Employers`, `Create your resume`, `Change country
+  🇺🇸 United States`. Underline on hover.
+- Hero block ~280px tall, centred max-width ~1080px.
+  - H1: blank in the literal sense — the hero composes from heading +
+    search form. In the captured live snapshot the heading reads
+    `Find your next job` (this exact phrase varies slightly across
+    A/B variants; we pick this canonical wording).
+  - Two-input search bar SIDE BY SIDE within a rounded border container,
+    1px solid `#D4D2D0`, height 56px, separator between inputs.
+    - Left: name=`q`, placeholder `Job title, keywords, or company`,
+      aria-label `search: Job title, keywords, or company`,
+      icon prefix 🔍 (Indeed actually renders a magnifier glyph).
+    - Right: name=`l`, placeholder `City, state, zip code, or "remote"`,
+      aria-label `Edit location`, icon prefix 📍.
+    - CTA: blue button `Search`, brand blue bg `#2557A7`, white text,
+      height 40px, border-radius 4px, padding 0 24px.
+- Below hero, two panels side by side:
+  - Left: `What's trending on Indeed` (H2 ~20px bold).
+    - Bullet list of 4-6 trending searches as chip-style links.
+  - Right: `Employer Resources` (H2 ~20px bold).
+    - Bullet list of resource links.
+
+## Typography
+
+- Body font: `"Indeed Sans", "Noto Sans", "Helvetica Neue", Helvetica,
+  Arial, "Liberation Sans", Roboto, Noto, sans-serif`.
+- H1: 32px / 40px line-height, weight 700.
+- H2: 20px / 28px line-height, weight 700.
+- Body: 16px / 24px.
+- Small body: 14px / 20px.
+
+## Colour palette
+
+- Brand blue: `#2557A7`. Hover-darken: `#164081`.
+- Text primary: `#2D2D2D`.
+- Text secondary: `#595959`.
+- Border / dividers: `#D4D2D0`.
+- Light grey bg surface: `#F3F2F1`.
+- Link visited: same as primary (no purple).
+- White: `#FFFFFF`.
+
+## Interaction signals
+
+- Tabbing through hero inputs uses focus-outline 2px solid `#2557A7`.
+- Search submits to `/jobs?q=...&l=...` (GET form).
+- The right input does NOT auto-submit on 5-digit zip in this canonical
+  capture (see capture brief — convention only).
+
+## Capture status
+
+- Notes derived from `_capture_brief.md` § indeed + training-data
+  recollection. Live Chrome MCP capture not attempted in this turn
+  (Indeed presents Cloudflare interstitials anonymously); fidelity
+  follow-up agents should run the per-element probe and update
+  `dom.html` / `styles.json` / `screenshot.png`.

--- a/deploy/sim_envs/mantis_indeed/_captured/jobs_search/notes.md
+++ b/deploy/sim_envs/mantis_indeed/_captured/jobs_search/notes.md
@@ -1,0 +1,82 @@
+# `/jobs?q=software+engineer&l=Austin%2C+TX` — search results
+
+## Layout (1440×900 desktop)
+
+- Sticky top nav same as `/`.
+- Just below: a secondary search bar that mirrors hero (compact 40px
+  height) so the agent can re-search without scrolling up. Two inputs +
+  Search CTA. Pre-fills with `q` + `l`.
+- Underneath the secondary search: H1 `software engineer jobs in Austin,
+  TX` — lowercase echo of query + location. font-size 20px / weight 700.
+- Filter chip rail beneath the H1. 11 chips, horizontal, scrollable
+  overflow on narrow viewports. Exact order:
+  1. `Date posted`
+  2. `Remote`
+  3. `Developer skill`
+  4. `Job Type`
+  5. `Experience level`
+  6. `Pay`
+  7. `Education`
+  8. `Clearance type`
+  9. `Developer type`
+  10. `Compensation package`
+  11. `Distance`
+  - Each chip ~32px tall, 1px border `#D4D2D0`, padding 6px 12px,
+    border-radius 16px, font 14px / weight 400. Active chip: brand blue
+    border + `#E4F1FF` bg.
+- Sub-strip with sort dropdown `Sort by: relevance` (right-aligned),
+  and result-count caption left: `1-15 of 1,234 jobs`.
+
+## 3-pane body
+
+- Container max-width 1440px. Two columns: results list (480px) +
+  detail pane (680px). Combined `grid-template-columns: 480px 680px`
+  with 20px gap, centred.
+- **Left list — result card**:
+  - 1 px border `#D4D2D0`, padding 16px, border-radius 8px, gap 12px
+    between cards, white bg. Selected card bg `#E4F1FF`, 2px brand-blue
+    left-border accent (4px wide actually) on the selected card.
+  - Inner shape:
+    - Row 1: title `h2.jobTitle` 18px bold brand blue (acts as link).
+    - Row 2: company name in `#2D2D2D` 14px + rating stars + review
+      count `(N reviews)` 12px grey.
+    - Row 3: location 14px `#595959`.
+    - Row 4: salary range `$130,000 - $170,000 a year` 14px `#2D2D2D`.
+    - Row 5: snippet 14px line-clamped to 3 lines `#595959`.
+    - Row 6: footer with posted-date `Posted 3 days ago` 12px grey +
+      bookmark-icon button right-aligned (filled when saved).
+  - Card is wholly clickable — clicking anywhere selects it (right pane
+    re-renders, URL gets `?vjk=<jk>` appended).
+- **Right detail pane**:
+  - 680px wide, sticky-positioned top:60px so it stays visible as the
+    user scrolls the left list.
+  - Header block:
+    - Big title H2 `{Job Title} - job post` (the suffix is canonical) —
+      24px bold.
+    - Company name 16px + location 14px grey.
+    - `Apply now` primary CTA button (blue, 40px tall, white text) +
+      `Save job` secondary outline button.
+  - Tab strip: `Job details`, `Company`, `Reviews`. Default `Job details`.
+  - Body: salary range strip with `$130K - $170K a year` + remote flag
+    chip + job-type chip; full description (10 paragraphs); benefits
+    bullets; apply-CTA footer.
+
+## Interaction signals
+
+- Clicking a left card → JS toggles `data-selected="true"` on that
+  card + clears it on siblings; updates `?vjk=<jk>` in URL via
+  `history.replaceState`; XHR/fetch GETs `/jobs/_detail?jk=<jk>` and
+  swaps the right pane HTML.
+- Clicking the bookmark icon → fetch POST `/jobs/<jk>/save` (toggle);
+  icon swaps optimistically.
+- Clicking `Apply now` → navigate to `/apply/<jk>`.
+- Clicking the title link → navigate to `/viewjob?jk=<jk>`.
+- Filter chip click → opens a popover with options; selecting one
+  updates URL params and reloads.
+
+## Capture status
+
+- Notes derived from `_capture_brief.md`. Indeed's anonymous traffic
+  faces Cloudflare; live MCP capture not attempted this turn. Follow-up
+  agents should run the per-element probe + capture `dom.html`,
+  `styles.json`, `screenshot.png`.

--- a/deploy/sim_envs/mantis_indeed/_captured/login/notes.md
+++ b/deploy/sim_envs/mantis_indeed/_captured/login/notes.md
@@ -1,0 +1,16 @@
+# `/login`, `/signup`
+
+## Login
+
+- Card width 360px centred, white bg, 1px border `#D4D2D0`, radius 8px.
+- H1 `Sign in`.
+- Email input + Password input + `Continue` blue button.
+- Below: `Don't have an account? Create one` link to `/signup`.
+- Errors (bad creds): red banner `Email or password incorrect.`
+
+## Signup
+
+- Same card layout.
+- H1 `Create your account`.
+- Email + Password + Confirm Password + Role select
+  (`Job seeker` default | `Employer`) + `Create account`.

--- a/deploy/sim_envs/mantis_indeed/_captured/myjobs/notes.md
+++ b/deploy/sim_envs/mantis_indeed/_captured/myjobs/notes.md
@@ -1,0 +1,23 @@
+# `/myjobs` — Saved + Applied tabs
+
+## Layout
+
+- Sticky top nav.
+- H1 `My jobs`.
+- Tab strip: `Saved` (default) | `Applied`. Active tab has brand-blue
+  underline 2px.
+- Tab body shows a list of job cards with the same card shape as the
+  `/jobs` left list (slightly compacted — no snippet).
+- Empty states:
+  - Saved: `You haven't saved any jobs yet. Save jobs from search results
+    to find them here.`
+  - Applied: `You haven't applied to any jobs yet.`
+
+## Interaction
+
+- Click tab → `?tab=saved` or `?tab=applied`.
+- Click a card title → `/viewjob?jk=<jk>`.
+- Bookmark icon on saved card → toggles off → POST `/jobs/<jk>/save`
+  removes the saved_jobs row.
+- On Applied: each card shows status badge (New/Reviewed/Rejected/Hired)
+  and `Applied 3 days ago` microcopy.

--- a/deploy/sim_envs/mantis_indeed/_captured/resumes/notes.md
+++ b/deploy/sim_envs/mantis_indeed/_captured/resumes/notes.md
@@ -1,0 +1,19 @@
+# `/resumes` — resume manager
+
+## Layout
+
+- Sticky top nav.
+- H1 `Your resumes`.
+- List of resume cards, each with:
+  - Title input (editable inline).
+  - `Last updated 2 days ago` microcopy.
+  - `Edit` and `Delete` outline buttons.
+- `+ Add new resume` button (blue primary) below the list.
+- New resume form (modal-like inline panel): title, summary textarea,
+  skills (comma list), experience (textarea), `Save`.
+
+## Interaction
+
+- POST `/resumes/new` → resume row + audit row + back to list.
+- POST `/resumes/<id>/edit` → patch row + audit.
+- POST `/resumes/<id>/delete` → soft delete + audit.

--- a/deploy/sim_envs/mantis_indeed/_captured/viewjob/notes.md
+++ b/deploy/sim_envs/mantis_indeed/_captured/viewjob/notes.md
@@ -1,0 +1,23 @@
+# `/viewjob?jk=<id>` — full job detail page
+
+## Layout
+
+- Sticky top nav.
+- Container max-width 1024px, centred.
+- Job header card (white bg, 1px border `#D4D2D0`, padding 24px,
+  border-radius 8px):
+  - H1 `{Job Title} - job post` (same canonical suffix).
+  - Company name + location row.
+  - Salary range chip + job-type chip + remote chip.
+  - `Apply now` blue primary CTA + `Save job` outline.
+- Tab strip: `Job details`, `Company`, `Reviews`.
+- Body: salary strip, benefits, full description, requirements, footer
+  CTA.
+
+## Interaction
+
+- `Apply now` → `/apply/<jk>`.
+- `Save job` → POST `/jobs/<jk>/save` toggle.
+
+Same visual rules as the right detail pane on `/jobs`. Reused template
+fragment.

--- a/deploy/sim_envs/mantis_indeed/app/__init__.py
+++ b/deploy/sim_envs/mantis_indeed/app/__init__.py
@@ -1,0 +1,1 @@
+"""mantis-indeed — synthetic Indeed.com mirror for mantis CUA training."""

--- a/deploy/sim_envs/mantis_indeed/app/auth.py
+++ b/deploy/sim_envs/mantis_indeed/app/auth.py
@@ -1,0 +1,155 @@
+"""Mock auth surface — signed-cookie sessions.
+
+Same shape as mantis-shop/app/auth.py minus the OAuth bits (Indeed
+mirror is username+password only per scope).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import os
+import time
+from typing import Any
+
+from fastapi import Request, Response
+from fastapi.responses import RedirectResponse
+
+from . import db
+
+SESSION_COOKIE = "mantis_indeed_session"
+SESSION_TTL_DEFAULT_S = 60 * 60
+LOGIN_PATH = "/login"
+
+
+def session_secret() -> str:
+    return os.environ.get("ENV_SESSION_SECRET", "dev-only-do-not-use-in-prod")
+
+
+def session_ttl_s() -> int:
+    raw = os.environ.get("ENV_SESSION_TTL_S")
+    try:
+        return int(raw) if raw else SESSION_TTL_DEFAULT_S
+    except ValueError:
+        return SESSION_TTL_DEFAULT_S
+
+
+def auth_required() -> bool:
+    return os.environ.get("ENV_REQUIRE_AUTH", "0").lower() in {"1", "true", "yes"}
+
+
+def hash_password(plain: str) -> str:
+    return hashlib.sha256(plain.encode("utf-8")).hexdigest()
+
+
+def verify_password(plain: str, stored: str) -> bool:
+    return hmac.compare_digest(hash_password(plain), stored)
+
+
+def mint_session(user_id: str, *, now: float | None = None) -> str:
+    issued = int(now if now is not None else time.time())
+    payload = f"{user_id}|{issued}"
+    sig = hmac.new(
+        session_secret().encode("utf-8"),
+        payload.encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+    return f"{payload}|{sig}"
+
+
+def verify_session(cookie_val: str, *, now: float | None = None) -> str | None:
+    if not cookie_val:
+        return None
+    parts = cookie_val.split("|")
+    if len(parts) != 3:
+        return None
+    user_id, issued_at_s, sig = parts
+    try:
+        issued_at = int(issued_at_s)
+    except ValueError:
+        return None
+    payload = f"{user_id}|{issued_at}"
+    expected = hmac.new(
+        session_secret().encode("utf-8"),
+        payload.encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+    if not hmac.compare_digest(sig, expected):
+        return None
+    now_ts = now if now is not None else time.time()
+    if now_ts - issued_at > session_ttl_s():
+        return None
+    return user_id
+
+
+def set_session_cookie(response: Response, user_id: str) -> None:
+    response.set_cookie(
+        SESSION_COOKIE,
+        mint_session(user_id),
+        httponly=True,
+        samesite="lax",
+        max_age=session_ttl_s(),
+        path="/",
+    )
+
+
+def clear_session_cookie(response: Response) -> None:
+    response.delete_cookie(SESSION_COOKIE, path="/")
+
+
+def lookup_user_by_id(user_id: str) -> dict[str, Any] | None:
+    conn = db.connect()
+    row = conn.execute(
+        "SELECT id, email, role, name, company_id FROM users WHERE id = ?",
+        (user_id,),
+    ).fetchone()
+    return dict(row) if row else None
+
+
+def lookup_user_by_email(email: str) -> dict[str, Any] | None:
+    conn = db.connect()
+    row = conn.execute(
+        "SELECT id, email, password_hash, role, name, company_id "
+        "FROM users WHERE email = ?",
+        (email.strip().lower(),),
+    ).fetchone()
+    return dict(row) if row else None
+
+
+def current_user(request: Request) -> dict[str, Any] | None:
+    raw = request.cookies.get(SESSION_COOKIE)
+    user_id = verify_session(raw or "")
+    if user_id is None:
+        return None
+    return lookup_user_by_id(user_id)
+
+
+def require_user(
+    request: Request, *, roles: list[str] | None = None
+) -> Response | None:
+    if not auth_required():
+        # When auth not required, default acting-user is a seeker.
+        return None
+    user = current_user(request)
+    next_path = request.url.path
+    if user is None:
+        return RedirectResponse(
+            f"{LOGIN_PATH}?next={next_path}", status_code=303
+        )
+    if roles and user.get("role") not in roles:
+        return RedirectResponse(LOGIN_PATH, status_code=303)
+    return None
+
+
+def effective_user_id(request: Request, *, default: str = "user_00001") -> str:
+    user = current_user(request)
+    if user:
+        return str(user["id"])
+    return default
+
+
+def effective_employer_id(request: Request, *, default: str = "user_emp_00003") -> str:
+    user = current_user(request)
+    if user and user.get("role") == "employer":
+        return str(user["id"])
+    return default

--- a/deploy/sim_envs/mantis_indeed/app/db.py
+++ b/deploy/sim_envs/mantis_indeed/app/db.py
@@ -1,0 +1,207 @@
+"""SQLite schema + helpers for mantis-indeed.
+
+Same pattern as mantis-shop: in-memory by default, a single module-level
+connection guarded by a re-entrant lock, schema applied at first connect.
+
+Schema highlights
+-----------------
+
+* ``companies`` — employer companies (logo letter is auto-derived from
+  company name).
+* ``users`` — seekers + employers. ``role`` is ``seeker`` or ``employer``.
+* ``jobs`` — title, company_id, location, salary_low/high, remote_flag,
+  job_type, posted_date, description, ``jk`` (Indeed-style 16-hex job
+  key — what URLs reference).
+* ``resumes`` — per-seeker resumes.
+* ``applications`` — seeker submitting to a job. Status field tracks the
+  employer's review workflow.
+* ``saved_jobs`` — seeker bookmarks.
+* ``audit_log`` — append-only mutation record. Oracle reads this +
+  current DB state to grade runs.
+
+IDs are deterministic strings: ``user_00007``, ``job_00012``, etc.
+Job-key ``jk`` is the URL-facing 16-hex token, separate from ``id``
+since Indeed's URLs use ``jk=...``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import threading
+from contextlib import contextmanager
+from typing import Any, Iterator
+
+_DB_LOCK = threading.RLock()
+_DB: sqlite3.Connection | None = None
+
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS companies (
+    id              TEXT PRIMARY KEY,           -- 'company_00001'
+    name            TEXT NOT NULL UNIQUE,
+    rating          REAL NOT NULL DEFAULT 4.0,
+    review_count    INTEGER NOT NULL DEFAULT 0,
+    industry        TEXT NOT NULL DEFAULT '',
+    headquarters    TEXT NOT NULL DEFAULT ''
+);
+CREATE INDEX IF NOT EXISTS idx_companies_name ON companies(name);
+
+CREATE TABLE IF NOT EXISTS users (
+    id              TEXT PRIMARY KEY,           -- 'user_00007'
+    email           TEXT NOT NULL UNIQUE,
+    password_hash   TEXT NOT NULL,
+    role            TEXT NOT NULL,              -- 'seeker' | 'employer'
+    name            TEXT NOT NULL DEFAULT '',
+    phone           TEXT NOT NULL DEFAULT '',
+    city            TEXT NOT NULL DEFAULT '',
+    state           TEXT NOT NULL DEFAULT '',
+    zip             TEXT NOT NULL DEFAULT '',
+    company_id      TEXT REFERENCES companies(id),    -- employers only
+    created_at      TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_users_email ON users(email);
+CREATE INDEX IF NOT EXISTS idx_users_role ON users(role);
+CREATE INDEX IF NOT EXISTS idx_users_company ON users(company_id);
+
+CREATE TABLE IF NOT EXISTS jobs (
+    id              TEXT PRIMARY KEY,           -- 'job_00012'
+    jk              TEXT NOT NULL UNIQUE,       -- 16-hex URL key
+    title           TEXT NOT NULL,
+    company_id      TEXT NOT NULL REFERENCES companies(id),
+    location        TEXT NOT NULL,              -- 'Austin, TX'
+    salary_low      INTEGER NOT NULL DEFAULT 0,
+    salary_high     INTEGER NOT NULL DEFAULT 0,
+    salary_period   TEXT NOT NULL DEFAULT 'year', -- 'year' | 'hour'
+    remote_flag     INTEGER NOT NULL DEFAULT 0,
+    job_type        TEXT NOT NULL DEFAULT 'Full-time',
+    experience_level TEXT NOT NULL DEFAULT 'Mid level',
+    posted_at       TEXT NOT NULL,
+    description     TEXT NOT NULL DEFAULT '',
+    snippet         TEXT NOT NULL DEFAULT '',
+    status          TEXT NOT NULL DEFAULT 'active'   -- 'active' | 'draft' | 'closed'
+);
+CREATE INDEX IF NOT EXISTS idx_jobs_jk ON jobs(jk);
+CREATE INDEX IF NOT EXISTS idx_jobs_company ON jobs(company_id);
+CREATE INDEX IF NOT EXISTS idx_jobs_location ON jobs(location);
+CREATE INDEX IF NOT EXISTS idx_jobs_status ON jobs(status);
+
+CREATE TABLE IF NOT EXISTS resumes (
+    id              TEXT PRIMARY KEY,           -- 'resume_00001'
+    user_id         TEXT NOT NULL REFERENCES users(id),
+    title           TEXT NOT NULL,
+    summary         TEXT NOT NULL DEFAULT '',
+    skills          TEXT NOT NULL DEFAULT '[]',   -- JSON list
+    experience      TEXT NOT NULL DEFAULT '',
+    updated_at      TEXT NOT NULL,
+    deleted_at      TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_resumes_user ON resumes(user_id);
+
+CREATE TABLE IF NOT EXISTS applications (
+    id              TEXT PRIMARY KEY,           -- 'application_00001'
+    user_id         TEXT NOT NULL REFERENCES users(id),
+    job_id          TEXT NOT NULL REFERENCES jobs(id),
+    resume_id       TEXT REFERENCES resumes(id),
+    phone           TEXT NOT NULL DEFAULT '',
+    answers_json    TEXT NOT NULL DEFAULT '{}',   -- JSON dict of screening Q&A
+    status          TEXT NOT NULL DEFAULT 'new',  -- 'new' | 'reviewed' | 'rejected' | 'hired'
+    applied_at      TEXT NOT NULL,
+    reviewed_at     TEXT,
+    UNIQUE (user_id, job_id)
+);
+CREATE INDEX IF NOT EXISTS idx_apps_user ON applications(user_id);
+CREATE INDEX IF NOT EXISTS idx_apps_job ON applications(job_id);
+CREATE INDEX IF NOT EXISTS idx_apps_status ON applications(status);
+
+CREATE TABLE IF NOT EXISTS saved_jobs (
+    user_id         TEXT NOT NULL REFERENCES users(id),
+    job_id          TEXT NOT NULL REFERENCES jobs(id),
+    saved_at        TEXT NOT NULL,
+    PRIMARY KEY (user_id, job_id)
+);
+
+CREATE TABLE IF NOT EXISTS audit_log (
+    -- Append-only mutation record. The oracle reads this + the DB
+    -- snapshot to grade runs.
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    occurred_at     TEXT NOT NULL,
+    operation       TEXT NOT NULL,
+    target_type     TEXT NOT NULL,
+    target_id       TEXT NOT NULL,
+    payload_json    TEXT NOT NULL DEFAULT '{}'
+);
+CREATE INDEX IF NOT EXISTS idx_audit_op ON audit_log(operation);
+CREATE INDEX IF NOT EXISTS idx_audit_target ON audit_log(target_id);
+"""
+
+
+def db_path() -> str:
+    return os.environ.get("DB_PATH") or ":memory:"
+
+
+def connect() -> sqlite3.Connection:
+    global _DB
+    with _DB_LOCK:
+        if _DB is None:
+            conn = sqlite3.connect(db_path(), check_same_thread=False)
+            conn.row_factory = sqlite3.Row
+            conn.executescript(SCHEMA)
+            _DB = conn
+        return _DB
+
+
+def reset_connection() -> None:
+    global _DB
+    with _DB_LOCK:
+        if _DB is not None:
+            _DB.close()
+            _DB = None
+
+
+@contextmanager
+def transaction() -> Iterator[sqlite3.Connection]:
+    conn = connect()
+    with _DB_LOCK:
+        try:
+            yield conn
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+
+
+# ── JSON helpers ──────────────────────────────────────────────────────
+
+
+def pack_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True)
+
+
+def unpack_json(raw: str) -> Any:
+    try:
+        return json.loads(raw or "{}")
+    except json.JSONDecodeError:
+        return {}
+
+
+# ── audit log ─────────────────────────────────────────────────────────
+
+
+def log_audit(
+    conn: sqlite3.Connection,
+    *,
+    occurred_at: str,
+    operation: str,
+    target_type: str,
+    target_id: str,
+    payload: dict[str, Any] | None = None,
+) -> None:
+    """Append a row to ``audit_log``. The oracle reads this to grade runs."""
+    conn.execute(
+        "INSERT INTO audit_log (occurred_at, operation, target_type, target_id, payload_json) "
+        "VALUES (?, ?, ?, ?, ?)",
+        (occurred_at, operation, target_type, target_id,
+         json.dumps(payload or {}, sort_keys=True)),
+    )

--- a/deploy/sim_envs/mantis_indeed/app/main.py
+++ b/deploy/sim_envs/mantis_indeed/app/main.py
@@ -1,0 +1,164 @@
+"""mantis-indeed FastAPI app — entrypoint mounted by Docker + Modal."""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+from fastapi import FastAPI, Request, Response
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
+from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
+
+from . import auth, db, seed
+
+APP_DIR = Path(__file__).parent
+ADMIN_TOKEN_ENV = "ENV_ADMIN_TOKEN"
+ADMIN_HEADER = "X-Env-Admin"
+
+
+def _admin_token() -> str:
+    token = os.environ.get(ADMIN_TOKEN_ENV, "").strip()
+    if not token:
+        # In sim env: require the harness to set this. For local dev
+        # default to "test" so the import-time check doesn't break
+        # tests / smoke runs that forgot to export it.
+        token = "test"
+        os.environ.setdefault(ADMIN_TOKEN_ENV, token)
+    return token
+
+
+def _now() -> str:
+    return os.environ.get("FAKE_NOW") or seed.FAKE_NOW_DEFAULT
+
+
+def _seed_val() -> int:
+    return int(os.environ.get("SEED") or 42)
+
+
+# ── event log ─────────────────────────────────────────────────────────
+
+
+_EVENTS: list[dict[str, Any]] = []
+_BOOT_TIME = time.time()
+
+
+def _emit_event(event: str, data: dict[str, Any] | None = None) -> None:
+    _EVENTS.append({
+        "ts": time.time(),
+        "event": event,
+        "data": data or {},
+    })
+
+
+# ── app factory ───────────────────────────────────────────────────────
+
+
+def create_app() -> FastAPI:
+    app = FastAPI(title="mantis-indeed", docs_url=None, redoc_url=None)
+
+    templates = Jinja2Templates(directory=str(APP_DIR / "templates"))
+    app.state.templates = templates
+    app.state.admin_token = _admin_token()
+
+    @app.middleware("http")
+    async def _auth_gate(request: Request, call_next):
+        try:
+            request.state.current_user = auth.current_user(request)
+        except Exception:
+            request.state.current_user = None
+
+        if auth.auth_required():
+            path = request.url.path
+            open_prefixes = (
+                "/login", "/logout", "/signup", "/__env__/",
+                "/static/", "/jobs", "/viewjob",
+            )
+            if path == "/" or path.startswith(open_prefixes):
+                pass
+            elif path.startswith(("/apply/", "/myjobs", "/resumes",
+                                  "/employers/")):
+                user = request.state.current_user
+                if user is None:
+                    return RedirectResponse(
+                        f"/login?next={path}", status_code=303,
+                    )
+                if path.startswith("/employers/") and user.get("role") != "employer":
+                    return RedirectResponse(
+                        "/login?error=employer+only", status_code=303,
+                    )
+        return await call_next(request)
+
+    @app.on_event("startup")
+    def _bootstrap() -> None:
+        conn = db.connect()
+        cur = conn.execute("SELECT COUNT(*) FROM jobs")
+        if cur.fetchone()[0] == 0:
+            seed.seed(conn, seed_val=_seed_val(), fake_now=_now())
+            _emit_event("seeded", {"seed": _seed_val(), "now": _now()})
+
+    app.mount(
+        "/static",
+        StaticFiles(directory=str(APP_DIR / "static")),
+        name="static",
+    )
+
+    from .routes import env_admin as env_admin_router
+    from .routes import auth as auth_router
+    from .routes import home as home_router
+    from .routes import jobs as jobs_router
+    from .routes import apply as apply_router
+    from .routes import myjobs as myjobs_router
+    from .routes import resumes as resumes_router
+    from .routes import employers as employers_router
+
+    app.include_router(env_admin_router.router)
+    app.include_router(auth_router.router)
+    app.include_router(home_router.router)
+    app.include_router(jobs_router.router)
+    app.include_router(apply_router.router)
+    app.include_router(myjobs_router.router)
+    app.include_router(resumes_router.router)
+    app.include_router(employers_router.router)
+
+    return app
+
+
+app = create_app()
+
+
+# Helpers exposed to the routes package -----------------------------
+
+
+def admin_token_ok(request: Request) -> bool:
+    return request.headers.get(ADMIN_HEADER) == request.app.state.admin_token
+
+
+def admin_required_response() -> JSONResponse:
+    return JSONResponse({"error": "admin token required"}, status_code=401)
+
+
+def now_value() -> str:
+    return _now()
+
+
+def seed_value() -> int:
+    return _seed_val()
+
+
+def boot_time() -> float:
+    return _BOOT_TIME
+
+
+def emit(event: str, data: dict[str, Any] | None = None) -> None:
+    _emit_event(event, data)
+
+
+def events_since(ts: float) -> list[dict[str, Any]]:
+    return [e for e in _EVENTS if e["ts"] >= ts]
+
+
+def clear_events() -> None:
+    _EVENTS.clear()

--- a/deploy/sim_envs/mantis_indeed/app/main.py
+++ b/deploy/sim_envs/mantis_indeed/app/main.py
@@ -7,8 +7,8 @@ import time
 from pathlib import Path
 from typing import Any
 
-from fastapi import FastAPI, Request, Response
-from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 

--- a/deploy/sim_envs/mantis_indeed/app/oracles/__init__.py
+++ b/deploy/sim_envs/mantis_indeed/app/oracles/__init__.py
@@ -1,0 +1,40 @@
+"""mantis-indeed oracles — server-side graders.
+
+Each oracle reads DB state + audit_log. Never the agent's transcript.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Any, Callable
+
+from . import t01_search_save_remote, t02_easy_apply, t03_employer_review_applicant
+
+GraderFn = Callable[..., dict[str, Any]]
+
+
+GRADERS: dict[str, GraderFn] = {
+    "t01_search_save_remote": t01_search_save_remote.grade,
+    "t02_easy_apply": t02_easy_apply.grade,
+    "t03_employer_review_applicant": t03_employer_review_applicant.grade,
+    # Convenience aliases (UPPER variants like mantis-shop)
+    "T01_search_save_remote": t01_search_save_remote.grade,
+    "T02_easy_apply": t02_easy_apply.grade,
+    "T03_employer_review_applicant": t03_employer_review_applicant.grade,
+}
+
+
+def grade(task_id: str, conn: sqlite3.Connection, *,
+          now: str, seed_val: int) -> dict[str, Any]:
+    fn = GRADERS.get(task_id)
+    if fn is None:
+        return {
+            "passed": False,
+            "score": 0.0,
+            "task_id": task_id,
+            "reasons": [f"no oracle registered for task_id={task_id!r}"],
+            "diff": {},
+        }
+    result = fn(conn, now=now, seed_val=seed_val)
+    result.setdefault("task_id", task_id)
+    return result

--- a/deploy/sim_envs/mantis_indeed/app/oracles/t01_search_save_remote.py
+++ b/deploy/sim_envs/mantis_indeed/app/oracles/t01_search_save_remote.py
@@ -35,7 +35,7 @@ def grade(conn: sqlite3.Connection, *, now: str, seed_val: int) -> dict[str, Any
         except json.JSONDecodeError:
             p = {}
         q = (p.get("q") or "").lower()
-        l = (p.get("l") or "").lower()
+        l = (p.get("l") or "").lower()  # noqa: E741 -- Indeed query-param convention
         remote = (p.get("remote") or "").lower()
         if "software engineer" in q and "austin" in l and remote in {"1", "true", "on"}:
             matching_search = p

--- a/deploy/sim_envs/mantis_indeed/app/oracles/t01_search_save_remote.py
+++ b/deploy/sim_envs/mantis_indeed/app/oracles/t01_search_save_remote.py
@@ -1,0 +1,90 @@
+"""t01_search_save_remote — seeker searches "software engineer" in "Austin,
+TX" with remote=1, then saves job_00007.
+
+Pass conditions:
+
+1. A `search_submitted` audit row exists with payload `q` containing
+   "software engineer", `l` containing "austin", and `remote` non-empty.
+2. A `job_saved` audit row exists for `user_00001` (the default
+   acting seeker) targeting `job_00007`.
+3. The saved_jobs table reflects that row.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from typing import Any
+
+EXPECTED_USER_ID = "user_00001"
+EXPECTED_JOB_ID = "job_00007"
+
+
+def grade(conn: sqlite3.Connection, *, now: str, seed_val: int) -> dict[str, Any]:
+    reasons: list[str] = []
+
+    # 1. search_submitted with the right filters.
+    rows = conn.execute(
+        "SELECT payload_json FROM audit_log "
+        "WHERE operation = 'search_submitted' ORDER BY id"
+    ).fetchall()
+    matching_search = None
+    for r in rows:
+        try:
+            p = json.loads(r["payload_json"] or "{}")
+        except json.JSONDecodeError:
+            p = {}
+        q = (p.get("q") or "").lower()
+        l = (p.get("l") or "").lower()
+        remote = (p.get("remote") or "").lower()
+        if "software engineer" in q and "austin" in l and remote in {"1", "true", "on"}:
+            matching_search = p
+            break
+    if matching_search is None:
+        reasons.append(
+            "no search_submitted audit row with q~'software engineer', "
+            "l~'austin', remote=1"
+        )
+
+    # 2. job_saved audit row for the target seeker + job.
+    saved_rows = conn.execute(
+        "SELECT payload_json FROM audit_log "
+        "WHERE operation = 'job_saved' ORDER BY id"
+    ).fetchall()
+    saved_match = None
+    for r in saved_rows:
+        try:
+            p = json.loads(r["payload_json"] or "{}")
+        except json.JSONDecodeError:
+            p = {}
+        if p.get("user_id") == EXPECTED_USER_ID and p.get("job_id") == EXPECTED_JOB_ID:
+            saved_match = p
+            break
+    if saved_match is None:
+        reasons.append(
+            f"no job_saved audit row for user={EXPECTED_USER_ID}, "
+            f"job={EXPECTED_JOB_ID}"
+        )
+
+    # 3. saved_jobs row exists.
+    row = conn.execute(
+        "SELECT 1 FROM saved_jobs WHERE user_id = ? AND job_id = ?",
+        (EXPECTED_USER_ID, EXPECTED_JOB_ID),
+    ).fetchone()
+    if row is None:
+        reasons.append(
+            f"saved_jobs has no row for {EXPECTED_USER_ID} + {EXPECTED_JOB_ID}"
+        )
+
+    passed = not reasons
+    return {
+        "passed": passed,
+        "score": 1.0 if passed else 0.0,
+        "reasons": reasons or [
+            f"search performed + {EXPECTED_JOB_ID} saved by {EXPECTED_USER_ID}"
+        ],
+        "diff": {
+            "matching_search": matching_search,
+            "saved_match": saved_match,
+        },
+    }

--- a/deploy/sim_envs/mantis_indeed/app/oracles/t02_easy_apply.py
+++ b/deploy/sim_envs/mantis_indeed/app/oracles/t02_easy_apply.py
@@ -1,0 +1,85 @@
+"""t02_easy_apply — seeker Easy Applies to job_00012 with phone +
+resume_00001 + screening answers.
+
+Pass conditions:
+
+1. An `application_submitted` audit row exists for `user_00001` +
+   `job_00012` with non-empty phone, resume_id, and answers.
+2. The `applications` row matches: status='new', resume_id present,
+   answers_json non-empty.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from typing import Any
+
+EXPECTED_USER_ID = "user_00001"
+EXPECTED_JOB_ID = "job_00012"
+
+
+def grade(conn: sqlite3.Connection, *, now: str, seed_val: int) -> dict[str, Any]:
+    reasons: list[str] = []
+
+    audit = conn.execute(
+        "SELECT payload_json FROM audit_log "
+        "WHERE operation = 'application_submitted' ORDER BY id"
+    ).fetchall()
+    match = None
+    for r in audit:
+        try:
+            p = json.loads(r["payload_json"] or "{}")
+        except json.JSONDecodeError:
+            p = {}
+        if p.get("user_id") == EXPECTED_USER_ID and p.get("job_id") == EXPECTED_JOB_ID:
+            match = p
+            break
+    if match is None:
+        reasons.append(
+            f"no application_submitted audit row for {EXPECTED_USER_ID} + {EXPECTED_JOB_ID}"
+        )
+        return _fail(reasons, {})
+
+    if not match.get("phone"):
+        reasons.append("application phone missing")
+    if not match.get("resume_id"):
+        reasons.append("application resume_id missing")
+    if not match.get("answers"):
+        reasons.append("application answers missing")
+
+    # DB-state guard.
+    app_row = conn.execute(
+        "SELECT * FROM applications WHERE user_id = ? AND job_id = ?",
+        (EXPECTED_USER_ID, EXPECTED_JOB_ID),
+    ).fetchone()
+    if app_row is None:
+        reasons.append("applications table missing the row")
+    else:
+        if not app_row["resume_id"]:
+            reasons.append("applications.resume_id is empty")
+        if not app_row["phone"]:
+            reasons.append("applications.phone is empty")
+        try:
+            ans = json.loads(app_row["answers_json"] or "{}")
+        except json.JSONDecodeError:
+            ans = {}
+        if not ans:
+            reasons.append("applications.answers_json is empty")
+
+    passed = not reasons
+    return {
+        "passed": passed,
+        "score": 1.0 if passed else 0.0,
+        "reasons": reasons or [
+            f"application submitted by {EXPECTED_USER_ID} for {EXPECTED_JOB_ID}"
+        ],
+        "diff": {
+            "audit_payload": match,
+            "applications_row": dict(app_row) if app_row else None,
+        },
+    }
+
+
+def _fail(reasons: list[str], diff: dict[str, Any]) -> dict[str, Any]:
+    return {"passed": False, "score": 0.0, "reasons": reasons, "diff": diff}

--- a/deploy/sim_envs/mantis_indeed/app/oracles/t03_employer_review_applicant.py
+++ b/deploy/sim_envs/mantis_indeed/app/oracles/t03_employer_review_applicant.py
@@ -1,0 +1,83 @@
+"""t03_employer_review_applicant — employer (`user_emp_00003`) moves an
+applicant on `job_00003` from "new" to "reviewed".
+
+Pass conditions:
+
+1. At least one `application_status_changed` audit row exists with
+   `previous_status='new'` and `new_status='reviewed'` targeting an
+   application whose `job_id = job_00003`.
+2. The applications row reflects status='reviewed' + reviewed_at not
+   NULL.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from typing import Any
+
+EXPECTED_JOB_ID = "job_00003"
+
+
+def grade(conn: sqlite3.Connection, *, now: str, seed_val: int) -> dict[str, Any]:
+    reasons: list[str] = []
+
+    audit = conn.execute(
+        "SELECT target_id, payload_json FROM audit_log "
+        "WHERE operation = 'application_status_changed' ORDER BY id"
+    ).fetchall()
+    match = None
+    for r in audit:
+        try:
+            p = json.loads(r["payload_json"] or "{}")
+        except json.JSONDecodeError:
+            p = {}
+        if p.get("previous_status") == "new" and p.get("new_status") == "reviewed":
+            # Confirm the target application is on job_00003.
+            app_row = conn.execute(
+                "SELECT job_id FROM applications WHERE id = ?",
+                (r["target_id"],),
+            ).fetchone()
+            if app_row and app_row["job_id"] == EXPECTED_JOB_ID:
+                match = {
+                    "target_id": r["target_id"],
+                    "payload": p,
+                }
+                break
+    if match is None:
+        reasons.append(
+            "no application_status_changed audit row for an application on "
+            f"{EXPECTED_JOB_ID} moving 'new' → 'reviewed'"
+        )
+        return _fail(reasons, {})
+
+    app_row = conn.execute(
+        "SELECT * FROM applications WHERE id = ?",
+        (match["target_id"],),
+    ).fetchone()
+    if app_row is None:
+        reasons.append("application row missing post-update")
+    else:
+        if app_row["status"] != "reviewed":
+            reasons.append(
+                f"applications.status is {app_row['status']!r}, expected 'reviewed'"
+            )
+        if not app_row["reviewed_at"]:
+            reasons.append("applications.reviewed_at is empty")
+
+    passed = not reasons
+    return {
+        "passed": passed,
+        "score": 1.0 if passed else 0.0,
+        "reasons": reasons or [
+            f"application {match['target_id']} moved new→reviewed on {EXPECTED_JOB_ID}"
+        ],
+        "diff": {
+            "match": match,
+            "applications_row": dict(app_row) if app_row else None,
+        },
+    }
+
+
+def _fail(reasons: list[str], diff: dict[str, Any]) -> dict[str, Any]:
+    return {"passed": False, "score": 0.0, "reasons": reasons, "diff": diff}

--- a/deploy/sim_envs/mantis_indeed/app/routes/__init__.py
+++ b/deploy/sim_envs/mantis_indeed/app/routes/__init__.py
@@ -1,0 +1,1 @@
+"""mantis-indeed routes package."""

--- a/deploy/sim_envs/mantis_indeed/app/routes/apply.py
+++ b/deploy/sim_envs/mantis_indeed/app/routes/apply.py
@@ -1,0 +1,235 @@
+"""Easy Apply (`/apply/<jk>`) — 3 steps + review + submit."""
+
+from __future__ import annotations
+
+import json
+
+from fastapi import APIRouter, Form, Request
+from fastapi.responses import HTMLResponse, RedirectResponse, Response
+
+from .. import auth, db, main as app_main
+
+router = APIRouter()
+
+
+def _job_by_jk(conn, jk: str):
+    return conn.execute("SELECT * FROM jobs WHERE jk = ?", (jk,)).fetchone()
+
+
+def _user_resumes(conn, uid: str):
+    return [dict(r) for r in conn.execute(
+        "SELECT * FROM resumes WHERE user_id = ? AND deleted_at IS NULL "
+        "ORDER BY id",
+        (uid,),
+    ).fetchall()]
+
+
+@router.get("/apply/{jk}", response_class=HTMLResponse)
+async def apply_step1(jk: str, request: Request) -> Response:
+    """Step 1 — contact information."""
+    conn = db.connect()
+    job_row = _job_by_jk(conn, jk)
+    if job_row is None:
+        return HTMLResponse("<h1>Job not found</h1>", status_code=404)
+    uid = auth.effective_user_id(request)
+    user = conn.execute(
+        "SELECT * FROM users WHERE id = ?", (uid,),
+    ).fetchone()
+    user = dict(user) if user else {}
+    return request.app.state.templates.TemplateResponse(
+        "apply_step1.html",
+        {
+            "request": request,
+            "job": dict(job_row),
+            "user": user,
+            "step": 1,
+        },
+    )
+
+
+@router.post("/apply/{jk}/step2")
+async def apply_step2_submit(
+    jk: str,
+    request: Request,
+    full_name: str = Form(""),
+    email: str = Form(""),
+    phone: str = Form(""),
+    city: str = Form(""),
+    state: str = Form(""),
+    zip: str = Form(""),
+) -> Response:
+    """Persist step 1 to session-like in-memory store keyed by user+jk."""
+    state_dict = request.app.state
+    if not hasattr(state_dict, "_apply_drafts"):
+        state_dict._apply_drafts = {}
+    uid = auth.effective_user_id(request)
+    state_dict._apply_drafts[(uid, jk)] = {
+        "full_name": full_name,
+        "email": email,
+        "phone": phone,
+        "city": city,
+        "state": state,
+        "zip": zip,
+    }
+    return RedirectResponse(f"/apply/{jk}/resume", status_code=303)
+
+
+@router.get("/apply/{jk}/resume", response_class=HTMLResponse)
+async def apply_resume(jk: str, request: Request) -> Response:
+    conn = db.connect()
+    job_row = _job_by_jk(conn, jk)
+    if job_row is None:
+        return HTMLResponse("<h1>Job not found</h1>", status_code=404)
+    uid = auth.effective_user_id(request)
+    return request.app.state.templates.TemplateResponse(
+        "apply_step2.html",
+        {
+            "request": request,
+            "job": dict(job_row),
+            "resumes": _user_resumes(conn, uid),
+            "step": 2,
+        },
+    )
+
+
+@router.post("/apply/{jk}/questions")
+async def apply_questions_submit(
+    jk: str,
+    request: Request,
+    resume_id: str = Form(""),
+) -> Response:
+    state_dict = request.app.state
+    if not hasattr(state_dict, "_apply_drafts"):
+        state_dict._apply_drafts = {}
+    uid = auth.effective_user_id(request)
+    draft = state_dict._apply_drafts.setdefault((uid, jk), {})
+    draft["resume_id"] = resume_id
+    return RedirectResponse(f"/apply/{jk}/questions", status_code=303)
+
+
+@router.get("/apply/{jk}/questions", response_class=HTMLResponse)
+async def apply_questions(jk: str, request: Request) -> Response:
+    conn = db.connect()
+    job_row = _job_by_jk(conn, jk)
+    if job_row is None:
+        return HTMLResponse("<h1>Job not found</h1>", status_code=404)
+    return request.app.state.templates.TemplateResponse(
+        "apply_step3.html",
+        {
+            "request": request,
+            "job": dict(job_row),
+            "step": 3,
+        },
+    )
+
+
+@router.post("/apply/{jk}/review")
+async def apply_review_submit(
+    jk: str,
+    request: Request,
+    yrs_experience: str = Form("0"),
+    auth_to_work: str = Form("Yes"),
+    sponsorship: str = Form("No"),
+) -> Response:
+    state_dict = request.app.state
+    if not hasattr(state_dict, "_apply_drafts"):
+        state_dict._apply_drafts = {}
+    uid = auth.effective_user_id(request)
+    draft = state_dict._apply_drafts.setdefault((uid, jk), {})
+    draft["answers"] = {
+        "yrs_experience": yrs_experience,
+        "auth_to_work": auth_to_work,
+        "sponsorship": sponsorship,
+    }
+    return RedirectResponse(f"/apply/{jk}/review", status_code=303)
+
+
+@router.get("/apply/{jk}/review", response_class=HTMLResponse)
+async def apply_review(jk: str, request: Request) -> Response:
+    conn = db.connect()
+    job_row = _job_by_jk(conn, jk)
+    if job_row is None:
+        return HTMLResponse("<h1>Job not found</h1>", status_code=404)
+    uid = auth.effective_user_id(request)
+    state_dict = request.app.state
+    draft = getattr(state_dict, "_apply_drafts", {}).get((uid, jk), {})
+    return request.app.state.templates.TemplateResponse(
+        "apply_review.html",
+        {
+            "request": request,
+            "job": dict(job_row),
+            "draft": draft,
+            "step": 4,
+        },
+    )
+
+
+@router.post("/apply/{jk}/submit")
+async def apply_submit(jk: str, request: Request) -> Response:
+    conn = db.connect()
+    job_row = _job_by_jk(conn, jk)
+    if job_row is None:
+        return HTMLResponse("<h1>Job not found</h1>", status_code=404)
+    uid = auth.effective_user_id(request)
+    state_dict = request.app.state
+    draft = getattr(state_dict, "_apply_drafts", {}).get((uid, jk), {})
+
+    job_id = job_row["id"]
+    existing = conn.execute(
+        "SELECT id FROM applications WHERE user_id = ? AND job_id = ?",
+        (uid, job_id),
+    ).fetchone()
+    if existing:
+        # Update phone+answers idempotently.
+        conn.execute(
+            "UPDATE applications SET phone = ?, answers_json = ?, "
+            "resume_id = ?, applied_at = ? WHERE id = ?",
+            (draft.get("phone", ""),
+             json.dumps(draft.get("answers", {}), sort_keys=True),
+             draft.get("resume_id") or None,
+             app_main.now_value(),
+             existing["id"]),
+        )
+        app_id = existing["id"]
+    else:
+        # Generate a fresh id by counting.
+        n = conn.execute("SELECT COUNT(*) FROM applications").fetchone()[0]
+        app_id = f"application_run_{n + 1:05d}"
+        conn.execute(
+            "INSERT INTO applications (id, user_id, job_id, resume_id, "
+            "phone, answers_json, status, applied_at, reviewed_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, 'new', ?, NULL)",
+            (app_id, uid, job_id, draft.get("resume_id") or None,
+             draft.get("phone", ""),
+             json.dumps(draft.get("answers", {}), sort_keys=True),
+             app_main.now_value()),
+        )
+    db.log_audit(
+        conn,
+        occurred_at=app_main.now_value(),
+        operation="application_submitted",
+        target_type="application",
+        target_id=app_id,
+        payload={
+            "user_id": uid,
+            "job_id": job_id,
+            "jk": jk,
+            "resume_id": draft.get("resume_id"),
+            "phone": draft.get("phone", ""),
+            "answers": draft.get("answers", {}),
+        },
+    )
+    conn.commit()
+    return RedirectResponse(f"/apply/{jk}/confirm", status_code=303)
+
+
+@router.get("/apply/{jk}/confirm", response_class=HTMLResponse)
+async def apply_confirm(jk: str, request: Request) -> Response:
+    conn = db.connect()
+    job_row = _job_by_jk(conn, jk)
+    if job_row is None:
+        return HTMLResponse("<h1>Job not found</h1>", status_code=404)
+    return request.app.state.templates.TemplateResponse(
+        "apply_confirm.html",
+        {"request": request, "job": dict(job_row)},
+    )

--- a/deploy/sim_envs/mantis_indeed/app/routes/auth.py
+++ b/deploy/sim_envs/mantis_indeed/app/routes/auth.py
@@ -1,0 +1,118 @@
+"""Login / signup / logout."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Form, Request
+from fastapi.responses import HTMLResponse, RedirectResponse, Response
+
+from .. import auth, db, main as app_main
+
+router = APIRouter()
+
+
+@router.get("/login", response_class=HTMLResponse)
+async def login_form(request: Request) -> Response:
+    return request.app.state.templates.TemplateResponse(
+        "login.html",
+        {
+            "request": request,
+            "error": request.query_params.get("error"),
+            "next": request.query_params.get("next") or "/",
+        },
+    )
+
+
+@router.post("/login")
+async def login_submit(
+    request: Request,
+    email: str = Form(...),
+    password: str = Form(...),
+    next: str = Form("/"),
+) -> Response:
+    user = auth.lookup_user_by_email(email)
+    if user is None or not auth.verify_password(password, user["password_hash"]):
+        return request.app.state.templates.TemplateResponse(
+            "login.html",
+            {
+                "request": request,
+                "error": "Email or password incorrect.",
+                "next": next,
+            },
+            status_code=400,
+        )
+    conn = db.connect()
+    db.log_audit(
+        conn,
+        occurred_at=app_main.now_value(),
+        operation="login_succeeded",
+        target_type="user",
+        target_id=user["id"],
+        payload={"email": user["email"]},
+    )
+    conn.commit()
+    response = RedirectResponse(next or "/", status_code=303)
+    auth.set_session_cookie(response, user["id"])
+    return response
+
+
+@router.post("/logout")
+async def logout(request: Request) -> Response:
+    response = RedirectResponse("/", status_code=303)
+    auth.clear_session_cookie(response)
+    return response
+
+
+@router.get("/signup", response_class=HTMLResponse)
+async def signup_form(request: Request) -> Response:
+    return request.app.state.templates.TemplateResponse(
+        "signup.html",
+        {"request": request, "error": None},
+    )
+
+
+@router.post("/signup")
+async def signup_submit(
+    request: Request,
+    email: str = Form(...),
+    password: str = Form(...),
+    confirm: str = Form(...),
+    role: str = Form("seeker"),
+) -> Response:
+    if password != confirm:
+        return request.app.state.templates.TemplateResponse(
+            "signup.html",
+            {"request": request, "error": "Passwords do not match."},
+            status_code=400,
+        )
+    existing = auth.lookup_user_by_email(email)
+    if existing:
+        return request.app.state.templates.TemplateResponse(
+            "signup.html",
+            {"request": request, "error": "Email already registered."},
+            status_code=400,
+        )
+    conn = db.connect()
+    # Generate a fresh user id by counting.
+    count = conn.execute("SELECT COUNT(*) FROM users").fetchone()[0]
+    uid = f"user_signup_{count + 1:05d}"
+    if role == "employer":
+        uid = f"user_emp_signup_{count + 1:05d}"
+    conn.execute(
+        "INSERT INTO users (id, email, password_hash, role, name, created_at) "
+        "VALUES (?, ?, ?, ?, '', ?)",
+        (uid, email.strip().lower(), auth.hash_password(password),
+         role if role in {"seeker", "employer"} else "seeker",
+         app_main.now_value()),
+    )
+    db.log_audit(
+        conn,
+        occurred_at=app_main.now_value(),
+        operation="user_created",
+        target_type="user",
+        target_id=uid,
+        payload={"email": email, "role": role},
+    )
+    conn.commit()
+    response = RedirectResponse("/", status_code=303)
+    auth.set_session_cookie(response, uid)
+    return response

--- a/deploy/sim_envs/mantis_indeed/app/routes/employers.py
+++ b/deploy/sim_envs/mantis_indeed/app/routes/employers.py
@@ -1,0 +1,179 @@
+"""/employers/* — dashboard + posting review + applicant status change."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Form, Request
+from fastapi.responses import HTMLResponse, RedirectResponse, Response
+
+from .. import auth, db, main as app_main
+
+router = APIRouter()
+
+
+def _format_salary(low: int, high: int, period: str) -> str:
+    if not low and not high:
+        return ""
+    suffix = "a year" if period == "year" else "an hour"
+    if low and high and low != high:
+        return f"${low:,} - ${high:,} {suffix}"
+    return f"${low or high:,} {suffix}"
+
+
+@router.get("/employers/dashboard", response_class=HTMLResponse)
+async def employer_dashboard(request: Request) -> Response:
+    eid = auth.effective_employer_id(request)
+    conn = db.connect()
+    user = conn.execute("SELECT * FROM users WHERE id = ?", (eid,)).fetchone()
+    if user is None:
+        return HTMLResponse("<h1>Not found</h1>", status_code=404)
+    cid = user["company_id"]
+    jobs = conn.execute(
+        "SELECT * FROM jobs WHERE company_id = ? ORDER BY posted_at DESC",
+        (cid,),
+    ).fetchall()
+    job_dicts = []
+    for j in jobs:
+        d = dict(j)
+        d["app_counts"] = {
+            "new": 0,
+            "reviewed": 0,
+            "rejected": 0,
+            "hired": 0,
+        }
+        for r in conn.execute(
+            "SELECT status, COUNT(*) AS n FROM applications "
+            "WHERE job_id = ? GROUP BY status",
+            (j["id"],),
+        ).fetchall():
+            d["app_counts"][r["status"]] = r["n"]
+        d["app_total"] = sum(d["app_counts"].values())
+        job_dicts.append(d)
+    new_this_week = sum(d["app_counts"]["new"] for d in job_dicts)
+    return request.app.state.templates.TemplateResponse(
+        "employer_dashboard.html",
+        {
+            "request": request,
+            "user": dict(user),
+            "jobs": job_dicts,
+            "kpi_active": len([j for j in job_dicts if j["status"] == "active"]),
+            "kpi_new_apps": new_this_week,
+            "kpi_views": 1234,  # synthetic
+        },
+    )
+
+
+@router.get("/employers/jobs/{job_id}", response_class=HTMLResponse)
+async def employer_posting_detail(job_id: str, request: Request) -> Response:
+    conn = db.connect()
+    job = conn.execute("SELECT * FROM jobs WHERE id = ?", (job_id,)).fetchone()
+    if job is None:
+        return HTMLResponse("<h1>Posting not found</h1>", status_code=404)
+    status_filter = request.query_params.get("status") or ""
+    sql = (
+        "SELECT a.*, u.name AS user_name, u.email AS user_email, "
+        "r.title AS resume_title FROM applications a "
+        "JOIN users u ON u.id = a.user_id "
+        "LEFT JOIN resumes r ON r.id = a.resume_id "
+        "WHERE a.job_id = ?"
+    )
+    params = [job_id]
+    if status_filter in {"new", "reviewed", "rejected", "hired"}:
+        sql += " AND a.status = ?"
+        params.append(status_filter)
+    sql += " ORDER BY a.applied_at DESC"
+    apps = [dict(r) for r in conn.execute(sql, params).fetchall()]
+    return request.app.state.templates.TemplateResponse(
+        "employer_posting.html",
+        {
+            "request": request,
+            "job": dict(job),
+            "applications": apps,
+            "status_filter": status_filter,
+        },
+    )
+
+
+@router.post("/employers/applications/{app_id}/status")
+async def employer_application_status(
+    app_id: str,
+    request: Request,
+    status: str = Form(...),
+) -> Response:
+    if status not in {"new", "reviewed", "rejected", "hired"}:
+        return HTMLResponse("invalid status", status_code=400)
+    conn = db.connect()
+    row = conn.execute(
+        "SELECT job_id, status FROM applications WHERE id = ?", (app_id,),
+    ).fetchone()
+    if row is None:
+        return HTMLResponse("application not found", status_code=404)
+    previous = row["status"]
+    now = app_main.now_value()
+    reviewed_at = now if status != "new" else None
+    conn.execute(
+        "UPDATE applications SET status = ?, reviewed_at = ? WHERE id = ?",
+        (status, reviewed_at, app_id),
+    )
+    db.log_audit(
+        conn,
+        occurred_at=now,
+        operation="application_status_changed",
+        target_type="application",
+        target_id=app_id,
+        payload={
+            "previous_status": previous,
+            "new_status": status,
+            "reviewed_at": reviewed_at,
+        },
+    )
+    conn.commit()
+    next_url = request.headers.get("referer") or f"/employers/jobs/{row['job_id']}"
+    return RedirectResponse(next_url, status_code=303)
+
+
+@router.get("/employers/jobs/new", response_class=HTMLResponse)
+async def employer_new_posting_form(request: Request) -> Response:
+    return request.app.state.templates.TemplateResponse(
+        "employer_new_posting.html",
+        {"request": request},
+    )
+
+
+@router.post("/employers/jobs/new")
+async def employer_new_posting_submit(
+    request: Request,
+    title: str = Form(...),
+    location: str = Form(...),
+    salary_low: int = Form(0),
+    salary_high: int = Form(0),
+    remote: str = Form(""),
+    job_type: str = Form("Full-time"),
+    description: str = Form(""),
+) -> Response:
+    eid = auth.effective_employer_id(request)
+    conn = db.connect()
+    user = conn.execute("SELECT * FROM users WHERE id = ?", (eid,)).fetchone()
+    if user is None:
+        return HTMLResponse("not authorized", status_code=403)
+    n = conn.execute("SELECT COUNT(*) FROM jobs").fetchone()[0]
+    jid = f"job_new_{n + 1:05d}"
+    jk = f"{n + 1:016x}"
+    conn.execute(
+        "INSERT INTO jobs (id, jk, title, company_id, location, salary_low, "
+        "salary_high, salary_period, remote_flag, job_type, experience_level, "
+        "posted_at, description, snippet, status) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, 'year', ?, ?, 'Mid level', ?, ?, ?, 'active')",
+        (jid, jk, title, user["company_id"], location, salary_low, salary_high,
+         1 if remote in {"on", "1", "true"} else 0, job_type,
+         app_main.now_value(), description, description[:240]),
+    )
+    db.log_audit(
+        conn,
+        occurred_at=app_main.now_value(),
+        operation="job_created",
+        target_type="job",
+        target_id=jid,
+        payload={"title": title, "company_id": user["company_id"]},
+    )
+    conn.commit()
+    return RedirectResponse(f"/employers/jobs/{jid}", status_code=303)

--- a/deploy/sim_envs/mantis_indeed/app/routes/env_admin.py
+++ b/deploy/sim_envs/mantis_indeed/app/routes/env_admin.py
@@ -1,0 +1,153 @@
+"""Harness endpoints — `/__env__/{health,reset,seed,clock,oracle,state,events,mutations}`."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse
+
+from .. import db, main as app_main, seed
+
+router = APIRouter(prefix="/__env__")
+
+
+@router.get("/health")
+async def health() -> JSONResponse:
+    return JSONResponse({
+        "ok": True,
+        "seed": app_main.seed_value(),
+        "now": app_main.now_value(),
+        "boot_time": app_main.boot_time(),
+    })
+
+
+@router.post("/reset")
+async def reset(request: Request) -> JSONResponse:
+    if not app_main.admin_token_ok(request):
+        return app_main.admin_required_response()
+    conn = db.connect()
+    seed.seed(conn, seed_val=app_main.seed_value(), fake_now=app_main.now_value())
+    app_main.clear_events()
+    app_main.emit("reset")
+    return JSONResponse({"ok": True})
+
+
+@router.post("/seed")
+async def reseed(request: Request) -> JSONResponse:
+    if not app_main.admin_token_ok(request):
+        return app_main.admin_required_response()
+    try:
+        payload = await request.json()
+    except Exception:
+        payload = {}
+    new_seed = int(payload.get("seed", app_main.seed_value()))
+    conn = db.connect()
+    seed.seed(conn, seed_val=new_seed, fake_now=app_main.now_value())
+    app_main.emit("reseeded", {"seed": new_seed})
+    return JSONResponse({"ok": True, "seed": new_seed})
+
+
+@router.post("/clock")
+async def clock(request: Request) -> JSONResponse:
+    if not app_main.admin_token_ok(request):
+        return app_main.admin_required_response()
+    try:
+        payload = await request.json()
+    except Exception:
+        payload = {}
+    import os
+    new_now = str(payload.get("now") or app_main.now_value())
+    os.environ["FAKE_NOW"] = new_now
+    app_main.emit("clock_set", {"now": new_now})
+    return JSONResponse({"ok": True, "now": new_now})
+
+
+@router.get("/oracle")
+async def oracle(request: Request) -> JSONResponse:
+    if not app_main.admin_token_ok(request):
+        return app_main.admin_required_response()
+    task_id = (request.query_params.get("task_id") or "").strip()
+    if not task_id:
+        return JSONResponse({"passed": False, "score": 0.0,
+                             "reasons": ["task_id is required"], "diff": {}})
+
+    from ..oracles import grade
+    result = grade(task_id, db.connect(), now=app_main.now_value(),
+                   seed_val=app_main.seed_value())
+    app_main.emit("oracle_query", {"task_id": task_id, "passed": result["passed"]})
+    return JSONResponse(result)
+
+
+@router.get("/state")
+async def state(request: Request) -> JSONResponse:
+    if not app_main.admin_token_ok(request):
+        return app_main.admin_required_response()
+    conn = db.connect()
+
+    def count(table: str) -> int:
+        return int(conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0])
+
+    recent_audit = [
+        {
+            "id": r["id"],
+            "occurred_at": r["occurred_at"],
+            "operation": r["operation"],
+            "target_type": r["target_type"],
+            "target_id": r["target_id"],
+        }
+        for r in conn.execute(
+            "SELECT * FROM audit_log ORDER BY id DESC LIMIT 50"
+        ).fetchall()
+    ]
+
+    return JSONResponse({
+        "seed": app_main.seed_value(),
+        "now": app_main.now_value(),
+        "counts": {
+            "companies": count("companies"),
+            "users": count("users"),
+            "jobs": count("jobs"),
+            "resumes": count("resumes"),
+            "applications": count("applications"),
+            "saved_jobs": count("saved_jobs"),
+            "audit_log": count("audit_log"),
+        },
+        "recent_audit": recent_audit,
+    })
+
+
+@router.get("/events")
+async def events(request: Request) -> JSONResponse:
+    if not app_main.admin_token_ok(request):
+        return app_main.admin_required_response()
+    since = float(request.query_params.get("since") or 0)
+    return JSONResponse({"events": app_main.events_since(since)})
+
+
+@router.get("/mutations")
+async def mutations(request: Request) -> JSONResponse:
+    if not app_main.admin_token_ok(request):
+        return app_main.admin_required_response()
+    since_raw = request.query_params.get("since") or ""
+    conn = db.connect()
+    if since_raw:
+        rows = conn.execute(
+            "SELECT * FROM audit_log WHERE occurred_at >= ? ORDER BY id",
+            (since_raw,),
+        ).fetchall()
+    else:
+        rows = conn.execute(
+            "SELECT * FROM audit_log ORDER BY id"
+        ).fetchall()
+    return JSONResponse({
+        "mutations": [
+            {
+                "id": r["id"],
+                "ts": r["occurred_at"],
+                "op": r["operation"],
+                "target_type": r["target_type"],
+                "target_id": r["target_id"],
+                "payload": r["payload_json"],
+            }
+            for r in rows
+        ],
+    })

--- a/deploy/sim_envs/mantis_indeed/app/routes/home.py
+++ b/deploy/sim_envs/mantis_indeed/app/routes/home.py
@@ -1,0 +1,45 @@
+"""Home page (`/`) — the two-input hero search."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Request
+from fastapi.responses import HTMLResponse, Response
+
+from .. import db
+
+router = APIRouter()
+
+
+TRENDING_SEARCHES = [
+    "software engineer",
+    "remote",
+    "warehouse",
+    "registered nurse",
+    "data analyst",
+    "customer service",
+]
+
+EMPLOYER_RESOURCES = [
+    "Post a job",
+    "Employer reviews",
+    "Pricing",
+    "Hiring lab",
+    "Resume search",
+]
+
+
+@router.get("/", response_class=HTMLResponse)
+async def home(request: Request) -> Response:
+    conn = db.connect()
+    job_count = conn.execute(
+        "SELECT COUNT(*) FROM jobs WHERE status = 'active'"
+    ).fetchone()[0]
+    return request.app.state.templates.TemplateResponse(
+        "home.html",
+        {
+            "request": request,
+            "job_count": job_count,
+            "trending": TRENDING_SEARCHES,
+            "resources": EMPLOYER_RESOURCES,
+        },
+    )

--- a/deploy/sim_envs/mantis_indeed/app/routes/jobs.py
+++ b/deploy/sim_envs/mantis_indeed/app/routes/jobs.py
@@ -1,0 +1,301 @@
+"""Search results (`/jobs`), detail HTMX fragment, viewjob, save-toggle."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from fastapi import APIRouter, Request
+from fastapi.responses import HTMLResponse, JSONResponse, Response
+
+from .. import auth, db, main as app_main
+
+router = APIRouter()
+
+
+FILTER_CHIPS = [
+    "Date posted",
+    "Remote",
+    "Developer skill",
+    "Job Type",
+    "Experience level",
+    "Pay",
+    "Education",
+    "Clearance type",
+    "Developer type",
+    "Compensation package",
+    "Distance",
+]
+
+
+def _job_row(row) -> dict[str, Any]:
+    out = dict(row)
+    return out
+
+
+def _join_company(conn, jobs: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    if not jobs:
+        return jobs
+    cids = {j["company_id"] for j in jobs}
+    placeholders = ",".join(["?"] * len(cids))
+    rows = conn.execute(
+        f"SELECT * FROM companies WHERE id IN ({placeholders})",
+        list(cids),
+    ).fetchall()
+    by_id = {r["id"]: dict(r) for r in rows}
+    for j in jobs:
+        j["company"] = by_id.get(j["company_id"], {"name": "Unknown",
+                                                   "rating": 0,
+                                                   "review_count": 0})
+    return jobs
+
+
+def _format_salary(low: int, high: int, period: str) -> str:
+    if not low and not high:
+        return ""
+    suffix = "a year" if period == "year" else "an hour"
+    if low and high and low != high:
+        return f"${low:,} - ${high:,} {suffix}"
+    return f"${low or high:,} {suffix}"
+
+
+def _relative_posted(now_iso: str, posted_iso: str) -> str:
+    from datetime import datetime
+    try:
+        n = datetime.fromisoformat(now_iso.rstrip("Z"))
+        p = datetime.fromisoformat(posted_iso.rstrip("Z"))
+    except ValueError:
+        return ""
+    delta = n - p
+    days = delta.days
+    if days <= 0:
+        return "Just posted"
+    if days == 1:
+        return "Posted 1 day ago"
+    if days < 30:
+        return f"Posted {days} days ago"
+    return f"Posted 30+ days ago"
+
+
+def _search_jobs(conn, q: str, l: str, remote: bool, date_max_days: int | None,
+                 job_type: str | None) -> list[dict[str, Any]]:
+    """Substring + filter search. Trivial — no fancy ranking."""
+    sql = "SELECT * FROM jobs WHERE status = 'active'"
+    params: list[Any] = []
+    if q.strip():
+        sql += " AND (LOWER(title) LIKE ? OR LOWER(snippet) LIKE ?)"
+        pat = f"%{q.strip().lower()}%"
+        params.extend([pat, pat])
+    if l.strip():
+        # Treat `remote` location as the remote-only filter.
+        ll = l.strip().lower()
+        if ll == "remote":
+            sql += " AND remote_flag = 1"
+        else:
+            sql += " AND LOWER(location) LIKE ?"
+            params.append(f"%{ll}%")
+    if remote:
+        sql += " AND remote_flag = 1"
+    if job_type:
+        sql += " AND job_type = ?"
+        params.append(job_type)
+    sql += " ORDER BY posted_at DESC"
+    rows = conn.execute(sql, params).fetchall()
+    return [_job_row(r) for r in rows]
+
+
+@router.get("/jobs", response_class=HTMLResponse)
+async def jobs_search(request: Request) -> Response:
+    qp = request.query_params
+    q = qp.get("q", "")
+    l = qp.get("l", "")
+    vjk = qp.get("vjk", "")
+    remote = qp.get("remote", "") in {"1", "true", "on"}
+    job_type = qp.get("job_type") or None
+
+    conn = db.connect()
+    jobs = _search_jobs(conn, q, l, remote, None, job_type)
+    jobs = _join_company(conn, jobs)
+
+    # Decorate cards with display-friendly salary + relative date.
+    for j in jobs:
+        j["salary_display"] = _format_salary(j["salary_low"], j["salary_high"],
+                                              j["salary_period"])
+        j["posted_display"] = _relative_posted(app_main.now_value(),
+                                                j["posted_at"])
+        j["snippet_short"] = (j["snippet"][:240]
+                              + ("…" if len(j["snippet"]) > 240 else ""))
+
+    # Selected job: vjk in URL, else first job.
+    selected: dict[str, Any] | None = None
+    if vjk:
+        selected = next((j for j in jobs if j["jk"] == vjk), None)
+    if selected is None and jobs:
+        selected = jobs[0]
+
+    # T01-style saved jobs lookup (anonymous default seeker).
+    uid = auth.effective_user_id(request)
+    saved_ids = {
+        r["job_id"] for r in conn.execute(
+            "SELECT job_id FROM saved_jobs WHERE user_id = ?",
+            (uid,),
+        ).fetchall()
+    }
+
+    # Active filter chips for visual state.
+    active_chips = set()
+    if remote:
+        active_chips.add("Remote")
+
+    h1 = f"{q.lower()} jobs in {l}" if q and l else (
+        f"{q.lower()} jobs" if q else "All jobs"
+    )
+
+    return request.app.state.templates.TemplateResponse(
+        "jobs_search.html",
+        {
+            "request": request,
+            "q": q,
+            "l": l,
+            "vjk": vjk,
+            "remote": remote,
+            "job_type": job_type,
+            "jobs": jobs,
+            "selected": selected,
+            "saved_ids": saved_ids,
+            "filter_chips": FILTER_CHIPS,
+            "active_chips": active_chips,
+            "h1": h1,
+            "total_count": len(jobs),
+        },
+    )
+
+
+@router.get("/jobs/_detail", response_class=HTMLResponse)
+async def jobs_detail_fragment(request: Request) -> Response:
+    """HTMX-style fragment to swap into the right pane without nav."""
+    jk = request.query_params.get("jk", "")
+    conn = db.connect()
+    row = conn.execute("SELECT * FROM jobs WHERE jk = ?", (jk,)).fetchone()
+    if row is None:
+        return HTMLResponse("<div class='empty-pane'>Job not found.</div>",
+                            status_code=404)
+    job = _join_company(conn, [_job_row(row)])[0]
+    job["salary_display"] = _format_salary(job["salary_low"], job["salary_high"],
+                                            job["salary_period"])
+    job["posted_display"] = _relative_posted(app_main.now_value(),
+                                              job["posted_at"])
+    uid = auth.effective_user_id(request)
+    is_saved = bool(conn.execute(
+        "SELECT 1 FROM saved_jobs WHERE user_id = ? AND job_id = ?",
+        (uid, job["id"]),
+    ).fetchone())
+    return request.app.state.templates.TemplateResponse(
+        "_detail_pane.html",
+        {"request": request, "job": job, "is_saved": is_saved},
+    )
+
+
+@router.get("/viewjob", response_class=HTMLResponse)
+async def viewjob(request: Request) -> Response:
+    jk = request.query_params.get("jk", "")
+    conn = db.connect()
+    row = conn.execute("SELECT * FROM jobs WHERE jk = ?", (jk,)).fetchone()
+    if row is None:
+        return HTMLResponse("<h1>Job not found</h1>", status_code=404)
+    job = _join_company(conn, [_job_row(row)])[0]
+    job["salary_display"] = _format_salary(job["salary_low"], job["salary_high"],
+                                            job["salary_period"])
+    job["posted_display"] = _relative_posted(app_main.now_value(),
+                                              job["posted_at"])
+    uid = auth.effective_user_id(request)
+    is_saved = bool(conn.execute(
+        "SELECT 1 FROM saved_jobs WHERE user_id = ? AND job_id = ?",
+        (uid, job["id"]),
+    ).fetchone())
+    return request.app.state.templates.TemplateResponse(
+        "viewjob.html",
+        {"request": request, "job": job, "is_saved": is_saved},
+    )
+
+
+@router.post("/jobs/{jk}/save")
+async def jobs_save_toggle(jk: str, request: Request) -> JSONResponse:
+    """Toggle saved_jobs row. Returns {saved: bool}."""
+    conn = db.connect()
+    row = conn.execute("SELECT id FROM jobs WHERE jk = ?", (jk,)).fetchone()
+    if row is None:
+        return JSONResponse({"error": "job not found"}, status_code=404)
+    job_id = row["id"]
+    uid = auth.effective_user_id(request)
+
+    existing = conn.execute(
+        "SELECT 1 FROM saved_jobs WHERE user_id = ? AND job_id = ?",
+        (uid, job_id),
+    ).fetchone()
+    if existing:
+        conn.execute(
+            "DELETE FROM saved_jobs WHERE user_id = ? AND job_id = ?",
+            (uid, job_id),
+        )
+        db.log_audit(
+            conn,
+            occurred_at=app_main.now_value(),
+            operation="job_unsaved",
+            target_type="saved_job",
+            target_id=f"{uid}:{job_id}",
+            payload={"user_id": uid, "job_id": job_id, "jk": jk},
+        )
+        conn.commit()
+        return JSONResponse({"saved": False, "job_id": job_id})
+    conn.execute(
+        "INSERT INTO saved_jobs (user_id, job_id, saved_at) VALUES (?, ?, ?)",
+        (uid, job_id, app_main.now_value()),
+    )
+    # Capture the search filters at save time (so T01 can verify
+    # "saved with the right filters in scope").
+    db.log_audit(
+        conn,
+        occurred_at=app_main.now_value(),
+        operation="job_saved",
+        target_type="saved_job",
+        target_id=f"{uid}:{job_id}",
+        payload={
+            "user_id": uid,
+            "job_id": job_id,
+            "jk": jk,
+            "filters": {
+                "q": request.query_params.get("q") or "",
+                "l": request.query_params.get("l") or "",
+                "remote": request.query_params.get("remote") or "",
+            },
+        },
+    )
+    conn.commit()
+    return JSONResponse({"saved": True, "job_id": job_id})
+
+
+@router.get("/jobs/_search_audit")
+async def jobs_search_audit(request: Request) -> JSONResponse:
+    """Lightweight audit-emitter the front-end calls on search submit so
+    the oracle can verify the agent actually performed the search with
+    the right filters. Idempotent — emits once per unique (q,l,remote)
+    tuple per second.
+    """
+    qp = request.query_params
+    payload = {
+        "q": qp.get("q") or "",
+        "l": qp.get("l") or "",
+        "remote": qp.get("remote") or "",
+    }
+    conn = db.connect()
+    db.log_audit(
+        conn,
+        occurred_at=app_main.now_value(),
+        operation="search_submitted",
+        target_type="search",
+        target_id=f"{payload['q']}|{payload['l']}|{payload['remote']}",
+        payload=payload,
+    )
+    conn.commit()
+    return JSONResponse({"ok": True})

--- a/deploy/sim_envs/mantis_indeed/app/routes/jobs.py
+++ b/deploy/sim_envs/mantis_indeed/app/routes/jobs.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 from typing import Any
 
 from fastapi import APIRouter, Request
@@ -74,11 +73,17 @@ def _relative_posted(now_iso: str, posted_iso: str) -> str:
         return "Posted 1 day ago"
     if days < 30:
         return f"Posted {days} days ago"
-    return f"Posted 30+ days ago"
+    return "Posted 30+ days ago"
 
 
-def _search_jobs(conn, q: str, l: str, remote: bool, date_max_days: int | None,
-                 job_type: str | None) -> list[dict[str, Any]]:
+def _search_jobs(
+    conn,
+    q: str,
+    l: str,  # noqa: E741 -- `l` mirrors Indeed's location query param
+    remote: bool,
+    date_max_days: int | None,
+    job_type: str | None,
+) -> list[dict[str, Any]]:
     """Substring + filter search. Trivial — no fancy ranking."""
     sql = "SELECT * FROM jobs WHERE status = 'active'"
     params: list[Any] = []
@@ -108,7 +113,7 @@ def _search_jobs(conn, q: str, l: str, remote: bool, date_max_days: int | None,
 async def jobs_search(request: Request) -> Response:
     qp = request.query_params
     q = qp.get("q", "")
-    l = qp.get("l", "")
+    l = qp.get("l", "")  # noqa: E741 -- Indeed query-param convention
     vjk = qp.get("vjk", "")
     remote = qp.get("remote", "") in {"1", "true", "on"}
     job_type = qp.get("job_type") or None

--- a/deploy/sim_envs/mantis_indeed/app/routes/myjobs.py
+++ b/deploy/sim_envs/mantis_indeed/app/routes/myjobs.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from fastapi import APIRouter, Request
 from fastapi.responses import HTMLResponse, Response
 
-from .. import auth, db, main as app_main
+from .. import auth, db
 
 router = APIRouter()
 

--- a/deploy/sim_envs/mantis_indeed/app/routes/myjobs.py
+++ b/deploy/sim_envs/mantis_indeed/app/routes/myjobs.py
@@ -1,0 +1,60 @@
+"""/myjobs — Saved + Applied tabs."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Request
+from fastapi.responses import HTMLResponse, Response
+
+from .. import auth, db, main as app_main
+
+router = APIRouter()
+
+
+def _format_salary(low: int, high: int, period: str) -> str:
+    if not low and not high:
+        return ""
+    suffix = "a year" if period == "year" else "an hour"
+    if low and high and low != high:
+        return f"${low:,} - ${high:,} {suffix}"
+    return f"${low or high:,} {suffix}"
+
+
+@router.get("/myjobs", response_class=HTMLResponse)
+async def myjobs(request: Request) -> Response:
+    tab = request.query_params.get("tab", "saved")
+    if tab not in {"saved", "applied"}:
+        tab = "saved"
+    conn = db.connect()
+    uid = auth.effective_user_id(request)
+
+    if tab == "saved":
+        rows = conn.execute(
+            "SELECT j.*, c.name AS company_name FROM saved_jobs s "
+            "JOIN jobs j ON j.id = s.job_id "
+            "JOIN companies c ON c.id = j.company_id "
+            "WHERE s.user_id = ? "
+            "ORDER BY s.saved_at DESC",
+            (uid,),
+        ).fetchall()
+    else:
+        rows = conn.execute(
+            "SELECT j.*, c.name AS company_name, a.status AS app_status, "
+            "a.applied_at AS app_applied_at FROM applications a "
+            "JOIN jobs j ON j.id = a.job_id "
+            "JOIN companies c ON c.id = j.company_id "
+            "WHERE a.user_id = ? "
+            "ORDER BY a.applied_at DESC",
+            (uid,),
+        ).fetchall()
+
+    items = []
+    for r in rows:
+        d = dict(r)
+        d["salary_display"] = _format_salary(d["salary_low"], d["salary_high"],
+                                              d["salary_period"])
+        items.append(d)
+
+    return request.app.state.templates.TemplateResponse(
+        "myjobs.html",
+        {"request": request, "tab": tab, "items": items},
+    )

--- a/deploy/sim_envs/mantis_indeed/app/routes/resumes.py
+++ b/deploy/sim_envs/mantis_indeed/app/routes/resumes.py
@@ -1,0 +1,87 @@
+"""/resumes — resume manager."""
+
+from __future__ import annotations
+
+import json
+
+from fastapi import APIRouter, Form, Request
+from fastapi.responses import HTMLResponse, RedirectResponse, Response
+
+from .. import auth, db, main as app_main
+
+router = APIRouter()
+
+
+@router.get("/resumes", response_class=HTMLResponse)
+async def resumes_list(request: Request) -> Response:
+    conn = db.connect()
+    uid = auth.effective_user_id(request)
+    rows = conn.execute(
+        "SELECT * FROM resumes WHERE user_id = ? AND deleted_at IS NULL "
+        "ORDER BY id",
+        (uid,),
+    ).fetchall()
+    resumes = []
+    for r in rows:
+        d = dict(r)
+        try:
+            d["skills_list"] = json.loads(d.get("skills") or "[]")
+        except json.JSONDecodeError:
+            d["skills_list"] = []
+        resumes.append(d)
+    return request.app.state.templates.TemplateResponse(
+        "resumes.html",
+        {"request": request, "resumes": resumes},
+    )
+
+
+@router.post("/resumes/new")
+async def resumes_new(
+    request: Request,
+    title: str = Form("New resume"),
+    summary: str = Form(""),
+    skills: str = Form(""),
+    experience: str = Form(""),
+) -> Response:
+    conn = db.connect()
+    uid = auth.effective_user_id(request)
+    n = conn.execute("SELECT COUNT(*) FROM resumes").fetchone()[0]
+    rid = f"resume_run_{n + 1:05d}"
+    skills_list = [s.strip() for s in skills.split(",") if s.strip()]
+    conn.execute(
+        "INSERT INTO resumes (id, user_id, title, summary, skills, experience, "
+        "updated_at, deleted_at) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, NULL)",
+        (rid, uid, title, summary, json.dumps(skills_list), experience,
+         app_main.now_value()),
+    )
+    db.log_audit(
+        conn,
+        occurred_at=app_main.now_value(),
+        operation="resume_created",
+        target_type="resume",
+        target_id=rid,
+        payload={"user_id": uid, "title": title},
+    )
+    conn.commit()
+    return RedirectResponse("/resumes", status_code=303)
+
+
+@router.post("/resumes/{rid}/delete")
+async def resumes_delete(rid: str, request: Request) -> Response:
+    conn = db.connect()
+    uid = auth.effective_user_id(request)
+    conn.execute(
+        "UPDATE resumes SET deleted_at = ? WHERE id = ? AND user_id = ?",
+        (app_main.now_value(), rid, uid),
+    )
+    db.log_audit(
+        conn,
+        occurred_at=app_main.now_value(),
+        operation="resume_deleted",
+        target_type="resume",
+        target_id=rid,
+        payload={"user_id": uid},
+    )
+    conn.commit()
+    return RedirectResponse("/resumes", status_code=303)

--- a/deploy/sim_envs/mantis_indeed/app/seed.py
+++ b/deploy/sim_envs/mantis_indeed/app/seed.py
@@ -24,7 +24,6 @@ import json
 import random
 import sqlite3
 from datetime import datetime, timedelta
-from typing import Any
 
 FAKE_NOW_DEFAULT = "2026-01-15T09:00:00Z"
 

--- a/deploy/sim_envs/mantis_indeed/app/seed.py
+++ b/deploy/sim_envs/mantis_indeed/app/seed.py
@@ -1,0 +1,320 @@
+"""Deterministic seed for mantis-indeed.
+
+Given ``SEED``, this module deterministically produces:
+
+* 50 companies + their employer users (1 per company)
+* 50 seekers + their resumes (1 per seeker)
+* 30 active jobs (varied titles, locations, salary ranges)
+* ~100 historical applications spread across seekers/jobs
+* 1 known T01 seeker (`user_00007`, email `seeker7@example.com`,
+  password `seekerpass`) with no saved jobs at boot.
+* 1 known T02 seeker (`user_00012`, email `seeker12@example.com`,
+  password `seekerpass`) targeted by T02 Easy Apply.
+* 1 known T03 employer (`user_emp_00003`, email
+  `employer3@example.com`, password `emppass`) owning `job_00003`
+  / `posting_00003` with at least one `new` applicant.
+
+Same SEED → identical row IDs + identical column values.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import random
+import sqlite3
+from datetime import datetime, timedelta
+from typing import Any
+
+FAKE_NOW_DEFAULT = "2026-01-15T09:00:00Z"
+
+N_COMPANIES = 50
+N_SEEKERS = 50
+N_JOBS = 30
+N_HISTORICAL_APPS = 100
+
+_COMPANY_NAMES = [
+    "Acme Software", "Northwind Robotics", "Globex Health", "Initech Cloud",
+    "Stark Industries", "Hooli", "Pied Piper", "Massive Dynamic",
+    "Soylent Systems", "Cyberdyne Solutions", "Wayne Enterprises",
+    "Aperture Science", "Tyrell Compute", "Weyland Logistics",
+    "OsCorp Bio", "Umbrella Analytics", "Wonka Foods", "Vandelay Imports",
+    "Bluth Real Estate", "Dunder Mifflin Tech", "Sterling Cooper Media",
+    "Los Pollos Hermanos", "Costco North", "Mooby's Corp", "Krusty Krab",
+    "Spacely Sprockets", "Cogswell Cogs", "InGen Genetics", "Yoyodyne",
+    "Genco Pura", "Macrohard", "Compuglobalhypermeganet", "Bushwood",
+    "Veridian Dynamics", "Globo Gym", "Trade Federation", "Cyrez Group",
+    "Daystrom Institute", "Tessier-Ashpool", "Buy n Large", "Soylent Green",
+    "Bigweld Industries", "Planet Express", "Slate Rock Co", "Vault-Tec",
+    "Black Mesa", "Aperture Labs", "Octan Energy", "Cyberlife", "Olisarra",
+]
+_LOCATIONS = [
+    "Austin, TX", "San Francisco, CA", "New York, NY", "Seattle, WA",
+    "Boston, MA", "Chicago, IL", "Denver, CO", "Atlanta, GA",
+    "Portland, OR", "Los Angeles, CA", "Remote", "Washington, DC",
+    "Raleigh, NC", "Minneapolis, MN", "Pittsburgh, PA",
+]
+_JOB_TITLES = [
+    "Software Engineer", "Senior Software Engineer", "Frontend Engineer",
+    "Backend Engineer", "Full Stack Engineer", "DevOps Engineer",
+    "Site Reliability Engineer", "Data Engineer", "Machine Learning Engineer",
+    "Engineering Manager", "Staff Software Engineer", "Principal Engineer",
+    "Mobile Engineer", "iOS Engineer", "Android Engineer", "Platform Engineer",
+    "Security Engineer", "QA Engineer", "Embedded Software Engineer",
+    "Cloud Engineer", "Solutions Engineer", "Software Developer",
+    "Junior Software Engineer", "Data Scientist", "Product Engineer",
+    "Test Engineer", "Build Engineer", "Release Engineer",
+    "Distributed Systems Engineer", "Database Engineer",
+]
+_JOB_TYPES = ["Full-time", "Part-time", "Contract", "Internship"]
+_EXPERIENCE = ["Entry level", "Mid level", "Senior level", "Director"]
+_INDUSTRIES = ["Software", "Healthcare", "Finance", "Retail", "Manufacturing",
+               "Education", "Media", "Government"]
+_FIRST_NAMES = ["Alex", "Sam", "Jordan", "Taylor", "Casey", "Morgan", "Riley",
+                "Avery", "Quinn", "Drew", "Reese", "Charlie", "Sky", "Robin",
+                "Pat", "Jamie", "Lee", "Frankie", "Tracy", "Dakota"]
+_LAST_NAMES = ["Lee", "Patel", "Chen", "Garcia", "Smith", "Brown", "Johnson",
+               "Davis", "Wilson", "Anderson", "Martin", "Thompson", "White",
+               "Walker", "Hall", "Green", "Adams", "Baker", "Nelson", "Hill"]
+_SKILLS_POOL = ["Python", "JavaScript", "TypeScript", "Go", "Rust", "Java",
+                "Kotlin", "Swift", "C++", "C#", "Ruby", "PHP", "SQL",
+                "PostgreSQL", "Redis", "AWS", "GCP", "Azure", "Docker",
+                "Kubernetes", "Terraform", "React", "Vue", "Angular", "Django",
+                "FastAPI", "Flask", "Spring", "Rails", "Node.js"]
+
+
+def _sha256(plain: str) -> str:
+    return hashlib.sha256(plain.encode("utf-8")).hexdigest()
+
+
+def _jk(rng: random.Random) -> str:
+    return "%016x" % rng.getrandbits(64)
+
+
+def _wipe(conn: sqlite3.Connection) -> None:
+    for table in [
+        "audit_log", "saved_jobs", "applications", "resumes",
+        "jobs", "users", "companies",
+    ]:
+        conn.execute(f"DELETE FROM {table}")
+
+
+def _parse_now(now: str) -> datetime:
+    if now.endswith("Z"):
+        return datetime.fromisoformat(now[:-1])
+    return datetime.fromisoformat(now)
+
+
+def _iso(dt: datetime) -> str:
+    return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def seed(conn: sqlite3.Connection, *, seed_val: int, fake_now: str) -> None:
+    """Idempotent reseed — wipe + recreate. Mirrors mantis-shop."""
+    rng = random.Random(seed_val)
+    now_dt = _parse_now(fake_now)
+
+    _wipe(conn)
+
+    # ── companies ─────────────────────────────────────────────────────
+    for i, name in enumerate(_COMPANY_NAMES[:N_COMPANIES], start=1):
+        cid = f"company_{i:05d}"
+        rating = round(rng.uniform(2.8, 4.7), 1)
+        review_count = rng.randint(20, 4000)
+        industry = rng.choice(_INDUSTRIES)
+        hq = rng.choice(_LOCATIONS)
+        conn.execute(
+            "INSERT INTO companies (id, name, rating, review_count, industry, headquarters) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (cid, name, rating, review_count, industry, hq),
+        )
+
+    # ── employers (one per company, but only fill first 20 with users) ──
+    # T03 expects user_emp_00003.
+    for i in range(1, 21):
+        uid = f"user_emp_{i:05d}"
+        email = f"employer{i}@example.com"
+        conn.execute(
+            "INSERT INTO users (id, email, password_hash, role, name, "
+            "phone, city, state, zip, company_id, created_at) "
+            "VALUES (?, ?, ?, 'employer', ?, '', '', '', '', ?, ?)",
+            (
+                uid, email, _sha256("emppass"),
+                f"Employer #{i}",
+                f"company_{i:05d}",
+                _iso(now_dt - timedelta(days=180 + i)),
+            ),
+        )
+
+    # ── seekers ───────────────────────────────────────────────────────
+    for i in range(1, N_SEEKERS + 1):
+        uid = f"user_{i:05d}"
+        email = f"seeker{i}@example.com"
+        name = f"{rng.choice(_FIRST_NAMES)} {rng.choice(_LAST_NAMES)}"
+        loc = rng.choice(_LOCATIONS)
+        # crude location split
+        if "," in loc:
+            city, state = [s.strip() for s in loc.split(",")]
+        else:
+            city, state = loc, ""
+        zip_code = f"{rng.randint(10000, 99999)}"
+        phone = f"({rng.randint(200,999)}) {rng.randint(200,999)}-{rng.randint(1000,9999)}"
+        conn.execute(
+            "INSERT INTO users (id, email, password_hash, role, name, phone, "
+            "city, state, zip, company_id, created_at) "
+            "VALUES (?, ?, ?, 'seeker', ?, ?, ?, ?, ?, NULL, ?)",
+            (
+                uid, email, _sha256("seekerpass"),
+                name, phone, city, state, zip_code,
+                _iso(now_dt - timedelta(days=30 + i)),
+            ),
+        )
+
+    # one resume per seeker
+    for i in range(1, N_SEEKERS + 1):
+        rid = f"resume_{i:05d}"
+        uid = f"user_{i:05d}"
+        skills = rng.sample(_SKILLS_POOL, 6)
+        conn.execute(
+            "INSERT INTO resumes (id, user_id, title, summary, skills, experience, updated_at, deleted_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, NULL)",
+            (
+                rid, uid,
+                "Default resume",
+                f"Software professional with {rng.randint(2, 12)} years of experience.",
+                json.dumps(skills),
+                "Various roles across the industry.",
+                _iso(now_dt - timedelta(days=rng.randint(1, 90))),
+            ),
+        )
+
+    # ── jobs ──────────────────────────────────────────────────────────
+    # Pin job_00001 = first software engineer in Austin TX (T01 target).
+    # job_00007 = a remote SE in Austin TX (T01 save target).
+    # job_00012 = T02 Easy Apply target.
+    # job_00003 = T03 employer review target.
+    pinned_jobs: list[tuple[str, str, str, int, int, int, str]] = [
+        # (title, company_id, location, salary_low, salary_high, remote, jk_seed)
+        ("Software Engineer", "company_00001", "Austin, TX", 120000, 160000, 0, "0000000000000001"),
+        ("Senior Software Engineer", "company_00002", "Remote", 150000, 200000, 1, "0000000000000002"),
+        ("Frontend Engineer", "company_00003", "San Francisco, CA", 130000, 170000, 0, "0000000000000003"),
+        ("Backend Engineer", "company_00004", "Seattle, WA", 130000, 170000, 0, "0000000000000004"),
+        ("Full Stack Engineer", "company_00005", "Austin, TX", 110000, 150000, 0, "0000000000000005"),
+        ("DevOps Engineer", "company_00006", "Austin, TX", 130000, 170000, 1, "0000000000000006"),
+        # job_00007 — explicit T01 save target. SE, Austin TX, remote=1.
+        ("Software Engineer", "company_00007", "Austin, TX", 140000, 180000, 1, "0000000000000007"),
+        ("Data Engineer", "company_00008", "New York, NY", 140000, 180000, 0, "0000000000000008"),
+        ("Machine Learning Engineer", "company_00009", "Boston, MA", 150000, 200000, 0, "0000000000000009"),
+        ("Mobile Engineer", "company_00010", "Chicago, IL", 120000, 160000, 0, "000000000000000a"),
+        ("iOS Engineer", "company_00011", "Austin, TX", 120000, 160000, 0, "000000000000000b"),
+        # job_00012 — T02 Easy Apply target. SE, Austin TX.
+        ("Software Engineer", "company_00012", "Austin, TX", 130000, 175000, 0, "000000000000000c"),
+        ("Android Engineer", "company_00013", "Denver, CO", 120000, 160000, 0, "000000000000000d"),
+        ("Site Reliability Engineer", "company_00014", "San Francisco, CA", 150000, 200000, 1, "000000000000000e"),
+        ("Platform Engineer", "company_00015", "Austin, TX", 140000, 185000, 0, "000000000000000f"),
+        ("Security Engineer", "company_00016", "Washington, DC", 140000, 180000, 0, "0000000000000010"),
+        ("QA Engineer", "company_00017", "Atlanta, GA", 95000, 130000, 0, "0000000000000011"),
+        ("Engineering Manager", "company_00018", "Seattle, WA", 180000, 240000, 0, "0000000000000012"),
+        ("Staff Software Engineer", "company_00019", "Remote", 200000, 270000, 1, "0000000000000013"),
+        ("Principal Engineer", "company_00020", "New York, NY", 220000, 300000, 0, "0000000000000014"),
+        ("Software Developer", "company_00021", "Pittsburgh, PA", 100000, 140000, 0, "0000000000000015"),
+        ("Junior Software Engineer", "company_00022", "Minneapolis, MN", 80000, 110000, 0, "0000000000000016"),
+        ("Data Scientist", "company_00023", "Boston, MA", 140000, 180000, 0, "0000000000000017"),
+        ("Test Engineer", "company_00024", "Raleigh, NC", 95000, 125000, 0, "0000000000000018"),
+        ("Cloud Engineer", "company_00025", "Austin, TX", 130000, 170000, 1, "0000000000000019"),
+        ("Solutions Engineer", "company_00026", "Los Angeles, CA", 130000, 170000, 0, "000000000000001a"),
+        ("Embedded Software Engineer", "company_00027", "Portland, OR", 120000, 160000, 0, "000000000000001b"),
+        ("Build Engineer", "company_00028", "Austin, TX", 110000, 145000, 0, "000000000000001c"),
+        ("Release Engineer", "company_00029", "San Francisco, CA", 130000, 170000, 1, "000000000000001d"),
+        ("Database Engineer", "company_00030", "Remote", 130000, 170000, 1, "000000000000001e"),
+    ]
+
+    for idx, (title, cid, loc, sl, sh, rem, jk_seed) in enumerate(pinned_jobs, start=1):
+        jid = f"job_{idx:05d}"
+        snippet = (
+            f"{title} role at {cid.replace('company_','co').replace('_', '')}. "
+            "Work with a modern stack, ship to production, collaborate "
+            "across a small autonomous team."
+        )
+        desc = (
+            f"## About the role\n\n{snippet}\n\n"
+            "## What you'll do\n\n"
+            "- Own end-to-end delivery of features in production.\n"
+            "- Partner with PM and design to scope and ship.\n"
+            "- Mentor junior teammates and review PRs.\n\n"
+            "## What you bring\n\n"
+            f"- {rng.randint(2, 10)}+ years of relevant engineering experience.\n"
+            "- Strong fundamentals in computer science.\n"
+            "- Excellent written communication.\n\n"
+            "## Benefits\n\n"
+            "- Competitive salary + equity.\n"
+            "- Comprehensive health insurance.\n"
+            "- 401(k) match.\n"
+            "- Generous PTO.\n"
+        )
+        # Vary posted_at: most jobs posted in last 30 days.
+        days_ago = rng.randint(0, 30)
+        posted_at = _iso(now_dt - timedelta(days=days_ago))
+        job_type = rng.choice(_JOB_TYPES)
+        experience = rng.choice(_EXPERIENCE)
+        conn.execute(
+            "INSERT INTO jobs (id, jk, title, company_id, location, salary_low, "
+            "salary_high, salary_period, remote_flag, job_type, experience_level, "
+            "posted_at, description, snippet, status) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, 'year', ?, ?, ?, ?, ?, ?, 'active')",
+            (jid, jk_seed, title, cid, loc, sl, sh, rem, job_type,
+             experience, posted_at, desc, snippet),
+        )
+
+    # ── historical applications ───────────────────────────────────────
+    # ~100 historical applications spread across seekers/jobs. T03 needs
+    # at least one `new` applicant on job_00003.
+    seeker_ids = [f"user_{i:05d}" for i in range(1, N_SEEKERS + 1)]
+    job_ids = [f"job_{i:05d}" for i in range(1, N_JOBS + 1)]
+    placed = set()
+    for n in range(N_HISTORICAL_APPS):
+        uid = rng.choice(seeker_ids)
+        jid = rng.choice(job_ids)
+        if (uid, jid) in placed:
+            continue
+        placed.add((uid, jid))
+        aid = f"application_{len(placed):05d}"
+        rid = f"resume_{int(uid.split('_')[1]):05d}"
+        # Status mix: 50% new, 30% reviewed, 10% rejected, 10% hired.
+        r = rng.random()
+        if r < 0.5:
+            status, reviewed_at = "new", None
+        elif r < 0.8:
+            status, reviewed_at = "reviewed", _iso(now_dt - timedelta(days=rng.randint(0, 10)))
+        elif r < 0.9:
+            status, reviewed_at = "rejected", _iso(now_dt - timedelta(days=rng.randint(0, 10)))
+        else:
+            status, reviewed_at = "hired", _iso(now_dt - timedelta(days=rng.randint(0, 10)))
+        applied_days = rng.randint(1, 60)
+        conn.execute(
+            "INSERT INTO applications (id, user_id, job_id, resume_id, phone, "
+            "answers_json, status, applied_at, reviewed_at) "
+            "VALUES (?, ?, ?, ?, '', '{}', ?, ?, ?)",
+            (aid, uid, jid, rid, status,
+             _iso(now_dt - timedelta(days=applied_days)), reviewed_at),
+        )
+
+    # Pinned T03: ensure `application_seed_t03` always exists on
+    # job_00003 by user_00001 with status='new'. If a prior random
+    # application already occupied that (user_id, job_id) slot, blow
+    # it away first so the UNIQUE constraint doesn't fight us.
+    conn.execute(
+        "DELETE FROM applications WHERE user_id = ? AND job_id = ?",
+        ("user_00001", "job_00003"),
+    )
+    aid = "application_seed_t03"
+    rid = "resume_00001"
+    conn.execute(
+        "INSERT INTO applications (id, user_id, job_id, resume_id, phone, "
+        "answers_json, status, applied_at, reviewed_at) "
+        "VALUES (?, ?, ?, ?, '', '{}', 'new', ?, NULL)",
+        (aid, "user_00001", "job_00003", rid,
+         _iso(now_dt - timedelta(days=2))),
+    )
+
+    conn.commit()

--- a/deploy/sim_envs/mantis_indeed/app/static/logo.svg
+++ b/deploy/sim_envs/mantis_indeed/app/static/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="80" height="32" viewBox="0 0 80 32">
+  <text x="0" y="26" font-family="Helvetica Neue, Helvetica, Arial, sans-serif"
+        font-size="28" font-weight="700" fill="#2557A7">indeed</text>
+</svg>

--- a/deploy/sim_envs/mantis_indeed/app/static/site.css
+++ b/deploy/sim_envs/mantis_indeed/app/static/site.css
@@ -1,0 +1,637 @@
+/* mantis-indeed — hand-rolled CSS approximating indeed.com's surface.
+ *
+ * Palette + typography pulled from `_capture_brief.md`. Grouped by
+ * component, not by page. No outbound CDN fetches at runtime.
+ */
+
+:root {
+  --brand-blue: #2557A7;
+  --brand-blue-dark: #164081;
+  --brand-blue-tint: #E4F1FF;
+  --text-primary: #2D2D2D;
+  --text-secondary: #595959;
+  --text-tertiary: #767676;
+  --divider: #D4D2D0;
+  --surface-grey: #F3F2F1;
+  --white: #FFFFFF;
+  --green: #0e8345;
+  --red: #d63426;
+  --shadow-card: 0 0 0 1px var(--divider);
+  --radius-card: 8px;
+  --radius-chip: 16px;
+  --radius-button: 4px;
+  --font-body: "Indeed Sans", "Noto Sans", "Helvetica Neue", Helvetica, Arial,
+               "Liberation Sans", Roboto, Noto, sans-serif;
+}
+
+* { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; }
+body {
+  font-family: var(--font-body);
+  font-size: 16px;
+  line-height: 1.5;
+  color: var(--text-primary);
+  background: var(--white);
+}
+a { color: var(--brand-blue); text-decoration: none; }
+a:hover { text-decoration: underline; }
+.visually-hidden {
+  position: absolute; width: 1px; height: 1px;
+  padding: 0; margin: -1px; overflow: hidden;
+  clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0;
+}
+
+/* ── Top nav ───────────────────────────────────────────────────── */
+.top-nav {
+  position: sticky; top: 0; z-index: 100;
+  background: var(--white);
+  border-bottom: 1px solid var(--divider);
+}
+.top-nav-inner {
+  display: flex; align-items: center; justify-content: space-between;
+  max-width: 1440px; margin: 0 auto;
+  padding: 8px 24px;
+  height: 52px;
+}
+.brand { display: inline-flex; align-items: center; }
+.brand-wordmark {
+  color: var(--brand-blue);
+  font-size: 28px; font-weight: 700;
+  letter-spacing: -0.5px;
+}
+.top-nav-links {
+  display: flex; align-items: center; gap: 16px;
+  font-size: 14px;
+}
+.top-nav-links a { color: var(--text-primary); }
+.top-nav-links .nav-divider { color: var(--divider); }
+.user-chip { color: var(--text-secondary); font-size: 13px; }
+.link-button {
+  background: none; border: 0; color: var(--brand-blue);
+  cursor: pointer; padding: 0; font: inherit;
+}
+.inline-form { display: inline-block; margin: 0; }
+.secondary-strip {
+  display: flex; gap: 24px; align-items: center;
+  max-width: 1440px; margin: 0 auto;
+  padding: 6px 24px; font-size: 14px;
+  border-top: 1px solid transparent;
+  color: var(--text-secondary);
+}
+.secondary-strip a { color: var(--text-secondary); }
+.secondary-strip a:hover { color: var(--text-primary); text-decoration: underline; }
+.country-pill {
+  margin-left: auto;
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+
+/* ── Workspace container ──────────────────────────────────────── */
+.workspace {
+  max-width: 1440px; margin: 0 auto;
+  padding: 24px;
+}
+
+/* ── Buttons ──────────────────────────────────────────────────── */
+.btn {
+  display: inline-flex; align-items: center; justify-content: center;
+  height: 40px; padding: 0 20px;
+  font-size: 15px; font-weight: 700;
+  border-radius: var(--radius-button);
+  border: 1px solid transparent;
+  cursor: pointer;
+  text-decoration: none;
+  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+}
+.btn-primary {
+  background: var(--brand-blue); color: var(--white);
+}
+.btn-primary:hover { background: var(--brand-blue-dark); text-decoration: none; }
+.btn-outline {
+  background: var(--white); color: var(--brand-blue);
+  border: 1px solid var(--brand-blue);
+}
+.btn-outline:hover { background: var(--brand-blue-tint); text-decoration: none; }
+.btn:focus-visible {
+  outline: 2px solid var(--brand-blue);
+  outline-offset: 2px;
+}
+.btn[disabled] { opacity: 0.5; cursor: not-allowed; }
+
+/* ── Hero (home) ──────────────────────────────────────────────── */
+.hero {
+  background: var(--surface-grey);
+  padding: 64px 24px;
+  margin: -24px -24px 32px;
+}
+.hero-inner {
+  max-width: 1080px; margin: 0 auto;
+  text-align: center;
+}
+.hero-title {
+  font-size: 32px; line-height: 40px; font-weight: 700;
+  margin: 0 0 24px;
+}
+.hero-search {
+  display: flex; align-items: stretch;
+  background: var(--white);
+  border: 1px solid var(--divider);
+  border-radius: var(--radius-button);
+  height: 56px;
+  max-width: 880px; margin: 0 auto;
+  overflow: hidden;
+}
+.hero-search-group {
+  display: flex; align-items: center;
+  flex: 1; padding: 0 16px; gap: 8px;
+}
+.hero-input-icon { color: var(--text-tertiary); }
+.hero-input {
+  flex: 1; height: 100%;
+  border: 0; outline: 0; background: transparent;
+  font-size: 16px; color: var(--text-primary);
+}
+.hero-input::placeholder { color: var(--text-tertiary); }
+.hero-search-separator { width: 1px; background: var(--divider); margin: 8px 0; }
+.hero-cta { margin: 8px 8px 8px 0; }
+.hero-foot {
+  margin-top: 16px; color: var(--text-secondary); font-size: 14px;
+}
+
+/* ── Below-hero panels ────────────────────────────────────────── */
+.below-hero {
+  display: grid; grid-template-columns: 1fr 1fr;
+  gap: 24px; margin-top: 32px;
+}
+.panel {
+  background: var(--white);
+  border: 1px solid var(--divider);
+  border-radius: var(--radius-card);
+  padding: 20px;
+}
+.panel h2 { font-size: 20px; font-weight: 700; margin: 0 0 12px; }
+.chip-list { list-style: none; padding: 0; margin: 0; display: flex; gap: 8px; flex-wrap: wrap; }
+.link-list { list-style: none; padding: 0; margin: 0; }
+.link-list li { padding: 6px 0; }
+
+/* ── Search bar strip (on /jobs) ───────────────────────────────── */
+.search-bar-strip {
+  margin-bottom: 16px;
+}
+.search-bar {
+  display: flex; align-items: stretch;
+  background: var(--white);
+  border: 1px solid var(--divider);
+  border-radius: var(--radius-button);
+  height: 44px;
+}
+.search-bar-group {
+  display: flex; align-items: center;
+  flex: 1; padding: 0 12px; gap: 6px;
+}
+.search-bar-input {
+  flex: 1; border: 0; outline: 0; background: transparent;
+  font-size: 14px; height: 100%;
+}
+.search-bar-separator { width: 1px; background: var(--divider); margin: 6px 0; }
+.search-bar .btn { height: 32px; margin: 6px; }
+.search-bar-icon { color: var(--text-tertiary); font-size: 14px; }
+
+/* ── Results header ───────────────────────────────────────────── */
+.results-header { margin-bottom: 16px; }
+.results-h1 {
+  font-size: 20px; line-height: 28px; font-weight: 700;
+  margin: 0 0 12px;
+}
+.filter-chips {
+  display: flex; gap: 8px; flex-wrap: wrap;
+  margin-bottom: 12px;
+}
+.chip {
+  display: inline-flex; align-items: center;
+  height: 32px; padding: 6px 12px;
+  background: var(--white); color: var(--text-primary);
+  border: 1px solid var(--divider);
+  border-radius: var(--radius-chip);
+  font-size: 14px; font-weight: 400;
+  cursor: pointer; text-decoration: none;
+}
+.chip:hover { background: var(--surface-grey); text-decoration: none; }
+.chip-active {
+  background: var(--brand-blue-tint);
+  border-color: var(--brand-blue);
+  color: var(--brand-blue-dark);
+  font-weight: 700;
+}
+.results-substrip {
+  display: flex; justify-content: space-between; align-items: center;
+  font-size: 14px; color: var(--text-secondary);
+}
+.sort-by .sort-current { color: var(--text-primary); font-weight: 700; }
+
+/* ── 3-pane results layout ────────────────────────────────────── */
+.results-pane {
+  display: grid;
+  grid-template-columns: 480px 680px;
+  gap: 20px;
+  align-items: flex-start;
+}
+.results-list { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 12px; }
+.result-card {
+  background: var(--white);
+  border: 1px solid var(--divider);
+  border-radius: var(--radius-card);
+  padding: 16px;
+  cursor: pointer;
+  position: relative;
+  transition: box-shadow 0.15s ease;
+}
+.result-card:hover { box-shadow: 0 2px 6px rgba(0,0,0,0.08); }
+.result-card.selected {
+  background: var(--brand-blue-tint);
+}
+.result-card.selected::before {
+  content: ""; position: absolute;
+  left: -1px; top: -1px; bottom: -1px;
+  width: 4px; background: var(--brand-blue);
+  border-radius: var(--radius-card) 0 0 var(--radius-card);
+}
+.job-title {
+  font-size: 18px; line-height: 24px; font-weight: 700;
+  margin: 0 0 4px;
+}
+.job-title a { color: var(--brand-blue); }
+.company-row {
+  display: flex; align-items: center; gap: 8px;
+  font-size: 14px; color: var(--text-primary);
+  margin-bottom: 4px;
+}
+.rating-stars { color: var(--green); font-size: 12px; }
+.review-count { color: var(--text-tertiary); font-size: 12px; }
+.location-row {
+  font-size: 14px; color: var(--text-secondary);
+  margin-bottom: 4px;
+}
+.salary-row {
+  font-size: 14px; color: var(--text-primary);
+  margin-bottom: 8px;
+}
+.snippet {
+  font-size: 14px; line-height: 1.45;
+  color: var(--text-secondary);
+  margin: 0 0 8px;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.card-foot {
+  display: flex; justify-content: space-between; align-items: center;
+  font-size: 12px; color: var(--text-tertiary);
+}
+.bookmark-btn {
+  background: transparent; border: 0;
+  cursor: pointer;
+  font-size: 20px;
+  color: var(--text-tertiary);
+}
+.bookmark-btn.is-saved { color: var(--brand-blue); }
+.bookmark-btn:focus-visible {
+  outline: 2px solid var(--brand-blue);
+  outline-offset: 2px;
+}
+
+/* ── Detail pane ──────────────────────────────────────────────── */
+.detail-pane {
+  position: sticky; top: 64px;
+  background: var(--white);
+  border: 1px solid var(--divider);
+  border-radius: var(--radius-card);
+  max-height: calc(100vh - 80px);
+  overflow-y: auto;
+}
+.detail-pane-inner { padding: 24px; }
+.detail-h2 {
+  font-size: 24px; line-height: 32px; font-weight: 700;
+  margin: 0 0 8px;
+}
+.detail-company-row {
+  display: flex; gap: 12px; align-items: center;
+  font-size: 16px; margin-bottom: 12px;
+}
+.detail-company-row .location { color: var(--text-secondary); font-size: 14px; }
+.detail-chips {
+  display: flex; gap: 8px; flex-wrap: wrap;
+  margin-bottom: 16px;
+}
+.detail-chip {
+  display: inline-flex; align-items: center;
+  height: 28px; padding: 4px 10px;
+  background: var(--surface-grey);
+  border-radius: var(--radius-chip);
+  font-size: 13px; color: var(--text-primary);
+}
+.detail-actions {
+  display: flex; gap: 12px;
+  margin-bottom: 20px;
+}
+.detail-tabs {
+  display: flex; gap: 0;
+  border-bottom: 1px solid var(--divider);
+  margin-bottom: 16px;
+}
+.detail-tabs .tab {
+  padding: 10px 16px;
+  color: var(--text-secondary);
+  border-bottom: 2px solid transparent;
+  font-weight: 700; font-size: 14px;
+}
+.detail-tabs .tab-active {
+  color: var(--brand-blue);
+  border-bottom-color: var(--brand-blue);
+}
+.detail-salary-strip {
+  background: var(--surface-grey);
+  padding: 12px 16px;
+  border-radius: var(--radius-card);
+  margin-bottom: 16px;
+}
+.detail-description p {
+  margin: 0 0 16px;
+}
+.detail-description p:last-child { margin-bottom: 0; }
+.empty-pane {
+  padding: 60px 24px;
+  text-align: center;
+  color: var(--text-tertiary);
+}
+.empty-results {
+  padding: 24px;
+  text-align: center;
+  color: var(--text-tertiary);
+}
+
+/* ── Apply card / form ────────────────────────────────────────── */
+.apply-card {
+  max-width: 720px; margin: 0 auto;
+  background: var(--white);
+  border: 1px solid var(--divider);
+  border-radius: var(--radius-card);
+  padding: 32px;
+}
+.apply-stepper {
+  display: flex; gap: 8px; list-style: none;
+  padding: 0; margin: 0 0 20px;
+  font-size: 14px;
+}
+.apply-stepper .step {
+  display: flex; align-items: center; gap: 6px;
+  color: var(--text-tertiary);
+}
+.apply-stepper .step-num {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 24px; height: 24px;
+  background: var(--surface-grey);
+  border-radius: 50%;
+  font-weight: 700;
+}
+.apply-stepper .step-active .step-num,
+.apply-stepper .step-active {
+  color: var(--brand-blue);
+}
+.apply-stepper .step-active .step-num {
+  background: var(--brand-blue);
+  color: var(--white);
+}
+.apply-stepper .step + .step::before {
+  content: "→"; color: var(--text-tertiary); margin-right: 6px;
+}
+.apply-h1 {
+  font-size: 24px; line-height: 32px; font-weight: 700;
+  margin: 0 0 8px;
+}
+.apply-sub { color: var(--text-secondary); margin: 0 0 24px; font-size: 14px; }
+.apply-form { display: flex; flex-direction: column; gap: 16px; }
+.apply-form label { display: flex; flex-direction: column; gap: 6px;
+                    font-size: 14px; color: var(--text-primary); font-weight: 700; }
+.apply-form input[type="text"],
+.apply-form input[type="email"],
+.apply-form input[type="tel"],
+.apply-form input[type="password"],
+.apply-form input[type="number"],
+.apply-form select,
+.apply-form textarea {
+  border: 1px solid var(--divider);
+  border-radius: var(--radius-button);
+  padding: 8px 12px;
+  font-size: 14px;
+  font-family: var(--font-body);
+}
+.apply-form input:focus,
+.apply-form textarea:focus,
+.apply-form select:focus {
+  outline: 2px solid var(--brand-blue);
+  outline-offset: 0;
+  border-color: var(--brand-blue);
+}
+.form-row-3, .form-row-2 {
+  display: grid; gap: 16px;
+}
+.form-row-3 { grid-template-columns: 1fr 1fr 1fr; }
+.form-row-2 { grid-template-columns: 1fr 1fr; }
+.form-actions {
+  display: flex; justify-content: space-between; align-items: center;
+  margin-top: 16px;
+}
+.resume-options {
+  border: 0; padding: 0; margin: 0;
+  display: flex; flex-direction: column; gap: 8px;
+}
+.resume-card {
+  display: flex; gap: 12px; align-items: flex-start;
+  padding: 12px; border: 1px solid var(--divider);
+  border-radius: var(--radius-card); cursor: pointer;
+}
+.resume-card-body { display: flex; flex-direction: column; gap: 4px; }
+.resume-card-body strong { font-size: 14px; }
+.resume-card-body small { font-size: 12px; color: var(--text-tertiary); }
+.review-section {
+  background: var(--surface-grey);
+  padding: 16px;
+  border-radius: var(--radius-card);
+  margin-bottom: 12px;
+}
+.review-section h2 { font-size: 16px; margin: 0 0 8px; }
+.success-card { text-align: center; }
+.success-icon {
+  width: 56px; height: 56px;
+  border-radius: 50%;
+  background: var(--green); color: var(--white);
+  font-size: 28px; line-height: 56px;
+  margin: 0 auto 16px;
+}
+
+/* ── /myjobs ──────────────────────────────────────────────────── */
+.myjobs h1 { font-size: 28px; margin: 0 0 16px; }
+.myjobs-tabs {
+  display: flex; gap: 0;
+  border-bottom: 1px solid var(--divider);
+  margin-bottom: 16px;
+}
+.tab {
+  padding: 10px 16px;
+  color: var(--text-secondary);
+  border-bottom: 2px solid transparent;
+  font-weight: 700; font-size: 14px;
+}
+.tab-active { color: var(--brand-blue); border-bottom-color: var(--brand-blue); }
+.myjobs-list { list-style: none; padding: 0; margin: 0;
+               display: flex; flex-direction: column; gap: 12px; }
+.status-row {
+  display: flex; gap: 12px; align-items: center;
+  font-size: 12px; margin-top: 8px;
+}
+.status-badge {
+  display: inline-block;
+  padding: 2px 8px; border-radius: var(--radius-chip);
+  font-size: 12px; font-weight: 700;
+  background: var(--surface-grey); color: var(--text-primary);
+}
+.status-new { background: #FFF4D6; color: #6B4500; }
+.status-reviewed { background: var(--brand-blue-tint); color: var(--brand-blue-dark); }
+.status-rejected { background: #FFE2E0; color: #7B1E18; }
+.status-hired { background: #D7F5E3; color: #0E5C2C; }
+.status-active { background: #D7F5E3; color: #0E5C2C; }
+.status-draft { background: var(--surface-grey); color: var(--text-secondary); }
+.status-closed { background: var(--surface-grey); color: var(--text-secondary); }
+
+/* ── /resumes ─────────────────────────────────────────────────── */
+.resumes h1 { font-size: 28px; margin: 0 0 16px; }
+.resume-list { list-style: none; padding: 0; margin: 0;
+               display: flex; flex-direction: column; gap: 12px;
+               margin-bottom: 16px; }
+.resume-row {
+  background: var(--white);
+  border: 1px solid var(--divider);
+  border-radius: var(--radius-card);
+  padding: 16px;
+  display: grid; grid-template-columns: 1fr auto;
+  gap: 12px;
+}
+.resume-title { font-size: 16px; font-weight: 700; }
+.resume-meta { font-size: 12px; color: var(--text-tertiary); grid-column: 1; }
+.resume-actions { display: flex; gap: 8px; grid-row: 1 / 3; align-items: center; }
+.add-resume summary { list-style: none; cursor: pointer; display: inline-flex; }
+.add-resume summary::-webkit-details-marker { display: none; }
+.resume-form {
+  margin-top: 16px;
+  display: flex; flex-direction: column; gap: 12px;
+  padding: 16px; border: 1px solid var(--divider);
+  border-radius: var(--radius-card);
+}
+.resume-form label { display: flex; flex-direction: column; gap: 4px; font-size: 14px; }
+.resume-form input, .resume-form textarea {
+  border: 1px solid var(--divider);
+  border-radius: var(--radius-button);
+  padding: 8px; font-family: var(--font-body);
+}
+
+/* ── Employer dashboard ───────────────────────────────────────── */
+.employer-dashboard h1 { font-size: 28px; margin: 0 0 16px; }
+.kpi-strip {
+  display: grid; grid-template-columns: repeat(3, 1fr);
+  gap: 16px; margin-bottom: 24px;
+}
+.kpi-card {
+  background: var(--white); border: 1px solid var(--divider);
+  border-radius: var(--radius-card); padding: 16px;
+  display: flex; flex-direction: column; gap: 4px;
+}
+.kpi-card strong { font-size: 28px; line-height: 1; }
+.kpi-card span { color: var(--text-secondary); font-size: 14px; }
+.postings-actions { margin-bottom: 12px; }
+.postings-table, .applicants-table {
+  width: 100%; border-collapse: separate; border-spacing: 0;
+  background: var(--white); border: 1px solid var(--divider);
+  border-radius: var(--radius-card); overflow: hidden;
+}
+.postings-table th, .applicants-table th {
+  text-align: left; padding: 12px 16px;
+  background: var(--surface-grey);
+  font-size: 13px; color: var(--text-secondary); font-weight: 700;
+  border-bottom: 1px solid var(--divider);
+}
+.postings-table td, .applicants-table td {
+  padding: 12px 16px; font-size: 14px;
+  border-bottom: 1px solid var(--divider);
+  vertical-align: middle;
+}
+.postings-table tr:last-child td, .applicants-table tr:last-child td { border-bottom: 0; }
+.postings-table tr:hover td { background: var(--brand-blue-tint); cursor: pointer; }
+.badge {
+  display: inline-block; padding: 2px 8px;
+  border-radius: var(--radius-chip);
+  font-size: 12px; font-weight: 700;
+  background: var(--surface-grey);
+  color: var(--text-primary);
+  margin-right: 4px;
+}
+.badge-new { background: #FFF4D6; color: #6B4500; }
+.badge-reviewed { background: var(--brand-blue-tint); color: var(--brand-blue-dark); }
+
+/* ── Employer posting (applicant review) ──────────────────────── */
+.employer-posting h1 { font-size: 28px; margin: 0 0 4px; }
+.posting-meta { color: var(--text-secondary); margin: 0 0 16px; }
+.status-filter-chips {
+  display: flex; gap: 8px; margin-bottom: 16px;
+}
+
+/* ── Employer new posting form ────────────────────────────────── */
+.employer-form {
+  max-width: 720px;
+  display: flex; flex-direction: column; gap: 16px;
+}
+.employer-form label { display: flex; flex-direction: column; gap: 6px;
+                       font-size: 14px; font-weight: 700; }
+.employer-form input, .employer-form select, .employer-form textarea {
+  border: 1px solid var(--divider);
+  border-radius: var(--radius-button);
+  padding: 8px 12px;
+  font-family: var(--font-body); font-size: 14px;
+}
+.checkbox-row { flex-direction: row !important; gap: 8px; align-items: center; }
+.checkbox-row input { margin: 0; }
+
+/* ── Auth card ────────────────────────────────────────────────── */
+.auth-card {
+  max-width: 360px; margin: 40px auto;
+  background: var(--white);
+  border: 1px solid var(--divider);
+  border-radius: var(--radius-card);
+  padding: 24px;
+}
+.auth-card h1 { font-size: 22px; margin: 0 0 16px; }
+.auth-form { display: flex; flex-direction: column; gap: 12px; }
+.auth-form label { display: flex; flex-direction: column; gap: 4px;
+                   font-size: 14px; font-weight: 700; }
+.auth-form input {
+  border: 1px solid var(--divider);
+  border-radius: var(--radius-button);
+  padding: 8px 12px; font-size: 14px;
+  font-family: var(--font-body);
+}
+.auth-foot {
+  margin-top: 12px; font-size: 14px; text-align: center;
+  color: var(--text-secondary);
+}
+.error-banner {
+  background: #FFE2E0; color: #7B1E18;
+  padding: 10px 12px; border-radius: var(--radius-button);
+  margin-bottom: 12px; font-size: 14px;
+}
+
+/* ── Empty/utility ────────────────────────────────────────────── */
+.empty-state {
+  padding: 24px; text-align: center; color: var(--text-tertiary);
+  background: var(--surface-grey); border-radius: var(--radius-card);
+}

--- a/deploy/sim_envs/mantis_indeed/app/templates/_apply_stepper.html
+++ b/deploy/sim_envs/mantis_indeed/app/templates/_apply_stepper.html
@@ -1,0 +1,15 @@
+{# Stepper used by all apply pages. Caller passes `step` (1..4). #}
+<ol class="apply-stepper" data-testid="apply-stepper">
+  <li class="step {% if step >= 1 %}step-done{% endif %} {% if step == 1 %}step-active{% endif %}" data-testid="step-contact">
+    <span class="step-num">1</span> Contact
+  </li>
+  <li class="step {% if step >= 2 %}step-done{% endif %} {% if step == 2 %}step-active{% endif %}" data-testid="step-resume">
+    <span class="step-num">2</span> Resume
+  </li>
+  <li class="step {% if step >= 3 %}step-done{% endif %} {% if step == 3 %}step-active{% endif %}" data-testid="step-questions">
+    <span class="step-num">3</span> Questions
+  </li>
+  <li class="step {% if step >= 4 %}step-done{% endif %} {% if step == 4 %}step-active{% endif %}" data-testid="step-review">
+    <span class="step-num">4</span> Review
+  </li>
+</ol>

--- a/deploy/sim_envs/mantis_indeed/app/templates/_detail_pane.html
+++ b/deploy/sim_envs/mantis_indeed/app/templates/_detail_pane.html
@@ -1,0 +1,38 @@
+{# Renders the right-pane detail. Caller passes `job`. #}
+<div class="detail-pane-inner" data-testid="detail-pane-inner">
+  <h2 class="detail-h2" data-testid="detail-h2">{{ job.title }} - job post</h2>
+  <div class="detail-company-row">
+    <span class="company-name">{{ job.company.name }}</span>
+    <span class="location">{{ job.location }}</span>
+  </div>
+  <div class="detail-chips">
+    {% if job.salary_display %}<span class="detail-chip">{{ job.salary_display }}</span>{% endif %}
+    {% if job.remote_flag %}<span class="detail-chip">Remote</span>{% endif %}
+    <span class="detail-chip">{{ job.job_type }}</span>
+  </div>
+  <div class="detail-actions">
+    <a href="/apply/{{ job.jk }}" class="btn btn-primary" data-testid="detail-apply-cta">Apply now</a>
+    <form method="post" action="/jobs/{{ job.jk }}/save" class="inline-form"
+          onsubmit="event.preventDefault(); indeedToggleSave(event, '{{ job.jk }}', this.querySelector('button'));">
+      <button type="submit" class="btn btn-outline {% if is_saved %}is-saved{% endif %}"
+              data-testid="detail-save-btn">
+        {% if is_saved %}Saved{% else %}Save job{% endif %}
+      </button>
+    </form>
+  </div>
+  <nav class="detail-tabs" data-testid="detail-tabs">
+    <a class="tab tab-active" href="#">Job details</a>
+    <a class="tab" href="#">Company</a>
+    <a class="tab" href="#">Reviews</a>
+  </nav>
+  <div class="detail-body">
+    <div class="detail-salary-strip">
+      {% if job.salary_display %}<strong>{{ job.salary_display }}</strong>{% endif %}
+    </div>
+    <div class="detail-description">
+      {% for para in job.description.split('\n\n') %}
+        {% if para %}<p>{{ para }}</p>{% endif %}
+      {% endfor %}
+    </div>
+  </div>
+</div>

--- a/deploy/sim_envs/mantis_indeed/app/templates/apply_confirm.html
+++ b/deploy/sim_envs/mantis_indeed/app/templates/apply_confirm.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %}
+{% block title %}Application submitted | Indeed{% endblock %}
+{% block content %}
+<section class="apply-card success-card" data-testid="apply-success">
+  <div class="success-icon" aria-hidden="true">✓</div>
+  <h1 class="apply-h1">Application submitted</h1>
+  <p>Your application for <strong>{{ job.title }}</strong> has been sent to the employer.</p>
+  <div class="form-actions">
+    <a class="btn btn-outline" href="/myjobs?tab=applied">View my applications</a>
+    <a class="btn btn-primary" href="/jobs">Find more jobs</a>
+  </div>
+</section>
+{% endblock %}

--- a/deploy/sim_envs/mantis_indeed/app/templates/apply_review.html
+++ b/deploy/sim_envs/mantis_indeed/app/templates/apply_review.html
@@ -1,0 +1,36 @@
+{% extends "base.html" %}
+{% block title %}Review application: {{ job.title }} | Indeed{% endblock %}
+{% block content %}
+<section class="apply-card" data-testid="apply-card">
+  {% include '_apply_stepper.html' %}
+  <h1 class="apply-h1">Review your application</h1>
+  <div class="review-section">
+    <h2>Contact</h2>
+    <p>{{ draft.full_name }} · {{ draft.email }} · {{ draft.phone }}</p>
+    <p>{{ draft.city }}, {{ draft.state }} {{ draft.zip }}</p>
+    <a class="link-button" href="/apply/{{ job.jk }}" data-testid="edit-contact">Edit</a>
+  </div>
+  <div class="review-section">
+    <h2>Resume</h2>
+    <p>{{ draft.resume_id or 'No resume selected' }}</p>
+    <a class="link-button" href="/apply/{{ job.jk }}/resume" data-testid="edit-resume">Edit</a>
+  </div>
+  <div class="review-section">
+    <h2>Screening questions</h2>
+    <ul>
+      {% if draft.answers %}
+      <li>Years of experience: {{ draft.answers.yrs_experience }}</li>
+      <li>Authorized to work: {{ draft.answers.auth_to_work }}</li>
+      <li>Sponsorship: {{ draft.answers.sponsorship }}</li>
+      {% endif %}
+    </ul>
+    <a class="link-button" href="/apply/{{ job.jk }}/questions" data-testid="edit-q">Edit</a>
+  </div>
+  <form method="post" action="/apply/{{ job.jk }}/submit" class="apply-form">
+    <div class="form-actions">
+      <a class="btn btn-outline" href="/apply/{{ job.jk }}/questions">Back</a>
+      <button type="submit" class="btn btn-primary" data-testid="apply-submit">Submit application</button>
+    </div>
+  </form>
+</section>
+{% endblock %}

--- a/deploy/sim_envs/mantis_indeed/app/templates/apply_step1.html
+++ b/deploy/sim_envs/mantis_indeed/app/templates/apply_step1.html
@@ -1,0 +1,35 @@
+{% extends "base.html" %}
+{% block title %}Apply: {{ job.title }} | Indeed{% endblock %}
+{% block content %}
+<section class="apply-card" data-testid="apply-card">
+  {% include '_apply_stepper.html' %}
+  <h1 class="apply-h1">Add your contact information</h1>
+  <p class="apply-sub">Applying to <strong>{{ job.title }}</strong></p>
+  <form method="post" action="/apply/{{ job.jk }}/step2" class="apply-form">
+    <label>
+      Full name
+      <input type="text" name="full_name" required value="{{ user.name or '' }}"
+             data-testid="apply-fullname"/>
+    </label>
+    <label>
+      Email
+      <input type="email" name="email" required value="{{ user.email or '' }}"
+             data-testid="apply-email"/>
+    </label>
+    <label>
+      Phone
+      <input type="tel" name="phone" required value="{{ user.phone or '' }}"
+             data-testid="apply-phone"/>
+    </label>
+    <div class="form-row-3">
+      <label>City <input type="text" name="city" value="{{ user.city or '' }}" data-testid="apply-city"/></label>
+      <label>State <input type="text" name="state" value="{{ user.state or '' }}" data-testid="apply-state"/></label>
+      <label>Zip <input type="text" name="zip" value="{{ user.zip or '' }}" data-testid="apply-zip"/></label>
+    </div>
+    <div class="form-actions">
+      <a class="btn btn-outline" href="/viewjob?jk={{ job.jk }}">Back</a>
+      <button type="submit" class="btn btn-primary" data-testid="apply-continue">Continue</button>
+    </div>
+  </form>
+</section>
+{% endblock %}

--- a/deploy/sim_envs/mantis_indeed/app/templates/apply_step2.html
+++ b/deploy/sim_envs/mantis_indeed/app/templates/apply_step2.html
@@ -1,0 +1,30 @@
+{% extends "base.html" %}
+{% block title %}Apply: {{ job.title }} | Indeed{% endblock %}
+{% block content %}
+<section class="apply-card" data-testid="apply-card">
+  {% include '_apply_stepper.html' %}
+  <h1 class="apply-h1">Add your resume</h1>
+  <form method="post" action="/apply/{{ job.jk }}/questions" class="apply-form">
+    <fieldset class="resume-options">
+      <legend>Select an existing resume</legend>
+      {% for r in resumes %}
+      <label class="resume-card">
+        <input type="radio" name="resume_id" value="{{ r.id }}"
+               data-testid="apply-resume-{{ r.id }}"
+               {% if loop.first %}checked{% endif %}/>
+        <span class="resume-card-body">
+          <strong>{{ r.title }}</strong>
+          <small>Updated {{ r.updated_at }}</small>
+        </span>
+      </label>
+      {% else %}
+      <p class="empty-state">No resumes yet. <a href="/resumes">Create one</a>.</p>
+      {% endfor %}
+    </fieldset>
+    <div class="form-actions">
+      <a class="btn btn-outline" href="/apply/{{ job.jk }}">Back</a>
+      <button type="submit" class="btn btn-primary" data-testid="apply-continue">Continue</button>
+    </div>
+  </form>
+</section>
+{% endblock %}

--- a/deploy/sim_envs/mantis_indeed/app/templates/apply_step3.html
+++ b/deploy/sim_envs/mantis_indeed/app/templates/apply_step3.html
@@ -1,0 +1,33 @@
+{% extends "base.html" %}
+{% block title %}Apply: {{ job.title }} | Indeed{% endblock %}
+{% block content %}
+<section class="apply-card" data-testid="apply-card">
+  {% include '_apply_stepper.html' %}
+  <h1 class="apply-h1">Answer screening questions</h1>
+  <form method="post" action="/apply/{{ job.jk }}/review" class="apply-form">
+    <label>
+      How many years of professional experience do you have?
+      <input type="text" name="yrs_experience" required value="5"
+             data-testid="apply-q-yrs"/>
+    </label>
+    <label>
+      Are you authorized to work in the United States?
+      <select name="auth_to_work" data-testid="apply-q-auth">
+        <option>Yes</option>
+        <option>No</option>
+      </select>
+    </label>
+    <label>
+      Will you require visa sponsorship now or in the future?
+      <select name="sponsorship" data-testid="apply-q-sponsor">
+        <option>No</option>
+        <option>Yes</option>
+      </select>
+    </label>
+    <div class="form-actions">
+      <a class="btn btn-outline" href="/apply/{{ job.jk }}/resume">Back</a>
+      <button type="submit" class="btn btn-primary" data-testid="apply-continue">Continue</button>
+    </div>
+  </form>
+</section>
+{% endblock %}

--- a/deploy/sim_envs/mantis_indeed/app/templates/base.html
+++ b/deploy/sim_envs/mantis_indeed/app/templates/base.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>{% block title %}Indeed{% endblock %}</title>
+  <link rel="stylesheet" href="/static/site.css" />
+</head>
+<body>
+  <header class="top-nav" data-testid="top-nav">
+    <div class="top-nav-inner">
+      <a href="/" class="brand" data-testid="brand">
+        <span class="brand-wordmark">indeed</span>
+      </a>
+      <nav class="top-nav-links">
+        {% set _u = request.state.current_user if request.state and request.state.current_user else None %}
+        {% if _u %}
+          <a href="/myjobs" data-testid="nav-myjobs">My jobs</a>
+          {% if _u.role == 'employer' %}
+            <a href="/employers/dashboard" data-testid="nav-employer">Employer dashboard</a>
+          {% endif %}
+          <span class="user-chip">{{ _u.email }}</span>
+          <form method="post" action="/logout" class="inline-form">
+            <button type="submit" class="link-button" data-testid="nav-signout">Sign out</button>
+          </form>
+        {% else %}
+          <a href="/login" data-testid="nav-signin">Sign in</a>
+          <span class="nav-divider">|</span>
+          <a href="/employers/dashboard" data-testid="nav-employer-cta">Employers / Post Job</a>
+        {% endif %}
+      </nav>
+    </div>
+    <div class="secondary-strip" data-testid="secondary-strip">
+      <a href="/">Home</a>
+      <a href="#">Company reviews</a>
+      <a href="#">Find salaries</a>
+      <a href="/employers/dashboard">Employers</a>
+      <a href="/resumes">Create your resume</a>
+      <span class="country-pill">Change country <span aria-hidden="true">🇺🇸</span> United States</span>
+    </div>
+  </header>
+  <main class="workspace">
+    {% block content %}{% endblock %}
+  </main>
+</body>
+</html>

--- a/deploy/sim_envs/mantis_indeed/app/templates/employer_dashboard.html
+++ b/deploy/sim_envs/mantis_indeed/app/templates/employer_dashboard.html
@@ -1,0 +1,41 @@
+{% extends "base.html" %}
+{% block title %}Employer dashboard | Indeed{% endblock %}
+{% block content %}
+<section class="employer-dashboard">
+  <h1>Employer dashboard</h1>
+  <div class="kpi-strip" data-testid="kpi-strip">
+    <div class="kpi-card"><strong>{{ kpi_active }}</strong><span>Active postings</span></div>
+    <div class="kpi-card"><strong>{{ kpi_new_apps }}</strong><span>New applicants this week</span></div>
+    <div class="kpi-card"><strong>{{ kpi_views }}</strong><span>Total views</span></div>
+  </div>
+  <div class="postings-actions">
+    <a class="btn btn-primary" href="/employers/jobs/new" data-testid="new-posting-cta">+ Post a job</a>
+  </div>
+  <table class="postings-table" data-testid="postings-table">
+    <thead>
+      <tr>
+        <th>Title</th>
+        <th>Location</th>
+        <th>Applicants</th>
+        <th>Posted</th>
+        <th>Status</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for j in jobs %}
+      <tr onclick="window.location='/employers/jobs/{{ j.id }}'" data-testid="posting-row-{{ j.id }}">
+        <td><a href="/employers/jobs/{{ j.id }}">{{ j.title }}</a></td>
+        <td>{{ j.location }}</td>
+        <td>
+          <span class="badge badge-new">{{ j.app_counts.new }} new</span>
+          <span class="badge badge-reviewed">{{ j.app_counts.reviewed }} reviewed</span>
+          <span class="badge">{{ j.app_total }} total</span>
+        </td>
+        <td>{{ j.posted_at }}</td>
+        <td><span class="status-badge status-{{ j.status }}">{{ j.status|capitalize }}</span></td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</section>
+{% endblock %}

--- a/deploy/sim_envs/mantis_indeed/app/templates/employer_new_posting.html
+++ b/deploy/sim_envs/mantis_indeed/app/templates/employer_new_posting.html
@@ -1,0 +1,31 @@
+{% extends "base.html" %}
+{% block title %}Post a job | Employer | Indeed{% endblock %}
+{% block content %}
+<section class="employer-new-posting">
+  <h1>Post a job</h1>
+  <form method="post" action="/employers/jobs/new" class="employer-form">
+    <label>Job title <input type="text" name="title" required data-testid="posting-title"/></label>
+    <label>Location <input type="text" name="location" required data-testid="posting-location"/></label>
+    <div class="form-row-2">
+      <label>Salary low <input type="number" name="salary_low" min="0" data-testid="posting-sal-low"/></label>
+      <label>Salary high <input type="number" name="salary_high" min="0" data-testid="posting-sal-high"/></label>
+    </div>
+    <label class="checkbox-row">
+      <input type="checkbox" name="remote" data-testid="posting-remote"/> Remote
+    </label>
+    <label>Job type
+      <select name="job_type" data-testid="posting-type">
+        <option>Full-time</option>
+        <option>Part-time</option>
+        <option>Contract</option>
+        <option>Internship</option>
+      </select>
+    </label>
+    <label>Description <textarea name="description" rows="8" required data-testid="posting-desc"></textarea></label>
+    <div class="form-actions">
+      <button type="submit" class="btn btn-primary" data-testid="publish">Publish</button>
+      <button type="submit" name="status" value="draft" class="btn btn-outline">Save as draft</button>
+    </div>
+  </form>
+</section>
+{% endblock %}

--- a/deploy/sim_envs/mantis_indeed/app/templates/employer_posting.html
+++ b/deploy/sim_envs/mantis_indeed/app/templates/employer_posting.html
@@ -1,0 +1,55 @@
+{% extends "base.html" %}
+{% block title %}{{ job.title }} | Employer | Indeed{% endblock %}
+{% block content %}
+<section class="employer-posting">
+  <h1>{{ job.title }}</h1>
+  <p class="posting-meta">{{ job.location }} · Posted {{ job.posted_at }}</p>
+  <nav class="status-filter-chips" data-testid="status-filter-chips">
+    <a class="chip {% if status_filter == '' %}chip-active{% endif %}" href="/employers/jobs/{{ job.id }}">All</a>
+    <a class="chip {% if status_filter == 'new' %}chip-active{% endif %}" href="/employers/jobs/{{ job.id }}?status=new">New</a>
+    <a class="chip {% if status_filter == 'reviewed' %}chip-active{% endif %}" href="/employers/jobs/{{ job.id }}?status=reviewed">Reviewed</a>
+    <a class="chip {% if status_filter == 'rejected' %}chip-active{% endif %}" href="/employers/jobs/{{ job.id }}?status=rejected">Rejected</a>
+    <a class="chip {% if status_filter == 'hired' %}chip-active{% endif %}" href="/employers/jobs/{{ job.id }}?status=hired">Hired</a>
+  </nav>
+  <table class="applicants-table" data-testid="applicants-table">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Resume</th>
+        <th>Status</th>
+        <th>Applied</th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for a in applications %}
+      <tr data-testid="applicant-row-{{ a.id }}">
+        <td>{{ a.user_name }}<br/><small>{{ a.user_email }}</small></td>
+        <td>{{ a.resume_title or 'no resume' }}</td>
+        <td>
+          <form method="post" action="/employers/applications/{{ a.id }}/status" class="inline-form">
+            <select name="status" onchange="this.form.submit()" data-testid="status-select-{{ a.id }}">
+              <option value="new" {% if a.status == 'new' %}selected{% endif %}>New</option>
+              <option value="reviewed" {% if a.status == 'reviewed' %}selected{% endif %}>Reviewed</option>
+              <option value="rejected" {% if a.status == 'rejected' %}selected{% endif %}>Rejected</option>
+              <option value="hired" {% if a.status == 'hired' %}selected{% endif %}>Hired</option>
+            </select>
+          </form>
+        </td>
+        <td>{{ a.applied_at }}</td>
+        <td>
+          <form method="post" action="/employers/applications/{{ a.id }}/status" class="inline-form">
+            <input type="hidden" name="status" value="reviewed"/>
+            {% if a.status == 'new' %}
+            <button type="submit" class="btn btn-outline" data-testid="mark-reviewed-{{ a.id }}">Mark reviewed</button>
+            {% endif %}
+          </form>
+        </td>
+      </tr>
+      {% else %}
+      <tr><td colspan="5" class="empty-state">No applicants in this view.</td></tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</section>
+{% endblock %}

--- a/deploy/sim_envs/mantis_indeed/app/templates/home.html
+++ b/deploy/sim_envs/mantis_indeed/app/templates/home.html
@@ -1,0 +1,58 @@
+{% extends "base.html" %}
+{% block title %}Job Search | Indeed{% endblock %}
+{% block content %}
+<section class="hero" data-testid="hero">
+  <div class="hero-inner">
+    <h1 class="hero-title">Find your next job</h1>
+    <form class="hero-search" action="/jobs" method="get" data-testid="hero-search-form">
+      <div class="hero-search-group">
+        <label class="visually-hidden" for="hero-q">search: Job title, keywords, or company</label>
+        <span class="hero-input-icon" aria-hidden="true">🔍</span>
+        <input
+          id="hero-q"
+          class="hero-input hero-input-q"
+          type="text"
+          name="q"
+          placeholder="Job title, keywords, or company"
+          aria-label="search: Job title, keywords, or company"
+          data-testid="hero-input-q"
+        />
+      </div>
+      <div class="hero-search-separator" aria-hidden="true"></div>
+      <div class="hero-search-group">
+        <label class="visually-hidden" for="hero-l">Edit location</label>
+        <span class="hero-input-icon" aria-hidden="true">📍</span>
+        <input
+          id="hero-l"
+          class="hero-input hero-input-l"
+          type="text"
+          name="l"
+          placeholder='City, state, zip code, or "remote"'
+          aria-label="Edit location"
+          data-testid="hero-input-l"
+        />
+      </div>
+      <button type="submit" class="btn btn-primary hero-cta" data-testid="hero-cta">Search</button>
+    </form>
+    <p class="hero-foot">{{ job_count }} jobs available right now.</p>
+  </div>
+</section>
+<section class="below-hero">
+  <div class="panel" data-testid="trending-panel">
+    <h2>What's trending on Indeed</h2>
+    <ul class="chip-list">
+      {% for t in trending %}
+      <li><a class="chip" href="/jobs?q={{ t|urlencode }}">{{ t }}</a></li>
+      {% endfor %}
+    </ul>
+  </div>
+  <div class="panel" data-testid="resources-panel">
+    <h2>Employer Resources</h2>
+    <ul class="link-list">
+      {% for r in resources %}
+      <li><a href="#">{{ r }}</a></li>
+      {% endfor %}
+    </ul>
+  </div>
+</section>
+{% endblock %}

--- a/deploy/sim_envs/mantis_indeed/app/templates/jobs_search.html
+++ b/deploy/sim_envs/mantis_indeed/app/templates/jobs_search.html
@@ -1,0 +1,128 @@
+{% extends "base.html" %}
+{% block title %}{{ h1 }} | Indeed{% endblock %}
+{% block content %}
+
+<section class="search-bar-strip" data-testid="search-bar-strip">
+  <form class="search-bar" action="/jobs" method="get">
+    <div class="search-bar-group">
+      <span class="search-bar-icon" aria-hidden="true">🔍</span>
+      <input class="search-bar-input" type="text" name="q" value="{{ q }}"
+             placeholder="Job title, keywords, or company"
+             aria-label="search: Job title, keywords, or company"
+             data-testid="search-input-q"/>
+    </div>
+    <div class="search-bar-separator" aria-hidden="true"></div>
+    <div class="search-bar-group">
+      <span class="search-bar-icon" aria-hidden="true">📍</span>
+      <input class="search-bar-input" type="text" name="l" value="{{ l }}"
+             placeholder='City, state, zip code, or "remote"'
+             aria-label="Edit location"
+             data-testid="search-input-l"/>
+    </div>
+    {% if remote %}<input type="hidden" name="remote" value="1"/>{% endif %}
+    <button type="submit" class="btn btn-primary" data-testid="search-cta">Search</button>
+  </form>
+</section>
+
+<section class="results-header">
+  <h1 class="results-h1" data-testid="results-h1">{{ h1 }}</h1>
+  <div class="filter-chips" data-testid="filter-chips" role="tablist">
+    {% for chip in filter_chips %}
+      {% if chip == 'Remote' %}
+        {% set url_remote = ('/jobs?q=' + (q|urlencode) + '&l=' + (l|urlencode)) %}
+        {% if remote %}
+          <a href="{{ url_remote }}" class="chip chip-active" data-testid="chip-remote" role="tab" aria-selected="true">Remote</a>
+        {% else %}
+          <a href="{{ url_remote }}&remote=1" class="chip" data-testid="chip-remote" role="tab" aria-selected="false">Remote</a>
+        {% endif %}
+      {% else %}
+        <span class="chip" data-testid="chip-{{ chip|lower|replace(' ', '-') }}" role="tab" aria-selected="false">{{ chip }}</span>
+      {% endif %}
+    {% endfor %}
+  </div>
+  <div class="results-substrip">
+    <span class="result-count" data-testid="result-count">1-{{ total_count }} of {{ total_count }} jobs</span>
+    <span class="sort-by"><label>Sort by:</label> <span class="sort-current">relevance</span></span>
+  </div>
+</section>
+
+<section class="results-pane" data-testid="results-pane">
+  <ul class="results-list" data-testid="results-list">
+    {% for job in jobs %}
+    <li class="result-card {% if selected and job.jk == selected.jk %}selected{% endif %}"
+        data-jk="{{ job.jk }}"
+        data-testid="result-card"
+        onclick="indeedSelectCard(event, '{{ job.jk }}')">
+      <h2 class="job-title"><a href="/viewjob?jk={{ job.jk }}" data-testid="job-title-link">{{ job.title }}</a></h2>
+      <div class="company-row">
+        <span class="company-name">{{ job.company.name }}</span>
+        <span class="rating-stars">★ {{ '%.1f'|format(job.company.rating) }}</span>
+        <span class="review-count">({{ job.company.review_count }} reviews)</span>
+      </div>
+      <div class="location-row">{{ job.location }}</div>
+      <div class="salary-row" data-testid="salary">{{ job.salary_display }}</div>
+      <p class="snippet">{{ job.snippet_short }}</p>
+      <div class="card-foot">
+        <span class="posted-rel">{{ job.posted_display }}</span>
+        <button class="bookmark-btn {% if job.id in saved_ids %}is-saved{% endif %}"
+                data-jk="{{ job.jk }}"
+                data-testid="bookmark-{{ job.jk }}"
+                onclick="indeedToggleSave(event, '{{ job.jk }}', this)"
+                aria-label="Save job">
+          <span class="bookmark-icon" aria-hidden="true">{% if job.id in saved_ids %}★{% else %}☆{% endif %}</span>
+        </button>
+      </div>
+    </li>
+    {% else %}
+    <li class="empty-results">No jobs match. Try a different query.</li>
+    {% endfor %}
+  </ul>
+
+  <aside class="detail-pane" id="detail-pane" data-testid="detail-pane">
+    {% if selected %}
+      {% with job = selected, is_saved = (selected.id in saved_ids) %}
+        {% include '_detail_pane.html' %}
+      {% endwith %}
+    {% else %}
+      <div class="empty-pane">Select a job to see details.</div>
+    {% endif %}
+  </aside>
+</section>
+
+<script>
+  // Track current selection client-side; update detail pane without nav.
+  function indeedSelectCard(ev, jk) {
+    if (ev.target.tagName === 'A' || ev.target.tagName === 'BUTTON' ||
+        ev.target.closest('a') || ev.target.closest('button')) return;
+    document.querySelectorAll('.result-card').forEach(c => c.classList.remove('selected'));
+    var card = document.querySelector('.result-card[data-jk="' + jk + '"]');
+    if (card) card.classList.add('selected');
+    var url = new URL(window.location.href);
+    url.searchParams.set('vjk', jk);
+    history.replaceState(null, '', url.toString());
+    fetch('/jobs/_detail?jk=' + encodeURIComponent(jk))
+      .then(r => r.text())
+      .then(html => { document.getElementById('detail-pane').innerHTML = html; });
+  }
+  function indeedToggleSave(ev, jk, btn) {
+    ev.stopPropagation();
+    var url = new URL(window.location.href);
+    var qs = '?q=' + encodeURIComponent(url.searchParams.get('q') || '')
+           + '&l=' + encodeURIComponent(url.searchParams.get('l') || '')
+           + '&remote=' + encodeURIComponent(url.searchParams.get('remote') || '');
+    fetch('/jobs/' + encodeURIComponent(jk) + '/save' + qs, {method: 'POST'})
+      .then(r => r.json())
+      .then(j => {
+        if (j.saved) { btn.classList.add('is-saved'); btn.querySelector('.bookmark-icon').textContent = '★'; }
+        else { btn.classList.remove('is-saved'); btn.querySelector('.bookmark-icon').textContent = '☆'; }
+      });
+  }
+  // Audit-log the search on page load so the oracle sees it.
+  (function () {
+    var qp = new URLSearchParams(window.location.search);
+    if (qp.get('q') || qp.get('l')) {
+      fetch('/jobs/_search_audit?' + qp.toString());
+    }
+  })();
+</script>
+{% endblock %}

--- a/deploy/sim_envs/mantis_indeed/app/templates/login.html
+++ b/deploy/sim_envs/mantis_indeed/app/templates/login.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+{% block title %}Sign in | Indeed{% endblock %}
+{% block content %}
+<section class="auth-card" data-testid="login-card">
+  <h1>Sign in</h1>
+  {% if error %}<div class="error-banner" data-testid="login-error">{{ error }}</div>{% endif %}
+  <form method="post" action="/login" class="auth-form">
+    <input type="hidden" name="next" value="{{ next }}"/>
+    <label>Email <input type="email" name="email" required data-testid="login-email"/></label>
+    <label>Password <input type="password" name="password" required data-testid="login-password"/></label>
+    <button type="submit" class="btn btn-primary" data-testid="login-submit">Continue</button>
+  </form>
+  <p class="auth-foot">Don't have an account? <a href="/signup">Create one</a></p>
+</section>
+{% endblock %}

--- a/deploy/sim_envs/mantis_indeed/app/templates/myjobs.html
+++ b/deploy/sim_envs/mantis_indeed/app/templates/myjobs.html
@@ -1,0 +1,39 @@
+{% extends "base.html" %}
+{% block title %}My jobs | Indeed{% endblock %}
+{% block content %}
+<section class="myjobs">
+  <h1>My jobs</h1>
+  <nav class="myjobs-tabs" data-testid="myjobs-tabs">
+    <a class="tab {% if tab == 'saved' %}tab-active{% endif %}"
+       href="/myjobs?tab=saved" data-testid="tab-saved">Saved</a>
+    <a class="tab {% if tab == 'applied' %}tab-active{% endif %}"
+       href="/myjobs?tab=applied" data-testid="tab-applied">Applied</a>
+  </nav>
+  <ul class="myjobs-list" data-testid="myjobs-list">
+    {% for j in items %}
+    <li class="result-card" data-jk="{{ j.jk }}" data-testid="myjobs-card">
+      <h2 class="job-title"><a href="/viewjob?jk={{ j.jk }}">{{ j.title }}</a></h2>
+      <div class="company-row">
+        <span class="company-name">{{ j.company_name }}</span>
+      </div>
+      <div class="location-row">{{ j.location }}</div>
+      <div class="salary-row">{{ j.salary_display }}</div>
+      {% if tab == 'applied' %}
+      <div class="status-row">
+        <span class="status-badge status-{{ j.app_status }}">{{ j.app_status|capitalize }}</span>
+        <span class="applied-ago">Applied {{ j.app_applied_at }}</span>
+      </div>
+      {% endif %}
+    </li>
+    {% else %}
+    <li class="empty-state">
+      {% if tab == 'saved' %}
+        You haven't saved any jobs yet. Save jobs from search results to find them here.
+      {% else %}
+        You haven't applied to any jobs yet.
+      {% endif %}
+    </li>
+    {% endfor %}
+  </ul>
+</section>
+{% endblock %}

--- a/deploy/sim_envs/mantis_indeed/app/templates/resumes.html
+++ b/deploy/sim_envs/mantis_indeed/app/templates/resumes.html
@@ -1,0 +1,33 @@
+{% extends "base.html" %}
+{% block title %}Your resumes | Indeed{% endblock %}
+{% block content %}
+<section class="resumes">
+  <h1>Your resumes</h1>
+  <ul class="resume-list" data-testid="resume-list">
+    {% for r in resumes %}
+    <li class="resume-row" data-testid="resume-{{ r.id }}">
+      <div class="resume-title">{{ r.title }}</div>
+      <div class="resume-meta">Updated {{ r.updated_at }} · {{ r.skills_list|length }} skills</div>
+      <div class="resume-actions">
+        <a class="btn btn-outline" href="#" data-testid="resume-edit-{{ r.id }}">Edit</a>
+        <form method="post" action="/resumes/{{ r.id }}/delete" class="inline-form">
+          <button type="submit" class="btn btn-outline" data-testid="resume-delete-{{ r.id }}">Delete</button>
+        </form>
+      </div>
+    </li>
+    {% else %}
+    <li class="empty-state">No resumes yet.</li>
+    {% endfor %}
+  </ul>
+  <details class="add-resume" data-testid="add-resume-disclosure">
+    <summary class="btn btn-primary">+ Add new resume</summary>
+    <form method="post" action="/resumes/new" class="resume-form">
+      <label>Title <input type="text" name="title" required data-testid="resume-title-input"/></label>
+      <label>Summary <textarea name="summary" rows="3" data-testid="resume-summary-input"></textarea></label>
+      <label>Skills (comma separated) <input type="text" name="skills" data-testid="resume-skills-input"/></label>
+      <label>Experience <textarea name="experience" rows="5" data-testid="resume-exp-input"></textarea></label>
+      <button type="submit" class="btn btn-primary" data-testid="resume-save">Save</button>
+    </form>
+  </details>
+</section>
+{% endblock %}

--- a/deploy/sim_envs/mantis_indeed/app/templates/signup.html
+++ b/deploy/sim_envs/mantis_indeed/app/templates/signup.html
@@ -1,0 +1,20 @@
+{% extends "base.html" %}
+{% block title %}Create your account | Indeed{% endblock %}
+{% block content %}
+<section class="auth-card" data-testid="signup-card">
+  <h1>Create your account</h1>
+  {% if error %}<div class="error-banner" data-testid="signup-error">{{ error }}</div>{% endif %}
+  <form method="post" action="/signup" class="auth-form">
+    <label>Email <input type="email" name="email" required data-testid="signup-email"/></label>
+    <label>Password <input type="password" name="password" required data-testid="signup-password"/></label>
+    <label>Confirm password <input type="password" name="confirm" required data-testid="signup-confirm"/></label>
+    <label>Role
+      <select name="role" data-testid="signup-role">
+        <option value="seeker">Job seeker</option>
+        <option value="employer">Employer</option>
+      </select>
+    </label>
+    <button type="submit" class="btn btn-primary" data-testid="signup-submit">Create account</button>
+  </form>
+</section>
+{% endblock %}

--- a/deploy/sim_envs/mantis_indeed/app/templates/viewjob.html
+++ b/deploy/sim_envs/mantis_indeed/app/templates/viewjob.html
@@ -1,0 +1,7 @@
+{% extends "base.html" %}
+{% block title %}{{ job.title }} - {{ job.company.name }} | Indeed{% endblock %}
+{% block content %}
+<section class="viewjob-pane" data-testid="viewjob-pane">
+  {% include '_detail_pane.html' %}
+</section>
+{% endblock %}

--- a/deploy/sim_envs/mantis_indeed/requirements.txt
+++ b/deploy/sim_envs/mantis_indeed/requirements.txt
@@ -1,0 +1,6 @@
+fastapi>=0.110
+uvicorn>=0.27
+jinja2>=3.1
+python-multipart>=0.0.9
+starlette>=0.27,<1.0
+itsdangerous>=2.1

--- a/deploy/sim_envs/mantis_indeed/scripts/smoke.py
+++ b/deploy/sim_envs/mantis_indeed/scripts/smoke.py
@@ -1,0 +1,185 @@
+"""End-to-end smoke test for mantis_indeed.
+
+Uses FastAPI TestClient (Starlette's WSGI-style in-process client) — no
+external uvicorn needed, no port to allocate. Verifies:
+
+1. GET / returns 200 + valid HTML.
+2. Each in-scope page returns 200.
+3. GET /__env__/health returns ok=true (no auth header).
+4. Admin endpoints require X-Env-Admin.
+5. t01_search_save_remote oracle round-trips: search audit + save → passes.
+6. t02_easy_apply oracle round-trips: 4-step Easy Apply → passes.
+7. t03_employer_review_applicant oracle round-trips: status change → passes.
+
+Exit code 0 on full pass; 1 on any failure.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+# Ensure the package is importable when run directly.
+HERE = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(HERE))
+
+os.environ.setdefault("ENV_ADMIN_TOKEN", "test-smoke")
+os.environ.setdefault("SEED", "42")
+os.environ.setdefault("FAKE_NOW", "2026-01-15T09:00:00Z")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from app.main import app  # noqa: E402
+
+ADMIN_HEADERS = {"X-Env-Admin": os.environ["ENV_ADMIN_TOKEN"]}
+
+
+def must(cond: bool, msg: str) -> None:
+    if not cond:
+        print(f"FAIL: {msg}")
+        sys.exit(1)
+    print(f"OK: {msg}")
+
+
+def main() -> None:
+    client = TestClient(app)
+
+    # 1. health (open)
+    r = client.get("/__env__/health")
+    must(r.status_code == 200 and r.json().get("ok") is True,
+         "/__env__/health returns ok=true")
+
+    # 2. health-gate on admin endpoints
+    r = client.get("/__env__/state")
+    must(r.status_code == 401, "/__env__/state without admin header → 401")
+
+    r = client.get("/__env__/state", headers=ADMIN_HEADERS)
+    must(r.status_code == 200 and "counts" in r.json(),
+         "/__env__/state with admin header → 200 + counts")
+
+    # 3. reset to known baseline (re-seed via /__env__/reset)
+    r = client.post("/__env__/reset", headers=ADMIN_HEADERS)
+    must(r.status_code == 200, "/__env__/reset → 200")
+
+    # 4. home renders
+    r = client.get("/")
+    must(r.status_code == 200 and "Find your next job" in r.text,
+         "GET / renders home")
+
+    # 5. search renders
+    r = client.get("/jobs", params={"q": "software engineer", "l": "Austin, TX"})
+    must(r.status_code == 200 and "software engineer jobs in Austin, TX" in r.text,
+         "GET /jobs renders results with correct H1")
+
+    # 6. detail fragment swap
+    # First find an existing jk via state — pull from /jobs html.
+    import re
+    m = re.search(r'data-jk="([0-9a-f]+)"', r.text)
+    must(m is not None, "results page contains a result card with data-jk")
+    a_jk = m.group(1)
+    r2 = client.get("/jobs/_detail", params={"jk": a_jk})
+    must(r2.status_code == 200 and "- job post" in r2.text,
+         "GET /jobs/_detail returns detail fragment")
+
+    # 7. viewjob renders
+    r3 = client.get("/viewjob", params={"jk": a_jk})
+    must(r3.status_code == 200 and "- job post" in r3.text,
+         "GET /viewjob renders")
+
+    # 8. myjobs / resumes / employer dashboard
+    r4 = client.get("/myjobs")
+    must(r4.status_code == 200 and "My jobs" in r4.text, "GET /myjobs renders")
+    r5 = client.get("/resumes")
+    must(r5.status_code == 200 and "Your resumes" in r5.text, "GET /resumes renders")
+    r6 = client.get("/employers/dashboard")
+    must(r6.status_code == 200 and "Employer dashboard" in r6.text,
+         "GET /employers/dashboard renders")
+    r7 = client.get("/login")
+    must(r7.status_code == 200 and "Sign in" in r7.text, "GET /login renders")
+    r8 = client.get("/signup")
+    must(r8.status_code == 200 and "Create your account" in r8.text,
+         "GET /signup renders")
+
+    # 9. Oracle dispatch contract — unknown task returns shape, not crash.
+    r9 = client.get("/__env__/oracle", params={"task_id": "no_such_task"},
+                    headers=ADMIN_HEADERS)
+    must(r9.status_code == 200 and "passed" in r9.json(),
+         "/__env__/oracle returns shape for unknown task")
+
+    # 10. t01 — search audit + save job_00007 (jk=0000000000000007)
+    r = client.post("/__env__/reset", headers=ADMIN_HEADERS)
+    must(r.status_code == 200, "reset before t01")
+    # Trigger search audit via the dedicated endpoint.
+    r = client.get("/jobs/_search_audit",
+                   params={"q": "software engineer", "l": "Austin, TX",
+                           "remote": "1"})
+    must(r.status_code == 200, "search audit submitted")
+    # Save job_00007 by jk=0000000000000007 (set in seed.py).
+    r = client.post("/jobs/0000000000000007/save")
+    must(r.status_code == 200 and r.json().get("saved") is True,
+         "POST /jobs/<jk>/save saves the job")
+    r = client.get("/__env__/oracle", params={"task_id": "t01_search_save_remote"},
+                   headers=ADMIN_HEADERS)
+    body = r.json()
+    must(r.status_code == 200 and body.get("passed") is True,
+         f"t01 oracle passes (reasons={body.get('reasons')})")
+
+    # 11. t02 — Easy Apply to job_00012 (jk=000000000000000c)
+    r = client.post("/__env__/reset", headers=ADMIN_HEADERS)
+    must(r.status_code == 200, "reset before t02")
+    jk_12 = "000000000000000c"
+    # Step 1 → step 2
+    r = client.post(
+        f"/apply/{jk_12}/step2",
+        data={"full_name": "Alex Smith", "email": "alex@example.com",
+              "phone": "555-1234", "city": "Austin", "state": "TX",
+              "zip": "78701"},
+        follow_redirects=False,
+    )
+    must(r.status_code in (303, 307), "step1 → step2 redirect")
+    # Step 2 → step 3 (select resume_00001)
+    r = client.post(
+        f"/apply/{jk_12}/questions",
+        data={"resume_id": "resume_00001"},
+        follow_redirects=False,
+    )
+    must(r.status_code in (303, 307), "step2 → step3 redirect")
+    # Step 3 → step 4
+    r = client.post(
+        f"/apply/{jk_12}/review",
+        data={"yrs_experience": "5", "auth_to_work": "Yes",
+              "sponsorship": "No"},
+        follow_redirects=False,
+    )
+    must(r.status_code in (303, 307), "step3 → review redirect")
+    # Submit.
+    r = client.post(f"/apply/{jk_12}/submit", follow_redirects=False)
+    must(r.status_code in (303, 307), "submit application")
+    r = client.get("/__env__/oracle", params={"task_id": "t02_easy_apply"},
+                   headers=ADMIN_HEADERS)
+    body = r.json()
+    must(r.status_code == 200 and body.get("passed") is True,
+         f"t02 oracle passes (reasons={body.get('reasons')})")
+
+    # 12. t03 — employer moves the seeded new applicant on job_00003 → reviewed
+    r = client.post("/__env__/reset", headers=ADMIN_HEADERS)
+    must(r.status_code == 200, "reset before t03")
+    r = client.post(
+        "/employers/applications/application_seed_t03/status",
+        data={"status": "reviewed"},
+        follow_redirects=False,
+    )
+    must(r.status_code in (303, 307), "applicant status change → 303")
+    r = client.get("/__env__/oracle",
+                   params={"task_id": "t03_employer_review_applicant"},
+                   headers=ADMIN_HEADERS)
+    body = r.json()
+    must(r.status_code == 200 and body.get("passed") is True,
+         f"t03 oracle passes (reasons={body.get('reasons')})")
+
+    print("\nAll smoke checks passed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/deploy/sim_envs/mantis_linkedin/Dockerfile
+++ b/deploy/sim_envs/mantis_linkedin/Dockerfile
@@ -1,0 +1,35 @@
+# mantis-linkedin — server-rendered LinkedIn mirror sim env.
+#
+# Build:
+#     docker build -t mantis/sim-env-mantis-linkedin:latest deploy/sim_envs/mantis_linkedin
+#
+# Run:
+#     docker run --rm -p 8090:8080 \
+#         -e SEED=42 \
+#         -e FAKE_NOW=2026-06-08T09:00:00Z \
+#         -e ENV_ADMIN_TOKEN=$(python -c 'import secrets;print(secrets.token_urlsafe(32))') \
+#         mantis/sim-env-mantis-linkedin:latest
+
+FROM python:3.11-slim
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends curl \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /srv
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY app ./app
+
+ENV PORT=8080 \
+    SEED=42 \
+    FAKE_NOW=2026-06-08T09:00:00Z \
+    PYTHONUNBUFFERED=1
+
+EXPOSE 8080
+HEALTHCHECK --interval=5s --timeout=2s --start-period=10s --retries=6 \
+    CMD curl -fs http://127.0.0.1:8080/__env__/health || exit 1
+
+CMD ["python", "-m", "uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/deploy/sim_envs/mantis_linkedin/FIDELITY.md
+++ b/deploy/sim_envs/mantis_linkedin/FIDELITY.md
@@ -1,0 +1,173 @@
+# mantis-linkedin fidelity tracker
+
+**Last updated:** 2026-06-08
+
+Per-page match matrix vs the captured spec in `_captured/<slug>/notes.md`.
+Status legend (mantis_boattrader convention):
+
+- **exact** — pixel-parity (≤2px structural delta, <0.5% perceptual diff).
+- **close** — matches structurally; minor pixel diff in spacing/weights/radius.
+- **partial** — visible delta but recognisable as the same element.
+- **missing** — not yet implemented.
+- **not-matched** — implemented differently / intentionally simplified.
+
+## Method note
+
+The corpus in `_captured/` was authored offline from training-data
+recollection because linkedin.com requires authentication and challenges
+automated browsers on most surfaces. A Chrome-MCP–driven capture pass
+should be run later to validate the offline spec; FIDELITY rows below
+are confident but unverified vs the live site. Any disagreement found
+during that pass should land here as new rows + updated status.
+
+## Global brand / shell
+
+| Element                     | Real spec                                                                                | Mine                                  | Status |
+| --------------------------- | ---------------------------------------------------------------------------------------- | ------------------------------------- | ------ |
+| Page background             | `#f3f2ef`                                                                                | `#f3f2ef`                             | exact  |
+| Body font stack             | `-apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial`                              | same                                  | exact  |
+| Body type                   | 14px / 1.4286 / rgba(0,0,0,0.9)                                                          | same                                  | exact  |
+| Primary blue                | `#0a66c2` / hover `#004182`                                                              | same                                  | exact  |
+| Primary button              | 9999px pill, 600 weight, 6/16 padding                                                    | same                                  | exact  |
+| Card surface                | `#fff`, 8px radius, `0 0 0 1px rgb(0 0 0 / 8%), 0 2px 3px rgb(0 0 0 / 8%)`               | same                                  | exact  |
+| Top nav height              | 52px fixed, content max-width 1128px                                                     | same                                  | exact  |
+| Top nav `in` mark           | Blue square 32×32, 4px radius, 700 weight                                                | same                                  | exact  |
+| Top nav search              | Pill 280px, `#edf3f8` bg, search-icon left, 14px label                                   | same                                  | close  |
+| Top nav icon stack          | Home / My Network / Jobs / Messaging / Notifications / Me                                | same order + glyph + caption          | close  |
+
+## /feed/
+
+| Element                       | Real spec                                                                | Mine                                              | Status   |
+| ----------------------------- | ------------------------------------------------------------------------ | ------------------------------------------------- | -------- |
+| Layout grid                   | 225 / 555 / 300 with 24px gaps under 1128px max-width                    | same                                              | exact    |
+| Left rail — profile card      | Banner 60px gradient + 72px avatar overlap + name/headline + Connections | banner 56px, otherwise matches                    | close    |
+| Left rail — My items mini     | Bookmark glyph + label                                                   | bookmark + label                                  | close    |
+| Centre — Start a post         | Avatar 48px + pill input + 4-up action row (Photo/Video/Event/Article)   | same                                              | close    |
+| Centre — post card author row | 48px avatar + name + headline + time + globe icon + ⋯ menu               | same                                              | close    |
+| Centre — post counters row    | reaction blob + count + "N comments"                                     | same                                              | close    |
+| Centre — post action bar      | Like / Comment / Repost / Send 4-up                                      | same                                              | close    |
+| Right rail — Add to your feed | Header + 3 suggested follows w/ Connect pill                             | same shape, "Follow" pill                         | close    |
+| Right rail — News card        | Stack of 5 stories                                                       | same                                              | close    |
+| Start-a-post modal            | Avatar/name header, textarea, blue Post button (disabled when empty)     | same                                              | close    |
+
+## /in/<handle>/
+
+| Element                | Real spec                                                          | Mine                                          | Status   |
+| ---------------------- | ------------------------------------------------------------------ | --------------------------------------------- | -------- |
+| Hero banner            | 200px gradient strip                                               | same                                          | exact    |
+| Hero avatar            | 160px circle, 4px white border, overlapping banner                 | same                                          | exact    |
+| Hero name + headline   | H1 24/600 + 14/400 grey                                            | same                                          | exact    |
+| Hero actions           | Connect (primary), Message (secondary), More                       | same; Open to/Add section variants for self   | close    |
+| About card             | H2 + body                                                          | same                                          | close    |
+| Experience rows        | 48px company logo + title + company + dates + location + body      | same                                          | close    |
+| Education rows         | School logo + school + degree + dates                              | same                                          | close    |
+| Skills section         | Skill name + "Endorsed by N connections"                           | same                                          | close    |
+| Activity card          | Header + recent posts                                              | header + last 5 posts; no tabs yet            | partial  |
+| Connect modal          | Title "Add a note", 300-char textarea, Cancel + Send blue          | same                                          | close    |
+
+## /mynetwork/
+
+| Element                       | Real spec                                  | Mine                          | Status |
+| ----------------------------- | ------------------------------------------ | ----------------------------- | ------ |
+| Manage-my-network rail        | Connections / Contacts / Following / etc.  | same items + counts           | close  |
+| Invitations card              | Up to 3 with Accept/Ignore                 | same                          | close  |
+| People you may know grid      | Mini cards w/ banner + avatar + Connect    | same                          | close  |
+| Mini card Connect button      | Outlined pill                              | same                          | close  |
+
+## /mynetwork/invitation-manager/
+
+| Element            | Real spec                                                | Mine                            | Status |
+| ------------------ | -------------------------------------------------------- | ------------------------------- | ------ |
+| Tabs               | Received / Sent / I don't know                           | same                            | exact  |
+| Meta row           | "N pending invitations" + sort dropdown                  | same                            | close  |
+| Row layout         | Avatar 56 + name + headline + actions on right           | same                            | close  |
+| Sent tab actions   | Withdraw (outlined)                                      | same                            | close  |
+| Received actions   | Ignore (outlined) + Accept (primary)                     | same                            | close  |
+
+## /messaging/
+
+| Element              | Real spec                                                 | Mine                                | Status   |
+| -------------------- | --------------------------------------------------------- | ----------------------------------- | -------- |
+| Two-pane card        | 320 / rest, total 1056×720                                | same                                | close    |
+| Thread list header   | Title + filter + compose pencil                           | same                                | close    |
+| Thread search        | Pill, `#edf3f8`                                           | same                                | exact    |
+| Focused/Other tabs   | Blue underline on active                                  | same                                | exact    |
+| Thread row           | Avatar 56 + name + snippet + timestamp                    | uses 48px avatar; otherwise matches | close    |
+| Active thread row    | Bg `#eef3f8`                                              | same                                | exact    |
+| Pane header          | Avatar + name + headline + ⋯                              | same                                | close    |
+| Message bubbles      | Self right blue, peer left grey, 12px radius corner-clip  | same                                | close    |
+| Composer             | Textarea + tool row + blue Send                           | same                                | close    |
+
+## /jobs/
+
+| Element             | Real spec                                                  | Mine                             | Status |
+| ------------------- | ---------------------------------------------------------- | -------------------------------- | ------ |
+| Rail "Job collections" | Links list w/ glyph + label                              | same                             | close  |
+| Search card         | Title + Location + Search button                           | same                             | close  |
+| Top picks carousel  | 6 mini cards 240px wide                                    | grid auto-fill min 240px         | close  |
+| Recommended list    | 5 rows w/ logo + title + meta                              | same                             | close  |
+
+## /jobs/search/
+
+| Element             | Real spec                                                  | Mine                             | Status   |
+| ------------------- | ---------------------------------------------------------- | -------------------------------- | -------- |
+| Filter chip row     | Sticky chips                                               | same; 4px shorter                | close    |
+| Left list           | 420px, selected row 4px left blue border                   | same                             | close    |
+| Right detail        | Sticky header card + tabs + body                           | header + tabs + md-body          | close    |
+| Easy Apply pill     | Filled blue header pill on detail                          | same                             | close    |
+
+## /jobs/view/<id>/
+
+| Element                  | Real spec                                                       | Mine                                 | Status   |
+| ------------------------ | --------------------------------------------------------------- | ------------------------------------ | -------- |
+| Centre header card       | Logo 64 + title 24/600 + company + meta + Easy Apply primary    | same                                 | close    |
+| About card               | Markdown rendered body                                          | pre.md-body (preserves md formatting)| close    |
+| Company rail card        | 96px logo + name + tagline + followers + Follow                 | same                                 | close    |
+| Easy Apply modal width   | 520px fixed                                                     | 552px max via `<dialog>`              | close    |
+| Easy Apply progress      | 4 dots, active blue                                             | same                                 | close    |
+| Easy Apply steps         | Contact → Resume → Screening → Review                           | same; vanilla JS step machine        | close    |
+| Submit success           | "Application submitted!" toast                                  | redirect → ?applied=1; no toast yet  | partial  |
+
+## /login
+
+| Element             | Real spec                                                                          | Mine                       | Status |
+| ------------------- | ---------------------------------------------------------------------------------- | -------------------------- | ------ |
+| Card width          | 400px, centred                                                                     | same                       | exact  |
+| Brand mark above    | 32px square logo                                                                   | same                       | exact  |
+| Inputs              | 12px padding, 4px radius, focus = 2px blue outline                                 | same                       | close  |
+| Sign-in button      | Filled blue pill, 48px tall, 16px 600                                              | same                       | close  |
+| OAuth buttons       | Continue with Google / Apple (outlined)                                            | omitted (out of scope)     | not-matched |
+| Footer "Join now"   | Centred 14px link                                                                  | same                       | exact  |
+
+## Interaction parity
+
+| Interaction         | Real behaviour                                                | Mine                                                     | Status |
+| ------------------- | ------------------------------------------------------------- | -------------------------------------------------------- | ------ |
+| Start a post        | Modal → submit → post appears top of feed                     | same; audit_log `post_created`                           | close  |
+| Like a post         | Toggle reaction + count bump                                  | same; audit_log `reaction_added` / `reaction_removed`    | close  |
+| Comment on a post   | In-place composer reveal → submit                             | same; audit_log `comment_added`                          | close  |
+| Connect             | Profile → modal → Send → invitation row                       | same; audit_log `connection_requested`                   | close  |
+| Easy Apply          | 4-step modal → submit → application row                       | same; audit_log `job_application_submitted`              | close  |
+| Send message        | Composer → bubble appears + thread bumps                      | same; audit_log `message_sent`                           | close  |
+| Accept invitation   | Row removed + Connections count bump                          | same; audit_log `connection_accepted`                    | close  |
+
+## Iteration log
+
+- **2026-06-08 v1** — Phases 0–6 first pass. All in-scope pages render
+  200 OK; oracle dispatch + happy paths for t01/t02/t03 pass via
+  `scripts/smoke.py`. Brand palette + typography exact-matched from
+  the offline spec. Visual fidelity at "close" majority; chasing
+  "exact" deferred until a live Chrome-MCP capture pass can validate
+  per-pixel deltas.
+
+## Open gaps (carry to next pass)
+
+- No live screenshots captured — `_captured/<slug>/screenshot.png` absent.
+  Run a Chrome-MCP capture pass against a real LinkedIn session and update
+  rows that disagree.
+- Activity tabs on `/in/<handle>/` (Posts / Comments / Videos / Images) — only
+  Posts implemented as a flat list. Tab UI is `partial`.
+- Easy Apply submit success uses a `?applied=1` URL flag instead of an in-page
+  toast — `partial`.
+- OAuth login buttons intentionally omitted; flagged `not-matched`.
+- Notifications icon in topnav is a stub link — no `/notifications` page yet.

--- a/deploy/sim_envs/mantis_linkedin/FIDELITY_AGENT_PROMPT.md
+++ b/deploy/sim_envs/mantis_linkedin/FIDELITY_AGENT_PROMPT.md
@@ -1,0 +1,65 @@
+# mantis-linkedin — gap-fix agent prompt
+
+You are picking up a fidelity-iteration session against the mantis-linkedin
+sim env. The end state bar is a high-fidelity replica of linkedin.com
+(structural deltas ≤2px, perceptual diff <0.5%, every in-scope interaction
+replays with matching URL/DOM/network deltas).
+
+## Read first (in order)
+
+1. `SCOPE.md` — in-scope pages, in-scope interactions, done bar.
+2. `FIDELITY.md` — current match matrix + iteration log + open gaps.
+3. `_captured/README.md` + each `_captured/<slug>/notes.md` — the ground-truth
+   spec for the surface you're improving.
+4. `app/main.py`, `app/routes/<surface>.py`, `app/templates/<surface>.html`,
+   `app/static/site.css` — the actual implementation.
+
+## Loop
+
+For each row in `FIDELITY.md` not at `exact`:
+
+1. **Verify the spec.** Re-read `_captured/<slug>/notes.md`. If a live
+   Chrome-MCP capture for this slug becomes available, trust it over the
+   offline notes — but flag any disagreement in `FIDELITY.md` so the user
+   can audit.
+2. **Identify the delta.** Open the rendered page locally
+   (`ENV_ADMIN_TOKEN=test python -m uvicorn app.main:app --port 8090`) and
+   measure. Use DevTools box-model + computed styles.
+3. **Decide.** Cosmetic CSS in `app/static/site.css`. Structural fixes in
+   templates. Behavioural fixes in routes. Never touch tests to mask
+   regressions.
+4. **Patch + re-verify.** Run `python scripts/smoke.py` after every patch.
+   It must stay green.
+5. **Update FIDELITY.md.** Bump the row status and append to the iteration
+   log at the bottom — date stamp + 1-line summary of what landed.
+
+## Hard rules
+
+- Single CSS file (`site.css`). Group by component. Don't fragment.
+- No JS framework. Small vanilla JS only where the interaction demands it
+  (modals, multi-step Easy Apply, Send button enable/disable).
+- No real brand assets. Placeholder SVGs / colour blocks only.
+- Every state-changing route writes to `audit_log` with `(operation,
+  target_type, target_id, payload_json, occurred_at)`. Oracles grade by
+  reading audit_log + state — don't migrate to deriving from current state.
+- Smoke MUST stay green. Don't ship a patch that breaks
+  `scripts/smoke.py`.
+
+## Anti-patterns
+
+- **Drift on the brand palette.** The hex codes in
+  `_captured/README.md` are canonical. Don't introduce a new shade of
+  blue without verifying.
+- **One-off "fix" to one page that breaks shared components.** A change
+  to `.btn-primary` cascades — re-check every page.
+- **Removing data-testid attributes.** Templates carry stable
+  data-testid hooks (e.g. `post-card`, `connect-modal`,
+  `easy-apply-modal`). Keep them — the CUA harness uses them indirectly
+  via vision-derived element identification.
+
+## Done check before handing off
+
+- `python scripts/smoke.py` → SMOKE PASSED.
+- `curl -fs http://127.0.0.1:8090/__env__/health` → `ok=true`.
+- `FIDELITY.md` iteration log has a new dated entry.
+- Any new `not-matched` or `partial` rows have a 1-line reason.

--- a/deploy/sim_envs/mantis_linkedin/README.md
+++ b/deploy/sim_envs/mantis_linkedin/README.md
@@ -1,0 +1,91 @@
+# mantis-linkedin — server-rendered LinkedIn mirror
+
+High-fidelity sim env mirroring **linkedin.com** for the mantis CUA harness.
+Covers the professional-network surface: profile, feed, jobs, connections,
+messaging. The agent drives this env via vision in Chrome; the oracle
+harness grades actions against `audit_log`.
+
+## Surfaces shipped
+
+- `/feed/` — main feed (left rail + centre + right rail)
+- `/in/<handle>/` — profile (hero, About, Experience, Education, Skills, Activity)
+- `/mynetwork/` — connections home + People you may know
+- `/mynetwork/invitation-manager/` — received + sent invitations
+- `/messaging/` — two-pane messaging (thread list + thread pane + composer)
+- `/jobs/`, `/jobs/search/?keywords=`, `/jobs/view/<id>/` — jobs flow + Easy Apply
+- `/login`, `/signup`, `/`
+
+See `SCOPE.md` for the full in-scope spec and `FIDELITY.md` for the
+per-section match matrix vs the offline ground-truth captures in
+`_captured/`.
+
+## Run locally
+
+```
+cd deploy/sim_envs/mantis_linkedin
+ENV_ADMIN_TOKEN=test python -m uvicorn app.main:app --port 8090
+```
+
+Visit:
+- http://127.0.0.1:8090/ — anonymous splash
+- http://127.0.0.1:8090/feed/ — feed (acts as `user_00001` "Demo Mantis"
+  when `ENV_REQUIRE_AUTH` is unset)
+- http://127.0.0.1:8090/__env__/health — public; returns
+  `{"ok": true, "seed": 42, "now": …, "boot_time": …}`
+
+When `ENV_REQUIRE_AUTH=1`, log in as `demo@mantis.example` /
+`mantis-demo` from `/login`.
+
+## Docker
+
+```
+docker build -t mantis/sim-env-mantis-linkedin:latest deploy/sim_envs/mantis_linkedin
+docker run --rm -p 8090:8080 \
+    -e SEED=42 \
+    -e FAKE_NOW=2026-06-08T09:00:00Z \
+    -e ENV_ADMIN_TOKEN=$(python -c 'import secrets;print(secrets.token_urlsafe(32))') \
+    mantis/sim-env-mantis-linkedin:latest
+```
+
+## Harness contract — `/__env__/*`
+
+All routes (except `/health`) are gated on `X-Env-Admin: <ENV_ADMIN_TOKEN>`.
+
+| Route              | Method | Purpose                                          |
+| ------------------ | ------ | ------------------------------------------------ |
+| `/health`          | GET    | Public; returns `{ok, seed, now, boot_time}`     |
+| `/reset`           | POST   | Reseed DB to baseline + clear events             |
+| `/seed`            | POST   | Reseed with `{seed: int}` body                   |
+| `/clock`           | POST   | Advance FAKE_NOW with `{now: ISO8601}`           |
+| `/oracle?task_id=` | GET    | Run grader for a task_id                         |
+| `/state`           | GET    | Structured snapshot (counts + recent audit rows) |
+| `/events`          | GET    | Process-level event log since `?since=`          |
+| `/mutations`       | GET    | Mutation records since `?since=`                 |
+
+## Oracles
+
+| task_id                       | Goal                                                                                                |
+| ----------------------------- | --------------------------------------------------------------------------------------------------- |
+| `t01_connect_with_user`       | Demo user sends a Connect request to `user_00042` **with a note**.                                  |
+| `t02_post_text_update`        | Demo user posts a text update containing at least one `#hashtag`.                                   |
+| `t03_easy_apply_to_job`       | Demo user Easy-Applies to `job_00003` with phone + resume confirm.                                  |
+
+Each oracle reads `audit_log` + DB only — never the agent transcript.
+Aliases `t01`, `t02`, `t03` are accepted as a convenience.
+
+## Smoke
+
+```
+ENV_ADMIN_TOKEN=test python scripts/smoke.py
+```
+
+Boots the app in-process, hits every in-scope page, dispatches every
+oracle, then drives each oracle's happy path and confirms `passed=true`.
+
+## Fidelity tracker
+
+`FIDELITY.md` is the canonical source of truth for per-section match
+status. Open it BEFORE touching templates / CSS so you don't relitigate
+known close/exact rows.
+
+The follow-up agent prompt lives in `FIDELITY_AGENT_PROMPT.md`.

--- a/deploy/sim_envs/mantis_linkedin/SCOPE.md
+++ b/deploy/sim_envs/mantis_linkedin/SCOPE.md
@@ -1,0 +1,63 @@
+# mantis-linkedin — in-scope spec
+
+This sim env mirrors **linkedin.com** as a deterministic, server-rendered
+replica of the professional-network surface. The mantis CUA agent will
+drive it through Chrome (vision-grounded) and the oracle harness will
+grade actions against the audit_log.
+
+Live home URL: https://www.linkedin.com/
+
+## Surface
+
+The mirror covers four flows: **profile**, **feed**, **jobs**,
+**connections**, plus **messaging** as the cross-flow surface.
+
+## Core entities
+
+- `users` — profile (headline, about, experience[], education[], skills[])
+- `posts` — feed posts (text, optional #hashtag), authored by a user
+- `comments` — comment on a post, authored by a user
+- `reactions` — per-post per-user (like, celebrate, support, love, insightful, funny)
+- `connections` — directed accept/pending (from_user → to_user, status, note)
+- `messages` — within a `thread`, ordered, plain text
+- `jobs` — title, company, location, easy_apply flag, description_md
+- `job_applications` — user × job, status='submitted', payload (phone, resume_id)
+
+## In-scope pages
+
+- `/feed/`  — main feed (left rail profile-card + saved-items, centre feed of posts, right rail people-you-may-know + news)
+- `/in/<username>/` — profile (sticky header with name+headline+actions, About, Experience, Education, Skills, Activity)
+- `/mynetwork/` — connections home (manage + invitations summary cards)
+- `/mynetwork/invitation-manager/` — received + sent invitations tabs
+- `/messaging/` — left thread list, right thread pane + composer
+- `/jobs/` — jobs home (recommended for you + recent searches)
+- `/jobs/search/?keywords=` — search results (left filter, middle list, right detail pane)
+- `/jobs/view/<id>/` — job detail (Easy Apply or Apply on company site)
+- `/login`, `/signup` — auth pages
+
+## In-scope interactions
+
+- **Connect** — profile page → Connect button → 'Add a note' modal → Send → invitation row + audit
+- **Post** — feed → Start a post → modal → submit → post appears top of feed + audit row
+- **React** — like a post → reactions row + count bump
+- **Comment** — leave a comment on a post → comments row + count bump
+- **Easy Apply** — job detail → Easy Apply modal (contact → resume → screening → review → submit) → application row + audit
+- **Message** — open a thread → type → send → message row + thread bump
+
+## Out of scope (explicitly NOT mirrored)
+
+- Real brand assets / photography (placeholder SVGs only)
+- Advertising, analytics, tracking scripts
+- Third-party widgets (Intercom, Hotjar)
+- OAuth / social login (username + password only)
+- Payment processing (Premium upsell stripped)
+- Real-time websockets / SSE (polling or static)
+- A/B variant pages (pick the canonical anonymous-visitor variant)
+- Groups, Pages, Events, Premium, Sales Nav, Learning, Newsletters, Live Video
+
+## Done bar
+
+- Pixel diff per section vs the live site captured in `_captured/<slug>/`: ≤2px structural deltas, <0.5% perceptual diff (NORTH STAR; first-pass target is "close (matches structurally; minor pixel diff)" per FIDELITY.md).
+- Every in-scope interaction replays through HTTP and writes an audit_log row matching the oracle contract.
+- `scripts/smoke.py` passes — boot, every in-scope page returns 200, each oracle dispatches and returns the JSON shape, the happy path for each task drives the oracle to `passed=true`.
+- FIDELITY.md lists every in-scope page with ≥5 element rows and an honest status per row.

--- a/deploy/sim_envs/mantis_linkedin/_captured/README.md
+++ b/deploy/sim_envs/mantis_linkedin/_captured/README.md
@@ -1,0 +1,41 @@
+# Captured corpus — mantis-linkedin
+
+This directory holds the ground-truth spec for each in-scope page of the
+live linkedin.com surface. Each slug is built from offline notes
+(training-data recollection) because LinkedIn requires auth and
+challenges automated browsers on most surfaces, so live MCP-driven
+captures were not viable.
+
+When a Chrome-MCP–driven capture pass is later possible (e.g. via a
+human-supplied authenticated session), regenerate each slug's
+`dom.html`/`styles.json`/`screenshot.png` and update FIDELITY.md.
+
+## Per-slug contents
+
+- `notes.md` — page layout, typography, palette, key element labels, interactions
+- `styles.json` — per-element computed-style observations (offline)
+- `dom.html` — best-effort structural HTML (offline)
+- `screenshot.png` — NOT captured (auth-gated). See `notes.md` for the visual spec.
+
+## Brand spec (canonical, applied site-wide)
+
+- Primary palette
+  - LinkedIn blue: `#0a66c2` (button, link, brand)
+  - Hover blue: `#004182`
+  - Text near-black: `#000000e6` (rgba 0,0,0,0.9)
+  - Text grey: `#00000099` (rgba 0,0,0,0.6)
+  - Surface white: `#ffffff`
+  - Page bg: `#f3f2ef`
+  - Card border: `#e0dfdc` (1px solid #00000022)
+  - Success green: `#057642`
+  - Danger red: `#cc1016`
+- Font stack: `-apple-system, system-ui, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif`
+- Type scale
+  - Display H1: 24px / 600
+  - Card H2: 20px / 600
+  - Body: 14px / 400, line-height 1.42857
+  - Caption: 12px / 400, color rgba(0,0,0,0.6)
+- Layout
+  - Global top nav: 52px fixed, 1128px content max-width
+  - Card radius: 8px; box-shadow `0 0 0 1px rgb(0 0 0 / 8%), 0 2px 3px rgb(0 0 0 / 8%)`
+  - Three-column grid on /feed/: 225px / 555px / 300px (gaps 24px)

--- a/deploy/sim_envs/mantis_linkedin/_captured/feed/notes.md
+++ b/deploy/sim_envs/mantis_linkedin/_captured/feed/notes.md
@@ -1,0 +1,85 @@
+# /feed/ — main feed
+
+## Layout
+
+Three columns under a fixed top nav. Page bg `#f3f2ef`. Content max-width 1128px,
+horizontally centred. Top nav 52px tall.
+
+```
+┌── top nav (logo + search + Home/My Network/Jobs/Messaging/Notifications/Me) ─┐
+│                                                                              │
+│  [left rail 225]   [centre feed 555]   [right rail 300]                       │
+│                                                                              │
+│  - profile card    - "Start a post" card   - Add to your feed                 │
+│  - groups item     - posts (scroll)        - LinkedIn News                    │
+│  - events item                                                                │
+└──────────────────────────────────────────────────────────────────────────────┘
+```
+
+## Top nav (52px, white bg, bottom border 1px #e0dfdc)
+
+Left: LinkedIn logo (`in` mark blue square). Search box: pill shape, bg `#edf3f8`,
+placeholder "Search", width ~280px, left-padding 40px (search icon).
+
+Right (icon-stack, vertical icon + caption label):
+- Home (filled when active, underline bar 2px below icon)
+- My Network
+- Jobs
+- Messaging
+- Notifications
+- Me (avatar circle + caret)
+- Divider
+- For Business
+- Try Premium for free (link, gold colour)
+
+## Left rail (profile card)
+
+White card, 8px radius, drop shadow.
+- Banner strip (60px tall, brand-grad blue).
+- Avatar circle 72px, centred horizontally, overlapping banner by 36px.
+- Name (16px bold, centred).
+- Headline (12px regular, color rgba 0,0,0,0.6).
+- Below divider: "Connections" label + count (right-aligned), then
+  "Grow your network" caption.
+- Second card: "My items" with bookmark icon.
+
+## Centre feed
+
+Top card: "Start a post"
+- Avatar 48px left, single-line input bar (placeholder "Start a post"), pill button.
+- Action row: Photo (icon green), Video (icon teal), Event (icon orange),
+  Write article (icon orange-red).
+
+Each post card:
+- Author chip: avatar 48px, name (14px 600), headline (12px regular grey),
+  timestamp + " • " + globe icon.
+- Body text (14px regular, max-3 lines truncated with "…see more" link).
+- Optional media slot (omitted in mirror).
+- Counters row: like-icon + count, "N comments • M reposts".
+- Action bar: Like, Comment, Repost, Send (each icon + label, 4-up grid).
+
+## Right rail
+
+Card 1 — "Add to your feed": header, then 3 suggested follows
+(avatar + name + headline + "+ Follow" pill).
+
+Card 2 — "LinkedIn News" with stacked stories
+(title 14px 600, "N hours ago • N readers" caption).
+
+## Interactions
+
+- "Start a post" opens modal `#start-post-modal`. Modal has avatar+name header,
+  textarea (placeholder "What do you want to talk about?"), bottom action bar,
+  blue "Post" button (disabled until text non-empty).
+- Like button: click toggles. Heart fills, count bumps.
+- Comment button: scrolls/reveals comment composer under post.
+
+## Computed-style highlights
+
+- Body: `font-family: -apple-system, "Segoe UI", Roboto, Arial, sans-serif`;
+  font-size 14px; color rgba(0,0,0,0.9); line-height 1.42857.
+- Cards: `background: #fff; border-radius: 8px;
+  box-shadow: 0 0 0 1px rgba(0,0,0,0.08), 0 2px 3px rgba(0,0,0,0.08);`
+- Primary action button: bg #0a66c2; color #fff; border-radius: 9999px;
+  padding 6px 16px; font-weight 600; hover bg #004182.
+- Secondary button: 1px solid #0a66c2; color #0a66c2; transparent bg.

--- a/deploy/sim_envs/mantis_linkedin/_captured/invitation_manager/notes.md
+++ b/deploy/sim_envs/mantis_linkedin/_captured/invitation_manager/notes.md
@@ -1,0 +1,21 @@
+# /mynetwork/invitation-manager/
+
+## Layout
+
+Single centre column 720px. Top: tabs Received | Sent | I don't know.
+
+## Received tab
+
+- Header row: "N pending invitations" + sort dropdown (Newest / Oldest).
+- List rows. Each row: avatar 56px, name + headline + "Sent N days ago",
+  "Ignore" outlined + "Accept" filled blue (right-aligned).
+
+## Sent tab
+
+- Header "N pending requests".
+- Same row shape but actions are "Withdraw" outlined.
+
+## Interactions
+
+- Accept: writes connections.status='accepted' + audit_log row.
+- Withdraw: removes row from sent + audit_log.

--- a/deploy/sim_envs/mantis_linkedin/_captured/jobs/notes.md
+++ b/deploy/sim_envs/mantis_linkedin/_captured/jobs/notes.md
@@ -1,0 +1,43 @@
+# /jobs/ — jobs home
+
+## Layout
+
+Two-column. Left rail 225px, centre 860px.
+
+## Left rail
+
+- "Job collections" header.
+- Links: My jobs, Preferences, Post a free job, Interview prep,
+  Salary explorer, Job seeker guidance.
+
+## Centre column
+
+### Search bar card
+
+- "Search by title, skill or company" input (pill, white bg).
+- "City, state or zip" input adjacent.
+- "Search" filled-blue button.
+
+### Top job picks for you card
+
+- H2 "Top job picks for you".
+- Caption "Based on your profile and search history".
+- Horizontal carousel of 6 job cards. Each card 240px wide:
+  company logo 48px + title (14px 600 blue) + company (12px) + location +
+  promoted/Easy Apply tag.
+
+### Recommended for you card
+
+- H2 "Recommended for you".
+- Vertical list of 5 job rows. Each row: logo 48px + title + company +
+  location + caption "N hours ago • N applicants".
+
+### Recent job searches card
+
+- H2 "Recent job searches".
+- List of saved searches with edit/delete icons.
+
+## Interactions
+
+- Click a job card → navigates to `/jobs/view/<id>/`.
+- Click "Search" → `/jobs/search/?keywords=...&location=...`.

--- a/deploy/sim_envs/mantis_linkedin/_captured/jobs_search/notes.md
+++ b/deploy/sim_envs/mantis_linkedin/_captured/jobs_search/notes.md
@@ -1,0 +1,32 @@
+# /jobs/search/?keywords=...
+
+## Layout
+
+Three-pane. Top filter bar (sticky). Left list 420px, right detail 700px.
+
+## Top filter chip row
+
+- Sticky under the topnav (52+44=96px from top).
+- Chips: "Date posted ▾", "Experience level ▾", "Company ▾",
+  "Job type ▾", "Remote ▾", "Easy Apply" (toggle), "All filters".
+
+## Left list (420px)
+
+- Header: "<N> results for "<keyword>"" + sort dropdown (Most relevant / Most recent).
+- List of job result cards. Each row 88px tall: company logo 56px left,
+  title (16px 600 blue) + company (14px) + location (12px grey) +
+  "Easy Apply" tag (when applicable) + caption "N applicants • N hours ago".
+- Selected row: bg `#f3f2ef`, 4px left border `#0a66c2`.
+
+## Right detail (700px)
+
+- Sticky header card: logo + title (24px 600) + company + location +
+  applicants + "Easy Apply" filled-blue pill (or "Apply" outlined-blue for external).
+- Tabs: About the job (default), Hiring team, Related jobs.
+- About body: description_md rendered as paragraphs + bulleted requirements.
+- Bottom: "How your profile matches" mini card.
+
+## Interactions
+
+- Click a job row → updates right pane URL `?id=<job_id>`. No full nav.
+- Easy Apply opens multi-step modal (see `_captured/jobs_view/`).

--- a/deploy/sim_envs/mantis_linkedin/_captured/jobs_view/notes.md
+++ b/deploy/sim_envs/mantis_linkedin/_captured/jobs_view/notes.md
@@ -1,0 +1,50 @@
+# /jobs/view/<id>/
+
+## Layout
+
+Two-column. Centre 720px (job content card), right rail 300px (company info).
+
+## Centre column
+
+Single card stack:
+
+### Header card
+
+- Company logo 64px + title H1 (24px 600) + company link (14px blue) +
+  location + "Posted N days ago • N applicants".
+- Action row: "Easy Apply" (filled blue, 36px tall) or "Apply" outlined +
+  "Save" bookmark icon-button + "Share" link.
+
+### About the job card
+
+- "About the job" header (16px 600).
+- Description body (markdown rendered).
+- "Show more" link if truncated.
+
+### How your profile matches card
+
+- Skills checklist, applicants graph etc. (mirror omits).
+
+## Right rail
+
+- Company logo 96px + name + tagline + N followers + "Follow" button.
+
+## Easy Apply modal (multi-step)
+
+Trigger: click "Easy Apply" → opens dialog `#easy-apply-modal`.
+
+Steps (top progress bar, 4 dots):
+1. **Contact info** — name (read-only), email (read-only), phone (input req'd),
+   country dropdown. "Next" button (disabled until phone non-empty).
+2. **Resume** — radio "Use my profile" (default) or "Upload resume". "Next".
+3. **Screening questions** — 1-2 text inputs (e.g. "Years of experience?"). "Next".
+4. **Review** — summary list of all collected fields. "Submit application" filled blue.
+
+POST `/jobs/<job_id>/apply` with phone + answers → writes
+applications row + audit, modal flips to "Application submitted!" success.
+
+## Styles
+
+- Modal: width 520px, max-height 720px, white bg, 8px radius, backdrop
+  rgba(0,0,0,0.6).
+- Progress bar: 4 dots, active blue, inactive grey.

--- a/deploy/sim_envs/mantis_linkedin/_captured/login/notes.md
+++ b/deploy/sim_envs/mantis_linkedin/_captured/login/notes.md
@@ -1,0 +1,23 @@
+# /login
+
+## Layout
+
+Centred card 400px wide on page bg `#f3f2ef`. LinkedIn `in` logo blue 32px above card.
+
+## Card
+
+- H1 "Sign in" (24px 600).
+- Caption "Stay updated on your professional world" (14px grey).
+- Email input (full width, 12px padding, 4px radius, 1px border).
+- Password input (full width).
+- "Forgot password?" link (right-aligned, 14px blue).
+- "Sign in" button (filled blue, full width, 9999px pill, 48px tall, 16px 600).
+- "or" divider (14px grey, 1px lines either side).
+- "Continue with Google" / "Continue with Apple" buttons (outlined, full width).
+  Mirror omits OAuth buttons (out of scope).
+- Footer "New to LinkedIn? Join now" (centred, 14px).
+
+## Styles
+
+- Input focus: 2px solid #0a66c2, no glow.
+- Errors: red border + 12px red caption under input.

--- a/deploy/sim_envs/mantis_linkedin/_captured/messaging/notes.md
+++ b/deploy/sim_envs/mantis_linkedin/_captured/messaging/notes.md
@@ -1,0 +1,34 @@
+# /messaging/
+
+## Layout
+
+Two-pane "focused inbox" pattern in a single card spanning 1056px wide,
+720px tall. Left pane 320px (thread list), right pane fills the rest.
+
+## Left pane (thread list)
+
+- Header: "Messaging" + filter dropdown + edit pencil icon.
+- Search bar (pill, bg #edf3f8).
+- Tabs: "Focused" (active blue underline) | "Other".
+- Thread rows. Each row: avatar 56px, name 14px 600, snippet 13px grey
+  (one-line truncated), timestamp 12px grey (right). Unread → bold name
+  + blue dot indicator.
+
+## Right pane (thread)
+
+- Header: avatar 32px + name (14px 600) + headline grey caption + 3-dot menu.
+- Messages list: bubbles, sender on right (blue bg #0a66c2 text white),
+  recipient on left (bg #e5e5e5 text near-black).
+- Each bubble: 12px radius (top-right 4px when right sender),
+  padding 10px 12px, max-width 60%.
+- Composer at bottom: "Write a message…" textarea + attach/gif/photo icons
+  + blue "Send" button (disabled when empty).
+
+## Interactions
+
+- Send: POST `/messaging/<thread>/send` → bubble appears, thread bumps to top.
+
+## Styles
+
+- Active thread row: bg `#eef3f8`.
+- Message bubble timestamps appear on hover.

--- a/deploy/sim_envs/mantis_linkedin/_captured/mynetwork/notes.md
+++ b/deploy/sim_envs/mantis_linkedin/_captured/mynetwork/notes.md
@@ -1,0 +1,37 @@
+# /mynetwork/ — connections home
+
+## Layout
+
+Two-column. Left rail 225px ("Manage my network" links), centre 860px.
+
+## Manage my network rail
+
+- Header "Manage my network" (16px 600).
+- Rows: Connections (count), Contacts, Following & followers, Groups, Events, Pages.
+  Each row icon left, label, count right (12px grey).
+
+## Centre column
+
+### Invitations card
+
+- H2 "Invitations" + "Show all (N)" link.
+- 0..3 invitation rows. Each row: avatar 56px, name + headline, two pill buttons
+  ("Ignore" outlined, "Accept" filled blue).
+
+### People you may know
+
+- H2 "People you may know based on your profile".
+- Horizontal scroll-list of mini cards. Each card 200px wide:
+  avatar 72px centred, name, headline (2-line truncated),
+  "Connect" outlined-pill, bottom-spanning.
+
+## Interactions
+
+- Accept: green flash on row, removes after 200ms, count bumps Connections.
+- Ignore: row removed.
+- Connect (mini card): adds outgoing invitation, button → "Pending".
+
+## Styles
+
+- Cards same as feed.
+- Mini card hover: lift 2px, border darker.

--- a/deploy/sim_envs/mantis_linkedin/_captured/profile/notes.md
+++ b/deploy/sim_envs/mantis_linkedin/_captured/profile/notes.md
@@ -1,0 +1,59 @@
+# /in/<username>/ — profile
+
+## Layout
+
+Two-column under top nav. Centre column 760px, right rail 300px (omitted on /in/).
+Full-width banner card up top.
+
+## Hero card
+
+- Banner image strip 200px tall (gradient placeholder).
+- Avatar 160px circle, bottom-left, overlapping banner.
+- Name H1 24px / 600.
+- Headline 14px / 400 grey.
+- Location row (14px grey, with country dot bullet).
+- "N connections • Contact info" inline link (12px blue).
+- Actions row: "Open to", "Add profile section", "Enhance profile", "More".
+  When viewing a different user: "Connect" (primary), "Message" (secondary), "More".
+
+## About section card
+
+- H2 "About" (20px 600).
+- Pencil edit icon top-right (own profile only).
+- Body 14px, expandable "...see more" after 3 lines.
+
+## Experience section card
+
+- H2 "Experience" + edit icon.
+- List of roles. Each row: company logo 48px square + title (14px 600),
+  company (14px 400), dates (12px grey), location (12px grey), description.
+- Multiple roles at one company nested under company header.
+
+## Education section card
+
+- H2 "Education" + edit icon.
+- Each row: school logo 48px square + school (14px 600), degree (14px),
+  dates (12px grey).
+
+## Skills section card
+
+- H2 "Skills" + edit icon.
+- List of skills with "Endorsed by N connections" caption.
+
+## Activity card
+
+- H2 "Activity" + "N followers" + "Create a post" button (right).
+- Tabs: Posts, Comments, Videos, Images.
+- 3 recent post cards.
+
+## Interactions
+
+- Connect (primary CTA on others' profiles): opens modal
+  `#connect-modal` with copy "How do you know <Name>?", a 300-char textarea
+  (placeholder "Add a note"), Cancel + Send buttons.
+- Message: navigates to `/messaging/?to=<username>`.
+
+## Styles
+
+- Hero card same shadow/radius as feed cards.
+- Section headers 20px 600 with 16px margin-bottom.

--- a/deploy/sim_envs/mantis_linkedin/_captured/styles_global.json
+++ b/deploy/sim_envs/mantis_linkedin/_captured/styles_global.json
@@ -1,0 +1,66 @@
+{
+  "body": {
+    "background": "#f3f2ef",
+    "color": "rgba(0,0,0,0.9)",
+    "font-family": "-apple-system, system-ui, \"Segoe UI\", Roboto, \"Helvetica Neue\", Arial, sans-serif",
+    "font-size": "14px",
+    "line-height": "1.42857"
+  },
+  "topnav": {
+    "height": "52px",
+    "background": "#ffffff",
+    "border-bottom": "1px solid #e0dfdc",
+    "position": "fixed",
+    "content-max-width": "1128px"
+  },
+  "card": {
+    "background": "#ffffff",
+    "border-radius": "8px",
+    "box-shadow": "0 0 0 1px rgba(0,0,0,0.08), 0 2px 3px rgba(0,0,0,0.08)",
+    "padding": "16px"
+  },
+  "button_primary": {
+    "background": "#0a66c2",
+    "color": "#ffffff",
+    "border": "0",
+    "border-radius": "9999px",
+    "padding": "6px 16px",
+    "font-weight": "600",
+    "hover-background": "#004182",
+    "disabled-background": "rgba(0,0,0,0.08)",
+    "disabled-color": "rgba(0,0,0,0.6)"
+  },
+  "button_secondary": {
+    "background": "transparent",
+    "color": "#0a66c2",
+    "border": "1px solid #0a66c2",
+    "border-radius": "9999px",
+    "padding": "5px 16px",
+    "font-weight": "600",
+    "hover-background": "rgba(112,181,249,0.2)"
+  },
+  "input_pill": {
+    "background": "#edf3f8",
+    "border": "0",
+    "border-radius": "4px",
+    "height": "34px",
+    "padding": "0 8px 0 40px",
+    "font-size": "14px"
+  },
+  "link": {
+    "color": "#0a66c2",
+    "font-weight": "600",
+    "text-decoration": "none",
+    "hover-text-decoration": "underline"
+  },
+  "headings": {
+    "h1": {"font-size": "24px", "font-weight": "600"},
+    "h2": {"font-size": "20px", "font-weight": "600"},
+    "h3": {"font-size": "16px", "font-weight": "600"}
+  },
+  "feed_grid": {
+    "columns": "225px 555px 300px",
+    "gap": "24px",
+    "max-width": "1128px"
+  }
+}

--- a/deploy/sim_envs/mantis_linkedin/app/__init__.py
+++ b/deploy/sim_envs/mantis_linkedin/app/__init__.py
@@ -1,0 +1,1 @@
+"""mantis-linkedin sim env."""

--- a/deploy/sim_envs/mantis_linkedin/app/auth.py
+++ b/deploy/sim_envs/mantis_linkedin/app/auth.py
@@ -1,0 +1,144 @@
+"""Mock auth surface for mantis-linkedin.
+
+Email-password only (no OAuth). Sessions are signed cookies with HMAC-SHA256.
+``ENV_REQUIRE_AUTH=1`` flips the gate on protected routes.
+
+The canonical authenticated user is ``user_00001`` (email
+``demo@mantis.example``, password ``mantis-demo``) so the oracle harness
+has a stable acting subject.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import os
+import time
+from typing import Any
+
+from fastapi import Request, Response
+from fastapi.responses import RedirectResponse
+
+from . import db
+
+SESSION_COOKIE = "mantis_linkedin_session"
+SESSION_TTL_DEFAULT_S = 60 * 60  # 1h
+LOGIN_PATH = "/login"
+
+
+def session_secret() -> str:
+    return os.environ.get("ENV_SESSION_SECRET", "dev-only-do-not-use-in-prod")
+
+
+def session_ttl_s() -> int:
+    raw = os.environ.get("ENV_SESSION_TTL_S")
+    try:
+        return int(raw) if raw else SESSION_TTL_DEFAULT_S
+    except ValueError:
+        return SESSION_TTL_DEFAULT_S
+
+
+def auth_required() -> bool:
+    return os.environ.get("ENV_REQUIRE_AUTH", "0").lower() in {"1", "true", "yes"}
+
+
+def hash_password(plain: str) -> str:
+    return hashlib.sha256(plain.encode("utf-8")).hexdigest()
+
+
+def verify_password(plain: str, stored: str) -> bool:
+    return hmac.compare_digest(hash_password(plain), stored)
+
+
+def mint_session(user_id: str, *, now: float | None = None) -> str:
+    issued = int(now if now is not None else time.time())
+    payload = f"{user_id}|{issued}"
+    sig = hmac.new(
+        session_secret().encode("utf-8"),
+        payload.encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+    return f"{payload}|{sig}"
+
+
+def verify_session(cookie_val: str, *, now: float | None = None) -> str | None:
+    if not cookie_val:
+        return None
+    parts = cookie_val.split("|")
+    if len(parts) != 3:
+        return None
+    user_id, issued_s, sig = parts
+    try:
+        issued_at = int(issued_s)
+    except ValueError:
+        return None
+    payload = f"{user_id}|{issued_at}"
+    expected = hmac.new(
+        session_secret().encode("utf-8"),
+        payload.encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+    if not hmac.compare_digest(sig, expected):
+        return None
+    now_ts = now if now is not None else time.time()
+    if now_ts - issued_at > session_ttl_s():
+        return None
+    return user_id
+
+
+def set_session_cookie(response: Response, user_id: str) -> None:
+    response.set_cookie(
+        SESSION_COOKIE,
+        mint_session(user_id),
+        httponly=True,
+        samesite="lax",
+        max_age=session_ttl_s(),
+        path="/",
+    )
+
+
+def clear_session_cookie(response: Response) -> None:
+    response.delete_cookie(SESSION_COOKIE, path="/")
+
+
+def lookup_user_by_id(user_id: str) -> dict[str, Any] | None:
+    conn = db.connect()
+    row = conn.execute(
+        "SELECT id, handle, name, headline, email, avatar_color "
+        "FROM users WHERE id = ?",
+        (user_id,),
+    ).fetchone()
+    return dict(row) if row else None
+
+
+def lookup_user_by_email(email: str) -> dict[str, Any] | None:
+    conn = db.connect()
+    row = conn.execute(
+        "SELECT id, handle, name, headline, email, password_hash, avatar_color "
+        "FROM users WHERE email = ?",
+        (email.strip().lower(),),
+    ).fetchone()
+    return dict(row) if row else None
+
+
+def current_user(request: Request) -> dict[str, Any] | None:
+    raw = request.cookies.get(SESSION_COOKIE)
+    user_id = verify_session(raw or "")
+    if user_id is None:
+        # Auth disabled → fall back to the seeded canonical user so the
+        # T01..T03 oracles can grade against a stable acting subject.
+        if not auth_required():
+            return lookup_user_by_id("user_00001")
+        return None
+    return lookup_user_by_id(user_id)
+
+
+def require_user(request: Request) -> RedirectResponse | None:
+    if not auth_required():
+        return None
+    user = current_user(request)
+    if user is None:
+        return RedirectResponse(
+            f"{LOGIN_PATH}?next={request.url.path}", status_code=303
+        )
+    return None

--- a/deploy/sim_envs/mantis_linkedin/app/db.py
+++ b/deploy/sim_envs/mantis_linkedin/app/db.py
@@ -1,0 +1,244 @@
+"""SQLite schema + helpers for mantis-linkedin.
+
+In-memory by default. Single module-level connection guarded by a
+re-entrant lock, schema applied at first connect.
+
+Tables
+------
+
+* ``users`` — profile rows (handle, name, headline, about, location).
+* ``experience``, ``education``, ``skills`` — per-user list rows.
+* ``connections`` — directed: from_user_id → to_user_id; status
+  ``pending`` | ``accepted``. The ``note`` column carries the
+  Connect-modal note text.
+* ``posts``, ``comments``, ``reactions`` — feed graph.
+* ``threads`` + ``messages`` — messaging.
+* ``jobs`` + ``job_applications`` — jobs + Easy Apply submissions.
+* ``audit_log`` — the source of truth for oracles. Every
+  state-changing route writes to it.
+
+All IDs are deterministic strings (``user_00042``, ``job_00003`` etc.)
+so the same SEED produces the same surface.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import threading
+from contextlib import contextmanager
+from typing import Any, Iterator
+
+_DB_LOCK = threading.RLock()
+_DB: sqlite3.Connection | None = None
+
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS users (
+    id              TEXT PRIMARY KEY,        -- 'user_00042'
+    handle          TEXT NOT NULL UNIQUE,    -- 'jane-doe-9a2f'
+    name            TEXT NOT NULL,
+    headline        TEXT NOT NULL DEFAULT '',
+    about           TEXT NOT NULL DEFAULT '',
+    location        TEXT NOT NULL DEFAULT '',
+    email           TEXT NOT NULL UNIQUE,
+    password_hash   TEXT NOT NULL,
+    avatar_color    TEXT NOT NULL DEFAULT '#0a66c2',
+    created_at      TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_users_handle ON users(handle);
+
+CREATE TABLE IF NOT EXISTS experience (
+    id              TEXT PRIMARY KEY,
+    user_id         TEXT NOT NULL REFERENCES users(id),
+    title           TEXT NOT NULL,
+    company         TEXT NOT NULL,
+    location        TEXT NOT NULL DEFAULT '',
+    start_date      TEXT NOT NULL,
+    end_date        TEXT,                    -- NULL = current
+    description     TEXT NOT NULL DEFAULT '',
+    sort_idx        INTEGER NOT NULL DEFAULT 0
+);
+CREATE INDEX IF NOT EXISTS idx_exp_user ON experience(user_id);
+
+CREATE TABLE IF NOT EXISTS education (
+    id              TEXT PRIMARY KEY,
+    user_id         TEXT NOT NULL REFERENCES users(id),
+    school          TEXT NOT NULL,
+    degree          TEXT NOT NULL DEFAULT '',
+    field           TEXT NOT NULL DEFAULT '',
+    start_year      INTEGER,
+    end_year        INTEGER,
+    sort_idx        INTEGER NOT NULL DEFAULT 0
+);
+CREATE INDEX IF NOT EXISTS idx_edu_user ON education(user_id);
+
+CREATE TABLE IF NOT EXISTS skills (
+    id              TEXT PRIMARY KEY,
+    user_id         TEXT NOT NULL REFERENCES users(id),
+    name            TEXT NOT NULL,
+    endorsements    INTEGER NOT NULL DEFAULT 0,
+    sort_idx        INTEGER NOT NULL DEFAULT 0
+);
+CREATE INDEX IF NOT EXISTS idx_skills_user ON skills(user_id);
+
+CREATE TABLE IF NOT EXISTS connections (
+    id              TEXT PRIMARY KEY,        -- 'conn_00001'
+    from_user_id    TEXT NOT NULL REFERENCES users(id),
+    to_user_id      TEXT NOT NULL REFERENCES users(id),
+    status          TEXT NOT NULL,           -- 'pending' | 'accepted'
+    note            TEXT NOT NULL DEFAULT '',
+    created_at      TEXT NOT NULL,
+    accepted_at     TEXT,
+    UNIQUE (from_user_id, to_user_id)
+);
+CREATE INDEX IF NOT EXISTS idx_conn_to ON connections(to_user_id, status);
+CREATE INDEX IF NOT EXISTS idx_conn_from ON connections(from_user_id, status);
+
+CREATE TABLE IF NOT EXISTS posts (
+    id              TEXT PRIMARY KEY,        -- 'post_00012'
+    author_id       TEXT NOT NULL REFERENCES users(id),
+    body            TEXT NOT NULL,
+    hashtags        TEXT NOT NULL DEFAULT '[]',  -- JSON list of strings (no leading #)
+    visibility      TEXT NOT NULL DEFAULT 'public',
+    created_at      TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_posts_author ON posts(author_id);
+CREATE INDEX IF NOT EXISTS idx_posts_created ON posts(created_at);
+
+CREATE TABLE IF NOT EXISTS comments (
+    id              TEXT PRIMARY KEY,
+    post_id         TEXT NOT NULL REFERENCES posts(id),
+    author_id       TEXT NOT NULL REFERENCES users(id),
+    body            TEXT NOT NULL,
+    created_at      TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_comments_post ON comments(post_id);
+
+CREATE TABLE IF NOT EXISTS reactions (
+    post_id         TEXT NOT NULL REFERENCES posts(id),
+    user_id         TEXT NOT NULL REFERENCES users(id),
+    kind            TEXT NOT NULL,           -- 'like' | 'celebrate' | 'support' | 'love' | 'insightful' | 'funny'
+    created_at      TEXT NOT NULL,
+    PRIMARY KEY (post_id, user_id)
+);
+CREATE INDEX IF NOT EXISTS idx_reactions_post ON reactions(post_id);
+
+CREATE TABLE IF NOT EXISTS threads (
+    id              TEXT PRIMARY KEY,        -- 'thread_00003'
+    participants    TEXT NOT NULL,           -- JSON list of user_ids
+    last_message_at TEXT NOT NULL,
+    created_at      TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS messages (
+    id              TEXT PRIMARY KEY,
+    thread_id       TEXT NOT NULL REFERENCES threads(id),
+    sender_id       TEXT NOT NULL REFERENCES users(id),
+    body            TEXT NOT NULL,
+    created_at      TEXT NOT NULL,
+    read_at         TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_messages_thread ON messages(thread_id);
+
+CREATE TABLE IF NOT EXISTS jobs (
+    id              TEXT PRIMARY KEY,        -- 'job_00003'
+    title           TEXT NOT NULL,
+    company         TEXT NOT NULL,
+    location        TEXT NOT NULL,
+    description_md  TEXT NOT NULL DEFAULT '',
+    easy_apply      INTEGER NOT NULL DEFAULT 1,
+    promoted        INTEGER NOT NULL DEFAULT 0,
+    applicants      INTEGER NOT NULL DEFAULT 0,
+    posted_at       TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_jobs_title ON jobs(title);
+
+CREATE TABLE IF NOT EXISTS job_applications (
+    id              TEXT PRIMARY KEY,        -- 'app_00001'
+    user_id         TEXT NOT NULL REFERENCES users(id),
+    job_id          TEXT NOT NULL REFERENCES jobs(id),
+    status          TEXT NOT NULL DEFAULT 'submitted',
+    phone           TEXT NOT NULL DEFAULT '',
+    resume_label    TEXT NOT NULL DEFAULT '',
+    answers_json    TEXT NOT NULL DEFAULT '{}',
+    submitted_at    TEXT NOT NULL,
+    UNIQUE (user_id, job_id)
+);
+
+CREATE TABLE IF NOT EXISTS audit_log (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    occurred_at     TEXT NOT NULL,
+    operation       TEXT NOT NULL,
+    target_type     TEXT NOT NULL,
+    target_id       TEXT NOT NULL,
+    payload_json    TEXT NOT NULL DEFAULT '{}'
+);
+CREATE INDEX IF NOT EXISTS idx_audit_op ON audit_log(operation);
+"""
+
+
+def db_path() -> str:
+    return os.environ.get("DB_PATH") or ":memory:"
+
+
+def connect() -> sqlite3.Connection:
+    """Return the shared SQLite connection, creating it on first use."""
+    global _DB
+    with _DB_LOCK:
+        if _DB is None:
+            conn = sqlite3.connect(db_path(), check_same_thread=False)
+            conn.row_factory = sqlite3.Row
+            conn.executescript(SCHEMA)
+            _DB = conn
+        return _DB
+
+
+def reset_connection() -> None:
+    global _DB
+    with _DB_LOCK:
+        if _DB is not None:
+            _DB.close()
+            _DB = None
+
+
+@contextmanager
+def transaction() -> Iterator[sqlite3.Connection]:
+    conn = connect()
+    with _DB_LOCK:
+        try:
+            yield conn
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+
+
+def pack_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True)
+
+
+def unpack_json(raw: str) -> Any:
+    try:
+        return json.loads(raw or "{}")
+    except json.JSONDecodeError:
+        return {}
+
+
+def log_audit(
+    conn: sqlite3.Connection,
+    *,
+    occurred_at: str,
+    operation: str,
+    target_type: str,
+    target_id: str,
+    payload: dict[str, Any] | None = None,
+) -> None:
+    """Append a row to ``audit_log``. Oracles read this to grade runs."""
+    conn.execute(
+        "INSERT INTO audit_log (occurred_at, operation, target_type, target_id, payload_json) "
+        "VALUES (?, ?, ?, ?, ?)",
+        (occurred_at, operation, target_type, target_id,
+         json.dumps(payload or {}, sort_keys=True)),
+    )

--- a/deploy/sim_envs/mantis_linkedin/app/main.py
+++ b/deploy/sim_envs/mantis_linkedin/app/main.py
@@ -1,0 +1,196 @@
+"""mantis-linkedin FastAPI app entrypoint.
+
+Mirrors the mantis-shop / mantis-boattrader shape:
+
+* ``/`` — agent-facing pages (server-rendered HTML).
+* ``/__env__/*`` — harness-only, gated on ``X-Env-Admin`` header.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+from fastapi import FastAPI, Request, Response
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
+from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
+
+from . import auth, db, seed
+
+APP_DIR = Path(__file__).parent
+ADMIN_TOKEN_ENV = "ENV_ADMIN_TOKEN"
+ADMIN_HEADER = "X-Env-Admin"
+
+
+def _admin_token() -> str:
+    token = os.environ.get(ADMIN_TOKEN_ENV, "").strip()
+    if not token:
+        # Fall back to a constant in dev so smoke tests work without
+        # explicit env var. Harness always sets one in prod.
+        return "dev-admin-token"
+    return token
+
+
+def _now() -> str:
+    return os.environ.get("FAKE_NOW") or seed.FAKE_NOW_DEFAULT
+
+
+def _seed_val() -> int:
+    return int(os.environ.get("SEED") or 42)
+
+
+# ── event log + mutations ─────────────────────────────────────────────
+
+
+_EVENTS: list[dict[str, Any]] = []
+_MUTATIONS: list[dict[str, Any]] = []
+_BOOT_TIME = time.time()
+
+
+def _emit_event(event: str, data: dict[str, Any] | None = None) -> None:
+    _EVENTS.append({"ts": time.time(), "event": event, "data": data or {}})
+
+
+def _emit_mutation(
+    *, op: str, target_type: str, target_id: str,
+    payload: dict[str, Any] | None = None,
+) -> None:
+    _MUTATIONS.append({
+        "ts": time.time(),
+        "op": op,
+        "target_type": target_type,
+        "target_id": target_id,
+        "payload": payload or {},
+    })
+
+
+# ── app factory ──────────────────────────────────────────────────────
+
+
+def create_app() -> FastAPI:
+    app = FastAPI(title="mantis-linkedin", docs_url=None, redoc_url=None)
+
+    templates = Jinja2Templates(directory=str(APP_DIR / "templates"))
+    app.state.templates = templates
+    app.state.admin_token = _admin_token()
+
+    @app.middleware("http")
+    async def _auth_gate(request: Request, call_next):  # noqa: ANN202
+        try:
+            request.state.current_user = auth.current_user(request)
+        except Exception:  # noqa: BLE001
+            request.state.current_user = None
+
+        if auth.auth_required():
+            path = request.url.path
+            open_prefixes = ("/login", "/logout", "/signup", "/static/",
+                             "/__env__/")
+            if path == "/" or path.startswith(open_prefixes):
+                pass
+            else:
+                user = request.state.current_user
+                if user is None:
+                    return RedirectResponse(
+                        f"/login?next={path}", status_code=303,
+                    )
+        return await call_next(request)
+
+    @app.on_event("startup")
+    def _bootstrap() -> None:
+        conn = db.connect()
+        cur = conn.execute("SELECT COUNT(*) FROM users")
+        if cur.fetchone()[0] == 0:
+            seed.seed(conn, seed_val=_seed_val(), fake_now=_now())
+            _emit_event("seeded", {"seed": _seed_val(), "now": _now()})
+
+    app.mount(
+        "/static",
+        StaticFiles(directory=str(APP_DIR / "static")),
+        name="static",
+    )
+
+    # Routers — split by surface.
+    from .routes import env_admin as env_admin_router
+    from .routes import auth as auth_router
+    from .routes import feed as feed_router
+    from .routes import profile as profile_router
+    from .routes import network as network_router
+    from .routes import messaging as messaging_router
+    from .routes import jobs as jobs_router
+
+    app.include_router(env_admin_router.router)
+    app.include_router(auth_router.router)
+    app.include_router(feed_router.router)
+    app.include_router(profile_router.router)
+    app.include_router(network_router.router)
+    app.include_router(messaging_router.router)
+    app.include_router(jobs_router.router)
+
+    @app.get("/", response_class=HTMLResponse)
+    async def root(request: Request) -> Response:
+        # The live linkedin.com redirects authed users to /feed/. For
+        # anonymous visitors it serves a marketing splash; we render a
+        # minimal "home" template that points to login / feed so the
+        # CUA can pick either path.
+        return templates.TemplateResponse(
+            "home.html",
+            {
+                "request": request,
+                "now": _now(),
+            },
+        )
+
+    return app
+
+
+app = create_app()
+
+
+# Helpers exposed to the routes package -------------------------------
+
+
+def admin_token_ok(request: Request) -> bool:
+    return request.headers.get(ADMIN_HEADER) == request.app.state.admin_token
+
+
+def admin_required_response() -> JSONResponse:
+    return JSONResponse({"error": "admin token required"}, status_code=401)
+
+
+def now_value() -> str:
+    return _now()
+
+
+def seed_value() -> int:
+    return _seed_val()
+
+
+def boot_time() -> float:
+    return _BOOT_TIME
+
+
+def emit(event: str, data: dict[str, Any] | None = None) -> None:
+    _emit_event(event, data)
+
+
+def emit_mutation(*, op: str, target_type: str, target_id: str,
+                  payload: dict[str, Any] | None = None) -> None:
+    _emit_mutation(
+        op=op, target_type=target_type, target_id=target_id, payload=payload,
+    )
+
+
+def events_since(ts: float) -> list[dict[str, Any]]:
+    return [e for e in _EVENTS if e["ts"] >= ts]
+
+
+def mutations_since(ts: float) -> list[dict[str, Any]]:
+    return [m for m in _MUTATIONS if m["ts"] >= ts]
+
+
+def clear_events() -> None:
+    _EVENTS.clear()
+    _MUTATIONS.clear()

--- a/deploy/sim_envs/mantis_linkedin/app/oracles/__init__.py
+++ b/deploy/sim_envs/mantis_linkedin/app/oracles/__init__.py
@@ -1,0 +1,47 @@
+"""Oracles — server-side graders for mantis-linkedin tasks.
+
+Each oracle reads the DB + audit log only (never the agent transcript).
+Return shape mirrors mantis-shop / mantis-boattrader:
+
+    {"passed": bool, "score": float, "task_id": str,
+     "reasons": [str, ...], "diff": {...}}
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Any, Callable
+
+from . import (
+    t01_connect_with_user,
+    t02_post_text_update,
+    t03_easy_apply_to_job,
+)
+
+GraderFn = Callable[..., dict[str, Any]]
+
+GRADERS: dict[str, GraderFn] = {
+    "t01_connect_with_user": t01_connect_with_user.grade,
+    "t02_post_text_update": t02_post_text_update.grade,
+    "t03_easy_apply_to_job": t03_easy_apply_to_job.grade,
+    # Convenience aliases — match the README's tNN shorthand.
+    "t01": t01_connect_with_user.grade,
+    "t02": t02_post_text_update.grade,
+    "t03": t03_easy_apply_to_job.grade,
+}
+
+
+def grade(task_id: str, conn: sqlite3.Connection, *, now: str,
+          seed_val: int) -> dict[str, Any]:
+    fn = GRADERS.get(task_id)
+    if fn is None:
+        return {
+            "passed": False,
+            "score": 0.0,
+            "task_id": task_id,
+            "reasons": [f"no oracle registered for task_id={task_id!r}"],
+            "diff": {},
+        }
+    result = fn(conn, now=now, seed_val=seed_val)
+    result.setdefault("task_id", task_id)
+    return result

--- a/deploy/sim_envs/mantis_linkedin/app/oracles/t01_connect_with_user.py
+++ b/deploy/sim_envs/mantis_linkedin/app/oracles/t01_connect_with_user.py
@@ -1,0 +1,77 @@
+"""t01_connect_with_user — current user sends a connection request to user_00042 with a note.
+
+Pass criteria:
+- A ``connections`` row exists with from_user_id='user_00001',
+  to_user_id='user_00042', status='pending'.
+- ``note`` column is non-empty (the modal's textarea was populated).
+- An audit_log row with operation='connection_requested' covers the same
+  edge.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from typing import Any
+
+
+def grade(conn: sqlite3.Connection, *, now: str,
+          seed_val: int) -> dict[str, Any]:
+    reasons: list[str] = []
+    target_from = "user_00001"
+    target_to = "user_00042"
+
+    row = conn.execute(
+        "SELECT id, status, note FROM connections "
+        "WHERE from_user_id = ? AND to_user_id = ?",
+        (target_from, target_to),
+    ).fetchone()
+
+    if not row:
+        return {
+            "passed": False,
+            "score": 0.0,
+            "reasons": [
+                f"no connection row from {target_from} → {target_to}",
+            ],
+            "diff": {"expected": {
+                "from_user_id": target_from, "to_user_id": target_to,
+                "status": "pending", "note": "<non-empty>",
+            }, "actual": None},
+        }
+
+    if row["status"] != "pending":
+        reasons.append(
+            f"connection status is {row['status']!r}, expected 'pending'"
+        )
+    if not (row["note"] or "").strip():
+        reasons.append("connection note is empty — modal textarea expected")
+
+    audit_row = conn.execute(
+        "SELECT id, payload_json FROM audit_log "
+        "WHERE operation = 'connection_requested' "
+        "AND target_id = ? ORDER BY id DESC LIMIT 1",
+        (row["id"],),
+    ).fetchone()
+    if not audit_row:
+        reasons.append("no audit_log row for connection_requested")
+
+    audit_payload: dict[str, Any] = {}
+    if audit_row:
+        try:
+            audit_payload = json.loads(audit_row["payload_json"])
+        except json.JSONDecodeError:
+            audit_payload = {}
+
+    passed = not reasons
+    return {
+        "passed": passed,
+        "score": 1.0 if passed else 0.0,
+        "reasons": reasons or ["all checks passed"],
+        "diff": {
+            "connection": {
+                "id": row["id"], "status": row["status"], "note": row["note"],
+            },
+            "audit_payload": audit_payload,
+        },
+    }

--- a/deploy/sim_envs/mantis_linkedin/app/oracles/t02_post_text_update.py
+++ b/deploy/sim_envs/mantis_linkedin/app/oracles/t02_post_text_update.py
@@ -1,0 +1,82 @@
+"""t02_post_text_update — current user creates a feed post containing text + a #hashtag.
+
+Pass criteria:
+- A row in ``posts`` exists authored by user_00001 with at least one
+  hashtag stored in the JSON ``hashtags`` column.
+- The hashtag must be extracted (i.e. the row was created via the post
+  route, which calls ``extract_hashtags``).
+- An audit_log row with operation='post_created' references the post id.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from typing import Any
+
+
+def grade(conn: sqlite3.Connection, *, now: str,
+          seed_val: int) -> dict[str, Any]:
+    reasons: list[str] = []
+    author = "user_00001"
+
+    # Find the most recent post by demo that includes at least one hashtag.
+    candidates = conn.execute(
+        "SELECT id, body, hashtags, created_at FROM posts "
+        "WHERE author_id = ? AND hashtags != '[]' "
+        "ORDER BY id DESC LIMIT 5",
+        (author,),
+    ).fetchall()
+    seed_post_ids = {f"post_{i:05d}" for i in range(1, 31)}
+
+    # Skip seeded posts — only count posts the agent created (those have
+    # ids > 30 because seed is fixed to 30).
+    fresh = [r for r in candidates if r["id"] not in seed_post_ids]
+
+    if not fresh:
+        return {
+            "passed": False,
+            "score": 0.0,
+            "reasons": [
+                f"no agent-authored post for {author} with a hashtag found"
+            ],
+            "diff": {"expected": {
+                "author_id": author, "hashtags": "<at-least-one>",
+            }, "actual_candidates": [dict(r) for r in candidates]},
+        }
+
+    post = dict(fresh[0])
+    tags = json.loads(post["hashtags"])
+    if not tags:
+        reasons.append("post.hashtags is empty after extraction")
+
+    audit_row = conn.execute(
+        "SELECT id, payload_json FROM audit_log "
+        "WHERE operation = 'post_created' AND target_id = ? LIMIT 1",
+        (post["id"],),
+    ).fetchone()
+    if not audit_row:
+        reasons.append("no audit_log row for post_created")
+
+    audit_payload: dict[str, Any] = {}
+    if audit_row:
+        try:
+            audit_payload = json.loads(audit_row["payload_json"])
+        except json.JSONDecodeError:
+            audit_payload = {}
+
+    if not post["body"].strip():
+        reasons.append("post body is empty")
+
+    passed = not reasons
+    return {
+        "passed": passed,
+        "score": 1.0 if passed else 0.0,
+        "reasons": reasons or ["all checks passed"],
+        "diff": {
+            "post": {
+                "id": post["id"], "body": post["body"], "hashtags": tags,
+            },
+            "audit_payload": audit_payload,
+        },
+    }

--- a/deploy/sim_envs/mantis_linkedin/app/oracles/t03_easy_apply_to_job.py
+++ b/deploy/sim_envs/mantis_linkedin/app/oracles/t03_easy_apply_to_job.py
@@ -1,0 +1,76 @@
+"""t03_easy_apply_to_job — user Easy Applies on job_00003 with phone + resume confirm.
+
+Pass criteria:
+- Row in job_applications with user_00001 + job_00003, status='submitted',
+  non-empty phone.
+- audit_log row operation='job_application_submitted' for the same id.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from typing import Any
+
+
+def grade(conn: sqlite3.Connection, *, now: str,
+          seed_val: int) -> dict[str, Any]:
+    reasons: list[str] = []
+    user_id = "user_00001"
+    job_id = "job_00003"
+
+    row = conn.execute(
+        "SELECT id, status, phone, resume_label, answers_json "
+        "FROM job_applications WHERE user_id = ? AND job_id = ?",
+        (user_id, job_id),
+    ).fetchone()
+
+    if not row:
+        return {
+            "passed": False,
+            "score": 0.0,
+            "reasons": [
+                f"no job_application row for {user_id} × {job_id}"
+            ],
+            "diff": {"expected": {
+                "user_id": user_id, "job_id": job_id,
+                "status": "submitted", "phone": "<non-empty>",
+            }, "actual": None},
+        }
+
+    if row["status"] != "submitted":
+        reasons.append(
+            f"application status is {row['status']!r}, expected 'submitted'"
+        )
+    if not (row["phone"] or "").strip():
+        reasons.append("application phone is empty")
+
+    audit_row = conn.execute(
+        "SELECT id, payload_json FROM audit_log "
+        "WHERE operation = 'job_application_submitted' "
+        "AND target_id = ? ORDER BY id DESC LIMIT 1",
+        (row["id"],),
+    ).fetchone()
+    if not audit_row:
+        reasons.append("no audit_log row for job_application_submitted")
+
+    audit_payload: dict[str, Any] = {}
+    if audit_row:
+        try:
+            audit_payload = json.loads(audit_row["payload_json"])
+        except json.JSONDecodeError:
+            audit_payload = {}
+
+    passed = not reasons
+    return {
+        "passed": passed,
+        "score": 1.0 if passed else 0.0,
+        "reasons": reasons or ["all checks passed"],
+        "diff": {
+            "application": {
+                "id": row["id"], "status": row["status"],
+                "phone": row["phone"], "resume_label": row["resume_label"],
+            },
+            "audit_payload": audit_payload,
+        },
+    }

--- a/deploy/sim_envs/mantis_linkedin/app/routes/__init__.py
+++ b/deploy/sim_envs/mantis_linkedin/app/routes/__init__.py
@@ -1,0 +1,1 @@
+"""Routers for mantis-linkedin."""

--- a/deploy/sim_envs/mantis_linkedin/app/routes/auth.py
+++ b/deploy/sim_envs/mantis_linkedin/app/routes/auth.py
@@ -1,0 +1,68 @@
+"""Login / logout / signup routes."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Form, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+
+from .. import auth, db, main as app_main
+
+router = APIRouter()
+
+
+@router.get("/login", response_class=HTMLResponse)
+async def login_form(request: Request, next: str = "/feed/",
+                     error: str | None = None):
+    tpls = request.app.state.templates
+    return tpls.TemplateResponse("login.html", {
+        "request": request, "next_path": next, "error": error,
+    })
+
+
+@router.post("/login")
+async def login_submit(
+    request: Request,
+    email: str = Form(...),
+    password: str = Form(...),
+    next: str = Form("/feed/"),
+):
+    user = auth.lookup_user_by_email(email)
+    if not user or not auth.verify_password(password, user["password_hash"]):
+        tpls = request.app.state.templates
+        return tpls.TemplateResponse("login.html", {
+            "request": request, "next_path": next,
+            "error": "Wrong email or password.",
+        }, status_code=400)
+
+    resp = RedirectResponse(next or "/feed/", status_code=303)
+    auth.set_session_cookie(resp, user["id"])
+
+    conn = db.connect()
+    db.log_audit(
+        conn,
+        occurred_at=app_main.now_value(),
+        operation="login_succeeded",
+        target_type="user",
+        target_id=user["id"],
+        payload={"email": user["email"]},
+    )
+    conn.commit()
+    app_main.emit("login_succeeded", {"user_id": user["id"]})
+    app_main.emit_mutation(
+        op="login_succeeded", target_type="user",
+        target_id=user["id"], payload={"email": user["email"]},
+    )
+    return resp
+
+
+@router.post("/logout")
+async def logout():
+    resp = RedirectResponse("/login", status_code=303)
+    auth.clear_session_cookie(resp)
+    return resp
+
+
+@router.get("/signup", response_class=HTMLResponse)
+async def signup_form(request: Request):
+    tpls = request.app.state.templates
+    return tpls.TemplateResponse("signup.html", {"request": request})

--- a/deploy/sim_envs/mantis_linkedin/app/routes/env_admin.py
+++ b/deploy/sim_envs/mantis_linkedin/app/routes/env_admin.py
@@ -1,0 +1,146 @@
+"""Harness endpoints — ``/__env__/{health,reset,seed,clock,oracle,state,events,mutations}``.
+
+Every route except ``health`` is gated on ``X-Env-Admin``.
+"""
+
+from __future__ import annotations
+
+import os
+
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse
+
+from .. import db, main as app_main, seed
+
+router = APIRouter(prefix="/__env__")
+
+
+@router.get("/health")
+async def health() -> JSONResponse:
+    return JSONResponse({
+        "ok": True,
+        "seed": app_main.seed_value(),
+        "now": app_main.now_value(),
+        "boot_time": app_main.boot_time(),
+    })
+
+
+@router.post("/reset")
+async def reset(request: Request) -> JSONResponse:
+    if not app_main.admin_token_ok(request):
+        return app_main.admin_required_response()
+    conn = db.connect()
+    seed.seed(conn, seed_val=app_main.seed_value(), fake_now=app_main.now_value())
+    app_main.clear_events()
+    app_main.emit("reset")
+    return JSONResponse({"ok": True})
+
+
+@router.post("/seed")
+async def reseed(request: Request) -> JSONResponse:
+    if not app_main.admin_token_ok(request):
+        return app_main.admin_required_response()
+    try:
+        payload = await request.json()
+    except Exception:  # noqa: BLE001
+        payload = {}
+    new_seed = int(payload.get("seed", app_main.seed_value()))
+    os.environ["SEED"] = str(new_seed)
+    conn = db.connect()
+    seed.seed(conn, seed_val=new_seed, fake_now=app_main.now_value())
+    app_main.emit("reseeded", {"seed": new_seed})
+    return JSONResponse({"ok": True, "seed": new_seed})
+
+
+@router.post("/clock")
+async def clock(request: Request) -> JSONResponse:
+    if not app_main.admin_token_ok(request):
+        return app_main.admin_required_response()
+    try:
+        payload = await request.json()
+    except Exception:  # noqa: BLE001
+        payload = {}
+    new_now = str(payload.get("now") or app_main.now_value())
+    os.environ["FAKE_NOW"] = new_now
+    app_main.emit("clock_set", {"now": new_now})
+    return JSONResponse({"ok": True, "now": new_now})
+
+
+@router.get("/oracle")
+async def oracle(request: Request) -> JSONResponse:
+    if not app_main.admin_token_ok(request):
+        return app_main.admin_required_response()
+    task_id = (request.query_params.get("task_id") or "").strip()
+    if not task_id:
+        return JSONResponse({"passed": False, "score": 0.0,
+                             "reasons": ["task_id is required"], "diff": {}})
+
+    from ..oracles import grade
+    result = grade(
+        task_id, db.connect(), now=app_main.now_value(),
+        seed_val=app_main.seed_value(),
+    )
+    app_main.emit("oracle_query", {"task_id": task_id,
+                                   "passed": result["passed"]})
+    return JSONResponse(result)
+
+
+@router.get("/state")
+async def state(request: Request) -> JSONResponse:
+    if not app_main.admin_token_ok(request):
+        return app_main.admin_required_response()
+    conn = db.connect()
+
+    def count(table: str) -> int:
+        return int(conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0])
+
+    recent_audit = [
+        {
+            "id": r["id"],
+            "occurred_at": r["occurred_at"],
+            "operation": r["operation"],
+            "target_type": r["target_type"],
+            "target_id": r["target_id"],
+        }
+        for r in conn.execute(
+            "SELECT * FROM audit_log ORDER BY id DESC LIMIT 50"
+        ).fetchall()
+    ]
+
+    return JSONResponse({
+        "seed": app_main.seed_value(),
+        "now": app_main.now_value(),
+        "counts": {
+            "users": count("users"),
+            "experience": count("experience"),
+            "education": count("education"),
+            "skills": count("skills"),
+            "connections": count("connections"),
+            "posts": count("posts"),
+            "comments": count("comments"),
+            "reactions": count("reactions"),
+            "threads": count("threads"),
+            "messages": count("messages"),
+            "jobs": count("jobs"),
+            "job_applications": count("job_applications"),
+            "audit_log": count("audit_log"),
+        },
+        "recent_audit": recent_audit,
+    })
+
+
+@router.get("/events")
+async def events(request: Request) -> JSONResponse:
+    if not app_main.admin_token_ok(request):
+        return app_main.admin_required_response()
+    since = float(request.query_params.get("since") or 0)
+    return JSONResponse({"events": app_main.events_since(since)})
+
+
+@router.get("/mutations")
+async def mutations(request: Request) -> JSONResponse:
+    """Structured mutation log for unified-grader contracts."""
+    if not app_main.admin_token_ok(request):
+        return app_main.admin_required_response()
+    since = float(request.query_params.get("since") or 0)
+    return JSONResponse({"mutations": app_main.mutations_since(since)})

--- a/deploy/sim_envs/mantis_linkedin/app/routes/feed.py
+++ b/deploy/sim_envs/mantis_linkedin/app/routes/feed.py
@@ -1,0 +1,235 @@
+"""Feed surface: /feed/, post create, react, comment."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Form, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+
+from .. import db, main as app_main
+from ..util import extract_hashtags, truncate
+
+router = APIRouter()
+
+
+def _author_chip(conn, user_id: str) -> dict[str, Any]:
+    r = conn.execute(
+        "SELECT id, name, headline, handle, avatar_color FROM users WHERE id=?",
+        (user_id,),
+    ).fetchone()
+    return dict(r) if r else {
+        "id": user_id, "name": "Unknown", "headline": "",
+        "handle": "unknown", "avatar_color": "#666",
+    }
+
+
+def _post_view(conn, row) -> dict[str, Any]:
+    author = _author_chip(conn, row["author_id"])
+    reactions = conn.execute(
+        "SELECT COUNT(*) AS n FROM reactions WHERE post_id = ?",
+        (row["id"],),
+    ).fetchone()["n"]
+    comments = conn.execute(
+        "SELECT COUNT(*) AS n FROM comments WHERE post_id = ?",
+        (row["id"],),
+    ).fetchone()["n"]
+    return {
+        "id": row["id"],
+        "author": author,
+        "body": row["body"],
+        "body_short": truncate(row["body"], max_chars=320),
+        "hashtags": db.unpack_json(row["hashtags"]),
+        "created_at": row["created_at"],
+        "reactions": reactions,
+        "comments": comments,
+    }
+
+
+def _suggested_connections(conn, current_user_id: str, limit: int = 3):
+    """Users we don't have a connection edge to."""
+    rows = conn.execute(
+        "SELECT id, name, headline, handle, avatar_color FROM users "
+        "WHERE id != ? "
+        "AND id NOT IN (SELECT to_user_id FROM connections WHERE from_user_id = ?) "
+        "AND id NOT IN (SELECT from_user_id FROM connections WHERE to_user_id = ?) "
+        "ORDER BY id LIMIT ?",
+        (current_user_id, current_user_id, current_user_id, limit),
+    ).fetchall()
+    return [dict(r) for r in rows]
+
+
+@router.get("/feed/", response_class=HTMLResponse)
+async def feed(request: Request):
+    conn = db.connect()
+    user = request.state.current_user or {}
+    user_id = user.get("id", "user_00001")
+
+    posts = [
+        _post_view(conn, r)
+        for r in conn.execute(
+            "SELECT id, author_id, body, hashtags, created_at "
+            "FROM posts ORDER BY created_at DESC, id DESC LIMIT 30"
+        ).fetchall()
+    ]
+    connection_count = conn.execute(
+        "SELECT COUNT(*) AS n FROM connections "
+        "WHERE (from_user_id = ? OR to_user_id = ?) AND status = 'accepted'",
+        (user_id, user_id),
+    ).fetchone()["n"]
+
+    suggested = _suggested_connections(conn, user_id)
+    me = _author_chip(conn, user_id)
+
+    return request.app.state.templates.TemplateResponse(
+        "feed.html",
+        {
+            "request": request,
+            "me": me,
+            "posts": posts,
+            "connection_count": connection_count,
+            "suggested": suggested,
+            "news_items": [
+                ("New funding rounds for AI infra startups", "2h ago • 4,201 readers"),
+                ("Remote work trends — Q2 2026 report", "5h ago • 2,810 readers"),
+                ("Why postmortem culture matters more than ever", "1d ago • 6,144 readers"),
+                ("Hiring slowed in May; tech roles steady", "1d ago • 1,902 readers"),
+                ("Open-source funding models that actually work", "2d ago • 980 readers"),
+            ],
+        },
+    )
+
+
+@router.post("/feed/post")
+async def create_post(request: Request, body: str = Form(...)):
+    conn = db.connect()
+    user = request.state.current_user or {}
+    user_id = user.get("id", "user_00001")
+
+    text = (body or "").strip()
+    if not text:
+        return RedirectResponse("/feed/", status_code=303)
+
+    # Generate a fresh deterministic-ish ID.
+    next_idx = conn.execute(
+        "SELECT COALESCE(MAX(CAST(SUBSTR(id, 6) AS INTEGER)), 0) + 1 AS n "
+        "FROM posts"
+    ).fetchone()["n"]
+    pid = f"post_{next_idx:05d}"
+    tags = extract_hashtags(text)
+    created_at = app_main.now_value()
+
+    conn.execute(
+        "INSERT INTO posts (id, author_id, body, hashtags, visibility, "
+        "created_at) VALUES (?,?,?,?,?,?)",
+        (pid, user_id, text, db.pack_json(tags), "public", created_at),
+    )
+    db.log_audit(
+        conn,
+        occurred_at=created_at,
+        operation="post_created",
+        target_type="post",
+        target_id=pid,
+        payload={"author_id": user_id, "body": text, "hashtags": tags},
+    )
+    conn.commit()
+    app_main.emit("post_created", {"post_id": pid, "user_id": user_id})
+    app_main.emit_mutation(
+        op="post_created", target_type="post", target_id=pid,
+        payload={"author_id": user_id, "body": text, "hashtags": tags},
+    )
+    return RedirectResponse("/feed/", status_code=303)
+
+
+@router.post("/feed/posts/{post_id}/react")
+async def react_to_post(
+    request: Request, post_id: str,
+    kind: str = Form("like"),
+):
+    conn = db.connect()
+    user = request.state.current_user or {}
+    user_id = user.get("id", "user_00001")
+    now = app_main.now_value()
+
+    # Toggle: if existing row matches kind, remove. Else upsert.
+    existing = conn.execute(
+        "SELECT kind FROM reactions WHERE post_id = ? AND user_id = ?",
+        (post_id, user_id),
+    ).fetchone()
+    if existing and existing["kind"] == kind:
+        conn.execute(
+            "DELETE FROM reactions WHERE post_id = ? AND user_id = ?",
+            (post_id, user_id),
+        )
+        op = "reaction_removed"
+    else:
+        if existing:
+            conn.execute(
+                "UPDATE reactions SET kind = ?, created_at = ? "
+                "WHERE post_id = ? AND user_id = ?",
+                (kind, now, post_id, user_id),
+            )
+        else:
+            conn.execute(
+                "INSERT INTO reactions (post_id, user_id, kind, created_at) "
+                "VALUES (?,?,?,?)",
+                (post_id, user_id, kind, now),
+            )
+        op = "reaction_added"
+
+    db.log_audit(
+        conn,
+        occurred_at=now,
+        operation=op,
+        target_type="post",
+        target_id=post_id,
+        payload={"user_id": user_id, "kind": kind},
+    )
+    conn.commit()
+    app_main.emit(op, {"post_id": post_id, "user_id": user_id, "kind": kind})
+    app_main.emit_mutation(
+        op=op, target_type="post", target_id=post_id,
+        payload={"user_id": user_id, "kind": kind},
+    )
+    return RedirectResponse("/feed/", status_code=303)
+
+
+@router.post("/feed/posts/{post_id}/comment")
+async def comment_on_post(
+    request: Request, post_id: str,
+    body: str = Form(...),
+):
+    conn = db.connect()
+    user = request.state.current_user or {}
+    user_id = user.get("id", "user_00001")
+    text = (body or "").strip()
+    if not text:
+        return RedirectResponse("/feed/", status_code=303)
+    now = app_main.now_value()
+
+    next_idx = conn.execute(
+        "SELECT COALESCE(MAX(CAST(SUBSTR(id, 5) AS INTEGER)), 0) + 1 AS n "
+        "FROM comments"
+    ).fetchone()["n"]
+    cid = f"com_{next_idx:06d}"
+
+    conn.execute(
+        "INSERT INTO comments (id, post_id, author_id, body, created_at) "
+        "VALUES (?,?,?,?,?)",
+        (cid, post_id, user_id, text, now),
+    )
+    db.log_audit(
+        conn,
+        occurred_at=now,
+        operation="comment_added",
+        target_type="post",
+        target_id=post_id,
+        payload={"comment_id": cid, "author_id": user_id, "body": text},
+    )
+    conn.commit()
+    app_main.emit("comment_added", {"post_id": post_id, "comment_id": cid})
+    app_main.emit_mutation(
+        op="comment_added", target_type="post", target_id=post_id,
+        payload={"comment_id": cid, "author_id": user_id, "body": text},
+    )
+    return RedirectResponse("/feed/", status_code=303)

--- a/deploy/sim_envs/mantis_linkedin/app/routes/jobs.py
+++ b/deploy/sim_envs/mantis_linkedin/app/routes/jobs.py
@@ -1,0 +1,200 @@
+"""Jobs surface: home, search, detail, Easy Apply."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from fastapi import APIRouter, Form, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+
+from .. import db, main as app_main
+
+router = APIRouter()
+
+
+def _me_id(request: Request) -> str:
+    me = request.state.current_user or {"id": "user_00001"}
+    return me["id"]
+
+
+def _job_view(row) -> dict[str, Any]:
+    return {
+        "id": row["id"],
+        "title": row["title"],
+        "company": row["company"],
+        "location": row["location"],
+        "description_md": row["description_md"],
+        "easy_apply": bool(row["easy_apply"]),
+        "promoted": bool(row["promoted"]),
+        "applicants": row["applicants"],
+        "posted_at": row["posted_at"],
+    }
+
+
+@router.get("/jobs/", response_class=HTMLResponse)
+async def jobs_home(request: Request):
+    conn = db.connect()
+    rows = conn.execute(
+        "SELECT * FROM jobs ORDER BY promoted DESC, id LIMIT 8"
+    ).fetchall()
+    top_picks = [_job_view(r) for r in rows]
+    recommended = [
+        _job_view(r) for r in conn.execute(
+            "SELECT * FROM jobs ORDER BY id DESC LIMIT 5"
+        ).fetchall()
+    ]
+    return request.app.state.templates.TemplateResponse(
+        "jobs.html",
+        {
+            "request": request,
+            "top_picks": top_picks,
+            "recommended": recommended,
+        },
+    )
+
+
+@router.get("/jobs/search/", response_class=HTMLResponse)
+async def jobs_search(
+    request: Request,
+    keywords: str = "",
+    location: str = "",
+    easy_apply: int = 0,
+    id: str | None = None,
+):
+    conn = db.connect()
+
+    sql = "SELECT * FROM jobs WHERE 1=1"
+    args: list[Any] = []
+    if keywords.strip():
+        like = f"%{keywords.strip().lower()}%"
+        sql += " AND (lower(title) LIKE ? OR lower(company) LIKE ?)"
+        args.extend([like, like])
+    if location.strip():
+        sql += " AND lower(location) LIKE ?"
+        args.append(f"%{location.strip().lower()}%")
+    if easy_apply:
+        sql += " AND easy_apply = 1"
+    sql += " ORDER BY promoted DESC, id"
+    rows = conn.execute(sql, args).fetchall()
+    results = [_job_view(r) for r in rows]
+
+    selected = None
+    if id:
+        for r in results:
+            if r["id"] == id:
+                selected = r
+                break
+    if selected is None and results:
+        selected = results[0]
+
+    return request.app.state.templates.TemplateResponse(
+        "jobs_search.html",
+        {
+            "request": request,
+            "results": results,
+            "keywords": keywords,
+            "location": location,
+            "easy_apply": easy_apply,
+            "selected": selected,
+        },
+    )
+
+
+@router.get("/jobs/view/{job_id}/", response_class=HTMLResponse)
+@router.get("/jobs/view/{job_id}", response_class=HTMLResponse)
+async def job_view(request: Request, job_id: str):
+    conn = db.connect()
+    row = conn.execute("SELECT * FROM jobs WHERE id = ?", (job_id,)).fetchone()
+    if not row:
+        return HTMLResponse("Job not found", status_code=404)
+    me_id = _me_id(request)
+    applied = conn.execute(
+        "SELECT id FROM job_applications WHERE user_id = ? AND job_id = ?",
+        (me_id, job_id),
+    ).fetchone() is not None
+    return request.app.state.templates.TemplateResponse(
+        "job_view.html",
+        {
+            "request": request,
+            "job": _job_view(row),
+            "applied": applied,
+        },
+    )
+
+
+@router.post("/jobs/{job_id}/apply")
+async def apply_to_job(
+    request: Request, job_id: str,
+    phone: str = Form(...),
+    resume_label: str = Form("Use my profile"),
+    answers: str = Form("{}"),
+):
+    conn = db.connect()
+    me_id = _me_id(request)
+    now = app_main.now_value()
+
+    job = conn.execute(
+        "SELECT id, title, company, easy_apply FROM jobs WHERE id = ?",
+        (job_id,),
+    ).fetchone()
+    if not job:
+        return RedirectResponse(f"/jobs/view/{job_id}/", status_code=303)
+    if not job["easy_apply"]:
+        return RedirectResponse(f"/jobs/view/{job_id}/?error=external_apply",
+                                status_code=303)
+    if not phone.strip():
+        return RedirectResponse(f"/jobs/view/{job_id}/?error=phone_required",
+                                status_code=303)
+
+    try:
+        answers_obj = json.loads(answers or "{}")
+        if not isinstance(answers_obj, dict):
+            answers_obj = {"raw": str(answers)}
+    except json.JSONDecodeError:
+        answers_obj = {"raw": str(answers)}
+
+    next_idx = conn.execute(
+        "SELECT COALESCE(MAX(CAST(SUBSTR(id, 5) AS INTEGER)), 0) + 1 AS n "
+        "FROM job_applications"
+    ).fetchone()["n"]
+    aid = f"app_{next_idx:05d}"
+
+    try:
+        conn.execute(
+            "INSERT INTO job_applications (id, user_id, job_id, status, phone, "
+            "resume_label, answers_json, submitted_at) VALUES (?,?,?,?,?,?,?,?)",
+            (aid, me_id, job_id, "submitted", phone.strip(),
+             resume_label.strip(), db.pack_json(answers_obj), now),
+        )
+    except Exception:
+        # Already applied — surface the existing record but skip new audit.
+        conn.commit()
+        return RedirectResponse(f"/jobs/view/{job_id}/?applied=1",
+                                status_code=303)
+
+    db.log_audit(
+        conn,
+        occurred_at=now,
+        operation="job_application_submitted",
+        target_type="job_application",
+        target_id=aid,
+        payload={
+            "user_id": me_id, "job_id": job_id,
+            "phone": phone.strip(), "resume_label": resume_label.strip(),
+            "answers": answers_obj,
+        },
+    )
+    conn.commit()
+    app_main.emit("job_application_submitted",
+                  {"application_id": aid, "job_id": job_id, "user_id": me_id})
+    app_main.emit_mutation(
+        op="job_application_submitted", target_type="job_application",
+        target_id=aid,
+        payload={
+            "user_id": me_id, "job_id": job_id, "phone": phone.strip(),
+            "answers": answers_obj,
+        },
+    )
+    return RedirectResponse(f"/jobs/view/{job_id}/?applied=1",
+                            status_code=303)

--- a/deploy/sim_envs/mantis_linkedin/app/routes/messaging.py
+++ b/deploy/sim_envs/mantis_linkedin/app/routes/messaging.py
@@ -1,0 +1,135 @@
+"""Messaging surface: /messaging/, thread view, send."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Form, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+
+from .. import db, main as app_main
+
+router = APIRouter()
+
+
+def _me_id(request: Request) -> str:
+    me = request.state.current_user or {"id": "user_00001"}
+    return me["id"]
+
+
+def _user_chip(conn, uid: str):
+    r = conn.execute(
+        "SELECT id, handle, name, headline, avatar_color FROM users WHERE id=?",
+        (uid,),
+    ).fetchone()
+    return dict(r) if r else None
+
+
+def _thread_summary(conn, thread_row, me_id: str):
+    parts = db.unpack_json(thread_row["participants"])
+    peer_id = next((p for p in parts if p != me_id), None)
+    peer = _user_chip(conn, peer_id) if peer_id else None
+    last = conn.execute(
+        "SELECT body, created_at FROM messages WHERE thread_id = ? "
+        "ORDER BY created_at DESC, id DESC LIMIT 1",
+        (thread_row["id"],),
+    ).fetchone()
+    snippet = last["body"] if last else ""
+    if len(snippet) > 60:
+        snippet = snippet[:57].rstrip() + "…"
+    return {
+        "id": thread_row["id"],
+        "peer": peer,
+        "snippet": snippet,
+        "last_at": thread_row["last_message_at"],
+    }
+
+
+@router.get("/messaging/", response_class=HTMLResponse)
+async def messaging(request: Request, thread: str | None = None):
+    conn = db.connect()
+    me_id = _me_id(request)
+
+    thread_rows = conn.execute(
+        "SELECT id, participants, last_message_at FROM threads "
+        "WHERE participants LIKE ? "
+        "ORDER BY last_message_at DESC, id DESC",
+        (f'%"{me_id}"%',),
+    ).fetchall()
+    threads = [_thread_summary(conn, r, me_id) for r in thread_rows]
+
+    active_id = thread or (threads[0]["id"] if threads else None)
+    active = None
+    messages = []
+    if active_id:
+        row = conn.execute(
+            "SELECT id, participants FROM threads WHERE id = ?",
+            (active_id,),
+        ).fetchone()
+        if row:
+            parts = db.unpack_json(row["participants"])
+            peer_id = next((p for p in parts if p != me_id), None)
+            peer = _user_chip(conn, peer_id) if peer_id else None
+            active = {"id": active_id, "peer": peer}
+            messages = [
+                dict(m) for m in conn.execute(
+                    "SELECT id, sender_id, body, created_at "
+                    "FROM messages WHERE thread_id = ? "
+                    "ORDER BY created_at, id",
+                    (active_id,),
+                ).fetchall()
+            ]
+
+    return request.app.state.templates.TemplateResponse(
+        "messaging.html",
+        {
+            "request": request,
+            "me_id": me_id,
+            "threads": threads,
+            "active": active,
+            "messages": messages,
+        },
+    )
+
+
+@router.post("/messaging/{thread_id}/send")
+async def send_message(request: Request, thread_id: str,
+                       body: str = Form(...)):
+    conn = db.connect()
+    me_id = _me_id(request)
+    text = (body or "").strip()
+    if not text:
+        return RedirectResponse(f"/messaging/?thread={thread_id}",
+                                status_code=303)
+    now = app_main.now_value()
+
+    next_idx = conn.execute(
+        "SELECT COALESCE(MAX(CAST(SUBSTR(id, 5) AS INTEGER)), 0) + 1 AS n "
+        "FROM messages WHERE id LIKE 'msg_n%'"
+    ).fetchone()["n"]
+    mid = f"msg_n{next_idx:06d}"
+
+    conn.execute(
+        "INSERT INTO messages (id, thread_id, sender_id, body, created_at) "
+        "VALUES (?,?,?,?,?)",
+        (mid, thread_id, me_id, text, now),
+    )
+    conn.execute(
+        "UPDATE threads SET last_message_at = ? WHERE id = ?",
+        (now, thread_id),
+    )
+    db.log_audit(
+        conn,
+        occurred_at=now,
+        operation="message_sent",
+        target_type="message",
+        target_id=mid,
+        payload={"thread_id": thread_id, "sender_id": me_id, "body": text},
+    )
+    conn.commit()
+    app_main.emit("message_sent",
+                  {"message_id": mid, "thread_id": thread_id})
+    app_main.emit_mutation(
+        op="message_sent", target_type="message", target_id=mid,
+        payload={"thread_id": thread_id, "sender_id": me_id, "body": text},
+    )
+    return RedirectResponse(f"/messaging/?thread={thread_id}",
+                            status_code=303)

--- a/deploy/sim_envs/mantis_linkedin/app/routes/network.py
+++ b/deploy/sim_envs/mantis_linkedin/app/routes/network.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Form, Request
+from fastapi import APIRouter, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
 
 from .. import db, main as app_main

--- a/deploy/sim_envs/mantis_linkedin/app/routes/network.py
+++ b/deploy/sim_envs/mantis_linkedin/app/routes/network.py
@@ -1,0 +1,226 @@
+"""Connections surface: /mynetwork/ and /mynetwork/invitation-manager/."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Form, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+
+from .. import db, main as app_main
+
+router = APIRouter()
+
+
+def _me(request: Request) -> dict:
+    me = request.state.current_user or {}
+    if not me:
+        return {"id": "user_00001"}
+    return me
+
+
+def _user_chip(conn, uid: str):
+    r = conn.execute(
+        "SELECT id, handle, name, headline, avatar_color FROM users WHERE id=?",
+        (uid,),
+    ).fetchone()
+    return dict(r) if r else None
+
+
+@router.get("/mynetwork/", response_class=HTMLResponse)
+async def mynetwork(request: Request):
+    conn = db.connect()
+    me = _me(request)
+    me_id = me["id"]
+
+    counts = {
+        "connections": conn.execute(
+            "SELECT COUNT(*) AS n FROM connections "
+            "WHERE (from_user_id = ? OR to_user_id = ?) AND status = 'accepted'",
+            (me_id, me_id),
+        ).fetchone()["n"],
+        "received_pending": conn.execute(
+            "SELECT COUNT(*) AS n FROM connections "
+            "WHERE to_user_id = ? AND status = 'pending'",
+            (me_id,),
+        ).fetchone()["n"],
+        "sent_pending": conn.execute(
+            "SELECT COUNT(*) AS n FROM connections "
+            "WHERE from_user_id = ? AND status = 'pending'",
+            (me_id,),
+        ).fetchone()["n"],
+    }
+
+    received = [
+        {
+            "id": r["id"],
+            "note": r["note"],
+            "user": _user_chip(conn, r["from_user_id"]),
+            "created_at": r["created_at"],
+        }
+        for r in conn.execute(
+            "SELECT * FROM connections WHERE to_user_id = ? "
+            "AND status = 'pending' ORDER BY id DESC LIMIT 3",
+            (me_id,),
+        ).fetchall()
+    ]
+
+    # People you may know — same shape as feed suggestion.
+    suggested_rows = conn.execute(
+        "SELECT id, name, headline, handle, avatar_color FROM users "
+        "WHERE id != ? "
+        "AND id NOT IN (SELECT to_user_id FROM connections WHERE from_user_id = ?) "
+        "AND id NOT IN (SELECT from_user_id FROM connections WHERE to_user_id = ?) "
+        "ORDER BY id LIMIT 12",
+        (me_id, me_id, me_id),
+    ).fetchall()
+    suggested = [dict(r) for r in suggested_rows]
+
+    return request.app.state.templates.TemplateResponse(
+        "mynetwork.html",
+        {
+            "request": request,
+            "me": me,
+            "counts": counts,
+            "received": received,
+            "suggested": suggested,
+        },
+    )
+
+
+@router.get("/mynetwork/invitation-manager/", response_class=HTMLResponse)
+async def invitation_manager(request: Request, tab: str = "received"):
+    conn = db.connect()
+    me = _me(request)
+    me_id = me["id"]
+
+    if tab == "sent":
+        rows = conn.execute(
+            "SELECT * FROM connections WHERE from_user_id = ? "
+            "AND status = 'pending' ORDER BY id DESC",
+            (me_id,),
+        ).fetchall()
+        items = [
+            {
+                "id": r["id"],
+                "note": r["note"],
+                "user": _user_chip(conn, r["to_user_id"]),
+                "created_at": r["created_at"],
+            }
+            for r in rows
+        ]
+    else:
+        rows = conn.execute(
+            "SELECT * FROM connections WHERE to_user_id = ? "
+            "AND status = 'pending' ORDER BY id DESC",
+            (me_id,),
+        ).fetchall()
+        items = [
+            {
+                "id": r["id"],
+                "note": r["note"],
+                "user": _user_chip(conn, r["from_user_id"]),
+                "created_at": r["created_at"],
+            }
+            for r in rows
+        ]
+
+    return request.app.state.templates.TemplateResponse(
+        "invitation_manager.html",
+        {
+            "request": request,
+            "me": me,
+            "tab": tab,
+            "items": items,
+        },
+    )
+
+
+@router.post("/mynetwork/invitations/{conn_id}/accept")
+async def accept_invitation(request: Request, conn_id: str):
+    conn = db.connect()
+    me = _me(request)
+    me_id = me["id"]
+    now = app_main.now_value()
+
+    row = conn.execute(
+        "SELECT * FROM connections WHERE id = ? AND to_user_id = ? "
+        "AND status = 'pending'",
+        (conn_id, me_id),
+    ).fetchone()
+    if not row:
+        return RedirectResponse("/mynetwork/invitation-manager/",
+                                status_code=303)
+
+    conn.execute(
+        "UPDATE connections SET status = 'accepted', accepted_at = ? "
+        "WHERE id = ?",
+        (now, conn_id),
+    )
+    db.log_audit(
+        conn,
+        occurred_at=now,
+        operation="connection_accepted",
+        target_type="connection",
+        target_id=conn_id,
+        payload={"from_user_id": row["from_user_id"], "to_user_id": me_id},
+    )
+    conn.commit()
+    app_main.emit("connection_accepted", {"connection_id": conn_id})
+    app_main.emit_mutation(
+        op="connection_accepted", target_type="connection",
+        target_id=conn_id,
+        payload={"from_user_id": row["from_user_id"], "to_user_id": me_id},
+    )
+    return RedirectResponse("/mynetwork/invitation-manager/", status_code=303)
+
+
+@router.post("/mynetwork/invitations/{conn_id}/ignore")
+async def ignore_invitation(request: Request, conn_id: str):
+    conn = db.connect()
+    me = _me(request)
+    me_id = me["id"]
+    now = app_main.now_value()
+    conn.execute(
+        "DELETE FROM connections WHERE id = ? AND to_user_id = ?",
+        (conn_id, me_id),
+    )
+    db.log_audit(
+        conn,
+        occurred_at=now,
+        operation="connection_ignored",
+        target_type="connection",
+        target_id=conn_id,
+    )
+    conn.commit()
+    app_main.emit("connection_ignored", {"connection_id": conn_id})
+    app_main.emit_mutation(
+        op="connection_ignored", target_type="connection",
+        target_id=conn_id,
+    )
+    return RedirectResponse("/mynetwork/invitation-manager/", status_code=303)
+
+
+@router.post("/mynetwork/invitations/{conn_id}/withdraw")
+async def withdraw_invitation(request: Request, conn_id: str):
+    conn = db.connect()
+    me = _me(request)
+    me_id = me["id"]
+    now = app_main.now_value()
+    conn.execute(
+        "DELETE FROM connections WHERE id = ? AND from_user_id = ?",
+        (conn_id, me_id),
+    )
+    db.log_audit(
+        conn,
+        occurred_at=now,
+        operation="connection_withdrawn",
+        target_type="connection",
+        target_id=conn_id,
+    )
+    conn.commit()
+    app_main.emit("connection_withdrawn", {"connection_id": conn_id})
+    app_main.emit_mutation(
+        op="connection_withdrawn", target_type="connection",
+        target_id=conn_id,
+    )
+    return RedirectResponse("/mynetwork/invitation-manager/?tab=sent",
+                            status_code=303)

--- a/deploy/sim_envs/mantis_linkedin/app/routes/profile.py
+++ b/deploy/sim_envs/mantis_linkedin/app/routes/profile.py
@@ -1,0 +1,156 @@
+"""Profile surface: /in/<handle>/ and the Connect action."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Form, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+
+from .. import db, main as app_main
+
+router = APIRouter()
+
+
+def _user_by_handle(conn, handle: str):
+    r = conn.execute(
+        "SELECT id, handle, name, headline, about, location, avatar_color, "
+        "email FROM users WHERE handle = ?",
+        (handle,),
+    ).fetchone()
+    return dict(r) if r else None
+
+
+def _user_by_id(conn, uid: str):
+    r = conn.execute(
+        "SELECT id, handle, name, headline, about, location, avatar_color "
+        "FROM users WHERE id = ?",
+        (uid,),
+    ).fetchone()
+    return dict(r) if r else None
+
+
+@router.get("/in/{handle}/", response_class=HTMLResponse)
+@router.get("/in/{handle}", response_class=HTMLResponse)
+async def profile(request: Request, handle: str):
+    conn = db.connect()
+    profile = _user_by_handle(conn, handle)
+    if not profile:
+        return HTMLResponse("Profile not found", status_code=404)
+
+    me = request.state.current_user or _user_by_id(conn, "user_00001")
+    me_id = me["id"] if me else "user_00001"
+    is_self = me_id == profile["id"]
+
+    experience = [dict(r) for r in conn.execute(
+        "SELECT * FROM experience WHERE user_id = ? ORDER BY sort_idx",
+        (profile["id"],),
+    ).fetchall()]
+    education = [dict(r) for r in conn.execute(
+        "SELECT * FROM education WHERE user_id = ? ORDER BY sort_idx",
+        (profile["id"],),
+    ).fetchall()]
+    skills = [dict(r) for r in conn.execute(
+        "SELECT * FROM skills WHERE user_id = ? ORDER BY sort_idx",
+        (profile["id"],),
+    ).fetchall()]
+
+    conn_count = conn.execute(
+        "SELECT COUNT(*) AS n FROM connections "
+        "WHERE (from_user_id = ? OR to_user_id = ?) AND status = 'accepted'",
+        (profile["id"], profile["id"]),
+    ).fetchone()["n"]
+
+    existing_conn = conn.execute(
+        "SELECT status FROM connections WHERE "
+        "(from_user_id = ? AND to_user_id = ?) "
+        "OR (from_user_id = ? AND to_user_id = ?)",
+        (me_id, profile["id"], profile["id"], me_id),
+    ).fetchone()
+    conn_state = existing_conn["status"] if existing_conn else None
+
+    # Activity: this user's posts (most recent 5)
+    activity = [
+        dict(r) for r in conn.execute(
+            "SELECT id, body, created_at FROM posts "
+            "WHERE author_id = ? ORDER BY created_at DESC, id DESC LIMIT 5",
+            (profile["id"],),
+        ).fetchall()
+    ]
+
+    return request.app.state.templates.TemplateResponse(
+        "profile.html",
+        {
+            "request": request,
+            "profile": profile,
+            "me": me,
+            "is_self": is_self,
+            "experience": experience,
+            "education": education,
+            "skills": skills,
+            "connection_count": conn_count,
+            "conn_state": conn_state,
+            "activity": activity,
+        },
+    )
+
+
+@router.post("/in/{handle}/connect")
+async def connect(
+    request: Request, handle: str,
+    note: str = Form(""),
+):
+    conn = db.connect()
+    target = _user_by_handle(conn, handle)
+    if not target:
+        return HTMLResponse("Profile not found", status_code=404)
+
+    me = request.state.current_user or _user_by_id(conn, "user_00001")
+    me_id = me["id"] if me else "user_00001"
+
+    if me_id == target["id"]:
+        return RedirectResponse(f"/in/{handle}/", status_code=303)
+
+    # Reject duplicate edges.
+    existing = conn.execute(
+        "SELECT id FROM connections WHERE "
+        "(from_user_id = ? AND to_user_id = ?) "
+        "OR (from_user_id = ? AND to_user_id = ?)",
+        (me_id, target["id"], target["id"], me_id),
+    ).fetchone()
+    if existing:
+        return RedirectResponse(f"/in/{handle}/", status_code=303)
+
+    next_idx = conn.execute(
+        "SELECT COALESCE(MAX(CAST(SUBSTR(id, 6) AS INTEGER)), 0) + 1 AS n "
+        "FROM connections"
+    ).fetchone()["n"]
+    cid = f"conn_{next_idx:06d}"
+    now = app_main.now_value()
+
+    conn.execute(
+        "INSERT INTO connections (id, from_user_id, to_user_id, status, "
+        "note, created_at, accepted_at) VALUES (?,?,?,?,?,?,?)",
+        (cid, me_id, target["id"], "pending", note.strip(), now, None),
+    )
+    db.log_audit(
+        conn,
+        occurred_at=now,
+        operation="connection_requested",
+        target_type="connection",
+        target_id=cid,
+        payload={
+            "from_user_id": me_id,
+            "to_user_id": target["id"],
+            "note": note.strip(),
+        },
+    )
+    conn.commit()
+    app_main.emit("connection_requested",
+                  {"connection_id": cid, "from": me_id, "to": target["id"]})
+    app_main.emit_mutation(
+        op="connection_requested", target_type="connection", target_id=cid,
+        payload={
+            "from_user_id": me_id, "to_user_id": target["id"],
+            "note": note.strip(),
+        },
+    )
+    return RedirectResponse(f"/in/{handle}/", status_code=303)

--- a/deploy/sim_envs/mantis_linkedin/app/seed.py
+++ b/deploy/sim_envs/mantis_linkedin/app/seed.py
@@ -1,0 +1,459 @@
+"""Deterministic seed for mantis-linkedin.
+
+Seeded ``random.Random`` only — no ``faker``. Same SEED → identical IDs
++ identical column values.
+
+Counts (per SEED=42):
+  - 50 users (user_00001 = demo acting subject)
+  - ~150 experience rows
+  - ~100 education rows
+  - ~250 skill rows
+  - ~80 connections (mix of accepted/pending so the UI has invitations visible)
+  - 30 posts
+  - ~60 comments, ~120 reactions
+  - 8 messaging threads + ~60 messages
+  - 25 jobs
+"""
+
+from __future__ import annotations
+
+import hashlib
+import random
+import sqlite3
+from typing import Any
+
+from . import auth, db
+
+FAKE_NOW_DEFAULT = "2026-06-08T09:00:00Z"
+
+# Compact lists for deterministic generation.
+_FIRST_NAMES = [
+    "Aarav", "Aiko", "Alex", "Amir", "Ana", "Ben", "Bianca", "Chen", "Daniel",
+    "Diana", "Eli", "Emma", "Faisal", "Fatima", "Gabriel", "Grace", "Hassan",
+    "Hina", "Ivan", "Jasmin", "Jin", "Karim", "Kira", "Lena", "Liam", "Mei",
+    "Nadia", "Noah", "Olu", "Priya", "Qing", "Raj", "Rosa", "Sam", "Sara",
+    "Tara", "Thabo", "Uma", "Viktor", "Wei", "Yasmin", "Zara", "Demo", "Pat",
+    "Quinn", "Rio", "Sky", "Toni", "Val", "Wren",
+]
+_LAST_NAMES = [
+    "Patel", "Smith", "Garcia", "Chen", "Kim", "Cohen", "Singh", "Brown",
+    "Khan", "Davis", "Nakamura", "Rossi", "Lopez", "Müller", "Ito", "Adeyemi",
+    "Ng", "Silva", "Park", "Olsen", "Hassan", "Yoon", "Lebedev", "Nguyen",
+    "Oliveira", "Schmidt", "Anand", "Diaz", "Berg", "Ahmed", "Hoffmann",
+    "Sato", "Tan", "Romero", "Cruz", "Fischer", "Walker", "Reyes", "Bauer",
+    "Ricci", "Vogel", "Mohamed", "Marin", "Yu", "Demir", "Karlsson",
+    "Whitaker", "Cohn", "Tanaka", "Singh-Roy",
+]
+_HEADLINES = [
+    "Senior Software Engineer @ Acme",
+    "Product Manager • B2B SaaS",
+    "Design Lead, Platform",
+    "Data Engineer specialising in real-time pipelines",
+    "Director of Engineering | Building distributed systems",
+    "ML Researcher → Applied Scientist",
+    "Founder & CEO at NorthForge",
+    "Backend Engineer @ FintechCo",
+    "Engineering Manager • Hiring",
+    "Staff Developer Advocate, Open Source",
+    "UX Researcher • Healthcare",
+    "Full-stack Engineer • TypeScript / Rust",
+    "Security Engineer (Application Security)",
+    "Recruiter — Engineering & Product",
+    "DevRel & community at LaunchOps",
+]
+_LOCATIONS = [
+    "San Francisco, CA", "New York, NY", "Seattle, WA", "Austin, TX",
+    "Boston, MA", "Chicago, IL", "Denver, CO", "Toronto, ON",
+    "London, UK", "Berlin, DE", "Dublin, IE", "Singapore", "Bengaluru, IN",
+    "Sydney, AU", "Tokyo, JP", "Mexico City, MX",
+]
+_COMPANIES = [
+    "Acme Corp", "NorthForge", "LaunchOps", "FintechCo", "Quanta Labs",
+    "Helix Robotics", "BlueOcean Analytics", "Modal Labs", "Hyperion AI",
+    "Civium", "OpenForge", "Lattice Systems", "Lumen Data",
+]
+_SCHOOLS = [
+    "Stanford University", "MIT", "Carnegie Mellon University",
+    "UC Berkeley", "University of Washington", "Georgia Tech",
+    "ETH Zürich", "University of Cambridge", "IIT Bombay",
+    "National University of Singapore", "University of Toronto",
+]
+_DEGREES = [
+    ("B.S.", "Computer Science"),
+    ("M.S.", "Computer Science"),
+    ("B.A.", "Design"),
+    ("M.B.A.", "Business Administration"),
+    ("Ph.D.", "Machine Learning"),
+    ("B.S.", "Electrical Engineering"),
+]
+_SKILLS = [
+    "Python", "TypeScript", "Rust", "Go", "Kubernetes", "PostgreSQL",
+    "FastAPI", "React", "GraphQL", "AWS", "GCP", "Distributed Systems",
+    "System Design", "Mentoring", "Leadership", "Product Strategy",
+    "Figma", "Customer Research", "Data Modeling", "SQL",
+]
+_HASHTAGS = [
+    "hiring", "remote", "buildinpublic", "ai", "softwareengineering",
+    "productmanagement", "design", "leadership", "career", "opensource",
+]
+_POST_TEMPLATES = [
+    "Excited to share that our team just shipped a major refactor of the "
+    "ingestion pipeline. P99 dropped from 480ms → 90ms. #{tag}",
+    "We're hiring two senior engineers on the platform team. DM me if you "
+    "want to chat about distributed systems and high-throughput APIs. #{tag}",
+    "Three lessons from migrating a monolith to event-driven microservices "
+    "the hard way. Thread below. #{tag}",
+    "Wrote up our approach to feature-flag hygiene and the playbook for "
+    "removing stale flags safely. #{tag}",
+    "Joined an incredible team last month. Already learning a ton from "
+    "engineers who think deeply about reliability. #{tag}",
+    "Hot take: most observability dashboards are noise. Three signals you "
+    "should actually wake up to. #{tag}",
+    "Going to ICML this year — happy to meet folks working on RL for "
+    "agentic systems. #{tag}",
+    "Postmortem of a 4-hour incident we just shipped to the public — the "
+    "Swiss-cheese of failures was wild. #{tag}",
+    "If you're early-career and asking what to learn next: get _great_ "
+    "at debugging. Not glamorous. Maximally compounding. #{tag}",
+    "I'm mentoring 3 engineers this quarter through ADPlist. DM me if "
+    "you're navigating the senior → staff jump. #{tag}",
+]
+_JOB_TITLES = [
+    ("Senior Software Engineer, Backend", "Acme Corp"),
+    ("Staff Engineer, Platform", "NorthForge"),
+    ("Product Manager, Growth", "LaunchOps"),
+    ("Engineering Manager, Payments", "FintechCo"),
+    ("Senior Designer, Product", "Quanta Labs"),
+    ("Data Engineer (Streaming)", "BlueOcean Analytics"),
+    ("Site Reliability Engineer", "Modal Labs"),
+    ("ML Engineer, Recommendations", "Hyperion AI"),
+    ("Director of Engineering", "Civium"),
+    ("Solutions Architect", "OpenForge"),
+    ("Senior Backend Engineer, Rust", "Lattice Systems"),
+    ("Staff Product Designer", "Lumen Data"),
+    ("Full-stack Engineer, Early Stage", "Helix Robotics"),
+    ("Developer Advocate", "Modal Labs"),
+    ("Security Engineer, AppSec", "Acme Corp"),
+    ("Customer Engineer", "OpenForge"),
+    ("Technical Recruiter, Eng", "FintechCo"),
+    ("Data Scientist, Experimentation", "BlueOcean Analytics"),
+    ("Frontend Engineer, Design Systems", "Quanta Labs"),
+    ("Product Marketing Manager", "LaunchOps"),
+    ("Engineering Manager, Infra", "NorthForge"),
+    ("ML Researcher", "Hyperion AI"),
+    ("Backend Engineer, Go", "Civium"),
+    ("UX Researcher", "Quanta Labs"),
+    ("Founding Engineer", "Helix Robotics"),
+]
+
+_JOB_DESCRIPTION_TEMPLATE = """\
+## About the role
+
+We're hiring a {title} to join {company}'s {team} team.
+
+You'll partner with senior engineers and product leaders to ship
+high-impact features used by millions of customers worldwide. Our
+stack is Python 3.12, FastAPI, Postgres 16, Kubernetes, and Modal.
+
+## What you'll do
+
+- Design and ship async-first services with strong reliability
+  guarantees.
+- Mentor 2–3 engineers and raise the bar on testing + observability.
+- Own one of: ingestion, query, retention, or experimentation.
+
+## What we're looking for
+
+- 5+ years building production back-ends in Python or Go.
+- Comfortable with distributed systems trade-offs.
+- Excellent written communication.
+
+## Nice to have
+
+- Open-source contributions.
+- Experience with high-throughput event pipelines.
+
+## Location
+
+{location} — hybrid or remote within the U.S.
+"""
+
+
+def _hid(prefix: str, idx: int, width: int = 5) -> str:
+    return f"{prefix}_{idx:0{width}d}"
+
+
+def _handle(name: str, rng: random.Random) -> str:
+    base = name.lower().replace(" ", "-").replace(".", "")
+    suffix = hashlib.sha1(
+        f"{name}-{rng.random()}".encode("utf-8")
+    ).hexdigest()[:4]
+    return f"{base}-{suffix}"
+
+
+def _wipe(conn: sqlite3.Connection) -> None:
+    for tbl in (
+        "audit_log",
+        "job_applications", "jobs",
+        "messages", "threads",
+        "reactions", "comments", "posts",
+        "connections",
+        "skills", "education", "experience",
+        "users",
+    ):
+        conn.execute(f"DELETE FROM {tbl}")
+    # Reset autoincrement counters so seed is reproducible.
+    conn.execute("DELETE FROM sqlite_sequence")
+
+
+def seed(conn: sqlite3.Connection, *, seed_val: int, fake_now: str) -> None:
+    rng = random.Random(seed_val)
+    db.reset_connection()
+    # The previous statement closed the connection — reconnect.
+    conn = db.connect()
+
+    _wipe(conn)
+
+    # ── users ────────────────────────────────────────────────────────
+    users: list[dict[str, Any]] = []
+    for i in range(1, 51):
+        if i == 1:
+            name = "Demo Mantis"
+            handle = "demo-mantis"
+            email = "demo@mantis.example"
+        else:
+            first = rng.choice(_FIRST_NAMES)
+            last = rng.choice(_LAST_NAMES)
+            name = f"{first} {last}"
+            handle = _handle(name, rng)
+            email = f"{first.lower()}.{last.lower().replace('-', '')}{i:03d}@example.com"
+        users.append({
+            "id": _hid("user", i),
+            "handle": handle,
+            "name": name,
+            "headline": rng.choice(_HEADLINES),
+            "about": (
+                "I work at the intersection of distributed systems and "
+                "developer productivity. Happy to chat about anything from "
+                "incident reviews to writing better postmortems."
+            ),
+            "location": rng.choice(_LOCATIONS),
+            "email": email,
+            "password_hash": auth.hash_password("mantis-demo"),
+            "avatar_color": rng.choice([
+                "#0a66c2", "#057642", "#915907", "#7a3e9d", "#cc1016",
+                "#1d4477",
+            ]),
+        })
+    for u in users:
+        conn.execute(
+            "INSERT INTO users (id, handle, name, headline, about, location, "
+            "email, password_hash, avatar_color, created_at) VALUES "
+            "(?,?,?,?,?,?,?,?,?,?)",
+            (u["id"], u["handle"], u["name"], u["headline"], u["about"],
+             u["location"], u["email"], u["password_hash"],
+             u["avatar_color"], fake_now),
+        )
+
+    # ── experience: 2-4 per user ─────────────────────────────────────
+    exp_idx = 0
+    for u in users:
+        n_roles = rng.randint(2, 4)
+        for k in range(n_roles):
+            exp_idx += 1
+            company = rng.choice(_COMPANIES)
+            title = rng.choice([
+                "Software Engineer", "Senior Engineer", "Staff Engineer",
+                "Engineering Manager", "Product Manager", "Designer",
+                "Data Engineer", "Researcher",
+            ])
+            start_year = 2018 + k
+            end_year = start_year + rng.randint(1, 3)
+            end_date = None if k == 0 else f"{end_year}-01-01"
+            conn.execute(
+                "INSERT INTO experience (id, user_id, title, company, location, "
+                "start_date, end_date, description, sort_idx) VALUES "
+                "(?,?,?,?,?,?,?,?,?)",
+                (_hid("exp", exp_idx, 6), u["id"], title, company,
+                 rng.choice(_LOCATIONS),
+                 f"{start_year}-01-01", end_date,
+                 "Led a small team owning a critical service.", k),
+            )
+
+    # ── education: 1-3 per user ──────────────────────────────────────
+    edu_idx = 0
+    for u in users:
+        for k in range(rng.randint(1, 3)):
+            edu_idx += 1
+            degree, field = rng.choice(_DEGREES)
+            start_year = 2010 + rng.randint(0, 6)
+            conn.execute(
+                "INSERT INTO education (id, user_id, school, degree, field, "
+                "start_year, end_year, sort_idx) VALUES (?,?,?,?,?,?,?,?)",
+                (_hid("edu", edu_idx, 6), u["id"], rng.choice(_SCHOOLS),
+                 degree, field, start_year, start_year + 4, k),
+            )
+
+    # ── skills: 4-6 per user ─────────────────────────────────────────
+    skill_idx = 0
+    for u in users:
+        chosen = rng.sample(_SKILLS, rng.randint(4, 6))
+        for k, s in enumerate(chosen):
+            skill_idx += 1
+            conn.execute(
+                "INSERT INTO skills (id, user_id, name, endorsements, sort_idx) "
+                "VALUES (?,?,?,?,?)",
+                (_hid("skill", skill_idx, 6), u["id"], s,
+                 rng.randint(0, 24), k),
+            )
+
+    # ── connections: scatter accepted + a few pending toward demo ───
+    conn_idx = 0
+    pairs_seen: set[tuple[str, str]] = set()
+
+    def _add_conn(a: str, b: str, *, status: str, note: str = "") -> None:
+        nonlocal conn_idx
+        key = (a, b)
+        if key in pairs_seen or a == b:
+            return
+        pairs_seen.add(key)
+        conn_idx += 1
+        accepted_at = fake_now if status == "accepted" else None
+        conn.execute(
+            "INSERT INTO connections (id, from_user_id, to_user_id, status, "
+            "note, created_at, accepted_at) VALUES (?,?,?,?,?,?,?)",
+            (_hid("conn", conn_idx, 6), a, b, status, note, fake_now,
+             accepted_at),
+        )
+
+    # demo user gets ~30 accepted connections — but user_00042 is reserved
+    # as the t01 oracle target and MUST stay unconnected.
+    others = [u["id"] for u in users[1:] if u["id"] != "user_00042"]
+    rng.shuffle(others)
+    for uid in others[:30]:
+        _add_conn(users[0]["id"], uid, status="accepted")
+    # incoming pending invitations to demo from 4 users
+    for uid in others[30:34]:
+        _add_conn(uid, users[0]["id"], status="pending",
+                  note="Met at PyData NYC — would love to stay in touch.")
+    # outgoing pending from demo to a couple
+    for uid in others[34:36]:
+        _add_conn(users[0]["id"], uid, status="pending",
+                  note="Enjoyed your talk on async patterns!")
+    # peer connections so the feed has authors. Keep these between non-demo,
+    # non-target peers so the t01 target stays clean.
+    peer_pool = [uid for uid in others if uid != users[0]["id"]]
+    for _ in range(40):
+        a, b = rng.sample(peer_pool, 2)
+        _add_conn(a, b, status="accepted")
+
+    # ── posts: 30 in reverse-chronological time ─────────────────────
+    post_idx = 0
+    for i in range(30):
+        post_idx += 1
+        author = rng.choice(users)
+        tag = rng.choice(_HASHTAGS)
+        body = rng.choice(_POST_TEMPLATES).format(tag=tag)
+        # Extract hashtags (no leading #) from the body so seeded posts
+        # exercise the same extraction code path as user-authored posts.
+        from .util import extract_hashtags
+        tags = extract_hashtags(body)
+        # back-dated by i hours
+        created_at = f"2026-06-08T0{(8 - (i % 8)):d}:00:00Z"
+        conn.execute(
+            "INSERT INTO posts (id, author_id, body, hashtags, visibility, "
+            "created_at) VALUES (?,?,?,?,?,?)",
+            (_hid("post", post_idx, 5), author["id"], body,
+             db.pack_json(tags), "public", created_at),
+        )
+
+    # ── comments + reactions on the first 15 posts ──────────────────
+    com_idx = 0
+    for i in range(1, 16):
+        post_id = _hid("post", i, 5)
+        for _ in range(rng.randint(1, 4)):
+            com_idx += 1
+            author = rng.choice(users[1:])
+            conn.execute(
+                "INSERT INTO comments (id, post_id, author_id, body, "
+                "created_at) VALUES (?,?,?,?,?)",
+                (_hid("com", com_idx, 6), post_id, author["id"],
+                 rng.choice([
+                     "Great post — sharing with my team.",
+                     "This resonates. Thanks for writing it up.",
+                     "Curious about your tooling for the migration.",
+                     "Following along.",
+                 ]), fake_now),
+            )
+        for _ in range(rng.randint(2, 6)):
+            reactor = rng.choice(users[1:])
+            try:
+                conn.execute(
+                    "INSERT INTO reactions (post_id, user_id, kind, created_at) "
+                    "VALUES (?,?,?,?)",
+                    (post_id, reactor["id"],
+                     rng.choice(["like", "celebrate", "support", "insightful"]),
+                     fake_now),
+                )
+            except sqlite3.IntegrityError:
+                pass
+
+    # ── threads + messages: 8 threads anchored on demo ──────────────
+    for t in range(1, 9):
+        peer = users[t]
+        tid = _hid("thread", t, 5)
+        participants = db.pack_json(sorted([users[0]["id"], peer["id"]]))
+        conn.execute(
+            "INSERT INTO threads (id, participants, last_message_at, "
+            "created_at) VALUES (?,?,?,?)",
+            (tid, participants, fake_now, fake_now),
+        )
+        n_msgs = rng.randint(3, 8)
+        for m in range(1, n_msgs + 1):
+            sender = users[0] if m % 2 == 0 else peer
+            mid = f"msg_{t:03d}_{m:03d}"
+            conn.execute(
+                "INSERT INTO messages (id, thread_id, sender_id, body, "
+                "created_at, read_at) VALUES (?,?,?,?,?,?)",
+                (mid, tid, sender["id"],
+                 rng.choice([
+                     "Hey — good to connect!",
+                     "Thanks again for jumping on the call yesterday.",
+                     "Sharing the doc I mentioned: see attached.",
+                     "When does your team start the next planning cycle?",
+                     "Quick question on the rollout plan.",
+                 ]), fake_now, fake_now),
+            )
+
+    # ── jobs ────────────────────────────────────────────────────────
+    for i, (title, company) in enumerate(_JOB_TITLES, start=1):
+        loc = rng.choice(_LOCATIONS)
+        desc = _JOB_DESCRIPTION_TEMPLATE.format(
+            title=title, company=company,
+            team=rng.choice([
+                "platform", "growth", "infrastructure", "data",
+                "experimentation", "developer-experience",
+            ]),
+            location=loc,
+        )
+        conn.execute(
+            "INSERT INTO jobs (id, title, company, location, description_md, "
+            "easy_apply, promoted, applicants, posted_at) VALUES "
+            "(?,?,?,?,?,?,?,?,?)",
+            (_hid("job", i, 5), title, company, loc, desc,
+             1 if i % 5 != 0 else 0,  # most are easy_apply, ~20% external
+             1 if i % 7 == 0 else 0,
+             rng.randint(8, 230),
+             fake_now),
+        )
+
+    conn.commit()
+
+
+def find_demo_user(conn: sqlite3.Connection) -> dict[str, Any]:
+    row = conn.execute(
+        "SELECT id, handle, name FROM users WHERE id = 'user_00001'"
+    ).fetchone()
+    if not row:
+        raise RuntimeError("seed did not insert user_00001")
+    return dict(row)

--- a/deploy/sim_envs/mantis_linkedin/app/static/brand.svg
+++ b/deploy/sim_envs/mantis_linkedin/app/static/brand.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32"
+     role="img" aria-label="mantis-linkedin mirror brand mark">
+  <rect width="32" height="32" rx="4" fill="#0a66c2"/>
+  <text x="16" y="22" text-anchor="middle" font-family="-apple-system,Segoe UI,Roboto,sans-serif"
+        font-weight="700" font-size="16" fill="#ffffff">in</text>
+</svg>

--- a/deploy/sim_envs/mantis_linkedin/app/static/site.css
+++ b/deploy/sim_envs/mantis_linkedin/app/static/site.css
@@ -1,0 +1,718 @@
+/* mantis-linkedin — hand-rolled CSS, grouped by component.
+ *
+ * Brand: #0a66c2 (primary), hover #004182, surface #fff, page #f3f2ef.
+ * Type: -apple-system stack, 14px/1.43 body.
+ */
+
+/* ────────────────────── reset & base ────────────────────── */
+*, *::before, *::after { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; }
+html { -webkit-text-size-adjust: 100%; }
+body {
+  font-family: -apple-system, system-ui, "Segoe UI", Roboto,
+    "Helvetica Neue", Arial, sans-serif;
+  font-size: 14px;
+  line-height: 1.42857;
+  color: rgba(0, 0, 0, 0.9);
+  background: #f3f2ef;
+  -webkit-font-smoothing: antialiased;
+}
+a { color: #0a66c2; text-decoration: none; font-weight: 600; }
+a:hover { text-decoration: underline; }
+button { font-family: inherit; cursor: pointer; }
+button:disabled { cursor: not-allowed; opacity: 0.6; }
+h1, h2, h3, h4 { margin: 0; font-weight: 600; }
+h1 { font-size: 24px; }
+h2 { font-size: 20px; }
+h3 { font-size: 16px; }
+.muted { color: rgba(0, 0, 0, 0.6); }
+.text-num { color: #0a66c2; font-weight: 600; }
+pre.md-body {
+  margin: 0; padding: 0; font-family: inherit; white-space: pre-wrap;
+  font-size: 14px; line-height: 1.5;
+}
+
+/* ────────────────────── shared primitives ────────────────────── */
+.card {
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 0 0 1px rgba(0,0,0,0.08), 0 2px 3px rgba(0,0,0,0.08);
+  padding: 16px;
+  margin-bottom: 8px;
+}
+
+.btn-primary, .btn-secondary {
+  display: inline-flex; align-items: center; justify-content: center;
+  gap: 6px;
+  border-radius: 9999px;
+  padding: 6px 16px;
+  font-weight: 600;
+  font-size: 14px;
+  text-decoration: none;
+  transition: background 0.12s ease;
+}
+.btn-primary { background: #0a66c2; color: #fff; border: 1px solid #0a66c2; }
+.btn-primary:hover { background: #004182; border-color: #004182; text-decoration: none; }
+.btn-primary:disabled { background: rgba(0,0,0,0.08); color: rgba(0,0,0,0.4); border-color: transparent; }
+
+.btn-secondary {
+  background: transparent; color: #0a66c2; border: 1px solid #0a66c2;
+}
+.btn-secondary:hover { background: rgba(112,181,249,0.2); text-decoration: none; }
+.btn-secondary:disabled { color: rgba(0,0,0,0.4); border-color: rgba(0,0,0,0.2); }
+
+.btn-pill { padding: 4px 12px; font-size: 13px; }
+.btn-small { padding: 4px 12px; font-size: 13px; }
+.link-button {
+  background: transparent; border: 0; color: #0a66c2; font-weight: 600;
+  font-size: 14px;
+}
+.link-button:hover { text-decoration: underline; }
+.ico-link {
+  background: transparent; border: 0; color: rgba(0,0,0,0.6);
+  font-size: 14px; padding: 4px 8px;
+}
+.ico-link:hover { color: rgba(0,0,0,0.9); }
+
+.avatar {
+  display: inline-flex; align-items: center; justify-content: center;
+  border-radius: 50%; color: #fff; font-weight: 600;
+}
+.avatar-sm { width: 24px; height: 24px; font-size: 12px; }
+.avatar-md { width: 48px; height: 48px; font-size: 18px; }
+.avatar-lg { width: 72px; height: 72px; font-size: 28px; }
+
+.tag {
+  display: inline-block; font-size: 12px; padding: 2px 8px; border-radius: 4px;
+  margin-right: 4px;
+}
+.tag-easy { background: #d0e8ff; color: #004182; }
+.tag-promoted { background: #f4e0c1; color: #6a4807; }
+
+.field { display: block; margin-bottom: 12px; }
+.field-label { display: block; font-size: 13px; color: rgba(0,0,0,0.6);
+  margin-bottom: 4px; }
+.field input, .field select {
+  width: 100%; padding: 8px 12px; border-radius: 4px;
+  border: 1px solid rgba(0,0,0,0.6); font-size: 14px; background: #fff;
+}
+.field input:focus, .field select:focus {
+  outline: 2px solid #0a66c2; outline-offset: -1px; border-color: transparent;
+}
+.radio-row { display: block; padding: 8px 0; font-size: 14px; }
+.radio-row input { margin-right: 8px; }
+
+.page { padding-top: 64px; max-width: 1128px; margin: 0 auto;
+  padding-left: 12px; padding-right: 12px; padding-bottom: 24px; }
+
+/* ────────────────────── topnav ────────────────────── */
+.topnav {
+  position: fixed; top: 0; left: 0; right: 0; height: 52px;
+  background: #fff; border-bottom: 1px solid #e0dfdc; z-index: 100;
+}
+.topnav-inner {
+  display: flex; align-items: center; gap: 8px;
+  max-width: 1128px; margin: 0 auto; padding: 0 12px; height: 52px;
+}
+.brand-mark {
+  display: inline-flex; align-items: center; gap: 4px; color: inherit;
+}
+.brand-mark:hover { text-decoration: none; }
+.brand-square {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 32px; height: 32px; background: #0a66c2; color: #fff;
+  border-radius: 4px; font-weight: 700; font-size: 16px;
+  font-style: normal;
+}
+.brand-mark--standalone { margin: 24px auto 16px; display: flex;
+  justify-content: center; }
+
+.topnav-search {
+  flex: 0 0 280px; position: relative;
+}
+.topnav-search::before {
+  content: "⌕"; position: absolute; left: 12px; top: 6px;
+  color: rgba(0,0,0,0.6); font-size: 16px;
+}
+.topnav-search input {
+  width: 100%; height: 34px; padding: 0 8px 0 36px; border: 0;
+  border-radius: 4px; background: #edf3f8; font-size: 14px;
+}
+.topnav-search input:focus { outline: 2px solid #0a66c2; outline-offset: -2px; background: #fff; }
+
+.topnav-icons { display: flex; align-items: center; gap: 4px; margin-left: auto; }
+.ico {
+  display: inline-flex; flex-direction: column; align-items: center;
+  padding: 6px 12px; color: rgba(0,0,0,0.6); font-size: 12px;
+  border-bottom: 2px solid transparent; min-width: 60px;
+}
+.ico:hover { color: rgba(0,0,0,0.9); text-decoration: none; }
+.ico.active { color: rgba(0,0,0,0.9); border-bottom-color: rgba(0,0,0,0.9); }
+.ico-glyph { font-size: 20px; line-height: 1; }
+.ico-label { font-size: 12px; margin-top: 2px; }
+.me-chip { flex-direction: row; gap: 4px; }
+
+/* ────────────────────── home (anonymous splash) ────────────────────── */
+.home-topnav .topnav-icons { gap: 12px; }
+.home-hero {
+  display: grid; grid-template-columns: 1fr 380px; gap: 48px;
+  padding: 48px 0; align-items: center;
+}
+.home-copy h1 {
+  font-size: 56px; line-height: 1.1; color: #b24020; font-weight: 200;
+  margin-bottom: 12px;
+}
+.home-sub { font-size: 18px; color: rgba(0,0,0,0.9); margin-bottom: 24px; }
+.home-cta { margin-right: 12px; }
+.home-tile {
+  width: 380px; height: 320px;
+  background: radial-gradient(circle at top left, #cae3ff 0%, #f3f2ef 60%);
+  border-radius: 8px; position: relative; overflow: hidden;
+}
+.home-blob {
+  position: absolute; width: 240px; height: 240px;
+  background: #0a66c2; border-radius: 50%; bottom: -40px; right: -40px;
+  opacity: 0.85;
+}
+
+/* ────────────────────── auth ────────────────────── */
+.auth-shell { max-width: 400px; margin: 16px auto 32px; padding-top: 64px;
+  padding-bottom: 64px; }
+.auth-card { padding: 24px; }
+.auth-card h1 { margin-bottom: 4px; }
+.auth-sub { color: rgba(0,0,0,0.6); margin-bottom: 16px; }
+.auth-error {
+  border: 1px solid #cc1016; background: #ffeaea; color: #6f0510;
+  padding: 8px 12px; border-radius: 4px; margin-bottom: 12px;
+}
+.auth-forgot { font-size: 14px; }
+.auth-submit { width: 100%; padding: 12px; margin-top: 12px; font-size: 16px; }
+.auth-divider {
+  display: flex; align-items: center; gap: 8px; margin: 16px 0; color: rgba(0,0,0,0.6);
+}
+.auth-divider::before, .auth-divider::after {
+  content: ""; flex: 1; height: 1px; background: rgba(0,0,0,0.2);
+}
+.auth-footer { text-align: center; margin: 0; font-size: 14px; }
+.auth-hint { font-size: 12px; color: rgba(0,0,0,0.55);
+  text-align: center; margin-top: 8px; }
+.auth-hint code { background: #fff; padding: 1px 4px; border-radius: 3px; }
+
+/* ────────────────────── feed grid ────────────────────── */
+.feed-grid {
+  display: grid; grid-template-columns: 225px 555px 300px;
+  gap: 24px; margin-top: 8px;
+}
+.feed-rail-left, .feed-rail-right { display: flex; flex-direction: column; }
+.feed-col { display: flex; flex-direction: column; }
+
+/* profile mini card on left rail */
+.profile-card { position: relative; padding: 0 16px 12px; overflow: hidden; }
+.profile-banner { height: 56px; margin: 0 -16px 32px; }
+.profile-avatar {
+  position: absolute; top: 24px; left: 50%; transform: translateX(-50%);
+  border: 2px solid #fff;
+}
+.profile-name {
+  display: block; text-align: center; font-size: 16px; font-weight: 600;
+  color: rgba(0,0,0,0.9); margin-top: 0; margin-bottom: 4px;
+}
+.profile-headline { text-align: center; font-size: 12px; color: rgba(0,0,0,0.6); }
+.profile-card-divider {
+  height: 1px; background: rgba(0,0,0,0.08); margin: 12px -16px;
+}
+.profile-card-row {
+  display: flex; justify-content: space-between; padding: 4px 0;
+  font-size: 12px; color: rgba(0,0,0,0.6);
+}
+.profile-card-row:hover { background: rgba(0,0,0,0.04); text-decoration: none; }
+.profile-card-caption { font-size: 12px; color: rgba(0,0,0,0.9); margin-top: 4px;
+  font-weight: 600; }
+
+.mini-card .mini-card-row {
+  display: flex; align-items: center; gap: 6px; padding: 4px 0;
+  color: rgba(0,0,0,0.9);
+}
+.mini-card-icon { font-size: 16px; color: #c37d16; }
+.mini-card-links { display: flex; flex-direction: column; gap: 6px;
+  font-size: 13px; }
+.mini-card-links .link-plus { color: #cc1016; font-weight: 700; }
+
+/* start a post card */
+.start-post-card { padding: 12px 16px; }
+.start-post-row { display: flex; align-items: center; gap: 8px; }
+.start-post-button {
+  flex: 1; text-align: left; padding: 10px 16px;
+  border: 1px solid rgba(0,0,0,0.6); background: transparent; border-radius: 9999px;
+  color: rgba(0,0,0,0.6); font-weight: 600;
+}
+.start-post-button:hover { background: rgba(0,0,0,0.06); }
+.start-post-actions { display: flex; justify-content: space-around; margin-top: 8px; }
+.start-post-action {
+  background: transparent; border: 0; color: rgba(0,0,0,0.6);
+  font-weight: 600; font-size: 14px; padding: 6px 10px; border-radius: 4px;
+}
+.start-post-action:hover { background: rgba(0,0,0,0.06); }
+
+.feed-divider {
+  display: flex; align-items: center; justify-content: space-between;
+  margin: 4px 0; color: rgba(0,0,0,0.6); font-size: 12px;
+}
+.feed-divider-line {
+  flex: 1; height: 1px; background: rgba(0,0,0,0.12); margin-right: 8px;
+}
+
+/* post card */
+.post-card { padding: 12px 16px; }
+.post-author-row { display: flex; align-items: flex-start; gap: 8px; }
+.post-author-meta { flex: 1; }
+.post-author-name { color: rgba(0,0,0,0.9); font-weight: 600; font-size: 14px; }
+.post-author-headline { color: rgba(0,0,0,0.6); font-size: 12px; }
+.post-author-time { color: rgba(0,0,0,0.6); font-size: 12px; }
+.post-more {
+  background: transparent; border: 0; color: rgba(0,0,0,0.6);
+  font-size: 20px; padding: 4px;
+}
+.post-body { margin: 8px 0 12px; font-size: 14px; color: rgba(0,0,0,0.9);
+  white-space: pre-wrap; }
+.post-counters {
+  display: flex; align-items: center; gap: 4px;
+  color: rgba(0,0,0,0.6); font-size: 12px; padding-bottom: 8px;
+  border-bottom: 1px solid rgba(0,0,0,0.08);
+}
+.reaction-blob { font-size: 12px; }
+.post-count-sep { color: rgba(0,0,0,0.4); }
+.post-actions {
+  display: grid; grid-template-columns: repeat(4, 1fr);
+  padding-top: 4px;
+}
+.post-action {
+  background: transparent; border: 0; padding: 8px 4px; border-radius: 4px;
+  color: rgba(0,0,0,0.6); font-weight: 600; font-size: 13px;
+}
+.post-action:hover { background: rgba(0,0,0,0.06); color: rgba(0,0,0,0.9); }
+
+.comment-form {
+  display: flex; gap: 8px; margin-top: 8px; padding-top: 8px;
+  border-top: 1px solid rgba(0,0,0,0.08);
+}
+.comment-form input {
+  flex: 1; padding: 8px 12px; border: 1px solid rgba(0,0,0,0.3);
+  border-radius: 9999px; font-size: 14px;
+}
+
+/* right rail */
+.right-card-header {
+  display: flex; align-items: center; justify-content: space-between;
+  margin-bottom: 8px;
+}
+.right-card-header h2 { font-size: 16px; }
+.suggested-row {
+  display: flex; align-items: flex-start; gap: 8px; padding: 8px 0;
+  border-bottom: 1px solid rgba(0,0,0,0.06);
+}
+.suggested-row:last-of-type { border-bottom: 0; }
+.suggested-meta { flex: 1; }
+.suggested-name { color: rgba(0,0,0,0.9); font-size: 14px; font-weight: 600; }
+.suggested-headline { font-size: 12px; color: rgba(0,0,0,0.6);
+  margin: 2px 0 6px; }
+.right-card-footer { display: block; text-align: center; margin-top: 8px;
+  font-size: 12px; color: rgba(0,0,0,0.6); }
+.news-list { list-style: none; margin: 0; padding: 0; }
+.news-item { padding: 6px 0; border-bottom: 1px solid rgba(0,0,0,0.04); }
+.news-item:last-child { border-bottom: 0; }
+.news-title { font-size: 14px; font-weight: 600; color: rgba(0,0,0,0.9); }
+.news-caption { font-size: 12px; color: rgba(0,0,0,0.6); }
+
+/* ────────────────────── modal ────────────────────── */
+.modal {
+  border: 0; padding: 0; max-width: 552px; width: 92vw;
+  background: transparent;
+}
+.modal::backdrop { background: rgba(0,0,0,0.6); }
+.modal-card {
+  background: #fff; border-radius: 8px; padding: 16px; margin: 0;
+  display: flex; flex-direction: column; gap: 12px;
+  box-shadow: 0 8px 24px rgba(0,0,0,0.16);
+}
+.modal-header {
+  display: flex; align-items: center; gap: 8px;
+}
+.modal-header h3 { flex: 1; font-size: 16px; }
+.modal-author-name { font-weight: 600; }
+.modal-author-headline { font-size: 12px; color: rgba(0,0,0,0.6); }
+.modal-close {
+  background: transparent; border: 0; font-size: 24px; color: rgba(0,0,0,0.6);
+  padding: 4px 8px;
+}
+.modal-close:hover { color: rgba(0,0,0,0.9); }
+.modal-sub { font-size: 14px; color: rgba(0,0,0,0.6); margin: 0; }
+.modal-footer {
+  display: flex; align-items: center; justify-content: flex-end;
+  gap: 8px; padding-top: 8px; border-top: 1px solid rgba(0,0,0,0.08);
+}
+.modal-toolbar { display: flex; gap: 12px; margin-right: auto; }
+.modal-tool {
+  background: transparent; border: 0; font-size: 18px; padding: 4px;
+}
+.modal textarea {
+  width: 100%; border: 0; resize: vertical; font-family: inherit;
+  font-size: 16px; padding: 8px; line-height: 1.4;
+}
+.modal textarea:focus { outline: 0; }
+.connect-modal textarea {
+  border: 1px solid rgba(0,0,0,0.3); border-radius: 4px; min-height: 120px;
+}
+
+/* easy apply modal */
+.easy-apply-card { max-height: 80vh; overflow-y: auto; }
+.ea-progress { display: flex; gap: 8px; justify-content: center; padding: 4px 0; }
+.ea-dot {
+  width: 8px; height: 8px; background: rgba(0,0,0,0.16); border-radius: 50%;
+}
+.ea-dot-active { background: #0a66c2; }
+.ea-step { border: 0; padding: 0; margin: 0; }
+.ea-review dt { font-weight: 600; margin-top: 8px; }
+.ea-review dd { margin: 0 0 4px 0; color: rgba(0,0,0,0.7); }
+
+/* ────────────────────── profile page ────────────────────── */
+.profile-grid { display: grid; grid-template-columns: 1fr;
+  max-width: 760px; margin: 0 auto; gap: 8px; }
+.hero-card { padding: 0; overflow: hidden; }
+.hero-banner { height: 200px; }
+.hero-body { padding: 0 24px 24px; position: relative; }
+.hero-avatar {
+  width: 160px; height: 160px; font-size: 56px; border: 4px solid #fff;
+  margin-top: -80px; margin-bottom: 12px;
+}
+.hero-name { margin: 8px 0 4px; }
+.hero-headline { font-size: 16px; color: rgba(0,0,0,0.9); margin-bottom: 6px; }
+.hero-meta { font-size: 14px; color: rgba(0,0,0,0.6); display: flex; gap: 6px;
+  align-items: center; flex-wrap: wrap; }
+.hero-meta-sep { color: rgba(0,0,0,0.4); }
+.hero-contact { font-size: 14px; }
+.hero-conn-link { margin: 6px 0 12px; }
+.hero-actions { display: flex; gap: 8px; flex-wrap: wrap; }
+
+.section-card { padding: 16px 24px; }
+.section-header {
+  display: flex; align-items: center; justify-content: space-between;
+  margin-bottom: 12px;
+}
+.section-caption { font-size: 12px; color: rgba(0,0,0,0.6); }
+.section-action { font-size: 14px; }
+.about-body { white-space: pre-wrap; margin: 0; }
+
+.role-list, .skills-list, .activity-list { list-style: none; margin: 0; padding: 0; }
+.role-row {
+  display: flex; gap: 12px; padding: 12px 0;
+  border-bottom: 1px solid rgba(0,0,0,0.06);
+}
+.role-row:last-child { border-bottom: 0; }
+.role-logo {
+  width: 48px; height: 48px; background: rgba(0,0,0,0.06); color: rgba(0,0,0,0.7);
+  border-radius: 4px; display: flex; align-items: center; justify-content: center;
+  font-weight: 600; flex-shrink: 0;
+}
+.role-title { font-size: 14px; font-weight: 600; color: rgba(0,0,0,0.9); }
+.role-company, .role-dates, .role-location { font-size: 12px;
+  color: rgba(0,0,0,0.6); margin-top: 2px; }
+.role-desc { font-size: 14px; margin-top: 6px; color: rgba(0,0,0,0.9); }
+
+.skill-row {
+  display: flex; justify-content: space-between; padding: 8px 0;
+  border-bottom: 1px solid rgba(0,0,0,0.06); font-size: 14px;
+}
+.skill-row:last-child { border-bottom: 0; }
+.skill-endorse { color: rgba(0,0,0,0.6); font-size: 12px; }
+
+.activity-row {
+  padding: 10px 0;
+  border-bottom: 1px solid rgba(0,0,0,0.06);
+}
+.activity-row:last-child { border-bottom: 0; }
+.activity-body { font-size: 14px; color: rgba(0,0,0,0.9);
+  white-space: pre-wrap; }
+.activity-meta { font-size: 12px; color: rgba(0,0,0,0.6); margin-top: 4px; }
+
+/* ────────────────────── mynetwork ────────────────────── */
+.network-grid { display: grid; grid-template-columns: 225px 1fr; gap: 24px; }
+.rail-title { font-size: 14px; font-weight: 600; margin-bottom: 8px; }
+.rail-list { list-style: none; margin: 0; padding: 0; }
+.rail-list a {
+  display: flex; align-items: center; gap: 8px; padding: 6px 0;
+  color: rgba(0,0,0,0.9); font-weight: 400; font-size: 14px;
+}
+.rail-list a:hover { color: #0a66c2; }
+.invitations-card { padding-bottom: 0; }
+.invitation-list { list-style: none; margin: 0; padding: 0; }
+.invitation-row {
+  display: grid; grid-template-columns: 56px 1fr auto; gap: 12px;
+  align-items: center; padding: 12px 0;
+  border-bottom: 1px solid rgba(0,0,0,0.06);
+}
+.invitation-row:last-child { border-bottom: 0; }
+.invitation-name { color: rgba(0,0,0,0.9); font-weight: 600; }
+.invitation-headline { font-size: 12px; color: rgba(0,0,0,0.6); }
+.invitation-note { font-size: 13px; color: rgba(0,0,0,0.75);
+  margin-top: 4px; font-style: italic; }
+.invitation-actions { display: flex; gap: 8px; }
+
+.pymk-card { padding-bottom: 8px; }
+.pymk-grid {
+  display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 8px;
+}
+.pymk-card-mini {
+  background: #fff; border: 1px solid #e0dfdc; border-radius: 8px;
+  overflow: hidden; padding-bottom: 12px; text-align: center;
+  position: relative;
+}
+.pymk-card-mini:hover { border-color: rgba(0,0,0,0.32); }
+.pymk-banner { height: 54px; }
+.pymk-avatar { margin: -36px auto 8px; border: 2px solid #fff;
+  display: flex; }
+.pymk-name { display: block; font-weight: 600; padding: 0 8px;
+  color: rgba(0,0,0,0.9); font-size: 14px; }
+.pymk-headline { font-size: 12px; color: rgba(0,0,0,0.6);
+  padding: 0 8px; margin: 4px 0 8px; min-height: 28px; }
+
+/* ────────────────────── invitation manager ────────────────────── */
+.invman-shell { max-width: 720px; margin: 0 auto; }
+.invman-tabs { display: flex; gap: 16px; border-bottom: 1px solid rgba(0,0,0,0.08);
+  padding-bottom: 8px; margin-bottom: 8px; }
+.tab {
+  padding: 8px 4px; color: rgba(0,0,0,0.6); font-weight: 600;
+  border-bottom: 2px solid transparent;
+}
+.tab:hover { color: rgba(0,0,0,0.9); text-decoration: none; }
+.tab-active { color: rgba(0,0,0,0.9); border-bottom-color: #0a66c2; }
+.invman-meta {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 8px 0 12px; color: rgba(0,0,0,0.6); font-size: 14px;
+}
+.invman-sort {
+  border: 0; background: transparent; color: rgba(0,0,0,0.9);
+  font-weight: 600; font-size: 14px;
+}
+
+/* ────────────────────── messaging ────────────────────── */
+.messaging-shell { max-width: 1056px; margin: 0 auto; }
+.messaging-card {
+  display: grid; grid-template-columns: 320px 1fr; padding: 0;
+  min-height: 720px;
+}
+.msg-list { border-right: 1px solid rgba(0,0,0,0.08);
+  display: flex; flex-direction: column; }
+.msg-list-header {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 12px 16px; border-bottom: 1px solid rgba(0,0,0,0.08);
+}
+.msg-list-tools { display: flex; gap: 8px; }
+.msg-search { padding: 8px 16px; }
+.msg-search input {
+  width: 100%; padding: 8px 12px; border-radius: 4px; border: 0;
+  background: #edf3f8; font-size: 14px;
+}
+.msg-tabs { display: flex; gap: 8px; padding: 0 16px;
+  border-bottom: 1px solid rgba(0,0,0,0.08); }
+.msg-tab { padding: 8px 12px; color: rgba(0,0,0,0.6);
+  border-bottom: 2px solid transparent; font-weight: 600; }
+.msg-tab-active { color: #0a66c2; border-bottom-color: #0a66c2; }
+
+.msg-thread-list { list-style: none; margin: 0; padding: 0;
+  overflow-y: auto; flex: 1; }
+.msg-thread-row { border-bottom: 1px solid rgba(0,0,0,0.06); }
+.msg-thread-row:last-child { border-bottom: 0; }
+.msg-thread-active { background: #eef3f8; }
+.msg-thread-link {
+  display: grid; grid-template-columns: 48px 1fr auto; gap: 8px;
+  padding: 12px 16px; color: rgba(0,0,0,0.9); align-items: center;
+}
+.msg-thread-link:hover { background: rgba(0,0,0,0.03); text-decoration: none; }
+.msg-thread-name { font-weight: 600; font-size: 14px; }
+.msg-thread-snippet { font-size: 13px; color: rgba(0,0,0,0.6);
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  max-width: 200px; }
+.msg-thread-time { font-size: 12px; color: rgba(0,0,0,0.6); }
+
+.msg-pane { display: flex; flex-direction: column; height: 720px; }
+.msg-pane-header {
+  display: flex; align-items: center; gap: 8px;
+  padding: 12px 16px; border-bottom: 1px solid rgba(0,0,0,0.08);
+}
+.msg-pane-name { font-weight: 600; }
+.msg-pane-headline { font-size: 12px; color: rgba(0,0,0,0.6); }
+.msg-pane-more {
+  margin-left: auto; background: transparent; border: 0; font-size: 20px;
+  color: rgba(0,0,0,0.6);
+}
+.msg-bubbles {
+  list-style: none; margin: 0; padding: 16px; flex: 1;
+  display: flex; flex-direction: column; gap: 8px; overflow-y: auto;
+}
+.msg-bubble {
+  max-width: 60%; padding: 10px 12px; border-radius: 12px;
+  font-size: 14px;
+}
+.msg-bubble-peer { align-self: flex-start; background: #e5e5e5;
+  color: rgba(0,0,0,0.9); border-top-left-radius: 4px; }
+.msg-bubble-self { align-self: flex-end; background: #0a66c2;
+  color: #fff; border-top-right-radius: 4px; }
+.msg-bubble-time { font-size: 11px; opacity: 0.7; margin-top: 4px; }
+
+.msg-composer {
+  border-top: 1px solid rgba(0,0,0,0.08);
+  padding: 8px 12px;
+}
+.msg-composer textarea {
+  width: 100%; padding: 8px; border: 0; resize: none;
+  font-family: inherit; font-size: 14px;
+}
+.msg-composer textarea:focus { outline: 0; }
+.msg-composer-actions {
+  display: flex; align-items: center; justify-content: space-between;
+  padding-top: 4px;
+}
+.msg-composer-tools { display: flex; gap: 8px; }
+.msg-tool { background: transparent; border: 0; font-size: 18px;
+  color: rgba(0,0,0,0.6); }
+.msg-empty {
+  display: flex; align-items: center; justify-content: center;
+  flex: 1; color: rgba(0,0,0,0.6);
+}
+
+/* ────────────────────── jobs ────────────────────── */
+.jobs-grid { display: grid; grid-template-columns: 225px 1fr; gap: 24px; }
+.jobs-main { display: flex; flex-direction: column; gap: 8px; }
+.jobs-search-card { padding: 16px; }
+.jobs-search-form {
+  display: grid; grid-template-columns: 2fr 1.2fr auto; gap: 8px;
+}
+.jobs-search-form input {
+  height: 36px; padding: 0 12px; border-radius: 4px;
+  border: 1px solid rgba(0,0,0,0.32); background: #fff; font-size: 14px;
+}
+.jobs-search-form input:focus { outline: 2px solid #0a66c2; outline-offset: -1px;
+  border-color: transparent; }
+
+.jobs-carousel {
+  display: grid; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 8px;
+}
+.job-mini-card {
+  display: block; border: 1px solid #e0dfdc; padding: 12px;
+  border-radius: 8px; color: rgba(0,0,0,0.9);
+}
+.job-mini-card:hover { background: rgba(0,0,0,0.03); text-decoration: none; }
+.job-mini-logo {
+  width: 48px; height: 48px; background: rgba(0,0,0,0.06); border-radius: 4px;
+  display: flex; align-items: center; justify-content: center;
+  font-weight: 600; color: rgba(0,0,0,0.7); margin-bottom: 8px;
+}
+.job-mini-title { color: #0a66c2; font-weight: 600; }
+.job-mini-company, .job-mini-location { font-size: 12px;
+  color: rgba(0,0,0,0.6); }
+
+.job-row-list { list-style: none; margin: 0; padding: 0; }
+.job-row {
+  display: grid; grid-template-columns: 48px 1fr; gap: 12px;
+  padding: 12px 0; border-bottom: 1px solid rgba(0,0,0,0.06);
+}
+.job-row:last-child { border-bottom: 0; }
+.job-row-logo {
+  width: 48px; height: 48px; background: rgba(0,0,0,0.06);
+  display: flex; align-items: center; justify-content: center;
+  border-radius: 4px; color: rgba(0,0,0,0.7); font-weight: 600;
+}
+.job-row-title { color: #0a66c2; font-weight: 600; font-size: 16px; }
+.job-row-company, .job-row-location, .job-row-caption {
+  font-size: 12px; color: rgba(0,0,0,0.6);
+}
+
+/* jobs search */
+.jobs-search-shell { max-width: 1128px; margin: 0 auto; }
+.jobs-search-filterbar {
+  display: flex; gap: 8px; padding: 8px 12px; flex-wrap: wrap;
+  position: sticky; top: 60px; z-index: 2;
+}
+.filter-chip {
+  border: 1px solid rgba(0,0,0,0.6); background: transparent;
+  border-radius: 9999px; padding: 4px 14px; font-size: 13px;
+  color: rgba(0,0,0,0.9);
+}
+.filter-chip-on { background: rgba(112,181,249,0.2); color: #004182;
+  border-color: #0a66c2; }
+.jobs-search-grid {
+  display: grid; grid-template-columns: 420px 1fr; gap: 8px;
+  margin-top: 8px;
+}
+.jobs-results { padding: 0; max-height: calc(100vh - 120px); overflow-y: auto; }
+.results-title { font-size: 16px; }
+.results-sort {
+  background: transparent; border: 0; color: rgba(0,0,0,0.9); font-weight: 600;
+}
+.job-result-list { list-style: none; margin: 0; padding: 0; }
+.job-result-row { border-bottom: 1px solid rgba(0,0,0,0.06); }
+.job-result-row:last-child { border-bottom: 0; }
+.job-result-active { background: #f3f2ef;
+  border-left: 4px solid #0a66c2; }
+.job-result-link {
+  display: grid; grid-template-columns: 56px 1fr; gap: 12px;
+  padding: 12px 16px; color: rgba(0,0,0,0.9); align-items: flex-start;
+}
+.job-result-link:hover { background: rgba(0,0,0,0.03); text-decoration: none; }
+.job-result-title { color: #0a66c2; font-weight: 600; font-size: 16px; }
+.job-result-company, .job-result-location, .job-result-caption {
+  font-size: 12px; color: rgba(0,0,0,0.6); margin-top: 2px;
+}
+
+.jobs-detail { padding: 0; }
+.job-detail-header {
+  display: grid; grid-template-columns: 80px 1fr; gap: 16px;
+  padding: 16px;
+}
+.job-row-logo-big { width: 64px; height: 64px; font-size: 22px; }
+.job-detail-title { font-size: 24px; }
+.job-detail-company { font-size: 14px; }
+.job-detail-location, .job-detail-caption {
+  font-size: 12px; color: rgba(0,0,0,0.6); margin-top: 2px;
+}
+.job-detail-actions { margin-top: 12px; display: flex; gap: 8px; flex-wrap: wrap; }
+.job-detail-tabs {
+  display: flex; gap: 16px; padding: 0 16px;
+  border-bottom: 1px solid rgba(0,0,0,0.08);
+}
+.job-detail-body { padding: 16px; }
+
+/* job view */
+.job-view-grid {
+  display: grid; grid-template-columns: 720px 300px;
+  gap: 8px; max-width: 1128px; margin: 0 auto;
+}
+.job-view-main { display: flex; flex-direction: column; gap: 8px; }
+.job-view-rail { display: flex; flex-direction: column; gap: 8px; }
+.company-card { text-align: center; }
+.company-logo-big {
+  width: 96px; height: 96px; background: rgba(0,0,0,0.06);
+  display: flex; align-items: center; justify-content: center;
+  border-radius: 8px; font-size: 36px; color: rgba(0,0,0,0.7);
+  margin: 0 auto 12px;
+}
+.company-name { margin-bottom: 4px; }
+.company-tagline { color: rgba(0,0,0,0.7); font-size: 14px; }
+.company-followers { color: rgba(0,0,0,0.6); font-size: 12px; margin-bottom: 8px; }
+
+/* ────────────────────── responsive guard ────────────────────── */
+@media (max-width: 1240px) {
+  .feed-grid { grid-template-columns: 200px 540px 280px; gap: 16px; }
+}
+@media (max-width: 960px) {
+  .feed-grid { grid-template-columns: 1fr; }
+  .feed-rail-left, .feed-rail-right { display: none; }
+  .network-grid, .jobs-grid { grid-template-columns: 1fr; }
+  .jobs-search-grid { grid-template-columns: 1fr; }
+  .messaging-card { grid-template-columns: 1fr; }
+  .job-view-grid { grid-template-columns: 1fr; }
+  .home-hero { grid-template-columns: 1fr; }
+}

--- a/deploy/sim_envs/mantis_linkedin/app/templates/base.html
+++ b/deploy/sim_envs/mantis_linkedin/app/templates/base.html
@@ -1,0 +1,68 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>{% block title %}LinkedIn (mantis mirror){% endblock %}</title>
+  <link rel="stylesheet" href="/static/site.css" />
+</head>
+<body>
+{% block topnav %}
+<header class="topnav" data-testid="topnav">
+  <div class="topnav-inner">
+    <a href="/feed/" class="brand-mark" data-testid="brand">
+      <span class="brand-square">in</span>
+    </a>
+    <form class="topnav-search" action="/jobs/search/" method="get">
+      <input type="text" name="keywords"
+             value="{{ request.query_params.get('keywords') or '' }}"
+             placeholder="Search" data-testid="topnav-search"/>
+    </form>
+    <nav class="topnav-icons" data-testid="topnav-icons">
+      <a class="ico {% if request.url.path.startswith('/feed') %}active{% endif %}"
+         href="/feed/" data-testid="nav-home">
+        <span class="ico-glyph">⌂</span><span class="ico-label">Home</span>
+      </a>
+      <a class="ico {% if request.url.path.startswith('/mynetwork') %}active{% endif %}"
+         href="/mynetwork/" data-testid="nav-network">
+        <span class="ico-glyph">◉</span><span class="ico-label">My Network</span>
+      </a>
+      <a class="ico {% if request.url.path.startswith('/jobs') %}active{% endif %}"
+         href="/jobs/" data-testid="nav-jobs">
+        <span class="ico-glyph">▤</span><span class="ico-label">Jobs</span>
+      </a>
+      <a class="ico {% if request.url.path.startswith('/messaging') %}active{% endif %}"
+         href="/messaging/" data-testid="nav-messaging">
+        <span class="ico-glyph">✉</span><span class="ico-label">Messaging</span>
+      </a>
+      <a class="ico" href="#" data-testid="nav-notifications">
+        <span class="ico-glyph">🔔</span><span class="ico-label">Notifications</span>
+      </a>
+      {% set _u = request.state.current_user if request.state and request.state.current_user else None %}
+      {% if _u %}
+        <div class="ico me-chip" data-testid="nav-me">
+          <span class="avatar avatar-sm"
+                style="background:{{ _u.avatar_color or '#0a66c2' }}">
+            {{ _u.name[:1]|upper }}</span>
+          <span class="ico-label">Me ▾</span>
+        </div>
+        <form method="post" action="/logout" style="display:inline">
+          <button type="submit" class="ico-link" data-testid="nav-logout">Sign out</button>
+        </form>
+      {% else %}
+        <a class="ico" href="/login" data-testid="nav-login">
+          <span class="ico-glyph">→</span><span class="ico-label">Sign in</span>
+        </a>
+      {% endif %}
+    </nav>
+  </div>
+</header>
+{% endblock %}
+
+<main class="page" data-testid="page">
+  {% block content %}{% endblock %}
+</main>
+
+{% block scripts %}{% endblock %}
+</body>
+</html>

--- a/deploy/sim_envs/mantis_linkedin/app/templates/feed.html
+++ b/deploy/sim_envs/mantis_linkedin/app/templates/feed.html
@@ -1,0 +1,208 @@
+{% extends "base.html" %}
+{% block title %}Feed | LinkedIn (mantis mirror){% endblock %}
+{% block content %}
+<div class="feed-grid" data-testid="feed-grid">
+
+  {# Left rail #}
+  <aside class="feed-rail-left" data-testid="rail-left">
+    <section class="card profile-card" data-testid="profile-card">
+      <div class="profile-banner"
+           style="background:linear-gradient(135deg,{{ me.avatar_color }} 0%,#1d4477 100%);"></div>
+      <a class="avatar avatar-lg profile-avatar"
+         style="background:{{ me.avatar_color }}"
+         href="/in/{{ me.handle }}/" data-testid="profile-avatar">
+        {{ me.name[:1]|upper }}
+      </a>
+      <a class="profile-name" href="/in/{{ me.handle }}/">{{ me.name }}</a>
+      <div class="profile-headline">{{ me.headline }}</div>
+      <div class="profile-card-divider"></div>
+      <a class="profile-card-row" href="/mynetwork/">
+        <span>Connections</span>
+        <span class="text-num">{{ connection_count }}</span>
+      </a>
+      <div class="profile-card-caption">Grow your network</div>
+    </section>
+
+    <section class="card mini-card" data-testid="my-items-card">
+      <a class="mini-card-row" href="#">
+        <span class="mini-card-icon">🔖</span> My items
+      </a>
+    </section>
+
+    <section class="card mini-card mini-card-links" data-testid="rail-links">
+      <a href="#">Groups</a>
+      <a href="#">Events <span class="link-plus">+</span></a>
+      <a href="#">Followed Hashtags</a>
+      <a href="#">Discover more</a>
+    </section>
+  </aside>
+
+  {# Centre column #}
+  <section class="feed-col" data-testid="feed-col">
+
+    <section class="card start-post-card" data-testid="start-post-card">
+      <div class="start-post-row">
+        <span class="avatar avatar-md" style="background:{{ me.avatar_color }}">
+          {{ me.name[:1]|upper }}
+        </span>
+        <button class="start-post-button" data-testid="start-post-open"
+                onclick="document.getElementById('start-post-modal').showModal()">
+          Start a post
+        </button>
+      </div>
+      <div class="start-post-actions">
+        <button class="start-post-action" data-testid="action-photo">
+          <span class="ico-glyph" style="color:#378fe9">▤</span> Photo
+        </button>
+        <button class="start-post-action" data-testid="action-video">
+          <span class="ico-glyph" style="color:#5f9b41">▶</span> Video
+        </button>
+        <button class="start-post-action" data-testid="action-event">
+          <span class="ico-glyph" style="color:#c37d16">📅</span> Event
+        </button>
+        <button class="start-post-action" data-testid="action-article">
+          <span class="ico-glyph" style="color:#e06847">✎</span> Write article
+        </button>
+      </div>
+    </section>
+
+    <div class="feed-divider"><span class="feed-divider-line"></span>
+      <span class="feed-divider-text">Sort by: <strong>Top ▾</strong></span>
+    </div>
+
+    {% for post in posts %}
+      <article class="card post-card" data-testid="post-card"
+               data-post-id="{{ post.id }}">
+        <header class="post-author-row">
+          <a class="avatar avatar-md" style="background:{{ post.author.avatar_color }}"
+             href="/in/{{ post.author.handle }}/">
+            {{ post.author.name[:1]|upper }}
+          </a>
+          <div class="post-author-meta">
+            <a class="post-author-name" href="/in/{{ post.author.handle }}/">{{ post.author.name }}</a>
+            <div class="post-author-headline">{{ post.author.headline }}</div>
+            <div class="post-author-time">{{ post.created_at }} • 🌐</div>
+          </div>
+          <button class="post-more" aria-label="More" data-testid="post-more">⋯</button>
+        </header>
+
+        <p class="post-body" data-testid="post-body">{{ post.body_short }}</p>
+
+        <div class="post-counters" data-testid="post-counters">
+          <span class="reaction-blob">👍 ❤ 🎉</span>
+          <span class="post-count-label">{{ post.reactions }}</span>
+          <span class="post-count-sep">•</span>
+          <span class="post-count-comments">{{ post.comments }} comments</span>
+        </div>
+
+        <div class="post-actions" data-testid="post-actions">
+          <form method="post" action="/feed/posts/{{ post.id }}/react"
+                style="display:inline">
+            <input type="hidden" name="kind" value="like"/>
+            <button class="post-action" data-testid="action-like" type="submit">
+              <span class="ico-glyph">👍</span> Like
+            </button>
+          </form>
+          <button class="post-action" data-testid="action-comment"
+                  onclick="document.getElementById('comment-form-{{ post.id }}').style.display='block'">
+            <span class="ico-glyph">💬</span> Comment
+          </button>
+          <button class="post-action" data-testid="action-repost">
+            <span class="ico-glyph">↻</span> Repost
+          </button>
+          <button class="post-action" data-testid="action-send">
+            <span class="ico-glyph">➤</span> Send
+          </button>
+        </div>
+
+        <form id="comment-form-{{ post.id }}" method="post"
+              action="/feed/posts/{{ post.id }}/comment"
+              class="comment-form" style="display:none">
+          <input type="text" name="body" placeholder="Add a comment…"
+                 data-testid="comment-input"/>
+          <button class="btn-primary btn-small" type="submit">Post</button>
+        </form>
+      </article>
+    {% endfor %}
+  </section>
+
+  {# Right rail #}
+  <aside class="feed-rail-right" data-testid="rail-right">
+    <section class="card right-card" data-testid="add-to-feed-card">
+      <header class="right-card-header">
+        <h2>Add to your feed</h2>
+        <span class="ico-glyph muted">ⓘ</span>
+      </header>
+      {% for s in suggested %}
+        <div class="suggested-row" data-testid="suggested-row">
+          <a class="avatar avatar-md" style="background:{{ s.avatar_color }}"
+             href="/in/{{ s.handle }}/">{{ s.name[:1]|upper }}</a>
+          <div class="suggested-meta">
+            <a class="suggested-name" href="/in/{{ s.handle }}/">{{ s.name }}</a>
+            <div class="suggested-headline">{{ s.headline }}</div>
+            <button class="btn-secondary btn-pill" data-testid="follow-btn">
+              + Follow
+            </button>
+          </div>
+        </div>
+      {% endfor %}
+      <a class="right-card-footer" href="#">View all recommendations →</a>
+    </section>
+
+    <section class="card right-card" data-testid="news-card">
+      <header class="right-card-header">
+        <h2>LinkedIn News</h2>
+        <span class="ico-glyph muted">ⓘ</span>
+      </header>
+      <ul class="news-list">
+        {% for item in news_items %}
+          <li class="news-item">
+            <div class="news-title">{{ item[0] }}</div>
+            <div class="news-caption">{{ item[1] }}</div>
+          </li>
+        {% endfor %}
+      </ul>
+    </section>
+  </aside>
+
+</div>
+
+{# Start-a-post modal #}
+<dialog id="start-post-modal" class="modal" data-testid="start-post-modal">
+  <form method="post" action="/feed/post" class="modal-card">
+    <header class="modal-header">
+      <span class="avatar avatar-md" style="background:{{ me.avatar_color }}">
+        {{ me.name[:1]|upper }}</span>
+      <div>
+        <div class="modal-author-name">{{ me.name }}</div>
+        <div class="modal-author-headline">Post to Anyone ▾</div>
+      </div>
+      <button type="button" class="modal-close"
+              onclick="document.getElementById('start-post-modal').close()">×</button>
+    </header>
+    <textarea name="body" placeholder="What do you want to talk about?"
+              rows="6" required data-testid="post-textarea"></textarea>
+    <footer class="modal-footer">
+      <div class="modal-toolbar">
+        <button type="button" class="modal-tool">📷</button>
+        <button type="button" class="modal-tool">▶</button>
+        <button type="button" class="modal-tool">📅</button>
+        <button type="button" class="modal-tool">📝</button>
+      </div>
+      <button class="btn-primary" type="submit" data-testid="post-submit">Post</button>
+    </footer>
+  </form>
+</dialog>
+{% endblock %}
+{% block scripts %}
+<script>
+  // Toggle textarea-driven Post button enable/disable
+  (function() {
+    var t = document.querySelector('[data-testid="post-textarea"]');
+    var btn = document.querySelector('[data-testid="post-submit"]');
+    if (!t || !btn) return;
+    function sync() { btn.disabled = !t.value.trim(); }
+    t.addEventListener('input', sync); sync();
+  })();
+</script>
+{% endblock %}

--- a/deploy/sim_envs/mantis_linkedin/app/templates/home.html
+++ b/deploy/sim_envs/mantis_linkedin/app/templates/home.html
@@ -1,0 +1,27 @@
+{% extends "base.html" %}
+{% block title %}LinkedIn (mantis mirror) — Sign in{% endblock %}
+{% block topnav %}
+<header class="topnav home-topnav">
+  <div class="topnav-inner">
+    <a href="/" class="brand-mark"><span class="brand-square">in</span> Linked<em>in</em></a>
+    <nav class="topnav-icons">
+      <a class="ico" href="/jobs/">Jobs</a>
+      <a class="ico" href="/signup">Join now</a>
+      <a class="btn-secondary" href="/login" data-testid="cta-signin">Sign in</a>
+    </nav>
+  </div>
+</header>
+{% endblock %}
+{% block content %}
+<section class="home-hero">
+  <div class="home-copy">
+    <h1>Welcome to your professional community</h1>
+    <p class="home-sub">Search jobs, share updates, and stay connected.</p>
+    <a class="btn-primary home-cta" href="/feed/" data-testid="cta-feed">Go to feed</a>
+    <a class="btn-secondary home-cta" href="/login">Sign in with email</a>
+  </div>
+  <div class="home-tile" aria-hidden="true">
+    <div class="home-blob"></div>
+  </div>
+</section>
+{% endblock %}

--- a/deploy/sim_envs/mantis_linkedin/app/templates/invitation_manager.html
+++ b/deploy/sim_envs/mantis_linkedin/app/templates/invitation_manager.html
@@ -1,0 +1,61 @@
+{% extends "base.html" %}
+{% block title %}Invitation manager | LinkedIn (mantis mirror){% endblock %}
+{% block content %}
+<div class="invman-shell" data-testid="invman-shell">
+  <section class="card">
+    <header class="invman-tabs">
+      <a class="tab {% if tab == 'received' %}tab-active{% endif %}"
+         href="/mynetwork/invitation-manager/?tab=received"
+         data-testid="tab-received">Received</a>
+      <a class="tab {% if tab == 'sent' %}tab-active{% endif %}"
+         href="/mynetwork/invitation-manager/?tab=sent"
+         data-testid="tab-sent">Sent</a>
+      <a class="tab" href="#" data-testid="tab-idk">I don't know</a>
+    </header>
+    <div class="invman-meta">
+      <span>{{ items|length }} pending {% if tab == 'sent' %}requests{% else %}invitations{% endif %}</span>
+      <select class="invman-sort" data-testid="invman-sort">
+        <option>Newest</option><option>Oldest</option>
+      </select>
+    </div>
+    <ul class="invitation-list">
+      {% for inv in items %}
+        <li class="invitation-row" data-testid="invitation-row"
+            data-invitation-id="{{ inv.id }}">
+          <a class="avatar avatar-md"
+             style="background:{{ inv.user.avatar_color }}"
+             href="/in/{{ inv.user.handle }}/">{{ inv.user.name[:1]|upper }}</a>
+          <div class="invitation-meta">
+            <a class="invitation-name" href="/in/{{ inv.user.handle }}/">{{ inv.user.name }}</a>
+            <div class="invitation-headline">{{ inv.user.headline }}</div>
+            {% if inv.note %}
+              <div class="invitation-note">“{{ inv.note }}”</div>
+            {% endif %}
+          </div>
+          <div class="invitation-actions">
+            {% if tab == 'sent' %}
+              <form method="post" action="/mynetwork/invitations/{{ inv.id }}/withdraw">
+                <button class="btn-secondary" type="submit"
+                        data-testid="action-withdraw">Withdraw</button>
+              </form>
+            {% else %}
+              <form method="post" action="/mynetwork/invitations/{{ inv.id }}/ignore"
+                    style="display:inline">
+                <button class="btn-secondary" type="submit"
+                        data-testid="action-ignore">Ignore</button>
+              </form>
+              <form method="post" action="/mynetwork/invitations/{{ inv.id }}/accept"
+                    style="display:inline">
+                <button class="btn-primary" type="submit"
+                        data-testid="action-accept">Accept</button>
+              </form>
+            {% endif %}
+          </div>
+        </li>
+      {% else %}
+        <p class="muted">Nothing here yet.</p>
+      {% endfor %}
+    </ul>
+  </section>
+</div>
+{% endblock %}

--- a/deploy/sim_envs/mantis_linkedin/app/templates/job_view.html
+++ b/deploy/sim_envs/mantis_linkedin/app/templates/job_view.html
@@ -1,0 +1,173 @@
+{% extends "base.html" %}
+{% block title %}{{ job.title }} | {{ job.company }} | LinkedIn (mantis mirror){% endblock %}
+{% block content %}
+<div class="job-view-grid" data-testid="job-view-grid">
+  <section class="job-view-main">
+    <section class="card" data-testid="job-view-header">
+      <header class="job-detail-header">
+        <span class="job-row-logo job-row-logo-big">{{ job.company[:1]|upper }}</span>
+        <div class="job-detail-meta">
+          <h1 class="job-detail-title">{{ job.title }}</h1>
+          <a class="job-detail-company" href="#">{{ job.company }}</a>
+          <div class="job-detail-location">{{ job.location }}</div>
+          <div class="job-detail-caption">{{ job.applicants }} applicants • posted {{ job.posted_at }}</div>
+          <div class="job-detail-actions">
+            {% if applied %}
+              <button class="btn-secondary" disabled data-testid="apply-applied">Applied ✓</button>
+            {% elif job.easy_apply %}
+              <button class="btn-primary" data-testid="easy-apply-open"
+                      onclick="openEasyApply()">Easy Apply</button>
+            {% else %}
+              <a class="btn-secondary" href="#" data-testid="external-apply">Apply</a>
+            {% endif %}
+            <button class="btn-secondary" data-testid="save-btn">Save</button>
+            <a class="link-button" href="#">Share</a>
+          </div>
+        </div>
+      </header>
+    </section>
+
+    <section class="card" data-testid="job-about">
+      <header class="section-header"><h2>About the job</h2></header>
+      <pre class="md-body">{{ job.description_md }}</pre>
+    </section>
+
+    <section class="card" data-testid="job-match">
+      <header class="section-header"><h2>How your profile matches</h2></header>
+      <p class="muted">Skills, experience and education matching this role appear here.</p>
+    </section>
+  </section>
+
+  <aside class="job-view-rail">
+    <section class="card company-card" data-testid="company-card">
+      <div class="company-logo-big">{{ job.company[:1]|upper }}</div>
+      <h2 class="company-name">{{ job.company }}</h2>
+      <div class="company-tagline">Engineering team is hiring</div>
+      <div class="company-followers">12,840 followers</div>
+      <button class="btn-secondary btn-pill" data-testid="follow-company">+ Follow</button>
+    </section>
+  </aside>
+</div>
+
+{% if not applied and job.easy_apply %}
+<dialog id="easy-apply-modal" class="modal" data-testid="easy-apply-modal">
+  <form method="post" action="/jobs/{{ job.id }}/apply" id="easy-apply-form"
+        class="modal-card easy-apply-card">
+    <header class="modal-header">
+      <h3 id="ea-step-title">Contact info</h3>
+      <button type="button" class="modal-close"
+              onclick="document.getElementById('easy-apply-modal').close()">×</button>
+    </header>
+    <div class="ea-progress">
+      <span class="ea-dot ea-dot-active" data-step="1"></span>
+      <span class="ea-dot" data-step="2"></span>
+      <span class="ea-dot" data-step="3"></span>
+      <span class="ea-dot" data-step="4"></span>
+    </div>
+
+    {# Step 1: contact #}
+    <fieldset class="ea-step" data-step="1">
+      <label class="field"><span class="field-label">Email</span>
+        <input type="email" value="demo@mantis.example" readonly/></label>
+      <label class="field"><span class="field-label">Phone country code</span>
+        <select><option>United States (+1)</option></select></label>
+      <label class="field"><span class="field-label">Mobile phone number*</span>
+        <input type="tel" name="phone" required data-testid="ea-phone"/></label>
+    </fieldset>
+
+    {# Step 2: resume #}
+    <fieldset class="ea-step" data-step="2" hidden>
+      <label class="radio-row">
+        <input type="radio" name="resume_label" value="Use my profile" checked/>
+        Use my profile
+      </label>
+      <label class="radio-row">
+        <input type="radio" name="resume_label" value="Upload resume"/>
+        Upload resume
+      </label>
+    </fieldset>
+
+    {# Step 3: screening #}
+    <fieldset class="ea-step" data-step="3" hidden>
+      <label class="field"><span class="field-label">How many years of experience do you have?</span>
+        <input type="text" id="ea-q-years" value="5"/></label>
+      <label class="field"><span class="field-label">Are you authorised to work in the listed location?</span>
+        <select id="ea-q-auth">
+          <option>Yes</option><option>No</option>
+        </select>
+      </label>
+    </fieldset>
+
+    {# Step 4: review #}
+    <fieldset class="ea-step" data-step="4" hidden data-testid="ea-review">
+      <p>Review your information and submit.</p>
+      <dl class="ea-review">
+        <dt>Phone</dt><dd id="ea-review-phone"></dd>
+        <dt>Resume</dt><dd id="ea-review-resume"></dd>
+        <dt>Years</dt><dd id="ea-review-years"></dd>
+      </dl>
+      <input type="hidden" name="answers" id="ea-answers" value="{}"/>
+    </fieldset>
+
+    <footer class="modal-footer">
+      <button type="button" class="btn-secondary" id="ea-back" hidden>Back</button>
+      <button type="button" class="btn-primary" id="ea-next"
+              data-testid="ea-next">Next</button>
+      <button type="submit" class="btn-primary" id="ea-submit" hidden
+              data-testid="ea-submit">Submit application</button>
+    </footer>
+  </form>
+</dialog>
+
+<script>
+  function openEasyApply() {
+    var d = document.getElementById('easy-apply-modal');
+    if (d && typeof d.showModal === 'function') d.showModal();
+  }
+  (function(){
+    var step = 1;
+    var titles = {1:"Contact info", 2:"Resume", 3:"Screening questions", 4:"Review"};
+    var form = document.getElementById('easy-apply-form');
+    if (!form) return;
+    var nextBtn = document.getElementById('ea-next');
+    var backBtn = document.getElementById('ea-back');
+    var submitBtn = document.getElementById('ea-submit');
+    function render(){
+      form.querySelectorAll('.ea-step').forEach(function(f){
+        f.hidden = (parseInt(f.getAttribute('data-step'),10) !== step);
+      });
+      form.querySelectorAll('.ea-dot').forEach(function(d){
+        var idx = parseInt(d.getAttribute('data-step'),10);
+        d.classList.toggle('ea-dot-active', idx <= step);
+      });
+      document.getElementById('ea-step-title').textContent = titles[step];
+      backBtn.hidden = (step === 1);
+      nextBtn.hidden = (step === 4);
+      submitBtn.hidden = (step !== 4);
+      if (step === 4) {
+        document.getElementById('ea-review-phone').textContent =
+          form.querySelector('[name=phone]').value || '(missing)';
+        document.getElementById('ea-review-resume').textContent =
+          (form.querySelector('[name=resume_label]:checked') || {}).value || '';
+        var years = document.getElementById('ea-q-years').value || '';
+        var auth = document.getElementById('ea-q-auth').value || '';
+        document.getElementById('ea-review-years').textContent = years;
+        document.getElementById('ea-answers').value =
+          JSON.stringify({years_experience: years, work_authorized: auth});
+      }
+    }
+    nextBtn.addEventListener('click', function(){
+      if (step === 1) {
+        var p = form.querySelector('[name=phone]');
+        if (!p.value.trim()) { p.focus(); return; }
+      }
+      if (step < 4) { step += 1; render(); }
+    });
+    backBtn.addEventListener('click', function(){
+      if (step > 1) { step -= 1; render(); }
+    });
+    render();
+  })();
+</script>
+{% endif %}
+{% endblock %}

--- a/deploy/sim_envs/mantis_linkedin/app/templates/jobs.html
+++ b/deploy/sim_envs/mantis_linkedin/app/templates/jobs.html
@@ -1,0 +1,72 @@
+{% extends "base.html" %}
+{% block title %}Jobs | LinkedIn (mantis mirror){% endblock %}
+{% block content %}
+<div class="jobs-grid" data-testid="jobs-grid">
+  <aside class="jobs-rail">
+    <section class="card">
+      <h2 class="rail-title">Job collections</h2>
+      <ul class="rail-list">
+        <li><a href="#"><span class="ico-glyph">📋</span> My jobs</a></li>
+        <li><a href="#"><span class="ico-glyph">⚙</span> Preferences</a></li>
+        <li><a href="#"><span class="ico-glyph">＋</span> Post a free job</a></li>
+        <li><a href="#"><span class="ico-glyph">★</span> Interview prep</a></li>
+        <li><a href="#"><span class="ico-glyph">＄</span> Salary explorer</a></li>
+        <li><a href="#"><span class="ico-glyph">★</span> Job seeker guidance</a></li>
+      </ul>
+    </section>
+  </aside>
+
+  <section class="jobs-main">
+    <section class="card jobs-search-card" data-testid="jobs-search-card">
+      <form action="/jobs/search/" method="get" class="jobs-search-form">
+        <input class="jobs-search-keywords" type="text" name="keywords"
+               placeholder="Search by title, skill or company"
+               data-testid="jobs-search-keywords"/>
+        <input class="jobs-search-location" type="text" name="location"
+               placeholder="City, state or zip"
+               data-testid="jobs-search-location"/>
+        <button class="btn-primary" type="submit"
+                data-testid="jobs-search-submit">Search</button>
+      </form>
+    </section>
+
+    <section class="card jobs-card" data-testid="top-picks-card">
+      <header class="section-header"><h2>Top job picks for you</h2></header>
+      <p class="section-caption">Based on your profile and search history</p>
+      <div class="jobs-carousel">
+        {% for j in top_picks %}
+          <a class="job-mini-card" href="/jobs/view/{{ j.id }}/" data-testid="job-mini-card">
+            <div class="job-mini-logo">{{ j.company[:1]|upper }}</div>
+            <div class="job-mini-title">{{ j.title }}</div>
+            <div class="job-mini-company">{{ j.company }}</div>
+            <div class="job-mini-location">{{ j.location }}</div>
+            {% if j.easy_apply %}
+              <span class="tag tag-easy">Easy Apply</span>
+            {% endif %}
+            {% if j.promoted %}
+              <span class="tag tag-promoted">Promoted</span>
+            {% endif %}
+          </a>
+        {% endfor %}
+      </div>
+    </section>
+
+    <section class="card jobs-card" data-testid="recommended-card">
+      <header class="section-header"><h2>Recommended for you</h2></header>
+      <ul class="job-row-list">
+        {% for j in recommended %}
+          <li class="job-row" data-testid="job-row">
+            <span class="job-row-logo">{{ j.company[:1]|upper }}</span>
+            <div class="job-row-meta">
+              <a class="job-row-title" href="/jobs/view/{{ j.id }}/">{{ j.title }}</a>
+              <div class="job-row-company">{{ j.company }}</div>
+              <div class="job-row-location">{{ j.location }}</div>
+              <div class="job-row-caption">{{ j.applicants }} applicants</div>
+            </div>
+          </li>
+        {% endfor %}
+      </ul>
+    </section>
+  </section>
+</div>
+{% endblock %}

--- a/deploy/sim_envs/mantis_linkedin/app/templates/jobs_search.html
+++ b/deploy/sim_envs/mantis_linkedin/app/templates/jobs_search.html
@@ -1,0 +1,87 @@
+{% extends "base.html" %}
+{% block title %}Jobs search | LinkedIn (mantis mirror){% endblock %}
+{% block content %}
+<div class="jobs-search-shell" data-testid="jobs-search-shell">
+  <div class="jobs-search-filterbar card" data-testid="jobs-filterbar">
+    <button class="filter-chip">Date posted ▾</button>
+    <button class="filter-chip">Experience level ▾</button>
+    <button class="filter-chip">Company ▾</button>
+    <button class="filter-chip">Job type ▾</button>
+    <button class="filter-chip">Remote ▾</button>
+    <form method="get" action="/jobs/search/" style="display:contents">
+      <input type="hidden" name="keywords" value="{{ keywords }}"/>
+      <input type="hidden" name="location" value="{{ location }}"/>
+      <button class="filter-chip {% if easy_apply %}filter-chip-on{% endif %}"
+              name="easy_apply" value="{{ 0 if easy_apply else 1 }}"
+              type="submit">Easy Apply</button>
+    </form>
+    <button class="filter-chip">All filters</button>
+  </div>
+
+  <div class="jobs-search-grid">
+    <aside class="jobs-results card" data-testid="jobs-results">
+      <header class="section-header" style="padding:12px 16px;">
+        <h2 class="results-title">{{ results|length }} results{% if keywords %} for “{{ keywords }}”{% endif %}</h2>
+        <select class="results-sort" data-testid="results-sort">
+          <option>Most relevant</option><option>Most recent</option>
+        </select>
+      </header>
+      <ul class="job-result-list">
+        {% for j in results %}
+          <li class="job-result-row {% if selected and j.id == selected.id %}job-result-active{% endif %}"
+              data-testid="job-result-row" data-job-id="{{ j.id }}">
+            <a href="/jobs/search/?keywords={{ keywords }}&location={{ location }}&easy_apply={{ easy_apply }}&id={{ j.id }}"
+               class="job-result-link">
+              <span class="job-row-logo">{{ j.company[:1]|upper }}</span>
+              <div class="job-result-meta">
+                <div class="job-result-title">{{ j.title }}</div>
+                <div class="job-result-company">{{ j.company }}</div>
+                <div class="job-result-location">{{ j.location }}</div>
+                <div class="job-result-caption">
+                  {% if j.easy_apply %}
+                    <span class="tag tag-easy">Easy Apply</span>
+                  {% endif %}
+                  {{ j.applicants }} applicants
+                </div>
+              </div>
+            </a>
+          </li>
+        {% else %}
+          <li class="muted" style="padding:16px;">No results.</li>
+        {% endfor %}
+      </ul>
+    </aside>
+
+    {% if selected %}
+      <section class="jobs-detail card" data-testid="jobs-detail">
+        <header class="job-detail-header">
+          <span class="job-row-logo job-row-logo-big">{{ selected.company[:1]|upper }}</span>
+          <div class="job-detail-meta">
+            <h1 class="job-detail-title">{{ selected.title }}</h1>
+            <a class="job-detail-company" href="#">{{ selected.company }}</a>
+            <div class="job-detail-location">{{ selected.location }}</div>
+            <div class="job-detail-caption">{{ selected.applicants }} applicants • posted {{ selected.posted_at }}</div>
+            <div class="job-detail-actions">
+              {% if selected.easy_apply %}
+                <a class="btn-primary" href="/jobs/view/{{ selected.id }}/"
+                   data-testid="apply-btn">Easy Apply</a>
+              {% else %}
+                <a class="btn-secondary" href="/jobs/view/{{ selected.id }}/">Apply</a>
+              {% endif %}
+              <button class="btn-secondary" data-testid="save-btn">Save</button>
+            </div>
+          </div>
+        </header>
+        <div class="job-detail-tabs">
+          <a class="tab tab-active">About the job</a>
+          <a class="tab">Hiring team</a>
+          <a class="tab">Related jobs</a>
+        </div>
+        <article class="job-detail-body">
+          <pre class="md-body">{{ selected.description_md }}</pre>
+        </article>
+      </section>
+    {% endif %}
+  </div>
+</div>
+{% endblock %}

--- a/deploy/sim_envs/mantis_linkedin/app/templates/login.html
+++ b/deploy/sim_envs/mantis_linkedin/app/templates/login.html
@@ -1,0 +1,41 @@
+{% extends "base.html" %}
+{% block title %}Sign in | LinkedIn (mantis mirror){% endblock %}
+{% block topnav %}{% endblock %}
+{% block content %}
+<div class="auth-shell">
+  <a class="brand-mark brand-mark--standalone" href="/" data-testid="brand">
+    <span class="brand-square">in</span>
+  </a>
+  <section class="card auth-card" data-testid="login-card">
+    <h1>Sign in</h1>
+    <p class="auth-sub">Stay updated on your professional world</p>
+    {% if error %}
+      <div class="auth-error" data-testid="login-error">{{ error }}</div>
+    {% endif %}
+    <form method="post" action="/login" data-testid="login-form">
+      <label class="field">
+        <span class="field-label">Email</span>
+        <input type="email" name="email" required autocomplete="username"
+               data-testid="login-email"/>
+      </label>
+      <label class="field">
+        <span class="field-label">Password</span>
+        <input type="password" name="password" required
+               autocomplete="current-password" data-testid="login-password"/>
+      </label>
+      <input type="hidden" name="next" value="{{ next_path }}"/>
+      <a class="auth-forgot" href="#" tabindex="-1">Forgot password?</a>
+      <button class="btn-primary auth-submit" type="submit"
+              data-testid="login-submit">Sign in</button>
+    </form>
+    <div class="auth-divider"><span>or</span></div>
+    <p class="auth-footer">
+      New to LinkedIn? <a href="/signup">Join now</a>
+    </p>
+  </section>
+  <p class="auth-hint">
+    Demo creds: <code>demo@mantis.example</code> /
+    <code>mantis-demo</code>
+  </p>
+</div>
+{% endblock %}

--- a/deploy/sim_envs/mantis_linkedin/app/templates/messaging.html
+++ b/deploy/sim_envs/mantis_linkedin/app/templates/messaging.html
@@ -1,0 +1,96 @@
+{% extends "base.html" %}
+{% block title %}Messaging | LinkedIn (mantis mirror){% endblock %}
+{% block content %}
+<div class="messaging-shell" data-testid="messaging-shell">
+  <section class="card messaging-card">
+    <aside class="msg-list" data-testid="msg-list">
+      <header class="msg-list-header">
+        <h2>Messaging</h2>
+        <div class="msg-list-tools">
+          <button class="ico-link" data-testid="msg-filter">▾</button>
+          <button class="ico-link" data-testid="msg-compose">✎</button>
+        </div>
+      </header>
+      <div class="msg-search">
+        <input type="text" placeholder="Search messages" data-testid="msg-search-input"/>
+      </div>
+      <div class="msg-tabs">
+        <a class="msg-tab msg-tab-active" data-testid="msg-tab-focused">Focused</a>
+        <a class="msg-tab" data-testid="msg-tab-other">Other</a>
+      </div>
+      <ul class="msg-thread-list">
+        {% for t in threads %}
+          <li class="msg-thread-row {% if active and t.id == active.id %}msg-thread-active{% endif %}"
+              data-testid="msg-thread-row" data-thread-id="{{ t.id }}">
+            <a href="/messaging/?thread={{ t.id }}" class="msg-thread-link">
+              <span class="avatar avatar-md"
+                    style="background:{{ t.peer.avatar_color if t.peer else '#888' }}">
+                {{ (t.peer.name[:1]|upper) if t.peer else '?' }}
+              </span>
+              <div class="msg-thread-meta">
+                <div class="msg-thread-name">{{ t.peer.name if t.peer else 'Unknown' }}</div>
+                <div class="msg-thread-snippet">{{ t.snippet }}</div>
+              </div>
+              <div class="msg-thread-time">{{ t.last_at }}</div>
+            </a>
+          </li>
+        {% endfor %}
+      </ul>
+    </aside>
+
+    <section class="msg-pane" data-testid="msg-pane">
+      {% if active %}
+        <header class="msg-pane-header">
+          <span class="avatar avatar-sm"
+                style="background:{{ active.peer.avatar_color }}">
+            {{ active.peer.name[:1]|upper }}
+          </span>
+          <div>
+            <div class="msg-pane-name">{{ active.peer.name }}</div>
+            <div class="msg-pane-headline">{{ active.peer.headline }}</div>
+          </div>
+          <button class="msg-pane-more" data-testid="msg-pane-more">⋯</button>
+        </header>
+        <ul class="msg-bubbles" data-testid="msg-bubbles">
+          {% for m in messages %}
+            <li class="msg-bubble {% if m.sender_id == me_id %}msg-bubble-self{% else %}msg-bubble-peer{% endif %}"
+                data-testid="msg-bubble">
+              <div class="msg-bubble-body">{{ m.body }}</div>
+              <div class="msg-bubble-time">{{ m.created_at }}</div>
+            </li>
+          {% endfor %}
+        </ul>
+        <form class="msg-composer" method="post"
+              action="/messaging/{{ active.id }}/send" data-testid="msg-composer">
+          <textarea name="body" placeholder="Write a message…" rows="2"
+                    data-testid="msg-composer-input"></textarea>
+          <div class="msg-composer-actions">
+            <div class="msg-composer-tools">
+              <button type="button" class="msg-tool">📎</button>
+              <button type="button" class="msg-tool">😊</button>
+              <button type="button" class="msg-tool">🖼</button>
+            </div>
+            <button class="btn-primary" type="submit"
+                    data-testid="msg-send">Send</button>
+          </div>
+        </form>
+      {% else %}
+        <div class="msg-empty">
+          <p>No conversations yet.</p>
+        </div>
+      {% endif %}
+    </section>
+  </section>
+</div>
+{% endblock %}
+{% block scripts %}
+<script>
+  (function(){
+    var t = document.querySelector('[data-testid="msg-composer-input"]');
+    var btn = document.querySelector('[data-testid="msg-send"]');
+    if (!t || !btn) return;
+    function sync(){ btn.disabled = !t.value.trim(); }
+    t.addEventListener('input', sync); sync();
+  })();
+</script>
+{% endblock %}

--- a/deploy/sim_envs/mantis_linkedin/app/templates/mynetwork.html
+++ b/deploy/sim_envs/mantis_linkedin/app/templates/mynetwork.html
@@ -1,0 +1,86 @@
+{% extends "base.html" %}
+{% block title %}My Network | LinkedIn (mantis mirror){% endblock %}
+{% block content %}
+<div class="network-grid" data-testid="network-grid">
+  <aside class="network-rail">
+    <section class="card">
+      <h2 class="rail-title">Manage my network</h2>
+      <ul class="rail-list">
+        <li><a href="/mynetwork/"><span class="ico-glyph">◉</span> Connections <span class="text-num">{{ counts.connections }}</span></a></li>
+        <li><a href="#"><span class="ico-glyph">☎</span> Contacts</a></li>
+        <li><a href="#"><span class="ico-glyph">⇣</span> Following &amp; followers</a></li>
+        <li><a href="#"><span class="ico-glyph">⌘</span> Groups</a></li>
+        <li><a href="#"><span class="ico-glyph">📅</span> Events</a></li>
+        <li><a href="#"><span class="ico-glyph">📄</span> Pages</a></li>
+      </ul>
+    </section>
+  </aside>
+
+  <section class="network-main">
+
+    <section class="card invitations-card" data-testid="invitations-card">
+      <header class="section-header">
+        <h2>Invitations</h2>
+        <a class="section-action"
+           href="/mynetwork/invitation-manager/" data-testid="invitations-show-all">
+          Show all ({{ counts.received_pending }})
+        </a>
+      </header>
+      {% if received %}
+        <ul class="invitation-list">
+          {% for inv in received %}
+            <li class="invitation-row" data-testid="invitation-row"
+                data-invitation-id="{{ inv.id }}">
+              <a class="avatar avatar-md"
+                 style="background:{{ inv.user.avatar_color }}"
+                 href="/in/{{ inv.user.handle }}/">{{ inv.user.name[:1]|upper }}</a>
+              <div class="invitation-meta">
+                <a class="invitation-name" href="/in/{{ inv.user.handle }}/">{{ inv.user.name }}</a>
+                <div class="invitation-headline">{{ inv.user.headline }}</div>
+                {% if inv.note %}
+                  <div class="invitation-note">“{{ inv.note }}”</div>
+                {% endif %}
+              </div>
+              <div class="invitation-actions">
+                <form method="post" action="/mynetwork/invitations/{{ inv.id }}/ignore"
+                      style="display:inline">
+                  <button class="btn-secondary" type="submit">Ignore</button>
+                </form>
+                <form method="post" action="/mynetwork/invitations/{{ inv.id }}/accept"
+                      style="display:inline">
+                  <button class="btn-primary" type="submit">Accept</button>
+                </form>
+              </div>
+            </li>
+          {% endfor %}
+        </ul>
+      {% else %}
+        <p class="muted">No new invitations right now.</p>
+      {% endif %}
+    </section>
+
+    <section class="card pymk-card" data-testid="pymk-card">
+      <header class="section-header">
+        <h2>People you may know based on your profile</h2>
+      </header>
+      <div class="pymk-grid">
+        {% for s in suggested %}
+          <div class="pymk-card-mini" data-testid="pymk-row">
+            <div class="pymk-banner"
+                 style="background:linear-gradient(135deg,{{ s.avatar_color }} 0%,#1d4477 100%)"></div>
+            <a class="avatar avatar-lg pymk-avatar"
+               style="background:{{ s.avatar_color }}"
+               href="/in/{{ s.handle }}/">{{ s.name[:1]|upper }}</a>
+            <a class="pymk-name" href="/in/{{ s.handle }}/">{{ s.name }}</a>
+            <div class="pymk-headline">{{ s.headline }}</div>
+            <form method="post" action="/in/{{ s.handle }}/connect">
+              <input type="hidden" name="note" value=""/>
+              <button class="btn-secondary btn-pill" type="submit">Connect</button>
+            </form>
+          </div>
+        {% endfor %}
+      </div>
+    </section>
+  </section>
+</div>
+{% endblock %}

--- a/deploy/sim_envs/mantis_linkedin/app/templates/profile.html
+++ b/deploy/sim_envs/mantis_linkedin/app/templates/profile.html
@@ -1,0 +1,141 @@
+{% extends "base.html" %}
+{% block title %}{{ profile.name }} | LinkedIn (mantis mirror){% endblock %}
+{% block content %}
+<div class="profile-grid" data-testid="profile-grid">
+  <section class="profile-main">
+
+    <section class="card hero-card" data-testid="profile-hero">
+      <div class="hero-banner"
+           style="background:linear-gradient(135deg,{{ profile.avatar_color }} 0%,#1d4477 100%)"></div>
+      <div class="hero-body">
+        <div class="hero-avatar avatar"
+             style="background:{{ profile.avatar_color }}">
+          {{ profile.name[:1]|upper }}
+        </div>
+        <h1 class="hero-name" data-testid="profile-name">{{ profile.name }}</h1>
+        <div class="hero-headline" data-testid="profile-headline">{{ profile.headline }}</div>
+        <div class="hero-meta">
+          <span class="hero-location">{{ profile.location }}</span>
+          <span class="hero-meta-sep">•</span>
+          <a class="hero-contact" href="#">Contact info</a>
+        </div>
+        <div class="hero-conn-link">
+          <a href="/mynetwork/">{{ connection_count }} connections</a>
+        </div>
+        <div class="hero-actions">
+          {% if is_self %}
+            <button class="btn-primary" data-testid="action-open-to">Open to ▾</button>
+            <button class="btn-secondary" data-testid="action-add-section">Add profile section</button>
+            <button class="btn-secondary" data-testid="action-enhance">Enhance profile</button>
+            <button class="btn-secondary" data-testid="action-more">More</button>
+          {% else %}
+            {% if conn_state == 'accepted' %}
+              <button class="btn-secondary" disabled data-testid="action-connected">✓ Connected</button>
+            {% elif conn_state == 'pending' %}
+              <button class="btn-secondary" disabled data-testid="action-pending">Pending</button>
+            {% else %}
+              <button class="btn-primary" data-testid="action-connect"
+                      onclick="document.getElementById('connect-modal').showModal()">Connect</button>
+            {% endif %}
+            <a class="btn-secondary" href="/messaging/?to={{ profile.handle }}"
+               data-testid="action-message">Message</a>
+            <button class="btn-secondary" data-testid="action-more">More</button>
+          {% endif %}
+        </div>
+      </div>
+    </section>
+
+    <section class="card section-card" data-testid="about-section">
+      <header class="section-header"><h2>About</h2></header>
+      <p class="about-body">{{ profile.about }}</p>
+    </section>
+
+    <section class="card section-card" data-testid="experience-section">
+      <header class="section-header"><h2>Experience</h2></header>
+      <ul class="role-list">
+        {% for r in experience %}
+          <li class="role-row" data-testid="experience-row">
+            <span class="role-logo" aria-hidden="true">{{ r.company[:1]|upper }}</span>
+            <div class="role-meta">
+              <div class="role-title">{{ r.title }}</div>
+              <div class="role-company">{{ r.company }}</div>
+              <div class="role-dates">
+                {{ r.start_date[:7] }} — {{ r.end_date[:7] if r.end_date else 'Present' }}
+              </div>
+              <div class="role-location">{{ r.location }}</div>
+              <div class="role-desc">{{ r.description }}</div>
+            </div>
+          </li>
+        {% endfor %}
+      </ul>
+    </section>
+
+    <section class="card section-card" data-testid="education-section">
+      <header class="section-header"><h2>Education</h2></header>
+      <ul class="role-list">
+        {% for e in education %}
+          <li class="role-row" data-testid="education-row">
+            <span class="role-logo">{{ e.school[:1]|upper }}</span>
+            <div class="role-meta">
+              <div class="role-title">{{ e.school }}</div>
+              <div class="role-company">{{ e.degree }}, {{ e.field }}</div>
+              <div class="role-dates">{{ e.start_year }} — {{ e.end_year }}</div>
+            </div>
+          </li>
+        {% endfor %}
+      </ul>
+    </section>
+
+    <section class="card section-card" data-testid="skills-section">
+      <header class="section-header"><h2>Skills</h2></header>
+      <ul class="skills-list">
+        {% for s in skills %}
+          <li class="skill-row" data-testid="skill-row">
+            <span class="skill-name">{{ s.name }}</span>
+            <span class="skill-endorse">Endorsed by {{ s.endorsements }} connections</span>
+          </li>
+        {% endfor %}
+      </ul>
+    </section>
+
+    <section class="card section-card" data-testid="activity-section">
+      <header class="section-header">
+        <h2>Activity</h2>
+        <span class="section-caption">{{ activity|length }} recent posts</span>
+      </header>
+      {% if activity %}
+        <ul class="activity-list">
+          {% for a in activity %}
+            <li class="activity-row">
+              <div class="activity-body">{{ a.body[:240] }}</div>
+              <div class="activity-meta">{{ a.created_at }}</div>
+            </li>
+          {% endfor %}
+        </ul>
+      {% else %}
+        <p class="muted">No recent activity.</p>
+      {% endif %}
+    </section>
+  </section>
+</div>
+
+<dialog id="connect-modal" class="modal" data-testid="connect-modal">
+  <form method="post" action="/in/{{ profile.handle }}/connect" class="modal-card connect-modal">
+    <header class="modal-header">
+      <h3>Add a note to your invitation?</h3>
+      <button type="button" class="modal-close"
+              onclick="document.getElementById('connect-modal').close()">×</button>
+    </header>
+    <p class="modal-sub">
+      Including a personal note can help you connect with {{ profile.name.split()[0] }}.
+    </p>
+    <textarea name="note" rows="4" maxlength="300" placeholder="Add a note"
+              data-testid="connect-note"></textarea>
+    <footer class="modal-footer">
+      <button type="button" class="btn-secondary"
+              onclick="document.getElementById('connect-modal').close()">Cancel</button>
+      <button class="btn-primary" type="submit" data-testid="connect-send">Send</button>
+    </footer>
+  </form>
+</dialog>
+{% endblock %}

--- a/deploy/sim_envs/mantis_linkedin/app/templates/signup.html
+++ b/deploy/sim_envs/mantis_linkedin/app/templates/signup.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %}
+{% block title %}Join LinkedIn (mantis mirror){% endblock %}
+{% block topnav %}{% endblock %}
+{% block content %}
+<div class="auth-shell">
+  <a class="brand-mark brand-mark--standalone" href="/"><span class="brand-square">in</span></a>
+  <section class="card auth-card" data-testid="signup-card">
+    <h1>Make the most of your professional life</h1>
+    <p class="auth-sub">Signup mocked — sign in as the demo user instead.</p>
+    <a class="btn-primary auth-submit" href="/login">Go to sign in</a>
+  </section>
+</div>
+{% endblock %}

--- a/deploy/sim_envs/mantis_linkedin/app/util.py
+++ b/deploy/sim_envs/mantis_linkedin/app/util.py
@@ -1,0 +1,42 @@
+"""Small utility helpers shared across the app."""
+
+from __future__ import annotations
+
+import re
+from typing import Iterable
+
+_HASHTAG_RE = re.compile(r"#(\w{2,40})")
+
+
+def extract_hashtags(body: str) -> list[str]:
+    """Return the unique hashtags found in ``body``, lower-cased, no leading #."""
+    if not body:
+        return []
+    found: list[str] = []
+    seen: set[str] = set()
+    for m in _HASHTAG_RE.finditer(body):
+        tag = m.group(1).lower()
+        if tag in seen:
+            continue
+        seen.add(tag)
+        found.append(tag)
+    return found
+
+
+def truncate(text: str, *, max_chars: int = 320) -> str:
+    if len(text) <= max_chars:
+        return text
+    return text[: max_chars - 1].rstrip() + "…"
+
+
+def initials(name: str) -> str:
+    parts = [p for p in name.split() if p]
+    if not parts:
+        return "?"
+    if len(parts) == 1:
+        return parts[0][:1].upper()
+    return (parts[0][:1] + parts[-1][:1]).upper()
+
+
+def join_tokens(tokens: Iterable[str]) -> str:
+    return " ".join(t for t in tokens if t)

--- a/deploy/sim_envs/mantis_linkedin/requirements.txt
+++ b/deploy/sim_envs/mantis_linkedin/requirements.txt
@@ -1,0 +1,6 @@
+fastapi>=0.110
+uvicorn>=0.27
+jinja2>=3.1
+python-multipart>=0.0.9
+starlette>=0.27,<1.0
+itsdangerous>=2.1

--- a/deploy/sim_envs/mantis_linkedin/scripts/smoke.py
+++ b/deploy/sim_envs/mantis_linkedin/scripts/smoke.py
@@ -1,0 +1,258 @@
+"""Smoke tests for mantis-linkedin.
+
+Boots the app in-process via Starlette's TestClient, exercises every
+in-scope page (expecting 200), runs every oracle's happy-path through
+HTTP, then queries the oracle endpoint to confirm passed=true.
+
+Run with::
+
+    cd deploy/sim_envs/mantis_linkedin
+    ENV_ADMIN_TOKEN=test python scripts/smoke.py
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+# Ensure ``app.main`` is importable when run from the env's root.
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+os.environ.setdefault("ENV_ADMIN_TOKEN", "test")
+os.environ.setdefault("SEED", "42")
+os.environ.setdefault("FAKE_NOW", "2026-06-08T09:00:00Z")
+
+# Defer imports until env is set.
+from starlette.testclient import TestClient  # noqa: E402
+
+from app.main import app  # noqa: E402
+
+
+ADMIN_HEADERS = {"X-Env-Admin": os.environ["ENV_ADMIN_TOKEN"]}
+
+
+def _check(label: str, predicate, *, exit_on_fail: bool = False) -> bool:
+    ok = bool(predicate)
+    icon = "PASS" if ok else "FAIL"
+    print(f"  [{icon}] {label}")
+    if not ok and exit_on_fail:
+        sys.exit(1)
+    return ok
+
+
+def smoke_pages(client: TestClient) -> int:
+    failures = 0
+    print("== Page smoke ==")
+    pages = [
+        ("GET /", "/", 200),
+        ("GET /feed/", "/feed/", 200),
+        ("GET /in/demo-mantis/", "/in/demo-mantis/", 200),
+        ("GET /mynetwork/", "/mynetwork/", 200),
+        ("GET /mynetwork/invitation-manager/",
+         "/mynetwork/invitation-manager/", 200),
+        ("GET /messaging/", "/messaging/", 200),
+        ("GET /jobs/", "/jobs/", 200),
+        ("GET /jobs/search/?keywords=engineer",
+         "/jobs/search/?keywords=engineer", 200),
+        ("GET /jobs/view/job_00003/", "/jobs/view/job_00003/", 200),
+        ("GET /login", "/login", 200),
+        ("GET /__env__/health", "/__env__/health", 200),
+    ]
+    for label, url, expected in pages:
+        resp = client.get(url)
+        ok = _check(
+            f"{label} → {resp.status_code} (expected {expected})",
+            resp.status_code == expected,
+        )
+        if not ok:
+            failures += 1
+            continue
+        if url == "/__env__/health":
+            ok = _check(
+                "health returns ok=true",
+                resp.json().get("ok") is True,
+            )
+            if not ok:
+                failures += 1
+        else:
+            ok = _check(
+                f"{url} returns HTML",
+                "<html" in resp.text.lower(),
+            )
+            if not ok:
+                failures += 1
+    return failures
+
+
+def smoke_oracle_dispatch(client: TestClient) -> int:
+    failures = 0
+    print("== Oracle dispatch ==")
+    for task_id in ("t01", "t02", "t03", "t01_connect_with_user"):
+        resp = client.get(
+            f"/__env__/oracle?task_id={task_id}", headers=ADMIN_HEADERS,
+        )
+        if not _check(
+            f"oracle?task_id={task_id} → 200",
+            resp.status_code == 200,
+        ):
+            failures += 1
+            continue
+        body = resp.json()
+        if not _check(
+            f"oracle?task_id={task_id} returns required keys",
+            {"passed", "score", "reasons"}.issubset(body.keys()),
+        ):
+            failures += 1
+    # Unknown task should respond with passed=false rather than 500.
+    resp = client.get(
+        "/__env__/oracle?task_id=nonexistent", headers=ADMIN_HEADERS,
+    )
+    if not _check(
+        "unknown task_id returns passed=false",
+        resp.status_code == 200 and resp.json().get("passed") is False,
+    ):
+        failures += 1
+    return failures
+
+
+def reset(client: TestClient) -> None:
+    client.post("/__env__/reset", headers=ADMIN_HEADERS)
+
+
+def smoke_t01(client: TestClient) -> int:
+    """Connect to user_00042 with a note."""
+    failures = 0
+    print("== t01_connect_with_user happy path ==")
+    reset(client)
+    # Find target handle.
+    resp = client.get("/in/demo-mantis/")
+    if not _check("baseline profile loads", resp.status_code == 200):
+        failures += 1
+        return failures
+
+    # Look up handle for user_00042 via the seed (predictable: hit /in/?).
+    # Cheaper: query state endpoint for the user.
+    resp = client.get("/__env__/state", headers=ADMIN_HEADERS)
+    _ = resp.json()  # state doesn't directly include user_00042 handle
+
+    # Resolve via DB import — simpler than walking state.
+    from app import db as _db
+    conn = _db.connect()
+    row = conn.execute(
+        "SELECT handle FROM users WHERE id = 'user_00042'"
+    ).fetchone()
+    handle = row["handle"]
+    print(f"  target handle: {handle}")
+
+    resp = client.post(
+        f"/in/{handle}/connect",
+        data={"note": "Hi — would love to connect after PyCon."},
+        follow_redirects=False,
+    )
+    if not _check(
+        f"POST /in/{handle}/connect returns 303",
+        resp.status_code == 303,
+    ):
+        failures += 1
+
+    resp = client.get(
+        "/__env__/oracle?task_id=t01_connect_with_user",
+        headers=ADMIN_HEADERS,
+    )
+    body = resp.json()
+    if not _check(
+        f"oracle t01 passed=true (reasons={body.get('reasons')})",
+        body.get("passed") is True,
+    ):
+        failures += 1
+    return failures
+
+
+def smoke_t02(client: TestClient) -> int:
+    """Create a feed post with #hashtag."""
+    failures = 0
+    print("== t02_post_text_update happy path ==")
+    reset(client)
+
+    resp = client.post(
+        "/feed/post",
+        data={"body": "First day on the new team — already learning a ton. "
+              "#opensource"},
+        follow_redirects=False,
+    )
+    if not _check(
+        "POST /feed/post returns 303",
+        resp.status_code == 303,
+    ):
+        failures += 1
+
+    resp = client.get(
+        "/__env__/oracle?task_id=t02_post_text_update",
+        headers=ADMIN_HEADERS,
+    )
+    body = resp.json()
+    if not _check(
+        f"oracle t02 passed=true (reasons={body.get('reasons')})",
+        body.get("passed") is True,
+    ):
+        failures += 1
+    return failures
+
+
+def smoke_t03(client: TestClient) -> int:
+    """Easy Apply to job_00003."""
+    failures = 0
+    print("== t03_easy_apply_to_job happy path ==")
+    reset(client)
+
+    resp = client.post(
+        "/jobs/job_00003/apply",
+        data={
+            "phone": "+1 415 555 0177",
+            "resume_label": "Use my profile",
+            "answers": '{"years_experience": "5", "work_authorized": "Yes"}',
+        },
+        follow_redirects=False,
+    )
+    if not _check(
+        "POST /jobs/job_00003/apply returns 303",
+        resp.status_code == 303,
+    ):
+        failures += 1
+
+    resp = client.get(
+        "/__env__/oracle?task_id=t03_easy_apply_to_job",
+        headers=ADMIN_HEADERS,
+    )
+    body = resp.json()
+    if not _check(
+        f"oracle t03 passed=true (reasons={body.get('reasons')})",
+        body.get("passed") is True,
+    ):
+        failures += 1
+    return failures
+
+
+def main() -> int:
+    client = TestClient(app)
+    # Force startup so DB is seeded before the first call hits a fresh
+    # TestClient request-cycle.
+    with client:
+        failures = 0
+        failures += smoke_pages(client)
+        failures += smoke_oracle_dispatch(client)
+        failures += smoke_t01(client)
+        failures += smoke_t02(client)
+        failures += smoke_t03(client)
+    print()
+    if failures:
+        print(f"SMOKE FAILED — {failures} check(s) failed")
+        return 1
+    print("SMOKE PASSED")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/deploy/sim_envs/mantis_mercor/Dockerfile
+++ b/deploy/sim_envs/mantis_mercor/Dockerfile
@@ -1,0 +1,40 @@
+# mantis-mercor — simulated mercor.com AI-talent-marketplace mirror.
+#
+# Image goals:
+#   * <500MB final size (slim base + ~5 pip deps).
+#   * <30s cold boot.
+#   * No outbound network at runtime.
+#
+# Build:
+#     docker build -t mantis/sim-env-mantis-mercor:latest deploy/sim_envs/mantis_mercor
+#
+# Run:
+#     docker run --rm -p 8090:8080 \
+#         -e SEED=42 \
+#         -e FAKE_NOW=2026-06-08T09:00:00Z \
+#         -e ENV_ADMIN_TOKEN=$(python -c 'import secrets;print(secrets.token_urlsafe(32))') \
+#         mantis/sim-env-mantis-mercor:latest
+
+FROM python:3.11-slim
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends curl \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /srv
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY app ./app
+
+ENV PORT=8080 \
+    SEED=42 \
+    FAKE_NOW=2026-06-08T09:00:00Z \
+    PYTHONUNBUFFERED=1
+
+EXPOSE 8080
+HEALTHCHECK --interval=5s --timeout=2s --start-period=10s --retries=6 \
+    CMD curl -fs http://127.0.0.1:8080/__env__/health || exit 1
+
+CMD ["python", "-m", "uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/deploy/sim_envs/mantis_mercor/FIDELITY.md
+++ b/deploy/sim_envs/mantis_mercor/FIDELITY.md
@@ -1,0 +1,167 @@
+# `mantis_mercor` — Fidelity match log
+
+Working doc tracking each element's match status against
+`https://www.mercor.com/`. Update as iterations land.
+
+Last updated: **first-pass scaffold** (2026-06-08) — initial pass
+implementing the captured spec from `_capture_brief.md`. No live
+re-probe this turn; subsequent passes should re-capture via Chrome
+MCP at 1440×900 and update the rows below in place.
+
+## Methodology
+
+Each row records the element/region, the real Mercor measurement
+(from the capture brief or future direct probes), and the current
+state. Status legend:
+
+- ✅ exact (within 1-2px rendering tolerance)
+- 🟡 close (matches structurally; minor pixel diff)
+- ⏳ partial (some pieces match, more work needed)
+- ❌ missing / broken
+- 🚫 intentionally not matched (e.g. real photos, A/B variants)
+
+## Global / palette / typography
+
+| Element | Real Mercor | Mine | Status |
+|---|---|---|---|
+| Body color | `#000000` pure black | `#000000` via `body { color: var(--black) }` | ✅ |
+| Body bg | `#FFFFFF` white | `#FFFFFF` | ✅ |
+| Brand color | `#4F46E5` indigo-600 | `--indigo-600: #4F46E5` | ✅ |
+| Font family | `Inter, "Inter Fallback"` | `Inter, "Inter Fallback", system-ui, ...` | ✅ |
+| gray-100 | `#F3F4F6` | `--gray-100: #F3F4F6` | ✅ |
+| gray-200 | `#E5E7EB` | `--gray-200: #E5E7EB` | ✅ |
+| gray-500 | `#6B7280` | `--gray-500: #6B7280` | ✅ |
+| gray-800 | `#1F2937` | `--gray-800: #1F2937` | ✅ |
+| Focus ring | Tailwind ring-2 ring-indigo-500/15 | `0 0 0 3px rgba(79,70,229,0.15)` | 🟡 |
+
+## Topbar / nav (`/`)
+
+| Element | Real Mercor | Mine | Status |
+|---|---|---|---|
+| Header height | ~52px sticky thin | 52px sticky | ✅ |
+| Border-bottom | 1px gray-200 | 1px var(--gray-200) | ✅ |
+| Nav items order | APEX, APEX-Agents, APEX-SWE, Research, Enterprise, Experts | same | ✅ |
+| Nav item font | 13/500 | 13/500 | 🟡 |
+| Right actions | Sign in (anonymous) | Sign in + Sign up (added Sign up to give CUA an entry) | 🟡 |
+| Brand mark | (no large brand bar on real site) | small `M` mark + "mercor" lowercase | 🟡 |
+
+## Hero (`/`)
+
+| Element | Real Mercor | Mine | Status |
+|---|---|---|---|
+| H1 text | "Shape the frontier of AI" | "Shape the frontier of AI" | ✅ |
+| H1 font | Inter 48/700 | 48/700 | 🟡 |
+| Hero CTA buttons | (1 primary on live) | 2 buttons (added "How it works") | ⏳ |
+| Stats strip | 3 stats (Avg pay $/hr, Roles created k, Daily payouts $) | 3 stats, same labels | ✅ |
+| Stats values | live values vary; brief noted layout | seed-driven static (95 / 12k / 240k) | ⏳ |
+
+## Latest roles grid (`/`)
+
+| Element | Real Mercor | Mine | Status |
+|---|---|---|---|
+| Section H2 | "Latest roles" | "Latest roles" | ✅ |
+| Card grid columns | likely 3 at desktop | 3 cols, responsive 2/1 | ✅ |
+| Card shape | title / $X-$Y/hr / 3-letter avatar / "N hired recently" / Apply | same | ✅ |
+| Card avatar | 3-letter initials on gray background | gray-100 bg, gray-800 text, 34x34 circle | 🟡 |
+| Apply CTA color | indigo-600 background, white text | indigo-600 / white | ✅ |
+| Card border | 1px gray-200 + 12px radius | 1px gray-200 + 12px radius | 🟡 |
+| Card hover | shadow lift | shadow-md on hover | 🟡 |
+
+## `/experts` page
+
+| Element | Real Mercor | Mine | Status |
+|---|---|---|---|
+| H1 | "Get paid to work on AI projects" | same | ✅ |
+| 3-step "how it works" | 1. Create profile, 2. Take AI assessments, 3. Find opportunities | same | ✅ |
+| Latest roles section | present below how-it-works | present | ✅ |
+| FAQ H2s | "What is Mercor?", "What is AI training work?" | both present, `<details>` | ✅ |
+| Per-role sections per category | real site renders per-category H2 + cards | not yet — single grid only | ⏳ |
+
+## `/jobs` filter rail + results
+
+| Element | Real Mercor | Mine | Status |
+|---|---|---|---|
+| Filter rail position | left side | left, 260px sticky | 🟡 |
+| Filter labels | Category, Rate, Engagement type | same | ✅ |
+| Filter widget kind | chip radios | chip radios | ✅ |
+| Sort label | "Sort by: Latest" | "Sort by: Latest" (static) | 🟡 |
+| Results grid | 3-col desktop card grid | 3-col, same card | ✅ |
+
+## `/jobs/<id>` detail
+
+| Element | Real Mercor | Mine | Status |
+|---|---|---|---|
+| H1 = role title | yes | yes | ✅ |
+| Right rail summary card | rate + engagement + Apply CTA | same, 320px sticky | ✅ |
+| Description rendering | Markdown / paragraphs | Markdown → `<br/>` substitution | ⏳ |
+| Skills chips | gray-100 chips | gray-100 chips | ✅ |
+| Screening preview | yes | numbered list | 🟡 |
+
+## `/apply/<id>` multi-step
+
+| Element | Real Mercor | Mine | Status |
+|---|---|---|---|
+| Step progress | "Step N of M" + step list | both rendered | 🟡 |
+| Persisted draft on Back | yes | in-memory `APPLY_DRAFTS` keyed by (user, job) | ✅ |
+| Step fields | profile / resume / Q&A / review / submit | same 5 steps | ✅ |
+| Confirmation banner | "Application submitted" | "Application submitted — we'll be in touch." | 🟡 |
+
+## `/login`, `/signup`
+
+| Element | Real Mercor | Mine | Status |
+|---|---|---|---|
+| Centered card layout | yes | max-width 480px centered card | ✅ |
+| H1 | "Sign in to Mercor" | same | ✅ |
+| Error inline | yes | red alert div | 🟡 |
+| Signup role radio | (real site uses path branching, not radio) | Candidate / Client radio | 🚫 (intentional — gives CUA explicit role pick) |
+
+## `/dashboard` (candidate + client)
+
+| Element | Real Mercor | Mine | Status |
+|---|---|---|---|
+| Role-sensitive view | yes | yes (sniffs session.users.role) | ✅ |
+| Candidate H1 | "My applications" | same | ✅ |
+| Status badges | colored | indigo / amber / blue / green / red per status | 🟡 |
+| Client H1 | "Review queue" | same | ✅ |
+| Add-to-shortlist toggle | inline | inline form posts → redirect; not yet AJAX-toggle to "Added" | ⏳ |
+| Decline reason required | yes | required + inline `<details>` form | ✅ |
+
+## `/profile`
+
+| Element | Real Mercor | Mine | Status |
+|---|---|---|---|
+| Fields | headline / skills / rate / availability | same | ✅ |
+| Save → audit_log | yes | `profile_updated` audit row | ✅ |
+
+## Iteration log
+
+- **2026-06-08 v=1 (first-pass scaffold)** — captured spec from
+  `_capture_brief.md`, scaffolded 8 templates + shared CSS, wired
+  all 7 routes, shipped 3 oracles + smoke test (31/31 checks pass).
+  Mostly 🟡-close; no live re-probe yet so most rows can't escalate
+  to ✅. Open follow-up: capture corpus via Chrome MCP, then per-row
+  pixel-diff pass.
+
+## Remaining gaps for follow-up agents
+
+1. **No `_captured/*/dom.html` / `screenshot.png` / `styles.json`** —
+   only `notes.md` slugs. A follow-up should fire up Chrome MCP at
+   1440×900, snapshot each page's served HTML + computed-style probe
+   per element, then diff vs current templates.
+2. **Description rendering** in `job_detail.html` uses
+   `\n→<br/>` — should run a tiny Markdown subset (headings, lists)
+   without adding a dep.
+3. **Sort dropdown is static** on `/jobs`; should at minimum
+   render a real `<select>` with `Latest`, `Highest pay`,
+   `Most hires`.
+4. **Per-category role sections on `/experts`** missing; render a
+   section-per-category with own H2.
+5. **Client dashboard "Add to shortlist" toggle** — currently
+   navigates; convert to small vanilla-JS inline toggle with
+   `disabled` + label flip to "Added" on success.
+6. **Stats values on `/`** are seed-static; consider deriving
+   from real `applications.hourly_rate` percentile for non-trivial
+   matchability with the live site's numbers.
+7. **Pixel-level fidelity** — none of the rows above are ✅ except
+   palette tokens. After capture corpus lands, run section-by-section
+   sizes/spacing diff.

--- a/deploy/sim_envs/mantis_mercor/FIDELITY_AGENT_PROMPT.md
+++ b/deploy/sim_envs/mantis_mercor/FIDELITY_AGENT_PROMPT.md
@@ -1,0 +1,111 @@
+# Mercor fidelity gap-fix prompt
+
+You're a follow-up agent improving the `mantis_mercor` synthetic
+mirror's match against `https://www.mercor.com/`. The first-pass
+scaffold landed: all routes serve 200, three oracles pass via
+`scripts/smoke.py`, and the section-by-section status lives in
+`FIDELITY.md`. Your job is to convert 🟡-close rows to ✅-exact and
+close any ⏳-partial / ❌-missing gaps.
+
+## Read first
+
+1. `SCOPE.md` — what's in / out of scope.
+2. `FIDELITY.md` — the section-by-section match log.
+3. `_captured/<slug>/notes.md` — captured spec per page.
+4. `deploy/sim_envs/_capture_brief.md` — parent-session ground-truth
+   palette + nav + typography for mercor.com.
+5. The exemplar: `deploy/sim_envs/mantis_boattrader/FIDELITY.md`
+   — the bar for pixel-parity, and the iteration log style.
+
+## Workflow — one section per loop
+
+For each section in `FIDELITY.md` ordered by impact (start at the
+top — palette/typography/topbar; descend through hero, latest-roles,
+jobs detail, apply, dashboard):
+
+1. **Capture** the real Mercor section via Chrome MCP at 1440×900:
+   - Load the page (`mcp__claude-in-chrome__navigate`).
+   - Probe the section's bounding box + computed style via
+     `mcp__claude-in-chrome__javascript_tool`, e.g.
+
+     ```js
+     (() => {
+       const el = document.querySelector('h1');
+       const r = el.getBoundingClientRect();
+       const cs = getComputedStyle(el);
+       return {
+         text: el.innerText,
+         rect: {x: r.x, y: r.y, w: r.width, h: r.height},
+         font: cs.font,
+         color: cs.color,
+         padding: cs.padding,
+         margin: cs.margin,
+       };
+     })()
+     ```
+   - Save the raw probe into
+     `_captured/<slug>/styles.json` (append; don't overwrite past
+     iterations).
+
+2. **Diff** against current sim:
+   - Boot the sim locally
+     (`ENV_ADMIN_TOKEN=test python -m uvicorn app.main:app --port 8090`).
+   - Probe the same section via Chrome MCP on
+     `http://127.0.0.1:8090/<path>`.
+   - Compute deltas. Anything > 2px structural or wrong-token
+     palette is an action item.
+
+3. **Patch** `app/static/site.css` or the matching template.
+   Tweak component CSS in `site.css` (it's grouped by component —
+   look for the matching `/* N. <component> */` banner). Don't bolt
+   on inline styles or one-off classes; promote shared tokens to
+   `:root` if you need new ones.
+
+4. **Re-probe & verify** via Chrome MCP that the section now
+   matches within 2px.
+
+5. **Update `FIDELITY.md`** in place: flip the row to ✅ (or 🟡
+   with a one-line note) and append a one-liner to the
+   "Iteration log" section at the top with the section name +
+   what landed.
+
+6. **Re-run smoke** (`python scripts/smoke.py`) to confirm nothing
+   regressed.
+
+## Anti-patterns to avoid
+
+- **Inline styles** on a template — keep all styling in
+  `site.css`.
+- **Page-scoped CSS** for shared components — if `.role-card`
+  needs a tweak for `/jobs`, change `.role-card` once.
+- **Touching the audit_log shape** — oracles are wired to the
+  current payload keys. If you must add a key, append; never rename.
+- **Adding Google Fonts at runtime** — the live site uses Inter
+  but does not pull from Google Fonts at the path we capture.
+  Keep the system-stack fallback.
+- **Hardcoding seed-dependent values** — if a chart number is
+  seed-driven, write a helper instead of hardcoding "75 hired
+  recently" in the template.
+- **Removing `data-testid` attributes** — the harness uses them
+  to drive deterministic Chrome MCP-style locators.
+
+## Suggested priority order
+
+1. Hero H1 font size + line-height + letter-spacing (visible above
+   the fold; biggest first-impression delta).
+2. Role-card spacing — gap between rate, avatar, "N hired recently",
+   Apply.
+3. Stats strip layout — column widths, separator, label color.
+4. Filter rail typography + chip spacing.
+5. Job detail rail-card padding + sticky offset.
+6. Apply step-list active-pill color + radius.
+7. Dashboard table row padding + status badge size.
+
+## What "done" looks like
+
+- Every FIDELITY.md row that isn't 🚫 (intentionally not matched)
+  reads ✅ or 🟡 with a 1-line justification.
+- `scripts/smoke.py` still passes 100%.
+- Iteration log at top of FIDELITY.md shows your work.
+- No outbound network at runtime (verify with `--network none` if
+  you spin up the container).

--- a/deploy/sim_envs/mantis_mercor/README.md
+++ b/deploy/sim_envs/mantis_mercor/README.md
@@ -1,0 +1,106 @@
+# mantis_mercor
+
+Synthetic mirror of `mercor.com` — an AI talent marketplace. Built
+to the same fidelity bar as `mantis_boattrader` and `mantis_shop`:
+server-rendered FastAPI + Jinja approximation that the mantis CUA
+agent drives end-to-end and the oracle grades.
+
+## Scope
+
+See `SCOPE.md`. In-scope pages: `/`, `/jobs`, `/jobs/<id>`,
+`/apply/<id>/...`, `/login`, `/signup`, `/dashboard`, `/profile`,
+`/experts`. Three oracle tasks (`t01`, `t02`, `t03`).
+
+## Run
+
+### Local (Python)
+
+```bash
+cd deploy/sim_envs/mantis_mercor
+pip install -r requirements.txt
+ENV_ADMIN_TOKEN=test python -m uvicorn app.main:app --port 8090
+```
+
+Open `http://127.0.0.1:8090/` for the home page.
+`http://127.0.0.1:8090/__env__/health` is public; everything else
+under `/__env__/` requires header `X-Env-Admin: test`.
+
+### Docker
+
+```bash
+docker build -t mantis/sim-env-mantis-mercor:latest deploy/sim_envs/mantis_mercor
+docker run --rm -p 8090:8080 \
+    -e SEED=42 \
+    -e FAKE_NOW=2026-06-08T09:00:00Z \
+    -e ENV_ADMIN_TOKEN=$(python -c 'import secrets;print(secrets.token_urlsafe(32))') \
+    mantis/sim-env-mantis-mercor:latest
+```
+
+### Smoke test
+
+```bash
+cd deploy/sim_envs/mantis_mercor
+ENV_ADMIN_TOKEN=test python scripts/smoke.py
+```
+
+Boots the app in-process via `fastapi.testclient.TestClient`, drives
+each oracle's happy path, and asserts all three pass.
+
+## Oracle tasks
+
+| ID | Description | Pass condition |
+|----|-------------|----------------|
+| `t01` (`t01_apply_to_ml_engineer`) | Candidate applies to `job_00001` | application row submitted with all screening answers filled |
+| `t02` (`t02_shortlist_candidate`) | Client shortlists `candidate_00007` for `job_00001` | shortlist row + audit_log `candidate_shortlisted` |
+| `t03` (`t03_decline_application`) | Client declines `app_00001` with reason | applications.status='rejected' + reason text + audit_log |
+
+Dispatch via `GET /__env__/oracle?task_id=t01` (with admin header).
+
+## Fidelity tracker
+
+`FIDELITY.md` — section-by-section structural match log vs the live
+`mercor.com`. Status legend matches `mantis_boattrader/FIDELITY.md`.
+
+## Layout
+
+```
+deploy/sim_envs/mantis_mercor/
+├── Dockerfile
+├── README.md
+├── SCOPE.md
+├── FIDELITY.md
+├── FIDELITY_AGENT_PROMPT.md
+├── requirements.txt
+├── _captured/              # Phase-1 discovery corpus (one slug per page).
+├── scripts/
+│   └── smoke.py
+└── app/
+    ├── __init__.py
+    ├── main.py             # FastAPI factory + helpers
+    ├── auth.py             # email + password sessions
+    ├── db.py               # SQLite schema + audit_log
+    ├── seed.py             # deterministic per-seed fixture
+    ├── routes/
+    │   ├── env_admin.py    # /__env__/{health,reset,seed,clock,oracle,state,events,mutations}
+    │   ├── auth.py
+    │   ├── marketing.py    # / and /experts
+    │   ├── jobs.py
+    │   ├── apply.py        # 5-step apply flow
+    │   ├── dashboard.py    # candidate + client surfaces + shortlist/decline
+    │   └── profile.py
+    ├── oracles/
+    │   ├── __init__.py
+    │   ├── t01_apply_to_ml_engineer.py
+    │   ├── t02_shortlist_candidate.py
+    │   └── t03_decline_application.py
+    ├── static/
+    │   └── site.css        # hand-rolled, grouped by component
+    └── templates/
+        ├── base.html, home.html, experts.html
+        ├── jobs_list.html, job_detail.html
+        ├── apply_step.html, apply_review.html, apply_confirm.html
+        ├── login.html, signup.html
+        ├── dashboard_candidate.html, dashboard_client.html
+        ├── profile.html
+        └── _role_card.html (Jinja macro)
+```

--- a/deploy/sim_envs/mantis_mercor/SCOPE.md
+++ b/deploy/sim_envs/mantis_mercor/SCOPE.md
@@ -1,0 +1,69 @@
+# `mantis_mercor` — Scope
+
+Synthetic mirror of `mercor.com` — an AI talent marketplace where
+candidates create profiles and apply to AI-evaluator / contractor
+roles, and clients (signed-in with role=client) review applicants +
+maintain shortlists.
+
+## In-scope pages
+
+- `/` — marketing home (hero "Shape the frontier of AI", stats strip,
+  Latest roles grid, footer).
+- `/jobs` — open roles list with filter rail + role cards.
+- `/jobs/<id>` — role detail (description, skills, comp, Apply CTA).
+- `/apply/<id>` — multi-step apply flow:
+    1. Profile (headline, skills, hourly rate, availability)
+    2. Resume upload (text paste fallback — no real file storage)
+    3. Screening Q&A (per-role questions)
+    4. Review
+    5. Submit → confirmation banner
+- `/login`, `/signup` — auth (email + password only; no OAuth).
+- `/dashboard` — role-sensitive:
+    - Candidate: My applications + status column.
+    - Client: Inbox of applications for my postings, shortlist count,
+      review queue.
+- `/profile` — candidate profile editor (headline, skills,
+  hourly rate, availability).
+
+## In-scope interactions
+
+1. **Apply flow** — click Apply on a role card →
+   multi-step apply form → submit. Side-effects:
+   `applications` row inserted, status=`submitted`, audit_log row.
+2. **Shortlist** — client clicks Add to Shortlist on a candidate row
+   on `/dashboard` (client view). Side-effects:
+   `shortlist_entries` row, audit_log row.
+3. **Decline** — client moves a pending application to `rejected`
+   with a reason text. Side-effects: applications.status update,
+   audit_log row.
+4. **Profile edit** — candidate edits headline + skills + rate +
+   availability → saves. Side-effects: candidate_profiles row update,
+   audit_log row.
+
+## Out-of-scope (explicitly NOT mirrored)
+
+- Real brand photography → deterministic initial-block avatars only.
+- Analytics / advertising / tracking scripts.
+- Third-party widgets (intercom, hotjar, etc.).
+- OAuth / social login (email + password only).
+- Payment processing — payments table is read-only seed data.
+- Real-time websockets / SSE.
+- A/B variant flags — canonical variant only (the one the live site
+  shows for an anonymous visitor).
+- Real Inter font from Google Fonts — system stack only at runtime.
+
+## Done bar
+
+Section-by-section structural fidelity vs `https://www.mercor.com/`:
+
+- Visual: structural deltas ≤ 2px on hero / nav / Latest-roles card
+  grid; palette matches captured spec (indigo-600 `#4F46E5`, grays
+  100/200/400/500/600/800).
+- Interaction: each of the 4 interactions writes the matching
+  audit_log row(s) and the matching DB state change. Oracles
+  T01..T03 pass.
+- Smoke: `scripts/smoke.py` boots app and asserts all routes 200
+  + oracles dispatchable.
+
+Initial pass is "close, not exact" — see `FIDELITY.md` for the
+section-by-section match log and remaining gaps.

--- a/deploy/sim_envs/mantis_mercor/_captured/apply/notes.md
+++ b/deploy/sim_envs/mantis_mercor/_captured/apply/notes.md
@@ -1,0 +1,23 @@
+# `/apply/<id>` — Multi-step apply
+
+5 steps, persisted draft per step:
+
+1. Profile — headline, skills (comma-separated), hourly rate.
+2. Resume — paste raw resume text (text area). No upload widget.
+3. Screening Q&A — 2-3 free-text questions per role.
+4. Review — read-only summary of all fields.
+5. Submit — POST that writes the application + audit_log row, then
+   shows a confirmation banner.
+
+Each step has Back + Next buttons; Back preserves filled fields.
+
+Auth: routes require login. Anonymous user hitting `/apply/<id>` is
+303'd to `/login?next=/apply/<id>` (when ENV_REQUIRE_AUTH=1) or
+auto-acts-as the seeded canonical candidate (when 0).
+
+## Mirror priorities
+
+- Persisted draft (in-memory keyed by user_id+role_id) — Back must
+  preserve fields.
+- Confirmation banner copy: `Application submitted — we'll be in
+  touch.`

--- a/deploy/sim_envs/mantis_mercor/_captured/dashboard/notes.md
+++ b/deploy/sim_envs/mantis_mercor/_captured/dashboard/notes.md
@@ -1,0 +1,24 @@
+# `/dashboard` — Role-sensitive
+
+## Candidate view
+
+- H1: `My applications`
+- Table: Role / Company / Status / Applied at / Actions
+- Each row's Status is one of: submitted / under_review / interview /
+  rejected / hired.
+
+## Client view
+
+- H1: `Review queue`
+- Two side-by-side panels:
+    - Left: pending applications for postings I own. Each row has
+      `Add to shortlist` and `Decline` buttons.
+    - Right: shortlist count + the most recent 5 shortlisted
+      candidates.
+- Decline button opens an inline form prompting `Reason` (required).
+
+## Mirror priorities
+
+- Role sniffed from session.users.role.
+- Add-to-shortlist button toggles to `Added` inline (no nav).
+- Decline reason required before submit enables.

--- a/deploy/sim_envs/mantis_mercor/_captured/home/notes.md
+++ b/deploy/sim_envs/mantis_mercor/_captured/home/notes.md
@@ -1,0 +1,55 @@
+# `/` — Home / marketing
+
+Source: anchored on `deploy/sim_envs/_capture_brief.md` (parent session
+captured the live mercor.com on 2026-06-08 via Chrome MCP @ 1512×677).
+Direct re-capture not run this turn — flagged ⏳ in FIDELITY.md where
+the brief leaves ambiguity.
+
+## Brand & typography
+
+- Font family: `Inter, "Inter Fallback", system-ui, sans-serif`
+  (system stack fallback at runtime; no Google Fonts).
+- Body background: white `#FFFFFF`.
+- Body color: pure black `#000000`.
+- Accent / brand: indigo-600 `#4F46E5` (`rgb(79, 70, 229)`).
+- Surface greys (Tailwind palette, exact hex):
+    - gray-100 `#F3F4F6`
+    - gray-200 `#E5E7EB`
+    - gray-400 `#9CA3AF`
+    - gray-500 `#6B7280`
+    - gray-600 `#4B5563`
+    - gray-800 `#1F2937`
+
+## Layout
+
+- Slim sticky header; nav width compact (~374px) left-aligned.
+- Header items, in order: `APEX`, `APEX-Agents`, `APEX-SWE`,
+  `Research`, `Enterprise`, `Experts`. (We add `Sign in` / `Sign up`
+  on the right of the bar; the live site puts these elsewhere but the
+  CUA needs an entry point.)
+- Hero H1: `Shape the frontier of AI`.
+- Stats strip just below hero with three pseudo-stats:
+    - `Average pay $/hr`
+    - `Roles created (k)`
+    - `Daily payouts ($)`
+- "Latest roles" section H2 (only H2 in fold).
+- Role card shape:
+    - Role title (e.g. `Internal Medicine Expert`)
+    - Rate range (e.g. `$130-$180/hr`)
+    - 3-letter avatar badge (deterministic initials, e.g. `LFA`,
+      `JDT`, `GBR`) — gray-100 background, gray-800 text.
+    - `N hired recently` microcopy.
+    - `Apply` CTA button (indigo-600 background, white text).
+
+## Interaction triggers
+
+- `Apply` button on each card → `GET /apply/<role_id>`.
+- Header nav links → page changes only (no in-page nav drawer).
+
+## Mirror priorities
+
+1. Tailwind grey + indigo palette must match exactly.
+2. 3-letter initial avatar pattern is distinctive — replicate as
+   deterministic SVG / div blocks.
+3. Card shape `title / $X-$Y/hr / NNN hired recently / Apply` is the
+   canonical role card across home + jobs + experts.

--- a/deploy/sim_envs/mantis_mercor/_captured/jobs/notes.md
+++ b/deploy/sim_envs/mantis_mercor/_captured/jobs/notes.md
@@ -1,0 +1,29 @@
+# `/jobs` — Open roles list
+
+Captured from `/experts/` shape in capture brief (similar list
+surface). Direct `/jobs` re-capture flagged ⏳ in FIDELITY.md.
+
+## Layout
+
+- Slim sticky header (same as home).
+- Left filter rail (~260px wide):
+    - "Category" multi-select chips (Medical, Legal, Finance,
+      Software, Consulting, Office)
+    - "Rate" range filter (min/max numeric inputs)
+    - "Engagement type" radio (Hourly / Project / Full-time)
+- Right results pane (~880px wide), 3-column card grid.
+- Cards use the canonical role-card component (see home/notes.md).
+- Sort dropdown top-right of results pane: `Sort by: Latest`.
+
+## Interaction triggers
+
+- Card click → `GET /jobs/<id>`.
+- Apply button on card → `GET /apply/<id>` (skipping detail page).
+- Filter chip toggle → updates URL query params (`?category=Medical`).
+
+## Mirror priorities
+
+- 3-col grid at desktop, stacking responsive at narrow.
+- Filter rail labels must match: "Category", "Rate", "Engagement
+  type".
+- Sort label: `Sort by: Latest`.

--- a/deploy/sim_envs/mantis_mercor/_captured/jobs_detail/notes.md
+++ b/deploy/sim_envs/mantis_mercor/_captured/jobs_detail/notes.md
@@ -1,0 +1,22 @@
+# `/jobs/<id>` — Role detail page
+
+## Layout
+
+- Slim sticky header.
+- Two-column body:
+    - Main (~880px): role title H1, rate range, "N hired recently",
+      Description (Markdown rendered), Skills required (chip list),
+      Screening questions preview list.
+    - Right rail (~320px sticky): summary card (rate, engagement type,
+      hours/week), big `Apply` button (indigo-600 bg, white text).
+
+## Interaction triggers
+
+- Apply CTA → `GET /apply/<id>` (or `POST /apply/<id>/start` if logged
+  out, redirects to login).
+
+## Mirror priorities
+
+- The right-rail summary card sticky behaviour matters for layout
+  realism; can be regular block in v1 (no sticky JS).
+- H1 must be the role title (no marketing tagline above).

--- a/deploy/sim_envs/mantis_mercor/_captured/login/notes.md
+++ b/deploy/sim_envs/mantis_mercor/_captured/login/notes.md
@@ -1,0 +1,17 @@
+# `/login` — Auth
+
+Simple centered card. Email + password fields, primary CTA.
+
+## Layout
+
+- White page bg, centered card max-width 420px.
+- Card has 1px gray-200 border, 12px radius.
+- H1: `Sign in to Mercor`
+- Email input, Password input, `Sign in` button (indigo-600).
+- Below: `Don't have an account? Sign up` link.
+
+## Mirror priorities
+
+- ENV_REQUIRE_AUTH=1 triggers 303→/login on protected paths
+  (/apply/*, /dashboard, /profile).
+- After success: 303→ next param (default `/dashboard`).

--- a/deploy/sim_envs/mantis_mercor/_captured/profile/notes.md
+++ b/deploy/sim_envs/mantis_mercor/_captured/profile/notes.md
@@ -1,0 +1,18 @@
+# `/profile` — Candidate profile editor
+
+H1: `Your profile`
+
+Form fields:
+
+- `Headline` text input — e.g. "Internal Medicine Physician, 8 years"
+- `Skills` (comma-separated text input)
+- `Hourly rate ($/hr)` numeric input
+- `Availability` select: `Full-time`, `Part-time`, `Project-based`
+
+`Save` button (indigo-600).
+
+## Mirror priorities
+
+- Save writes candidate_profiles row update + audit_log
+  `profile_updated`.
+- Page re-renders with new state inline (303→/profile after POST).

--- a/deploy/sim_envs/mantis_mercor/_captured/signup/notes.md
+++ b/deploy/sim_envs/mantis_mercor/_captured/signup/notes.md
@@ -1,0 +1,10 @@
+# `/signup` — Auth
+
+Same shape as `/login` but with a role radio at the top:
+"I'm a Candidate / I'm a Client" — defaults to Candidate.
+
+## Mirror priorities
+
+- POST creates `users` row + (for candidates) a candidate_profiles
+  shell row + (for clients) a `companies` row owned by them.
+- 303→/dashboard after success.

--- a/deploy/sim_envs/mantis_mercor/app/__init__.py
+++ b/deploy/sim_envs/mantis_mercor/app/__init__.py
@@ -1,0 +1,1 @@
+"""mantis-mercor sim env package."""

--- a/deploy/sim_envs/mantis_mercor/app/auth.py
+++ b/deploy/sim_envs/mantis_mercor/app/auth.py
@@ -1,0 +1,154 @@
+"""Mock auth for mantis-mercor — email + password only.
+
+Mirrors mantis-shop's auth module but stripped to email-password
+(no OAuth). Sessions are signed cookies via plain hmac.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import os
+import time
+from typing import Any
+
+from fastapi import Request, Response
+from fastapi.responses import RedirectResponse
+
+from . import db
+
+SESSION_COOKIE = "mantis_mercor_session"
+SESSION_TTL_DEFAULT_S = 60 * 60  # 1h
+LOGIN_PATH = "/login"
+
+
+def session_secret() -> str:
+    return os.environ.get("ENV_SESSION_SECRET", "dev-only-do-not-use-in-prod")
+
+
+def session_ttl_s() -> int:
+    raw = os.environ.get("ENV_SESSION_TTL_S")
+    try:
+        return int(raw) if raw else SESSION_TTL_DEFAULT_S
+    except ValueError:
+        return SESSION_TTL_DEFAULT_S
+
+
+def auth_required() -> bool:
+    return os.environ.get("ENV_REQUIRE_AUTH", "0").lower() in {"1", "true", "yes"}
+
+
+def hash_password(plain: str) -> str:
+    return hashlib.sha256(plain.encode("utf-8")).hexdigest()
+
+
+def verify_password(plain: str, stored: str) -> bool:
+    return hmac.compare_digest(hash_password(plain), stored)
+
+
+def mint_session(user_id: str, *, now: float | None = None) -> str:
+    issued = int(now if now is not None else time.time())
+    payload = f"{user_id}|{issued}"
+    sig = hmac.new(
+        session_secret().encode("utf-8"),
+        payload.encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+    return f"{payload}|{sig}"
+
+
+def verify_session(cookie_val: str, *, now: float | None = None) -> str | None:
+    if not cookie_val:
+        return None
+    parts = cookie_val.split("|")
+    if len(parts) != 3:
+        return None
+    user_id, issued_at_s, sig = parts
+    try:
+        issued_at = int(issued_at_s)
+    except ValueError:
+        return None
+    payload = f"{user_id}|{issued_at}"
+    expected = hmac.new(
+        session_secret().encode("utf-8"),
+        payload.encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+    if not hmac.compare_digest(sig, expected):
+        return None
+    now_ts = now if now is not None else time.time()
+    if now_ts - issued_at > session_ttl_s():
+        return None
+    return user_id
+
+
+def set_session_cookie(response: Response, user_id: str) -> None:
+    response.set_cookie(
+        SESSION_COOKIE,
+        mint_session(user_id),
+        httponly=True,
+        samesite="lax",
+        max_age=session_ttl_s(),
+        path="/",
+    )
+
+
+def clear_session_cookie(response: Response) -> None:
+    response.delete_cookie(SESSION_COOKIE, path="/")
+
+
+def lookup_user_by_id(user_id: str) -> dict[str, Any] | None:
+    conn = db.connect()
+    row = conn.execute(
+        "SELECT id, email, role, name, company_id FROM users WHERE id = ?",
+        (user_id,),
+    ).fetchone()
+    return dict(row) if row else None
+
+
+def lookup_user_by_email(email: str) -> dict[str, Any] | None:
+    conn = db.connect()
+    row = conn.execute(
+        "SELECT id, email, password_hash, role, name, company_id "
+        "FROM users WHERE email = ?",
+        (email.strip().lower(),),
+    ).fetchone()
+    return dict(row) if row else None
+
+
+def current_user(request: Request) -> dict[str, Any] | None:
+    raw = request.cookies.get(SESSION_COOKIE)
+    user_id = verify_session(raw or "")
+    if user_id is None:
+        return None
+    return lookup_user_by_id(user_id)
+
+
+def effective_user(request: Request, *, default_role: str = "candidate") -> dict[str, Any]:
+    """Return current user, or the canonical seeded fallback if no auth.
+
+    Keeps oracle behaviour deterministic when ENV_REQUIRE_AUTH=0.
+    """
+    u = current_user(request)
+    if u:
+        return u
+    fallback_id = "candidate_00001" if default_role == "candidate" else "client_00001"
+    fb = lookup_user_by_id(fallback_id)
+    return fb or {"id": fallback_id, "email": "", "role": default_role, "name": "",
+                  "company_id": None}
+
+
+def require_user(
+    request: Request, *, roles: list[str] | None = None
+) -> Response | None:
+    if not auth_required():
+        return None
+    user = current_user(request)
+    next_path = request.url.path
+    if user is None:
+        return RedirectResponse(
+            f"{LOGIN_PATH}?next={next_path}", status_code=303
+        )
+    if roles and user.get("role") not in roles:
+        return RedirectResponse(LOGIN_PATH, status_code=303)
+    return None

--- a/deploy/sim_envs/mantis_mercor/app/db.py
+++ b/deploy/sim_envs/mantis_mercor/app/db.py
@@ -1,0 +1,210 @@
+"""SQLite schema + helpers for mantis-mercor.
+
+Mirrors mantis-shop / mantis-crm: in-memory by default, single shared
+connection, schema applied at first connect.
+
+Entities
+--------
+* ``users`` — candidates + clients (role column).
+* ``companies`` — client orgs (owner = client user).
+* ``jobs`` — open roles posted by a company.
+* ``candidate_profiles`` — resume / skills / hourly_rate / availability
+  per candidate user.
+* ``applications`` — a candidate applying to a job. Tracks status +
+  screening_answers.
+* ``shortlist_entries`` — a client adding a candidate to a job-level
+  shortlist.
+* ``interviews``, ``reviews``, ``payments`` — historical / read-only.
+* ``audit_log`` — the SOURCE OF TRUTH oracles grade against.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import threading
+from contextlib import contextmanager
+from typing import Any, Iterator
+
+_DB_LOCK = threading.RLock()
+_DB: sqlite3.Connection | None = None
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS users (
+    id              TEXT PRIMARY KEY,
+    email           TEXT NOT NULL UNIQUE,
+    password_hash   TEXT NOT NULL,
+    role            TEXT NOT NULL,            -- 'candidate' | 'client' | 'admin'
+    name            TEXT NOT NULL DEFAULT '',
+    company_id      TEXT,                     -- nullable; set for clients
+    created_at      TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_users_email ON users(email);
+
+CREATE TABLE IF NOT EXISTS companies (
+    id              TEXT PRIMARY KEY,
+    name            TEXT NOT NULL,
+    domain          TEXT NOT NULL DEFAULT '',
+    owner_user_id   TEXT REFERENCES users(id)
+);
+
+CREATE TABLE IF NOT EXISTS candidate_profiles (
+    user_id         TEXT PRIMARY KEY REFERENCES users(id),
+    headline        TEXT NOT NULL DEFAULT '',
+    skills_json     TEXT NOT NULL DEFAULT '[]',
+    hourly_rate     REAL NOT NULL DEFAULT 0,
+    availability    TEXT NOT NULL DEFAULT 'Part-time',
+    resume_text     TEXT NOT NULL DEFAULT '',
+    updated_at      TEXT NOT NULL DEFAULT ''
+);
+
+CREATE TABLE IF NOT EXISTS jobs (
+    id              TEXT PRIMARY KEY,
+    company_id      TEXT NOT NULL REFERENCES companies(id),
+    title           TEXT NOT NULL,
+    category        TEXT NOT NULL,            -- 'Medical' | 'Legal' | 'Finance' | 'Software' | 'Consulting' | 'Office'
+    description_md  TEXT NOT NULL DEFAULT '',
+    skills_json     TEXT NOT NULL DEFAULT '[]',
+    rate_min        REAL NOT NULL,
+    rate_max        REAL NOT NULL,
+    engagement      TEXT NOT NULL,            -- 'Hourly' | 'Project' | 'Full-time'
+    hours_per_week  INTEGER NOT NULL DEFAULT 20,
+    hires_recently  INTEGER NOT NULL DEFAULT 0,
+    screening_qs    TEXT NOT NULL DEFAULT '[]',
+    status          TEXT NOT NULL DEFAULT 'open',
+    posted_at       TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_jobs_category ON jobs(category);
+CREATE INDEX IF NOT EXISTS idx_jobs_company ON jobs(company_id);
+
+CREATE TABLE IF NOT EXISTS applications (
+    id              TEXT PRIMARY KEY,
+    job_id          TEXT NOT NULL REFERENCES jobs(id),
+    candidate_id    TEXT NOT NULL REFERENCES users(id),
+    status          TEXT NOT NULL,            -- 'draft' | 'submitted' | 'under_review' | 'interview' | 'rejected' | 'hired'
+    headline        TEXT NOT NULL DEFAULT '',
+    skills_json     TEXT NOT NULL DEFAULT '[]',
+    hourly_rate     REAL NOT NULL DEFAULT 0,
+    resume_text     TEXT NOT NULL DEFAULT '',
+    screening_answers TEXT NOT NULL DEFAULT '[]',
+    reject_reason   TEXT NOT NULL DEFAULT '',
+    submitted_at    TEXT,
+    updated_at      TEXT NOT NULL,
+    UNIQUE (job_id, candidate_id)
+);
+CREATE INDEX IF NOT EXISTS idx_app_status ON applications(status);
+CREATE INDEX IF NOT EXISTS idx_app_job ON applications(job_id);
+CREATE INDEX IF NOT EXISTS idx_app_cand ON applications(candidate_id);
+
+CREATE TABLE IF NOT EXISTS shortlist_entries (
+    id              TEXT PRIMARY KEY,
+    job_id          TEXT NOT NULL REFERENCES jobs(id),
+    candidate_id    TEXT NOT NULL REFERENCES users(id),
+    added_by        TEXT NOT NULL REFERENCES users(id),
+    created_at      TEXT NOT NULL,
+    UNIQUE (job_id, candidate_id)
+);
+CREATE INDEX IF NOT EXISTS idx_shortlist_job ON shortlist_entries(job_id);
+
+CREATE TABLE IF NOT EXISTS interviews (
+    id              TEXT PRIMARY KEY,
+    application_id  TEXT NOT NULL REFERENCES applications(id),
+    scheduled_at    TEXT NOT NULL,
+    interviewer     TEXT NOT NULL,
+    outcome         TEXT NOT NULL DEFAULT 'pending'
+);
+
+CREATE TABLE IF NOT EXISTS reviews (
+    id              TEXT PRIMARY KEY,
+    application_id  TEXT NOT NULL REFERENCES applications(id),
+    rating          INTEGER NOT NULL,
+    comments        TEXT NOT NULL DEFAULT '',
+    created_at      TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS payments (
+    id              TEXT PRIMARY KEY,
+    application_id  TEXT NOT NULL REFERENCES applications(id),
+    amount          REAL NOT NULL,
+    occurred_at     TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS audit_log (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    occurred_at     TEXT NOT NULL,
+    operation       TEXT NOT NULL,
+    target_type     TEXT NOT NULL,
+    target_id       TEXT NOT NULL,
+    payload_json    TEXT NOT NULL DEFAULT '{}'
+);
+CREATE INDEX IF NOT EXISTS idx_audit_op ON audit_log(operation);
+"""
+
+
+def db_path() -> str:
+    return os.environ.get("DB_PATH") or ":memory:"
+
+
+def connect() -> sqlite3.Connection:
+    global _DB
+    with _DB_LOCK:
+        if _DB is None:
+            conn = sqlite3.connect(db_path(), check_same_thread=False)
+            conn.row_factory = sqlite3.Row
+            conn.executescript(SCHEMA)
+            _DB = conn
+        return _DB
+
+
+def reset_connection() -> None:
+    global _DB
+    with _DB_LOCK:
+        if _DB is not None:
+            _DB.close()
+            _DB = None
+
+
+@contextmanager
+def transaction() -> Iterator[sqlite3.Connection]:
+    conn = connect()
+    with _DB_LOCK:
+        try:
+            yield conn
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+
+
+def pack_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True)
+
+
+def unpack_json(raw: str, default: Any = None) -> Any:
+    try:
+        return json.loads(raw or ("[]" if default is None else json.dumps(default)))
+    except json.JSONDecodeError:
+        return default if default is not None else []
+
+
+def log_audit(
+    conn: sqlite3.Connection,
+    *,
+    occurred_at: str,
+    operation: str,
+    target_type: str,
+    target_id: str,
+    payload: dict[str, Any] | None = None,
+) -> None:
+    conn.execute(
+        "INSERT INTO audit_log (occurred_at, operation, target_type, target_id, payload_json) "
+        "VALUES (?, ?, ?, ?, ?)",
+        (
+            occurred_at,
+            operation,
+            target_type,
+            target_id,
+            json.dumps(payload or {}, sort_keys=True),
+        ),
+    )

--- a/deploy/sim_envs/mantis_mercor/app/main.py
+++ b/deploy/sim_envs/mantis_mercor/app/main.py
@@ -1,0 +1,198 @@
+"""mantis-mercor FastAPI app — entrypoint for Docker + Modal.
+
+Two route surfaces:
+
+* ``/`` — the marketing + candidate + client surface (server-rendered).
+* ``/__env__/*`` — harness-only, gated on ``X-Env-Admin`` header.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+from fastapi import FastAPI, Request, Response
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
+from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
+
+from . import auth, db, seed
+
+APP_DIR = Path(__file__).parent
+ADMIN_TOKEN_ENV = "ENV_ADMIN_TOKEN"
+ADMIN_HEADER = "X-Env-Admin"
+
+
+def _admin_token() -> str:
+    token = os.environ.get(ADMIN_TOKEN_ENV, "").strip()
+    if not token:
+        # Fail loudly — the harness ALWAYS sets this. Locally devs may
+        # set it themselves; default to a banner if missing.
+        raise RuntimeError(
+            f"{ADMIN_TOKEN_ENV} is required — harness generates it per run."
+        )
+    return token
+
+
+def _now() -> str:
+    return os.environ.get("FAKE_NOW") or seed.FAKE_NOW_DEFAULT
+
+
+def _seed_val() -> int:
+    return int(os.environ.get("SEED") or 42)
+
+
+_EVENTS: list[dict[str, Any]] = []
+_BOOT_TIME = time.time()
+
+
+def _emit_event(event: str, data: dict[str, Any] | None = None) -> None:
+    _EVENTS.append({
+        "ts": time.time(),
+        "event": event,
+        "data": data or {},
+    })
+
+
+def _initials_for(name: str) -> str:
+    parts = [p for p in (name or "").split() if p]
+    if len(parts) >= 3:
+        return (parts[0][0] + parts[1][0] + parts[2][0]).upper()
+    if len(parts) == 2:
+        return (parts[0][0] + parts[1][0] + parts[1][-1]).upper()
+    base = (parts[0] if parts else "X").upper()
+    return (base + "XX")[:3]
+
+
+def create_app() -> FastAPI:
+    app = FastAPI(title="mantis-mercor", docs_url=None, redoc_url=None)
+
+    templates = Jinja2Templates(directory=str(APP_DIR / "templates"))
+    # Make initials helper available in templates.
+    templates.env.filters["initials"] = _initials_for
+    app.state.templates = templates
+    app.state.admin_token = _admin_token()
+
+    @app.middleware("http")
+    async def _auth_gate(request: Request, call_next):  # noqa: ANN202
+        try:
+            request.state.current_user = auth.current_user(request)
+        except Exception:  # noqa: BLE001
+            request.state.current_user = None
+
+        if auth.auth_required():
+            path = request.url.path
+            open_prefixes = (
+                "/login", "/signup", "/logout", "/__env__/",
+                "/static/", "/jobs", "/experts",
+            )
+            if path == "/" or path.startswith(open_prefixes):
+                pass
+            elif path.startswith(("/apply/", "/dashboard", "/profile")):
+                user = request.state.current_user
+                if user is None:
+                    return RedirectResponse(
+                        f"/login?next={path}", status_code=303,
+                    )
+        return await call_next(request)
+
+    @app.on_event("startup")
+    def _bootstrap() -> None:
+        conn = db.connect()
+        cur = conn.execute("SELECT COUNT(*) FROM jobs")
+        if cur.fetchone()[0] == 0:
+            seed.seed(conn, seed_val=_seed_val(), fake_now=_now())
+            _emit_event("seeded", {"seed": _seed_val(), "now": _now()})
+
+    app.mount(
+        "/static",
+        StaticFiles(directory=str(APP_DIR / "static")),
+        name="static",
+    )
+
+    from .routes import (
+        apply as apply_router,
+        auth as auth_router,
+        dashboard as dashboard_router,
+        env_admin as env_admin_router,
+        jobs as jobs_router,
+        marketing as marketing_router,
+        profile as profile_router,
+    )
+
+    app.include_router(env_admin_router.router)
+    app.include_router(auth_router.router)
+    app.include_router(marketing_router.router)
+    app.include_router(jobs_router.router)
+    app.include_router(apply_router.router)
+    app.include_router(dashboard_router.router)
+    app.include_router(profile_router.router)
+
+    return app
+
+
+app = create_app()
+
+
+# Helpers exposed to the routes package ------------------------------
+
+
+def admin_token_ok(request: Request) -> bool:
+    return request.headers.get(ADMIN_HEADER) == request.app.state.admin_token
+
+
+def admin_required_response() -> JSONResponse:
+    return JSONResponse({"error": "admin token required"}, status_code=401)
+
+
+def now_value() -> str:
+    return _now()
+
+
+def seed_value() -> int:
+    return _seed_val()
+
+
+def boot_time() -> float:
+    return _BOOT_TIME
+
+
+def emit(event: str, data: dict[str, Any] | None = None) -> None:
+    _emit_event(event, data)
+
+
+def events_since(ts: float) -> list[dict[str, Any]]:
+    return [e for e in _EVENTS if e["ts"] >= ts]
+
+
+def clear_events() -> None:
+    _EVENTS.clear()
+
+
+# Apply-draft store — in-memory, per (user_id, job_id) tuple.
+# Persists across step submits within one process; cleared on reset.
+APPLY_DRAFTS: dict[tuple[str, str], dict[str, Any]] = {}
+
+
+def get_draft(user_id: str, job_id: str) -> dict[str, Any]:
+    return APPLY_DRAFTS.setdefault(
+        (user_id, job_id),
+        {"headline": "", "skills": "", "hourly_rate": "",
+         "resume_text": "", "answers": []},
+    )
+
+
+def set_draft(user_id: str, job_id: str, **updates: Any) -> dict[str, Any]:
+    cur = get_draft(user_id, job_id)
+    cur.update(updates)
+    return cur
+
+
+def clear_draft(user_id: str, job_id: str) -> None:
+    APPLY_DRAFTS.pop((user_id, job_id), None)
+
+
+def clear_all_drafts() -> None:
+    APPLY_DRAFTS.clear()

--- a/deploy/sim_envs/mantis_mercor/app/main.py
+++ b/deploy/sim_envs/mantis_mercor/app/main.py
@@ -13,8 +13,8 @@ import time
 from pathlib import Path
 from typing import Any
 
-from fastapi import FastAPI, Request, Response
-from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 

--- a/deploy/sim_envs/mantis_mercor/app/oracles/__init__.py
+++ b/deploy/sim_envs/mantis_mercor/app/oracles/__init__.py
@@ -1,0 +1,38 @@
+"""Oracles — server-side graders for mantis-mercor.
+
+Each oracle reads DB state + audit_log. Never the agent transcript.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Any, Callable
+
+from . import t01_apply_to_ml_engineer, t02_shortlist_candidate, t03_decline_application
+
+GraderFn = Callable[..., dict[str, Any]]
+
+GRADERS: dict[str, GraderFn] = {
+    "t01": t01_apply_to_ml_engineer.grade,
+    "t01_apply_to_ml_engineer": t01_apply_to_ml_engineer.grade,
+    "t02": t02_shortlist_candidate.grade,
+    "t02_shortlist_candidate": t02_shortlist_candidate.grade,
+    "t03": t03_decline_application.grade,
+    "t03_decline_application": t03_decline_application.grade,
+}
+
+
+def grade(task_id: str, conn: sqlite3.Connection, *, now: str,
+          seed_val: int) -> dict[str, Any]:
+    fn = GRADERS.get(task_id)
+    if fn is None:
+        return {
+            "passed": False,
+            "score": 0.0,
+            "task_id": task_id,
+            "reasons": [f"no oracle registered for task_id={task_id!r}"],
+            "diff": {},
+        }
+    result = fn(conn, now=now, seed_val=seed_val)
+    result.setdefault("task_id", task_id)
+    return result

--- a/deploy/sim_envs/mantis_mercor/app/oracles/t01_apply_to_ml_engineer.py
+++ b/deploy/sim_envs/mantis_mercor/app/oracles/t01_apply_to_ml_engineer.py
@@ -1,0 +1,100 @@
+"""t01 — Candidate applies to ``job_00001`` (Internal Medicine Expert).
+
+The task is named "apply_to_ml_engineer" historically per the task
+suite naming convention; in this env the canonical ``job_00001`` is
+the Internal Medicine Expert role (the first role visible on home).
+The grader works against ``job_00001`` regardless of title.
+
+Pass conditions:
+
+1. An ``application_submitted`` audit row exists with
+   ``target_id`` referencing a row in ``applications``.
+2. The application's ``job_id == 'job_00001'``.
+3. The application's ``candidate_id == 'candidate_00001'`` (or any
+   candidate when ENV_REQUIRE_AUTH=0 and effective_user is canonical).
+4. ``status == 'submitted'`` after the run.
+5. ``screening_answers`` is a JSON array with the same length as
+   the job's ``screening_qs`` and EVERY answer is non-empty.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from typing import Any
+
+EXPECTED_JOB_ID = "job_00001"
+EXPECTED_CANDIDATE = "candidate_00001"
+
+
+def grade(conn: sqlite3.Connection, *, now: str, seed_val: int) -> dict[str, Any]:
+    reasons: list[str] = []
+
+    audit_rows = conn.execute(
+        "SELECT target_id, payload_json FROM audit_log "
+        "WHERE operation = 'application_submitted' ORDER BY id"
+    ).fetchall()
+
+    job_row = conn.execute(
+        "SELECT screening_qs FROM jobs WHERE id=?", (EXPECTED_JOB_ID,),
+    ).fetchone()
+    if job_row is None:
+        return _fail([f"job {EXPECTED_JOB_ID} missing in seed"], {})
+    expected_n_qs = len(json.loads(job_row["screening_qs"] or "[]"))
+
+    matched_app: dict[str, Any] | None = None
+    for r in audit_rows:
+        payload = json.loads(r["payload_json"] or "{}")
+        if payload.get("job_id") != EXPECTED_JOB_ID:
+            continue
+        if payload.get("candidate_id") != EXPECTED_CANDIDATE:
+            continue
+        app_row = conn.execute(
+            "SELECT * FROM applications WHERE id=?", (r["target_id"],),
+        ).fetchone()
+        if app_row is None:
+            continue
+        matched_app = dict(app_row)
+        break
+
+    if matched_app is None:
+        reasons.append(
+            f"no application_submitted audit row found for "
+            f"candidate={EXPECTED_CANDIDATE} job={EXPECTED_JOB_ID}"
+        )
+        return _fail(reasons, {"audit_rows_seen": len(audit_rows)})
+
+    if matched_app["status"] != "submitted":
+        reasons.append(f"status {matched_app['status']!r} ≠ 'submitted'")
+
+    answers = json.loads(matched_app.get("screening_answers") or "[]")
+    if not isinstance(answers, list):
+        reasons.append("screening_answers is not a list")
+    elif len(answers) != expected_n_qs:
+        reasons.append(
+            f"screening_answers has {len(answers)} entries; job has "
+            f"{expected_n_qs} screening questions"
+        )
+    else:
+        for i, a in enumerate(answers):
+            if not (isinstance(a, str) and a.strip()):
+                reasons.append(f"screening_answers[{i}] is empty")
+
+    passed = not reasons
+    return {
+        "passed": passed,
+        "score": 1.0 if passed else 0.0,
+        "reasons": reasons or [
+            f"application {matched_app['id']} submitted with complete "
+            f"screening answers"
+        ],
+        "diff": {
+            "application_id": matched_app["id"],
+            "status": matched_app["status"],
+            "n_answers": len(answers) if isinstance(answers, list) else 0,
+        },
+    }
+
+
+def _fail(reasons: list[str], diff: dict[str, Any]) -> dict[str, Any]:
+    return {"passed": False, "score": 0.0, "reasons": reasons, "diff": diff}

--- a/deploy/sim_envs/mantis_mercor/app/oracles/t02_shortlist_candidate.py
+++ b/deploy/sim_envs/mantis_mercor/app/oracles/t02_shortlist_candidate.py
@@ -1,0 +1,83 @@
+"""t02 — Client adds candidate_00007 to the shortlist for job_00001.
+
+Pass conditions:
+
+1. A ``shortlist_entries`` row exists with ``job_id='job_00001'``,
+   ``candidate_id='candidate_00007'``.
+2. An ``audit_log`` row with operation=``candidate_shortlisted`` and
+   matching target.
+3. ``added_by`` references a user with role=``client`` (the canonical
+   ``client_00001`` when ENV_REQUIRE_AUTH=0).
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from typing import Any
+
+EXPECTED_JOB = "job_00001"
+EXPECTED_CANDIDATE = "candidate_00007"
+
+
+def grade(conn: sqlite3.Connection, *, now: str, seed_val: int) -> dict[str, Any]:
+    reasons: list[str] = []
+
+    row = conn.execute(
+        "SELECT * FROM shortlist_entries WHERE job_id=? AND candidate_id=?",
+        (EXPECTED_JOB, EXPECTED_CANDIDATE),
+    ).fetchone()
+    if row is None:
+        reasons.append(
+            f"no shortlist_entries row for job={EXPECTED_JOB} "
+            f"candidate={EXPECTED_CANDIDATE}"
+        )
+        return _fail(reasons, {})
+
+    entry = dict(row)
+
+    added_by = entry.get("added_by")
+    if added_by:
+        u = conn.execute(
+            "SELECT role FROM users WHERE id=?", (added_by,),
+        ).fetchone()
+        if u is None or u["role"] not in {"client", "admin"}:
+            reasons.append(
+                f"added_by user {added_by!r} not a client/admin"
+            )
+
+    audit = conn.execute(
+        "SELECT id, payload_json FROM audit_log "
+        "WHERE operation='candidate_shortlisted' AND target_id=?",
+        (entry["id"],),
+    ).fetchone()
+    if audit is None:
+        reasons.append("no candidate_shortlisted audit row for the entry")
+    else:
+        payload = json.loads(audit["payload_json"] or "{}")
+        if payload.get("job_id") != EXPECTED_JOB:
+            reasons.append(
+                f"audit payload.job_id {payload.get('job_id')!r} ≠ {EXPECTED_JOB}"
+            )
+        if payload.get("candidate_id") != EXPECTED_CANDIDATE:
+            reasons.append(
+                f"audit payload.candidate_id {payload.get('candidate_id')!r} "
+                f"≠ {EXPECTED_CANDIDATE}"
+            )
+
+    passed = not reasons
+    return {
+        "passed": passed,
+        "score": 1.0 if passed else 0.0,
+        "reasons": reasons or [
+            f"candidate {EXPECTED_CANDIDATE} shortlisted for {EXPECTED_JOB}"
+        ],
+        "diff": {
+            "shortlist_id": entry["id"],
+            "added_by": entry.get("added_by"),
+        },
+    }
+
+
+def _fail(reasons: list[str], diff: dict[str, Any]) -> dict[str, Any]:
+    return {"passed": False, "score": 0.0, "reasons": reasons, "diff": diff}

--- a/deploy/sim_envs/mantis_mercor/app/oracles/t03_decline_application.py
+++ b/deploy/sim_envs/mantis_mercor/app/oracles/t03_decline_application.py
@@ -1,0 +1,73 @@
+"""t03 — Client declines the canonical pending application ``app_00001``.
+
+Pass conditions:
+
+1. The seeded ``app_00001`` row now has ``status='rejected'`` and a
+   non-empty ``reject_reason``.
+2. An ``audit_log`` row with operation=``application_declined`` and
+   target_id=``app_00001`` exists, and its payload carries the reason
+   + previous_status='submitted'.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from typing import Any
+
+TARGET_APP = "app_00001"
+
+
+def grade(conn: sqlite3.Connection, *, now: str, seed_val: int) -> dict[str, Any]:
+    reasons: list[str] = []
+
+    app_row = conn.execute(
+        "SELECT * FROM applications WHERE id=?", (TARGET_APP,),
+    ).fetchone()
+    if app_row is None:
+        return _fail(
+            [f"application {TARGET_APP} missing — seed did not initialise"],
+            {},
+        )
+    app = dict(app_row)
+
+    if app["status"] != "rejected":
+        reasons.append(f"status {app['status']!r} ≠ 'rejected'")
+    if not (app.get("reject_reason") or "").strip():
+        reasons.append("reject_reason is empty")
+
+    audit = conn.execute(
+        "SELECT payload_json FROM audit_log "
+        "WHERE operation='application_declined' AND target_id=?",
+        (TARGET_APP,),
+    ).fetchone()
+    if audit is None:
+        reasons.append("no application_declined audit row")
+    else:
+        payload = json.loads(audit["payload_json"] or "{}")
+        if not (payload.get("reason") or "").strip():
+            reasons.append("audit payload.reason is empty")
+        if payload.get("previous_status") not in {"submitted", "under_review"}:
+            reasons.append(
+                f"audit payload.previous_status "
+                f"{payload.get('previous_status')!r} not in submitted/under_review"
+            )
+
+    passed = not reasons
+    return {
+        "passed": passed,
+        "score": 1.0 if passed else 0.0,
+        "reasons": reasons or [
+            f"application {TARGET_APP} declined with reason "
+            f"{app.get('reject_reason')!r}"
+        ],
+        "diff": {
+            "application_id": TARGET_APP,
+            "status": app["status"],
+            "reject_reason": app.get("reject_reason"),
+        },
+    }
+
+
+def _fail(reasons: list[str], diff: dict[str, Any]) -> dict[str, Any]:
+    return {"passed": False, "score": 0.0, "reasons": reasons, "diff": diff}

--- a/deploy/sim_envs/mantis_mercor/app/routes/__init__.py
+++ b/deploy/sim_envs/mantis_mercor/app/routes/__init__.py
@@ -1,0 +1,1 @@
+"""Route modules for mantis-mercor."""

--- a/deploy/sim_envs/mantis_mercor/app/routes/apply.py
+++ b/deploy/sim_envs/mantis_mercor/app/routes/apply.py
@@ -1,0 +1,205 @@
+"""Multi-step apply flow — 5 steps, draft persisted in-memory.
+
+Routes:
+
+* ``GET /apply/<job_id>`` — redirects to step 1.
+* ``GET/POST /apply/<job_id>/step/<n>`` — render + persist each step.
+* ``POST /apply/<job_id>/submit`` — write the application row + audit.
+"""
+
+from __future__ import annotations
+
+import json
+
+from fastapi import APIRouter, Form, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+
+from .. import auth as auth_mod, db, main as app_main
+
+router = APIRouter()
+
+
+def _job(conn, job_id: str) -> dict | None:
+    row = conn.execute(
+        "SELECT j.*, c.name AS company_name FROM jobs j "
+        "JOIN companies c ON c.id = j.company_id WHERE j.id = ?",
+        (job_id,),
+    ).fetchone()
+    return dict(row) if row else None
+
+
+@router.get("/apply/{job_id}")
+async def apply_root(job_id: str):
+    return RedirectResponse(f"/apply/{job_id}/step/1", status_code=303)
+
+
+@router.get("/apply/{job_id}/step/{n}", response_class=HTMLResponse)
+async def apply_step(request: Request, job_id: str, n: int):
+    conn = db.connect()
+    job = _job(conn, job_id)
+    if job is None:
+        return HTMLResponse("<h1>Role not found</h1>", status_code=404)
+
+    user = auth_mod.effective_user(request, default_role="candidate")
+    draft = app_main.get_draft(user["id"], job_id)
+    screening_qs = json.loads(job.get("screening_qs") or "[]")
+
+    return request.app.state.templates.TemplateResponse(
+        "apply_step.html",
+        {
+            "request": request,
+            "job": job,
+            "draft": draft,
+            "step": n,
+            "screening_qs": screening_qs,
+            "total_steps": 5,
+        },
+    )
+
+
+@router.post("/apply/{job_id}/step/{n}")
+async def apply_step_submit(
+    request: Request,
+    job_id: str,
+    n: int,
+):
+    form = await request.form()
+    user = auth_mod.effective_user(request, default_role="candidate")
+    updates: dict = {}
+
+    if n == 1:
+        updates["headline"] = (form.get("headline") or "").strip()
+        updates["skills"] = (form.get("skills") or "").strip()
+        try:
+            updates["hourly_rate"] = float(form.get("hourly_rate") or 0)
+        except ValueError:
+            updates["hourly_rate"] = 0.0
+    elif n == 2:
+        updates["resume_text"] = (form.get("resume_text") or "").strip()
+    elif n == 3:
+        # Screening answers — fields named answer_0, answer_1, ...
+        conn = db.connect()
+        job = _job(conn, job_id)
+        n_qs = len(json.loads(job.get("screening_qs") or "[]")) if job else 0
+        answers = []
+        for i in range(n_qs):
+            answers.append((form.get(f"answer_{i}") or "").strip())
+        updates["answers"] = answers
+
+    if updates:
+        app_main.set_draft(user["id"], job_id, **updates)
+
+    nav = (form.get("nav") or "next").strip()
+    if nav == "back" and n > 1:
+        return RedirectResponse(f"/apply/{job_id}/step/{n - 1}", status_code=303)
+    if n >= 5:
+        return RedirectResponse(
+            f"/apply/{job_id}/submit", status_code=303,
+        )
+    return RedirectResponse(f"/apply/{job_id}/step/{n + 1}", status_code=303)
+
+
+@router.get("/apply/{job_id}/submit", response_class=HTMLResponse)
+async def apply_submit_get(request: Request, job_id: str):
+    # Render the review screen with a Submit button.
+    conn = db.connect()
+    job = _job(conn, job_id)
+    if job is None:
+        return HTMLResponse("<h1>Role not found</h1>", status_code=404)
+    user = auth_mod.effective_user(request, default_role="candidate")
+    draft = app_main.get_draft(user["id"], job_id)
+    screening_qs = json.loads(job.get("screening_qs") or "[]")
+    return request.app.state.templates.TemplateResponse(
+        "apply_review.html",
+        {
+            "request": request,
+            "job": job,
+            "draft": draft,
+            "screening_qs": screening_qs,
+        },
+    )
+
+
+@router.post("/apply/{job_id}/submit", response_class=HTMLResponse)
+async def apply_submit_post(request: Request, job_id: str):
+    conn_check = db.connect()
+    job = _job(conn_check, job_id)
+    if job is None:
+        return HTMLResponse("<h1>Role not found</h1>", status_code=404)
+
+    user = auth_mod.effective_user(request, default_role="candidate")
+    draft = app_main.get_draft(user["id"], job_id)
+    now = app_main.now_value()
+
+    skills_list = [s.strip() for s in (draft.get("skills") or "").split(",") if s.strip()]
+    answers = draft.get("answers") or []
+    headline = draft.get("headline") or ""
+    hourly_rate = float(draft.get("hourly_rate") or 0)
+    resume_text = draft.get("resume_text") or ""
+
+    app_id = f"app_run_{abs(hash((user['id'], job_id))) % 1_000_000:06d}"
+
+    with db.transaction() as conn:
+        existing = conn.execute(
+            "SELECT id FROM applications WHERE job_id=? AND candidate_id=?",
+            (job_id, user["id"]),
+        ).fetchone()
+        if existing:
+            # Upsert: update existing application to submitted with fresh fields.
+            app_id = existing["id"]
+            conn.execute(
+                "UPDATE applications SET status='submitted', headline=?, "
+                "skills_json=?, hourly_rate=?, resume_text=?, screening_answers=?, "
+                "submitted_at=?, updated_at=? WHERE id=?",
+                (
+                    headline,
+                    db.pack_json(skills_list),
+                    hourly_rate,
+                    resume_text,
+                    db.pack_json(answers),
+                    now,
+                    now,
+                    app_id,
+                ),
+            )
+        else:
+            conn.execute(
+                "INSERT INTO applications (id, job_id, candidate_id, status, "
+                "headline, skills_json, hourly_rate, resume_text, "
+                "screening_answers, reject_reason, submitted_at, updated_at) "
+                "VALUES (?,?,?,?,?,?,?,?,?,?,?,?)",
+                (
+                    app_id, job_id, user["id"], "submitted",
+                    headline,
+                    db.pack_json(skills_list),
+                    hourly_rate,
+                    resume_text,
+                    db.pack_json(answers),
+                    "",
+                    now,
+                    now,
+                ),
+            )
+
+        db.log_audit(
+            conn,
+            occurred_at=now,
+            operation="application_submitted",
+            target_type="application",
+            target_id=app_id,
+            payload={
+                "job_id": job_id,
+                "candidate_id": user["id"],
+                "screening_answers": answers,
+                "headline": headline,
+            },
+        )
+
+    app_main.clear_draft(user["id"], job_id)
+    app_main.emit("application_submitted",
+                  {"application_id": app_id, "job_id": job_id})
+
+    return request.app.state.templates.TemplateResponse(
+        "apply_confirm.html",
+        {"request": request, "job": job, "application_id": app_id},
+    )

--- a/deploy/sim_envs/mantis_mercor/app/routes/apply.py
+++ b/deploy/sim_envs/mantis_mercor/app/routes/apply.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import json
 
-from fastapi import APIRouter, Form, Request
+from fastapi import APIRouter, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
 
 from .. import auth as auth_mod, db, main as app_main

--- a/deploy/sim_envs/mantis_mercor/app/routes/auth.py
+++ b/deploy/sim_envs/mantis_mercor/app/routes/auth.py
@@ -1,0 +1,120 @@
+"""Login / signup / logout routes."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Form, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+
+from .. import auth as auth_mod, db, main as app_main
+
+router = APIRouter()
+
+
+@router.get("/login", response_class=HTMLResponse)
+async def login_form(request: Request, next: str = "/dashboard",
+                     error: str | None = None):
+    templates = request.app.state.templates
+    return templates.TemplateResponse(
+        "login.html",
+        {"request": request, "next": next, "error": error},
+    )
+
+
+@router.post("/login")
+async def login_submit(
+    request: Request,
+    email: str = Form(...),
+    password: str = Form(...),
+    next: str = Form("/dashboard"),
+):
+    user = auth_mod.lookup_user_by_email(email)
+    if not user or not auth_mod.verify_password(password, user["password_hash"]):
+        return RedirectResponse(
+            f"/login?next={next}&error=Invalid+credentials", status_code=303,
+        )
+    response = RedirectResponse(next, status_code=303)
+    auth_mod.set_session_cookie(response, user["id"])
+
+    with db.transaction() as conn:
+        db.log_audit(
+            conn,
+            occurred_at=app_main.now_value(),
+            operation="login_succeeded",
+            target_type="user",
+            target_id=user["id"],
+            payload={"email": user["email"], "role": user["role"]},
+        )
+    app_main.emit("login_succeeded", {"user_id": user["id"]})
+    return response
+
+
+@router.get("/signup", response_class=HTMLResponse)
+async def signup_form(request: Request, error: str | None = None):
+    templates = request.app.state.templates
+    return templates.TemplateResponse(
+        "signup.html",
+        {"request": request, "error": error},
+    )
+
+
+@router.post("/signup")
+async def signup_submit(
+    request: Request,
+    email: str = Form(...),
+    password: str = Form(...),
+    name: str = Form(""),
+    role: str = Form("candidate"),
+):
+    if role not in {"candidate", "client"}:
+        role = "candidate"
+    email_lc = email.strip().lower()
+    existing = auth_mod.lookup_user_by_email(email_lc)
+    if existing:
+        return RedirectResponse(
+            "/signup?error=Email+already+in+use", status_code=303,
+        )
+
+    now = app_main.now_value()
+    user_id = f"{role}_signup_{abs(hash(email_lc)) % 1_000_000:06d}"
+    with db.transaction() as conn:
+        company_id = None
+        if role == "client":
+            company_id = f"company_signup_{user_id[-6:]}"
+            conn.execute(
+                "INSERT INTO companies (id, name, domain, owner_user_id) "
+                "VALUES (?, ?, ?, ?)",
+                (company_id, name or "Self-serve client", "", user_id),
+            )
+        conn.execute(
+            "INSERT INTO users (id, email, password_hash, role, name, company_id, "
+            "created_at) VALUES (?,?,?,?,?,?,?)",
+            (user_id, email_lc, auth_mod.hash_password(password), role,
+             name or "", company_id, now),
+        )
+        if role == "candidate":
+            conn.execute(
+                "INSERT INTO candidate_profiles (user_id, headline, skills_json, "
+                "hourly_rate, availability, resume_text, updated_at) "
+                "VALUES (?,?,?,?,?,?,?)",
+                (user_id, "", "[]", 0.0, "Part-time", "", now),
+            )
+        db.log_audit(
+            conn,
+            occurred_at=now,
+            operation="user_signed_up",
+            target_type="user",
+            target_id=user_id,
+            payload={"email": email_lc, "role": role},
+        )
+
+    response = RedirectResponse("/dashboard", status_code=303)
+    auth_mod.set_session_cookie(response, user_id)
+    app_main.emit("user_signed_up", {"user_id": user_id})
+    return response
+
+
+@router.post("/logout")
+async def logout(request: Request):
+    response = RedirectResponse("/", status_code=303)
+    auth_mod.clear_session_cookie(response)
+    return response

--- a/deploy/sim_envs/mantis_mercor/app/routes/dashboard.py
+++ b/deploy/sim_envs/mantis_mercor/app/routes/dashboard.py
@@ -1,0 +1,157 @@
+"""Dashboard — role-sensitive (candidate vs client)."""
+
+from __future__ import annotations
+
+import json
+
+from fastapi import APIRouter, Form, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+
+from .. import auth as auth_mod, db, main as app_main
+
+router = APIRouter()
+
+
+@router.get("/dashboard", response_class=HTMLResponse)
+async def dashboard(request: Request):
+    conn = db.connect()
+    user = auth_mod.effective_user(request, default_role="candidate")
+    templates = request.app.state.templates
+
+    if user.get("role") == "client":
+        company_id = user.get("company_id") or ""
+        # Pending applications for jobs owned by my company.
+        pending = [
+            dict(r) for r in conn.execute(
+                "SELECT a.*, j.title AS job_title, u.name AS candidate_name "
+                "FROM applications a "
+                "JOIN jobs j ON j.id = a.job_id "
+                "JOIN users u ON u.id = a.candidate_id "
+                "WHERE j.company_id = ? AND a.status IN ('submitted', 'under_review') "
+                "ORDER BY a.updated_at DESC LIMIT 25",
+                (company_id,),
+            ).fetchall()
+        ]
+        shortlist = [
+            dict(r) for r in conn.execute(
+                "SELECT s.*, j.title AS job_title, u.name AS candidate_name "
+                "FROM shortlist_entries s "
+                "JOIN jobs j ON j.id = s.job_id "
+                "JOIN users u ON u.id = s.candidate_id "
+                "WHERE s.added_by = ? "
+                "ORDER BY s.created_at DESC LIMIT 5",
+                (user["id"],),
+            ).fetchall()
+        ]
+        return templates.TemplateResponse(
+            "dashboard_client.html",
+            {"request": request, "user": user, "pending": pending,
+             "shortlist": shortlist},
+        )
+
+    # Candidate view
+    my_apps = [
+        dict(r) for r in conn.execute(
+            "SELECT a.*, j.title AS job_title, c.name AS company_name "
+            "FROM applications a "
+            "JOIN jobs j ON j.id = a.job_id "
+            "JOIN companies c ON c.id = j.company_id "
+            "WHERE a.candidate_id = ? "
+            "ORDER BY a.updated_at DESC",
+            (user["id"],),
+        ).fetchall()
+    ]
+    return templates.TemplateResponse(
+        "dashboard_candidate.html",
+        {"request": request, "user": user, "applications": my_apps},
+    )
+
+
+@router.post("/dashboard/shortlist")
+async def add_shortlist(
+    request: Request,
+    job_id: str = Form(...),
+    candidate_id: str = Form(...),
+):
+    user = auth_mod.effective_user(request, default_role="client")
+    if user.get("role") not in {"client", "admin"}:
+        return RedirectResponse("/dashboard", status_code=303)
+    now = app_main.now_value()
+    entry_id = f"shortlist_run_{abs(hash((job_id, candidate_id))) % 1_000_000:06d}"
+
+    with db.transaction() as conn:
+        existing = conn.execute(
+            "SELECT id FROM shortlist_entries WHERE job_id=? AND candidate_id=?",
+            (job_id, candidate_id),
+        ).fetchone()
+        if existing:
+            entry_id = existing["id"]
+        else:
+            conn.execute(
+                "INSERT INTO shortlist_entries (id, job_id, candidate_id, "
+                "added_by, created_at) VALUES (?,?,?,?,?)",
+                (entry_id, job_id, candidate_id, user["id"], now),
+            )
+        db.log_audit(
+            conn,
+            occurred_at=now,
+            operation="candidate_shortlisted",
+            target_type="shortlist_entry",
+            target_id=entry_id,
+            payload={
+                "job_id": job_id,
+                "candidate_id": candidate_id,
+                "added_by": user["id"],
+            },
+        )
+    app_main.emit("candidate_shortlisted",
+                  {"job_id": job_id, "candidate_id": candidate_id})
+    return RedirectResponse("/dashboard", status_code=303)
+
+
+@router.post("/dashboard/decline")
+async def decline_application(
+    request: Request,
+    application_id: str = Form(...),
+    reason: str = Form(...),
+):
+    user = auth_mod.effective_user(request, default_role="client")
+    if user.get("role") not in {"client", "admin"}:
+        return RedirectResponse("/dashboard", status_code=303)
+    reason = (reason or "").strip()
+    if not reason:
+        return RedirectResponse(
+            "/dashboard?error=Reason+required", status_code=303,
+        )
+    now = app_main.now_value()
+    with db.transaction() as conn:
+        row = conn.execute(
+            "SELECT id, status FROM applications WHERE id=?",
+            (application_id,),
+        ).fetchone()
+        if row is None:
+            return RedirectResponse("/dashboard?error=Not+found", status_code=303)
+        if row["status"] not in {"submitted", "under_review"}:
+            return RedirectResponse(
+                "/dashboard?error=Not+pending", status_code=303,
+            )
+        conn.execute(
+            "UPDATE applications SET status='rejected', reject_reason=?, "
+            "updated_at=? WHERE id=?",
+            (reason, now, application_id),
+        )
+        db.log_audit(
+            conn,
+            occurred_at=now,
+            operation="application_declined",
+            target_type="application",
+            target_id=application_id,
+            payload={
+                "reason": reason,
+                "declined_by": user["id"],
+                "previous_status": row["status"],
+            },
+        )
+    app_main.emit("application_declined",
+                  {"application_id": application_id})
+    return RedirectResponse("/dashboard", status_code=303)

--- a/deploy/sim_envs/mantis_mercor/app/routes/dashboard.py
+++ b/deploy/sim_envs/mantis_mercor/app/routes/dashboard.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 
 from fastapi import APIRouter, Form, Request
 from fastapi.responses import HTMLResponse, RedirectResponse

--- a/deploy/sim_envs/mantis_mercor/app/routes/env_admin.py
+++ b/deploy/sim_envs/mantis_mercor/app/routes/env_admin.py
@@ -1,0 +1,163 @@
+"""Harness contract — ``/__env__/{health,reset,seed,clock,oracle,state,events,mutations}``."""
+
+from __future__ import annotations
+
+import json
+import os
+
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse
+
+from .. import db, main as app_main, seed
+
+router = APIRouter(prefix="/__env__")
+
+
+@router.get("/health")
+async def health() -> JSONResponse:
+    return JSONResponse({
+        "ok": True,
+        "seed": app_main.seed_value(),
+        "now": app_main.now_value(),
+        "boot_time": app_main.boot_time(),
+    })
+
+
+@router.post("/reset")
+async def reset(request: Request) -> JSONResponse:
+    if not app_main.admin_token_ok(request):
+        return app_main.admin_required_response()
+    conn = db.connect()
+    seed.seed(conn, seed_val=app_main.seed_value(), fake_now=app_main.now_value())
+    app_main.clear_events()
+    app_main.clear_all_drafts()
+    app_main.emit("reset")
+    return JSONResponse({"ok": True})
+
+
+@router.post("/seed")
+async def reseed(request: Request) -> JSONResponse:
+    if not app_main.admin_token_ok(request):
+        return app_main.admin_required_response()
+    try:
+        payload = await request.json()
+    except Exception:  # noqa: BLE001
+        payload = {}
+    new_seed = int(payload.get("seed", app_main.seed_value()))
+    conn = db.connect()
+    seed.seed(conn, seed_val=new_seed, fake_now=app_main.now_value())
+    app_main.clear_all_drafts()
+    app_main.emit("reseeded", {"seed": new_seed})
+    return JSONResponse({"ok": True, "seed": new_seed})
+
+
+@router.post("/clock")
+async def clock(request: Request) -> JSONResponse:
+    if not app_main.admin_token_ok(request):
+        return app_main.admin_required_response()
+    try:
+        payload = await request.json()
+    except Exception:  # noqa: BLE001
+        payload = {}
+    new_now = str(payload.get("now") or app_main.now_value())
+    os.environ["FAKE_NOW"] = new_now
+    app_main.emit("clock_set", {"now": new_now})
+    return JSONResponse({"ok": True, "now": new_now})
+
+
+@router.get("/oracle")
+async def oracle(request: Request) -> JSONResponse:
+    if not app_main.admin_token_ok(request):
+        return app_main.admin_required_response()
+    task_id = (request.query_params.get("task_id") or "").strip()
+    if not task_id:
+        return JSONResponse({"passed": False, "score": 0.0,
+                             "reasons": ["task_id is required"], "diff": {}})
+
+    from ..oracles import grade
+    result = grade(task_id, db.connect(), now=app_main.now_value(),
+                   seed_val=app_main.seed_value())
+    app_main.emit("oracle_query", {"task_id": task_id, "passed": result["passed"]})
+    return JSONResponse(result)
+
+
+@router.get("/state")
+async def state(request: Request) -> JSONResponse:
+    if not app_main.admin_token_ok(request):
+        return app_main.admin_required_response()
+    conn = db.connect()
+
+    def count(table: str) -> int:
+        return int(conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0])
+
+    recent_audit = [
+        {
+            "id": r["id"],
+            "occurred_at": r["occurred_at"],
+            "operation": r["operation"],
+            "target_type": r["target_type"],
+            "target_id": r["target_id"],
+        }
+        for r in conn.execute(
+            "SELECT * FROM audit_log ORDER BY id DESC LIMIT 50"
+        ).fetchall()
+    ]
+
+    return JSONResponse({
+        "seed": app_main.seed_value(),
+        "now": app_main.now_value(),
+        "counts": {
+            "users": count("users"),
+            "companies": count("companies"),
+            "jobs": count("jobs"),
+            "candidate_profiles": count("candidate_profiles"),
+            "applications": count("applications"),
+            "shortlist_entries": count("shortlist_entries"),
+            "interviews": count("interviews"),
+            "audit_log": count("audit_log"),
+        },
+        "recent_audit": recent_audit,
+    })
+
+
+@router.get("/events")
+async def events(request: Request) -> JSONResponse:
+    if not app_main.admin_token_ok(request):
+        return app_main.admin_required_response()
+    since = float(request.query_params.get("since") or 0)
+    return JSONResponse({"events": app_main.events_since(since)})
+
+
+@router.get("/mutations")
+async def mutations(request: Request) -> JSONResponse:
+    """Return ordered mutation records from audit_log since ``since``.
+
+    Param ``since`` is a row id (integer); rows with id > since are
+    returned. Default 0 (all rows). Matches the contract documented in
+    AGENTS.md.
+    """
+    if not app_main.admin_token_ok(request):
+        return app_main.admin_required_response()
+    try:
+        since_id = int(request.query_params.get("since") or 0)
+    except ValueError:
+        since_id = 0
+    conn = db.connect()
+    rows = conn.execute(
+        "SELECT id, occurred_at, operation, target_type, target_id, payload_json "
+        "FROM audit_log WHERE id > ? ORDER BY id ASC",
+        (since_id,),
+    ).fetchall()
+    return JSONResponse({
+        "mutations": [
+            {
+                "id": r["id"],
+                "ts": r["occurred_at"],
+                "op": r["operation"],
+                "target_type": r["target_type"],
+                "target_id": r["target_id"],
+                "payload": json.loads(r["payload_json"] or "{}"),
+            }
+            for r in rows
+        ]
+    })

--- a/deploy/sim_envs/mantis_mercor/app/routes/jobs.py
+++ b/deploy/sim_envs/mantis_mercor/app/routes/jobs.py
@@ -1,0 +1,81 @@
+"""Jobs list + detail routes."""
+
+from __future__ import annotations
+
+import json
+
+from fastapi import APIRouter, Request
+from fastapi.responses import HTMLResponse
+
+from .. import db
+
+router = APIRouter()
+
+
+@router.get("/jobs", response_class=HTMLResponse)
+async def jobs_list(
+    request: Request,
+    category: str | None = None,
+    engagement: str | None = None,
+    rate_min: int | None = None,
+    rate_max: int | None = None,
+):
+    templates = request.app.state.templates
+    conn = db.connect()
+
+    sql = (
+        "SELECT j.*, c.name AS company_name "
+        "FROM jobs j JOIN companies c ON c.id = j.company_id "
+        "WHERE j.status = 'open'"
+    )
+    params: list = []
+    if category:
+        sql += " AND j.category = ?"
+        params.append(category)
+    if engagement:
+        sql += " AND j.engagement = ?"
+        params.append(engagement)
+    if rate_min is not None:
+        sql += " AND j.rate_max >= ?"
+        params.append(rate_min)
+    if rate_max is not None:
+        sql += " AND j.rate_min <= ?"
+        params.append(rate_max)
+    sql += " ORDER BY j.id"
+
+    rows = [dict(r) for r in conn.execute(sql, params).fetchall()]
+    categories = ["Medical", "Legal", "Finance", "Software", "Consulting", "Office"]
+
+    return templates.TemplateResponse(
+        "jobs_list.html",
+        {
+            "request": request,
+            "jobs": rows,
+            "categories": categories,
+            "filter_category": category or "",
+            "filter_engagement": engagement or "",
+            "filter_rate_min": rate_min,
+            "filter_rate_max": rate_max,
+        },
+    )
+
+
+@router.get("/jobs/{job_id}", response_class=HTMLResponse)
+async def job_detail(request: Request, job_id: str):
+    templates = request.app.state.templates
+    conn = db.connect()
+    row = conn.execute(
+        "SELECT j.*, c.name AS company_name "
+        "FROM jobs j JOIN companies c ON c.id = j.company_id "
+        "WHERE j.id = ?",
+        (job_id,),
+    ).fetchone()
+    if row is None:
+        return HTMLResponse("<h1>Role not found</h1>", status_code=404)
+    job = dict(row)
+    job["skills"] = json.loads(job.get("skills_json") or "[]")
+    job["screening_questions"] = json.loads(job.get("screening_qs") or "[]")
+    return templates.TemplateResponse(
+        "job_detail.html",
+        {"request": request, "job": job},
+    )

--- a/deploy/sim_envs/mantis_mercor/app/routes/marketing.py
+++ b/deploy/sim_envs/mantis_mercor/app/routes/marketing.py
@@ -1,0 +1,58 @@
+"""Marketing surface — `/` home + `/experts` landing."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Request
+from fastapi.responses import HTMLResponse
+
+from .. import db, main as app_main
+
+router = APIRouter()
+
+
+@router.get("/", response_class=HTMLResponse)
+async def home(request: Request):
+    templates = request.app.state.templates
+    conn = db.connect()
+    latest = [
+        dict(r) for r in conn.execute(
+            "SELECT j.*, c.name AS company_name "
+            "FROM jobs j JOIN companies c ON c.id = j.company_id "
+            "WHERE j.status = 'open' "
+            "ORDER BY j.id LIMIT 9"
+        ).fetchall()
+    ]
+    return templates.TemplateResponse(
+        "home.html",
+        {
+            "request": request,
+            "latest_jobs": latest,
+            "stats": {
+                "avg_pay": 95,
+                "roles_created_k": 12,
+                "daily_payouts_usd": 240_000,
+            },
+            "now": app_main.now_value(),
+        },
+    )
+
+
+@router.get("/experts", response_class=HTMLResponse)
+async def experts(request: Request):
+    templates = request.app.state.templates
+    conn = db.connect()
+    latest = [
+        dict(r) for r in conn.execute(
+            "SELECT j.*, c.name AS company_name "
+            "FROM jobs j JOIN companies c ON c.id = j.company_id "
+            "WHERE j.status = 'open' "
+            "ORDER BY j.id LIMIT 12"
+        ).fetchall()
+    ]
+    return templates.TemplateResponse(
+        "experts.html",
+        {
+            "request": request,
+            "latest_jobs": latest,
+        },
+    )

--- a/deploy/sim_envs/mantis_mercor/app/routes/profile.py
+++ b/deploy/sim_envs/mantis_mercor/app/routes/profile.py
@@ -1,0 +1,87 @@
+"""Candidate profile editor."""
+
+from __future__ import annotations
+
+import json
+
+from fastapi import APIRouter, Form, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+
+from .. import auth as auth_mod, db, main as app_main
+
+router = APIRouter()
+
+
+@router.get("/profile", response_class=HTMLResponse)
+async def profile_view(request: Request):
+    conn = db.connect()
+    user = auth_mod.effective_user(request, default_role="candidate")
+    row = conn.execute(
+        "SELECT * FROM candidate_profiles WHERE user_id=?", (user["id"],),
+    ).fetchone()
+    profile = dict(row) if row else {
+        "user_id": user["id"], "headline": "", "skills_json": "[]",
+        "hourly_rate": 0.0, "availability": "Part-time",
+        "resume_text": "", "updated_at": "",
+    }
+    profile["skills"] = json.loads(profile.get("skills_json") or "[]")
+    return request.app.state.templates.TemplateResponse(
+        "profile.html",
+        {"request": request, "user": user, "profile": profile},
+    )
+
+
+@router.post("/profile")
+async def profile_save(
+    request: Request,
+    headline: str = Form(""),
+    skills: str = Form(""),
+    hourly_rate: str = Form("0"),
+    availability: str = Form("Part-time"),
+):
+    user = auth_mod.effective_user(request, default_role="candidate")
+    try:
+        rate = float(hourly_rate or 0)
+    except ValueError:
+        rate = 0.0
+    skills_list = [s.strip() for s in skills.split(",") if s.strip()]
+    if availability not in {"Full-time", "Part-time", "Project-based"}:
+        availability = "Part-time"
+
+    now = app_main.now_value()
+    with db.transaction() as conn:
+        existing = conn.execute(
+            "SELECT user_id FROM candidate_profiles WHERE user_id=?",
+            (user["id"],),
+        ).fetchone()
+        if existing:
+            conn.execute(
+                "UPDATE candidate_profiles SET headline=?, skills_json=?, "
+                "hourly_rate=?, availability=?, updated_at=? WHERE user_id=?",
+                (headline, db.pack_json(skills_list), rate, availability, now,
+                 user["id"]),
+            )
+        else:
+            conn.execute(
+                "INSERT INTO candidate_profiles (user_id, headline, skills_json, "
+                "hourly_rate, availability, resume_text, updated_at) "
+                "VALUES (?,?,?,?,?,?,?)",
+                (user["id"], headline, db.pack_json(skills_list), rate,
+                 availability, "", now),
+            )
+        db.log_audit(
+            conn,
+            occurred_at=now,
+            operation="profile_updated",
+            target_type="candidate_profile",
+            target_id=user["id"],
+            payload={
+                "headline": headline,
+                "skills": skills_list,
+                "hourly_rate": rate,
+                "availability": availability,
+            },
+        )
+
+    app_main.emit("profile_updated", {"user_id": user["id"]})
+    return RedirectResponse("/profile", status_code=303)

--- a/deploy/sim_envs/mantis_mercor/app/seed.py
+++ b/deploy/sim_envs/mantis_mercor/app/seed.py
@@ -1,0 +1,438 @@
+"""Deterministic seed for mantis-mercor.
+
+Same seed → identical DB. Generates:
+
+* ~50 users (40 candidates + 9 clients + 1 admin)
+* ~12 companies (one per client + a few unowned shells)
+* ~30 jobs spread across the 6 categories
+* ~100 historical applications + some interviews / payments
+
+ID conventions:
+
+* ``candidate_00007``, ``client_00003``, ``job_00001``, ``app_00042``,
+  ``company_00005``, ``shortlist_00012``.
+
+Canonical fixtures the oracles assume exist:
+
+* ``candidate_00001`` — the canonical candidate user (password: pass).
+* ``client_00001`` — the canonical client (password: pass).
+* ``job_00001`` — Internal Medicine Expert (Medical, $130-$180/hr).
+* ``app_pending_for_client_00001`` synthesised: a pending submitted
+  application from ``candidate_00007`` to ``job_00001``. (T03 decline
+  oracle targets this one.)
+"""
+
+from __future__ import annotations
+
+import hashlib
+import random
+import sqlite3
+from typing import Any
+
+FAKE_NOW_DEFAULT = "2026-06-08T09:00:00Z"
+
+CATEGORIES = ["Medical", "Legal", "Finance", "Software", "Consulting", "Office"]
+
+CATEGORY_TITLES: dict[str, list[str]] = {
+    "Medical": [
+        "Internal Medicine Expert",
+        "Hematology/Oncology Expert",
+        "Biology PhD Expert",
+        "Radiology Expert",
+        "Pediatrics Expert",
+    ],
+    "Legal": [
+        "Legal Expert — Litigation",
+        "Legal Expert — Contracts",
+        "Legal Expert — IP",
+        "Compliance Reviewer",
+    ],
+    "Finance": [
+        "Private Equity Expert",
+        "Equity Research Analyst",
+        "Quantitative Strategist",
+        "Tax Specialist",
+    ],
+    "Software": [
+        "Senior Software Engineer",
+        "ML Engineer",
+        "Frontend Engineer",
+        "Site Reliability Engineer",
+    ],
+    "Consulting": [
+        "Management & Strategy Consultant (MBB)",
+        "Operations Consultant",
+        "Healthcare Consultant",
+    ],
+    "Office": [
+        "Office-Suite Expert",
+        "Executive Assistant Specialist",
+        "Data Entry Expert",
+    ],
+}
+
+RATE_BANDS: dict[str, tuple[int, int]] = {
+    "Medical": (130, 180),
+    "Legal": (110, 160),
+    "Finance": (120, 200),
+    "Software": (90, 150),
+    "Consulting": (100, 175),
+    "Office": (35, 65),
+}
+
+CATEGORY_SKILLS: dict[str, list[str]] = {
+    "Medical": ["clinical-reasoning", "literature-review", "case-study"],
+    "Legal": ["contract-review", "case-law", "drafting"],
+    "Finance": ["financial-modeling", "valuation", "DCF"],
+    "Software": ["python", "typescript", "system-design"],
+    "Consulting": ["strategy", "operations", "market-analysis"],
+    "Office": ["excel", "google-sheets", "data-cleanup"],
+}
+
+SCREENING_QS_DEFAULT = [
+    "Briefly describe your most relevant experience.",
+    "Why are you interested in this role?",
+    "What is your earliest start date?",
+]
+
+
+def _hash(plain: str) -> str:
+    return hashlib.sha256(plain.encode("utf-8")).hexdigest()
+
+
+def _initials(name: str) -> str:
+    parts = [p for p in name.split() if p]
+    if len(parts) >= 3:
+        return (parts[0][0] + parts[1][0] + parts[2][0]).upper()
+    if len(parts) == 2:
+        return (parts[0][0] + parts[1][0] + parts[1][-1]).upper()
+    base = (parts[0] if parts else "X").upper()
+    return (base + "XX")[:3]
+
+
+FIRST_NAMES = [
+    "Alex", "Jordan", "Taylor", "Casey", "Morgan", "Riley", "Cameron",
+    "Skyler", "Quinn", "Avery", "Drew", "Hayden", "Logan", "Reese",
+    "Sage", "Devon", "Emerson", "Finley", "Harper", "Justice",
+    "Kennedy", "Lennon", "Marlowe", "Noor", "Onyx", "Parker",
+    "Rowan", "Saylor", "Tatum", "Umber", "Vesper", "Wynn", "Xander",
+    "Yael", "Zion", "Arden", "Briar", "Cedar", "Dune", "Echo",
+]
+
+LAST_NAMES = [
+    "Smith", "Johnson", "Williams", "Brown", "Jones", "Garcia",
+    "Miller", "Davis", "Rodriguez", "Martinez", "Hernandez", "Lopez",
+    "Gonzalez", "Wilson", "Anderson", "Thomas", "Taylor", "Moore",
+    "Jackson", "Martin", "Lee", "Perez", "Thompson", "White",
+    "Harris", "Sanchez", "Clark", "Ramirez", "Lewis", "Robinson",
+    "Walker", "Young", "Allen", "King", "Wright", "Scott",
+    "Torres", "Nguyen", "Hill", "Flores",
+]
+
+
+def _name(rng: random.Random) -> str:
+    return f"{rng.choice(FIRST_NAMES)} {rng.choice(LAST_NAMES)}"
+
+
+def seed(conn: sqlite3.Connection, *, seed_val: int, fake_now: str) -> None:
+    """Re-seed the DB to a deterministic baseline."""
+    rng = random.Random(seed_val)
+
+    # Wipe existing rows (preserves schema).
+    tables = [
+        "audit_log",
+        "payments",
+        "reviews",
+        "interviews",
+        "shortlist_entries",
+        "applications",
+        "candidate_profiles",
+        "jobs",
+        "companies",
+        "users",
+    ]
+    for t in tables:
+        conn.execute(f"DELETE FROM {t}")
+
+    # ── canonical users ──────────────────────────────────────────
+    pw = _hash("pass")
+    cano_users: list[dict[str, Any]] = [
+        {
+            "id": "candidate_00001",
+            "email": "candidate@mercor.example",
+            "password_hash": pw,
+            "role": "candidate",
+            "name": "Alex Reyes",
+            "company_id": None,
+            "created_at": fake_now,
+        },
+        {
+            "id": "client_00001",
+            "email": "client@mercor.example",
+            "password_hash": pw,
+            "role": "client",
+            "name": "Jordan Chen",
+            "company_id": "company_00001",
+            "created_at": fake_now,
+        },
+        {
+            "id": "admin_00001",
+            "email": "admin@mercor.example",
+            "password_hash": pw,
+            "role": "admin",
+            "name": "Admin User",
+            "company_id": None,
+            "created_at": fake_now,
+        },
+    ]
+    for u in cano_users:
+        conn.execute(
+            "INSERT INTO users (id, email, password_hash, role, name, company_id, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (u["id"], u["email"], u["password_hash"], u["role"], u["name"],
+             u["company_id"], u["created_at"]),
+        )
+
+    # Extra candidates (candidate_00002 ... candidate_00040)
+    for i in range(2, 41):
+        nm = _name(rng)
+        conn.execute(
+            "INSERT INTO users (id, email, password_hash, role, name, company_id, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (
+                f"candidate_{i:05d}",
+                f"cand{i:03d}@mercor.example",
+                pw,
+                "candidate",
+                nm,
+                None,
+                fake_now,
+            ),
+        )
+
+    # Extra clients (client_00002 ... client_00009)
+    for i in range(2, 10):
+        nm = _name(rng)
+        conn.execute(
+            "INSERT INTO users (id, email, password_hash, role, name, company_id, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (
+                f"client_{i:05d}",
+                f"client{i:03d}@mercor.example",
+                pw,
+                "client",
+                nm,
+                f"company_{i:05d}",
+                fake_now,
+            ),
+        )
+
+    # ── companies ────────────────────────────────────────────────
+    companies = [
+        ("company_00001", "Acme AI Labs", "acmeai.example", "client_00001"),
+    ]
+    for i in range(2, 10):
+        rng_name = f"{rng.choice(['Helio', 'Nova', 'Bright', 'North', 'Spark', 'Quanta', 'Mirror', 'Echo'])} {rng.choice(['AI', 'Labs', 'Research', 'Studio', 'Works'])}"
+        companies.append(
+            (f"company_{i:05d}", rng_name, f"company{i:03d}.example",
+             f"client_{i:05d}")
+        )
+    for c in companies:
+        conn.execute(
+            "INSERT INTO companies (id, name, domain, owner_user_id) VALUES (?, ?, ?, ?)",
+            c,
+        )
+
+    # ── candidate profiles ───────────────────────────────────────
+    for i in range(1, 41):
+        cid = f"candidate_{i:05d}"
+        cat = CATEGORIES[i % len(CATEGORIES)]
+        skills = CATEGORY_SKILLS[cat]
+        rate = rng.randint(*RATE_BANDS[cat])
+        avail = rng.choice(["Full-time", "Part-time", "Project-based"])
+        headline = f"{cat} Specialist, {rng.randint(2, 15)} years"
+        conn.execute(
+            "INSERT INTO candidate_profiles (user_id, headline, skills_json, "
+            "hourly_rate, availability, resume_text, updated_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (
+                cid,
+                headline,
+                "[" + ", ".join(f'"{s}"' for s in skills) + "]",
+                float(rate),
+                avail,
+                f"Seeded resume for {cid}.",
+                fake_now,
+            ),
+        )
+
+    # ── jobs ─────────────────────────────────────────────────────
+    # canonical job_00001 — Internal Medicine Expert.
+    cano_job = {
+        "id": "job_00001",
+        "company_id": "company_00001",
+        "title": "Internal Medicine Expert",
+        "category": "Medical",
+        "description_md": (
+            "We're hiring board-eligible Internal Medicine physicians to "
+            "evaluate and improve frontier AI clinical reasoning. "
+            "Sessions are async and remote.\n\n"
+            "**You'll**: review AI outputs against real-world cases; flag "
+            "factual errors; submit case-based critiques."
+        ),
+        "skills_json": '["clinical-reasoning", "literature-review", "case-study"]',
+        "rate_min": 130,
+        "rate_max": 180,
+        "engagement": "Hourly",
+        "hours_per_week": 10,
+        "hires_recently": 75,
+        "screening_qs": (
+            '["Are you board-eligible or board-certified in Internal Medicine?",'
+            '"Briefly describe a complex case you handled in the last year.",'
+            '"What is your earliest start date?"]'
+        ),
+        "status": "open",
+        "posted_at": fake_now,
+    }
+    conn.execute(
+        "INSERT INTO jobs (id, company_id, title, category, description_md, "
+        "skills_json, rate_min, rate_max, engagement, hours_per_week, "
+        "hires_recently, screening_qs, status, posted_at) "
+        "VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+        tuple(cano_job.values()),
+    )
+
+    # Other jobs (job_00002 ... job_00030).
+    job_counter = 2
+    for cat in CATEGORIES:
+        titles = CATEGORY_TITLES[cat]
+        for title in titles:
+            if job_counter > 30:
+                break
+            rate_min, rate_max = RATE_BANDS[cat]
+            rate_min = rate_min + rng.randint(-5, 5)
+            rate_max = rate_max + rng.randint(-5, 10)
+            skills = CATEGORY_SKILLS[cat]
+            engagement = rng.choice(["Hourly", "Project", "Full-time"])
+            company_id = f"company_{rng.randint(1, 9):05d}"
+            jid = f"job_{job_counter:05d}"
+            conn.execute(
+                "INSERT INTO jobs (id, company_id, title, category, description_md, "
+                "skills_json, rate_min, rate_max, engagement, hours_per_week, "
+                "hires_recently, screening_qs, status, posted_at) "
+                "VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+                (
+                    jid,
+                    company_id,
+                    title,
+                    cat,
+                    f"## About this role\n\n{title} for {cat} domain. "
+                    f"Remote, async, rate ${rate_min}-${rate_max}/hr.",
+                    "[" + ", ".join(f'"{s}"' for s in skills) + "]",
+                    float(rate_min),
+                    float(rate_max),
+                    engagement,
+                    rng.choice([10, 15, 20, 30, 40]),
+                    rng.randint(5, 90),
+                    "[" + ", ".join(f'"{q}"' for q in SCREENING_QS_DEFAULT) + "]",
+                    "open",
+                    fake_now,
+                ),
+            )
+            job_counter += 1
+
+    # ── canonical pending application for T03 ────────────────────
+    # candidate_00007 applied to job_00001 — status=submitted.
+    conn.execute(
+        "INSERT INTO applications (id, job_id, candidate_id, status, headline, "
+        "skills_json, hourly_rate, resume_text, screening_answers, reject_reason, "
+        "submitted_at, updated_at) VALUES (?,?,?,?,?,?,?,?,?,?,?,?)",
+        (
+            "app_00001",
+            "job_00001",
+            "candidate_00007",
+            "submitted",
+            "Internal Medicine PGY-4",
+            '["clinical-reasoning"]',
+            145.0,
+            "Seeded resume for candidate_00007.",
+            '["yes", "saw a rare ARDS case in February", "two weeks"]',
+            "",
+            fake_now,
+            fake_now,
+        ),
+    )
+
+    # Historical applications (different jobs, varied status).
+    app_counter = 2
+    for cand_i in range(2, 41):
+        if app_counter > 100:
+            break
+        cid = f"candidate_{cand_i:05d}"
+        jobs_to_try = rng.sample(range(2, 31), k=rng.randint(1, 3))
+        for jid_n in jobs_to_try:
+            if app_counter > 100:
+                break
+            jid = f"job_{jid_n:05d}"
+            status = rng.choice([
+                "submitted", "under_review", "interview", "rejected", "hired",
+            ])
+            aid = f"app_{app_counter:05d}"
+            try:
+                conn.execute(
+                    "INSERT INTO applications (id, job_id, candidate_id, status, "
+                    "headline, skills_json, hourly_rate, resume_text, "
+                    "screening_answers, reject_reason, submitted_at, updated_at) "
+                    "VALUES (?,?,?,?,?,?,?,?,?,?,?,?)",
+                    (
+                        aid, jid, cid, status,
+                        f"{cid} headline",
+                        '["domain-skill"]',
+                        float(rng.randint(50, 200)),
+                        f"Seeded resume for {cid}.",
+                        '["seeded", "seeded", "seeded"]',
+                        "low cultural fit" if status == "rejected" else "",
+                        fake_now,
+                        fake_now,
+                    ),
+                )
+                app_counter += 1
+            except sqlite3.IntegrityError:
+                # UNIQUE(job_id, candidate_id) — skip dupes.
+                continue
+
+    # Interviews + payments — light historical sprinkle.
+    int_id = 1
+    for row in conn.execute(
+        "SELECT id FROM applications WHERE status IN ('interview', 'hired') LIMIT 20"
+    ).fetchall():
+        conn.execute(
+            "INSERT INTO interviews (id, application_id, scheduled_at, "
+            "interviewer, outcome) VALUES (?,?,?,?,?)",
+            (
+                f"interview_{int_id:05d}",
+                row["id"],
+                fake_now,
+                "client_00001",
+                rng.choice(["pending", "passed", "failed"]),
+            ),
+        )
+        int_id += 1
+
+    pay_id = 1
+    for row in conn.execute(
+        "SELECT id FROM applications WHERE status='hired' LIMIT 20"
+    ).fetchall():
+        conn.execute(
+            "INSERT INTO payments (id, application_id, amount, occurred_at) "
+            "VALUES (?,?,?,?)",
+            (
+                f"payment_{pay_id:05d}",
+                row["id"],
+                float(rng.randint(500, 5000)),
+                fake_now,
+            ),
+        )
+        pay_id += 1
+
+    conn.commit()

--- a/deploy/sim_envs/mantis_mercor/app/static/site.css
+++ b/deploy/sim_envs/mantis_mercor/app/static/site.css
@@ -1,0 +1,764 @@
+/* mantis-mercor — site.css
+ *
+ * Hand-rolled stylesheet mirroring mercor.com's surface.
+ * Palette per `_capture_brief.md`:
+ *   - body color #000, body bg #fff
+ *   - brand indigo-600 #4F46E5
+ *   - gray-100 #F3F4F6, gray-200 #E5E7EB, gray-400 #9CA3AF,
+ *     gray-500 #6B7280, gray-600 #4B5563, gray-800 #1F2937
+ *
+ * Component groupings:
+ *   1. Tokens & reset
+ *   2. Topbar / nav
+ *   3. Buttons / chips / links
+ *   4. Hero / stats / latest-roles
+ *   5. Role card (canonical)
+ *   6. Jobs list (filter rail + results)
+ *   7. Job detail
+ *   8. Apply flow
+ *   9. Auth pages
+ *  10. Dashboard
+ *  11. Profile
+ *  12. Footer / utility / form
+ */
+
+/* 1. Tokens & reset ---------------------------------------------------- */
+:root {
+  --indigo-600: #4F46E5;
+  --indigo-700: #4338CA;
+  --gray-50:  #F9FAFB;
+  --gray-100: #F3F4F6;
+  --gray-200: #E5E7EB;
+  --gray-300: #D1D5DB;
+  --gray-400: #9CA3AF;
+  --gray-500: #6B7280;
+  --gray-600: #4B5563;
+  --gray-700: #374151;
+  --gray-800: #1F2937;
+  --black: #000000;
+  --white: #FFFFFF;
+  --radius-card: 12px;
+  --radius-chip: 9999px;
+  --shadow-sm: 0 1px 2px rgba(0,0,0,0.04);
+  --shadow-md: 0 4px 10px rgba(0,0,0,0.06);
+  --font: Inter, "Inter Fallback", system-ui, -apple-system,
+          "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+}
+
+* { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; }
+body {
+  font-family: var(--font);
+  font-size: 15px;
+  line-height: 1.5;
+  color: var(--black);
+  background: var(--white);
+  -webkit-font-smoothing: antialiased;
+}
+a { color: inherit; text-decoration: none; }
+a:hover { color: var(--indigo-600); }
+img { max-width: 100%; display: block; }
+
+/* 2. Topbar / nav ------------------------------------------------------ */
+.topbar {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: var(--white);
+  border-bottom: 1px solid var(--gray-200);
+}
+.topbar-inner {
+  max-width: 1280px;
+  margin: 0 auto;
+  height: 52px;
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  padding: 0 24px;
+}
+.brand {
+  font-weight: 700;
+  font-size: 16px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--black);
+}
+.brand-mark {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px; height: 22px;
+  background: var(--black);
+  color: var(--white);
+  border-radius: 4px;
+  font-size: 13px;
+}
+.primary-nav {
+  display: flex;
+  gap: 18px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--gray-700);
+}
+.primary-nav a:hover { color: var(--black); }
+.topbar-actions {
+  margin-left: auto;
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  font-size: 14px;
+}
+.topbar-avatar {
+  width: 30px; height: 30px;
+  background: var(--gray-100);
+  color: var(--gray-800);
+  font-weight: 600;
+  font-size: 12px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+}
+
+/* 3. Buttons / chips / links ------------------------------------------- */
+.btn-primary, .btn-secondary, .btn-quiet {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-family: inherit;
+  font-size: 14px;
+  font-weight: 500;
+  padding: 8px 14px;
+  border-radius: 8px;
+  border: 1px solid transparent;
+  cursor: pointer;
+  text-decoration: none;
+  line-height: 1;
+  transition: background 0.12s, border-color 0.12s, color 0.12s;
+}
+.btn-primary {
+  background: var(--indigo-600);
+  color: var(--white);
+}
+.btn-primary:hover { background: var(--indigo-700); color: var(--white); }
+.btn-primary:disabled { background: var(--gray-300); cursor: not-allowed; }
+.btn-secondary {
+  background: var(--white);
+  color: var(--gray-800);
+  border-color: var(--gray-300);
+}
+.btn-secondary:hover { background: var(--gray-100); }
+.btn-quiet {
+  background: transparent;
+  color: var(--gray-700);
+  border-color: transparent;
+}
+.btn-quiet:hover { background: var(--gray-100); color: var(--black); }
+.btn-primary.block, .btn-secondary.block { width: 100%; }
+.btn-primary.small, .btn-secondary.small, .btn-quiet.small {
+  padding: 5px 10px;
+  font-size: 13px;
+}
+.link-quiet { color: var(--gray-600); font-size: 14px; }
+.link-quiet:hover { color: var(--black); }
+.chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 10px;
+  border-radius: var(--radius-chip);
+  background: var(--gray-100);
+  color: var(--gray-700);
+  font-size: 12px;
+  font-weight: 500;
+  margin-right: 6px;
+  margin-bottom: 6px;
+}
+.chip-radio input { display: none; }
+.chip-radio input:checked + .chip {
+  background: var(--indigo-600);
+  color: var(--white);
+}
+
+/* 4. Hero / stats / latest-roles --------------------------------------- */
+.page {
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 32px 24px 64px;
+}
+.hero {
+  text-align: center;
+  padding: 64px 24px 32px;
+}
+.hero-inner { max-width: 720px; margin: 0 auto; }
+.hero-h1 {
+  font-size: 48px;
+  font-weight: 700;
+  line-height: 1.1;
+  letter-spacing: -0.02em;
+  margin: 0 0 16px;
+  color: var(--black);
+}
+.hero-sub {
+  font-size: 18px;
+  color: var(--gray-600);
+  margin: 0 0 24px;
+}
+.hero-ctas { display: flex; gap: 12px; justify-content: center; }
+.stats-strip {
+  margin: 24px auto 48px;
+  max-width: 980px;
+}
+.stats-strip-inner {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+  background: var(--gray-50);
+  border: 1px solid var(--gray-200);
+  border-radius: var(--radius-card);
+  padding: 24px;
+}
+.stat { text-align: center; }
+.stat-value {
+  font-size: 28px;
+  font-weight: 600;
+  color: var(--black);
+}
+.stat-label {
+  font-size: 13px;
+  color: var(--gray-500);
+  margin-top: 4px;
+}
+.latest-roles { margin-top: 48px; }
+.latest-roles-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  margin-bottom: 16px;
+}
+.latest-roles-header h2 {
+  font-size: 22px;
+  font-weight: 600;
+  margin: 0;
+}
+
+/* 5. Role card (canonical) --------------------------------------------- */
+.role-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+}
+@media (max-width: 960px) {
+  .role-grid { grid-template-columns: repeat(2, 1fr); }
+}
+@media (max-width: 640px) {
+  .role-grid { grid-template-columns: 1fr; }
+}
+.role-card {
+  background: var(--white);
+  border: 1px solid var(--gray-200);
+  border-radius: var(--radius-card);
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  box-shadow: var(--shadow-sm);
+  transition: box-shadow 0.12s, border-color 0.12s;
+}
+.role-card:hover {
+  box-shadow: var(--shadow-md);
+  border-color: var(--gray-300);
+}
+.role-card-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 8px;
+}
+.role-card-title {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--black);
+}
+.role-card-title a { color: inherit; }
+.role-card-rate {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--gray-700);
+  white-space: nowrap;
+}
+.role-card-meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--gray-500);
+  font-size: 13px;
+}
+.role-card-avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--gray-100);
+  color: var(--gray-800);
+  width: 34px; height: 34px;
+  border-radius: 50%;
+  font-weight: 600;
+  font-size: 12px;
+  letter-spacing: 0.5px;
+}
+.role-card-avatar.small { width: 26px; height: 26px; font-size: 10px; }
+.role-card-recent { color: var(--gray-500); }
+.role-card-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 4px;
+}
+.role-card-tag {
+  font-size: 11px;
+  color: var(--gray-500);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+/* 6. Jobs list --------------------------------------------------------- */
+.jobs-layout {
+  display: grid;
+  grid-template-columns: 260px 1fr;
+  gap: 24px;
+  align-items: start;
+}
+@media (max-width: 880px) { .jobs-layout { grid-template-columns: 1fr; } }
+.filter-rail {
+  background: var(--white);
+  border: 1px solid var(--gray-200);
+  border-radius: var(--radius-card);
+  padding: 16px;
+  position: sticky;
+  top: 68px;
+}
+.filter-group { margin-bottom: 16px; }
+.filter-label {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--gray-700);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: 8px;
+}
+.filter-rate-row { display: flex; gap: 8px; }
+.filter-rate-row input { flex: 1; }
+.results-pane-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  margin-bottom: 16px;
+}
+.results-pane-header h1 {
+  font-size: 22px;
+  font-weight: 600;
+  margin: 0;
+}
+.sort-by { font-size: 13px; color: var(--gray-500); }
+.sort-label { color: var(--gray-800); font-weight: 500; }
+.empty {
+  text-align: center;
+  padding: 32px;
+  color: var(--gray-500);
+}
+
+/* 7. Job detail -------------------------------------------------------- */
+.job-detail {
+  display: grid;
+  grid-template-columns: 1fr 320px;
+  gap: 32px;
+  align-items: start;
+}
+@media (max-width: 880px) { .job-detail { grid-template-columns: 1fr; } }
+.job-detail-main h1 {
+  font-size: 32px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  margin: 0 0 8px;
+}
+.job-detail-rate {
+  color: var(--gray-700);
+  font-size: 15px;
+  margin-bottom: 4px;
+}
+.job-detail-company {
+  color: var(--gray-500);
+  font-size: 14px;
+  margin-bottom: 24px;
+}
+.job-detail-main h2 {
+  font-size: 18px;
+  font-weight: 600;
+  margin: 32px 0 12px;
+}
+.job-detail-desc {
+  color: var(--gray-700);
+  line-height: 1.6;
+}
+.skill-chips { display: flex; flex-wrap: wrap; }
+.screening-list { padding-left: 18px; color: var(--gray-700); }
+.screening-list li { margin: 6px 0; }
+.rail-card {
+  background: var(--gray-50);
+  border: 1px solid var(--gray-200);
+  border-radius: var(--radius-card);
+  padding: 20px;
+  position: sticky;
+  top: 68px;
+}
+.rail-rate {
+  font-size: 22px;
+  font-weight: 600;
+  margin-bottom: 16px;
+}
+.rail-card dl {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 6px 12px;
+  margin: 0 0 20px;
+  font-size: 13px;
+}
+.rail-card dt { color: var(--gray-500); }
+.rail-card dd { margin: 0; color: var(--gray-800); }
+
+/* 8. Apply flow -------------------------------------------------------- */
+.apply-flow {
+  max-width: 720px;
+  margin: 0 auto;
+}
+.apply-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 16px;
+}
+.apply-crumbs { color: var(--gray-500); font-size: 13px; }
+.apply-crumbs a { color: var(--gray-700); }
+.apply-progress {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--indigo-600);
+}
+.apply-steplist {
+  display: flex;
+  list-style: none;
+  padding: 0;
+  margin: 0 0 24px;
+  gap: 6px;
+  counter-reset: step;
+}
+.apply-steplist li {
+  flex: 1;
+  text-align: center;
+  font-size: 12px;
+  color: var(--gray-500);
+  padding: 6px 8px;
+  border-radius: 8px;
+  background: var(--gray-100);
+}
+.apply-steplist li.active {
+  background: var(--indigo-600);
+  color: var(--white);
+  font-weight: 600;
+}
+.apply-form h1 {
+  font-size: 24px;
+  font-weight: 700;
+  margin: 0 0 16px;
+}
+.apply-form label {
+  display: block;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--gray-700);
+  margin-bottom: 14px;
+}
+.apply-form input,
+.apply-form textarea,
+.apply-form select,
+.profile-form input,
+.profile-form select,
+.auth-card input,
+.filter-rail input {
+  display: block;
+  width: 100%;
+  margin-top: 6px;
+  padding: 9px 12px;
+  font: inherit;
+  font-size: 14px;
+  color: var(--black);
+  background: var(--white);
+  border: 1px solid var(--gray-300);
+  border-radius: 8px;
+  outline: none;
+}
+.apply-form input:focus,
+.apply-form textarea:focus,
+.apply-form select:focus,
+.profile-form input:focus,
+.profile-form select:focus,
+.auth-card input:focus {
+  border-color: var(--indigo-600);
+  box-shadow: 0 0 0 3px rgba(79, 70, 229, 0.15);
+}
+.apply-actions {
+  display: flex;
+  gap: 12px;
+  justify-content: flex-end;
+  margin-top: 24px;
+}
+.review-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+  background: var(--gray-50);
+  border: 1px solid var(--gray-200);
+  border-radius: var(--radius-card);
+  padding: 16px;
+  font-size: 14px;
+}
+.review-grid > div { min-width: 0; word-break: break-word; }
+.banner-success {
+  background: #ECFDF5;
+  border: 1px solid #34D399;
+  color: #065F46;
+  padding: 12px 16px;
+  border-radius: 8px;
+  margin-bottom: 16px;
+  font-weight: 500;
+}
+
+/* 9. Auth pages -------------------------------------------------------- */
+.auth-page {
+  max-width: 480px;
+  margin: 64px auto;
+}
+.auth-card {
+  background: var(--white);
+  border: 1px solid var(--gray-200);
+  border-radius: var(--radius-card);
+  padding: 32px;
+  box-shadow: var(--shadow-md);
+}
+.auth-card h1 {
+  font-size: 22px;
+  font-weight: 700;
+  margin: 0 0 16px;
+}
+.auth-card label {
+  display: block;
+  font-size: 13px;
+  color: var(--gray-700);
+  margin-bottom: 12px;
+}
+.auth-alt {
+  margin-top: 16px;
+  font-size: 13px;
+  color: var(--gray-500);
+  text-align: center;
+}
+.auth-alt a { color: var(--indigo-600); }
+.alert {
+  padding: 10px 12px;
+  border-radius: 8px;
+  font-size: 13px;
+  margin-bottom: 12px;
+}
+.alert-error {
+  background: #FEF2F2;
+  border: 1px solid #FCA5A5;
+  color: #991B1B;
+}
+.role-radio {
+  border: 1px solid var(--gray-200);
+  border-radius: 8px;
+  padding: 10px 12px;
+  margin: 0 0 12px;
+  font-size: 13px;
+}
+.role-radio legend { padding: 0 6px; color: var(--gray-500); }
+
+/* 10. Dashboard -------------------------------------------------------- */
+.dashboard h1 {
+  font-size: 26px;
+  font-weight: 700;
+  margin: 0 0 4px;
+}
+.dashboard .muted { font-size: 13px; color: var(--gray-500); margin-bottom: 16px; }
+.dashboard-grid {
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  gap: 24px;
+}
+@media (max-width: 880px) { .dashboard-grid { grid-template-columns: 1fr; } }
+.dashboard-pane {
+  background: var(--white);
+  border: 1px solid var(--gray-200);
+  border-radius: var(--radius-card);
+  padding: 16px;
+}
+.dashboard-pane h2 {
+  font-size: 16px;
+  font-weight: 600;
+  margin: 0 0 8px;
+}
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14px;
+}
+.data-table thead th {
+  text-align: left;
+  font-weight: 600;
+  font-size: 12px;
+  color: var(--gray-500);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  padding: 8px;
+  border-bottom: 1px solid var(--gray-200);
+}
+.data-table tbody td {
+  padding: 12px 8px;
+  border-bottom: 1px solid var(--gray-100);
+  vertical-align: top;
+}
+.status {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: var(--radius-chip);
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: capitalize;
+  background: var(--gray-100);
+  color: var(--gray-700);
+}
+.status-submitted { background: #EEF2FF; color: var(--indigo-700); }
+.status-under_review { background: #FEF3C7; color: #92400E; }
+.status-interview { background: #DBEAFE; color: #1E3A8A; }
+.status-hired { background: #D1FAE5; color: #065F46; }
+.status-rejected { background: #FEE2E2; color: #991B1B; }
+.inline-form { display: inline-block; }
+.decline-details { display: inline-block; margin-left: 4px; }
+.decline-details summary {
+  display: inline-block;
+  cursor: pointer;
+  list-style: none;
+  user-select: none;
+}
+.decline-details summary::-webkit-details-marker { display: none; }
+.decline-form {
+  display: inline-flex;
+  gap: 6px;
+  align-items: center;
+  margin-top: 6px;
+  padding: 6px;
+  border: 1px dashed var(--gray-300);
+  border-radius: 8px;
+}
+.decline-form input {
+  padding: 5px 8px;
+  font-size: 12px;
+  border: 1px solid var(--gray-300);
+  border-radius: 6px;
+}
+.shortlist-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+.shortlist-list li {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  padding: 8px 0;
+  border-bottom: 1px solid var(--gray-100);
+}
+.small { font-size: 12px; }
+.muted { color: var(--gray-500); }
+
+/* 11. Profile ---------------------------------------------------------- */
+.profile-page h1 {
+  font-size: 26px;
+  font-weight: 700;
+  margin: 0 0 4px;
+}
+.profile-form {
+  max-width: 560px;
+  margin-top: 16px;
+}
+.profile-form label {
+  display: block;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--gray-700);
+  margin-bottom: 14px;
+}
+
+/* 12. Footer / utility ------------------------------------------------- */
+.site-footer {
+  border-top: 1px solid var(--gray-200);
+  background: var(--gray-50);
+  padding: 24px;
+  margin-top: 64px;
+}
+.footer-inner {
+  max-width: 1280px;
+  margin: 0 auto;
+  display: flex;
+  justify-content: space-between;
+  font-size: 13px;
+  color: var(--gray-500);
+}
+.footer-links { display: flex; gap: 16px; }
+.footer-links a { color: var(--gray-700); }
+
+/* 13. Howitworks / FAQ ------------------------------------------------- */
+.howitworks { margin: 32px 0; }
+.howitworks-inner {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+}
+@media (max-width: 880px) { .howitworks-inner { grid-template-columns: 1fr; } }
+.howitworks-step {
+  display: flex;
+  gap: 12px;
+  padding: 16px;
+  background: var(--white);
+  border: 1px solid var(--gray-200);
+  border-radius: var(--radius-card);
+}
+.step-num {
+  width: 28px; height: 28px;
+  background: var(--indigo-600);
+  color: var(--white);
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  font-size: 14px;
+  flex-shrink: 0;
+}
+.step-title { font-weight: 600; }
+.step-blurb { font-size: 13px; color: var(--gray-500); }
+.faq { margin-top: 48px; }
+.faq h2 { font-size: 20px; font-weight: 600; }
+.faq details {
+  padding: 12px 16px;
+  border: 1px solid var(--gray-200);
+  border-radius: 8px;
+  margin: 8px 0;
+}
+.faq summary { cursor: pointer; font-weight: 500; }
+
+/* 14. Focus visibility ------------------------------------------------- */
+:focus-visible {
+  outline: 2px solid var(--indigo-600);
+  outline-offset: 2px;
+}

--- a/deploy/sim_envs/mantis_mercor/app/templates/_role_card.html
+++ b/deploy/sim_envs/mantis_mercor/app/templates/_role_card.html
@@ -1,0 +1,18 @@
+{% macro role_card(job) -%}
+<article class="role-card" data-testid="role-card" data-role-id="{{ job.id }}">
+  <div class="role-card-header">
+    <div class="role-card-title">
+      <a href="/jobs/{{ job.id }}" data-testid="role-card-title">{{ job.title }}</a>
+    </div>
+    <div class="role-card-rate" data-testid="role-card-rate">${{ job.rate_min | int }}-${{ job.rate_max | int }}/hr</div>
+  </div>
+  <div class="role-card-meta">
+    <span class="role-card-avatar" data-testid="role-card-avatar">{{ job.title | initials }}</span>
+    <span class="role-card-recent" data-testid="role-card-recent">{{ job.hires_recently }} hired recently</span>
+  </div>
+  <div class="role-card-footer">
+    <span class="role-card-tag">{{ job.category }}</span>
+    <a class="btn-primary" href="/apply/{{ job.id }}" data-testid="role-card-apply">Apply</a>
+  </div>
+</article>
+{%- endmacro %}

--- a/deploy/sim_envs/mantis_mercor/app/templates/apply_confirm.html
+++ b/deploy/sim_envs/mantis_mercor/app/templates/apply_confirm.html
@@ -1,0 +1,16 @@
+{% extends "base.html" %}
+
+{% block title %}Application submitted — Mercor{% endblock %}
+
+{% block content %}
+<section class="apply-confirm" data-testid="apply-confirm">
+  <div class="banner-success" data-testid="apply-confirm-banner">
+    Application submitted — we'll be in touch.
+  </div>
+  <p>Your application for <b>{{ job.title }}</b> has been received. Reference: <code>{{ application_id }}</code>.</p>
+  <div class="apply-actions">
+    <a class="btn-secondary" href="/jobs">Browse more roles</a>
+    <a class="btn-primary" href="/dashboard" data-testid="apply-confirm-dashboard">Go to dashboard</a>
+  </div>
+</section>
+{% endblock %}

--- a/deploy/sim_envs/mantis_mercor/app/templates/apply_review.html
+++ b/deploy/sim_envs/mantis_mercor/app/templates/apply_review.html
@@ -1,0 +1,36 @@
+{% extends "base.html" %}
+
+{% block title %}Submit application — Mercor{% endblock %}
+
+{% block content %}
+<section class="apply-flow" data-testid="apply-flow">
+  <div class="apply-header">
+    <div class="apply-crumbs">
+      <a href="/jobs/{{ job.id }}">{{ job.title }}</a> · Review &amp; submit
+    </div>
+    <div class="apply-progress">Final step</div>
+  </div>
+
+  <h1>Review your application</h1>
+  <div class="review-grid" data-testid="apply-review-grid">
+    <div><b>Role</b><div>{{ job.title }}</div></div>
+    <div><b>Headline</b><div>{{ draft.headline or '—' }}</div></div>
+    <div><b>Skills</b><div>{{ draft.skills or '—' }}</div></div>
+    <div><b>Rate</b><div>${{ draft.hourly_rate or '—' }}/hr</div></div>
+    <div><b>Resume preview</b><div>{{ (draft.resume_text or '')[:200] }}{% if draft.resume_text and draft.resume_text|length > 200 %}…{% endif %}</div></div>
+    <div><b>Screening answers</b>
+      <ol>
+        {% for q in screening_qs %}
+          <li><b>{{ q }}</b><br/>{{ draft.answers[loop.index0] if draft.answers and draft.answers|length > loop.index0 else '' }}</li>
+        {% endfor %}
+      </ol>
+    </div>
+  </div>
+  <form method="post" action="/apply/{{ job.id }}/submit" class="apply-form" data-testid="apply-submit-form">
+    <div class="apply-actions">
+      <a class="btn-secondary" href="/apply/{{ job.id }}/step/4" data-testid="apply-back-review">Back</a>
+      <button class="btn-primary" type="submit" data-testid="apply-submit">Submit application</button>
+    </div>
+  </form>
+</section>
+{% endblock %}

--- a/deploy/sim_envs/mantis_mercor/app/templates/apply_step.html
+++ b/deploy/sim_envs/mantis_mercor/app/templates/apply_step.html
@@ -1,0 +1,77 @@
+{% extends "base.html" %}
+
+{% block title %}Apply — {{ job.title }} — Mercor{% endblock %}
+
+{% block content %}
+<section class="apply-flow" data-testid="apply-flow">
+  <div class="apply-header">
+    <div class="apply-crumbs">
+      <a href="/jobs/{{ job.id }}">{{ job.title }}</a> · Apply
+    </div>
+    <div class="apply-progress" data-testid="apply-progress">
+      Step {{ step }} of {{ total_steps }}
+    </div>
+  </div>
+
+  <ol class="apply-steplist">
+    <li class="{% if step == 1 %}active{% endif %}">Profile</li>
+    <li class="{% if step == 2 %}active{% endif %}">Resume</li>
+    <li class="{% if step == 3 %}active{% endif %}">Screening</li>
+    <li class="{% if step == 4 %}active{% endif %}">Review</li>
+    <li class="{% if step == 5 %}active{% endif %}">Submit</li>
+  </ol>
+
+  <form method="post" action="/apply/{{ job.id }}/step/{{ step }}" class="apply-form" data-testid="apply-form">
+    {% if step == 1 %}
+      <h1>Your profile</h1>
+      <label>Headline
+        <input type="text" name="headline" value="{{ draft.headline }}" placeholder="Internal Medicine Physician, 8 years" data-testid="apply-headline" />
+      </label>
+      <label>Skills (comma-separated)
+        <input type="text" name="skills" value="{{ draft.skills }}" placeholder="clinical-reasoning, literature-review" data-testid="apply-skills" />
+      </label>
+      <label>Hourly rate ($/hr)
+        <input type="number" step="1" name="hourly_rate" value="{{ draft.hourly_rate }}" data-testid="apply-rate" />
+      </label>
+    {% elif step == 2 %}
+      <h1>Resume</h1>
+      <p class="muted">Paste your resume text below. (This synthetic mirror does not store uploaded files.)</p>
+      <label>Resume text
+        <textarea name="resume_text" rows="10" data-testid="apply-resume">{{ draft.resume_text }}</textarea>
+      </label>
+    {% elif step == 3 %}
+      <h1>Screening questions</h1>
+      {% for q in screening_qs %}
+      <label>{{ q }}
+        <textarea name="answer_{{ loop.index0 }}" rows="3" data-testid="apply-answer-{{ loop.index0 }}">{% if draft.answers and draft.answers[loop.index0] %}{{ draft.answers[loop.index0] }}{% endif %}</textarea>
+      </label>
+      {% endfor %}
+    {% elif step == 4 %}
+      <h1>Review</h1>
+      <div class="review-grid" data-testid="apply-review-grid">
+        <div><b>Headline</b><div>{{ draft.headline or '—' }}</div></div>
+        <div><b>Skills</b><div>{{ draft.skills or '—' }}</div></div>
+        <div><b>Rate</b><div>${{ draft.hourly_rate or '—' }}/hr</div></div>
+        <div><b>Resume preview</b><div>{{ (draft.resume_text or '')[:200] }}{% if draft.resume_text and draft.resume_text|length > 200 %}…{% endif %}</div></div>
+        <div><b>Screening answers</b>
+          <ol>
+            {% for a in draft.answers %}<li>{{ a }}</li>{% endfor %}
+          </ol>
+        </div>
+      </div>
+    {% elif step == 5 %}
+      <h1>Confirm and submit</h1>
+      <p>Click Submit to send your application to {{ job.company_name }}.</p>
+    {% endif %}
+
+    <div class="apply-actions">
+      {% if step > 1 %}
+        <button class="btn-secondary" type="submit" name="nav" value="back" data-testid="apply-back">Back</button>
+      {% endif %}
+      <button class="btn-primary" type="submit" name="nav" value="next" data-testid="apply-next">
+        {% if step >= 5 %}Continue{% else %}Next{% endif %}
+      </button>
+    </div>
+  </form>
+</section>
+{% endblock %}

--- a/deploy/sim_envs/mantis_mercor/app/templates/base.html
+++ b/deploy/sim_envs/mantis_mercor/app/templates/base.html
@@ -1,0 +1,52 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>{% block title %}Mercor — Shape the frontier of AI{% endblock %}</title>
+  <link rel="stylesheet" href="/static/site.css" />
+</head>
+<body>
+<header class="topbar" data-testid="topbar">
+  <div class="topbar-inner">
+    <a class="brand" href="/" data-testid="brand">
+      <span class="brand-mark">M</span> mercor
+    </a>
+    <nav class="primary-nav" data-testid="primary-nav">
+      <a href="/jobs?category=Software" data-testid="nav-apex">APEX</a>
+      <a href="/jobs?category=Software" data-testid="nav-apex-agents">APEX-Agents</a>
+      <a href="/jobs?category=Software" data-testid="nav-apex-swe">APEX-SWE</a>
+      <a href="/jobs" data-testid="nav-research">Research</a>
+      <a href="/jobs" data-testid="nav-enterprise">Enterprise</a>
+      <a href="/experts" data-testid="nav-experts">Experts</a>
+    </nav>
+    <div class="topbar-actions" data-testid="topbar-actions">
+      {% set _u = request.state.current_user if request.state and request.state.current_user else None %}
+      {% if _u %}
+        <a class="link-quiet" href="/dashboard" data-testid="topbar-dashboard">Dashboard</a>
+        <span class="topbar-avatar" data-testid="topbar-avatar">{{ _u.name | initials }}</span>
+        <form method="post" action="/logout" style="display:inline">
+          <button type="submit" class="btn-quiet" data-testid="topbar-logout">Sign out</button>
+        </form>
+      {% else %}
+        <a class="link-quiet" href="/login" data-testid="topbar-login">Sign in</a>
+        <a class="btn-primary" href="/signup" data-testid="topbar-signup">Sign up</a>
+      {% endif %}
+    </div>
+  </div>
+</header>
+<main class="page" data-testid="main">
+  {% block content %}{% endblock %}
+</main>
+<footer class="site-footer" data-testid="footer">
+  <div class="footer-inner">
+    <div>&copy; 2026 Mercor — synthetic mirror for agent training.</div>
+    <div class="footer-links">
+      <a href="/jobs">Roles</a>
+      <a href="/experts">Experts</a>
+      <a href="/login">Sign in</a>
+    </div>
+  </div>
+</footer>
+</body>
+</html>

--- a/deploy/sim_envs/mantis_mercor/app/templates/dashboard_candidate.html
+++ b/deploy/sim_envs/mantis_mercor/app/templates/dashboard_candidate.html
@@ -1,0 +1,28 @@
+{% extends "base.html" %}
+
+{% block title %}My applications — Mercor{% endblock %}
+
+{% block content %}
+<section class="dashboard" data-testid="dashboard">
+  <h1>My applications</h1>
+  <p class="muted">Signed in as <b>{{ user.name or user.email }}</b> · candidate</p>
+  <table class="data-table" data-testid="apps-table">
+    <thead>
+      <tr><th>Role</th><th>Company</th><th>Status</th><th>Applied</th><th>Actions</th></tr>
+    </thead>
+    <tbody>
+      {% for a in applications %}
+      <tr data-app-id="{{ a.id }}" data-testid="app-row">
+        <td>{{ a.job_title }}</td>
+        <td>{{ a.company_name }}</td>
+        <td><span class="status status-{{ a.status }}">{{ a.status }}</span></td>
+        <td>{{ a.submitted_at or a.updated_at }}</td>
+        <td><a class="link-quiet" href="/jobs/{{ a.job_id }}">View role</a></td>
+      </tr>
+      {% else %}
+      <tr><td colspan="5" class="empty">No applications yet — <a href="/jobs">browse roles</a>.</td></tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</section>
+{% endblock %}

--- a/deploy/sim_envs/mantis_mercor/app/templates/dashboard_client.html
+++ b/deploy/sim_envs/mantis_mercor/app/templates/dashboard_client.html
@@ -1,0 +1,65 @@
+{% extends "base.html" %}
+
+{% block title %}Review queue — Mercor{% endblock %}
+
+{% block content %}
+<section class="dashboard dashboard-client" data-testid="dashboard">
+  <h1>Review queue</h1>
+  <p class="muted">Signed in as <b>{{ user.name or user.email }}</b> · client</p>
+  <div class="dashboard-grid">
+    <div class="dashboard-pane" data-testid="pending-pane">
+      <h2>Pending applications</h2>
+      <table class="data-table" data-testid="pending-table">
+        <thead><tr><th>Candidate</th><th>Role</th><th>Status</th><th>Actions</th></tr></thead>
+        <tbody>
+          {% for a in pending %}
+          <tr data-app-id="{{ a.id }}" data-testid="pending-row">
+            <td>
+              <span class="role-card-avatar small">{{ a.candidate_name | initials }}</span>
+              {{ a.candidate_name }}
+              <div class="muted small">{{ a.candidate_id }}</div>
+            </td>
+            <td>{{ a.job_title }}</td>
+            <td><span class="status status-{{ a.status }}">{{ a.status }}</span></td>
+            <td>
+              <form method="post" action="/dashboard/shortlist" class="inline-form" data-testid="shortlist-form-{{ a.id }}">
+                <input type="hidden" name="job_id" value="{{ a.job_id }}" />
+                <input type="hidden" name="candidate_id" value="{{ a.candidate_id }}" />
+                <button type="submit" class="btn-secondary small" data-testid="shortlist-btn">Add to shortlist</button>
+              </form>
+              <details class="decline-details">
+                <summary class="btn-quiet small" data-testid="decline-toggle">Decline</summary>
+                <form method="post" action="/dashboard/decline" class="decline-form" data-testid="decline-form-{{ a.id }}">
+                  <input type="hidden" name="application_id" value="{{ a.id }}" />
+                  <input type="text" name="reason" placeholder="Reason (required)" required data-testid="decline-reason-{{ a.id }}" />
+                  <button type="submit" class="btn-primary small" data-testid="decline-submit-{{ a.id }}">Decline</button>
+                </form>
+              </details>
+            </td>
+          </tr>
+          {% else %}
+          <tr><td colspan="4" class="empty">No pending applications.</td></tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+    <div class="dashboard-pane" data-testid="shortlist-pane">
+      <h2>Recent shortlist</h2>
+      <div class="muted small">{{ shortlist | length }} recent</div>
+      <ul class="shortlist-list">
+        {% for s in shortlist %}
+        <li>
+          <span class="role-card-avatar small">{{ s.candidate_name | initials }}</span>
+          <div>
+            <div>{{ s.candidate_name }}</div>
+            <div class="muted small">{{ s.job_title }} · {{ s.created_at }}</div>
+          </div>
+        </li>
+        {% else %}
+        <li class="empty">No shortlist entries yet.</li>
+        {% endfor %}
+      </ul>
+    </div>
+  </div>
+</section>
+{% endblock %}

--- a/deploy/sim_envs/mantis_mercor/app/templates/experts.html
+++ b/deploy/sim_envs/mantis_mercor/app/templates/experts.html
@@ -1,0 +1,63 @@
+{% extends "base.html" %}
+{% from "_role_card.html" import role_card %}
+
+{% block title %}Experts — Mercor{% endblock %}
+
+{% block content %}
+<section class="hero" data-testid="hero">
+  <div class="hero-inner">
+    <h1 class="hero-h1" data-testid="hero-h1">Get paid to work on AI projects</h1>
+    <p class="hero-sub" data-testid="hero-sub">Domain experts shape frontier AI — on your schedule, fully remote.</p>
+  </div>
+</section>
+
+<section class="howitworks" data-testid="howitworks">
+  <div class="howitworks-inner">
+    <div class="howitworks-step">
+      <div class="step-num">1</div>
+      <div class="step-body">
+        <div class="step-title">Create a profile</div>
+        <div class="step-blurb">Tell us your domain, rate and availability.</div>
+      </div>
+    </div>
+    <div class="howitworks-step">
+      <div class="step-num">2</div>
+      <div class="step-body">
+        <div class="step-title">Take AI assessments</div>
+        <div class="step-blurb">Calibrate your skills against the role.</div>
+      </div>
+    </div>
+    <div class="howitworks-step">
+      <div class="step-num">3</div>
+      <div class="step-body">
+        <div class="step-title">Find opportunities</div>
+        <div class="step-blurb">Apply to current listings — get hired fast.</div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="latest-roles" data-testid="latest-roles">
+  <div class="latest-roles-header">
+    <h2>Latest roles</h2>
+    <a class="link-quiet" href="/jobs">See all →</a>
+  </div>
+  <div class="role-grid">
+    {% for job in latest_jobs %}
+      {{ role_card(job) }}
+    {% endfor %}
+  </div>
+</section>
+
+<section class="faq" data-testid="faq">
+  <h2>FAQ</h2>
+  <details>
+    <summary>What is Mercor?</summary>
+    <p>Mercor is an AI talent marketplace that connects domain experts with frontier AI labs.</p>
+  </details>
+  <details>
+    <summary>What is AI training work?</summary>
+    <p>You'll review AI outputs in your area of expertise, flag errors, and help calibrate models.</p>
+  </details>
+</section>
+{% endblock %}

--- a/deploy/sim_envs/mantis_mercor/app/templates/home.html
+++ b/deploy/sim_envs/mantis_mercor/app/templates/home.html
@@ -1,0 +1,46 @@
+{% extends "base.html" %}
+{% from "_role_card.html" import role_card %}
+
+{% block title %}Mercor — Shape the frontier of AI{% endblock %}
+
+{% block content %}
+<section class="hero" data-testid="hero">
+  <div class="hero-inner">
+    <h1 class="hero-h1" data-testid="hero-h1">Shape the frontier of AI</h1>
+    <p class="hero-sub" data-testid="hero-sub">Work with the world's leading AI labs as a domain expert.</p>
+    <div class="hero-ctas">
+      <a class="btn-primary" href="/jobs" data-testid="hero-cta-jobs">Browse roles</a>
+      <a class="btn-secondary" href="/experts" data-testid="hero-cta-experts">How it works</a>
+    </div>
+  </div>
+</section>
+
+<section class="stats-strip" data-testid="stats-strip">
+  <div class="stats-strip-inner">
+    <div class="stat">
+      <div class="stat-value" data-testid="stat-avg-pay">${{ stats.avg_pay }}</div>
+      <div class="stat-label">Average pay $/hr</div>
+    </div>
+    <div class="stat">
+      <div class="stat-value" data-testid="stat-roles">{{ stats.roles_created_k }}k</div>
+      <div class="stat-label">Roles created (k)</div>
+    </div>
+    <div class="stat">
+      <div class="stat-value" data-testid="stat-payouts">${{ '{:,.0f}'.format(stats.daily_payouts_usd) }}</div>
+      <div class="stat-label">Daily payouts ($)</div>
+    </div>
+  </div>
+</section>
+
+<section class="latest-roles" data-testid="latest-roles">
+  <div class="latest-roles-header">
+    <h2 data-testid="latest-roles-h2">Latest roles</h2>
+    <a class="link-quiet" href="/jobs" data-testid="see-all-jobs">See all →</a>
+  </div>
+  <div class="role-grid">
+    {% for job in latest_jobs %}
+      {{ role_card(job) }}
+    {% endfor %}
+  </div>
+</section>
+{% endblock %}

--- a/deploy/sim_envs/mantis_mercor/app/templates/job_detail.html
+++ b/deploy/sim_envs/mantis_mercor/app/templates/job_detail.html
@@ -1,0 +1,45 @@
+{% extends "base.html" %}
+
+{% block title %}{{ job.title }} — Mercor{% endblock %}
+
+{% block content %}
+<section class="job-detail" data-testid="job-detail">
+  <div class="job-detail-main">
+    <div class="role-card-meta" style="margin-bottom: 8px;">
+      <span class="role-card-avatar">{{ job.title | initials }}</span>
+      <span class="role-card-recent">{{ job.hires_recently }} hired recently</span>
+    </div>
+    <h1 data-testid="job-detail-title">{{ job.title }}</h1>
+    <div class="job-detail-rate" data-testid="job-detail-rate">${{ job.rate_min | int }}-${{ job.rate_max | int }}/hr · {{ job.engagement }} · {{ job.hours_per_week }} hrs/wk</div>
+    <div class="job-detail-company" data-testid="job-detail-company">{{ job.company_name }}</div>
+
+    <h2>About this role</h2>
+    <div class="job-detail-desc">{{ job.description_md | replace('\n', '<br/>') | safe }}</div>
+
+    <h2>Skills required</h2>
+    <div class="skill-chips" data-testid="skills">
+      {% for s in job.skills %}
+        <span class="chip">{{ s }}</span>
+      {% endfor %}
+    </div>
+
+    <h2>Screening questions</h2>
+    <ol class="screening-list" data-testid="screening-preview">
+      {% for q in job.screening_questions %}
+        <li>{{ q }}</li>
+      {% endfor %}
+    </ol>
+  </div>
+  <aside class="job-detail-rail" data-testid="job-detail-rail">
+    <div class="rail-card">
+      <div class="rail-rate">${{ job.rate_min | int }}-${{ job.rate_max | int }}/hr</div>
+      <dl>
+        <dt>Engagement</dt><dd>{{ job.engagement }}</dd>
+        <dt>Hours / week</dt><dd>{{ job.hours_per_week }}</dd>
+        <dt>Category</dt><dd>{{ job.category }}</dd>
+      </dl>
+      <a class="btn-primary block" href="/apply/{{ job.id }}" data-testid="job-detail-apply">Apply</a>
+    </div>
+  </aside>
+</section>
+{% endblock %}

--- a/deploy/sim_envs/mantis_mercor/app/templates/jobs_list.html
+++ b/deploy/sim_envs/mantis_mercor/app/templates/jobs_list.html
@@ -1,0 +1,61 @@
+{% extends "base.html" %}
+{% from "_role_card.html" import role_card %}
+
+{% block title %}Roles — Mercor{% endblock %}
+
+{% block content %}
+<section class="jobs-layout" data-testid="jobs-layout">
+  <aside class="filter-rail" data-testid="filter-rail">
+    <form method="get" action="/jobs" data-testid="filter-form">
+      <div class="filter-group">
+        <div class="filter-label">Category</div>
+        {% for c in categories %}
+        <label class="chip-radio">
+          <input type="radio" name="category" value="{{ c }}" {% if filter_category == c %}checked{% endif %} />
+          <span class="chip">{{ c }}</span>
+        </label>
+        {% endfor %}
+        <label class="chip-radio">
+          <input type="radio" name="category" value="" {% if not filter_category %}checked{% endif %} />
+          <span class="chip">Any</span>
+        </label>
+      </div>
+      <div class="filter-group">
+        <div class="filter-label">Engagement type</div>
+        {% for e in ['Hourly', 'Project', 'Full-time'] %}
+        <label class="chip-radio">
+          <input type="radio" name="engagement" value="{{ e }}" {% if filter_engagement == e %}checked{% endif %} />
+          <span class="chip">{{ e }}</span>
+        </label>
+        {% endfor %}
+        <label class="chip-radio">
+          <input type="radio" name="engagement" value="" {% if not filter_engagement %}checked{% endif %} />
+          <span class="chip">Any</span>
+        </label>
+      </div>
+      <div class="filter-group">
+        <div class="filter-label">Rate ($/hr)</div>
+        <div class="filter-rate-row">
+          <input type="number" name="rate_min" placeholder="min" value="{{ filter_rate_min or '' }}" data-testid="filter-rate-min" />
+          <input type="number" name="rate_max" placeholder="max" value="{{ filter_rate_max or '' }}" data-testid="filter-rate-max" />
+        </div>
+      </div>
+      <button class="btn-primary" type="submit" data-testid="filter-apply">Apply filters</button>
+    </form>
+  </aside>
+  <section class="results-pane" data-testid="results-pane">
+    <div class="results-pane-header">
+      <h1>Open roles</h1>
+      <div class="sort-by">Sort by: <span class="sort-label">Latest</span></div>
+    </div>
+    <div class="role-grid" data-testid="role-grid">
+      {% for job in jobs %}
+        {{ role_card(job) }}
+      {% endfor %}
+    </div>
+    {% if not jobs %}
+    <div class="empty" data-testid="empty-jobs">No roles match your filters.</div>
+    {% endif %}
+  </section>
+</section>
+{% endblock %}

--- a/deploy/sim_envs/mantis_mercor/app/templates/login.html
+++ b/deploy/sim_envs/mantis_mercor/app/templates/login.html
@@ -1,0 +1,23 @@
+{% extends "base.html" %}
+
+{% block title %}Sign in — Mercor{% endblock %}
+
+{% block content %}
+<section class="auth-page" data-testid="auth-page">
+  <div class="auth-card" data-testid="auth-card">
+    <h1>Sign in to Mercor</h1>
+    {% if error %}<div class="alert alert-error" data-testid="login-error">{{ error }}</div>{% endif %}
+    <form method="post" action="/login" data-testid="login-form">
+      <input type="hidden" name="next" value="{{ next }}" />
+      <label>Email
+        <input type="email" name="email" required data-testid="login-email" />
+      </label>
+      <label>Password
+        <input type="password" name="password" required data-testid="login-password" />
+      </label>
+      <button type="submit" class="btn-primary block" data-testid="login-submit">Sign in</button>
+    </form>
+    <div class="auth-alt">Don't have an account? <a href="/signup">Sign up</a></div>
+  </div>
+</section>
+{% endblock %}

--- a/deploy/sim_envs/mantis_mercor/app/templates/profile.html
+++ b/deploy/sim_envs/mantis_mercor/app/templates/profile.html
@@ -1,0 +1,29 @@
+{% extends "base.html" %}
+
+{% block title %}Your profile — Mercor{% endblock %}
+
+{% block content %}
+<section class="profile-page" data-testid="profile-page">
+  <h1>Your profile</h1>
+  <p class="muted">Signed in as <b>{{ user.name or user.email }}</b></p>
+  <form method="post" action="/profile" class="profile-form" data-testid="profile-form">
+    <label>Headline
+      <input type="text" name="headline" value="{{ profile.headline }}" placeholder="Internal Medicine Physician, 8 years" data-testid="profile-headline" />
+    </label>
+    <label>Skills (comma-separated)
+      <input type="text" name="skills" value="{{ profile.skills | join(', ') }}" data-testid="profile-skills" />
+    </label>
+    <label>Hourly rate ($/hr)
+      <input type="number" step="1" name="hourly_rate" value="{{ profile.hourly_rate | int }}" data-testid="profile-rate" />
+    </label>
+    <label>Availability
+      <select name="availability" data-testid="profile-availability">
+        {% for opt in ['Full-time', 'Part-time', 'Project-based'] %}
+        <option value="{{ opt }}" {% if profile.availability == opt %}selected{% endif %}>{{ opt }}</option>
+        {% endfor %}
+      </select>
+    </label>
+    <button type="submit" class="btn-primary" data-testid="profile-save">Save</button>
+  </form>
+</section>
+{% endblock %}

--- a/deploy/sim_envs/mantis_mercor/app/templates/signup.html
+++ b/deploy/sim_envs/mantis_mercor/app/templates/signup.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %}
+
+{% block title %}Sign up — Mercor{% endblock %}
+
+{% block content %}
+<section class="auth-page" data-testid="auth-page">
+  <div class="auth-card" data-testid="auth-card">
+    <h1>Join Mercor</h1>
+    {% if error %}<div class="alert alert-error" data-testid="signup-error">{{ error }}</div>{% endif %}
+    <form method="post" action="/signup" data-testid="signup-form">
+      <fieldset class="role-radio">
+        <legend>I'm a</legend>
+        <label><input type="radio" name="role" value="candidate" checked /> Candidate</label>
+        <label><input type="radio" name="role" value="client" /> Client</label>
+      </fieldset>
+      <label>Name<input type="text" name="name" data-testid="signup-name" /></label>
+      <label>Email<input type="email" name="email" required data-testid="signup-email" /></label>
+      <label>Password<input type="password" name="password" required data-testid="signup-password" /></label>
+      <button type="submit" class="btn-primary block" data-testid="signup-submit">Create account</button>
+    </form>
+    <div class="auth-alt">Already have an account? <a href="/login">Sign in</a></div>
+  </div>
+</section>
+{% endblock %}

--- a/deploy/sim_envs/mantis_mercor/requirements.txt
+++ b/deploy/sim_envs/mantis_mercor/requirements.txt
@@ -1,0 +1,6 @@
+fastapi>=0.110
+uvicorn>=0.27
+jinja2>=3.1
+python-multipart>=0.0.9
+starlette>=0.27,<1.0
+itsdangerous>=2.1

--- a/deploy/sim_envs/mantis_mercor/scripts/smoke.py
+++ b/deploy/sim_envs/mantis_mercor/scripts/smoke.py
@@ -30,10 +30,10 @@ sys.path.insert(0, str(ROOT))
 
 os.environ.setdefault("ENV_ADMIN_TOKEN", "test")
 
-from fastapi.testclient import TestClient
+from fastapi.testclient import TestClient  # noqa: E402 -- env vars must be set first
 
-from app import auth as auth_mod
-from app.main import app
+from app import auth as auth_mod  # noqa: E402 -- env vars must be set first
+from app.main import app  # noqa: E402 -- env vars must be set first
 
 
 client = TestClient(app)

--- a/deploy/sim_envs/mantis_mercor/scripts/smoke.py
+++ b/deploy/sim_envs/mantis_mercor/scripts/smoke.py
@@ -1,0 +1,254 @@
+"""mantis-mercor smoke test.
+
+Boots the app in-process via TestClient and drives:
+
+1. Every in-scope page returns 200.
+2. /__env__/health returns ok=true (no auth).
+3. /__env__/oracle dispatches (without admin token: 401; with: returns
+   passing/failing result for each task).
+4. End-to-end happy path for each oracle task:
+    * t01 — apply to job_00001 as candidate_00001.
+    * t02 — shortlist candidate_00007 for job_00001 (as client).
+    * t03 — decline app_00001 (as client).
+   After each happy-path drive, /__env__/oracle?task_id=tNN must
+   return passed=true.
+
+Run:
+    cd deploy/sim_envs/mantis_mercor
+    ENV_ADMIN_TOKEN=test python scripts/smoke.py
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+# Allow `python scripts/smoke.py` from the env root.
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+os.environ.setdefault("ENV_ADMIN_TOKEN", "test")
+
+from fastapi.testclient import TestClient
+
+from app import auth as auth_mod
+from app.main import app
+
+
+client = TestClient(app)
+ADMIN = {"X-Env-Admin": "test"}
+
+
+def _mint_session(user_id: str) -> str:
+    return auth_mod.mint_session(user_id)
+
+
+def _login_as(user_id: str) -> None:
+    """Set the session cookie to act as user_id for subsequent requests."""
+    client.cookies.set("mantis_mercor_session", _mint_session(user_id))
+
+
+def _logout() -> None:
+    client.cookies.clear()
+
+
+def _check(name: str, cond: bool, extra: str = "") -> None:
+    sym = "PASS" if cond else "FAIL"
+    print(f"  [{sym}] {name}{' — ' + extra if extra else ''}")
+    if not cond:
+        global _failed
+        _failed += 1
+
+
+_failed = 0
+
+
+def step_health() -> None:
+    print("\n# Phase 1: harness contract")
+    r = client.get("/__env__/health")
+    _check("GET /__env__/health", r.status_code == 200 and r.json()["ok"])
+
+    r = client.post("/__env__/reset")  # no token
+    _check("POST /__env__/reset without token → 401", r.status_code == 401)
+
+    r = client.post("/__env__/reset", headers=ADMIN)
+    _check("POST /__env__/reset with token → 200", r.status_code == 200)
+
+    r = client.get("/__env__/state", headers=ADMIN)
+    _check(
+        "GET /__env__/state with counts",
+        r.status_code == 200 and r.json()["counts"]["jobs"] > 0,
+    )
+
+    r = client.get("/__env__/mutations?since=0", headers=ADMIN)
+    _check(
+        "GET /__env__/mutations returns list",
+        r.status_code == 200 and "mutations" in r.json(),
+    )
+
+
+def step_pages() -> None:
+    print("\n# Phase 2: in-scope pages")
+    pages = [
+        "/", "/jobs", "/jobs/job_00001", "/login", "/signup",
+        "/experts", "/dashboard", "/profile",
+    ]
+    for p in pages:
+        r = client.get(p)
+        _check(
+            f"GET {p} → 200",
+            r.status_code == 200,
+            extra=f"(got {r.status_code})",
+        )
+        if p == "/":
+            html = r.text
+            _check(
+                "  home contains 'Shape the frontier of AI'",
+                "Shape the frontier of AI" in html,
+            )
+            _check(
+                "  home contains 'Latest roles'",
+                "Latest roles" in html,
+            )
+
+    # Apply root redirects to step/1.
+    r = client.get("/apply/job_00001", follow_redirects=False)
+    _check("GET /apply/job_00001 → 303", r.status_code == 303)
+
+
+def step_t01_apply() -> None:
+    print("\n# Phase 3: t01 — apply flow as candidate_00001")
+    # Reset env to clean baseline.
+    client.post("/__env__/reset", headers=ADMIN)
+    _login_as("candidate_00001")
+
+    # Step 1: profile
+    r = client.post(
+        "/apply/job_00001/step/1",
+        data={
+            "headline": "Internal Medicine PGY-4",
+            "skills": "clinical-reasoning, literature-review",
+            "hourly_rate": "150",
+            "nav": "next",
+        },
+        follow_redirects=False,
+    )
+    _check("apply step 1 → 303", r.status_code == 303)
+
+    r = client.post(
+        "/apply/job_00001/step/2",
+        data={"resume_text": "5 years general internal medicine.", "nav": "next"},
+        follow_redirects=False,
+    )
+    _check("apply step 2 → 303", r.status_code == 303)
+
+    r = client.post(
+        "/apply/job_00001/step/3",
+        data={
+            "answer_0": "Board eligible.",
+            "answer_1": "Managed a rare ARDS case last quarter.",
+            "answer_2": "Two weeks notice.",
+            "nav": "next",
+        },
+        follow_redirects=False,
+    )
+    _check("apply step 3 → 303", r.status_code == 303)
+
+    r = client.post("/apply/job_00001/step/4", data={"nav": "next"},
+                    follow_redirects=False)
+    _check("apply step 4 → 303", r.status_code == 303)
+
+    r = client.post("/apply/job_00001/step/5", data={"nav": "next"},
+                    follow_redirects=False)
+    _check("apply step 5 → 303 to /submit", r.status_code == 303)
+
+    r = client.post("/apply/job_00001/submit")
+    _check("apply submit → 200", r.status_code == 200)
+    _check(
+        "submit banner present",
+        "Application submitted" in r.text,
+    )
+
+    r = client.get("/__env__/oracle?task_id=t01", headers=ADMIN)
+    body = r.json()
+    _check("t01 oracle passed", body["passed"], extra=str(body.get("reasons")))
+    _logout()
+
+
+def step_t02_shortlist() -> None:
+    print("\n# Phase 4: t02 — shortlist candidate_00007 for job_00001")
+    client.post("/__env__/reset", headers=ADMIN)
+    _login_as("client_00001")
+
+    r = client.post(
+        "/dashboard/shortlist",
+        data={"job_id": "job_00001", "candidate_id": "candidate_00007"},
+        follow_redirects=False,
+    )
+    _check("POST /dashboard/shortlist → 303", r.status_code == 303)
+
+    r = client.get("/__env__/oracle?task_id=t02", headers=ADMIN)
+    body = r.json()
+    _check("t02 oracle passed", body["passed"], extra=str(body.get("reasons")))
+    _logout()
+
+
+def step_t03_decline() -> None:
+    print("\n# Phase 5: t03 — decline app_00001 with reason")
+    client.post("/__env__/reset", headers=ADMIN)
+    _login_as("client_00001")
+
+    r = client.post(
+        "/dashboard/decline",
+        data={"application_id": "app_00001", "reason": "Insufficient experience"},
+        follow_redirects=False,
+    )
+    _check("POST /dashboard/decline → 303", r.status_code == 303)
+
+    r = client.get("/__env__/oracle?task_id=t03", headers=ADMIN)
+    body = r.json()
+    _check("t03 oracle passed", body["passed"], extra=str(body.get("reasons")))
+    _logout()
+
+
+def step_profile_edit() -> None:
+    print("\n# Phase 6: profile edit (no oracle, audit log only)")
+    client.post("/__env__/reset", headers=ADMIN)
+    _login_as("candidate_00001")
+
+    r = client.post(
+        "/profile",
+        data={
+            "headline": "Senior Internal Med Physician",
+            "skills": "clinical-reasoning, dx",
+            "hourly_rate": "170",
+            "availability": "Project-based",
+        },
+        follow_redirects=False,
+    )
+    _check("POST /profile → 303", r.status_code == 303)
+
+    r = client.get("/__env__/mutations?since=0", headers=ADMIN)
+    ops = [m["op"] for m in r.json()["mutations"]]
+    _check(
+        "profile_updated audit row present",
+        "profile_updated" in ops,
+        extra=f"ops={ops[-5:]}",
+    )
+    _logout()
+
+
+def main() -> int:
+    step_health()
+    step_pages()
+    step_t01_apply()
+    step_t02_shortlist()
+    step_t03_decline()
+    step_profile_edit()
+    print(f"\n# Result: {_failed} failure(s)")
+    return 0 if _failed == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/mantis_agent/extraction/result.py
+++ b/src/mantis_agent/extraction/result.py
@@ -121,12 +121,20 @@ class ExtractionResult:
         (canonical strict set). ``SEARCH_TILE`` uses
         ``schema.tile_required_fields`` when set — typically just
         ``["url"]`` so the runner keeps the row to drive a follow-up
-        navigate-into-detail. ``UNKNOWN`` (default) preserves legacy
-        behavior: enforces ``required_fields`` regardless of context.
+        navigate-into-detail. ``UNKNOWN`` (default) enforces
+        ``required_fields`` regardless of context.
 
         When the schema doesn't define ``tile_required_fields`` (empty
         list), ``SEARCH_TILE`` falls back to ``required_fields`` —
         recipes that don't opt into the split see no behavior change.
+
+        When ``_schema`` is None (no recipe / no schema configured),
+        returns ``no_schema_configured`` so the failure mode is honest
+        rather than the historical ``missing required field(s): year,
+        make`` lie that fired on every non-marketplace plan. The
+        ``# Legacy`` boattrader fallback the year/make check used to
+        live in was the exact contamination pattern flagged in
+        ``feedback_legacy_fallback_smell.md`` (#785 follow-up).
         """
         if self._schema:
             if (
@@ -141,13 +149,7 @@ class ExtractionResult:
                 if self._is_unknown(self.extracted_fields.get(name))
             ]
             return f"missing required field(s): {', '.join(missing)}" if missing else ""
-        # Legacy
-        missing = []
-        if self._is_unknown(self.year):
-            missing.append("year")
-        if self._is_unknown(self.make):
-            missing.append("make")
-        return f"missing required field(s): {', '.join(missing)}" if missing else ""
+        return "no_schema_configured"
 
     def to_summary(self) -> str:
         """Format as the VIABLE summary string."""
@@ -188,6 +190,14 @@ class ExtractionResult:
         as missing for the required-field check, so a detail-page
         extract that landed on a marketing CTA (every field returned
         as a placeholder) is rejected as non-viable.
+
+        Without an ``ExtractionSchema`` configured, returns ``False``:
+        a result has no schema contract to satisfy, so it can't be
+        certified viable. The historical ``# Legacy`` path silently
+        treated ``year + make + private_seller`` as the universal
+        viability contract — boattrader-shape baggage that leaked
+        into every non-marketplace plan (#785 follow-up;
+        ``feedback_legacy_fallback_smell.md``).
         """
         if self._schema:
             has_required = all(
@@ -195,9 +205,4 @@ class ExtractionResult:
                 for name in self._schema.required_fields
             )
             return has_required and self.is_private_seller()
-        # Legacy
-        return bool(
-            not self._is_unknown(self.year)
-            and not self._is_unknown(self.make)
-            and self.is_private_seller()
-        )
+        return False

--- a/tests/test_browser_use_plane_client.py
+++ b/tests/test_browser_use_plane_client.py
@@ -163,10 +163,32 @@ def test_step_dispatches_click_action():
     assert dispatch_payload["params"]["y"] == 200
 
 
-def test_unconfigured_url_raises_executor_construction_error():
+def test_unconfigured_url_raises_executor_construction_error(monkeypatch):
+    """When MANTIS_BROWSER_USE_URL is unset AND Modal SDK resolution
+    fails, the executor must raise rather than silently return a
+    client with no base_url.
+
+    The Modal SDK lookup is patched to raise so the test runs
+    deterministically — on a dev machine where ``mantis-browser-use``
+    is deployed, the live ``modal.Function.from_name(...)`` call
+    would succeed and silently mask the no-URL case the test is
+    pinning down.
+    """
+    import mantis_agent.run_browser_use as run_browser_use_mod
     from mantis_agent.run_browser_use import make_browser_use_client
 
-    # No MANTIS_BROWSER_USE_URL and no Modal SDK lookup → must raise.
+    monkeypatch.delenv("MANTIS_BROWSER_USE_URL", raising=False)
+
+    # Force the Modal SDK lookup to fail — production sometimes can't
+    # reach Modal (network blip, missing auth) and the executor must
+    # surface the misconfig clearly in that case.
+    def _fail_resolve() -> str:
+        return ""
+
+    monkeypatch.setattr(
+        run_browser_use_mod, "resolve_browser_use_base_url", _fail_resolve
+    )
+
     with pytest.raises(RuntimeError, match="Browser-Use Plane URL is not configured"):
         make_browser_use_client(base_url=None)
 

--- a/tests/test_extraction_quality_578_579.py
+++ b/tests/test_extraction_quality_578_579.py
@@ -42,35 +42,27 @@ def _result_schema(year: str = "", make: str = "") -> ExtractionResult:
     return r
 
 
-def test_legacy_all_empty_not_viable() -> None:
-    assert _result_legacy(year="", make="").is_viable() is False
+# Legacy no-schema viability tests deleted (#785 follow-up).
+#
+# Pre-rip the validator silently treated ``year + make + private_seller``
+# as the universal viability contract — boattrader-shape baggage leaking
+# into every plan. Post-rip, no schema → not viable, with an explicit
+# ``no_schema_configured`` reason. The schema-driven test cases below
+# (``test_schema_*``) carry the same coverage on the supported code
+# path. See ``feedback_legacy_fallback_smell.md``.
 
 
-def test_legacy_unknown_placeholder_not_viable() -> None:
-    # The bug from boattrader run 20260521_234022_65ddaaff: model
-    # returned "<UNKNOWN>" for every field, dedup accepted it.
-    r = _result_legacy(year="<UNKNOWN>", make="<UNKNOWN>", seller="private seller")
+def test_no_schema_returns_no_schema_configured_reason() -> None:
+    """The honest replacement for the deleted legacy tests."""
+    r = _result_legacy(year="", make="")
     assert r.is_viable() is False
-    assert "year" in r.missing_required_reason()
-    assert "make" in r.missing_required_reason()
+    assert r.missing_required_reason() == "no_schema_configured"
 
-
-def test_legacy_none_placeholder_not_viable() -> None:
-    r = _result_legacy(year="none", make="N/A", seller="private seller")
-    assert r.is_viable() is False
-
-
-def test_legacy_real_values_viable() -> None:
-    r = _result_legacy(
-        year="2020", make="Sea Ray", seller="John Smith (private)",
-    )
-    assert r.is_viable() is True
-
-
-def test_legacy_year_real_make_unknown_not_viable() -> None:
-    # Partial-UNKNOWN still fails the required check.
-    r = _result_legacy(year="2020", make="<UNKNOWN>", seller="private")
-    assert r.is_viable() is False
+    # Real values without a schema are still not viable — having
+    # year/make populated doesn't certify the contract.
+    r_real = _result_legacy(year="2020", make="Sea Ray", seller="private")
+    assert r_real.is_viable() is False
+    assert r_real.missing_required_reason() == "no_schema_configured"
 
 
 def test_schema_all_unknown_not_viable() -> None:

--- a/tests/test_extraction_schema.py
+++ b/tests/test_extraction_schema.py
@@ -187,16 +187,32 @@ def test_result_with_schema_to_summary():
 
 
 def test_result_without_schema_backward_compat():
+    """Historical no-schema results are no longer viable.
+
+    Pre-rip the validator silently treated ``year + make`` as the
+    universal viability contract — boattrader-shape baggage leaking
+    into every plan. Post-rip (#785 follow-up), no schema → not
+    viable, with an explicit ``no_schema_configured`` reason. The
+    no-schema ``to_summary`` format is preserved for legacy display
+    (the rip only touched the validation gate, not output rendering).
+    """
     result = ExtractionResult(year="2020", make="Sea Ray", model="240")
-    assert result.is_viable()
+    assert not result.is_viable()
     assert "Year: 2020" in result.to_summary()
-    assert result.missing_required_reason() == ""
+    assert result.missing_required_reason() == "no_schema_configured"
 
 
 def test_result_without_schema_not_viable():
+    """No schema configured → result is not viable and the failure
+    reason is explicit (``no_schema_configured``), not the historical
+    boattrader-shape ``missing required field(s): year, make`` lie
+    that leaked into every non-marketplace plan (#785 follow-up;
+    ``feedback_legacy_fallback_smell.md``).
+    """
     result = ExtractionResult(make="Sea Ray")
     assert not result.is_viable()
-    assert "year" in result.missing_required_reason()
+    reason = result.missing_required_reason()
+    assert reason == "no_schema_configured", reason
 
 
 def test_dealer_reason_recipe_gated_without_schema() -> None:


### PR DESCRIPTION
## Summary

The extraction validator IS schema-driven by design — recipes own their `ExtractionSchema(required_fields=[...])` and the validator enforces that contract. But `extraction/result.py` carried a `# Legacy` fallback that silently treated **`year + make + private_seller`** as a universal viability contract when no schema was configured. Boattrader-shape baggage leaking into every non-marketplace plan.

This is the exact pattern memory `feedback_legacy_fallback_smell.md` flags. The dealer-detection sibling was already ripped 2026-05-17 (see test docstring `test_dealer_reason_recipe_gated_without_schema`); this PR finishes the job on the required-field path.

## How it surfaced

While smoke-testing the #785 PR chain end-to-end:

- Modal `mantis-cua-server` ran the HN plan to completion
- Holo3 navigated, Chrome rendered, Claude extracted data
- Validator dropped the result: \`missing required field(s): year, make url=news.ycombinator.com\` — a misleading rejection. HN stories have no year/make to begin with.

The framework worked; the validator's no-schema fallback lied.

## Changes

| File | Change |
|---|---|
| `extraction/result.py::missing_required_reason()` | When `_schema` is None, return `"no_schema_configured"` — honest failure mode instead of the year/make pretense |
| `extraction/result.py::is_viable()` | When `_schema` is None, return `False` — a result without a schema contract can't be certified viable; fail loud |
| `to_summary()` legacy block | **Untouched** — that's output rendering, not validation. Ripping it would change display formatting without affecting correctness |

## Test changes

- `tests/test_extraction_schema.py::test_result_without_schema_not_viable` + `test_result_without_schema_backward_compat` — updated to assert the new `no_schema_configured` reason
- `tests/test_extraction_quality_578_579.py` — deleted 4 `test_legacy_*_viable` tests encoding the boattrader-as-universal contract; replaced with one `test_no_schema_returns_no_schema_configured_reason`. Schema-driven coverage (`test_schema_*`) already existed and carries the meaningful intent
- `tests/test_browser_use_plane_client.py::test_unconfigured_url_*` — fixed flakiness from PR #793: the test depended on Modal SDK resolution failing, but on a dev machine where `mantis-browser-use` is deployed the SDK lookup succeeds. Now monkeypatches the resolver so the failure mode is deterministic

## Test sweep

- **Local:** 4766 passed, 31 skipped
- **1 pre-existing failure** unrelated to this PR: `test_modal_endpoint.py::test_result_action_returns_executor_result` fails on `main` too (response envelope gained an `artifacts` block the test wasn't updated for)

## Refs

- Epic: #785
- Memory: `feedback_legacy_fallback_smell.md`
- Sibling rip precedent: `test_dealer_reason_recipe_gated_without_schema` (2026-05-17 — same shape of contamination on the dealer-detection path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)