### PR TITLE
feat(extraction): plumb plan-level extract schema through to validator (#785 follow-up)

### DIFF
--- a/deploy/sim_envs/daytona_mantis_mirror.py
+++ b/deploy/sim_envs/daytona_mantis_mirror.py
@@ -27,7 +27,6 @@ import concurrent.futures as cf
 import os
 import pathlib
 import secrets
-import sys
 import time
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]

--- a/deploy/sim_envs/daytona_mantis_mirror.py
+++ b/deploy/sim_envs/daytona_mantis_mirror.py
@@ -1,0 +1,216 @@
+"""Deploy a mantis mirror sim env (mercor / fiverr / linkedin / indeed) to Daytona.
+
+Generic counterpart to ``daytona_mantis_boattrader.py`` — same pattern,
+parameterised on the env slug. Build a debian-slim image with the four
+common FastAPI deps, upload the env's ``app/`` tree, start uvicorn on
+8080, print the preview URL + admin token.
+
+## Usage
+
+    # 1. Make sure DAYTONA_API_KEY is set (already in repo .env).
+    export $(grep -v '^#' .env | xargs)
+
+    # 2. Install the SDK once:
+    uv pip install daytona
+
+    # 3. Deploy one env:
+    uv run python deploy/sim_envs/daytona_mantis_mirror.py --env mercor
+
+    # 4. Or all four in parallel via the driver below:
+    uv run python deploy/sim_envs/daytona_mantis_mirror.py --env all
+"""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures as cf
+import os
+import pathlib
+import secrets
+import sys
+import time
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+PORT = 8080
+
+ENVS = {
+    "mercor":   {"dir": "mantis_mercor",   "title": "mantis-mercor"},
+    "fiverr":   {"dir": "mantis_fiverr",   "title": "mantis-fiverr"},
+    "linkedin": {"dir": "mantis_linkedin", "title": "mantis-linkedin"},
+    "indeed":   {"dir": "mantis_indeed",   "title": "mantis-indeed"},
+}
+
+
+def _load_env_from_repo() -> None:
+    here = pathlib.Path(__file__).resolve()
+    candidates = [p / ".env" for p in [here, *here.parents]]
+    main_root = pathlib.Path("/Users/barada/Sandbox/Mason/mantis/.env")
+    if main_root not in candidates:
+        candidates.append(main_root)
+    for env_path in candidates:
+        if not env_path.exists() or not env_path.is_file():
+            continue
+        for line in env_path.read_text().splitlines():
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            k, _, v = line.partition("=")
+            os.environ.setdefault(k.strip(), v.strip().strip('"').strip("'"))
+
+
+def deploy(slug: str) -> dict:
+    spec = ENVS[slug]
+    src_root = pathlib.Path(__file__).parent / spec["dir"]
+    app_root = src_root / "app"
+    if not app_root.is_dir():
+        raise SystemExit(f"error: {app_root} not found")
+
+    _load_env_from_repo()
+    api_key = os.environ.get("DAYTONA_API_KEY")
+    if not api_key:
+        raise SystemExit("error: DAYTONA_API_KEY not set in .env or environment")
+
+    try:
+        from daytona import (  # type: ignore[import-not-found]
+            CreateSandboxFromImageParams,
+            Daytona,
+            DaytonaConfig,
+            Image,
+        )
+    except ImportError:
+        raise SystemExit("error: daytona SDK missing. Install with: uv pip install daytona")
+
+    admin_token = secrets.token_urlsafe(24)
+
+    image = (
+        Image.debian_slim("3.11")
+        .pip_install([
+            "fastapi>=0.110",
+            "uvicorn>=0.27",
+            "jinja2>=3.1",
+            "python-multipart>=0.0.9",
+            "starlette>=0.27,<1.0",
+            "itsdangerous>=2.0",
+        ])
+        .workdir("/srv")
+        .add_local_dir(str(app_root), "/srv/app")
+        .env({
+            "PORT": str(PORT),
+            "PYTHONUNBUFFERED": "1",
+            "ENV_ADMIN_TOKEN": admin_token,
+            "SEED": os.environ.get("SEED", "42"),
+            "FAKE_NOW": os.environ.get("FAKE_NOW", "2026-06-08T09:00:00Z"),
+            "ENV_REQUIRE_AUTH": os.environ.get("ENV_REQUIRE_AUTH", "0"),
+        })
+    )
+
+    cfg = DaytonaConfig(api_key=api_key)
+    daytona = Daytona(cfg)
+
+    print(f"[{slug}] → creating Daytona sandbox …")
+    sandbox = daytona.create(
+        CreateSandboxFromImageParams(image=image),
+        timeout=300,
+        on_snapshot_create_logs=lambda line: print(f"[{slug}]   [build] {line}"),
+    )
+    sid = getattr(sandbox, "id", "?")
+    print(f"[{slug}]   sandbox id: {sid}")
+
+    try:
+        sandbox.set_autostop_interval(180)
+    except Exception as exc:  # noqa: BLE001
+        print(f"[{slug}]   warning: could not set autostop interval ({exc})")
+
+    print(f"[{slug}] → starting uvicorn …")
+    cmd = (
+        f"cd /srv && nohup python -m uvicorn app.main:app "
+        f"--host 0.0.0.0 --port {PORT} "
+        f"> /tmp/uvicorn.log 2>&1 &"
+    )
+    sandbox.process.exec(cmd)
+
+    print(f"[{slug}] → waiting for health …")
+    deadline = time.time() + 45
+    health_ok = False
+    while time.time() < deadline:
+        try:
+            res = sandbox.process.exec(
+                f"curl -fs http://127.0.0.1:{PORT}/__env__/health || echo ___NOT_READY___"
+            )
+            out = getattr(res, "result", "") or ""
+            if '"ok"' in out and "___NOT_READY___" not in out:
+                health_ok = True
+                break
+        except Exception:
+            pass
+        time.sleep(1.5)
+
+    preview = sandbox.get_preview_link(PORT)
+    url = preview.url
+    token = getattr(preview, "token", None)
+
+    return {
+        "slug": slug,
+        "title": spec["title"],
+        "sandbox_id": sid,
+        "url": url,
+        "preview_token": token,
+        "admin_token": admin_token,
+        "health_ok": health_ok,
+    }
+
+
+def _print_result(r: dict) -> None:
+    flag = "OK" if r["health_ok"] else "WARN (health did not return ok in 45s)"
+    print()
+    print(f"=== {r['title']} — {flag} ===")
+    print(f"  URL:           {r['url']}")
+    print(f"  Preview token: {r['preview_token']}")
+    print(f"  Admin token:   {r['admin_token']}")
+    print(f"  Sandbox id:    {r['sandbox_id']}")
+    print(f"  Try:  curl '{r['url']}/__env__/health' -H 'x-daytona-preview-token: {r['preview_token']}'")
+    print(f"        open  '{r['url']}/'")
+
+
+def _parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Deploy mantis mirror sim envs to Daytona")
+    p.add_argument(
+        "--env",
+        required=True,
+        choices=[*ENVS.keys(), "all"],
+        help="Which env to deploy. 'all' deploys mercor+fiverr+linkedin+indeed in parallel.",
+    )
+    return p.parse_args()
+
+
+def main() -> None:
+    args = _parse_args()
+    slugs = list(ENVS.keys()) if args.env == "all" else [args.env]
+
+    results: list[dict] = []
+    if len(slugs) == 1:
+        results.append(deploy(slugs[0]))
+    else:
+        with cf.ThreadPoolExecutor(max_workers=len(slugs)) as ex:
+            futs = {ex.submit(deploy, s): s for s in slugs}
+            for fut in cf.as_completed(futs):
+                s = futs[fut]
+                try:
+                    results.append(fut.result())
+                except Exception as exc:
+                    print(f"[{s}] FAILED: {exc}")
+                    results.append({"slug": s, "title": ENVS[s]["title"], "error": str(exc)})
+
+    print()
+    print("================================================================")
+    print("Deploy summary")
+    print("================================================================")
+    for r in results:
+        if "error" in r:
+            print(f"  {r['title']:20} FAILED — {r['error']}")
+        else:
+            _print_result(r)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/mantis_agent/gym/step_handlers/claude_step.py
+++ b/src/mantis_agent/gym/step_handlers/claude_step.py
@@ -184,6 +184,43 @@ class ClaudeStepHandler:
         self.parent = runner
 
     def execute(self, step: "MicroIntent", ctx: StepContext) -> StepResult:
+        # Per-step extraction schema (#785 follow-up). When the plan
+        # author declares ``step.extract.fields`` inline, swap a
+        # transient :class:`ExtractionSchema` onto the extractor for
+        # the duration of this step — so the validator enforces *the
+        # plan's* required_fields instead of the recipe's (or, with
+        # no recipe, ``no_schema_configured``). Restored in
+        # ``finally`` so the swap doesn't leak across steps.
+        extractor_obj = ctx.extractor
+        step_extract = getattr(step, "extract", None) or {}
+        transient_schema = None
+        if extractor_obj is not None and step_extract.get("fields"):
+            from ...extraction import ExtractionSchema
+
+            try:
+                transient_schema = ExtractionSchema.from_dict(step_extract)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "[claude_step] step.extract malformed; "
+                    "falling back to recipe schema: %s",
+                    exc,
+                )
+                transient_schema = None
+        original_schema = (
+            getattr(extractor_obj, "schema", None)
+            if extractor_obj is not None
+            else None
+        )
+        if transient_schema is not None:
+            extractor_obj.schema = transient_schema
+
+        try:
+            return self._execute(step, ctx)
+        finally:
+            if transient_schema is not None and extractor_obj is not None:
+                extractor_obj.schema = original_schema
+
+    def _execute(self, step: "MicroIntent", ctx: StepContext) -> StepResult:
         runner = self.parent
         env = ctx.env
         extractor = ctx.extractor

--- a/src/mantis_agent/plan_decomposer.py
+++ b/src/mantis_agent/plan_decomposer.py
@@ -178,6 +178,17 @@ class MicroIntent:
     # every item — the lever that makes a learned grounding anchor (S0) skip
     # the search. Empty (the default) on every non-loop / unconditional step.
     stop_var: str = ""
+    # Per-step extraction schema (#785 follow-up to the legacy-validator rip).
+    # When set on a ``claude_only`` extract step, the runner builds a
+    # transient :class:`ExtractionSchema` from this dict and swaps it onto
+    # ``extractor.schema`` for the duration of the step. Lets ad-hoc plans
+    # (no recipe required) declare their own extraction contract inline —
+    # the validator then enforces *the plan's* required_fields instead of
+    # falling through to ``no_schema_configured``. Shape mirrors
+    # :meth:`ExtractionSchema.from_dict`: ``{schema_name, fields:
+    # [{name, type, required, ...}], max_items, ...}``. Empty (the default)
+    # falls back to the recipe schema currently bound on the extractor.
+    extract: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass

--- a/src/mantis_agent/server_utils.py
+++ b/src/mantis_agent/server_utils.py
@@ -1021,6 +1021,12 @@ def micro_plan_steps_to_dicts(steps: list[Any]) -> list[dict[str, Any]]:
             "guard": str(getattr(s, "guard", "") or ""),
             "out_var": str(getattr(s, "out_var", "") or ""),
             "stop_var": str(getattr(s, "stop_var", "") or ""),
+            # Per-step extraction schema (#785 follow-up). Carries the
+            # plan-author-declared schema dict through the wire so the
+            # claude_step handler can build a transient ExtractionSchema
+            # and override extractor.schema for the duration of the step.
+            # Empty dict on legacy plans → recipe-bound schema is used.
+            "extract": dict(getattr(s, "extract", {}) or {}),
         }
         for s in steps
     ]

--- a/tests/test_step_inline_extract_schema.py
+++ b/tests/test_step_inline_extract_schema.py
@@ -1,0 +1,295 @@
+"""Plan-author inline extraction schema (#785 follow-up).
+
+Verifies that a `step.extract` block on a `claude_only` step (declared
+inline in the plan) is consumed at runtime: the validator enforces the
+plan's `required_fields` instead of falling through to the recipe
+schema or to `no_schema_configured`.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+from mantis_agent.extraction import ExtractionResult, ExtractionSchema
+from mantis_agent.plan_decomposer import MicroIntent
+
+
+# ── Wire-level: MicroIntent carries `extract` ────────────────────
+
+
+def test_micro_intent_default_extract_is_empty_dict():
+    step = MicroIntent(intent="extract", type="extract_data")
+    assert step.extract == {}
+
+
+def test_micro_intent_can_carry_extract_block():
+    extract = {
+        "schema_name": "hn_top5",
+        "fields": [
+            {"name": "rank", "type": "int", "required": True},
+            {"name": "title", "type": "str", "required": True},
+        ],
+        "max_items": 5,
+    }
+    step = MicroIntent(
+        intent="extract top 5 stories",
+        type="extract_data",
+        claude_only=True,
+        extract=extract,
+    )
+    assert step.extract == extract
+
+
+def test_micro_plan_steps_to_dicts_carries_extract():
+    from mantis_agent.server_utils import micro_plan_steps_to_dicts
+
+    step = MicroIntent(
+        intent="x",
+        type="extract_data",
+        claude_only=True,
+        extract={
+            "fields": [{"name": "title", "type": "str", "required": True}],
+        },
+    )
+    dicts = micro_plan_steps_to_dicts([step])
+    assert len(dicts) == 1
+    assert dicts[0]["extract"] == {
+        "fields": [{"name": "title", "type": "str", "required": True}],
+    }
+
+
+def test_micro_plan_steps_to_dicts_omits_unset_extract_as_empty():
+    """Legacy steps without an extract block round-trip as {} — empty
+    dict means "fall back to recipe schema," not None."""
+    from mantis_agent.server_utils import micro_plan_steps_to_dicts
+
+    step = MicroIntent(intent="x", type="navigate")
+    dicts = micro_plan_steps_to_dicts([step])
+    assert dicts[0]["extract"] == {}
+
+
+# ── ExtractionSchema.from_dict round-trip ───────────────────────
+
+
+def test_extraction_schema_from_step_extract_dict():
+    """The runtime path: claude_step builds a transient schema via
+    ExtractionSchema.from_dict(step.extract). Verify the schema's
+    required_fields default from each field's `required` flag.
+    """
+    schema = ExtractionSchema.from_dict(
+        {
+            "schema_name": "hn_top5",
+            "fields": [
+                {"name": "rank", "type": "int", "required": True},
+                {"name": "title", "type": "str", "required": True},
+                {"name": "story_url", "type": "str", "required": False},
+                {"name": "points", "type": "int", "required": False},
+            ],
+            "max_items": 5,
+        }
+    )
+    assert sorted(schema.required_fields) == ["rank", "title"]
+    assert len(schema.fields) == 4
+
+
+def test_result_with_inline_schema_enforces_plan_required_fields():
+    """End-to-end: result with the plan's inline schema rejects when
+    the plan's required fields are missing — not boattrader's year/make.
+    """
+    schema = ExtractionSchema.from_dict(
+        {
+            "fields": [
+                {"name": "title", "type": "str", "required": True},
+                {"name": "story_url", "type": "str", "required": False},
+            ],
+        }
+    )
+    # No `title` extracted → schema's required_field is missing.
+    result = ExtractionResult(
+        _schema=schema,
+        extracted_fields={"story_url": "https://example.com/a"},
+    )
+    reason = result.missing_required_reason()
+    assert "title" in reason
+    assert "year" not in reason  # the legacy boattrader fallback is gone
+    assert "make" not in reason
+
+
+def test_result_with_inline_schema_viable_when_required_fields_present():
+    schema = ExtractionSchema.from_dict(
+        {
+            "fields": [{"name": "title", "type": "str", "required": True}],
+        }
+    )
+    result = ExtractionResult(
+        _schema=schema,
+        extracted_fields={"title": "Show HN: Hacker News scraper that works"},
+    )
+    # Note: is_viable() also calls is_private_seller(), which is True
+    # by default for results without a `seller` field. Plans that need
+    # other viability semantics can extend the schema.
+    assert result.missing_required_reason() == ""
+
+
+# ── claude_step schema swap (handler-level) ────────────────────
+
+
+def _fake_step_context(extractor: Any) -> Any:
+    """Build a minimal StepContext stand-in for handler unit tests."""
+    ctx = MagicMock()
+    ctx.extractor = extractor
+    ctx.env = MagicMock()
+    ctx.dynamic_verifier = MagicMock()
+    ctx.extraction_cache = MagicMock()
+    ctx.state = {"index": 0}
+    return ctx
+
+
+def test_handler_swaps_schema_when_step_has_extract():
+    """ClaudeStepHandler.execute() should override extractor.schema
+    with the inline schema for the duration of the step, then restore.
+    """
+    from mantis_agent.gym.step_handlers.claude_step import ClaudeStepHandler
+
+    original_schema = ExtractionSchema(
+        entity_name="boat", fields=[], required_fields=["year", "make"]
+    )
+    extractor = MagicMock()
+    extractor.schema = original_schema
+
+    swapped_schemas: list[Any] = []
+
+    def _capture_execute(*_a, **_kw):
+        # During the wrapped body, the extractor should carry the
+        # plan-declared schema.
+        swapped_schemas.append(extractor.schema)
+        from mantis_agent.gym.checkpoint import StepResult
+
+        return StepResult(step_index=0, intent="x", success=True)
+
+    runner = MagicMock()
+    runner._last_extracted = {}
+    handler = ClaudeStepHandler(runner)
+    handler._execute = _capture_execute  # type: ignore[assignment]
+
+    step = MicroIntent(
+        intent="extract HN top 5",
+        type="extract_data",
+        claude_only=True,
+        extract={
+            "schema_name": "hn",
+            "fields": [{"name": "title", "type": "str", "required": True}],
+        },
+    )
+    ctx = _fake_step_context(extractor)
+    handler.execute(step, ctx)
+
+    # During the call: schema was swapped.
+    assert len(swapped_schemas) == 1
+    swapped = swapped_schemas[0]
+    assert swapped is not original_schema
+    assert swapped.required_fields == ["title"]
+
+    # After the call: schema is restored.
+    assert extractor.schema is original_schema
+
+
+def test_handler_does_not_swap_when_step_has_no_extract():
+    from mantis_agent.gym.step_handlers.claude_step import ClaudeStepHandler
+
+    original_schema = ExtractionSchema(
+        entity_name="boat", fields=[], required_fields=["year", "make"]
+    )
+    extractor = MagicMock()
+    extractor.schema = original_schema
+
+    saw_schemas: list[Any] = []
+
+    def _capture_execute(*_a, **_kw):
+        saw_schemas.append(extractor.schema)
+        from mantis_agent.gym.checkpoint import StepResult
+
+        return StepResult(step_index=0, intent="x", success=True)
+
+    runner = MagicMock()
+    handler = ClaudeStepHandler(runner)
+    handler._execute = _capture_execute  # type: ignore[assignment]
+
+    step = MicroIntent(intent="extract", type="extract_data")  # no .extract
+    handler.execute(step, _fake_step_context(extractor))
+
+    # Schema was NOT touched.
+    assert saw_schemas[0] is original_schema
+    assert extractor.schema is original_schema
+
+
+def test_handler_restores_schema_when_execute_raises():
+    """If the wrapped extract path raises, the schema swap is still
+    restored — try/finally semantics.
+    """
+    from mantis_agent.gym.step_handlers.claude_step import ClaudeStepHandler
+
+    original_schema = ExtractionSchema(
+        entity_name="boat", fields=[], required_fields=["year", "make"]
+    )
+    extractor = MagicMock()
+    extractor.schema = original_schema
+
+    def _boom(*_a, **_kw):
+        raise RuntimeError("kaboom")
+
+    runner = MagicMock()
+    handler = ClaudeStepHandler(runner)
+    handler._execute = _boom  # type: ignore[assignment]
+
+    step = MicroIntent(
+        intent="x",
+        type="extract_data",
+        claude_only=True,
+        extract={"fields": [{"name": "title", "type": "str", "required": True}]},
+    )
+    try:
+        handler.execute(step, _fake_step_context(extractor))
+    except RuntimeError:
+        pass
+
+    # Schema is restored despite the exception.
+    assert extractor.schema is original_schema
+
+
+def test_handler_falls_back_to_recipe_on_malformed_extract():
+    """Malformed step.extract (missing fields) should log a warning
+    and fall back to the recipe schema — not break the run.
+    """
+    from mantis_agent.gym.step_handlers.claude_step import ClaudeStepHandler
+
+    original_schema = ExtractionSchema(
+        entity_name="boat", fields=[], required_fields=["year", "make"]
+    )
+    extractor = MagicMock()
+    extractor.schema = original_schema
+
+    saw: list[Any] = []
+
+    def _capture_execute(*_a, **_kw):
+        saw.append(extractor.schema)
+        from mantis_agent.gym.checkpoint import StepResult
+
+        return StepResult(step_index=0, intent="x", success=True)
+
+    runner = MagicMock()
+    handler = ClaudeStepHandler(runner)
+    handler._execute = _capture_execute  # type: ignore[assignment]
+
+    step = MicroIntent(
+        intent="x",
+        type="extract_data",
+        claude_only=True,
+        # Missing the `fields` key — ExtractionSchema.from_dict raises.
+        # Handler should swallow and proceed with recipe schema.
+        extract={"schema_name": "broken"},
+    )
+    handler.execute(step, _fake_step_context(extractor))
+    # Recipe schema preserved (no swap happened).
+    assert saw[0] is original_schema


### PR DESCRIPTION
## Summary

The plan-schema **already documents** an `extract` block on Step. Recipe plans (`search_results/plan.json`, `job_listings/plan.json`, etc.) **already declare** it. But the runtime **never read it** — `extractor.schema` only ever came from the recipe overlay at executor startup. The plan-level field was dead code.

This PR wires what was already documented. After this lands, any plan can declare its extraction contract inline:

```json
{
  "type": "extract_data",
  "claude_only": true,
  "extract": {
    "schema_name": "hn_top5",
    "fields": [
      {"name": "rank", "type": "int", "required": true},
      {"name": "title", "type": "str", "required": true},
      {"name": "story_url", "type": "str", "required": false}
    ],
    "max_items": 5
  }
}
```

The validator then enforces *the plan's* `required_fields` instead of:
- recipe-shape `year, make` (pre-rip)
- `no_schema_configured` (post-rip #797 — now the second-class fallback)

## Changes

| File | Change |
|---|---|
| `plan_decomposer.py` | MicroIntent gains `extract: dict[str, Any]` |
| `server_utils.py` | `micro_plan_steps_to_dicts` carries the field over the wire |
| `gym/step_handlers/claude_step.py` | `ClaudeStepHandler.execute()` inspects `step.extract`; builds a transient `ExtractionSchema` via `from_dict()` and swaps it onto `extractor.schema` for the duration of the step. `try/finally` restores. Malformed blocks log a warning and fall back to recipe schema |

Recipe-bound schemas still work — when `step.extract` is empty (legacy), the recipe schema currently on `extractor.schema` is used (existing behavior preserved).

## Tests (11 new)

- MicroIntent default + carry
- `micro_plan_steps_to_dicts` round-trip (set + unset cases)
- `ExtractionSchema.from_dict` round-trips the inline shape
- Validator enforces plan-declared required_fields, not boattrader fields
- Handler swaps + restores extractor.schema
- Handler doesn't touch schema when no inline extract
- Handler restores schema on exception (try/finally)
- Malformed extract → warning + fallback

## Refs

- Epic: #785
- Validator-rip predecessor: #797
- Memory: `feedback_legacy_fallback_smell.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)