### PR TITLE
feat(stealth): honest mode — present as Linux Chrome instead of fake Windows (closes #823)

### DIFF
--- a/docs/operations/stealth-diagnostics.md
+++ b/docs/operations/stealth-diagnostics.md
@@ -14,7 +14,8 @@ result, and the recommended tuning workflow.
 
 | Variable | Default | Effect |
 |---|---|---|
-| `MANTIS_CDP_STEALTH` | `1` | CDP-injected fingerprint patches (`navigator.webdriver` undefined, plugins, WebGL, etc.). |
+| `MANTIS_CDP_STEALTH` | `1` | Master switch for CDP-injected fingerprint patches. When off, nothing else in this table fires either. |
+| `MANTIS_STEALTH_HONEST` | `1` | **Default-on as of [#823](https://github.com/mercurialsolo/mantis/issues/823).** Present as honest Linux Chrome (matches the binary). Set `0` to fall back to the legacy Windows-claiming deceptive spoof. |
 | `MANTIS_BEHAVIORAL_JITTER` | `1` | Pre-click Bezier mouse path + jittered settle times ([#824](https://github.com/mercurialsolo/mantis/issues/824)). |
 | `MANTIS_GEO_CONSISTENCY` | `1` | Set Chrome's `TZ` and `LANG` to match the proxy exit geo ([#825](https://github.com/mercurialsolo/mantis/issues/825)). |
 | `MANTIS_BROWSER_USE_DRIVER` | unset → `patchright` | Browser-Use Plane driver. Set to `playwright` to force the vanilla import ([#826](https://github.com/mercurialsolo/mantis/issues/826)). |
@@ -109,12 +110,49 @@ so up to 60 fingerprint test rows come back from one Claude call.
 
 ### `MANTIS_CDP_STEALTH=1` (default)
 
-`src/mantis_agent/gym/cdp_stealth.py` injects 12 JS patches at
-`Page.addScriptToEvaluateOnNewDocument` time, plus a CDP
-`Network.setUserAgentOverride` that aligns `sec-ch-ua-*` headers with
-the UA we claim. Patches cover `navigator.webdriver`, `plugins`,
-`languages`, WebGL vendor/renderer, canvas + audio fingerprint noise,
-font enumeration, and platform spoofing.
+Master switch for the CDP-injected stealth path. When on, the
+specific patches that fire are gated by `MANTIS_STEALTH_HONEST`
+(below).
+
+### Honest mode (#823)
+
+`MANTIS_STEALTH_HONEST=1` (the default since the [#827](https://github.com/mercurialsolo/mantis/issues/827)
+fingerprint diagnostic confirmed the legacy spoof was leaking) makes
+Mantis present as the **real Linux Chrome** the binary actually is:
+
+- UA: `Mozilla/5.0 (X11; Linux x86_64) ... Chrome/<actual-major>.0.0.0`. The
+  major version is read from `chrome --version` at startup; falls back
+  to a documented baseline when the binary can't be probed.
+- `sec-ch-ua-platform: "Linux"` — consistent with the UA and with the
+  TLS ClientHello / HTTP/2 SETTINGS Chrome ships with on Linux.
+- WebGL strings: not patched. Real Mesa / SwiftShader values pass
+  through. Inventing `Intel Iris OpenGL Engine` (a macOS string) on a
+  Linux binary contradicted the TLS signal and the spoof was leaking
+  through anyway.
+- Canvas / audio fingerprint noise: not applied. Per-call randomization
+  is itself a detectable signal.
+- `navigator.platform`, `userAgentData.platform`: untouched. Real
+  values agree with the rest of the stack.
+
+The **only** patches that still fire are the unambiguous bot-tell
+removals:
+
+- `navigator.webdriver` returns `undefined`
+- `navigator.plugins` populated with the built-in PDF viewers (real
+  Chrome on every platform has these)
+- `navigator.languages` non-empty
+- `permissions.query("notifications")` returns the real permission
+- `window.chrome.{runtime,app}` shim populated
+- `Function.prototype.toString` proxy keeps the patched
+  `permissions.query` looking native
+
+Hiding `navigator.webdriver` is honest in the sense that no
+*legitimate* user has that flag set; only automation frameworks do.
+We're hiding the *framework*, not pretending to be a different OS.
+
+Opt-out: set `MANTIS_STEALTH_HONEST=0` to fall back to the legacy
+12-patch deceptive set (Windows UA, Intel macOS WebGL, canvas/audio
+noise, etc.). The legacy path is retained one release for rollback.
 
 ### `MANTIS_BEHAVIORAL_JITTER=1` (default)
 
@@ -155,8 +193,8 @@ specifically.
   already handles residual cases).
 - TLS / JA3 spoofing at the network layer. Real Chrome's TLS is the
   honest answer — see the epic for the rationale.
-- `MANTIS_STEALTH_HONEST` (drop Windows spoof, present as real Linux
-  Chrome) — tracked separately as [#823](https://github.com/mercurialsolo/mantis/issues/823).
+- `MANTIS_STEALTH_HONEST=0` is reachable on the legacy code path —
+  reverts to the Windows-claiming spoof. See [Honest mode](#honest-mode-823).
 
 ## See also
 

--- a/src/mantis_agent/gym/cdp_stealth.py
+++ b/src/mantis_agent/gym/cdp_stealth.py
@@ -275,10 +275,15 @@ STEALTH_JS: str = r"""
 })();
 """
 
-# Spoofed UA + UA-CH metadata to claim Windows 10 / Chrome 132.
-# Applied via CDP ``Network.setUserAgentOverride`` so the sec-ch-ua-*
-# request headers also align (the bare ``--user-agent`` Chrome flag
-# only sets User-Agent, not the metadata headers — CF reads both).
+# Spoofed UA + UA-CH metadata. Pre-honest-mode (#823) these claimed
+# Windows 10 / Chrome 132 — but the binary actually runs on Linux, and
+# the TLS ClientHello / HTTP/2 SETTINGS that Chrome sends are detectably
+# Linux-shaped. Scoring models that reconcile UA against the TLS
+# fingerprint flagged the mismatch, raising the bot score. The honest-
+# mode build below presents as the real Linux Chrome (#823 fix for the
+# UA leak the #827 diagnostic surfaced — sannysoft saw the raw
+# ``Mozilla/5.0 (X11; Linux x86_64)...`` UA leak through despite our
+# Windows spoof).
 _SPOOF_UA: str = (
     "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
     "AppleWebKit/537.36 (KHTML, like Gecko) "
@@ -305,6 +310,204 @@ _SPOOF_UA_METADATA: dict[str, Any] = {
     "bitness": "64",
     "wow64": False,
 }
+
+
+def is_honest_mode() -> bool:
+    """Whether honest-presentation mode is active (#823).
+
+    Default ``True`` — opt out with ``MANTIS_STEALTH_HONEST=0`` to
+    fall back to the legacy Windows-claiming UA spoof. Honest mode
+    drops platform spoofing entirely so we don't create a TLS / UA
+    mismatch with the underlying Linux Chrome binary; the bot-tell
+    removals (``navigator.webdriver``, plugins, languages,
+    automation flags) stay in.
+
+    Why default-on: the #827 fingerprint diagnostic against
+    bot.sannysoft.com showed the Windows UA spoof partially leaking
+    (raw Linux UA bleeding through alongside the Windows override).
+    A mixed signal is detectably worse than a consistent honest one;
+    presenting as the Linux Chrome we actually are is the
+    higher-trust posture.
+    """
+    raw = os.environ.get("MANTIS_STEALTH_HONEST", "").strip().lower()
+    if raw in {"0", "false", "no", "off"}:
+        return False
+    return True
+
+
+def _detect_chrome_major_version() -> int:
+    """Best-effort: read the actual Chrome major version from the
+    binary so the UA we emit matches the TLS / HTTP/2 stack the binary
+    ships with. Returns 0 on failure — callers fall back to the
+    documented default.
+
+    Cached on first successful read so we don't spawn a subprocess on
+    every CDP call.
+    """
+    global _CHROME_MAJOR_CACHE
+    if _CHROME_MAJOR_CACHE is not None:
+        return _CHROME_MAJOR_CACHE
+    import subprocess
+    for binary in ("google-chrome", "chromium", "chromium-browser", "chrome"):
+        try:
+            r = subprocess.run(
+                [binary, "--version"], capture_output=True, text=True, timeout=2,
+            )
+            out = (r.stdout or "") + (r.stderr or "")
+            # e.g. "Google Chrome 132.0.6834.110" or "Chromium 131.0.6778.85"
+            import re
+            m = re.search(r"\b(\d+)\.\d+\.\d+\.\d+", out)
+            if m:
+                _CHROME_MAJOR_CACHE = int(m.group(1))
+                return _CHROME_MAJOR_CACHE
+        except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+            continue
+    _CHROME_MAJOR_CACHE = 0
+    return 0
+
+
+_CHROME_MAJOR_CACHE: int | None = None
+# Documented Linux Chrome version baseline. Used when the binary can't
+# be probed (test contexts, future Chrome rename). Bump when production
+# images update to a newer major.
+_HONEST_CHROME_MAJOR_FALLBACK = 132
+
+
+def _honest_ua() -> tuple[str, dict[str, Any]]:
+    """Build the honest Linux Chrome UA + sec-ch-ua-* metadata.
+
+    Reads the binary's actual major version when possible; falls back
+    to ``_HONEST_CHROME_MAJOR_FALLBACK`` when the probe fails. The
+    returned UA, platform, brands, and fullVersionList all consistently
+    say Linux Chrome — no mixed signal across surfaces.
+    """
+    major = _detect_chrome_major_version() or _HONEST_CHROME_MAJOR_FALLBACK
+    ua = (
+        f"Mozilla/5.0 (X11; Linux x86_64) "
+        f"AppleWebKit/537.36 (KHTML, like Gecko) "
+        f"Chrome/{major}.0.0.0 Safari/537.36"
+    )
+    metadata: dict[str, Any] = {
+        "brands": [
+            {"brand": "Not_A Brand", "version": "8"},
+            {"brand": "Chromium", "version": str(major)},
+            {"brand": "Google Chrome", "version": str(major)},
+        ],
+        "fullVersion": f"{major}.0.0.0",
+        "fullVersionList": [
+            {"brand": "Not_A Brand", "version": "8.0.0.0"},
+            {"brand": "Chromium", "version": f"{major}.0.0.0"},
+            {"brand": "Google Chrome", "version": f"{major}.0.0.0"},
+        ],
+        "platform": "Linux",
+        "platformVersion": "6.5.0",
+        "architecture": "x86",
+        "model": "",
+        "mobile": False,
+        "bitness": "64",
+        "wow64": False,
+    }
+    return ua, metadata
+
+
+# Honest-mode JS payload — only the bot-tell removals, no platform
+# spoofing / WebGL invention / canvas+audio noise. Per #823: the
+# leverage isn't fooling the fingerprint hash, it's not triggering
+# escalation in the first place. We DO hide the automation framework
+# leaks (webdriver flag, headless plugin shape) because those are
+# automation-context tells. We DON'T pretend to be Windows when we're
+# on Linux because the TLS / HTTP/2 stack tells the truth anyway.
+STEALTH_JS_HONEST: str = r"""
+(() => {
+  // [1] navigator.webdriver — hide the automation flag. This is the
+  // ONLY signal we still spoof: it's an automation context tell, not
+  // a platform claim.
+  try {
+    Object.defineProperty(navigator, 'webdriver', { get: () => undefined });
+  } catch (e) {}
+
+  // [2] navigator.permissions.query — make notifications report
+  // Notification.permission instead of "denied" (which only happens
+  // in headless / automated contexts).
+  try {
+    const originalQuery = window.navigator.permissions &&
+      window.navigator.permissions.query &&
+      window.navigator.permissions.query.bind(window.navigator.permissions);
+    if (originalQuery) {
+      window.navigator.permissions.query = (parameters) =>
+        parameters && parameters.name === 'notifications'
+          ? Promise.resolve({ state: Notification.permission })
+          : originalQuery(parameters);
+    }
+  } catch (e) {}
+
+  // [3] navigator.plugins — populate with a realistic non-empty array.
+  // Headless Chromium ships with zero plugins; real Chrome (Linux,
+  // Windows, macOS) always has the built-in PDF viewer entries.
+  try {
+    Object.defineProperty(navigator, 'plugins', {
+      get: () => {
+        const plugins = [
+          { name: 'PDF Viewer', filename: 'internal-pdf-viewer', description: 'Portable Document Format' },
+          { name: 'Chrome PDF Viewer', filename: 'internal-pdf-viewer', description: 'Portable Document Format' },
+          { name: 'Chromium PDF Viewer', filename: 'internal-pdf-viewer', description: 'Portable Document Format' },
+          { name: 'Microsoft Edge PDF Viewer', filename: 'internal-pdf-viewer', description: 'Portable Document Format' },
+          { name: 'WebKit built-in PDF', filename: 'internal-pdf-viewer', description: 'Portable Document Format' },
+        ];
+        Object.defineProperty(plugins, 'length', { value: 5 });
+        return plugins;
+      },
+    });
+  } catch (e) {}
+
+  // [4] navigator.languages — empty array is a headless tell.
+  try {
+    Object.defineProperty(navigator, 'languages', { get: () => ['en-US', 'en'] });
+  } catch (e) {}
+
+  // [5] window.chrome.runtime — must exist with a plausible shape
+  // (real Chrome has this object; bare puppeteer / playwright builds
+  // don't unless --enable-features=ChromiumExtensions).
+  try {
+    window.chrome = window.chrome || {};
+    window.chrome.runtime = window.chrome.runtime || {
+      OnInstalledReason: {},
+      OnRestartRequiredReason: {},
+      PlatformArch: {},
+      PlatformNaclArch: {},
+      PlatformOs: {},
+      RequestUpdateCheckStatus: {},
+    };
+    window.chrome.app = window.chrome.app || {
+      InstallState: { DISABLED: 'disabled', INSTALLED: 'installed', NOT_INSTALLED: 'not_installed' },
+      RunningState: { CANNOT_RUN: 'cannot_run', READY_TO_RUN: 'ready_to_run', RUNNING: 'running' },
+    };
+  } catch (e) {}
+
+  // [6] Function.prototype.toString proxy — the patched
+  // permissions.query must still serialize as ``[native code]``
+  // (some scorers probe Function.toString to detect monkey-patches).
+  try {
+    const proxyToString = Function.prototype.toString;
+    Function.prototype.toString = new Proxy(proxyToString, {
+      apply(target, thisArg, args) {
+        if (thisArg === window.navigator.permissions.query) {
+          return 'function query() { [native code] }';
+        }
+        return Reflect.apply(target, thisArg, args);
+      },
+    });
+  } catch (e) {}
+
+  // Deliberately NOT patched in honest mode — the design rationale
+  // and the patches we dropped are documented on the Python side in
+  // ``docs/operations/stealth-diagnostics.md`` (see "What each flag
+  // actually does"). Keeping that documentation in Python rather
+  // than inside the JS payload avoids tripping page-side scorers
+  // that scan injected scripts for strings like the macOS WebGL
+  // renderer name.
+})();
+"""
 
 
 def is_enabled() -> bool:
@@ -341,10 +544,14 @@ def inject_stealth_patches(cdp_call: Callable[[str, dict[str, Any]], tuple[bool,
     """
     if not is_enabled():
         return False
+    # #823: honest mode uses the minimal patch set (bot-tell removals
+    # only, no platform / WebGL / canvas spoofing). Falls back to the
+    # legacy 12-patch deceptive set when opted out.
+    source = STEALTH_JS_HONEST if is_honest_mode() else STEALTH_JS
     try:
         ok, payload = cdp_call(
             "Page.addScriptToEvaluateOnNewDocument",
-            {"source": STEALTH_JS},
+            {"source": source},
         )
         if ok:
             # WARN so Modal's INFO/DEBUG suppression doesn't hide the
@@ -385,18 +592,29 @@ def apply_ua_override(
     """
     if not is_enabled():
         return False
+    # #823: honest mode sends the real Linux Chrome UA (matching the
+    # binary that's actually running). Legacy deceptive path falls
+    # through when opted out — kept on one release for rollback.
+    if is_honest_mode():
+        ua, metadata = _honest_ua()
+        platform_claim = "Linux"
+    else:
+        ua = _SPOOF_UA
+        metadata = _SPOOF_UA_METADATA
+        platform_claim = "Windows"
     try:
         ok, payload = cdp_call(
             "Network.setUserAgentOverride",
             {
-                "userAgent": _SPOOF_UA,
-                "platform": "Windows",
-                "userAgentMetadata": _SPOOF_UA_METADATA,
+                "userAgent": ua,
+                "platform": platform_claim,
+                "userAgentMetadata": metadata,
             },
         )
         if ok:
             logger.warning(
-                "CDP stealth: UA override applied (platform=Windows, chrome=132)",
+                "CDP stealth: UA override applied (platform=%s, chrome=%s)",
+                platform_claim, metadata.get("brands", [{}])[-1].get("version", "?"),
             )
         else:
             logger.warning(

--- a/src/mantis_agent/gym/xdotool_env.py
+++ b/src/mantis_agent/gym/xdotool_env.py
@@ -332,9 +332,20 @@ class XdotoolGymEnv(GymEnvironment):
         # Context at the C++ binding level. More thorough than our
         # JS-injected getParameter patch which is page-context only
         # and can be probed away.
-        _stealth_ext_dir = "/opt/chrome-extensions/webgl-spoof"
-        if os.path.isdir(_stealth_ext_dir):
-            cmd.append(f"--load-extension={_stealth_ext_dir}")
+        #
+        # #823 honest mode: skip the WebGL spoof entirely. Inventing
+        # "Intel Iris OpenGL Engine" (a macOS string) on a Linux
+        # binary running SwiftShader contradicts the TLS / HTTP/2
+        # signal. Real Mesa / SwiftShader strings reported by Linux
+        # Chrome are perfectly legitimate — millions of Linux users
+        # browse the web every day. The diagnostic (#827) against
+        # bot.sannysoft.com showed the spoofed strings were leaking
+        # through anyway; honesty is the higher-trust posture.
+        from .cdp_stealth import is_honest_mode as _is_honest_mode
+        if not _is_honest_mode():
+            _stealth_ext_dir = "/opt/chrome-extensions/webgl-spoof"
+            if os.path.isdir(_stealth_ext_dir):
+                cmd.append(f"--load-extension={_stealth_ext_dir}")
         if self._proxy_server:
             cmd.append(f"--proxy-server={self._proxy_server}")
         # When extra request headers are configured (canonically a sim-env

--- a/tests/test_cdp_stealth_539.py
+++ b/tests/test_cdp_stealth_539.py
@@ -134,16 +134,25 @@ def test_is_enabled_garbage_falls_through_to_enabled(monkeypatch):
 
 def test_inject_calls_cdp_with_correct_method_and_source(monkeypatch):
     """The single observable side-effect: a CDP call to
-    ``Page.addScriptToEvaluateOnNewDocument`` with the STEALTH_JS
-    string as ``source``."""
+    ``Page.addScriptToEvaluateOnNewDocument``.
+
+    Honest mode (#823, default-on as of 2026-06) sends the minimal
+    ``STEALTH_JS_HONEST`` payload (no platform / WebGL / canvas
+    spoofing — just the bot-tell removals). The legacy ``STEALTH_JS``
+    is still reachable via ``MANTIS_STEALTH_HONEST=0`` on this same
+    code path; that opt-out branch is covered by
+    ``test_inject_uses_legacy_source_when_opted_out`` in
+    ``test_stealth_honest_mode.py``.
+    """
     monkeypatch.delenv("MANTIS_CDP_STEALTH", raising=False)
+    monkeypatch.delenv("MANTIS_STEALTH_HONEST", raising=False)
     cdp_call = MagicMock(return_value=(True, {"identifier": "id-001"}))
     ok = cdp_stealth.inject_stealth_patches(cdp_call)
     assert ok is True
     cdp_call.assert_called_once()
     method, params = cdp_call.call_args.args
     assert method == "Page.addScriptToEvaluateOnNewDocument"
-    assert params == {"source": cdp_stealth.STEALTH_JS}
+    assert params == {"source": cdp_stealth.STEALTH_JS_HONEST}
 
 
 def test_inject_noop_when_disabled(monkeypatch):
@@ -250,22 +259,28 @@ def test_stealth_js_patches_platform_spoofing():
 
 def test_apply_ua_override_calls_network_setuseragent(monkeypatch):
     """The single observable side-effect: a CDP call to
-    ``Network.setUserAgentOverride`` with a Windows Chrome UA +
-    full UA-CH metadata so both request-layer and JS-layer
-    fingerprints match."""
+    ``Network.setUserAgentOverride`` with the right UA + full UA-CH
+    metadata so the request-layer and JS-layer surfaces match.
+
+    Honest mode (#823, default-on) sends a Linux Chrome UA that
+    matches the binary the Modal image actually runs. The legacy
+    Windows spoof remains reachable via ``MANTIS_STEALTH_HONEST=0``
+    (covered by ``test_ua_override_sends_windows_when_opted_out``
+    in ``test_stealth_honest_mode.py``).
+    """
     monkeypatch.delenv("MANTIS_CDP_STEALTH", raising=False)
+    monkeypatch.delenv("MANTIS_STEALTH_HONEST", raising=False)
     cdp_call = MagicMock(return_value=(True, {}))
     ok = cdp_stealth.apply_ua_override(cdp_call)
     assert ok is True
     cdp_call.assert_called_once()
     method, params = cdp_call.call_args.args
     assert method == "Network.setUserAgentOverride"
-    # Must spoof a Windows + Chrome 132 UA string.
-    assert "Windows NT 10.0" in params["userAgent"]
-    assert "Chrome/132" in params["userAgent"]
-    # Must include userAgentMetadata for the sec-ch-ua-* headers.
+    # Honest mode → Linux Chrome UA matching the binary.
+    assert "X11; Linux x86_64" in params["userAgent"]
+    assert "Chrome/" in params["userAgent"]
     md = params["userAgentMetadata"]
-    assert md["platform"] == "Windows"
+    assert md["platform"] == "Linux"
     assert md["mobile"] is False
     assert any(b["brand"] == "Google Chrome" for b in md["brands"])
 

--- a/tests/test_stealth_honest_mode.py
+++ b/tests/test_stealth_honest_mode.py
@@ -1,0 +1,246 @@
+"""Tests for honest-presentation stealth mode (#823).
+
+The #827 fingerprint diagnostic against bot.sannysoft.com showed the
+Windows UA spoof leaking — the raw ``Mozilla/5.0 (X11; Linux x86_64)``
+UA bled through alongside the Windows override, and WebGL kept
+reporting the real Google/SwiftShader stack despite our Intel Iris
+spoof. Honest mode (default-on) flips the posture: drop the platform
+deception entirely, send the Linux UA that matches the binary, let
+the real Linux/Mesa WebGL strings through, keep only the automation-
+tell removals (``navigator.webdriver`` undefined, plugins populated,
+languages non-empty).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mantis_agent.gym import cdp_stealth
+from mantis_agent.gym.cdp_stealth import (
+    STEALTH_JS,
+    STEALTH_JS_HONEST,
+    _honest_ua,
+    apply_ua_override,
+    inject_stealth_patches,
+    is_honest_mode,
+)
+
+
+# ── is_honest_mode env gating ─────────────────────────────────────
+
+
+def test_honest_mode_defaults_true(monkeypatch):
+    monkeypatch.delenv("MANTIS_STEALTH_HONEST", raising=False)
+    assert is_honest_mode() is True
+
+
+@pytest.mark.parametrize("value", ["0", "false", "no", "off", "FALSE"])
+def test_honest_mode_falsy_values(monkeypatch, value):
+    monkeypatch.setenv("MANTIS_STEALTH_HONEST", value)
+    assert is_honest_mode() is False
+
+
+@pytest.mark.parametrize("value", ["1", "true", "anything"])
+def test_honest_mode_truthy_values(monkeypatch, value):
+    monkeypatch.setenv("MANTIS_STEALTH_HONEST", value)
+    assert is_honest_mode() is True
+
+
+# ── _honest_ua structure ──────────────────────────────────────────
+
+
+def test_honest_ua_advertises_linux(monkeypatch):
+    """The honest UA must say Linux x86_64 — no platform deception."""
+    monkeypatch.setattr(cdp_stealth, "_CHROME_MAJOR_CACHE", 132)
+    ua, metadata = _honest_ua()
+    assert "X11; Linux x86_64" in ua
+    assert "Chrome/132." in ua
+    assert metadata["platform"] == "Linux"
+
+
+def test_honest_ua_metadata_is_self_consistent(monkeypatch):
+    """sec-ch-ua-* brands and fullVersionList must agree with the UA
+    string's Chrome major. A mixed signal across surfaces is what
+    we're avoiding."""
+    monkeypatch.setattr(cdp_stealth, "_CHROME_MAJOR_CACHE", 132)
+    ua, metadata = _honest_ua()
+    chrome_brand = next(
+        (b for b in metadata["brands"] if "Google Chrome" in b["brand"]),
+        None,
+    )
+    assert chrome_brand is not None
+    assert chrome_brand["version"] == "132"
+    assert metadata["fullVersion"].startswith("132.")
+    assert "Chrome/132." in ua
+
+
+def test_honest_ua_falls_back_when_chrome_missing(monkeypatch):
+    """When the chrome binary can't be probed, fall back to the
+    documented baseline rather than emit Chrome/0.0.0.0."""
+    monkeypatch.setattr(cdp_stealth, "_CHROME_MAJOR_CACHE", 0)
+    ua, metadata = _honest_ua()
+    fallback = cdp_stealth._HONEST_CHROME_MAJOR_FALLBACK
+    assert f"Chrome/{fallback}." in ua
+    assert metadata["fullVersion"].startswith(f"{fallback}.")
+
+
+def test_honest_ua_never_mentions_windows(monkeypatch):
+    monkeypatch.setattr(cdp_stealth, "_CHROME_MAJOR_CACHE", 132)
+    ua, metadata = _honest_ua()
+    assert "Windows" not in ua
+    assert "Win" not in ua
+    assert metadata["platform"].lower() == "linux"
+
+
+# ── STEALTH_JS_HONEST shape ───────────────────────────────────────
+
+
+def test_honest_js_hides_webdriver():
+    """The one signal we still spoof in honest mode is the automation
+    context tell — navigator.webdriver."""
+    assert "navigator, 'webdriver'" in STEALTH_JS_HONEST
+    assert "get: () => undefined" in STEALTH_JS_HONEST
+
+
+def test_honest_js_populates_plugins():
+    """Headless Chromium has zero plugins; real Chrome on every
+    platform has the built-in PDF viewers. Populating the array is
+    truthful (real Chrome users see these)."""
+    assert "PDF Viewer" in STEALTH_JS_HONEST
+    assert "length" in STEALTH_JS_HONEST
+
+
+def test_honest_js_does_not_patch_webgl():
+    """The legacy Intel Iris OpenGL Engine string is a macOS string —
+    contradicted our Linux TLS stack. Honest mode lets Mesa /
+    SwiftShader report truthfully."""
+    assert "Intel Iris" not in STEALTH_JS_HONEST
+    assert "37445" not in STEALTH_JS_HONEST  # UNMASKED_VENDOR_WEBGL constant
+    assert "37446" not in STEALTH_JS_HONEST  # UNMASKED_RENDERER_WEBGL constant
+
+
+def test_honest_js_does_not_patch_canvas():
+    """Per-call canvas noise was itself a tell — real users don't
+    perturb their canvas hash every call."""
+    assert "toDataURL" not in STEALTH_JS_HONEST
+    assert "getImageData" not in STEALTH_JS_HONEST
+
+
+def test_honest_js_does_not_patch_audio():
+    assert "getChannelData" not in STEALTH_JS_HONEST
+    assert "OfflineAudioContext" not in STEALTH_JS_HONEST
+
+
+def test_honest_js_does_not_spoof_platform():
+    """navigator.platform = 'Win32' on a Linux binary creates a
+    mismatch with the TLS stack. Honest mode skips the spoof."""
+    assert "Win32" not in STEALTH_JS_HONEST
+    assert "navigator.platform" not in STEALTH_JS_HONEST
+    assert "userAgentData" not in STEALTH_JS_HONEST
+
+
+def test_honest_js_does_not_fake_fonts():
+    """Claiming Helvetica Neue on Linux contradicts
+    OffscreenCanvas text-metric cross-checks."""
+    assert "Helvetica Neue" not in STEALTH_JS_HONEST
+    assert "document.fonts" not in STEALTH_JS_HONEST
+
+
+def test_honest_js_strictly_smaller_than_deceptive():
+    """The honest payload is the minimal patch set — should be
+    substantially smaller than the legacy deceptive set."""
+    assert len(STEALTH_JS_HONEST) < len(STEALTH_JS)
+
+
+# ── inject_stealth_patches routing ────────────────────────────────
+
+
+def test_inject_uses_honest_source_when_honest(monkeypatch):
+    monkeypatch.delenv("MANTIS_STEALTH_HONEST", raising=False)
+    captured: dict = {}
+
+    def fake_call(method, params):
+        captured["method"] = method
+        captured["source"] = params["source"]
+        return True, {"identifier": "x"}
+
+    inject_stealth_patches(fake_call)
+    assert captured["method"] == "Page.addScriptToEvaluateOnNewDocument"
+    assert captured["source"] is STEALTH_JS_HONEST
+
+
+def test_inject_uses_legacy_source_when_opted_out(monkeypatch):
+    monkeypatch.setenv("MANTIS_STEALTH_HONEST", "0")
+    captured: dict = {}
+
+    def fake_call(method, params):
+        captured["source"] = params["source"]
+        return True, {"identifier": "x"}
+
+    inject_stealth_patches(fake_call)
+    assert captured["source"] is STEALTH_JS
+
+
+def test_inject_noop_when_cdp_stealth_disabled(monkeypatch):
+    """``MANTIS_CDP_STEALTH=0`` disables the patch path entirely —
+    honest mode is a sub-flag, not an override."""
+    monkeypatch.setenv("MANTIS_CDP_STEALTH", "0")
+    monkeypatch.setenv("MANTIS_STEALTH_HONEST", "1")
+    called: list = []
+
+    def fake_call(method, params):
+        called.append((method, params))
+        return True, {}
+
+    result = inject_stealth_patches(fake_call)
+    assert result is False
+    assert called == []
+
+
+# ── apply_ua_override routing ─────────────────────────────────────
+
+
+def test_ua_override_sends_linux_when_honest(monkeypatch):
+    monkeypatch.delenv("MANTIS_STEALTH_HONEST", raising=False)
+    monkeypatch.setattr(cdp_stealth, "_CHROME_MAJOR_CACHE", 132)
+    captured: dict = {}
+
+    def fake_call(method, params):
+        captured["params"] = params
+        return True, {}
+
+    apply_ua_override(fake_call)
+    p = captured["params"]
+    assert "Linux" in p["userAgent"]
+    assert "Windows" not in p["userAgent"]
+    assert p["platform"] == "Linux"
+    assert p["userAgentMetadata"]["platform"] == "Linux"
+
+
+def test_ua_override_sends_windows_when_opted_out(monkeypatch):
+    """Legacy deceptive path still reachable via opt-out."""
+    monkeypatch.setenv("MANTIS_STEALTH_HONEST", "0")
+    captured: dict = {}
+
+    def fake_call(method, params):
+        captured["params"] = params
+        return True, {}
+
+    apply_ua_override(fake_call)
+    p = captured["params"]
+    assert "Windows NT" in p["userAgent"]
+    assert p["platform"] == "Windows"
+    assert p["userAgentMetadata"]["platform"] == "Windows"
+
+
+def test_ua_override_noop_when_cdp_stealth_disabled(monkeypatch):
+    monkeypatch.setenv("MANTIS_CDP_STEALTH", "0")
+    called: list = []
+
+    def fake_call(method, params):
+        called.append((method, params))
+        return True, {}
+
+    result = apply_ua_override(fake_call)
+    assert result is False
+    assert called == []


### PR DESCRIPTION
## Summary

Closes the leaks the [#827](https://github.com/mercurialsolo/mantis/issues/827) fingerprint diagnostic surfaced.

After the diagnostic against `bot.sannysoft.com`:

- `User Agent` row showed `Mozilla/5.0 (X11; Linux x86_64) ...` — the raw Linux UA bled through despite the Windows override.
- `WebGL Vendor` reported `Google Inc.` (real); `WebGL Renderer` reported `ANGLE (Google, Vulkan ... SwiftShader)` (real) — the invented `Intel Iris OpenGL Engine` (a macOS string!) never applied.

A mixed UA / TLS signal is detectably worse than a consistent honest one. Modern bot-detection scoring reconciles the UA against the TLS ClientHello and HTTP/2 SETTINGS Chrome sends — Linux Chrome has its own fingerprint, and millions of legitimate users have it.

## What honest mode does

- UA: `Mozilla/5.0 (X11; Linux x86_64) ... Chrome/<actual-major>.0.0.0`. Major version read from `chrome --version` at startup; documented fallback when probe fails.
- `sec-ch-ua-platform: "Linux"`; `userAgentMetadata.platform` / brands / fullVersionList all agree with the UA major.
- **NOT** patched: WebGL strings (real Mesa/SwiftShader pass through), canvas/audio noise (per-call randomization is itself a tell), `navigator.platform` / `userAgentData.platform` / fonts. The `--load-extension=/opt/chrome-extensions/webgl-spoof` arg is skipped.
- **Kept** — unambiguous automation-context tells, never present on legitimate browsers: `navigator.webdriver → undefined`, plugins populated, languages non-empty, `permissions.query("notifications")` returns real permission, `window.chrome.{runtime,app}` shim, `Function.prototype.toString` proxy for the patched query.

Hiding `navigator.webdriver` is honest in the sense that no *legitimate* user has that flag set; only automation frameworks do. We're hiding the *framework*, not pretending to be a different OS.

## Routing

| Env | Effect |
|---|---|
| `MANTIS_STEALTH_HONEST=1` (default) | `STEALTH_JS_HONEST` + `_honest_ua()` |
| `MANTIS_STEALTH_HONEST=0` | Legacy 12-patch deceptive set + Windows UA spoof — kept one release for rollback |
| `MANTIS_CDP_STEALTH=0` | Master kill switch; nothing fires |

## Files touched

- `src/mantis_agent/gym/cdp_stealth.py` — `is_honest_mode()`, `_detect_chrome_major_version()`, `_honest_ua()`, `STEALTH_JS_HONEST`. `inject_stealth_patches` + `apply_ua_override` route to honest payloads.
- `src/mantis_agent/gym/xdotool_env.py` — skip `--load-extension=/opt/chrome-extensions/webgl-spoof` in honest mode.
- `tests/test_stealth_honest_mode.py` (new, 27 cases) — env gating, `_honest_ua` shape, Linux platform never mentions Windows, fallback when binary unprobed, `STEALTH_JS_HONEST` patch coverage (positive + negative), routing.
- `tests/test_cdp_stealth_539.py` — updated 2 existing tests that asserted the legacy Windows default; now reflect the honest default and cross-reference opt-out coverage.
- `docs/operations/stealth-diagnostics.md` — new "Honest mode" subsection with the full rationale.

## Test plan

- [x] `pytest tests/test_stealth_honest_mode.py tests/test_cdp_stealth_539.py` — 54/54 pass
- [x] `pytest` adjacent stealth tests (behavioral, geo, fingerprint diagnostic) — no regression, 129 total pass
- [x] `ruff check` clean
- [x] `mkdocs build --strict` clean
- [ ] CI shards green
- [ ] Modal redeploy + diagnostic endpoint re-run against bot.sannysoft.com; expect the UA row to consistently show Linux Chrome and the WebGL strings to be real Mesa/SwiftShader (no mixed signal)

Closes #823

🤖 Generated with [Claude Code](https://claude.com/claude-code)