### PR TITLE
docs(plans): note where multi-row rows surface in the response

### DIFF
--- a/docs/client/plans.md
+++ b/docs/client/plans.md
@@ -243,6 +243,17 @@ behind a "Show" button, full job description on a sub-page), the
 single-row `extract_data` inside a `collect_urls` → `loop` chain is
 still the right pattern.
 
+**Where multi-row rows surface in the response.** The captured rows
+land in three places, all consistent since [#842](https://github.com/mercurialsolo/mantis/pull/842):
+
+- `extracted_rows.json` / `extracted_rows.csv` artifacts — one entry per row, canonical structured form
+- `leads.csv` artifact — same rows in CSV summary form
+- Lifecycle envelope — `viable: N` counts every row whose `required: true` fields are all populated, and `leads: [...]` carries one `"VIABLE | Field: value | …"` summary string per row
+
+Pre-#842 the counter and summary array silently reported `viable: 0`
+and `leads: []` even when the multi-row primitive captured rows
+correctly — only the artifacts were trustworthy. They now agree.
+
 ## Control-flow primitives
 
 For plans that need to vary their behaviour based on what the page


### PR DESCRIPTION
## Summary
- After [#842](https://github.com/mercurialsolo/mantis/pull/842) fixed the `viable` counter and `leads[]` array to reflect multi-row branch rows, callers reading `docs/client/plans.md` had no signal that the lifecycle envelope is now trustworthy for multi-row runs.
- Adds a short note under the multi-row `max_items` section listing the three places captured rows surface (artifacts / `leads.csv` / lifecycle envelope) and calling out that pre-#842 the counter silently lied (`viable: 0` despite N rows in the artifact).

## Test plan
- [x] No code change — docs-only
- [ ] CI markdown lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)