### PR TITLE
feat(computer-plane): Phase 1.5 foundation — session-router wire contract (#846)

### DIFF
--- a/src/mantis_agent/run_state_store.py
+++ b/src/mantis_agent/run_state_store.py
@@ -46,8 +46,16 @@ KIND_STATUS = "status"
 KIND_VIEWER = "viewer"
 KIND_AUGUR = "augur"
 KIND_PAUSE_REQUEST = "pause_request"
+# Phase 1.5 (#846): per-session computer-plane record. Keyed by the
+# router-minted ``session_id``, not the ``run_id`` — one run can
+# theoretically open and close multiple sessions (e.g. reaper kills
+# one and the brain transparently re-creates), and we want both
+# records discoverable for forensics.
+KIND_SESSION = "session"
 
-_VALID_KINDS = frozenset({KIND_STATUS, KIND_VIEWER, KIND_AUGUR, KIND_PAUSE_REQUEST})
+_VALID_KINDS = frozenset({
+    KIND_STATUS, KIND_VIEWER, KIND_AUGUR, KIND_PAUSE_REQUEST, KIND_SESSION,
+})
 
 
 def _safe(value: str) -> str:

--- a/src/mantis_agent/session_wire.py
+++ b/src/mantis_agent/session_wire.py
@@ -1,0 +1,258 @@
+"""Pydantic wire models for the Session Router RPC (Phase 1.5, #846).
+
+The session router sits in front of the Modal computer plane. Instead
+of every brain pointing at one pinned ``computer_plane()`` ASGI app
+(``min_containers=1, max_containers=1``), each run mints a *session*
+that owns a dedicated computer-plane sandbox/container for its
+lifetime. The router records that mapping cross-replica so polls and
+cleanups stay coherent.
+
+This module defines the wire contract; the orchestrator (PR 2) and the
+brain-side resolver (PR 3) import from it.
+
+Layering vs. ``computer_wire.py``:
+
+* ``computer_wire`` — what the *brain → computer plane* RPC looks like
+  (screenshot, xdotool, cdp). Per-step. Unchanged by Phase 1.5.
+* ``session_wire`` — what the *brain → session router → orchestrator*
+  RPC looks like (create-session, close-session). Once per run.
+
+The two contracts deliberately don't share fields so a router-side
+change can't ripple into the per-step wire.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+# ── Create session ────────────────────────────────────────────────────
+
+
+class SessionCreateRequest(BaseModel):
+    """Ask the router to allocate a new computer-plane session.
+
+    The brain calls this once at the start of a run. The router
+    spawns/leases a dedicated computer-plane container, waits for it
+    to be reachable, and returns the per-session base URL the brain
+    uses for the rest of the run.
+
+    Identity (``tenant_id`` + ``profile_id`` + ``run_id``) is required
+    so the router can:
+
+    1. Stamp the per-session lock against the same ``(tenant, profile)``
+       the API-side ``acquire_profile_lock`` would use.
+    2. Look up an existing session by ``run_id`` for idempotent
+       create-on-retry semantics.
+    3. Surface the session to the reaper keyed by ``run_id`` (so a
+       crashed brain can be cleaned up without the router holding
+       its own out-of-band registry).
+
+    Everything else mirrors the ``computer_wire.SessionInitRequest``
+    shape so the orchestrator can forward fields straight through to
+    ``ComputerAgent.session/init`` without translation.
+    """
+
+    tenant_id: str = Field(..., min_length=1, max_length=128)
+    profile_id: str = Field(..., min_length=1, max_length=128)
+    run_id: str = Field(..., min_length=1, max_length=128)
+
+    # Forwarded to ComputerAgent.session/init verbatim.
+    start_url: str = Field(default="about:blank", max_length=2048)
+    viewport: tuple[int, int] = Field(default=(1280, 720))
+    proxy_server: str = Field(default="", max_length=512)
+    profile_dir: Optional[str] = Field(default=None, max_length=512)
+    extra_http_headers: Optional[dict[str, str]] = None
+    enable_cdp: bool = False
+
+    # Router-only. TTL after which the reaper considers this session
+    # orphaned and terminates the underlying container. Brain-supplied
+    # so a long-running plan can opt into a longer TTL; clamped server-
+    # side against a deployment cap.
+    ttl_seconds: int = Field(default=3600, ge=60, le=14400)
+
+
+class SessionCreateResponse(BaseModel):
+    """Reply once the orchestrator has a reachable session.
+
+    Carries the per-session ``base_url`` the brain plugs into
+    ``RemoteComputerImpl(base_url=...)``. ``session_token`` is
+    pre-minted by the router so the brain doesn't have to do a
+    separate ``ComputerAgent.session/init`` hop — the orchestrator
+    has already issued the token against the bound session.
+
+    ``sandbox_id`` is the Modal sandbox / function-call handle the
+    router uses to terminate the session. Exposed so an operator can
+    correlate logs; opaque to the brain.
+    """
+
+    session_id: str
+    base_url: str
+    session_token: str
+    expires_at_ms: int
+    sandbox_id: str = ""
+
+    # Idempotent-create signal — ``true`` means the router returned
+    # a pre-existing session for this ``(tenant, profile, run_id)``
+    # tuple instead of spawning a new one.
+    reused: bool = False
+
+
+# ── Close session ─────────────────────────────────────────────────────
+
+
+class SessionCloseRequest(BaseModel):
+    """Tear down a session and release the underlying container."""
+
+    session_id: str = Field(..., min_length=1, max_length=128)
+    # Optional — surfaces in observability for "why did this session
+    # end?" without grepping the runner's terminal status.
+    reason: str = Field(default="brain_closed", max_length=64)
+
+
+class SessionCloseResponse(BaseModel):
+    closed: bool
+    # Echo of ``reason`` plus the terminal status the router observed
+    # for the underlying container — useful when the brain calls
+    # close on an already-terminated session.
+    terminal_state: str = ""
+
+
+# ── Diagnostics: list sessions ────────────────────────────────────────
+
+
+class SessionRecord(BaseModel):
+    """One entry in ``GET /v1/computer_sessions`` and the persisted
+    ``KIND_SESSION`` blob in :class:`RunStateStore`.
+
+    Reaper + router both read this shape; keep additions backwards-
+    compatible so a stale on-disk record still parses.
+    """
+
+    session_id: str
+    tenant_id: str
+    profile_id: str
+    run_id: str
+    base_url: str
+    sandbox_id: str = ""
+    session_token: str = ""
+    created_at_ms: int
+    expires_at_ms: int
+    last_action_ms: int = 0
+    status: str = "active"  # active | closed | reaped | error
+    error: str = ""
+
+
+class SessionListResponse(BaseModel):
+    """Reply to ``GET /v1/computer_sessions`` (operator/diagnostic)."""
+
+    sessions: list[SessionRecord]
+    count: int
+
+
+# ── Errors ────────────────────────────────────────────────────────────
+
+
+# Distinct exception types the router raises; the FastAPI shell maps
+# them to HTTP status codes. Defined here so PR 2's orchestrator and
+# PR 3's brain-side resolver can both import + react to them without
+# pulling in FastAPI.
+
+
+class SessionRouterError(Exception):
+    """Base — never raised directly; always one of the subclasses."""
+
+    http_status: int = 500
+
+
+class SessionNotFoundError(SessionRouterError):
+    http_status = 404
+
+
+class SessionUnreachableError(SessionRouterError):
+    """Orchestrator spawned the container but it never became
+    reachable before timeout."""
+
+    http_status = 504
+
+
+class SessionQuotaExceededError(SessionRouterError):
+    """Tenant hit a per-tenant active-session cap. Distinct from a
+    profile-lock 409 — quota is across all profiles."""
+
+    http_status = 429
+
+
+# ── Store helpers ─────────────────────────────────────────────────────
+
+
+# Wire-contract namespace. The router/orchestrator + reaper both use
+# these to read and write SessionRecord blobs into the cross-replica
+# :class:`run_state_store.RunStateStore`. Defined here so the
+# brain-side resolver can read sessions without importing the
+# orchestrator (which would pull in Modal SDK).
+
+
+def parse_session_record(blob: dict | None) -> SessionRecord | None:
+    """Permissive parse — None or shape-mismatched blob → None.
+
+    Reaper iterates many records; one corrupt blob shouldn't poison
+    the whole sweep. The reaper falls back to the underlying string
+    representation for logging.
+    """
+    if not isinstance(blob, dict):
+        return None
+    try:
+        return SessionRecord.model_validate(blob)
+    except Exception:  # noqa: BLE001 — store fault ≠ run fault
+        return None
+
+
+def serialize_session_record(record: SessionRecord) -> dict:
+    """Round-trip-safe dict for storage. Always JSON-friendly."""
+    return record.model_dump(mode="json")
+
+
+def iter_session_records(
+    store, *, tenant_id: str | None = None,
+):
+    """Yield ``SessionRecord`` for each persisted session.
+
+    ``store`` is a :class:`run_state_store.RunStateStore` (or any
+    backing whose ``_d.keys()`` yields the canonical key strings).
+    Unparseable entries are skipped with no exception so a reaper
+    sweep can't be derailed by one bad record.
+
+    ``tenant_id`` filter is best-effort — based on the key prefix
+    sanitization done at write time. ``None`` (default) yields all
+    tenants.
+    """
+    from .run_state_store import KIND_SESSION, list_active_keys
+
+    suffix = f"/{KIND_SESSION}"
+    prefix = ""
+    if tenant_id:
+        # Cheap-and-cheerful prefix match — mirrors run_state_store's
+        # ``_safe`` sanitization (alnum + dash/underscore preserved).
+        prefix = "".join(
+            c if c.isalnum() or c in {"-", "_"} else "_" for c in tenant_id
+        ) + "/"
+
+    for key in list_active_keys(store):
+        if not isinstance(key, str) or not key.endswith(suffix):
+            continue
+        if prefix and not key.startswith(prefix):
+            continue
+        # Reconstruct (tenant_id, session_id, kind) from the key shape
+        # ``<tenant>/<session_id>/<kind>``. ``rsplit`` is enough — the
+        # tenant slot can never contain "/" after sanitization.
+        try:
+            tenant_seg, sid, _kind = key.rsplit("/", 2)
+        except ValueError:
+            continue
+        blob = store.get(tenant_seg, sid, KIND_SESSION)
+        record = parse_session_record(blob)
+        if record is not None:
+            yield record

--- a/tests/test_session_wire.py
+++ b/tests/test_session_wire.py
@@ -1,0 +1,236 @@
+"""Unit tests for the session-router wire contract (Phase 1.5, #846).
+
+Foundation PR — wire models + KIND_SESSION on RunStateStore. No Modal,
+no FastAPI, no HTTP.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from mantis_agent.session_wire import (
+    SessionCloseRequest,
+    SessionCloseResponse,
+    SessionCreateRequest,
+    SessionCreateResponse,
+    SessionNotFoundError,
+    SessionQuotaExceededError,
+    SessionRecord,
+    SessionRouterError,
+    SessionUnreachableError,
+    iter_session_records,
+    parse_session_record,
+    serialize_session_record,
+)
+from mantis_agent.run_state_store import KIND_SESSION, RunStateStore
+
+
+# ── Wire models ───────────────────────────────────────────────────────
+
+
+def test_session_create_request_defaults() -> None:
+    req = SessionCreateRequest(
+        tenant_id="t1", profile_id="alice", run_id="r1",
+    )
+    assert req.start_url == "about:blank"
+    assert req.viewport == (1280, 720)
+    assert req.enable_cdp is False
+    assert req.ttl_seconds == 3600
+
+
+def test_session_create_request_clamps_ttl() -> None:
+    # Below floor → ValidationError
+    with pytest.raises(Exception):
+        SessionCreateRequest(
+            tenant_id="t1", profile_id="p", run_id="r", ttl_seconds=30,
+        )
+    # Above ceiling → ValidationError
+    with pytest.raises(Exception):
+        SessionCreateRequest(
+            tenant_id="t1", profile_id="p", run_id="r", ttl_seconds=999999,
+        )
+
+
+def test_session_create_request_round_trips_through_json() -> None:
+    req = SessionCreateRequest(
+        tenant_id="t1", profile_id="alice", run_id="r1",
+        start_url="https://example.com",
+        viewport=(1920, 1080),
+        proxy_server="http://proxy:8080",
+        profile_dir="/data/chrome-profile/x",
+        extra_http_headers={"X-Bypass-Warning": "1"},
+        enable_cdp=True,
+        ttl_seconds=7200,
+    )
+    blob = req.model_dump(mode="json")
+    same = SessionCreateRequest.model_validate(blob)
+    assert same == req
+
+
+def test_session_create_response_carries_required_fields() -> None:
+    resp = SessionCreateResponse(
+        session_id="sess_abc",
+        base_url="https://t-abc.modal.run",
+        session_token="tok_xyz",
+        expires_at_ms=int(time.time() * 1000) + 3_600_000,
+    )
+    assert resp.reused is False
+    assert resp.sandbox_id == ""
+
+
+def test_session_close_request_default_reason() -> None:
+    req = SessionCloseRequest(session_id="sess_1")
+    assert req.reason == "brain_closed"
+
+
+def test_session_close_response_defaults() -> None:
+    resp = SessionCloseResponse(closed=True)
+    assert resp.terminal_state == ""
+
+
+# ── Error subclasses keep their http_status ───────────────────────────
+
+
+def test_router_errors_carry_http_status() -> None:
+    assert SessionNotFoundError.http_status == 404
+    assert SessionUnreachableError.http_status == 504
+    assert SessionQuotaExceededError.http_status == 429
+    assert SessionRouterError.http_status == 500
+    # All subclass the base.
+    assert issubclass(SessionNotFoundError, SessionRouterError)
+    assert issubclass(SessionUnreachableError, SessionRouterError)
+    assert issubclass(SessionQuotaExceededError, SessionRouterError)
+
+
+# ── parse / serialize round-trip ──────────────────────────────────────
+
+
+def test_parse_session_record_round_trip() -> None:
+    record = SessionRecord(
+        session_id="sess_1",
+        tenant_id="t1",
+        profile_id="alice",
+        run_id="r1",
+        base_url="https://x.modal.run",
+        sandbox_id="sb_1",
+        session_token="tok_1",
+        created_at_ms=1_000_000,
+        expires_at_ms=2_000_000,
+    )
+    blob = serialize_session_record(record)
+    assert blob["session_id"] == "sess_1"
+    parsed = parse_session_record(blob)
+    assert parsed == record
+
+
+def test_parse_session_record_handles_none_and_garbage() -> None:
+    assert parse_session_record(None) is None
+    assert parse_session_record({}) is None
+    assert parse_session_record({"session_id": 1}) is None
+    assert parse_session_record({"unexpected": "shape"}) is None
+
+
+def test_parse_session_record_tolerates_extra_fields() -> None:
+    """Forward compat — a newer router can add fields without breaking
+    an older reaper that reads existing records."""
+    record = SessionRecord(
+        session_id="sess_1", tenant_id="t1", profile_id="p", run_id="r",
+        base_url="x", created_at_ms=0, expires_at_ms=0,
+    )
+    blob = serialize_session_record(record) | {"future_field": "ignored"}
+    parsed = parse_session_record(blob)
+    assert parsed is not None
+    assert parsed.session_id == "sess_1"
+
+
+# ── iter_session_records: list across tenants + filter by tenant ─────
+
+
+def _store_with_sessions(records: list[SessionRecord]) -> RunStateStore:
+    """Plain-dict-backed store with KIND_SESSION blobs for each record.
+
+    Session blobs are stored under the (tenant_id, session_id,
+    KIND_SESSION) tuple — session_id occupies the run_id slot of the
+    canonical key, because sessions outlive runs sometimes (reaper
+    sweep recreates).
+    """
+    store = RunStateStore(backing={})
+    for r in records:
+        store.put(r.tenant_id, r.session_id, KIND_SESSION,
+                  serialize_session_record(r))
+    return store
+
+
+def _mk(session_id: str, tenant_id: str = "t1") -> SessionRecord:
+    return SessionRecord(
+        session_id=session_id, tenant_id=tenant_id,
+        profile_id="p", run_id="r",
+        base_url=f"https://{session_id}.x",
+        created_at_ms=0, expires_at_ms=0,
+    )
+
+
+def test_iter_session_records_returns_all_across_tenants() -> None:
+    store = _store_with_sessions([_mk("a"), _mk("b", "t2"), _mk("c", "t3")])
+    out = list(iter_session_records(store))
+    ids = sorted(r.session_id for r in out)
+    assert ids == ["a", "b", "c"]
+
+
+def test_iter_session_records_filters_by_tenant() -> None:
+    store = _store_with_sessions([_mk("a", "alice"), _mk("b", "bob"), _mk("c", "alice")])
+    out = sorted(r.session_id for r in iter_session_records(store, tenant_id="alice"))
+    assert out == ["a", "c"]
+
+
+def test_iter_session_records_skips_unrelated_kinds() -> None:
+    """The store is shared with KIND_STATUS / KIND_VIEWER / etc.;
+    listing must not pick those up."""
+    from mantis_agent.run_state_store import (
+        KIND_AUGUR,
+        KIND_STATUS,
+        KIND_VIEWER,
+    )
+    store = _store_with_sessions([_mk("a")])
+    store.put("t1", "run-1", KIND_STATUS, {"status": "running"})
+    store.put("t1", "run-1", KIND_VIEWER, {"viewer_url": "x"})
+    store.put("t1", "run-1", KIND_AUGUR, {"augur_run_id": "y"})
+    out = [r.session_id for r in iter_session_records(store)]
+    assert out == ["a"]
+
+
+def test_iter_session_records_handles_corrupt_blob_gracefully() -> None:
+    """A SessionRecord blob written by a newer/older shape that fails
+    validation must be skipped, not raised."""
+    store = _store_with_sessions([_mk("ok")])
+    # Inject a corrupt blob under a session-shaped key by reaching
+    # into the backing dict directly.
+    store._d["t1/corrupt/session"] = {"not_a_session": True}  # noqa: SLF001
+    out = [r.session_id for r in iter_session_records(store)]
+    assert out == ["ok"]
+
+
+def test_iter_session_records_with_unknown_tenant_returns_nothing() -> None:
+    store = _store_with_sessions([_mk("a", "alice")])
+    assert list(iter_session_records(store, tenant_id="bob")) == []
+
+
+# ── KIND_SESSION registered ───────────────────────────────────────────
+
+
+def test_kind_session_round_trip_through_store() -> None:
+    """Smoke: KIND_SESSION is wired into the store's validator set so
+    put/get with it works without raising."""
+    store = RunStateStore(backing={})
+    blob = {"hello": "world"}
+    store.put("t1", "sess_x", KIND_SESSION, blob)
+    assert store.get("t1", "sess_x", KIND_SESSION) == blob
+
+
+def test_kind_session_typo_still_rejected() -> None:
+    """Sanity — the validator wasn't loosened when KIND_SESSION was added."""
+    store = RunStateStore(backing={})
+    with pytest.raises(ValueError):
+        store.put("t1", "sess_x", "sesion", {})  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

**PR 1 of 4** for #846 (Phase 1.5 — per-session Modal containers + session router).

Pure-additive foundation. Zero behavior change for prod. Lays the wire contract + state-store namespace the next 3 PRs build on.

## Staged plan

| PR | Branch | Scope |
|---|---|---|
| **1 (this)** | `feat/phase15-session-router-foundation` | Wire contract + `KIND_SESSION` + tests |
| 2 | `feat/phase15-orchestrator` | `computer_session` Modal function + `POST/DELETE /v1/computer_sessions` endpoints |
| 3 | `feat/phase15-brain-wireup` | `SessionRoutedComputerImpl` + executor switchover (env-flag gated) |
| 4 | `feat/phase15-reaper` | Scheduled cleanup of orphaned sandboxes |

## Changes

- **`src/mantis_agent/gym/session_wire.py`** — Pydantic models for the session router:
  - `SessionCreateRequest` / `SessionCreateResponse`
  - `SessionCloseRequest` / `SessionCloseResponse`
  - `SessionRecord` (the persisted blob), `SessionListResponse`
  - Typed error subclasses: `SessionNotFoundError` (404), `SessionUnreachableError` (504), `SessionQuotaExceededError` (429), base `SessionRouterError` (500)
  - Store helpers: `iter_session_records()`, `parse_session_record()`, `serialize_session_record()`
- **`src/mantis_agent/run_state_store.py`** — register `KIND_SESSION`. Stored under `(tenant_id, session_id, KIND_SESSION)` so the record survives the run that opened it (reaper forensics).
- **`tests/test_session_wire.py`** — 17 cases: round-trip, defaults, TTL clamps, tenant filter, corrupt-blob skip, KIND validator regression guard.

## Why it's safe

- No existing code imports from `session_wire.py` yet — it's net-new
- `KIND_SESSION` is registered but no one writes to it yet
- `iter_session_records` is unused outside tests until PR 4
- The two-line `_VALID_KINDS` change is the only edit to a touched file; covered by the existing typo-rejection test

## Test plan

- [x] `tests/test_session_wire.py` — 17 new cases, all green
- [x] `tests/test_run_state_store.py` — 11 existing cases still green
- [x] Full sweep across the modal/lifecycle suites — no regressions (1 pre-existing failure on main unrelated)
- [x] Ruff clean

## Next

After this merges I'll open PR 2 (`feat/phase15-orchestrator`) with the actual Modal session function + router endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)