### PR TITLE
feat(computer-plane): Phase 1.5 brain-side session wireup (#846)

### DIFF
--- a/src/mantis_agent/gym/computer_client.py
+++ b/src/mantis_agent/gym/computer_client.py
@@ -46,6 +46,16 @@ class ComputerPlaneConfig:
     # Opt-in CDP escape hatch. Defaults off per `feedback_cua_no_dom_access`.
     enable_cdp: bool = False
 
+    # Phase 1.5 (#846) — when set, brain talks to the session router
+    # to mint a per-session computer-plane container instead of the
+    # pinned ``computer_plane()`` ASGI app. ``session_router_url`` is
+    # the base URL of the router (typically the api() ASGI URL);
+    # ``session_router_auth_token`` is the tenant token the router's
+    # ``require_run_scope`` middleware expects.
+    session_router_url: str | None = None
+    session_router_auth_token: str | None = None
+    session_ttl_seconds: int = 3600
+
     # Per-executor overrides — `{"run_claude_cua": "modal"}`.
     per_executor_overrides: dict[str, ComputerPlaneBackend] = field(default_factory=dict)
 
@@ -65,6 +75,9 @@ class ComputerPlaneConfig:
             remote_base_url=self.remote_base_url,
             remote_auth_token=self.remote_auth_token,
             enable_cdp=self.enable_cdp,
+            session_router_url=self.session_router_url,
+            session_router_auth_token=self.session_router_auth_token,
+            session_ttl_seconds=self.session_ttl_seconds,
             per_executor_overrides=self.per_executor_overrides,
         )
 
@@ -103,9 +116,32 @@ def make_computer_client(
         return LocalXdotoolImpl(**env_kwargs)
 
     if backend == "modal":
+        # Phase 1.5 (#846) — session-routed path. When the caller
+        # configured a session router, mint a per-session container
+        # via the router and talk to that container's tunnel URL.
+        # Falls through to the pinned ``computer_plane()`` ASGI app
+        # when ``session_router_url`` isn't set, preserving Phase 1
+        # behaviour for callers that haven't opted in.
+        if cfg.session_router_url:
+            if not cfg.session_router_auth_token:
+                raise ValueError(
+                    "ComputerPlaneConfig.session_router_url requires "
+                    "session_router_auth_token"
+                )
+            from .session_routed_impl import SessionRoutedComputerImpl
+
+            return SessionRoutedComputerImpl(
+                router_url=cfg.session_router_url,
+                auth_token=cfg.session_router_auth_token,
+                enable_cdp=cfg.enable_cdp,
+                ttl_seconds=cfg.session_ttl_seconds,
+                **env_kwargs,
+            )
+
         if not cfg.remote_base_url:
             raise ValueError(
-                "ComputerPlaneConfig.backend='modal' requires remote_base_url"
+                "ComputerPlaneConfig.backend='modal' requires remote_base_url "
+                "(or session_router_url for the Phase 1.5 path)"
             )
         from .remote_computer_impl import RemoteComputerImpl
 

--- a/src/mantis_agent/gym/remote_computer_impl.py
+++ b/src/mantis_agent/gym/remote_computer_impl.py
@@ -95,6 +95,13 @@ class RemoteComputerImpl(ComputerClient):
         # profile with the brain-supplied header set.
         profile_dir: str | None = None,
         extra_http_headers: dict[str, str] | None = None,
+        # Phase 1.5 (#846): when the brain talks to a per-session
+        # container via the router, the router has already bound the
+        # session and minted a token before publishing the tunnel URL.
+        # Pre-setting ``self._session_token`` short-circuits
+        # ``session_init()`` so we don't double-bind (which would 409
+        # against the orchestrator's existing session).
+        pre_minted_session_token: str | None = None,
         # The following kwargs are accepted for parity with
         # XdotoolGymEnv.__init__ but unused server-side (computer plane
         # manages its own lifecycle).
@@ -119,7 +126,7 @@ class RemoteComputerImpl(ComputerClient):
         self._timeout = request_timeout_seconds
         self._profile_dir = profile_dir
         self._extra_http_headers = extra_http_headers or None
-        self._session_token: str | None = None
+        self._session_token: str | None = pre_minted_session_token or None
 
         self.screenshot_latency = LatencyTracker("screenshot")
         self.xdotool_latency = LatencyTracker("xdotool")
@@ -225,6 +232,16 @@ class RemoteComputerImpl(ComputerClient):
     # ── wire contract surface (used by tests + advanced callers) ────
 
     def session_init(self) -> SessionInitResponse:
+        # Phase 1.5 (#846): when the router already minted a session
+        # against the per-session container, skip the /session/init
+        # hop — that container's ComputerAgent state is already bound
+        # and a second init would 409 against the live session.
+        if self._session_token:
+            return SessionInitResponse(
+                session_token=self._session_token,
+                chrome_pid=None,
+                xvfb_display=":99",
+            )
         req = SessionInitRequest(
             tenant_id=self._tenant_id,
             profile_id=self._profile_id,

--- a/src/mantis_agent/gym/session_routed_impl.py
+++ b/src/mantis_agent/gym/session_routed_impl.py
@@ -1,0 +1,134 @@
+"""``SessionRoutedComputerImpl`` — RemoteComputerImpl backed by the
+Phase 1.5 session router (#846).
+
+On construction this client calls the router's
+``POST /v1/computer_sessions`` to mint a dedicated per-session
+container, then constructs the underlying ``RemoteComputerImpl``
+against the per-session tunnel URL (with the pre-minted session token
+short-circuiting the ``/session/init`` hop).
+
+On ``shutdown()`` it tears the session down via the router's
+``DELETE /v1/computer_sessions/{session_id}`` before delegating to
+the superclass's session-close path. Close is best-effort by default
+— a 404 from the router (reaper already terminated) is swallowed so
+the brain's teardown doesn't surface noise.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from ..server.session_router_client import SessionRouterClient
+from .remote_computer_impl import RemoteComputerImpl
+from ..session_wire import SessionCreateRequest
+
+logger = logging.getLogger(__name__)
+
+
+class SessionRoutedComputerImpl(RemoteComputerImpl):
+    """Construct-then-delegate wrapper around the per-session router."""
+
+    def __init__(
+        self,
+        *,
+        router_url: str,
+        auth_token: str,
+        # Forwarded into SessionCreateRequest:
+        tenant_id: str,
+        profile_id: str,
+        run_id: str,
+        start_url: str = "about:blank",
+        viewport: tuple[int, int] = (1280, 720),
+        proxy_server: str = "",
+        profile_dir: str | None = None,
+        extra_http_headers: dict[str, str] | None = None,
+        enable_cdp: bool = False,
+        ttl_seconds: int = 3600,
+        # Optional DI for tests:
+        router_client: SessionRouterClient | None = None,
+        # Everything else (chrome_flags, settle_time, …) is forwarded
+        # straight through to ``RemoteComputerImpl.__init__`` for
+        # XdotoolGymEnv kwarg parity.
+        **remote_kwargs: Any,
+    ) -> None:
+        client = router_client or SessionRouterClient(
+            router_url=router_url, auth_token=auth_token,
+        )
+        req = SessionCreateRequest(
+            tenant_id=tenant_id,
+            profile_id=profile_id,
+            run_id=run_id,
+            start_url=start_url,
+            viewport=viewport,
+            proxy_server=proxy_server,
+            profile_dir=profile_dir,
+            extra_http_headers=extra_http_headers,
+            enable_cdp=enable_cdp,
+            ttl_seconds=ttl_seconds,
+        )
+        # Bubble SessionRouterError up unchanged — make_computer_client
+        # callers decide whether to fall back to the pinned
+        # ``computer_plane`` ASGI URL.
+        response = client.create_session(req)
+
+        self._router_client = client
+        self._session_id = response.session_id
+        self._session_expires_at_ms = response.expires_at_ms
+        self._session_sandbox_id = response.sandbox_id
+
+        super().__init__(
+            base_url=response.base_url,
+            auth_token=None,  # tunnel URLs are unauthenticated; session
+                              # token is the only credential the
+                              # ComputerAgent enforces (X-Mantis-Session).
+            tenant_id=tenant_id,
+            profile_id=profile_id,
+            run_id=run_id,
+            start_url=start_url,
+            viewport=viewport,
+            proxy_server=proxy_server,
+            profile_dir=profile_dir,
+            extra_http_headers=extra_http_headers,
+            enable_cdp=enable_cdp,
+            pre_minted_session_token=response.session_token,
+            **remote_kwargs,
+        )
+
+    # ── lifecycle ─────────────────────────────────────────────────────
+
+    def close(self) -> None:
+        """Tear the session down via the router, then delegate.
+
+        Best-effort: a router-side 404 (already reaped) is swallowed so
+        the brain doesn't see noise when shutting down a session the
+        reaper already cleaned up.
+        """
+        try:
+            self._router_client.close_session(
+                self._session_id, reason="brain_closed", quiet=True,
+            )
+        except Exception as exc:  # noqa: BLE001 — never block teardown
+            logger.warning(
+                "SessionRoutedComputerImpl: router close raised (%s); "
+                "delegating to super().close() anyway",
+                exc,
+            )
+        super().close()
+
+    # ── observability ─────────────────────────────────────────────────
+
+    @property
+    def session_id(self) -> str:
+        """Router-minted session id; useful for log correlation."""
+        return self._session_id
+
+    @property
+    def sandbox_id(self) -> str:
+        """Modal FunctionCall id for the per-session container."""
+        return self._session_sandbox_id
+
+    @property
+    def session_expires_at_ms(self) -> int:
+        """When the reaper will consider this session orphaned."""
+        return self._session_expires_at_ms

--- a/src/mantis_agent/server/session_router_client.py
+++ b/src/mantis_agent/server/session_router_client.py
@@ -1,0 +1,162 @@
+"""HTTPS client for the session-router endpoints (Phase 1.5, #846, PR 3).
+
+The brain plane uses this to mint a dedicated computer-plane session
+at run start (``POST /v1/computer_sessions``) and tear it down at
+end (``DELETE /v1/computer_sessions/{session_id}``). Pure-HTTPS, no
+Modal client dependency — works the same from inside or outside a
+Modal container.
+
+Talks to the router defined in
+``deploy/modal/modal_cua_server.build_api_app``; wire-contract from
+``mantis_agent.session_wire``.
+
+Failure semantics — quiet by default:
+
+* Connection / 5xx → ``SessionRouterError`` with the upstream detail.
+  Caller decides whether to fall back to the pinned ``computer_plane``
+  ASGI app (the current Phase 1 behaviour).
+* 4xx → raised with the upstream detail; not retried.
+* ``close_session`` failures are best-effort by default — closing a
+  session that the reaper already terminated should not surface as
+  an error to the brain.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import requests
+
+from ..session_wire import (
+    SessionCloseResponse,
+    SessionCreateRequest,
+    SessionCreateResponse,
+    SessionNotFoundError,
+    SessionQuotaExceededError,
+    SessionRouterError,
+    SessionUnreachableError,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# Defaults tuned for the cold-start + tunnel-publish budget on the
+# orchestrator side. The router itself caps the wait at 120s; we add
+# a small margin so the HTTPS layer doesn't timeout first.
+_DEFAULT_CREATE_TIMEOUT_SECONDS = 150.0
+_DEFAULT_CLOSE_TIMEOUT_SECONDS = 15.0
+
+
+class SessionRouterClient:
+    """Tiny HTTPS shim around ``/v1/computer_sessions``.
+
+    Stateless — constructed once per executor, used to create the
+    session and (later) close it.
+    """
+
+    def __init__(
+        self,
+        *,
+        router_url: str,
+        auth_token: str,
+        create_timeout_seconds: float = _DEFAULT_CREATE_TIMEOUT_SECONDS,
+        close_timeout_seconds: float = _DEFAULT_CLOSE_TIMEOUT_SECONDS,
+        # DI seam so tests can swap out the HTTP layer without
+        # monkeypatching ``requests`` globally.
+        session: Any | None = None,
+    ) -> None:
+        if not router_url:
+            raise ValueError("SessionRouterClient requires a non-empty router_url")
+        if not auth_token:
+            raise ValueError("SessionRouterClient requires a non-empty auth_token")
+        self._router_url = router_url.rstrip("/")
+        self._auth_token = auth_token
+        self._create_timeout = float(create_timeout_seconds)
+        self._close_timeout = float(close_timeout_seconds)
+        self._http = session or requests
+
+    def _headers(self) -> dict[str, str]:
+        return {
+            "X-Mantis-Token": self._auth_token,
+            "Content-Type": "application/json",
+        }
+
+    def _raise_for_status(self, resp: Any, op: str) -> None:
+        if resp.status_code < 400:
+            return
+        try:
+            detail = resp.json().get("detail") or resp.text
+        except ValueError:
+            detail = resp.text
+        if resp.status_code == 404:
+            raise SessionNotFoundError(f"{op}: {detail}")
+        if resp.status_code == 429:
+            raise SessionQuotaExceededError(f"{op}: {detail}")
+        if resp.status_code == 504:
+            raise SessionUnreachableError(f"{op}: {detail}")
+        # Catch-all — preserves the upstream status code in the message.
+        raise SessionRouterError(f"{op} HTTP {resp.status_code}: {detail}")
+
+    # ── Create ────────────────────────────────────────────────────────
+
+    def create_session(self, req: SessionCreateRequest) -> SessionCreateResponse:
+        """Mint a session via the router. Blocks up to the
+        ``create_timeout_seconds`` budget while the orchestrator does
+        its cold-start + ``modal.forward`` dance."""
+        try:
+            resp = self._http.post(
+                self._router_url + "/v1/computer_sessions",
+                json=req.model_dump(mode="json"),
+                headers=self._headers(),
+                timeout=self._create_timeout,
+            )
+        except requests.RequestException as exc:
+            raise SessionUnreachableError(
+                f"create_session: router unreachable ({exc})"
+            ) from exc
+        self._raise_for_status(resp, "create_session")
+        return SessionCreateResponse.model_validate(resp.json())
+
+    # ── Close ─────────────────────────────────────────────────────────
+
+    def close_session(
+        self, session_id: str, *, reason: str = "brain_closed",
+        quiet: bool = True,
+    ) -> SessionCloseResponse | None:
+        """Best-effort by default — a 404 here means the reaper got
+        there first, and the brain shouldn't surface that. Set
+        ``quiet=False`` to bubble errors when callers care.
+        """
+        url = f"{self._router_url}/v1/computer_sessions/{session_id}"
+        try:
+            resp = self._http.delete(
+                url,
+                headers={**self._headers(), "X-Mantis-Reason": reason},
+                timeout=self._close_timeout,
+            )
+        except requests.RequestException as exc:
+            if quiet:
+                logger.warning(
+                    "close_session: router unreachable session=%s (%s)",
+                    session_id, exc,
+                )
+                return None
+            raise SessionUnreachableError(
+                f"close_session: router unreachable ({exc})"
+            ) from exc
+        try:
+            self._raise_for_status(resp, "close_session")
+        except SessionNotFoundError:
+            if quiet:
+                return None
+            raise
+        except SessionRouterError:
+            if quiet:
+                logger.warning(
+                    "close_session: router error session=%s status=%s",
+                    session_id, resp.status_code,
+                )
+                return None
+            raise
+        return SessionCloseResponse.model_validate(resp.json())

--- a/src/mantis_agent/task_loop.py
+++ b/src/mantis_agent/task_loop.py
@@ -141,6 +141,18 @@ def _computer_plane_config_from_env(
     * `MANTIS_COMPUTER_PLANE_TOKEN` — `Authorization: Bearer ...`
     * `MANTIS_COMPUTER_PLANE_ENABLE_CDP` — `1`/`true` to opt in
       (off by default per the wire-contract CUA-purity constraint).
+
+    Phase 1.5 (#846) — session-routed mode:
+
+    * `MANTIS_SESSION_ROUTER_URL` — router base URL (typically the
+      ``api()`` ASGI URL). When set, brain mints a dedicated
+      per-session computer-plane container via
+      ``POST /v1/computer_sessions`` instead of sharing the pinned
+      ``computer_plane()`` ASGI app.
+    * `MANTIS_SESSION_ROUTER_TOKEN` — tenant token forwarded to the
+      router's ``require_run_scope`` middleware.
+    * `MANTIS_SESSION_TTL_SECONDS` — per-session lifetime (seconds);
+      clamped against the deployment cap server-side.
     """
     from .gym.computer_client import ComputerPlaneConfig
 
@@ -150,11 +162,18 @@ def _computer_plane_config_from_env(
     enable_cdp = (os.environ.get("MANTIS_COMPUTER_PLANE_ENABLE_CDP") or "").strip().lower() in (
         "1", "true", "yes", "on",
     )
+    try:
+        session_ttl = int(os.environ.get("MANTIS_SESSION_TTL_SECONDS") or "3600")
+    except ValueError:
+        session_ttl = 3600
     cfg = ComputerPlaneConfig(
         backend=backend_env,  # type: ignore[arg-type]
         remote_base_url=(os.environ.get("MANTIS_COMPUTER_PLANE_URL") or "").strip() or None,
         remote_auth_token=(os.environ.get("MANTIS_COMPUTER_PLANE_TOKEN") or "").strip() or None,
         enable_cdp=enable_cdp,
+        session_router_url=(os.environ.get("MANTIS_SESSION_ROUTER_URL") or "").strip() or None,
+        session_router_auth_token=(os.environ.get("MANTIS_SESSION_ROUTER_TOKEN") or "").strip() or None,
+        session_ttl_seconds=session_ttl,
     )
     return cfg.resolve_for_executor(executor_name)
 

--- a/tests/test_session_routed_impl.py
+++ b/tests/test_session_routed_impl.py
@@ -1,0 +1,234 @@
+"""Tests for ``SessionRoutedComputerImpl`` (Phase 1.5, #846, PR 3).
+
+Drives the wrapper against a stubbed ``SessionRouterClient`` so the
+construct → mint-session → delegate flow is exercised without Modal,
+without HTTP, without Xvfb / Chrome.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from mantis_agent.gym.computer_client import (
+    ComputerPlaneConfig,
+    make_computer_client,
+)
+from mantis_agent.gym.session_routed_impl import SessionRoutedComputerImpl
+from mantis_agent.session_wire import (
+    SessionCloseResponse,
+    SessionCreateResponse,
+    SessionRouterError,
+    SessionUnreachableError,
+)
+
+
+class _StubRouterClient:
+    """Records calls + serves canned responses."""
+
+    def __init__(
+        self,
+        create_response: SessionCreateResponse | Exception | None = None,
+    ) -> None:
+        self.create_calls: list[Any] = []
+        self.close_calls: list[tuple[str, str]] = []
+        self._create_response = create_response or SessionCreateResponse(
+            session_id="sess_stub",
+            base_url="https://stub.modal.run",
+            session_token="tok_stub",
+            expires_at_ms=2_000_000_000_000,
+            sandbox_id="fc-stub",
+        )
+
+    def create_session(self, req):
+        self.create_calls.append(req)
+        if isinstance(self._create_response, Exception):
+            raise self._create_response
+        return self._create_response
+
+    def close_session(self, session_id: str, *, reason: str = "brain_closed", quiet: bool = True):
+        self.close_calls.append((session_id, reason))
+        return SessionCloseResponse(closed=True, terminal_state="closed")
+
+
+# ── Construction wires session_token via pre_minted path ─────────────
+
+
+def test_construct_mints_session_and_pre_seeds_token() -> None:
+    client = _StubRouterClient()
+    impl = SessionRoutedComputerImpl(
+        router_url="https://api.modal.run",
+        auth_token="my-token",
+        tenant_id="t1",
+        profile_id="alice",
+        run_id="r1",
+        router_client=client,
+    )
+    # Router was called once with the right identity.
+    assert len(client.create_calls) == 1
+    req = client.create_calls[0]
+    assert req.tenant_id == "t1"
+    assert req.profile_id == "alice"
+    assert req.run_id == "r1"
+    # base_url + token bubbled through to the underlying impl.
+    assert impl._base_url == "https://stub.modal.run"  # noqa: SLF001
+    assert impl._session_token == "tok_stub"  # noqa: SLF001
+    # session_id exposed for log correlation.
+    assert impl.session_id == "sess_stub"
+    assert impl.sandbox_id == "fc-stub"
+
+
+def test_construct_propagates_session_create_failure() -> None:
+    """Router unreachable → SessionUnreachableError bubbles up.
+    make_computer_client callers decide whether to fall back to the
+    pinned computer_plane URL."""
+    client = _StubRouterClient(
+        create_response=SessionUnreachableError("router timeout"),
+    )
+    with pytest.raises(SessionUnreachableError):
+        SessionRoutedComputerImpl(
+            router_url="https://api.modal.run",
+            auth_token="my-token",
+            tenant_id="t", profile_id="p", run_id="r",
+            router_client=client,
+        )
+
+
+# ── close() teardown calls the router then super().close() ──────────
+
+
+def test_close_calls_router_then_super_close() -> None:
+    client = _StubRouterClient()
+    impl = SessionRoutedComputerImpl(
+        router_url="https://x", auth_token="t",
+        tenant_id="t1", profile_id="p", run_id="r",
+        router_client=client,
+    )
+    # Patch super().close — we just want to verify ordering, not test
+    # the network teardown.
+    super_called = {"hit": False}
+
+    def fake_super_close(self) -> None:
+        super_called["hit"] = True
+
+    SessionRoutedComputerImpl.__mro__[1].close = fake_super_close  # type: ignore[assignment]
+    impl.close()
+    assert client.close_calls == [("sess_stub", "brain_closed")]
+    assert super_called["hit"]
+
+
+def test_close_swallows_router_failure() -> None:
+    """A router-side failure on close must not prevent the underlying
+    super().close() — otherwise we leak the session-token cache + the
+    brain's teardown surface gets noisy."""
+
+    class _Boom(_StubRouterClient):
+        def close_session(self, *args, **kwargs):
+            raise SessionRouterError("router 500")
+
+    impl = SessionRoutedComputerImpl(
+        router_url="https://x", auth_token="t",
+        tenant_id="t1", profile_id="p", run_id="r",
+        router_client=_Boom(),
+    )
+    super_called = {"hit": False}
+
+    def fake_super_close(self) -> None:
+        super_called["hit"] = True
+
+    SessionRoutedComputerImpl.__mro__[1].close = fake_super_close  # type: ignore[assignment]
+    impl.close()
+    assert super_called["hit"]
+
+
+# ── make_computer_client dispatches to the session-routed path ──────
+
+
+def test_make_computer_client_routes_to_session_when_router_url_set(monkeypatch) -> None:
+    """The factory must pick SessionRoutedComputerImpl when
+    ``session_router_url`` is set; otherwise fall back to the pinned
+    RemoteComputerImpl path."""
+    captured = {}
+
+    class _StubImpl:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(
+        "mantis_agent.gym.session_routed_impl.SessionRoutedComputerImpl",
+        _StubImpl,
+    )
+
+    cfg = ComputerPlaneConfig(
+        backend="modal",
+        session_router_url="https://api.modal.run",
+        session_router_auth_token="my-token",
+        session_ttl_seconds=1800,
+    )
+    out = make_computer_client(
+        cfg,
+        tenant_id="t1", profile_id="p", run_id="r",
+        start_url="https://example.com",
+    )
+    assert isinstance(out, _StubImpl)
+    assert captured["router_url"] == "https://api.modal.run"
+    assert captured["auth_token"] == "my-token"
+    assert captured["ttl_seconds"] == 1800
+    assert captured["tenant_id"] == "t1"
+    assert captured["start_url"] == "https://example.com"
+
+
+def test_make_computer_client_falls_back_to_remote_when_no_router_url(monkeypatch) -> None:
+    """No router URL set → falls through to the existing
+    RemoteComputerImpl path (Phase 1 behaviour preserved)."""
+    captured = {}
+
+    class _StubRemote:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(
+        "mantis_agent.gym.remote_computer_impl.RemoteComputerImpl",
+        _StubRemote,
+    )
+    cfg = ComputerPlaneConfig(
+        backend="modal",
+        remote_base_url="https://pinned-computer-plane.modal.run",
+        remote_auth_token="some-bearer",
+    )
+    out = make_computer_client(cfg, tenant_id="t1", profile_id="p", run_id="r")
+    assert isinstance(out, _StubRemote)
+    assert captured["base_url"] == "https://pinned-computer-plane.modal.run"
+
+
+def test_make_computer_client_session_router_requires_token() -> None:
+    cfg = ComputerPlaneConfig(
+        backend="modal",
+        session_router_url="https://api.modal.run",
+        # No token.
+    )
+    with pytest.raises(ValueError, match="session_router_auth_token"):
+        make_computer_client(cfg, tenant_id="t", profile_id="p", run_id="r")
+
+
+# ── RemoteComputerImpl pre_minted_session_token short-circuit ───────
+
+
+def test_remote_computer_impl_skips_session_init_when_token_pre_minted(monkeypatch) -> None:
+    """When pre_minted_session_token is set, session_init() returns the
+    cached token instead of POSTing /session/init."""
+    from mantis_agent.gym.remote_computer_impl import RemoteComputerImpl
+
+    impl = RemoteComputerImpl(
+        base_url="https://x",
+        tenant_id="t", profile_id="p", run_id="r",
+        pre_minted_session_token="cached_tok",
+    )
+    # Prove that no _post is needed — by patching it to raise on call.
+    monkeypatch.setattr(
+        impl, "_post",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("should not POST")),
+    )
+    resp = impl.session_init()
+    assert resp.session_token == "cached_tok"

--- a/tests/test_session_router_client.py
+++ b/tests/test_session_router_client.py
@@ -1,0 +1,186 @@
+"""Tests for the brain-side ``SessionRouterClient`` (Phase 1.5, #846, PR 3).
+
+Drives the client against a stubbed HTTP session — no Modal, no
+network. Covers happy path, 404, 429, 504, network failure, and the
+quiet-close semantics.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+import requests
+
+from mantis_agent.session_wire import (
+    SessionCreateRequest,
+    SessionCreateResponse,
+    SessionNotFoundError,
+    SessionQuotaExceededError,
+    SessionRouterError,
+    SessionUnreachableError,
+)
+from mantis_agent.server.session_router_client import SessionRouterClient
+
+
+class _StubResp:
+    def __init__(self, status_code: int, body: Any) -> None:
+        self.status_code = status_code
+        self._body = body
+
+    def json(self) -> Any:
+        if isinstance(self._body, str):
+            return json.loads(self._body)
+        return self._body
+
+    @property
+    def text(self) -> str:
+        if isinstance(self._body, str):
+            return self._body
+        return json.dumps(self._body)
+
+
+class _StubHttp:
+    """Captures the post/delete calls so tests can assert on them."""
+
+    def __init__(self, post_resp: _StubResp | Exception, delete_resp: _StubResp | Exception | None = None) -> None:
+        self._post_resp = post_resp
+        self._delete_resp = delete_resp
+        self.post_calls: list[dict] = []
+        self.delete_calls: list[dict] = []
+
+    def post(self, url, *, json=None, headers=None, timeout=None) -> _StubResp:
+        self.post_calls.append({"url": url, "json": json, "headers": headers, "timeout": timeout})
+        if isinstance(self._post_resp, Exception):
+            raise self._post_resp
+        return self._post_resp
+
+    def delete(self, url, *, headers=None, timeout=None) -> _StubResp:
+        self.delete_calls.append({"url": url, "headers": headers, "timeout": timeout})
+        if isinstance(self._delete_resp, Exception):
+            raise self._delete_resp
+        return self._delete_resp
+
+
+def _req() -> SessionCreateRequest:
+    return SessionCreateRequest(
+        tenant_id="t1", profile_id="alice", run_id="r1",
+    )
+
+
+# ── Construction ──────────────────────────────────────────────────────
+
+
+def test_requires_router_url() -> None:
+    with pytest.raises(ValueError):
+        SessionRouterClient(router_url="", auth_token="t")
+
+
+def test_requires_auth_token() -> None:
+    with pytest.raises(ValueError):
+        SessionRouterClient(router_url="https://x", auth_token="")
+
+
+# ── create_session ────────────────────────────────────────────────────
+
+
+def test_create_session_happy_path() -> None:
+    body = {
+        "session_id": "sess_abc",
+        "base_url": "https://sess.modal.run",
+        "session_token": "tok_xyz",
+        "expires_at_ms": 1_700_000_000_000,
+        "sandbox_id": "fc-1",
+        "reused": False,
+    }
+    http = _StubHttp(_StubResp(200, body))
+    client = SessionRouterClient(
+        router_url="https://api.modal.run/", auth_token="my-token", session=http,
+    )
+    resp = client.create_session(_req())
+    assert isinstance(resp, SessionCreateResponse)
+    assert resp.session_id == "sess_abc"
+    assert resp.base_url == "https://sess.modal.run"
+    # URL trailing slash got stripped.
+    assert http.post_calls[0]["url"] == "https://api.modal.run/v1/computer_sessions"
+    # Token forwarded.
+    assert http.post_calls[0]["headers"]["X-Mantis-Token"] == "my-token"
+
+
+def test_create_session_504_raises_unreachable() -> None:
+    http = _StubHttp(_StubResp(504, {"detail": "did not publish tunnel URL"}))
+    client = SessionRouterClient(
+        router_url="https://x", auth_token="t", session=http,
+    )
+    with pytest.raises(SessionUnreachableError) as exc:
+        client.create_session(_req())
+    assert "did not publish tunnel URL" in str(exc.value)
+
+
+def test_create_session_429_raises_quota() -> None:
+    http = _StubHttp(_StubResp(429, {"detail": "tenant quota exceeded"}))
+    client = SessionRouterClient(router_url="https://x", auth_token="t", session=http)
+    with pytest.raises(SessionQuotaExceededError):
+        client.create_session(_req())
+
+
+def test_create_session_other_4xx_raises_base_error() -> None:
+    http = _StubHttp(_StubResp(403, {"detail": "tenant_id mismatch"}))
+    client = SessionRouterClient(router_url="https://x", auth_token="t", session=http)
+    with pytest.raises(SessionRouterError) as exc:
+        client.create_session(_req())
+    assert "403" in str(exc.value)
+
+
+def test_create_session_network_error_raises_unreachable() -> None:
+    http = _StubHttp(requests.ConnectionError("dns fail"))
+    client = SessionRouterClient(router_url="https://x", auth_token="t", session=http)
+    with pytest.raises(SessionUnreachableError):
+        client.create_session(_req())
+
+
+# ── close_session ─────────────────────────────────────────────────────
+
+
+def test_close_session_happy_path() -> None:
+    http = _StubHttp(
+        _StubResp(200, {"session_id": "x"}),
+        delete_resp=_StubResp(200, {"closed": True, "terminal_state": "closed"}),
+    )
+    client = SessionRouterClient(router_url="https://x", auth_token="t", session=http)
+    resp = client.close_session("sess_abc")
+    assert resp is not None
+    assert resp.closed is True
+    assert http.delete_calls[0]["url"] == "https://x/v1/computer_sessions/sess_abc"
+    assert http.delete_calls[0]["headers"]["X-Mantis-Reason"] == "brain_closed"
+
+
+def test_close_session_404_is_quiet_by_default() -> None:
+    """Reaper already cleaned up — close should not raise."""
+    http = _StubHttp(
+        _StubResp(200, {}),
+        delete_resp=_StubResp(404, {"detail": "unknown session_id"}),
+    )
+    client = SessionRouterClient(router_url="https://x", auth_token="t", session=http)
+    result = client.close_session("sess_gone")
+    assert result is None
+
+
+def test_close_session_404_raises_when_not_quiet() -> None:
+    http = _StubHttp(
+        _StubResp(200, {}),
+        delete_resp=_StubResp(404, {"detail": "unknown session_id"}),
+    )
+    client = SessionRouterClient(router_url="https://x", auth_token="t", session=http)
+    with pytest.raises(SessionNotFoundError):
+        client.close_session("sess_gone", quiet=False)
+
+
+def test_close_session_network_error_is_quiet_by_default() -> None:
+    http = _StubHttp(
+        _StubResp(200, {}),
+        delete_resp=requests.ConnectionError("split brain"),
+    )
+    client = SessionRouterClient(router_url="https://x", auth_token="t", session=http)
+    assert client.close_session("sess_x") is None


### PR DESCRIPTION
## Summary

**PR 3 of 4** for #846. **Stacked on #857** (orchestrator) which sits on #856 (foundation). Review/merge order: #856 → #857 → this.

Adds the brain-side path that mints a per-session computer-plane container via the router instead of sharing the pinned `computer_plane()` ASGI app. **Env-flag gated and opt-in per config** — no production runtime change until `MANTIS_SESSION_ROUTER_URL` is set.

## Changes

- **`SessionRouterClient`** (`mantis_agent.server.session_router_client`) — HTTPS shim. Typed errors. Close is best-effort by default.
- **`SessionRoutedComputerImpl`** (`mantis_agent.gym.session_routed_impl`) — `RemoteComputerImpl` subclass that creates/closes sessions on init/shutdown. Exposes `session_id` / `sandbox_id` / `session_expires_at_ms`.
- **`ComputerPlaneConfig`** — adds `session_router_url`, `session_router_auth_token`, `session_ttl_seconds`. `resolve_for_executor` carries them through.
- **`make_computer_client`** — dispatches to `SessionRoutedComputerImpl` when `session_router_url` is set; falls through to Phase 1 path otherwise.
- **`RemoteComputerImpl`** — accepts `pre_minted_session_token` kwarg. When set, `session_init()` short-circuits the `/session/init` HTTP call (router already bound the session).
- **`task_loop._computer_plane_config_from_env`** — reads three new env vars: `MANTIS_SESSION_ROUTER_URL`, `MANTIS_SESSION_ROUTER_TOKEN`, `MANTIS_SESSION_TTL_SECONDS`. Empty/unset → Phase 1 behaviour preserved.

## Test plan

- [x] `test_session_router_client.py` — 11 cases (construction validation, happy path, 404/429/504 mapping, network failure, quiet/non-quiet close)
- [x] `test_session_routed_impl.py` — 8 cases (construction wires session_token, propagates create-failure, close teardown order, router-failure swallow, `make_computer_client` dispatch both paths, `RemoteComputerImpl.session_init` short-circuit)
- [x] Full sweep: 106 passing across modal/lifecycle/state-store/session test families
- [x] Ruff clean

## Rollout

Once #856 → #857 → this all merge:

1. Confirm the new endpoints respond (curl `POST /v1/computer_sessions` with a tiny ttl).
2. Set `MANTIS_SESSION_ROUTER_URL` + `MANTIS_SESSION_ROUTER_TOKEN` on one tenant's executor secret.
3. Run a CUA plan — verify the brain hits the per-session URL (correlate `session_id` in logs).
4. Run 4 parallel plans (distinct `profile_id`s) — wall-clock should approximate 1× single-run.

## What's next

- **PR 4** — scheduled reaper for orphaned sandboxes (the brain's `close()` is the happy path; reaper handles brain crashes + TTL expiry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)