### PR TITLE
docs(nav): move top-level sections from header tabs to left sidebar

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,9 +30,16 @@ theme:
         icon: material/weather-night
         name: Switch to light mode
   features:
-    - navigation.tabs
-    - navigation.tabs.sticky
+    # `navigation.tabs` and `navigation.tabs.sticky` were ON previously,
+    # which pulled top-level sections (Getting started / Hosting / ...)
+    # into a horizontal header bar. Removed so everything lives in the
+    # left sidebar tree — easier to scan the whole doc set at once.
+    # `navigation.sections` keeps top-level groups as collapsible headers
+    # in the sidebar instead of flat links.
+    # `navigation.expand` opens all sections by default; drop if you
+    # prefer collapsed-on-load.
     - navigation.sections
+    - navigation.expand
     - navigation.top
     - navigation.indexes
     - navigation.tracking


### PR DESCRIPTION
The \`navigation.tabs\` + \`navigation.tabs.sticky\` Material features were pulling top-level sections (Getting started / Hosting / Client / Operations / Integrations / Reference / Appendix) into a horizontal header bar — see attached screenshot. With ~7 top-level groups the header gets crowded and you can't see the whole doc tree at once.

This PR drops both \`navigation.tabs\` lines so everything renders in the left sidebar. Added \`navigation.expand\` so sections open on load (drop if you'd prefer collapsed).

\`mkdocs build --strict\` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)