### PR TITLE
fix(api): cross-replica run-state + terminal-sticky cancel guard (#866)

### DIFF
--- a/deploy/modal/modal_cua_server.py
+++ b/deploy/modal/modal_cua_server.py
@@ -28,6 +28,15 @@ import time
 
 import modal
 
+from mantis_agent.run_state_store import (
+    KIND_AUGUR,
+    KIND_PAUSE_REQUEST,
+    KIND_STATUS,
+    KIND_VIEWER,
+    NullRunStateStore,
+    RunStateStore,
+    read_with_store,
+)
 from mantis_agent.server_utils import (
     build_micro_result,
     build_micro_suite,
@@ -2081,16 +2090,9 @@ def _commit_volume() -> None:
 #
 # Off-Modal contexts (unit tests, local dev) get a ``NullRunStateStore``
 # by default; tests override via ``build_api_app(run_state_store=...)``
-# with a plain-dict-backed store.
-from mantis_agent.run_state_store import (
-    KIND_AUGUR,
-    KIND_PAUSE_REQUEST,
-    KIND_STATUS,
-    KIND_VIEWER,
-    NullRunStateStore,
-    RunStateStore,
-    read_with_store,
-)
+# with a plain-dict-backed store. The ``run_state_store`` module is
+# imported at the top of the file alongside the other ``mantis_agent``
+# imports so ruff doesn't trip on the inline-import pattern.
 
 # First-terminal-wins. Once a run reaches any of these, subsequent
 # writes that would change the status field are rejected so a late

--- a/deploy/modal/modal_cua_server.py
+++ b/deploy/modal/modal_cua_server.py
@@ -2117,11 +2117,23 @@ def _get_run_state_store() -> object:
     a single ``modal.Dict``-backed store on first use; failures fall
     back to the no-op store so a control-plane hiccup never breaks
     a request.
+
+    Outside a Modal container (CI, local dev, unit tests that didn't
+    inject a store) we explicitly skip the ``modal.Dict`` construction
+    — ``modal.Dict.from_name`` blocks waiting for control-plane auth
+    when there are no credentials, which manifested as a CI hang on
+    the test_modal_endpoint fixture (PR #845). Gating on
+    ``MODAL_TASK_ID`` keeps the production path unchanged while making
+    the off-Modal path fail fast.
     """
     global _RUN_STATE_STORE, _RUN_STATE_STORE_INIT
     if _RUN_STATE_STORE_INIT:
         return _RUN_STATE_STORE
     _RUN_STATE_STORE_INIT = True
+    inside_modal = bool(os.environ.get("MODAL_TASK_ID"))
+    if not inside_modal:
+        _RUN_STATE_STORE = NullRunStateStore()
+        return _RUN_STATE_STORE
     try:
         _RUN_STATE_STORE = RunStateStore.from_name(
             "mantis-cua-run-state", create_if_missing=True,

--- a/deploy/modal/modal_cua_server.py
+++ b/deploy/modal/modal_cua_server.py
@@ -2070,71 +2070,130 @@ def _commit_volume() -> None:
         pass
 
 
-# In-memory recent-runs cache. Modal Volume commit + reload has a small
-# eventual-consistency window: an immediate poll right after submit
-# could land on a container whose volume mount hasn't yet seen the
-# status.json we just wrote, returning a misleading 404 / "unknown
-# run_id". This cache backstops that window — when the same container
-# that wrote a status reads it back, the cache is authoritative.
+# Cross-replica run-state cache (#866). Modal Volume commit + reload has
+# a small eventual-consistency window: a poll that lands on a different
+# replica than the writer can read stale data or 404 a freshly-minted
+# run. The legacy in-memory cache (``_RECENT_RUNS``) only helped when
+# the same container that wrote a status read it back. The shared
+# store lifts that to a ``modal.Dict`` so every replica sees writes
+# immediately — disk stays as the durable backing store (queue scans
+# and the lifecycle phase route still read files directly).
 #
-# Bounded LRU-style: at 1024 entries we drop the oldest. The cache is
-# also cleared lazily when a status flips to a terminal phase (no point
-# caching a finished run that the client will fetch via /result).
-_RECENT_RUNS: dict[str, dict] = {}
-_RECENT_RUNS_MAX = 1024
+# Off-Modal contexts (unit tests, local dev) get a ``NullRunStateStore``
+# by default; tests override via ``build_api_app(run_state_store=...)``
+# with a plain-dict-backed store.
+from mantis_agent.run_state_store import (
+    KIND_AUGUR,
+    KIND_PAUSE_REQUEST,
+    KIND_STATUS,
+    KIND_VIEWER,
+    NullRunStateStore,
+    RunStateStore,
+    read_with_store,
+)
+
+# First-terminal-wins. Once a run reaches any of these, subsequent
+# writes that would change the status field are rejected so a late
+# executor terminal-write cannot clobber an API-side cancel (#866).
 _TERMINAL_STATUSES = frozenset({
     "succeeded", "failed", "cancelled", "completed_with_failures",
     "timeout", "halted",
 })
 
+# Module-level default. Initialized lazily so module import doesn't
+# touch the Modal control plane (unit tests import this file without
+# being inside a Modal app context).
+_RUN_STATE_STORE: object = NullRunStateStore()
+_RUN_STATE_STORE_INIT = False
 
-def _cache_status(tenant_id: str, run_id: str, status: dict) -> None:
-    """Stash ``status`` in the in-memory cache keyed by (tenant, run)."""
-    key = f"{tenant_id}::{run_id}"
-    _RECENT_RUNS[key] = dict(status)
-    if len(_RECENT_RUNS) > _RECENT_RUNS_MAX:
-        # Drop the oldest ~25% so we don't trim on every write.
-        drop = max(1, _RECENT_RUNS_MAX // 4)
-        for k in list(_RECENT_RUNS.keys())[:drop]:
-            _RECENT_RUNS.pop(k, None)
+
+def _get_run_state_store() -> object:
+    """Return the active run-state store, building the default lazily.
+
+    Tests inject via ``build_api_app(run_state_store=...)`` and bypass
+    this path entirely. Inside a deployed Modal container this builds
+    a single ``modal.Dict``-backed store on first use; failures fall
+    back to the no-op store so a control-plane hiccup never breaks
+    a request.
+    """
+    global _RUN_STATE_STORE, _RUN_STATE_STORE_INIT
+    if _RUN_STATE_STORE_INIT:
+        return _RUN_STATE_STORE
+    _RUN_STATE_STORE_INIT = True
+    try:
+        _RUN_STATE_STORE = RunStateStore.from_name(
+            "mantis-cua-run-state", create_if_missing=True,
+        )
+    except Exception as exc:  # noqa: BLE001 — falls back to disk-only
+        print(f"WARNING: run-state store init failed, using disk-only: {exc}")
+        _RUN_STATE_STORE = NullRunStateStore()
+    return _RUN_STATE_STORE
+
+
+def _read_status_disk(tenant_id: str, run_id: str) -> dict | None:
+    """Disk-only status read. Used as the fallback when the cross-replica
+    store misses (or as the primary in tests with the null store)."""
+    path = _run_dir(tenant_id, run_id) / "status.json"
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text())
+    except Exception:
+        return None
 
 
 def _write_status(tenant_id: str, run_id: str, status: dict) -> None:
+    """Persist ``status``. First-terminal-wins guard (#866).
+
+    If the current on-record status is terminal AND the incoming
+    write would change the status field, the write is rejected (logged
+    at WARNING). This keeps a cancel sticky against late executor
+    terminal writes from a different container.
+    """
     run_dir = _run_dir(tenant_id, run_id)
     run_dir.mkdir(parents=True, exist_ok=True)
+
+    store = _get_run_state_store()
+    existing = read_with_store(
+        store,
+        tenant_id=tenant_id, run_id=run_id, kind=KIND_STATUS,
+        disk_reader=lambda: _read_status_disk(tenant_id, run_id),
+    )
+    if existing is not None:
+        cur = str(existing.get("status", "")).lower()
+        new = str(status.get("status", "")).lower()
+        if cur in _TERMINAL_STATUSES and new != cur:
+            print(
+                f"WARNING: refusing to overwrite terminal status "
+                f"tenant={tenant_id} run={run_id} cur={cur!r} new={new!r}"
+            )
+            return
+
     (run_dir / "status.json").write_text(json.dumps(status, indent=2))
-    _cache_status(tenant_id, run_id, status)
+    try:
+        store.put(tenant_id, run_id, KIND_STATUS, status)  # type: ignore[attr-defined]
+    except Exception:  # noqa: BLE001 — cache write is best-effort
+        pass
     _commit_volume()
 
 
 def _read_status(tenant_id: str, run_id: str) -> dict | None:
     """Return the run's status dict.
 
-    Reads the in-memory cache first (covers the volume-commit
-    eventual-consistency window), then falls back to the file-backed
-    status.json. When the file read returns a newer status than the
-    cache (executor wrote it from a different container), the cache
-    is refreshed so subsequent calls see the latest.
+    Reads the cross-replica store first (immediate visibility across
+    container replicas), then falls back to the file-backed
+    status.json on disk. When disk has a newer updated_at than the
+    cache, the cache is refreshed so subsequent calls see the latest.
     """
-    key = f"{tenant_id}::{run_id}"
-    cached = _RECENT_RUNS.get(key)
-    path = _run_dir(tenant_id, run_id) / "status.json"
-    on_disk: dict | None = None
-    if path.exists():
-        try:
-            on_disk = json.loads(path.read_text())
-        except Exception:
-            on_disk = None
-    # Prefer the on-disk view when it exists AND its updated_at is
-    # newer than the cached view — that's the executor having
-    # progressed the run from a different container.
+    store = _get_run_state_store()
+    cached = store.get(tenant_id, run_id, KIND_STATUS)  # type: ignore[attr-defined]
+    on_disk = _read_status_disk(tenant_id, run_id)
     if on_disk is not None:
         if cached is None or str(on_disk.get("updated_at", "")) >= str(cached.get("updated_at", "")):
-            _cache_status(tenant_id, run_id, on_disk)
-            # Evict from cache once terminal — no need to keep
-            # finished runs around.
-            if str(on_disk.get("status", "")).lower() in _TERMINAL_STATUSES:
-                _RECENT_RUNS.pop(key, None)
+            try:
+                store.put(tenant_id, run_id, KIND_STATUS, on_disk)  # type: ignore[attr-defined]
+            except Exception:  # noqa: BLE001
+                pass
             return on_disk
     return cached
 
@@ -2143,22 +2202,43 @@ def _write_viewer_url(tenant_id: str, run_id: str, viewer_url: str) -> None:
     """Persist the live-viewer URL in a side-channel file (#416).
 
     Kept separate from ``status.json`` so the executor never has to
-    read-merge-write a file the API container also owns.
+    read-merge-write a file the API container also owns. Mirrored
+    into the cross-replica store (#866) so a status poll on a
+    different container sees the viewer URL without waiting for the
+    volume reload window.
     """
     run_dir = _run_dir(tenant_id, run_id)
     run_dir.mkdir(parents=True, exist_ok=True)
-    (run_dir / "viewer.json").write_text(json.dumps({"viewer_url": viewer_url}))
+    blob = {"viewer_url": viewer_url}
+    (run_dir / "viewer.json").write_text(json.dumps(blob))
+    try:
+        _get_run_state_store().put(  # type: ignore[attr-defined]
+            tenant_id, run_id, KIND_VIEWER, blob,
+        )
+    except Exception:  # noqa: BLE001 — cache write is best-effort
+        pass
     _commit_volume()
 
 
-def _read_viewer_url(tenant_id: str, run_id: str) -> str | None:
+def _read_viewer_url_disk(tenant_id: str, run_id: str) -> dict | None:
     path = _run_dir(tenant_id, run_id) / "viewer.json"
     if not path.exists():
         return None
     try:
-        return json.loads(path.read_text()).get("viewer_url")
+        return json.loads(path.read_text())
     except Exception:
         return None
+
+
+def _read_viewer_url(tenant_id: str, run_id: str) -> str | None:
+    blob = read_with_store(
+        _get_run_state_store(),
+        tenant_id=tenant_id, run_id=run_id, kind=KIND_VIEWER,
+        disk_reader=lambda: _read_viewer_url_disk(tenant_id, run_id),
+    )
+    if not blob:
+        return None
+    return blob.get("viewer_url")
 
 
 def _augur_bundle_dir(augur_run_id: str):
@@ -2192,15 +2272,22 @@ def _write_augur_metadata(
         return
     run_dir = _run_dir(tenant_id, run_id)
     run_dir.mkdir(parents=True, exist_ok=True)
-    (run_dir / "augur.json").write_text(json.dumps({
+    blob = {
         "augur_run_id": augur_run_id,
         "bundle_dir": str(_augur_bundle_dir(augur_run_id)),
         "dsn_workspace": os.environ.get("AUGUR_DSN_WORKSPACE_URL", "") or "",
-    }))
+    }
+    (run_dir / "augur.json").write_text(json.dumps(blob))
+    try:
+        _get_run_state_store().put(  # type: ignore[attr-defined]
+            tenant_id, run_id, KIND_AUGUR, blob,
+        )
+    except Exception:  # noqa: BLE001
+        pass
     _commit_volume()
 
 
-def _read_augur_metadata(tenant_id: str, run_id: str) -> dict | None:
+def _read_augur_metadata_disk(tenant_id: str, run_id: str) -> dict | None:
     path = _run_dir(tenant_id, run_id) / "augur.json"
     if not path.exists():
         return None
@@ -2208,6 +2295,14 @@ def _read_augur_metadata(tenant_id: str, run_id: str) -> dict | None:
         return json.loads(path.read_text())
     except Exception:
         return None
+
+
+def _read_augur_metadata(tenant_id: str, run_id: str) -> dict | None:
+    return read_with_store(
+        _get_run_state_store(),
+        tenant_id=tenant_id, run_id=run_id, kind=KIND_AUGUR,
+        disk_reader=lambda: _read_augur_metadata_disk(tenant_id, run_id),
+    )
 
 
 def _write_result(tenant_id: str, run_id: str, result: dict) -> None:
@@ -2273,7 +2368,8 @@ def _read_task_suite(tenant_id: str, run_id: str) -> str | None:
         return None
 
 
-def build_api_app(executor_resolver=None, function_call_lookup=None):
+def build_api_app(executor_resolver=None, function_call_lookup=None,
+                  run_state_store=None):
     """Construct the FastAPI app exposed by the Modal ASGI endpoint (#342).
 
     Factored into a plain function (not wrapped by ``@modal.asgi_app()``)
@@ -2287,6 +2383,10 @@ def build_api_app(executor_resolver=None, function_call_lookup=None):
       ``modal.FunctionCall.from_id``. Tests pass a stub that returns
       a fake ``.get(timeout=...) / .cancel()`` interface so polling
       doesn't need a live Modal runtime.
+    * ``run_state_store`` — overrides the cross-replica run-state
+      cache (#866). Tests pass a plain-dict-backed ``RunStateStore``
+      so the terminal-sticky and cancel-race paths are exercised
+      without going through ``modal.Dict``.
     """
     from datetime import datetime, timezone
 
@@ -2305,6 +2405,14 @@ def build_api_app(executor_resolver=None, function_call_lookup=None):
 
     resolve_executor = executor_resolver or _executor_for_model
     lookup_function_call = function_call_lookup or modal.FunctionCall.from_id
+
+    # #866: override the module-level run-state store when the caller
+    # supplied one (tests). The module reads through ``_get_run_state_store``
+    # so a global swap is enough — no per-request plumbing.
+    if run_state_store is not None:
+        global _RUN_STATE_STORE, _RUN_STATE_STORE_INIT
+        _RUN_STATE_STORE = run_state_store
+        _RUN_STATE_STORE_INIT = True
 
     fastapi_app = FastAPI(
         title="Mantis CUA (Modal)",
@@ -2481,16 +2589,28 @@ def build_api_app(executor_resolver=None, function_call_lookup=None):
         # from Modal's perspective (executor is sleeping in
         # wait_while_paused), but for the caller we want the
         # paused-state signal so the dashboard / poll loop knows to
-        # surface the viewer URL + the resume hint.
+        # surface the viewer URL + the resume hint. Reads the
+        # cross-replica store (#866) first so a poll that lands on a
+        # different replica from the pause-write sees the sentinel
+        # without waiting for the volume reload window.
         pause_path = _run_dir(tenant.tenant_id, run_id) / "pause_request.json"
-        if pause_path.exists() and status.get("status") in {"queued", "running"}:
-            try:
-                pause_blob = json.loads(pause_path.read_text())
-                status["status"] = "paused"
-                status["pause_reason"] = pause_blob.get("reason", "")
-                status["paused_at"] = pause_blob.get("requested_at", "")
-            except (OSError, json.JSONDecodeError):
-                pass
+        pause_blob: dict | None = None
+        try:
+            pause_blob = read_with_store(
+                _get_run_state_store(),
+                tenant_id=tenant.tenant_id, run_id=run_id,
+                kind=KIND_PAUSE_REQUEST,
+                disk_reader=lambda: (
+                    json.loads(pause_path.read_text())
+                    if pause_path.exists() else None
+                ),
+            )
+        except (OSError, json.JSONDecodeError):
+            pause_blob = None
+        if pause_blob and status.get("status") in {"queued", "running"}:
+            status["status"] = "paused"
+            status["pause_reason"] = pause_blob.get("reason", "")
+            status["paused_at"] = pause_blob.get("requested_at", "")
 
         action = payload["action"]
 
@@ -2536,21 +2656,45 @@ def build_api_app(executor_resolver=None, function_call_lookup=None):
             }
 
         if action == "cancel":
+            cancel_lookup_error: str | None = None
             if status.get("status") in {"queued", "running", "paused"}:
                 call_id = status.get("modal_call_id", "")
                 if call_id and status.get("status") != "paused":
+                    # Surface the lookup failure (#866). Previously the
+                    # exception was swallowed, so an unreachable Modal
+                    # control-plane left the executor running while the
+                    # API reported ``cancelled``. The terminal-sticky
+                    # guard in ``_write_status`` then blocked the
+                    # executor's eventual terminal write, masking the
+                    # real outcome. We still write the cancelled status
+                    # — the user's intent stands — but we surface the
+                    # lookup failure so the caller can retry the Modal
+                    # cancel if needed.
                     try:
                         lookup_function_call(call_id).cancel()
-                    except Exception:
-                        pass
+                    except Exception as exc:  # noqa: BLE001
+                        cancel_lookup_error = f"{type(exc).__name__}: {exc}"
+                        print(
+                            f"WARNING: cancel lookup failed for "
+                            f"run={run_id} call_id={call_id!r}: "
+                            f"{cancel_lookup_error}"
+                        )
                 status["status"] = "cancelled"
                 status["updated_at"] = datetime.now(timezone.utc).isoformat()
+                if cancel_lookup_error:
+                    status["cancel_lookup_error"] = cancel_lookup_error
                 _write_status(tenant.tenant_id, run_id, status)
                 release_profile_lock(tenant, status.get("profile_id", ""))
             # #541: tidy the pause sentinel on cancel too.
             try:
                 pause_path.unlink(missing_ok=True)
             except OSError:
+                pass
+            try:
+                _get_run_state_store().delete(  # type: ignore[attr-defined]
+                    tenant.tenant_id, run_id, KIND_PAUSE_REQUEST,
+                )
+            except Exception:  # noqa: BLE001
                 pass
             return status
 
@@ -2570,14 +2714,22 @@ def build_api_app(executor_resolver=None, function_call_lookup=None):
                 )
             reason = str(payload.get("reason") or "external") or "external"
             now_iso = datetime.now(timezone.utc).isoformat()
+            pause_blob_write = {
+                "reason": reason,
+                "requested_at": now_iso,
+            }
             try:
                 pause_path.parent.mkdir(parents=True, exist_ok=True)
-                pause_path.write_text(json.dumps({
-                    "reason": reason,
-                    "requested_at": now_iso,
-                }))
+                pause_path.write_text(json.dumps(pause_blob_write))
             except OSError as exc:
                 raise HTTPException(500, f"failed to write pause sentinel: {exc}")
+            try:
+                _get_run_state_store().put(  # type: ignore[attr-defined]
+                    tenant.tenant_id, run_id, KIND_PAUSE_REQUEST,
+                    pause_blob_write,
+                )
+            except Exception:  # noqa: BLE001
+                pass
             status["status"] = "paused"
             status["pause_reason"] = reason
             status["paused_at"] = now_iso
@@ -2593,13 +2745,28 @@ def build_api_app(executor_resolver=None, function_call_lookup=None):
             # task_suite rehydration / spawn / user_input needed —
             # this path is for human-takeover-via-viewer, where the
             # user has already cleared the page state manually.
-            if pause_path.exists():
+            # Sentinel may exist on disk, in the cross-replica store, or
+            # both. Clear it from both backings so a stale read from the
+            # other side can't re-pause the run on the next poll.
+            store_has_pause = (
+                _get_run_state_store().get(  # type: ignore[attr-defined]
+                    tenant.tenant_id, run_id, KIND_PAUSE_REQUEST,
+                )
+                is not None
+            )
+            if pause_path.exists() or store_has_pause:
                 try:
                     pause_path.unlink(missing_ok=True)
                 except OSError as exc:
                     raise HTTPException(
                         500, f"failed to clear pause sentinel: {exc}",
                     )
+                try:
+                    _get_run_state_store().delete(  # type: ignore[attr-defined]
+                        tenant.tenant_id, run_id, KIND_PAUSE_REQUEST,
+                    )
+                except Exception:  # noqa: BLE001
+                    pass
                 status["status"] = "running"
                 status.pop("pause_reason", None)
                 status.pop("paused_at", None)

--- a/src/mantis_agent/run_state_store.py
+++ b/src/mantis_agent/run_state_store.py
@@ -1,0 +1,215 @@
+"""Cross-replica run-state store for small hot JSON sidecars.
+
+The Modal CUA API runs as an ASGI ``@app.function(...)`` with no
+``max_containers=1`` pin, so submissions can land on container A while
+the poll for the same ``run_id`` lands on container B. The sidecar
+files used by ``_do_action`` — ``status.json``, ``viewer.json``,
+``augur.json``, ``pause_request.json`` — were originally stored only on
+the ``/data`` Modal Volume. Volume writes are durable but propagation
+across replicas is eventually consistent: a poll inside that window
+legitimately sees ``None`` and 404s the run_id.
+
+This module introduces a small key-value store that sits in front of
+the disk sidecars and is shared across replicas at write time. In
+production it is backed by a ``modal.Dict``; in tests (or off-Modal
+contexts) a plain ``dict`` works the same way.
+
+Layout — one entry per ``(tenant_id, run_id, kind)``::
+
+    "<tenant>/<run_id>/<kind>"  →  {<json-blob>}
+
+The store is a *cache* layered on top of disk: writes go to both the
+backing object and disk (via the caller-supplied disk writer), so
+unrelated code paths that still read the file directly (the queue scan
+in ``modal_cua_server.get_queue``, the lifecycle phase response, etc.)
+keep working. Reads consult the cache first; missing keys fall back to
+the disk read.
+
+The cache is bounded so a runaway tenant cannot exhaust container
+memory or the modal.Dict shard. ``put`` evicts the oldest ~25% when
+the in-process LRU mirror crosses ``max_entries`` so we drop entries
+in batches rather than on every write.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import OrderedDict
+from typing import Any, Callable, Iterable, Optional
+
+logger = logging.getLogger(__name__)
+
+
+# Sidecar kinds — keep the set explicit so a typo doesn't silently
+# create a new namespace.
+KIND_STATUS = "status"
+KIND_VIEWER = "viewer"
+KIND_AUGUR = "augur"
+KIND_PAUSE_REQUEST = "pause_request"
+
+_VALID_KINDS = frozenset({KIND_STATUS, KIND_VIEWER, KIND_AUGUR, KIND_PAUSE_REQUEST})
+
+
+def _safe(value: str) -> str:
+    """Filesystem-safe scope segment. Mirrors ``server_utils.safe_state_key``
+    without importing FastAPI machinery."""
+    return "".join(c if c.isalnum() or c in {"-", "_"} else "_" for c in value)
+
+
+def _entry_key(tenant_id: str, run_id: str, kind: str) -> str:
+    if kind not in _VALID_KINDS:
+        raise ValueError(f"unknown run-state kind: {kind!r}")
+    return f"{_safe(tenant_id)}/{_safe(run_id)}/{kind}"
+
+
+class RunStateStore:
+    """Dependency-injected backing for the run-state cache.
+
+    The backing object only needs ``get``/``__setitem__``/``__delitem__``
+    plus iteration over ``keys()``. ``modal.Dict`` satisfies this in
+    prod; a plain ``dict`` works for tests. We never call ``len()`` on
+    the backing — ``modal.Dict`` raises ``TypeError`` on that
+    (see ``feedback_modal_dict_no_len``).
+    """
+
+    def __init__(self, backing: Any, *, max_entries: int = 4096) -> None:
+        self._d = backing
+        # Per-container LRU mirror — bounds growth without iterating
+        # the backing object on every write.
+        self._lru: "OrderedDict[str, None]" = OrderedDict()
+        self.max_entries = max(64, int(max_entries))
+
+    @classmethod
+    def from_name(cls, dict_name: str, *, create_if_missing: bool = True,
+                  max_entries: int = 4096) -> "RunStateStore":
+        """Build against a named ``modal.Dict``. ``modal`` is imported
+        lazily so this module stays importable off-Modal (tests use the
+        plain-``dict`` constructor instead)."""
+        import modal  # noqa: PLC0415 — lazy so the module imports without modal
+
+        backing = modal.Dict.from_name(dict_name, create_if_missing=create_if_missing)
+        return cls(backing, max_entries=max_entries)
+
+    # ── reads ──
+
+    def get(self, tenant_id: str, run_id: str, kind: str) -> Optional[dict]:
+        key = _entry_key(tenant_id, run_id, kind)
+        try:
+            raw = self._d.get(key)
+        except Exception as exc:  # noqa: BLE001 — store fault ≠ run fault
+            logger.warning("RunStateStore.get failed key=%s (%s)", key, exc)
+            return None
+        if raw is None:
+            return None
+        if not isinstance(raw, dict):
+            logger.warning("RunStateStore.get non-dict value key=%s type=%s",
+                           key, type(raw).__name__)
+            return None
+        return raw
+
+    # ── writes ──
+
+    def put(self, tenant_id: str, run_id: str, kind: str, value: dict) -> None:
+        if not isinstance(value, dict):
+            raise TypeError(
+                f"RunStateStore.put value must be a dict, got {type(value).__name__}"
+            )
+        key = _entry_key(tenant_id, run_id, kind)
+        try:
+            self._d[key] = dict(value)  # defensive copy — backing may not
+        except Exception as exc:  # noqa: BLE001 — store fault ≠ run fault
+            logger.warning("RunStateStore.put failed key=%s (%s)", key, exc)
+            return
+        self._touch(key)
+
+    def delete(self, tenant_id: str, run_id: str, kind: str) -> None:
+        key = _entry_key(tenant_id, run_id, kind)
+        try:
+            del self._d[key]
+        except KeyError:
+            pass
+        except Exception as exc:  # noqa: BLE001 — store fault ≠ run fault
+            logger.warning("RunStateStore.delete failed key=%s (%s)", key, exc)
+        self._lru.pop(key, None)
+
+    # ── LRU bookkeeping ──
+
+    def _touch(self, key: str) -> None:
+        self._lru.pop(key, None)
+        self._lru[key] = None
+        if len(self._lru) > self.max_entries:
+            drop = max(1, self.max_entries // 4)
+            for _ in range(drop):
+                try:
+                    evicted, _ = self._lru.popitem(last=False)
+                except KeyError:
+                    break
+                try:
+                    del self._d[evicted]
+                except KeyError:
+                    pass
+                except Exception:  # noqa: BLE001 — best-effort eviction
+                    pass
+
+
+# ── No-op store for environments without a backing object ──
+
+
+class NullRunStateStore:
+    """Fallback when no shared backing is configured.
+
+    Always misses on read, drops on write. Lets the disk fallback do
+    all the work without forcing callers to branch on store presence.
+    """
+
+    def get(self, tenant_id: str, run_id: str, kind: str) -> Optional[dict]:
+        return None
+
+    def put(self, tenant_id: str, run_id: str, kind: str, value: dict) -> None:
+        return None
+
+    def delete(self, tenant_id: str, run_id: str, kind: str) -> None:
+        return None
+
+
+# ── Helpers for the disk-mirrored read path ──
+
+
+def read_with_store(
+    store: Any,
+    *,
+    tenant_id: str,
+    run_id: str,
+    kind: str,
+    disk_reader: Callable[[], Optional[dict]],
+) -> Optional[dict]:
+    """Cache-first read; fall back to ``disk_reader`` on miss.
+
+    On a disk hit we backfill the cache so subsequent reads on the
+    same replica skip the file read. Disk reads must already validate
+    JSON shape; the helper just forwards their return value.
+    """
+    cached = store.get(tenant_id, run_id, kind)
+    if cached is not None:
+        return cached
+    on_disk = disk_reader()
+    if on_disk is not None:
+        try:
+            store.put(tenant_id, run_id, kind, on_disk)
+        except Exception:  # noqa: BLE001 — backfill is best-effort
+            pass
+    return on_disk
+
+
+def list_active_keys(store: Any) -> Iterable[str]:
+    """Iterate the store's keys (useful in tests/diagnostics).
+
+    Lazy iteration — caller can break early. We catch the typical
+    store-fault and yield nothing rather than propagating.
+    """
+    try:
+        keys = store._d.keys()  # noqa: SLF001 — diagnostic helper
+    except Exception:  # noqa: BLE001
+        return
+    for k in keys:
+        yield k

--- a/tests/test_augur_runtime_surface.py
+++ b/tests/test_augur_runtime_surface.py
@@ -54,7 +54,9 @@ def mcs(monkeypatch, tmp_path):
 
     import modal_cua_server as mod  # type: ignore[import-not-found]
     importlib.reload(mod)
-    mod._RECENT_RUNS.clear()
+    from mantis_agent.run_state_store import RunStateStore
+    mod._RUN_STATE_STORE = RunStateStore(backing={})
+    mod._RUN_STATE_STORE_INIT = True
     return mod
 
 

--- a/tests/test_failure_help_on_lifecycle.py
+++ b/tests/test_failure_help_on_lifecycle.py
@@ -40,7 +40,11 @@ def mcs(monkeypatch, tmp_path):
 
     import modal_cua_server as mod  # type: ignore[import-not-found]
     importlib.reload(mod)
-    mod._RECENT_RUNS.clear()
+    # #866: per-test plain-dict cross-replica store so leakage between
+    # cases can't make a regression look like a pass.
+    from mantis_agent.run_state_store import RunStateStore
+    mod._RUN_STATE_STORE = RunStateStore(backing={})
+    mod._RUN_STATE_STORE_INIT = True
     return mod
 
 

--- a/tests/test_modal_cancel_race.py
+++ b/tests/test_modal_cancel_race.py
@@ -231,6 +231,55 @@ def test_unknown_run_id_returns_404(app_with_stub) -> None:
     assert "unknown run_id" in r.json()["detail"]
 
 
+# ── Lazy init doesn't hang off-Modal (CI regression guard) ──────────
+
+
+def test_lazy_init_does_not_hit_modal_outside_container(monkeypatch, tmp_path) -> None:
+    """Regression guard for PR #845 CI hang.
+
+    Outside a Modal container (no ``MODAL_TASK_ID`` env var), the
+    lazy ``_get_run_state_store`` path must NOT call
+    ``modal.Dict.from_name`` — that blocks waiting for control-plane
+    auth in CI and previously hung shard 2 for >75 minutes.
+    """
+    monkeypatch.setenv("MANTIS_API_TOKEN", "test-token")
+    monkeypatch.setenv("MANTIS_DATA_DIR", str(tmp_path / "mantis-data"))
+    monkeypatch.delenv("MODAL_TASK_ID", raising=False)
+    monkeypatch.delenv("MANTIS_TENANT_KEYS_PATH", raising=False)
+    ta_mod.reset_key_store()
+
+    import modal_cua_server as mcs  # type: ignore[import-not-found]
+    importlib.reload(mcs)
+
+    # Sentinel: monkey-patch RunStateStore.from_name to explode if hit.
+    called = {"n": 0}
+
+    def _boom(*args, **kwargs):
+        called["n"] += 1
+        raise RuntimeError("modal.Dict.from_name should not be called off-Modal")
+
+    monkeypatch.setattr(mcs.RunStateStore, "from_name", _boom)
+
+    # First call to _get_run_state_store should return NullRunStateStore
+    # without touching modal.Dict.
+    store = mcs._get_run_state_store()
+    assert isinstance(store, mcs.NullRunStateStore)
+    assert called["n"] == 0
+
+    # And inside a Modal container, the path IS taken — verified by
+    # flipping the env var, resetting module state, and confirming
+    # from_name was called. The function swallows the sentinel
+    # RuntimeError and falls back to NullRunStateStore, so we assert
+    # via the call counter rather than via raises.
+    monkeypatch.setenv("MODAL_TASK_ID", "ta-stub-123")
+    mcs._RUN_STATE_STORE = mcs.NullRunStateStore()
+    mcs._RUN_STATE_STORE_INIT = False
+    store2 = mcs._get_run_state_store()
+    assert called["n"] == 1, "from_name must be called when MODAL_TASK_ID is set"
+    # Fell back to NullRunStateStore because sentinel raised.
+    assert isinstance(store2, mcs.NullRunStateStore)
+
+
 # ── Store is the cross-replica visibility layer ──────────────────────
 
 

--- a/tests/test_modal_cancel_race.py
+++ b/tests/test_modal_cancel_race.py
@@ -1,0 +1,254 @@
+"""Tests for the cancel-overwrite race + terminal-sticky guard (#866).
+
+Two related bugs the previous server had:
+
+1. ``_do_action`` for ``action=cancel`` swallowed any exception from
+   ``lookup_function_call(call_id).cancel()`` — so when the Modal
+   control-plane lookup failed the API reported ``cancelled`` while
+   the executor kept running, eventually clobbering the cancelled
+   status with its own terminal write.
+
+2. ``_write_status`` had no guard against terminal overwrites — once
+   a run was ``cancelled`` (or ``halted``), the executor's later
+   ``succeeded`` / ``failed`` write would silently overwrite it.
+
+These tests drive the FastAPI app via the existing test harness and
+cover both paths.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+pytest.importorskip("modal")
+
+from fastapi.testclient import TestClient
+
+from mantis_agent import tenant_auth as ta_mod
+from mantis_agent.run_state_store import RunStateStore
+
+
+_DEPLOY_MODAL = Path(__file__).resolve().parent.parent / "deploy" / "modal"
+if str(_DEPLOY_MODAL) not in sys.path:
+    sys.path.insert(0, str(_DEPLOY_MODAL))
+
+
+class _StubFunctionCall:
+    def __init__(self, *, raise_on_cancel: Exception | None = None) -> None:
+        self.object_id = "fc-stub-001"
+        self.cancel_calls = 0
+        self._raise_on_cancel = raise_on_cancel
+
+    def get(self, timeout: float = 0.1) -> Any:
+        # Never finishes — exercising cancel paths, not result paths.
+        raise TimeoutError("still running")
+
+    def cancel(self) -> None:
+        self.cancel_calls += 1
+        if self._raise_on_cancel is not None:
+            raise self._raise_on_cancel
+
+
+class _StubExecutor:
+    def __init__(self, call: _StubFunctionCall) -> None:
+        self.call = call
+
+    def spawn(self, *, task_file_contents: str, **kwargs):  # noqa: D401
+        return self.call
+
+
+def _auth_headers() -> dict[str, str]:
+    return {"X-Mantis-Token": "test-token", "Content-Type": "application/json"}
+
+
+@pytest.fixture
+def app_with_stub(monkeypatch, tmp_path):
+    monkeypatch.setenv("MANTIS_API_TOKEN", "test-token")
+    monkeypatch.setenv("MANTIS_DATA_DIR", str(tmp_path / "mantis-data"))
+    monkeypatch.delenv("MANTIS_TENANT_KEYS_PATH", raising=False)
+    ta_mod.reset_key_store()
+
+    import modal_cua_server as mcs  # type: ignore[import-not-found]
+    importlib.reload(mcs)
+
+    stub_call = _StubFunctionCall()
+    stub_executor = _StubExecutor(stub_call)
+    store = RunStateStore(backing={})
+
+    app = mcs.build_api_app(
+        executor_resolver=lambda model: stub_executor,
+        function_call_lookup=lambda call_id: stub_call,
+        run_state_store=store,
+    )
+    return TestClient(app), stub_call, store, mcs
+
+
+def _submit(client: TestClient, profile_id: str = "alice") -> str:
+    r = client.post(
+        "/v1/predict",
+        headers=_auth_headers(),
+        data=json.dumps({
+            "task_suite": {"tasks": [{"intent": "x"}]},
+            "profile_id": profile_id,
+        }),
+    )
+    assert r.status_code == 200, r.text
+    return r.json()["run_id"]
+
+
+def _cancel(client: TestClient, run_id: str) -> dict:
+    r = client.post(
+        "/v1/predict",
+        headers=_auth_headers(),
+        data=json.dumps({"action": "cancel", "run_id": run_id}),
+    )
+    assert r.status_code == 200, r.text
+    return r.json()
+
+
+def _status(client: TestClient, run_id: str) -> dict:
+    r = client.post(
+        "/v1/predict",
+        headers=_auth_headers(),
+        data=json.dumps({"action": "status", "run_id": run_id}),
+    )
+    assert r.status_code == 200, r.text
+    return r.json()
+
+
+# ── Terminal-sticky guard ────────────────────────────────────────────
+
+
+def test_executor_terminal_write_cannot_overwrite_cancelled(app_with_stub) -> None:
+    """Once cancel writes status=cancelled, a later executor terminal
+    write (succeeded/failed/halted) is rejected. The cancel must stick."""
+    client, _call, _store, mcs = app_with_stub
+    run_id = _submit(client)
+    body = _cancel(client, run_id)
+    assert body["status"] == "cancelled"
+
+    # Simulate the executor finishing AFTER the cancel landed — it
+    # calls _write_status directly with its own terminal phase.
+    tenant_id = body.get("tenant_id") or ""
+    assert tenant_id, "submit response should carry tenant_id"
+    mcs._write_status(tenant_id, run_id, {
+        **body,
+        "status": "succeeded",
+        "updated_at": "2099-01-01T00:00:00Z",
+    })
+
+    # Read it back through the API — must still be cancelled.
+    final = _status(client, run_id)
+    assert final["status"] == "cancelled", (
+        f"executor terminal write clobbered cancelled: {final}"
+    )
+
+
+def test_terminal_status_blocks_any_change(app_with_stub) -> None:
+    client, _call, _store, mcs = app_with_stub
+    run_id = _submit(client)
+    cancelled = _cancel(client, run_id)
+    tenant_id = cancelled["tenant_id"]
+
+    # Try a transition that would step BACK to running — must be blocked.
+    mcs._write_status(tenant_id, run_id, {
+        **cancelled, "status": "running",
+    })
+    assert _status(client, run_id)["status"] == "cancelled"
+
+    # Same-status write is a no-op effectively — value changes that
+    # don't touch the ``status`` field are still allowed (they're a
+    # legitimate way to add fields like ``cancel_lookup_error``).
+    mcs._write_status(tenant_id, run_id, {
+        **cancelled, "status": "cancelled", "extra_field": "ok",
+    })
+    after = _status(client, run_id)
+    assert after["status"] == "cancelled"
+    assert after.get("extra_field") == "ok"
+
+
+# ── Cancel-call failure surfaced ─────────────────────────────────────
+
+
+def test_cancel_surfaces_lookup_failure(monkeypatch, tmp_path) -> None:
+    """When ``lookup_function_call(...).cancel()`` raises, the cancel
+    still records cancelled but surfaces the failure to the caller via
+    ``cancel_lookup_error`` on the status payload."""
+    monkeypatch.setenv("MANTIS_API_TOKEN", "test-token")
+    monkeypatch.setenv("MANTIS_DATA_DIR", str(tmp_path / "mantis-data"))
+    monkeypatch.delenv("MANTIS_TENANT_KEYS_PATH", raising=False)
+    ta_mod.reset_key_store()
+
+    import modal_cua_server as mcs  # type: ignore[import-not-found]
+    importlib.reload(mcs)
+
+    call = _StubFunctionCall(raise_on_cancel=RuntimeError("control-plane unreachable"))
+    executor = _StubExecutor(call)
+    store = RunStateStore(backing={})
+    app = mcs.build_api_app(
+        executor_resolver=lambda model: executor,
+        function_call_lookup=lambda call_id: call,
+        run_state_store=store,
+    )
+    client = TestClient(app)
+
+    run_id = _submit(client)
+    body = _cancel(client, run_id)
+    assert body["status"] == "cancelled"
+    assert "cancel_lookup_error" in body, (
+        "cancel must surface the lookup failure instead of swallowing it"
+    )
+    assert "control-plane unreachable" in body["cancel_lookup_error"]
+    assert call.cancel_calls == 1
+
+
+def test_cancel_succeeds_silently_when_lookup_ok(app_with_stub) -> None:
+    client, call, _store, _mcs = app_with_stub
+    run_id = _submit(client)
+    body = _cancel(client, run_id)
+    assert body["status"] == "cancelled"
+    assert "cancel_lookup_error" not in body
+    assert call.cancel_calls == 1
+
+
+# ── Unknown run_id still 404s (regression guard) ─────────────────────
+
+
+def test_unknown_run_id_returns_404(app_with_stub) -> None:
+    client, _call, _store, _mcs = app_with_stub
+    r = client.post(
+        "/v1/predict",
+        headers=_auth_headers(),
+        data=json.dumps({"action": "cancel", "run_id": "20990101_000000_deadbeef"}),
+    )
+    assert r.status_code == 404, r.text
+    assert "unknown run_id" in r.json()["detail"]
+
+
+# ── Store is the cross-replica visibility layer ──────────────────────
+
+
+def test_status_visible_through_store_without_disk(app_with_stub) -> None:
+    """Verify the store-first read path: a status written into the
+    store but NOT on disk (simulating a write that hasn't reached the
+    other replica's volume mount yet) is visible to a status read."""
+    client, _call, store, mcs = app_with_stub
+    run_id = _submit(client)
+    body = _status(client, run_id)
+    tenant_id = body["tenant_id"]
+
+    # Wipe the disk copy to simulate a replica that hasn't picked up
+    # the volume reload yet. The store is the cross-replica truth.
+    disk_path = mcs._run_dir(tenant_id, run_id) / "status.json"
+    disk_path.unlink()
+
+    # Re-read — must come from the store.
+    out = _status(client, run_id)
+    assert out["run_id"] == run_id
+    assert out["status"] in {"queued", "running"}

--- a/tests/test_run_state_store.py
+++ b/tests/test_run_state_store.py
@@ -1,0 +1,138 @@
+"""Unit tests for the cross-replica run-state store (#866)."""
+
+from __future__ import annotations
+
+import pytest
+
+from mantis_agent.run_state_store import (
+    KIND_AUGUR,
+    KIND_PAUSE_REQUEST,
+    KIND_STATUS,
+    KIND_VIEWER,
+    NullRunStateStore,
+    RunStateStore,
+    read_with_store,
+)
+
+
+def test_round_trip_status() -> None:
+    store = RunStateStore(backing={})
+    blob = {"status": "running", "updated_at": "2026-06-11T08:00:00Z"}
+    store.put("t1", "r1", KIND_STATUS, blob)
+    out = store.get("t1", "r1", KIND_STATUS)
+    assert out == blob
+    # Defensive copy — mutating the returned dict shouldn't affect store.
+    out["status"] = "tampered"
+    refetch = store.get("t1", "r1", KIND_STATUS)
+    assert refetch is not None
+    # The store stored a copy at put-time; the returned dict comes from
+    # the backing and may be the same reference. The contract is that
+    # writes are deep-enough copies — we verify by re-putting and
+    # re-reading.
+    store.put("t1", "r1", KIND_STATUS, blob)
+    assert store.get("t1", "r1", KIND_STATUS) == blob
+
+
+def test_kind_validation_rejects_typo() -> None:
+    store = RunStateStore(backing={})
+    with pytest.raises(ValueError):
+        store.put("t1", "r1", "satus", {"x": 1})  # type: ignore[arg-type]
+    with pytest.raises(ValueError):
+        store.get("t1", "r1", "satus")  # type: ignore[arg-type]
+
+
+def test_tenant_isolation() -> None:
+    store = RunStateStore(backing={})
+    store.put("alice", "r1", KIND_STATUS, {"status": "running"})
+    store.put("bob", "r1", KIND_STATUS, {"status": "succeeded"})
+    assert store.get("alice", "r1", KIND_STATUS) == {"status": "running"}
+    assert store.get("bob", "r1", KIND_STATUS) == {"status": "succeeded"}
+
+
+def test_delete_idempotent() -> None:
+    store = RunStateStore(backing={})
+    store.put("t1", "r1", KIND_VIEWER, {"viewer_url": "https://x"})
+    store.delete("t1", "r1", KIND_VIEWER)
+    assert store.get("t1", "r1", KIND_VIEWER) is None
+    # Second delete is a no-op, not an error.
+    store.delete("t1", "r1", KIND_VIEWER)
+
+
+def test_lru_eviction_drops_oldest() -> None:
+    store = RunStateStore(backing={}, max_entries=64)
+    # Fill above the cap so eviction fires.
+    for i in range(80):
+        store.put("t1", f"r{i}", KIND_STATUS, {"status": "running"})
+    # The first batch of writes should have been evicted (drop ~25%
+    # when crossing the cap). Newest writes are still present.
+    assert store.get("t1", "r79", KIND_STATUS) is not None
+    # Some prefix of early writes is gone.
+    assert store.get("t1", "r0", KIND_STATUS) is None
+
+
+def test_read_with_store_disk_backfill() -> None:
+    store = RunStateStore(backing={})
+    calls = {"n": 0}
+
+    def disk_reader() -> dict | None:
+        calls["n"] += 1
+        return {"status": "from_disk"}
+
+    # First read misses cache, hits disk, backfills.
+    out1 = read_with_store(
+        store, tenant_id="t1", run_id="r1", kind=KIND_STATUS,
+        disk_reader=disk_reader,
+    )
+    assert out1 == {"status": "from_disk"}
+    assert calls["n"] == 1
+
+    # Second read hits cache.
+    out2 = read_with_store(
+        store, tenant_id="t1", run_id="r1", kind=KIND_STATUS,
+        disk_reader=disk_reader,
+    )
+    assert out2 == {"status": "from_disk"}
+    assert calls["n"] == 1  # disk_reader not called again
+
+
+def test_read_with_store_disk_miss_returns_none() -> None:
+    store = RunStateStore(backing={})
+    out = read_with_store(
+        store, tenant_id="t1", run_id="missing", kind=KIND_AUGUR,
+        disk_reader=lambda: None,
+    )
+    assert out is None
+
+
+def test_null_store_no_op() -> None:
+    store = NullRunStateStore()
+    store.put("t1", "r1", KIND_PAUSE_REQUEST, {"reason": "test"})
+    assert store.get("t1", "r1", KIND_PAUSE_REQUEST) is None
+    # Delete is also a no-op.
+    store.delete("t1", "r1", KIND_PAUSE_REQUEST)
+
+
+def test_get_returns_none_on_backing_fault() -> None:
+    class _Faulty:
+        def get(self, k):  # noqa: D401
+            raise RuntimeError("boom")
+
+    store = RunStateStore(backing=_Faulty())
+    # Store fault doesn't raise — degrades to miss.
+    assert store.get("t1", "r1", KIND_STATUS) is None
+
+
+def test_put_rejects_non_dict() -> None:
+    store = RunStateStore(backing={})
+    with pytest.raises(TypeError):
+        store.put("t1", "r1", KIND_STATUS, "not a dict")  # type: ignore[arg-type]
+
+
+def test_safe_key_handles_special_chars() -> None:
+    store = RunStateStore(backing={})
+    # Tenant ids and run ids with characters that shouldn't escape the
+    # namespace get sanitized — verified by writing under a weird id
+    # and reading it back under the same id (round-trip).
+    store.put("tenant/../escape", "run::1", KIND_STATUS, {"status": "x"})
+    out = store.get("tenant/../escape", "run::1", KIND_STATUS)
+    assert out == {"status": "x"}

--- a/tests/test_run_status_race.py
+++ b/tests/test_run_status_race.py
@@ -9,10 +9,10 @@ lands on a different container, the volume mount on that container
 might not have seen the ``status.json`` we just wrote — so the poll
 returns 404.
 
-Fix: an in-memory recent-runs cache on the API container, queried
-ahead of the file-backed read. When the executor (different container)
-later writes a fresher status to the volume, the file read trumps the
-cache.
+Fix (#866): a cross-replica run-state store (``modal.Dict`` in prod,
+plain ``dict`` in tests) queried ahead of the file-backed read. When
+the executor (different container) later writes a fresher status to
+the volume, the file read trumps the cache.
 """
 
 from __future__ import annotations
@@ -28,6 +28,7 @@ pytest.importorskip("modal")
 from fastapi.testclient import TestClient  # noqa: E402 — guarded by importorskip
 
 from mantis_agent import tenant_auth as ta_mod
+from mantis_agent.run_state_store import KIND_STATUS, RunStateStore
 
 
 _DEPLOY_MODAL = Path(__file__).resolve().parent.parent / "deploy" / "modal"
@@ -44,26 +45,30 @@ def mcs(monkeypatch, tmp_path):
 
     import modal_cua_server as mod  # type: ignore[import-not-found]
     importlib.reload(mod)
-    # Wipe the module-level cache between tests so leakage between
+    # Install a fresh per-test plain-dict store so leakage between
     # cases doesn't make a regression look like a pass.
-    mod._RECENT_RUNS.clear()
+    store = RunStateStore(backing={})
+    mod._RUN_STATE_STORE = store
+    mod._RUN_STATE_STORE_INIT = True
     return mod
 
 
-def test_write_status_seeds_cache(mcs):
-    """``_write_status`` must put the status in the in-memory cache
-    so the same container's poll-immediately-after path hits it."""
+def test_write_status_seeds_store(mcs):
+    """``_write_status`` must put the status in the cross-replica
+    store so the same container's poll-immediately-after path hits it."""
     status = {"run_id": "r1", "status": "queued", "updated_at": "2026-06-09T20:00:00+00:00"}
     mcs._write_status("default", "r1", status)
-    assert "default::r1" in mcs._RECENT_RUNS
-    assert mcs._RECENT_RUNS["default::r1"]["status"] == "queued"
+    store = mcs._get_run_state_store()
+    cached = store.get("default", "r1", KIND_STATUS)
+    assert cached is not None
+    assert cached["status"] == "queued"
 
 
 def test_read_status_returns_cached_when_volume_empty(mcs, tmp_path):
     """The cache must satisfy a poll even when the on-disk status.json
     isn't there yet (volume eventual-consistency window)."""
     status = {"run_id": "r-fresh", "status": "queued", "updated_at": "2026-06-09T20:00:00+00:00"}
-    mcs._cache_status("default", "r-fresh", status)
+    mcs._get_run_state_store().put("default", "r-fresh", KIND_STATUS, status)
     # Confirm the file doesn't exist.
     assert not (mcs._run_dir("default", "r-fresh") / "status.json").exists()
     got = mcs._read_status("default", "r-fresh")
@@ -80,19 +85,16 @@ def test_read_status_returns_none_for_truly_unknown(mcs):
 def test_on_disk_newer_wins_over_cache(mcs):
     """The executor writes the status from a different container; on
     next read the file should win and refresh the cache."""
+    store = mcs._get_run_state_store()
     # Seed cache with an older queued state.
-    mcs._cache_status("default", "r1", {
+    store.put("default", "r1", KIND_STATUS, {
         "run_id": "r1",
         "status": "queued",
         "updated_at": "2026-06-09T20:00:00+00:00",
     })
     # Executor flips it to running via the file (simulating a
     # different-container write that the API hasn't cached).
-    mcs._write_status_raw_to_file("default", "r1", {
-        "run_id": "r1",
-        "status": "running",
-        "updated_at": "2026-06-09T20:00:30+00:00",
-    }) if hasattr(mcs, "_write_status_raw_to_file") else _direct_file_write(
+    _direct_file_write(
         mcs, "default", "r1", {
             "run_id": "r1",
             "status": "running",
@@ -103,40 +105,9 @@ def test_on_disk_newer_wins_over_cache(mcs):
     assert got is not None
     assert got["status"] == "running"
     # Cache should have been refreshed.
-    assert mcs._RECENT_RUNS["default::r1"]["status"] == "running"
-
-
-def test_cache_evicts_terminal_runs(mcs):
-    """Finished runs don't need to stay in the cache — the client
-    will use the result endpoint after a terminal poll."""
-    _direct_file_write(mcs, "default", "r-done", {
-        "run_id": "r-done",
-        "status": "succeeded",
-        "updated_at": "2026-06-09T20:01:00+00:00",
-    })
-    mcs._cache_status("default", "r-done", {
-        "run_id": "r-done",
-        "status": "running",
-        "updated_at": "2026-06-09T20:00:00+00:00",
-    })
-    got = mcs._read_status("default", "r-done")
-    assert got["status"] == "succeeded"
-    assert "default::r-done" not in mcs._RECENT_RUNS
-
-
-def test_cache_bounded(mcs):
-    """Cache must not grow unboundedly — eviction kicks in past the cap."""
-    cap = mcs._RECENT_RUNS_MAX
-    for i in range(cap + 100):
-        mcs._cache_status("default", f"r-{i}", {
-            "run_id": f"r-{i}",
-            "status": "queued",
-            "updated_at": "2026-06-09T20:00:00+00:00",
-        })
-    assert len(mcs._RECENT_RUNS) <= cap + 100  # at minimum: hasn't exploded
-    # Some old entries must have been evicted — the most recent ones
-    # survive.
-    assert f"default::r-{cap + 50}" in mcs._RECENT_RUNS
+    refreshed = store.get("default", "r1", KIND_STATUS)
+    assert refreshed is not None
+    assert refreshed["status"] == "running"
 
 
 def _direct_file_write(mcs, tenant_id: str, run_id: str, payload: dict) -> None:
@@ -176,9 +147,11 @@ def test_immediate_poll_after_submit_does_not_return_404(mcs):
     import json
 
     executor = _StubExecutor()
+    store = RunStateStore(backing={})
     app = mcs.build_api_app(
         executor_resolver=lambda model: executor,
         function_call_lookup=lambda call_id: executor.call,
+        run_state_store=store,
     )
     client = TestClient(app)
     h = {"X-Mantis-Token": "test-token", "Content-Type": "application/json"}


### PR DESCRIPTION
## Summary

A user reported intermittent **unknown run_id / empty logs / broken cancel** on `mantis-cua-server`. Symptoms surface when a poll lands on a different ASGI replica than the writer (the `api()` function autoscales — no `max_containers=1` pin).

After auditing the current source, the user's diagnosis was partly outdated (`vol.commit()` + `vol.reload()` and the 404-on-unknown-run_id were already in place from #416), but the symptoms are real. Two distinct bugs:

1. **Modal Volume eventual consistency.** Cross-replica propagation has a small window. The legacy `_RECENT_RUNS` in-memory cache only helped same-container reads.
2. **Cancel-overwrite race.** `_do_action(action="cancel")` swallowed any exception from `lookup_function_call(call_id).cancel()`. If the Modal lookup failed, the executor kept running and its eventual terminal write clobbered the API's `cancelled` status.

## Changes

- **New `mantis_agent.run_state_store`** — DI'd key-value cache (`modal.Dict` in prod, plain `dict` in tests) for the small/hot sidecars: status, viewer, augur, pause_request. Disk stays as the durable backing store; queue scan and lifecycle phase route keep reading files directly. Mirrors the `ModalDictHintStore` pattern.
- **`_write_status` first-terminal-wins guard.** Refuses to overwrite a status that's already in `_TERMINAL_STATUSES` with a different status. Cancel sticks against late executor terminal writes.
- **`_do_action(action="cancel")` surfaces lookup failures.** Returns `cancel_lookup_error` on the response (and persists it on `status.json`) instead of swallowing the exception. Cancel still records `cancelled` — caller's intent stands but they now know the executor may keep running.
- **`build_api_app(run_state_store=...)`** DI for unit tests.
- Removes `_RECENT_RUNS` / `_cache_status` / `_RECENT_RUNS_MAX`. Fixture updates in `test_run_status_race.py`, `test_failure_help_on_lifecycle.py`, `test_augur_runtime_surface.py` to seed the new store.

## Live verification (against a redeployed `mantis-cua-server`)

| Scenario | Result |
|---|---|
| Immediate post-submit poll | 200, `phase=running` (no 404) |
| Cancel mid-run + 10 polls over 30s | All `cancelled` — sticky |
| Unknown run_id → cancel | 404 `unknown run_id` |
| HN top-5 extraction end-to-end | `succeeded` in 51s, 5 rows |

## Test plan

- [x] `tests/test_run_state_store.py` — 11 cases (round-trip, eviction, tenant isolation, faulty backings)
- [x] `tests/test_modal_cancel_race.py` — 6 cases (executor-terminal-write-after-cancel cannot overwrite, cancel surfaces lookup failure, unknown run_id 404 regression guard, store-first read path)
- [x] All existing modal/lifecycle/augur tests still pass (114 passing; one pre-existing failure on main — `test_result_action_returns_executor_result` — that's unrelated)
- [x] Live smoke against deployed API: cancel race, sticky cancel, HN top-5 extraction

## Notes

- **Deferred:** `max_containers=1` on `api()` as a stopgap — the cross-replica fix removes the need; preserves autoscale.
- **Cosmetic:** pytest warns about blocking `vol.commit`/`vol.reload`/`modal.Dict` calls in async context. No behavior impact; can be async-ified in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)