### PR TITLE
docs: cover loop / if_else / extract_rows across authoring docs

### DIFF
--- a/docs/client/plans.md
+++ b/docs/client/plans.md
@@ -211,6 +211,76 @@ The fields below live on `ExtractionSchema` but the inline path doesn't expose t
 
 For straight "give me these N fields from each item" extraction — the inline block is enough.
 
+### Multi-row from a single list page — `max_items`
+
+If your target page has N items already visible on a single screen
+(HN top stories, GitHub issue list, search-results-style pages), set
+`extract.max_items > 1` on a single `extract_data` step. One Claude
+call returns all N rows; each lands as a separate entry in
+`extracted_rows.json` / `extracted_rows.csv` / `leads.csv`.
+
+```jsonc
+{
+  "intent": "Extract the top 5 stories from HN",
+  "type": "extract_data",
+  "claude_only": true,
+  "extract": {
+    "schema_name": "hn_top5",
+    "entity_name": "hn_story",
+    "fields": [
+      {"name": "rank", "type": "int", "required": true},
+      {"name": "title", "type": "str", "required": true},
+      {"name": "story_url", "type": "str", "required": false},
+      {"name": "points", "type": "int", "required": false}
+    ],
+    "max_items": 5
+  }
+}
+```
+
+For pages where each item needs detail-page enrichment (seller phone
+behind a "Show" button, full job description on a sub-page), the
+single-row `extract_data` inside a `collect_urls` → `loop` chain is
+still the right pattern.
+
+## Control-flow primitives
+
+For plans that need to vary their behaviour based on what the page
+actually shows, three primitives compose:
+
+| Step type | Effect |
+|---|---|
+| `detect_visible` | One vision call: "is X visible?" Writes a bool to `runner._state_vars[out_var]`. |
+| `if_else` | Reads `condition_var`, jumps to `then_target` (truthy) or `else_target` (falsy). |
+| `loop` | Jumps to `loop_target` up to `loop_count` times. Optional `stop_var` exits early. |
+
+Worked example — skip a cookie-consent dance when the banner isn't shown:
+
+```jsonc
+[
+  {"intent": "Navigate to the dashboard", "type": "navigate",
+   "params": {"url": "https://example.com/dashboard"}},
+  {"intent": "Cookie banner visible?", "type": "detect_visible",
+   "out_var": "cookie_shown"},
+  {"intent": "Branch", "type": "if_else",
+   "condition_var": "cookie_shown",
+   "then_target": 3,        // dismiss
+   "else_target": 5},       // skip dismiss
+  {"intent": "Click Accept", "type": "submit",
+   "params": {"label": "Accept"}},
+  {"intent": "Wait briefly", "type": "scroll", "budget": 1},
+  {"intent": "Extract dashboard data", "type": "extract_data", "claude_only": true,
+   "extract": {"fields": [{"name": "title", "required": true}]}}
+]
+```
+
+Safety: missing `condition_var`, unset target (`-1`), or out-of-range
+index falls through to `step_index + 1` instead of teleporting or
+hanging. The runner records a synthetic `StepResult` for every
+branch so the trace shows `var=value→target`.
+
+Full reference: [Plan formats → control-flow primitives](../getting-started/plan-formats.md#control-flow-primitives-loop-if_else-multi-row-extract_data).
+
 ## Picking a compute plane
 
 Every run executes on one of two compute planes. Default is **Computer Plane** — the production-stealth path. **Browser-Use Plane** is opt-in for plans that need DOM-aware reads (current URL, anchor `href` peek before click, semantic role disambiguation on dense list pages, tab management).

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -51,7 +51,10 @@ Each step in a micro-plan is a JSON object with a `type` and an `intent`:
 | `extract_data` | Claude reads the screenshot and emits structured fields per the schema |
 | `navigate_back` | Alt+Left + verify URL change |
 | `paginate` | URL-based or grounded click on the Next button |
-| `loop` | Jumps back to step `loop_target` up to `loop_count` times |
+| `loop` | Jumps back to step `loop_target` up to `loop_count` times. Optional `stop_var` reads a runner state variable and exits the loop early when truthy. |
+| `if_else` | Branches on `runner._state_vars[condition_var]` to `then_target` (truthy) or `else_target` (falsy/missing). Composes with `detect_visible`. Missing var / out-of-range target falls through to the next step. ([#820](https://github.com/mercurialsolo/mantis/pull/820)) |
+| `detect_visible` | One Claude/Holo3 yes/no vision call ("is the cookie banner visible?"); writes a bool to `runner._state_vars[out_var]`. Pairs with `if_else` and step-level `guard`. |
+| `extract_rows` | Multi-row extraction in one Claude call (top-N from a list page). Same handler as `extract_data`; `extract_data` also takes the multi-row branch when its schema has `max_items > 1`. ([#820](https://github.com/mercurialsolo/mantis/pull/820)) |
 | `filter` | Claude finds the filter checkbox and clicks it |
 | `fill_field` | Claude finds the labelled input (`params.label`), clears it, types `params.value` |
 | `submit` | Claude finds the labelled button / nav-link / row-link (`params.label` + `params.kind`) and left-clicks it |
@@ -71,6 +74,11 @@ Useful per-step modifiers:
 | `budget` | Max actions Holo3 can take in this step (default 8). |
 | `loop_target` | Step index to jump back to (only on `loop` steps). |
 | `loop_count` | Max loop iterations; clamped to `MANTIS_MAX_LOOP_ITERATIONS`. |
+| `stop_var` | (`loop` only) Name of a runner state variable; when truthy, exit the loop early instead of running remaining iterations. |
+| `condition_var` | (`if_else` only) Name of a state variable read for the branch decision. |
+| `then_target` / `else_target` | (`if_else` only) Absolute step indices to jump to. -1 = fall through to next step. |
+| `out_var` | (`detect_visible` only) Name of the state variable that receives the boolean answer. |
+| `guard` | Name of a state variable; when falsy, the step is skipped entirely (no vision call, no env action). |
 
 ## Tenants and tokens
 

--- a/docs/getting-started/plan-formats.md
+++ b/docs/getting-started/plan-formats.md
@@ -75,6 +75,109 @@ A flat JSON list of step objects executed by `MicroPlanRunner`. Best reliability
 
 Field reference is on the [Concepts](concepts.md#step-types-micro-plan-shape) page.
 
+### Control-flow primitives — `loop`, `if_else`, multi-row `extract_data`
+
+The `loop` step is the basic iteration primitive — jump back to an
+earlier step up to `loop_count` times. The `if_else` step branches on
+a runtime variable. Both compose with `detect_visible` (which writes
+a bool to `runner._state_vars`).
+
+**`loop` — iterate over the same body N times.**
+
+```jsonc
+[
+  {"intent": "Navigate to results page", "type": "navigate",
+   "params": {"url": "https://example.com/search"}},
+
+  // — loop body starts here (index 1)
+  {"intent": "Click the next result", "type": "click", "section": "extraction"},
+  {"intent": "Extract the detail page", "type": "extract_data",
+   "claude_only": true, "section": "extraction"},
+  {"intent": "Go back to the results", "type": "navigate_back", "section": "extraction"},
+  // — body ends; loop step at index 4 jumps back to index 1 —
+
+  {"intent": "Repeat next-result/extract/back", "type": "loop",
+   "loop_target": 1, "loop_count": 5, "section": "extraction"}
+]
+```
+
+`loop_target` is the **absolute** step index the runner jumps to.
+`loop_count` caps the iterations (server clamps it to
+`MANTIS_MAX_LOOP_ITERATIONS`, default 50). Optional `stop_var` reads
+a runner state variable and exits the loop early when truthy — pair
+it with a `detect_visible` body step to halt as soon as a target is
+found, instead of walking every iteration.
+
+**`if_else` — branch on a state variable.**
+
+Composes with `detect_visible`: the prior step writes a bool to
+`runner._state_vars[<var>]`, then `if_else` reads the same var and
+jumps to `then_target` (truthy) or `else_target` (falsy / missing).
+Step indices are absolute.
+
+```jsonc
+[
+  {"intent": "Navigate to the dashboard", "type": "navigate",
+   "params": {"url": "https://example.com/dashboard"}},
+
+  {"intent": "Is a cookie consent banner visible?", "type": "detect_visible",
+   "out_var": "cookie_banner_shown"},
+
+  {"intent": "Branch on whether the banner is up", "type": "if_else",
+   "condition_var": "cookie_banner_shown",
+   "then_target": 3,   // → step 3: dismiss the banner first
+   "else_target": 5},  // → step 5: skip the dismiss + proceed
+
+  {"intent": "Click Accept on the cookie banner", "type": "submit",
+   "params": {"label": "Accept"}},
+  {"intent": "Wait briefly", "type": "scroll", "budget": 1},
+
+  {"intent": "Extract the dashboard tiles", "type": "extract_data",
+   "claude_only": true,
+   "extract": {"fields": [{"name": "title", "required": true}]}}
+]
+```
+
+Safety: when `condition_var` is empty, `then_target`/`else_target`
+default to `-1`, or the index is out of range, `if_else` falls through
+to `step_index + 1` instead of teleporting / hanging. A synthetic
+`StepResult` records the decision (`var=value→target`) so the run
+trace is grep-able.
+
+**Multi-row `extract_data` / `extract_rows` — top-N from a list page.**
+
+Set `extract.max_items > 1` on an `extract_data` step (or use step type
+`extract_rows`) to extract up to N rows in **one** Claude call instead
+of N navigate→extract→back round trips. Each row lands as a separate
+entry in `extracted_rows.json` / `extracted_rows.csv` / `leads.csv`.
+
+```jsonc
+{
+  "intent": "Extract the top 5 stories from HN",
+  "type": "extract_data",
+  "claude_only": true,
+  "extract": {
+    "schema_name": "hn_top5",
+    "entity_name": "hn_story",
+    "fields": [
+      {"name": "rank", "type": "int", "required": true},
+      {"name": "title", "type": "str", "required": true},
+      {"name": "story_url", "type": "str", "required": false},
+      {"name": "points", "type": "int", "required": false},
+      {"name": "author", "type": "str", "required": false},
+      {"name": "age", "type": "str", "required": false},
+      {"name": "comments_count", "type": "int", "required": false}
+    ],
+    "max_items": 5
+  }
+}
+```
+
+When NOT to use multi-row: pages where each item needs detail-page
+enrichment (e.g. seller phone behind a "Show" button). Stick with
+`collect_urls` → `loop` → `navigate` → single-row `extract_data` →
+`navigate_back`.
+
 ### Declaring runtime defaults inside the plan
 
 A plan can carry a top-level `runtime` block so it's self-describing — no submitter has to remember the right proxy / cost / time flags. The bare-array form above stays valid; the wrapped form adds a sibling next to `steps`:


### PR DESCRIPTION
## Summary

PR #820 added \`if_else\` + multi-row \`extract_data\` to \`docs/llms.txt\` (§3.5a). This PR brings the three control-flow primitives to **parity across all the authoring surfaces a developer reads first** — concepts, plan-formats, client/plans.

## Changes

- **\`docs/getting-started/concepts.md\`** — step-types table extended with \`if_else\`, \`detect_visible\`, \`extract_rows\`. Per-step modifier table extended with \`stop_var\`, \`condition_var\`, \`then_target\` / \`else_target\`, \`out_var\`, \`guard\`.

- **\`docs/getting-started/plan-formats.md\`** — new "Control-flow primitives" section with three worked examples (\`loop\` body, \`detect_visible\` → \`if_else\` cookie-banner branch, \`extract.max_items: 5\` for HN-style top-N extraction).

- **\`docs/client/plans.md\`** — new "Multi-row from a single list page" + "Control-flow primitives" sections with cross-link to plan-formats reference. Same HN top-5 worked example so cross-doc copy/paste is friction-free.

## Test plan

- [x] \`mkdocs build --strict\` — clean (no broken anchors)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)