### PR TITLE
sim_envs: shopify Partners mirror + post-login fidelity polish (fiverr/indeed/linkedin/mercor)

### DIFF
--- a/deploy/sim_envs/_shopify_spec.md
+++ b/deploy/sim_envs/_shopify_spec.md
@@ -1,0 +1,304 @@
+# mantis_shopify — Shopify Partners mirror spec
+
+Captured 2026-06-08 from a live Shopify Partners dashboard via Chrome
+MCP. The aim is a functional, high-fidelity mirror of the Partners
+back office IA — usable as a CUA training sim env with oracles. The
+**App distribution / `/apps`** sub-section is intentionally excluded
+per scope.
+
+Path prefix in the mirror: all routes hang off `/`. Partners uses
+`/<partner_id>/<section>` in production; we drop the partner-id
+segment since the env is single-tenant.
+
+---
+
+## Global chrome
+
+- **Topbar** (`<header class="sp-topbar">`)
+  - Brand mark: green leaf shopping-bag glyph + "shopify partners"
+    in italic Shopify Sans (use any web-safe italic serif fallback;
+    `font-family: "Source Serif Pro", Georgia, serif; font-style:italic`).
+  - Center: **Search input** with magnifier glyph, full-width 720px max.
+  - Right cluster: **Notifications bell** with red badge (number),
+    **avatar chip** with initials + name + subtitle (display name on
+    one line, email/business name on a second line).
+- **Left sidebar** (`<aside class="sp-sidebar">`, 232px wide)
+  - **Group 1 (main, no header)**
+    - Home → `/`
+    - Stores → `/stores`
+    - Sales → `/sales` (sub-nav: Leads, Referrals)
+    - Catalogs → `/catalogs` (we DO include this — sidebar showed it)
+    - Themes → `/themes`
+    - Partner Directory → `/partner_directory` (sub-nav: Profile)
+    - Shopify POS → `/pos`
+  - **Group 2 — "Resources"** (group label small all-caps grey)
+    - Partner docs → `/docs/partner`
+    - Product docs → `/docs/product`
+    - Support → `/support`
+  - **Group 3 — "Admin"**
+    - Payouts → `/payouts`
+    - Team → `/team`
+    - Settings → `/settings`
+  - Each row: 20-px glyph + label; **active** row gets a 4-px green
+    bar on the left edge + green text + light-grey background tint.
+- **Page surface**: light grey body `#f6f6f7`. Content cards: white,
+  `border-radius: 8px`, `box-shadow: 0 0 0 1px #e1e3e5, 0 1px 0
+  rgba(0,0,0,0.05)`.
+- **Primary CTA**: filled green `#008060` button, `border-radius:
+  6px`.
+- **Secondary button**: white with `#c9cccf` border.
+- **Topbar banner row** (only on some pages): yellow `#ffeb78` strip
+  with "Update emergency contact information" text + dismiss × +
+  "Add contact information" inline button.
+
+Colour palette captured:
+- Sidebar bg: `#f6f6f7` (same as body).
+- Active row tint: `#ebebee`.
+- Active accent (left bar + text): `#008060`.
+- Sidebar text default: `#202223`.
+- Sidebar group label: `#6d7175`.
+- Topbar bg: `#fff`.
+- Topbar brand strip border-bottom: `1px solid #e1e3e5`.
+- Page H1: `#202223` 24px regular.
+- Subdued text: `#6d7175`.
+- Link blue: `#2c6ecb`.
+- Yellow banner: `#ffeb78` strip `#b54708` accent rule top.
+
+---
+
+## Sub-sections
+
+### 1. Home — `/`
+- **H1**: "Home"
+- **Stores section**
+  - White card: header row `<h2>Stores</h2>` + right-aligned green
+    **Add store** primary CTA.
+  - Then a stores list (top 5) with the same row layout as `/stores`
+    (name bold, type pill, action dropdown + Log in link).
+  - Footer link: "View all stores →"
+- **Business overview** (3 columns)
+  - Card 1: "Pending payout" + USD amount (e.g. `$2,151.43 USD`) +
+    "View payouts" link.
+  - Card 2: "Active store referrals" + number + "Submit a lead" link.
+  - Card 3: "Lifetime leads submitted" + number + "View leads" link.
+- **Right rail — Changelog** (`<aside class="sp-changelog">`)
+  - h2 "Changelog" + small "View all" link.
+  - List of 6 dated items. Each item: small grey date (`Jun 5, 2026`)
+    + bold title + small grey category pill ("Admin", "Payments",
+    "POS", "Analytics", "Catalogs").
+  - Use neutral, generated text — do NOT mirror real changelog copy
+    verbatim. Example: "Improved catalog publishing UX".
+
+### 2. Stores — `/stores`
+- **H1**: "Stores"; right-side **Add store ▾** primary, **More
+  actions ▾** secondary.
+- **Tabs** (full-width underline tabs): All • Client transfer •
+  Collaborator access • Archived • Inactive (`/stores?tab=...`).
+- Below tabs: **Search input** ("Filter stores"), **Store status**
+  dropdown right-aligned.
+- "Showing N stores" caption + right-aligned "Sort by Last login"
+  dropdown.
+- **List rows** (10 per page): each row 3 cols
+  - Col 1: store name bold + subtle URL underneath
+    (`mm-jop5.myshopify.com`).
+  - Col 2: type pill in grey: "Client transfer" / "Collaborator
+    access" / "Active development store".
+  - Col 3 (right): **Actions ▾** dropdown + **Log in** link (blue,
+    underline-on-hover).
+- Empty-state and pagination footer.
+
+### 3. Sales — `/sales` (sub-nav: Leads / Referrals)
+- **H1**: "Leads"
+- Subtitle: "Earn revenue by referring merchants to Shopify."
+- **Submit a lead** card with three rows; each row: icon + product
+  name (`Plus`, `Shopify POS`, `Shopify Plus B2B`) + 2-line desc +
+  right-aligned outline button ("Submit a Plus lead", etc.). Buttons
+  POST to `/sales/leads/new?product=plus|pos|plus_b2b`.
+- **Submitted leads** card: tabbed table or empty-state
+  illustration with "Earn monthly referring merchants" caption + CTA
+  "Submit a lead".
+- Sub-nav row above page (between sidebar and main): two tabs
+  (`Leads` underlined, `Referrals` outline) — clicking "Referrals"
+  goes to `/sales/referrals` which shows a table of `Referral ID /
+  Merchant / Earned / Status`.
+
+### 4. Catalogs — `/catalogs`
+- **H1**: "Catalogs"
+- Empty marketing-card layout: "Publish products to merchant stores
+  via Catalogs API" subtitle + primary CTA "Create catalog" + two
+  info cards ("How catalogs work", "API reference").
+
+### 5. Themes — `/themes`
+- **H1**: "Build themes for the Shopify Theme Store"
+- Subtitle paragraph + right-aligned green CTA "Submit a theme".
+- Card 1: **Build and sell your theme on the leading commerce
+  platform** with 3 bullet list + illustration placeholder.
+- Card 2: **Move fast with smart tooling** with 3 external links
+  ("Explore developer tooling ↗", "Download Shopify CLI ↗", "Get
+  started with our Skeleton theme ↗").
+- Card 3: **Submit your theme for review** with a step list + CTA.
+
+### 6. Partner Directory — `/partner_directory`
+- **H1**: "Partner Directory"
+- Right header: "👁 View" link + **Edit profile** primary green.
+- Card "Eligible directory reviews" with paragraph + "Learn more
+  about review eligibility requirements" inline link.
+- **Reviews table**: cols Business Name | Plan | Review Status.
+  Plan values: Plus / Grow / Basic / Partner Test / Custom. Status:
+  green pill "Available". 10 rows.
+- **Sub-route**: `/partner_directory/profile` — public-facing
+  profile editor (form fields: Studio name, Bio, Services offered,
+  Featured projects, Languages, Locations served, Hourly rate).
+
+### 7. Shopify POS — `/pos`
+- **No H1** (the title is a small caption "Shopify Point of Sale").
+- **Hero**: H2 "Built for merchants selling in person and online" +
+  paragraph + green CTA **Submit POS Pro referral** + outline link
+  "Learn how to sell Shopify POS Pro" + "View your referrals via
+  your Leads dashboard" small caption.
+- Hero right: image card (green block) with "How to Earn with
+  Shopify POS".
+- **Three info cards** in 2-col grid:
+  - "Shopify POS Marketing Toolkit" — outline CTA "Access Marketing
+    Toolkit"
+  - "Shopify POS Verified Skills" — outline CTA "Learn more now"
+- **Learning Path** card: "Solution-Based Selling with Shopify POS"
+  + outline CTA.
+- **Why recommend Shopify POS**: 3-col row of feature blurbs
+  (Get a unified back office / Close more sales / Offer flexible
+  checkouts).
+- **Selling Shopify POS**: section with 2 video cards (1:13 and
+  10:18 durations) — render as `<figure>` with play-triangle SVG +
+  duration chip; href to `#`.
+- **How Shopify POS comes together**: 4 numbered step cards.
+
+### 8. Partner docs — `/docs/partner`
+- **H1**: "Partner docs"
+- Search input at top.
+- Two-col layout: left = sticky TOC nav (Getting started, Build
+  apps, Build themes, Earn revenue, App listings, Partner Directory,
+  Compliance), right = doc body with 3 sample article cards.
+
+### 9. Product docs — `/docs/product`
+- **H1**: "Product docs"
+- Same layout as partner docs but TOC labels = Admin API, Storefront
+  API, Webhooks, Functions, Polaris (UI), Hydrogen, Liquid.
+
+### 10. Support — `/support`
+- **H1**: "Support"
+- Two-card layout:
+  - Card 1 (75% width): "Visit the community forum" + paragraph +
+    green CTA "Visit the forum" (links to `/support/forum` stub).
+  - Card 2 (right column): "Partner support" small caption + 3-line
+    contact paragraph with "Partner Support" inline link
+    (`/support/contact`).
+- **Sub-route**: `/support/contact` — form (Subject, Category
+  dropdown, Description textarea) POSTing to `/support/tickets`
+  creating an audit row. Confirmation page after submit.
+
+### 11. Payouts — `/payouts`
+- **H1**: "Payouts"; right-aligned green **Export CSV** secondary
+  CTA.
+- **Pending card** (white panel):
+  - h2 "Pending" + right-aligned link "View pending transactions".
+  - Big USD figure (e.g. `$2,151.43 USD`) + sub-caption "Estimated
+    amount excluding taxes".
+  - Below figure: "Estimated payout date Jun 22, 2026 via bank
+    account (***05)".
+- **Payouts history list**: 12 rows. Each row: left = link "May 16,
+  2026 – June 1, 2026 – Sales" (`/payouts/<id>`); center = small grey
+  "Sent Jun 5, 2026"; right = `$923.25 USD` right-aligned.
+- **Sub-route**: `/payouts/<id>` — detail page showing line items
+  (Date | Description | Amount).
+
+### 12. Team — `/team`
+- **H1**: "Team"
+- Yellow banner at top: "Update emergency contact information to
+  receive important API alerts" + outline CTA "Add contact
+  information" + dismiss ×.
+- **Owners** section: left col = label + description; right col =
+  card with **Active / Invited** tabs, list of owner rows (avatar +
+  name + "Last login about 1 hour ago"). Footer: outline button
+  "Invite owner".
+- **Staff members** section: same layout, list of staff users.
+- **Sub-route**: `/team/invite` — form (Email, Role dropdown:
+  owner|staff_business|staff_dev|staff_marketing|staff_support|
+  staff_finance) POSTing to `/team/invites`.
+
+### 13. Settings — `/settings`
+- **H1**: "Partner account settings"
+- Yellow emergency-contact banner at top.
+- **Sections** (each: left description col + right white-card form
+  col)
+  - **Personal profile information** — avatar + name + email + lang
+    + "Last login ..." + outline **Edit personal profile** CTA.
+  - **Account information** — Partner ID label + value; App Store
+    Registration label + green pill "Registered".
+  - **Business details** — read-only fields (business name, type,
+    industry).
+  - **Contact information** — form (Business name, Website, Business
+    email, Support email, Phone, Address 1, Address 2, City, ZIP,
+    State, Country) with Cancel / Save row at bottom.
+  - **Emergency developer contact information** — form (Name, Email,
+    Phone).
+  - **Payouts** — display payout method (Bank account ending ***05)
+    + link "Edit payout method".
+
+---
+
+## Authentication
+
+Single user signed in by default; mirrors the post-login Partners
+shell. Provide a `/login` page (email + password form) that issues a
+signed cookie session. Default credentials seeded:
+`barada@example.com` / `password`. Anonymous access redirects to
+login except `/login`, `/__env__/*`, `/static/*`.
+
+## DB schema sketch
+
+- `partners` — single row, the org (id, name, email, business_name,
+  website, support_email, phone, address fields, partner_id=1146365).
+- `users` — owners + staff (id, email, name, role, last_login_at,
+  status `active|invited`).
+- `stores` — id, name, slug (`mm-jop5`), kind (`client_transfer` /
+  `collaborator` / `active_development`), last_login_at, status.
+- `payouts` — id, period_start, period_end, sent_at, amount_cents,
+  currency, method ("bank ***05"), status (`paid`|`pending`).
+- `payout_line_items` — payout_id, date, description, amount_cents.
+- `leads` — id, product (`plus`|`pos`|`plus_b2b`), merchant_name,
+  contact_email, status (`submitted`|`qualified`|`won`|`lost`),
+  earnings_cents, submitted_at.
+- `referrals` — id, merchant_name, plan, status, earnings_cents.
+- `directory_listings` — id, business_name, plan, review_status.
+- `tickets` — support tickets.
+- `themes` — id, name, status (`draft`|`in_review`|`approved`).
+- `catalogs` — id, name, products_count, status.
+- `audit_log` — id, occurred_at, operation, target_type, target_id,
+  payload_json. Source of truth for oracles.
+
+## Oracles (initial set)
+
+1. `t01_submit_plus_lead` — audit row `lead_submitted` w/
+   product=plus + leads row populated with merchant_name + email.
+2. `t02_invite_staff_member` — `staff_invited` audit row w/ email +
+   role; users row with status=invited.
+3. `t03_export_payouts_csv` — `payouts_export_requested` audit
+   row.
+4. `t04_create_support_ticket` — `support_ticket_created` audit row
+   + tickets row w/ subject + category + non-empty description.
+5. `t05_update_business_email` — `settings_updated` audit row w/
+   field=business_email; partners row email matches.
+6. `t06_view_payout_detail` — `payout_viewed` audit row; payout_id
+   resolves to valid row.
+7. `t07_dismiss_emergency_banner` — `banner_dismissed` audit row
+   with banner=emergency_contact.
+8. `t08_partner_directory_request_review` — `directory_review_requested`
+   audit row w/ business_name resolving to a `directory_listings`
+   row.
+9. `t09_search_stores_filter` — `stores_filter_applied` audit row
+   with non-empty search OR status filter.
+10. `t10_submit_pos_referral` — `lead_submitted` audit row w/
+    product=pos.
+
+All oracles run via `/__env__/oracle?task_id=tNN` returning
+`{passed, score, reasons[], diff}`.

--- a/deploy/sim_envs/daytona_mantis_shopify.py
+++ b/deploy/sim_envs/daytona_mantis_shopify.py
@@ -1,0 +1,198 @@
+"""Hang-tolerant deploy for mantis-shopify on Daytona.
+
+Adapted from daytona_mantis_mirror_v2.py — see that file for the
+explanation of the create() hang workaround.
+
+Usage:
+    uv run python deploy/sim_envs/daytona_mantis_shopify.py
+"""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import secrets
+import threading
+import time
+
+PORT = 8080
+TITLE = "mantis-shopify"
+
+
+def _load_env() -> None:
+    for env_path in [pathlib.Path("/Users/barada/Sandbox/Mason/mantis/.env")]:
+        if not env_path.is_file():
+            continue
+        for line in env_path.read_text().splitlines():
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            k, _, v = line.partition("=")
+            os.environ.setdefault(k.strip(), v.strip().strip('"').strip("'"))
+
+
+def _build_image(app_root: pathlib.Path, admin_token: str):
+    from daytona import Image
+    return (
+        Image.debian_slim("3.11")
+        .pip_install([
+            "fastapi>=0.110",
+            "uvicorn>=0.27",
+            "jinja2>=3.1",
+            "python-multipart>=0.0.9",
+            "starlette>=0.27,<1.0",
+            "itsdangerous>=2.0",
+        ])
+        .workdir("/srv")
+        .add_local_dir(str(app_root), "/srv/app")
+        .env({
+            "PORT": str(PORT),
+            "PYTHONUNBUFFERED": "1",
+            "ENV_ADMIN_TOKEN": admin_token,
+            "SEED": "42",
+            "FAKE_NOW": "2026-06-09T09:00:00Z",
+            "ENV_REQUIRE_AUTH": "0",
+        })
+    )
+
+
+def _identify_sandbox(d, exclude_ids: set[str]):
+    title_marker = f'title="{TITLE}"'
+    for s in d.list():
+        sid = getattr(s, "id", "")
+        if sid in exclude_ids:
+            continue
+        state = str(getattr(s, "state", "")).replace("SandboxState.", "")
+        if state != "STARTED":
+            continue
+        try:
+            r = s.process.exec(
+                "grep -h 'title=' /srv/app/main.py 2>/dev/null | head -1"
+            )
+            out = (getattr(r, "result", "") or "")
+            if title_marker in out:
+                return s
+        except Exception:
+            continue
+    return None
+
+
+def _start_uvicorn(sandbox) -> None:
+    sandbox.process.exec(
+        "python3 -c \""
+        "import os, signal\n"
+        "for pid in os.listdir('/proc'):\n"
+        "    if not pid.isdigit(): continue\n"
+        "    try:\n"
+        "        with open(f'/proc/{pid}/cmdline','rb') as f: c=f.read()\n"
+        "    except: continue\n"
+        "    if b'uvicorn' in c or b'app.main' in c:\n"
+        "        try: os.kill(int(pid), signal.SIGKILL)\n"
+        "        except: pass\n"
+        "\""
+    )
+    time.sleep(1)
+    sandbox.process.exec(
+        f"cd /srv && nohup python3 -m uvicorn app.main:app "
+        f"--host 0.0.0.0 --port {PORT} > /tmp/uvicorn.log 2>&1 &"
+    )
+
+
+def _wait_healthy(sandbox, timeout: int = 45) -> bool:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            r = sandbox.process.exec(
+                f"python3 -c \"import urllib.request; "
+                f"print(urllib.request.urlopen('http://127.0.0.1:{PORT}/__env__/health',"
+                f"timeout=3).read().decode())\""
+            )
+            out = (getattr(r, "result", "") or "").strip()
+            if '"ok"' in out:
+                return True
+        except Exception:
+            pass
+        time.sleep(2)
+    return False
+
+
+def main() -> None:
+    from daytona import (
+        CreateSandboxFromImageParams,
+        Daytona,
+        DaytonaConfig,
+    )
+
+    _load_env()
+    if not os.environ.get("DAYTONA_API_KEY"):
+        raise SystemExit("error: DAYTONA_API_KEY not set")
+
+    app_root = pathlib.Path(__file__).parent / "mantis_shopify" / "app"
+    if not app_root.is_dir():
+        raise SystemExit(f"error: {app_root} not found")
+
+    admin_token = secrets.token_urlsafe(24)
+    d = Daytona(DaytonaConfig(api_key=os.environ["DAYTONA_API_KEY"]))
+    pre_existing = {getattr(s, "id", "") for s in d.list()}
+
+    image = _build_image(app_root, admin_token)
+    print("→ creating sandbox …", flush=True)
+
+    result_holder: dict = {}
+    def _create():
+        try:
+            sb = d.create(
+                CreateSandboxFromImageParams(image=image),
+                timeout=300,
+                on_snapshot_create_logs=lambda line: print(f"  [build] {line[:140]}", flush=True),
+            )
+            result_holder["sb"] = sb
+        except Exception as exc:
+            result_holder["err"] = exc
+
+    t = threading.Thread(target=_create, daemon=True)
+    t.start()
+    t.join(360)
+
+    sb = result_holder.get("sb")
+    err = result_holder.get("err")
+    if err and not sb:
+        raise RuntimeError(f"create() failed: {err}")
+    if sb is None:
+        print("SDK create() hung — identifying sandbox via list() …", flush=True)
+        for _ in range(8):
+            sb = _identify_sandbox(d, pre_existing)
+            if sb:
+                break
+            time.sleep(5)
+        if sb is None:
+            raise RuntimeError("create() hung and could not identify sandbox post-hoc")
+        print(f"identified hung sandbox: {sb.id}", flush=True)
+
+    sid = getattr(sb, "id", "?")
+    print(f"  sandbox id: {sid}", flush=True)
+
+    try:
+        sb.set_autostop_interval(180)
+    except Exception as exc:
+        print(f"  warning: autostop not set ({exc})", flush=True)
+
+    print("→ starting uvicorn …", flush=True)
+    _start_uvicorn(sb)
+
+    print("→ waiting for health …", flush=True)
+    healthy = _wait_healthy(sb, timeout=60)
+
+    preview = sb.get_preview_link(PORT)
+    flag = "OK" if healthy else "WARN (health did not return ok yet)"
+    print()
+    print("=" * 64)
+    print(f"=== {TITLE} — {flag} ===")
+    print(f"  URL:           {preview.url}")
+    print(f"  Preview token: {getattr(preview, 'token', None)}")
+    print(f"  Admin token:   {admin_token}")
+    print(f"  Sandbox id:    {sid}")
+
+
+if __name__ == "__main__":
+    main()

--- a/deploy/sim_envs/mantis_fiverr/app/static/polish.css
+++ b/deploy/sim_envs/mantis_fiverr/app/static/polish.css
@@ -1,0 +1,119 @@
+/* mantis-polish.css — universal UI fidelity polish.
+   Drops into every env. Uses semantic selectors so no per-env classes needed.
+   Lift, focus rings, transitions, reduced-motion respect. */
+
+/* Smoother default font rendering (matches real Shopify/LinkedIn/Indeed) */
+html {
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+/* Universal focus-visible ring — keyboard accessibility */
+*:focus {
+  outline: none;
+}
+:focus-visible {
+  outline: 2px solid #2c6ecb;
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+button:focus-visible,
+a:focus-visible,
+[role=button]:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible,
+summary:focus-visible {
+  outline: 2px solid #2c6ecb;
+  outline-offset: 2px;
+}
+
+/* Card hover lift — only when motion not reduced */
+@media (prefers-reduced-motion: no-preference) {
+  .sp-card, .adm-card, .card, article,
+  .sp-stat-card, .adm-stat-card,
+  [data-testid$="-card"], [data-testid^="post-card"],
+  [data-testid$="-row"], [data-testid$="-cell"],
+  .jh-job-row, .opp-card,
+  .info-card, .gig-card, .job-card {
+    transition: transform 120ms cubic-bezier(.4,0,.2,1),
+                box-shadow 120ms cubic-bezier(.4,0,.2,1);
+  }
+  /* Subtle lift on hover for clickable cards */
+  a:hover > .sp-card,
+  a:hover > .adm-card,
+  .opp-card:hover,
+  .info-card:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 6px 20px rgba(0,0,0,0.08);
+  }
+}
+
+/* Reduced-motion users: no animations */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
+/* Toast notifications — shared across envs */
+.mantis-toast {
+  position: fixed;
+  bottom: 24px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: #1a1a1a;
+  color: #fff;
+  padding: 12px 18px;
+  border-radius: 10px;
+  font-size: 13px;
+  font-weight: 500;
+  box-shadow: 0 8px 24px rgba(0,0,0,0.25);
+  z-index: 9999;
+  pointer-events: none;
+  transition: opacity 240ms ease, transform 240ms ease;
+}
+.mantis-toast-success {
+  background: #0c5132;
+  border-left: 4px solid #aee9d1;
+}
+.mantis-toast-critical {
+  background: #8e0a04;
+  border-left: 4px solid #fda9a4;
+}
+@keyframes mantis-toast-in {
+  from { opacity: 0; transform: translate(-50%, 12px); }
+  to   { opacity: 1; transform: translate(-50%, 0); }
+}
+.mantis-toast {
+  animation: mantis-toast-in 200ms ease forwards;
+}
+
+/* Skeleton shimmer for loading states (utility) */
+.mantis-skeleton {
+  background: linear-gradient(90deg, #ececec 0%, #f6f6f6 50%, #ececec 100%);
+  background-size: 200% 100%;
+  border-radius: 4px;
+  animation: mantis-shimmer 1.4s linear infinite;
+  color: transparent !important;
+  pointer-events: none;
+}
+@keyframes mantis-shimmer {
+  0%   { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+/* Selection color — matches the active dropdown blue */
+::selection {
+  background: #d6e4ff;
+  color: #1a1a1a;
+}
+
+/* Smoother native form-field appearance */
+button, input, select, textarea {
+  font-family: inherit;
+}

--- a/deploy/sim_envs/mantis_fiverr/app/static/polish.js
+++ b/deploy/sim_envs/mantis_fiverr/app/static/polish.js
@@ -1,0 +1,129 @@
+/* mantis-polish.js — universal interaction polish for all envs. */
+
+(function () {
+  "use strict";
+
+  // ── Close <details> on outside click + Esc ───────────────────
+  document.addEventListener("click", function (e) {
+    document.querySelectorAll("details[open]").forEach(function (d) {
+      if (!d.contains(e.target)) d.removeAttribute("open");
+    });
+  });
+  document.addEventListener("keydown", function (e) {
+    if (e.key === "Escape") {
+      document.querySelectorAll("details[open]").forEach(function (d) {
+        d.removeAttribute("open");
+      });
+    }
+  });
+
+  // ── Toast helper ────────────────────────────────────────────
+  function toast(message, variant) {
+    var t = document.createElement("div");
+    t.className = "mantis-toast" + (variant ? " mantis-toast-" + variant : "");
+    t.setAttribute("role", "status");
+    t.setAttribute("aria-live", "polite");
+    t.textContent = message;
+    document.body.appendChild(t);
+    setTimeout(function () {
+      t.style.opacity = "0";
+      setTimeout(function () { t.remove(); }, 240);
+    }, 2400);
+  }
+  window.mantisToast = toast;
+
+  // ── URL-driven toasts (POST-redirect-GET) ───────────────────
+  var url = new URL(location.href);
+  var created = url.searchParams.get("created");
+  if (created) {
+    var labels = {
+      order: "Order created.", product: "Product saved.",
+      customer: "Customer saved.", discount: "Discount created.",
+      lead: "Lead submitted.", ticket: "Ticket submitted.",
+      campaign: "Campaign created.", post: "Post published.",
+    };
+    toast(labels[created] || "Saved.", "success");
+  }
+  ["fulfilled", "refunded", "archived", "published", "saved",
+   "deleted", "applied", "sent"].forEach(function (k) {
+    if (url.searchParams.get(k)) {
+      var t = k.charAt(0).toUpperCase() + k.slice(1) + ".";
+      toast(t, k === "deleted" ? "critical" : "success");
+    }
+  });
+
+  // ── Keyboard shortcuts ──────────────────────────────────────
+  var chord = null;
+  var chordTimer = null;
+  document.addEventListener("keydown", function (e) {
+    if (e.target.matches("input, textarea, select, [contenteditable]")) return;
+    if (e.metaKey || e.ctrlKey || e.altKey) return;
+
+    // `/` focuses the search bar
+    if (e.key === "/") {
+      var search = document.querySelector(
+        'input[type=search]:not([disabled]), ' +
+        'input[name=q]:not([disabled]), ' +
+        '[data-testid$="search"]:not([disabled])'
+      );
+      if (search) {
+        e.preventDefault();
+        search.focus();
+        search.select && search.select();
+      }
+      return;
+    }
+
+    // g + X chord navigation
+    if (e.key === "g" && !chord) {
+      chord = "g";
+      clearTimeout(chordTimer);
+      chordTimer = setTimeout(function () { chord = null; }, 1000);
+      return;
+    }
+    if (chord === "g") {
+      chord = null;
+      clearTimeout(chordTimer);
+      var m = location.pathname.match(/^(\/store\/[^/]+\/admin)/);
+      var adminMap = {
+        h: "", o: "/orders", p: "/products", c: "/customers",
+        a: "/analytics", m: "/marketing", d: "/discounts", s: "/settings",
+      };
+      if (m && adminMap[e.key] !== undefined) {
+        e.preventDefault();
+        location.href = m[1] + adminMap[e.key];
+        return;
+      }
+      var rootMap = {
+        h: "/", j: "/jobs", o: "/orders", f: "/feed",
+        m: "/messaging", n: "/mynetwork", e: "/explore",
+      };
+      if (rootMap[e.key]) {
+        e.preventDefault();
+        location.href = rootMap[e.key];
+      }
+    }
+  });
+
+  // ── Show chord-hint helper on `?` ───────────────────────────
+  document.addEventListener("keydown", function (e) {
+    if (e.target.matches("input, textarea, select, [contenteditable]")) return;
+    if (e.key === "?" && e.shiftKey) {
+      e.preventDefault();
+      toast(
+        "g+h home, g+o orders, g+p products, g+c customers, / search",
+        "success",
+      );
+    }
+  });
+
+  // ── Auto-emit ARIA role on tabs lacking it ──────────────────
+  document.querySelectorAll(
+    ".sp-tab, .adm-tab, .tab, [data-testid$=-tab], [data-testid^=tab-]",
+  ).forEach(function (t) {
+    if (!t.getAttribute("role")) t.setAttribute("role", "tab");
+    if (t.classList.contains("is-active")) {
+      t.setAttribute("aria-current", "page");
+    }
+  });
+})();

--- a/deploy/sim_envs/mantis_fiverr/app/templates/base.html
+++ b/deploy/sim_envs/mantis_fiverr/app/templates/base.html
@@ -5,6 +5,8 @@
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>{% block title %}{{ site_name }}: Find the right freelance service{% endblock %}</title>
 <link rel="stylesheet" href="/static/site.css">
+<link rel="stylesheet" href="/static/polish.css?v=20260610a">
+<script src="/static/polish.js?v=20260610a" defer></script>
 <link rel="icon" href="/assets/logo.svg" type="image/svg+xml">
 </head>
 <body>

--- a/deploy/sim_envs/mantis_indeed/app/auth.py
+++ b/deploy/sim_envs/mantis_indeed/app/auth.py
@@ -148,6 +148,22 @@ def effective_user_id(request: Request, *, default: str = "user_00001") -> str:
     return default
 
 
+def effective_user(request: Request, *, default_id: str = "user_00001") -> dict[str, Any]:
+    """Return the current user OR the canonical seeded fallback so the
+    post-login topbar/sidebar shell always renders. Mirrors the pattern
+    used in mantis_shopify."""
+    u = current_user(request)
+    if u:
+        return u
+    fb = lookup_user_by_id(default_id)
+    return fb or {
+        "id": default_id,
+        "email": "demo@indeed.example",
+        "role": "seeker",
+        "name": "Demo Mantis",
+    }
+
+
 def effective_employer_id(request: Request, *, default: str = "user_emp_00003") -> str:
     user = current_user(request)
     if user and user.get("role") == "employer":

--- a/deploy/sim_envs/mantis_indeed/app/main.py
+++ b/deploy/sim_envs/mantis_indeed/app/main.py
@@ -81,18 +81,21 @@ def create_app() -> FastAPI:
             m_h = _re.match(r"^(#{1,6})\s+(.*)$", line)
             if m_h:
                 if in_ul:
-                    out_lines.append("</ul>"); in_ul = False
+                    out_lines.append("</ul>")
+                    in_ul = False
                 lvl = len(m_h.group(1))
                 out_lines.append(f"<h{lvl}>{html.escape(m_h.group(2))}</h{lvl}>")
                 continue
             if line.lstrip().startswith(("- ", "* ")):
                 if not in_ul:
-                    out_lines.append("<ul>"); in_ul = True
+                    out_lines.append("<ul>")
+                    in_ul = True
                 item = line.lstrip()[2:]
                 out_lines.append(f"<li>{html.escape(item)}</li>")
                 continue
             if in_ul:
-                out_lines.append("</ul>"); in_ul = False
+                out_lines.append("</ul>")
+                in_ul = False
             out_lines.append(f"<p>{html.escape(line)}</p>")
         if in_ul:
             out_lines.append("</ul>")

--- a/deploy/sim_envs/mantis_indeed/app/main.py
+++ b/deploy/sim_envs/mantis_indeed/app/main.py
@@ -60,6 +60,48 @@ def create_app() -> FastAPI:
     app = FastAPI(title="mantis-indeed", docs_url=None, redoc_url=None)
 
     templates = Jinja2Templates(directory=str(APP_DIR / "templates"))
+
+    # Tiny markdown filter for templates that use `{{ x | md | safe }}`.
+    # Handles ##/###/**bold**/bullet lists; otherwise wraps paragraphs.
+    def _md(text: str) -> str:
+        import html
+        import re as _re
+        if not text:
+            return ""
+        out_lines: list[str] = []
+        in_ul = False
+        for raw in str(text).split("\n"):
+            line = raw.rstrip()
+            if not line:
+                if in_ul:
+                    out_lines.append("</ul>")
+                    in_ul = False
+                out_lines.append("")
+                continue
+            m_h = _re.match(r"^(#{1,6})\s+(.*)$", line)
+            if m_h:
+                if in_ul:
+                    out_lines.append("</ul>"); in_ul = False
+                lvl = len(m_h.group(1))
+                out_lines.append(f"<h{lvl}>{html.escape(m_h.group(2))}</h{lvl}>")
+                continue
+            if line.lstrip().startswith(("- ", "* ")):
+                if not in_ul:
+                    out_lines.append("<ul>"); in_ul = True
+                item = line.lstrip()[2:]
+                out_lines.append(f"<li>{html.escape(item)}</li>")
+                continue
+            if in_ul:
+                out_lines.append("</ul>"); in_ul = False
+            out_lines.append(f"<p>{html.escape(line)}</p>")
+        if in_ul:
+            out_lines.append("</ul>")
+        body = "\n".join(out_lines)
+        # **bold** → <strong>
+        body = _re.sub(r"\*\*([^*]+)\*\*", r"<strong>\1</strong>", body)
+        return body
+
+    templates.env.filters["md"] = _md
     app.state.templates = templates
     app.state.admin_token = _admin_token()
 
@@ -69,6 +111,13 @@ def create_app() -> FastAPI:
             request.state.current_user = auth.current_user(request)
         except Exception:
             request.state.current_user = None
+
+        # Always populate an effective_user so the post-login topnav
+        # renders the signed-in shell when ENV_REQUIRE_AUTH=0 (default).
+        try:
+            request.state.effective_user = auth.effective_user(request)
+        except Exception:
+            request.state.effective_user = None
 
         if auth.auth_required():
             path = request.url.path

--- a/deploy/sim_envs/mantis_indeed/app/static/polish.css
+++ b/deploy/sim_envs/mantis_indeed/app/static/polish.css
@@ -1,0 +1,119 @@
+/* mantis-polish.css — universal UI fidelity polish.
+   Drops into every env. Uses semantic selectors so no per-env classes needed.
+   Lift, focus rings, transitions, reduced-motion respect. */
+
+/* Smoother default font rendering (matches real Shopify/LinkedIn/Indeed) */
+html {
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+/* Universal focus-visible ring — keyboard accessibility */
+*:focus {
+  outline: none;
+}
+:focus-visible {
+  outline: 2px solid #2c6ecb;
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+button:focus-visible,
+a:focus-visible,
+[role=button]:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible,
+summary:focus-visible {
+  outline: 2px solid #2c6ecb;
+  outline-offset: 2px;
+}
+
+/* Card hover lift — only when motion not reduced */
+@media (prefers-reduced-motion: no-preference) {
+  .sp-card, .adm-card, .card, article,
+  .sp-stat-card, .adm-stat-card,
+  [data-testid$="-card"], [data-testid^="post-card"],
+  [data-testid$="-row"], [data-testid$="-cell"],
+  .jh-job-row, .opp-card,
+  .info-card, .gig-card, .job-card {
+    transition: transform 120ms cubic-bezier(.4,0,.2,1),
+                box-shadow 120ms cubic-bezier(.4,0,.2,1);
+  }
+  /* Subtle lift on hover for clickable cards */
+  a:hover > .sp-card,
+  a:hover > .adm-card,
+  .opp-card:hover,
+  .info-card:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 6px 20px rgba(0,0,0,0.08);
+  }
+}
+
+/* Reduced-motion users: no animations */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
+/* Toast notifications — shared across envs */
+.mantis-toast {
+  position: fixed;
+  bottom: 24px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: #1a1a1a;
+  color: #fff;
+  padding: 12px 18px;
+  border-radius: 10px;
+  font-size: 13px;
+  font-weight: 500;
+  box-shadow: 0 8px 24px rgba(0,0,0,0.25);
+  z-index: 9999;
+  pointer-events: none;
+  transition: opacity 240ms ease, transform 240ms ease;
+}
+.mantis-toast-success {
+  background: #0c5132;
+  border-left: 4px solid #aee9d1;
+}
+.mantis-toast-critical {
+  background: #8e0a04;
+  border-left: 4px solid #fda9a4;
+}
+@keyframes mantis-toast-in {
+  from { opacity: 0; transform: translate(-50%, 12px); }
+  to   { opacity: 1; transform: translate(-50%, 0); }
+}
+.mantis-toast {
+  animation: mantis-toast-in 200ms ease forwards;
+}
+
+/* Skeleton shimmer for loading states (utility) */
+.mantis-skeleton {
+  background: linear-gradient(90deg, #ececec 0%, #f6f6f6 50%, #ececec 100%);
+  background-size: 200% 100%;
+  border-radius: 4px;
+  animation: mantis-shimmer 1.4s linear infinite;
+  color: transparent !important;
+  pointer-events: none;
+}
+@keyframes mantis-shimmer {
+  0%   { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+/* Selection color — matches the active dropdown blue */
+::selection {
+  background: #d6e4ff;
+  color: #1a1a1a;
+}
+
+/* Smoother native form-field appearance */
+button, input, select, textarea {
+  font-family: inherit;
+}

--- a/deploy/sim_envs/mantis_indeed/app/static/polish.js
+++ b/deploy/sim_envs/mantis_indeed/app/static/polish.js
@@ -1,0 +1,129 @@
+/* mantis-polish.js — universal interaction polish for all envs. */
+
+(function () {
+  "use strict";
+
+  // ── Close <details> on outside click + Esc ───────────────────
+  document.addEventListener("click", function (e) {
+    document.querySelectorAll("details[open]").forEach(function (d) {
+      if (!d.contains(e.target)) d.removeAttribute("open");
+    });
+  });
+  document.addEventListener("keydown", function (e) {
+    if (e.key === "Escape") {
+      document.querySelectorAll("details[open]").forEach(function (d) {
+        d.removeAttribute("open");
+      });
+    }
+  });
+
+  // ── Toast helper ────────────────────────────────────────────
+  function toast(message, variant) {
+    var t = document.createElement("div");
+    t.className = "mantis-toast" + (variant ? " mantis-toast-" + variant : "");
+    t.setAttribute("role", "status");
+    t.setAttribute("aria-live", "polite");
+    t.textContent = message;
+    document.body.appendChild(t);
+    setTimeout(function () {
+      t.style.opacity = "0";
+      setTimeout(function () { t.remove(); }, 240);
+    }, 2400);
+  }
+  window.mantisToast = toast;
+
+  // ── URL-driven toasts (POST-redirect-GET) ───────────────────
+  var url = new URL(location.href);
+  var created = url.searchParams.get("created");
+  if (created) {
+    var labels = {
+      order: "Order created.", product: "Product saved.",
+      customer: "Customer saved.", discount: "Discount created.",
+      lead: "Lead submitted.", ticket: "Ticket submitted.",
+      campaign: "Campaign created.", post: "Post published.",
+    };
+    toast(labels[created] || "Saved.", "success");
+  }
+  ["fulfilled", "refunded", "archived", "published", "saved",
+   "deleted", "applied", "sent"].forEach(function (k) {
+    if (url.searchParams.get(k)) {
+      var t = k.charAt(0).toUpperCase() + k.slice(1) + ".";
+      toast(t, k === "deleted" ? "critical" : "success");
+    }
+  });
+
+  // ── Keyboard shortcuts ──────────────────────────────────────
+  var chord = null;
+  var chordTimer = null;
+  document.addEventListener("keydown", function (e) {
+    if (e.target.matches("input, textarea, select, [contenteditable]")) return;
+    if (e.metaKey || e.ctrlKey || e.altKey) return;
+
+    // `/` focuses the search bar
+    if (e.key === "/") {
+      var search = document.querySelector(
+        'input[type=search]:not([disabled]), ' +
+        'input[name=q]:not([disabled]), ' +
+        '[data-testid$="search"]:not([disabled])'
+      );
+      if (search) {
+        e.preventDefault();
+        search.focus();
+        search.select && search.select();
+      }
+      return;
+    }
+
+    // g + X chord navigation
+    if (e.key === "g" && !chord) {
+      chord = "g";
+      clearTimeout(chordTimer);
+      chordTimer = setTimeout(function () { chord = null; }, 1000);
+      return;
+    }
+    if (chord === "g") {
+      chord = null;
+      clearTimeout(chordTimer);
+      var m = location.pathname.match(/^(\/store\/[^/]+\/admin)/);
+      var adminMap = {
+        h: "", o: "/orders", p: "/products", c: "/customers",
+        a: "/analytics", m: "/marketing", d: "/discounts", s: "/settings",
+      };
+      if (m && adminMap[e.key] !== undefined) {
+        e.preventDefault();
+        location.href = m[1] + adminMap[e.key];
+        return;
+      }
+      var rootMap = {
+        h: "/", j: "/jobs", o: "/orders", f: "/feed",
+        m: "/messaging", n: "/mynetwork", e: "/explore",
+      };
+      if (rootMap[e.key]) {
+        e.preventDefault();
+        location.href = rootMap[e.key];
+      }
+    }
+  });
+
+  // ── Show chord-hint helper on `?` ───────────────────────────
+  document.addEventListener("keydown", function (e) {
+    if (e.target.matches("input, textarea, select, [contenteditable]")) return;
+    if (e.key === "?" && e.shiftKey) {
+      e.preventDefault();
+      toast(
+        "g+h home, g+o orders, g+p products, g+c customers, / search",
+        "success",
+      );
+    }
+  });
+
+  // ── Auto-emit ARIA role on tabs lacking it ──────────────────
+  document.querySelectorAll(
+    ".sp-tab, .adm-tab, .tab, [data-testid$=-tab], [data-testid^=tab-]",
+  ).forEach(function (t) {
+    if (!t.getAttribute("role")) t.setAttribute("role", "tab");
+    if (t.classList.contains("is-active")) {
+      t.setAttribute("aria-current", "page");
+    }
+  });
+})();

--- a/deploy/sim_envs/mantis_indeed/app/templates/base.html
+++ b/deploy/sim_envs/mantis_indeed/app/templates/base.html
@@ -5,6 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>{% block title %}Indeed{% endblock %}</title>
   <link rel="stylesheet" href="/static/site.css" />
+  <link rel="stylesheet" href="/static/polish.css?v=20260610a" />
+  <script src="/static/polish.js?v=20260610a" defer></script>
 </head>
 <body>
   <header class="top-nav" data-testid="top-nav">
@@ -13,16 +15,42 @@
         <span class="brand-wordmark">indeed</span>
       </a>
       <nav class="top-nav-links">
+        {# Show signed-in topnav whenever we have an effective_user
+           AND we're on a post-login route (or current_user is real). #}
+        {% set _path = request.url.path %}
+        {% set _post_login = _path.startswith(('/myjobs', '/resumes',
+            '/apply/', '/employers/')) %}
         {% set _u = request.state.current_user if request.state and request.state.current_user else None %}
-        {% if _u %}
+        {% set _eu = request.state.effective_user if request.state and request.state.effective_user else None %}
+        {% set _display = _u or (_eu if _post_login else None) %}
+        {% if _display %}
           <a href="/myjobs" data-testid="nav-myjobs">My jobs</a>
-          {% if _u.role == 'employer' %}
+          {% if _display.role == 'employer' %}
             <a href="/employers/dashboard" data-testid="nav-employer">Employer dashboard</a>
           {% endif %}
-          <span class="user-chip">{{ _u.email }}</span>
+          <a href="#messages" class="top-nav-icon" data-testid="nav-messages" aria-label="Messages">
+            <span style="display:inline-flex;flex-direction:column;align-items:center;gap:2px;font-size:11px">
+              <svg viewBox="0 0 20 20" width="16" height="16" aria-hidden="true">
+                <path d="M3 5h14v10H3V5zm0 0l7 5 7-5" fill="none" stroke="#5a5a5a" stroke-width="1.5"/>
+              </svg>
+              Messages
+            </span>
+          </a>
+          <a href="#notifications" class="top-nav-icon" data-testid="nav-notifications" aria-label="Notifications">
+            <span style="display:inline-flex;flex-direction:column;align-items:center;gap:2px;font-size:11px">
+              <svg viewBox="0 0 20 20" width="16" height="16" aria-hidden="true">
+                <path d="M10 2a5 5 0 00-5 5v3l-2 2v1h14v-1l-2-2V7a5 5 0 00-5-5zM8 16a2 2 0 004 0H8z" fill="#5a5a5a"/>
+              </svg>
+              Notifications
+            </span>
+          </a>
+          <span class="user-chip" data-testid="nav-user-chip"
+                style="background:#2557A7;color:#fff;width:32px;height:32px;border-radius:999px;display:inline-flex;align-items:center;justify-content:center;font-weight:600;font-size:13px">{{ (_display.name or _display.email)[:1] | upper }}</span>
+          {% if _u %}
           <form method="post" action="/logout" class="inline-form">
             <button type="submit" class="link-button" data-testid="nav-signout">Sign out</button>
           </form>
+          {% endif %}
         {% else %}
           <a href="/login" data-testid="nav-signin">Sign in</a>
           <span class="nav-divider">|</span>

--- a/deploy/sim_envs/mantis_linkedin/app/static/polish.css
+++ b/deploy/sim_envs/mantis_linkedin/app/static/polish.css
@@ -1,0 +1,119 @@
+/* mantis-polish.css — universal UI fidelity polish.
+   Drops into every env. Uses semantic selectors so no per-env classes needed.
+   Lift, focus rings, transitions, reduced-motion respect. */
+
+/* Smoother default font rendering (matches real Shopify/LinkedIn/Indeed) */
+html {
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+/* Universal focus-visible ring — keyboard accessibility */
+*:focus {
+  outline: none;
+}
+:focus-visible {
+  outline: 2px solid #2c6ecb;
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+button:focus-visible,
+a:focus-visible,
+[role=button]:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible,
+summary:focus-visible {
+  outline: 2px solid #2c6ecb;
+  outline-offset: 2px;
+}
+
+/* Card hover lift — only when motion not reduced */
+@media (prefers-reduced-motion: no-preference) {
+  .sp-card, .adm-card, .card, article,
+  .sp-stat-card, .adm-stat-card,
+  [data-testid$="-card"], [data-testid^="post-card"],
+  [data-testid$="-row"], [data-testid$="-cell"],
+  .jh-job-row, .opp-card,
+  .info-card, .gig-card, .job-card {
+    transition: transform 120ms cubic-bezier(.4,0,.2,1),
+                box-shadow 120ms cubic-bezier(.4,0,.2,1);
+  }
+  /* Subtle lift on hover for clickable cards */
+  a:hover > .sp-card,
+  a:hover > .adm-card,
+  .opp-card:hover,
+  .info-card:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 6px 20px rgba(0,0,0,0.08);
+  }
+}
+
+/* Reduced-motion users: no animations */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
+/* Toast notifications — shared across envs */
+.mantis-toast {
+  position: fixed;
+  bottom: 24px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: #1a1a1a;
+  color: #fff;
+  padding: 12px 18px;
+  border-radius: 10px;
+  font-size: 13px;
+  font-weight: 500;
+  box-shadow: 0 8px 24px rgba(0,0,0,0.25);
+  z-index: 9999;
+  pointer-events: none;
+  transition: opacity 240ms ease, transform 240ms ease;
+}
+.mantis-toast-success {
+  background: #0c5132;
+  border-left: 4px solid #aee9d1;
+}
+.mantis-toast-critical {
+  background: #8e0a04;
+  border-left: 4px solid #fda9a4;
+}
+@keyframes mantis-toast-in {
+  from { opacity: 0; transform: translate(-50%, 12px); }
+  to   { opacity: 1; transform: translate(-50%, 0); }
+}
+.mantis-toast {
+  animation: mantis-toast-in 200ms ease forwards;
+}
+
+/* Skeleton shimmer for loading states (utility) */
+.mantis-skeleton {
+  background: linear-gradient(90deg, #ececec 0%, #f6f6f6 50%, #ececec 100%);
+  background-size: 200% 100%;
+  border-radius: 4px;
+  animation: mantis-shimmer 1.4s linear infinite;
+  color: transparent !important;
+  pointer-events: none;
+}
+@keyframes mantis-shimmer {
+  0%   { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+/* Selection color — matches the active dropdown blue */
+::selection {
+  background: #d6e4ff;
+  color: #1a1a1a;
+}
+
+/* Smoother native form-field appearance */
+button, input, select, textarea {
+  font-family: inherit;
+}

--- a/deploy/sim_envs/mantis_linkedin/app/static/polish.js
+++ b/deploy/sim_envs/mantis_linkedin/app/static/polish.js
@@ -1,0 +1,129 @@
+/* mantis-polish.js — universal interaction polish for all envs. */
+
+(function () {
+  "use strict";
+
+  // ── Close <details> on outside click + Esc ───────────────────
+  document.addEventListener("click", function (e) {
+    document.querySelectorAll("details[open]").forEach(function (d) {
+      if (!d.contains(e.target)) d.removeAttribute("open");
+    });
+  });
+  document.addEventListener("keydown", function (e) {
+    if (e.key === "Escape") {
+      document.querySelectorAll("details[open]").forEach(function (d) {
+        d.removeAttribute("open");
+      });
+    }
+  });
+
+  // ── Toast helper ────────────────────────────────────────────
+  function toast(message, variant) {
+    var t = document.createElement("div");
+    t.className = "mantis-toast" + (variant ? " mantis-toast-" + variant : "");
+    t.setAttribute("role", "status");
+    t.setAttribute("aria-live", "polite");
+    t.textContent = message;
+    document.body.appendChild(t);
+    setTimeout(function () {
+      t.style.opacity = "0";
+      setTimeout(function () { t.remove(); }, 240);
+    }, 2400);
+  }
+  window.mantisToast = toast;
+
+  // ── URL-driven toasts (POST-redirect-GET) ───────────────────
+  var url = new URL(location.href);
+  var created = url.searchParams.get("created");
+  if (created) {
+    var labels = {
+      order: "Order created.", product: "Product saved.",
+      customer: "Customer saved.", discount: "Discount created.",
+      lead: "Lead submitted.", ticket: "Ticket submitted.",
+      campaign: "Campaign created.", post: "Post published.",
+    };
+    toast(labels[created] || "Saved.", "success");
+  }
+  ["fulfilled", "refunded", "archived", "published", "saved",
+   "deleted", "applied", "sent"].forEach(function (k) {
+    if (url.searchParams.get(k)) {
+      var t = k.charAt(0).toUpperCase() + k.slice(1) + ".";
+      toast(t, k === "deleted" ? "critical" : "success");
+    }
+  });
+
+  // ── Keyboard shortcuts ──────────────────────────────────────
+  var chord = null;
+  var chordTimer = null;
+  document.addEventListener("keydown", function (e) {
+    if (e.target.matches("input, textarea, select, [contenteditable]")) return;
+    if (e.metaKey || e.ctrlKey || e.altKey) return;
+
+    // `/` focuses the search bar
+    if (e.key === "/") {
+      var search = document.querySelector(
+        'input[type=search]:not([disabled]), ' +
+        'input[name=q]:not([disabled]), ' +
+        '[data-testid$="search"]:not([disabled])'
+      );
+      if (search) {
+        e.preventDefault();
+        search.focus();
+        search.select && search.select();
+      }
+      return;
+    }
+
+    // g + X chord navigation
+    if (e.key === "g" && !chord) {
+      chord = "g";
+      clearTimeout(chordTimer);
+      chordTimer = setTimeout(function () { chord = null; }, 1000);
+      return;
+    }
+    if (chord === "g") {
+      chord = null;
+      clearTimeout(chordTimer);
+      var m = location.pathname.match(/^(\/store\/[^/]+\/admin)/);
+      var adminMap = {
+        h: "", o: "/orders", p: "/products", c: "/customers",
+        a: "/analytics", m: "/marketing", d: "/discounts", s: "/settings",
+      };
+      if (m && adminMap[e.key] !== undefined) {
+        e.preventDefault();
+        location.href = m[1] + adminMap[e.key];
+        return;
+      }
+      var rootMap = {
+        h: "/", j: "/jobs", o: "/orders", f: "/feed",
+        m: "/messaging", n: "/mynetwork", e: "/explore",
+      };
+      if (rootMap[e.key]) {
+        e.preventDefault();
+        location.href = rootMap[e.key];
+      }
+    }
+  });
+
+  // ── Show chord-hint helper on `?` ───────────────────────────
+  document.addEventListener("keydown", function (e) {
+    if (e.target.matches("input, textarea, select, [contenteditable]")) return;
+    if (e.key === "?" && e.shiftKey) {
+      e.preventDefault();
+      toast(
+        "g+h home, g+o orders, g+p products, g+c customers, / search",
+        "success",
+      );
+    }
+  });
+
+  // ── Auto-emit ARIA role on tabs lacking it ──────────────────
+  document.querySelectorAll(
+    ".sp-tab, .adm-tab, .tab, [data-testid$=-tab], [data-testid^=tab-]",
+  ).forEach(function (t) {
+    if (!t.getAttribute("role")) t.setAttribute("role", "tab");
+    if (t.classList.contains("is-active")) {
+      t.setAttribute("aria-current", "page");
+    }
+  });
+})();

--- a/deploy/sim_envs/mantis_linkedin/app/static/site.css
+++ b/deploy/sim_envs/mantis_linkedin/app/static/site.css
@@ -293,12 +293,88 @@ pre.md-body {
 .post-action:hover { background: rgba(0,0,0,0.06); color: rgba(0,0,0,0.9); }
 
 .comment-form {
-  display: flex; gap: 8px; margin-top: 8px; padding-top: 8px;
+  display: flex; gap: 8px; margin-top: 8px; padding-top: 12px;
   border-top: 1px solid rgba(0,0,0,0.08);
+  align-items: flex-start;
 }
-.comment-form input {
-  flex: 1; padding: 8px 12px; border: 1px solid rgba(0,0,0,0.3);
-  border-radius: 9999px; font-size: 14px;
+.comment-form-avatar {
+  width: 32px; height: 32px;
+  border-radius: 999px;
+  background: #0a66c2;
+  color: #fff;
+  display: inline-flex; align-items: center; justify-content: center;
+  font-weight: 600; font-size: 13px;
+  flex-shrink: 0;
+}
+.comment-form-input-wrap {
+  flex: 1;
+  background: #fff;
+  border: 1px solid rgba(0,0,0,0.6);
+  border-radius: 16px;
+  padding: 8px 12px;
+  transition: border-color 0.12s, box-shadow 0.12s;
+  display: flex; flex-direction: column;
+}
+.comment-form-input-wrap:focus-within {
+  border-color: #0a66c2;
+  box-shadow: 0 0 0 1px #0a66c2;
+}
+.comment-form-input {
+  flex: 1;
+  border: 0; outline: 0;
+  background: transparent;
+  padding: 4px 0;
+  font-size: 14px;
+  font-family: inherit;
+  color: rgba(0,0,0,0.9);
+}
+.comment-form-input::placeholder { color: rgba(0,0,0,0.6); }
+/* Suppress polish.css focus-visible ring on the inner input; wrap shows its own */
+.comment-form-input:focus,
+.comment-form-input:focus-visible {
+  outline: none !important;
+  box-shadow: none !important;
+  border: 0 !important;
+}
+.comment-form-actions {
+  display: flex; align-items: center; gap: 4px;
+  margin-top: 6px;
+  padding-top: 6px;
+  border-top: 1px solid rgba(0,0,0,0.06);
+}
+.comment-form-icon {
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  width: 32px; height: 32px;
+  border-radius: 4px;
+  color: rgba(0,0,0,0.6);
+  font-size: 16px;
+  font-weight: 600;
+  display: inline-flex; align-items: center; justify-content: center;
+  transition: background 0.12s;
+}
+.comment-form-icon:hover {
+  background: rgba(0,0,0,0.06); color: rgba(0,0,0,0.9);
+}
+.comment-form-submit {
+  margin-left: auto;
+  background: #0a66c2;
+  color: #fff;
+  border: 0;
+  padding: 6px 14px;
+  border-radius: 9999px;
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 600;
+  font-family: inherit;
+  transition: background 0.12s, opacity 0.12s;
+}
+.comment-form-submit:hover:not([disabled]) { background: #084d92; }
+.comment-form-submit[disabled] {
+  background: rgba(0,0,0,0.08);
+  color: rgba(0,0,0,0.4);
+  cursor: not-allowed;
 }
 
 /* right rail */

--- a/deploy/sim_envs/mantis_linkedin/app/templates/base.html
+++ b/deploy/sim_envs/mantis_linkedin/app/templates/base.html
@@ -4,7 +4,9 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>{% block title %}LinkedIn (mantis mirror){% endblock %}</title>
-  <link rel="stylesheet" href="/static/site.css" />
+  <link rel="stylesheet" href="/static/site.css?v=20260610d" />
+  <link rel="stylesheet" href="/static/polish.css?v=20260610a" />
+  <script src="/static/polish.js?v=20260610a" defer></script>
 </head>
 <body>
 {% block topnav %}

--- a/deploy/sim_envs/mantis_linkedin/app/templates/feed.html
+++ b/deploy/sim_envs/mantis_linkedin/app/templates/feed.html
@@ -168,7 +168,7 @@
             </button>
           </form>
           <button class="post-action" data-testid="action-comment"
-                  onclick="document.getElementById('comment-form-{{ post.id }}').style.display='block'">
+                  onclick="(function(f){f.style.display='flex';f.querySelector('input').focus();})(document.getElementById('comment-form-{{ post.id }}'))">
             <span class="ico-glyph">💬</span> Comment
           </button>
           <button class="post-action" data-testid="action-repost">
@@ -181,10 +181,26 @@
 
         <form id="comment-form-{{ post.id }}" method="post"
               action="/feed/posts/{{ post.id }}/comment"
-              class="comment-form" style="display:none">
-          <input type="text" name="body" placeholder="Add a comment…"
-                 data-testid="comment-input"/>
-          <button class="btn-primary btn-small" type="submit">Post</button>
+              class="comment-form" style="display:none"
+              data-testid="comment-form">
+          <span class="comment-form-avatar"
+                style="background:{{ me.avatar_color }}">
+            {{ me.name[:1]|upper }}</span>
+          <div class="comment-form-input-wrap">
+            <input type="text" name="body" placeholder="Add a comment…"
+                   class="comment-form-input"
+                   data-testid="comment-input"/>
+            <div class="comment-form-actions">
+              <button type="button" class="comment-form-icon" title="Emoji"
+                      data-testid="comment-emoji">😊</button>
+              <button type="button" class="comment-form-icon" title="Photo"
+                      data-testid="comment-photo">▤</button>
+              <button type="button" class="comment-form-icon" title="GIF"
+                      data-testid="comment-gif">GIF</button>
+              <button type="submit" class="comment-form-submit"
+                      data-testid="comment-submit" disabled>Comment</button>
+            </div>
+          </div>
         </form>
       </article>
     {% endfor %}
@@ -268,5 +284,13 @@
     function sync() { btn.disabled = !t.value.trim(); }
     t.addEventListener('input', sync); sync();
   })();
+  // Enable per-comment Post button on input
+  document.querySelectorAll('[data-testid="comment-form"]').forEach(function(f) {
+    var input = f.querySelector('[data-testid="comment-input"]');
+    var submit = f.querySelector('[data-testid="comment-submit"]');
+    if (!input || !submit) return;
+    function sync() { submit.disabled = !input.value.trim(); }
+    input.addEventListener('input', sync); sync();
+  });
 </script>
 {% endblock %}

--- a/deploy/sim_envs/mantis_mercor/app/main.py
+++ b/deploy/sim_envs/mantis_mercor/app/main.py
@@ -81,6 +81,12 @@ def create_app() -> FastAPI:
             request.state.current_user = auth.current_user(request)
         except Exception:  # noqa: BLE001
             request.state.current_user = None
+        try:
+            request.state.effective_user = auth.effective_user(
+                request, default_role="candidate",
+            )
+        except Exception:  # noqa: BLE001
+            request.state.effective_user = None
 
         if auth.auth_required():
             path = request.url.path

--- a/deploy/sim_envs/mantis_mercor/app/static/polish.css
+++ b/deploy/sim_envs/mantis_mercor/app/static/polish.css
@@ -1,0 +1,119 @@
+/* mantis-polish.css — universal UI fidelity polish.
+   Drops into every env. Uses semantic selectors so no per-env classes needed.
+   Lift, focus rings, transitions, reduced-motion respect. */
+
+/* Smoother default font rendering (matches real Shopify/LinkedIn/Indeed) */
+html {
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+/* Universal focus-visible ring — keyboard accessibility */
+*:focus {
+  outline: none;
+}
+:focus-visible {
+  outline: 2px solid #2c6ecb;
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+button:focus-visible,
+a:focus-visible,
+[role=button]:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible,
+summary:focus-visible {
+  outline: 2px solid #2c6ecb;
+  outline-offset: 2px;
+}
+
+/* Card hover lift — only when motion not reduced */
+@media (prefers-reduced-motion: no-preference) {
+  .sp-card, .adm-card, .card, article,
+  .sp-stat-card, .adm-stat-card,
+  [data-testid$="-card"], [data-testid^="post-card"],
+  [data-testid$="-row"], [data-testid$="-cell"],
+  .jh-job-row, .opp-card,
+  .info-card, .gig-card, .job-card {
+    transition: transform 120ms cubic-bezier(.4,0,.2,1),
+                box-shadow 120ms cubic-bezier(.4,0,.2,1);
+  }
+  /* Subtle lift on hover for clickable cards */
+  a:hover > .sp-card,
+  a:hover > .adm-card,
+  .opp-card:hover,
+  .info-card:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 6px 20px rgba(0,0,0,0.08);
+  }
+}
+
+/* Reduced-motion users: no animations */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
+/* Toast notifications — shared across envs */
+.mantis-toast {
+  position: fixed;
+  bottom: 24px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: #1a1a1a;
+  color: #fff;
+  padding: 12px 18px;
+  border-radius: 10px;
+  font-size: 13px;
+  font-weight: 500;
+  box-shadow: 0 8px 24px rgba(0,0,0,0.25);
+  z-index: 9999;
+  pointer-events: none;
+  transition: opacity 240ms ease, transform 240ms ease;
+}
+.mantis-toast-success {
+  background: #0c5132;
+  border-left: 4px solid #aee9d1;
+}
+.mantis-toast-critical {
+  background: #8e0a04;
+  border-left: 4px solid #fda9a4;
+}
+@keyframes mantis-toast-in {
+  from { opacity: 0; transform: translate(-50%, 12px); }
+  to   { opacity: 1; transform: translate(-50%, 0); }
+}
+.mantis-toast {
+  animation: mantis-toast-in 200ms ease forwards;
+}
+
+/* Skeleton shimmer for loading states (utility) */
+.mantis-skeleton {
+  background: linear-gradient(90deg, #ececec 0%, #f6f6f6 50%, #ececec 100%);
+  background-size: 200% 100%;
+  border-radius: 4px;
+  animation: mantis-shimmer 1.4s linear infinite;
+  color: transparent !important;
+  pointer-events: none;
+}
+@keyframes mantis-shimmer {
+  0%   { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+/* Selection color — matches the active dropdown blue */
+::selection {
+  background: #d6e4ff;
+  color: #1a1a1a;
+}
+
+/* Smoother native form-field appearance */
+button, input, select, textarea {
+  font-family: inherit;
+}

--- a/deploy/sim_envs/mantis_mercor/app/static/polish.js
+++ b/deploy/sim_envs/mantis_mercor/app/static/polish.js
@@ -1,0 +1,129 @@
+/* mantis-polish.js — universal interaction polish for all envs. */
+
+(function () {
+  "use strict";
+
+  // ── Close <details> on outside click + Esc ───────────────────
+  document.addEventListener("click", function (e) {
+    document.querySelectorAll("details[open]").forEach(function (d) {
+      if (!d.contains(e.target)) d.removeAttribute("open");
+    });
+  });
+  document.addEventListener("keydown", function (e) {
+    if (e.key === "Escape") {
+      document.querySelectorAll("details[open]").forEach(function (d) {
+        d.removeAttribute("open");
+      });
+    }
+  });
+
+  // ── Toast helper ────────────────────────────────────────────
+  function toast(message, variant) {
+    var t = document.createElement("div");
+    t.className = "mantis-toast" + (variant ? " mantis-toast-" + variant : "");
+    t.setAttribute("role", "status");
+    t.setAttribute("aria-live", "polite");
+    t.textContent = message;
+    document.body.appendChild(t);
+    setTimeout(function () {
+      t.style.opacity = "0";
+      setTimeout(function () { t.remove(); }, 240);
+    }, 2400);
+  }
+  window.mantisToast = toast;
+
+  // ── URL-driven toasts (POST-redirect-GET) ───────────────────
+  var url = new URL(location.href);
+  var created = url.searchParams.get("created");
+  if (created) {
+    var labels = {
+      order: "Order created.", product: "Product saved.",
+      customer: "Customer saved.", discount: "Discount created.",
+      lead: "Lead submitted.", ticket: "Ticket submitted.",
+      campaign: "Campaign created.", post: "Post published.",
+    };
+    toast(labels[created] || "Saved.", "success");
+  }
+  ["fulfilled", "refunded", "archived", "published", "saved",
+   "deleted", "applied", "sent"].forEach(function (k) {
+    if (url.searchParams.get(k)) {
+      var t = k.charAt(0).toUpperCase() + k.slice(1) + ".";
+      toast(t, k === "deleted" ? "critical" : "success");
+    }
+  });
+
+  // ── Keyboard shortcuts ──────────────────────────────────────
+  var chord = null;
+  var chordTimer = null;
+  document.addEventListener("keydown", function (e) {
+    if (e.target.matches("input, textarea, select, [contenteditable]")) return;
+    if (e.metaKey || e.ctrlKey || e.altKey) return;
+
+    // `/` focuses the search bar
+    if (e.key === "/") {
+      var search = document.querySelector(
+        'input[type=search]:not([disabled]), ' +
+        'input[name=q]:not([disabled]), ' +
+        '[data-testid$="search"]:not([disabled])'
+      );
+      if (search) {
+        e.preventDefault();
+        search.focus();
+        search.select && search.select();
+      }
+      return;
+    }
+
+    // g + X chord navigation
+    if (e.key === "g" && !chord) {
+      chord = "g";
+      clearTimeout(chordTimer);
+      chordTimer = setTimeout(function () { chord = null; }, 1000);
+      return;
+    }
+    if (chord === "g") {
+      chord = null;
+      clearTimeout(chordTimer);
+      var m = location.pathname.match(/^(\/store\/[^/]+\/admin)/);
+      var adminMap = {
+        h: "", o: "/orders", p: "/products", c: "/customers",
+        a: "/analytics", m: "/marketing", d: "/discounts", s: "/settings",
+      };
+      if (m && adminMap[e.key] !== undefined) {
+        e.preventDefault();
+        location.href = m[1] + adminMap[e.key];
+        return;
+      }
+      var rootMap = {
+        h: "/", j: "/jobs", o: "/orders", f: "/feed",
+        m: "/messaging", n: "/mynetwork", e: "/explore",
+      };
+      if (rootMap[e.key]) {
+        e.preventDefault();
+        location.href = rootMap[e.key];
+      }
+    }
+  });
+
+  // ── Show chord-hint helper on `?` ───────────────────────────
+  document.addEventListener("keydown", function (e) {
+    if (e.target.matches("input, textarea, select, [contenteditable]")) return;
+    if (e.key === "?" && e.shiftKey) {
+      e.preventDefault();
+      toast(
+        "g+h home, g+o orders, g+p products, g+c customers, / search",
+        "success",
+      );
+    }
+  });
+
+  // ── Auto-emit ARIA role on tabs lacking it ──────────────────
+  document.querySelectorAll(
+    ".sp-tab, .adm-tab, .tab, [data-testid$=-tab], [data-testid^=tab-]",
+  ).forEach(function (t) {
+    if (!t.getAttribute("role")) t.setAttribute("role", "tab");
+    if (t.classList.contains("is-active")) {
+      t.setAttribute("aria-current", "page");
+    }
+  });
+})();

--- a/deploy/sim_envs/mantis_mercor/app/templates/base.html
+++ b/deploy/sim_envs/mantis_mercor/app/templates/base.html
@@ -5,6 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>{% block title %}Mercor — Shape the frontier of AI{% endblock %}</title>
   <link rel="stylesheet" href="/static/site.css" />
+  <link rel="stylesheet" href="/static/polish.css?v=20260610a" />
+  <script src="/static/polish.js?v=20260610a" defer></script>
 </head>
 <body>
 <header class="topbar" data-testid="topbar">
@@ -21,10 +23,12 @@
       <a href="/experts" data-testid="nav-experts">Experts</a>
     </nav>
     <div class="topbar-actions" data-testid="topbar-actions">
-      {% set _u = request.state.current_user if request.state and request.state.current_user else None %}
+      {% set _u = (request.state.current_user if request.state and request.state.current_user else None) or (request.state.effective_user if request.state and request.state.effective_user else None) %}
       {% if _u %}
         <a class="link-quiet" href="/dashboard" data-testid="topbar-dashboard">Dashboard</a>
-        <span class="topbar-avatar" data-testid="topbar-avatar">{{ _u.name | initials }}</span>
+        <a class="link-quiet" href="/profile" data-testid="topbar-profile">Profile</a>
+        <span class="topbar-avatar" data-testid="topbar-avatar"
+              title="{{ _u.name }}">{{ _u.name | initials }}</span>
         <form method="post" action="/logout" style="display:inline">
           <button type="submit" class="btn-quiet" data-testid="topbar-logout">Sign out</button>
         </form>
@@ -44,7 +48,9 @@
     <div class="footer-links">
       <a href="/jobs">Roles</a>
       <a href="/experts">Experts</a>
-      <a href="/login">Sign in</a>
+      {% if not ((request.state.current_user if request.state else None) or (request.state.effective_user if request.state else None)) %}
+        <a href="/login">Sign in</a>
+      {% endif %}
     </div>
   </div>
 </footer>

--- a/deploy/sim_envs/mantis_shopify/Dockerfile
+++ b/deploy/sim_envs/mantis_shopify/Dockerfile
@@ -1,0 +1,23 @@
+FROM python:3.11-slim
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends curl \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /srv
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY app ./app
+
+ENV PORT=8080 \
+    SEED=42 \
+    FAKE_NOW=2026-06-09T09:00:00Z \
+    PYTHONUNBUFFERED=1
+
+EXPOSE 8080
+HEALTHCHECK --interval=5s --timeout=2s --start-period=10s --retries=6 \
+    CMD curl -fs http://127.0.0.1:8080/__env__/health || exit 1
+
+CMD ["python", "-m", "uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/deploy/sim_envs/mantis_shopify/README.md
+++ b/deploy/sim_envs/mantis_shopify/README.md
@@ -1,0 +1,99 @@
+# mantis-shopify — Shopify Partners back-office mirror
+
+Functional, high-fidelity mirror of the Shopify Partners dashboard
+post-login, for use as a CUA training sim env. Mirrors every
+sub-section EXCEPT `App distribution / /apps` (per scope).
+
+## Sections mirrored
+
+| Route                         | Section                |
+| ----------------------------- | ---------------------- |
+| `/`                           | Home (stores + KPIs + changelog) |
+| `/stores`                     | Stores                 |
+| `/sales`                      | Sales → Leads          |
+| `/sales/referrals`            | Sales → Referrals      |
+| `/sales/leads/new`            | Submit a lead          |
+| `/catalogs`                   | Catalogs               |
+| `/themes`                     | Themes                 |
+| `/partner_directory`          | Partner Directory      |
+| `/partner_directory/profile`  | Directory profile edit |
+| `/pos`                        | Shopify POS marketing surface |
+| `/docs/partner`               | Partner docs           |
+| `/docs/product`               | Product docs           |
+| `/support`                    | Support landing        |
+| `/support/contact`            | Submit ticket          |
+| `/payouts`                    | Payouts list           |
+| `/payouts/<id>`               | Payout detail          |
+| `/team`                       | Team (owners + staff)  |
+| `/team/invite`                | Invite team member     |
+| `/settings`                   | Partner account settings |
+| `/notifications`              | Notifications list     |
+
+## Oracles
+
+10 programmable verifiers live in `app/oracles/`, each reading
+DB state + `audit_log` (never the agent transcript). All run in
+<100 ms.
+
+| Task | Pass criteria summary |
+| ---- | -------------------- |
+| `t01_submit_plus_lead` | `lead_submitted` audit row with `product=plus` resolves to a `leads` row with merchant + email |
+| `t02_invite_staff_member` | `staff_invited` audit row resolves to a users row with `status=invited` and a valid role |
+| `t03_export_payouts_csv` | `payouts_export_requested` audit row exists |
+| `t04_create_support_ticket` | `support_ticket_created` audit row + `tickets` row with subject + category + non-empty description |
+| `t05_update_business_email` | `settings_updated` audit row w/ `field=business_email` and the partners row's `business_email` matches |
+| `t06_view_payout_detail` | `payout_viewed` audit row that resolves to a `payouts` row |
+| `t07_dismiss_emergency_banner` | `banner_dismissed` audit row with `target_id=emergency_contact` |
+| `t08_directory_request_review` | `directory_review_requested` audit row + listing's `review_status` is `requested` or `received` |
+| `t09_search_stores_filter` | `stores_filter_applied` audit row with non-empty `q` or `status` |
+| `t10_submit_pos_referral` | `lead_submitted` audit row with `product=pos` resolves to a valid `leads` row |
+
+Run them locally:
+
+```bash
+cd deploy/sim_envs/mantis_shopify
+ENV_ADMIN_TOKEN=test python scripts/oracle_smoke.py
+```
+
+## Local dev
+
+```bash
+cd deploy/sim_envs/mantis_shopify
+pip install -r requirements.txt
+ENV_ADMIN_TOKEN=test python -m uvicorn app.main:app --port 8080
+```
+
+## Docker
+
+```bash
+docker build -t mantis/sim-env-mantis-shopify:latest .
+docker run --rm -p 8080:8080 \
+  -e ENV_ADMIN_TOKEN=$(python -c 'import secrets;print(secrets.token_urlsafe(32))') \
+  mantis/sim-env-mantis-shopify:latest
+```
+
+## Daytona deploy
+
+```bash
+uv run python deploy/sim_envs/daytona_mantis_shopify.py
+```
+
+## Auth model
+
+By default `ENV_REQUIRE_AUTH=0` — the canonical owner
+(`owner@example.com` / `barada@example.com`) is silently treated as
+the signed-in user. Set `ENV_REQUIRE_AUTH=1` to require the cookie
+login (demo creds: `barada@example.com` / `password`).
+
+## Harness contract
+
+* `GET /__env__/health`
+* `POST /__env__/reset`
+* `POST /__env__/seed`
+* `POST /__env__/clock`
+* `GET /__env__/oracle?task_id=tNN`
+* `GET /__env__/state`
+* `GET /__env__/events?since=<ts>`
+* `GET /__env__/mutations?since=<id>`
+
+All non-health admin routes require header `X-Env-Admin: <ENV_ADMIN_TOKEN>`.

--- a/deploy/sim_envs/mantis_shopify/app/auth.py
+++ b/deploy/sim_envs/mantis_shopify/app/auth.py
@@ -15,7 +15,6 @@ import time
 from typing import Any
 
 from fastapi import Request, Response
-from fastapi.responses import RedirectResponse
 
 from . import db
 

--- a/deploy/sim_envs/mantis_shopify/app/auth.py
+++ b/deploy/sim_envs/mantis_shopify/app/auth.py
@@ -1,0 +1,150 @@
+"""Mock auth for mantis-shopify.
+
+Single-tenant Partners shell — the seeded owner is auto-signed-in
+when ENV_REQUIRE_AUTH=0 (the default), so the entire post-login
+dashboard is reachable without a real session cookie. Sessions are
+signed cookies via plain hmac for the optional login flow.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import os
+import time
+from typing import Any
+
+from fastapi import Request, Response
+from fastapi.responses import RedirectResponse
+
+from . import db
+
+SESSION_COOKIE = "mantis_shopify_session"
+SESSION_TTL_DEFAULT_S = 60 * 60 * 8  # 8h
+LOGIN_PATH = "/login"
+
+CANONICAL_OWNER_ID = "owner_00001"
+
+
+def session_secret() -> str:
+    return os.environ.get("ENV_SESSION_SECRET", "dev-only-do-not-use-in-prod")
+
+
+def session_ttl_s() -> int:
+    raw = os.environ.get("ENV_SESSION_TTL_S")
+    try:
+        return int(raw) if raw else SESSION_TTL_DEFAULT_S
+    except ValueError:
+        return SESSION_TTL_DEFAULT_S
+
+
+def auth_required() -> bool:
+    return os.environ.get("ENV_REQUIRE_AUTH", "0").lower() in {"1", "true", "yes"}
+
+
+def hash_password(plain: str) -> str:
+    return hashlib.sha256(plain.encode("utf-8")).hexdigest()
+
+
+def verify_password(plain: str, stored: str) -> bool:
+    return hmac.compare_digest(hash_password(plain), stored)
+
+
+def mint_session(user_id: str, *, now: float | None = None) -> str:
+    issued = int(now if now is not None else time.time())
+    payload = f"{user_id}|{issued}"
+    sig = hmac.new(
+        session_secret().encode("utf-8"),
+        payload.encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+    return f"{payload}|{sig}"
+
+
+def verify_session(cookie_val: str, *, now: float | None = None) -> str | None:
+    if not cookie_val:
+        return None
+    parts = cookie_val.split("|")
+    if len(parts) != 3:
+        return None
+    user_id, issued_at_s, sig = parts
+    try:
+        issued_at = int(issued_at_s)
+    except ValueError:
+        return None
+    payload = f"{user_id}|{issued_at}"
+    expected = hmac.new(
+        session_secret().encode("utf-8"),
+        payload.encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+    if not hmac.compare_digest(sig, expected):
+        return None
+    now_ts = now if now is not None else time.time()
+    if now_ts - issued_at > session_ttl_s():
+        return None
+    return user_id
+
+
+def set_session_cookie(response: Response, user_id: str) -> None:
+    response.set_cookie(
+        SESSION_COOKIE,
+        mint_session(user_id),
+        httponly=True,
+        samesite="lax",
+        max_age=session_ttl_s(),
+        path="/",
+    )
+
+
+def clear_session_cookie(response: Response) -> None:
+    response.delete_cookie(SESSION_COOKIE, path="/")
+
+
+def lookup_user_by_id(user_id: str) -> dict[str, Any] | None:
+    conn = db.connect()
+    row = conn.execute(
+        "SELECT id, email, name, role, status, last_login_at, avatar_color "
+        "FROM users WHERE id = ?",
+        (user_id,),
+    ).fetchone()
+    return dict(row) if row else None
+
+
+def lookup_user_by_email(email: str) -> dict[str, Any] | None:
+    conn = db.connect()
+    row = conn.execute(
+        "SELECT id, email, password_hash, name, role, status, last_login_at, avatar_color "
+        "FROM users WHERE email = ?",
+        (email.strip().lower(),),
+    ).fetchone()
+    return dict(row) if row else None
+
+
+def current_user(request: Request) -> dict[str, Any] | None:
+    raw = request.cookies.get(SESSION_COOKIE)
+    user_id = verify_session(raw or "")
+    if user_id is None:
+        return None
+    return lookup_user_by_id(user_id)
+
+
+def effective_user(request: Request) -> dict[str, Any]:
+    """Return current user, or the canonical seeded owner if no auth.
+
+    Keeps the Partners shell rendering the owner identity in the
+    topbar even when ENV_REQUIRE_AUTH=0 (default).
+    """
+    u = current_user(request)
+    if u:
+        return u
+    fb = lookup_user_by_id(CANONICAL_OWNER_ID)
+    return fb or {
+        "id": CANONICAL_OWNER_ID,
+        "email": "barada@example.com",
+        "name": "Barada Sahu",
+        "role": "owner",
+        "status": "active",
+        "last_login_at": "",
+        "avatar_color": "#5c6ac4",
+    }

--- a/deploy/sim_envs/mantis_shopify/app/db.py
+++ b/deploy/sim_envs/mantis_shopify/app/db.py
@@ -1,0 +1,265 @@
+"""SQLite schema for mantis-shopify.
+
+Mirrors mantis-mercor's pattern: in-memory by default, single shared
+connection, schema applied on first connect. audit_log is the
+oracle source-of-truth.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import threading
+from contextlib import contextmanager
+from typing import Any, Iterator
+
+_DB_LOCK = threading.RLock()
+_DB: sqlite3.Connection | None = None
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS partners (
+    id              TEXT PRIMARY KEY,
+    partner_id      TEXT NOT NULL,
+    business_name   TEXT NOT NULL DEFAULT '',
+    website         TEXT NOT NULL DEFAULT '',
+    business_email  TEXT NOT NULL DEFAULT '',
+    support_email   TEXT NOT NULL DEFAULT '',
+    phone           TEXT NOT NULL DEFAULT '',
+    address1        TEXT NOT NULL DEFAULT '',
+    address2        TEXT NOT NULL DEFAULT '',
+    city            TEXT NOT NULL DEFAULT '',
+    zip             TEXT NOT NULL DEFAULT '',
+    state           TEXT NOT NULL DEFAULT '',
+    country         TEXT NOT NULL DEFAULT '',
+    emergency_name  TEXT NOT NULL DEFAULT '',
+    emergency_email TEXT NOT NULL DEFAULT '',
+    emergency_phone TEXT NOT NULL DEFAULT '',
+    payout_method   TEXT NOT NULL DEFAULT '',
+    updated_at      TEXT NOT NULL DEFAULT ''
+);
+
+CREATE TABLE IF NOT EXISTS users (
+    id              TEXT PRIMARY KEY,
+    email           TEXT NOT NULL UNIQUE,
+    password_hash   TEXT NOT NULL DEFAULT '',
+    name            TEXT NOT NULL DEFAULT '',
+    role            TEXT NOT NULL DEFAULT 'staff',  -- 'owner' | 'staff'
+    status          TEXT NOT NULL DEFAULT 'active', -- 'active' | 'invited'
+    last_login_at   TEXT NOT NULL DEFAULT '',
+    avatar_color    TEXT NOT NULL DEFAULT '#5c6ac4',
+    created_at      TEXT NOT NULL DEFAULT ''
+);
+CREATE INDEX IF NOT EXISTS idx_users_email ON users(email);
+
+CREATE TABLE IF NOT EXISTS stores (
+    id              TEXT PRIMARY KEY,
+    name            TEXT NOT NULL,
+    slug            TEXT NOT NULL,
+    kind            TEXT NOT NULL,                  -- 'client_transfer' | 'collaborator' | 'active_development'
+    status          TEXT NOT NULL DEFAULT 'active', -- 'active' | 'archived' | 'inactive'
+    last_login_at   TEXT NOT NULL DEFAULT '',
+    plan            TEXT NOT NULL DEFAULT ''
+);
+CREATE INDEX IF NOT EXISTS idx_stores_kind ON stores(kind);
+CREATE INDEX IF NOT EXISTS idx_stores_status ON stores(status);
+
+CREATE TABLE IF NOT EXISTS payouts (
+    id              TEXT PRIMARY KEY,
+    period_start    TEXT NOT NULL,
+    period_end      TEXT NOT NULL,
+    sent_at         TEXT NOT NULL DEFAULT '',
+    amount_cents    INTEGER NOT NULL,
+    currency        TEXT NOT NULL DEFAULT 'USD',
+    method          TEXT NOT NULL DEFAULT 'bank account (***05)',
+    status          TEXT NOT NULL DEFAULT 'paid'    -- 'paid' | 'pending'
+);
+
+CREATE TABLE IF NOT EXISTS payout_line_items (
+    id              TEXT PRIMARY KEY,
+    payout_id       TEXT NOT NULL REFERENCES payouts(id),
+    occurred_at     TEXT NOT NULL,
+    description     TEXT NOT NULL,
+    amount_cents    INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_pli_payout ON payout_line_items(payout_id);
+
+CREATE TABLE IF NOT EXISTS leads (
+    id              TEXT PRIMARY KEY,
+    product         TEXT NOT NULL,                  -- 'plus' | 'pos' | 'plus_b2b'
+    merchant_name   TEXT NOT NULL,
+    contact_email   TEXT NOT NULL DEFAULT '',
+    contact_name    TEXT NOT NULL DEFAULT '',
+    status          TEXT NOT NULL DEFAULT 'submitted', -- 'submitted' | 'qualified' | 'won' | 'lost'
+    earnings_cents  INTEGER NOT NULL DEFAULT 0,
+    submitted_at    TEXT NOT NULL,
+    notes           TEXT NOT NULL DEFAULT ''
+);
+
+CREATE TABLE IF NOT EXISTS referrals (
+    id              TEXT PRIMARY KEY,
+    merchant_name   TEXT NOT NULL,
+    plan            TEXT NOT NULL,
+    status          TEXT NOT NULL DEFAULT 'active',
+    earnings_cents  INTEGER NOT NULL DEFAULT 0,
+    created_at      TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS directory_listings (
+    id              TEXT PRIMARY KEY,
+    business_name   TEXT NOT NULL,
+    plan            TEXT NOT NULL,
+    review_status   TEXT NOT NULL DEFAULT 'available' -- 'available' | 'requested' | 'received'
+);
+
+CREATE TABLE IF NOT EXISTS tickets (
+    id              TEXT PRIMARY KEY,
+    subject         TEXT NOT NULL,
+    category        TEXT NOT NULL,
+    description     TEXT NOT NULL,
+    status          TEXT NOT NULL DEFAULT 'open',
+    created_at      TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS themes (
+    id              TEXT PRIMARY KEY,
+    name            TEXT NOT NULL,
+    status          TEXT NOT NULL DEFAULT 'draft',  -- 'draft' | 'in_review' | 'approved' | 'rejected'
+    created_at      TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS catalogs (
+    id              TEXT PRIMARY KEY,
+    name            TEXT NOT NULL,
+    products_count  INTEGER NOT NULL DEFAULT 0,
+    status          TEXT NOT NULL DEFAULT 'draft',  -- 'draft' | 'published'
+    created_at      TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS changelog (
+    id              TEXT PRIMARY KEY,
+    published_at    TEXT NOT NULL,
+    category        TEXT NOT NULL,
+    title           TEXT NOT NULL,
+    summary         TEXT NOT NULL DEFAULT ''
+);
+
+CREATE TABLE IF NOT EXISTS notifications (
+    id              TEXT PRIMARY KEY,
+    occurred_at     TEXT NOT NULL,
+    title           TEXT NOT NULL,
+    body            TEXT NOT NULL DEFAULT '',
+    read            INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS merchant_orders (
+    id              TEXT PRIMARY KEY,
+    store_id        TEXT NOT NULL REFERENCES stores(id),
+    order_number    TEXT NOT NULL,                  -- '#1042'
+    customer_name   TEXT NOT NULL,
+    customer_email  TEXT NOT NULL DEFAULT '',
+    total_cents     INTEGER NOT NULL,
+    currency        TEXT NOT NULL DEFAULT 'USD',
+    financial_status TEXT NOT NULL DEFAULT 'paid',  -- 'paid' | 'pending' | 'refunded'
+    fulfillment_status TEXT NOT NULL DEFAULT 'unfulfilled', -- 'unfulfilled' | 'fulfilled' | 'partial'
+    items_count     INTEGER NOT NULL DEFAULT 1,
+    items_json      TEXT NOT NULL DEFAULT '[]',
+    ordered_at      TEXT NOT NULL,
+    delivery_method TEXT NOT NULL DEFAULT 'Standard'
+);
+CREATE INDEX IF NOT EXISTS idx_mo_store ON merchant_orders(store_id);
+
+CREATE TABLE IF NOT EXISTS merchant_products (
+    id              TEXT PRIMARY KEY,
+    store_id        TEXT NOT NULL REFERENCES stores(id),
+    title           TEXT NOT NULL,
+    status          TEXT NOT NULL DEFAULT 'active', -- 'active' | 'draft' | 'archived'
+    inventory       INTEGER NOT NULL DEFAULT 0,
+    vendor          TEXT NOT NULL DEFAULT '',
+    product_type    TEXT NOT NULL DEFAULT '',
+    price_cents     INTEGER NOT NULL DEFAULT 0,
+    sku             TEXT NOT NULL DEFAULT '',
+    created_at      TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_mp_store ON merchant_products(store_id);
+
+CREATE TABLE IF NOT EXISTS merchant_customers (
+    id              TEXT PRIMARY KEY,
+    store_id        TEXT NOT NULL REFERENCES stores(id),
+    name            TEXT NOT NULL,
+    email           TEXT NOT NULL DEFAULT '',
+    orders_count    INTEGER NOT NULL DEFAULT 0,
+    total_spent_cents INTEGER NOT NULL DEFAULT 0,
+    location        TEXT NOT NULL DEFAULT '',
+    last_order_at   TEXT NOT NULL DEFAULT '',
+    created_at      TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_mc_store ON merchant_customers(store_id);
+
+CREATE TABLE IF NOT EXISTS audit_log (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    occurred_at     TEXT NOT NULL,
+    operation       TEXT NOT NULL,
+    target_type     TEXT NOT NULL,
+    target_id       TEXT NOT NULL,
+    payload_json    TEXT NOT NULL DEFAULT '{}'
+);
+CREATE INDEX IF NOT EXISTS idx_audit_op ON audit_log(operation);
+"""
+
+
+def db_path() -> str:
+    return os.environ.get("DB_PATH") or ":memory:"
+
+
+def connect() -> sqlite3.Connection:
+    global _DB
+    with _DB_LOCK:
+        if _DB is None:
+            conn = sqlite3.connect(db_path(), check_same_thread=False)
+            conn.row_factory = sqlite3.Row
+            conn.executescript(SCHEMA)
+            _DB = conn
+        return _DB
+
+
+def reset_connection() -> None:
+    global _DB
+    with _DB_LOCK:
+        if _DB is not None:
+            _DB.close()
+            _DB = None
+
+
+@contextmanager
+def transaction() -> Iterator[sqlite3.Connection]:
+    conn = connect()
+    with _DB_LOCK:
+        try:
+            yield conn
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+
+
+def log_audit(
+    conn: sqlite3.Connection,
+    *,
+    occurred_at: str,
+    operation: str,
+    target_type: str,
+    target_id: str,
+    payload: dict[str, Any] | None = None,
+) -> None:
+    conn.execute(
+        "INSERT INTO audit_log (occurred_at, operation, target_type, target_id, payload_json) "
+        "VALUES (?, ?, ?, ?, ?)",
+        (
+            occurred_at,
+            operation,
+            target_type,
+            target_id,
+            json.dumps(payload or {}, sort_keys=True),
+        ),
+    )

--- a/deploy/sim_envs/mantis_shopify/app/main.py
+++ b/deploy/sim_envs/mantis_shopify/app/main.py
@@ -1,0 +1,234 @@
+"""mantis-shopify FastAPI app — entrypoint.
+
+Surfaces:
+
+* ``/`` — the Shopify Partners back-office mirror (server-rendered).
+* ``/__env__/*`` — harness-only, gated on ``X-Env-Admin`` header.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse, RedirectResponse
+from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
+
+from . import auth, db, seed
+
+APP_DIR = Path(__file__).parent
+ADMIN_TOKEN_ENV = "ENV_ADMIN_TOKEN"
+ADMIN_HEADER = "X-Env-Admin"
+
+
+def _admin_token() -> str:
+    token = os.environ.get(ADMIN_TOKEN_ENV, "").strip()
+    if not token:
+        raise RuntimeError(
+            f"{ADMIN_TOKEN_ENV} is required — harness generates it per run."
+        )
+    return token
+
+
+def _now() -> str:
+    return os.environ.get("FAKE_NOW") or seed.FAKE_NOW_DEFAULT
+
+
+def _seed_val() -> int:
+    return int(os.environ.get("SEED") or 42)
+
+
+_EVENTS: list[dict[str, Any]] = []
+_BOOT_TIME = time.time()
+
+
+def _emit_event(event: str, data: dict[str, Any] | None = None) -> None:
+    _EVENTS.append({
+        "ts": time.time(),
+        "event": event,
+        "data": data or {},
+    })
+
+
+def _initials_for(name: str) -> str:
+    parts = [p for p in (name or "").split() if p]
+    if len(parts) >= 2:
+        return (parts[0][0] + parts[1][0]).upper()
+    base = (parts[0] if parts else "?").upper()
+    return (base + "?")[:2]
+
+
+def _money(cents: int | float | None) -> str:
+    if cents is None:
+        return "$0.00"
+    dollars = (int(cents) / 100.0)
+    return f"${dollars:,.2f}"
+
+
+def _short_date(iso: str) -> str:
+    """Format an ISO date like '2026-06-09T09:00:00Z' → 'Jun 9, 2026'."""
+    if not iso:
+        return ""
+    s = iso.replace("Z", "+00:00")
+    try:
+        from datetime import datetime
+        dt = datetime.fromisoformat(s)
+        return dt.strftime("%b %-d, %Y")
+    except Exception:  # noqa: BLE001
+        return iso
+
+
+def _humanize_last_login(iso: str, now_iso: str) -> str:
+    if not iso:
+        return "never"
+    from datetime import datetime
+    try:
+        dt = datetime.fromisoformat(iso.replace("Z", "+00:00"))
+        nt = datetime.fromisoformat(now_iso.replace("Z", "+00:00"))
+    except Exception:  # noqa: BLE001
+        return iso
+    delta = nt - dt
+    seconds = int(delta.total_seconds())
+    if seconds < 0:
+        return "just now"
+    if seconds < 90 * 60:
+        return f"about {max(1, seconds // 60)} minutes ago"
+    hours = seconds // 3600
+    if hours < 24:
+        return f"about {hours} hour{'s' if hours != 1 else ''} ago"
+    days = hours // 24
+    if days < 30:
+        return f"{days} day{'s' if days != 1 else ''} ago"
+    months = days // 30
+    if months < 12:
+        return f"{months} month{'s' if months != 1 else ''} ago"
+    years = months // 12
+    return f"over {years} year{'s' if years != 1 else ''} ago"
+
+
+def create_app() -> FastAPI:
+    app = FastAPI(title="mantis-shopify", docs_url=None, redoc_url=None)
+
+    templates = Jinja2Templates(directory=str(APP_DIR / "templates"))
+    templates.env.filters["initials"] = _initials_for
+    templates.env.filters["money"] = _money
+    templates.env.filters["short_date"] = _short_date
+    templates.env.globals["humanize_last_login"] = _humanize_last_login
+    app.state.templates = templates
+    app.state.admin_token = _admin_token()
+
+    @app.middleware("http")
+    async def _auth_gate(request: Request, call_next):  # noqa: ANN202
+        try:
+            request.state.current_user = auth.current_user(request)
+        except Exception:  # noqa: BLE001
+            request.state.current_user = None
+
+        # Inject the effective owner identity so templates always render
+        # the topbar / sidebar shell — Partners is a post-login surface.
+        request.state.effective_user = auth.effective_user(request)
+
+        if auth.auth_required():
+            path = request.url.path
+            open_prefixes = (
+                "/login", "/logout", "/__env__/", "/static/",
+            )
+            if not (path.startswith(open_prefixes)):
+                user = request.state.current_user
+                if user is None:
+                    return RedirectResponse(
+                        f"/login?next={path}", status_code=303,
+                    )
+        return await call_next(request)
+
+    @app.on_event("startup")
+    def _bootstrap() -> None:
+        conn = db.connect()
+        cur = conn.execute("SELECT COUNT(*) FROM partners")
+        if cur.fetchone()[0] == 0:
+            seed.seed(conn, seed_val=_seed_val(), fake_now=_now())
+            _emit_event("seeded", {"seed": _seed_val(), "now": _now()})
+
+    app.mount(
+        "/static",
+        StaticFiles(directory=str(APP_DIR / "static")),
+        name="static",
+    )
+
+    from .routes import (
+        admin as admin_router,
+        auth as auth_router,
+        catalogs as catalogs_router,
+        directory as directory_router,
+        docs as docs_router,
+        env_admin as env_admin_router,
+        home as home_router,
+        payouts as payouts_router,
+        pos as pos_router,
+        sales as sales_router,
+        settings as settings_router,
+        stores as stores_router,
+        support as support_router,
+        team as team_router,
+        themes as themes_router,
+    )
+
+    app.include_router(env_admin_router.router)
+    app.include_router(auth_router.router)
+    app.include_router(home_router.router)
+    app.include_router(stores_router.router)
+    app.include_router(sales_router.router)
+    app.include_router(catalogs_router.router)
+    app.include_router(themes_router.router)
+    app.include_router(directory_router.router)
+    app.include_router(pos_router.router)
+    app.include_router(docs_router.router)
+    app.include_router(support_router.router)
+    app.include_router(payouts_router.router)
+    app.include_router(team_router.router)
+    app.include_router(settings_router.router)
+    app.include_router(admin_router.router)
+
+    return app
+
+
+app = create_app()
+
+
+# Helpers exposed to the routes package ------------------------------
+
+
+def admin_token_ok(request: Request) -> bool:
+    return request.headers.get(ADMIN_HEADER) == request.app.state.admin_token
+
+
+def admin_required_response() -> JSONResponse:
+    return JSONResponse({"error": "admin token required"}, status_code=401)
+
+
+def now_value() -> str:
+    return _now()
+
+
+def seed_value() -> int:
+    return _seed_val()
+
+
+def boot_time() -> float:
+    return _BOOT_TIME
+
+
+def emit(event: str, data: dict[str, Any] | None = None) -> None:
+    _emit_event(event, data)
+
+
+def events_since(ts: float) -> list[dict[str, Any]]:
+    return [e for e in _EVENTS if e["ts"] >= ts]
+
+
+def clear_events() -> None:
+    _EVENTS.clear()

--- a/deploy/sim_envs/mantis_shopify/app/oracles/__init__.py
+++ b/deploy/sim_envs/mantis_shopify/app/oracles/__init__.py
@@ -1,0 +1,75 @@
+"""Oracles — server-side graders for mantis-shopify.
+
+Each oracle reads DB state + audit_log. Never the agent transcript.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Any, Callable
+
+from . import (
+    t01_submit_plus_lead,
+    t02_invite_staff_member,
+    t03_export_payouts_csv,
+    t04_create_support_ticket,
+    t05_update_business_email,
+    t06_view_payout_detail,
+    t07_dismiss_emergency_banner,
+    t08_directory_request_review,
+    t09_search_stores_filter,
+    t10_submit_pos_referral,
+    t11_view_store_detail,
+    t12_view_catalog_detail,
+    t13_view_merchant_order,
+    t14_fulfill_merchant_order,
+)
+
+GraderFn = Callable[..., dict[str, Any]]
+
+GRADERS: dict[str, GraderFn] = {
+    "t01": t01_submit_plus_lead.grade,
+    "t01_submit_plus_lead": t01_submit_plus_lead.grade,
+    "t02": t02_invite_staff_member.grade,
+    "t02_invite_staff_member": t02_invite_staff_member.grade,
+    "t03": t03_export_payouts_csv.grade,
+    "t03_export_payouts_csv": t03_export_payouts_csv.grade,
+    "t04": t04_create_support_ticket.grade,
+    "t04_create_support_ticket": t04_create_support_ticket.grade,
+    "t05": t05_update_business_email.grade,
+    "t05_update_business_email": t05_update_business_email.grade,
+    "t06": t06_view_payout_detail.grade,
+    "t06_view_payout_detail": t06_view_payout_detail.grade,
+    "t07": t07_dismiss_emergency_banner.grade,
+    "t07_dismiss_emergency_banner": t07_dismiss_emergency_banner.grade,
+    "t08": t08_directory_request_review.grade,
+    "t08_directory_request_review": t08_directory_request_review.grade,
+    "t09": t09_search_stores_filter.grade,
+    "t09_search_stores_filter": t09_search_stores_filter.grade,
+    "t10": t10_submit_pos_referral.grade,
+    "t10_submit_pos_referral": t10_submit_pos_referral.grade,
+    "t11": t11_view_store_detail.grade,
+    "t11_view_store_detail": t11_view_store_detail.grade,
+    "t12": t12_view_catalog_detail.grade,
+    "t12_view_catalog_detail": t12_view_catalog_detail.grade,
+    "t13": t13_view_merchant_order.grade,
+    "t13_view_merchant_order": t13_view_merchant_order.grade,
+    "t14": t14_fulfill_merchant_order.grade,
+    "t14_fulfill_merchant_order": t14_fulfill_merchant_order.grade,
+}
+
+
+def grade(task_id: str, conn: sqlite3.Connection, *, now: str,
+          seed_val: int) -> dict[str, Any]:
+    fn = GRADERS.get(task_id)
+    if fn is None:
+        return {
+            "passed": False,
+            "score": 0.0,
+            "task_id": task_id,
+            "reasons": [f"no oracle registered for task_id={task_id!r}"],
+            "diff": {},
+        }
+    result = fn(conn, now=now, seed_val=seed_val)
+    result.setdefault("task_id", task_id)
+    return result

--- a/deploy/sim_envs/mantis_shopify/app/oracles/t01_submit_plus_lead.py
+++ b/deploy/sim_envs/mantis_shopify/app/oracles/t01_submit_plus_lead.py
@@ -1,0 +1,59 @@
+"""t01 — Submit a Plus lead via Sales → Submit a Plus lead."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from typing import Any
+
+
+def grade(conn: sqlite3.Connection, *, now: str, seed_val: int) -> dict[str, Any]:
+    reasons: list[str] = []
+
+    audit_rows = conn.execute(
+        "SELECT target_id, payload_json FROM audit_log "
+        "WHERE operation='lead_submitted' ORDER BY id DESC"
+    ).fetchall()
+
+    matched: dict[str, Any] | None = None
+    for r in audit_rows:
+        payload = json.loads(r["payload_json"] or "{}")
+        if payload.get("product") != "plus":
+            continue
+        lead = conn.execute(
+            "SELECT * FROM leads WHERE id=?", (r["target_id"],),
+        ).fetchone()
+        if lead is None:
+            continue
+        matched = dict(lead)
+        break
+
+    if matched is None:
+        return _fail(
+            ["no lead_submitted audit row with product='plus' found"],
+            {"audit_rows": len(audit_rows)},
+        )
+
+    if not matched.get("merchant_name", "").strip():
+        reasons.append("merchant_name is empty on the matched lead")
+    if "@" not in (matched.get("contact_email") or ""):
+        reasons.append("contact_email missing or invalid on the matched lead")
+
+    passed = not reasons
+    return {
+        "passed": passed,
+        "score": 1.0 if passed else 0.0,
+        "reasons": reasons or [
+            f"lead {matched['id']} submitted as Plus for "
+            f"{matched['merchant_name']!r}"
+        ],
+        "diff": {
+            "lead_id": matched["id"],
+            "merchant_name": matched["merchant_name"],
+            "contact_email": matched["contact_email"],
+        },
+    }
+
+
+def _fail(reasons, diff):
+    return {"passed": False, "score": 0.0, "reasons": reasons, "diff": diff}

--- a/deploy/sim_envs/mantis_shopify/app/oracles/t02_invite_staff_member.py
+++ b/deploy/sim_envs/mantis_shopify/app/oracles/t02_invite_staff_member.py
@@ -1,0 +1,70 @@
+"""t02 — Invite a new staff member via Team → Invite staff."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from typing import Any
+
+ACCEPTABLE_ROLES = {
+    "owner", "staff_business", "staff_dev", "staff_marketing",
+    "staff_support", "staff_finance",
+}
+
+
+def grade(conn: sqlite3.Connection, *, now: str, seed_val: int) -> dict[str, Any]:
+    reasons: list[str] = []
+
+    audit_rows = conn.execute(
+        "SELECT id, target_id, payload_json FROM audit_log "
+        "WHERE operation='staff_invited' ORDER BY id DESC"
+    ).fetchall()
+
+    if not audit_rows:
+        return _fail(["no staff_invited audit row"], {})
+
+    matched = None
+    for r in audit_rows:
+        payload = json.loads(r["payload_json"] or "{}")
+        email = (payload.get("email") or "").strip()
+        role = (payload.get("role") or "").strip()
+        if "@" not in email:
+            continue
+        if role not in ACCEPTABLE_ROLES:
+            continue
+        user = conn.execute(
+            "SELECT * FROM users WHERE id=?", (r["target_id"],),
+        ).fetchone()
+        if user is None:
+            continue
+        if user["status"] != "invited":
+            continue
+        matched = (dict(user), payload)
+        break
+
+    if matched is None:
+        return _fail(
+            ["no staff_invited audit row produced an invited users row "
+             "with a valid role and email"],
+            {"audit_rows_seen": len(audit_rows)},
+        )
+
+    user_row, payload = matched
+    passed = True
+    return {
+        "passed": passed,
+        "score": 1.0,
+        "reasons": [
+            f"user {user_row['id']} invited with role={payload['role']!r}"
+        ],
+        "diff": {
+            "user_id": user_row["id"],
+            "email": user_row["email"],
+            "role": user_row["role"],
+            "status": user_row["status"],
+        },
+    }
+
+
+def _fail(reasons, diff):
+    return {"passed": False, "score": 0.0, "reasons": reasons, "diff": diff}

--- a/deploy/sim_envs/mantis_shopify/app/oracles/t02_invite_staff_member.py
+++ b/deploy/sim_envs/mantis_shopify/app/oracles/t02_invite_staff_member.py
@@ -13,8 +13,6 @@ ACCEPTABLE_ROLES = {
 
 
 def grade(conn: sqlite3.Connection, *, now: str, seed_val: int) -> dict[str, Any]:
-    reasons: list[str] = []
-
     audit_rows = conn.execute(
         "SELECT id, target_id, payload_json FROM audit_log "
         "WHERE operation='staff_invited' ORDER BY id DESC"

--- a/deploy/sim_envs/mantis_shopify/app/oracles/t03_export_payouts_csv.py
+++ b/deploy/sim_envs/mantis_shopify/app/oracles/t03_export_payouts_csv.py
@@ -1,0 +1,24 @@
+"""t03 — Export the payouts list as CSV (Payouts → Export CSV)."""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Any
+
+
+def grade(conn: sqlite3.Connection, *, now: str, seed_val: int) -> dict[str, Any]:
+    row = conn.execute(
+        "SELECT id FROM audit_log WHERE operation='payouts_export_requested' "
+        "ORDER BY id DESC LIMIT 1"
+    ).fetchone()
+    if row is None:
+        return {
+            "passed": False, "score": 0.0,
+            "reasons": ["no payouts_export_requested audit row"],
+            "diff": {},
+        }
+    return {
+        "passed": True, "score": 1.0,
+        "reasons": ["payouts export was triggered"],
+        "diff": {"audit_id": row["id"]},
+    }

--- a/deploy/sim_envs/mantis_shopify/app/oracles/t04_create_support_ticket.py
+++ b/deploy/sim_envs/mantis_shopify/app/oracles/t04_create_support_ticket.py
@@ -10,8 +10,6 @@ MIN_DESC_LEN = 5
 
 
 def grade(conn: sqlite3.Connection, *, now: str, seed_val: int) -> dict[str, Any]:
-    reasons: list[str] = []
-
     audit_rows = conn.execute(
         "SELECT id, target_id, payload_json FROM audit_log "
         "WHERE operation='support_ticket_created' ORDER BY id DESC"

--- a/deploy/sim_envs/mantis_shopify/app/oracles/t04_create_support_ticket.py
+++ b/deploy/sim_envs/mantis_shopify/app/oracles/t04_create_support_ticket.py
@@ -1,0 +1,63 @@
+"""t04 — Create a support ticket via Support → Contact Partner Support."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from typing import Any
+
+MIN_DESC_LEN = 5
+
+
+def grade(conn: sqlite3.Connection, *, now: str, seed_val: int) -> dict[str, Any]:
+    reasons: list[str] = []
+
+    audit_rows = conn.execute(
+        "SELECT id, target_id, payload_json FROM audit_log "
+        "WHERE operation='support_ticket_created' ORDER BY id DESC"
+    ).fetchall()
+    if not audit_rows:
+        return _fail(["no support_ticket_created audit row"], {})
+
+    matched = None
+    for r in audit_rows:
+        payload = json.loads(r["payload_json"] or "{}")
+        if not payload.get("subject", "").strip():
+            continue
+        if not payload.get("category", "").strip():
+            continue
+        if int(payload.get("description_len") or 0) < MIN_DESC_LEN:
+            continue
+        ticket = conn.execute(
+            "SELECT * FROM tickets WHERE id=?", (r["target_id"],),
+        ).fetchone()
+        if ticket is None:
+            continue
+        if not (ticket["description"] or "").strip():
+            continue
+        matched = (dict(ticket), payload)
+        break
+
+    if matched is None:
+        return _fail(
+            ["no support_ticket_created audit row has subject + category + "
+             f"description≥{MIN_DESC_LEN} chars resolving to a tickets row"],
+            {"audit_rows_seen": len(audit_rows)},
+        )
+
+    ticket, payload = matched
+    return {
+        "passed": True, "score": 1.0,
+        "reasons": [f"ticket {ticket['id']} created with category="
+                    f"{ticket['category']!r}"],
+        "diff": {
+            "ticket_id": ticket["id"],
+            "subject": ticket["subject"],
+            "category": ticket["category"],
+            "status": ticket["status"],
+        },
+    }
+
+
+def _fail(reasons, diff):
+    return {"passed": False, "score": 0.0, "reasons": reasons, "diff": diff}

--- a/deploy/sim_envs/mantis_shopify/app/oracles/t05_update_business_email.py
+++ b/deploy/sim_envs/mantis_shopify/app/oracles/t05_update_business_email.py
@@ -1,0 +1,57 @@
+"""t05 — Update the partner's business email in Settings → Business details."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from typing import Any
+
+
+def grade(conn: sqlite3.Connection, *, now: str, seed_val: int) -> dict[str, Any]:
+    rows = conn.execute(
+        "SELECT id, target_id, payload_json FROM audit_log "
+        "WHERE operation='settings_updated' ORDER BY id DESC"
+    ).fetchall()
+    if not rows:
+        return _fail(["no settings_updated audit row"], {})
+
+    matched = None
+    for r in rows:
+        payload = json.loads(r["payload_json"] or "{}")
+        if payload.get("field") != "business_email":
+            continue
+        if "@" not in (payload.get("value") or ""):
+            continue
+        partner = conn.execute(
+            "SELECT * FROM partners WHERE id=?", (r["target_id"],),
+        ).fetchone()
+        if partner is None:
+            continue
+        if partner["business_email"] != payload["value"]:
+            continue
+        matched = (dict(partner), payload)
+        break
+
+    if matched is None:
+        return _fail(
+            ["no settings_updated row for business_email matches the current "
+             "partners.business_email"],
+            {"audit_rows_seen": len(rows)},
+        )
+
+    partner, payload = matched
+    return {
+        "passed": True, "score": 1.0,
+        "reasons": [
+            f"partner {partner['id']} business_email now "
+            f"{partner['business_email']!r}"
+        ],
+        "diff": {
+            "partner_id": partner["id"],
+            "business_email": partner["business_email"],
+        },
+    }
+
+
+def _fail(reasons, diff):
+    return {"passed": False, "score": 0.0, "reasons": reasons, "diff": diff}

--- a/deploy/sim_envs/mantis_shopify/app/oracles/t06_view_payout_detail.py
+++ b/deploy/sim_envs/mantis_shopify/app/oracles/t06_view_payout_detail.py
@@ -1,0 +1,46 @@
+"""t06 — Open a payout detail page from the Payouts history list."""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Any
+
+
+def grade(conn: sqlite3.Connection, *, now: str, seed_val: int) -> dict[str, Any]:
+    rows = conn.execute(
+        "SELECT id, target_id FROM audit_log WHERE operation='payout_viewed' "
+        "ORDER BY id DESC"
+    ).fetchall()
+    if not rows:
+        return _fail(["no payout_viewed audit row"], {})
+
+    matched = None
+    for r in rows:
+        payout = conn.execute(
+            "SELECT * FROM payouts WHERE id=?", (r["target_id"],),
+        ).fetchone()
+        if payout is None:
+            continue
+        matched = dict(payout)
+        break
+
+    if matched is None:
+        return _fail(
+            ["payout_viewed audit row(s) found but none reference a valid "
+             "payouts row"],
+            {"audit_rows_seen": len(rows)},
+        )
+
+    return {
+        "passed": True, "score": 1.0,
+        "reasons": [f"payout {matched['id']} detail page was opened"],
+        "diff": {
+            "payout_id": matched["id"],
+            "amount_cents": matched["amount_cents"],
+            "status": matched["status"],
+        },
+    }
+
+
+def _fail(reasons, diff):
+    return {"passed": False, "score": 0.0, "reasons": reasons, "diff": diff}

--- a/deploy/sim_envs/mantis_shopify/app/oracles/t07_dismiss_emergency_banner.py
+++ b/deploy/sim_envs/mantis_shopify/app/oracles/t07_dismiss_emergency_banner.py
@@ -1,0 +1,24 @@
+"""t07 — Dismiss the emergency-contact banner."""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Any
+
+
+def grade(conn: sqlite3.Connection, *, now: str, seed_val: int) -> dict[str, Any]:
+    row = conn.execute(
+        "SELECT id FROM audit_log WHERE operation='banner_dismissed' "
+        "AND target_id='emergency_contact' ORDER BY id DESC LIMIT 1"
+    ).fetchone()
+    if row is None:
+        return {
+            "passed": False, "score": 0.0,
+            "reasons": ["no banner_dismissed audit row for emergency_contact"],
+            "diff": {},
+        }
+    return {
+        "passed": True, "score": 1.0,
+        "reasons": ["emergency-contact banner was dismissed"],
+        "diff": {"audit_id": row["id"]},
+    }

--- a/deploy/sim_envs/mantis_shopify/app/oracles/t08_directory_request_review.py
+++ b/deploy/sim_envs/mantis_shopify/app/oracles/t08_directory_request_review.py
@@ -1,0 +1,53 @@
+"""t08 — Request a directory review for a listing in the Partner Directory."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from typing import Any
+
+
+def grade(conn: sqlite3.Connection, *, now: str, seed_val: int) -> dict[str, Any]:
+    rows = conn.execute(
+        "SELECT id, target_id, payload_json FROM audit_log "
+        "WHERE operation='directory_review_requested' ORDER BY id DESC"
+    ).fetchall()
+    if not rows:
+        return _fail(["no directory_review_requested audit row"], {})
+
+    matched = None
+    for r in rows:
+        payload = json.loads(r["payload_json"] or "{}")
+        listing = conn.execute(
+            "SELECT * FROM directory_listings WHERE id=?", (r["target_id"],),
+        ).fetchone()
+        if listing is None:
+            continue
+        if listing["review_status"] not in {"requested", "received"}:
+            continue
+        if not payload.get("business_name", "").strip():
+            continue
+        matched = (dict(listing), payload)
+        break
+
+    if matched is None:
+        return _fail(
+            ["directory_review_requested rows present but none reference a "
+             "listing with review_status in {requested, received}"],
+            {"audit_rows_seen": len(rows)},
+        )
+
+    listing, payload = matched
+    return {
+        "passed": True, "score": 1.0,
+        "reasons": [f"review requested for {listing['business_name']!r}"],
+        "diff": {
+            "listing_id": listing["id"],
+            "business_name": listing["business_name"],
+            "review_status": listing["review_status"],
+        },
+    }
+
+
+def _fail(reasons, diff):
+    return {"passed": False, "score": 0.0, "reasons": reasons, "diff": diff}

--- a/deploy/sim_envs/mantis_shopify/app/oracles/t09_search_stores_filter.py
+++ b/deploy/sim_envs/mantis_shopify/app/oracles/t09_search_stores_filter.py
@@ -1,0 +1,40 @@
+"""t09 — Filter or search the Stores list."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from typing import Any
+
+
+def grade(conn: sqlite3.Connection, *, now: str, seed_val: int) -> dict[str, Any]:
+    rows = conn.execute(
+        "SELECT id, payload_json FROM audit_log "
+        "WHERE operation='stores_filter_applied' ORDER BY id DESC LIMIT 5"
+    ).fetchall()
+    if not rows:
+        return {
+            "passed": False, "score": 0.0,
+            "reasons": ["no stores_filter_applied audit row"],
+            "diff": {},
+        }
+    for r in rows:
+        payload = json.loads(r["payload_json"] or "{}")
+        q = (payload.get("q") or "").strip()
+        st = (payload.get("status") or "").strip()
+        if q or st:
+            return {
+                "passed": True, "score": 1.0,
+                "reasons": [
+                    f"stores filter applied with q={q!r} status={st!r} "
+                    f"matched={payload.get('matched')}"
+                ],
+                "diff": {"q": q, "status": st,
+                         "matched": payload.get("matched")},
+            }
+    return {
+        "passed": False, "score": 0.0,
+        "reasons": ["stores_filter_applied rows exist but every payload "
+                    "had empty q and status"],
+        "diff": {"rows": len(rows)},
+    }

--- a/deploy/sim_envs/mantis_shopify/app/oracles/t10_submit_pos_referral.py
+++ b/deploy/sim_envs/mantis_shopify/app/oracles/t10_submit_pos_referral.py
@@ -1,0 +1,44 @@
+"""t10 — Submit a Shopify POS Pro referral."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from typing import Any
+
+
+def grade(conn: sqlite3.Connection, *, now: str, seed_val: int) -> dict[str, Any]:
+    rows = conn.execute(
+        "SELECT id, target_id, payload_json FROM audit_log "
+        "WHERE operation='lead_submitted' ORDER BY id DESC"
+    ).fetchall()
+
+    for r in rows:
+        payload = json.loads(r["payload_json"] or "{}")
+        if payload.get("product") != "pos":
+            continue
+        lead = conn.execute(
+            "SELECT * FROM leads WHERE id=?", (r["target_id"],),
+        ).fetchone()
+        if lead is None:
+            continue
+        if not (lead["merchant_name"] or "").strip():
+            continue
+        if "@" not in (lead["contact_email"] or ""):
+            continue
+        return {
+            "passed": True, "score": 1.0,
+            "reasons": [f"POS Pro referral submitted for "
+                        f"{lead['merchant_name']!r}"],
+            "diff": {
+                "lead_id": lead["id"],
+                "merchant_name": lead["merchant_name"],
+                "contact_email": lead["contact_email"],
+            },
+        }
+    return {
+        "passed": False, "score": 0.0,
+        "reasons": ["no lead_submitted audit row with product='pos' "
+                    "references a valid leads row with merchant + email"],
+        "diff": {"audit_rows": len(rows)},
+    }

--- a/deploy/sim_envs/mantis_shopify/app/oracles/t11_view_store_detail.py
+++ b/deploy/sim_envs/mantis_shopify/app/oracles/t11_view_store_detail.py
@@ -1,0 +1,36 @@
+"""t11 — Open a store detail page from the Stores list."""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Any
+
+
+def grade(conn: sqlite3.Connection, *, now: str, seed_val: int) -> dict[str, Any]:
+    rows = conn.execute(
+        "SELECT id, target_id FROM audit_log WHERE operation='store_viewed' "
+        "ORDER BY id DESC"
+    ).fetchall()
+    if not rows:
+        return _fail(["no store_viewed audit row"], {})
+    for r in rows:
+        store = conn.execute(
+            "SELECT * FROM stores WHERE id=?", (r["target_id"],),
+        ).fetchone()
+        if store is None:
+            continue
+        return {
+            "passed": True, "score": 1.0,
+            "reasons": [f"store {store['id']} detail page was opened"],
+            "diff": {
+                "store_id": store["id"],
+                "name": store["name"],
+                "kind": store["kind"],
+            },
+        }
+    return _fail(["store_viewed audit row(s) found but none reference a "
+                  "valid stores row"], {"audit_rows_seen": len(rows)})
+
+
+def _fail(reasons, diff):
+    return {"passed": False, "score": 0.0, "reasons": reasons, "diff": diff}

--- a/deploy/sim_envs/mantis_shopify/app/oracles/t12_view_catalog_detail.py
+++ b/deploy/sim_envs/mantis_shopify/app/oracles/t12_view_catalog_detail.py
@@ -1,0 +1,36 @@
+"""t12 — Open a catalog detail page from the Catalogs list."""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Any
+
+
+def grade(conn: sqlite3.Connection, *, now: str, seed_val: int) -> dict[str, Any]:
+    rows = conn.execute(
+        "SELECT id, target_id FROM audit_log WHERE operation='catalog_viewed' "
+        "ORDER BY id DESC"
+    ).fetchall()
+    if not rows:
+        return _fail(["no catalog_viewed audit row"], {})
+    for r in rows:
+        catalog = conn.execute(
+            "SELECT * FROM catalogs WHERE id=?", (r["target_id"],),
+        ).fetchone()
+        if catalog is None:
+            continue
+        return {
+            "passed": True, "score": 1.0,
+            "reasons": [f"catalog {catalog['id']} detail page was opened"],
+            "diff": {
+                "catalog_id": catalog["id"],
+                "name": catalog["name"],
+                "status": catalog["status"],
+            },
+        }
+    return _fail(["catalog_viewed audit row(s) found but none reference a "
+                  "valid catalogs row"], {"audit_rows_seen": len(rows)})
+
+
+def _fail(reasons, diff):
+    return {"passed": False, "score": 0.0, "reasons": reasons, "diff": diff}

--- a/deploy/sim_envs/mantis_shopify/app/oracles/t13_view_merchant_order.py
+++ b/deploy/sim_envs/mantis_shopify/app/oracles/t13_view_merchant_order.py
@@ -1,0 +1,37 @@
+"""t13 — Open a merchant order detail page from a store's Admin."""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Any
+
+
+def grade(conn: sqlite3.Connection, *, now: str, seed_val: int) -> dict[str, Any]:
+    rows = conn.execute(
+        "SELECT id, target_id FROM audit_log WHERE operation='order_viewed' "
+        "ORDER BY id DESC"
+    ).fetchall()
+    if not rows:
+        return _fail(["no order_viewed audit row"], {})
+    for r in rows:
+        order = conn.execute(
+            "SELECT * FROM merchant_orders WHERE id=?", (r["target_id"],),
+        ).fetchone()
+        if order is None:
+            continue
+        return {
+            "passed": True, "score": 1.0,
+            "reasons": [f"order {order['order_number']!r} detail page opened"],
+            "diff": {
+                "order_id": order["id"],
+                "order_number": order["order_number"],
+                "store_id": order["store_id"],
+                "total_cents": order["total_cents"],
+            },
+        }
+    return _fail(["order_viewed audit row(s) found but none reference a "
+                  "valid merchant_orders row"], {"audit_rows_seen": len(rows)})
+
+
+def _fail(reasons, diff):
+    return {"passed": False, "score": 0.0, "reasons": reasons, "diff": diff}

--- a/deploy/sim_envs/mantis_shopify/app/oracles/t14_fulfill_merchant_order.py
+++ b/deploy/sim_envs/mantis_shopify/app/oracles/t14_fulfill_merchant_order.py
@@ -1,0 +1,39 @@
+"""t14 — Fulfill an unfulfilled merchant order from store Admin."""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Any
+
+
+def grade(conn: sqlite3.Connection, *, now: str, seed_val: int) -> dict[str, Any]:
+    rows = conn.execute(
+        "SELECT id, target_id FROM audit_log WHERE operation='order_fulfilled' "
+        "ORDER BY id DESC"
+    ).fetchall()
+    if not rows:
+        return _fail(["no order_fulfilled audit row"], {})
+    for r in rows:
+        order = conn.execute(
+            "SELECT * FROM merchant_orders WHERE id=?", (r["target_id"],),
+        ).fetchone()
+        if order is None:
+            continue
+        if order["fulfillment_status"] != "fulfilled":
+            continue
+        return {
+            "passed": True, "score": 1.0,
+            "reasons": [f"order {order['order_number']!r} fulfilled"],
+            "diff": {
+                "order_id": order["id"],
+                "order_number": order["order_number"],
+                "fulfillment_status": order["fulfillment_status"],
+            },
+        }
+    return _fail(["order_fulfilled audit row(s) found but none reference a "
+                  "valid merchant_orders row in 'fulfilled' state"],
+                 {"audit_rows_seen": len(rows)})
+
+
+def _fail(reasons, diff):
+    return {"passed": False, "score": 0.0, "reasons": reasons, "diff": diff}

--- a/deploy/sim_envs/mantis_shopify/app/routes/admin.py
+++ b/deploy/sim_envs/mantis_shopify/app/routes/admin.py
@@ -1,0 +1,877 @@
+"""Merchant Admin shell — `/store/<store_id>/admin/*`.
+
+Mimics the post-login Shopify Admin experience: Home dashboard,
+Orders, Products, Customers, Settings. Wired from the "Log in"
+CTA on the Partners /stores list.
+"""
+
+from __future__ import annotations
+
+import json
+
+from fastapi import APIRouter, Form, Path, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+
+from .. import db, main as app_main
+
+router = APIRouter()
+
+
+def _store_or_404(store_id: str):
+    conn = db.connect()
+    row = conn.execute(
+        "SELECT * FROM stores WHERE id=?", (store_id,),
+    ).fetchone()
+    return dict(row) if row else None
+
+
+def _admin_ctx(request: Request, store_id: str, active: str,
+               extra: dict | None = None) -> dict | HTMLResponse:
+    store = _store_or_404(store_id)
+    if store is None:
+        return HTMLResponse("Store not found", status_code=404)
+    ctx = {
+        "request": request,
+        "store": store,
+        "admin_section": active,
+        "store_id": store_id,
+    }
+    if extra:
+        ctx.update(extra)
+    return ctx
+
+
+@router.get("/store/{store_id}/admin", response_class=HTMLResponse)
+async def admin_home(store_id: str, request: Request):
+    ctx = _admin_ctx(request, store_id, "home")
+    if isinstance(ctx, HTMLResponse):
+        return ctx
+    conn = db.connect()
+    # Today/recent stats
+    total_sales = int(conn.execute(
+        "SELECT COALESCE(SUM(total_cents),0) FROM merchant_orders WHERE store_id=?",
+        (store_id,),
+    ).fetchone()[0])
+    orders_total = int(conn.execute(
+        "SELECT COUNT(*) FROM merchant_orders WHERE store_id=?",
+        (store_id,),
+    ).fetchone()[0])
+    products_total = int(conn.execute(
+        "SELECT COUNT(*) FROM merchant_products WHERE store_id=?",
+        (store_id,),
+    ).fetchone()[0])
+    customers_total = int(conn.execute(
+        "SELECT COUNT(*) FROM merchant_customers WHERE store_id=?",
+        (store_id,),
+    ).fetchone()[0])
+    recent_orders = [dict(r) for r in conn.execute(
+        "SELECT * FROM merchant_orders WHERE store_id=? "
+        "ORDER BY ordered_at DESC LIMIT 5",
+        (store_id,),
+    ).fetchall()]
+    unfulfilled = int(conn.execute(
+        "SELECT COUNT(*) FROM merchant_orders WHERE store_id=? "
+        "AND fulfillment_status='unfulfilled'",
+        (store_id,),
+    ).fetchone()[0])
+    ctx.update({
+        "total_sales": total_sales,
+        "orders_total": orders_total,
+        "products_total": products_total,
+        "customers_total": customers_total,
+        "recent_orders": recent_orders,
+        "unfulfilled": unfulfilled,
+        "conversion_rate": "1.8%",
+        "sessions": 423,
+    })
+    db.log_audit(
+        conn,
+        occurred_at=app_main.now_value(),
+        operation="admin_home_viewed",
+        target_type="store",
+        target_id=store_id,
+        payload={},
+    )
+    conn.commit()
+    app_main.emit("admin_home_viewed", {"store_id": store_id})
+    templates = request.app.state.templates
+    return templates.TemplateResponse("admin_home.html", ctx)
+
+
+@router.get("/store/{store_id}/admin/orders", response_class=HTMLResponse)
+async def admin_orders(store_id: str, request: Request,
+                       tab: str = "all", q: str = "",
+                       sort: str = "newest"):
+    ctx = _admin_ctx(request, store_id, "orders")
+    if isinstance(ctx, HTMLResponse):
+        return ctx
+    conn = db.connect()
+    where = ["store_id=?"]
+    params: list = [store_id]
+    if tab == "unfulfilled":
+        where.append("fulfillment_status='unfulfilled'")
+    elif tab == "unpaid":
+        where.append("financial_status='pending'")
+    elif tab == "open":
+        where.append("fulfillment_status != 'fulfilled'")
+    elif tab == "closed":
+        where.append("fulfillment_status='fulfilled'")
+    if q.strip():
+        where.append("(order_number LIKE ? OR customer_name LIKE ?)")
+        params.extend([f"%{q.strip()}%", f"%{q.strip()}%"])
+    order_by = {
+        "newest":         "ordered_at DESC",
+        "oldest":         "ordered_at ASC",
+        "total_desc":     "total_cents DESC",
+        "total_asc":      "total_cents ASC",
+        "customer":       "customer_name COLLATE NOCASE ASC",
+    }.get(sort, "ordered_at DESC")
+    rows = [dict(r) for r in conn.execute(
+        f"SELECT * FROM merchant_orders WHERE {' AND '.join(where)} "
+        f"ORDER BY {order_by} LIMIT 50",
+        params,
+    ).fetchall()]
+    tab_counts = {}
+    for t, w in [("all", "1=1"),
+                 ("unfulfilled", "fulfillment_status='unfulfilled'"),
+                 ("unpaid", "financial_status='pending'"),
+                 ("open", "fulfillment_status != 'fulfilled'"),
+                 ("closed", "fulfillment_status='fulfilled'")]:
+        tab_counts[t] = int(conn.execute(
+            f"SELECT COUNT(*) FROM merchant_orders WHERE store_id=? AND {w}",
+            (store_id,),
+        ).fetchone()[0])
+    ctx.update({
+        "orders": rows,
+        "tab": tab,
+        "q": q,
+        "sort": sort,
+        "tab_counts": tab_counts,
+    })
+    templates = request.app.state.templates
+    return templates.TemplateResponse("admin_orders.html", ctx)
+
+
+@router.get("/store/{store_id}/admin/orders/create",
+            response_class=HTMLResponse)
+async def admin_order_create_form(store_id: str, request: Request):
+    """Form to create a new merchant order. MUST be declared before
+    /orders/{order_id} so 'create' isn't matched as an order_id."""
+    ctx = _admin_ctx(request, store_id, "orders")
+    if isinstance(ctx, HTMLResponse):
+        return ctx
+    templates = request.app.state.templates
+    return templates.TemplateResponse("admin_order_new.html", ctx)
+
+
+@router.post("/store/{store_id}/admin/orders/create")
+async def admin_order_create_submit(
+    store_id: str, request: Request,
+    customer_name: str = Form(...),
+    customer_email: str = Form(""),
+    item_title: str = Form(...),
+    item_qty: int = Form(1),
+    item_price: int = Form(0),
+    delivery_method: str = Form("Standard"),
+):
+    conn = db.connect()
+    oid = _make_id(conn, "merchant_orders", "mo_")
+    order_number = f"#{1000 + int(conn.execute('SELECT COUNT(*) FROM merchant_orders').fetchone()[0]) + 1}"
+    total = int(item_price) * int(item_qty) * 100
+    items = [{"title": item_title, "qty": int(item_qty),
+              "price_cents": int(item_price) * 100}]
+    conn.execute(
+        "INSERT INTO merchant_orders (id, store_id, order_number, "
+        "customer_name, customer_email, total_cents, currency, "
+        "financial_status, fulfillment_status, items_count, items_json, "
+        "ordered_at, delivery_method) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)",
+        (oid, store_id, order_number, customer_name.strip(),
+         customer_email.strip(), total, "USD", "paid", "unfulfilled",
+         1, json.dumps(items), app_main.now_value(), delivery_method),
+    )
+    db.log_audit(
+        conn,
+        occurred_at=app_main.now_value(),
+        operation="order_created",
+        target_type="merchant_order",
+        target_id=oid,
+        payload={"store_id": store_id, "order_number": order_number,
+                 "customer_name": customer_name.strip()},
+    )
+    conn.commit()
+    app_main.emit("order_created", {"order_id": oid})
+    return RedirectResponse(
+        f"/store/{store_id}/admin/orders/{oid}?created=order",
+        status_code=303,
+    )
+
+
+@router.get("/store/{store_id}/admin/orders/{order_id}",
+            response_class=HTMLResponse)
+async def admin_order_detail(store_id: str, order_id: str, request: Request):
+    ctx = _admin_ctx(request, store_id, "orders")
+    if isinstance(ctx, HTMLResponse):
+        return ctx
+    conn = db.connect()
+    row = conn.execute(
+        "SELECT * FROM merchant_orders WHERE id=? AND store_id=?",
+        (order_id, store_id),
+    ).fetchone()
+    if row is None:
+        return HTMLResponse("Order not found", status_code=404)
+    order = dict(row)
+    items = json.loads(order["items_json"] or "[]")
+    db.log_audit(
+        conn,
+        occurred_at=app_main.now_value(),
+        operation="order_viewed",
+        target_type="merchant_order",
+        target_id=order_id,
+        payload={"store_id": store_id, "order_number": order["order_number"]},
+    )
+    conn.commit()
+    app_main.emit("order_viewed", {"order_id": order_id})
+    ctx.update({"order": order, "items": items})
+    templates = request.app.state.templates
+    return templates.TemplateResponse("admin_order_detail.html", ctx)
+
+
+@router.post("/store/{store_id}/admin/orders/{order_id}/fulfill")
+async def admin_order_fulfill(store_id: str, order_id: str, request: Request):
+    conn = db.connect()
+    row = conn.execute(
+        "SELECT * FROM merchant_orders WHERE id=? AND store_id=?",
+        (order_id, store_id),
+    ).fetchone()
+    if row is None:
+        return HTMLResponse("Order not found", status_code=404)
+    conn.execute(
+        "UPDATE merchant_orders SET fulfillment_status='fulfilled' WHERE id=?",
+        (order_id,),
+    )
+    db.log_audit(
+        conn,
+        occurred_at=app_main.now_value(),
+        operation="order_fulfilled",
+        target_type="merchant_order",
+        target_id=order_id,
+        payload={"store_id": store_id, "order_number": row["order_number"]},
+    )
+    conn.commit()
+    app_main.emit("order_fulfilled", {"order_id": order_id})
+    return RedirectResponse(
+        f"/store/{store_id}/admin/orders/{order_id}?fulfilled=1",
+        status_code=303,
+    )
+
+
+@router.get("/store/{store_id}/admin/products", response_class=HTMLResponse)
+async def admin_products(store_id: str, request: Request,
+                          q: str = "", sort: str = "newest"):
+    ctx = _admin_ctx(request, store_id, "products")
+    if isinstance(ctx, HTMLResponse):
+        return ctx
+    conn = db.connect()
+    where = ["store_id=?"]
+    params: list = [store_id]
+    if q.strip():
+        where.append("title LIKE ?")
+        params.append(f"%{q.strip()}%")
+    order_by = {
+        "newest":     "created_at DESC",
+        "oldest":     "created_at ASC",
+        "title_asc":  "title COLLATE NOCASE ASC",
+        "title_desc": "title COLLATE NOCASE DESC",
+        "price_high": "price_cents DESC",
+        "price_low":  "price_cents ASC",
+        "inv_low":    "inventory ASC",
+    }.get(sort, "created_at DESC")
+    rows = [dict(r) for r in conn.execute(
+        f"SELECT * FROM merchant_products WHERE {' AND '.join(where)} "
+        f"ORDER BY {order_by} LIMIT 100",
+        params,
+    ).fetchall()]
+    ctx.update({"products": rows, "q": q, "sort": sort})
+    templates = request.app.state.templates
+    return templates.TemplateResponse("admin_products.html", ctx)
+
+
+@router.get("/store/{store_id}/admin/customers", response_class=HTMLResponse)
+async def admin_customers(store_id: str, request: Request,
+                           q: str = "", sort: str = "spent_desc"):
+    ctx = _admin_ctx(request, store_id, "customers")
+    if isinstance(ctx, HTMLResponse):
+        return ctx
+    conn = db.connect()
+    where = ["store_id=?"]
+    params: list = [store_id]
+    if q.strip():
+        where.append("(name LIKE ? OR email LIKE ?)")
+        params.extend([f"%{q.strip()}%", f"%{q.strip()}%"])
+    order_by = {
+        "spent_desc":  "total_spent_cents DESC",
+        "spent_asc":   "total_spent_cents ASC",
+        "name_asc":    "name COLLATE NOCASE ASC",
+        "name_desc":   "name COLLATE NOCASE DESC",
+        "orders_desc": "orders_count DESC",
+        "recent":      "last_order_at DESC",
+    }.get(sort, "total_spent_cents DESC")
+    rows = [dict(r) for r in conn.execute(
+        f"SELECT * FROM merchant_customers WHERE {' AND '.join(where)} "
+        f"ORDER BY {order_by} LIMIT 100",
+        params,
+    ).fetchall()]
+    ctx.update({"customers": rows, "q": q, "sort": sort})
+    templates = request.app.state.templates
+    return templates.TemplateResponse("admin_customers.html", ctx)
+
+
+@router.get("/store/{store_id}/admin/customers/create",
+            response_class=HTMLResponse)
+async def admin_customer_create_form(store_id: str, request: Request):
+    """Must precede /customers/{customer_id}."""
+    ctx = _admin_ctx(request, store_id, "customers")
+    if isinstance(ctx, HTMLResponse):
+        return ctx
+    templates = request.app.state.templates
+    return templates.TemplateResponse("admin_customer_new.html", ctx)
+
+
+@router.post("/store/{store_id}/admin/customers/create")
+async def admin_customer_create_submit(
+    store_id: str, request: Request,
+    name: str = Form(...),
+    email: str = Form(...),
+    location: str = Form(""),
+):
+    conn = db.connect()
+    cid = _make_id(conn, "merchant_customers", "mc_")
+    conn.execute(
+        "INSERT INTO merchant_customers (id, store_id, name, email, "
+        "orders_count, total_spent_cents, location, last_order_at, "
+        "created_at) VALUES (?,?,?,?,?,?,?,?,?)",
+        (cid, store_id, name.strip(), email.strip(), 0, 0,
+         location.strip(), "", app_main.now_value()),
+    )
+    db.log_audit(
+        conn,
+        occurred_at=app_main.now_value(),
+        operation="customer_created",
+        target_type="merchant_customer",
+        target_id=cid,
+        payload={"store_id": store_id, "name": name.strip(),
+                 "email": email.strip()},
+    )
+    conn.commit()
+    app_main.emit("customer_created", {"customer_id": cid})
+    return RedirectResponse(
+        f"/store/{store_id}/admin/customers/{cid}?created=customer",
+        status_code=303,
+    )
+
+
+@router.get("/store/{store_id}/admin/customers/{customer_id}",
+            response_class=HTMLResponse)
+async def admin_customer_detail(store_id: str, customer_id: str,
+                                 request: Request):
+    ctx = _admin_ctx(request, store_id, "customers")
+    if isinstance(ctx, HTMLResponse):
+        return ctx
+    conn = db.connect()
+    row = conn.execute(
+        "SELECT * FROM merchant_customers WHERE id=? AND store_id=?",
+        (customer_id, store_id),
+    ).fetchone()
+    if row is None:
+        return HTMLResponse("Customer not found", status_code=404)
+    customer = dict(row)
+    # Recent orders for this customer (match on customer_email)
+    recent = [dict(r) for r in conn.execute(
+        "SELECT * FROM merchant_orders WHERE store_id=? AND customer_email=? "
+        "ORDER BY ordered_at DESC LIMIT 8",
+        (store_id, customer["email"]),
+    ).fetchall()]
+    db.log_audit(
+        conn,
+        occurred_at=app_main.now_value(),
+        operation="customer_viewed",
+        target_type="merchant_customer",
+        target_id=customer_id,
+        payload={"store_id": store_id, "name": customer["name"]},
+    )
+    conn.commit()
+    app_main.emit("customer_viewed", {"customer_id": customer_id})
+    ctx.update({"customer": customer, "recent_orders": recent})
+    templates = request.app.state.templates
+    return templates.TemplateResponse("admin_customer_detail.html", ctx)
+
+
+# ── Create / Add form routes ──────────────────────────────────
+
+def _make_id(conn, table, prefix):
+    n = int(conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]) + 1
+    return f"{prefix}{n:06d}"
+
+
+@router.get("/store/{store_id}/admin/orders/create", response_class=HTMLResponse)
+async def admin_order_new_form(store_id: str, request: Request):
+    ctx = _admin_ctx(request, store_id, "orders")
+    if isinstance(ctx, HTMLResponse):
+        return ctx
+    templates = request.app.state.templates
+    return templates.TemplateResponse("admin_order_new.html", ctx)
+
+
+@router.post("/store/{store_id}/admin/orders/create")
+async def admin_order_new_submit(
+    store_id: str, request: Request,
+    customer_name: str = Form(...),
+    customer_email: str = Form(""),
+    item_title: str = Form(...),
+    item_qty: int = Form(1),
+    item_price: int = Form(0),
+    delivery_method: str = Form("Standard"),
+):
+    conn = db.connect()
+    oid = _make_id(conn, "merchant_orders", "mo_")
+    order_number = f"#{1000 + int(conn.execute('SELECT COUNT(*) FROM merchant_orders').fetchone()[0]) + 1}"
+    total = int(item_price) * int(item_qty) * 100  # price entered as dollars
+    items = [{"title": item_title, "qty": int(item_qty),
+              "price_cents": int(item_price) * 100}]
+    conn.execute(
+        "INSERT INTO merchant_orders (id, store_id, order_number, "
+        "customer_name, customer_email, total_cents, currency, "
+        "financial_status, fulfillment_status, items_count, items_json, "
+        "ordered_at, delivery_method) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)",
+        (oid, store_id, order_number, customer_name.strip(),
+         customer_email.strip(), total, "USD", "paid", "unfulfilled",
+         1, json.dumps(items), app_main.now_value(), delivery_method),
+    )
+    db.log_audit(
+        conn,
+        occurred_at=app_main.now_value(),
+        operation="order_created",
+        target_type="merchant_order",
+        target_id=oid,
+        payload={"store_id": store_id, "order_number": order_number,
+                 "customer_name": customer_name.strip()},
+    )
+    conn.commit()
+    app_main.emit("order_created", {"order_id": oid})
+    return RedirectResponse(
+        f"/store/{store_id}/admin/orders/{oid}?created=order",
+        status_code=303,
+    )
+
+
+@router.get("/store/{store_id}/admin/products/create", response_class=HTMLResponse)
+async def admin_product_new_form(store_id: str, request: Request):
+    ctx = _admin_ctx(request, store_id, "products")
+    if isinstance(ctx, HTMLResponse):
+        return ctx
+    templates = request.app.state.templates
+    return templates.TemplateResponse("admin_product_new.html", ctx)
+
+
+@router.post("/store/{store_id}/admin/products/create")
+async def admin_product_new_submit(
+    store_id: str, request: Request,
+    title: str = Form(...),
+    price: int = Form(0),
+    inventory: int = Form(0),
+    vendor: str = Form(""),
+    product_type: str = Form(""),
+    status: str = Form("draft"),
+):
+    conn = db.connect()
+    pid = _make_id(conn, "merchant_products", "mp_")
+    conn.execute(
+        "INSERT INTO merchant_products (id, store_id, title, status, "
+        "inventory, vendor, product_type, price_cents, sku, created_at) "
+        "VALUES (?,?,?,?,?,?,?,?,?,?)",
+        (pid, store_id, title.strip(), status, int(inventory),
+         vendor.strip(), product_type.strip(), int(price) * 100,
+         f"SKU-{pid[3:]}", app_main.now_value()),
+    )
+    db.log_audit(
+        conn,
+        occurred_at=app_main.now_value(),
+        operation="product_created",
+        target_type="merchant_product",
+        target_id=pid,
+        payload={"store_id": store_id, "title": title.strip(),
+                 "status": status},
+    )
+    conn.commit()
+    app_main.emit("product_created", {"product_id": pid})
+    return RedirectResponse(
+        f"/store/{store_id}/admin/products/{pid}?created=product",
+        status_code=303,
+    )
+
+
+@router.get("/store/{store_id}/admin/customers/create",
+            response_class=HTMLResponse)
+async def admin_customer_new_form(store_id: str, request: Request):
+    ctx = _admin_ctx(request, store_id, "customers")
+    if isinstance(ctx, HTMLResponse):
+        return ctx
+    templates = request.app.state.templates
+    return templates.TemplateResponse("admin_customer_new.html", ctx)
+
+
+@router.post("/store/{store_id}/admin/customers/create")
+async def admin_customer_new_submit(
+    store_id: str, request: Request,
+    name: str = Form(...),
+    email: str = Form(...),
+    location: str = Form(""),
+):
+    conn = db.connect()
+    cid = _make_id(conn, "merchant_customers", "mc_")
+    conn.execute(
+        "INSERT INTO merchant_customers (id, store_id, name, email, "
+        "orders_count, total_spent_cents, location, last_order_at, "
+        "created_at) VALUES (?,?,?,?,?,?,?,?,?)",
+        (cid, store_id, name.strip(), email.strip(), 0, 0,
+         location.strip(), "", app_main.now_value()),
+    )
+    db.log_audit(
+        conn,
+        occurred_at=app_main.now_value(),
+        operation="customer_created",
+        target_type="merchant_customer",
+        target_id=cid,
+        payload={"store_id": store_id, "name": name.strip(),
+                 "email": email.strip()},
+    )
+    conn.commit()
+    app_main.emit("customer_created", {"customer_id": cid})
+    return RedirectResponse(
+        f"/store/{store_id}/admin/customers/{cid}?created=customer",
+        status_code=303,
+    )
+
+
+@router.get("/store/{store_id}/admin/discounts/new",
+            response_class=HTMLResponse)
+async def admin_discount_new_form(store_id: str, request: Request):
+    ctx = _admin_ctx(request, store_id, "discounts")
+    if isinstance(ctx, HTMLResponse):
+        return ctx
+    templates = request.app.state.templates
+    return templates.TemplateResponse("admin_discount_new.html", ctx)
+
+
+@router.post("/store/{store_id}/admin/discounts/new")
+async def admin_discount_new_submit(
+    store_id: str, request: Request,
+    code: str = Form(...),
+    discount_type: str = Form("Amount off products"),
+    value: str = Form(""),
+):
+    conn = db.connect()
+    db.log_audit(
+        conn,
+        occurred_at=app_main.now_value(),
+        operation="discount_created",
+        target_type="discount_code",
+        target_id=code.strip().upper(),
+        payload={"store_id": store_id, "code": code.strip().upper(),
+                 "type": discount_type, "value": value.strip()},
+    )
+    conn.commit()
+    app_main.emit("discount_created", {"code": code.strip().upper()})
+    return RedirectResponse(
+        f"/store/{store_id}/admin/discounts?created=discount",
+        status_code=303,
+    )
+
+
+@router.post("/store/{store_id}/admin/orders/{order_id}/refund")
+async def admin_order_refund(store_id: str, order_id: str, request: Request):
+    conn = db.connect()
+    row = conn.execute(
+        "SELECT * FROM merchant_orders WHERE id=? AND store_id=?",
+        (order_id, store_id),
+    ).fetchone()
+    if row is None:
+        return HTMLResponse("Order not found", status_code=404)
+    conn.execute(
+        "UPDATE merchant_orders SET financial_status='refunded' WHERE id=?",
+        (order_id,),
+    )
+    db.log_audit(
+        conn,
+        occurred_at=app_main.now_value(),
+        operation="order_refunded",
+        target_type="merchant_order",
+        target_id=order_id,
+        payload={"store_id": store_id, "order_number": row["order_number"]},
+    )
+    conn.commit()
+    app_main.emit("order_refunded", {"order_id": order_id})
+    return RedirectResponse(
+        f"/store/{store_id}/admin/orders/{order_id}?refunded=1",
+        status_code=303,
+    )
+
+
+@router.get("/store/{store_id}/admin/marketing", response_class=HTMLResponse)
+async def admin_marketing(store_id: str, request: Request):
+    ctx = _admin_ctx(request, store_id, "marketing")
+    if isinstance(ctx, HTMLResponse):
+        return ctx
+    # Synthetic campaigns derived from store id for determinism
+    base = [
+        ("Spring Awakening", "Email", "Active", 4200, "Apr 2 – May 16"),
+        ("Mother's Day Drop", "Facebook + Instagram", "Completed", 6800, "Apr 28 – May 12"),
+        ("New Arrivals Boost", "Google Ads", "Active", 3120, "May 5 – Jun 5"),
+        ("Lapsed-Customer Win-Back", "Email", "Scheduled", 1500, "Jun 10 – Jun 24"),
+        ("Summer Solstice Tease", "TikTok", "Draft", 0, "—"),
+    ]
+    campaigns = [
+        {"id": f"camp_{i:04d}", "name": n, "channel": ch, "status": st,
+         "spend_cents": sp * 100, "window": w}
+        for i, (n, ch, st, sp, w) in enumerate(base, start=1)
+    ]
+    ctx["campaigns"] = campaigns
+    templates = request.app.state.templates
+    return templates.TemplateResponse("admin_marketing.html", ctx)
+
+
+@router.get("/store/{store_id}/admin/discounts", response_class=HTMLResponse)
+async def admin_discounts(store_id: str, request: Request):
+    ctx = _admin_ctx(request, store_id, "discounts")
+    if isinstance(ctx, HTMLResponse):
+        return ctx
+    base = [
+        ("SPRING25",     "Amount off products", "25% off all", "Active",     142, "Expires Jun 15, 2026"),
+        ("FREESHIP",     "Free shipping",       "Free shipping ≥ $50", "Active", 286, "No end date"),
+        ("WELCOME10",    "Amount off order",    "$10 off first order", "Active", 1342, "No end date"),
+        ("LOYAL-LOY",    "Amount off products", "15% loyalty",        "Scheduled", 0,   "Starts Jun 12, 2026"),
+        ("VIP-Holiday-24", "Amount off order",  "$30 off",            "Expired", 89,   "Expired Jan 6, 2026"),
+        ("BUNDLE-3",     "Buy X get Y",         "Buy 2 get 1 free",   "Active", 56,    "No end date"),
+    ]
+    discounts = [
+        {"code": c, "type": t, "value": v, "status": s, "uses": u, "schedule": sc}
+        for c, t, v, s, u, sc in base
+    ]
+    ctx["discounts"] = discounts
+    templates = request.app.state.templates
+    return templates.TemplateResponse("admin_discounts.html", ctx)
+
+
+@router.get("/store/{store_id}/admin/analytics", response_class=HTMLResponse)
+async def admin_analytics(store_id: str, request: Request):
+    ctx = _admin_ctx(request, store_id, "analytics")
+    if isinstance(ctx, HTMLResponse):
+        return ctx
+    conn = db.connect()
+    total_sales = int(conn.execute(
+        "SELECT COALESCE(SUM(total_cents),0) FROM merchant_orders WHERE store_id=?",
+        (store_id,),
+    ).fetchone()[0])
+    orders_total = int(conn.execute(
+        "SELECT COUNT(*) FROM merchant_orders WHERE store_id=?",
+        (store_id,),
+    ).fetchone()[0])
+    # Top products by occurrence in orders
+    top_products = [dict(r) for r in conn.execute(
+        "SELECT title, COUNT(*) as units, SUM(price_cents) as revenue "
+        "FROM merchant_products WHERE store_id=? "
+        "GROUP BY title ORDER BY revenue DESC LIMIT 5",
+        (store_id,),
+    ).fetchall()]
+    ctx.update({
+        "total_sales": total_sales,
+        "orders_total": orders_total,
+        "aov_cents": total_sales // max(1, orders_total),
+        "returning_rate": "31%",
+        "top_products": top_products,
+    })
+    templates = request.app.state.templates
+    return templates.TemplateResponse("admin_analytics.html", ctx)
+
+
+@router.get("/store/{store_id}/admin/content", response_class=HTMLResponse)
+async def admin_content(store_id: str, request: Request,
+                         tab: str = "pages"):
+    ctx = _admin_ctx(request, store_id, "content")
+    if isinstance(ctx, HTMLResponse):
+        return ctx
+    pages = [
+        {"id": "pg_about",    "title": "About us",         "status": "Visible", "updated": "May 28, 2026"},
+        {"id": "pg_contact",  "title": "Contact",          "status": "Visible", "updated": "May 10, 2026"},
+        {"id": "pg_returns",  "title": "Returns policy",   "status": "Visible", "updated": "Apr 22, 2026"},
+        {"id": "pg_privacy",  "title": "Privacy policy",   "status": "Visible", "updated": "Apr 22, 2026"},
+        {"id": "pg_holiday",  "title": "Holiday lookbook", "status": "Hidden",  "updated": "Dec 1, 2025"},
+    ]
+    blog_posts = [
+        {"id": "bp_journal_01", "title": "Inside the studio: spring drop",
+         "author": "Mason", "status": "Published",  "published": "May 24, 2026"},
+        {"id": "bp_journal_02", "title": "Sourcing notes: small batch ceramics",
+         "author": "Mason", "status": "Published",  "published": "May 8, 2026"},
+        {"id": "bp_journal_03", "title": "Behind the new linen line",
+         "author": "Mason", "status": "Scheduled",  "published": "Jun 18, 2026"},
+        {"id": "bp_journal_04", "title": "Customer spotlight: Lena's living room",
+         "author": "Mason", "status": "Draft",      "published": "—"},
+    ]
+    files = [
+        {"name": "spring-drop-hero.jpg", "size": "2.4 MB", "kind": "Image"},
+        {"name": "size-guide-2026.pdf",  "size": "412 KB", "kind": "PDF"},
+        {"name": "studio-walkthrough.mp4", "size": "18.6 MB", "kind": "Video"},
+        {"name": "lookbook-summer.pdf",   "size": "1.1 MB", "kind": "PDF"},
+    ]
+    metaobjects = [
+        {"name": "Studio location", "entries": 3,  "updated": "May 30, 2026"},
+        {"name": "Press feature",   "entries": 12, "updated": "May 18, 2026"},
+        {"name": "Founder bio",     "entries": 1,  "updated": "Apr 11, 2026"},
+    ]
+    if tab not in {"pages", "blog_posts", "files", "metaobjects"}:
+        tab = "pages"
+    ctx.update({
+        "tab": tab, "pages": pages, "blog_posts": blog_posts,
+        "files": files, "metaobjects": metaobjects,
+    })
+    templates = request.app.state.templates
+    return templates.TemplateResponse("admin_content.html", ctx)
+
+
+@router.get("/store/{store_id}/admin/online-store", response_class=HTMLResponse)
+async def admin_online_store(store_id: str, request: Request):
+    ctx = _admin_ctx(request, store_id, "online_store")
+    if isinstance(ctx, HTMLResponse):
+        return ctx
+    templates_list = [
+        {"name": "Linen — Spring 2026", "role": "Live theme",
+         "updated": "May 24, 2026", "status": "Published"},
+        {"name": "Skeleton — testing",  "role": "Unpublished",
+         "updated": "May 12, 2026", "status": "Draft"},
+        {"name": "Marble — holiday",    "role": "Unpublished",
+         "updated": "Dec 5, 2025",   "status": "Draft"},
+    ]
+    pages = [
+        {"name": "About",    "type": "Page"},
+        {"name": "Contact",  "type": "Page"},
+        {"name": "Journal",  "type": "Blog"},
+    ]
+    menus = [
+        {"name": "Main menu",   "item_count": 6},
+        {"name": "Footer menu", "item_count": 4},
+    ]
+    ctx.update({
+        "themes": templates_list,
+        "pages": pages, "menus": menus,
+        "domain": f"{ctx['store']['slug']}.myshopify.com",
+        "custom_domain": "mason.example",
+    })
+    templates_ = request.app.state.templates
+    return templates_.TemplateResponse("admin_online_store.html", ctx)
+
+
+@router.get("/store/{store_id}/admin/pos", response_class=HTMLResponse)
+async def admin_pos(store_id: str, request: Request):
+    ctx = _admin_ctx(request, store_id, "pos")
+    if isinstance(ctx, HTMLResponse):
+        return ctx
+    locations = [
+        {"name": "Boylston St flagship",   "city": "Boston, MA",
+         "staff": 4, "devices": 3, "status": "Open"},
+        {"name": "Studio + Café (popup)",  "city": "Brooklyn, NY",
+         "staff": 2, "devices": 1, "status": "Open"},
+        {"name": "Holiday pop-in",          "city": "Portland, OR",
+         "staff": 1, "devices": 1, "status": "Inactive"},
+    ]
+    ctx["locations"] = locations
+    templates = request.app.state.templates
+    return templates.TemplateResponse("admin_pos.html", ctx)
+
+
+@router.get("/store/{store_id}/admin/apps", response_class=HTMLResponse)
+async def admin_apps(store_id: str, request: Request):
+    ctx = _admin_ctx(request, store_id, "apps")
+    if isinstance(ctx, HTMLResponse):
+        return ctx
+    installed = [
+        {"name": "Klaviyo: Email Marketing", "category": "Marketing",
+         "rating": 4.6, "installed": True},
+        {"name": "Recharge Subscriptions",   "category": "Selling",
+         "rating": 4.8, "installed": True},
+        {"name": "Judge.me Product Reviews", "category": "Reviews",
+         "rating": 4.9, "installed": True},
+    ]
+    suggested = [
+        {"name": "Shopify Inbox", "category": "Customer support", "rating": 4.7},
+        {"name": "Loox Photo Reviews", "category": "Reviews", "rating": 4.9},
+        {"name": "PageFly Page Builder", "category": "Store design", "rating": 4.9},
+        {"name": "SEO Manager", "category": "Marketing", "rating": 4.8},
+    ]
+    ctx.update({"installed": installed, "suggested": suggested})
+    templates = request.app.state.templates
+    return templates.TemplateResponse("admin_apps.html", ctx)
+
+
+@router.get("/store/{store_id}/admin/settings", response_class=HTMLResponse)
+async def admin_settings(store_id: str, request: Request):
+    ctx = _admin_ctx(request, store_id, "settings")
+    if isinstance(ctx, HTMLResponse):
+        return ctx
+    groups = [
+        ("Store details", [
+            ("General",            "Store name, address, and contact details"),
+            ("Plan",               "Manage subscription and billing"),
+            ("Domains",            "Manage URL and routing for your store"),
+        ]),
+        ("Selling", [
+            ("Payments",           "Accept payments and manage providers"),
+            ("Checkout",           "Customize checkout, post-purchase, and policies"),
+            ("Shipping & delivery","Rates and zones"),
+            ("Taxes & duties",     "Tax overrides, exemptions, and duties"),
+        ]),
+        ("Customer experience", [
+            ("Locations",          "Manage retail and fulfillment locations"),
+            ("Markets",            "Sell into new geographies"),
+            ("Notifications",      "Edit transactional emails and SMS"),
+            ("Gift cards",         "Issue and refund balances"),
+        ]),
+        ("Operations", [
+            ("Users and permissions",  "Invite staff and configure roles"),
+            ("Apps and sales channels","Manage installed integrations"),
+            ("Files",                  "Storage for uploaded files"),
+            ("Custom data",            "Metafields, metaobjects, schemas"),
+        ]),
+    ]
+    ctx["groups"] = groups
+    templates = request.app.state.templates
+    return templates.TemplateResponse("admin_settings.html", ctx)
+
+
+@router.get("/store/{store_id}/admin/products/{product_id}",
+            response_class=HTMLResponse)
+async def admin_product_detail(store_id: str, product_id: str,
+                                request: Request):
+    ctx = _admin_ctx(request, store_id, "products")
+    if isinstance(ctx, HTMLResponse):
+        return ctx
+    conn = db.connect()
+    row = conn.execute(
+        "SELECT * FROM merchant_products WHERE id=? AND store_id=?",
+        (product_id, store_id),
+    ).fetchone()
+    if row is None:
+        return HTMLResponse("Product not found", status_code=404)
+    product = dict(row)
+    db.log_audit(
+        conn,
+        occurred_at=app_main.now_value(),
+        operation="product_viewed",
+        target_type="merchant_product",
+        target_id=product_id,
+        payload={"store_id": store_id, "title": product["title"]},
+    )
+    conn.commit()
+    app_main.emit("product_viewed", {"product_id": product_id})
+    ctx.update({"product": product})
+    templates = request.app.state.templates
+    return templates.TemplateResponse("admin_product_detail.html", ctx)

--- a/deploy/sim_envs/mantis_shopify/app/routes/admin.py
+++ b/deploy/sim_envs/mantis_shopify/app/routes/admin.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import json
 
-from fastapi import APIRouter, Form, Path, Request
+from fastapi import APIRouter, Form, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
 
 from .. import db, main as app_main

--- a/deploy/sim_envs/mantis_shopify/app/routes/auth.py
+++ b/deploy/sim_envs/mantis_shopify/app/routes/auth.py
@@ -1,0 +1,54 @@
+"""Login / logout for mantis-shopify (optional; default is no-auth)."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Form, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+
+from .. import auth as auth_lib
+
+router = APIRouter()
+
+
+@router.get("/login", response_class=HTMLResponse)
+async def login_form(request: Request, next: str = "/"):
+    templates = request.app.state.templates
+    return templates.TemplateResponse(
+        "login.html",
+        {
+            "request": request,
+            "next_path": next,
+            "error": None,
+        },
+    )
+
+
+@router.post("/login", response_class=HTMLResponse)
+async def login_submit(
+    request: Request,
+    email: str = Form(...),
+    password: str = Form(...),
+    next: str = Form("/"),
+):
+    templates = request.app.state.templates
+    row = auth_lib.lookup_user_by_email(email)
+    if row is None or not auth_lib.verify_password(password, row.get("password_hash", "")):
+        return templates.TemplateResponse(
+            "login.html",
+            {
+                "request": request,
+                "next_path": next,
+                "error": "Incorrect email or password.",
+            },
+            status_code=400,
+        )
+    response = RedirectResponse(next or "/", status_code=303)
+    auth_lib.set_session_cookie(response, row["id"])
+    return response
+
+
+@router.post("/logout")
+async def logout():
+    response = RedirectResponse("/login", status_code=303)
+    auth_lib.clear_session_cookie(response)
+    return response

--- a/deploy/sim_envs/mantis_shopify/app/routes/catalogs.py
+++ b/deploy/sim_envs/mantis_shopify/app/routes/catalogs.py
@@ -1,0 +1,149 @@
+"""Catalogs — `/catalogs`, `/catalogs/new`, `/catalogs/<id>/publish`."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Form, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+
+from .. import db, main as app_main
+
+router = APIRouter()
+
+
+@router.get("/catalogs", response_class=HTMLResponse)
+async def catalogs(request: Request):
+    templates = request.app.state.templates
+    conn = db.connect()
+    rows = [dict(r) for r in conn.execute(
+        "SELECT * FROM catalogs ORDER BY created_at DESC"
+    ).fetchall()]
+    return templates.TemplateResponse(
+        "catalogs.html",
+        {
+            "request": request,
+            "active_section": "catalogs",
+            "rows": rows,
+        },
+    )
+
+
+@router.get("/catalogs/new", response_class=HTMLResponse)
+async def catalog_new_form(request: Request):
+    templates = request.app.state.templates
+    return templates.TemplateResponse(
+        "catalog_new.html",
+        {"request": request, "active_section": "catalogs"},
+    )
+
+
+@router.post("/catalogs/new")
+async def catalog_new_submit(
+    request: Request,
+    name: str = Form(...),
+    products_count: int = Form(0),
+):
+    conn = db.connect()
+    cid = f"catalog_user_{int(conn.execute('SELECT COUNT(*) FROM catalogs').fetchone()[0]) + 1:05d}"
+    conn.execute(
+        "INSERT INTO catalogs (id, name, products_count, status, created_at) "
+        "VALUES (?,?,?,?,?)",
+        (cid, name.strip(), int(products_count), "draft", app_main.now_value()),
+    )
+    db.log_audit(
+        conn,
+        occurred_at=app_main.now_value(),
+        operation="catalog_created",
+        target_type="catalog",
+        target_id=cid,
+        payload={"name": name.strip(), "products_count": int(products_count)},
+    )
+    conn.commit()
+    app_main.emit("catalog_created", {"catalog_id": cid})
+    return RedirectResponse("/catalogs", status_code=303)
+
+
+@router.post("/catalogs/{catalog_id}/publish")
+async def catalog_publish(catalog_id: str, request: Request):
+    conn = db.connect()
+    conn.execute(
+        "UPDATE catalogs SET status='published' WHERE id=?",
+        (catalog_id,),
+    )
+    db.log_audit(
+        conn,
+        occurred_at=app_main.now_value(),
+        operation="catalog_published",
+        target_type="catalog",
+        target_id=catalog_id,
+        payload={},
+    )
+    conn.commit()
+    app_main.emit("catalog_published", {"catalog_id": catalog_id})
+    return RedirectResponse(f"/catalogs/{catalog_id}", status_code=303)
+
+
+@router.get("/catalogs/{catalog_id}", response_class=HTMLResponse)
+async def catalog_detail(catalog_id: str, request: Request, tab: str = "products"):
+    templates = request.app.state.templates
+    conn = db.connect()
+    row = conn.execute(
+        "SELECT * FROM catalogs WHERE id=?", (catalog_id,),
+    ).fetchone()
+    if row is None:
+        return HTMLResponse("Catalog not found", status_code=404)
+    catalog = dict(row)
+    if tab not in {"products", "stores", "settings"}:
+        tab = "products"
+
+    # Synthetic product list — derived deterministically from the
+    # catalog name so it's stable but varied.
+    base_products = [
+        ("Hand-poured candle, juniper", 24, 1280, "Active"),
+        ("Linen apron, oat", 36, 4200, "Active"),
+        ("Brass desk lamp, matte", 142, 950, "Active"),
+        ("Riverstone tumbler set (4)", 58, 220, "Active"),
+        ("Felted wool throw, sage", 145, 410, "Draft"),
+        ("Ceramic pour-over kit", 42, 1830, "Active"),
+        ("Cedar cutting board, large", 64, 745, "Active"),
+        ("Walnut wall mirror, round", 198, 86, "Draft"),
+    ]
+    rng = catalog["products_count"] or 1
+    products = [
+        {
+            "sku": f"sku-{i:04d}",
+            "title": p[0],
+            "price_cents": p[1] * 100,
+            "inventory": p[2] + (i * 11) % 30,
+            "status": p[3],
+        }
+        for i, p in enumerate(base_products[:min(rng, len(base_products))])
+    ]
+
+    # Stores this catalog is published to (subset of stores table).
+    target_stores = [dict(r) for r in conn.execute(
+        "SELECT id, name, slug, plan FROM stores ORDER BY last_login_at DESC "
+        "LIMIT 4"
+    ).fetchall()]
+
+    db.log_audit(
+        conn,
+        occurred_at=app_main.now_value(),
+        operation="catalog_viewed",
+        target_type="catalog",
+        target_id=catalog_id,
+        payload={"name": catalog["name"], "status": catalog["status"]},
+    )
+    conn.commit()
+    app_main.emit("catalog_viewed", {"catalog_id": catalog_id})
+
+    return templates.TemplateResponse(
+        "catalog_detail.html",
+        {
+            "request": request,
+            "active_section": "catalogs",
+            "catalog": catalog,
+            "products": products,
+            "target_stores": target_stores,
+            "current_tab": tab,
+        },
+    )

--- a/deploy/sim_envs/mantis_shopify/app/routes/directory.py
+++ b/deploy/sim_envs/mantis_shopify/app/routes/directory.py
@@ -1,0 +1,100 @@
+"""Partner Directory — `/partner_directory`, profile, review request."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Form, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+
+from .. import db, main as app_main
+
+router = APIRouter()
+
+
+@router.get("/partner_directory", response_class=HTMLResponse)
+async def directory(request: Request):
+    templates = request.app.state.templates
+    conn = db.connect()
+    rows = [dict(r) for r in conn.execute(
+        "SELECT * FROM directory_listings ORDER BY id"
+    ).fetchall()]
+    return templates.TemplateResponse(
+        "directory.html",
+        {
+            "request": request,
+            "active_section": "directory",
+            "sub_section": "",
+            "rows": rows,
+        },
+    )
+
+
+@router.get("/partner_directory/profile", response_class=HTMLResponse)
+async def directory_profile(request: Request):
+    templates = request.app.state.templates
+    conn = db.connect()
+    partner = dict(conn.execute("SELECT * FROM partners LIMIT 1").fetchone())
+    return templates.TemplateResponse(
+        "directory_profile.html",
+        {
+            "request": request,
+            "active_section": "directory",
+            "sub_section": "profile",
+            "partner": partner,
+        },
+    )
+
+
+@router.post("/partner_directory/profile")
+async def directory_profile_save(
+    request: Request,
+    studio_name: str = Form(""),
+    bio: str = Form(""),
+    services: str = Form(""),
+    languages: str = Form(""),
+    locations: str = Form(""),
+    hourly_rate: str = Form(""),
+):
+    conn = db.connect()
+    db.log_audit(
+        conn,
+        occurred_at=app_main.now_value(),
+        operation="directory_profile_updated",
+        target_type="directory_profile",
+        target_id="self",
+        payload={
+            "studio_name": studio_name.strip(),
+            "bio": bio.strip()[:300],
+            "services": services.strip(),
+            "languages": languages.strip(),
+            "locations": locations.strip(),
+            "hourly_rate": hourly_rate.strip(),
+        },
+    )
+    conn.commit()
+    app_main.emit("directory_profile_updated", {})
+    return RedirectResponse("/partner_directory/profile", status_code=303)
+
+
+@router.post("/partner_directory/{listing_id}/request_review")
+async def directory_request_review(listing_id: str, request: Request):
+    conn = db.connect()
+    row = conn.execute(
+        "SELECT * FROM directory_listings WHERE id=?", (listing_id,),
+    ).fetchone()
+    if row is None:
+        return RedirectResponse("/partner_directory", status_code=303)
+    conn.execute(
+        "UPDATE directory_listings SET review_status='requested' WHERE id=?",
+        (listing_id,),
+    )
+    db.log_audit(
+        conn,
+        occurred_at=app_main.now_value(),
+        operation="directory_review_requested",
+        target_type="directory_listing",
+        target_id=listing_id,
+        payload={"business_name": row["business_name"]},
+    )
+    conn.commit()
+    app_main.emit("directory_review_requested", {"listing_id": listing_id})
+    return RedirectResponse("/partner_directory", status_code=303)

--- a/deploy/sim_envs/mantis_shopify/app/routes/docs.py
+++ b/deploy/sim_envs/mantis_shopify/app/routes/docs.py
@@ -1,0 +1,81 @@
+"""Partner / Product docs — `/docs/partner`, `/docs/product`."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Request
+from fastapi.responses import HTMLResponse
+
+router = APIRouter()
+
+
+PARTNER_TOC = [
+    "Getting started",
+    "Build apps",
+    "Build themes",
+    "Earn revenue",
+    "App listings",
+    "Partner Directory",
+    "Compliance",
+]
+
+PRODUCT_TOC = [
+    "Admin API",
+    "Storefront API",
+    "Webhooks",
+    "Functions",
+    "Polaris (UI)",
+    "Hydrogen",
+    "Liquid",
+]
+
+PARTNER_ARTICLES = [
+    ("Getting started as a Shopify Partner",
+     "Set up your Partners account, install the Shopify CLI, and create your first development store."),
+    ("Build your first app",
+     "Walk through scaffolding, OAuth, and webhooks. Bring an app from idea to listing in a day."),
+    ("Earn revenue through referrals",
+     "Plus, POS, and B2B referral programs explained — payouts, eligibility, and lifecycle."),
+]
+
+PRODUCT_ARTICLES = [
+    ("Admin API: GraphQL vs REST",
+     "When to pick which surface, paginate large queries, and stay under rate limits."),
+    ("Hydrogen + Oxygen: production setup",
+     "Deploy a custom storefront on Oxygen with Hydrogen's data primitives."),
+    ("Functions: replace deprecated apps",
+     "Build server-side commerce logic with no app sidecar."),
+]
+
+
+@router.get("/docs/partner", response_class=HTMLResponse)
+async def partner_docs(request: Request, q: str = ""):
+    templates = request.app.state.templates
+    return templates.TemplateResponse(
+        "docs.html",
+        {
+            "request": request,
+            "active_section": "partner_docs",
+            "title": "Partner docs",
+            "subtitle": "Everything you need to build and grow with Shopify.",
+            "toc": PARTNER_TOC,
+            "articles": PARTNER_ARTICLES,
+            "q": q,
+        },
+    )
+
+
+@router.get("/docs/product", response_class=HTMLResponse)
+async def product_docs(request: Request, q: str = ""):
+    templates = request.app.state.templates
+    return templates.TemplateResponse(
+        "docs.html",
+        {
+            "request": request,
+            "active_section": "product_docs",
+            "title": "Product docs",
+            "subtitle": "Reference for every Shopify developer surface.",
+            "toc": PRODUCT_TOC,
+            "articles": PRODUCT_ARTICLES,
+            "q": q,
+        },
+    )

--- a/deploy/sim_envs/mantis_shopify/app/routes/env_admin.py
+++ b/deploy/sim_envs/mantis_shopify/app/routes/env_admin.py
@@ -1,0 +1,162 @@
+"""Harness contract — ``/__env__/{health,reset,seed,clock,oracle,state,events,mutations}``."""
+
+from __future__ import annotations
+
+import json
+import os
+
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse
+
+from .. import db, main as app_main, seed
+
+router = APIRouter(prefix="/__env__")
+
+
+@router.get("/health")
+async def health() -> JSONResponse:
+    return JSONResponse({
+        "ok": True,
+        "seed": app_main.seed_value(),
+        "now": app_main.now_value(),
+        "boot_time": app_main.boot_time(),
+    })
+
+
+@router.post("/reset")
+async def reset(request: Request) -> JSONResponse:
+    if not app_main.admin_token_ok(request):
+        return app_main.admin_required_response()
+    conn = db.connect()
+    seed.seed(conn, seed_val=app_main.seed_value(), fake_now=app_main.now_value())
+    app_main.clear_events()
+    app_main.emit("reset")
+    return JSONResponse({"ok": True})
+
+
+@router.post("/seed")
+async def reseed(request: Request) -> JSONResponse:
+    if not app_main.admin_token_ok(request):
+        return app_main.admin_required_response()
+    try:
+        payload = await request.json()
+    except Exception:  # noqa: BLE001
+        payload = {}
+    new_seed = int(payload.get("seed", app_main.seed_value()))
+    conn = db.connect()
+    seed.seed(conn, seed_val=new_seed, fake_now=app_main.now_value())
+    app_main.emit("reseeded", {"seed": new_seed})
+    return JSONResponse({"ok": True, "seed": new_seed})
+
+
+@router.post("/clock")
+async def clock(request: Request) -> JSONResponse:
+    if not app_main.admin_token_ok(request):
+        return app_main.admin_required_response()
+    try:
+        payload = await request.json()
+    except Exception:  # noqa: BLE001
+        payload = {}
+    new_now = str(payload.get("now") or app_main.now_value())
+    os.environ["FAKE_NOW"] = new_now
+    app_main.emit("clock_set", {"now": new_now})
+    return JSONResponse({"ok": True, "now": new_now})
+
+
+@router.get("/oracle")
+async def oracle(request: Request) -> JSONResponse:
+    if not app_main.admin_token_ok(request):
+        return app_main.admin_required_response()
+    task_id = (request.query_params.get("task_id") or "").strip()
+    if not task_id:
+        return JSONResponse({"passed": False, "score": 0.0,
+                             "reasons": ["task_id is required"], "diff": {}})
+
+    from ..oracles import grade
+    result = grade(task_id, db.connect(), now=app_main.now_value(),
+                   seed_val=app_main.seed_value())
+    app_main.emit("oracle_query", {"task_id": task_id, "passed": result["passed"]})
+    return JSONResponse(result)
+
+
+@router.get("/state")
+async def state(request: Request) -> JSONResponse:
+    if not app_main.admin_token_ok(request):
+        return app_main.admin_required_response()
+    conn = db.connect()
+
+    def count(table: str) -> int:
+        return int(conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0])
+
+    recent_audit = [
+        {
+            "id": r["id"],
+            "occurred_at": r["occurred_at"],
+            "operation": r["operation"],
+            "target_type": r["target_type"],
+            "target_id": r["target_id"],
+        }
+        for r in conn.execute(
+            "SELECT * FROM audit_log ORDER BY id DESC LIMIT 50"
+        ).fetchall()
+    ]
+
+    return JSONResponse({
+        "seed": app_main.seed_value(),
+        "now": app_main.now_value(),
+        "counts": {
+            "partners": count("partners"),
+            "users": count("users"),
+            "stores": count("stores"),
+            "payouts": count("payouts"),
+            "payout_line_items": count("payout_line_items"),
+            "leads": count("leads"),
+            "referrals": count("referrals"),
+            "directory_listings": count("directory_listings"),
+            "tickets": count("tickets"),
+            "themes": count("themes"),
+            "catalogs": count("catalogs"),
+            "changelog": count("changelog"),
+            "notifications": count("notifications"),
+            "audit_log": count("audit_log"),
+        },
+        "recent_audit": recent_audit,
+    })
+
+
+@router.get("/events")
+async def events(request: Request) -> JSONResponse:
+    if not app_main.admin_token_ok(request):
+        return app_main.admin_required_response()
+    since = float(request.query_params.get("since") or 0)
+    return JSONResponse({"events": app_main.events_since(since)})
+
+
+@router.get("/mutations")
+async def mutations(request: Request) -> JSONResponse:
+    """Return ordered mutation records from audit_log since ``since``."""
+    if not app_main.admin_token_ok(request):
+        return app_main.admin_required_response()
+    try:
+        since_id = int(request.query_params.get("since") or 0)
+    except ValueError:
+        since_id = 0
+    conn = db.connect()
+    rows = conn.execute(
+        "SELECT id, occurred_at, operation, target_type, target_id, payload_json "
+        "FROM audit_log WHERE id > ? ORDER BY id ASC",
+        (since_id,),
+    ).fetchall()
+    return JSONResponse({
+        "mutations": [
+            {
+                "id": r["id"],
+                "ts": r["occurred_at"],
+                "op": r["operation"],
+                "target_type": r["target_type"],
+                "target_id": r["target_id"],
+                "payload": json.loads(r["payload_json"] or "{}"),
+            }
+            for r in rows
+        ]
+    })

--- a/deploy/sim_envs/mantis_shopify/app/routes/home.py
+++ b/deploy/sim_envs/mantis_shopify/app/routes/home.py
@@ -1,0 +1,65 @@
+"""Home dashboard — `/`."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Request
+from fastapi.responses import HTMLResponse
+
+from .. import db
+
+router = APIRouter()
+
+
+@router.get("/", response_class=HTMLResponse)
+async def home(request: Request):
+    templates = request.app.state.templates
+    conn = db.connect()
+
+    stores = [dict(r) for r in conn.execute(
+        "SELECT * FROM stores ORDER BY last_login_at DESC LIMIT 5"
+    ).fetchall()]
+    total_stores = int(conn.execute(
+        "SELECT COUNT(*) FROM stores"
+    ).fetchone()[0])
+
+    pending = conn.execute(
+        "SELECT * FROM payouts WHERE status='pending' "
+        "ORDER BY period_end DESC LIMIT 1"
+    ).fetchone()
+    active_referrals = int(conn.execute(
+        "SELECT COUNT(*) FROM referrals WHERE status='active'"
+    ).fetchone()[0])
+    lifetime_leads = int(conn.execute(
+        "SELECT COUNT(*) FROM leads"
+    ).fetchone()[0])
+
+    changelog = [dict(r) for r in conn.execute(
+        "SELECT * FROM changelog ORDER BY published_at DESC LIMIT 6"
+    ).fetchall()]
+
+    return templates.TemplateResponse(
+        "home.html",
+        {
+            "request": request,
+            "active_section": "home",
+            "stores": stores,
+            "total_stores": total_stores,
+            "pending_payout": dict(pending) if pending else None,
+            "active_referrals": active_referrals,
+            "lifetime_leads": lifetime_leads,
+            "changelog": changelog,
+        },
+    )
+
+
+@router.get("/notifications", response_class=HTMLResponse)
+async def notifications(request: Request):
+    templates = request.app.state.templates
+    conn = db.connect()
+    rows = [dict(r) for r in conn.execute(
+        "SELECT * FROM notifications ORDER BY occurred_at DESC"
+    ).fetchall()]
+    return templates.TemplateResponse(
+        "notifications.html",
+        {"request": request, "active_section": "", "notifications": rows},
+    )

--- a/deploy/sim_envs/mantis_shopify/app/routes/payouts.py
+++ b/deploy/sim_envs/mantis_shopify/app/routes/payouts.py
@@ -1,0 +1,103 @@
+"""Payouts — `/payouts`, `/payouts/<id>`, `/payouts/export`."""
+
+from __future__ import annotations
+
+import io
+
+from fastapi import APIRouter, Request
+from fastapi.responses import HTMLResponse, StreamingResponse
+
+from .. import db, main as app_main
+
+router = APIRouter()
+
+
+@router.get("/payouts", response_class=HTMLResponse)
+async def payouts(request: Request):
+    templates = request.app.state.templates
+    conn = db.connect()
+    pending = conn.execute(
+        "SELECT * FROM payouts WHERE status='pending' "
+        "ORDER BY period_end DESC LIMIT 1"
+    ).fetchone()
+    sent = [dict(r) for r in conn.execute(
+        "SELECT * FROM payouts WHERE status='paid' "
+        "ORDER BY period_end DESC LIMIT 24"
+    ).fetchall()]
+    return templates.TemplateResponse(
+        "payouts.html",
+        {
+            "request": request,
+            "active_section": "payouts",
+            "pending": dict(pending) if pending else None,
+            "sent": sent,
+        },
+    )
+
+
+@router.get("/payouts/export")
+async def payouts_export(request: Request):
+    conn = db.connect()
+    rows = conn.execute(
+        "SELECT id, period_start, period_end, sent_at, amount_cents, currency, "
+        "method, status FROM payouts ORDER BY period_end DESC"
+    ).fetchall()
+    buf = io.StringIO()
+    buf.write("id,period_start,period_end,sent_at,amount,currency,method,status\n")
+    for r in rows:
+        amount = (r["amount_cents"] / 100.0)
+        buf.write(
+            f"{r['id']},{r['period_start']},{r['period_end']},{r['sent_at']},"
+            f"{amount:.2f},{r['currency']},\"{r['method']}\",{r['status']}\n"
+        )
+    db.log_audit(
+        conn,
+        occurred_at=app_main.now_value(),
+        operation="payouts_export_requested",
+        target_type="payouts",
+        target_id="export",
+        payload={"rows": len(rows)},
+    )
+    conn.commit()
+    app_main.emit("payouts_export_requested", {"rows": len(rows)})
+    buf.seek(0)
+    return StreamingResponse(
+        iter([buf.read()]),
+        media_type="text/csv",
+        headers={"Content-Disposition": "attachment; filename=payouts.csv"},
+    )
+
+
+@router.get("/payouts/{payout_id}", response_class=HTMLResponse)
+async def payout_detail(payout_id: str, request: Request):
+    templates = request.app.state.templates
+    conn = db.connect()
+    payout = conn.execute(
+        "SELECT * FROM payouts WHERE id=?", (payout_id,),
+    ).fetchone()
+    if payout is None:
+        return HTMLResponse("Payout not found", status_code=404)
+    items = [dict(r) for r in conn.execute(
+        "SELECT * FROM payout_line_items WHERE payout_id=? "
+        "ORDER BY occurred_at ASC",
+        (payout_id,),
+    ).fetchall()]
+    db.log_audit(
+        conn,
+        occurred_at=app_main.now_value(),
+        operation="payout_viewed",
+        target_type="payout",
+        target_id=payout_id,
+        payload={"line_items": len(items)},
+    )
+    conn.commit()
+    app_main.emit("payout_viewed", {"payout_id": payout_id})
+    return templates.TemplateResponse(
+        "payout_detail.html",
+        {
+            "request": request,
+            "active_section": "payouts",
+            "payout": dict(payout),
+            "items": items,
+        },
+    )

--- a/deploy/sim_envs/mantis_shopify/app/routes/pos.py
+++ b/deploy/sim_envs/mantis_shopify/app/routes/pos.py
@@ -1,0 +1,19 @@
+"""Shopify POS — `/pos`. Renders the marketing surface + a shortcut to
+submit a POS referral that funnels through /sales/leads/new?product=pos.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Request
+from fastapi.responses import HTMLResponse
+
+router = APIRouter()
+
+
+@router.get("/pos", response_class=HTMLResponse)
+async def pos(request: Request):
+    templates = request.app.state.templates
+    return templates.TemplateResponse(
+        "pos.html",
+        {"request": request, "active_section": "pos"},
+    )

--- a/deploy/sim_envs/mantis_shopify/app/routes/sales.py
+++ b/deploy/sim_envs/mantis_shopify/app/routes/sales.py
@@ -1,0 +1,110 @@
+"""Sales (Partner leads) — `/sales`, `/sales/referrals`, `/sales/leads/new`."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Form, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+
+from .. import db, main as app_main
+
+router = APIRouter()
+
+VALID_PRODUCTS = {"plus", "pos", "plus_b2b"}
+
+
+@router.get("/sales", response_class=HTMLResponse)
+async def sales_leads(request: Request):
+    templates = request.app.state.templates
+    conn = db.connect()
+    submitted = [dict(r) for r in conn.execute(
+        "SELECT * FROM leads ORDER BY submitted_at DESC LIMIT 20"
+    ).fetchall()]
+    return templates.TemplateResponse(
+        "sales_leads.html",
+        {
+            "request": request,
+            "active_section": "sales",
+            "sub_section": "leads",
+            "leads": submitted,
+        },
+    )
+
+
+@router.get("/sales/referrals", response_class=HTMLResponse)
+async def sales_referrals(request: Request):
+    templates = request.app.state.templates
+    conn = db.connect()
+    rows = [dict(r) for r in conn.execute(
+        "SELECT * FROM referrals ORDER BY created_at DESC"
+    ).fetchall()]
+    return templates.TemplateResponse(
+        "sales_referrals.html",
+        {
+            "request": request,
+            "active_section": "sales",
+            "sub_section": "referrals",
+            "rows": rows,
+        },
+    )
+
+
+@router.get("/sales/leads/new", response_class=HTMLResponse)
+async def lead_new_form(request: Request, product: str = "plus"):
+    templates = request.app.state.templates
+    if product not in VALID_PRODUCTS:
+        product = "plus"
+    titles = {
+        "plus": "Submit a Plus lead",
+        "pos": "Submit a POS lead",
+        "plus_b2b": "Submit a Plus B2B lead",
+    }
+    return templates.TemplateResponse(
+        "lead_new.html",
+        {
+            "request": request,
+            "active_section": "sales",
+            "sub_section": "leads",
+            "product": product,
+            "title": titles[product],
+        },
+    )
+
+
+@router.post("/sales/leads/new")
+async def lead_new_submit(
+    request: Request,
+    product: str = Form("plus"),
+    merchant_name: str = Form(...),
+    contact_email: str = Form(...),
+    contact_name: str = Form(""),
+    notes: str = Form(""),
+):
+    if product not in VALID_PRODUCTS:
+        product = "plus"
+    conn = db.connect()
+    nid = f"lead_user_{int(conn.execute('SELECT COUNT(*) FROM leads').fetchone()[0]) + 1:05d}"
+    conn.execute(
+        "INSERT INTO leads (id, product, merchant_name, contact_email, "
+        "contact_name, status, earnings_cents, submitted_at, notes) "
+        "VALUES (?,?,?,?,?,?,?,?,?)",
+        (
+            nid, product, merchant_name.strip(),
+            contact_email.strip(), contact_name.strip(),
+            "submitted", 0, app_main.now_value(), notes.strip(),
+        ),
+    )
+    db.log_audit(
+        conn,
+        occurred_at=app_main.now_value(),
+        operation="lead_submitted",
+        target_type="lead",
+        target_id=nid,
+        payload={
+            "product": product,
+            "merchant_name": merchant_name.strip(),
+            "contact_email": contact_email.strip(),
+        },
+    )
+    conn.commit()
+    app_main.emit("lead_submitted", {"lead_id": nid, "product": product})
+    return RedirectResponse("/sales", status_code=303)

--- a/deploy/sim_envs/mantis_shopify/app/routes/settings.py
+++ b/deploy/sim_envs/mantis_shopify/app/routes/settings.py
@@ -1,0 +1,115 @@
+"""Settings — `/settings` + business/emergency/profile forms."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Form, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+
+from .. import db, main as app_main
+
+router = APIRouter()
+
+
+def _partner_row(conn):
+    return conn.execute("SELECT * FROM partners LIMIT 1").fetchone()
+
+
+@router.get("/settings", response_class=HTMLResponse)
+async def settings(request: Request):
+    templates = request.app.state.templates
+    conn = db.connect()
+    partner = dict(_partner_row(conn))
+    banner_dismissed = bool(conn.execute(
+        "SELECT 1 FROM audit_log WHERE operation='banner_dismissed' "
+        "AND target_id='emergency_contact' LIMIT 1"
+    ).fetchone())
+    return templates.TemplateResponse(
+        "settings.html",
+        {
+            "request": request,
+            "active_section": "settings",
+            "partner": partner,
+            "owner": request.state.effective_user,
+            "banner_dismissed": banner_dismissed,
+            "now": app_main.now_value(),
+        },
+    )
+
+
+@router.post("/settings/business")
+async def settings_business(
+    request: Request,
+    business_name: str = Form(""),
+    website: str = Form(""),
+    business_email: str = Form(""),
+    support_email: str = Form(""),
+    phone: str = Form(""),
+    address1: str = Form(""),
+    address2: str = Form(""),
+    city: str = Form(""),
+    zip: str = Form(""),
+    state: str = Form(""),
+    country: str = Form(""),
+):
+    conn = db.connect()
+    changed_fields: dict[str, str] = {}
+    raw_kwargs = {
+        "business_name": business_name, "website": website,
+        "business_email": business_email, "support_email": support_email,
+        "phone": phone, "address1": address1, "address2": address2,
+        "city": city, "zip": zip, "state": state, "country": country,
+    }
+    existing = dict(_partner_row(conn))
+    for k, v in raw_kwargs.items():
+        if v != existing.get(k, ""):
+            changed_fields[k] = v.strip()
+
+    cols = ", ".join(f"{k}=?" for k in raw_kwargs)
+    conn.execute(
+        f"UPDATE partners SET {cols}, updated_at=? WHERE id=?",
+        (*[v.strip() for v in raw_kwargs.values()],
+         app_main.now_value(), existing["id"]),
+    )
+    for k, v in changed_fields.items():
+        db.log_audit(
+            conn,
+            occurred_at=app_main.now_value(),
+            operation="settings_updated",
+            target_type="partner",
+            target_id=existing["id"],
+            payload={"field": k, "value": v},
+        )
+    conn.commit()
+    app_main.emit("settings_updated", {"fields": list(changed_fields.keys())})
+    return RedirectResponse("/settings", status_code=303)
+
+
+@router.post("/settings/emergency")
+async def settings_emergency(
+    request: Request,
+    emergency_name: str = Form(""),
+    emergency_email: str = Form(""),
+    emergency_phone: str = Form(""),
+):
+    conn = db.connect()
+    existing = dict(_partner_row(conn))
+    conn.execute(
+        "UPDATE partners SET emergency_name=?, emergency_email=?, "
+        "emergency_phone=?, updated_at=? WHERE id=?",
+        (emergency_name.strip(), emergency_email.strip(),
+         emergency_phone.strip(), app_main.now_value(), existing["id"]),
+    )
+    for k, v in [("emergency_name", emergency_name),
+                 ("emergency_email", emergency_email),
+                 ("emergency_phone", emergency_phone)]:
+        db.log_audit(
+            conn,
+            occurred_at=app_main.now_value(),
+            operation="emergency_contact_updated",
+            target_type="partner",
+            target_id=existing["id"],
+            payload={"field": k, "value": v.strip()},
+        )
+    conn.commit()
+    app_main.emit("emergency_contact_updated", {})
+    return RedirectResponse("/settings", status_code=303)

--- a/deploy/sim_envs/mantis_shopify/app/routes/stores.py
+++ b/deploy/sim_envs/mantis_shopify/app/routes/stores.py
@@ -31,11 +31,14 @@ async def stores(request: Request, tab: str = "all", q: str = "",
     tab_norm = tab if tab in TAB_KIND_MAP else "all"
     kind_filter = TAB_KIND_MAP[tab_norm]
     if tab_norm == "archived":
-        where.append("status = ?"); params.append("archived")
+        where.append("status = ?")
+        params.append("archived")
     elif tab_norm == "inactive":
-        where.append("status = ?"); params.append("inactive")
+        where.append("status = ?")
+        params.append("inactive")
     elif kind_filter:
-        where.append("kind = ? AND status='active'"); params.append(kind_filter)
+        where.append("kind = ? AND status='active'")
+        params.append(kind_filter)
     else:
         where.append("status='active'")
 

--- a/deploy/sim_envs/mantis_shopify/app/routes/stores.py
+++ b/deploy/sim_envs/mantis_shopify/app/routes/stores.py
@@ -1,0 +1,216 @@
+"""Stores — `/stores`."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Form, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+
+from .. import db, main as app_main
+
+router = APIRouter()
+
+
+TAB_KIND_MAP = {
+    "all": None,
+    "client_transfer": "client_transfer",
+    "collaborator": "collaborator",
+    "archived": "archived",
+    "inactive": "inactive",
+}
+
+
+@router.get("/stores", response_class=HTMLResponse)
+async def stores(request: Request, tab: str = "all", q: str = "",
+                 status: str = "", sort: str = "last_login"):
+    templates = request.app.state.templates
+    conn = db.connect()
+
+    where = []
+    params: list = []
+
+    tab_norm = tab if tab in TAB_KIND_MAP else "all"
+    kind_filter = TAB_KIND_MAP[tab_norm]
+    if tab_norm == "archived":
+        where.append("status = ?"); params.append("archived")
+    elif tab_norm == "inactive":
+        where.append("status = ?"); params.append("inactive")
+    elif kind_filter:
+        where.append("kind = ? AND status='active'"); params.append(kind_filter)
+    else:
+        where.append("status='active'")
+
+    if q.strip():
+        where.append("(name LIKE ? OR slug LIKE ?)")
+        params.extend([f"%{q.strip()}%", f"%{q.strip()}%"])
+    if status.strip():
+        where.append("plan = ?")
+        params.append(status.strip())
+
+    where_clause = " AND ".join(where) or "1=1"
+    order = "last_login_at DESC" if sort != "name" else "name COLLATE NOCASE ASC"
+    rows = [dict(r) for r in conn.execute(
+        f"SELECT * FROM stores WHERE {where_clause} ORDER BY {order}",
+        params,
+    ).fetchall()]
+
+    if q.strip() or status.strip():
+        db.log_audit(
+            conn,
+            occurred_at=app_main.now_value(),
+            operation="stores_filter_applied",
+            target_type="stores",
+            target_id="search",
+            payload={"q": q.strip(), "status": status.strip(),
+                     "tab": tab_norm, "matched": len(rows)},
+        )
+        conn.commit()
+        app_main.emit("stores_filter_applied", {"q": q, "status": status})
+
+    return templates.TemplateResponse(
+        "stores.html",
+        {
+            "request": request,
+            "active_section": "stores",
+            "rows": rows,
+            "current_tab": tab_norm,
+            "q": q,
+            "status_filter": status,
+            "sort": sort,
+            "n": len(rows),
+        },
+    )
+
+
+@router.post("/stores/{store_id}/login")
+async def store_login(store_id: str, request: Request):
+    conn = db.connect()
+    db.log_audit(
+        conn,
+        occurred_at=app_main.now_value(),
+        operation="store_login_followed",
+        target_type="store",
+        target_id=store_id,
+        payload={},
+    )
+    conn.commit()
+    app_main.emit("store_login_followed", {"store_id": store_id})
+    return RedirectResponse(f"/store/{store_id}/admin", status_code=303)
+
+
+@router.post("/stores/{store_id}/archive")
+async def store_archive(store_id: str, request: Request):
+    conn = db.connect()
+    conn.execute(
+        "UPDATE stores SET status='archived' WHERE id=?", (store_id,),
+    )
+    db.log_audit(
+        conn,
+        occurred_at=app_main.now_value(),
+        operation="store_archived",
+        target_type="store",
+        target_id=store_id,
+        payload={},
+    )
+    conn.commit()
+    app_main.emit("store_archived", {"store_id": store_id})
+    return RedirectResponse("/stores", status_code=303)
+
+
+@router.get("/stores/{store_id}", response_class=HTMLResponse)
+async def store_detail(store_id: str, request: Request):
+    templates = request.app.state.templates
+    conn = db.connect()
+    row = conn.execute(
+        "SELECT * FROM stores WHERE id=?", (store_id,),
+    ).fetchone()
+    if row is None:
+        return HTMLResponse("Store not found", status_code=404)
+    store = dict(row)
+
+    # Synthesise a deterministic activity feed from audit_log + a few
+    # store-anchored derived rows so the page isn't bare for fresh data.
+    activity = [
+        {
+            "ts": r["occurred_at"],
+            "operation": r["operation"],
+            "payload": r["payload_json"],
+        }
+        for r in conn.execute(
+            "SELECT occurred_at, operation, payload_json FROM audit_log "
+            "WHERE target_id=? ORDER BY id DESC LIMIT 25",
+            (store_id,),
+        ).fetchall()
+    ]
+
+    # Team members with access — owner first, then a small slice of staff.
+    members = [dict(r) for r in conn.execute(
+        "SELECT id, name, avatar_color FROM users WHERE role='owner' "
+        "ORDER BY name LIMIT 1"
+    ).fetchall()]
+    members += [dict(r) for r in conn.execute(
+        "SELECT id, name, avatar_color FROM users WHERE role != 'owner' "
+        "AND status='active' ORDER BY name LIMIT 2"
+    ).fetchall()]
+
+    db.log_audit(
+        conn,
+        occurred_at=app_main.now_value(),
+        operation="store_viewed",
+        target_type="store",
+        target_id=store_id,
+        payload={"name": store["name"], "kind": store["kind"]},
+    )
+    conn.commit()
+    app_main.emit("store_viewed", {"store_id": store_id})
+
+    return templates.TemplateResponse(
+        "store_detail.html",
+        {
+            "request": request,
+            "active_section": "stores",
+            "store": store,
+            "activity": activity,
+            "members": members,
+            "support_email": "support@" + store["slug"].replace("-", "") + ".example",
+            "country": "United States",
+            "created_human": "May 26, 2022",
+        },
+    )
+
+
+@router.get("/stores/new", response_class=HTMLResponse)
+async def store_new_form(request: Request):
+    templates = request.app.state.templates
+    return templates.TemplateResponse(
+        "store_new.html",
+        {"request": request, "active_section": "stores"},
+    )
+
+
+@router.post("/stores/new")
+async def store_new_submit(
+    request: Request,
+    name: str = Form(...),
+    slug: str = Form(""),
+    kind: str = Form("client_transfer"),
+):
+    conn = db.connect()
+    sid = f"store_user_{int(conn.execute('SELECT COUNT(*) FROM stores').fetchone()[0]) + 1:05d}"
+    eff_slug = slug.strip() or name.lower().replace(' ', '-')[:32]
+    conn.execute(
+        "INSERT INTO stores (id, name, slug, kind, status, last_login_at, plan) "
+        "VALUES (?,?,?,?,?,?,?)",
+        (sid, name.strip(), eff_slug, kind, "active",
+         app_main.now_value(), "Basic"),
+    )
+    db.log_audit(
+        conn,
+        occurred_at=app_main.now_value(),
+        operation="store_added",
+        target_type="store",
+        target_id=sid,
+        payload={"name": name, "slug": eff_slug, "kind": kind},
+    )
+    conn.commit()
+    app_main.emit("store_added", {"store_id": sid})
+    return RedirectResponse("/stores", status_code=303)

--- a/deploy/sim_envs/mantis_shopify/app/routes/support.py
+++ b/deploy/sim_envs/mantis_shopify/app/routes/support.py
@@ -1,0 +1,83 @@
+"""Support — `/support`, `/support/contact`, `/support/tickets`."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Form, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+
+from .. import db, main as app_main
+
+router = APIRouter()
+
+CATEGORIES = [
+    "Account access",
+    "Payouts",
+    "App distribution",
+    "Themes",
+    "Partner Directory",
+    "Other",
+]
+
+
+@router.get("/support", response_class=HTMLResponse)
+async def support(request: Request):
+    templates = request.app.state.templates
+    return templates.TemplateResponse(
+        "support.html",
+        {"request": request, "active_section": "support"},
+    )
+
+
+@router.get("/support/contact", response_class=HTMLResponse)
+async def support_contact_form(request: Request):
+    templates = request.app.state.templates
+    return templates.TemplateResponse(
+        "support_contact.html",
+        {
+            "request": request,
+            "active_section": "support",
+            "categories": CATEGORIES,
+        },
+    )
+
+
+@router.post("/support/contact")
+async def support_contact_submit(
+    request: Request,
+    subject: str = Form(...),
+    category: str = Form(...),
+    description: str = Form(...),
+):
+    conn = db.connect()
+    tid = f"ticket_{int(conn.execute('SELECT COUNT(*) FROM tickets').fetchone()[0]) + 1:05d}"
+    conn.execute(
+        "INSERT INTO tickets (id, subject, category, description, status, "
+        "created_at) VALUES (?,?,?,?,?,?)",
+        (tid, subject.strip(), category.strip(), description.strip(),
+         "open", app_main.now_value()),
+    )
+    db.log_audit(
+        conn,
+        occurred_at=app_main.now_value(),
+        operation="support_ticket_created",
+        target_type="ticket",
+        target_id=tid,
+        payload={
+            "subject": subject.strip(),
+            "category": category.strip(),
+            "description_len": len(description.strip()),
+        },
+    )
+    conn.commit()
+    app_main.emit("support_ticket_created", {"ticket_id": tid})
+
+    templates = request.app.state.templates
+    return templates.TemplateResponse(
+        "support_confirm.html",
+        {
+            "request": request,
+            "active_section": "support",
+            "ticket_id": tid,
+        },
+        status_code=201,
+    )

--- a/deploy/sim_envs/mantis_shopify/app/routes/support.py
+++ b/deploy/sim_envs/mantis_shopify/app/routes/support.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from fastapi import APIRouter, Form, Request
-from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.responses import HTMLResponse
 
 from .. import db, main as app_main
 

--- a/deploy/sim_envs/mantis_shopify/app/routes/team.py
+++ b/deploy/sim_envs/mantis_shopify/app/routes/team.py
@@ -1,0 +1,113 @@
+"""Team — `/team`, `/team/invite`, `/team/banner/dismiss`."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Form, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+
+from .. import db, main as app_main
+
+router = APIRouter()
+
+VALID_STAFF_ROLES = {
+    "owner", "staff_business", "staff_dev", "staff_marketing",
+    "staff_support", "staff_finance",
+}
+
+
+@router.get("/team", response_class=HTMLResponse)
+async def team(request: Request, tab: str = "active"):
+    templates = request.app.state.templates
+    conn = db.connect()
+    owners = [dict(r) for r in conn.execute(
+        "SELECT * FROM users WHERE role='owner' ORDER BY name"
+    ).fetchall()]
+    staff_active = [dict(r) for r in conn.execute(
+        "SELECT * FROM users WHERE role != 'owner' AND status='active' "
+        "ORDER BY name"
+    ).fetchall()]
+    staff_invited = [dict(r) for r in conn.execute(
+        "SELECT * FROM users WHERE role != 'owner' AND status='invited' "
+        "ORDER BY name"
+    ).fetchall()]
+    # Was the banner dismissed?
+    banner_dismissed = bool(conn.execute(
+        "SELECT 1 FROM audit_log WHERE operation='banner_dismissed' "
+        "AND target_id='emergency_contact' LIMIT 1"
+    ).fetchone())
+    return templates.TemplateResponse(
+        "team.html",
+        {
+            "request": request,
+            "active_section": "team",
+            "owners": owners,
+            "staff_active": staff_active,
+            "staff_invited": staff_invited,
+            "tab": tab,
+            "banner_dismissed": banner_dismissed,
+            "now": app_main.now_value(),
+        },
+    )
+
+
+@router.post("/team/banner/dismiss")
+async def banner_dismiss(request: Request):
+    conn = db.connect()
+    db.log_audit(
+        conn,
+        occurred_at=app_main.now_value(),
+        operation="banner_dismissed",
+        target_type="banner",
+        target_id="emergency_contact",
+        payload={"page": "team"},
+    )
+    conn.commit()
+    app_main.emit("banner_dismissed", {"banner": "emergency_contact"})
+    return RedirectResponse(request.headers.get("referer") or "/team",
+                            status_code=303)
+
+
+@router.get("/team/invite", response_class=HTMLResponse)
+async def team_invite_form(request: Request, role: str = "staff_business"):
+    templates = request.app.state.templates
+    return templates.TemplateResponse(
+        "team_invite.html",
+        {
+            "request": request,
+            "active_section": "team",
+            "role_default": role,
+        },
+    )
+
+
+@router.post("/team/invite")
+async def team_invite_submit(
+    request: Request,
+    email: str = Form(...),
+    name: str = Form(""),
+    role: str = Form("staff_business"),
+):
+    if role not in VALID_STAFF_ROLES:
+        role = "staff_business"
+    conn = db.connect()
+    uid = f"invite_{int(conn.execute('SELECT COUNT(*) FROM users').fetchone()[0]) + 1:05d}"
+    conn.execute(
+        "INSERT INTO users (id, email, password_hash, name, role, status, "
+        "last_login_at, avatar_color, created_at) VALUES (?,?,?,?,?,?,?,?,?)",
+        (
+            uid, email.strip().lower(), "", name.strip() or email.split("@")[0],
+            "owner" if role == "owner" else role,
+            "invited", "", "#9c6ade", app_main.now_value(),
+        ),
+    )
+    db.log_audit(
+        conn,
+        occurred_at=app_main.now_value(),
+        operation="staff_invited",
+        target_type="user",
+        target_id=uid,
+        payload={"email": email.strip(), "role": role},
+    )
+    conn.commit()
+    app_main.emit("staff_invited", {"user_id": uid, "role": role})
+    return RedirectResponse("/team?tab=invited", status_code=303)

--- a/deploy/sim_envs/mantis_shopify/app/routes/themes.py
+++ b/deploy/sim_envs/mantis_shopify/app/routes/themes.py
@@ -1,0 +1,60 @@
+"""Themes — `/themes`, `/themes/new`."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Form, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+
+from .. import db, main as app_main
+
+router = APIRouter()
+
+
+@router.get("/themes", response_class=HTMLResponse)
+async def themes(request: Request):
+    templates = request.app.state.templates
+    conn = db.connect()
+    rows = [dict(r) for r in conn.execute(
+        "SELECT * FROM themes ORDER BY created_at DESC"
+    ).fetchall()]
+    return templates.TemplateResponse(
+        "themes.html",
+        {
+            "request": request,
+            "active_section": "themes",
+            "rows": rows,
+        },
+    )
+
+
+@router.get("/themes/new", response_class=HTMLResponse)
+async def theme_new_form(request: Request):
+    templates = request.app.state.templates
+    return templates.TemplateResponse(
+        "theme_new.html",
+        {"request": request, "active_section": "themes"},
+    )
+
+
+@router.post("/themes/new")
+async def theme_new_submit(
+    request: Request,
+    name: str = Form(...),
+):
+    conn = db.connect()
+    tid = f"theme_user_{int(conn.execute('SELECT COUNT(*) FROM themes').fetchone()[0]) + 1:05d}"
+    conn.execute(
+        "INSERT INTO themes (id, name, status, created_at) VALUES (?,?,?,?)",
+        (tid, name.strip(), "in_review", app_main.now_value()),
+    )
+    db.log_audit(
+        conn,
+        occurred_at=app_main.now_value(),
+        operation="theme_submitted",
+        target_type="theme",
+        target_id=tid,
+        payload={"name": name.strip()},
+    )
+    conn.commit()
+    app_main.emit("theme_submitted", {"theme_id": tid})
+    return RedirectResponse("/themes", status_code=303)

--- a/deploy/sim_envs/mantis_shopify/app/seed.py
+++ b/deploy/sim_envs/mantis_shopify/app/seed.py
@@ -19,7 +19,6 @@ import hashlib
 import random
 import sqlite3
 from datetime import datetime, timedelta
-from typing import Any
 
 FAKE_NOW_DEFAULT = "2026-06-09T09:00:00Z"
 

--- a/deploy/sim_envs/mantis_shopify/app/seed.py
+++ b/deploy/sim_envs/mantis_shopify/app/seed.py
@@ -1,0 +1,554 @@
+"""Deterministic seed for mantis-shopify.
+
+Same seed → identical DB. Generates:
+* 1 partner record (the org)
+* ~15 users (2 owners + 13 staff)
+* ~12 stores across the three kinds
+* 18 payouts spanning 9 months, each with line items
+* 20 leads (mix of products + statuses)
+* 12 referrals
+* 14 directory listings
+* 6 themes, 8 catalogs
+* 8 changelog items
+* 8 notifications
+"""
+
+from __future__ import annotations
+
+import hashlib
+import random
+import sqlite3
+from datetime import datetime, timedelta
+from typing import Any
+
+FAKE_NOW_DEFAULT = "2026-06-09T09:00:00Z"
+
+CANONICAL_PARTNER_ID = "partner_00001"
+CANONICAL_OWNER_ID = "owner_00001"
+
+STORE_NAMES = [
+    ("EA demostore", "ea-demostore", "client_transfer", "Plus"),
+    ("demo-store-test-07", "demo-store-test-07", "client_transfer", "Grow"),
+    ("store-demo-new", "store-demo-new", "client_transfer", "Basic"),
+    ("mohit-demo-store-01", "mohit-demo-store-01", "client_transfer", "Grow"),
+    ("Test Demostore R", "test-demostore-r", "client_transfer", "Basic"),
+    ("for-demo-purposes", "for-demo-purposes", "client_transfer", "Grow"),
+    ("MM-shan", "mm-shan", "client_transfer", "Plus"),
+    ("Remi", "remi", "client_transfer", "Plus"),
+    ("Lifelong Online", "lifelong-online", "collaborator", "Grow"),
+    ("Green Heads", "green-heads", "collaborator", "Grow"),
+    ("Ratton Pantry", "ratton-pantry", "collaborator", "Grow"),
+    ("Salon Bosman", "salon-bosman", "collaborator", "Basic"),
+    ("Remi Development Store", "remi-dev", "active_development", "Partner Test"),
+    ("Tungsten and Tool", "tungsten-and-tool", "active_development", "Basic"),
+    ("CylaStore1", "cylastore1", "active_development", "Custom"),
+    ("caresmith-stg", "caresmith-stg", "active_development", "Partner Test"),
+    ("auli-stg", "auli-stg", "active_development", "Partner Test"),
+    ("mm-jop5", "mm-jop5", "client_transfer", "Plus"),
+]
+
+STAFF_NAMES = [
+    ("Jophin Joseph", "jophin@example.com", "staff_business"),
+    ("Mariam Khan", "mariam@example.com", "staff_dev"),
+    ("Devon Park", "devon@example.com", "staff_marketing"),
+    ("Sage Wong", "sage@example.com", "staff_support"),
+    ("Avery Lin", "avery@example.com", "staff_finance"),
+    ("Riley Tan", "riley@example.com", "staff_dev"),
+    ("Casey Brooks", "casey@example.com", "staff_business"),
+    ("Quinn Davies", "quinn@example.com", "staff_support"),
+    ("Morgan Reyes", "morgan@example.com", "staff_marketing"),
+    ("Taylor Singh", "taylor@example.com", "staff_dev"),
+    ("Jordan Cole", "jordan@example.com", "staff_business"),
+    ("Cameron Wu", "cameron@example.com", "staff_finance"),
+    ("Hayden Choi", "hayden@example.com", "staff_dev"),
+]
+
+LEAD_MERCHANTS = [
+    ("Pacific Outerwear", "ops@pacificouterwear.example"),
+    ("Hearth & Hollow Furniture", "owner@hearthandhollow.example"),
+    ("Tundra Coffee Co.", "buyer@tundracoffee.example"),
+    ("Cedar & Pine Apothecary", "hello@cedarpine.example"),
+    ("Northstar Athletics", "store@northstarath.example"),
+    ("Stratos Audio", "team@stratosaudio.example"),
+    ("Maple Lane Bakery", "info@maplelane.example"),
+    ("Verdant Garden Supply", "garden@verdant.example"),
+    ("Coastal Stoneware", "sales@coastalstoneware.example"),
+    ("Brassbird Books", "shop@brassbird.example"),
+    ("Hollowfield Distillery", "trade@hollowfield.example"),
+    ("Lichen + Loam", "hello@lichenloam.example"),
+    ("Slate Atelier", "studio@slateatelier.example"),
+    ("Driftwood Surf Co.", "shop@driftwoodsurf.example"),
+    ("Westwood Print Studio", "press@westwoodprint.example"),
+    ("Almond Branch Co.", "owner@almondbranch.example"),
+    ("Bramble Mercantile", "store@bramble.example"),
+    ("Half-Moon Records", "music@halfmoon.example"),
+    ("Iron Owl Bakery", "owner@ironowl.example"),
+    ("Quill & Caraway", "hello@quillcaraway.example"),
+]
+
+DIRECTORY_PLANS = [
+    ("MM-shan", "Plus"),
+    ("Remi", "Plus"),
+    ("Green Heads", "Grow"),
+    ("Lifelong Online", "Grow"),
+    ("Ratton Pantry", "Grow"),
+    ("Salon Bosman", "Basic"),
+    ("Remi Development Store", "Partner Test"),
+    ("Tungsten and Tool", "Basic"),
+    ("CylaStore1", "Custom"),
+    ("EA Demostore", "Plus"),
+    ("Northstar Athletics", "Grow"),
+    ("Brassbird Books", "Basic"),
+    ("Slate Atelier", "Custom"),
+    ("Maple Lane Bakery", "Grow"),
+]
+
+CHANGELOG_ITEMS = [
+    ("Catalogs", "Improved catalog publishing UX",
+     "You can now stage and publish catalogs to multiple merchant stores from one panel."),
+    ("Admin", "New permission scopes for staff roles",
+     "Granular scopes let owners restrict staff access to specific surfaces."),
+    ("Payments", "Local payment methods added in 4 new regions",
+     "Klarna, iDEAL, and BLIK now appear in eligible checkouts."),
+    ("Analytics", "Lead-to-revenue funnel chart in Sales",
+     "Track which leads convert to active paying merchants over time."),
+    ("POS",     "Shopify POS verified-skills assessment v3 launched",
+     "Refreshed coverage of high-volume retail flows and POS Pro reporting."),
+    ("Admin",   "Bulk invite for staff members",
+     "Invite up to 20 staff members from a CSV upload."),
+    ("Themes",  "New skeleton theme dev tooling",
+     "Hot reload and section auto-population now work with the skeleton theme."),
+    ("Payments","Pending payout summary moved to Home",
+     "Estimated payout amount and ETA are now shown on the Home dashboard."),
+]
+
+
+def _hash(plain: str) -> str:
+    return hashlib.sha256(plain.encode("utf-8")).hexdigest()
+
+
+def _iso_date(d: datetime) -> str:
+    return d.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _human_date(d: datetime) -> str:
+    return d.strftime("%b %-d, %Y") if hasattr(d, "strftime") else str(d)
+
+
+def seed(conn: sqlite3.Connection, *, seed_val: int, fake_now: str) -> None:
+    """Re-seed the DB to a deterministic baseline."""
+    rng = random.Random(seed_val)
+
+    # Wipe tables in FK-safe order.
+    for t in [
+        "audit_log", "notifications", "changelog", "catalogs", "themes",
+        "tickets", "directory_listings", "referrals", "leads",
+        "merchant_customers", "merchant_products", "merchant_orders",
+        "payout_line_items", "payouts", "stores", "users", "partners",
+    ]:
+        conn.execute(f"DELETE FROM {t}")
+
+    now_dt = datetime.fromisoformat(fake_now.replace("Z", "+00:00"))
+
+    # ── partners (single row) ───────────────────────────────────
+    conn.execute(
+        "INSERT INTO partners (id, partner_id, business_name, website, "
+        "business_email, support_email, phone, address1, address2, city, "
+        "zip, state, country, emergency_name, emergency_email, "
+        "emergency_phone, payout_method, updated_at) "
+        "VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+        (
+            CANONICAL_PARTNER_ID,
+            "1146365",
+            "Mason Partners",
+            "https://mason.example",
+            "partners@mason.example",
+            "support@mason.example",
+            "+1 415 555 0142",
+            "1101 Mission Street",
+            "Suite 400",
+            "San Francisco",
+            "94103",
+            "California",
+            "United States",
+            "Operations On-Call",
+            "oncall@mason.example",
+            "+1 415 555 0188",
+            "bank account (***05)",
+            fake_now,
+        ),
+    )
+
+    # ── users (owners + staff) ──────────────────────────────────
+    pw = _hash("password")
+    owner_rows = [
+        (CANONICAL_OWNER_ID, "barada@example.com", pw, "Barada Sahu",
+         "owner", "active", _iso_date(now_dt - timedelta(hours=1)), "#5c6ac4"),
+        ("owner_00002", "kay@example.com", pw, "Kay Mann", "owner", "active",
+         _iso_date(now_dt - timedelta(days=120)), "#bf0711"),
+    ]
+    for r in owner_rows:
+        conn.execute(
+            "INSERT INTO users (id, email, password_hash, name, role, status, "
+            "last_login_at, avatar_color, created_at) VALUES (?,?,?,?,?,?,?,?,?)",
+            r + (fake_now,),
+        )
+
+    for i, (nm, em, role) in enumerate(STAFF_NAMES, start=1):
+        last_login = _iso_date(
+            now_dt - timedelta(days=rng.randint(0, 540))
+        )
+        status = "active" if i <= 11 else "invited"
+        conn.execute(
+            "INSERT INTO users (id, email, password_hash, name, role, status, "
+            "last_login_at, avatar_color, created_at) VALUES (?,?,?,?,?,?,?,?,?)",
+            (
+                f"staff_{i:05d}", em, pw, nm, role, status,
+                last_login,
+                rng.choice(["#5c6ac4", "#bf0711", "#108043", "#9c6ade",
+                            "#47c1bf", "#de3618", "#bf6900"]),
+                fake_now,
+            ),
+        )
+
+    # ── stores ──────────────────────────────────────────────────
+    for i, (nm, slug, kind, plan) in enumerate(STORE_NAMES, start=1):
+        days_ago = rng.randint(0, 400)
+        conn.execute(
+            "INSERT INTO stores (id, name, slug, kind, status, last_login_at, plan) "
+            "VALUES (?,?,?,?,?,?,?)",
+            (
+                f"store_{i:05d}", nm, slug, kind,
+                "active",
+                _iso_date(now_dt - timedelta(days=days_ago)),
+                plan,
+            ),
+        )
+
+    # ── payouts (last 9 months, biweekly) ───────────────────────
+    payouts: list[tuple[str, str, str, str, int, str, str, str]] = []
+    # Pending payout (most recent, unsent)
+    pending_start = now_dt - timedelta(days=8)
+    pending_end = now_dt + timedelta(days=5)
+    payouts.append((
+        "payout_pending",
+        _iso_date(pending_start),
+        _iso_date(pending_end),
+        "",
+        215143,
+        "USD",
+        "bank account (***05)",
+        "pending",
+    ))
+
+    cursor = now_dt - timedelta(days=15)
+    for i in range(1, 19):
+        period_end = cursor
+        period_start = cursor - timedelta(days=15)
+        sent = period_end + timedelta(days=5)
+        amt = rng.randint(85000, 260000)
+        payouts.append((
+            f"payout_{i:05d}",
+            _iso_date(period_start),
+            _iso_date(period_end),
+            _iso_date(sent),
+            amt,
+            "USD",
+            "bank account (***05)",
+            "paid",
+        ))
+        cursor = period_start
+    for p in payouts:
+        conn.execute(
+            "INSERT INTO payouts (id, period_start, period_end, sent_at, "
+            "amount_cents, currency, method, status) VALUES (?,?,?,?,?,?,?,?)",
+            p,
+        )
+
+    # Line items for each payout.
+    li_counter = 1
+    for payout_id, ps, pe, _sent, amt, _ccy, _method, _status in payouts:
+        n_items = rng.randint(3, 7)
+        remaining = amt
+        for j in range(n_items):
+            if j == n_items - 1:
+                slice_amt = remaining
+            else:
+                slice_amt = rng.randint(2000, max(3000, remaining // max(1, n_items - j)))
+                slice_amt = min(slice_amt, max(2000, remaining - 1000))
+            remaining -= slice_amt
+            occ = _iso_date(
+                datetime.fromisoformat(ps.replace("Z", "+00:00"))
+                + timedelta(days=rng.randint(0, 14))
+            )
+            kind = rng.choice([
+                "Plus referral — recurring",
+                "POS Pro referral — recurring",
+                "Plus referral — one-time",
+                "Theme commission",
+                "App distribution",
+            ])
+            conn.execute(
+                "INSERT INTO payout_line_items (id, payout_id, occurred_at, "
+                "description, amount_cents) VALUES (?,?,?,?,?)",
+                (f"pli_{li_counter:06d}", payout_id, occ, kind, slice_amt),
+            )
+            li_counter += 1
+
+    # ── leads ───────────────────────────────────────────────────
+    products = ["plus", "pos", "plus_b2b"]
+    statuses = ["submitted", "qualified", "won", "lost"]
+    for i, (merchant, email) in enumerate(LEAD_MERCHANTS, start=1):
+        product = rng.choice(products)
+        status = rng.choice(statuses)
+        earnings = 0
+        if status == "won":
+            earnings = rng.choice([250000, 250000, 280000, 320000])
+        days_ago = rng.randint(0, 270)
+        conn.execute(
+            "INSERT INTO leads (id, product, merchant_name, contact_email, "
+            "contact_name, status, earnings_cents, submitted_at, notes) "
+            "VALUES (?,?,?,?,?,?,?,?,?)",
+            (
+                f"lead_{i:05d}", product, merchant, email,
+                merchant.split()[0] + " Owner",
+                status, earnings,
+                _iso_date(now_dt - timedelta(days=days_ago)),
+                "Referred via the Partner Directory listing.",
+            ),
+        )
+
+    # ── referrals ───────────────────────────────────────────────
+    for i in range(1, 13):
+        merchant = LEAD_MERCHANTS[i % len(LEAD_MERCHANTS)][0]
+        plan = rng.choice(["Plus", "Grow", "Basic"])
+        conn.execute(
+            "INSERT INTO referrals (id, merchant_name, plan, status, "
+            "earnings_cents, created_at) VALUES (?,?,?,?,?,?)",
+            (
+                f"referral_{i:05d}", merchant + f" #{i:02d}", plan,
+                rng.choice(["active", "active", "active", "churned"]),
+                rng.randint(15000, 92000),
+                _iso_date(now_dt - timedelta(days=rng.randint(30, 540))),
+            ),
+        )
+
+    # ── directory listings ──────────────────────────────────────
+    for i, (biz, plan) in enumerate(DIRECTORY_PLANS, start=1):
+        conn.execute(
+            "INSERT INTO directory_listings (id, business_name, plan, "
+            "review_status) VALUES (?,?,?,?)",
+            (f"dirlst_{i:05d}", biz, plan, "available"),
+        )
+
+    # ── themes & catalogs ───────────────────────────────────────
+    theme_names = [
+        ("Skeleton", "approved"),
+        ("Slate Studio", "in_review"),
+        ("Linen", "approved"),
+        ("Pinecone", "draft"),
+        ("Marble", "approved"),
+        ("Wave", "rejected"),
+    ]
+    for i, (nm, st) in enumerate(theme_names, start=1):
+        conn.execute(
+            "INSERT INTO themes (id, name, status, created_at) VALUES (?,?,?,?)",
+            (f"theme_{i:05d}", nm, st,
+             _iso_date(now_dt - timedelta(days=rng.randint(30, 400)))),
+        )
+
+    catalog_names = [
+        ("Spring Wholesale", 124, "published"),
+        ("Holiday 2025", 86, "published"),
+        ("Outdoor Living", 52, "published"),
+        ("Limited Edition Drops", 14, "draft"),
+        ("Restaurant Supplies", 210, "published"),
+        ("Studio Essentials", 38, "draft"),
+        ("Wedding Collection", 73, "published"),
+        ("Back-to-School", 19, "draft"),
+    ]
+    for i, (nm, pc, st) in enumerate(catalog_names, start=1):
+        conn.execute(
+            "INSERT INTO catalogs (id, name, products_count, status, "
+            "created_at) VALUES (?,?,?,?,?)",
+            (f"catalog_{i:05d}", nm, pc, st,
+             _iso_date(now_dt - timedelta(days=rng.randint(15, 220)))),
+        )
+
+    # ── changelog ───────────────────────────────────────────────
+    for i, (cat, title, summary) in enumerate(CHANGELOG_ITEMS, start=1):
+        published_at = _iso_date(now_dt - timedelta(days=i * 4))
+        conn.execute(
+            "INSERT INTO changelog (id, published_at, category, title, summary) "
+            "VALUES (?,?,?,?,?)",
+            (f"cl_{i:05d}", published_at, cat, title, summary),
+        )
+
+    # ── per-store merchant data ────────────────────────────────
+    _seed_merchant_data(conn, rng=rng, now_dt=now_dt)
+
+    # ── notifications ──────────────────────────────────────────
+    notif_titles = [
+        ("Pending payout updated", "Your next payout will arrive Jun 22, 2026."),
+        ("New lead status", "Pacific Outerwear marked qualified."),
+        ("Staff invite accepted", "Quinn Davies joined as Support staff."),
+        ("Theme submitted for review", "Slate Studio is awaiting review."),
+        ("Catalog published", "Spring Wholesale was published to 6 stores."),
+        ("New community forum post", "Webhook signature regen — questions."),
+        ("API change notice", "Admin REST endpoints have new rate limits."),
+        ("Partner Directory request received",
+         "Lifelong Online requested a review."),
+    ]
+    for i, (t, b) in enumerate(notif_titles, start=1):
+        conn.execute(
+            "INSERT INTO notifications (id, occurred_at, title, body, read) "
+            "VALUES (?,?,?,?,?)",
+            (
+                f"notif_{i:05d}",
+                _iso_date(now_dt - timedelta(hours=rng.randint(1, 96))),
+                t, b, 0,
+            ),
+        )
+
+    conn.commit()
+
+
+# ── Per-store merchant data ─────────────────────────────────────
+
+_PRODUCT_CATALOG = [
+    ("Hand-poured candle, juniper", "Bramble & Co", "Home goods", 24),
+    ("Linen apron, oat", "Bramble & Co", "Apparel", 36),
+    ("Brass desk lamp, matte", "Northwood Studio", "Lighting", 142),
+    ("Riverstone tumbler set (4)", "Northwood Studio", "Glassware", 58),
+    ("Felted wool throw, sage", "Almond Branch", "Home goods", 145),
+    ("Ceramic pour-over kit", "Almond Branch", "Kitchen", 42),
+    ("Cedar cutting board, large", "Slate Atelier", "Kitchen", 64),
+    ("Walnut wall mirror, round", "Slate Atelier", "Home decor", 198),
+    ("Hemlock incense bundle", "Cedar Pine", "Wellness", 18),
+    ("Stoneware mug, slate", "Cedar Pine", "Drinkware", 22),
+    ("Aged-cotton tote, indigo", "Drift Mill", "Bags", 34),
+    ("Marble cheese board", "Drift Mill", "Kitchen", 76),
+    ("Embossed leather wallet", "Half-Moon Goods", "Accessories", 88),
+    ("Speckled clay vase, large", "Half-Moon Goods", "Home decor", 56),
+]
+
+_CUSTOMER_NAMES = [
+    ("Lena Park", "lenapark", "Brooklyn, NY"),
+    ("Yusuf Aksoy", "yaksoy", "Istanbul, TR"),
+    ("Nora Lindgren", "nlindgren", "Malmö, SE"),
+    ("Tomás Vega", "tomasv", "CDMX, MX"),
+    ("Aliyah Brooks", "aliyahb", "Atlanta, GA"),
+    ("Kenji Iwata", "kiwata", "Osaka, JP"),
+    ("Mira Patel", "mpatel", "Bengaluru, IN"),
+    ("Hugo Schmitt", "hschmitt", "Berlin, DE"),
+    ("Saoirse Walsh", "swalsh", "Galway, IE"),
+    ("Esther Mwangi", "emwangi", "Nairobi, KE"),
+    ("Priya Lal", "plal", "Mumbai, IN"),
+    ("Mateusz Nowak", "mnowak", "Warsaw, PL"),
+]
+
+_DELIVERY = ["Standard", "Express", "Local pickup", "Same-day"]
+_FIN_STATUS = ["paid", "paid", "paid", "paid", "pending", "refunded"]
+_FUL_STATUS = ["unfulfilled", "unfulfilled", "fulfilled", "fulfilled", "partial"]
+
+
+def _seed_merchant_data(conn, *, rng, now_dt) -> None:
+    """Populate merchant_orders/products/customers for every store."""
+    from datetime import timedelta
+    import json as _json
+
+    stores = [dict(r) for r in conn.execute(
+        "SELECT id, name, slug FROM stores ORDER BY id"
+    ).fetchall()]
+
+    order_counter = 1
+    product_counter = 1
+    customer_counter = 1
+
+    for store in stores:
+        sid = store["id"]
+
+        # ── Products: 8-12 per store, deterministic per store id ──
+        n_prods = 8 + (int(sid.split("_")[-1] or 0) % 5)
+        seen_titles = set()
+        for i in range(n_prods):
+            base = _PRODUCT_CATALOG[(int(sid.split('_')[-1] or 0) * 3 + i)
+                                    % len(_PRODUCT_CATALOG)]
+            title = base[0]
+            if title in seen_titles:
+                title = f"{title} · v{i+2}"
+            seen_titles.add(title)
+            status = rng.choice(
+                ["active", "active", "active", "draft", "archived"]
+            )
+            conn.execute(
+                "INSERT INTO merchant_products (id, store_id, title, status, "
+                "inventory, vendor, product_type, price_cents, sku, created_at) "
+                "VALUES (?,?,?,?,?,?,?,?,?,?)",
+                (
+                    f"mp_{product_counter:06d}", sid, title, status,
+                    rng.randint(0, 320), base[1], base[2],
+                    base[3] * 100,
+                    f"SKU-{product_counter:06d}",
+                    _iso_date(now_dt - timedelta(days=rng.randint(20, 400))),
+                ),
+            )
+            product_counter += 1
+
+        # ── Customers: 6-9 per store ──
+        n_custs = 6 + (int(sid.split("_")[-1] or 0) % 4)
+        cust_ids_for_store = []
+        for i in range(n_custs):
+            base = _CUSTOMER_NAMES[(int(sid.split('_')[-1] or 0) * 2 + i)
+                                   % len(_CUSTOMER_NAMES)]
+            orders_ct = rng.randint(1, 9)
+            spent = orders_ct * rng.randint(2200, 18000)
+            cid = f"mc_{customer_counter:06d}"
+            conn.execute(
+                "INSERT INTO merchant_customers (id, store_id, name, email, "
+                "orders_count, total_spent_cents, location, last_order_at, "
+                "created_at) VALUES (?,?,?,?,?,?,?,?,?)",
+                (
+                    cid, sid, base[0],
+                    f"{base[1]}@example.com",
+                    orders_ct, spent, base[2],
+                    _iso_date(now_dt - timedelta(days=rng.randint(1, 60))),
+                    _iso_date(now_dt - timedelta(days=rng.randint(60, 700))),
+                ),
+            )
+            cust_ids_for_store.append((cid, base[0], f"{base[1]}@example.com"))
+            customer_counter += 1
+
+        # ── Orders: 10-14 per store ──
+        n_orders = 10 + (int(sid.split("_")[-1] or 0) % 5)
+        for i in range(n_orders):
+            cust = rng.choice(cust_ids_for_store)
+            items_n = rng.randint(1, 4)
+            items = []
+            total = 0
+            for j in range(items_n):
+                p = _PRODUCT_CATALOG[(i + j + int(sid.split('_')[-1] or 0))
+                                     % len(_PRODUCT_CATALOG)]
+                qty = rng.randint(1, 3)
+                total += p[3] * 100 * qty
+                items.append({"title": p[0], "qty": qty, "price_cents": p[3] * 100})
+            conn.execute(
+                "INSERT INTO merchant_orders (id, store_id, order_number, "
+                "customer_name, customer_email, total_cents, currency, "
+                "financial_status, fulfillment_status, items_count, items_json, "
+                "ordered_at, delivery_method) "
+                "VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)",
+                (
+                    f"mo_{order_counter:06d}", sid,
+                    f"#{1000 + order_counter}",
+                    cust[1], cust[2], total, "USD",
+                    rng.choice(_FIN_STATUS), rng.choice(_FUL_STATUS),
+                    items_n, _json.dumps(items),
+                    _iso_date(now_dt - timedelta(days=rng.randint(0, 90),
+                                                  hours=rng.randint(0, 23))),
+                    rng.choice(_DELIVERY),
+                ),
+            )
+            order_counter += 1
+
+    conn.commit()

--- a/deploy/sim_envs/mantis_shopify/app/static/admin.css
+++ b/deploy/sim_envs/mantis_shopify/app/static/admin.css
@@ -1,0 +1,520 @@
+/* mantis-shopify — merchant Admin shell.
+   Dark left sidebar + slim top bar — mirrors the post-login admin.shopify.com UI. */
+
+.adm-body {
+  margin: 0;
+  background: #f1f1f1;
+  color: #303030;
+  font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI",
+               Roboto, Helvetica, Arial, sans-serif;
+  font-size: 14px;
+  line-height: 1.45;
+  min-height: 100vh;
+}
+
+:root {
+  --adm-sidebar-w: 240px;
+  --adm-topbar-h: 56px;
+  --adm-sidebar-bg: #1a1a1a;
+  --adm-sidebar-fg: #e0e0e0;
+  --adm-sidebar-hover-bg: #2a2a2a;
+  --adm-sidebar-active-bg: #303030;
+  --adm-accent: #00a37a;
+  --adm-topbar-bg: #1a1a1a;
+}
+
+/* Topbar */
+.adm-topbar {
+  position: sticky; top: 0; z-index: 50;
+  height: var(--adm-topbar-h);
+  background: var(--adm-topbar-bg);
+  color: #fff;
+  display: grid;
+  grid-template-columns: var(--adm-sidebar-w) 1fr auto;
+  align-items: center;
+  padding: 0 16px;
+  gap: 16px;
+}
+.adm-topbar-left {
+  display: inline-flex; align-items: center; gap: 12px;
+}
+.adm-brand {
+  display: inline-flex; align-items: center;
+  color: #fff; text-decoration: none;
+}
+.adm-shop-switcher summary.adm-shop-summary {
+  list-style: none;
+  display: inline-flex; align-items: center; gap: 8px;
+  background: rgba(255,255,255,0.06);
+  padding: 6px 10px;
+  border-radius: 8px;
+  cursor: pointer;
+  color: #fff;
+  font-size: 13px;
+  font-weight: 500;
+  user-select: none;
+}
+.adm-shop-switcher summary::-webkit-details-marker { display: none; }
+.adm-shop-icon {
+  width: 22px; height: 22px;
+  background: linear-gradient(135deg, #ff7a59 0%, #ec5d99 100%);
+  color: #fff;
+  border-radius: 4px;
+  font-weight: 700; font-size: 11px;
+  display: inline-flex; align-items: center; justify-content: center;
+}
+.adm-shop-caret { font-size: 10px; opacity: 0.7; }
+.adm-shop-menu {
+  background: #fff;
+  color: var(--c-text, #303030);
+  min-width: 280px;
+}
+.adm-shop-menu .sp-dropdown-item { color: var(--c-text, #303030); }
+
+.adm-topbar-search {
+  position: relative;
+  max-width: 640px;
+  margin: 0 auto;
+  width: 100%;
+}
+.adm-topbar-search svg {
+  position: absolute; left: 10px; top: 50%; transform: translateY(-50%);
+}
+.adm-topbar-search input {
+  width: 100%;
+  height: 32px;
+  background: rgba(255,255,255,0.06);
+  border: 1px solid rgba(255,255,255,0.08);
+  border-radius: 8px;
+  padding: 0 12px 0 32px;
+  color: #fff;
+  font-size: 13px;
+  font-family: inherit;
+}
+.adm-topbar-search input::placeholder { color: #8c8c8c; }
+.adm-topbar-search input:focus {
+  outline: 2px solid #4d8cff;
+  outline-offset: -1px;
+  background: rgba(255,255,255,0.1);
+}
+.adm-topbar-actions {
+  display: inline-flex; align-items: center; gap: 6px;
+}
+.adm-icon-btn {
+  background: rgba(255,255,255,0.06);
+  border: 0;
+  color: #fff;
+  width: 32px; height: 32px;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 600;
+  display: inline-flex; align-items: center; justify-content: center;
+}
+.adm-icon-btn:hover { background: rgba(255,255,255,0.12); }
+.adm-user-avatar {
+  width: 28px; height: 28px;
+  background: #5c6ac4;
+  color: #fff;
+  border-radius: 999px;
+  font-size: 12px; font-weight: 600;
+  display: inline-flex; align-items: center; justify-content: center;
+  letter-spacing: 0.04em;
+}
+
+/* Shell */
+.adm-shell {
+  display: grid;
+  grid-template-columns: var(--adm-sidebar-w) 1fr;
+  min-height: calc(100vh - var(--adm-topbar-h));
+}
+.adm-sidebar {
+  background: var(--adm-sidebar-bg);
+  color: var(--adm-sidebar-fg);
+  padding: 14px 8px;
+  position: sticky;
+  top: var(--adm-topbar-h);
+  height: calc(100vh - var(--adm-topbar-h));
+  overflow-y: auto;
+  display: flex; flex-direction: column;
+}
+.adm-nav { display: flex; flex-direction: column; }
+.adm-nav-grouplabel {
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-size: 11px;
+  color: #8c8c8c;
+  padding: 16px 12px 6px;
+  font-weight: 600;
+}
+.adm-nav-row {
+  display: inline-flex; align-items: center;
+  gap: 12px;
+  padding: 7px 10px;
+  color: var(--adm-sidebar-fg);
+  text-decoration: none;
+  font-size: 13px;
+  font-weight: 500;
+  border-radius: 8px;
+  margin: 1px 0;
+}
+.adm-nav-row:hover { background: var(--adm-sidebar-hover-bg); color: #fff; text-decoration: none; }
+.adm-nav-row.is-active { background: var(--adm-sidebar-active-bg); color: #fff; }
+.adm-nav-icon { width: 18px; height: 18px; flex-shrink: 0; color: currentColor; }
+.adm-nav-icon-dot {
+  width: 6px; height: 6px;
+  border-radius: 999px;
+  background: #6a6a6a;
+  margin-left: 6px;
+}
+.adm-sidebar-bottom {
+  margin-top: auto;
+  padding-top: 12px;
+  border-top: 1px solid #2a2a2a;
+}
+
+/* Main */
+.adm-main {
+  padding: 24px 32px 64px;
+  background: #f1f1f1;
+  width: 100%;
+  max-width: 1280px;
+}
+.adm-page-header {
+  display: flex; align-items: center; justify-content: space-between;
+  margin: 0 0 24px 0;
+  gap: 16px;
+}
+.adm-page-h1 {
+  font-size: 22px; font-weight: 600;
+  color: #303030;
+  margin: 0;
+  letter-spacing: -0.005em;
+}
+.adm-page-actions { display: inline-flex; gap: 10px; align-items: center; }
+
+/* Stats grid */
+.adm-stats-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 12px;
+  margin-bottom: 16px;
+}
+.adm-stat-card {
+  background: #fff;
+  border-radius: 10px;
+  padding: 16px;
+  box-shadow: 0 0 0 1px #d9d9d9, 0 1px 0 rgba(0,0,0,0.04);
+}
+.adm-stat-label {
+  font-size: 12px; color: #6a6a6a;
+  margin-bottom: 4px;
+  font-weight: 500;
+}
+.adm-stat-value {
+  font-size: 22px; font-weight: 600;
+  color: #303030;
+}
+.adm-stat-delta {
+  font-size: 11px;
+  margin-top: 2px;
+}
+.adm-stat-delta.up { color: #008060; }
+.adm-stat-delta.down { color: #b54708; }
+
+/* Cards */
+.adm-card {
+  background: #fff;
+  border-radius: 10px;
+  box-shadow: 0 0 0 1px #d9d9d9, 0 1px 0 rgba(0,0,0,0.04);
+  margin-bottom: 16px;
+}
+.adm-card-header {
+  padding: 14px 18px;
+  border-bottom: 1px solid #e3e3e3;
+  display: flex; align-items: center; justify-content: space-between;
+}
+.adm-card-header h2 { margin: 0; font-size: 14px; font-weight: 600; }
+.adm-card-body { padding: 16px 18px; }
+
+/* Buttons — Shopify Admin Polaris-aligned */
+.adm-btn {
+  display: inline-flex; align-items: center; gap: 6px;
+  height: 32px; padding: 0 12px;
+  border-radius: 8px;
+  border: 1px solid #c3c3c3;
+  background: #fff;
+  color: #303030;
+  font-family: inherit; font-size: 13px; font-weight: 500;
+  cursor: pointer; text-decoration: none;
+  line-height: 1;
+  box-shadow: 0 1px 0 rgba(0,0,0,0.05);
+  transition: background 0.1s, border-color 0.1s;
+}
+.adm-btn:hover { background: #f6f6f6; border-color: #a8a8a8; }
+.adm-btn:active { background: #ececec; }
+.adm-btn:focus-visible { outline: 2px solid #4d8cff; outline-offset: 1px; }
+.adm-btn-primary {
+  background: #303030;
+  color: #fff;
+  border-color: #303030;
+}
+.adm-btn-primary:hover { background: #1a1a1a; color: #fff; border-color: #1a1a1a; }
+.adm-btn-primary:active { background: #000; }
+.adm-btn-critical {
+  background: #fff;
+  color: #d72c0d;
+  border-color: #d72c0d;
+}
+.adm-btn-critical:hover { background: #fff0ee; }
+.adm-btn-plain {
+  background: transparent;
+  border-color: transparent;
+  box-shadow: none;
+  color: #303030;
+}
+.adm-btn-plain:hover { background: #f1f1f1; }
+.adm-btn-tertiary {
+  background: transparent;
+  border: 0;
+  color: #2c6ecb;
+  padding: 0;
+  height: auto;
+  box-shadow: none;
+  font-weight: 500;
+}
+.adm-btn-tertiary:hover { background: transparent; color: #1f5199; text-decoration: underline; }
+
+/* Dropdown — admin variant for white-on-dark popovers via <details> */
+.adm-dropdown { position: relative; display: inline-block; }
+.adm-dropdown summary { list-style: none; cursor: pointer; user-select: none; }
+.adm-dropdown summary::-webkit-details-marker { display: none; }
+.adm-dropdown-menu {
+  position: absolute; right: 0; top: calc(100% + 4px);
+  z-index: 20;
+  background: #fff;
+  min-width: 220px;
+  border-radius: 10px;
+  box-shadow: 0 8px 24px rgba(0,0,0,0.18), 0 0 0 1px #d9d9d9;
+  padding: 6px;
+}
+.adm-dropdown-item {
+  display: block;
+  padding: 8px 12px;
+  color: #303030;
+  text-decoration: none;
+  font-size: 13px;
+  border-radius: 6px;
+  background: none;
+  border: 0;
+  width: 100%;
+  text-align: left;
+  cursor: pointer;
+  font-family: inherit;
+}
+.adm-dropdown-item:hover { background: #f1f1f1; color: #303030; text-decoration: none; }
+.adm-dropdown-item-critical { color: #d72c0d; }
+.adm-dropdown-item-critical:hover { background: #fff0ee; color: #d72c0d; }
+.adm-dropdown-sep { height: 1px; background: #ececec; margin: 4px 0; }
+
+/* Toast / confirmation banner */
+.adm-toast {
+  position: fixed; bottom: 24px; left: 50%; transform: translateX(-50%);
+  background: #303030; color: #fff;
+  padding: 12px 18px; border-radius: 10px;
+  font-size: 13px;
+  box-shadow: 0 8px 24px rgba(0,0,0,0.25);
+  z-index: 100;
+  animation: adm-toast-in 0.2s ease;
+  transition: opacity 0.24s ease;
+}
+.adm-toast-success {
+  background: #0c5132;
+  border-left: 4px solid #aee9d1;
+}
+.adm-toast-critical {
+  background: #8e0a04;
+  border-left: 4px solid #fda9a4;
+}
+@keyframes adm-toast-in { from { opacity: 0; transform: translate(-50%, 12px); } to { opacity: 1; transform: translate(-50%, 0); } }
+
+/* Bulk action bar */
+.adm-bulkbar {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 10px 18px;
+  background: #f6f6f7;
+  border: 1px solid #e3e3e3;
+  border-bottom: 0;
+  border-radius: 10px 10px 0 0;
+  font-size: 13px;
+}
+.adm-bulkbar-count {
+  font-weight: 600;
+  color: #303030;
+}
+.adm-bulkbar-spacer { flex: 1; }
+.adm-bulkbar .adm-btn {
+  height: 28px;
+  padding: 0 10px;
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+}
+.adm-bulkbar .adm-btn:hover { background: #ececec; }
+.adm-btn-critical-text { color: #d72c0d !important; }
+.adm-btn-critical-text:hover { background: #fff0ee !important; }
+
+/* Card hover lift (subtle Polaris-style) */
+.adm-card { transition: box-shadow 0.15s ease, transform 0.15s ease; }
+
+/* Row focus ring */
+.adm-table tbody tr:focus-within { background: #f6f6f7; }
+
+/* Product placeholder — per-product gradient (use CSS var --thumb-hue) */
+.adm-line-thumb[data-hue] {
+  background: linear-gradient(135deg,
+    hsl(var(--thumb-hue, 200), 40%, 90%) 0%,
+    hsl(var(--thumb-hue, 200), 30%, 78%) 100%);
+  color: hsl(var(--thumb-hue, 200), 35%, 40%);
+}
+
+/* Data table */
+.adm-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+.adm-table th {
+  text-align: left;
+  font-weight: 500;
+  color: #6a6a6a;
+  padding: 12px 18px;
+  border-bottom: 1px solid #e3e3e3;
+  font-size: 12px;
+}
+.adm-table td {
+  padding: 14px 18px;
+  border-top: 1px solid #e3e3e3;
+}
+.adm-table tr:first-child td { border-top: 0; }
+.adm-table tbody tr:hover { background: #fafafa; }
+.adm-table .col-right { text-align: right; }
+
+/* Tabs */
+.adm-tabs {
+  display: flex; gap: 0;
+  padding: 4px 16px 0;
+  border-bottom: 1px solid #e3e3e3;
+}
+.adm-tab {
+  padding: 10px 12px;
+  color: #6a6a6a;
+  font-size: 13px;
+  text-decoration: none;
+  border-bottom: 2px solid transparent;
+  display: inline-flex; align-items: center; gap: 6px;
+}
+.adm-tab:hover { color: #303030; text-decoration: none; }
+.adm-tab.is-active {
+  color: #303030;
+  font-weight: 600;
+  border-bottom-color: #303030;
+}
+.adm-tab-count {
+  background: #ececec;
+  color: #6a6a6a;
+  border-radius: 999px;
+  padding: 0 6px;
+  font-size: 11px;
+  font-weight: 500;
+}
+
+/* Pills */
+.adm-pill {
+  display: inline-flex; align-items: center;
+  padding: 3px 8px;
+  border-radius: 999px;
+  font-size: 12px; font-weight: 500;
+  gap: 4px;
+  background: #ececec;
+  color: #6a6a6a;
+}
+.adm-pill::before {
+  content: "";
+  width: 6px; height: 6px;
+  border-radius: 999px;
+  background: currentColor;
+  opacity: 0.6;
+}
+.adm-pill-paid     { background: #d9f4e8; color: #095a3a; }
+.adm-pill-pending  { background: #fff1c2; color: #6e4d00; }
+.adm-pill-refunded { background: #e7e7e7; color: #5a5a5a; }
+.adm-pill-fulfilled   { background: #d9f4e8; color: #095a3a; }
+.adm-pill-unfulfilled { background: #fff1c2; color: #6e4d00; }
+.adm-pill-partial     { background: #fde2c9; color: #803c00; }
+.adm-pill-active   { background: #d9f4e8; color: #095a3a; }
+.adm-pill-draft    { background: #ececec; color: #6a6a6a; }
+.adm-pill-archived { background: #f5d9d9; color: #7a2020; }
+
+/* Search bar */
+.adm-filterrow {
+  display: flex; gap: 10px; padding: 12px 18px;
+  align-items: center;
+  border-bottom: 1px solid #e3e3e3;
+}
+.adm-filterrow input[type=search] {
+  flex: 1;
+  height: 32px;
+  border: 1px solid #c3c3c3;
+  border-radius: 8px;
+  padding: 0 12px;
+  background: #fff;
+  font-size: 13px;
+  font-family: inherit;
+}
+
+/* Order detail layout */
+.adm-detail-grid {
+  display: grid;
+  grid-template-columns: minmax(0,1fr) 320px;
+  gap: 16px;
+  align-items: start;
+}
+.adm-line-item {
+  display: grid;
+  grid-template-columns: 48px 1fr auto;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 18px;
+  border-top: 1px solid #e3e3e3;
+}
+.adm-line-item:first-child { border-top: 0; }
+.adm-line-thumb {
+  width: 40px; height: 40px;
+  background: linear-gradient(135deg, #f1f1f1 0%, #e7e7e7 100%);
+  border-radius: 6px;
+  display: inline-flex; align-items: center; justify-content: center;
+  font-size: 14px; color: #b4b4b4;
+}
+.adm-line-title { font-weight: 500; }
+.adm-line-meta  { color: #6a6a6a; font-size: 12px; }
+
+/* Greeting hero */
+.adm-greeting {
+  margin: 4px 0 20px;
+}
+.adm-greeting-h1 {
+  font-size: 22px; font-weight: 600;
+  margin: 0 0 4px 0;
+  color: #303030;
+}
+.adm-greeting-sub { color: #6a6a6a; font-size: 13px; margin: 0; }
+
+/* Empty state */
+.adm-empty {
+  padding: 32px 18px;
+  text-align: center;
+  color: #6a6a6a;
+}

--- a/deploy/sim_envs/mantis_shopify/app/static/admin.js
+++ b/deploy/sim_envs/mantis_shopify/app/static/admin.js
@@ -1,0 +1,95 @@
+/* mantis-shopify admin shell — interaction polish to push toward
+   Polaris fidelity: close-on-outside-click + Esc, toast on success
+   redirect, bulk action bar when checkboxes selected. */
+
+(function () {
+  "use strict";
+
+  // ── Close <details> dropdowns on outside click / Esc ─────────
+  document.addEventListener("click", (e) => {
+    document.querySelectorAll("details[open]").forEach((d) => {
+      if (!d.contains(e.target)) d.removeAttribute("open");
+    });
+  });
+  document.addEventListener("keydown", (e) => {
+    if (e.key === "Escape") {
+      document.querySelectorAll("details[open]").forEach((d) =>
+        d.removeAttribute("open"),
+      );
+    }
+  });
+
+  // ── Toast notification system ────────────────────────────────
+  function showToast(message, variant) {
+    const t = document.createElement("div");
+    t.className = "adm-toast" + (variant ? " adm-toast-" + variant : "");
+    t.setAttribute("role", "status");
+    t.textContent = message;
+    document.body.appendChild(t);
+    setTimeout(() => {
+      t.style.opacity = "0";
+      setTimeout(() => t.remove(), 240);
+    }, 2400);
+  }
+
+  // Surface a toast for ?created=order/product/customer/discount or
+  // ?fulfilled=1 / ?refunded=1 in the URL (set by POST-redirect-GET).
+  const url = new URL(location.href);
+  const created = url.searchParams.get("created");
+  if (created) {
+    const labels = {
+      order: "Order created.",
+      product: "Product saved.",
+      customer: "Customer saved.",
+      discount: "Discount code created.",
+    };
+    showToast(labels[created] || "Saved.", "success");
+  }
+  if (url.searchParams.get("fulfilled")) showToast("Order fulfilled.", "success");
+  if (url.searchParams.get("refunded")) showToast("Refund issued.", "success");
+  if (url.searchParams.get("archived")) showToast("Archived.", "success");
+  if (url.searchParams.get("published")) showToast("Published.", "success");
+
+  // Expose for ad-hoc use
+  window.admToast = showToast;
+
+  // ── Bulk action bar when checkboxes selected ─────────────────
+  document.querySelectorAll("table.adm-table").forEach((tbl) => {
+    const allCb = tbl.querySelector('thead input[type="checkbox"]');
+    const rowCbs = tbl.querySelectorAll('tbody input[type="checkbox"]');
+    if (!rowCbs.length) return;
+
+    // Create the bulk bar (one per table, inserted before <table>)
+    const bar = document.createElement("div");
+    bar.className = "adm-bulkbar";
+    bar.setAttribute("data-testid", "adm-bulkbar");
+    bar.innerHTML =
+      '<span class="adm-bulkbar-count" data-testid="adm-bulkbar-count">0 selected</span>' +
+      '<span class="adm-bulkbar-spacer"></span>' +
+      '<a href="#tag" class="adm-btn adm-btn-plain">Tag</a>' +
+      '<a href="#edit" class="adm-btn adm-btn-plain">Edit</a>' +
+      '<a href="#archive" class="adm-btn adm-btn-plain">Archive</a>' +
+      '<a href="#delete" class="adm-btn adm-btn-plain adm-btn-critical-text">Delete</a>';
+    bar.style.display = "none";
+    tbl.parentElement.insertBefore(bar, tbl);
+
+    function refresh() {
+      const sel = Array.from(rowCbs).filter((c) => c.checked).length;
+      bar.querySelector(".adm-bulkbar-count").textContent = sel + " selected";
+      bar.style.display = sel ? "flex" : "none";
+      // Sync header checkbox indeterminate state
+      if (allCb) {
+        allCb.checked = sel > 0 && sel === rowCbs.length;
+        allCb.indeterminate = sel > 0 && sel < rowCbs.length;
+      }
+    }
+
+    rowCbs.forEach((c) => c.addEventListener("change", refresh));
+    if (allCb) {
+      allCb.addEventListener("change", () => {
+        rowCbs.forEach((c) => (c.checked = allCb.checked));
+        refresh();
+      });
+    }
+  });
+})();

--- a/deploy/sim_envs/mantis_shopify/app/static/polish.css
+++ b/deploy/sim_envs/mantis_shopify/app/static/polish.css
@@ -1,0 +1,119 @@
+/* mantis-polish.css — universal UI fidelity polish.
+   Drops into every env. Uses semantic selectors so no per-env classes needed.
+   Lift, focus rings, transitions, reduced-motion respect. */
+
+/* Smoother default font rendering (matches real Shopify/LinkedIn/Indeed) */
+html {
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+/* Universal focus-visible ring — keyboard accessibility */
+*:focus {
+  outline: none;
+}
+:focus-visible {
+  outline: 2px solid #2c6ecb;
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+button:focus-visible,
+a:focus-visible,
+[role=button]:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible,
+summary:focus-visible {
+  outline: 2px solid #2c6ecb;
+  outline-offset: 2px;
+}
+
+/* Card hover lift — only when motion not reduced */
+@media (prefers-reduced-motion: no-preference) {
+  .sp-card, .adm-card, .card, article,
+  .sp-stat-card, .adm-stat-card,
+  [data-testid$="-card"], [data-testid^="post-card"],
+  [data-testid$="-row"], [data-testid$="-cell"],
+  .jh-job-row, .opp-card,
+  .info-card, .gig-card, .job-card {
+    transition: transform 120ms cubic-bezier(.4,0,.2,1),
+                box-shadow 120ms cubic-bezier(.4,0,.2,1);
+  }
+  /* Subtle lift on hover for clickable cards */
+  a:hover > .sp-card,
+  a:hover > .adm-card,
+  .opp-card:hover,
+  .info-card:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 6px 20px rgba(0,0,0,0.08);
+  }
+}
+
+/* Reduced-motion users: no animations */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
+/* Toast notifications — shared across envs */
+.mantis-toast {
+  position: fixed;
+  bottom: 24px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: #1a1a1a;
+  color: #fff;
+  padding: 12px 18px;
+  border-radius: 10px;
+  font-size: 13px;
+  font-weight: 500;
+  box-shadow: 0 8px 24px rgba(0,0,0,0.25);
+  z-index: 9999;
+  pointer-events: none;
+  transition: opacity 240ms ease, transform 240ms ease;
+}
+.mantis-toast-success {
+  background: #0c5132;
+  border-left: 4px solid #aee9d1;
+}
+.mantis-toast-critical {
+  background: #8e0a04;
+  border-left: 4px solid #fda9a4;
+}
+@keyframes mantis-toast-in {
+  from { opacity: 0; transform: translate(-50%, 12px); }
+  to   { opacity: 1; transform: translate(-50%, 0); }
+}
+.mantis-toast {
+  animation: mantis-toast-in 200ms ease forwards;
+}
+
+/* Skeleton shimmer for loading states (utility) */
+.mantis-skeleton {
+  background: linear-gradient(90deg, #ececec 0%, #f6f6f6 50%, #ececec 100%);
+  background-size: 200% 100%;
+  border-radius: 4px;
+  animation: mantis-shimmer 1.4s linear infinite;
+  color: transparent !important;
+  pointer-events: none;
+}
+@keyframes mantis-shimmer {
+  0%   { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+/* Selection color — matches the active dropdown blue */
+::selection {
+  background: #d6e4ff;
+  color: #1a1a1a;
+}
+
+/* Smoother native form-field appearance */
+button, input, select, textarea {
+  font-family: inherit;
+}

--- a/deploy/sim_envs/mantis_shopify/app/static/polish.js
+++ b/deploy/sim_envs/mantis_shopify/app/static/polish.js
@@ -1,0 +1,129 @@
+/* mantis-polish.js — universal interaction polish for all envs. */
+
+(function () {
+  "use strict";
+
+  // ── Close <details> on outside click + Esc ───────────────────
+  document.addEventListener("click", function (e) {
+    document.querySelectorAll("details[open]").forEach(function (d) {
+      if (!d.contains(e.target)) d.removeAttribute("open");
+    });
+  });
+  document.addEventListener("keydown", function (e) {
+    if (e.key === "Escape") {
+      document.querySelectorAll("details[open]").forEach(function (d) {
+        d.removeAttribute("open");
+      });
+    }
+  });
+
+  // ── Toast helper ────────────────────────────────────────────
+  function toast(message, variant) {
+    var t = document.createElement("div");
+    t.className = "mantis-toast" + (variant ? " mantis-toast-" + variant : "");
+    t.setAttribute("role", "status");
+    t.setAttribute("aria-live", "polite");
+    t.textContent = message;
+    document.body.appendChild(t);
+    setTimeout(function () {
+      t.style.opacity = "0";
+      setTimeout(function () { t.remove(); }, 240);
+    }, 2400);
+  }
+  window.mantisToast = toast;
+
+  // ── URL-driven toasts (POST-redirect-GET) ───────────────────
+  var url = new URL(location.href);
+  var created = url.searchParams.get("created");
+  if (created) {
+    var labels = {
+      order: "Order created.", product: "Product saved.",
+      customer: "Customer saved.", discount: "Discount created.",
+      lead: "Lead submitted.", ticket: "Ticket submitted.",
+      campaign: "Campaign created.", post: "Post published.",
+    };
+    toast(labels[created] || "Saved.", "success");
+  }
+  ["fulfilled", "refunded", "archived", "published", "saved",
+   "deleted", "applied", "sent"].forEach(function (k) {
+    if (url.searchParams.get(k)) {
+      var t = k.charAt(0).toUpperCase() + k.slice(1) + ".";
+      toast(t, k === "deleted" ? "critical" : "success");
+    }
+  });
+
+  // ── Keyboard shortcuts ──────────────────────────────────────
+  var chord = null;
+  var chordTimer = null;
+  document.addEventListener("keydown", function (e) {
+    if (e.target.matches("input, textarea, select, [contenteditable]")) return;
+    if (e.metaKey || e.ctrlKey || e.altKey) return;
+
+    // `/` focuses the search bar
+    if (e.key === "/") {
+      var search = document.querySelector(
+        'input[type=search]:not([disabled]), ' +
+        'input[name=q]:not([disabled]), ' +
+        '[data-testid$="search"]:not([disabled])'
+      );
+      if (search) {
+        e.preventDefault();
+        search.focus();
+        search.select && search.select();
+      }
+      return;
+    }
+
+    // g + X chord navigation
+    if (e.key === "g" && !chord) {
+      chord = "g";
+      clearTimeout(chordTimer);
+      chordTimer = setTimeout(function () { chord = null; }, 1000);
+      return;
+    }
+    if (chord === "g") {
+      chord = null;
+      clearTimeout(chordTimer);
+      var m = location.pathname.match(/^(\/store\/[^/]+\/admin)/);
+      var adminMap = {
+        h: "", o: "/orders", p: "/products", c: "/customers",
+        a: "/analytics", m: "/marketing", d: "/discounts", s: "/settings",
+      };
+      if (m && adminMap[e.key] !== undefined) {
+        e.preventDefault();
+        location.href = m[1] + adminMap[e.key];
+        return;
+      }
+      var rootMap = {
+        h: "/", j: "/jobs", o: "/orders", f: "/feed",
+        m: "/messaging", n: "/mynetwork", e: "/explore",
+      };
+      if (rootMap[e.key]) {
+        e.preventDefault();
+        location.href = rootMap[e.key];
+      }
+    }
+  });
+
+  // ── Show chord-hint helper on `?` ───────────────────────────
+  document.addEventListener("keydown", function (e) {
+    if (e.target.matches("input, textarea, select, [contenteditable]")) return;
+    if (e.key === "?" && e.shiftKey) {
+      e.preventDefault();
+      toast(
+        "g+h home, g+o orders, g+p products, g+c customers, / search",
+        "success",
+      );
+    }
+  });
+
+  // ── Auto-emit ARIA role on tabs lacking it ──────────────────
+  document.querySelectorAll(
+    ".sp-tab, .adm-tab, .tab, [data-testid$=-tab], [data-testid^=tab-]",
+  ).forEach(function (t) {
+    if (!t.getAttribute("role")) t.setAttribute("role", "tab");
+    if (t.classList.contains("is-active")) {
+      t.setAttribute("aria-current", "page");
+    }
+  });
+})();

--- a/deploy/sim_envs/mantis_shopify/app/static/site.css
+++ b/deploy/sim_envs/mantis_shopify/app/static/site.css
@@ -1,0 +1,845 @@
+/* mantis-shopify — Shopify Partners back-office mirror.
+   Hand-rolled, namespaced under .sp- so it can't bleed into other envs. */
+
+:root {
+  --c-bg:        #f6f6f7;
+  --c-card:      #ffffff;
+  --c-border:    #e1e3e5;
+  --c-border-hover: #babec3;
+  --c-text:      #202223;
+  --c-text-sub:  #6d7175;
+  --c-link:      #2c6ecb;
+  --c-link-hover:#1f5199;
+  --c-accent:    #008060;
+  --c-accent-hover: #006e52;
+  --c-accent-bg-tint: #f0f8f5;
+  --c-warning-bg:#ffeb78;
+  --c-warning-accent:#b54708;
+  --c-danger:    #d72c0d;
+  --c-pill-grey: #f1f2f4;
+  --c-pill-green-bg: #aee9d1;
+  --c-pill-green-text: #0c5132;
+  --shadow-card: 0 0 0 1px var(--c-border), 0 1px 0 rgba(0,0,0,0.05);
+
+  --radius-card: 8px;
+  --radius-btn:  6px;
+
+  --sidebar-w: 232px;
+  --topbar-h:  60px;
+
+  --font-base: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI",
+               Roboto, Helvetica, Arial, sans-serif;
+  --font-serif: "Source Serif Pro", "Iowan Old Style", Georgia, serif;
+}
+
+* { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; }
+body {
+  font-family: var(--font-base);
+  background: var(--c-bg);
+  color: var(--c-text);
+  font-size: 14px;
+  line-height: 1.45;
+  -webkit-font-smoothing: antialiased;
+}
+a { color: var(--c-link); text-decoration: none; }
+a:hover { color: var(--c-link-hover); text-decoration: underline; }
+
+/* ───────── topbar ───────── */
+.sp-topbar {
+  position: sticky; top: 0; z-index: 50;
+  height: var(--topbar-h);
+  background: #fff;
+  border-bottom: 1px solid var(--c-border);
+  display: grid;
+  grid-template-columns: var(--sidebar-w) 1fr auto;
+  align-items: center;
+  padding: 0 24px 0 16px;
+  gap: 24px;
+}
+.sp-brand {
+  display: inline-flex; align-items: center; gap: 8px;
+  color: var(--c-text); text-decoration: none;
+}
+.sp-brand:hover { text-decoration: none; }
+.sp-brand-text {
+  font-family: var(--font-serif);
+  font-size: 19px;
+  font-weight: 400;
+  letter-spacing: -0.005em;
+}
+.sp-brand-text em {
+  font-style: italic;
+  margin-left: 2px;
+}
+.sp-topbar-search {
+  position: relative;
+  max-width: 720px;
+  margin: 0 auto;
+  width: 100%;
+}
+.sp-topbar-search svg {
+  position: absolute; left: 12px; top: 50%; transform: translateY(-50%);
+}
+.sp-topbar-search input {
+  width: 100%;
+  height: 36px;
+  border: 1px solid var(--c-border);
+  border-radius: 8px;
+  padding: 0 12px 0 38px;
+  background: #f1f2f4;
+  font-size: 14px;
+  color: var(--c-text);
+  font-family: inherit;
+}
+.sp-topbar-search input:focus {
+  outline: 2px solid #458fff;
+  outline-offset: -1px;
+  background: #fff;
+}
+.sp-topbar-actions {
+  display: inline-flex; align-items: center; gap: 16px;
+}
+.sp-notif {
+  position: relative;
+  width: 36px; height: 36px;
+  display: inline-flex; align-items: center; justify-content: center;
+  border-radius: 8px;
+  color: var(--c-text);
+}
+.sp-notif:hover { background: #f1f2f4; }
+.sp-notif-badge {
+  position: absolute; top: 2px; right: 2px;
+  min-width: 18px; height: 18px;
+  background: var(--c-danger);
+  color: #fff;
+  border-radius: 999px;
+  font-size: 11px; font-weight: 600;
+  display: inline-flex; align-items: center; justify-content: center;
+  padding: 0 5px;
+  border: 2px solid #fff;
+}
+.sp-user {
+  display: inline-flex; align-items: center; gap: 10px;
+  color: var(--c-text);
+}
+.sp-user:hover { text-decoration: none; }
+.sp-user-avatar {
+  width: 32px; height: 32px;
+  border-radius: 999px;
+  background: #5c6ac4;
+  color: #fff;
+  font-weight: 600; font-size: 12px;
+  display: inline-flex; align-items: center; justify-content: center;
+  letter-spacing: 0.04em;
+}
+.sp-user-meta {
+  display: inline-flex; flex-direction: column;
+  line-height: 1.15;
+  font-size: 13px;
+}
+.sp-user-name { font-weight: 600; }
+.sp-user-sub  { color: var(--c-text-sub); font-size: 12px; }
+
+/* ───────── shell ───────── */
+.sp-shell {
+  display: grid;
+  grid-template-columns: var(--sidebar-w) 1fr;
+  align-items: start;
+  min-height: calc(100vh - var(--topbar-h));
+}
+.sp-sidebar {
+  background: var(--c-bg);
+  padding: 12px 0;
+  position: sticky;
+  top: var(--topbar-h);
+  height: calc(100vh - var(--topbar-h));
+  overflow-y: auto;
+}
+.sp-nav-group { display: flex; flex-direction: column; }
+.sp-nav-grouplabel {
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-size: 11px;
+  color: var(--c-text-sub);
+  padding: 14px 20px 6px;
+  font-weight: 600;
+}
+.sp-nav-row {
+  position: relative;
+  display: inline-flex; align-items: center;
+  gap: 12px;
+  padding: 8px 16px 8px 20px;
+  color: var(--c-text);
+  text-decoration: none;
+  font-size: 14px;
+  font-weight: 500;
+  border-radius: 0;
+  margin: 0 8px;
+  border-radius: 6px;
+}
+.sp-nav-row:hover { background: #ebebee; text-decoration: none; }
+.sp-nav-row.is-active {
+  background: #ebebee;
+  color: var(--c-accent);
+}
+.sp-nav-row.is-active::before {
+  content: "";
+  position: absolute; left: -8px; top: 6px; bottom: 6px;
+  width: 4px;
+  background: var(--c-accent);
+  border-radius: 0 4px 4px 0;
+}
+.sp-nav-sub {
+  display: block;
+  padding: 6px 16px 6px 48px;
+  color: var(--c-text);
+  font-size: 13px;
+  text-decoration: none;
+  margin: 0 8px;
+  border-radius: 6px;
+}
+.sp-nav-sub:hover { background: #ebebee; text-decoration: none; }
+.sp-nav-sub.is-active { color: var(--c-accent); font-weight: 600; }
+
+.sp-nav-ico {
+  width: 20px; height: 20px;
+  display: inline-block;
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: contain;
+  flex-shrink: 0;
+}
+/* Inline SVG icons via CSS background. Simple stroke icons in #202223. */
+.sp-ico-home { background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none"><path d="M3 10l7-6 7 6v6a1 1 0 01-1 1h-4v-5H8v5H4a1 1 0 01-1-1v-6z" stroke="%23202223" stroke-width="1.5" stroke-linejoin="round"/></svg>'); }
+.sp-ico-stores { background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none"><path d="M3 6l1.5-3h11L17 6M3 6h14M3 6v9a1 1 0 001 1h12a1 1 0 001-1V6M8 16v-5h4v5" stroke="%23202223" stroke-width="1.5" stroke-linejoin="round"/></svg>'); }
+.sp-ico-sales { background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none"><circle cx="10" cy="10" r="7" stroke="%23202223" stroke-width="1.5"/><path d="M8 10l2 2 3-4" stroke="%23202223" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>'); }
+.sp-ico-app_dist { background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none"><rect x="3" y="3" width="6" height="6" stroke="%23202223" stroke-width="1.5"/><rect x="11" y="3" width="6" height="6" stroke="%23202223" stroke-width="1.5"/><rect x="3" y="11" width="6" height="6" stroke="%23202223" stroke-width="1.5"/><rect x="11" y="11" width="6" height="6" stroke="%23202223" stroke-width="1.5"/></svg>'); }
+.sp-ico-catalogs { background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none"><rect x="3" y="4" width="14" height="12" rx="1" stroke="%23202223" stroke-width="1.5"/><path d="M3 8h14M7 4v4" stroke="%23202223" stroke-width="1.5"/></svg>'); }
+.sp-ico-themes { background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none"><rect x="3" y="3" width="6" height="14" stroke="%23202223" stroke-width="1.5"/><rect x="11" y="3" width="6" height="6" stroke="%23202223" stroke-width="1.5"/><rect x="11" y="11" width="6" height="6" stroke="%23202223" stroke-width="1.5"/></svg>'); }
+.sp-ico-directory { background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none"><path d="M4 5h12M4 10h12M4 15h12" stroke="%23202223" stroke-width="1.5" stroke-linecap="round"/><circle cx="3" cy="5" r="0.8" fill="%23202223"/><circle cx="3" cy="10" r="0.8" fill="%23202223"/><circle cx="3" cy="15" r="0.8" fill="%23202223"/></svg>'); }
+.sp-ico-pos { background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none"><rect x="3" y="5" width="14" height="9" rx="1" stroke="%23202223" stroke-width="1.5"/><path d="M2 16h16" stroke="%23202223" stroke-width="1.5" stroke-linecap="round"/></svg>'); }
+.sp-ico-partner_docs { background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none"><path d="M5 3h7l4 4v10a1 1 0 01-1 1H5a1 1 0 01-1-1V4a1 1 0 011-1z" stroke="%23202223" stroke-width="1.5" stroke-linejoin="round"/><path d="M12 3v4h4" stroke="%23202223" stroke-width="1.5"/></svg>'); }
+.sp-ico-product_docs { background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none"><path d="M4 3v14h12V3H4z" stroke="%23202223" stroke-width="1.5"/><path d="M7 7h6M7 10h6M7 13h4" stroke="%23202223" stroke-width="1.5" stroke-linecap="round"/></svg>'); }
+.sp-ico-support { background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none"><circle cx="10" cy="10" r="7" stroke="%23202223" stroke-width="1.5"/><path d="M8 8a2 2 0 014 0c0 1.5-2 1.5-2 3" stroke="%23202223" stroke-width="1.5" stroke-linecap="round"/><circle cx="10" cy="14.5" r="0.9" fill="%23202223"/></svg>'); }
+.sp-ico-payouts { background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none"><rect x="3" y="5" width="14" height="10" rx="1" stroke="%23202223" stroke-width="1.5"/><circle cx="10" cy="10" r="2" stroke="%23202223" stroke-width="1.5"/></svg>'); }
+.sp-ico-team { background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none"><path d="M10 4l4 3v7l-4 3-4-3V7l4-3z" stroke="%23202223" stroke-width="1.5" stroke-linejoin="round"/><path d="M10 4v13" stroke="%23202223" stroke-width="1.5"/></svg>'); }
+.sp-ico-settings { background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none"><circle cx="10" cy="10" r="2.5" stroke="%23202223" stroke-width="1.5"/><path d="M10 3v2M10 15v2M3 10h2M15 10h2M5.4 5.4l1.4 1.4M13.2 13.2l1.4 1.4M5.4 14.6l1.4-1.4M13.2 6.8l1.4-1.4" stroke="%23202223" stroke-width="1.5" stroke-linecap="round"/></svg>'); }
+
+/* ───────── main page ───────── */
+.sp-main {
+  padding: 28px 32px 64px;
+  max-width: 1200px;
+  width: 100%;
+}
+.sp-page-header {
+  display: flex; align-items: center; justify-content: space-between;
+  margin: 0 0 24px 0;
+  gap: 16px;
+}
+.sp-page-h1 {
+  font-size: 24px; font-weight: 600;
+  color: var(--c-text);
+  margin: 0;
+  line-height: 1.2;
+  letter-spacing: -0.005em;
+}
+.sp-page-subtitle {
+  color: var(--c-text-sub);
+  font-size: 14px;
+  margin: -16px 0 24px 0;
+}
+.sp-page-actions {
+  display: inline-flex; gap: 12px; align-items: center;
+}
+
+/* Cards */
+.sp-card {
+  background: var(--c-card);
+  border-radius: var(--radius-card);
+  box-shadow: var(--shadow-card);
+  margin: 0 0 16px 0;
+}
+.sp-card-header {
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--c-border);
+  display: flex; align-items: center; justify-content: space-between;
+  gap: 16px;
+}
+.sp-card-header h2 {
+  margin: 0;
+  font-size: 14px; font-weight: 600;
+}
+.sp-card-body { padding: 16px 20px; }
+.sp-card-body-flush { padding: 0; }
+.sp-card-footer {
+  padding: 12px 20px;
+  border-top: 1px solid var(--c-border);
+  display: flex; justify-content: space-between; align-items: center;
+}
+
+/* Buttons */
+.sp-btn {
+  display: inline-flex; align-items: center; gap: 6px;
+  height: 32px;
+  padding: 0 12px;
+  border-radius: var(--radius-btn);
+  border: 1px solid var(--c-border);
+  background: #fff;
+  color: var(--c-text);
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  text-decoration: none;
+  line-height: 1;
+}
+.sp-btn:hover { background: #f6f6f7; border-color: var(--c-border-hover); text-decoration: none; }
+.sp-btn-primary {
+  background: var(--c-accent);
+  color: #fff;
+  border-color: var(--c-accent);
+}
+.sp-btn-primary:hover { background: var(--c-accent-hover); border-color: var(--c-accent-hover); color: #fff; }
+.sp-btn-danger { color: var(--c-danger); }
+.sp-btn-icon-after::after { content: "▾"; margin-left: 4px; font-size: 10px; opacity: 0.7; }
+
+/* Banner */
+.sp-banner {
+  background: var(--c-warning-bg);
+  border-top: 3px solid var(--c-warning-accent);
+  border-radius: var(--radius-card);
+  padding: 14px 18px 14px 56px;
+  position: relative;
+  margin: 0 0 24px 0;
+}
+.sp-banner-icon {
+  position: absolute; left: 18px; top: 16px;
+  width: 22px; height: 22px;
+  background: #ffd400;
+  border-radius: 999px;
+  display: inline-flex; align-items: center; justify-content: center;
+  font-weight: 700;
+  color: #5a3a01;
+}
+.sp-banner h3 { margin: 0 0 4px 0; font-size: 14px; font-weight: 600; }
+.sp-banner p { margin: 0 0 10px 0; color: var(--c-text); font-size: 13px; }
+.sp-banner-dismiss {
+  position: absolute; right: 12px; top: 12px;
+  width: 24px; height: 24px;
+  border: 0; background: transparent; cursor: pointer;
+  font-size: 18px; color: var(--c-text);
+}
+
+/* Pills */
+.sp-pill {
+  display: inline-flex; align-items: center;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: var(--c-pill-grey);
+  color: var(--c-text-sub);
+  font-size: 12px; font-weight: 500;
+}
+.sp-pill-green {
+  background: var(--c-pill-green-bg);
+  color: var(--c-pill-green-text);
+}
+
+/* Tabs */
+.sp-tabs {
+  display: flex; gap: 4px;
+  border-bottom: 1px solid var(--c-border);
+  padding: 0 20px;
+}
+.sp-tab {
+  display: inline-flex; align-items: center;
+  padding: 12px 12px;
+  color: var(--c-text-sub);
+  text-decoration: none;
+  border-bottom: 2px solid transparent;
+  font-size: 13px;
+  font-weight: 500;
+}
+.sp-tab:hover { color: var(--c-text); text-decoration: none; }
+.sp-tab.is-active {
+  color: var(--c-text);
+  border-bottom-color: var(--c-accent);
+  font-weight: 600;
+}
+
+/* Data list (Stores, Payouts, etc.) */
+.sp-list {
+  list-style: none; padding: 0; margin: 0;
+}
+.sp-list-row {
+  display: grid;
+  grid-template-columns: 2fr 1fr auto;
+  align-items: center;
+  gap: 16px;
+  padding: 16px 20px;
+  border-top: 1px solid var(--c-border);
+}
+.sp-list-row:first-child { border-top: 0; }
+.sp-list-row-name { font-weight: 600; }
+.sp-list-row-sub { color: var(--c-text-sub); font-size: 12px; }
+.sp-list-row-actions {
+  display: inline-flex; gap: 18px; align-items: center;
+  justify-content: flex-end;
+}
+
+/* Stats overview cards */
+.sp-stats-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+}
+.sp-stat-card {
+  background: var(--c-card);
+  border-radius: var(--radius-card);
+  box-shadow: var(--shadow-card);
+  padding: 18px 20px;
+}
+.sp-stat-label {
+  color: var(--c-text-sub);
+  font-size: 13px;
+  margin-bottom: 4px;
+}
+.sp-stat-value {
+  font-size: 22px;
+  font-weight: 600;
+  color: var(--c-text);
+  margin-bottom: 8px;
+}
+.sp-stat-link {
+  font-size: 13px;
+}
+
+/* Home grid with changelog right rail */
+.sp-home-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 320px;
+  gap: 24px;
+}
+
+/* Changelog */
+.sp-changelog {
+  background: var(--c-card);
+  border-radius: var(--radius-card);
+  box-shadow: var(--shadow-card);
+  padding: 18px 20px;
+}
+.sp-changelog header {
+  display: flex; align-items: center; justify-content: space-between;
+  margin-bottom: 14px;
+}
+.sp-changelog h2 {
+  font-size: 14px; font-weight: 600;
+  margin: 0;
+}
+.sp-changelog-item {
+  padding: 14px 0;
+  border-top: 1px solid var(--c-border);
+}
+.sp-changelog-item:first-of-type { border-top: 0; padding-top: 4px; }
+.sp-changelog-date {
+  font-size: 12px; color: var(--c-text-sub);
+  display: flex; gap: 8px; align-items: center;
+  margin-bottom: 4px;
+}
+.sp-changelog-title {
+  font-size: 13px; font-weight: 600;
+  margin: 0 0 4px 0;
+  color: var(--c-text);
+}
+.sp-changelog-summary {
+  font-size: 13px; color: var(--c-text-sub);
+  margin: 0;
+}
+
+/* Filter row */
+.sp-filterrow {
+  display: flex; gap: 12px;
+  padding: 12px 20px;
+  align-items: center;
+  border-bottom: 1px solid var(--c-border);
+}
+.sp-filterrow input[type=search],
+.sp-filterrow input[type=text] {
+  flex: 1;
+  height: 36px;
+  border: 1px solid var(--c-border);
+  border-radius: 8px;
+  padding: 0 12px;
+  background: #fff;
+  font-family: inherit;
+  font-size: 13px;
+}
+.sp-select {
+  height: 36px;
+  border: 1px solid var(--c-border);
+  border-radius: 8px;
+  background: #fff;
+  padding: 0 28px 0 12px;
+  font-family: inherit;
+  font-size: 13px;
+  -webkit-appearance: none; appearance: none;
+  background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12" fill="none"><path d="M3 5l3 3 3-3" stroke="%23202223" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>');
+  background-repeat: no-repeat;
+  background-position: right 10px center;
+}
+
+.sp-summary-row {
+  display: flex; justify-content: space-between; align-items: center;
+  padding: 12px 20px;
+  border-bottom: 1px solid var(--c-border);
+  font-size: 13px;
+  color: var(--c-text-sub);
+}
+
+/* Sales — Submit a lead card rows */
+.sp-product-row {
+  display: grid;
+  grid-template-columns: 40px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 16px;
+  padding: 16px 20px;
+  border-top: 1px solid var(--c-border);
+}
+.sp-product-row:first-child { border-top: 0; }
+.sp-product-row-glyph {
+  width: 36px; height: 36px;
+  border-radius: 6px;
+  background: #f0f8f5;
+  color: var(--c-accent);
+  display: inline-flex; align-items: center; justify-content: center;
+  font-weight: 700;
+}
+.sp-product-row-name { font-weight: 600; margin-bottom: 4px; }
+.sp-product-row-desc { color: var(--c-text-sub); font-size: 13px; }
+
+/* Sales empty illustration */
+.sp-empty-state {
+  display: flex; flex-direction: column; align-items: center;
+  padding: 32px 20px;
+}
+.sp-empty-illu {
+  width: 240px; height: 180px;
+  background: linear-gradient(135deg, #f3eefe 0%, #fce8ef 100%);
+  border-radius: 12px;
+  margin-bottom: 16px;
+  position: relative;
+  overflow: hidden;
+}
+.sp-empty-illu::after {
+  content: "";
+  position: absolute; inset: 30% 25%;
+  background: linear-gradient(135deg, #8a72ee 0%, #ec5d99 100%);
+  border-radius: 50% 50% 8px 8px;
+  opacity: 0.4;
+}
+
+/* Payouts */
+.sp-pending-card {
+  padding: 18px 20px;
+}
+.sp-pending-card .sp-pending-amt {
+  font-size: 32px; font-weight: 600;
+  margin: 4px 0 4px;
+}
+.sp-pending-card .sp-pending-sub {
+  color: var(--c-text-sub);
+  font-size: 12px; margin: 0;
+}
+.sp-pending-card .sp-pending-eta {
+  margin-top: 12px;
+  font-size: 13px;
+}
+
+.sp-payouts-list {
+  background: var(--c-card);
+  border-radius: var(--radius-card);
+  box-shadow: var(--shadow-card);
+}
+.sp-payouts-row {
+  display: grid;
+  grid-template-columns: 2fr 1fr auto;
+  gap: 12px;
+  padding: 14px 20px;
+  border-top: 1px solid var(--c-border);
+  align-items: center;
+  font-size: 13px;
+}
+.sp-payouts-row:first-child { border-top: 0; }
+.sp-payouts-row .sp-payouts-amount {
+  text-align: right;
+  color: var(--c-text);
+  font-weight: 500;
+}
+.sp-payouts-row .sp-payouts-sent {
+  color: var(--c-text-sub);
+}
+
+/* Team */
+.sp-section {
+  display: grid;
+  grid-template-columns: 1fr 1.7fr;
+  gap: 32px;
+  margin: 24px 0 40px 0;
+}
+.sp-section h2 {
+  margin: 0 0 8px 0;
+  font-size: 14px; font-weight: 600;
+}
+.sp-section-desc {
+  color: var(--c-text-sub);
+  font-size: 13px;
+  margin: 0;
+}
+.sp-roster {
+  background: var(--c-card);
+  border-radius: var(--radius-card);
+  box-shadow: var(--shadow-card);
+}
+.sp-roster-tabs {
+  display: flex; gap: 4px;
+  border-bottom: 1px solid var(--c-border);
+  padding: 0 16px;
+}
+.sp-roster-tab {
+  padding: 12px 8px;
+  font-size: 13px;
+  color: var(--c-text-sub);
+  border-bottom: 2px solid transparent;
+}
+.sp-roster-tab.is-active {
+  color: var(--c-text);
+  border-bottom-color: var(--c-accent);
+  font-weight: 600;
+}
+.sp-member-row {
+  display: grid;
+  grid-template-columns: 40px 1fr auto;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  border-top: 1px solid var(--c-border);
+}
+.sp-member-row:first-of-type { border-top: 0; }
+.sp-member-avatar {
+  width: 32px; height: 32px; border-radius: 999px;
+  display: inline-flex; align-items: center; justify-content: center;
+  color: #fff; font-weight: 600; font-size: 12px;
+}
+.sp-member-name a { color: var(--c-link); font-weight: 500; font-size: 13px; }
+.sp-member-meta { color: var(--c-text-sub); font-size: 12px; }
+
+/* Settings */
+.sp-form-row { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+.sp-form-row.sp-form-row-full { grid-template-columns: 1fr; }
+.sp-form-group { display: flex; flex-direction: column; gap: 4px; margin-bottom: 16px; }
+.sp-form-group label {
+  font-size: 13px;
+  color: var(--c-text);
+  font-weight: 500;
+}
+.sp-form-group input,
+.sp-form-group textarea,
+.sp-form-group select {
+  height: 36px;
+  border: 1px solid var(--c-border);
+  border-radius: 6px;
+  padding: 0 12px;
+  background: #fff;
+  font-family: inherit;
+  font-size: 13px;
+  color: var(--c-text);
+}
+.sp-form-group textarea { height: 100px; padding: 8px 12px; }
+.sp-form-actions {
+  display: flex; justify-content: flex-end; gap: 12px;
+  padding-top: 16px;
+  border-top: 1px solid var(--c-border);
+}
+
+/* Marketing card (POS / Themes) */
+.sp-hero {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 24px;
+  background: var(--c-card);
+  border-radius: var(--radius-card);
+  box-shadow: var(--shadow-card);
+  padding: 24px;
+  margin-bottom: 16px;
+  align-items: center;
+}
+.sp-hero h2 {
+  font-size: 22px; font-weight: 600;
+  margin: 0 0 12px 0;
+  line-height: 1.2;
+}
+.sp-hero p {
+  color: var(--c-text);
+  margin: 0 0 16px 0;
+}
+.sp-hero-art {
+  background: linear-gradient(135deg, #2c8d63 0%, #156c43 100%);
+  border-radius: 8px;
+  padding: 28px 24px;
+  color: #fff;
+  font-size: 26px;
+  font-weight: 600;
+  min-height: 200px;
+  position: relative;
+}
+.sp-hero-art-coin {
+  position: absolute; right: 36px; bottom: 36px;
+  width: 80px; height: 80px;
+  border-radius: 999px;
+  background: radial-gradient(circle at 35% 30%, #f6d066 0, #b5862c 80%);
+  box-shadow: 0 2px 6px rgba(0,0,0,0.25);
+}
+.sp-hero-art-coin::after {
+  content: "$"; position: absolute; inset: 0;
+  display: inline-flex; align-items: center; justify-content: center;
+  font-size: 32px; font-weight: 700; color: #5a3a01;
+}
+
+.sp-info-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+.sp-info-card {
+  background: var(--c-card);
+  border-radius: var(--radius-card);
+  box-shadow: var(--shadow-card);
+  padding: 20px;
+}
+.sp-info-card h3 {
+  margin: 0 0 8px 0;
+  font-size: 15px;
+  font-weight: 600;
+}
+.sp-info-card p {
+  margin: 0 0 16px 0;
+  color: var(--c-text-sub);
+}
+
+/* Sub-nav tabs row */
+.sp-subnav {
+  display: flex; gap: 4px;
+  margin-bottom: 16px;
+  border-bottom: 1px solid var(--c-border);
+  padding: 0 4px;
+}
+.sp-subnav a {
+  padding: 10px 12px;
+  color: var(--c-text-sub);
+  font-size: 13px;
+  border-bottom: 2px solid transparent;
+  text-decoration: none;
+}
+.sp-subnav a.is-active { color: var(--c-text); border-bottom-color: var(--c-accent); font-weight: 600; }
+
+/* Reviews / directory table */
+.sp-data-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+.sp-data-table th {
+  text-align: left;
+  font-weight: 500;
+  color: var(--c-text-sub);
+  padding: 14px 20px;
+  border-bottom: 1px solid var(--c-border);
+}
+.sp-data-table td {
+  padding: 14px 20px;
+  border-top: 1px solid var(--c-border);
+}
+.sp-data-table tr:first-child td { border-top: 0; }
+.sp-data-table tbody td:first-child { font-weight: 600; }
+
+/* Login */
+.sp-login {
+  min-height: 100vh;
+  background: var(--c-bg);
+  display: flex; align-items: center; justify-content: center;
+}
+.sp-login-card {
+  width: 380px;
+  background: #fff;
+  border-radius: 12px;
+  padding: 32px;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.06), 0 0 0 1px var(--c-border);
+}
+
+/* Native dropdowns via <details> */
+.sp-dropdown {
+  position: relative;
+  display: inline-block;
+}
+.sp-dropdown summary {
+  list-style: none;
+  cursor: pointer;
+  user-select: none;
+}
+.sp-dropdown summary::-webkit-details-marker { display: none; }
+/* Only quiet-link summaries get the blue link color */
+.sp-dropdown summary.sp-link-quiet,
+.sp-dropdown summary.sp-dropdown-summary {
+  color: var(--c-link);
+  font-size: 13px;
+}
+.sp-dropdown summary.sp-link-quiet:hover,
+.sp-dropdown-summary:hover { color: var(--c-link-hover); }
+/* Button-styled summaries inherit their button color (sp-btn / sp-btn-primary) */
+.sp-dropdown summary.sp-btn { color: var(--c-text); }
+.sp-dropdown summary.sp-btn-primary { color: #fff; }
+.sp-dropdown-menu {
+  position: absolute;
+  right: 0;
+  top: calc(100% + 4px);
+  z-index: 10;
+  background: #fff;
+  min-width: 200px;
+  border-radius: 8px;
+  box-shadow: 0 6px 20px rgba(0,0,0,0.15), 0 0 0 1px var(--c-border);
+  padding: 4px;
+}
+.sp-dropdown-item {
+  display: block;
+  padding: 8px 12px;
+  color: var(--c-text);
+  text-decoration: none;
+  font-size: 13px;
+  border-radius: 4px;
+  background: none;
+  border: 0;
+  width: 100%;
+  text-align: left;
+  cursor: pointer;
+  font-family: inherit;
+}
+.sp-dropdown-item:hover {
+  background: #f1f2f4;
+  text-decoration: none;
+  color: var(--c-text);
+}
+.sp-dropdown-item-danger { color: var(--c-danger); }
+.sp-dropdown-item-danger:hover { color: var(--c-danger); background: #fff0ee; }
+
+/* utils */
+.sp-row { display: flex; align-items: center; gap: 12px; }
+.sp-row-between { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+.sp-link-quiet { color: var(--c-link); font-size: 13px; }
+.sp-mt-12 { margin-top: 12px; }
+.sp-mt-24 { margin-top: 24px; }
+.sp-mt-40 { margin-top: 40px; }
+.sp-text-sub { color: var(--c-text-sub); }
+.sp-text-right { text-align: right; }
+.sp-pl-bullet li { margin: 6px 0; }
+.sp-divider { border-top: 1px solid var(--c-border); margin: 24px 0; }

--- a/deploy/sim_envs/mantis_shopify/app/templates/_banner.html
+++ b/deploy/sim_envs/mantis_shopify/app/templates/_banner.html
@@ -1,0 +1,11 @@
+{% if not banner_dismissed %}
+<div class="sp-banner" data-testid="emergency-banner">
+  <span class="sp-banner-icon">!</span>
+  <form method="post" action="/team/banner/dismiss" style="position:absolute;right:8px;top:8px">
+    <button class="sp-banner-dismiss" data-testid="emergency-banner-dismiss" aria-label="Dismiss banner">×</button>
+  </form>
+  <h3>Update emergency contact information to receive important API alerts</h3>
+  <p>Developers on your team will be notified about urgent and upcoming changes to the Shopify API.</p>
+  <a class="sp-btn" href="/settings#emergency" data-testid="emergency-banner-add-contact">Add contact information</a>
+</div>
+{% endif %}

--- a/deploy/sim_envs/mantis_shopify/app/templates/admin_analytics.html
+++ b/deploy/sim_envs/mantis_shopify/app/templates/admin_analytics.html
@@ -1,0 +1,77 @@
+{% extends "admin_base.html" %}
+{% block title %}Analytics · {{ store.name }} — Shopify{% endblock %}
+
+{% block content %}
+<div class="adm-page-header">
+  <h1 class="adm-page-h1">Analytics</h1>
+  <div class="adm-page-actions">
+    <a class="adm-btn" href="#export" data-testid="adm-an-export">Export</a>
+    <a class="adm-btn" href="#date-range" data-testid="adm-an-range">Last 7 days ▾</a>
+    <a class="adm-btn" href="#compare" data-testid="adm-an-compare">Compare ▾</a>
+  </div>
+</div>
+
+<div class="adm-stats-grid">
+  <div class="adm-stat-card"><div class="adm-stat-label">Total sales</div><div class="adm-stat-value">{{ total_sales | money }}</div><div class="adm-stat-delta up">▲ 12.4%</div></div>
+  <div class="adm-stat-card"><div class="adm-stat-label">Orders</div><div class="adm-stat-value">{{ orders_total }}</div><div class="adm-stat-delta up">▲ 4.2%</div></div>
+  <div class="adm-stat-card"><div class="adm-stat-label">Average order value</div><div class="adm-stat-value">{{ aov_cents | money }}</div><div class="adm-stat-delta up">▲ 3.4%</div></div>
+  <div class="adm-stat-card"><div class="adm-stat-label">Returning customer rate</div><div class="adm-stat-value">{{ returning_rate }}</div><div class="adm-stat-delta up">▲ 1.1 pts</div></div>
+</div>
+
+<section class="adm-card" data-testid="adm-an-chart">
+  <header class="adm-card-header">
+    <h2>Sales over time</h2>
+    <a href="#open-chart">Open report</a>
+  </header>
+  <div class="adm-card-body">
+    {# Sparkline-style SVG chart #}
+    <svg viewBox="0 0 1024 220" preserveAspectRatio="none" width="100%" height="220" aria-label="Sales last 7 days">
+      <defs>
+        <linearGradient id="g-sales" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stop-color="#0e8767" stop-opacity="0.25"/>
+          <stop offset="100%" stop-color="#0e8767" stop-opacity="0"/>
+        </linearGradient>
+      </defs>
+      <polyline points="0,160 146,140 292,150 438,90 584,110 730,70 876,80 1024,40" fill="none" stroke="#0e8767" stroke-width="2.5"/>
+      <polygon points="0,160 146,140 292,150 438,90 584,110 730,70 876,80 1024,40 1024,220 0,220" fill="url(#g-sales)"/>
+      {% for x in [0, 146, 292, 438, 584, 730, 876, 1024] %}
+        <line x1="{{ x }}" y1="0" x2="{{ x }}" y2="220" stroke="#ececec" stroke-dasharray="2 4"/>
+      {% endfor %}
+    </svg>
+    <div style="display:flex;justify-content:space-between;font-size:11px;color:#6a6a6a;margin-top:6px">
+      <span>Jun 3</span><span>Jun 4</span><span>Jun 5</span><span>Jun 6</span>
+      <span>Jun 7</span><span>Jun 8</span><span>Jun 9</span><span>Today</span>
+    </div>
+  </div>
+</section>
+
+<div class="adm-detail-grid">
+  <section class="adm-card" data-testid="adm-an-top-products">
+    <header class="adm-card-header"><h2>Top products by sales</h2></header>
+    <table class="adm-table">
+      <thead><tr><th>Product</th><th class="col-right">Units</th><th class="col-right">Revenue</th></tr></thead>
+      <tbody>
+        {% for p in top_products %}
+        <tr>
+          <td>{{ p.title }}</td>
+          <td class="col-right">{{ p.units }}</td>
+          <td class="col-right">{{ p.revenue | money }}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </section>
+  <aside class="adm-card" data-testid="adm-an-reports">
+    <header class="adm-card-header"><h2>Saved reports</h2></header>
+    <div class="adm-card-body">
+      <div style="display:flex;flex-direction:column;gap:8px;font-size:13px">
+        <a href="#r-sessions">Sessions by device</a>
+        <a href="#r-conv">Conversion funnel</a>
+        <a href="#r-cart">Cart abandonment</a>
+        <a href="#r-segments">Customer segments</a>
+        <a href="#r-ltv">Lifetime value</a>
+      </div>
+    </div>
+  </aside>
+</div>
+{% endblock %}

--- a/deploy/sim_envs/mantis_shopify/app/templates/admin_apps.html
+++ b/deploy/sim_envs/mantis_shopify/app/templates/admin_apps.html
@@ -1,0 +1,49 @@
+{% extends "admin_base.html" %}
+{% block title %}Apps · {{ store.name }} — Shopify{% endblock %}
+
+{% block content %}
+<div class="adm-page-header">
+  <h1 class="adm-page-h1">Apps</h1>
+  <div class="adm-page-actions">
+    <input type="search" placeholder="Search the App Store" style="width:280px;height:32px;padding:0 12px;border:1px solid #c3c3c3;border-radius:8px;background:#fff;font-size:13px;font-family:inherit"/>
+    <a class="adm-btn adm-btn-primary" href="#open-store" data-testid="adm-apps-open-store">Visit App Store</a>
+  </div>
+</div>
+
+<section class="adm-card" data-testid="adm-apps-installed">
+  <header class="adm-card-header"><h2>Installed</h2></header>
+  <div class="adm-card-body">
+    <div style="display:grid;grid-template-columns:repeat(3,1fr);gap:12px">
+      {% for a in installed %}
+      <div style="border:1px solid #e3e3e3;border-radius:8px;padding:14px" data-testid="adm-app-installed-card">
+        <div style="display:flex;align-items:center;gap:10px;margin-bottom:6px">
+          <div style="width:36px;height:36px;background:linear-gradient(135deg,#9c6ade,#5c6ac4);border-radius:8px"></div>
+          <strong>{{ a.name }}</strong>
+        </div>
+        <div style="font-size:12px;color:#6a6a6a;margin-bottom:6px">{{ a.category }} · ★ {{ a.rating }}</div>
+        <a class="adm-btn" href="#open">Open</a>
+      </div>
+      {% endfor %}
+    </div>
+  </div>
+</section>
+
+<section class="adm-card" data-testid="adm-apps-suggested">
+  <header class="adm-card-header">
+    <h2>Recommended for you</h2>
+    <a href="#all">See all</a>
+  </header>
+  <div class="adm-card-body">
+    <div style="display:grid;grid-template-columns:repeat(4,1fr);gap:12px">
+      {% for a in suggested %}
+      <div style="border:1px solid #e3e3e3;border-radius:8px;padding:14px" data-testid="adm-app-suggested-card">
+        <div style="width:48px;height:48px;background:linear-gradient(135deg,#f4a261,#e76f51);border-radius:10px;margin-bottom:8px"></div>
+        <div style="font-weight:600;margin-bottom:2px">{{ a.name }}</div>
+        <div style="font-size:12px;color:#6a6a6a;margin-bottom:8px">{{ a.category }} · ★ {{ a.rating }}</div>
+        <a class="adm-btn" href="#install" style="font-size:12px">Install</a>
+      </div>
+      {% endfor %}
+    </div>
+  </div>
+</section>
+{% endblock %}

--- a/deploy/sim_envs/mantis_shopify/app/templates/admin_base.html
+++ b/deploy/sim_envs/mantis_shopify/app/templates/admin_base.html
@@ -1,0 +1,119 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>{% block title %}{{ store.name }} · Shopify{% endblock %}</title>
+  <link rel="stylesheet" href="/static/site.css?v=20260609c" />
+  <link rel="stylesheet" href="/static/admin.css?v=20260609b" />
+  <link rel="stylesheet" href="/static/polish.css?v=20260610a" />
+  <script src="/static/admin.js?v=20260609a" defer></script>
+  <script src="/static/polish.js?v=20260610a" defer></script>
+</head>
+<body class="adm-body">
+
+<header class="adm-topbar" data-testid="adm-topbar">
+  <div class="adm-topbar-left">
+    <a class="adm-brand" href="/store/{{ store_id }}/admin" aria-label="Shopify Admin">
+      <svg viewBox="0 0 32 36" width="22" height="24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+        <path d="M27.7 7.4c0-.2-.2-.4-.4-.4l-3.6-.3-2.4-2.4c-.2-.2-.7-.2-.9 0l-.9.3c-.6-1.7-1.5-3.3-3.4-3.3h-.2c-.5-.7-1.2-1-1.8-1-4.6.1-6.8 5.9-7.5 8.8l-3.2 1c-1 .3-1 .3-1.2 1.3L0 30.6l16.6 3.1 15.4-3.3L27.7 7.4z" fill="#95BF47"/>
+        <path d="M27.3 7c-.2 0-3.6-.3-3.6-.3l-2.4-2.4c-.2-.2-.5-.2-.7-.2v30.6l15.4-3.3L27.7 7.4c0-.2-.2-.4-.4-.4z" fill="#5E8E3E"/>
+      </svg>
+    </a>
+    <details class="sp-dropdown adm-shop-switcher" data-testid="adm-shop-switcher">
+      <summary class="adm-shop-summary">
+        <span class="adm-shop-icon">{{ store.name[:1] | upper }}</span>
+        <span class="adm-shop-name">{{ store.name }}</span>
+        <span class="adm-shop-caret">▾</span>
+      </summary>
+      <div class="sp-dropdown-menu adm-shop-menu">
+        <div style="padding:8px 12px;font-size:11px;text-transform:uppercase;color:var(--c-text-sub);letter-spacing:0.06em">Current store</div>
+        <div class="sp-dropdown-item" style="opacity:0.7;cursor:default">{{ store.name }} ({{ store.slug }}.myshopify.com)</div>
+        <div style="border-top:1px solid var(--c-border);margin:4px 0"></div>
+        <a class="sp-dropdown-item" href="/stores" data-testid="adm-back-to-partners">← Back to Shopify Partners</a>
+        <a class="sp-dropdown-item" href="/store/{{ store_id }}/admin/settings/general" data-testid="adm-shop-settings">Store settings</a>
+      </div>
+    </details>
+  </div>
+  <div class="adm-topbar-search">
+    <svg viewBox="0 0 20 20" width="14" height="14" aria-hidden="true">
+      <path d="M9 3a6 6 0 014.47 10.03l3.25 3.25-1.42 1.42-3.25-3.25A6 6 0 119 3zm0 2a4 4 0 100 8 4 4 0 000-8z" fill="#c7c9cc"/>
+    </svg>
+    <input type="search" placeholder="Search" data-testid="adm-search" />
+  </div>
+  <div class="adm-topbar-actions">
+    <button class="adm-icon-btn" data-testid="adm-help" aria-label="Help">?</button>
+    <button class="adm-icon-btn" data-testid="adm-notif" aria-label="Notifications">
+      <svg viewBox="0 0 20 20" width="14" height="14" aria-hidden="true">
+        <path d="M10 2a5 5 0 00-5 5v3l-2 2v1h14v-1l-2-2V7a5 5 0 00-5-5zM8 16a2 2 0 004 0H8z" fill="#fff"/>
+      </svg>
+    </button>
+    <span class="adm-user-avatar" data-testid="adm-user">MA</span>
+  </div>
+</header>
+
+<div class="adm-shell">
+  <aside class="adm-sidebar" data-testid="adm-sidebar" aria-label="Primary">
+    <nav class="adm-nav">
+      {% set s = admin_section|default('') %}
+      {% for it in [
+        ('home',       'Home',           'M10 2L2 9h2v7h12V9h2L10 2zm-2 9h4v5H8v-5z',     '/store/'~store_id~'/admin'),
+        ('orders',     'Orders',         'M3 4h14v3H3V4zm0 5h14v9H3V9zm3 3v4h8v-4H6z',     '/store/'~store_id~'/admin/orders'),
+        ('products',   'Products',       'M3 6l7-4 7 4-7 4-7-4zm0 4l7 4 7-4M3 14l7 4 7-4', '/store/'~store_id~'/admin/products'),
+        ('customers',  'Customers',      'M10 4a3 3 0 100 6 3 3 0 000-6zM4 17c0-3 2.6-5 6-5s6 2 6 5v1H4v-1z', '/store/'~store_id~'/admin/customers'),
+        ('marketing',  'Marketing',      'M3 9l4 1 8-6v12L7 10l-4 1V9z', '/store/'~store_id~'/admin/marketing'),
+        ('discounts',  'Discounts',      'M5 5a2 2 0 110 4 2 2 0 010-4zm10 6a2 2 0 110 4 2 2 0 010-4zM4 16L16 4', '/store/'~store_id~'/admin/discounts'),
+        ('analytics',  'Analytics',      'M3 16h14M5 14V8m4 6V4m4 10V10m4 4V6', '/store/'~store_id~'/admin/analytics'),
+        ('content',    'Content',        'M5 3h10v14H5V3zm2 3h6v2H7V6zm0 4h6v2H7v-2zm0 4h4v2H7v-2z', '/store/'~store_id~'/admin/content'),
+      ] %}
+      <a class="adm-nav-row{% if s == it[0] %} is-active{% endif %}"
+         href="{{ it[3] }}" data-testid="adm-nav-{{ it[0] }}">
+        <svg class="adm-nav-icon" viewBox="0 0 20 20" width="18" height="18" aria-hidden="true">
+          <path d="{{ it[2] }}" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+        <span class="adm-nav-label">{{ it[1] }}</span>
+      </a>
+      {% endfor %}
+    </nav>
+
+    <div class="adm-nav-grouplabel">Sales channels</div>
+    <nav class="adm-nav">
+      {% for it in [
+        ('online_store','Online Store',  '/store/'~store_id~'/admin/online-store'),
+        ('pos',         'Point of Sale', '/store/'~store_id~'/admin/pos'),
+      ] %}
+      <a class="adm-nav-row{% if s == it[0] %} is-active{% endif %}"
+         href="{{ it[2] }}" data-testid="adm-nav-{{ it[0] }}">
+        <span class="adm-nav-icon adm-nav-icon-dot"></span>
+        <span class="adm-nav-label">{{ it[1] }}</span>
+      </a>
+      {% endfor %}
+    </nav>
+
+    <div class="adm-nav-grouplabel">Apps</div>
+    <nav class="adm-nav">
+      <a class="adm-nav-row{% if s == 'apps' %} is-active{% endif %}"
+         href="/store/{{ store_id }}/admin/apps" data-testid="adm-nav-apps">
+        <span class="adm-nav-icon adm-nav-icon-dot"></span>
+        <span class="adm-nav-label">Browse apps</span>
+      </a>
+    </nav>
+
+    <div class="adm-sidebar-bottom">
+      <a class="adm-nav-row{% if s == 'settings' %} is-active{% endif %}"
+         href="/store/{{ store_id }}/admin/settings" data-testid="adm-nav-settings">
+        <svg class="adm-nav-icon" viewBox="0 0 20 20" width="18" height="18" aria-hidden="true">
+          <circle cx="10" cy="10" r="2.5" fill="none" stroke="currentColor" stroke-width="1.5"/>
+          <path d="M10 3v2M10 15v2M3 10h2M15 10h2M5.4 5.4l1.4 1.4M13.2 13.2l1.4 1.4M5.4 14.6l1.4-1.4M13.2 6.8l1.4-1.4" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+        </svg>
+        <span class="adm-nav-label">Settings</span>
+      </a>
+    </div>
+  </aside>
+
+  <main class="adm-main" data-testid="adm-main">
+    {% block content %}{% endblock %}
+  </main>
+</div>
+</body>
+</html>

--- a/deploy/sim_envs/mantis_shopify/app/templates/admin_content.html
+++ b/deploy/sim_envs/mantis_shopify/app/templates/admin_content.html
@@ -1,0 +1,93 @@
+{% extends "admin_base.html" %}
+{% block title %}Content · {{ store.name }} — Shopify{% endblock %}
+
+{% block content %}
+<div class="adm-page-header">
+  <h1 class="adm-page-h1">Content</h1>
+  <div class="adm-page-actions">
+    <a class="adm-btn" href="#more" data-testid="adm-content-more">More actions ▾</a>
+    {% if tab == 'pages' %}<a class="adm-btn adm-btn-primary" href="#add" data-testid="adm-content-add-page">Add page</a>
+    {% elif tab == 'blog_posts' %}<a class="adm-btn adm-btn-primary" href="#add" data-testid="adm-content-add-post">Add blog post</a>
+    {% elif tab == 'files' %}<a class="adm-btn adm-btn-primary" href="#add" data-testid="adm-content-upload">Upload</a>
+    {% else %}<a class="adm-btn adm-btn-primary" href="#add" data-testid="adm-content-add-meta">Add definition</a>
+    {% endif %}
+  </div>
+</div>
+
+<section class="adm-card">
+  <div class="adm-tabs" data-testid="adm-content-tabs">
+    {% for tid, label, n in [
+      ('pages', 'Pages', pages|length),
+      ('blog_posts', 'Blog posts', blog_posts|length),
+      ('files', 'Files', files|length),
+      ('metaobjects', 'Metaobjects', metaobjects|length),
+    ] %}
+    <a class="adm-tab{% if tab == tid %} is-active{% endif %}"
+       href="/store/{{ store_id }}/admin/content?tab={{ tid }}"
+       data-testid="adm-content-tab-{{ tid }}">{{ label }} <span class="adm-tab-count">{{ n }}</span></a>
+    {% endfor %}
+  </div>
+
+  {% if tab == 'pages' %}
+  <table class="adm-table" data-testid="adm-content-pages">
+    <thead><tr><th><input type="checkbox"/></th><th>Title</th><th>Status</th><th>Last updated</th></tr></thead>
+    <tbody>
+      {% for p in pages %}
+      <tr data-testid="adm-content-page-row">
+        <td><input type="checkbox"/></td>
+        <td><a href="#pg/{{ p.id }}">{{ p.title }}</a></td>
+        <td><span class="adm-pill {% if p.status == 'Visible' %}adm-pill-active{% else %}adm-pill-draft{% endif %}">{{ p.status }}</span></td>
+        <td>{{ p.updated }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% elif tab == 'blog_posts' %}
+  <table class="adm-table" data-testid="adm-content-blog">
+    <thead><tr><th><input type="checkbox"/></th><th>Title</th><th>Author</th><th>Status</th><th>Published</th></tr></thead>
+    <tbody>
+      {% for b in blog_posts %}
+      <tr data-testid="adm-content-blog-row">
+        <td><input type="checkbox"/></td>
+        <td><a href="#bp/{{ b.id }}">{{ b.title }}</a></td>
+        <td>{{ b.author }}</td>
+        <td>
+          {% if b.status == 'Published' %}<span class="adm-pill adm-pill-active">Published</span>
+          {% elif b.status == 'Scheduled' %}<span class="adm-pill adm-pill-pending">Scheduled</span>
+          {% else %}<span class="adm-pill adm-pill-draft">Draft</span>{% endif %}
+        </td>
+        <td>{{ b.published }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% elif tab == 'files' %}
+  <table class="adm-table" data-testid="adm-content-files">
+    <thead><tr><th><input type="checkbox"/></th><th>File</th><th>Kind</th><th class="col-right">Size</th></tr></thead>
+    <tbody>
+      {% for f in files %}
+      <tr data-testid="adm-content-file-row">
+        <td><input type="checkbox"/></td>
+        <td><a href="#file/{{ f.name }}">{{ f.name }}</a></td>
+        <td>{{ f.kind }}</td>
+        <td class="col-right">{{ f.size }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% else %}
+  <table class="adm-table" data-testid="adm-content-meta">
+    <thead><tr><th>Definition</th><th class="col-right">Entries</th><th>Last updated</th></tr></thead>
+    <tbody>
+      {% for m in metaobjects %}
+      <tr data-testid="adm-content-meta-row">
+        <td><a href="#meta/{{ m.name }}">{{ m.name }}</a></td>
+        <td class="col-right">{{ m.entries }}</td>
+        <td>{{ m.updated }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% endif %}
+</section>
+{% endblock %}

--- a/deploy/sim_envs/mantis_shopify/app/templates/admin_customer_detail.html
+++ b/deploy/sim_envs/mantis_shopify/app/templates/admin_customer_detail.html
@@ -1,0 +1,92 @@
+{% extends "admin_base.html" %}
+{% block title %}{{ customer.name }} · {{ store.name }} — Shopify{% endblock %}
+
+{% block content %}
+<div class="adm-page-header">
+  <div>
+    <div class="sp-row" style="gap:12px;align-items:center;flex-wrap:wrap">
+      <h1 class="adm-page-h1" data-testid="adm-cust-name">{{ customer.name }}</h1>
+      <span class="adm-pill adm-pill-active" data-testid="adm-cust-status">Customer</span>
+    </div>
+    <p style="color:#6a6a6a;font-size:13px;margin:6px 0 0 0" data-testid="adm-cust-meta">
+      {{ customer.location }} · Customer since {{ customer.created_at | short_date }}
+    </p>
+  </div>
+  <div class="adm-page-actions">
+    <a class="adm-btn" href="#email" data-testid="adm-cust-email-cta">Send email</a>
+    <a class="adm-btn" href="#more" data-testid="adm-cust-more">More actions ▾</a>
+    <a class="adm-btn adm-btn-primary" href="#edit" data-testid="adm-cust-edit">Edit customer</a>
+  </div>
+</div>
+
+<div class="adm-detail-grid">
+  <div>
+    <section class="adm-card" data-testid="adm-cust-orders-card">
+      <header class="adm-card-header">
+        <h2>Last orders ({{ recent_orders|length }})</h2>
+        <a href="/store/{{ store_id }}/admin/orders?q={{ customer.email }}">View all</a>
+      </header>
+      {% if recent_orders %}
+      <table class="adm-table">
+        <thead>
+          <tr><th>Order</th><th>Date</th><th>Payment</th><th>Fulfillment</th><th class="col-right">Total</th></tr>
+        </thead>
+        <tbody>
+          {% for o in recent_orders %}
+          <tr data-testid="adm-cust-order-row">
+            <td><a href="/store/{{ store_id }}/admin/orders/{{ o.id }}">{{ o.order_number }}</a></td>
+            <td>{{ o.ordered_at | short_date }}</td>
+            <td><span class="adm-pill adm-pill-{{ o.financial_status }}">{{ o.financial_status | title }}</span></td>
+            <td><span class="adm-pill adm-pill-{{ o.fulfillment_status }}">{{ o.fulfillment_status | title }}</span></td>
+            <td class="col-right">{{ o.total_cents | money }}</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+      {% else %}
+      <div class="adm-empty">No orders yet from this customer.</div>
+      {% endif %}
+    </section>
+
+    <section class="adm-card" data-testid="adm-cust-notes">
+      <div class="adm-card-body">
+        <h3 style="margin:0 0 8px 0;font-size:14px">Notes</h3>
+        <div style="font-size:13px;color:#6a6a6a">No notes from staff yet.</div>
+      </div>
+    </section>
+  </div>
+
+  <aside>
+    <section class="adm-card" data-testid="adm-cust-overview">
+      <div class="adm-card-body">
+        <h3 style="margin:0 0 10px 0;font-size:14px">Customer overview</h3>
+        <div style="font-weight:500">{{ customer.name }}</div>
+        <div style="font-size:12px;color:#6a6a6a">
+          <a href="mailto:{{ customer.email }}">{{ customer.email }}</a>
+        </div>
+        <div style="font-size:12px;color:#6a6a6a">{{ customer.location }}</div>
+        <div class="sp-divider" style="margin:12px 0"></div>
+        <div style="display:flex;justify-content:space-between;padding:4px 0">
+          <span style="color:#6a6a6a">Amount spent</span>
+          <strong>{{ customer.total_spent_cents | money }}</strong>
+        </div>
+        <div style="display:flex;justify-content:space-between;padding:4px 0">
+          <span style="color:#6a6a6a">Orders</span>
+          <strong>{{ customer.orders_count }}</strong>
+        </div>
+        <div style="display:flex;justify-content:space-between;padding:4px 0">
+          <span style="color:#6a6a6a">Last order</span>
+          <strong>{{ customer.last_order_at | short_date }}</strong>
+        </div>
+      </div>
+    </section>
+
+    <section class="adm-card" data-testid="adm-cust-tags">
+      <div class="adm-card-body">
+        <h3 style="margin:0 0 8px 0;font-size:14px">Tags</h3>
+        <div style="font-size:12px;color:#6a6a6a">No tags yet — <a href="#tag">add a tag</a></div>
+      </div>
+    </section>
+  </aside>
+</div>
+{% endblock %}

--- a/deploy/sim_envs/mantis_shopify/app/templates/admin_customer_new.html
+++ b/deploy/sim_envs/mantis_shopify/app/templates/admin_customer_new.html
@@ -1,0 +1,31 @@
+{% extends "admin_base.html" %}
+{% block title %}Add customer · {{ store.name }} — Shopify{% endblock %}
+
+{% block content %}
+<div class="adm-page-header">
+  <div>
+    <a href="/store/{{ store_id }}/admin/customers" style="color:#6a6a6a;font-size:13px;text-decoration:none">← Customers</a>
+    <h1 class="adm-page-h1" style="margin-top:4px">Add customer</h1>
+  </div>
+</div>
+
+<form method="post" action="/store/{{ store_id }}/admin/customers/create" data-testid="adm-customer-new-form">
+<section class="adm-card" style="max-width:720px">
+  <header class="adm-card-header"><h2>Customer overview</h2></header>
+  <div class="adm-card-body">
+    <div style="display:grid;grid-template-columns:1fr 1fr;gap:12px;margin-bottom:12px">
+      <div><label style="font-size:12px;color:#6a6a6a">Name</label>
+        <input type="text" name="name" required style="width:100%;height:36px;padding:0 12px;border:1px solid #c3c3c3;border-radius:6px;font-size:13px" data-testid="adm-customer-new-name"/></div>
+      <div><label style="font-size:12px;color:#6a6a6a">Email</label>
+        <input type="email" name="email" required style="width:100%;height:36px;padding:0 12px;border:1px solid #c3c3c3;border-radius:6px;font-size:13px" data-testid="adm-customer-new-email"/></div>
+    </div>
+    <div><label style="font-size:12px;color:#6a6a6a">Location</label>
+      <input type="text" name="location" placeholder="City, Country" style="width:100%;height:36px;padding:0 12px;border:1px solid #c3c3c3;border-radius:6px;font-size:13px"/></div>
+  </div>
+</section>
+<div style="display:flex;justify-content:flex-end;gap:10px;margin-top:16px;max-width:720px">
+  <a class="adm-btn" href="/store/{{ store_id }}/admin/customers">Cancel</a>
+  <button type="submit" class="adm-btn adm-btn-primary" data-testid="adm-customer-new-submit">Save customer</button>
+</div>
+</form>
+{% endblock %}

--- a/deploy/sim_envs/mantis_shopify/app/templates/admin_customers.html
+++ b/deploy/sim_envs/mantis_shopify/app/templates/admin_customers.html
@@ -1,0 +1,81 @@
+{% extends "admin_base.html" %}
+{% block title %}Customers · {{ store.name }} — Shopify{% endblock %}
+
+{% block content %}
+<div class="adm-page-header">
+  <h1 class="adm-page-h1">Customers</h1>
+  <div class="adm-page-actions">
+    <a class="adm-btn" href="/store/{{ store_id }}/admin/customers?export=csv" data-testid="adm-cust-export">Export</a>
+    <a class="adm-btn" href="/store/{{ store_id }}/admin/customers?import=1" data-testid="adm-cust-import">Import</a>
+    <a class="adm-btn" href="/store/{{ store_id }}/admin/customers?view=segments" data-testid="adm-cust-segments">Segments</a>
+    <a class="adm-btn adm-btn-primary" href="/store/{{ store_id }}/admin/customers/create" data-testid="adm-cust-add">Add customer</a>
+  </div>
+</div>
+
+<section class="adm-card">
+  <form class="adm-filterrow" method="get" action="/store/{{ store_id }}/admin/customers">
+    <input type="search" name="q" value="{{ q }}" placeholder="Search customers" data-testid="adm-cust-search" />
+    <details class="adm-dropdown">
+      <summary class="adm-btn" data-testid="adm-cust-filter">Filter ▾</summary>
+      <div class="adm-dropdown-menu" style="min-width:220px">
+        <div style="padding:6px 12px;font-size:11px;text-transform:uppercase;color:#6a6a6a">Segment</div>
+        <a class="adm-dropdown-item" href="?q=&amp;sort=spent_desc">Highest spenders</a>
+        <a class="adm-dropdown-item" href="?q=&amp;sort=orders_desc">Most orders</a>
+        <a class="adm-dropdown-item" href="?q=&amp;sort=recent">Recently active</a>
+        <div class="adm-dropdown-sep"></div>
+        <a class="adm-dropdown-item" href="?q=">Clear filter</a>
+      </div>
+    </details>
+    <details class="adm-dropdown">
+      <summary class="adm-btn" data-testid="adm-cust-sort">Sort
+        {% if sort == 'spent_asc' %}: Spent ↑{% elif sort == 'name_asc' %}: A→Z{% elif sort == 'name_desc' %}: Z→A{% elif sort == 'orders_desc' %}: Most orders{% elif sort == 'recent' %}: Recent{% else %}: Spent ↓{% endif %}
+        ▾</summary>
+      <div class="adm-dropdown-menu">
+        {% for sid, label in [
+          ('spent_desc',  'Highest spent first'),
+          ('spent_asc',   'Lowest spent first'),
+          ('name_asc',    'Name A → Z'),
+          ('name_desc',   'Name Z → A'),
+          ('orders_desc', 'Most orders'),
+          ('recent',      'Most recent order'),
+        ] %}
+        <a class="adm-dropdown-item" href="?q={{ q }}&sort={{ sid }}">{{ label }}</a>
+        {% endfor %}
+      </div>
+    </details>
+  </form>
+
+  {% if customers %}
+  <table class="adm-table" data-testid="adm-cust-table">
+    <thead>
+      <tr>
+        <th><input type="checkbox" aria-label="Select all" /></th>
+        <th>Customer</th><th>Email</th><th>Location</th>
+        <th>Orders</th><th class="col-right">Amount spent</th><th>Last order</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for c in customers %}
+      <tr data-testid="adm-cust-row">
+        <td><input type="checkbox" aria-label="Select {{ c.name }}"/></td>
+        <td>
+          <div style="display:flex;gap:10px;align-items:center">
+            <span class="sp-user-avatar" style="background:#5c6ac4;width:28px;height:28px">{{ c.name | initials }}</span>
+            <a href="/store/{{ store_id }}/admin/customers/{{ c.id }}"
+               style="font-weight:500;color:#303030;text-decoration:none" data-testid="adm-cust-name-link">{{ c.name }}</a>
+          </div>
+        </td>
+        <td><a href="mailto:{{ c.email }}">{{ c.email }}</a></td>
+        <td>{{ c.location }}</td>
+        <td>{{ c.orders_count }}</td>
+        <td class="col-right">{{ c.total_spent_cents | money }}</td>
+        <td>{{ c.last_order_at | short_date }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% else %}
+  <div class="adm-empty">No customers match your search.</div>
+  {% endif %}
+</section>
+{% endblock %}

--- a/deploy/sim_envs/mantis_shopify/app/templates/admin_discount_new.html
+++ b/deploy/sim_envs/mantis_shopify/app/templates/admin_discount_new.html
@@ -1,0 +1,35 @@
+{% extends "admin_base.html" %}
+{% block title %}Create discount · {{ store.name }} — Shopify{% endblock %}
+
+{% block content %}
+<div class="adm-page-header">
+  <div>
+    <a href="/store/{{ store_id }}/admin/discounts" style="color:#6a6a6a;font-size:13px;text-decoration:none">← Discounts</a>
+    <h1 class="adm-page-h1" style="margin-top:4px">Create discount</h1>
+  </div>
+</div>
+
+<form method="post" action="/store/{{ store_id }}/admin/discounts/new" data-testid="adm-discount-new-form">
+<section class="adm-card" style="max-width:720px">
+  <div class="adm-card-body">
+    <label style="font-size:12px;color:#6a6a6a">Discount code</label>
+    <input type="text" name="code" required placeholder="SUMMER20" pattern="[A-Za-z0-9-]+" style="width:100%;height:36px;padding:0 12px;border:1px solid #c3c3c3;border-radius:6px;font-size:13px;font-family:JetBrains Mono,monospace;letter-spacing:0.04em;margin-bottom:14px" data-testid="adm-discount-new-code"/>
+
+    <label style="font-size:12px;color:#6a6a6a">Type</label>
+    <select name="discount_type" style="width:100%;height:36px;padding:0 12px;border:1px solid #c3c3c3;border-radius:6px;font-size:13px;margin-bottom:14px" data-testid="adm-discount-new-type">
+      <option>Amount off products</option>
+      <option>Amount off order</option>
+      <option>Free shipping</option>
+      <option>Buy X get Y</option>
+    </select>
+
+    <label style="font-size:12px;color:#6a6a6a">Value</label>
+    <input type="text" name="value" required placeholder="20% off all products" style="width:100%;height:36px;padding:0 12px;border:1px solid #c3c3c3;border-radius:6px;font-size:13px" data-testid="adm-discount-new-value"/>
+  </div>
+</section>
+<div style="display:flex;justify-content:flex-end;gap:10px;margin-top:16px;max-width:720px">
+  <a class="adm-btn" href="/store/{{ store_id }}/admin/discounts">Cancel</a>
+  <button type="submit" class="adm-btn adm-btn-primary" data-testid="adm-discount-new-submit">Save discount</button>
+</div>
+</form>
+{% endblock %}

--- a/deploy/sim_envs/mantis_shopify/app/templates/admin_discounts.html
+++ b/deploy/sim_envs/mantis_shopify/app/templates/admin_discounts.html
@@ -1,0 +1,55 @@
+{% extends "admin_base.html" %}
+{% block title %}Discounts · {{ store.name }} — Shopify{% endblock %}
+
+{% block content %}
+<div class="adm-page-header">
+  <h1 class="adm-page-h1">Discounts</h1>
+  <div class="adm-page-actions">
+    <a class="adm-btn" href="/store/{{ store_id }}/admin/discounts?export=csv" data-testid="adm-disc-export">Export</a>
+    <details class="adm-dropdown">
+      <summary class="adm-btn" data-testid="adm-disc-more">More actions ▾</summary>
+      <div class="adm-dropdown-menu">
+        <a href="/store/{{ store_id }}/admin/discounts?bulk=activate" class="adm-dropdown-item">Bulk activate</a>
+        <a href="/store/{{ store_id }}/admin/discounts?bulk=duplicate" class="adm-dropdown-item">Bulk duplicate</a>
+        <div class="adm-dropdown-sep"></div>
+        <a href="/store/{{ store_id }}/admin/discounts?bulk=delete" class="adm-dropdown-item adm-dropdown-item-critical">Bulk delete</a>
+      </div>
+    </details>
+    <a class="adm-btn adm-btn-primary" href="/store/{{ store_id }}/admin/discounts/new" data-testid="adm-disc-create">Create discount</a>
+  </div>
+</div>
+
+<section class="adm-card">
+  <div class="adm-tabs">
+    <a class="adm-tab is-active">All <span class="adm-tab-count">{{ discounts|length }}</span></a>
+    <a class="adm-tab">Active</a>
+    <a class="adm-tab">Scheduled</a>
+    <a class="adm-tab">Expired</a>
+  </div>
+  <div class="adm-filterrow">
+    <input type="search" placeholder="Search discount codes" data-testid="adm-disc-search"/>
+    <a class="adm-btn" href="#filter">Filter</a>
+    <a class="adm-btn" href="#sort">Sort ▾</a>
+  </div>
+  <table class="adm-table" data-testid="adm-disc-table">
+    <thead><tr><th><input type="checkbox" aria-label="Select all"/></th><th>Code</th><th>Type</th><th>Value</th><th>Status</th><th class="col-right">Uses</th><th>Schedule</th></tr></thead>
+    <tbody>
+      {% for d in discounts %}
+      <tr data-testid="adm-disc-row">
+        <td><input type="checkbox" aria-label="Select {{ d.code }}"/></td>
+        <td><a href="#disc/{{ d.code }}"><code style="font-family:'JetBrains Mono',monospace;font-weight:600">{{ d.code }}</code></a></td>
+        <td>{{ d.type }}</td>
+        <td>{{ d.value }}</td>
+        <td>
+          {% if d.status == 'Active' %}<span class="adm-pill adm-pill-active">Active</span>
+          {% elif d.status == 'Scheduled' %}<span class="adm-pill adm-pill-pending">Scheduled</span>
+          {% else %}<span class="adm-pill adm-pill-archived">Expired</span>{% endif %}
+        </td>
+        <td class="col-right">{{ d.uses }}</td>
+        <td>{{ d.schedule }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</section>
+{% endblock %}

--- a/deploy/sim_envs/mantis_shopify/app/templates/admin_home.html
+++ b/deploy/sim_envs/mantis_shopify/app/templates/admin_home.html
@@ -1,0 +1,89 @@
+{% extends "admin_base.html" %}
+{% block title %}Home · {{ store.name }} — Shopify{% endblock %}
+
+{% block content %}
+<div class="adm-greeting">
+  <h1 class="adm-greeting-h1" data-testid="adm-greeting">Good afternoon, Mason</h1>
+  <p class="adm-greeting-sub">Here's what's happening with your store today.</p>
+</div>
+
+<div class="adm-stats-grid" data-testid="adm-stats">
+  <div class="adm-stat-card" data-testid="adm-stat-sales">
+    <div class="adm-stat-label">Total sales</div>
+    <div class="adm-stat-value">{{ total_sales | money }}</div>
+    <div class="adm-stat-delta up">▲ 12.4% vs last 7 days</div>
+  </div>
+  <div class="adm-stat-card" data-testid="adm-stat-orders">
+    <div class="adm-stat-label">Orders</div>
+    <div class="adm-stat-value">{{ orders_total }}</div>
+    <div class="adm-stat-delta up">▲ 4.2% vs last 7 days</div>
+  </div>
+  <div class="adm-stat-card" data-testid="adm-stat-sessions">
+    <div class="adm-stat-label">Online store sessions</div>
+    <div class="adm-stat-value">{{ sessions }}</div>
+    <div class="adm-stat-delta down">▼ 2.1% vs last 7 days</div>
+  </div>
+  <div class="adm-stat-card" data-testid="adm-stat-conv">
+    <div class="adm-stat-label">Conversion rate</div>
+    <div class="adm-stat-value">{{ conversion_rate }}</div>
+    <div class="adm-stat-delta up">▲ 0.3 pts vs last 7 days</div>
+  </div>
+</div>
+
+<div class="adm-detail-grid">
+  <section class="adm-card" data-testid="adm-recent-orders">
+    <header class="adm-card-header">
+      <h2>Recent orders</h2>
+      <a href="/store/{{ store_id }}/admin/orders" data-testid="adm-recent-view-all">View all</a>
+    </header>
+    {% if recent_orders %}
+    <table class="adm-table">
+      <thead>
+        <tr><th>Order</th><th>Date</th><th>Customer</th><th>Payment</th><th>Fulfillment</th><th class="col-right">Total</th></tr>
+      </thead>
+      <tbody>
+        {% for o in recent_orders %}
+        <tr data-testid="adm-recent-order-row">
+          <td><a href="/store/{{ store_id }}/admin/orders/{{ o.id }}">{{ o.order_number }}</a></td>
+          <td>{{ o.ordered_at | short_date }}</td>
+          <td>{{ o.customer_name }}</td>
+          <td><span class="adm-pill adm-pill-{{ o.financial_status }}">{{ o.financial_status | title }}</span></td>
+          <td><span class="adm-pill adm-pill-{{ o.fulfillment_status }}">{{ o.fulfillment_status | title }}</span></td>
+          <td class="col-right">{{ o.total_cents | money }}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+    {% else %}
+    <div class="adm-empty">No orders yet</div>
+    {% endif %}
+  </section>
+
+  <aside>
+    <section class="adm-card" data-testid="adm-quick">
+      <div class="adm-card-body">
+        <h3 style="margin:0 0 6px 0;font-size:14px">Today's tasks</h3>
+        <div style="display:flex;flex-direction:column;gap:8px;font-size:13px">
+          <div data-testid="adm-task-unfulfilled">📦 <strong>{{ unfulfilled }}</strong> orders awaiting fulfillment</div>
+          <div>📊 Weekly recap report ready</div>
+          <div>📨 Reply to {{ customers_total // 4 }} customer messages</div>
+        </div>
+      </div>
+    </section>
+    <section class="adm-card" data-testid="adm-quick-counts">
+      <div class="adm-card-body">
+        <h3 style="margin:0 0 8px 0;font-size:14px">Catalog at a glance</h3>
+        <div style="display:flex;justify-content:space-between;padding:6px 0;border-bottom:1px solid #f0f0f0">
+          <span>Products</span><strong>{{ products_total }}</strong>
+        </div>
+        <div style="display:flex;justify-content:space-between;padding:6px 0;border-bottom:1px solid #f0f0f0">
+          <span>Customers</span><strong>{{ customers_total }}</strong>
+        </div>
+        <div style="display:flex;justify-content:space-between;padding:6px 0">
+          <span>Orders</span><strong>{{ orders_total }}</strong>
+        </div>
+      </div>
+    </section>
+  </aside>
+</div>
+{% endblock %}

--- a/deploy/sim_envs/mantis_shopify/app/templates/admin_marketing.html
+++ b/deploy/sim_envs/mantis_shopify/app/templates/admin_marketing.html
@@ -1,0 +1,48 @@
+{% extends "admin_base.html" %}
+{% block title %}Marketing · {{ store.name }} — Shopify{% endblock %}
+
+{% block content %}
+<div class="adm-page-header">
+  <h1 class="adm-page-h1">Marketing</h1>
+  <div class="adm-page-actions">
+    <a class="adm-btn" href="/store/{{ store_id }}/admin/marketing?view=templates" data-testid="adm-mkt-templates">Templates</a>
+    <a class="adm-btn adm-btn-primary" href="/store/{{ store_id }}/admin/discounts/new?from=marketing" data-testid="adm-mkt-create">Create campaign</a>
+  </div>
+</div>
+
+<div class="adm-stats-grid" data-testid="adm-mkt-stats">
+  <div class="adm-stat-card"><div class="adm-stat-label">Sessions from marketing</div><div class="adm-stat-value">1,284</div><div class="adm-stat-delta up">▲ 8.6% vs last period</div></div>
+  <div class="adm-stat-card"><div class="adm-stat-label">Orders attributed</div><div class="adm-stat-value">38</div><div class="adm-stat-delta up">▲ 4.1%</div></div>
+  <div class="adm-stat-card"><div class="adm-stat-label">Sales attributed</div><div class="adm-stat-value">$4,802.30</div><div class="adm-stat-delta up">▲ 11.0%</div></div>
+  <div class="adm-stat-card"><div class="adm-stat-label">Avg conversion rate</div><div class="adm-stat-value">2.4%</div><div class="adm-stat-delta down">▼ 0.2 pts</div></div>
+</div>
+
+<section class="adm-card" data-testid="adm-mkt-campaigns">
+  <header class="adm-card-header">
+    <h2>Campaigns</h2>
+    <div style="display:inline-flex;gap:8px">
+      <a class="adm-btn" href="#filter">Filter</a>
+      <a class="adm-btn" href="#sort">Sort ▾</a>
+    </div>
+  </header>
+  <table class="adm-table">
+    <thead><tr><th>Name</th><th>Channel</th><th>Status</th><th class="col-right">Spend</th><th>Window</th></tr></thead>
+    <tbody>
+      {% for c in campaigns %}
+      <tr data-testid="adm-mkt-row">
+        <td><a href="#campaign/{{ c.id }}">{{ c.name }}</a></td>
+        <td>{{ c.channel }}</td>
+        <td>
+          {% if c.status == 'Active' %}<span class="adm-pill adm-pill-active">Active</span>
+          {% elif c.status == 'Scheduled' %}<span class="adm-pill adm-pill-pending">Scheduled</span>
+          {% elif c.status == 'Completed' %}<span class="adm-pill adm-pill-fulfilled">Completed</span>
+          {% else %}<span class="adm-pill adm-pill-draft">{{ c.status }}</span>{% endif %}
+        </td>
+        <td class="col-right">{{ c.spend_cents | money }}</td>
+        <td>{{ c.window }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</section>
+{% endblock %}

--- a/deploy/sim_envs/mantis_shopify/app/templates/admin_online_store.html
+++ b/deploy/sim_envs/mantis_shopify/app/templates/admin_online_store.html
@@ -1,0 +1,72 @@
+{% extends "admin_base.html" %}
+{% block title %}Online Store · {{ store.name }} — Shopify{% endblock %}
+
+{% block content %}
+<div class="adm-page-header">
+  <div>
+    <h1 class="adm-page-h1">Online Store</h1>
+    <p style="color:#6a6a6a;font-size:13px;margin:4px 0 0 0">
+      Themes, pages, navigation, and storefront preferences for
+      <a href="https://{{ domain }}">{{ domain }}</a>.
+    </p>
+  </div>
+  <div class="adm-page-actions">
+    <a class="adm-btn" href="https://{{ domain }}" target="_blank" data-testid="adm-os-preview">Preview store</a>
+    <a class="adm-btn adm-btn-primary" href="#customize" data-testid="adm-os-customize">Customize</a>
+  </div>
+</div>
+
+<section class="adm-card" data-testid="adm-os-themes">
+  <header class="adm-card-header">
+    <h2>Themes</h2>
+    <a class="adm-btn" href="#add-theme">Add theme</a>
+  </header>
+  <table class="adm-table">
+    <thead><tr><th>Theme</th><th>Role</th><th>Status</th><th>Last updated</th><th></th></tr></thead>
+    <tbody>
+      {% for t in themes %}
+      <tr data-testid="adm-os-theme-row">
+        <td><a href="#theme">{{ t.name }}</a></td>
+        <td>{{ t.role }}</td>
+        <td><span class="adm-pill {% if t.status == 'Published' %}adm-pill-active{% else %}adm-pill-draft{% endif %}">{{ t.status }}</span></td>
+        <td>{{ t.updated }}</td>
+        <td class="col-right"><a href="#actions" class="adm-btn">Actions ▾</a></td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</section>
+
+<div class="adm-detail-grid">
+  <section class="adm-card" data-testid="adm-os-pages">
+    <header class="adm-card-header"><h2>Pages &amp; blogs</h2></header>
+    <table class="adm-table">
+      <tbody>
+        {% for p in pages %}
+        <tr><td>{{ p.name }}</td><td>{{ p.type }}</td><td class="col-right"><a href="#edit">Edit</a></td></tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </section>
+  <aside>
+    <section class="adm-card" data-testid="adm-os-menus">
+      <header class="adm-card-header"><h2>Navigation</h2></header>
+      <div class="adm-card-body">
+        {% for m in menus %}
+        <div style="display:flex;justify-content:space-between;padding:6px 0;border-bottom:1px solid #f0f0f0">
+          <span>{{ m.name }}</span><span style="color:#6a6a6a">{{ m.item_count }} items</span>
+        </div>
+        {% endfor %}
+        <a class="adm-btn" href="#add-menu" style="margin-top:10px">Add menu</a>
+      </div>
+    </section>
+    <section class="adm-card" data-testid="adm-os-domain">
+      <header class="adm-card-header"><h2>Domains</h2></header>
+      <div class="adm-card-body">
+        <div style="margin-bottom:8px"><strong>{{ custom_domain }}</strong> <span class="adm-pill adm-pill-active">Primary</span></div>
+        <div class="adm-pill adm-pill-draft">{{ domain }}</div>
+      </div>
+    </section>
+  </aside>
+</div>
+{% endblock %}

--- a/deploy/sim_envs/mantis_shopify/app/templates/admin_order_detail.html
+++ b/deploy/sim_envs/mantis_shopify/app/templates/admin_order_detail.html
@@ -1,0 +1,114 @@
+{% extends "admin_base.html" %}
+{% block title %}{{ order.order_number }} · {{ store.name }} — Shopify{% endblock %}
+
+{% block content %}
+<div class="adm-page-header">
+  <div>
+    <div class="sp-row" style="gap:10px;align-items:center;flex-wrap:wrap">
+      <h1 class="adm-page-h1" data-testid="adm-order-number">{{ order.order_number }}</h1>
+      <span class="adm-pill adm-pill-{{ order.financial_status }}" data-testid="adm-order-financial">{{ order.financial_status | title }}</span>
+      <span class="adm-pill adm-pill-{{ order.fulfillment_status }}" data-testid="adm-order-fulfillment">{{ order.fulfillment_status | title }}</span>
+    </div>
+    <p style="color:#6a6a6a;font-size:13px;margin:6px 0 0 0" data-testid="adm-order-meta">
+      {{ order.ordered_at | short_date }} · from Online Store · {{ order.items_count }} item{{ '' if order.items_count == 1 else 's' }}
+    </p>
+  </div>
+  <div class="adm-page-actions">
+    {% if order.financial_status != 'refunded' %}
+    <form method="post" action="/store/{{ store_id }}/admin/orders/{{ order.id }}/refund" style="display:inline">
+      <button type="submit" class="adm-btn adm-btn-critical" data-testid="adm-order-refund">Refund</button>
+    </form>
+    {% else %}
+    <span class="adm-pill adm-pill-refunded">Refunded</span>
+    {% endif %}
+    <details class="adm-dropdown">
+      <summary class="adm-btn" data-testid="adm-order-more">More actions ▾</summary>
+      <div class="adm-dropdown-menu">
+        <a href="/store/{{ store_id }}/admin/orders/{{ order.id }}?edit=1" class="adm-dropdown-item" data-testid="adm-order-edit">Edit</a>
+        <a href="/store/{{ store_id }}/admin/orders/{{ order.id }}?duplicate=1" class="adm-dropdown-item">Duplicate</a>
+        <a href="/store/{{ store_id }}/admin/orders/{{ order.id }}?print=1" class="adm-dropdown-item">Print packing slip</a>
+        <div class="adm-dropdown-sep"></div>
+        <a href="/store/{{ store_id }}/admin/orders/{{ order.id }}?cancel=1" class="adm-dropdown-item adm-dropdown-item-critical">Cancel order</a>
+      </div>
+    </details>
+    {% if order.fulfillment_status != 'fulfilled' %}
+    <form method="post" action="/store/{{ store_id }}/admin/orders/{{ order.id }}/fulfill" style="display:inline">
+      <button type="submit" class="adm-btn adm-btn-primary" data-testid="adm-order-fulfill">Fulfill items</button>
+    </form>
+    {% else %}
+    <span class="adm-pill adm-pill-fulfilled" data-testid="adm-order-fulfilled-state">Fulfilled</span>
+    {% endif %}
+  </div>
+</div>
+
+<div class="adm-detail-grid">
+  <div>
+    <section class="adm-card" data-testid="adm-order-items-card">
+      <header class="adm-card-header">
+        <h2>{{ order.fulfillment_status | title }} ({{ items|length }})</h2>
+        <span style="color:#6a6a6a;font-size:12px">{{ order.delivery_method }}</span>
+      </header>
+      {% for it in items %}
+      <div class="adm-line-item" data-testid="adm-order-item">
+        <div class="adm-line-thumb">▣</div>
+        <div>
+          <div class="adm-line-title">{{ it.title }}</div>
+          <div class="adm-line-meta">SKU · {{ it.qty }} × {{ it.price_cents | money }}</div>
+        </div>
+        <div style="font-weight:500">{{ (it.price_cents * it.qty) | money }}</div>
+      </div>
+      {% endfor %}
+    </section>
+
+    <section class="adm-card" data-testid="adm-order-totals">
+      <div class="adm-card-body">
+        <h3 style="margin:0 0 12px 0;font-size:14px">Paid</h3>
+        <div style="display:flex;justify-content:space-between;padding:4px 0">
+          <span>Subtotal</span><span>{{ order.total_cents | money }}</span>
+        </div>
+        <div style="display:flex;justify-content:space-between;padding:4px 0">
+          <span>Shipping</span><span>$0.00</span>
+        </div>
+        <div style="display:flex;justify-content:space-between;padding:4px 0">
+          <span>Tax</span><span>$0.00</span>
+        </div>
+        <div style="display:flex;justify-content:space-between;padding:8px 0;border-top:1px solid #e3e3e3;margin-top:6px;font-weight:600">
+          <span>Total</span><span>{{ order.total_cents | money }}</span>
+        </div>
+        <div style="font-size:12px;color:#6a6a6a;margin-top:6px">Paid via Shopify Payments</div>
+      </div>
+    </section>
+  </div>
+
+  <aside>
+    <section class="adm-card" data-testid="adm-order-customer">
+      <div class="adm-card-body">
+        <h3 style="margin:0 0 8px 0;font-size:14px">Customer</h3>
+        <div style="font-weight:500">{{ order.customer_name }}</div>
+        <div style="font-size:12px;color:#6a6a6a;margin-bottom:10px">{{ order.customer_email }}</div>
+        <div style="font-size:12px;color:#6a6a6a">3 orders all time</div>
+      </div>
+    </section>
+
+    <section class="adm-card" data-testid="adm-order-shipping">
+      <div class="adm-card-body">
+        <h3 style="margin:0 0 8px 0;font-size:14px">Shipping address</h3>
+        <div style="font-size:13px;line-height:1.6">
+          {{ order.customer_name }}<br/>
+          221 Linden Lane<br/>
+          Apartment 3B<br/>
+          Brooklyn NY 11215<br/>
+          United States
+        </div>
+      </div>
+    </section>
+
+    <section class="adm-card" data-testid="adm-order-tags">
+      <div class="adm-card-body">
+        <h3 style="margin:0 0 8px 0;font-size:14px">Tags</h3>
+        <div style="font-size:12px;color:#6a6a6a">No tags yet — <a href="#tag">add a tag</a></div>
+      </div>
+    </section>
+  </aside>
+</div>
+{% endblock %}

--- a/deploy/sim_envs/mantis_shopify/app/templates/admin_order_new.html
+++ b/deploy/sim_envs/mantis_shopify/app/templates/admin_order_new.html
@@ -1,0 +1,59 @@
+{% extends "admin_base.html" %}
+{% block title %}Create order · {{ store.name }} — Shopify{% endblock %}
+
+{% block content %}
+<div class="adm-page-header">
+  <div>
+    <a href="/store/{{ store_id }}/admin/orders" style="color:#6a6a6a;font-size:13px;text-decoration:none">← Orders</a>
+    <h1 class="adm-page-h1" style="margin-top:4px">Create order</h1>
+  </div>
+</div>
+
+<form method="post" action="/store/{{ store_id }}/admin/orders/create" data-testid="adm-order-new-form">
+<div class="adm-detail-grid">
+  <div>
+    <section class="adm-card">
+      <header class="adm-card-header"><h2>Customer</h2></header>
+      <div class="adm-card-body">
+        <div style="display:grid;grid-template-columns:1fr 1fr;gap:12px">
+          <div><label style="font-size:12px;color:#6a6a6a">Name</label>
+            <input type="text" name="customer_name" required style="width:100%;height:36px;padding:0 12px;border:1px solid #c3c3c3;border-radius:6px;font-size:13px" data-testid="adm-order-new-name"/></div>
+          <div><label style="font-size:12px;color:#6a6a6a">Email</label>
+            <input type="email" name="customer_email" style="width:100%;height:36px;padding:0 12px;border:1px solid #c3c3c3;border-radius:6px;font-size:13px" data-testid="adm-order-new-email"/></div>
+        </div>
+      </div>
+    </section>
+
+    <section class="adm-card">
+      <header class="adm-card-header"><h2>Line item</h2></header>
+      <div class="adm-card-body">
+        <div style="margin-bottom:10px"><label style="font-size:12px;color:#6a6a6a">Product</label>
+          <input type="text" name="item_title" required style="width:100%;height:36px;padding:0 12px;border:1px solid #c3c3c3;border-radius:6px;font-size:13px" data-testid="adm-order-new-item"/></div>
+        <div style="display:grid;grid-template-columns:1fr 1fr;gap:12px">
+          <div><label style="font-size:12px;color:#6a6a6a">Quantity</label>
+            <input type="number" name="item_qty" value="1" min="1" style="width:100%;height:36px;padding:0 12px;border:1px solid #c3c3c3;border-radius:6px;font-size:13px"/></div>
+          <div><label style="font-size:12px;color:#6a6a6a">Unit price (USD)</label>
+            <input type="number" name="item_price" value="0" min="0" style="width:100%;height:36px;padding:0 12px;border:1px solid #c3c3c3;border-radius:6px;font-size:13px"/></div>
+        </div>
+      </div>
+    </section>
+  </div>
+
+  <aside>
+    <section class="adm-card">
+      <header class="adm-card-header"><h2>Delivery</h2></header>
+      <div class="adm-card-body">
+        <select name="delivery_method" style="width:100%;height:36px;padding:0 12px;border:1px solid #c3c3c3;border-radius:6px;font-size:13px">
+          <option>Standard</option><option>Express</option>
+          <option>Local pickup</option><option>Same-day</option>
+        </select>
+      </div>
+    </section>
+    <div style="display:flex;justify-content:flex-end;gap:10px;margin-top:16px">
+      <a class="adm-btn" href="/store/{{ store_id }}/admin/orders">Cancel</a>
+      <button type="submit" class="adm-btn adm-btn-primary" data-testid="adm-order-new-submit">Create order</button>
+    </div>
+  </aside>
+</div>
+</form>
+{% endblock %}

--- a/deploy/sim_envs/mantis_shopify/app/templates/admin_orders.html
+++ b/deploy/sim_envs/mantis_shopify/app/templates/admin_orders.html
@@ -1,0 +1,104 @@
+{% extends "admin_base.html" %}
+{% block title %}Orders · {{ store.name }} — Shopify{% endblock %}
+
+{% block content %}
+<div class="adm-page-header">
+  <h1 class="adm-page-h1">Orders</h1>
+  <div class="adm-page-actions">
+    <a class="adm-btn" href="/store/{{ store_id }}/admin/orders?export=csv" data-testid="adm-orders-export">Export</a>
+    <details class="adm-dropdown">
+      <summary class="adm-btn" data-testid="adm-orders-more">More actions ▾</summary>
+      <div class="adm-dropdown-menu">
+        <a href="/store/{{ store_id }}/admin/orders?print=1" class="adm-dropdown-item">Print packing slips</a>
+        <a href="/store/{{ store_id }}/admin/orders?bulk=tag" class="adm-dropdown-item">Bulk tag</a>
+        <a href="/store/{{ store_id }}/admin/orders?bulk=archive" class="adm-dropdown-item">Bulk archive</a>
+        <div class="adm-dropdown-sep"></div>
+        <a href="/store/{{ store_id }}/admin/orders?bulk=cancel" class="adm-dropdown-item adm-dropdown-item-critical">Bulk cancel</a>
+      </div>
+    </details>
+    <a class="adm-btn adm-btn-primary" href="/store/{{ store_id }}/admin/orders/create" data-testid="adm-orders-create">Create order</a>
+  </div>
+</div>
+
+<section class="adm-card">
+  <div class="adm-tabs" data-testid="adm-orders-tabs">
+    {% for tid, label in [
+      ('all', 'All'),
+      ('unfulfilled', 'Unfulfilled'),
+      ('unpaid', 'Unpaid'),
+      ('open', 'Open'),
+      ('closed', 'Closed'),
+    ] %}
+      <a class="adm-tab{% if tab == tid %} is-active{% endif %}"
+         href="/store/{{ store_id }}/admin/orders?tab={{ tid }}"
+         data-testid="adm-orders-tab-{{ tid }}">
+        {{ label }} <span class="adm-tab-count">{{ tab_counts[tid] }}</span>
+      </a>
+    {% endfor %}
+  </div>
+  <form class="adm-filterrow" method="get" action="/store/{{ store_id }}/admin/orders">
+    <input type="hidden" name="tab" value="{{ tab }}" />
+    <input type="search" name="q" value="{{ q }}" placeholder="Search orders" data-testid="adm-orders-search" />
+    <details class="adm-dropdown">
+      <summary class="adm-btn" data-testid="adm-orders-filter">Filter ▾</summary>
+      <div class="adm-dropdown-menu" style="min-width:240px">
+        <div style="padding:6px 12px;font-size:11px;text-transform:uppercase;color:#6a6a6a">Quick filters</div>
+        <a class="adm-dropdown-item" href="?tab={{ tab }}&q=paid">Payment: Paid</a>
+        <a class="adm-dropdown-item" href="?tab={{ tab }}&q=pending">Payment: Pending</a>
+        <a class="adm-dropdown-item" href="?tab={{ tab }}&q=refunded">Payment: Refunded</a>
+        <div class="adm-dropdown-sep"></div>
+        <a class="adm-dropdown-item" href="?tab={{ tab }}">Clear all</a>
+      </div>
+    </details>
+    <details class="adm-dropdown">
+      <summary class="adm-btn" data-testid="adm-orders-sort">Sort
+        {% if sort == 'oldest' %}: Oldest{% elif sort == 'total_desc' %}: Total ↓{% elif sort == 'total_asc' %}: Total ↑{% elif sort == 'customer' %}: Customer{% else %}: Newest{% endif %}
+        ▾</summary>
+      <div class="adm-dropdown-menu">
+        {% for sid, label in [
+          ('newest', 'Newest first'),
+          ('oldest', 'Oldest first'),
+          ('total_desc', 'Highest total'),
+          ('total_asc', 'Lowest total'),
+          ('customer', 'Customer A → Z'),
+        ] %}
+        <a class="adm-dropdown-item{% if sort == sid %} adm-is-active{% endif %}"
+           href="?tab={{ tab }}&q={{ q }}&sort={{ sid }}">{{ label }}</a>
+        {% endfor %}
+      </div>
+    </details>
+  </form>
+
+  {% if orders %}
+  <table class="adm-table" data-testid="adm-orders-table">
+    <thead>
+      <tr>
+        <th><input type="checkbox" aria-label="Select all" /></th>
+        <th>Order</th><th>Date</th><th>Customer</th>
+        <th>Channel</th><th>Total</th>
+        <th>Payment status</th><th>Fulfillment status</th><th>Items</th>
+        <th>Delivery</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for o in orders %}
+      <tr data-testid="adm-orders-row">
+        <td><input type="checkbox" aria-label="Select {{ o.order_number }}"/></td>
+        <td><a href="/store/{{ store_id }}/admin/orders/{{ o.id }}">{{ o.order_number }}</a></td>
+        <td>{{ o.ordered_at | short_date }}</td>
+        <td>{{ o.customer_name }}</td>
+        <td>Online Store</td>
+        <td>{{ o.total_cents | money }}</td>
+        <td><span class="adm-pill adm-pill-{{ o.financial_status }}">{{ o.financial_status | title }}</span></td>
+        <td><span class="adm-pill adm-pill-{{ o.fulfillment_status }}">{{ o.fulfillment_status | title }}</span></td>
+        <td>{{ o.items_count }} item{{ '' if o.items_count == 1 else 's' }}</td>
+        <td>{{ o.delivery_method }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% else %}
+  <div class="adm-empty">No orders match this filter.</div>
+  {% endif %}
+</section>
+{% endblock %}

--- a/deploy/sim_envs/mantis_shopify/app/templates/admin_pos.html
+++ b/deploy/sim_envs/mantis_shopify/app/templates/admin_pos.html
@@ -1,0 +1,56 @@
+{% extends "admin_base.html" %}
+{% block title %}Point of Sale · {{ store.name }} — Shopify{% endblock %}
+
+{% block content %}
+<div class="adm-page-header">
+  <div>
+    <h1 class="adm-page-h1">Point of Sale</h1>
+    <p style="color:#6a6a6a;font-size:13px;margin:4px 0 0 0">
+      Run in-person sales at your physical locations with Shopify POS.
+    </p>
+  </div>
+  <div class="adm-page-actions">
+    <a class="adm-btn" href="#install-app" data-testid="adm-pos-app">Get the POS app</a>
+    <a class="adm-btn adm-btn-primary" href="#upgrade-pro" data-testid="adm-pos-pro">Upgrade to POS Pro</a>
+  </div>
+</div>
+
+<div class="adm-stats-grid" data-testid="adm-pos-stats">
+  <div class="adm-stat-card"><div class="adm-stat-label">In-person sales (7d)</div><div class="adm-stat-value">$3,124.40</div><div class="adm-stat-delta up">▲ 9.2%</div></div>
+  <div class="adm-stat-card"><div class="adm-stat-label">Transactions (7d)</div><div class="adm-stat-value">82</div><div class="adm-stat-delta up">▲ 4%</div></div>
+  <div class="adm-stat-card"><div class="adm-stat-label">Locations</div><div class="adm-stat-value">{{ locations | length }}</div><div class="adm-stat-delta">2 open · 1 inactive</div></div>
+  <div class="adm-stat-card"><div class="adm-stat-label">Devices</div><div class="adm-stat-value">5</div><div class="adm-stat-delta">All connected</div></div>
+</div>
+
+<section class="adm-card" data-testid="adm-pos-locations">
+  <header class="adm-card-header">
+    <h2>Locations</h2>
+    <a class="adm-btn" href="#add-location">Add location</a>
+  </header>
+  <table class="adm-table">
+    <thead><tr><th>Location</th><th>City</th><th>Staff</th><th>Devices</th><th>Status</th><th></th></tr></thead>
+    <tbody>
+      {% for l in locations %}
+      <tr data-testid="adm-pos-location-row">
+        <td><a href="#loc">{{ l.name }}</a></td>
+        <td>{{ l.city }}</td>
+        <td>{{ l.staff }}</td>
+        <td>{{ l.devices }}</td>
+        <td><span class="adm-pill {% if l.status == 'Open' %}adm-pill-active{% else %}adm-pill-draft{% endif %}">{{ l.status }}</span></td>
+        <td class="col-right"><a href="#manage" class="adm-btn">Manage</a></td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</section>
+
+<section class="adm-card" data-testid="adm-pos-pro-card">
+  <div class="adm-card-body" style="display:flex;gap:24px;align-items:center">
+    <div style="flex:1">
+      <h3 style="margin:0 0 6px 0">Unlock POS Pro</h3>
+      <p style="margin:0;color:#6a6a6a">Smart inventory, line-busting, BOPIS, custom permissions, and reporting per-staff. $89/mo per location.</p>
+    </div>
+    <a class="adm-btn adm-btn-primary" href="#upgrade">Upgrade</a>
+  </div>
+</section>
+{% endblock %}

--- a/deploy/sim_envs/mantis_shopify/app/templates/admin_product_detail.html
+++ b/deploy/sim_envs/mantis_shopify/app/templates/admin_product_detail.html
@@ -1,0 +1,106 @@
+{% extends "admin_base.html" %}
+{% block title %}{{ product.title }} · {{ store.name }} — Shopify{% endblock %}
+
+{% block content %}
+<div class="adm-page-header">
+  <div>
+    <div class="sp-row" style="gap:12px;align-items:center;flex-wrap:wrap">
+      <h1 class="adm-page-h1" data-testid="adm-prod-title">{{ product.title }}</h1>
+      <span class="adm-pill adm-pill-{{ product.status }}" data-testid="adm-prod-status">{{ product.status | title }}</span>
+    </div>
+    <p style="color:#6a6a6a;font-size:13px;margin:6px 0 0 0" data-testid="adm-prod-meta">
+      {{ product.product_type }} · {{ product.vendor }} · {{ product.sku }}
+    </p>
+  </div>
+  <div class="adm-page-actions">
+    <a class="adm-btn" href="#duplicate" data-testid="adm-prod-duplicate">Duplicate</a>
+    <a class="adm-btn" href="#more" data-testid="adm-prod-more">More actions ▾</a>
+    <a class="adm-btn adm-btn-primary" href="#save" data-testid="adm-prod-save">Save</a>
+  </div>
+</div>
+
+<div class="adm-detail-grid">
+  <div>
+    <section class="adm-card" data-testid="adm-prod-info">
+      <div class="adm-card-body">
+        <h3 style="margin:0 0 12px 0;font-size:14px">Title</h3>
+        <input type="text" value="{{ product.title }}" class="sp-form-group" style="width:100%;height:36px;padding:0 12px;border:1px solid #c3c3c3;border-radius:6px;font-size:13px"/>
+        <h3 style="margin:18px 0 12px 0;font-size:14px">Description</h3>
+        <textarea rows="6" class="sp-form-group" style="width:100%;padding:8px 12px;border:1px solid #c3c3c3;border-radius:6px;font-size:13px;font-family:inherit">A premium {{ product.product_type|lower }} from {{ product.vendor }} — small-batch, hand-finished, and built to last.</textarea>
+      </div>
+    </section>
+
+    <section class="adm-card" data-testid="adm-prod-media">
+      <header class="adm-card-header"><h2>Media</h2></header>
+      <div class="adm-card-body">
+        <div style="display:grid;grid-template-columns:repeat(4,1fr);gap:12px">
+          {% for n in range(4) %}
+          <div style="aspect-ratio:1;background:linear-gradient(135deg,#f1f1f1 0%,#e7e7e7 100%);border-radius:8px;display:flex;align-items:center;justify-content:center;font-size:32px;color:#b4b4b4">▣</div>
+          {% endfor %}
+        </div>
+      </div>
+    </section>
+
+    <section class="adm-card" data-testid="adm-prod-pricing">
+      <header class="adm-card-header"><h2>Pricing</h2></header>
+      <div class="adm-card-body">
+        <div style="display:grid;grid-template-columns:1fr 1fr 1fr;gap:12px">
+          <div>
+            <label style="font-size:12px;color:#6a6a6a">Price</label>
+            <input type="text" value="{{ product.price_cents | money }}" style="width:100%;height:36px;padding:0 12px;border:1px solid #c3c3c3;border-radius:6px;font-size:13px"/>
+          </div>
+          <div>
+            <label style="font-size:12px;color:#6a6a6a">Compare-at</label>
+            <input type="text" placeholder="$0.00" style="width:100%;height:36px;padding:0 12px;border:1px solid #c3c3c3;border-radius:6px;font-size:13px"/>
+          </div>
+          <div>
+            <label style="font-size:12px;color:#6a6a6a">Cost per item</label>
+            <input type="text" placeholder="$0.00" style="width:100%;height:36px;padding:0 12px;border:1px solid #c3c3c3;border-radius:6px;font-size:13px"/>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="adm-card" data-testid="adm-prod-inventory">
+      <header class="adm-card-header"><h2>Inventory</h2></header>
+      <div class="adm-card-body">
+        <div style="display:flex;gap:32px;align-items:center;font-size:13px">
+          <div>SKU<br/><strong>{{ product.sku }}</strong></div>
+          <div>In stock<br/><strong>{{ product.inventory }}</strong></div>
+        </div>
+      </div>
+    </section>
+  </div>
+
+  <aside>
+    <section class="adm-card" data-testid="adm-prod-status-card">
+      <div class="adm-card-body">
+        <h3 style="margin:0 0 8px 0;font-size:14px">Status</h3>
+        <select style="width:100%;height:32px;padding:0 8px;border:1px solid #c3c3c3;border-radius:6px;font-size:13px">
+          <option value="active" {% if product.status == 'active' %}selected{% endif %}>Active</option>
+          <option value="draft" {% if product.status == 'draft' %}selected{% endif %}>Draft</option>
+          <option value="archived" {% if product.status == 'archived' %}selected{% endif %}>Archived</option>
+        </select>
+      </div>
+    </section>
+
+    <section class="adm-card" data-testid="adm-prod-org">
+      <div class="adm-card-body">
+        <h3 style="margin:0 0 8px 0;font-size:14px">Product organization</h3>
+        <div style="font-size:12px;color:#6a6a6a">TYPE</div>
+        <div style="margin-bottom:8px">{{ product.product_type }}</div>
+        <div style="font-size:12px;color:#6a6a6a">VENDOR</div>
+        <div>{{ product.vendor }}</div>
+      </div>
+    </section>
+
+    <section class="adm-card" data-testid="adm-prod-channels">
+      <div class="adm-card-body">
+        <h3 style="margin:0 0 8px 0;font-size:14px">Sales channels</h3>
+        <div style="font-size:13px">✓ Online Store</div>
+        <div style="font-size:13px">✓ Point of Sale</div>
+      </div>
+    </section>
+  </aside>
+</div>
+{% endblock %}

--- a/deploy/sim_envs/mantis_shopify/app/templates/admin_product_new.html
+++ b/deploy/sim_envs/mantis_shopify/app/templates/admin_product_new.html
@@ -1,0 +1,64 @@
+{% extends "admin_base.html" %}
+{% block title %}Add product · {{ store.name }} — Shopify{% endblock %}
+
+{% block content %}
+<div class="adm-page-header">
+  <div>
+    <a href="/store/{{ store_id }}/admin/products" style="color:#6a6a6a;font-size:13px;text-decoration:none">← Products</a>
+    <h1 class="adm-page-h1" style="margin-top:4px">Add product</h1>
+  </div>
+</div>
+
+<form method="post" action="/store/{{ store_id }}/admin/products/create" data-testid="adm-product-new-form">
+<div class="adm-detail-grid">
+  <div>
+    <section class="adm-card">
+      <div class="adm-card-body">
+        <label style="font-size:12px;color:#6a6a6a">Title</label>
+        <input type="text" name="title" required placeholder="Short sleeve t-shirt" style="width:100%;height:36px;padding:0 12px;border:1px solid #c3c3c3;border-radius:6px;font-size:13px;margin-bottom:14px" data-testid="adm-product-new-title"/>
+        <label style="font-size:12px;color:#6a6a6a">Description</label>
+        <textarea rows="5" placeholder="Tell shoppers about this product" style="width:100%;padding:8px 12px;border:1px solid #c3c3c3;border-radius:6px;font-size:13px;font-family:inherit"></textarea>
+      </div>
+    </section>
+
+    <section class="adm-card">
+      <header class="adm-card-header"><h2>Pricing</h2></header>
+      <div class="adm-card-body">
+        <div style="display:grid;grid-template-columns:1fr 1fr;gap:12px">
+          <div><label style="font-size:12px;color:#6a6a6a">Price (USD)</label>
+            <input type="number" name="price" value="0" min="0" style="width:100%;height:36px;padding:0 12px;border:1px solid #c3c3c3;border-radius:6px;font-size:13px"/></div>
+          <div><label style="font-size:12px;color:#6a6a6a">Inventory</label>
+            <input type="number" name="inventory" value="0" min="0" style="width:100%;height:36px;padding:0 12px;border:1px solid #c3c3c3;border-radius:6px;font-size:13px"/></div>
+        </div>
+      </div>
+    </section>
+  </div>
+
+  <aside>
+    <section class="adm-card">
+      <div class="adm-card-body">
+        <h3 style="margin:0 0 8px 0;font-size:14px">Status</h3>
+        <select name="status" style="width:100%;height:36px;padding:0 12px;border:1px solid #c3c3c3;border-radius:6px;font-size:13px">
+          <option value="draft">Draft</option>
+          <option value="active">Active</option>
+          <option value="archived">Archived</option>
+        </select>
+      </div>
+    </section>
+    <section class="adm-card">
+      <div class="adm-card-body">
+        <h3 style="margin:0 0 8px 0;font-size:14px">Product organization</h3>
+        <label style="font-size:12px;color:#6a6a6a">TYPE</label>
+        <input type="text" name="product_type" placeholder="Apparel" style="width:100%;height:32px;padding:0 12px;border:1px solid #c3c3c3;border-radius:6px;font-size:13px;margin-bottom:10px"/>
+        <label style="font-size:12px;color:#6a6a6a">VENDOR</label>
+        <input type="text" name="vendor" placeholder="Bramble & Co" style="width:100%;height:32px;padding:0 12px;border:1px solid #c3c3c3;border-radius:6px;font-size:13px"/>
+      </div>
+    </section>
+    <div style="display:flex;justify-content:flex-end;gap:10px;margin-top:16px">
+      <a class="adm-btn" href="/store/{{ store_id }}/admin/products">Cancel</a>
+      <button type="submit" class="adm-btn adm-btn-primary" data-testid="adm-product-new-submit">Save product</button>
+    </div>
+  </aside>
+</div>
+</form>
+{% endblock %}

--- a/deploy/sim_envs/mantis_shopify/app/templates/admin_products.html
+++ b/deploy/sim_envs/mantis_shopify/app/templates/admin_products.html
@@ -1,0 +1,108 @@
+{% extends "admin_base.html" %}
+{% block title %}Products · {{ store.name }} — Shopify{% endblock %}
+
+{% block content %}
+<div class="adm-page-header">
+  <h1 class="adm-page-h1">Products</h1>
+  <div class="adm-page-actions">
+    <a class="adm-btn" href="/store/{{ store_id }}/admin/products?export=csv" data-testid="adm-prod-export">Export</a>
+    <a class="adm-btn" href="/store/{{ store_id }}/admin/products?import=1" data-testid="adm-prod-import">Import</a>
+    <details class="adm-dropdown">
+      <summary class="adm-btn" data-testid="adm-prod-more">More actions ▾</summary>
+      <div class="adm-dropdown-menu">
+        <a href="/store/{{ store_id }}/admin/products?bulk=tag" class="adm-dropdown-item">Bulk tag</a>
+        <a href="/store/{{ store_id }}/admin/products?bulk=set_vendor" class="adm-dropdown-item">Set vendor</a>
+        <a href="/store/{{ store_id }}/admin/products?bulk=publish" class="adm-dropdown-item">Publish to channels</a>
+        <div class="adm-dropdown-sep"></div>
+        <a href="/store/{{ store_id }}/admin/products?bulk=archive" class="adm-dropdown-item adm-dropdown-item-critical">Bulk archive</a>
+      </div>
+    </details>
+    <a class="adm-btn adm-btn-primary" href="/store/{{ store_id }}/admin/products/create" data-testid="adm-prod-add">Add product</a>
+  </div>
+</div>
+
+<section class="adm-card">
+  <div class="adm-tabs">
+    <a class="adm-tab is-active">All <span class="adm-tab-count">{{ products|length }}</span></a>
+    <a class="adm-tab">Active</a>
+    <a class="adm-tab">Draft</a>
+    <a class="adm-tab">Archived</a>
+  </div>
+  <form class="adm-filterrow" method="get" action="/store/{{ store_id }}/admin/products">
+    <input type="search" name="q" value="{{ q }}" placeholder="Search products" data-testid="adm-prod-search" />
+    <details class="adm-dropdown">
+      <summary class="adm-btn" data-testid="adm-prod-filter">Filter ▾</summary>
+      <div class="adm-dropdown-menu" style="min-width:220px">
+        <div style="padding:6px 12px;font-size:11px;text-transform:uppercase;color:#6a6a6a">Status</div>
+        <a class="adm-dropdown-item" href="?q=active">Active only</a>
+        <a class="adm-dropdown-item" href="?q=draft">Draft only</a>
+        <a class="adm-dropdown-item" href="?q=archived">Archived only</a>
+        <div class="adm-dropdown-sep"></div>
+        <a class="adm-dropdown-item" href="?q=">Clear filter</a>
+      </div>
+    </details>
+    <details class="adm-dropdown">
+      <summary class="adm-btn" data-testid="adm-prod-sort">Sort
+        {% if sort == 'title_asc' %}: A→Z{% elif sort == 'title_desc' %}: Z→A{% elif sort == 'price_high' %}: Price ↓{% elif sort == 'price_low' %}: Price ↑{% elif sort == 'inv_low' %}: Low stock{% elif sort == 'oldest' %}: Oldest{% else %}: Newest{% endif %}
+        ▾</summary>
+      <div class="adm-dropdown-menu">
+        {% for sid, label in [
+          ('newest',     'Newest first'),
+          ('oldest',     'Oldest first'),
+          ('title_asc',  'Title A → Z'),
+          ('title_desc', 'Title Z → A'),
+          ('price_high', 'Highest price'),
+          ('price_low',  'Lowest price'),
+          ('inv_low',    'Low inventory first'),
+        ] %}
+        <a class="adm-dropdown-item" href="?q={{ q }}&sort={{ sid }}">{{ label }}</a>
+        {% endfor %}
+      </div>
+    </details>
+  </form>
+
+  {% if products %}
+  <table class="adm-table" data-testid="adm-prod-table">
+    <thead>
+      <tr>
+        <th><input type="checkbox" aria-label="Select all" /></th>
+        <th>Product</th><th>Status</th><th>Inventory</th>
+        <th>Type</th><th>Vendor</th><th class="col-right">Price</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for p in products %}
+      <tr data-testid="adm-prod-row">
+        <td><input type="checkbox" aria-label="Select {{ p.title }}"/></td>
+        <td>
+          <div style="display:flex;gap:10px;align-items:center">
+            <div class="adm-line-thumb" style="width:36px;height:36px">▣</div>
+            <div>
+              <a href="/store/{{ store_id }}/admin/products/{{ p.id }}"
+                 style="font-weight:500;color:#303030;text-decoration:none" data-testid="adm-prod-name-link">{{ p.title }}</a>
+              <div style="font-size:12px;color:#6a6a6a">{{ p.sku }}</div>
+            </div>
+          </div>
+        </td>
+        <td><span class="adm-pill adm-pill-{{ p.status }}">{{ p.status | title }}</span></td>
+        <td>
+          {% if p.inventory == 0 %}
+            <span style="color:#b54708">Out of stock</span>
+          {% elif p.inventory < 10 %}
+            <span style="color:#b54708">{{ p.inventory }} low</span>
+          {% else %}
+            {{ p.inventory }} in stock
+          {% endif %}
+        </td>
+        <td>{{ p.product_type }}</td>
+        <td>{{ p.vendor }}</td>
+        <td class="col-right">{{ p.price_cents | money }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% else %}
+  <div class="adm-empty">No products match your search.</div>
+  {% endif %}
+</section>
+{% endblock %}

--- a/deploy/sim_envs/mantis_shopify/app/templates/admin_settings.html
+++ b/deploy/sim_envs/mantis_shopify/app/templates/admin_settings.html
@@ -1,0 +1,32 @@
+{% extends "admin_base.html" %}
+{% block title %}Settings · {{ store.name }} — Shopify{% endblock %}
+
+{% block content %}
+<div class="adm-page-header">
+  <h1 class="adm-page-h1">Settings</h1>
+  <div class="adm-page-actions">
+    <a class="adm-btn" href="/store/{{ store_id }}/admin" data-testid="adm-set-back">← Back to admin</a>
+  </div>
+</div>
+
+<p style="color:#6a6a6a;font-size:13px;margin:-12px 0 16px 0">
+  {{ store.name }} ({{ store.slug }}.myshopify.com)
+</p>
+
+{% for group_name, items in groups %}
+<section class="adm-card" data-testid="adm-set-group">
+  <header class="adm-card-header"><h2>{{ group_name }}</h2></header>
+  <div class="adm-card-body" style="padding:0">
+    {% for label, desc in items %}
+    <a href="#{{ label|lower|replace(' ', '-') }}"
+       class="adm-set-row" data-testid="adm-set-item"
+       style="display:grid;grid-template-columns:200px 1fr auto;gap:16px;padding:14px 18px;border-top:1px solid #e3e3e3;text-decoration:none;color:#303030;align-items:center">
+      <strong style="font-size:13px">{{ label }}</strong>
+      <span style="color:#6a6a6a;font-size:13px">{{ desc }}</span>
+      <span style="color:#6a6a6a;font-size:14px">›</span>
+    </a>
+    {% endfor %}
+  </div>
+</section>
+{% endfor %}
+{% endblock %}

--- a/deploy/sim_envs/mantis_shopify/app/templates/base.html
+++ b/deploy/sim_envs/mantis_shopify/app/templates/base.html
@@ -1,0 +1,122 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>{% block title %}Shopify Partners{% endblock %}</title>
+  <link rel="stylesheet" href="/static/site.css?v=20260609c" />
+  <link rel="stylesheet" href="/static/polish.css?v=20260610a" />
+  <script src="/static/polish.js?v=20260610a" defer></script>
+</head>
+<body>
+{% set _u = request.state.effective_user %}
+{% set _n = notification_count if notification_count is defined else 22 %}
+
+<header class="sp-topbar" data-testid="sp-topbar">
+  <a class="sp-brand" href="/" data-testid="sp-brand" aria-label="Shopify Partners home">
+    <svg class="sp-brand-mark" viewBox="0 0 32 36" width="28" height="32"
+         xmlns="http://www.w3.org/2000/svg" role="img" aria-hidden="true">
+      <path d="M27.7 7.4c0-.2-.2-.4-.4-.4l-3.6-.3-2.4-2.4c-.2-.2-.7-.2-.9 0l-.9.3c-.6-1.7-1.5-3.3-3.4-3.3h-.2c-.5-.7-1.2-1-1.8-1-4.6.1-6.8 5.9-7.5 8.8l-3.2 1c-1 .3-1 .3-1.2 1.3L0 30.6l16.6 3.1 15.4-3.3L27.7 7.4z" fill="#95BF47"/>
+      <path d="M27.3 7c-.2 0-3.6-.3-3.6-.3l-2.4-2.4c-.2-.2-.5-.2-.7-.2v30.6l15.4-3.3L27.7 7.4c0-.2-.2-.4-.4-.4z" fill="#5E8E3E"/>
+      <path d="M16.6 14.4l-1.9 5.6s-1.6-.9-3.6-.9c-2.9 0-3 1.8-3 2.3 0 2.5 6.6 3.4 6.6 9.3 0 4.6-2.9 7.6-6.9 7.6-4.7 0-7.2-3-7.2-3l1.3-4.2s2.5 2.1 4.6 2.1c1.4 0 2-1.1 2-1.9 0-3.2-5.4-3.4-5.4-8.7 0-4.5 3.2-8.9 9.8-8.9 2.5 0 3.7.7 3.7.7z" fill="#FFF"/>
+    </svg>
+    <span class="sp-brand-text">shopify <em>partners</em></span>
+  </a>
+
+  <div class="sp-topbar-search">
+    <svg viewBox="0 0 20 20" width="16" height="16" aria-hidden="true">
+      <path d="M9 3a6 6 0 014.47 10.03l3.25 3.25-1.42 1.42-3.25-3.25A6 6 0 119 3zm0 2a4 4 0 100 8 4 4 0 000-8z" fill="#6d7175"/>
+    </svg>
+    <input type="search" placeholder="Search" data-testid="sp-search" name="q"
+           aria-label="Search Partners dashboard" />
+  </div>
+
+  <div class="sp-topbar-actions" data-testid="sp-topbar-actions">
+    <a class="sp-notif" href="/notifications" data-testid="sp-notif"
+       aria-label="Notifications">
+      <svg viewBox="0 0 20 20" width="18" height="18" aria-hidden="true">
+        <path d="M10 2a5 5 0 00-5 5v3l-2 2v1h14v-1l-2-2V7a5 5 0 00-5-5zM8 16a2 2 0 004 0H8z" fill="#202223"/>
+      </svg>
+      {% if _n %}<span class="sp-notif-badge">{{ _n }}</span>{% endif %}
+    </a>
+    <a class="sp-user" href="/settings" data-testid="sp-user-chip">
+      <span class="sp-user-avatar" style="background:#6d7175">MA</span>
+      <span class="sp-user-meta">
+        <span class="sp-user-name">Mason</span>
+        <span class="sp-user-sub">{{ _u.name }}</span>
+      </span>
+    </a>
+  </div>
+</header>
+
+<div class="sp-shell">
+  <aside class="sp-sidebar" data-testid="sp-sidebar" aria-label="Primary">
+    {% set active = active_section|default('') %}
+    <nav class="sp-nav-group">
+      {% for item in [
+        ('home',          'Home',            '/'),
+        ('stores',        'Stores',          '/stores'),
+        ('sales',         'Sales',           '/sales'),
+        ('app_dist',      'App distribution','/apps'),
+        ('catalogs',      'Catalogs',        '/catalogs'),
+        ('themes',        'Themes',          '/themes'),
+        ('directory',     'Partner Directory','/partner_directory'),
+        ('pos',           'Shopify POS',     '/pos'),
+      ] %}
+        <a class="sp-nav-row{% if active == item[0] %} is-active{% endif %}"
+           href="{{ item[2] }}" data-testid="sp-nav-{{ item[0] }}">
+          <span class="sp-nav-ico sp-ico-{{ item[0] }}" aria-hidden="true"></span>
+          <span class="sp-nav-label">{{ item[1] }}</span>
+        </a>
+        {% if active == 'sales' and item[0] == 'sales' %}
+          <a class="sp-nav-sub{% if (sub_section|default('')) == 'leads' %} is-active{% endif %}"
+             href="/sales" data-testid="sp-nav-sales-leads">Leads</a>
+          <a class="sp-nav-sub{% if (sub_section|default('')) == 'referrals' %} is-active{% endif %}"
+             href="/sales/referrals" data-testid="sp-nav-sales-referrals">Referrals</a>
+        {% endif %}
+        {% if active == 'directory' and item[0] == 'directory' %}
+          <a class="sp-nav-sub{% if (sub_section|default('')) == 'profile' %} is-active{% endif %}"
+             href="/partner_directory/profile" data-testid="sp-nav-dir-profile">Profile</a>
+        {% endif %}
+      {% endfor %}
+    </nav>
+
+    <div class="sp-nav-grouplabel">Resources</div>
+    <nav class="sp-nav-group">
+      {% for item in [
+        ('partner_docs', 'Partner docs', '/docs/partner'),
+        ('product_docs', 'Product docs', '/docs/product'),
+        ('support',      'Support',      '/support'),
+      ] %}
+        <a class="sp-nav-row{% if active == item[0] %} is-active{% endif %}"
+           href="{{ item[2] }}" data-testid="sp-nav-{{ item[0] }}">
+          <span class="sp-nav-ico sp-ico-{{ item[0] }}" aria-hidden="true"></span>
+          <span class="sp-nav-label">{{ item[1] }}</span>
+        </a>
+      {% endfor %}
+    </nav>
+
+    <div class="sp-nav-grouplabel">Admin</div>
+    <nav class="sp-nav-group">
+      {% for item in [
+        ('payouts',  'Payouts',  '/payouts'),
+        ('team',     'Team',     '/team'),
+        ('settings', 'Settings', '/settings'),
+      ] %}
+        <a class="sp-nav-row{% if active == item[0] %} is-active{% endif %}"
+           href="{{ item[2] }}" data-testid="sp-nav-{{ item[0] }}">
+          <span class="sp-nav-ico sp-ico-{{ item[0] }}" aria-hidden="true"></span>
+          <span class="sp-nav-label">{{ item[1] }}</span>
+        </a>
+      {% endfor %}
+    </nav>
+  </aside>
+
+  <main class="sp-main" data-testid="sp-main">
+    {% block content %}{% endblock %}
+  </main>
+</div>
+
+{% block scripts %}{% endblock %}
+</body>
+</html>

--- a/deploy/sim_envs/mantis_shopify/app/templates/catalog_detail.html
+++ b/deploy/sim_envs/mantis_shopify/app/templates/catalog_detail.html
@@ -1,0 +1,112 @@
+{% extends "base.html" %}
+{% block title %}{{ catalog.name }} — Shopify Partners{% endblock %}
+
+{% block content %}
+<div class="sp-row-between" style="align-items:flex-start;gap:16px;margin-bottom:24px">
+  <div>
+    <div class="sp-row" style="gap:12px;align-items:center;flex-wrap:wrap">
+      <h1 class="sp-page-h1" data-testid="catalog-detail-name">{{ catalog.name }}</h1>
+      <span class="sp-pill {% if catalog.status == 'published' %}sp-pill-green{% endif %}"
+            data-testid="catalog-detail-status">{{ catalog.status }}</span>
+    </div>
+    <p class="sp-text-sub" style="margin:6px 0 0 0;font-size:13px">
+      Created {{ catalog.created_at | short_date }} · {{ catalog.products_count }} product{{ '' if catalog.products_count == 1 else 's' }}
+    </p>
+  </div>
+  <div class="sp-page-actions">
+    <a class="sp-btn sp-btn-icon-after" href="#" data-testid="catalog-detail-more">More actions</a>
+    {% if catalog.status == 'draft' %}
+    <form method="post" action="/catalogs/{{ catalog.id }}/publish" style="display:inline">
+      <button class="sp-btn sp-btn-primary" type="submit" data-testid="catalog-detail-publish">Publish</button>
+    </form>
+    {% else %}
+    <form method="post" action="/catalogs/{{ catalog.id }}/publish" style="display:inline">
+      <button class="sp-btn" type="submit" data-testid="catalog-detail-republish">Republish</button>
+    </form>
+    {% endif %}
+  </div>
+</div>
+
+<section class="sp-card" data-testid="catalog-detail-card">
+  <div class="sp-tabs" data-testid="catalog-detail-tabs">
+    {% for tab_id, label in [
+      ('products', 'Products'),
+      ('stores',   'Stores'),
+      ('settings', 'Settings'),
+    ] %}
+      <a class="sp-tab{% if current_tab == tab_id %} is-active{% endif %}"
+         href="/catalogs/{{ catalog.id }}?tab={{ tab_id }}"
+         data-testid="catalog-tab-{{ tab_id }}">{{ label }}</a>
+    {% endfor %}
+  </div>
+
+  {% if current_tab == 'products' %}
+    <table class="sp-data-table" data-testid="catalog-products-table">
+      <thead>
+        <tr><th>Product</th><th>SKU</th><th class="sp-text-right">Inventory</th><th class="sp-text-right">Price</th><th>Status</th></tr>
+      </thead>
+      <tbody>
+        {% for p in products %}
+        <tr data-testid="catalog-product-row">
+          <td>{{ p.title }}</td>
+          <td><span class="sp-text-sub" style="font-size:12px">{{ p.sku }}</span></td>
+          <td class="sp-text-right">{{ p.inventory }}</td>
+          <td class="sp-text-right">{{ p.price_cents | money }}</td>
+          <td><span class="sp-pill {% if p.status == 'Active' %}sp-pill-green{% endif %}">{{ p.status }}</span></td>
+        </tr>
+        {% endfor %}
+        {% if not products %}
+        <tr><td colspan="5"><div class="sp-text-sub" style="padding:24px;text-align:center">No products in this catalog yet.</div></td></tr>
+        {% endif %}
+      </tbody>
+    </table>
+    <div class="sp-card-footer">
+      <a href="#" class="sp-btn" data-testid="catalog-add-product">Add product</a>
+      <span class="sp-text-sub">{{ products|length }} of {{ catalog.products_count }} shown</span>
+    </div>
+  {% elif current_tab == 'stores' %}
+    <table class="sp-data-table" data-testid="catalog-stores-table">
+      <thead><tr><th>Store</th><th>Plan</th><th>Status</th><th></th></tr></thead>
+      <tbody>
+        {% for s in target_stores %}
+        <tr data-testid="catalog-target-store-row">
+          <td><a href="/stores/{{ s.id }}">{{ s.name }}</a><div class="sp-text-sub" style="font-size:12px">{{ s.slug }}.myshopify.com</div></td>
+          <td>{{ s.plan }}</td>
+          <td>
+            {% if catalog.status == 'published' %}
+              <span class="sp-pill sp-pill-green">Published</span>
+            {% else %}
+              <span class="sp-pill">Pending</span>
+            {% endif %}
+          </td>
+          <td class="sp-text-right"><a href="#" class="sp-link-quiet" data-testid="catalog-store-remove">Remove</a></td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+    <div class="sp-card-footer">
+      <a href="#" class="sp-btn" data-testid="catalog-add-store">Add store</a>
+      <span></span>
+    </div>
+  {% else %}
+    <div class="sp-card-body" data-testid="catalog-settings-pane">
+      <div class="sp-form-group">
+        <label>NAME</label>
+        <div style="font-size:14px">{{ catalog.name }}</div>
+      </div>
+      <div class="sp-form-group">
+        <label>PRICING</label>
+        <div class="sp-text-sub" style="font-size:13px">Default storefront prices</div>
+      </div>
+      <div class="sp-form-group">
+        <label>GEO RESTRICTIONS</label>
+        <div class="sp-text-sub" style="font-size:13px">No restrictions</div>
+      </div>
+      <div class="sp-form-actions">
+        <a class="sp-btn" href="/catalogs">Cancel</a>
+        <button class="sp-btn sp-btn-primary" type="submit" data-testid="catalog-settings-save">Save</button>
+      </div>
+    </div>
+  {% endif %}
+</section>
+{% endblock %}

--- a/deploy/sim_envs/mantis_shopify/app/templates/catalog_new.html
+++ b/deploy/sim_envs/mantis_shopify/app/templates/catalog_new.html
@@ -1,0 +1,25 @@
+{% extends "base.html" %}
+{% block title %}Create catalog — Shopify Partners{% endblock %}
+{% block content %}
+<header class="sp-page-header"><h1 class="sp-page-h1">Create catalog</h1></header>
+<section class="sp-card">
+  <div class="sp-card-body">
+    <form method="post" action="/catalogs/new" data-testid="catalog-new-form">
+      <div class="sp-form-row">
+        <div class="sp-form-group">
+          <label>Catalog name</label>
+          <input type="text" name="name" required data-testid="catalog-new-name"/>
+        </div>
+        <div class="sp-form-group">
+          <label>Products (initial count)</label>
+          <input type="number" name="products_count" value="0" min="0" data-testid="catalog-new-products"/>
+        </div>
+      </div>
+      <div class="sp-form-actions">
+        <a class="sp-btn" href="/catalogs">Cancel</a>
+        <button class="sp-btn sp-btn-primary" type="submit" data-testid="catalog-new-submit">Create catalog</button>
+      </div>
+    </form>
+  </div>
+</section>
+{% endblock %}

--- a/deploy/sim_envs/mantis_shopify/app/templates/catalogs.html
+++ b/deploy/sim_envs/mantis_shopify/app/templates/catalogs.html
@@ -1,0 +1,43 @@
+{% extends "base.html" %}
+{% block title %}Catalogs — Shopify Partners{% endblock %}
+
+{% block content %}
+<header class="sp-page-header">
+  <h1 class="sp-page-h1">Catalogs</h1>
+  <div class="sp-page-actions">
+    <a class="sp-btn sp-btn-primary" href="/catalogs/new" data-testid="catalogs-new-cta">Create catalog</a>
+  </div>
+</header>
+<p class="sp-page-subtitle">Publish products to merchant stores via the Catalogs API.</p>
+
+<div class="sp-info-grid">
+  <div class="sp-info-card"><h3>How catalogs work</h3>
+    <p>Group products into a catalog and publish it to one or many merchant stores. Each store sees the catalog as a hosted assortment.</p></div>
+  <div class="sp-info-card"><h3>Catalogs API reference</h3>
+    <p>REST + GraphQL surfaces with sandbox keys for dev stores. Idempotent publish endpoints.</p></div>
+</div>
+
+<section class="sp-card">
+  <header class="sp-card-header"><h2>Your catalogs</h2></header>
+  <table class="sp-data-table" data-testid="catalogs-table">
+    <thead><tr><th>Catalog</th><th>Products</th><th>Status</th><th>Created</th><th></th></tr></thead>
+    <tbody>
+      {% for c in rows %}
+      <tr data-testid="catalog-row">
+        <td><a href="/catalogs/{{ c.id }}" data-testid="catalog-name-link">{{ c.name }}</a></td>
+        <td>{{ c.products_count }}</td>
+        <td><span class="sp-pill {% if c.status == 'published' %}sp-pill-green{% endif %}">{{ c.status }}</span></td>
+        <td>{{ c.created_at | short_date }}</td>
+        <td class="sp-text-right">
+          {% if c.status == 'draft' %}
+          <form method="post" action="/catalogs/{{ c.id }}/publish" style="display:inline">
+            <button class="sp-link-quiet" style="background:none;border:0;cursor:pointer;color:var(--c-link);font-size:13px" data-testid="catalog-publish">Publish</button>
+          </form>
+          {% endif %}
+        </td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</section>
+{% endblock %}

--- a/deploy/sim_envs/mantis_shopify/app/templates/directory.html
+++ b/deploy/sim_envs/mantis_shopify/app/templates/directory.html
@@ -1,0 +1,39 @@
+{% extends "base.html" %}
+{% block title %}Partner Directory — Shopify Partners{% endblock %}
+
+{% block content %}
+<header class="sp-page-header">
+  <h1 class="sp-page-h1">Partner Directory</h1>
+  <div class="sp-page-actions">
+    <a class="sp-btn" href="/partner_directory/profile" data-testid="directory-view">👁 View</a>
+    <a class="sp-btn sp-btn-primary" href="/partner_directory/profile" data-testid="directory-edit-profile">Edit profile</a>
+  </div>
+</header>
+
+<section class="sp-card" data-testid="directory-eligible">
+  <header class="sp-card-header"><h2>Eligible directory reviews</h2></header>
+  <div class="sp-card-body">
+    <p>After collaborating with a merchant for more than 1 week, you can request a review. If you don't send a request within 90 days of the collaboration start date, and if the contact was initiated through the Partner Directory, an automatic request will be sent. <a href="#">Learn more about review eligibility requirements</a></p>
+  </div>
+  <table class="sp-data-table" data-testid="directory-table">
+    <thead><tr><th>Business Name</th><th>Plan</th><th>Review Status</th><th></th></tr></thead>
+    <tbody>
+      {% for row in rows %}
+      <tr data-testid="directory-row">
+        <td>{{ row.business_name }}</td>
+        <td>{{ row.plan }}</td>
+        <td><span class="sp-pill sp-pill-green">{{ row.review_status | replace('_', ' ') | title }}</span></td>
+        <td class="sp-text-right">
+          {% if row.review_status == 'available' %}
+          <form method="post" action="/partner_directory/{{ row.id }}/request_review" style="display:inline">
+            <button class="sp-link-quiet" style="background:none;border:0;cursor:pointer;color:var(--c-link);font-size:13px"
+                    data-testid="directory-request-review">Request review</button>
+          </form>
+          {% endif %}
+        </td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</section>
+{% endblock %}

--- a/deploy/sim_envs/mantis_shopify/app/templates/directory_profile.html
+++ b/deploy/sim_envs/mantis_shopify/app/templates/directory_profile.html
@@ -1,0 +1,33 @@
+{% extends "base.html" %}
+{% block title %}Directory profile — Shopify Partners{% endblock %}
+{% block content %}
+<header class="sp-page-header"><h1 class="sp-page-h1">Directory profile</h1></header>
+<p class="sp-page-subtitle">Edit how your business appears in the Partner Directory.</p>
+
+<section class="sp-card">
+  <div class="sp-card-body">
+    <form method="post" action="/partner_directory/profile" data-testid="directory-profile-form">
+      <div class="sp-form-group"><label>Studio name</label>
+        <input type="text" name="studio_name" value="{{ partner.business_name }}" data-testid="dp-studio-name"/></div>
+      <div class="sp-form-group"><label>Bio</label>
+        <textarea name="bio" placeholder="What does your studio do?" data-testid="dp-bio"></textarea></div>
+      <div class="sp-form-row">
+        <div class="sp-form-group"><label>Services offered</label>
+          <input type="text" name="services" placeholder="Design, Development, Marketing" data-testid="dp-services"/></div>
+        <div class="sp-form-group"><label>Languages</label>
+          <input type="text" name="languages" placeholder="English, Spanish, Portuguese" data-testid="dp-languages"/></div>
+      </div>
+      <div class="sp-form-row">
+        <div class="sp-form-group"><label>Locations served</label>
+          <input type="text" name="locations" placeholder="United States, Canada" data-testid="dp-locations"/></div>
+        <div class="sp-form-group"><label>Hourly rate (USD)</label>
+          <input type="text" name="hourly_rate" placeholder="$150" data-testid="dp-rate"/></div>
+      </div>
+      <div class="sp-form-actions">
+        <a class="sp-btn" href="/partner_directory">Cancel</a>
+        <button class="sp-btn sp-btn-primary" type="submit" data-testid="dp-save">Save profile</button>
+      </div>
+    </form>
+  </div>
+</section>
+{% endblock %}

--- a/deploy/sim_envs/mantis_shopify/app/templates/docs.html
+++ b/deploy/sim_envs/mantis_shopify/app/templates/docs.html
@@ -1,0 +1,32 @@
+{% extends "base.html" %}
+{% block title %}{{ title }} — Shopify Partners{% endblock %}
+
+{% block content %}
+<header class="sp-page-header"><h1 class="sp-page-h1">{{ title }}</h1></header>
+<p class="sp-page-subtitle">{{ subtitle }}</p>
+
+<section class="sp-card">
+  <div class="sp-filterrow">
+    <input type="search" name="q" value="{{ q }}" placeholder="Search the docs" data-testid="docs-search"/>
+    <button class="sp-btn">Search</button>
+  </div>
+  <div style="display:grid;grid-template-columns:240px 1fr;gap:24px;padding:20px">
+    <nav data-testid="docs-toc">
+      <h3 style="font-size:13px;margin:0 0 8px 0;color:var(--c-text-sub);text-transform:uppercase">Topics</h3>
+      <ul style="list-style:none;padding:0;margin:0">
+        {% for topic in toc %}
+        <li style="padding:8px 0;border-bottom:1px solid var(--c-border)"><a href="#" data-testid="docs-toc-link">{{ topic }}</a></li>
+        {% endfor %}
+      </ul>
+    </nav>
+    <div data-testid="docs-articles">
+      {% for title_, body in articles %}
+      <article style="padding:0 0 20px 0;border-bottom:1px solid var(--c-border);margin-bottom:20px">
+        <h3 style="margin:0 0 6px 0;font-size:15px"><a href="#" data-testid="docs-article-link">{{ title_ }}</a></h3>
+        <p style="margin:0;color:var(--c-text-sub)">{{ body }}</p>
+      </article>
+      {% endfor %}
+    </div>
+  </div>
+</section>
+{% endblock %}

--- a/deploy/sim_envs/mantis_shopify/app/templates/home.html
+++ b/deploy/sim_envs/mantis_shopify/app/templates/home.html
@@ -1,0 +1,88 @@
+{% extends "base.html" %}
+{% block title %}Home — Shopify Partners{% endblock %}
+
+{% block content %}
+<header class="sp-page-header">
+  <h1 class="sp-page-h1">Stores</h1>
+  <div class="sp-page-actions">
+    <a class="sp-btn sp-btn-primary sp-btn-icon-after" href="/stores/new" data-testid="home-add-store">Add store</a>
+  </div>
+</header>
+
+<div class="sp-home-grid">
+  <div>
+    <section class="sp-card" data-testid="home-stores-card">
+      <ul class="sp-list">
+        {% for s in stores %}
+        <li class="sp-list-row" data-testid="home-store-row">
+          <div>
+            <a class="sp-list-row-name" href="/stores/{{ s.id }}"
+               style="color:var(--c-text);text-decoration:none" data-testid="home-store-name-link">{{ s.name }}</a>
+            <div class="sp-list-row-sub">{{ s.slug }}.myshopify.com</div>
+          </div>
+          <div>
+            <span class="sp-pill">
+              {% if s.kind == 'client_transfer' %}Client transfer
+              {% elif s.kind == 'collaborator' %}Collaborator access
+              {% else %}Active development store{% endif %}
+            </span>
+          </div>
+          <div class="sp-list-row-actions">
+            <a class="sp-link-quiet" href="/stores/{{ s.id }}/actions" data-testid="home-store-actions">Actions ▾</a>
+            <form method="post" action="/stores/{{ s.id }}/login" style="display:inline">
+              <button class="sp-link-quiet" style="background:none;border:0;cursor:pointer;color:var(--c-link);font-size:13px"
+                      data-testid="home-store-login">Log in</button>
+            </form>
+          </div>
+        </li>
+        {% endfor %}
+      </ul>
+      <div class="sp-card-footer">
+        <a href="/stores" class="sp-link-quiet" data-testid="home-view-all-stores">View all stores →</a>
+      </div>
+    </section>
+
+    <h2 style="font-size:14px; font-weight:600; margin:24px 0 12px;">Business overview</h2>
+    <div class="sp-stats-grid" data-testid="home-stats">
+      <div class="sp-stat-card">
+        <div class="sp-stat-label">Pending payout</div>
+        <div class="sp-stat-value" data-testid="home-pending-amount">
+          {% if pending_payout %}
+            {{ pending_payout.amount_cents | money }} USD
+          {% else %}
+            $0.00 USD
+          {% endif %}
+        </div>
+        <a class="sp-stat-link" href="/payouts">View payouts</a>
+      </div>
+      <div class="sp-stat-card">
+        <div class="sp-stat-label">Active store referrals</div>
+        <div class="sp-stat-value" data-testid="home-active-referrals">{{ active_referrals }}</div>
+        <a class="sp-stat-link" href="/sales">Submit a lead</a>
+      </div>
+      <div class="sp-stat-card">
+        <div class="sp-stat-label">Lifetime leads submitted</div>
+        <div class="sp-stat-value" data-testid="home-lifetime-leads">{{ lifetime_leads }}</div>
+        <a class="sp-stat-link" href="/sales">View leads</a>
+      </div>
+    </div>
+  </div>
+
+  <aside class="sp-changelog" data-testid="home-changelog">
+    <header>
+      <h2>Changelog</h2>
+      <a href="#" class="sp-link-quiet">View all</a>
+    </header>
+    {% for item in changelog %}
+    <div class="sp-changelog-item">
+      <div class="sp-changelog-date">
+        <span>{{ item.published_at | short_date }}</span>
+        <span class="sp-pill">{{ item.category }}</span>
+      </div>
+      <h3 class="sp-changelog-title">{{ item.title }}</h3>
+      <p class="sp-changelog-summary">{{ item.summary }}</p>
+    </div>
+    {% endfor %}
+  </aside>
+</div>
+{% endblock %}

--- a/deploy/sim_envs/mantis_shopify/app/templates/lead_new.html
+++ b/deploy/sim_envs/mantis_shopify/app/templates/lead_new.html
@@ -1,0 +1,37 @@
+{% extends "base.html" %}
+{% block title %}{{ title }} — Shopify Partners{% endblock %}
+
+{% block content %}
+<header class="sp-page-header"><h1 class="sp-page-h1">{{ title }}</h1></header>
+<p class="sp-page-subtitle">Provide the merchant's details to start the referral.</p>
+
+<section class="sp-card">
+  <div class="sp-card-body">
+    <form method="post" action="/sales/leads/new" data-testid="lead-new-form">
+      <input type="hidden" name="product" value="{{ product }}"/>
+      <div class="sp-form-row">
+        <div class="sp-form-group">
+          <label for="merchant_name">Merchant business name</label>
+          <input type="text" id="merchant_name" name="merchant_name" required data-testid="lead-merchant-name"/>
+        </div>
+        <div class="sp-form-group">
+          <label for="contact_name">Primary contact name</label>
+          <input type="text" id="contact_name" name="contact_name" data-testid="lead-contact-name"/>
+        </div>
+      </div>
+      <div class="sp-form-group">
+        <label for="contact_email">Primary contact email</label>
+        <input type="email" id="contact_email" name="contact_email" required data-testid="lead-contact-email"/>
+      </div>
+      <div class="sp-form-group">
+        <label for="notes">Notes</label>
+        <textarea id="notes" name="notes" placeholder="Anything to know about the merchant" data-testid="lead-notes"></textarea>
+      </div>
+      <div class="sp-form-actions">
+        <a class="sp-btn" href="/sales">Cancel</a>
+        <button class="sp-btn sp-btn-primary" type="submit" data-testid="lead-submit">Submit lead</button>
+      </div>
+    </form>
+  </div>
+</section>
+{% endblock %}

--- a/deploy/sim_envs/mantis_shopify/app/templates/login.html
+++ b/deploy/sim_envs/mantis_shopify/app/templates/login.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en"><head>
+<meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>Sign in — Shopify Partners</title>
+<link rel="stylesheet" href="/static/site.css?v=20260609b"/>
+</head>
+<body>
+<div class="sp-login">
+  <form class="sp-login-card" method="post" action="/login" data-testid="login-form">
+    <h1 style="font-size:18px;margin:0 0 16px 0">Sign in to Partners</h1>
+    {% if error %}<p style="color:var(--c-danger);margin:0 0 12px 0">{{ error }}</p>{% endif %}
+    <input type="hidden" name="next" value="{{ next_path }}"/>
+    <div class="sp-form-group"><label>Email</label>
+      <input type="email" name="email" autocomplete="username" required data-testid="login-email"/></div>
+    <div class="sp-form-group"><label>Password</label>
+      <input type="password" name="password" autocomplete="current-password" required data-testid="login-password"/></div>
+    <button class="sp-btn sp-btn-primary" type="submit" style="width:100%" data-testid="login-submit">Sign in</button>
+    <p class="sp-text-sub" style="margin:16px 0 0 0;font-size:12px">Demo credentials: barada@example.com / password</p>
+  </form>
+</div>
+</body></html>

--- a/deploy/sim_envs/mantis_shopify/app/templates/notifications.html
+++ b/deploy/sim_envs/mantis_shopify/app/templates/notifications.html
@@ -1,0 +1,23 @@
+{% extends "base.html" %}
+{% block title %}Notifications — Shopify Partners{% endblock %}
+
+{% block content %}
+<header class="sp-page-header">
+  <h1 class="sp-page-h1">Notifications</h1>
+</header>
+
+<section class="sp-card">
+  <ul class="sp-list">
+    {% for n in notifications %}
+    <li class="sp-list-row" data-testid="notif-row">
+      <div>
+        <div class="sp-list-row-name">{{ n.title }}</div>
+        <div class="sp-list-row-sub">{{ n.body }}</div>
+      </div>
+      <div class="sp-text-sub">{{ n.occurred_at | short_date }}</div>
+      <div></div>
+    </li>
+    {% endfor %}
+  </ul>
+</section>
+{% endblock %}

--- a/deploy/sim_envs/mantis_shopify/app/templates/payout_detail.html
+++ b/deploy/sim_envs/mantis_shopify/app/templates/payout_detail.html
@@ -1,0 +1,30 @@
+{% extends "base.html" %}
+{% block title %}Payout {{ payout.id }} — Shopify Partners{% endblock %}
+
+{% block content %}
+<header class="sp-page-header">
+  <h1 class="sp-page-h1">{{ payout.period_start | short_date }} – {{ payout.period_end | short_date }}</h1>
+</header>
+<p class="sp-page-subtitle">
+  {% if payout.status == 'paid' %}Sent {{ payout.sent_at | short_date }}{% else %}Pending{% endif %} via {{ payout.method }}
+</p>
+
+<section class="sp-card">
+  <header class="sp-card-header">
+    <h2>Line items</h2>
+    <div class="sp-text-sub">Total: {{ payout.amount_cents | money }} USD</div>
+  </header>
+  <table class="sp-data-table" data-testid="payout-line-items">
+    <thead><tr><th>Date</th><th>Description</th><th class="sp-text-right">Amount</th></tr></thead>
+    <tbody>
+      {% for li in items %}
+      <tr data-testid="payout-li">
+        <td>{{ li.occurred_at | short_date }}</td>
+        <td>{{ li.description }}</td>
+        <td class="sp-text-right">{{ li.amount_cents | money }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</section>
+{% endblock %}

--- a/deploy/sim_envs/mantis_shopify/app/templates/payouts.html
+++ b/deploy/sim_envs/mantis_shopify/app/templates/payouts.html
@@ -1,0 +1,35 @@
+{% extends "base.html" %}
+{% block title %}Payouts — Shopify Partners{% endblock %}
+
+{% block content %}
+<header class="sp-page-header">
+  <h1 class="sp-page-h1">Payouts</h1>
+  <div class="sp-page-actions">
+    <a class="sp-btn sp-btn-primary" href="/payouts/export" data-testid="payouts-export">Export CSV</a>
+  </div>
+</header>
+
+{% if pending %}
+<section class="sp-card" data-testid="payouts-pending">
+  <div class="sp-pending-card">
+    <div class="sp-row-between">
+      <h2 style="margin:0;font-size:14px;font-weight:600">Pending</h2>
+      <a class="sp-link-quiet" href="/payouts/{{ pending.id }}">View pending transactions</a>
+    </div>
+    <div class="sp-pending-amt" data-testid="payouts-pending-amt">{{ pending.amount_cents | money }} USD</div>
+    <p class="sp-pending-sub">Estimated amount excluding taxes</p>
+    <p class="sp-pending-eta">Estimated payout date {{ pending.period_end | short_date }} via {{ pending.method }}</p>
+  </div>
+</section>
+{% endif %}
+
+<section class="sp-payouts-list" data-testid="payouts-list">
+  {% for p in sent %}
+  <div class="sp-payouts-row" data-testid="payouts-row">
+    <a href="/payouts/{{ p.id }}">{{ p.period_start | short_date }} – {{ p.period_end | short_date }} – Sales</a>
+    <div class="sp-payouts-sent">Sent {{ p.sent_at | short_date }}</div>
+    <div class="sp-payouts-amount">{{ p.amount_cents | money }} USD</div>
+  </div>
+  {% endfor %}
+</section>
+{% endblock %}

--- a/deploy/sim_envs/mantis_shopify/app/templates/pos.html
+++ b/deploy/sim_envs/mantis_shopify/app/templates/pos.html
@@ -1,0 +1,89 @@
+{% extends "base.html" %}
+{% block title %}Shopify POS — Shopify Partners{% endblock %}
+
+{% block content %}
+<p class="sp-text-sub" style="margin-bottom:8px">Shopify Point of Sale</p>
+
+<section class="sp-hero" data-testid="pos-hero">
+  <div>
+    <h2>Built for merchants selling in person and online</h2>
+    <p>The POS system with everything you need to sell in person, backed by everything you need to sell online. Earn 20% recurring Shopify Payments profit-share, plus $500 USD for every new Shopify POS Pro merchant you refer.</p>
+    <div class="sp-row" style="gap:12px">
+      <a class="sp-btn sp-btn-primary" href="/sales/leads/new?product=pos" data-testid="pos-submit-referral">Submit POS Pro referral</a>
+      <a href="#" class="sp-link-quiet">Learn how to sell Shopify POS Pro</a>
+    </div>
+    <p class="sp-text-sub" style="margin-top:12px;font-size:12px">View your referrals via your <a href="/sales">Leads dashboard</a></p>
+  </div>
+  <div class="sp-hero-art">
+    How to Earn with Shopify POS
+    <div class="sp-hero-art-coin"></div>
+  </div>
+</section>
+
+<div class="sp-info-grid">
+  <div class="sp-info-card" data-testid="pos-toolkit">
+    <h3>Shopify POS Marketing Toolkit</h3>
+    <p>Access resources to build your own Shopify POS marketing campaigns and generate referrals.</p>
+    <a class="sp-btn" href="#">Access Marketing Toolkit</a>
+  </div>
+  <div class="sp-info-card" data-testid="pos-verified-skills">
+    <h3>Shopify POS Verified Skills</h3>
+    <p>Immerse yourself in comprehensive learning and assessments on Shopify POS. Built to support Shopify Partners working with retailers.</p>
+    <a class="sp-btn" href="#">Learn more now</a>
+  </div>
+</div>
+
+<section class="sp-card" data-testid="pos-learning-path">
+  <div class="sp-card-body">
+    <h3 style="margin:0 0 8px 0">Learning Path: Solution-Based Selling with Shopify POS</h3>
+    <p class="sp-text-sub">Master the consultative approach to selling Shopify POS to retail merchants.</p>
+    <a class="sp-btn" href="#">Start the learning path</a>
+  </div>
+</section>
+
+<section class="sp-card" data-testid="pos-why">
+  <div class="sp-card-body">
+    <h3 style="margin:0 0 16px 0">Why recommend Shopify POS</h3>
+    <div class="sp-stats-grid">
+      <div><strong>Get a unified back office</strong>
+        <p class="sp-text-sub">One platform for products, orders, and customers across in-person and online channels.</p></div>
+      <div><strong>Close more sales</strong>
+        <p class="sp-text-sub">Smart in-store features that help staff finish more transactions, including line busting.</p></div>
+      <div><strong>Offer flexible checkouts</strong>
+        <p class="sp-text-sub">Email or text receipts, ship-to-customer, BOPIS, and ROPIS — all on a single tablet.</p></div>
+    </div>
+  </div>
+</section>
+
+<section class="sp-card" data-testid="pos-videos">
+  <header class="sp-card-header"><h2>Selling Shopify POS</h2></header>
+  <div class="sp-info-grid">
+    <a class="sp-info-card" href="#" style="text-decoration:none;color:inherit">
+      <div style="background:#0c3b1f;color:#fff;border-radius:8px;padding:32px;font-size:18px;text-align:center;position:relative">
+        ▶
+        <span style="position:absolute;right:12px;bottom:12px;background:rgba(0,0,0,0.6);padding:2px 6px;border-radius:4px;font-size:11px">1:13</span>
+      </div>
+      <h3 style="margin:8px 0 0 0;font-size:14px">POS Pro in 90 seconds</h3>
+    </a>
+    <a class="sp-info-card" href="#" style="text-decoration:none;color:inherit">
+      <div style="background:#3a4f5c;color:#fff;border-radius:8px;padding:32px;font-size:18px;text-align:center;position:relative">
+        ▶
+        <span style="position:absolute;right:12px;bottom:12px;background:rgba(0,0,0,0.6);padding:2px 6px;border-radius:4px;font-size:11px">10:18</span>
+      </div>
+      <h3 style="margin:8px 0 0 0;font-size:14px">Deep dive on POS Pro reporting</h3>
+    </a>
+  </div>
+</section>
+
+<section class="sp-card" data-testid="pos-how-comes-together">
+  <header class="sp-card-header"><h2>How Shopify POS comes together</h2></header>
+  <div class="sp-card-body">
+    <ol style="padding-left:20px">
+      <li>Identify a retail merchant whose stack would benefit from a unified online + in-person POS.</li>
+      <li>Submit them as a POS Pro lead from your Partners dashboard.</li>
+      <li>Our team works with the merchant on a tailored onboarding plan.</li>
+      <li>Once they're live, you earn the activation bonus and recurring payments profit-share.</li>
+    </ol>
+  </div>
+</section>
+{% endblock %}

--- a/deploy/sim_envs/mantis_shopify/app/templates/sales_leads.html
+++ b/deploy/sim_envs/mantis_shopify/app/templates/sales_leads.html
@@ -1,0 +1,72 @@
+{% extends "base.html" %}
+{% block title %}Leads — Shopify Partners{% endblock %}
+
+{% block content %}
+<header class="sp-page-header">
+  <h1 class="sp-page-h1">Leads</h1>
+</header>
+<p class="sp-page-subtitle">Earn revenue by referring merchants to Shopify.
+  <a href="#">Learn more</a></p>
+
+<section class="sp-card" data-testid="sales-submit-card">
+  <header class="sp-card-header"><h2>Submit a lead</h2></header>
+  <div class="sp-card-body-flush">
+    <div class="sp-product-row" data-testid="product-plus">
+      <div class="sp-product-row-glyph">S</div>
+      <div>
+        <div class="sp-product-row-name">Plus</div>
+        <div class="sp-product-row-desc">
+          Earn $2,500 USD one-time referral when you submit an eligible Plus lead. Plus 15% recurring revenue and variable platform fees on successful launch.
+        </div>
+      </div>
+      <a class="sp-btn" href="/sales/leads/new?product=plus" data-testid="submit-plus">Submit a Plus lead</a>
+    </div>
+    <div class="sp-product-row" data-testid="product-pos">
+      <div class="sp-product-row-glyph" style="background:#fcefe0;color:#bf6900">P</div>
+      <div>
+        <div class="sp-product-row-name">Shopify POS</div>
+        <div class="sp-product-row-desc">
+          Earn a one-time POS Pro activation bonus plus a recurring 20% Shopify POS payments profit-share for 24 months.
+        </div>
+      </div>
+      <a class="sp-btn" href="/sales/leads/new?product=pos" data-testid="submit-pos">Submit a POS lead</a>
+    </div>
+    <div class="sp-product-row" data-testid="product-plus-b2b">
+      <div class="sp-product-row-glyph">B</div>
+      <div>
+        <div class="sp-product-row-name">Shopify Plus B2B</div>
+        <div class="sp-product-row-desc">
+          Refer a new B2B customer to Shopify Plus and earn qualified opportunities.
+        </div>
+      </div>
+      <a class="sp-btn" href="/sales/leads/new?product=plus_b2b" data-testid="submit-plus-b2b">Submit a Plus B2B lead</a>
+    </div>
+  </div>
+</section>
+
+<section class="sp-card" data-testid="sales-list-card">
+  <header class="sp-card-header"><h2>Submitted leads</h2></header>
+  <ul class="sp-list" data-testid="sales-leads-list">
+    {% if leads %}
+      {% for lead in leads %}
+      <li class="sp-list-row" data-testid="lead-row">
+        <div>
+          <div class="sp-list-row-name">{{ lead.merchant_name }}</div>
+          <div class="sp-list-row-sub">{{ lead.contact_email }}</div>
+        </div>
+        <div>
+          <span class="sp-pill">{{ lead.product|upper|replace('_',' ') }}</span>
+          <span class="sp-pill {% if lead.status == 'won' %}sp-pill-green{% endif %}" style="margin-left:8px">{{ lead.status }}</span>
+        </div>
+        <div class="sp-text-sub">{{ lead.submitted_at | short_date }}</div>
+      </li>
+      {% endfor %}
+    {% else %}
+      <li class="sp-empty-state">
+        <div class="sp-empty-illu"></div>
+        <p class="sp-text-sub">Earn monthly by referring merchants to Shopify.</p>
+      </li>
+    {% endif %}
+  </ul>
+</section>
+{% endblock %}

--- a/deploy/sim_envs/mantis_shopify/app/templates/sales_referrals.html
+++ b/deploy/sim_envs/mantis_shopify/app/templates/sales_referrals.html
@@ -1,0 +1,26 @@
+{% extends "base.html" %}
+{% block title %}Referrals — Shopify Partners{% endblock %}
+
+{% block content %}
+<header class="sp-page-header"><h1 class="sp-page-h1">Referrals</h1></header>
+<p class="sp-page-subtitle">Track your active referrals and recurring earnings.</p>
+
+<section class="sp-card">
+  <table class="sp-data-table" data-testid="referrals-table">
+    <thead>
+      <tr><th>Referral ID</th><th>Merchant</th><th>Plan</th><th>Status</th><th class="sp-text-right">Earned</th></tr>
+    </thead>
+    <tbody>
+      {% for r in rows %}
+      <tr data-testid="referral-row">
+        <td>{{ r.id }}</td>
+        <td>{{ r.merchant_name }}</td>
+        <td><span class="sp-pill">{{ r.plan }}</span></td>
+        <td><span class="sp-pill {% if r.status == 'active' %}sp-pill-green{% endif %}">{{ r.status }}</span></td>
+        <td class="sp-text-right">{{ r.earnings_cents | money }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</section>
+{% endblock %}

--- a/deploy/sim_envs/mantis_shopify/app/templates/settings.html
+++ b/deploy/sim_envs/mantis_shopify/app/templates/settings.html
@@ -1,0 +1,162 @@
+{% extends "base.html" %}
+{% block title %}Settings — Shopify Partners{% endblock %}
+
+{% block content %}
+{% include "_banner.html" %}
+
+<header class="sp-page-header">
+  <h1 class="sp-page-h1">Partner account settings</h1>
+</header>
+
+<section class="sp-section" data-testid="settings-profile">
+  <div>
+    <h2>Personal profile information</h2>
+    <p class="sp-section-desc">Edit your personal profile to change your password, email contact, avatar photo, and preferred language.</p>
+  </div>
+  <div class="sp-card">
+    <div class="sp-card-body">
+      <div class="sp-row" style="gap:16px">
+        <span class="sp-member-avatar" style="width:48px;height:48px;background:{{ owner.avatar_color }};font-size:14px">{{ owner.name | initials }}</span>
+        <div style="flex:1">
+          <div style="font-weight:600">{{ owner.name }}</div>
+          <div><a href="mailto:{{ owner.email }}">{{ owner.email }}</a></div>
+          <div class="sp-text-sub" style="font-size:12px">English</div>
+          <div class="sp-text-sub" style="font-size:12px">Last login {{ humanize_last_login(owner.last_login_at, now) }}</div>
+        </div>
+        <a class="sp-btn" href="#" data-testid="settings-edit-profile">Edit personal profile</a>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="sp-section" data-testid="settings-account">
+  <div>
+    <h2>Account information</h2>
+    <p class="sp-section-desc">Account-level identifiers for your Partner account.</p>
+  </div>
+  <div class="sp-card">
+    <div class="sp-card-body">
+      <div class="sp-form-group">
+        <label>PARTNER ID</label>
+        <div style="font-size:14px">{{ partner.partner_id }}</div>
+      </div>
+      <div class="sp-form-group">
+        <label>APP STORE REGISTRATION</label>
+        <div><span class="sp-pill sp-pill-green">Registered</span></div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="sp-section" data-testid="settings-business-details">
+  <div>
+    <h2>Business details</h2>
+    <p class="sp-section-desc">Information about your business. Used by Shopify to verify your Partner account.</p>
+  </div>
+  <div class="sp-card">
+    <div class="sp-card-body">
+      <div class="sp-form-group"><label>BUSINESS NAME</label>
+        <div style="font-size:14px">{{ partner.business_name }}</div></div>
+      <div class="sp-form-group"><label>BUSINESS TYPE</label>
+        <div style="font-size:14px">Limited liability company (LLC)</div></div>
+      <div class="sp-form-group"><label>INDUSTRY</label>
+        <div style="font-size:14px">Software &amp; technology consulting</div></div>
+    </div>
+  </div>
+</section>
+
+<section class="sp-section" data-testid="settings-contact">
+  <div>
+    <h2>Contact information</h2>
+    <p class="sp-section-desc">Business contact information and address. Used in payouts and tax filings.</p>
+  </div>
+  <div class="sp-card">
+    <div class="sp-card-body">
+      <form method="post" action="/settings/business" data-testid="settings-business-form">
+        <div class="sp-form-row">
+          <div class="sp-form-group"><label>Business name</label>
+            <input type="text" name="business_name" value="{{ partner.business_name }}" data-testid="settings-business-name"/></div>
+          <div class="sp-form-group"><label>Website</label>
+            <input type="text" name="website" value="{{ partner.website }}"/></div>
+        </div>
+        <div class="sp-form-row">
+          <div class="sp-form-group"><label>Business email</label>
+            <input type="email" name="business_email" value="{{ partner.business_email }}" data-testid="settings-business-email"/></div>
+          <div class="sp-form-group"><label>Support email</label>
+            <input type="email" name="support_email" value="{{ partner.support_email }}"/></div>
+        </div>
+        <div class="sp-form-row">
+          <div class="sp-form-group"><label>Phone number</label>
+            <input type="text" name="phone" value="{{ partner.phone }}"/></div>
+          <div class="sp-form-group"><label>Country</label>
+            <input type="text" name="country" value="{{ partner.country }}"/></div>
+        </div>
+        <div class="sp-form-row">
+          <div class="sp-form-group"><label>Address 1</label>
+            <input type="text" name="address1" value="{{ partner.address1 }}"/></div>
+          <div class="sp-form-group"><label>Address 2</label>
+            <input type="text" name="address2" value="{{ partner.address2 }}"/></div>
+        </div>
+        <div class="sp-form-row">
+          <div class="sp-form-group"><label>City</label>
+            <input type="text" name="city" value="{{ partner.city }}"/></div>
+          <div class="sp-form-group"><label>ZIP / Postal Code</label>
+            <input type="text" name="zip" value="{{ partner.zip }}"/></div>
+        </div>
+        <div class="sp-form-row">
+          <div class="sp-form-group"><label>State</label>
+            <input type="text" name="state" value="{{ partner.state }}"/></div>
+          <div></div>
+        </div>
+        <div class="sp-form-actions">
+          <a class="sp-btn" href="/settings">Cancel</a>
+          <button class="sp-btn sp-btn-primary" type="submit" data-testid="settings-business-save">Save</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</section>
+
+<section class="sp-section" id="emergency" data-testid="settings-emergency">
+  <div>
+    <h2>Emergency developer contact information</h2>
+    <p class="sp-section-desc">We'll contact this developer about urgent and upcoming changes to the Shopify API.</p>
+  </div>
+  <div class="sp-card">
+    <div class="sp-card-body">
+      <form method="post" action="/settings/emergency" data-testid="settings-emergency-form">
+        <div class="sp-form-group"><label>Name</label>
+          <input type="text" name="emergency_name" value="{{ partner.emergency_name }}" data-testid="settings-emergency-name"/></div>
+        <div class="sp-form-row">
+          <div class="sp-form-group"><label>Email</label>
+            <input type="email" name="emergency_email" value="{{ partner.emergency_email }}" data-testid="settings-emergency-email"/></div>
+          <div class="sp-form-group"><label>Phone</label>
+            <input type="text" name="emergency_phone" value="{{ partner.emergency_phone }}"/></div>
+        </div>
+        <div class="sp-form-actions">
+          <a class="sp-btn" href="/settings">Cancel</a>
+          <button class="sp-btn sp-btn-primary" type="submit" data-testid="settings-emergency-save">Save</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</section>
+
+<section class="sp-section" data-testid="settings-payouts">
+  <div>
+    <h2>Payouts</h2>
+    <p class="sp-section-desc">How and where you receive payouts.</p>
+  </div>
+  <div class="sp-card">
+    <div class="sp-card-body">
+      <div class="sp-row-between">
+        <div>
+          <div style="font-weight:600">Bank account</div>
+          <div class="sp-text-sub">{{ partner.payout_method }}</div>
+        </div>
+        <a class="sp-btn" href="#">Edit payout method</a>
+      </div>
+    </div>
+  </div>
+</section>
+{% endblock %}

--- a/deploy/sim_envs/mantis_shopify/app/templates/store_detail.html
+++ b/deploy/sim_envs/mantis_shopify/app/templates/store_detail.html
@@ -1,0 +1,97 @@
+{% extends "base.html" %}
+{% block title %}{{ store.name }} — Shopify Partners{% endblock %}
+
+{% block content %}
+{% include "_banner.html" %}
+
+<div class="sp-row-between" style="align-items:flex-start;gap:16px;margin-bottom:24px">
+  <div>
+    <div class="sp-row" style="gap:12px;align-items:center;flex-wrap:wrap">
+      <h1 class="sp-page-h1" data-testid="store-detail-name">{{ store.name }}</h1>
+      <span class="sp-pill" data-testid="store-detail-kind">
+        {% if store.kind == 'client_transfer' %}Client transfer
+        {% elif store.kind == 'collaborator' %}Collaborator access
+        {% else %}Active development store{% endif %}
+      </span>
+    </div>
+    <div class="sp-row" style="gap:16px;margin-top:6px">
+      <a class="sp-link-quiet" href="#" data-testid="store-detail-transfer">
+        <span style="font-size:12px;margin-right:4px">↑</span>Transfer ownership
+      </a>
+    </div>
+  </div>
+  <div class="sp-page-actions">
+    <a class="sp-btn sp-btn-icon-after" href="#" data-testid="store-detail-more">More actions</a>
+    <form method="post" action="/stores/{{ store.id }}/login" style="display:inline">
+      <button class="sp-btn sp-btn-primary" type="submit" data-testid="store-detail-login">Log in</button>
+    </form>
+  </div>
+</div>
+
+<div style="display:grid;grid-template-columns:minmax(0,1fr) 340px;gap:24px;align-items:start">
+
+  <div>
+    <section class="sp-card" data-testid="store-detail-activity">
+      <header class="sp-card-header"><h2>Store activity</h2></header>
+      {% if activity %}
+      <ul class="sp-list">
+        {% for ev in activity %}
+        <li class="sp-list-row" data-testid="store-activity-row">
+          <div>
+            <div class="sp-list-row-name">{{ ev.operation | replace('_', ' ') | title }}</div>
+            <div class="sp-list-row-sub">{{ ev.payload }}</div>
+          </div>
+          <div></div>
+          <div class="sp-text-sub">{{ ev.ts | short_date }}</div>
+        </li>
+        {% endfor %}
+      </ul>
+      {% else %}
+      <div class="sp-empty-state" data-testid="store-activity-empty">
+        <h3 style="margin:8px 0 4px 0;font-size:16px">No store events</h3>
+        <p class="sp-text-sub">There are no events related to this store</p>
+      </div>
+      {% endif %}
+    </section>
+  </div>
+
+  <aside>
+    <section class="sp-card" data-testid="store-info-card">
+      <div class="sp-card-body">
+        <h3 style="margin:0 0 8px 0;font-size:14px">{{ store.name }}</h3>
+        <div style="margin-bottom:16px">
+          <a href="#" class="sp-link-quiet" data-testid="store-info-url">
+            {{ store.slug }}.myshopify.com
+            <span style="font-size:10px">↗</span>
+          </a>
+        </div>
+
+        <div style="margin-bottom:6px"><label style="font-size:11px;font-weight:600;text-transform:uppercase;color:var(--c-text-sub);letter-spacing:0.06em">Store information</label></div>
+        <div><a href="#" class="sp-link-quiet" data-testid="store-info-email">{{ support_email }}</a></div>
+        <div class="sp-text-sub" style="margin-bottom:16px">{{ country }}</div>
+
+        <div class="sp-divider" style="margin:12px 0"></div>
+
+        <div style="margin-bottom:6px"><label style="font-size:11px;font-weight:600;text-transform:uppercase;color:var(--c-text-sub);letter-spacing:0.06em">Created</label></div>
+        <div data-testid="store-info-created">{{ created_human }}</div>
+      </div>
+    </section>
+
+    <section class="sp-card" data-testid="store-members-card">
+      <header class="sp-card-header">
+        <h2>Team members with access</h2>
+        <a class="sp-link-quiet" href="/team">View</a>
+      </header>
+      <div class="sp-card-body-flush">
+        {% for u in members %}
+        <div class="sp-member-row" data-testid="store-member-row">
+          <span class="sp-member-avatar" style="background:{{ u.avatar_color }}">{{ u.name | initials }}</span>
+          <div class="sp-member-name">{{ u.name }}</div>
+          <div></div>
+        </div>
+        {% endfor %}
+      </div>
+    </section>
+  </aside>
+</div>
+{% endblock %}

--- a/deploy/sim_envs/mantis_shopify/app/templates/store_new.html
+++ b/deploy/sim_envs/mantis_shopify/app/templates/store_new.html
@@ -1,0 +1,36 @@
+{% extends "base.html" %}
+{% block title %}Add store — Shopify Partners{% endblock %}
+{% block content %}
+<header class="sp-page-header">
+  <h1 class="sp-page-h1">Add store</h1>
+</header>
+
+<section class="sp-card">
+  <div class="sp-card-body">
+    <form method="post" action="/stores/new" data-testid="store-new-form">
+      <div class="sp-form-row">
+        <div class="sp-form-group">
+          <label for="name">Store name</label>
+          <input type="text" id="name" name="name" placeholder="Sample Store" required data-testid="store-new-name"/>
+        </div>
+        <div class="sp-form-group">
+          <label for="slug">Subdomain (optional)</label>
+          <input type="text" id="slug" name="slug" placeholder="sample-store" data-testid="store-new-slug"/>
+        </div>
+      </div>
+      <div class="sp-form-group">
+        <label for="kind">Store type</label>
+        <select id="kind" name="kind" class="sp-select" data-testid="store-new-kind">
+          <option value="client_transfer">Client transfer (new store)</option>
+          <option value="collaborator">Collaborator access</option>
+          <option value="active_development">Active development store</option>
+        </select>
+      </div>
+      <div class="sp-form-actions">
+        <a class="sp-btn" href="/stores">Cancel</a>
+        <button class="sp-btn sp-btn-primary" type="submit" data-testid="store-new-submit">Add store</button>
+      </div>
+    </form>
+  </div>
+</section>
+{% endblock %}

--- a/deploy/sim_envs/mantis_shopify/app/templates/stores.html
+++ b/deploy/sim_envs/mantis_shopify/app/templates/stores.html
@@ -1,0 +1,107 @@
+{% extends "base.html" %}
+{% block title %}Stores — Shopify Partners{% endblock %}
+
+{% block content %}
+<header class="sp-page-header">
+  <h1 class="sp-page-h1">Stores</h1>
+  <div class="sp-page-actions">
+    <details class="sp-dropdown">
+      <summary class="sp-btn sp-btn-icon-after" data-testid="stores-more-actions">More actions</summary>
+      <div class="sp-dropdown-menu" role="menu">
+        <a href="#export" class="sp-dropdown-item" data-testid="stores-menu-export">Export stores</a>
+        <a href="#bulk-archive" class="sp-dropdown-item" data-testid="stores-menu-bulk-archive">Bulk archive</a>
+        <a href="#bulk-transfer" class="sp-dropdown-item" data-testid="stores-menu-bulk-transfer">Bulk transfer</a>
+      </div>
+    </details>
+    <details class="sp-dropdown">
+      <summary class="sp-btn sp-btn-primary sp-btn-icon-after" data-testid="stores-add-store">Add store</summary>
+      <div class="sp-dropdown-menu" role="menu">
+        <a href="/stores/new?kind=client_transfer" class="sp-dropdown-item" data-testid="stores-add-menu-client">Create a development store</a>
+        <a href="/stores/new?kind=collaborator" class="sp-dropdown-item" data-testid="stores-add-menu-collab">Request collaborator access</a>
+        <a href="/stores/new?kind=active_development" class="sp-dropdown-item" data-testid="stores-add-menu-active">Add a Managed Markets store</a>
+      </div>
+    </details>
+  </div>
+</header>
+
+<section class="sp-card">
+  <div class="sp-tabs" data-testid="stores-tabs">
+    {% for tab_id, label in [
+      ('all', 'All'),
+      ('client_transfer', 'Client transfer'),
+      ('collaborator', 'Collaborator access'),
+      ('archived', 'Archived'),
+      ('inactive', 'Inactive'),
+    ] %}
+      <a class="sp-tab{% if current_tab == tab_id %} is-active{% endif %}"
+         href="/stores?tab={{ tab_id }}"
+         data-testid="stores-tab-{{ tab_id }}">{{ label }}</a>
+    {% endfor %}
+  </div>
+
+  <form class="sp-filterrow" method="get" action="/stores" data-testid="stores-filter-form">
+    <input type="hidden" name="tab" value="{{ current_tab }}" />
+    <input type="search" name="q" value="{{ q }}" placeholder="Filter stores"
+           data-testid="stores-search" onchange="this.form.submit()"/>
+    <select class="sp-select" name="status" data-testid="stores-status-filter"
+            onchange="this.form.submit()">
+      <option value="">Store status</option>
+      <option value="Plus" {% if status_filter == 'Plus' %}selected{% endif %}>Plus</option>
+      <option value="Grow" {% if status_filter == 'Grow' %}selected{% endif %}>Grow</option>
+      <option value="Basic" {% if status_filter == 'Basic' %}selected{% endif %}>Basic</option>
+      <option value="Custom" {% if status_filter == 'Custom' %}selected{% endif %}>Custom</option>
+      <option value="Partner Test" {% if status_filter == 'Partner Test' %}selected{% endif %}>Partner Test</option>
+    </select>
+  </form>
+
+  <div class="sp-summary-row">
+    <span>Showing {{ n }} store{{ '' if n == 1 else 's' }}</span>
+    <select class="sp-select" name="sort" onchange="window.location='/stores?tab={{ current_tab }}&sort='+this.value">
+      <option value="last_login" {% if sort == 'last_login' %}selected{% endif %}>Sort by Last login</option>
+      <option value="name" {% if sort == 'name' %}selected{% endif %}>Sort by Name</option>
+    </select>
+  </div>
+
+  <ul class="sp-list" data-testid="stores-list">
+    {% for s in rows %}
+    <li class="sp-list-row" data-testid="stores-row">
+      <div>
+        <a class="sp-list-row-name" href="/stores/{{ s.id }}"
+           style="color:var(--c-text);text-decoration:none" data-testid="stores-name-link">{{ s.name }}</a>
+        <div class="sp-list-row-sub">{{ s.slug }}.myshopify.com</div>
+      </div>
+      <div>
+        <span class="sp-pill">
+          {% if s.kind == 'client_transfer' %}Client transfer
+          {% elif s.kind == 'collaborator' %}Collaborator access
+          {% else %}Active development store{% endif %}
+        </span>
+      </div>
+      <div class="sp-list-row-actions">
+        <details class="sp-dropdown" data-testid="stores-actions-dd">
+          <summary class="sp-link-quiet sp-dropdown-summary"
+                   data-testid="stores-actions">Actions ▾</summary>
+          <div class="sp-dropdown-menu" role="menu">
+            <a href="/stores/{{ s.id }}" class="sp-dropdown-item" data-testid="stores-menu-view">View store details</a>
+            <a href="/stores/{{ s.id }}#edit" class="sp-dropdown-item" data-testid="stores-menu-edit">Edit info</a>
+            <a href="#transfer" class="sp-dropdown-item" data-testid="stores-menu-transfer">Transfer ownership</a>
+            <form method="post" action="/stores/{{ s.id }}/archive" style="margin:0">
+              <button type="submit" class="sp-dropdown-item sp-dropdown-item-danger"
+                      data-testid="stores-menu-archive">Archive store</button>
+            </form>
+          </div>
+        </details>
+        <form method="post" action="/stores/{{ s.id }}/login" style="display:inline">
+          <button class="sp-link-quiet"
+                  style="background:none;border:0;cursor:pointer;color:var(--c-link);font-size:13px"
+                  data-testid="stores-login">Log in</button>
+        </form>
+      </div>
+    </li>
+    {% endfor %}
+    {% if not rows %}
+    <li class="sp-list-row"><div class="sp-text-sub">No stores match the current filters.</div><div></div><div></div></li>
+    {% endif %}
+  </ul>
+</section>
+{% endblock %}

--- a/deploy/sim_envs/mantis_shopify/app/templates/support.html
+++ b/deploy/sim_envs/mantis_shopify/app/templates/support.html
@@ -1,0 +1,19 @@
+{% extends "base.html" %}
+{% block title %}Support — Shopify Partners{% endblock %}
+{% block content %}
+<header class="sp-page-header"><h1 class="sp-page-h1">Support</h1></header>
+
+<div style="display:grid;grid-template-columns:2fr 1fr;gap:24px">
+  <section class="sp-card" data-testid="support-forum-card">
+    <div class="sp-card-body">
+      <h3 style="margin:0 0 8px 0">Visit the community forum</h3>
+      <p>The developer community forum serves as a valuable resource for addressing frequently asked questions and offers access to a wide array of experts who can provide assistance.</p>
+      <a class="sp-btn sp-btn-primary" href="#" data-testid="support-visit-forum">Visit the forum</a>
+    </div>
+  </section>
+  <aside>
+    <h3 style="margin:0 0 8px 0;font-size:14px">Partner support</h3>
+    <p class="sp-text-sub">If you have questions pertaining to your Partner account, Payouts or you require additional help and would like to speak with a support agent, please contact <a href="/support/contact" data-testid="support-contact-link">Partner Support</a>.</p>
+  </aside>
+</div>
+{% endblock %}

--- a/deploy/sim_envs/mantis_shopify/app/templates/support_confirm.html
+++ b/deploy/sim_envs/mantis_shopify/app/templates/support_confirm.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+{% block title %}Ticket submitted — Shopify Partners{% endblock %}
+{% block content %}
+<header class="sp-page-header"><h1 class="sp-page-h1">Thanks — ticket submitted</h1></header>
+<section class="sp-card">
+  <div class="sp-card-body">
+    <p data-testid="support-confirm-id">Your ticket <strong>{{ ticket_id }}</strong> is in the queue. Expect an update within one business day.</p>
+    <a class="sp-btn" href="/support">Back to Support</a>
+  </div>
+</section>
+{% endblock %}

--- a/deploy/sim_envs/mantis_shopify/app/templates/support_contact.html
+++ b/deploy/sim_envs/mantis_shopify/app/templates/support_contact.html
@@ -1,0 +1,32 @@
+{% extends "base.html" %}
+{% block title %}Contact Partner Support — Shopify Partners{% endblock %}
+{% block content %}
+<header class="sp-page-header"><h1 class="sp-page-h1">Contact Partner Support</h1></header>
+
+<section class="sp-card">
+  <div class="sp-card-body">
+    <form method="post" action="/support/contact" data-testid="support-form">
+      <div class="sp-form-group">
+        <label>Subject</label>
+        <input type="text" name="subject" required data-testid="support-subject"/>
+      </div>
+      <div class="sp-form-group">
+        <label>Category</label>
+        <select name="category" class="sp-select" data-testid="support-category">
+          {% for c in categories %}
+          <option value="{{ c }}">{{ c }}</option>
+          {% endfor %}
+        </select>
+      </div>
+      <div class="sp-form-group">
+        <label>Description</label>
+        <textarea name="description" rows="6" required data-testid="support-description"></textarea>
+      </div>
+      <div class="sp-form-actions">
+        <a class="sp-btn" href="/support">Cancel</a>
+        <button class="sp-btn sp-btn-primary" type="submit" data-testid="support-submit">Submit ticket</button>
+      </div>
+    </form>
+  </div>
+</section>
+{% endblock %}

--- a/deploy/sim_envs/mantis_shopify/app/templates/team.html
+++ b/deploy/sim_envs/mantis_shopify/app/templates/team.html
@@ -1,0 +1,58 @@
+{% extends "base.html" %}
+{% block title %}Team — Shopify Partners{% endblock %}
+
+{% block content %}
+{% include "_banner.html" %}
+
+<header class="sp-page-header">
+  <h1 class="sp-page-h1">Team</h1>
+</header>
+
+<section class="sp-section" data-testid="team-owners">
+  <div>
+    <h2>Owners</h2>
+    <p class="sp-section-desc">Owners have permission to see and do everything. They can also add and remove other owners.</p>
+  </div>
+  <div class="sp-roster">
+    <div class="sp-roster-tabs">
+      <span class="sp-roster-tab is-active">Active</span>
+      <span class="sp-roster-tab">Invited</span>
+    </div>
+    {% for u in owners %}
+    <div class="sp-member-row" data-testid="owner-row">
+      <span class="sp-member-avatar" style="background:{{ u.avatar_color }}">{{ u.name | initials }}</span>
+      <div class="sp-member-name"><a href="#">{{ u.name }}</a></div>
+      <div class="sp-member-meta">Last login {{ humanize_last_login(u.last_login_at, now) }}</div>
+    </div>
+    {% endfor %}
+    <div class="sp-card-footer"><a class="sp-btn" href="/team/invite?role=owner" data-testid="invite-owner">Invite owner</a><span></span></div>
+  </div>
+</section>
+
+<section class="sp-section" data-testid="team-staff">
+  <div>
+    <h2>Staff members</h2>
+    <p class="sp-section-desc">Staff members can only see or manage sensitive business information such as financial data if you give them access.</p>
+  </div>
+  <div class="sp-roster">
+    <div class="sp-roster-tabs">
+      <span class="sp-roster-tab {% if tab == 'active' %}is-active{% endif %}">Active</span>
+      <span class="sp-roster-tab {% if tab == 'invited' %}is-active{% endif %}">Invited</span>
+    </div>
+    {% set rows = staff_invited if tab == 'invited' else staff_active %}
+    {% for u in rows %}
+    <div class="sp-member-row" data-testid="staff-row">
+      <span class="sp-member-avatar" style="background:{{ u.avatar_color }}">{{ u.name | initials }}</span>
+      <div class="sp-member-name"><a href="#">{{ u.name }}</a></div>
+      <div class="sp-member-meta">
+        {% if tab == 'invited' %}Invited{% else %}Last login {{ humanize_last_login(u.last_login_at, now) }}{% endif %}
+      </div>
+    </div>
+    {% endfor %}
+    <div class="sp-card-footer">
+      <a class="sp-btn" href="/team/invite" data-testid="invite-staff">Invite staff</a>
+      <a class="sp-link-quiet" href="/team?tab={{ 'active' if tab == 'invited' else 'invited' }}">View {{ 'active' if tab == 'invited' else 'invited' }} →</a>
+    </div>
+  </div>
+</section>
+{% endblock %}

--- a/deploy/sim_envs/mantis_shopify/app/templates/team_invite.html
+++ b/deploy/sim_envs/mantis_shopify/app/templates/team_invite.html
@@ -1,0 +1,37 @@
+{% extends "base.html" %}
+{% block title %}Invite team member — Shopify Partners{% endblock %}
+{% block content %}
+<header class="sp-page-header"><h1 class="sp-page-h1">Invite team member</h1></header>
+
+<section class="sp-card">
+  <div class="sp-card-body">
+    <form method="post" action="/team/invite" data-testid="team-invite-form">
+      <div class="sp-form-row">
+        <div class="sp-form-group">
+          <label for="name">Name</label>
+          <input type="text" id="name" name="name" data-testid="team-invite-name"/>
+        </div>
+        <div class="sp-form-group">
+          <label for="email">Email</label>
+          <input type="email" id="email" name="email" required data-testid="team-invite-email"/>
+        </div>
+      </div>
+      <div class="sp-form-group">
+        <label for="role">Role</label>
+        <select id="role" name="role" class="sp-select" data-testid="team-invite-role">
+          <option value="owner" {% if role_default == 'owner' %}selected{% endif %}>Owner</option>
+          <option value="staff_business" {% if role_default == 'staff_business' %}selected{% endif %}>Staff — Business</option>
+          <option value="staff_dev" {% if role_default == 'staff_dev' %}selected{% endif %}>Staff — Developer</option>
+          <option value="staff_marketing" {% if role_default == 'staff_marketing' %}selected{% endif %}>Staff — Marketing</option>
+          <option value="staff_support" {% if role_default == 'staff_support' %}selected{% endif %}>Staff — Support</option>
+          <option value="staff_finance" {% if role_default == 'staff_finance' %}selected{% endif %}>Staff — Finance</option>
+        </select>
+      </div>
+      <div class="sp-form-actions">
+        <a class="sp-btn" href="/team">Cancel</a>
+        <button type="submit" class="sp-btn sp-btn-primary" data-testid="team-invite-submit">Send invitation</button>
+      </div>
+    </form>
+  </div>
+</section>
+{% endblock %}

--- a/deploy/sim_envs/mantis_shopify/app/templates/theme_new.html
+++ b/deploy/sim_envs/mantis_shopify/app/templates/theme_new.html
@@ -1,0 +1,20 @@
+{% extends "base.html" %}
+{% block title %}Submit a theme — Shopify Partners{% endblock %}
+{% block content %}
+<header class="sp-page-header"><h1 class="sp-page-h1">Submit a theme</h1></header>
+
+<section class="sp-card">
+  <div class="sp-card-body">
+    <form method="post" action="/themes/new" data-testid="theme-new-form">
+      <div class="sp-form-group">
+        <label>Theme name</label>
+        <input type="text" name="name" required data-testid="theme-new-name"/>
+      </div>
+      <div class="sp-form-actions">
+        <a class="sp-btn" href="/themes">Cancel</a>
+        <button class="sp-btn sp-btn-primary" type="submit" data-testid="theme-new-submit">Submit for review</button>
+      </div>
+    </form>
+  </div>
+</section>
+{% endblock %}

--- a/deploy/sim_envs/mantis_shopify/app/templates/themes.html
+++ b/deploy/sim_envs/mantis_shopify/app/templates/themes.html
@@ -1,0 +1,70 @@
+{% extends "base.html" %}
+{% block title %}Themes — Shopify Partners{% endblock %}
+
+{% block content %}
+<header class="sp-page-header">
+  <h1 class="sp-page-h1">Build themes for the Shopify Theme Store</h1>
+  <div class="sp-page-actions">
+    <a class="sp-btn sp-btn-primary" href="/themes/new" data-testid="themes-submit-cta">Submit a theme</a>
+  </div>
+</header>
+<p class="sp-page-subtitle">Help power millions of merchant businesses by developing themes that drive conversions and build brands.</p>
+
+<section class="sp-card" data-testid="themes-card-1">
+  <div class="sp-card-body">
+    <div class="sp-row" style="gap:24px">
+      <div style="flex:1">
+        <h3 style="margin:0 0 8px 0">Build and sell your theme on the leading commerce platform</h3>
+        <ul class="sp-pl-bullet">
+          <li>Develop powerful themes for a specific commerce niche — from food to fashion</li>
+          <li>Streamline your workflow with the new Online Store and tooling, like the Shopify Github integration</li>
+          <li>Showcase your theme to a built-in market with millions of merchants on the <a href="#">Shopify Theme Store ↗</a></li>
+        </ul>
+      </div>
+      <div class="sp-hero-art" style="flex:0 0 240px;min-height:140px">
+        <div style="position:absolute;left:24px;top:24px;font-size:18px;font-weight:600">Theme Store</div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="sp-card" data-testid="themes-card-2">
+  <div class="sp-card-body">
+    <h3 style="margin:0 0 12px 0">Move fast with smart tooling</h3>
+    <div style="display:grid;grid-template-columns:1fr 1fr 1fr;gap:20px">
+      <div><a href="#" data-testid="themes-link-tooling">Explore developer tooling ↗</a>
+        <p style="margin:4px 0 0;color:var(--c-text-sub);font-size:13px">Optimize themes and avoid bugs with the unified theme development tools.</p></div>
+      <div><a href="#" data-testid="themes-link-cli">Download Shopify CLI ↗</a>
+        <p style="margin:4px 0 0;color:var(--c-text-sub);font-size:13px">Hot reload CSS and section changes, populate test data, and more.</p></div>
+      <div><a href="#" data-testid="themes-link-skeleton">Get started with our Skeleton theme ↗</a>
+        <p style="margin:4px 0 0;color:var(--c-text-sub);font-size:13px">A modern, minimal starting point for a new theme.</p></div>
+    </div>
+  </div>
+</section>
+
+<section class="sp-card" data-testid="themes-card-3">
+  <div class="sp-card-body">
+    <h3 style="margin:0 0 8px 0">Submit your theme for review</h3>
+    <p class="sp-text-sub">When your theme is ready for the Theme Store, submit it from here.</p>
+    <a class="sp-btn sp-btn-primary" href="/themes/new" data-testid="themes-card-submit-cta">Submit a theme</a>
+  </div>
+</section>
+
+{% if rows %}
+<section class="sp-card" data-testid="themes-history">
+  <header class="sp-card-header"><h2>Your themes</h2></header>
+  <table class="sp-data-table">
+    <thead><tr><th>Theme</th><th>Status</th><th>Submitted</th></tr></thead>
+    <tbody>
+      {% for t in rows %}
+      <tr data-testid="theme-row">
+        <td>{{ t.name }}</td>
+        <td><span class="sp-pill {% if t.status == 'approved' %}sp-pill-green{% endif %}">{{ t.status | replace('_', ' ') }}</span></td>
+        <td>{{ t.created_at | short_date }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</section>
+{% endif %}
+{% endblock %}

--- a/deploy/sim_envs/mantis_shopify/requirements.txt
+++ b/deploy/sim_envs/mantis_shopify/requirements.txt
@@ -1,0 +1,6 @@
+fastapi>=0.110
+uvicorn>=0.27
+jinja2>=3.1
+python-multipart>=0.0.9
+starlette>=0.27,<1.0
+itsdangerous>=2.1

--- a/deploy/sim_envs/mantis_shopify/scripts/oracle_smoke.py
+++ b/deploy/sim_envs/mantis_shopify/scripts/oracle_smoke.py
@@ -1,0 +1,138 @@
+"""Local oracle smoke — drive the env via TestClient, hit happy-path for
+each task, then call /__env__/oracle?task_id=tNN and assert each PASSes.
+
+Run: ENV_ADMIN_TOKEN=test python scripts/oracle_smoke.py
+"""
+
+from __future__ import annotations
+
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from fastapi.testclient import TestClient
+
+from app.main import create_app
+
+ADMIN = {"X-Env-Admin": os.environ.get("ENV_ADMIN_TOKEN", "test")}
+
+
+def run() -> int:
+    app = create_app()
+    failures: list[str] = []
+    with TestClient(app) as c:
+        # Reset to baseline.
+        c.post("/__env__/reset", headers=ADMIN)
+
+        # ── t01: submit Plus lead ──
+        c.post("/sales/leads/new", data={
+            "product": "plus",
+            "merchant_name": "Acme Outerwear",
+            "contact_email": "owner@acmeouterwear.example",
+            "contact_name": "Acme Owner",
+            "notes": "",
+        }, follow_redirects=False)
+
+        # ── t02: invite staff ──
+        c.post("/team/invite", data={
+            "name": "Marlowe Iverson",
+            "email": "marlowe@example.com",
+            "role": "staff_dev",
+        }, follow_redirects=False)
+
+        # ── t03: export payouts CSV ──
+        c.get("/payouts/export")
+
+        # ── t04: support ticket ──
+        c.post("/support/contact", data={
+            "subject": "Cannot access second-factor code",
+            "category": "Account access",
+            "description": "Lost my phone, need help recovering 2FA on the partner account.",
+        }, follow_redirects=False)
+
+        # ── t05: update business_email ──
+        c.post("/settings/business", data={
+            "business_name": "Mason Partners",
+            "website": "https://mason.example",
+            "business_email": "new-finance@mason.example",
+            "support_email": "support@mason.example",
+            "phone": "+1 415 555 0142",
+            "address1": "1101 Mission Street",
+            "address2": "Suite 400",
+            "city": "San Francisco",
+            "zip": "94103",
+            "state": "California",
+            "country": "United States",
+        }, follow_redirects=False)
+
+        # ── t06: open a payout detail page ──
+        sent = c.get("/__env__/state", headers=ADMIN).json()["counts"]
+        assert sent["payouts"] > 1, "seed should have multiple payouts"
+        # Pick the first paid payout id.
+        c.get("/payouts/payout_00001")
+
+        # ── t07: dismiss emergency banner ──
+        c.post("/team/banner/dismiss", follow_redirects=False)
+
+        # ── t08: directory review ──
+        c.post("/partner_directory/dirlst_00001/request_review",
+               follow_redirects=False)
+
+        # ── t09: search stores ──
+        c.get("/stores?tab=all&q=demo&status=")
+
+        # ── t10: submit POS lead ──
+        c.post("/sales/leads/new", data={
+            "product": "pos",
+            "merchant_name": "Brassbird Books",
+            "contact_email": "owner@brassbird.example",
+            "contact_name": "Brass Owner",
+            "notes": "Their in-store flow needs POS Pro.",
+        }, follow_redirects=False)
+
+        # ── t11: open a store detail page ──
+        c.get("/stores/store_00001")
+
+        # ── t12: open a catalog detail page ──
+        c.get("/catalogs/catalog_00001")
+
+        # ── t13: open a merchant order detail from store admin ──
+        # Pick the first order for store_00001 from the seed
+        admin_orders = c.get("/store/store_00001/admin/orders?tab=all")
+        # First merchant order id in the page text
+        import re as _re
+        m = _re.search(r'href="(/store/store_00001/admin/orders/(mo_\d+))"',
+                       admin_orders.text)
+        if m:
+            order_url, order_id = m.group(1), m.group(2)
+            c.get(order_url)
+            # ── t14: fulfill that order ──
+            c.post(f"/store/store_00001/admin/orders/{order_id}/fulfill",
+                   follow_redirects=False)
+
+        # Now grade every oracle.
+        for tid in ["t01", "t02", "t03", "t04", "t05",
+                    "t06", "t07", "t08", "t09", "t10",
+                    "t11", "t12", "t13", "t14"]:
+            r = c.get(f"/__env__/oracle?task_id={tid}", headers=ADMIN)
+            data = r.json()
+            ok = "PASS" if data["passed"] else "FAIL"
+            print(f"{ok}  {tid}  {data['reasons'][:1]}")
+            if not data["passed"]:
+                failures.append(tid)
+
+        # Negative test — unknown oracle
+        r = c.get("/__env__/oracle?task_id=t99", headers=ADMIN)
+        assert not r.json()["passed"], "unknown oracle must fail"
+        print("PASS  t99 (negative)")
+
+    if failures:
+        print(f"\n{len(failures)} oracle(s) FAILED: {failures}")
+        return 1
+    print("\nAll oracles PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(run())


### PR DESCRIPTION
## Summary

- **mantis_shopify (new):** Shopify Partners post-login mirror — 18 routes, 14 oracles (t01..t14), seeded SQLite fixture, Dockerfile, daytona deploy helper. Mirrors every Partners section except Apps. Follows the standard `/__env__/{health,reset,seed,oracle,events,mutations}` contract.
- **fiverr / indeed / linkedin / mercor:** layered `polish.css` + `polish.js` overlays + post-login topnav fidelity fixes so the four existing sim envs reach ≥95% alignment with their real-site post-login views.
  - Indeed gains `auth.effective_user()` + middleware seam so the signed-in topnav (messages, notifications, avatar chip) renders on post-login routes when `ENV_REQUIRE_AUTH=0`; small `md` Jinja filter added.
  - Mercor middleware also exposes `effective_user`; base topbar falls back to it so post-login pages show Dashboard / Profile / avatar / Sign-out instead of Sign-in / Sign-up.
  - LinkedIn feed comment composer now matches the real one (avatar + emoji/photo/GIF action row, per-comment submit-enable on input).
  - Fiverr wires the polish overlays onto `base.html`.

## Test plan

- [ ] `mantis-shopify` sim env: oracle smoke (`python scripts/oracle_smoke.py`) reports 10/10 PASS on a clean seed
- [ ] `/__env__/health` returns OK from a fresh container for shopify + the four polished envs
- [ ] Indeed `/myjobs` (logged-out, `ENV_REQUIRE_AUTH=0`): topnav shows messages + notifications icons + avatar chip, no Sign-in / Sign-up
- [ ] Mercor `/dashboard` and `/profile` (logged-out, `ENV_REQUIRE_AUTH=0`): topbar shows Dashboard / Profile / avatar (`ARS`) / Sign-out
- [ ] LinkedIn `/feed`: clicking Comment opens composer with avatar + emoji/photo/GIF action row; submit disabled until input non-empty
- [ ] Fiverr `/`: polish.css/.js load (200 in network tab)

🤖 Generated with [Claude Code](https://claude.com/claude-code)