### PR TITLE
feat(observability): surface Augur metadata + bundle access via /v1 routes (closes #838)

### DIFF
--- a/deploy/modal/modal_cua_server.py
+++ b/deploy/modal/modal_cua_server.py
@@ -966,6 +966,15 @@ def _run_holo3_executor(
             if workflow_id else _uuid_for_augur.uuid4().hex[:12]
         )
 
+        # Stamp the API-run-id → augur-run-id mapping into a side-channel
+        # file so the lifecycle endpoint can surface it to operators.
+        # Best-effort — telemetry must never block the run.
+        try:
+            if api_run_id and api_tenant_id:
+                _write_augur_metadata(api_tenant_id, api_run_id, augur_run_id)
+        except Exception as _augur_exc:  # noqa: BLE001
+            print(f"  WARNING: augur metadata write failed: {_augur_exc}")
+
         # #657 PR 2: read the per-domain ``SiteConfig`` from the suite
         # (written by ``build_micro_suite`` after resolving
         # ``MicroPlan.domain`` → DomainProfile). Passing it explicitly
@@ -2152,6 +2161,55 @@ def _read_viewer_url(tenant_id: str, run_id: str) -> str | None:
         return None
 
 
+def _augur_bundle_dir(augur_run_id: str):
+    """Resolve the on-disk Augur bundle directory for ``augur_run_id``.
+
+    Mirrors :func:`mantis_agent.observability.augur.default_out_dir` but
+    runs in the API container's filesystem (no extra import of the
+    augur_sdk package needed). Honors ``MANTIS_AUGUR_DIR`` for the same
+    override the runner reads.
+    """
+    from pathlib import Path as _Path
+    override = os.environ.get("MANTIS_AUGUR_DIR", "").strip()
+    if override:
+        return _Path(override) / augur_run_id
+    root = os.environ.get("MANTIS_DATA_DIR", "/data").strip() or "/data"
+    return _Path(root) / "augur" / augur_run_id
+
+
+def _write_augur_metadata(
+    tenant_id: str, run_id: str, augur_run_id: str,
+) -> None:
+    """Persist the API-run-id → augur-run-id mapping (gap #1 of the
+    observability ergonomics audit).
+
+    Stored in a side-channel file so the executor can stamp it from a
+    different container than the API. The API's lifecycle endpoint
+    reads this on every poll and surfaces ``augur_run_id`` plus a
+    derived bundle URL.
+    """
+    if not augur_run_id:
+        return
+    run_dir = _run_dir(tenant_id, run_id)
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / "augur.json").write_text(json.dumps({
+        "augur_run_id": augur_run_id,
+        "bundle_dir": str(_augur_bundle_dir(augur_run_id)),
+        "dsn_workspace": os.environ.get("AUGUR_DSN_WORKSPACE_URL", "") or "",
+    }))
+    _commit_volume()
+
+
+def _read_augur_metadata(tenant_id: str, run_id: str) -> dict | None:
+    path = _run_dir(tenant_id, run_id) / "augur.json"
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text())
+    except Exception:
+        return None
+
+
 def _write_result(tenant_id: str, run_id: str, result: dict) -> None:
     run_dir = _run_dir(tenant_id, run_id)
     run_dir.mkdir(parents=True, exist_ok=True)
@@ -2769,7 +2827,16 @@ def build_api_app(executor_resolver=None, function_call_lookup=None):
         status = _read_status(tenant.tenant_id, run_id)
         if status is None:
             raise HTTPException(404, f"unknown run_id: {run_id}")
-        return build_phase_response_from_status(status).model_dump()
+        body = build_phase_response_from_status(status).model_dump()
+        # Surface the Augur run id when available so consumers can
+        # cross-link to the Augur workspace / bundle (gap #1 of the
+        # observability ergonomics audit). Best-effort — missing
+        # metadata never breaks the lifecycle response.
+        augur_meta = _read_augur_metadata(tenant.tenant_id, run_id)
+        if augur_meta and augur_meta.get("augur_run_id"):
+            body["augur_run_id"] = augur_meta["augur_run_id"]
+            body["augur_bundle_url"] = f"/v1/runs/{run_id}/augur"
+        return body
 
     @fastapi_app.get("/v1/queue")
     def get_queue(
@@ -2858,6 +2925,111 @@ def build_api_app(executor_resolver=None, function_call_lookup=None):
                 status_code=404, detail=f"artifact not available: {name}",
             )
         return FileResponse(candidate, media_type=media_type, filename=name)
+
+    # ── Augur bundle access (observability ergonomics gap #2) ──────
+    #
+    # The runner writes the per-run Augur DebugSession bundle under
+    # ``/data/augur/<augur_run_id>/`` — separate from the API run dir.
+    # These routes let operators fetch the bundle by Mantis run_id
+    # without needing the Augur SDK workspace.
+    #
+    # Path-traversal guard via ``Path.resolve() + relative_to``. The
+    # allowlist of fetchable files is intentionally narrow — we
+    # don't stream the per-step PNG screenshots (heavyweight, the
+    # live viewer covers that lane).
+
+    _AUGUR_BUNDLE_FILE_TYPES: dict[str, str] = {
+        ".json": "application/json",
+        ".jsonl": "application/jsonl",
+        ".png": "image/png",
+    }
+
+    @fastapi_app.get("/v1/runs/{run_id}/augur")
+    def get_augur_envelope(
+        run_id: str,
+        tenant: TenantConfig = Depends(require_run_scope),
+    ) -> dict:
+        """Return the Augur metadata envelope for this run.
+
+        Includes the ``augur_run_id``, the on-disk bundle directory,
+        a list of fetchable files, and (when configured) the workspace
+        URL the live stream targets.
+        """
+        from pathlib import Path as _Path
+
+        try:
+            vol.reload()
+        except Exception:
+            pass
+        meta = _read_augur_metadata(tenant.tenant_id, run_id)
+        if meta is None:
+            raise HTTPException(
+                404,
+                f"no Augur metadata for run_id={run_id} — either the run "
+                "hasn't started or Augur is disabled",
+            )
+        bundle = _Path(meta.get("bundle_dir", ""))
+        files: list[dict] = []
+        if bundle.exists() and bundle.is_dir():
+            for path in sorted(bundle.rglob("*")):
+                if not path.is_file():
+                    continue
+                rel = path.relative_to(bundle)
+                files.append({
+                    "name": str(rel),
+                    "size_bytes": path.stat().st_size,
+                    "fetch_url": f"/v1/runs/{run_id}/augur/files/{rel}",
+                })
+        return {
+            "run_id": run_id,
+            "augur_run_id": meta.get("augur_run_id", ""),
+            "bundle_dir": meta.get("bundle_dir", ""),
+            "dsn_workspace": meta.get("dsn_workspace", ""),
+            "bundle_present": bool(files),
+            "files": files,
+        }
+
+    @fastapi_app.get("/v1/runs/{run_id}/augur/files/{path:path}")
+    def get_augur_file(
+        run_id: str,
+        path: str,
+        tenant: TenantConfig = Depends(require_run_scope),
+    ):
+        """Stream a specific file from the Augur bundle.
+
+        Path-traversal guard: the resolved path must live under the
+        bundle directory. File extension must be in the allowlist
+        (``.json``, ``.jsonl``, ``.png``). Returns 404 for missing
+        files; 400 for traversal attempts or disallowed extensions.
+        """
+        from pathlib import Path as _Path
+
+        from fastapi.responses import FileResponse
+
+        try:
+            vol.reload()
+        except Exception:
+            pass
+        meta = _read_augur_metadata(tenant.tenant_id, run_id)
+        if meta is None:
+            raise HTTPException(404, f"no Augur metadata for run_id={run_id}")
+        bundle = _Path(meta.get("bundle_dir", "")).resolve()
+        if not bundle.exists():
+            raise HTTPException(404, "augur bundle not present on volume")
+        candidate = (bundle / path).resolve()
+        try:
+            candidate.relative_to(bundle)
+        except ValueError:
+            raise HTTPException(400, "invalid bundle path")
+        if not candidate.exists() or not candidate.is_file():
+            raise HTTPException(404, f"file not in bundle: {path}")
+        ext = candidate.suffix.lower()
+        media_type = _AUGUR_BUNDLE_FILE_TYPES.get(ext)
+        if media_type is None:
+            raise HTTPException(400, f"file type not exposed via HTTP: {ext}")
+        return FileResponse(
+            candidate, media_type=media_type, filename=candidate.name,
+        )
 
     # ── SSE event stream (#808) ────────────────────────────────────
     #

--- a/tests/test_augur_runtime_surface.py
+++ b/tests/test_augur_runtime_surface.py
@@ -1,0 +1,362 @@
+"""Tests for the Augur runtime surface — gap-closing routes (#840+).
+
+Two ergonomic gaps in Augur observability surfaced during the audit:
+
+1. The Mantis ``run_id`` → Augur ``run_id`` mapping isn't visible
+   anywhere user-facing. Operators with a Mantis run_id can't easily
+   find the corresponding Augur session in the workspace.
+
+2. The Augur bundle lives at ``/data/augur/<augur_run_id>/`` but no
+   HTTP route on the Mantis API serves it. To inspect a bundle you
+   had to either SSH into the Modal volume or open the Augur SDK
+   workspace.
+
+This PR adds:
+
+- A side-channel ``augur.json`` written by the executor, mapping
+  ``api_run_id`` → ``augur_run_id``.
+- ``augur_run_id`` + ``augur_bundle_url`` surfaced on the cheap-poll
+  lifecycle response (``GET /v1/runs/{id}``).
+- ``GET /v1/runs/{id}/augur`` — envelope: augur_run_id, bundle_dir,
+  list of fetchable files, workspace URL.
+- ``GET /v1/runs/{id}/augur/files/{path}`` — streams a specific
+  bundle file. Allowlist on extension (``.json``, ``.jsonl``,
+  ``.png``); path-traversal guarded.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("modal")
+
+from fastapi.testclient import TestClient  # noqa: E402 — guarded by importorskip
+
+from mantis_agent import tenant_auth as ta_mod
+
+
+_DEPLOY_MODAL = Path(__file__).resolve().parent.parent / "deploy" / "modal"
+if str(_DEPLOY_MODAL) not in sys.path:
+    sys.path.insert(0, str(_DEPLOY_MODAL))
+
+
+@pytest.fixture
+def mcs(monkeypatch, tmp_path):
+    monkeypatch.setenv("MANTIS_API_TOKEN", "test-token")
+    monkeypatch.setenv("MANTIS_DATA_DIR", str(tmp_path / "mantis-data"))
+    monkeypatch.delenv("MANTIS_TENANT_KEYS_PATH", raising=False)
+    monkeypatch.setenv("AUGUR_DSN_WORKSPACE_URL", "https://augur.example.com/runs")
+    ta_mod.reset_key_store()
+
+    import modal_cua_server as mod  # type: ignore[import-not-found]
+    importlib.reload(mod)
+    mod._RECENT_RUNS.clear()
+    return mod
+
+
+def _h() -> dict:
+    return {"X-Mantis-Token": "test-token", "Content-Type": "application/json"}
+
+
+class _StubCall:
+    object_id = "fc-stub"
+
+    def get(self, timeout: float = 0.1):
+        return {}
+
+    def cancel(self) -> None:
+        return None
+
+
+class _StubExecutor:
+    def spawn(self, *, task_file_contents, **kwargs):
+        return _StubCall()
+
+
+# ── side-channel helpers ──────────────────────────────────────────
+
+
+def test_write_then_read_augur_metadata(mcs):
+    mcs._write_augur_metadata("default", "r1", "augur-r1-abc123")
+    got = mcs._read_augur_metadata("default", "r1")
+    assert got is not None
+    assert got["augur_run_id"] == "augur-r1-abc123"
+    # Bundle dir derives under MANTIS_DATA_DIR/augur/<augur_run_id>.
+    assert "augur" in got["bundle_dir"]
+    assert "augur-r1-abc123" in got["bundle_dir"]
+    # Workspace url surfaced from env.
+    assert got["dsn_workspace"] == "https://augur.example.com/runs"
+
+
+def test_write_skips_empty_augur_run_id(mcs):
+    """Empty id should be a no-op — never write garbage metadata."""
+    mcs._write_augur_metadata("default", "r1", "")
+    assert mcs._read_augur_metadata("default", "r1") is None
+
+
+def test_read_metadata_returns_none_for_unknown_run(mcs):
+    assert mcs._read_augur_metadata("default", "never-submitted") is None
+
+
+def test_bundle_dir_honors_data_dir_env(mcs, monkeypatch, tmp_path):
+    """The bundle path must use ``MANTIS_DATA_DIR/augur/<id>`` —
+    parity with ``observability.augur.default_out_dir`` so the API
+    and the runner agree on where to look."""
+    monkeypatch.setenv("MANTIS_DATA_DIR", str(tmp_path))
+    importlib.reload(mcs)
+    p = mcs._augur_bundle_dir("augur-xyz")
+    assert str(p) == str(tmp_path / "augur" / "augur-xyz")
+
+
+def test_bundle_dir_honors_explicit_override(mcs, monkeypatch, tmp_path):
+    """``MANTIS_AUGUR_DIR`` wins over ``MANTIS_DATA_DIR`` for the
+    Augur-specific path, matching the runner-side helper."""
+    monkeypatch.setenv("MANTIS_AUGUR_DIR", str(tmp_path / "custom"))
+    importlib.reload(mcs)
+    p = mcs._augur_bundle_dir("augur-xyz")
+    assert str(p) == str(tmp_path / "custom" / "augur-xyz")
+
+
+# ── Lifecycle response surfaces augur metadata (gap #1) ───────────
+
+
+def test_lifecycle_response_includes_augur_run_id(mcs):
+    """``GET /v1/runs/{id}`` returns ``augur_run_id`` + bundle URL when
+    the executor has stamped the metadata."""
+    executor = _StubExecutor()
+    app = mcs.build_api_app(
+        executor_resolver=lambda model: executor,
+        function_call_lookup=lambda call_id: executor,
+    )
+    client = TestClient(app)
+
+    # Seed status + augur metadata for the run.
+    mcs._write_status("default", "r1", {
+        "run_id": "r1", "status": "running",
+        "updated_at": "2026-06-09T20:00:00+00:00",
+    })
+    mcs._write_augur_metadata("default", "r1", "augur-r1-abc123")
+
+    r = client.get("/v1/runs/r1", headers=_h())
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["augur_run_id"] == "augur-r1-abc123"
+    assert body["augur_bundle_url"] == "/v1/runs/r1/augur"
+
+
+def test_lifecycle_response_omits_augur_when_missing(mcs):
+    """No augur metadata stamped → lifecycle response doesn't carry
+    the keys (rather than emitting empty strings)."""
+    executor = _StubExecutor()
+    app = mcs.build_api_app(
+        executor_resolver=lambda model: executor,
+        function_call_lookup=lambda call_id: executor,
+    )
+    client = TestClient(app)
+    mcs._write_status("default", "r-noaugur", {
+        "run_id": "r-noaugur", "status": "running",
+        "updated_at": "2026-06-09T20:00:00+00:00",
+    })
+    r = client.get("/v1/runs/r-noaugur", headers=_h())
+    assert r.status_code == 200
+    body = r.json()
+    assert "augur_run_id" not in body
+    assert "augur_bundle_url" not in body
+
+
+# ── Bundle envelope route (gap #2) ────────────────────────────────
+
+
+def test_augur_envelope_returns_metadata_and_files(mcs, tmp_path):
+    executor = _StubExecutor()
+    app = mcs.build_api_app(
+        executor_resolver=lambda model: executor,
+        function_call_lookup=lambda call_id: executor,
+    )
+    client = TestClient(app)
+
+    mcs._write_augur_metadata("default", "r-bundle", "augur-bundle-xyz")
+    # Materialise a small fake bundle.
+    bundle = mcs._augur_bundle_dir("augur-bundle-xyz")
+    bundle.mkdir(parents=True, exist_ok=True)
+    (bundle / "manifest.json").write_text('{"schema_version": "1"}')
+    (bundle / "trace.json").write_text('{"steps": []}')
+    (bundle / "events").mkdir(exist_ok=True)
+    (bundle / "events" / "0001.jsonl").write_text('{"ts": "x", "kind": "step"}\n')
+
+    r = client.get("/v1/runs/r-bundle/augur", headers=_h())
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["augur_run_id"] == "augur-bundle-xyz"
+    assert body["bundle_present"] is True
+    names = sorted(f["name"] for f in body["files"])
+    assert "manifest.json" in names
+    assert "trace.json" in names
+    assert any(n.endswith("0001.jsonl") for n in names)
+
+
+def test_augur_envelope_404_when_no_metadata(mcs):
+    executor = _StubExecutor()
+    app = mcs.build_api_app(
+        executor_resolver=lambda model: executor,
+        function_call_lookup=lambda call_id: executor,
+    )
+    client = TestClient(app)
+    r = client.get("/v1/runs/never/augur", headers=_h())
+    assert r.status_code == 404
+
+
+def test_augur_envelope_bundle_absent_but_metadata_present(mcs):
+    """Metadata stamped but bundle dir doesn't exist yet (race or
+    DebugSession opt-out) → envelope still 200s with bundle_present=False."""
+    executor = _StubExecutor()
+    app = mcs.build_api_app(
+        executor_resolver=lambda model: executor,
+        function_call_lookup=lambda call_id: executor,
+    )
+    client = TestClient(app)
+    mcs._write_augur_metadata("default", "r-no-bundle", "augur-no-bundle")
+
+    r = client.get("/v1/runs/r-no-bundle/augur", headers=_h())
+    assert r.status_code == 200
+    body = r.json()
+    assert body["augur_run_id"] == "augur-no-bundle"
+    assert body["bundle_present"] is False
+    assert body["files"] == []
+
+
+# ── File-fetch route ──────────────────────────────────────────────
+
+
+def test_augur_file_fetch_serves_manifest(mcs):
+    executor = _StubExecutor()
+    app = mcs.build_api_app(
+        executor_resolver=lambda model: executor,
+        function_call_lookup=lambda call_id: executor,
+    )
+    client = TestClient(app)
+
+    mcs._write_augur_metadata("default", "r-fetch", "augur-fetch-id")
+    bundle = mcs._augur_bundle_dir("augur-fetch-id")
+    bundle.mkdir(parents=True, exist_ok=True)
+    payload = '{"schema_version": "1", "run_id": "fetch"}'
+    (bundle / "manifest.json").write_text(payload)
+
+    r = client.get("/v1/runs/r-fetch/augur/files/manifest.json", headers=_h())
+    assert r.status_code == 200
+    assert r.text == payload
+    assert r.headers["content-type"].startswith("application/json")
+
+
+def test_augur_file_fetch_serves_nested_path(mcs):
+    """Nested files like ``events/0001.jsonl`` round-trip through the
+    path matcher correctly."""
+    executor = _StubExecutor()
+    app = mcs.build_api_app(
+        executor_resolver=lambda model: executor,
+        function_call_lookup=lambda call_id: executor,
+    )
+    client = TestClient(app)
+    mcs._write_augur_metadata("default", "r-nest", "augur-nest")
+    bundle = mcs._augur_bundle_dir("augur-nest")
+    (bundle / "events").mkdir(parents=True, exist_ok=True)
+    (bundle / "events" / "0001.jsonl").write_text(
+        '{"ts": "1", "kind": "step"}\n'
+    )
+
+    r = client.get(
+        "/v1/runs/r-nest/augur/files/events/0001.jsonl", headers=_h(),
+    )
+    assert r.status_code == 200
+    assert r.headers["content-type"].startswith("application/jsonl")
+    assert "kind" in r.text
+
+
+def test_augur_file_fetch_blocks_path_traversal(mcs, tmp_path):
+    """``..`` segments must NOT escape the bundle dir."""
+    executor = _StubExecutor()
+    app = mcs.build_api_app(
+        executor_resolver=lambda model: executor,
+        function_call_lookup=lambda call_id: executor,
+    )
+    client = TestClient(app)
+    mcs._write_augur_metadata("default", "r-trav", "augur-trav")
+    bundle = mcs._augur_bundle_dir("augur-trav")
+    bundle.mkdir(parents=True, exist_ok=True)
+    # Plant a sibling file outside the bundle.
+    parent = bundle.parent
+    secret = parent / "secret.txt"
+    secret.write_text("you should not see this")
+
+    r = client.get(
+        "/v1/runs/r-trav/augur/files/../secret.txt", headers=_h(),
+    )
+    # Either 400 (caught by our guard) or 404 (FastAPI route resolution
+    # normalised the path before the handler ran). Both are acceptable;
+    # what's NOT acceptable is 200 + the secret content.
+    assert r.status_code in {400, 404}
+    if r.status_code == 200:
+        assert "you should not see this" not in r.text
+
+
+def test_augur_file_fetch_rejects_disallowed_extension(mcs):
+    executor = _StubExecutor()
+    app = mcs.build_api_app(
+        executor_resolver=lambda model: executor,
+        function_call_lookup=lambda call_id: executor,
+    )
+    client = TestClient(app)
+    mcs._write_augur_metadata("default", "r-ext", "augur-ext")
+    bundle = mcs._augur_bundle_dir("augur-ext")
+    bundle.mkdir(parents=True, exist_ok=True)
+    (bundle / "weird.exe").write_bytes(b"\x00\x00")
+
+    r = client.get(
+        "/v1/runs/r-ext/augur/files/weird.exe", headers=_h(),
+    )
+    assert r.status_code == 400
+
+
+def test_augur_file_fetch_404_for_missing_file(mcs):
+    executor = _StubExecutor()
+    app = mcs.build_api_app(
+        executor_resolver=lambda model: executor,
+        function_call_lookup=lambda call_id: executor,
+    )
+    client = TestClient(app)
+    mcs._write_augur_metadata("default", "r-miss", "augur-miss")
+    bundle = mcs._augur_bundle_dir("augur-miss")
+    bundle.mkdir(parents=True, exist_ok=True)
+    r = client.get(
+        "/v1/runs/r-miss/augur/files/manifest.json", headers=_h(),
+    )
+    assert r.status_code == 404
+
+
+# ── Auth ───────────────────────────────────────────────────────────
+
+
+def test_augur_envelope_requires_auth(mcs):
+    executor = _StubExecutor()
+    app = mcs.build_api_app(
+        executor_resolver=lambda model: executor,
+        function_call_lookup=lambda call_id: executor,
+    )
+    client = TestClient(app)
+    r = client.get("/v1/runs/r1/augur")
+    assert r.status_code in {401, 403}
+
+
+def test_augur_file_fetch_requires_auth(mcs):
+    executor = _StubExecutor()
+    app = mcs.build_api_app(
+        executor_resolver=lambda model: executor,
+        function_call_lookup=lambda call_id: executor,
+    )
+    client = TestClient(app)
+    r = client.get("/v1/runs/r1/augur/files/manifest.json")
+    assert r.status_code in {401, 403}


### PR DESCRIPTION
## Summary

Closes the two ergonomic gaps in Augur observability surfaced during the audit:

- **Gap 1** — Mantis `run_id` ↔ Augur `run_id` mapping wasn't surfaced anywhere user-facing.
- **Gap 2** — No HTTP route on the Mantis API served the on-disk Augur bundle.

## Changes

- **`_write_augur_metadata` / `_read_augur_metadata`** — side-channel `augur.json` written by the executor when `augur_run_id` is minted. Mirrors the existing `viewer.json` pattern.
- **`_augur_bundle_dir`** — parity with `observability.augur.default_out_dir`; honors `MANTIS_AUGUR_DIR` + falls back to `MANTIS_DATA_DIR/augur/<id>`.
- Executor stamps the metadata at the same site that mints `augur_run_id` (run_holo3).
- **`GET /v1/runs/{run_id}`** lifecycle response gains `augur_run_id` + `augur_bundle_url` when metadata is present.
- **`GET /v1/runs/{run_id}/augur`** — full envelope: `{augur_run_id, bundle_dir, dsn_workspace, bundle_present, files: [{name, size_bytes, fetch_url}]}`.
- **`GET /v1/runs/{run_id}/augur/files/{path:path}`** — streams individual bundle files. Allowlisted extensions (`.json` / `.jsonl` / `.png`). Path-traversal guarded via `Path.resolve() + relative_to(bundle_dir)`.

## Usage

```bash
# Get a run's Augur metadata + file list
curl "$ENDPOINT/v1/runs/$RUN_ID/augur" -H "X-Mantis-Token: $TOKEN" | jq

# Fetch a specific bundle file
curl "$ENDPOINT/v1/runs/$RUN_ID/augur/files/manifest.json" -H "X-Mantis-Token: $TOKEN"
curl "$ENDPOINT/v1/runs/$RUN_ID/augur/files/events/0001.jsonl" -H "X-Mantis-Token: $TOKEN"
```

## Tests (17 new)

- Side-channel helpers: round-trip, empty-id no-op, unknown-run None, `MANTIS_DATA_DIR` + `MANTIS_AUGUR_DIR` honored.
- Lifecycle response: `augur_run_id` + `augur_bundle_url` surfaced when present; both keys omitted when not.
- Envelope route: metadata + file list when bundle on disk; `bundle_present=False` when metadata stamped but DebugSession hasn't materialised; 404 when no metadata.
- File-fetch route: serves manifest + nested paths; blocks path traversal; rejects disallowed extensions; 404 for missing files; auth enforced on both.

## Out of scope

- Unifying `reasoning.jsonl` with Augur `events/*.jsonl` into one writer — larger refactor.
- SSE-streaming "Augur events as they land" — the Augur workspace already provides this.

## Test plan

- [x] `pytest tests/test_augur_runtime_surface.py` — 17/17
- [x] Adjacent regression (lifecycle / endpoint) — pass
- [x] `ruff check` clean
- [ ] CI shards green
- [ ] Modal redeploy + verify augur metadata stamped on a real run

Closes #838

🤖 Generated with [Claude Code](https://claude.com/claude-code)