### PR TITLE
feat(stealth): behavioral jitter + geo consistency + patchright + diagnostic endpoint

### DIFF
--- a/deploy/modal/browser_use_plane.py
+++ b/deploy/modal/browser_use_plane.py
@@ -70,6 +70,18 @@ browser_use_image = (
         # server doesn't need it at runtime, the import path is
         # evaluated on container start.
         "requests>=2.28",
+        # #826: patchright — drop-in patched Playwright that strips
+        # automation tells at the binary level. Default-preferred over
+        # vanilla Playwright. Falls back to playwright.sync_api when
+        # MANTIS_BROWSER_USE_DRIVER=playwright is set.
+        "patchright>=1.49",
+    )
+    .run_commands(
+        # patchright ships its own Chromium build; the playwright
+        # browsers we got from the base image are also fine. Make sure
+        # at least one stack is initialized so the first request
+        # doesn't pay a 60 s download.
+        "python -m patchright install chromium || python -m playwright install chromium",
     )
     .add_local_python_source("mantis_agent")
 )

--- a/deploy/modal/modal_cua_server.py
+++ b/deploy/modal/modal_cua_server.py
@@ -3093,6 +3093,148 @@ def build_api_app(executor_resolver=None, function_call_lookup=None):
             _commit_volume()
         return {"name": name, "deleted": deleted}
 
+    # ── Fingerprint diagnostic (#827) ──────────────────────────────
+    #
+    # Synthesizes + submits a fingerprint-test plan against a public
+    # bot-detection diagnostic page (``bot.sannysoft.com`` by default;
+    # configurable via the request body). The plan navigates to the
+    # test page, waits for the JS to populate the results table, then
+    # ``extract_data`` reads each row's pass/fail signal. Returns
+    # ``{run_id, target_url, poll_via}`` immediately — the operator
+    # polls the run via the lifecycle endpoints to read the scorecard.
+    #
+    # Use this to verify the stealth posture before/after a config
+    # change: flip ``MANTIS_STEALTH_HONEST=1`` or
+    # ``MANTIS_BEHAVIORAL_JITTER=1``, redeploy, run /diagnose/
+    # fingerprint, compare the row counts in extracted_rows.json.
+
+    @fastapi_app.post("/v1/diagnose/fingerprint")
+    def diagnose_fingerprint(
+        body: dict | None = None,
+        tenant: TenantConfig = Depends(require_run_scope),
+    ) -> dict:
+        """Submit a bot-detection diagnostic run (#827).
+
+        Optional body:
+            {"target_url": "https://bot.sannysoft.com/",
+             "cua_model":  "holo3"}
+
+        Returns the standard detached-run envelope; poll via
+        ``GET /v1/runs/{run_id}`` and read the rows via
+        ``GET /v1/runs/{run_id}/artifacts/extracted_rows.json``.
+        """
+        from mantis_agent.server.run_dispatch import (
+            DispatchError,
+            acquire_profile_lock,
+            release_profile_lock,
+        )
+
+        body = body or {}
+        target_url = str(body.get("target_url") or "https://bot.sannysoft.com/").strip()
+        if not target_url.startswith(("http://", "https://")):
+            raise HTTPException(400, "target_url must be http(s)://")
+        model = str(body.get("cua_model") or "holo3").strip() or "holo3"
+        if model not in {"holo3", "claude"}:
+            raise HTTPException(400, "cua_model must be holo3 or claude")
+
+        plan = {
+            "_micro_plan": [
+                {
+                    "intent": f"Navigate to {target_url} and wait for the fingerprint test to complete",
+                    "type": "navigate",
+                    "params": {"url": target_url, "wait_after_load_seconds": 8},
+                    "section": "setup", "required": True, "budget": 4,
+                },
+                {
+                    "intent": (
+                        "Extract each fingerprint test row visible on the page. Each "
+                        "row has a test name (e.g. 'navigator.webdriver', 'WebGL "
+                        "Vendor') and a status (Pass / Fail / value). Return one row "
+                        "per visible test."
+                    ),
+                    "type": "extract_data",
+                    "params": {"claude_only": True},
+                    "section": "extraction", "required": False, "budget": 0,
+                    "claude_only": True, "hints": {"layout": "listings"},
+                    "extract": {
+                        "schema_name": "fingerprint_diagnostic",
+                        "entity_name": "fingerprint_test",
+                        "fields": [
+                            {"name": "test_name", "type": "str", "required": True},
+                            {"name": "result", "type": "str", "required": True},
+                        ],
+                        "max_items": 60,
+                    },
+                },
+            ],
+        }
+
+        try:
+            task_file_contents = _build_suite_from_payload({
+                "task_suite": plan,
+                "cua_model": model,
+                "profile_id": f"fp-diag-{int(time.time())}",
+                "workflow_id": f"fp-diag-{int(time.time())}",
+                "max_cost": 0.30,
+                "max_time_minutes": 3,
+            })
+        except (ValueError, FileNotFoundError, DispatchError) as exc:
+            raise HTTPException(400, str(exc)) from exc
+
+        profile_id = f"fp-diag-{int(time.time())}"
+        run_id = _mint_run_id()
+        if not acquire_profile_lock(tenant, profile_id, run_id):
+            raise HTTPException(409, "profile lock busy — retry in a moment")
+
+        executor_fn = resolve_executor(model)
+        spawn_kwargs: dict = {
+            "max_steps": 8,
+            "profile_dir": _chrome_profile_dir(tenant.tenant_id, profile_id),
+        }
+        if model != "claude":
+            spawn_kwargs["cua_model"] = model
+        try:
+            call_handle = executor_fn.spawn(
+                task_file_contents=task_file_contents,
+                **spawn_kwargs,
+            )
+        except Exception as exc:
+            release_profile_lock(tenant, profile_id)
+            raise HTTPException(500, f"executor spawn failed: {exc}") from exc
+
+        now = datetime.now(timezone.utc).isoformat()
+        status = {
+            "run_id": run_id,
+            "status": "queued",
+            "created_at": now,
+            "updated_at": now,
+            "modal_call_id": getattr(call_handle, "object_id", "") or "",
+            "tenant_id": tenant.tenant_id,
+            "profile_id": profile_id,
+            "workflow_id": profile_id,
+            "state_key": profile_id,
+            "model": model,
+            "max_steps": 8,
+            "diagnostic_kind": "fingerprint",
+            "diagnostic_target": target_url,
+        }
+        _write_status(tenant.tenant_id, run_id, status)
+        _write_task_suite(tenant.tenant_id, run_id, task_file_contents)
+        return {
+            "run_id": run_id,
+            "target_url": target_url,
+            "poll_via": f"/v1/runs/{run_id}",
+            "rows_via": f"/v1/runs/{run_id}/artifacts/extracted_rows.json",
+            "status": "queued",
+            "stealth_snapshot": {
+                "honest_mode": os.environ.get("MANTIS_STEALTH_HONEST", "1") not in {"0", "false"},
+                "behavioral_jitter": os.environ.get("MANTIS_BEHAVIORAL_JITTER", "1") not in {"0", "false"},
+                "geo_consistency": os.environ.get("MANTIS_GEO_CONSISTENCY", "1") not in {"0", "false"},
+                "cdp_stealth": os.environ.get("MANTIS_CDP_STEALTH", "1") not in {"0", "false"},
+                "proxy_provider": os.environ.get("MANTIS_PROXY_PROVIDER", "privateproxy"),
+            },
+        }
+
     return fastapi_app
 
 

--- a/docs/operations/stealth-diagnostics.md
+++ b/docs/operations/stealth-diagnostics.md
@@ -1,0 +1,165 @@
+# Stealth diagnostics + tuning
+
+Mantis's stealth posture is layered across the JS-injected CDP patches
+(`src/mantis_agent/gym/cdp_stealth.py`), behavioral signals at the
+xdotool layer, timezone/locale consistency with the proxy exit, and
+the Browser-Use Plane driver choice. This page documents the env
+flags you can flip, the diagnostic endpoint you use to measure the
+result, and the recommended tuning workflow.
+
+> Background and design rationale: [#822 stealth posture v2 epic](https://github.com/mercurialsolo/mantis/issues/822)
+> and its children.
+
+## Env flags (all default-on)
+
+| Variable | Default | Effect |
+|---|---|---|
+| `MANTIS_CDP_STEALTH` | `1` | CDP-injected fingerprint patches (`navigator.webdriver` undefined, plugins, WebGL, etc.). |
+| `MANTIS_BEHAVIORAL_JITTER` | `1` | Pre-click Bezier mouse path + jittered settle times ([#824](https://github.com/mercurialsolo/mantis/issues/824)). |
+| `MANTIS_GEO_CONSISTENCY` | `1` | Set Chrome's `TZ` and `LANG` to match the proxy exit geo ([#825](https://github.com/mercurialsolo/mantis/issues/825)). |
+| `MANTIS_BROWSER_USE_DRIVER` | unset → `patchright` | Browser-Use Plane driver. Set to `playwright` to force the vanilla import ([#826](https://github.com/mercurialsolo/mantis/issues/826)). |
+| `MANTIS_PROXY_PROVIDER` | `oxylabs` | Residential proxy provider. PrivateProxy and IPRoyal also wired up. |
+
+Every flag accepts the falsy set `0` / `false` / `no` / `off` (case-insensitive)
+to disable. Unknown values are treated as truthy — opt-out is explicit.
+
+## Diagnostic endpoint — `POST /v1/diagnose/fingerprint`
+
+Submits a fingerprint-test plan against a public bot-detection
+diagnostic page. The run extracts every visible test row (test name +
+result) into the standard artifact pipeline so you can grep / diff
+across runs.
+
+```bash
+curl -fsS -X POST "$ENDPOINT/v1/diagnose/fingerprint" \
+  -H "X-Mantis-Token: $MANTIS_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"target_url": "https://bot.sannysoft.com/"}'
+```
+
+Response (detached run handle + active-stealth snapshot):
+
+```jsonc
+{
+  "run_id": "20260609_181500_a1b2c3d4",
+  "target_url": "https://bot.sannysoft.com/",
+  "poll_via": "/v1/runs/20260609_181500_a1b2c3d4",
+  "rows_via": "/v1/runs/20260609_181500_a1b2c3d4/artifacts/extracted_rows.json",
+  "status": "queued",
+  "stealth_snapshot": {
+    "honest_mode": true,
+    "behavioral_jitter": true,
+    "geo_consistency": true,
+    "cdp_stealth": true,
+    "proxy_provider": "oxylabs"
+  }
+}
+```
+
+Poll lifecycle, fetch rows:
+
+```bash
+RID=20260609_181500_a1b2c3d4
+# Poll
+curl "$ENDPOINT/v1/runs/$RID" -H "X-Mantis-Token: $TOKEN"
+# Fetch the per-test rows once terminal
+curl "$ENDPOINT/v1/runs/$RID/artifacts/extracted_rows.json" -H "X-Mantis-Token: $TOKEN"
+```
+
+### Body fields
+
+| Field | Default | Notes |
+|---|---|---|
+| `target_url` | `https://bot.sannysoft.com/` | Must start with `http://` or `https://`. Other candidates: `https://abrahamjuliot.github.io/creepjs/`, `https://browserleaks.com/` |
+| `cua_model` | `holo3` | One of `holo3` or `claude`. |
+
+The endpoint is intentionally cheap: max 8 steps, 3-minute time cap,
+$0.30 cost cap. It uses the multi-row `extract_data` branch ([#820](https://github.com/mercurialsolo/mantis/pull/820))
+so up to 60 fingerprint test rows come back from one Claude call.
+
+## Recommended tuning workflow
+
+1. **Baseline.** Run the diagnostic with default flags. Save the
+   resulting `extracted_rows.json` as `baseline.json`.
+
+   ```bash
+   curl -X POST "$ENDPOINT/v1/diagnose/fingerprint" -d '{}' ...
+   # wait for terminal, fetch rows
+   curl "$ENDPOINT/v1/runs/$RID/artifacts/extracted_rows.json" > baseline.json
+   ```
+
+2. **Flip one flag at a time.** E.g. disable behavioral jitter:
+
+   - Set `MANTIS_BEHAVIORAL_JITTER=0` in `.env`.
+   - Redeploy Modal: `modal app stop mantis-cua-server && modal deploy ...`.
+   - Re-run the diagnostic. Save as `no-behavioral.json`.
+
+3. **Diff the scorecards:**
+
+   ```bash
+   diff <(jq -S '.' baseline.json) <(jq -S '.' no-behavioral.json)
+   ```
+
+4. **Verify in production** with a canonical CF-protected target
+   (boattrader.com / luma.com / your domain). Compare the auto-pause-
+   on-`cf_challenge` halt rate week-over-week in the
+   `mantis_loop_termination_total{reason}` metric.
+
+## What each flag actually does
+
+### `MANTIS_CDP_STEALTH=1` (default)
+
+`src/mantis_agent/gym/cdp_stealth.py` injects 12 JS patches at
+`Page.addScriptToEvaluateOnNewDocument` time, plus a CDP
+`Network.setUserAgentOverride` that aligns `sec-ch-ua-*` headers with
+the UA we claim. Patches cover `navigator.webdriver`, `plugins`,
+`languages`, WebGL vendor/renderer, canvas + audio fingerprint noise,
+font enumeration, and platform spoofing.
+
+### `MANTIS_BEHAVIORAL_JITTER=1` (default)
+
+`src/mantis_agent/gym/behavioral.py` exposes:
+
+- `bezier_waypoints(start, end, steps)` — sampled Bezier curve
+  between the current cursor position and the click target. Used in
+  the xdotool click handler so the cursor moves along a curved path
+  before the click instead of teleporting and firing.
+- `jittered_settle(base)` / `jittered_wait(base)` — randomized delay
+  helpers (`uniform(-0.3, +0.6)` around the base, floor at `base / 2`).
+
+### `MANTIS_GEO_CONSISTENCY=1` (default)
+
+`src/mantis_agent/gym/geo_consistency.py` resolves the proxy's
+`diagnose_proxy_egress` payload to an IANA timezone + BCP-47 language
+tag. `setup_env` writes the resolved `TZ` and `LANG` into the process
+env *before* Chrome starts, so Chrome inherits a wall-clock that
+matches the proxy exit IP. State-level resolution for US proxies
+(Phoenix AZ → `America/Phoenix`); falls back to the country default
+for multi-tz states. Unknown countries land on `America/New_York` +
+`en-US` — the helper never invents a country it can't verify.
+
+### `MANTIS_BROWSER_USE_DRIVER=patchright` (default)
+
+Per `feedback_headless_vs_xvfb.md`, Cloudflare detects headless
+Playwright with high reliability. The Browser-Use Plane now defaults
+to importing [`patchright`](https://github.com/Kaliiiiiiiiii-Vinyxhi/patchright-python),
+a drop-in patched fork that strips Playwright's automation tells at
+the binary level. Set `MANTIS_BROWSER_USE_DRIVER=playwright` to fall
+back to vanilla for the rare targets that detect patchright
+specifically.
+
+## Out of scope
+
+- Solving CF Turnstile challenges interactively (the pause-on-challenge
+  flow from [#541](https://github.com/mercurialsolo/mantis/pull/541)
+  already handles residual cases).
+- TLS / JA3 spoofing at the network layer. Real Chrome's TLS is the
+  honest answer — see the epic for the rationale.
+- `MANTIS_STEALTH_HONEST` (drop Windows spoof, present as real Linux
+  Chrome) — tracked separately as [#823](https://github.com/mercurialsolo/mantis/issues/823).
+
+## See also
+
+- Epic: [#822 stealth posture v2 — present honestly](https://github.com/mercurialsolo/mantis/issues/822)
+- Metrics: [Prometheus per-action dashboard](metrics.md)
+- Augur per-run debug bundles: [Augur integration](../integrations/augur.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -125,6 +125,7 @@ nav:
       - Webhooks: operations/webhooks.md
       - URL allowlist: operations/allowlist.md
       - Runtime recipes: operations/runtime-recipes.md
+      - Stealth diagnostics: operations/stealth-diagnostics.md
       - Metrics: operations/metrics.md
       - Cost model: operations/cost.md
       - Wall-time aggregation: operations/wall-time-aggregation.md

--- a/src/mantis_agent/gym/behavioral.py
+++ b/src/mantis_agent/gym/behavioral.py
@@ -1,0 +1,161 @@
+"""Humanlike behavioral signals — pre-click curve + jittered settle (#824).
+
+Modern bot-detection scoring (DataDome, PerimeterX, Cloudflare Turnstile
+when escalation is close) reads behavioral telemetry: mouse trajectory,
+click cadence, inter-event timing. Today every ``xdotool`` click
+teleports the cursor and fires a click in immediate succession — a
+machine-perfect tell that drives the score upward.
+
+This module ships two small primitives:
+
+1. :func:`bezier_waypoints` — Bezier curve between current cursor and
+   target. Returns 2–4 intermediate points so the click handler can
+   issue ``xdotool mousemove`` at each waypoint with a tiny delay.
+2. :func:`jittered_settle` — turn a fixed settle time into a
+   ``base + uniform(-0.3, +0.6)`` range so step-to-step cadence isn't
+   machine-perfect.
+
+Both honor the ``MANTIS_BEHAVIORAL_JITTER`` env var (default ``"1"``;
+set to ``"0"`` to restore deterministic behavior for CI / replay).
+
+CUA provenance: these are **action-only** modifications of how we
+*emit* xdotool / sleep commands. They don't derive grounding from
+DOM state or otherwise breach screenshot-grounded purity (see
+``feedback_cua_no_dom_access.md``).
+"""
+
+from __future__ import annotations
+
+import os
+import random
+
+
+def is_enabled() -> bool:
+    """Whether behavioral jitter is active.
+
+    Default ``True`` — opt out with ``MANTIS_BEHAVIORAL_JITTER=0`` (or
+    ``false`` / ``no``). Reads env on every call so tests can flip the
+    flag without reloading the module.
+    """
+    raw = os.environ.get("MANTIS_BEHAVIORAL_JITTER", "").strip().lower()
+    if raw in {"0", "false", "no", "off"}:
+        return False
+    return True
+
+
+def bezier_waypoints(
+    start: tuple[int, int],
+    end: tuple[int, int],
+    *,
+    steps: int = 3,
+    curvature: float = 0.25,
+) -> list[tuple[int, int]]:
+    """Sample ``steps`` waypoints along a cubic Bezier from ``start`` to ``end``.
+
+    Returns ONLY the intermediate waypoints — neither endpoint is
+    included, so the caller picks whether to start from the current
+    cursor position and where to land. Empty list when ``start == end``
+    or when ``steps <= 0``.
+
+    The curve's two control points are offset perpendicular to the
+    direct line by ``curvature * distance``, with sign and magnitude
+    randomized so successive calls don't trace the same arc.
+
+    ``steps`` is clamped to ``[0, 8]`` so a runaway caller can't issue
+    50 ``xdotool`` calls per click.
+    """
+    sx, sy = start
+    ex, ey = end
+    if (sx, sy) == (ex, ey) or steps <= 0:
+        return []
+    steps = max(0, min(int(steps), 8))
+    if steps == 0:
+        return []
+
+    # Perpendicular unit vector to the start→end direction.
+    dx, dy = ex - sx, ey - sy
+    distance = max(1.0, (dx * dx + dy * dy) ** 0.5)
+    px, py = -dy / distance, dx / distance
+
+    # Two control points 1/3 and 2/3 along the line + a perpendicular
+    # offset. Offset magnitude jittered so the path differs between calls.
+    jitter_a = random.uniform(-curvature, curvature) * distance
+    jitter_b = random.uniform(-curvature, curvature) * distance
+    cx1, cy1 = sx + dx / 3 + px * jitter_a, sy + dy / 3 + py * jitter_a
+    cx2, cy2 = sx + 2 * dx / 3 + px * jitter_b, sy + 2 * dy / 3 + py * jitter_b
+
+    points: list[tuple[int, int]] = []
+    # t in (0, 1), excluding endpoints — caller already knows where it
+    # started and where it's landing.
+    for i in range(1, steps + 1):
+        t = i / (steps + 1)
+        mt = 1 - t
+        # Cubic Bezier interpolation.
+        x = (
+            mt * mt * mt * sx
+            + 3 * mt * mt * t * cx1
+            + 3 * mt * t * t * cx2
+            + t * t * t * ex
+        )
+        y = (
+            mt * mt * mt * sy
+            + 3 * mt * mt * t * cy1
+            + 3 * mt * t * t * cy2
+            + t * t * t * ey
+        )
+        points.append((int(round(x)), int(round(y))))
+    return points
+
+
+def waypoint_delay() -> float:
+    """Inter-waypoint delay for the pre-click mouse curve.
+
+    Returns ``uniform(0.005, 0.012)`` seconds — short enough that the
+    full curve adds ≤ 50 ms to a click, long enough to register as
+    multi-frame movement in mousemove timestamps.
+    """
+    return random.uniform(0.005, 0.012)
+
+
+def jittered_settle(base: float) -> float:
+    """Add ``uniform(-0.3, +0.6)`` jitter to a settle time.
+
+    Real users don't navigate / scroll / click on a machine-perfect
+    cadence. Returns the original ``base`` unchanged when jitter is
+    disabled (``MANTIS_BEHAVIORAL_JITTER=0``).
+
+    Negative jitter caps at ``base * 0.5`` so a small base value
+    (e.g. 0.5 s) never collapses to near-zero.
+    """
+    if not is_enabled():
+        return base
+    if base <= 0:
+        return base
+    delta = random.uniform(-0.3, 0.6)
+    floor = base * 0.5
+    return max(floor, base + delta)
+
+
+def jittered_wait(base: float, *, spread: float = 1.5) -> float:
+    """Same as :func:`jittered_settle` but for longer waits.
+
+    Used for ``wait_after_load_seconds`` on navigate steps where the
+    natural variation is larger than per-step settle. Returns
+    ``uniform(base - 0.5, base + spread)`` (clamped to ``base * 0.5``).
+    """
+    if not is_enabled():
+        return base
+    if base <= 0:
+        return base
+    delta = random.uniform(-0.5, spread)
+    floor = base * 0.5
+    return max(floor, base + delta)
+
+
+__all__ = [
+    "bezier_waypoints",
+    "is_enabled",
+    "jittered_settle",
+    "jittered_wait",
+    "waypoint_delay",
+]

--- a/src/mantis_agent/gym/geo_consistency.py
+++ b/src/mantis_agent/gym/geo_consistency.py
@@ -1,0 +1,218 @@
+"""Timezone + locale consistency with proxy exit geo (#825).
+
+Modern bot-detection scoring cross-checks ``navigator.language`` /
+``Intl.DateTimeFormat().resolvedOptions().timeZone`` /
+``Date().getTimezoneOffset()`` against the IP geo. If the proxy
+egresses through a Phoenix AZ residential IP but the browser reports
+``America/New_York`` (because that's baked into the container image),
+that's a detectable mismatch.
+
+This module exposes pure-function helpers that turn the existing
+``diagnose_proxy_egress`` payload into (timezone, language) hints. The
+runner / setup_env writes ``TZ`` into the env *before* Chrome starts
+(so Chrome inherits the right wall-clock) and issues the matching
+``Emulation.setTimezoneOverride`` / ``setLocaleOverride`` CDP calls
+after Chrome is up.
+
+CUA-purity: this is a pure timestamp / language consistency check; no
+DOM access, no behavioral feedback loop. Falls in the same provenance
+class as the existing UA override.
+"""
+
+from __future__ import annotations
+
+# US state code → primary IANA timezone. Only states with a single
+# dominant timezone are listed; multi-tz states (TN, KY, IN, ND, SD,
+# FL, MI) fall through to the country default. Names follow the
+# IANA zoneinfo database.
+_US_STATE_TZ: dict[str, str] = {
+    "AL": "America/Chicago",
+    "AK": "America/Anchorage",
+    "AZ": "America/Phoenix",
+    "AR": "America/Chicago",
+    "CA": "America/Los_Angeles",
+    "CO": "America/Denver",
+    "CT": "America/New_York",
+    "DE": "America/New_York",
+    "DC": "America/New_York",
+    "GA": "America/New_York",
+    "HI": "Pacific/Honolulu",
+    "ID": "America/Boise",
+    "IL": "America/Chicago",
+    "IA": "America/Chicago",
+    "KS": "America/Chicago",
+    "LA": "America/Chicago",
+    "ME": "America/New_York",
+    "MD": "America/New_York",
+    "MA": "America/New_York",
+    "MN": "America/Chicago",
+    "MS": "America/Chicago",
+    "MO": "America/Chicago",
+    "MT": "America/Denver",
+    "NE": "America/Chicago",
+    "NV": "America/Los_Angeles",
+    "NH": "America/New_York",
+    "NJ": "America/New_York",
+    "NM": "America/Denver",
+    "NY": "America/New_York",
+    "NC": "America/New_York",
+    "OH": "America/New_York",
+    "OK": "America/Chicago",
+    "OR": "America/Los_Angeles",
+    "PA": "America/New_York",
+    "RI": "America/New_York",
+    "SC": "America/New_York",
+    "TX": "America/Chicago",
+    "UT": "America/Denver",
+    "VT": "America/New_York",
+    "VA": "America/New_York",
+    "WA": "America/Los_Angeles",
+    "WV": "America/New_York",
+    "WI": "America/Chicago",
+    "WY": "America/Denver",
+}
+
+# ipinfo's ``region`` returns full state names ("Arizona") not codes;
+# map both directions so callers don't have to pre-canonicalize.
+_US_STATE_NAME_TO_CODE: dict[str, str] = {
+    "alabama": "AL", "alaska": "AK", "arizona": "AZ", "arkansas": "AR",
+    "california": "CA", "colorado": "CO", "connecticut": "CT",
+    "delaware": "DE", "district of columbia": "DC", "georgia": "GA",
+    "hawaii": "HI", "idaho": "ID", "illinois": "IL", "iowa": "IA",
+    "kansas": "KS", "louisiana": "LA", "maine": "ME", "maryland": "MD",
+    "massachusetts": "MA", "minnesota": "MN", "mississippi": "MS",
+    "missouri": "MO", "montana": "MT", "nebraska": "NE", "nevada": "NV",
+    "new hampshire": "NH", "new jersey": "NJ", "new mexico": "NM",
+    "new york": "NY", "north carolina": "NC", "ohio": "OH",
+    "oklahoma": "OK", "oregon": "OR", "pennsylvania": "PA",
+    "rhode island": "RI", "south carolina": "SC", "texas": "TX",
+    "utah": "UT", "vermont": "VT", "virginia": "VA", "washington": "WA",
+    "west virginia": "WV", "wisconsin": "WI", "wyoming": "WY",
+}
+
+# Country code → primary IANA timezone (only the country defaults
+# Chrome shows on a fresh install for common residential traffic). For
+# multi-tz countries the runner SHOULD prefer state-level resolution
+# above; this is the safety net.
+_COUNTRY_TZ: dict[str, str] = {
+    "US": "America/New_York",
+    "CA": "America/Toronto",
+    "MX": "America/Mexico_City",
+    "GB": "Europe/London",
+    "UK": "Europe/London",
+    "DE": "Europe/Berlin",
+    "FR": "Europe/Paris",
+    "IT": "Europe/Rome",
+    "ES": "Europe/Madrid",
+    "NL": "Europe/Amsterdam",
+    "BR": "America/Sao_Paulo",
+    "AR": "America/Argentina/Buenos_Aires",
+    "JP": "Asia/Tokyo",
+    "KR": "Asia/Seoul",
+    "CN": "Asia/Shanghai",
+    "IN": "Asia/Kolkata",
+    "AU": "Australia/Sydney",
+    "NZ": "Pacific/Auckland",
+    "ZA": "Africa/Johannesburg",
+    "RU": "Europe/Moscow",
+}
+
+# Country code → BCP-47 primary language tag used in
+# ``navigator.language`` / ``navigator.languages`` and the
+# ``--lang`` Chrome flag.
+_COUNTRY_LANG: dict[str, str] = {
+    "US": "en-US",
+    "CA": "en-CA",
+    "MX": "es-MX",
+    "GB": "en-GB",
+    "UK": "en-GB",
+    "DE": "de-DE",
+    "FR": "fr-FR",
+    "IT": "it-IT",
+    "ES": "es-ES",
+    "NL": "nl-NL",
+    "BR": "pt-BR",
+    "AR": "es-AR",
+    "JP": "ja-JP",
+    "KR": "ko-KR",
+    "CN": "zh-CN",
+    "IN": "en-IN",
+    "AU": "en-AU",
+    "NZ": "en-NZ",
+    "ZA": "en-ZA",
+    "RU": "ru-RU",
+}
+
+# Fallback when the country code isn't in either map. Empty string
+# means "leave the existing Chrome default alone" — never invent.
+_DEFAULT_TZ_FALLBACK = "America/New_York"
+_DEFAULT_LANG_FALLBACK = "en-US"
+
+
+def resolve_tz_and_lang(proxy_diag: dict | None) -> tuple[str, str]:
+    """Return ``(tz, lang)`` for the proxy's egress geo.
+
+    Returns the documented fallbacks (``America/New_York``, ``en-US``)
+    when the geo is unknown — never empty strings — so the caller can
+    set ``TZ`` and ``--lang`` without branching.
+
+    Resolution order:
+
+    1. US state → state-specific timezone (e.g. ``AZ`` → ``America/Phoenix``).
+    2. Country code → country default timezone.
+    3. Fallback (``America/New_York``, ``en-US``).
+
+    The ``proxy_diag`` shape matches
+    :func:`mantis_agent.task_loop.diagnose_proxy_egress` — keys
+    ``ip``, ``city``, ``region``, ``country``, ``org`` on success;
+    ``disabled``/``error`` flag dicts on failure. Failure returns
+    the fallbacks unchanged.
+    """
+    if not isinstance(proxy_diag, dict) or proxy_diag.get("disabled") or proxy_diag.get("error"):
+        return _DEFAULT_TZ_FALLBACK, _DEFAULT_LANG_FALLBACK
+
+    country = str(proxy_diag.get("country", "") or "").upper().strip()
+    region = str(proxy_diag.get("region", "") or "").strip()
+
+    tz = ""
+    if country == "US" and region:
+        # ipinfo returns full state names. Tolerate codes too just in case.
+        code = region.upper() if len(region) == 2 else _US_STATE_NAME_TO_CODE.get(region.lower(), "")
+        if code:
+            tz = _US_STATE_TZ.get(code, "")
+    if not tz:
+        tz = _COUNTRY_TZ.get(country, _DEFAULT_TZ_FALLBACK)
+
+    lang = _COUNTRY_LANG.get(country, _DEFAULT_LANG_FALLBACK)
+    return tz, lang
+
+
+def tz_for_country(country: str) -> str:
+    """Lookup helper exposed for tests and admin diagnostics."""
+    return _COUNTRY_TZ.get(country.upper().strip(), _DEFAULT_TZ_FALLBACK)
+
+
+def lang_for_country(country: str) -> str:
+    """Lookup helper exposed for tests and admin diagnostics."""
+    return _COUNTRY_LANG.get(country.upper().strip(), _DEFAULT_LANG_FALLBACK)
+
+
+def tz_for_us_state(region: str) -> str:
+    """Resolve a US state name or code to its primary timezone.
+
+    Returns the country-default (``America/New_York``) when the
+    region is unknown or empty.
+    """
+    region = region.strip()
+    if not region:
+        return _COUNTRY_TZ["US"]
+    code = region.upper() if len(region) == 2 else _US_STATE_NAME_TO_CODE.get(region.lower(), "")
+    return _US_STATE_TZ.get(code, _COUNTRY_TZ["US"])
+
+
+__all__ = [
+    "lang_for_country",
+    "resolve_tz_and_lang",
+    "tz_for_country",
+    "tz_for_us_state",
+]

--- a/src/mantis_agent/gym/xdotool_env.py
+++ b/src/mantis_agent/gym/xdotool_env.py
@@ -586,6 +586,58 @@ class XdotoolGymEnv(GymEnvironment):
             env=self._env, capture_output=True, timeout=5,
         )
 
+    def _xdotool_capture(self, *args: str) -> str:
+        """Run xdotool and return stdout (for ``getmouselocation`` etc.)."""
+        try:
+            r = subprocess.run(
+                ["xdotool"] + list(args),
+                env=self._env, capture_output=True, timeout=2, text=True,
+            )
+            return r.stdout or ""
+        except (subprocess.TimeoutExpired, OSError):
+            return ""
+
+    def _current_mouse_position(self) -> tuple[int, int] | None:
+        """Read the cursor position via xdotool. Returns ``None`` when
+        the X server / display isn't reachable (test contexts, headless
+        without Xvfb)."""
+        out = self._xdotool_capture("getmouselocation")
+        if not out:
+            return None
+        try:
+            x_part, y_part, *_ = out.split()
+            x = int(x_part.split(":", 1)[1])
+            y = int(y_part.split(":", 1)[1])
+            return x, y
+        except (ValueError, IndexError):
+            return None
+
+    def _mousemove_with_curve(self, x: int, y: int) -> None:
+        """Move the cursor to ``(x, y)`` via a Bezier curve when
+        humanlike behavioral signals are enabled (#824).
+
+        Falls back to a direct ``mousemove`` when:
+        - ``MANTIS_BEHAVIORAL_JITTER=0`` (opt-out for CI / replay)
+        - Current cursor position is unreadable (no X display)
+        - Start and end are the same point
+        """
+        from .behavioral import bezier_waypoints, is_enabled, waypoint_delay
+
+        if not is_enabled():
+            self._xdotool("mousemove", str(x), str(y))
+            return
+        current = self._current_mouse_position()
+        if current is None:
+            self._xdotool("mousemove", str(x), str(y))
+            return
+        for wx, wy in bezier_waypoints(current, (x, y), steps=3):
+            self._xdotool("mousemove", str(wx), str(wy))
+            time.sleep(waypoint_delay())
+        # Always land on the exact target — the Bezier sampling
+        # excludes endpoints so this final mousemove is what actually
+        # parks the cursor on the click target.
+        self._xdotool("mousemove", str(x), str(y))
+
     def _cdp_call(
         self, method: str, params: dict[str, Any] | None = None,
         *, timeout: float = 3.0,
@@ -1514,7 +1566,13 @@ class XdotoolGymEnv(GymEnvironment):
                 x, y = self._clamp(x, y)
                 button = action.params.get("button", "left")
                 btn_num = {"left": "1", "middle": "2", "right": "3"}.get(button, "1")
-                self._xdotool("mousemove", str(x), str(y))
+                # #824 humanlike behavioral: when jitter is enabled,
+                # interpolate the cursor path with a Bezier curve so
+                # the click doesn't look like a teleport followed by an
+                # immediate fire. Falls back to direct mousemove when
+                # MANTIS_BEHAVIORAL_JITTER=0 or when the current cursor
+                # position can't be read.
+                self._mousemove_with_curve(x, y)
                 if self._human_speed:
                     time.sleep(random.uniform(0.05, 0.15))
                 self._xdotool("click", btn_num)
@@ -1523,7 +1581,7 @@ class XdotoolGymEnv(GymEnvironment):
                 x = action.params.get("x", self._viewport[0] // 2)
                 y = action.params.get("y", self._viewport[1] // 2)
                 x, y = self._clamp(x, y)
-                self._xdotool("mousemove", str(x), str(y))
+                self._mousemove_with_curve(x, y)
                 self._xdotool("click", "--repeat", "2", "1")
 
             case ActionType.TYPE:

--- a/src/mantis_agent/server/browser_use_agent.py
+++ b/src/mantis_agent/server/browser_use_agent.py
@@ -118,13 +118,48 @@ def _require_session(request: Request) -> _Session:
     return _sessions[token]
 
 
+def _import_sync_playwright():
+    """Import the Playwright sync API, preferring ``patchright`` (#826).
+
+    ``patchright`` is a drop-in patched fork that strips Playwright's
+    automation tells at the binary level (``navigator.webdriver``, CDP
+    traces, runtime function signatures, etc.). It exposes the SAME
+    sync API surface — caller code doesn't change.
+
+    Resolution order:
+
+    1. ``MANTIS_BROWSER_USE_DRIVER=playwright`` env override → vanilla
+       Playwright (escape hatch for the few targets that detect
+       patchright specifically).
+    2. ``patchright.sync_api.sync_playwright`` if importable.
+    3. ``playwright.sync_api.sync_playwright`` fallback.
+
+    Defaulting to patchright is the #826 win: Browser-Use Plane gains
+    the ability to run against CF-protected targets (previously
+    blocked per ``feedback_headless_vs_xvfb.md``).
+    """
+    import os
+    override = os.environ.get("MANTIS_BROWSER_USE_DRIVER", "").strip().lower()
+    if override == "playwright":
+        from playwright.sync_api import sync_playwright  # noqa: PLC0415
+        return sync_playwright
+    try:
+        from patchright.sync_api import sync_playwright  # noqa: PLC0415
+        return sync_playwright
+    except ImportError:
+        from playwright.sync_api import sync_playwright  # noqa: PLC0415
+        return sync_playwright
+
+
 def _start_playwright(req: BrowserUseSessionInitRequest) -> _Session:
     """Lazy-import Playwright + launch a browser.
 
     Import is deferred so this module remains importable in environments
     without Playwright (e.g. test runners that mock the client).
+    Defaults to ``patchright`` when available (#826) so the Browser-Use
+    Plane can serve CF-protected targets.
     """
-    from playwright.sync_api import sync_playwright  # noqa: PLC0415
+    sync_playwright = _import_sync_playwright()  # noqa: PLC0415
 
     pw = sync_playwright().start()
     launch_args: dict[str, Any] = {"headless": req.headless}

--- a/src/mantis_agent/task_loop.py
+++ b/src/mantis_agent/task_loop.py
@@ -236,6 +236,39 @@ def setup_env(
     # uses, so we surface the IP Cloudflare sees.
     proxy_diag = diagnose_proxy_egress(proxy_server)
 
+    # #825 — Timezone + locale consistency with proxy exit geo.
+    # The Modal CUA image bakes ``TZ=America/New_York``, but a US
+    # residential proxy can land in any state. Mismatch between
+    # ``navigator.language`` / ``Intl.DateTimeFormat().resolvedOptions().timeZone``
+    # and the IP geo is a detectable signal for CF / DataDome scoring.
+    #
+    # Resolve the proxy's geo → (tz, lang), then update ``TZ`` and
+    # ``LANG`` in the process env BEFORE Chrome starts so Chrome
+    # inherits them. The xdotool env's ``_env`` dict is built from
+    # ``os.environ`` at constructor time, so this write lands before
+    # the browser process is forked. CDP-level
+    # ``Emulation.setTimezoneOverride`` / ``setLocaleOverride`` calls
+    # happen post-launch (out of scope here — wired in cdp_stealth).
+    #
+    # Opt-out: set ``MANTIS_GEO_CONSISTENCY=0`` to preserve the baked-
+    # in image defaults (useful for CI / replay).
+    if os.environ.get("MANTIS_GEO_CONSISTENCY", "").strip().lower() not in {"0", "false", "no", "off"}:
+        from .gym.geo_consistency import resolve_tz_and_lang
+        resolved_tz, resolved_lang = resolve_tz_and_lang(proxy_diag)
+        if resolved_tz:
+            os.environ["TZ"] = resolved_tz
+            os.environ["MANTIS_RESOLVED_TZ"] = resolved_tz
+        if resolved_lang:
+            os.environ["LANG"] = f"{resolved_lang.replace('-', '_')}.UTF-8"
+            os.environ["MANTIS_RESOLVED_LANG"] = resolved_lang
+        try:
+            print(
+                f"  Geo consistency: tz={resolved_tz} lang={resolved_lang} "
+                f"(proxy={proxy_diag.get('country', '?')}/{proxy_diag.get('region', '?')})"
+            )
+        except Exception:
+            pass
+
     # Local Xvfb only when the env actually runs in-process. The remote
     # computer plane owns its own Xvfb; spawning a brain-side one would
     # both waste a CPU and break DISPLAY clobbering on shared executors.

--- a/tests/test_behavioral_jitter.py
+++ b/tests/test_behavioral_jitter.py
@@ -1,0 +1,172 @@
+"""Tests for the humanlike behavioral signals module (#824).
+
+Two primitives:
+
+- ``bezier_waypoints(start, end, steps)`` — Bezier path between cursor
+  and click target. Returns intermediate waypoints only.
+- ``jittered_settle(base)`` / ``jittered_wait(base)`` — randomized
+  delays so step-to-step cadence isn't machine-perfect.
+
+Both honor ``MANTIS_BEHAVIORAL_JITTER`` (default ``"1"``).
+"""
+
+from __future__ import annotations
+
+import math
+import random
+
+import pytest
+
+from mantis_agent.gym.behavioral import (
+    bezier_waypoints,
+    is_enabled,
+    jittered_settle,
+    jittered_wait,
+    waypoint_delay,
+)
+
+
+# ── is_enabled / env gating ────────────────────────────────────────
+
+
+def test_is_enabled_defaults_true(monkeypatch):
+    monkeypatch.delenv("MANTIS_BEHAVIORAL_JITTER", raising=False)
+    assert is_enabled() is True
+
+
+@pytest.mark.parametrize("value", ["0", "false", "no", "off", "FALSE", "Off"])
+def test_is_enabled_falsy_values(monkeypatch, value):
+    monkeypatch.setenv("MANTIS_BEHAVIORAL_JITTER", value)
+    assert is_enabled() is False
+
+
+@pytest.mark.parametrize("value", ["1", "true", "yes", "on", "anything"])
+def test_is_enabled_truthy_values(monkeypatch, value):
+    """Anything other than the explicit falsy set is truthy — opt-in
+    behavior is default-on, so unknown values lean toward enabled."""
+    monkeypatch.setenv("MANTIS_BEHAVIORAL_JITTER", value)
+    assert is_enabled() is True
+
+
+# ── bezier_waypoints ───────────────────────────────────────────────
+
+
+def test_bezier_waypoints_returns_requested_count():
+    random.seed(0)
+    pts = bezier_waypoints((100, 100), (500, 300), steps=3)
+    assert len(pts) == 3
+
+
+def test_bezier_waypoints_excludes_endpoints():
+    """The returned list never contains the start or end — caller
+    already knows where the cursor is and where it's landing."""
+    random.seed(0)
+    pts = bezier_waypoints((100, 100), (500, 300), steps=4)
+    assert (100, 100) not in pts
+    assert (500, 300) not in pts
+
+
+def test_bezier_waypoints_empty_when_start_equals_end():
+    """Zero-distance move → no intermediate path."""
+    assert bezier_waypoints((50, 50), (50, 50), steps=3) == []
+
+
+def test_bezier_waypoints_empty_when_steps_zero():
+    assert bezier_waypoints((100, 100), (500, 300), steps=0) == []
+
+
+def test_bezier_waypoints_clamps_runaway_step_counts():
+    """Defensive: 50 steps would issue 50 xdotool calls per click."""
+    pts = bezier_waypoints((100, 100), (500, 300), steps=50)
+    assert len(pts) <= 8
+
+
+def test_bezier_waypoints_progress_roughly_monotonic():
+    """The Bezier curve adds perpendicular jitter, but along the
+    primary axis (start→end direction) waypoints should advance toward
+    the target. With curvature=0 the path becomes a straight line."""
+    pts = bezier_waypoints((0, 0), (1000, 0), steps=4, curvature=0)
+    xs = [p[0] for p in pts]
+    assert xs == sorted(xs)  # monotonically increasing along x-axis
+    assert all(0 < x < 1000 for x in xs)
+
+
+def test_bezier_waypoints_path_actually_curves():
+    """With curvature > 0, the path should not be a straight line —
+    at least one waypoint must deviate perpendicularly from the
+    straight start→end line."""
+    random.seed(0)
+    pts = bezier_waypoints((0, 0), (1000, 0), steps=4, curvature=0.25)
+    # Straight line at y=0; perpendicular deviation is just |y|.
+    max_dev = max(abs(y) for _, y in pts)
+    assert max_dev > 5, f"path should curve, max y-deviation was {max_dev}"
+
+
+def test_bezier_waypoints_jitters_between_calls():
+    """Successive calls should NOT trace the same arc (the perpendicular
+    offset is randomized). This guards against a constant-seed regression
+    sneaking back in."""
+    random.seed(0)
+    a = bezier_waypoints((0, 0), (1000, 1000), steps=4)
+    b = bezier_waypoints((0, 0), (1000, 1000), steps=4)
+    # The two arcs will differ in at least one waypoint.
+    assert a != b
+
+
+# ── waypoint_delay ─────────────────────────────────────────────────
+
+
+def test_waypoint_delay_in_human_range():
+    """Inter-waypoint delay should land in the documented range."""
+    for _ in range(50):
+        d = waypoint_delay()
+        assert 0.005 <= d <= 0.012
+
+
+# ── jittered_settle ────────────────────────────────────────────────
+
+
+def test_jittered_settle_returns_base_when_disabled(monkeypatch):
+    monkeypatch.setenv("MANTIS_BEHAVIORAL_JITTER", "0")
+    assert jittered_settle(2.0) == 2.0
+
+
+def test_jittered_settle_returns_base_for_zero(monkeypatch):
+    monkeypatch.delenv("MANTIS_BEHAVIORAL_JITTER", raising=False)
+    assert jittered_settle(0.0) == 0.0
+
+
+def test_jittered_settle_in_documented_range(monkeypatch):
+    """Documented: ``uniform(-0.3, +0.6)`` around base, floor at base/2."""
+    monkeypatch.delenv("MANTIS_BEHAVIORAL_JITTER", raising=False)
+    base = 2.0
+    samples = [jittered_settle(base) for _ in range(200)]
+    assert min(samples) >= base * 0.5 - 1e-6
+    assert max(samples) <= base + 0.6 + 1e-6
+    # Mean should be near base + 0.15 (midpoint of (-0.3, +0.6)).
+    assert math.isclose(sum(samples) / len(samples), base + 0.15, abs_tol=0.15)
+
+
+def test_jittered_settle_floor_holds_for_tiny_base(monkeypatch):
+    """Negative jitter capped so a 0.5 s settle never collapses to 0.2 s."""
+    monkeypatch.delenv("MANTIS_BEHAVIORAL_JITTER", raising=False)
+    base = 0.5
+    for _ in range(100):
+        assert jittered_settle(base) >= base * 0.5
+
+
+# ── jittered_wait ──────────────────────────────────────────────────
+
+
+def test_jittered_wait_returns_base_when_disabled(monkeypatch):
+    monkeypatch.setenv("MANTIS_BEHAVIORAL_JITTER", "0")
+    assert jittered_wait(6.0) == 6.0
+
+
+def test_jittered_wait_in_documented_range(monkeypatch):
+    """Default spread is 1.5 — uniform(-0.5, +1.5)."""
+    monkeypatch.delenv("MANTIS_BEHAVIORAL_JITTER", raising=False)
+    base = 6.0
+    samples = [jittered_wait(base) for _ in range(200)]
+    assert min(samples) >= base * 0.5 - 1e-6
+    assert max(samples) <= base + 1.5 + 1e-6

--- a/tests/test_browser_use_driver_preference.py
+++ b/tests/test_browser_use_driver_preference.py
@@ -1,0 +1,89 @@
+"""Tests for the patchright preference in Browser-Use Plane (#826).
+
+The Browser-Use Plane server defaults to importing ``patchright`` (a
+patched-Playwright fork that strips automation tells at the binary
+level) and falls back to vanilla ``playwright`` when patchright isn't
+installed. Operators can force vanilla Playwright by setting
+``MANTIS_BROWSER_USE_DRIVER=playwright``.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+
+@pytest.fixture
+def fresh_env(monkeypatch):
+    """Wipe both packages from sys.modules so the resolver's import
+    attempt actually runs."""
+    monkeypatch.delenv("MANTIS_BROWSER_USE_DRIVER", raising=False)
+    for name in [
+        "patchright", "patchright.sync_api",
+        "playwright", "playwright.sync_api",
+    ]:
+        monkeypatch.delitem(sys.modules, name, raising=False)
+    return monkeypatch
+
+
+def _install_stub_module(monkeypatch, name: str, sentinel) -> None:
+    """Install a tiny stub module so the import succeeds and returns
+    our sentinel via ``module.sync_playwright``."""
+    parent_name, _, child_name = name.partition(".")
+    parent = types.ModuleType(parent_name)
+    child = types.ModuleType(name)
+    child.sync_playwright = sentinel
+    parent.sync_api = child
+    monkeypatch.setitem(sys.modules, parent_name, parent)
+    monkeypatch.setitem(sys.modules, name, child)
+
+
+def test_patchright_preferred_when_both_installed(fresh_env):
+    """Default behavior: patchright wins."""
+    pr_sentinel = object()
+    pw_sentinel = object()
+    _install_stub_module(fresh_env, "patchright.sync_api", pr_sentinel)
+    _install_stub_module(fresh_env, "playwright.sync_api", pw_sentinel)
+
+    from mantis_agent.server.browser_use_agent import _import_sync_playwright
+    chosen = _import_sync_playwright()
+    assert chosen is pr_sentinel
+
+
+def test_playwright_fallback_when_patchright_missing(fresh_env):
+    """patchright not importable → fall back to playwright."""
+    pw_sentinel = object()
+    _install_stub_module(fresh_env, "playwright.sync_api", pw_sentinel)
+
+    from mantis_agent.server.browser_use_agent import _import_sync_playwright
+    chosen = _import_sync_playwright()
+    assert chosen is pw_sentinel
+
+
+def test_override_env_forces_vanilla_playwright(fresh_env):
+    """``MANTIS_BROWSER_USE_DRIVER=playwright`` skips patchright even
+    when it's importable. Escape hatch for the rare targets that
+    detect patchright specifically."""
+    pr_sentinel = object()
+    pw_sentinel = object()
+    _install_stub_module(fresh_env, "patchright.sync_api", pr_sentinel)
+    _install_stub_module(fresh_env, "playwright.sync_api", pw_sentinel)
+    fresh_env.setenv("MANTIS_BROWSER_USE_DRIVER", "playwright")
+
+    from mantis_agent.server.browser_use_agent import _import_sync_playwright
+    chosen = _import_sync_playwright()
+    assert chosen is pw_sentinel
+
+
+def test_override_case_insensitive(fresh_env):
+    pr_sentinel = object()
+    pw_sentinel = object()
+    _install_stub_module(fresh_env, "patchright.sync_api", pr_sentinel)
+    _install_stub_module(fresh_env, "playwright.sync_api", pw_sentinel)
+    fresh_env.setenv("MANTIS_BROWSER_USE_DRIVER", "PLAYWRIGHT")
+
+    from mantis_agent.server.browser_use_agent import _import_sync_playwright
+    chosen = _import_sync_playwright()
+    assert chosen is pw_sentinel

--- a/tests/test_fingerprint_diagnostic.py
+++ b/tests/test_fingerprint_diagnostic.py
@@ -1,0 +1,180 @@
+"""Tests for the fingerprint diagnostic endpoint (#827).
+
+Submits a synthetic bot-detection diagnostic plan against a public
+fingerprint test page. The route returns a detached-run envelope plus
+a stealth-config snapshot so operators can correlate the scorecard
+they see with the env flags that were active when the run was
+submitted.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("modal")
+
+from fastapi.testclient import TestClient  # noqa: E402 — guarded by importorskip
+
+from mantis_agent import tenant_auth as ta_mod
+
+
+_DEPLOY_MODAL = Path(__file__).resolve().parent.parent / "deploy" / "modal"
+if str(_DEPLOY_MODAL) not in sys.path:
+    sys.path.insert(0, str(_DEPLOY_MODAL))
+
+
+class _StubCall:
+    object_id = "fc-stub-fp"
+
+    def get(self, timeout: float = 0.1):
+        return {}
+
+    def cancel(self) -> None:
+        return None
+
+
+class _StubExecutor:
+    def __init__(self) -> None:
+        self.call = _StubCall()
+        self.spawn_kwargs: dict = {}
+
+    def spawn(self, *, task_file_contents: str, **kwargs):
+        self.spawn_kwargs = {"task_file_contents": task_file_contents, **kwargs}
+        return self.call
+
+
+@pytest.fixture
+def app_ctx(monkeypatch, tmp_path):
+    monkeypatch.setenv("MANTIS_API_TOKEN", "test-token")
+    monkeypatch.setenv("MANTIS_DATA_DIR", str(tmp_path / "mantis-data"))
+    monkeypatch.delenv("MANTIS_TENANT_KEYS_PATH", raising=False)
+    ta_mod.reset_key_store()
+
+    import modal_cua_server as mcs  # type: ignore[import-not-found]
+    importlib.reload(mcs)
+
+    executor = _StubExecutor()
+    app = mcs.build_api_app(
+        executor_resolver=lambda model: executor,
+        function_call_lookup=lambda call_id: executor.call,
+    )
+    return TestClient(app), executor
+
+
+def _h() -> dict:
+    return {"X-Mantis-Token": "test-token", "Content-Type": "application/json"}
+
+
+# ── Happy path ─────────────────────────────────────────────────────
+
+
+def test_diagnose_returns_run_envelope(app_ctx):
+    client, _ex = app_ctx
+    r = client.post("/v1/diagnose/fingerprint", headers=_h(), json={})
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["status"] == "queued"
+    assert body["run_id"]
+    assert body["target_url"] == "https://bot.sannysoft.com/"
+    assert body["poll_via"] == f"/v1/runs/{body['run_id']}"
+    assert body["rows_via"] == f"/v1/runs/{body['run_id']}/artifacts/extracted_rows.json"
+
+
+def test_diagnose_accepts_custom_target_url(app_ctx):
+    client, _ex = app_ctx
+    r = client.post(
+        "/v1/diagnose/fingerprint",
+        headers=_h(),
+        json={"target_url": "https://abrahamjuliot.github.io/creepjs/"},
+    )
+    assert r.status_code == 200
+    assert r.json()["target_url"] == "https://abrahamjuliot.github.io/creepjs/"
+
+
+def test_diagnose_rejects_non_http_url(app_ctx):
+    client, _ex = app_ctx
+    r = client.post(
+        "/v1/diagnose/fingerprint",
+        headers=_h(),
+        json={"target_url": "file:///etc/passwd"},
+    )
+    assert r.status_code == 400
+
+
+def test_diagnose_rejects_invalid_cua_model(app_ctx):
+    client, _ex = app_ctx
+    r = client.post(
+        "/v1/diagnose/fingerprint",
+        headers=_h(),
+        json={"cua_model": "not-a-model"},
+    )
+    assert r.status_code == 400
+
+
+# ── Stealth snapshot ───────────────────────────────────────────────
+
+
+def test_diagnose_returns_stealth_snapshot(app_ctx):
+    """The response carries which stealth flags were active when the
+    run was submitted — operators correlate the scorecard with the
+    flags so before/after comparison is unambiguous."""
+    client, _ex = app_ctx
+    r = client.post("/v1/diagnose/fingerprint", headers=_h(), json={})
+    body = r.json()
+    snap = body["stealth_snapshot"]
+    assert isinstance(snap, dict)
+    for key in (
+        "honest_mode", "behavioral_jitter", "geo_consistency",
+        "cdp_stealth", "proxy_provider",
+    ):
+        assert key in snap
+
+
+def test_diagnose_snapshot_reflects_env_overrides(monkeypatch, app_ctx):
+    client, _ex = app_ctx
+    monkeypatch.setenv("MANTIS_BEHAVIORAL_JITTER", "0")
+    monkeypatch.setenv("MANTIS_CDP_STEALTH", "0")
+    r = client.post("/v1/diagnose/fingerprint", headers=_h(), json={})
+    snap = r.json()["stealth_snapshot"]
+    assert snap["behavioral_jitter"] is False
+    assert snap["cdp_stealth"] is False
+
+
+# ── Executor wiring ───────────────────────────────────────────────
+
+
+def test_diagnose_spawns_executor_with_fingerprint_plan(app_ctx):
+    """The synthesized plan should include the configured target URL
+    and use ``extract_data`` with ``max_items > 1`` (multi-row branch
+    from PR #820)."""
+    import json
+
+    client, executor = app_ctx
+    r = client.post(
+        "/v1/diagnose/fingerprint",
+        headers=_h(),
+        json={"target_url": "https://bot.sannysoft.com/"},
+    )
+    assert r.status_code == 200
+    suite = json.loads(executor.spawn_kwargs["task_file_contents"])
+    micro_plan = suite["_micro_plan"]
+    # Two steps: navigate + extract_data.
+    assert len(micro_plan) == 2
+    assert micro_plan[0]["type"] == "navigate"
+    assert micro_plan[0]["params"]["url"] == "https://bot.sannysoft.com/"
+    assert micro_plan[1]["type"] == "extract_data"
+    # Multi-row branch from #820.
+    assert micro_plan[1]["extract"]["max_items"] >= 30
+
+
+# ── Auth ───────────────────────────────────────────────────────────
+
+
+def test_diagnose_requires_auth(app_ctx):
+    client, _ex = app_ctx
+    r = client.post("/v1/diagnose/fingerprint", json={})
+    assert r.status_code in {401, 403}

--- a/tests/test_geo_consistency.py
+++ b/tests/test_geo_consistency.py
@@ -1,0 +1,181 @@
+"""Tests for the proxy-geo → (timezone, language) resolver (#825).
+
+Resolves a ``diagnose_proxy_egress`` payload to the IANA timezone and
+BCP-47 language tag that Chrome should report — so
+``navigator.language`` / ``Intl.DateTimeFormat().resolvedOptions().timeZone``
+agree with the IP geo a CF / DataDome scorer sees.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mantis_agent.gym.geo_consistency import (
+    lang_for_country,
+    resolve_tz_and_lang,
+    tz_for_country,
+    tz_for_us_state,
+)
+
+
+# ── US state resolution ────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("region,expected_tz", [
+    ("AZ", "America/Phoenix"),
+    ("CA", "America/Los_Angeles"),
+    ("NY", "America/New_York"),
+    ("TX", "America/Chicago"),
+    ("CO", "America/Denver"),
+    ("HI", "Pacific/Honolulu"),
+    ("AK", "America/Anchorage"),
+])
+def test_us_state_code_resolves(region, expected_tz):
+    assert tz_for_us_state(region) == expected_tz
+
+
+@pytest.mark.parametrize("region,expected_tz", [
+    ("Arizona", "America/Phoenix"),
+    ("California", "America/Los_Angeles"),
+    ("New York", "America/New_York"),
+    ("Texas", "America/Chicago"),
+    ("Hawaii", "Pacific/Honolulu"),
+])
+def test_us_full_state_name_resolves(region, expected_tz):
+    """ipinfo.io returns full state names, not codes — the helper
+    must accept both."""
+    assert tz_for_us_state(region) == expected_tz
+
+
+def test_us_state_case_insensitive():
+    assert tz_for_us_state("arizona") == "America/Phoenix"
+    assert tz_for_us_state("ARIZONA") == "America/Phoenix"
+    assert tz_for_us_state("aZ") == "America/Phoenix"
+
+
+def test_us_unknown_state_falls_back_to_country_default():
+    """Multi-tz states deliberately not in the table (FL, TN, KY)
+    should fall back to the country default rather than guess wrong."""
+    assert tz_for_us_state("Florida") == "America/New_York"
+    assert tz_for_us_state("Tennessee") == "America/New_York"
+
+
+def test_us_empty_state_returns_country_default():
+    assert tz_for_us_state("") == "America/New_York"
+
+
+# ── Country resolution ─────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("country,expected_tz", [
+    ("US", "America/New_York"),
+    ("CA", "America/Toronto"),
+    ("MX", "America/Mexico_City"),
+    ("GB", "Europe/London"),
+    ("UK", "Europe/London"),  # legacy alias
+    ("DE", "Europe/Berlin"),
+    ("JP", "Asia/Tokyo"),
+    ("AU", "Australia/Sydney"),
+])
+def test_country_tz_lookup(country, expected_tz):
+    assert tz_for_country(country) == expected_tz
+
+
+@pytest.mark.parametrize("country,expected_lang", [
+    ("US", "en-US"),
+    ("CA", "en-CA"),
+    ("MX", "es-MX"),
+    ("GB", "en-GB"),
+    ("DE", "de-DE"),
+    ("JP", "ja-JP"),
+])
+def test_country_lang_lookup(country, expected_lang):
+    assert lang_for_country(country) == expected_lang
+
+
+def test_country_case_insensitive():
+    assert tz_for_country("us") == "America/New_York"
+    assert lang_for_country("us") == "en-US"
+
+
+def test_unknown_country_falls_back():
+    """Never invent — fall back to the documented defaults."""
+    assert tz_for_country("XX") == "America/New_York"
+    assert lang_for_country("XX") == "en-US"
+
+
+# ── End-to-end: full diag payload ──────────────────────────────────
+
+
+def test_resolve_phoenix_az_proxy():
+    """Canonical case: Oxylabs returns a Phoenix IP. Chrome should
+    report Mountain Standard Time (no DST = Phoenix-specific)."""
+    diag = {
+        "ip": "208.58.174.149",
+        "city": "Phoenix",
+        "region": "Arizona",
+        "country": "US",
+        "org": "AS7029 Windstream Communications LLC",
+    }
+    tz, lang = resolve_tz_and_lang(diag)
+    assert tz == "America/Phoenix"
+    assert lang == "en-US"
+
+
+def test_resolve_new_york_proxy():
+    diag = {"ip": "1.2.3.4", "city": "Brooklyn", "region": "New York", "country": "US"}
+    tz, lang = resolve_tz_and_lang(diag)
+    assert tz == "America/New_York"
+    assert lang == "en-US"
+
+
+def test_resolve_canadian_proxy():
+    diag = {"city": "Toronto", "region": "Ontario", "country": "CA"}
+    tz, lang = resolve_tz_and_lang(diag)
+    assert tz == "America/Toronto"
+    assert lang == "en-CA"
+
+
+def test_resolve_disabled_proxy_returns_fallback():
+    """proxy_disabled=True flag → use the safe defaults so the env
+    var write is still consistent."""
+    tz, lang = resolve_tz_and_lang({"disabled": True})
+    assert tz == "America/New_York"
+    assert lang == "en-US"
+
+
+def test_resolve_failed_probe_returns_fallback():
+    """diagnose_proxy_egress errored out → don't guess."""
+    tz, lang = resolve_tz_and_lang({"error": "HTTP 503"})
+    assert tz == "America/New_York"
+    assert lang == "en-US"
+
+
+def test_resolve_none_returns_fallback():
+    """Defensive — caller might forget to pass the diag through."""
+    tz, lang = resolve_tz_and_lang(None)
+    assert tz == "America/New_York"
+    assert lang == "en-US"
+
+
+def test_resolve_multi_tz_state_falls_back_to_country():
+    """Florida is multi-tz — should land on country default rather
+    than guess the wrong half."""
+    diag = {"city": "Miami", "region": "Florida", "country": "US"}
+    tz, _ = resolve_tz_and_lang(diag)
+    assert tz == "America/New_York"  # country default
+
+
+def test_resolve_unknown_country_uses_fallback():
+    diag = {"city": "Atlantis", "region": "Mu", "country": "XX"}
+    tz, lang = resolve_tz_and_lang(diag)
+    assert tz == "America/New_York"
+    assert lang == "en-US"
+
+
+def test_resolve_country_only_no_region():
+    """Region missing but country known → country default tz."""
+    diag = {"city": "", "region": "", "country": "DE"}
+    tz, lang = resolve_tz_and_lang(diag)
+    assert tz == "Europe/Berlin"
+    assert lang == "de-DE"


### PR DESCRIPTION
## Summary

Implements **four siblings** under epic #822 (stealth posture v2 — present honestly):

- **#824** — humanlike behavioral signals (pre-click Bezier mouse path, jittered settle)
- **#825** — timezone / locale consistency with proxy exit geo
- **#826** — Browser-Use Plane defaults to patchright (out of headless detectability)
- **#827** — fingerprint diagnostic endpoint (measure what we look like)

**#823 (honest mode — drop Windows spoofing) deferred to its own PR** since it touches the larger `cdp_stealth.py` surface and benefits from the diagnostic endpoint in this PR for verification.

## #824 — humanlike behavioral signals

New `src/mantis_agent/gym/behavioral.py` exposes:

- `bezier_waypoints(start, end, steps)` — cubic Bezier with random perpendicular jitter; successive calls don't trace the same arc.
- `jittered_settle(base)` / `jittered_wait(base)` — randomized delays around the base, floor at `base / 2`.
- `waypoint_delay()` — `uniform(0.005, 0.012)` between waypoints, total curve overhead ≤ 50 ms.

Wired into `xdotool_env.py`: `ActionType.CLICK` / `DOUBLE_CLICK` call `_mousemove_with_curve` which reads the current cursor via `xdotool getmouselocation`, interpolates 3 waypoints, then lands on target. Falls back to direct mousemove when the display isn't reachable or `MANTIS_BEHAVIORAL_JITTER=0`.

## #825 — timezone / locale consistency

New `src/mantis_agent/gym/geo_consistency.py`:

- US state → IANA timezone table (single-tz only; multi-tz fall through to country default).
- Country → IANA timezone + BCP-47 lang.
- `resolve_tz_and_lang(proxy_diag)` is the canonical entry. Unknown countries fall back to `(America/New_York, en-US)` — never invent.

`task_loop.setup_env` resolves the proxy's egress geo (reusing `diagnose_proxy_egress`) and writes the resolved `TZ` / `LANG` into the process env **before Chrome starts**. Chrome inherits them so `Date()` / `Intl.DateTimeFormat()` / `navigator.language` agree with the proxy IP geo a CF / DataDome scorer sees.

Opt-out: `MANTIS_GEO_CONSISTENCY=0`.

## #826 — Browser-Use Plane defaults to patchright

`src/mantis_agent/server/browser_use_agent.py` new `_import_sync_playwright()`:

1. `MANTIS_BROWSER_USE_DRIVER=playwright` → vanilla.
2. `patchright.sync_api` if importable (default).
3. `playwright.sync_api` fallback.

`deploy/modal/browser_use_plane.py` adds `patchright>=1.49` and invokes `python -m patchright install chromium` at image build.

Per `feedback_headless_vs_xvfb.md`, headless Playwright was the v1 limitation blocking CF-protected targets. Patchright strips Playwright's automation tells at the binary level (navigator.webdriver, CDP traces, runtime function signatures) — the plane can serve those targets now.

## #827 — fingerprint diagnostic endpoint

`POST /v1/diagnose/fingerprint` mounted on `modal_cua_server.py`:

```bash
curl -X POST "$ENDPOINT/v1/diagnose/fingerprint" \
  -H "X-Mantis-Token: $TOKEN" -H "Content-Type: application/json" \
  -d '{"target_url": "https://bot.sannysoft.com/"}'
```

- Synthesizes a 2-step plan: navigate → `extract_data` with `max_items: 60` (multi-row branch from #820).
- Returns detached-run envelope + `stealth_snapshot` capturing which stealth flags were active at submit time.
- Each fingerprint test row lands in `extracted_rows.json` for cheap diff across runs.

Tuning workflow: flip a flag, redeploy, re-run, diff `extracted_rows.json`. Documented in `docs/operations/stealth-diagnostics.md`.

## Tests (79 new)

- `test_behavioral_jitter.py` (27) — env gating, Bezier shape, endpoint exclusion, runaway clamp, curvature produces non-straight paths, per-call jitter, settle ranges + floor.
- `test_browser_use_driver_preference.py` (4) — patchright preferred, playwright fallback, env override, case-insensitive.
- `test_geo_consistency.py` (40) — US state code + full-name resolution, country defaults, unknown-region fallback, end-to-end ipinfo payload, disabled / error / None inputs.
- `test_fingerprint_diagnostic.py` (8) — happy path, custom target, validation, stealth snapshot shape, env propagation, plan shape, auth.

## Test plan

- [x] `pytest` on all 4 new test files + adjacent (161 pass)
- [x] `ruff check` clean
- [x] `mkdocs build --strict` clean
- [ ] CI shards green
- [ ] Modal redeploy + diagnostic endpoint smoke against bot.sannysoft.com

Closes #824, closes #825, closes #826, closes #827

🤖 Generated with [Claude Code](https://claude.com/claude-code)