### PR TITLE
docs(examples): Python submission scripts demonstrating the #785 chain (DX-4)

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,4 +1,37 @@
-# Example plans
+# Example plans + submission scripts
+
+Two flavors of examples live here. Pick by integration shape:
+
+- **JSON plans** (this README's existing list below) — feed to `/v1/predict` via curl. Best for shell pipelines, CI smoke tests, and operator one-shots.
+- **Python submission scripts** (`*.py` files) — use the `mantis_agent.client.MantisClient` SDK. Best for application code that needs structured rows back.
+
+## Python submission scripts (showcases the #785 chain)
+
+| Script | Showcases | Cost (rough) | Plane |
+|---|---|---|---|
+| [`hn_top_5.py`](hn_top_5.py) | `plan_text` submission with decomposer-auto-emitted `extract` block (PR #801) | ~$0.20 | Browser-Use Plane |
+| [`github_issues.py`](github_issues.py) | Explicit `micro` step list with inline `extract` block and `compute_backend` selection | ~$0.30 | Browser-Use Plane |
+| [`pricing_page.py`](pricing_page.py) | `dry_run: true` preview before submitting for real (DX-3) | ~$0.08 | Computer Plane (default) |
+
+Setup:
+
+```bash
+pip install -e ".[client]"
+export MANTIS_API_ENDPOINT="https://your-deployment.modal.run"
+export MANTIS_API_TOKEN="mantis_..."
+python examples/hn_top_5.py
+```
+
+What if it fails:
+
+- **`HTTP 400 + \"cua_model='claude' requires task_suite.tasks\"`** — submit-time shape validation (PR #812). Either switch `cua_model` or restructure the suite.
+- **`status=succeeded` + `result.rows == []`** — your `extract` schema didn't match what the page actually has. Use `dry_run: true` (PR #813) to inspect the decomposed plan and verify the field list.
+- **`status=completed_with_failures` + `halt_reason=\"extract_data_failed\"`** — Claude got the schema but couldn't find the fields. Check `action=logs` for the per-step trace; the page may have changed structure.
+- **`profile_id` 409** — another run is holding the Chrome profile. Wait, or use a unique `profile_id` per call (typical: `f\"{user_id}-{job_id}\"`).
+
+---
+
+# JSON example plans (legacy curl-style)
 
 These are committed, generic micro-plans you can run against a fresh Mantis
 deployment. Unlike the customer-specific plans under `plans/` (gitignored),

--- a/examples/github_issues.py
+++ b/examples/github_issues.py
@@ -1,0 +1,142 @@
+"""Extract open issues from a GitHub repo.
+
+Demonstrates the explicit-`micro` path: you author the step list by
+hand, declare an inline `extract` block (PR #798), and opt into the
+Browser-Use Plane (PR #793) for DOM-aware reads. Use this shape when
+you need exact control over the plan structure — e.g. specifying gate
+steps, retry semantics, or per-step hints.
+
+Run:
+    export MANTIS_API_ENDPOINT="https://your-deployment.modal.run"
+    export MANTIS_API_TOKEN="mantis_..."
+    python examples/github_issues.py
+
+Cost: ~$0.30 / run.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+
+from mantis_agent.client import MantisClient, PredictRequest
+
+
+REPO = "mercurialsolo/mantis"        # change to your target repo
+ISSUE_COUNT = 5
+
+
+def build_plan() -> dict:
+    """Construct the task_suite body directly. Each step dict matches
+    the MicroIntent shape; the inline `extract` block declares the
+    rows the runtime should return."""
+    return {
+        "session_name": "github_issues",
+        # Plan-level runtime declares the compute plane. Survives across
+        # submissions — operators can rerun this body and the plane choice
+        # comes with it.
+        "runtime": {
+            "compute_backend": "browser_use_plane",
+            "max_cost": 0.50,
+            "max_time_minutes": 6,
+        },
+        "_micro_plan": [
+            {
+                "intent": f"Navigate to https://github.com/{REPO}/issues?q=is%3Aissue+is%3Aopen",
+                "type": "navigate",
+                "params": {
+                    "url": f"https://github.com/{REPO}/issues?q=is%3Aissue+is%3Aopen",
+                    "wait_after_load_seconds": 4,
+                },
+                "section": "setup",
+                "required": True,
+                "budget": 4,
+            },
+            {
+                "intent": (
+                    f"Extract the top {ISSUE_COUNT} open issues from the issue "
+                    "list. Read only what's visible on the list page; do not "
+                    "click into individual issues. For each issue return "
+                    "issue_number (integer), title, author, label_summary "
+                    "(comma-separated label names if any are visible), "
+                    "comment_count (integer), opened_age (e.g. 'opened 3 days ago')."
+                ),
+                "type": "extract_data",
+                "params": {"claude_only": True},
+                "section": "extraction",
+                "required": False,
+                "budget": 0,
+                "claude_only": True,
+                "hints": {"layout": "listings"},
+                # Inline extract block — validator enforces THIS contract
+                # per-step (PR #798), no recipe needed.
+                "extract": {
+                    "schema_name": "github_issues",
+                    "entity_name": "issue",
+                    "fields": [
+                        {"name": "issue_number",   "type": "int", "required": True},
+                        {"name": "title",          "type": "str", "required": True},
+                        {"name": "author",         "type": "str", "required": False},
+                        {"name": "label_summary",  "type": "str", "required": False},
+                        {"name": "comment_count",  "type": "int", "required": False},
+                        {"name": "opened_age",     "type": "str", "required": False},
+                    ],
+                    "max_items": ISSUE_COUNT,
+                },
+            },
+        ],
+    }
+
+
+def main() -> int:
+    if not os.environ.get("MANTIS_API_TOKEN") or not os.environ.get(
+        "MANTIS_API_ENDPOINT"
+    ):
+        print(
+            "set MANTIS_API_TOKEN and MANTIS_API_ENDPOINT in the environment",
+            file=sys.stderr,
+        )
+        return 1
+
+    client = MantisClient.from_env()
+
+    print(f"[1/3] Submitting explicit micro plan against {REPO}...")
+    handle = client.predict(
+        PredictRequest(
+            task_suite=build_plan(),
+            cua_model="holo3",
+            profile_id=f"gh-issues-{REPO.replace('/', '-')}",
+            workflow_id=f"gh-issues-{int(time.time())}",
+            max_cost=0.50,
+            max_time_minutes=6,
+        )
+    )
+    print(f"  run_id={handle.run_id!r}")
+
+    print("[2/3] Polling for terminal state...")
+    final = client.wait_for_completion(handle.run_id)
+    print(f"  status={final.status!r}")
+
+    print("[3/3] Fetching extracted rows...")
+    result = client.result(handle.run_id)
+    rows = (result or {}).get("rows") or []
+    if not rows:
+        print("  no rows returned — check action=logs for the per-step trace")
+        print(f"  full result envelope: {result!r}")
+        return 2
+
+    print(f"  got {len(rows)} issues:")
+    for row in rows:
+        num = row.get("issue_number", "?")
+        title = (row.get("title") or "")[:60]
+        author = row.get("author", "?")
+        comments = row.get("comment_count", 0)
+        age = row.get("opened_age", "")
+        print(f"    #{num:>4} {title!r:64} ({author}, {comments} comments, {age})")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/hn_top_5.py
+++ b/examples/hn_top_5.py
@@ -1,0 +1,85 @@
+"""Extract the top 5 Hacker News stories.
+
+The simplest dev path post-#785: write the goal in prose, let the
+decomposer (PR #801) emit the inline `extract` block automatically.
+Browser-Use Plane (PR #793) handles dense link disambiguation that
+pure-vision Holo3 struggles with on the HN row layout.
+
+Run:
+    export MANTIS_API_ENDPOINT="https://your-deployment.modal.run"
+    export MANTIS_API_TOKEN="mantis_..."
+    python examples/hn_top_5.py
+
+Cost: ~$0.20 / run (decomposer ~$0.02 + Holo3 GPU + Claude extract).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+
+from mantis_agent.client import MantisClient, PredictRequest
+
+
+def main() -> int:
+    if not os.environ.get("MANTIS_API_TOKEN") or not os.environ.get(
+        "MANTIS_API_ENDPOINT"
+    ):
+        print(
+            "set MANTIS_API_TOKEN and MANTIS_API_ENDPOINT in the environment",
+            file=sys.stderr,
+        )
+        return 1
+
+    client = MantisClient.from_env()
+
+    plan = (
+        "Go to https://news.ycombinator.com/ and extract the top 5 stories. "
+        "For each story return rank, title, story_url (the destination of the "
+        "title link, only if it can be read without clicking), points, author, "
+        "age (e.g. '2 hours ago'), and comments_count. Stay on the front page; "
+        "do not click any links. If a story's URL isn't readable inline, leave "
+        "story_url empty."
+    )
+
+    print("[1/3] Submitting plan_text — decomposer auto-emits the extract block...")
+    handle = client.predict(
+        PredictRequest(
+            plan_text=plan,
+            cua_model="holo3",
+            compute_backend="browser_use_plane",   # DOM-aware for the dense list
+            profile_id="hn-top5",
+            workflow_id=f"hn-top5-{int(time.time())}",
+            max_cost=0.50,
+            max_time_minutes=6,
+        )
+    )
+    print(f"  run_id={handle.run_id!r}")
+
+    print("[2/3] Polling for terminal state...")
+    final = client.wait_for_completion(handle.run_id)
+    print(f"  status={final.status!r}")
+
+    print("[3/3] Fetching extracted rows...")
+    result = client.result(handle.run_id)
+    rows = (result or {}).get("rows") or []
+    if not rows:
+        print("  no rows returned — check action=logs for the per-step trace")
+        print(f"  full result envelope: {result!r}")
+        return 2
+
+    print(f"  got {len(rows)} rows:")
+    for row in rows:
+        rank = row.get("rank", "?")
+        title = (row.get("title") or "")[:60]
+        points = row.get("points", "?")
+        author = row.get("author", "?")
+        url = (row.get("story_url") or "")[:50]
+        print(f"    {rank:>3}. {title!r:64} ({points} pts, {author}, {url})")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/pricing_page.py
+++ b/examples/pricing_page.py
@@ -1,0 +1,136 @@
+"""Extract a single product's pricing from a marketing page.
+
+Demonstrates the `dry_run` pattern (PR #813): preview the resolved
+plan + cost estimate BEFORE submitting for real. Useful when iterating
+on plan_text — you can verify the decomposer produced the steps you
+expected without burning $ on a Modal cold-start.
+
+This is the single-item shape: the plan asks for ONE row (not a list),
+so no `max_items` cap on the extract block and no loop step.
+
+Run:
+    export MANTIS_API_ENDPOINT="https://your-deployment.modal.run"
+    export MANTIS_API_TOKEN="mantis_..."
+    python examples/pricing_page.py
+
+Cost: ~$0.08 / real run (one navigate + one extract, no loop).
+The dry-run preview costs ~$0.02 (one decomposer call).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+
+from mantis_agent.client import MantisClient, PredictRequest
+
+
+TARGET_URL = "https://modal.com/pricing"
+PLAN_TEXT = (
+    f"Go to {TARGET_URL} and extract the pricing details for the entry-level "
+    "plan. Return plan_name, monthly_price_usd, included_compute, included_storage, "
+    "and notable_limit_note. If the page lists multiple tiers, return only the "
+    "cheapest paid tier (skip free tiers)."
+)
+
+
+def main() -> int:
+    if not os.environ.get("MANTIS_API_TOKEN") or not os.environ.get(
+        "MANTIS_API_ENDPOINT"
+    ):
+        print(
+            "set MANTIS_API_TOKEN and MANTIS_API_ENDPOINT in the environment",
+            file=sys.stderr,
+        )
+        return 1
+
+    client = MantisClient.from_env()
+
+    # ── Stage 1: dry-run preview. No executor spawned, no profile lock,
+    # no Modal cold-start. We just want to see what the decomposer
+    # produced + the estimated cost before committing.
+    print("[1/4] Submitting dry_run to preview the resolved plan + cost...")
+    preview = client.predict(
+        PredictRequest(
+            plan_text=PLAN_TEXT,
+            cua_model="holo3",
+            profile_id="pricing-page-prod",
+            workflow_id=f"pricing-{int(time.time())}",
+            dry_run=True,
+            max_cost=0.30,
+            max_time_minutes=4,
+        )
+    )
+
+    # Dry-run returns the resolved task_suite + plan_summary + cost_estimate
+    # directly (NOT a run_id + queued envelope).
+    preview_dict = (
+        preview if isinstance(preview, dict) else preview.model_dump()
+    )
+    summary = preview_dict.get("plan_summary", {})
+    estimate = preview_dict.get("cost_estimate", {})
+
+    print(f"  decomposed into {summary.get('step_count', '?')} steps:")
+    for step_type, n in (summary.get("by_type") or {}).items():
+        print(f"    {step_type}: {n}")
+    if summary.get("with_inline_extract_schema"):
+        print(
+            f"  {summary['with_inline_extract_schema']} step(s) carry an "
+            "inline extract block (decomposer auto-emitted per PR #801)"
+        )
+    print(f"  estimated cost: ${estimate.get('estimated_total_usd', '?')}")
+    print(f"  compute backend: {preview_dict.get('compute_backend', '?')}")
+
+    # Inspect the task_suite Claude produced. Comment out the dump
+    # once you're confident in the shape.
+    print()
+    print("  resolved task_suite._micro_plan:")
+    micro_plan = (preview_dict.get("task_suite", {}) or {}).get("_micro_plan", [])
+    for i, step in enumerate(micro_plan):
+        print(f"    [{i}] {step.get('type', '?'):15s} — {step.get('intent', '')[:80]}")
+        if step.get("extract"):
+            fields = ", ".join(
+                f["name"] for f in step["extract"].get("fields", [])
+            )
+            print(f"         extract: {fields}")
+    print()
+
+    # ── Stage 2: confirm + submit for real
+    if "--dry-only" in sys.argv:
+        print("dry-only mode (use without --dry-only to actually run)")
+        return 0
+
+    print("[2/4] Looks reasonable — submitting for real...")
+    handle = client.predict(
+        PredictRequest(
+            plan_text=PLAN_TEXT,
+            cua_model="holo3",
+            profile_id="pricing-page-prod",
+            workflow_id=f"pricing-{int(time.time())}",
+            max_cost=0.30,
+            max_time_minutes=4,
+        )
+    )
+    print(f"  run_id={handle.run_id!r}")
+
+    print("[3/4] Polling for terminal state...")
+    final = client.wait_for_completion(handle.run_id)
+    print(f"  status={final.status!r}")
+
+    print("[4/4] Fetching the extracted row...")
+    result = client.result(handle.run_id)
+    rows = (result or {}).get("rows") or []
+    if not rows:
+        print("  no rows returned — check action=logs for the per-step trace")
+        print(f"  full result envelope: {result!r}")
+        return 2
+
+    print("  extracted:")
+    print(json.dumps(rows[0], indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Three canonical end-user submission scripts in \`examples/\` — the kind I would have copy-pasted during the #785 verification chain instead of hand-rolling every smoke script. Each demonstrates one of the new patterns shipped in this chain.

## What lands

| Script | Demonstrates | Cost (rough) | Plane |
|---|---|---|---|
| [\`hn_top_5.py\`](examples/hn_top_5.py) | \`plan_text\` submission with decomposer-auto-emitted \`extract\` block (PR #801). Simplest dev path. | ~\$0.20 | Browser-Use Plane |
| [\`github_issues.py\`](examples/github_issues.py) | Explicit \`micro\` step list with hand-authored inline \`extract\` block. \`compute_backend\` declared in the plan's \`runtime\` block. | ~\$0.30 | Browser-Use Plane |
| [\`pricing_page.py\`](examples/pricing_page.py) | \`dry_run: true\` (PR #813) preview pattern — submit with dry_run first, inspect the decomposed plan + cost, then submit for real. | ~\$0.08 | Computer Plane (default) |

Each script:

- Reads \`MANTIS_API_ENDPOINT\` + \`MANTIS_API_TOKEN\` from env
- Uses the typed \`MantisClient\` from \`mantis_agent.client\`
- Docstring names what it demonstrates + the rough cost
- Self-contained: copy-paste, set env vars, run

## README

Updated with a \"Python submission scripts\" section + a debugging crib sheet covering the four common failure modes I actually hit during #785 verification:

- \`HTTP 400 + 'cua_model=claude requires task_suite.tasks'\` — submit-time shape validation (PR #812)
- \`status=succeeded + rows = []\` — schema mismatch; \`dry_run\` to debug
- \`status=completed_with_failures + halt_reason=extract_data_failed\` — Claude couldn't find the fields
- \`profile_id\` 409 — Chrome lock contention

Existing JSON example plans untouched — they're the curl/shell audience and stay as-is.

## Refs

- Epic: #785
- Companion DX PRs: #812 (shape validation), #813 (dry_run)
- Companion DX issues: #805 (PlanBuilder), #806 (lifecycle routes), #807 (prompt cleanup), #808 (SSE), #809 (recipe registration), #810 (web UI), #811 (papercuts tracker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)