### PR TITLE
feat(api): SSE event stream — GET /v1/runs/{id}/events (closes #808)

### DIFF
--- a/deploy/modal/modal_cua_server.py
+++ b/deploy/modal/modal_cua_server.py
@@ -2720,6 +2720,215 @@ def build_api_app(executor_resolver=None, function_call_lookup=None):
             )
         return FileResponse(candidate, media_type=media_type, filename=name)
 
+    # ── SSE event stream (#808) ────────────────────────────────────
+    #
+    # Server-Sent Events wrapper over the file-backed reasoning.jsonl
+    # the executor already writes. Reuses the same per-line JSON shape
+    # as ``action=reasoning_trace`` so consumers can re-use their
+    # existing event parsers. Adds:
+    #
+    # - ``phase`` events on every transition derived from status.json
+    # - ``terminal`` event when the run reaches a terminal phase
+    # - Heartbeat ``: ping\n\n`` every ~25s so reverse proxies don't
+    #   drop the connection (most close idle conns at 30-60s)
+    # - ``Last-Event-ID`` honored if the client supplies one; otherwise
+    #   the ``since`` query param works
+    #
+    # Reads are tail-only (no exclusive lock) so concurrent consumers
+    # don't fight each other or the writer.
+
+    @fastapi_app.get("/v1/runs/{run_id}/events")
+    def stream_run_events(
+        run_id: str,
+        request: Request,
+        sse: bool = False,
+        since: str = "",
+        tenant: TenantConfig = Depends(require_run_scope),
+    ):
+        """Stream run events as SSE (#808).
+
+        With ``?sse=true`` returns ``text/event-stream``. Without it,
+        falls back to the same JSON payload as
+        ``POST /v1/predict {action: reasoning_trace}`` for parity.
+        """
+        from fastapi.responses import StreamingResponse
+
+        try:
+            vol.reload()
+        except Exception:
+            pass
+        status = _read_status(tenant.tenant_id, run_id)
+        if status is None:
+            raise HTTPException(404, f"unknown run_id: {run_id}")
+
+        jsonl_path = _run_dir(tenant.tenant_id, run_id) / "reasoning.jsonl"
+
+        if not sse:
+            # Non-SSE fallback: same shape as action=reasoning_trace.
+            since_ts = since or None
+            events: list[dict] = []
+            if jsonl_path.exists():
+                try:
+                    with jsonl_path.open("r", encoding="utf-8") as f:
+                        for line in f:
+                            stripped = line.strip()
+                            if not stripped:
+                                continue
+                            try:
+                                ev = json.loads(stripped)
+                            except (json.JSONDecodeError, ValueError):
+                                continue
+                            if not isinstance(ev, dict):
+                                continue
+                            if since_ts and ev.get("ts", "") <= since_ts:
+                                continue
+                            events.append(ev)
+                except OSError:
+                    pass
+            return {**status, "events": events, "count": len(events)}
+
+        # SSE path. Honor Last-Event-ID per the SSE spec; fall through
+        # to ``?since`` if the header is absent.
+        last_event_id = request.headers.get("last-event-id", "") or since
+        last_phase_seen = ""
+
+        def _sse_format(event_name: str, payload: dict, event_id: str = "") -> str:
+            parts = []
+            if event_id:
+                parts.append(f"id: {event_id}")
+            parts.append(f"event: {event_name}")
+            parts.append(f"data: {json.dumps(payload, default=str)}")
+            return "\n".join(parts) + "\n\n"
+
+        # Local phase mapping — kept inline so this PR doesn't depend on
+        # the lifecycle-routes branch landing the shared helper. When
+        # both PRs merge, this collapses to a one-line call.
+        _STATUS_TO_PHASE = {
+            "queued": "queued",
+            "running": "running",
+            "paused": "running",
+            "recovering": "recovering",
+            "cancelled": "cancelled",
+            "succeeded": "complete",
+            "completed_with_failures": "complete",
+            "failed": "halted",
+            "halted": "halted",
+            "timeout": "halted",
+        }
+        _TERMINAL_PHASES = {"complete", "halted", "cancelled"}
+
+        def _current_phase(status_blob: dict) -> str:
+            s = str(status_blob.get("status", "") or "").lower()
+            return _STATUS_TO_PHASE.get(s, "running")
+
+        def _terminal_phase(status_blob: dict) -> str | None:
+            p = _current_phase(status_blob)
+            return p if p in _TERMINAL_PHASES else None
+
+        async def event_stream():
+            import asyncio
+
+            nonlocal last_event_id, last_phase_seen
+
+            # Stream guardrails. Bounded so a stuck client doesn't keep
+            # a container input slot forever; clients reconnect with
+            # ``Last-Event-ID`` to resume.
+            max_stream_seconds = 600
+            poll_interval = 1.0
+            heartbeat_interval = 25.0
+            t_start = time.monotonic()
+            t_last_heartbeat = t_start
+
+            # Emit initial phase event so clients have the current
+            # ground state immediately.
+            cur_phase = _current_phase(status)
+            yield _sse_format("phase", {"phase": cur_phase, "run_id": run_id})
+            last_phase_seen = cur_phase
+
+            while True:
+                if await request.is_disconnected():
+                    return
+                # Refresh volume so writes from the executor container
+                # are visible.
+                try:
+                    vol.reload()
+                except Exception:
+                    pass
+
+                # Drain new reasoning events.
+                if jsonl_path.exists():
+                    try:
+                        with jsonl_path.open("r", encoding="utf-8") as f:
+                            for line in f:
+                                stripped = line.strip()
+                                if not stripped:
+                                    continue
+                                try:
+                                    ev = json.loads(stripped)
+                                except (json.JSONDecodeError, ValueError):
+                                    continue
+                                if not isinstance(ev, dict):
+                                    continue
+                                ts = str(ev.get("ts", "") or "")
+                                if last_event_id and ts <= last_event_id:
+                                    continue
+                                # Use the event's own ``kind`` field as
+                                # the SSE event name when present;
+                                # ``message`` is the safe default the
+                                # SSE spec mandates for unspecified events.
+                                event_name = str(ev.get("kind") or ev.get("type") or "message")
+                                yield _sse_format(event_name, ev, event_id=ts)
+                                if ts:
+                                    last_event_id = ts
+                    except OSError:
+                        pass
+
+                # Re-read status for phase transitions + terminal check.
+                cur_status = _read_status(tenant.tenant_id, run_id) or status
+                phase_now = _current_phase(cur_status)
+                if phase_now != last_phase_seen:
+                    yield _sse_format(
+                        "phase",
+                        {"phase": phase_now, "run_id": run_id},
+                    )
+                    last_phase_seen = phase_now
+
+                terminal = _terminal_phase(cur_status)
+                if terminal is not None:
+                    yield _sse_format(
+                        "terminal",
+                        {
+                            "phase": terminal,
+                            "run_id": run_id,
+                            "halt_class": cur_status.get("halt_class")
+                            or cur_status.get("halt_reason"),
+                        },
+                    )
+                    return
+
+                # Heartbeat to keep proxies happy.
+                t_now = time.monotonic()
+                if (t_now - t_last_heartbeat) >= heartbeat_interval:
+                    yield ": ping\n\n"
+                    t_last_heartbeat = t_now
+
+                if (t_now - t_start) >= max_stream_seconds:
+                    # Clean close without a terminal event — client
+                    # reconnects with Last-Event-ID and we pick up.
+                    return
+
+                await asyncio.sleep(poll_interval)
+
+        return StreamingResponse(
+            event_stream(),
+            media_type="text/event-stream",
+            headers={
+                "Cache-Control": "no-cache, no-transform",
+                "X-Accel-Buffering": "no",  # nginx: don't buffer
+                "Connection": "keep-alive",
+            },
+        )
+
     return fastapi_app
 
 

--- a/docs/client/streaming-events.md
+++ b/docs/client/streaming-events.md
@@ -1,0 +1,132 @@
+# Streaming run events (SSE)
+
+For interactive UIs and live dashboards, polling
+`POST /v1/predict {action: status}` on a fixed cadence is laggy — a
+step change in the runner takes up to one cycle to appear. The SSE
+event stream pushes events as soon as the runner writes them.
+
+## Endpoint
+
+```
+GET /v1/runs/{run_id}/events?sse=true
+```
+
+Headers:
+
+| Header | Required | Notes |
+|---|---|---|
+| `X-Mantis-Token` | yes | Same per-tenant token as every other `/v1/*` route |
+| `Last-Event-ID` | no | Resume cursor — server skips rows with `ts ≤ this` |
+| `Accept` | no | Defaults to `text/event-stream` when `sse=true` |
+
+Query params:
+
+| Param | Default | Notes |
+|---|---|---|
+| `sse` | `false` | Set to `true` to opt into the streaming response |
+| `since` | `""` | Alternative to `Last-Event-ID` — same skip semantics |
+
+## Event shape
+
+The server emits one event per row in the run's `reasoning.jsonl`,
+plus a `phase` event on every phase transition and a single
+`terminal` event when the run finishes.
+
+```
+event: phase
+id: 
+data: {"phase": "running", "run_id": "<run_id>"}
+
+event: step
+id: 2026-06-08T00:00:01
+data: {"ts": "2026-06-08T00:00:01", "kind": "step", "step_index": 4, "type": "click", ...}
+
+event: extract
+id: 2026-06-08T00:00:05
+data: {"ts": "2026-06-08T00:00:05", "kind": "extract", "step_index": 7, "row": {...}}
+
+event: terminal
+id: 
+data: {"phase": "complete", "run_id": "<run_id>", "halt_class": null}
+```
+
+Event names match the row's `kind` (or `type`) field, falling back to
+`message` for rows that don't carry one. Phases are the same six-phase
+taxonomy the lifecycle routes use: `queued / running / recovering /
+complete / halted / cancelled`.
+
+## Resumability
+
+The server bounds each stream at ~10 minutes — long-running plans need
+the client to reconnect. The standard SSE pattern (most browser and
+Python EventSource libraries do this automatically): the client tracks
+the last `id:` it saw and sends it back as the `Last-Event-ID` header
+on reconnect. The server skips all rows with timestamp ≤ that cursor.
+
+```bash
+# Curl example — replace LAST_ID with the id of the last event you saw
+curl -N \
+  -H "X-Mantis-Token: $MANTIS_API_TOKEN" \
+  -H "Last-Event-ID: 2026-06-08T00:00:05" \
+  "$ENDPOINT/v1/runs/$RUN_ID/events?sse=true"
+```
+
+Heartbeat comments (`:ping`) arrive every ~25 seconds so reverse
+proxies don't drop the idle connection — the standard SSE parsers
+ignore them automatically.
+
+## Python SDK
+
+`MantisClient.stream_events` wraps the SSE parsing so callers iterate
+over dicts:
+
+```python
+from mantis_agent.client import MantisClient
+
+client = MantisClient.from_env()
+handle = client.predict({"task_suite": {"_micro_plan": [...]}})
+
+for event in client.stream_events(handle.run_id):
+    if event["event"] == "phase":
+        print(f"phase → {event['data']['phase']}")
+    elif event["event"] == "extract":
+        print(f"row: {event['data']['row']}")
+    elif event["event"] == "terminal":
+        print(f"done: {event['data']}")
+        break
+```
+
+The iterator exits on the `terminal` event, on a hung connection, or
+when the server reaches its 10-minute soft limit. For long runs, wrap
+in a reconnect loop that passes the last seen `id` back as `since=`:
+
+```python
+last_id = ""
+while True:
+    for event in client.stream_events(handle.run_id, since=last_id):
+        last_id = event["id"] or last_id
+        if event["event"] == "terminal":
+            break
+    else:
+        # Soft timeout — reconnect.
+        continue
+    break
+```
+
+## When NOT to use SSE
+
+| Need | Use |
+|---|---|
+| One-shot result fetch | `POST /v1/predict {action: result, run_id}` |
+| Polling status from a cron job | `GET /v1/runs/{id}` (cheap-poll + backoff hint) |
+| Backend-to-backend notification | Webhooks (see [Runs and polling](runs-and-polling.md#webhooks-instead-of-polling)) |
+
+SSE shines for interactive UX where every step transition should
+appear immediately. For batched / async consumers, the polling-with-
+backoff-hint path is cheaper.
+
+## See also
+
+- [Runs and polling](runs-and-polling.md) — the action-based status surface and webhooks
+- [Errors](errors.md) — error reference
+- [Reference / HTTP API](../api.md) — full endpoint detail

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -114,6 +114,7 @@ nav:
       - Sending plans: client/plans.md
       - Pure CUA mode: client/pure-cua.md
       - Runs and polling: client/runs-and-polling.md
+      - Streaming events (SSE): client/streaming-events.md
       - Recordings: client/recordings.md
       - Errors: client/errors.md
   - Operations:

--- a/src/mantis_agent/client/client.py
+++ b/src/mantis_agent/client/client.py
@@ -294,6 +294,52 @@ class MantisClient:
         self._raise_for_status(resp)
         return resp.json()
 
+    # ── SSE event stream (#808) ─────────────────────────────────────────
+
+    def stream_events(
+        self,
+        run_id: str,
+        *,
+        since: str = "",
+        timeout_s: float | None = None,
+    ):
+        """Stream run events as parsed dicts (#808).
+
+        Yields one dict per event:
+
+        - ``{"event": "phase", "data": {...}}`` on phase transitions
+        - ``{"event": "<kind>", "data": {...}}`` per reasoning-trace event
+        - ``{"event": "terminal", "data": {...}}`` once on terminal phase, then exits
+
+        The server bounds each stream at 600s; long runs need
+        reconnection. Pass ``since=<ts>`` (or rely on the iterator's own
+        cursor on retry) to resume.
+
+        Usage::
+
+            for event in client.stream_events(run_id):
+                if event["event"] == "terminal":
+                    break
+                print(event)
+        """
+        url = f"{self.endpoint}/v1/runs/{run_id}/events"
+        params = {"sse": "true"}
+        if since:
+            params["since"] = since
+        with self._session.get(
+            url,
+            params=params,
+            headers={
+                **self._headers(),
+                "Accept": "text/event-stream",
+                "Cache-Control": "no-cache",
+            },
+            timeout=timeout_s or self.timeout_s,
+            stream=True,
+        ) as resp:
+            self._raise_for_status(resp)
+            yield from _parse_sse_stream(resp)
+
     # ── Video + health ──────────────────────────────────────────────────
 
     def fetch_video(
@@ -440,3 +486,60 @@ class MantisClient:
         cursor-style pagination.
         """
         yield from self.logs(run_id, tail=batch)
+
+
+# ── SSE stream parser (#808 helper) ────────────────────────────────
+
+
+def _parse_sse_stream(resp) -> Iterable[dict]:
+    """Parse a ``text/event-stream`` HTTP response into event dicts.
+
+    Implements just enough of the SSE spec for our server's emits:
+    ``id:`` cursor, ``event:`` name, ``data:`` JSON body, ``:`` heartbeat
+    lines (skipped). Events end on a blank line — anything else is
+    accumulated. Robust to mid-line truncation: a partial event at EOF
+    is silently dropped (the caller reconnects with the last yielded id).
+    """
+    import json as _json
+
+    current_event = "message"
+    current_id = ""
+    data_buf: list[str] = []
+    for raw_line in resp.iter_lines(decode_unicode=True):
+        if raw_line is None:
+            continue
+        # Heartbeat comment lines (starting with ":") are ignored per
+        # the SSE spec — the server emits ``: ping`` every 25s.
+        if raw_line.startswith(":"):
+            continue
+        if raw_line == "":
+            # Event boundary.
+            if data_buf:
+                try:
+                    payload = _json.loads("\n".join(data_buf))
+                except (_json.JSONDecodeError, ValueError):
+                    payload = {"_raw": "\n".join(data_buf)}
+                yield {
+                    "event": current_event,
+                    "data": payload,
+                    "id": current_id,
+                }
+                if current_event == "terminal":
+                    return
+            current_event = "message"
+            current_id = ""
+            data_buf = []
+            continue
+        # Field parsing — split on first colon, strip optional leading space.
+        if ":" not in raw_line:
+            # SSE spec: line without colon → field name with empty value.
+            continue
+        field, _, value = raw_line.partition(":")
+        if value.startswith(" "):
+            value = value[1:]
+        if field == "event":
+            current_event = value
+        elif field == "id":
+            current_id = value
+        elif field == "data":
+            data_buf.append(value)

--- a/tests/test_sse_run_events.py
+++ b/tests/test_sse_run_events.py
@@ -1,0 +1,290 @@
+"""Tests for SSE event stream — GET /v1/runs/{id}/events?sse=true (#808).
+
+The endpoint wraps the file-backed reasoning.jsonl as a server-sent
+event stream. These tests drive the FastAPI app through TestClient
+and exercise:
+
+- Non-SSE fallback returns the existing reasoning-trace shape.
+- SSE response Content-Type + initial phase event.
+- Each reasoning.jsonl row → one SSE event with the right name + id.
+- Phase transitions emit phase events between data events.
+- Reaching a terminal status emits a ``terminal`` event and closes.
+- Last-Event-ID resume skips already-delivered rows.
+- 404 for unknown run_id, auth for unauthenticated callers.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("modal")
+
+from fastapi.testclient import TestClient
+
+from mantis_agent import tenant_auth as ta_mod
+
+
+_DEPLOY_MODAL = Path(__file__).resolve().parent.parent / "deploy" / "modal"
+if str(_DEPLOY_MODAL) not in sys.path:
+    sys.path.insert(0, str(_DEPLOY_MODAL))
+
+
+class _StubFunctionCall:
+    def __init__(self) -> None:
+        self.object_id = "fc-stub-sse"
+
+    def get(self, timeout: float = 0.1):
+        return {}
+
+    def cancel(self) -> None:
+        return None
+
+
+class _StubExecutor:
+    def __init__(self, call: _StubFunctionCall) -> None:
+        self.call = call
+        self.spawn_kwargs: dict = {}
+
+    def spawn(self, *, task_file_contents: str, **kwargs) -> _StubFunctionCall:
+        self.spawn_kwargs = {"task_file_contents": task_file_contents, **kwargs}
+        return self.call
+
+
+@pytest.fixture
+def app_ctx(monkeypatch, tmp_path):
+    monkeypatch.setenv("MANTIS_API_TOKEN", "test-token")
+    monkeypatch.setenv("MANTIS_DATA_DIR", str(tmp_path / "mantis-data"))
+    monkeypatch.delenv("MANTIS_TENANT_KEYS_PATH", raising=False)
+    ta_mod.reset_key_store()
+
+    import modal_cua_server as mcs  # type: ignore[import-not-found]
+    importlib.reload(mcs)
+
+    stub_call = _StubFunctionCall()
+    stub_executor = _StubExecutor(stub_call)
+    app = mcs.build_api_app(
+        executor_resolver=lambda model: stub_executor,
+        function_call_lookup=lambda call_id: stub_call,
+    )
+    return TestClient(app), mcs
+
+
+def _headers() -> dict:
+    return {"X-Mantis-Token": "test-token"}
+
+
+def _seed(mcs, *, run_id: str, status: str = "running", events: list[dict] | None = None) -> None:
+    mcs._write_status("default", run_id, {
+        "run_id": run_id,
+        "status": status,
+        "tenant_id": "default",
+        "created_at": "2026-06-08T00:00:00+00:00",
+        "updated_at": "2026-06-08T00:00:01+00:00",
+    })
+    if events is not None:
+        run_dir = mcs._run_dir("default", run_id)
+        run_dir.mkdir(parents=True, exist_ok=True)
+        (run_dir / "reasoning.jsonl").write_text(
+            "\n".join(json.dumps(e) for e in events) + ("\n" if events else "")
+        )
+
+
+def _parse_sse(body: str) -> list[dict]:
+    """Tiny SSE parser for test assertions. Returns one dict per event."""
+    out: list[dict] = []
+    cur_event = "message"
+    cur_id = ""
+    data_lines: list[str] = []
+    for line in body.split("\n"):
+        if line.startswith(":"):
+            # Heartbeat comment — track separately by appending a marker.
+            out.append({"_heartbeat": True, "raw": line})
+            continue
+        if line == "":
+            if data_lines:
+                try:
+                    payload = json.loads("\n".join(data_lines))
+                except json.JSONDecodeError:
+                    payload = {"_raw": "\n".join(data_lines)}
+                out.append({"event": cur_event, "id": cur_id, "data": payload})
+            cur_event = "message"
+            cur_id = ""
+            data_lines = []
+            continue
+        if line.startswith("event:"):
+            cur_event = line[len("event:"):].lstrip()
+        elif line.startswith("id:"):
+            cur_id = line[len("id:"):].lstrip()
+        elif line.startswith("data:"):
+            data_lines.append(line[len("data:"):].lstrip())
+    return out
+
+
+# ── Non-SSE fallback ───────────────────────────────────────────────
+
+
+def test_non_sse_returns_json_with_events_array(app_ctx):
+    client, mcs = app_ctx
+    _seed(mcs, run_id="r1", status="running", events=[
+        {"ts": "2026-06-08T00:00:01", "kind": "step", "step_index": 0},
+        {"ts": "2026-06-08T00:00:02", "kind": "step", "step_index": 1},
+    ])
+    r = client.get("/v1/runs/r1/events", headers=_headers())
+    assert r.status_code == 200
+    body = r.json()
+    assert body["count"] == 2
+    assert body["events"][0]["step_index"] == 0
+    assert body["events"][1]["step_index"] == 1
+
+
+def test_non_sse_honors_since_cursor(app_ctx):
+    client, mcs = app_ctx
+    _seed(mcs, run_id="r2", status="running", events=[
+        {"ts": "2026-06-08T00:00:01", "kind": "step", "step_index": 0},
+        {"ts": "2026-06-08T00:00:02", "kind": "step", "step_index": 1},
+        {"ts": "2026-06-08T00:00:03", "kind": "step", "step_index": 2},
+    ])
+    r = client.get(
+        "/v1/runs/r2/events?since=2026-06-08T00:00:01",
+        headers=_headers(),
+    )
+    body = r.json()
+    assert body["count"] == 2
+    assert body["events"][0]["step_index"] == 1
+
+
+# ── SSE shape ──────────────────────────────────────────────────────
+
+
+def test_sse_terminal_run_emits_initial_phase_then_terminal(app_ctx):
+    """Terminal runs short-circuit: client sees the initial phase event
+    + the terminal event and the stream closes immediately."""
+    client, mcs = app_ctx
+    _seed(mcs, run_id="r-done", status="succeeded", events=[
+        {"ts": "2026-06-08T00:00:01", "kind": "step", "step_index": 0},
+    ])
+    with client.stream("GET", "/v1/runs/r-done/events?sse=true", headers=_headers()) as resp:
+        assert resp.status_code == 200
+        assert resp.headers["content-type"].startswith("text/event-stream")
+        body = "".join(resp.iter_text())
+    parsed = [e for e in _parse_sse(body) if not e.get("_heartbeat")]
+    event_names = [e["event"] for e in parsed]
+    assert "phase" in event_names
+    assert "terminal" in event_names
+    # Phase event names the current state of the run.
+    phase_events = [e for e in parsed if e["event"] == "phase"]
+    assert phase_events[0]["data"]["phase"] == "complete"
+
+
+def test_sse_emits_reasoning_events_using_kind_as_event_name(app_ctx):
+    client, mcs = app_ctx
+    _seed(mcs, run_id="r-ev", status="succeeded", events=[
+        {"ts": "2026-06-08T00:00:01", "kind": "step", "step_index": 0},
+        {"ts": "2026-06-08T00:00:02", "kind": "extract", "row": {"title": "x"}},
+    ])
+    with client.stream("GET", "/v1/runs/r-ev/events?sse=true", headers=_headers()) as resp:
+        body = "".join(resp.iter_text())
+    parsed = [e for e in _parse_sse(body) if not e.get("_heartbeat")]
+    names = [e["event"] for e in parsed]
+    assert "step" in names
+    assert "extract" in names
+
+
+def test_sse_event_id_uses_ts_for_resume_cursor(app_ctx):
+    client, mcs = app_ctx
+    _seed(mcs, run_id="r-id", status="succeeded", events=[
+        {"ts": "2026-06-08T00:00:01", "kind": "step"},
+    ])
+    with client.stream("GET", "/v1/runs/r-id/events?sse=true", headers=_headers()) as resp:
+        body = "".join(resp.iter_text())
+    parsed = [e for e in _parse_sse(body) if not e.get("_heartbeat")]
+    step_events = [e for e in parsed if e["event"] == "step"]
+    assert step_events[0]["id"] == "2026-06-08T00:00:01"
+
+
+def test_sse_last_event_id_header_skips_delivered(app_ctx):
+    client, mcs = app_ctx
+    _seed(mcs, run_id="r-resume", status="succeeded", events=[
+        {"ts": "2026-06-08T00:00:01", "kind": "step", "i": 0},
+        {"ts": "2026-06-08T00:00:02", "kind": "step", "i": 1},
+        {"ts": "2026-06-08T00:00:03", "kind": "step", "i": 2},
+    ])
+    with client.stream(
+        "GET",
+        "/v1/runs/r-resume/events?sse=true",
+        headers={**_headers(), "Last-Event-ID": "2026-06-08T00:00:01"},
+    ) as resp:
+        body = "".join(resp.iter_text())
+    parsed = [e for e in _parse_sse(body) if not e.get("_heartbeat")]
+    step_events = [e for e in parsed if e["event"] == "step"]
+    # Only the two newer rows should be delivered.
+    assert [e["data"]["i"] for e in step_events] == [1, 2]
+
+
+def test_sse_since_query_param_skips_delivered(app_ctx):
+    client, mcs = app_ctx
+    _seed(mcs, run_id="r-since", status="succeeded", events=[
+        {"ts": "2026-06-08T00:00:01", "kind": "step", "i": 0},
+        {"ts": "2026-06-08T00:00:02", "kind": "step", "i": 1},
+    ])
+    with client.stream(
+        "GET",
+        "/v1/runs/r-since/events?sse=true&since=2026-06-08T00:00:01",
+        headers=_headers(),
+    ) as resp:
+        body = "".join(resp.iter_text())
+    parsed = [e for e in _parse_sse(body) if not e.get("_heartbeat")]
+    step_events = [e for e in parsed if e["event"] == "step"]
+    assert [e["data"]["i"] for e in step_events] == [1]
+
+
+def test_sse_tolerates_missing_reasoning_jsonl(app_ctx):
+    """A run that hasn't started writing reasoning events yet must
+    still produce a valid SSE response — initial phase + terminal."""
+    client, mcs = app_ctx
+    _seed(mcs, run_id="r-norjsonl", status="succeeded")
+    with client.stream("GET", "/v1/runs/r-norjsonl/events?sse=true", headers=_headers()) as resp:
+        assert resp.status_code == 200
+        body = "".join(resp.iter_text())
+    parsed = [e for e in _parse_sse(body) if not e.get("_heartbeat")]
+    assert any(e["event"] == "phase" for e in parsed)
+    assert any(e["event"] == "terminal" for e in parsed)
+
+
+def test_sse_skips_malformed_jsonl_lines(app_ctx):
+    """A garbage line in reasoning.jsonl shouldn't 500 the stream;
+    the well-formed rows around it must still deliver."""
+    client, mcs = app_ctx
+    _seed(mcs, run_id="r-bad", status="succeeded")
+    run_dir = mcs._run_dir("default", "r-bad")
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / "reasoning.jsonl").write_text(
+        json.dumps({"ts": "2026-06-08T00:00:01", "kind": "step", "i": 0}) + "\n"
+        + "{this is not valid json\n"
+        + json.dumps({"ts": "2026-06-08T00:00:02", "kind": "step", "i": 1}) + "\n"
+    )
+    with client.stream("GET", "/v1/runs/r-bad/events?sse=true", headers=_headers()) as resp:
+        body = "".join(resp.iter_text())
+    parsed = [e for e in _parse_sse(body) if not e.get("_heartbeat")]
+    step_events = [e for e in parsed if e["event"] == "step"]
+    assert [e["data"]["i"] for e in step_events] == [0, 1]
+
+
+# ── 404 + auth ─────────────────────────────────────────────────────
+
+
+def test_sse_returns_404_for_unknown_run(app_ctx):
+    client, _mcs = app_ctx
+    r = client.get("/v1/runs/missing/events?sse=true", headers=_headers())
+    assert r.status_code == 404
+
+
+def test_sse_requires_auth(app_ctx):
+    client, _mcs = app_ctx
+    r = client.get("/v1/runs/anything/events?sse=true")
+    assert r.status_code in {401, 403}


### PR DESCRIPTION
## Summary

Wraps the file-backed `reasoning.jsonl` as a server-sent event stream so interactive UIs and live dashboards see events the moment the runner writes them — no polling lag. Adds an SDK iterator + docs.

## New endpoint

```
GET /v1/runs/{run_id}/events?sse=true
```

- Without `?sse=true` → returns the same JSON shape as `POST /v1/predict {action: reasoning_trace}` (parity for batched consumers).
- With `?sse=true` → `text/event-stream` with `phase`, per-row reasoning events (using the row's `kind`/`type` as event name), and a single `terminal` event when the run finishes.

## Resumability

- `Last-Event-ID` header is honored per the SSE spec — server skips rows with `ts ≤ cursor`.
- `?since=<ts>` query param works as an alternative for clients that can't set headers.
- 600s soft timeout per connection (long runs reconnect with the cursor).
- 25s heartbeat (`: ping`) to keep proxies from dropping idle connections.

## SDK helper

```python
for event in client.stream_events(run_id):
    if event["event"] == "terminal":
        break
    print(event["event"], event["data"])
```

`stream_events()` returns parsed `{event, data, id}` dicts via `_parse_sse_stream` — handles heartbeats, multi-line data, graceful EOF.

## Implementation notes

- Tail-only access to `reasoning.jsonl` — no exclusive lock, concurrent consumers don't fight each other or the writer.
- `vol.reload()` each tick so executor-side writes from another Modal container become visible.
- Phase mapping inlined as a small local table rather than importing the helper added by the lifecycle-routes PR (#816). Both PRs are open in parallel; SSE route shouldn't block on merge order. Collapses to a one-line call after both land.

## Tests

`tests/test_sse_run_events.py` — 11 cases:

- Non-SSE fallback parity with `action=reasoning_trace`
- Content-Type, initial phase + terminal on a finished run
- Event names follow `kind`/`type`; `id` carries `ts`
- `Last-Event-ID` and `?since` cursors both skip delivered rows
- Missing `reasoning.jsonl` tolerated
- Malformed JSONL lines skipped without 500
- 404 + auth enforcement

## Test plan

- [x] `pytest tests/test_sse_run_events.py` — 11/11 pass locally
- [x] `ruff check` — clean
- [x] `mkdocs build --strict` — clean
- [ ] CI shards 1-4 green

## Out of scope

- Bidirectional WebSocket (`/v1/runs/{id}/control`) for interactive pause/resume — filed separately if demand surfaces.
- Modifying the reasoning-trace JSONL format — stream the existing events as-is.

Closes #808

🤖 Generated with [Claude Code](https://claude.com/claude-code)