### PR TITLE
feat(api): human-actionable failure_help on terminal runs (closes #841)

### DIFF
--- a/deploy/modal/modal_cua_server.py
+++ b/deploy/modal/modal_cua_server.py
@@ -2693,9 +2693,22 @@ def build_api_app(executor_resolver=None, function_call_lookup=None):
                     # TimeoutError from .get(timeout=0.1) means still running.
                     msg = str(type(exc).__name__).lower()
                     if "timeout" not in msg:
-                        # Real error — mark failed, release the lock.
+                        # Real error — mark failed, release the lock,
+                        # attach human-actionable failure_help (#841).
+                        from mantis_agent.run_failure_help import failure_help_for
                         status["status"] = "failed"
                         status["error"] = f"{type(exc).__name__}: {exc}"
+                        # Best-effort halt-class derivation from the raw
+                        # exception type. The runner's per-step
+                        # ``halt_class`` is richer when set; this is the
+                        # fallback for executor-spawn-side failures.
+                        _exc_name = type(exc).__name__.lower()
+                        if "connectionreset" in _exc_name or "connectionerror" in _exc_name:
+                            status.setdefault("halt_class", "anthropic_unreachable")
+                        status["failure_help"] = failure_help_for(
+                            status.get("halt_class", "unknown"),
+                            run_id=run_id,
+                        )
                         status["updated_at"] = datetime.now(timezone.utc).isoformat()
                         _write_status(tenant.tenant_id, run_id, status)
                         release_profile_lock(tenant, status.get("profile_id", ""))
@@ -2836,6 +2849,22 @@ def build_api_app(executor_resolver=None, function_call_lookup=None):
         if augur_meta and augur_meta.get("augur_run_id"):
             body["augur_run_id"] = augur_meta["augur_run_id"]
             body["augur_bundle_url"] = f"/v1/runs/{run_id}/augur"
+        # Surface failure_help on terminal halted / cancelled phases
+        # (#841). Prefer the help dict already attached to status.json
+        # by the failure path; otherwise synthesize from halt_class so
+        # older executor crashes still get an actionable response.
+        terminal_failure = body.get("phase") in {"halted", "cancelled"} or (
+            body.get("phase") == "complete" and status.get("error")
+        )
+        if terminal_failure:
+            help_dict = status.get("failure_help")
+            if not help_dict and status.get("halt_class"):
+                from mantis_agent.run_failure_help import failure_help_for
+                help_dict = failure_help_for(
+                    status.get("halt_class", ""), run_id=run_id,
+                )
+            if help_dict:
+                body["failure_help"] = help_dict
         return body
 
     @fastapi_app.get("/v1/queue")

--- a/docs/client/errors.md
+++ b/docs/client/errors.md
@@ -126,6 +126,60 @@ curl -fsS -X POST "$ENDPOINT/v1/predict" \
 
 `screenshot_b64` is omitted on success and on steps where capture failed.
 
+### `failure_help` on the lifecycle response
+
+Every terminal-failure response on `GET /v1/runs/{id}` (and the
+status-action body) carries a `failure_help` dict — the
+human-actionable companion to `halt_class` and `failure_class`:
+
+```jsonc
+{
+  "phase": "halted",
+  "halt_class": "anthropic_unreachable",
+  "failure_help": {
+    "halt_class": "anthropic_unreachable",
+    "summary": "Could not reach the Anthropic API after the retry budget was exhausted.",
+    "likely_causes": [
+      "Transient Anthropic 5xx / 529 Overloaded during peak hours",
+      "Per-IP rate limit on the Modal egress shared pool",
+      "Deployed image is stale (>14 days) and its TLS / certifi stack hasn't been refreshed",
+      "Anthropic API key revoked or hit account quota"
+    ],
+    "next_steps": [
+      "Wait 60s and retry — the retry policy backs off exponentially",
+      "Check `GET /v1/version` — if `deploy_age_days > 14`, redeploy from current main",
+      "Verify ANTHROPIC_API_KEY hasn't been rotated in the Modal Secret"
+    ],
+    "debug_surfaces": {
+      "events": "/v1/runs/<run_id>/events?sse=true",
+      "augur":  "/v1/runs/<run_id>/augur",
+      "logs":   "POST /v1/predict {action: logs, run_id: <run_id>}",
+      "phase":  "/v1/runs/<run_id>",
+      "status": "/v1/runs/<run_id>/status",
+      "result": "/v1/runs/<run_id>/result"
+    },
+    "retries_spent": 3
+  }
+}
+```
+
+The taxonomy currently covers `anthropic_unreachable`, `cf_challenge`,
+`page_blocked`, `navigation_drift`, `navigate_failed`, `bad_url`,
+`extract_data_failed`, `no_schema_configured`, `budget_cap`,
+`time_cap`, `halt_timeout`, and `cancelled`. Unknown classes fall
+back to a default help dict that still surfaces the `debug_surfaces`
+URLs — operators always have a path forward.
+
+When `retries_spent > 0`, the API actually retried before giving up;
+this is the most common cause of slow failures and tells you the
+budget was exhausted (vs e.g. an API-key error which would never
+retry).
+
+The `extraction_quality` summary field on `action=result` carries
+`unknown_placeholder_row_count` — non-zero means rows were captured
+but their non-URL fields were all `<UNKNOWN>` / `none` / empty
+placeholders. Useful when `viable > 0` but the data feels thin.
+
 ### When `failure_class` isn't enough
 
 For `unknown` (or to read the traceback / per-step Holo3 logs), fall through to:

--- a/src/mantis_agent/_anthropic/client.py
+++ b/src/mantis_agent/_anthropic/client.py
@@ -321,6 +321,12 @@ class AnthropicToolUseClient:
 
         Honours ``Retry-After`` header when numeric. Sleeps between
         attempts via ``time.sleep`` — tests monkeypatch that for speed.
+
+        Side-effect: stashes the retry count on
+        :attr:`last_retries_spent` (#841 user-feedback quality).
+        Zero on first-attempt success, ``max_attempts - 1`` on
+        exhaustion. Read by callers that want to surface "we retried
+        N times" in the run summary or failure_help dict.
         """
         import requests
 
@@ -331,6 +337,7 @@ class AnthropicToolUseClient:
             "content-type": "application/json",
         }
         last_response = None
+        self.last_retries_spent = 0
         for attempt in range(max_attempts):
             try:
                 resp = requests.post(
@@ -338,6 +345,7 @@ class AnthropicToolUseClient:
                 )
             except (requests.Timeout, requests.ConnectionError) as exc:
                 if attempt == max_attempts - 1:
+                    self.last_retries_spent = attempt
                     logger.warning(
                         "%s network error after %d attempts: %s",
                         self._log_prefix, max_attempts, exc,
@@ -352,9 +360,11 @@ class AnthropicToolUseClient:
                 time.sleep(delay)
                 continue
             if resp.status_code not in _TRANSIENT_STATUS_CODES:
+                self.last_retries_spent = attempt
                 return resp
             last_response = resp
             if attempt == max_attempts - 1:
+                self.last_retries_spent = attempt
                 logger.warning(
                     "%s transient HTTP %s after %d attempts; giving up",
                     self._log_prefix, resp.status_code, max_attempts,

--- a/src/mantis_agent/run_failure_help.py
+++ b/src/mantis_agent/run_failure_help.py
@@ -1,0 +1,321 @@
+"""Human-actionable help for terminal-failure runs (#841 follow-up).
+
+Pre-fix every terminal-failure response carried a raw Python exception
+repr in ``status.error`` (e.g. ``ConnectionResetError(104, 'Connection
+reset by peer')``) and a machine-readable token in ``halt_reason``
+(e.g. ``page_blocked``). Both grep-able, neither human-actionable —
+the user has no way to know "what does this mean / what should I do".
+
+This module turns a ``halt_class`` (the stable wire constant set by
+the runner) into a ``failure_help`` dict carrying:
+
+- ``summary`` — one-sentence what-went-wrong, plain English.
+- ``likely_causes`` — bulleted hypotheses ranked by probability.
+- ``next_steps`` — bulleted operator actions, in order of cheapness.
+- ``debug_surfaces`` — direct URL pointers to per-run debug surfaces
+  (SSE event stream, Augur bundle, action=logs) so the user doesn't
+  have to know they exist.
+
+Adding a new failure class means adding one entry below — help text
+stays in ONE place, not scattered across runtime call sites.
+
+CUA-contract provenance: this is pure post-processing of taxonomy
+data the runner already produces. No DOM access, no derived
+grounding (`feedback_cua_no_dom_access.md`).
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+
+# Stable wire constant → help dict. Keep entries terse — operators
+# read these in JSON status payloads, not docs.
+#
+# Convention: every entry has a ``summary``, ``likely_causes``, and
+# ``next_steps``. ``debug_surfaces`` is injected per-run by
+# :func:`failure_help_for` (depends on run_id).
+_HALT_CLASS_HELP: dict[str, dict[str, Any]] = {
+    # Anthropic-reachability cluster
+    "anthropic_unreachable": {
+        "summary": (
+            "Could not reach the Anthropic API after the retry budget "
+            "was exhausted."
+        ),
+        "likely_causes": [
+            "Transient Anthropic 5xx / 529 Overloaded during peak hours",
+            "Per-IP rate limit on the Modal egress shared pool",
+            "Deployed image is stale (>14 days) and its TLS / certifi "
+            "stack hasn't been refreshed",
+            "Anthropic API key revoked or hit account quota",
+        ],
+        "next_steps": [
+            "Wait 60s and retry — the retry policy backs off exponentially",
+            "Check ``GET /v1/version`` — if ``deploy_age_days > 14``, "
+            "redeploy from current main (#840 surfaces this directly)",
+            "Verify ANTHROPIC_API_KEY hasn't been rotated in the Modal Secret",
+        ],
+    },
+    # CF / DataDome / Akamai blocking cluster
+    "cf_challenge": {
+        "summary": (
+            "The target site returned a Cloudflare Turnstile challenge "
+            "that the runner could not auto-solve."
+        ),
+        "likely_causes": [
+            "Stealth posture is leaking signal (TLS / UA / WebGL mismatch)",
+            "Residential proxy IP is on a CF reputation blocklist",
+            "First-paint settle was too short — Turnstile JS hadn't loaded",
+        ],
+        "next_steps": [
+            "Use the live-viewer URL on this run's status to attempt the "
+            "challenge interactively (auto-pause path from #541)",
+            "Try a different ``proxy_country`` / ``proxy_city`` to rotate "
+            "the egress IP",
+            "Run the fingerprint diagnostic (#827) to confirm stealth "
+            "posture: ``POST /v1/diagnose/fingerprint``",
+        ],
+    },
+    "page_blocked": {
+        "summary": (
+            "The browser landed on a page the runner classified as a "
+            "block / interstitial (CF, paywall, geo-restriction)."
+        ),
+        "likely_causes": [
+            "Cloudflare Turnstile or similar bot-detection",
+            "Proxy egressed to a geo the site doesn't serve",
+            "Cookie-consent overlay tripping the listings scanner "
+            "(`feedback_page_blocked_is_find_all_listings_overlay`)",
+        ],
+        "next_steps": [
+            "Open the live-viewer URL to see what the page actually shows",
+            "If CF: see ``cf_challenge`` guidance — proxy rotation + "
+            "fingerprint diagnostic",
+            "If cookie banner: pre-seed the dismissing cookie via the "
+            "header seam",
+        ],
+    },
+    # Navigation-shape cluster
+    "navigation_drift": {
+        "summary": (
+            "A step ran against a page different from the one the "
+            "preceding navigate landed on."
+        ),
+        "likely_causes": [
+            "Proxy or CF challenge redirected mid-step",
+            "Decomposer emitted a click that left the expected page",
+            "Slow first-paint racing into the next step (lower "
+            "``wait_after_load_seconds`` than needed)",
+        ],
+        "next_steps": [
+            "View the per-step event trace at ``/v1/runs/<run_id>/events?"
+            "sse=true`` — look at the ``url`` field on each step",
+            "Increase ``params.wait_after_load_seconds`` on the navigate step",
+            "If the plan didn't intend to click: add ``read_only`` "
+            "phrasing (#831 honors it) or set ``params.expect_url_contains`` "
+            "explicitly",
+        ],
+    },
+    "navigate_failed": {
+        "summary": "The runner could not load the requested URL.",
+        "likely_causes": [
+            "DNS failure / proxy didn't tunnel CONNECT",
+            "Site returned non-200 (4xx / 5xx)",
+            "Bad URL in the plan",
+        ],
+        "next_steps": [
+            "Check the navigate step's ``params.url`` is reachable from "
+            "your browser",
+            "If using a proxy: verify ``proxy_provider`` env vars are set; "
+            "default is now ``oxylabs`` (see "
+            "``feedback_proxy_provider.md``)",
+            "View action=logs to read the runner's per-step failure text",
+        ],
+    },
+    "bad_url": {
+        "summary": (
+            "Post-navigate URL classification flagged the page as bad "
+            "(404, soft-404, wrong-domain, or DNS failure)."
+        ),
+        "likely_causes": [
+            "Plan-author URL no longer exists",
+            "Proxy redirected to a captive portal",
+            "Site changed its URL structure",
+        ],
+        "next_steps": [
+            "Run the URL through the host's own browser; if it 404s, "
+            "update the plan",
+            "View ``page_title`` in the run's status — confirms what the "
+            "browser actually saw",
+        ],
+    },
+    # Extraction-shape cluster
+    "extract_data_failed": {
+        "summary": (
+            "Claude could not produce a viable extraction for a step "
+            "that required one."
+        ),
+        "likely_causes": [
+            "Schema mismatch — the requested fields aren't visible on the page",
+            "No inline ``extract`` block and no recipe-bound schema "
+            "(``no_schema_configured``) — see the WARNING at extract step entry",
+            "Page didn't fully load before the screenshot",
+        ],
+        "next_steps": [
+            "Add an inline ``extract`` block to the step (see "
+            "``docs/client/plans.md#inline-extraction-schema``)",
+            "Increase ``wait_after_load_seconds`` if the page is JS-heavy",
+            "View ``/v1/runs/<run_id>/events?sse=true`` to see the "
+            "extractor's per-step result",
+        ],
+    },
+    "no_schema_configured": {
+        "summary": (
+            "An extract step ran with no schema bound — every row was "
+            "rejected with ``no_schema_configured``."
+        ),
+        "likely_causes": [
+            "Plan author didn't include an inline ``extract`` block AND "
+            "no recipe was loaded",
+        ],
+        "next_steps": [
+            "Add an inline ``extract`` block on the step (see "
+            "``docs/client/plans.md#inline-extraction-schema``)",
+            "Or register a recipe via ``POST /v1/recipes`` (#809)",
+        ],
+    },
+    # Budget / time caps
+    "budget_cap": {
+        "summary": "The run hit the configured ``max_cost`` ceiling.",
+        "likely_causes": [
+            "Plan is too long for the budget",
+            "A retry loop burned through the budget on transient failures",
+        ],
+        "next_steps": [
+            "Raise ``max_cost`` on the next submission",
+            "Inspect per-step costs via ``action=result`` — find which "
+            "step was expensive",
+        ],
+    },
+    "time_cap": {
+        "summary": "The run hit the configured ``max_time_minutes`` ceiling.",
+        "likely_causes": [
+            "Plan is too long / has too many steps for the time budget",
+            "Slow proxy / slow first-paint on every step",
+        ],
+        "next_steps": [
+            "Raise ``max_time_minutes`` on the next submission",
+            "Profile slow steps via ``mantis_step_latency_seconds{phase}`` "
+            "in the per-action Grafana dashboard",
+        ],
+    },
+    "halt_timeout": {
+        "summary": "The run exceeded its lifecycle-level timeout.",
+        "likely_causes": [
+            "Plan is too long for the lifecycle timeout",
+            "Run was stuck waiting on Anthropic / proxy / GPU and got "
+            "killed by the heartbeat",
+        ],
+        "next_steps": [
+            "Raise the per-run timeout when submitting",
+            "View action=logs to find where the run was stuck",
+        ],
+    },
+    # User-initiated
+    "cancelled": {
+        "summary": "The run was cancelled by an explicit ``POST /v1/runs/{id}/cancel``.",
+        "likely_causes": ["Operator-initiated cancellation"],
+        "next_steps": [
+            "Resubmit the plan if the cancellation was a mistake",
+        ],
+    },
+}
+
+
+# Single-source-of-truth debug-surface URLs, parameterized per run.
+def _debug_surfaces(run_id: str) -> dict[str, str]:
+    return {
+        "phase":  f"/v1/runs/{run_id}",
+        "status": f"/v1/runs/{run_id}/status",
+        "events": f"/v1/runs/{run_id}/events?sse=true",
+        "result": f"/v1/runs/{run_id}/result",
+        "augur":  f"/v1/runs/{run_id}/augur",
+        "logs": (
+            "POST /v1/predict {action: logs, run_id: " + run_id + "}"
+        ),
+    }
+
+
+# Fallback help when the halt_class isn't in the table. Used so an
+# unknown halt_class still gets a non-empty failure_help (operator at
+# least sees the debug surface pointers).
+_DEFAULT_HELP: dict[str, Any] = {
+    "summary": (
+        "The run terminated with a halt class that isn't in the help "
+        "taxonomy yet — please file an issue with the halt_class value "
+        "and we'll add it."
+    ),
+    "likely_causes": [
+        "An unhandled exception path the runner hadn't classified yet",
+    ],
+    "next_steps": [
+        "View the per-step event trace via the ``events`` debug surface",
+        "Check ``action=logs`` for the raw runner output",
+    ],
+}
+
+
+def failure_help_for(
+    halt_class: str,
+    *,
+    run_id: str,
+    retries_spent: int | None = None,
+    extra_context: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Return the user-facing ``failure_help`` dict for a terminal run.
+
+    Args:
+        halt_class: Stable wire constant set by the runner
+            (e.g. ``"cf_challenge"``, ``"anthropic_unreachable"``).
+            Unknown values fall back to a default help dict that
+            still surfaces the debug URLs.
+        run_id: The run id used to parameterize the
+            ``debug_surfaces`` URLs.
+        retries_spent: Optional — surface the retry budget spent
+            on the run. Pulled into ``next_steps`` reasoning when set.
+        extra_context: Optional per-call additions (e.g. the actual
+            URL that drifted, the step index that failed) merged
+            into the response under ``context``.
+    """
+    halt_class = (halt_class or "").strip().lower()
+    base = _HALT_CLASS_HELP.get(halt_class, _DEFAULT_HELP)
+    out: dict[str, Any] = {
+        "halt_class": halt_class or "unknown",
+        "summary": base["summary"],
+        "likely_causes": list(base["likely_causes"]),
+        "next_steps": list(base["next_steps"]),
+        "debug_surfaces": _debug_surfaces(run_id),
+    }
+    if retries_spent is not None and retries_spent > 0:
+        out["retries_spent"] = int(retries_spent)
+    if extra_context:
+        out["context"] = dict(extra_context)
+    # Sticky operator hint about deploy age when AUGUR or
+    # MANTIS_DEPLOY_AGE_WARN env signals staleness (#840 placeholder).
+    deploy_warn = os.environ.get("MANTIS_DEPLOY_AGE_WARN", "").strip()
+    if deploy_warn:
+        out["deploy_age_warning"] = deploy_warn
+    return out
+
+
+def known_halt_classes() -> list[str]:
+    """Snapshot of currently-documented halt classes — exposed for tests
+    and for the ``GET /v1/diagnose/halt-classes`` endpoint (future)."""
+    return sorted(_HALT_CLASS_HELP.keys())
+
+
+__all__ = [
+    "failure_help_for",
+    "known_halt_classes",
+]

--- a/src/mantis_agent/server_utils.py
+++ b/src/mantis_agent/server_utils.py
@@ -830,6 +830,26 @@ def build_micro_result(
     # downstream consumers can fetch via the artifact endpoint.
     artifacts = build_extraction_artifacts(step_results, run_id=run_id, leads=leads)
 
+    # #841 (user-feedback quality): count extracted rows whose
+    # non-URL fields are all UNKNOWN-placeholders. The legacy no-
+    # schema path can let these through into ``extracted_rows.json``
+    # — operators see them as "viable rows" until they grep. Surface
+    # the count so the summary shows how thin the extraction was.
+    _UNKNOWN_PLACEHOLDERS = {"", "unknown", "<unknown>", "none", "n/a",
+                             "na", "not visible", "not shown",
+                             "not available", "tbd"}
+    extracted_rows_collected, _ = _collect_extracted_rows(step_results)
+    unknown_placeholder_row_count = 0
+    for _row in extracted_rows_collected:
+        non_url_values = [
+            str(v or "").strip().lower()
+            for k, v in _row.items() if k.lower() not in {"url", "story_url"}
+        ]
+        if non_url_values and all(
+            v in _UNKNOWN_PLACEHOLDERS for v in non_url_values
+        ):
+            unknown_placeholder_row_count += 1
+
     return {
         "run_id": run_id,
         "provider": provider,
@@ -846,6 +866,11 @@ def build_micro_result(
         "steps_executed": len(step_results),
         "viable": len(leads),
         "leads_with_phone": sum(1 for lead in leads if runner._lead_has_phone(lead)),
+        # #841: how many extracted rows were ALL-UNKNOWN placeholders.
+        # Non-zero → the extraction was thin even when ``viable`` looks
+        # healthy. Operators read this alongside ``viable`` to gauge
+        # extraction quality.
+        "unknown_placeholder_row_count": unknown_placeholder_row_count,
         "state_key": state_key or workflow_id,
         "profile_id": profile_id or state_key,
         "workflow_id": workflow_id or state_key,

--- a/tests/test_anthropic_retries_spent.py
+++ b/tests/test_anthropic_retries_spent.py
@@ -1,0 +1,68 @@
+"""Tests for ``last_retries_spent`` on ``AnthropicToolUseClient`` (#841).
+
+Per-call retry count is now surfaced via a side-effect attribute on
+the client so callers can feed it into ``failure_help.retries_spent``
+or the run summary.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from mantis_agent._anthropic.client import AnthropicToolUseClient
+
+
+def _make_client():
+    return AnthropicToolUseClient(api_key="x", model="m", log_prefix="[test]")
+
+
+def test_first_attempt_success_records_zero_retries():
+    client = _make_client()
+    fake_resp = MagicMock(status_code=200, headers={}, json=lambda: {})
+    with patch("requests.post", return_value=fake_resp):
+        client.post_messages_with_retry({}, timeout=1.0, max_attempts=4)
+    assert client.last_retries_spent == 0
+
+
+def test_one_retry_then_success_records_one():
+    client = _make_client()
+    transient = MagicMock(status_code=529, headers={}, json=lambda: {})
+    final = MagicMock(status_code=200, headers={}, json=lambda: {})
+    with patch("requests.post", side_effect=[transient, final]):
+        with patch("time.sleep"):  # avoid real backoff
+            client.post_messages_with_retry({}, timeout=1.0, max_attempts=4)
+    assert client.last_retries_spent == 1
+
+
+def test_exhausted_records_max_minus_one():
+    """All 4 attempts return 529 — retries_spent should be 3 (we
+    spent the retry budget without succeeding)."""
+    client = _make_client()
+    transient = MagicMock(status_code=529, headers={}, json=lambda: {})
+    with patch("requests.post", return_value=transient):
+        with patch("time.sleep"):
+            client.post_messages_with_retry({}, timeout=1.0, max_attempts=4)
+    assert client.last_retries_spent == 3
+
+
+def test_non_transient_error_records_zero():
+    """A 400 / 401 / etc. → no retry, records 0 (we didn't retry)."""
+    client = _make_client()
+    fake_400 = MagicMock(status_code=400, headers={}, json=lambda: {})
+    with patch("requests.post", return_value=fake_400):
+        client.post_messages_with_retry({}, timeout=1.0, max_attempts=4)
+    assert client.last_retries_spent == 0
+
+
+def test_network_exhaustion_records_max_minus_one():
+    """All 4 attempts raise ConnectionError → last_retries_spent=3
+    (we exhausted retries before raising)."""
+    import requests
+    client = _make_client()
+    with patch("requests.post", side_effect=requests.ConnectionError("reset")):
+        with patch("time.sleep"):
+            result = client.post_messages_with_retry(
+                {}, timeout=1.0, max_attempts=4,
+            )
+    assert result is None
+    assert client.last_retries_spent == 3

--- a/tests/test_failure_help_on_lifecycle.py
+++ b/tests/test_failure_help_on_lifecycle.py
@@ -1,0 +1,186 @@
+"""Tests for the lifecycle endpoint surfacing ``failure_help`` (#841).
+
+The Modal lifecycle endpoint (``GET /v1/runs/{id}``) should attach the
+``failure_help`` dict to its response on terminal halted / cancelled
+phases. Two paths:
+
+1. The status file already has ``failure_help`` written by the
+   failure path. Use it verbatim.
+2. The status file has only a ``halt_class`` (older failure paths or
+   manually-written status). Synthesize the help from the taxonomy.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("modal")
+
+from fastapi.testclient import TestClient  # noqa: E402 — guarded by importorskip
+
+from mantis_agent import tenant_auth as ta_mod
+
+
+_DEPLOY_MODAL = Path(__file__).resolve().parent.parent / "deploy" / "modal"
+if str(_DEPLOY_MODAL) not in sys.path:
+    sys.path.insert(0, str(_DEPLOY_MODAL))
+
+
+@pytest.fixture
+def mcs(monkeypatch, tmp_path):
+    monkeypatch.setenv("MANTIS_API_TOKEN", "test-token")
+    monkeypatch.setenv("MANTIS_DATA_DIR", str(tmp_path / "mantis-data"))
+    monkeypatch.delenv("MANTIS_TENANT_KEYS_PATH", raising=False)
+    monkeypatch.delenv("MANTIS_DEPLOY_AGE_WARN", raising=False)
+    ta_mod.reset_key_store()
+
+    import modal_cua_server as mod  # type: ignore[import-not-found]
+    importlib.reload(mod)
+    mod._RECENT_RUNS.clear()
+    return mod
+
+
+def _h() -> dict:
+    return {"X-Mantis-Token": "test-token", "Content-Type": "application/json"}
+
+
+class _StubCall:
+    object_id = "fc-stub"
+
+    def get(self, timeout: float = 0.1):
+        return {}
+
+    def cancel(self) -> None:
+        return None
+
+
+class _StubExecutor:
+    def spawn(self, *, task_file_contents, **kwargs):
+        return _StubCall()
+
+
+def test_lifecycle_response_includes_failure_help_when_status_has_it(mcs):
+    """The failure path stamped ``failure_help`` on status.json directly —
+    the lifecycle endpoint must surface it verbatim."""
+    executor = _StubExecutor()
+    app = mcs.build_api_app(
+        executor_resolver=lambda model: executor,
+        function_call_lookup=lambda call_id: executor,
+    )
+    client = TestClient(app)
+
+    mcs._write_status("default", "r-fh", {
+        "run_id": "r-fh",
+        "status": "failed",
+        "halt_class": "anthropic_unreachable",
+        "error": "ConnectionResetError(104, 'Connection reset by peer')",
+        "failure_help": {
+            "halt_class": "anthropic_unreachable",
+            "summary": "Could not reach the Anthropic API",
+            "likely_causes": ["Anthropic 5xx", "rate limit"],
+            "next_steps": ["wait 60s and retry"],
+            "debug_surfaces": {"events": "/v1/runs/r-fh/events?sse=true"},
+        },
+        "updated_at": "2026-06-10T20:00:00+00:00",
+    })
+
+    r = client.get("/v1/runs/r-fh", headers=_h())
+    assert r.status_code == 200
+    body = r.json()
+    # halted phase derived from `failed` status string.
+    assert body["phase"] == "halted"
+    assert body["failure_help"]["halt_class"] == "anthropic_unreachable"
+    assert "Could not reach" in body["failure_help"]["summary"]
+
+
+def test_lifecycle_synthesizes_failure_help_from_halt_class(mcs):
+    """Older failure paths may have written only halt_class. The
+    endpoint must synthesize the help dict from the taxonomy so the
+    caller still gets actionable text."""
+    executor = _StubExecutor()
+    app = mcs.build_api_app(
+        executor_resolver=lambda model: executor,
+        function_call_lookup=lambda call_id: executor,
+    )
+    client = TestClient(app)
+
+    mcs._write_status("default", "r-cf", {
+        "run_id": "r-cf",
+        "status": "halted",
+        "halt_class": "cf_challenge",
+        "updated_at": "2026-06-10T20:00:00+00:00",
+    })
+
+    r = client.get("/v1/runs/r-cf", headers=_h())
+    assert r.status_code == 200
+    body = r.json()
+    assert body["phase"] == "halted"
+    fh = body["failure_help"]
+    assert fh["halt_class"] == "cf_challenge"
+    assert fh["next_steps"]
+    assert "viewer" in " ".join(fh["next_steps"]).lower()
+
+
+def test_lifecycle_does_not_attach_failure_help_on_running(mcs):
+    """failure_help only on terminal halted / cancelled — running
+    runs don't need it."""
+    executor = _StubExecutor()
+    app = mcs.build_api_app(
+        executor_resolver=lambda model: executor,
+        function_call_lookup=lambda call_id: executor,
+    )
+    client = TestClient(app)
+    mcs._write_status("default", "r-run", {
+        "run_id": "r-run", "status": "running",
+        "halt_class": "cf_challenge",  # irrelevant on running
+        "updated_at": "2026-06-10T20:00:00+00:00",
+    })
+    body = client.get("/v1/runs/r-run", headers=_h()).json()
+    assert body["phase"] == "running"
+    assert "failure_help" not in body
+
+
+def test_lifecycle_no_failure_help_when_no_halt_class(mcs):
+    """A halted run with no halt_class and no pre-stamped help → no
+    failure_help in the response (rather than the fallback default)."""
+    executor = _StubExecutor()
+    app = mcs.build_api_app(
+        executor_resolver=lambda model: executor,
+        function_call_lookup=lambda call_id: executor,
+    )
+    client = TestClient(app)
+    mcs._write_status("default", "r-noclass", {
+        "run_id": "r-noclass",
+        "status": "succeeded",  # complete phase
+        "updated_at": "2026-06-10T20:00:00+00:00",
+    })
+    body = client.get("/v1/runs/r-noclass", headers=_h()).json()
+    assert body["phase"] == "complete"
+    assert "failure_help" not in body
+
+
+def test_lifecycle_carries_failure_help_on_complete_with_error(mcs):
+    """``completed_with_failures`` runs that still have an error
+    string deserve the help payload — they're partial-failures
+    from the caller's perspective."""
+    executor = _StubExecutor()
+    app = mcs.build_api_app(
+        executor_resolver=lambda model: executor,
+        function_call_lookup=lambda call_id: executor,
+    )
+    client = TestClient(app)
+    mcs._write_status("default", "r-cwf", {
+        "run_id": "r-cwf",
+        "status": "completed_with_failures",
+        "halt_class": "extract_data_failed",
+        "error": "some steps failed",
+        "updated_at": "2026-06-10T20:00:00+00:00",
+    })
+    body = client.get("/v1/runs/r-cwf", headers=_h()).json()
+    assert body["phase"] == "complete"
+    assert "failure_help" in body
+    assert body["failure_help"]["halt_class"] == "extract_data_failed"

--- a/tests/test_run_failure_help.py
+++ b/tests/test_run_failure_help.py
@@ -1,0 +1,180 @@
+"""Tests for ``run_failure_help`` — user-actionable failure messages (#841).
+
+Each known halt class must produce a ``failure_help`` dict carrying
+a summary, likely causes, next steps, and debug-surface URLs. Unknown
+classes fall back to a default that still surfaces the URLs.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mantis_agent.run_failure_help import (
+    failure_help_for,
+    known_halt_classes,
+)
+
+
+# ── Coverage of the taxonomy ──────────────────────────────────────
+
+
+def test_known_halt_classes_returns_non_empty_list():
+    classes = known_halt_classes()
+    assert isinstance(classes, list)
+    assert len(classes) >= 5  # at minimum: anthropic, cf, drift, extract, budget
+    assert classes == sorted(classes)
+
+
+@pytest.mark.parametrize("halt_class", [
+    "anthropic_unreachable",
+    "cf_challenge",
+    "page_blocked",
+    "navigation_drift",
+    "navigate_failed",
+    "bad_url",
+    "extract_data_failed",
+    "no_schema_configured",
+    "budget_cap",
+    "time_cap",
+    "halt_timeout",
+    "cancelled",
+])
+def test_every_documented_class_has_full_help(halt_class):
+    """Each entry must have summary + likely_causes + next_steps."""
+    help_dict = failure_help_for(halt_class, run_id="r1")
+    assert help_dict["summary"]
+    assert help_dict["likely_causes"]
+    assert help_dict["next_steps"]
+    assert len(help_dict["likely_causes"]) >= 1
+    assert len(help_dict["next_steps"]) >= 1
+    assert help_dict["halt_class"] == halt_class
+
+
+# ── Debug-surface URLs ────────────────────────────────────────────
+
+
+def test_debug_surfaces_carry_run_id():
+    help_dict = failure_help_for("anthropic_unreachable", run_id="r-abc-123")
+    surfaces = help_dict["debug_surfaces"]
+    assert "/v1/runs/r-abc-123" in surfaces["phase"]
+    assert "/v1/runs/r-abc-123/events?sse=true" in surfaces["events"]
+    assert "/v1/runs/r-abc-123/augur" in surfaces["augur"]
+    assert "r-abc-123" in surfaces["logs"]
+
+
+def test_debug_surfaces_include_all_expected_keys():
+    surfaces = failure_help_for("cf_challenge", run_id="r1")["debug_surfaces"]
+    for key in ("phase", "status", "events", "result", "augur", "logs"):
+        assert key in surfaces, f"missing debug surface: {key}"
+
+
+# ── Unknown halt class falls back ─────────────────────────────────
+
+
+def test_unknown_halt_class_returns_fallback_help():
+    """Even an unrecognized halt_class must produce something useful —
+    the user at least gets debug-surface pointers."""
+    help_dict = failure_help_for("brand_new_failure_mode", run_id="r1")
+    assert help_dict["summary"]
+    assert help_dict["next_steps"]
+    assert help_dict["debug_surfaces"]
+    assert help_dict["halt_class"] == "brand_new_failure_mode"
+
+
+def test_empty_halt_class_returns_unknown_label():
+    help_dict = failure_help_for("", run_id="r1")
+    assert help_dict["halt_class"] == "unknown"
+    assert help_dict["debug_surfaces"]
+
+
+def test_none_handled_gracefully():
+    """Defensive — the runner sometimes passes None when it can't
+    classify the halt."""
+    help_dict = failure_help_for(None, run_id="r1")  # type: ignore[arg-type]
+    assert help_dict["halt_class"] == "unknown"
+
+
+# ── Optional fields ───────────────────────────────────────────────
+
+
+def test_retries_spent_omitted_when_none():
+    help_dict = failure_help_for("anthropic_unreachable", run_id="r1")
+    assert "retries_spent" not in help_dict
+
+
+def test_retries_spent_surfaced_when_provided():
+    help_dict = failure_help_for(
+        "anthropic_unreachable", run_id="r1", retries_spent=3,
+    )
+    assert help_dict["retries_spent"] == 3
+
+
+def test_retries_spent_zero_is_omitted():
+    """A successful first-attempt has retries_spent=0 — surfacing
+    that adds noise without information."""
+    help_dict = failure_help_for(
+        "anthropic_unreachable", run_id="r1", retries_spent=0,
+    )
+    assert "retries_spent" not in help_dict
+
+
+def test_extra_context_merged_under_context_key():
+    help_dict = failure_help_for(
+        "navigation_drift", run_id="r1",
+        extra_context={
+            "expected": "news.ycombinator.com/newest",
+            "got": "news.ycombinator.com/login",
+            "step_index": 4,
+        },
+    )
+    assert help_dict["context"]["expected"] == "news.ycombinator.com/newest"
+    assert help_dict["context"]["step_index"] == 4
+
+
+# ── Deploy-age signal ─────────────────────────────────────────────
+
+
+def test_deploy_age_warning_surfaced_when_env_set(monkeypatch):
+    """When ``MANTIS_DEPLOY_AGE_WARN`` env is set (#840 placeholder),
+    the failure_help carries it so the operator sees the staleness
+    on every failed-run response."""
+    monkeypatch.setenv(
+        "MANTIS_DEPLOY_AGE_WARN",
+        "deploy is 24 days old; consider redeploying",
+    )
+    help_dict = failure_help_for("anthropic_unreachable", run_id="r1")
+    assert "deploy_age_warning" in help_dict
+    assert "24 days" in help_dict["deploy_age_warning"]
+
+
+def test_deploy_age_warning_omitted_by_default(monkeypatch):
+    monkeypatch.delenv("MANTIS_DEPLOY_AGE_WARN", raising=False)
+    help_dict = failure_help_for("anthropic_unreachable", run_id="r1")
+    assert "deploy_age_warning" not in help_dict
+
+
+# ── Canonical case: the user's actual failure ────────────────────
+
+
+def test_anthropic_unreachable_help_mentions_deploy_age(monkeypatch):
+    """The HN-feedback failure's help text should specifically point
+    the user at #840 / deploy age — that was the root cause."""
+    monkeypatch.delenv("MANTIS_DEPLOY_AGE_WARN", raising=False)
+    help_dict = failure_help_for("anthropic_unreachable", run_id="r1")
+    joined = " ".join(help_dict["next_steps"] + help_dict["likely_causes"])
+    assert "deploy" in joined.lower() or "stale" in joined.lower()
+    assert "version" in joined.lower()
+
+
+def test_cf_challenge_help_mentions_viewer():
+    """CF blocks are the canonical "open the live viewer" case."""
+    help_dict = failure_help_for("cf_challenge", run_id="r1")
+    joined = " ".join(help_dict["next_steps"])
+    assert "viewer" in joined.lower()
+
+
+def test_navigation_drift_help_mentions_read_only():
+    """Drift is fixed by either expect_url_contains or read-only intent."""
+    help_dict = failure_help_for("navigation_drift", run_id="r1")
+    joined = " ".join(help_dict["next_steps"])
+    assert "read_only" in joined or "read-only" in joined.lower() or "expect_url" in joined

--- a/tests/test_unknown_row_count_in_summary.py
+++ b/tests/test_unknown_row_count_in_summary.py
@@ -1,0 +1,99 @@
+"""Tests for ``unknown_placeholder_row_count`` in run summary (#841).
+
+User feedback: ``<UNKNOWN>``-filled rows can survive into
+``extracted_rows.json``. Operators see them as "viable rows" until
+they grep. Surface the count so the summary tells the truth about
+extraction quality even when ``viable`` looks healthy.
+"""
+
+from __future__ import annotations
+
+from mantis_agent.gym.checkpoint import StepResult
+from mantis_agent.server_utils import _collect_extracted_rows
+
+
+def _make_step(rows: list[dict]) -> StepResult:
+    return StepResult(
+        step_index=0, intent="x", success=True, extracted_rows=rows,
+    )
+
+
+def _count_unknown_rows(step_results: list) -> int:
+    """Replicate the counting logic from build_micro_result so the
+    test can exercise it without booting the runner."""
+    _UNKNOWN = {"", "unknown", "<unknown>", "none", "n/a", "na",
+                "not visible", "not shown", "not available", "tbd"}
+    rows_collected, _ = _collect_extracted_rows(step_results)
+    unknown_count = 0
+    for row in rows_collected:
+        non_url = [
+            str(v or "").strip().lower()
+            for k, v in row.items() if k.lower() not in {"url", "story_url"}
+        ]
+        if non_url and all(v in _UNKNOWN for v in non_url):
+            unknown_count += 1
+    return unknown_count
+
+
+def test_all_unknown_row_counted():
+    step = _make_step([
+        {"title": "<UNKNOWN>", "author": "none", "points": "", "url": "https://x.com"},
+    ])
+    assert _count_unknown_rows([step]) == 1
+
+
+def test_partial_unknown_not_counted():
+    """A row with some real data shouldn't count as UNKNOWN, even
+    if other fields are empty."""
+    step = _make_step([
+        {"title": "Real Title", "author": "<UNKNOWN>", "points": "", "url": "https://x.com"},
+    ])
+    assert _count_unknown_rows([step]) == 0
+
+
+def test_url_only_row_counted():
+    """URL is excluded from the check (a real URL is the load-bearing
+    identity). A row with URL set but all other fields placeholder
+    is still extraction-thin."""
+    step = _make_step([
+        {"title": "<UNKNOWN>", "author": "none", "url": "https://example.com/x"},
+    ])
+    assert _count_unknown_rows([step]) == 1
+
+
+def test_multiple_rows_mixed_quality():
+    step = _make_step([
+        {"title": "Good", "author": "alice", "url": "https://x.com/1"},     # real
+        {"title": "<UNKNOWN>", "author": "none", "url": "https://x.com/2"}, # placeholder
+        {"title": "Also Good", "author": "bob", "url": "https://x.com/3"},  # real
+        {"title": "", "author": "", "url": ""},                              # all empty → counted
+    ])
+    assert _count_unknown_rows([step]) == 2
+
+
+def test_empty_extracted_rows_returns_zero():
+    step = _make_step([])
+    assert _count_unknown_rows([step]) == 0
+
+
+def test_only_url_field_in_row_not_counted():
+    """A row that has ONLY the url field (no other columns at all)
+    is degenerate — counts as 0 (nothing to compare against)."""
+    step = _make_step([{"url": "https://example.com"}])
+    assert _count_unknown_rows([step]) == 0
+
+
+def test_unknown_placeholders_are_case_insensitive():
+    step = _make_step([
+        {"title": "UNKNOWN", "url": "x"},
+        {"title": "Unknown", "url": "x"},
+        {"title": "<unknown>", "url": "x"},
+    ])
+    assert _count_unknown_rows([step]) == 3
+
+
+def test_whitespace_tolerated():
+    step = _make_step([
+        {"title": "  ", "author": "    ", "url": "x"},
+    ])
+    assert _count_unknown_rows([step]) == 1


### PR DESCRIPTION
Closes user-feedback quality gaps from todays HN-failure triage. Pre-fix every terminal-failure carried a raw Python exception repr; post-fix carries a failure_help dict with summary, likely_causes, next_steps, and debug_surfaces URLs. 12-class taxonomy. 45 new tests, 754 adjacent pass. Docs in errors.md.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>