### PR TITLE
feat(api): submit-time (cua_model, plan_shape) compatibility validation (#785 DX follow-up)

### DIFF
--- a/src/mantis_agent/api_schemas.py
+++ b/src/mantis_agent/api_schemas.py
@@ -45,6 +45,20 @@ MAX_COST_USD = _env_float("MANTIS_MAX_COST_USD", 25.0)
 
 
 # ── Request payloads ────────────────────────────────────────────────────────
+# Executors that read task_suite._micro_plan (vs claude which reads tasks[]).
+# Kept as a frozenset for fast membership check inside the model_validator.
+# Source of truth: deploy/modal/modal_cua_server.py:EXECUTOR_MAP.
+_MICRO_PLAN_EXECUTORS = frozenset({
+    "holo3",
+    "fara",
+    "gemma4-cua",
+    "evocua-8b",
+    "evocua-32b",
+    "opencua-32b",
+    "opencua-72b",
+})
+
+
 class PredictRequest(BaseModel):
     """Top-level /predict request.
 
@@ -203,6 +217,60 @@ class PredictRequest(BaseModel):
                 "request must provide one of: task_suite, task_file_contents, "
                 "task_file, micro, plan_text"
             )
+
+        # cua_model ↔ plan-shape compatibility check (DX-2 #785 follow-up).
+        # Pre-this, submitting a `_micro_plan` shape with `cua_model=claude`
+        # silently produced a 0/0/0 success — the Claude executor reads
+        # `task_suite.tasks[]`, not `_micro_plan`, and saw zero tasks.
+        # Memory: `feedback_cua_model_holo3_vs_claude_shape.md`,
+        # `feedback_task_suite_shape.md`.
+        #
+        # Two known canonical pairings:
+        #   cua_model = "claude"   → task_suite needs non-empty `tasks` array
+        #   cua_model in {"holo3", "fara", "gemma4-cua", "evocua-*",
+        #                 "opencua-*"} → task_suite needs `_micro_plan`
+        #
+        # The check fires only when task_suite is the plan-shape AND
+        # cua_model is one of the known values. plan_text / micro / task_file
+        # paths reconstruct task_suite server-side later — those checks
+        # happen in `prepare_predict_payload`.
+        cua_model = (self.model_extra or {}).get("cua_model")
+        if isinstance(cua_model, str) and self.task_suite is not None:
+            cm = cua_model.strip().lower()
+            suite = self.task_suite or {}
+            tasks_list = suite.get("tasks")
+            micro_plan = suite.get("_micro_plan")
+            has_tasks = isinstance(tasks_list, list) and len(tasks_list) > 0
+            has_micro = isinstance(micro_plan, list) and len(micro_plan) > 0
+
+            if cm == "claude" and not has_tasks and has_micro:
+                raise ValueError(
+                    "cua_model='claude' requires task_suite.tasks (a non-empty list "
+                    "of task dicts), but only task_suite._micro_plan was provided. "
+                    "Either switch to cua_model='holo3' (the executor that reads "
+                    "_micro_plan), or restructure your task_suite to use the "
+                    "tasks-array shape. See docs/llms.txt §3.4 for task_suite shape, "
+                    "or §3.2 for the micro-plan + holo3 pairing."
+                )
+            if (
+                cm in _MICRO_PLAN_EXECUTORS
+                and not has_micro
+                and not has_tasks
+            ):
+                raise ValueError(
+                    f"cua_model={cua_model!r} requires task_suite._micro_plan "
+                    "(a non-empty list of micro-intent steps), but task_suite "
+                    "had neither _micro_plan nor tasks populated. Use "
+                    "build_micro_suite() to construct the canonical shape, "
+                    "or hand-build the _micro_plan list per docs/client/plans.md."
+                )
+            if cm in _MICRO_PLAN_EXECUTORS and has_tasks and not has_micro:
+                raise ValueError(
+                    f"cua_model={cua_model!r} reads task_suite._micro_plan but "
+                    "task_suite.tasks was provided instead. Either switch to "
+                    "cua_model='claude' (the executor that reads tasks[]), or "
+                    "reshape the payload to put steps under _micro_plan."
+                )
         return self
 
 

--- a/tests/test_submit_time_shape_validation.py
+++ b/tests/test_submit_time_shape_validation.py
@@ -1,0 +1,186 @@
+"""Submit-time shape validation — reject (cua_model, plan_shape) mismatches.
+
+Pre-this PR, submitting a `task_suite._micro_plan` with `cua_model=claude`
+produced HTTP 200 + a silent 0/0/0 success (Claude executor reads
+`tasks[]`, saw zero tasks). Pre-this PR, submitting `task_suite.tasks`
+with `cua_model=holo3` produced the same silent zero (Holo3 reads
+`_micro_plan`, saw none). Both surface as `Tasks: 0` in Modal logs.
+
+This module pins the 400-at-submit behavior so neither failure mode
+recurs.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from mantis_agent.api_schemas import PredictRequest
+
+
+# ── Canonical pairings pass ───────────────────────────────────────
+
+
+def test_claude_with_tasks_array_validates():
+    """The canonical claude shape: `tasks` array on task_suite."""
+    req = PredictRequest(
+        task_suite={
+            "session_name": "x",
+            "tasks": [{"task_id": "a", "intent": "do x"}],
+        },
+        cua_model="claude",
+    )
+    assert req.task_suite is not None
+
+
+def test_holo3_with_micro_plan_validates():
+    """The canonical holo3 shape: `_micro_plan` list on task_suite."""
+    req = PredictRequest(
+        task_suite={
+            "session_name": "x",
+            "_micro_plan": [{"intent": "Go", "type": "navigate"}],
+        },
+        cua_model="holo3",
+    )
+    assert req.task_suite is not None
+
+
+def test_fara_with_micro_plan_validates():
+    PredictRequest(
+        task_suite={"_micro_plan": [{"intent": "x", "type": "navigate"}]},
+        cua_model="fara",
+    )
+
+
+def test_evocua_with_micro_plan_validates():
+    PredictRequest(
+        task_suite={"_micro_plan": [{"intent": "x", "type": "navigate"}]},
+        cua_model="evocua-8b",
+    )
+
+
+# ── Mismatches reject ────────────────────────────────────────────
+
+
+def test_claude_with_micro_plan_only_rejects():
+    """Real production bug — the trap that fired during #785 verification.
+    Claude executor reads tasks[], saw nothing because the payload
+    only had _micro_plan."""
+    with pytest.raises(ValidationError) as exc_info:
+        PredictRequest(
+            task_suite={
+                "_micro_plan": [{"intent": "Go", "type": "navigate"}],
+            },
+            cua_model="claude",
+        )
+    msg = str(exc_info.value)
+    assert "cua_model='claude' requires task_suite.tasks" in msg
+    assert "cua_model='holo3'" in msg, "should suggest the holo3 fix"
+
+
+def test_holo3_with_tasks_only_rejects():
+    """The reverse trap — holo3 sees no _micro_plan."""
+    with pytest.raises(ValidationError) as exc_info:
+        PredictRequest(
+            task_suite={
+                "tasks": [{"task_id": "a", "intent": "x"}],
+            },
+            cua_model="holo3",
+        )
+    msg = str(exc_info.value)
+    assert "cua_model='holo3'" in msg
+    assert "tasks[]" in msg
+    assert "cua_model='claude'" in msg, "should suggest the claude fix"
+
+
+def test_holo3_with_neither_rejects():
+    """Empty task_suite shape — most common decomposer-output error."""
+    with pytest.raises(ValidationError) as exc_info:
+        PredictRequest(
+            task_suite={"session_name": "x"},
+            cua_model="holo3",
+        )
+    msg = str(exc_info.value)
+    assert "cua_model='holo3'" in msg
+    assert "_micro_plan" in msg
+    assert "build_micro_suite" in msg, "should suggest the canonical helper"
+
+
+def test_evocua_with_neither_rejects():
+    """All micro-plan executors share the same error."""
+    with pytest.raises(ValidationError) as exc_info:
+        PredictRequest(
+            task_suite={"session_name": "x"},
+            cua_model="evocua-32b",
+        )
+    assert "cua_model='evocua-32b'" in str(exc_info.value)
+
+
+# ── Edge cases ──────────────────────────────────────────────────
+
+
+def test_no_cua_model_does_not_enforce_shape():
+    """Absent cua_model = server-side default — no validation. Lets
+    operators / older clients keep submitting without the field."""
+    req = PredictRequest(
+        task_suite={"_micro_plan": [{"intent": "x", "type": "navigate"}]},
+    )
+    assert req.task_suite is not None
+
+
+def test_unknown_cua_model_does_not_enforce_shape():
+    """Future / custom executors not in _MICRO_PLAN_EXECUTORS or
+    'claude' fall through — the check is conservative, only firing
+    on KNOWN mismatches."""
+    req = PredictRequest(
+        task_suite={"_micro_plan": [{"intent": "x", "type": "navigate"}]},
+        cua_model="my-future-executor",
+    )
+    assert req.task_suite is not None
+
+
+def test_plan_text_skips_task_suite_shape_check():
+    """plan_text reconstructs the suite server-side later — no shape
+    to validate at this layer."""
+    req = PredictRequest(plan_text="Go and extract things", cua_model="claude")
+    assert req.plan_text == "Go and extract things"
+
+
+def test_micro_path_skips_task_suite_shape_check():
+    """`micro` is a file path — also reconstructed later."""
+    req = PredictRequest(
+        micro="plans/example/extract.json",
+        cua_model="holo3",
+    )
+    assert req.micro == "plans/example/extract.json"
+
+
+def test_action_modes_skip_validation_entirely():
+    """status / result / cancel / resume / logs don't need a plan
+    body; the shape check must not block them."""
+    PredictRequest(action="status", run_id="r1")
+    PredictRequest(action="result", run_id="r1")
+    PredictRequest(action="cancel", run_id="r1")
+    PredictRequest(action="resume", run_id="r1", user_input="123")
+
+
+# ── Case insensitivity ──────────────────────────────────────────
+
+
+def test_cua_model_case_insensitive():
+    """`CLAUDE` and `claude` should behave the same — the check
+    normalizes case before matching against the known model set."""
+    with pytest.raises(ValidationError, match="requires task_suite.tasks"):
+        PredictRequest(
+            task_suite={"_micro_plan": [{"intent": "x", "type": "navigate"}]},
+            cua_model="CLAUDE",
+        )
+
+
+def test_cua_model_strip_whitespace():
+    """Leading / trailing whitespace shouldn't bypass the check."""
+    with pytest.raises(ValidationError, match="cua_model="):
+        PredictRequest(
+            task_suite={"_micro_plan": [{"intent": "x", "type": "navigate"}]},
+            cua_model="  claude  ",
+        )


### PR DESCRIPTION
## Summary

Reject mismatched \`(cua_model, plan_shape)\` combos at submit time with a 400, instead of producing HTTP 200 followed by a silent 0/0/0 success.

## The trap this closes

Two memory entries documented it; both surfaced during my own #785 verification (HN + Daytona smokes):

- \`feedback_cua_model_holo3_vs_claude_shape\` — Claude executor reads \`task_suite.tasks[]\`; Holo3 reads \`task_suite._micro_plan\`. Wrong pairing → \`Tasks: 0\` in Modal logs, \"succeeded\" status, zero rows.
- \`feedback_task_suite_shape\` — same shape, same silent zero.

Each cost ~60s of Modal cold-start + executor time before the silent zero surfaced in the result envelope.

## Logic

\`PredictRequest._clamp_caps_and_validate_action\` (existing model_validator) now checks:

| cua_model | Expected task_suite shape | Wrong → error |
|---|---|---|
| \`\"claude\"\` | non-empty \`tasks\` array | \"requires task_suite.tasks ... switch to cua_model='holo3' OR restructure\" |
| \`\"holo3\"\` / \`\"fara\"\` / \`\"gemma4-cua\"\` / \`\"evocua-*\"\` / \`\"opencua-*\"\` | non-empty \`_micro_plan\` array | \"requires task_suite._micro_plan ... use build_micro_suite() OR switch to claude\" |

The check is **conservative**:

- Only fires when \`cua_model\` is one of the known values + task_suite is the plan-shape
- Absent \`cua_model\` → server default, no validation
- Unknown \`cua_model\` → forward-compat, falls through
- \`plan_text\` / \`micro\` / \`task_file\` shapes reconstruct \`task_suite\` server-side later — those paths skip this check
- Action modes (\`status\` / \`result\` / \`cancel\` / \`resume\`) bypass entirely

## Tests (15 new)

- Canonical pairings pass: claude+tasks, holo3+micro, fara+micro, evocua+micro
- Mismatches reject with actionable messages: claude+_micro_plan, holo3+tasks, holo3+neither, evocua+neither
- Edge cases pass: no cua_model, unknown cua_model, plan_text, micro path, all action modes
- Case-insensitive (\"CLAUDE\" == \"claude\") + whitespace-stripped

154 existing schema/predict tests pass.

## Refs

- Epic: #785
- Companion DX issues: #805 (PlanBuilder), #806 (lifecycle routes), #807 (prompt cleanup), #808 (SSE), #809 (recipe registration), #810 (web UI), #811 (papercuts tracker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)