### PR TITLE
feat(decomposer): emit inline extract blocks from intent prose (#785 follow-up)

### DIFF
--- a/deploy/sim_envs/daytona_mantis_mirror_v2.py
+++ b/deploy/sim_envs/daytona_mantis_mirror_v2.py
@@ -1,0 +1,268 @@
+"""Hang-tolerant deploy for mantis mirror sim envs.
+
+The Daytona 0.183.0 SDK has a known hang in `daytona.create()` after
+debian_slim image build completes — see memory note
+`feedback_daytona_fresh_build_hang_reuse_or_snapshot.md`. The sandbox
+IS created and reaches STARTED state; the SDK call just never returns.
+
+This script works around it by running `create()` in a thread with a
+deadline, then falling back to identifying the just-created sandbox via
+`d.list()` if the call hasn't returned. It also handles uvicorn start
+robustly (kills any stale uvicorn first; uses python urllib for health
+since the slim image has no curl).
+
+Usage:
+    uv run python deploy/sim_envs/daytona_mantis_mirror_v2.py --env all
+"""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures as cf
+import os
+import pathlib
+import secrets
+import threading
+import time
+
+PORT = 8080
+
+ENVS = {
+    "mercor":   {"dir": "mantis_mercor",   "title": "mantis-mercor"},
+    "fiverr":   {"dir": "mantis_fiverr",   "title": "mantis-fiverr"},
+    "linkedin": {"dir": "mantis_linkedin", "title": "mantis-linkedin"},
+    "indeed":   {"dir": "mantis_indeed",   "title": "mantis-indeed"},
+}
+
+
+def _load_env() -> None:
+    for env_path in [pathlib.Path("/Users/barada/Sandbox/Mason/mantis/.env")]:
+        if not env_path.is_file():
+            continue
+        for line in env_path.read_text().splitlines():
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            k, _, v = line.partition("=")
+            os.environ.setdefault(k.strip(), v.strip().strip('"').strip("'"))
+
+
+def _build_image(app_root: pathlib.Path, admin_token: str):
+    from daytona import Image
+    return (
+        Image.debian_slim("3.11")
+        .pip_install([
+            "fastapi>=0.110",
+            "uvicorn>=0.27",
+            "jinja2>=3.1",
+            "python-multipart>=0.0.9",
+            "starlette>=0.27,<1.0",
+            "itsdangerous>=2.0",
+        ])
+        .workdir("/srv")
+        .add_local_dir(str(app_root), "/srv/app")
+        .env({
+            "PORT": str(PORT),
+            "PYTHONUNBUFFERED": "1",
+            "ENV_ADMIN_TOKEN": admin_token,
+            "SEED": "42",
+            "FAKE_NOW": "2026-06-08T09:00:00Z",
+            "ENV_REQUIRE_AUTH": "0",
+        })
+    )
+
+
+def _identify_sandbox(d, slug: str, exclude_ids: set[str]):
+    """After a create() hang, find the just-built sandbox by inspecting
+    /srv/app. We look at STARTED sandboxes not in `exclude_ids` and grep
+    for the title slot in main.py."""
+    from daytona import Daytona  # noqa: F401
+    title_marker = f'title="{ENVS[slug]["title"]}"'
+    for s in d.list():
+        sid = getattr(s, "id", "")
+        if sid in exclude_ids:
+            continue
+        state = str(getattr(s, "state", "")).replace("SandboxState.", "")
+        if state != "STARTED":
+            continue
+        try:
+            r = s.process.exec("grep -h 'title=' /srv/app/main.py 2>/dev/null | head -1")
+            out = (getattr(r, "result", "") or "")
+            if title_marker in out:
+                return s
+        except Exception:
+            continue
+    return None
+
+
+def _start_uvicorn(sandbox) -> None:
+    """Kill any stale uvicorn (no pgrep in slim — use /proc), then start fresh."""
+    sandbox.process.exec(
+        "python3 -c \""
+        "import os, signal\n"
+        "for pid in os.listdir('/proc'):\n"
+        "    if not pid.isdigit(): continue\n"
+        "    try:\n"
+        "        with open(f'/proc/{pid}/cmdline','rb') as f: c=f.read()\n"
+        "    except: continue\n"
+        "    if b'uvicorn' in c or b'app.main' in c:\n"
+        "        try: os.kill(int(pid), signal.SIGKILL)\n"
+        "        except: pass\n"
+        "\""
+    )
+    time.sleep(1)
+    sandbox.process.exec(
+        f"cd /srv && nohup python3 -m uvicorn app.main:app "
+        f"--host 0.0.0.0 --port {PORT} > /tmp/uvicorn.log 2>&1 &"
+    )
+
+
+def _wait_healthy(sandbox, timeout: int = 30) -> bool:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            r = sandbox.process.exec(
+                f"python3 -c \"import urllib.request; "
+                f"print(urllib.request.urlopen('http://127.0.0.1:{PORT}/__env__/health',timeout=3).read().decode())\""
+            )
+            out = (getattr(r, "result", "") or "").strip()
+            if '"ok"' in out:
+                return True
+        except Exception:
+            pass
+        time.sleep(2)
+    return False
+
+
+def deploy(slug: str, log) -> dict:
+    from daytona import (
+        CreateSandboxFromImageParams,
+        Daytona,
+        DaytonaConfig,
+    )
+
+    spec = ENVS[slug]
+    app_root = pathlib.Path(__file__).parent / spec["dir"] / "app"
+    if not app_root.is_dir():
+        raise SystemExit(f"error: {app_root} not found")
+
+    api_key = os.environ["DAYTONA_API_KEY"]
+    admin_token = secrets.token_urlsafe(24)
+    d = Daytona(DaytonaConfig(api_key=api_key))
+
+    pre_existing = {getattr(s, "id", "") for s in d.list()}
+
+    image = _build_image(app_root, admin_token)
+    log(f"[{slug}] → creating sandbox …")
+
+    result_holder = {}
+    def _create():
+        try:
+            sb = d.create(
+                CreateSandboxFromImageParams(image=image),
+                timeout=300,
+                on_snapshot_create_logs=lambda line: log(f"[{slug}]   [build] {line[:140]}"),
+            )
+            result_holder["sb"] = sb
+        except Exception as exc:
+            result_holder["err"] = exc
+
+    t = threading.Thread(target=_create, daemon=True)
+    t.start()
+
+    # Allow generous time for the build + a grace period for the hang
+    SDK_DEADLINE = 360  # 6 min
+    t.join(SDK_DEADLINE)
+
+    sb = result_holder.get("sb")
+    err = result_holder.get("err")
+    if err and not sb:
+        raise RuntimeError(f"create() failed: {err}")
+    if sb is None:
+        log(f"[{slug}] SDK create() hung — identifying sandbox via list() …")
+        # Give Daytona a moment to register the sandbox
+        for _ in range(8):
+            sb = _identify_sandbox(d, slug, pre_existing)
+            if sb:
+                break
+            time.sleep(5)
+        if sb is None:
+            raise RuntimeError("create() hung and could not identify sandbox post-hoc")
+        log(f"[{slug}] identified hung sandbox: {sb.id}")
+
+    sid = getattr(sb, "id", "?")
+    log(f"[{slug}]   sandbox id: {sid}")
+
+    try:
+        sb.set_autostop_interval(180)
+    except Exception as exc:
+        log(f"[{slug}]   warning: autostop not set ({exc})")
+
+    log(f"[{slug}] → starting uvicorn …")
+    _start_uvicorn(sb)
+
+    log(f"[{slug}] → waiting for health …")
+    healthy = _wait_healthy(sb, timeout=45)
+
+    preview = sb.get_preview_link(PORT)
+    return {
+        "slug": slug,
+        "title": spec["title"],
+        "sandbox_id": sid,
+        "url": preview.url,
+        "preview_token": getattr(preview, "token", None),
+        "admin_token": admin_token,
+        "health_ok": healthy,
+    }
+
+
+def _print_result(r: dict) -> None:
+    flag = "OK" if r["health_ok"] else "WARN (health did not return ok)"
+    print()
+    print(f"=== {r['title']} — {flag} ===")
+    print(f"  URL:           {r['url']}")
+    print(f"  Preview token: {r['preview_token']}")
+    print(f"  Admin token:   {r['admin_token']}")
+    print(f"  Sandbox id:    {r['sandbox_id']}")
+
+
+def main() -> None:
+    p = argparse.ArgumentParser()
+    p.add_argument("--env", required=True, choices=[*ENVS.keys(), "all"])
+    args = p.parse_args()
+
+    _load_env()
+    if not os.environ.get("DAYTONA_API_KEY"):
+        raise SystemExit("error: DAYTONA_API_KEY not set")
+
+    slugs = list(ENVS.keys()) if args.env == "all" else [args.env]
+    log_lock = threading.Lock()
+
+    def log(msg):
+        with log_lock:
+            print(msg, flush=True)
+
+    results: list[dict] = []
+    with cf.ThreadPoolExecutor(max_workers=len(slugs)) as ex:
+        futs = {ex.submit(deploy, s, log): s for s in slugs}
+        for fut in cf.as_completed(futs):
+            s = futs[fut]
+            try:
+                results.append(fut.result())
+            except Exception as exc:
+                log(f"[{s}] FAILED: {exc}")
+                results.append({"slug": s, "title": ENVS[s]["title"], "error": str(exc)})
+
+    print()
+    print("=" * 64)
+    print("Deploy summary")
+    print("=" * 64)
+    for r in results:
+        if "error" in r:
+            print(f"  {r['title']:20} FAILED — {r['error']}")
+        else:
+            _print_result(r)
+
+
+if __name__ == "__main__":
+    main()

--- a/deploy/sim_envs/mantis_linkedin/app/db.py
+++ b/deploy/sim_envs/mantis_linkedin/app/db.py
@@ -102,7 +102,12 @@ CREATE TABLE IF NOT EXISTS posts (
     body            TEXT NOT NULL,
     hashtags        TEXT NOT NULL DEFAULT '[]',  -- JSON list of strings (no leading #)
     visibility      TEXT NOT NULL DEFAULT 'public',
-    created_at      TEXT NOT NULL
+    created_at      TEXT NOT NULL,
+    media           TEXT NOT NULL DEFAULT '[]', -- JSON list of {kind, palette, caption, alt}
+    sponsored       INTEGER NOT NULL DEFAULT 0, -- 1 = promoted in feed
+    advertiser      TEXT NOT NULL DEFAULT '',   -- display name when sponsored=1
+    cta_label       TEXT NOT NULL DEFAULT '',   -- e.g. 'Learn more', 'Sign up'
+    cta_url         TEXT NOT NULL DEFAULT ''
 );
 CREATE INDEX IF NOT EXISTS idx_posts_author ON posts(author_id);
 CREATE INDEX IF NOT EXISTS idx_posts_created ON posts(created_at);

--- a/deploy/sim_envs/mantis_linkedin/app/routes/feed.py
+++ b/deploy/sim_envs/mantis_linkedin/app/routes/feed.py
@@ -24,8 +24,29 @@ def _author_chip(conn, user_id: str) -> dict[str, Any]:
     }
 
 
+_ADVERTISER_COLORS = {
+    "Vercel": "#000000",
+    "Stripe": "#635bff",
+    "Notion": "#191919",
+    "AWS":    "#ff9900",
+    "Figma":  "#a259ff",
+}
+
+
 def _post_view(conn, row) -> dict[str, Any]:
-    author = _author_chip(conn, row["author_id"])
+    keys = row.keys() if hasattr(row, "keys") else []
+    sponsored = bool(row["sponsored"]) if "sponsored" in keys else False
+    if sponsored:
+        adv = row["advertiser"]
+        author = {
+            "id": f"adv_{adv.lower()}",
+            "name": adv,
+            "handle": f"company-{adv.lower()}",
+            "headline": "Promoted",
+            "avatar_color": _ADVERTISER_COLORS.get(adv, "#666"),
+        }
+    else:
+        author = _author_chip(conn, row["author_id"])
     reactions = conn.execute(
         "SELECT COUNT(*) AS n FROM reactions WHERE post_id = ?",
         (row["id"],),
@@ -34,6 +55,7 @@ def _post_view(conn, row) -> dict[str, Any]:
         "SELECT COUNT(*) AS n FROM comments WHERE post_id = ?",
         (row["id"],),
     ).fetchone()["n"]
+    media = db.unpack_json(row["media"]) if "media" in keys else []
     return {
         "id": row["id"],
         "author": author,
@@ -43,6 +65,11 @@ def _post_view(conn, row) -> dict[str, Any]:
         "created_at": row["created_at"],
         "reactions": reactions,
         "comments": comments,
+        "media": media,
+        "sponsored": sponsored,
+        "advertiser": row["advertiser"] if "advertiser" in keys else "",
+        "cta_label": row["cta_label"] if "cta_label" in keys else "",
+        "cta_url": row["cta_url"] if "cta_url" in keys else "",
     }
 
 
@@ -65,13 +92,28 @@ async def feed(request: Request):
     user = request.state.current_user or {}
     user_id = user.get("id", "user_00001")
 
-    posts = [
-        _post_view(conn, r)
-        for r in conn.execute(
-            "SELECT id, author_id, body, hashtags, created_at "
-            "FROM posts ORDER BY created_at DESC, id DESC LIMIT 30"
-        ).fetchall()
-    ]
+    organic_rows = conn.execute(
+        "SELECT id, author_id, body, hashtags, created_at, media, sponsored, "
+        "advertiser, cta_label, cta_url FROM posts "
+        "WHERE sponsored = 0 ORDER BY created_at DESC, id DESC LIMIT 25"
+    ).fetchall()
+    sponsored_rows = conn.execute(
+        "SELECT id, author_id, body, hashtags, created_at, media, sponsored, "
+        "advertiser, cta_label, cta_url FROM posts "
+        "WHERE sponsored = 1 ORDER BY id"
+    ).fetchall()
+    organic = [_post_view(conn, r) for r in organic_rows]
+    sponsored_views = [_post_view(conn, r) for r in sponsored_rows]
+    # Interleave sponsored posts at fixed indexes (mirrors LinkedIn's
+    # ~every-4-posts cadence). Insert from the end so earlier indexes
+    # stay valid as we splice.
+    posts = list(organic)
+    sponsored_slots = [2, 6, 10, 14, 18]
+    for slot, sp in zip(reversed(sponsored_slots), reversed(sponsored_views)):
+        if slot <= len(posts):
+            posts.insert(slot, sp)
+        else:
+            posts.append(sp)
     connection_count = conn.execute(
         "SELECT COUNT(*) AS n FROM connections "
         "WHERE (from_user_id = ? OR to_user_id = ?) AND status = 'accepted'",

--- a/deploy/sim_envs/mantis_linkedin/app/seed.py
+++ b/deploy/sim_envs/mantis_linkedin/app/seed.py
@@ -348,6 +348,30 @@ def seed(conn: sqlite3.Connection, *, seed_val: int, fake_now: str) -> None:
         _add_conn(a, b, status="accepted")
 
     # ── posts: 30 in reverse-chronological time ─────────────────────
+    # ~70% of posts carry a media item (mix of images + videos). The
+    # field stores a JSON spec — feed.html renders a deterministic inline
+    # SVG from (kind, palette) so no static files need to ship.
+    _MEDIA_PALETTES = [
+        "sunset", "ocean", "forest", "midnight", "amber",
+        "violet", "slate", "ember", "mint", "rose",
+    ]
+    _IMAGE_CAPTIONS = [
+        "Architecture diagram of our new pipeline",
+        "Team offsite — Q2 in review",
+        "Conference talk slides — link in comments",
+        "Whiteboard from the design review",
+        "Mapping our roadmap for the next quarter",
+        "Snapshot from the platform migration",
+        "Charts from the latest retrospective",
+        "Annotated dashboard of yesterday's incident",
+    ]
+    _VIDEO_CAPTIONS = [
+        "5 min walkthrough of the new release",
+        "Demo: shipping the feature end-to-end",
+        "Recording from this morning's all-hands",
+        "Quick clip from the customer interview",
+        "Behind the scenes of the rebuild",
+    ]
     post_idx = 0
     for i in range(30):
         post_idx += 1
@@ -360,11 +384,134 @@ def seed(conn: sqlite3.Connection, *, seed_val: int, fake_now: str) -> None:
         tags = extract_hashtags(body)
         # back-dated by i hours
         created_at = f"2026-06-08T0{(8 - (i % 8)):d}:00:00Z"
+        # Attach media: ~50% image, ~20% video, ~30% text-only.
+        roll = rng.random()
+        if roll < 0.5:
+            media = [{
+                "kind": "image",
+                "palette": rng.choice(_MEDIA_PALETTES),
+                "caption": rng.choice(_IMAGE_CAPTIONS),
+                "alt": "Post image",
+            }]
+        elif roll < 0.7:
+            media = [{
+                "kind": "video",
+                "palette": rng.choice(_MEDIA_PALETTES),
+                "caption": rng.choice(_VIDEO_CAPTIONS),
+                "duration": f"{rng.randint(1,9)}:{rng.randint(10,59):02d}",
+                "alt": "Post video",
+            }]
+        else:
+            media = []
         conn.execute(
             "INSERT INTO posts (id, author_id, body, hashtags, visibility, "
-            "created_at) VALUES (?,?,?,?,?,?)",
+            "created_at, media, sponsored, advertiser, cta_label, cta_url) "
+            "VALUES (?,?,?,?,?,?,?,?,?,?,?)",
             (_hid("post", post_idx, 5), author["id"], body,
-             db.pack_json(tags), "public", created_at),
+             db.pack_json(tags), "public", created_at,
+             db.pack_json(media), 0, "", "", ""),
+        )
+
+    # ── sponsored posts: 5 promoted entries with explicit media ────
+    _SPONSORED = [
+        {
+            "advertiser": "Vercel",
+            "headline": "Sponsored",
+            "body": ("Ship faster with the platform purpose-built for "
+                     "frontend frameworks. Try Vercel free."),
+            "media_kind": "image",
+            "palette": "midnight",
+            "caption": "Deploy in 30 seconds",
+            "cta_label": "Sign up free",
+            "cta_url": "/promoted/vercel",
+            "avatar_color": "#000000",
+        },
+        {
+            "advertiser": "Stripe",
+            "headline": "Sponsored",
+            "body": ("Launch your subscription billing in days, not "
+                     "quarters. See how teams scale revenue with Stripe."),
+            "media_kind": "video",
+            "palette": "violet",
+            "caption": "2:14 — Walkthrough: invoicing & tax",
+            "duration": "2:14",
+            "cta_label": "Watch the demo",
+            "cta_url": "/promoted/stripe",
+            "avatar_color": "#635bff",
+        },
+        {
+            "advertiser": "Notion",
+            "headline": "Sponsored",
+            "body": ("The connected workspace where better, faster work "
+                     "happens. Free for teams, forever."),
+            "media_kind": "image",
+            "palette": "slate",
+            "caption": "Templates for engineering teams",
+            "cta_label": "Get Notion free",
+            "cta_url": "/promoted/notion",
+            "avatar_color": "#191919",
+        },
+        {
+            "advertiser": "AWS",
+            "headline": "Sponsored",
+            "body": ("Build & scale on the cloud trusted by the most "
+                     "demanding businesses. New free-tier credits live."),
+            "media_kind": "image",
+            "palette": "amber",
+            "caption": "Reference architecture: serverless data lakes",
+            "cta_label": "Learn more",
+            "cta_url": "/promoted/aws",
+            "avatar_color": "#ff9900",
+        },
+        {
+            "advertiser": "Figma",
+            "headline": "Promoted",
+            "body": ("Design, prototype, and collaborate in one place. "
+                     "Now with multiplayer Dev Mode."),
+            "media_kind": "video",
+            "palette": "rose",
+            "caption": "1:42 — What's new in Dev Mode",
+            "duration": "1:42",
+            "cta_label": "Try Figma free",
+            "cta_url": "/promoted/figma",
+            "avatar_color": "#a259ff",
+        },
+    ]
+    # Sponsored authors are 'pseudo-users' with the advertiser handle so
+    # the foreign key holds. We pick the first 5 user slots as proxies
+    # but override the displayed name + avatar via the post columns.
+    for s_idx, s in enumerate(_SPONSORED, start=1):
+        post_idx += 1
+        # back-date sponsored posts so they interleave with organic ones
+        # (post-rendering injects them at fixed indexes; see feed.py)
+        created_at = f"2026-06-08T0{(8 - (s_idx % 8)):d}:30:00Z"
+        media = [{
+            "kind": s["media_kind"],
+            "palette": s["palette"],
+            "caption": s["caption"],
+            "alt": f"{s['advertiser']} {s['media_kind']}",
+            **({"duration": s["duration"]} if "duration" in s else {}),
+        }]
+        # body uses the advertiser as 'author' label; we store a marker
+        # body field that the route layer recognises and replaces the
+        # author row with the advertiser brand.
+        conn.execute(
+            "INSERT INTO posts (id, author_id, body, hashtags, visibility, "
+            "created_at, media, sponsored, advertiser, cta_label, cta_url) "
+            "VALUES (?,?,?,?,?,?,?,?,?,?,?)",
+            (
+                _hid("post", post_idx, 5),
+                users[0]["id"],          # FK placeholder
+                s["body"],
+                db.pack_json([]),
+                "public",
+                created_at,
+                db.pack_json(media),
+                1,
+                s["advertiser"],
+                s["cta_label"],
+                s["cta_url"],
+            ),
         )
 
     # ── comments + reactions on the first 15 posts ──────────────────

--- a/deploy/sim_envs/mantis_linkedin/app/static/site.css
+++ b/deploy/sim_envs/mantis_linkedin/app/static/site.css
@@ -703,6 +703,70 @@ pre.md-body {
 .company-tagline { color: rgba(0,0,0,0.7); font-size: 14px; }
 .company-followers { color: rgba(0,0,0,0.6); font-size: 12px; margin-bottom: 8px; }
 
+/* ────────────────────── post media + sponsored ────────────────────── */
+.post-media {
+  position: relative;
+  margin: 0 -16px 0;
+  padding: 0;
+  background: #d9dde3;
+}
+.post-media svg {
+  display: block;
+  width: 100%;
+  height: auto;
+  max-height: 460px;
+}
+.post-media-video svg { cursor: pointer; }
+.post-media-duration {
+  position: absolute;
+  bottom: 10px;
+  right: 10px;
+  background: rgba(0,0,0,0.72);
+  color: #fff;
+  padding: 2px 6px;
+  border-radius: 3px;
+  font-size: 12px;
+  font-weight: 600;
+}
+.post-media-caption {
+  margin: 0;
+  padding: 8px 16px;
+  font-size: 13px;
+  color: rgba(0,0,0,0.7);
+  background: #f4f2ee;
+  border-top: 1px solid #ebe9e5;
+}
+.post-card-sponsored {
+  border-color: #e1dfd9;
+  background: #fffefb;
+}
+.post-promoted-badge {
+  display: inline-block;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  color: #4f4940;
+  background: #f3efe6;
+  border: 1px solid #e4ddd1;
+  border-radius: 3px;
+  padding: 1px 6px;
+  margin-right: 2px;
+  text-transform: uppercase;
+}
+.post-promoted-cta {
+  display: block;
+  text-align: center;
+  background: #0a66c2;
+  color: #fff;
+  font-weight: 600;
+  padding: 9px 14px;
+  border-radius: 22px;
+  margin: 12px 0 4px;
+  text-decoration: none;
+  font-size: 14px;
+}
+.post-promoted-cta:hover { background: #084c8e; }
+
 /* ────────────────────── responsive guard ────────────────────── */
 @media (max-width: 1240px) {
   .feed-grid { grid-template-columns: 200px 540px 280px; gap: 16px; }

--- a/deploy/sim_envs/mantis_linkedin/app/templates/feed.html
+++ b/deploy/sim_envs/mantis_linkedin/app/templates/feed.html
@@ -70,9 +70,56 @@
       <span class="feed-divider-text">Sort by: <strong>Top ▾</strong></span>
     </div>
 
+    {% macro post_media(item) %}
+      {% set palettes = {
+        'sunset':   ('#ff7a59', '#ffb37a', '#ffe0b3'),
+        'ocean':    ('#0a66c2', '#42a5f5', '#bbdefb'),
+        'forest':   ('#1b5e20', '#43a047', '#a5d6a7'),
+        'midnight': ('#0f172a', '#1e3a8a', '#475569'),
+        'amber':    ('#b45309', '#f59e0b', '#fde68a'),
+        'violet':   ('#5b21b6', '#8b5cf6', '#ddd6fe'),
+        'slate':    ('#1f2937', '#475569', '#cbd5e1'),
+        'ember':    ('#7f1d1d', '#dc2626', '#fecaca'),
+        'mint':     ('#065f46', '#10b981', '#a7f3d0'),
+        'rose':     ('#9d174d', '#ec4899', '#fbcfe8'),
+      } %}
+      {% set p = palettes.get(item.palette, palettes['ocean']) %}
+      <figure class="post-media post-media-{{ item.kind }}" data-testid="post-media">
+        <svg viewBox="0 0 800 420" xmlns="http://www.w3.org/2000/svg"
+             role="img" aria-label="{{ item.alt }}" preserveAspectRatio="xMidYMid slice">
+          <defs>
+            <linearGradient id="g-{{ item.palette }}-{{ loop.index0 if loop is defined else 0 }}" x1="0" y1="0" x2="1" y2="1">
+              <stop offset="0%" stop-color="{{ p[0] }}"/>
+              <stop offset="55%" stop-color="{{ p[1] }}"/>
+              <stop offset="100%" stop-color="{{ p[2] }}"/>
+            </linearGradient>
+          </defs>
+          <rect width="800" height="420" fill="url(#g-{{ item.palette }}-{{ loop.index0 if loop is defined else 0 }})"/>
+          {# Abstract decorative shapes — deterministic by palette #}
+          <circle cx="650" cy="110" r="90" fill="{{ p[2] }}" opacity="0.45"/>
+          <circle cx="170" cy="330" r="140" fill="{{ p[0] }}" opacity="0.35"/>
+          <rect x="280" y="170" width="240" height="80" rx="8" fill="{{ p[2] }}" opacity="0.55"/>
+          <rect x="280" y="260" width="160" height="14" rx="3" fill="{{ p[1] }}" opacity="0.7"/>
+          <rect x="280" y="282" width="200" height="10" rx="3" fill="{{ p[1] }}" opacity="0.5"/>
+          {% if item.kind == 'video' %}
+            <circle cx="400" cy="210" r="56" fill="rgba(0,0,0,0.55)"/>
+            <polygon points="382,182 382,238 432,210" fill="#ffffff"/>
+          {% endif %}
+        </svg>
+        {% if item.kind == 'video' and item.duration %}
+          <span class="post-media-duration" data-testid="post-media-duration">{{ item.duration }}</span>
+        {% endif %}
+        {% if item.caption %}
+          <figcaption class="post-media-caption">{{ item.caption }}</figcaption>
+        {% endif %}
+      </figure>
+    {% endmacro %}
+
     {% for post in posts %}
-      <article class="card post-card" data-testid="post-card"
-               data-post-id="{{ post.id }}">
+      <article class="card post-card{% if post.sponsored %} post-card-sponsored{% endif %}"
+               data-testid="{{ 'sponsored-post-card' if post.sponsored else 'post-card' }}"
+               data-post-id="{{ post.id }}"
+               data-sponsored="{{ '1' if post.sponsored else '0' }}">
         <header class="post-author-row">
           <a class="avatar avatar-md" style="background:{{ post.author.avatar_color }}"
              href="/in/{{ post.author.handle }}/">
@@ -81,12 +128,29 @@
           <div class="post-author-meta">
             <a class="post-author-name" href="/in/{{ post.author.handle }}/">{{ post.author.name }}</a>
             <div class="post-author-headline">{{ post.author.headline }}</div>
-            <div class="post-author-time">{{ post.created_at }} • 🌐</div>
+            <div class="post-author-time">
+              {% if post.sponsored %}
+                <span class="post-promoted-badge" data-testid="promoted-badge">Promoted</span> • 🌐
+              {% else %}
+                {{ post.created_at }} • 🌐
+              {% endif %}
+            </div>
           </div>
           <button class="post-more" aria-label="More" data-testid="post-more">⋯</button>
         </header>
 
         <p class="post-body" data-testid="post-body">{{ post.body_short }}</p>
+
+        {% if post.media %}
+          {% for item in post.media %}
+            {{ post_media(item) }}
+          {% endfor %}
+        {% endif %}
+
+        {% if post.sponsored and post.cta_label %}
+          <a class="post-promoted-cta" href="{{ post.cta_url }}"
+             data-testid="promoted-cta">{{ post.cta_label }} →</a>
+        {% endif %}
 
         <div class="post-counters" data-testid="post-counters">
           <span class="reaction-blob">👍 ❤ 🎉</span>

--- a/docs/client/plans.md
+++ b/docs/client/plans.md
@@ -127,6 +127,89 @@ If your tenant has `allowed_domains` configured, the server scans your plan's `n
 
 If you need to add a domain, ask your operator to update your tenant config — see [URL allowlist](../operations/allowlist.md).
 
+## Inline extraction schema
+
+For plans that don't have a registered server-side recipe (the common case for ad-hoc plans), declare your extraction contract **inline on the step**. The validator then enforces the fields *you* asked for instead of falling through to the framework's `no_schema_configured` rejection.
+
+Put an `extract` block at the top level of any `extract_data` (or `claude`) step:
+
+```jsonc
+{
+  "intent": "Extract the top 5 stories",
+  "type": "extract_data",
+  "claude_only": true,
+  "extract": {
+    "schema_name": "hn_top5",                        // identifier — used as CSV filename + Augur tag
+    "entity_name": "hn_story",                       // referenced in the extraction prompt
+    "fields": [
+      {"name": "rank",           "type": "int", "required": true},
+      {"name": "title",          "type": "str", "required": true},
+      {"name": "story_url",      "type": "str", "required": false},
+      {"name": "points",         "type": "int", "required": false},
+      {"name": "author",         "type": "str", "required": false},
+      {"name": "age",            "type": "str", "required": false},
+      {"name": "comments_count", "type": "int", "required": false}
+    ],
+    "max_items": 5                                    // optional cap on rows returned
+  }
+}
+```
+
+### Field reference
+
+| Field | Required | Effect |
+|---|---|---|
+| `schema_name` | yes | Logged at runtime; CSV output filename; Augur tag |
+| `entity_name` | optional (default `"item"`) | Used in the extractor prompt ("Extract from this {entity_name}…") |
+| `fields[].name` | yes | Column name in the CSV / key in the JSON output row |
+| `fields[].type` | yes | `int` / `str` / `bool` — passed to Claude's response schema |
+| `fields[].required` | optional (default `true`) | Validator rejects rows missing `required: true` fields; `required: false` is allowed to be empty |
+| `max_items` | optional | Cap on rows returned. Omit for single-row extraction |
+
+The same shape is documented in [plan.schema.json](../reference/plan.schema.json) under `$defs.Step.properties.extract`.
+
+### What if I don't include an `extract` block?
+
+The step still runs, but the framework needs to find a schema somewhere:
+
+1. **Inline `extract` block on the step** — described above. Wins when set.
+2. **Recipe-bound schema on the extractor** — set at executor startup when your plan domain has a registered recipe (e.g. `marketplace_listings`, `job_listings`, `search_results`). Plan authors don't see this directly; it comes from `ExtractionSchema` defined alongside the recipe.
+3. **No schema at all** — the validator rejects every extracted row with reason `no_schema_configured`. The runner emits a WARNING at step entry to surface the misconfig (see "Diagnostics" below).
+
+For ad-hoc plans against arbitrary sites, declare the inline `extract` block. Recipe registration is only useful when you need domain-specific spam/control rules (forbidden buttons to skip, dealer-vs-private classification, etc.) in addition to a field schema.
+
+### Diagnostics
+
+When you submit an `extract_data` / `extract_url` step with no schema available from any source, the runner logs at WARNING level:
+
+```
+[claude_step] extract_data step has no extraction schema
+  (no `extract` block on the step, no recipe-bound `extractor.schema`).
+  The validator will reject every extracted row with `no_schema_configured`.
+  Either add an inline `extract` block to this step
+  (see docs/client/plans.md#inline-extraction-schema) or configure a recipe
+  at executor startup.
+```
+
+This fires per step at WARNING level (visible in Modal app logs by default). The rejection itself still happens — the warning just makes the misconfig obvious in the trace instead of being buried in the trailing result envelope.
+
+### What the schema enforces
+
+`is_viable()` returns `True` only when every `required: true` field has a non-empty, non-placeholder value. The framework's `_UNKNOWN_PLACEHOLDERS` set treats these strings as empty: `"" / "unknown" / "<unknown>" / "none" / "n/a" / "na" / "not visible" / "not shown" / "not available" / "tbd"` (case + whitespace insensitive). So Claude returning `"<UNKNOWN>"` for `title` is treated the same as omitting the field.
+
+Fields marked `required: false` are kept on the row even when empty — they just don't gate viability.
+
+### What's NOT in the inline `extract` block (recipe-only)
+
+The fields below live on `ExtractionSchema` but the inline path doesn't expose them. If you need them, register a recipe:
+
+- `spam_indicators`, `spam_seller_indicators` — domain-specific text that marks a row as spam/dealer
+- `forbidden_controls`, `allowed_controls` — reveal-button name filters
+- `listing_card_exclusions` — listing-tile spam (financing CTAs, sponsored cards)
+- `rejection_intents` — skip-envelope routing for downstream short-circuits
+
+For straight "give me these N fields from each item" extraction — the inline block is enough.
+
 ## What the server returns
 
 For `detached: true` (the default) — a queued handle:

--- a/src/mantis_agent/gym/_runner_helpers.py
+++ b/src/mantis_agent/gym/_runner_helpers.py
@@ -909,6 +909,9 @@ def execute_step(
             loop_target=step.loop_target,
             loop_count=step.loop_count,
             params=step.params, hints=step.hints,
+            # #785 follow-up: carry the plan-author's inline extraction
+            # schema across the reconstruction so validator enforces it.
+            extract=dict(getattr(step, "extract", {}) or {}),
         )
         # WARNING level so the trace survives Modal's INFO-suppressed
         # log capture. Firing this is the canonical signal that the

--- a/src/mantis_agent/gym/fanout_runner.py
+++ b/src/mantis_agent/gym/fanout_runner.py
@@ -341,6 +341,9 @@ def _clone_step(step: MicroIntent) -> MicroIntent:
         loop_count=step.loop_count,
         params=dict(step.params or {}),
         hints=dict(step.hints or {}),
+        # #785 follow-up: carry plan-author inline extract schema across
+        # fanout step cloning.
+        extract=dict(getattr(step, "extract", {}) or {}),
     )
 
 

--- a/src/mantis_agent/gym/run_executor.py
+++ b/src/mantis_agent/gym/run_executor.py
@@ -883,6 +883,11 @@ class RunExecutor:
             guard=getattr(step, "guard", "") or "",
             out_var=getattr(step, "out_var", "") or "",
             stop_var=getattr(step, "stop_var", "") or "",
+            # #785 follow-up: plan-author inline extraction schema. Without
+            # this, the effective step that reaches `ClaudeStepHandler.execute`
+            # loses the schema declared on the original plan step and the
+            # validator falls through to `no_schema_configured`.
+            extract=dict(getattr(step, "extract", {}) or {}),
         )
 
     def _handle_loop_step(

--- a/src/mantis_agent/gym/step_handlers/claude_step.py
+++ b/src/mantis_agent/gym/step_handlers/claude_step.py
@@ -211,6 +211,31 @@ class ClaudeStepHandler:
             if extractor_obj is not None
             else None
         )
+        # Diagnostic when the step is an extraction step but no schema
+        # is available from any source (no inline `extract`, no
+        # recipe-bound `extractor.schema`). Without this, the only
+        # signal a plan author gets is the eventual
+        # ``no_schema_configured`` rejection in the trace — which is
+        # accurate but easy to miss. Surfaces the misconfig at the
+        # entry to the step instead. WARNING-level so it survives
+        # Modal's filter (`feedback_warning_level_for_modal_observability`).
+        if (
+            transient_schema is None
+            and original_schema is None
+            and step.type in ("extract_data", "extract_url")
+            and (step.claude_only or step.type == "extract_url")
+        ):
+            logger.warning(
+                "[claude_step] %s step has no extraction schema "
+                "(no `extract` block on the step, no recipe-bound "
+                "`extractor.schema`). The validator will reject every "
+                "extracted row with `no_schema_configured`. Either add "
+                "an inline `extract` block to this step (see "
+                "docs/client/plans.md#inline-extraction-schema) or "
+                "configure a recipe at executor startup.",
+                step.type,
+            )
+
         if transient_schema is not None:
             extractor_obj.schema = transient_schema
             # WARNING-level so it survives Modal's log filter (see

--- a/src/mantis_agent/gym/step_handlers/claude_step.py
+++ b/src/mantis_agent/gym/step_handlers/claude_step.py
@@ -213,6 +213,14 @@ class ClaudeStepHandler:
         )
         if transient_schema is not None:
             extractor_obj.schema = transient_schema
+            # WARNING-level so it survives Modal's log filter (see
+            # `feedback_warning_level_for_modal_observability.md`).
+            # One line per step that opts in; quiet for legacy plans.
+            logger.warning(
+                "[claude_step] inline-schema swap: required=%s (step.type=%s)",
+                transient_schema.required_fields,
+                step.type,
+            )
 
         try:
             return self._execute(step, ctx)

--- a/src/mantis_agent/plan_decomposer.py
+++ b/src/mantis_agent/plan_decomposer.py
@@ -827,6 +827,104 @@ STEP TYPES:
                  (budget=6, params={"dropdown_label": "<dropdown name>",
                                     "option_label": "<option text>"})
 
+PER-STEP EXTRACTION SCHEMA — emit on extract_data / extract_url steps
+whose source plan names specific fields the user wants returned.
+
+When the source plan says "extract X, Y, Z" (or "list the title, price,
+url of each item", or "return each story's rank, title, points, author"),
+ADD an `extract` block to the step. The runtime uses this to validate
+each row Claude returns — without it the validator falls through to the
+recipe schema if one is registered for the domain, or rejects every row
+with `no_schema_configured` for ad-hoc plans.
+
+Shape:
+
+  "extract": {
+    "schema_name": "<short identifier — used in logs + CSV filename>",
+    "entity_name": "<what each row represents, e.g. 'hn_story', 'product', 'lead'>",
+    "fields": [
+      {"name": "<column>", "type": "str|int|bool", "required": true|false},
+      ...
+    ],
+    "max_items": <int>   // optional — cap on rows returned
+  }
+
+When to mark a field `required: true`:
+  - The user named it as something the row MUST have to be useful.
+    "Extract title (required), points (if shown), author" → title is
+    required, points/author are required: false.
+  - In the absence of clear required-vs-optional language, default
+    `required: true` for fields the user lists FIRST (the primary
+    identifiers — title, name, id, url) and `required: false` for
+    fields that are obviously bonus context (timestamps, counts,
+    metadata).
+  - For verification-style extract_data steps (the source says "verify"
+    / "confirm" / "check that the page shows..."), DO NOT emit an
+    extract block. Those steps don't produce rows; they assert state.
+
+Types: pick `int` when the field is numerically aggregable (counts,
+prices, ranks, points); `bool` for true/false signals; `str` for
+everything else including URLs, emails, dates expressed in prose.
+
+WORKED EXAMPLES — extract block emission:
+
+  Source: "Extract the top 5 stories from Hacker News including rank,
+           title, story URL, points, author, age, and comment count."
+  → {"type": "extract_data", "intent": "Extract the top 5 stories...",
+     "claude_only": true,
+     "extract": {
+       "schema_name": "hn_top5",
+       "entity_name": "hn_story",
+       "fields": [
+         {"name": "rank",           "type": "int", "required": true},
+         {"name": "title",          "type": "str", "required": true},
+         {"name": "story_url",      "type": "str", "required": false},
+         {"name": "points",         "type": "int", "required": false},
+         {"name": "author",         "type": "str", "required": false},
+         {"name": "age",            "type": "str", "required": false},
+         {"name": "comments_count", "type": "int", "required": false}
+       ],
+       "max_items": 5
+     }, ...}
+
+  Source: "List each product's name, price, and stock status from the
+           catalog page."
+  → {"type": "extract_data", "intent": "List each product's name...",
+     "claude_only": true,
+     "extract": {
+       "schema_name": "catalog_products",
+       "entity_name": "product",
+       "fields": [
+         {"name": "name",         "type": "str", "required": true},
+         {"name": "price",        "type": "int", "required": false},
+         {"name": "stock_status", "type": "str", "required": false}
+       ]
+     }, ...}
+
+  Source: "Verify the heading reads 'Welcome back'."
+  → {"type": "extract_data", "intent": "Verify the heading...",
+     "claude_only": true,
+     "required": true,
+     "gate": true
+     # NO `extract` block — this is a verification gate, not data extraction
+    }
+
+  Source: "Go to the site and click around to see what's on the home page."
+  → No `extract_data` step at all, so no extract block needed.
+
+  Source: "Search and find any private-seller boats above $35,000 in
+           Florida and pull their full listing details."
+  → If the plan domain has a registered recipe (marketplace_listings,
+     here), OMIT the inline `extract` block — let the recipe's
+     schema govern. Emit a block only when the source plan names
+     specific fields that don't match the recipe's contract, or when
+     the plan is for an ad-hoc target with no recipe.
+
+Do NOT emit `extract` blocks on `click`, `navigate`, `scroll`, or any
+non-extraction step. Do NOT invent fields the source plan didn't ask
+for — better to omit the block (no validation) than hallucinate fields
+that constrain the validator incorrectly.
+
 OUTPUT FORMAT — emit ONE valid JSON object and nothing else.
 
 CRITICAL: do NOT include prose preamble ("Here's the decomposition:"),
@@ -929,7 +1027,7 @@ class PlanDecomposer:
             domain = m.group(1)
 
         # Check cache — include prompt version in hash to invalidate on schema changes
-        prompt_version = "v35_preferred_target_description_hints"  # Bump this when DECOMPOSE_PROMPT changes
+        prompt_version = "v36_emit_extract_blocks"  # Bump this when DECOMPOSE_PROMPT changes
         plan_hash = hashlib.md5(f"{prompt_version}:{plan_text}".encode()).hexdigest()[:8]
         cache_path = (
             cache_path_template.replace("{hash}", plan_hash)
@@ -1176,6 +1274,45 @@ class PlanDecomposer:
     )
 
     @staticmethod
+    def _coerce_extract_block(raw: Any) -> dict[str, Any]:
+        """Defensively normalize Claude's `extract` output into the
+        shape :class:`ExtractionSchema.from_dict` expects.
+
+        Tolerates malformed shapes (non-dict, missing fields, fields
+        not a list) by returning ``{}`` — the runtime falls back to
+        the recipe schema or the loud ``no_schema_configured``
+        warning. The handler also catches `from_dict` ValueError if a
+        partially-shaped block slips through.
+
+        Drops unknown top-level keys to keep the wire payload tight;
+        adds ``required: True`` default per field when Claude omitted
+        the flag (mirrors :meth:`ExtractionSchema.from_dict`).
+        """
+        if not isinstance(raw, dict):
+            return {}
+        fields = raw.get("fields")
+        if not isinstance(fields, list) or not fields:
+            return {}
+        cleaned_fields: list[dict[str, Any]] = []
+        for f in fields:
+            if not isinstance(f, dict) or not f.get("name"):
+                continue
+            cleaned_fields.append({
+                "name": str(f["name"]),
+                "type": str(f.get("type", "str")),
+                "required": bool(f.get("required", True)),
+            })
+        if not cleaned_fields:
+            return {}
+        out: dict[str, Any] = {"fields": cleaned_fields}
+        for key in ("schema_name", "entity_name"):
+            if raw.get(key):
+                out[key] = str(raw[key])
+        if isinstance(raw.get("max_items"), int) and raw["max_items"] > 0:
+            out["max_items"] = int(raw["max_items"])
+        return out
+
+    @staticmethod
     def _is_verification_intent(intent: str) -> bool:
         """Return True iff ``intent`` reads as verification language —
         i.e. asserting a state holds rather than reading authoritative
@@ -1272,6 +1409,15 @@ class PlanDecomposer:
             guard=str(s.get("guard", "") or ""),
             out_var=str(s.get("out_var", "") or ""),
             stop_var=str(s.get("stop_var", "") or ""),
+            # #785 follow-up: carry plan-author inline extract schema
+            # through the parser. The decomposer prompt asks Claude to
+            # emit `extract` blocks on extract_data steps whose source
+            # named specific fields ("extract title, price, ..."), so
+            # ad-hoc plans get a per-step schema without needing a
+            # registered recipe. Empty dict on legacy plans / steps
+            # without a schema → falls through to recipe-bound schema
+            # or the `no_schema_configured` rejection.
+            extract=PlanDecomposer._coerce_extract_block(s.get("extract", {})),
         )
 
     @staticmethod

--- a/tests/test_decomposer_emits_extract.py
+++ b/tests/test_decomposer_emits_extract.py
@@ -1,0 +1,212 @@
+"""Decomposer emits inline `extract` blocks from intent prose (#785 follow-up).
+
+The Claude-side prompt change (live trip to the API) is not unit-tested
+here — those land in `tests/test_plan_decomposer_live.py` if/when they
+land. This module pins the *parser* contract: when Claude returns an
+extract block in the step dict, the parser carries it through to
+MicroIntent, defensively normalized.
+"""
+
+from __future__ import annotations
+
+
+from mantis_agent.plan_decomposer import PlanDecomposer
+
+
+# ── _coerce_extract_block ────────────────────────────────────────────
+
+
+def test_coerce_passes_through_canonical_shape():
+    raw = {
+        "schema_name": "hn_top5",
+        "entity_name": "hn_story",
+        "fields": [
+            {"name": "rank", "type": "int", "required": True},
+            {"name": "title", "type": "str", "required": True},
+            {"name": "points", "type": "int", "required": False},
+        ],
+        "max_items": 5,
+    }
+    out = PlanDecomposer._coerce_extract_block(raw)
+    assert out["schema_name"] == "hn_top5"
+    assert out["entity_name"] == "hn_story"
+    assert out["max_items"] == 5
+    assert len(out["fields"]) == 3
+    assert out["fields"][0] == {"name": "rank", "type": "int", "required": True}
+
+
+def test_coerce_returns_empty_for_non_dict():
+    assert PlanDecomposer._coerce_extract_block(None) == {}
+    assert PlanDecomposer._coerce_extract_block("title,points") == {}
+    assert PlanDecomposer._coerce_extract_block(42) == {}
+
+
+def test_coerce_returns_empty_when_fields_missing_or_not_list():
+    assert PlanDecomposer._coerce_extract_block({"schema_name": "x"}) == {}
+    assert PlanDecomposer._coerce_extract_block({"fields": "title,price"}) == {}
+    assert PlanDecomposer._coerce_extract_block({"fields": []}) == {}
+
+
+def test_coerce_drops_fields_missing_name():
+    raw = {
+        "fields": [
+            {"name": "title", "type": "str", "required": True},
+            {"type": "int"},  # no name — dropped
+            {"name": "", "type": "str"},  # empty name — dropped
+            {"name": "points", "type": "int"},
+        ],
+    }
+    out = PlanDecomposer._coerce_extract_block(raw)
+    names = [f["name"] for f in out["fields"]]
+    assert names == ["title", "points"]
+
+
+def test_coerce_defaults_required_true_when_omitted():
+    """ExtractionSchema.from_dict treats missing `required` as True;
+    the coercion mirrors that so the runner contract is consistent."""
+    raw = {"fields": [{"name": "title", "type": "str"}]}
+    out = PlanDecomposer._coerce_extract_block(raw)
+    assert out["fields"][0]["required"] is True
+
+
+def test_coerce_defaults_type_to_str_when_omitted():
+    raw = {"fields": [{"name": "title"}]}
+    out = PlanDecomposer._coerce_extract_block(raw)
+    assert out["fields"][0]["type"] == "str"
+
+
+def test_coerce_drops_invalid_max_items():
+    raw = {
+        "fields": [{"name": "title", "type": "str"}],
+        "max_items": 0,  # invalid (must be > 0)
+    }
+    out = PlanDecomposer._coerce_extract_block(raw)
+    assert "max_items" not in out
+
+
+def test_coerce_drops_unknown_top_level_keys():
+    raw = {
+        "schema_name": "x",
+        "fields": [{"name": "title", "type": "str"}],
+        "side_dish": "pasta",  # not in the canonical shape
+    }
+    out = PlanDecomposer._coerce_extract_block(raw)
+    assert "side_dish" not in out
+
+
+def test_coerce_returns_empty_when_all_fields_get_dropped():
+    raw = {"fields": [{"type": "str"}, {"name": "", "type": "int"}]}
+    assert PlanDecomposer._coerce_extract_block(raw) == {}
+
+
+# ── parser end-to-end ────────────────────────────────────────────────
+
+
+def test_build_intent_carries_extract_block_to_micro_intent():
+    """Simulates what Claude's decomposer response looks like for an
+    extraction step that came from prose like "Extract title, points
+    of each story". The parser should build a MicroIntent whose
+    `extract` field carries the schema."""
+    raw_step = {
+        "intent": "Extract title and points for each story",
+        "type": "extract_data",
+        "claude_only": True,
+        "extract": {
+            "schema_name": "stories",
+            "entity_name": "story",
+            "fields": [
+                {"name": "title", "type": "str", "required": True},
+                {"name": "points", "type": "int", "required": False},
+            ],
+            "max_items": 5,
+        },
+    }
+    step = PlanDecomposer._build_intent(raw_step)
+    assert step.extract["schema_name"] == "stories"
+    assert len(step.extract["fields"]) == 2
+    assert step.extract["fields"][0]["required"] is True
+
+
+def test_build_intent_legacy_step_has_empty_extract():
+    """Steps without an `extract` block round-trip through the parser
+    with the default empty dict — preserves recipe-bound behavior for
+    boattrader and friends."""
+    raw_step = {
+        "intent": "Extract listing details",
+        "type": "extract_data",
+        "claude_only": True,
+        # no `extract` block
+    }
+    step = PlanDecomposer._build_intent(raw_step)
+    assert step.extract == {}
+
+
+def test_build_intent_malformed_extract_falls_back_to_empty():
+    """If Claude emits a partially-shaped extract block (e.g. fields
+    not a list), the parser drops it. Better than carrying a broken
+    schema downstream — the validator will surface no_schema_configured
+    with the runtime warning instead."""
+    raw_step = {
+        "intent": "Extract things",
+        "type": "extract_data",
+        "claude_only": True,
+        "extract": {"fields": "title,points"},  # malformed — not a list
+    }
+    step = PlanDecomposer._build_intent(raw_step)
+    assert step.extract == {}
+
+
+def test_build_intent_extract_with_only_one_required_field():
+    """Common case: prose mentions just one identifier ('the title of
+    each item'). The decomposer should emit a single required field
+    and the parser preserves it."""
+    raw_step = {
+        "intent": "Extract just the title of each item",
+        "type": "extract_data",
+        "claude_only": True,
+        "extract": {
+            "fields": [{"name": "title", "type": "str", "required": True}],
+        },
+    }
+    step = PlanDecomposer._build_intent(raw_step)
+    assert step.extract["fields"] == [{"name": "title", "type": "str", "required": True}]
+
+
+def test_build_intent_does_not_add_extract_to_navigate_step():
+    """Sanity: an `extract` block on a navigate step is a no-op
+    (handler only consumes it on extract_data / extract_url). The
+    parser still carries it (one place for the field), but the
+    runtime behavior is unchanged."""
+    raw_step = {
+        "intent": "Navigate to HN",
+        "type": "navigate",
+        "params": {"url": "https://news.ycombinator.com/"},
+        "extract": {
+            "fields": [{"name": "title", "type": "str", "required": True}],
+        },
+    }
+    step = PlanDecomposer._build_intent(raw_step)
+    # Field is carried (the parser is permissive), but the click_step
+    # handler is the only consumer — navigate ignores it.
+    assert step.extract["fields"][0]["name"] == "title"
+
+
+# ── prompt version invalidation ─────────────────────────────────────
+
+
+def test_prompt_version_bump_invalidates_cached_extract_decomposition():
+    """When the prompt grows new behavior (here: emitting `extract`
+    blocks), the cached decompositions must be re-derived. The
+    prompt_version literal in decompose_text gates this — bumping
+    it changes the cache key.
+
+    This test pins that the bump happened. If you reset the version
+    back to v35 without removing the extract-block instructions, the
+    cache wouldn't invalidate and old plans would silently miss
+    extract blocks for one run.
+    """
+    import inspect
+
+    src = inspect.getsource(PlanDecomposer.decompose_text)
+    # The literal lives in decompose_text. v36+ means the change landed.
+    assert 'prompt_version = "v36' in src or 'prompt_version = "v37' in src or 'prompt_version = "v38' in src

--- a/tests/test_step_inline_extract_schema.py
+++ b/tests/test_step_inline_extract_schema.py
@@ -258,6 +258,114 @@ def test_handler_restores_schema_when_execute_raises():
     assert extractor.schema is original_schema
 
 
+def test_handler_warns_when_extract_data_has_no_schema_anywhere(caplog):
+    """A developer submits an `extract_data` step with no inline
+    `extract` block AND no recipe-bound schema. The validator will
+    eventually reject every row with `no_schema_configured`; we
+    surface the misconfig at step entry so the WARNING is in the
+    trace alongside the offending step, not buried in the result
+    envelope.
+    """
+    import logging
+    from mantis_agent.gym.step_handlers.claude_step import ClaudeStepHandler
+
+    extractor = MagicMock()
+    extractor.schema = None  # no recipe-bound schema either
+
+    def _capture_execute(*_a, **_kw):
+        from mantis_agent.gym.checkpoint import StepResult
+
+        return StepResult(step_index=0, intent="x", success=True)
+
+    runner = MagicMock()
+    handler = ClaudeStepHandler(runner)
+    handler._execute = _capture_execute  # type: ignore[assignment]
+
+    step = MicroIntent(
+        intent="extract everything",
+        type="extract_data",
+        claude_only=True,
+        # no `extract` block
+    )
+    with caplog.at_level(logging.WARNING, logger="mantis_agent.gym.step_handlers.claude_step"):
+        handler.execute(step, _fake_step_context(extractor))
+
+    matched = [
+        r for r in caplog.records
+        if "no extraction schema" in r.getMessage()
+    ]
+    assert matched, "expected a no-schema WARNING; got: " + str(
+        [r.getMessage() for r in caplog.records]
+    )
+
+
+def test_handler_does_not_warn_when_recipe_schema_is_bound(caplog):
+    """No inline `extract`, but a recipe-bound schema exists. The
+    handler should NOT log the no-schema warning — the recipe path
+    is the canonical case for marketplace-shaped plans."""
+    import logging
+    from mantis_agent.gym.step_handlers.claude_step import ClaudeStepHandler
+
+    extractor = MagicMock()
+    extractor.schema = ExtractionSchema(
+        entity_name="boat", fields=[], required_fields=["year", "make"]
+    )
+
+    runner = MagicMock()
+    handler = ClaudeStepHandler(runner)
+    handler._execute = lambda *_a, **_kw: __import__(  # type: ignore[assignment]
+        "mantis_agent.gym.checkpoint", fromlist=["StepResult"]
+    ).StepResult(step_index=0, intent="x", success=True)
+
+    step = MicroIntent(
+        intent="extract", type="extract_data", claude_only=True
+    )
+    with caplog.at_level(logging.WARNING, logger="mantis_agent.gym.step_handlers.claude_step"):
+        handler.execute(step, _fake_step_context(extractor))
+
+    matched = [
+        r for r in caplog.records
+        if "no extraction schema" in r.getMessage()
+    ]
+    assert not matched, (
+        "expected NO no-schema WARNING since the recipe schema is bound"
+    )
+
+
+def test_handler_does_not_warn_when_inline_schema_provided(caplog):
+    """When the step has its own `extract` block, the handler should
+    log the swap line, NOT the no-schema warning."""
+    import logging
+    from mantis_agent.gym.step_handlers.claude_step import ClaudeStepHandler
+
+    extractor = MagicMock()
+    extractor.schema = None
+
+    runner = MagicMock()
+    handler = ClaudeStepHandler(runner)
+    handler._execute = lambda *_a, **_kw: __import__(  # type: ignore[assignment]
+        "mantis_agent.gym.checkpoint", fromlist=["StepResult"]
+    ).StepResult(step_index=0, intent="x", success=True)
+
+    step = MicroIntent(
+        intent="extract",
+        type="extract_data",
+        claude_only=True,
+        extract={
+            "schema_name": "hn",
+            "fields": [{"name": "title", "type": "str", "required": True}],
+        },
+    )
+    with caplog.at_level(logging.WARNING, logger="mantis_agent.gym.step_handlers.claude_step"):
+        handler.execute(step, _fake_step_context(extractor))
+
+    no_schema = [
+        r for r in caplog.records
+        if "no extraction schema" in r.getMessage()
+    ]
+    assert not no_schema, "no-schema warning should not fire when inline schema is set"
+
+
 def test_handler_falls_back_to_recipe_on_malformed_extract():
     """Malformed step.extract (missing fields) should log a warning
     and fall back to the recipe schema — not break the run.


### PR DESCRIPTION
## Summary

Closes the dev-experience loop for inline extraction schemas. PR #798 added the field, PR #799 carried it through reconstruction, this PR makes it **automatic** for plans submitted via `plan_text` / free-text — the decomposer now produces `extract` blocks from the source prose. Author writes natural language ("Extract title, points of each story"), the framework gets a per-step schema for free.

## Why this design (vs URL-based inference, the original proposal)

- **Signal isn't in the URL.** Same domain → very different intents. `news.ycombinator.com` could mean "extract titles" or "extract upvote counts" depending on the author's goal. The signal IS in the source prose.
- **Decomposer already runs one Claude call** to derive MicroIntent steps. Adding `extract` to its output costs no extra round-trip.
- **Schema is observable.** Augur trace records it; reproducible (same prose → same decomposition for a given prompt version); visible to the plan author before submit.

## Changes

| File | Change |
|---|---|
| `plan_decomposer.py` | `DECOMPOSE_PROMPT` — new "PER-STEP EXTRACTION SCHEMA" section + 4 worked examples (HN top-5, product catalog, verification-gate skip, recipe-bound skip); `prompt_version` v35 → v36 |
| `plan_decomposer.py` | `_coerce_extract_block()` defensive normalizer for Claude's output (drops malformed / missing-fields → `{}`) |
| `plan_decomposer.py` | `_build_intent()` reads + coerces `s["extract"]` into `MicroIntent.extract` |

## Prompt-side rules taught to Claude

- Emit `extract` ONLY on `extract_data` / `extract_url` steps whose source named specific fields
- Skip the block for verification-style intents (`verify…` / `confirm…`)
- Skip the block for plan domains with a registered recipe
- `required: true` for fields listed first / explicitly called required
- Type heuristic: `int` for counts/prices/ranks; `bool` for true/false signals; `str` for everything else
- Don't invent fields the source didn't ask for

## Tests (15 new)

`_coerce_extract_block` boundary coverage:
- Canonical pass-through, non-dict, missing fields, non-list fields
- Fields missing `name` get dropped; defaults (`required=True`, `type=str`)
- Invalid `max_items` rejected; unknown top-level keys dropped
- All-fields-dropped → `{}`

`_build_intent` end-to-end:
- Carries the block, legacy step has `{}`, malformed falls back
- Single-required-field, navigate-with-extract permissive (no-op)

Plus a prompt-version pin to guard against rollback without cache-key bump.

## Refs

- Epic: #785
- Predecessor: #798 (field), #799 (carry-through), #800 (no-schema warning + docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)