### PR TITLE
feat(computer-plane): Phase 1.5 reaper for orphaned sessions (#846)

### DIFF
--- a/deploy/modal/modal_cua_server.py
+++ b/deploy/modal/modal_cua_server.py
@@ -4026,6 +4026,74 @@ computer_plane_image = (
 
 
 @app.function(
+    image=api_image,
+    volumes={"/data": vol},
+    secrets=[modal.Secret.from_dotenv()],
+    timeout=300,
+    memory=1024,
+    cpu=1,
+    schedule=modal.Period(minutes=5),
+)
+def session_reaper() -> dict:
+    """Cleanup orphaned session containers (Phase 1.5, #846).
+
+    Runs every 5 minutes. Scans the run-state store for
+    ``KIND_SESSION`` records whose ``expires_at_ms`` has passed or
+    that look stuck in ``status="active"`` without a ``base_url``,
+    cancels the underlying Modal FunctionCall, and marks the record
+    as ``status="reaped"``.
+
+    Doesn't touch sessions in brain-terminal states
+    (``closed``/``reaped``/``error``/``expired``) — the brain's
+    happy-path teardown is preserved.
+
+    Returns the summary dict so ``modal app logs mantis-cua-server``
+    has the count visible (look for ``session_reaper summary``).
+    """
+    import time as _time
+
+    from mantis_agent.server.session_reaper import (
+        apply_reap_decisions,
+        find_reapable_sessions,
+    )
+
+    store = _get_run_state_store()
+    sd = _get_session_dict()
+    now_ms = int(_time.time() * 1000)
+
+    decisions = find_reapable_sessions(store, now_ms=now_ms)
+    if not decisions:
+        return {"reaped": 0, "skipped": 0, "errors": []}
+
+    def _cancel(sandbox_id: str) -> None:
+        try:
+            modal.FunctionCall.from_id(sandbox_id).cancel()
+        except Exception as exc:  # noqa: BLE001
+            print(f"  reaper: cancel({sandbox_id}) raised: {exc}")
+
+    def _signal_close(session_id: str) -> None:
+        try:
+            cur = sd.get(session_id) or {}  # type: ignore[attr-defined]
+            if not isinstance(cur, dict):
+                cur = {}
+            cur.update({"close_requested": True, "close_reason": "reaper"})
+            sd[session_id] = cur  # type: ignore[index]
+        except Exception as exc:  # noqa: BLE001
+            print(f"  reaper: signal({session_id}) raised: {exc}")
+
+    summary = apply_reap_decisions(
+        decisions,
+        store=store,
+        cancel_function_call=_cancel,
+        signal_close_in_session_dict=_signal_close,
+        now_ms=now_ms,
+    )
+    # Visible via ``modal app logs`` (per feedback_warning_level_for_modal_observability).
+    print(f"WARNING: session_reaper summary {summary}")
+    return summary
+
+
+@app.function(
     image=computer_plane_image,
     volumes={"/data": vol},
     secrets=[modal.Secret.from_dotenv()],

--- a/src/mantis_agent/gym/computer_client.py
+++ b/src/mantis_agent/gym/computer_client.py
@@ -46,6 +46,16 @@ class ComputerPlaneConfig:
     # Opt-in CDP escape hatch. Defaults off per `feedback_cua_no_dom_access`.
     enable_cdp: bool = False
 
+    # Phase 1.5 (#846) — when set, brain talks to the session router
+    # to mint a per-session computer-plane container instead of the
+    # pinned ``computer_plane()`` ASGI app. ``session_router_url`` is
+    # the base URL of the router (typically the api() ASGI URL);
+    # ``session_router_auth_token`` is the tenant token the router's
+    # ``require_run_scope`` middleware expects.
+    session_router_url: str | None = None
+    session_router_auth_token: str | None = None
+    session_ttl_seconds: int = 3600
+
     # Per-executor overrides — `{"run_claude_cua": "modal"}`.
     per_executor_overrides: dict[str, ComputerPlaneBackend] = field(default_factory=dict)
 
@@ -65,6 +75,9 @@ class ComputerPlaneConfig:
             remote_base_url=self.remote_base_url,
             remote_auth_token=self.remote_auth_token,
             enable_cdp=self.enable_cdp,
+            session_router_url=self.session_router_url,
+            session_router_auth_token=self.session_router_auth_token,
+            session_ttl_seconds=self.session_ttl_seconds,
             per_executor_overrides=self.per_executor_overrides,
         )
 
@@ -103,9 +116,32 @@ def make_computer_client(
         return LocalXdotoolImpl(**env_kwargs)
 
     if backend == "modal":
+        # Phase 1.5 (#846) — session-routed path. When the caller
+        # configured a session router, mint a per-session container
+        # via the router and talk to that container's tunnel URL.
+        # Falls through to the pinned ``computer_plane()`` ASGI app
+        # when ``session_router_url`` isn't set, preserving Phase 1
+        # behaviour for callers that haven't opted in.
+        if cfg.session_router_url:
+            if not cfg.session_router_auth_token:
+                raise ValueError(
+                    "ComputerPlaneConfig.session_router_url requires "
+                    "session_router_auth_token"
+                )
+            from .session_routed_impl import SessionRoutedComputerImpl
+
+            return SessionRoutedComputerImpl(
+                router_url=cfg.session_router_url,
+                auth_token=cfg.session_router_auth_token,
+                enable_cdp=cfg.enable_cdp,
+                ttl_seconds=cfg.session_ttl_seconds,
+                **env_kwargs,
+            )
+
         if not cfg.remote_base_url:
             raise ValueError(
-                "ComputerPlaneConfig.backend='modal' requires remote_base_url"
+                "ComputerPlaneConfig.backend='modal' requires remote_base_url "
+                "(or session_router_url for the Phase 1.5 path)"
             )
         from .remote_computer_impl import RemoteComputerImpl
 

--- a/src/mantis_agent/gym/remote_computer_impl.py
+++ b/src/mantis_agent/gym/remote_computer_impl.py
@@ -95,6 +95,13 @@ class RemoteComputerImpl(ComputerClient):
         # profile with the brain-supplied header set.
         profile_dir: str | None = None,
         extra_http_headers: dict[str, str] | None = None,
+        # Phase 1.5 (#846): when the brain talks to a per-session
+        # container via the router, the router has already bound the
+        # session and minted a token before publishing the tunnel URL.
+        # Pre-setting ``self._session_token`` short-circuits
+        # ``session_init()`` so we don't double-bind (which would 409
+        # against the orchestrator's existing session).
+        pre_minted_session_token: str | None = None,
         # The following kwargs are accepted for parity with
         # XdotoolGymEnv.__init__ but unused server-side (computer plane
         # manages its own lifecycle).
@@ -119,7 +126,7 @@ class RemoteComputerImpl(ComputerClient):
         self._timeout = request_timeout_seconds
         self._profile_dir = profile_dir
         self._extra_http_headers = extra_http_headers or None
-        self._session_token: str | None = None
+        self._session_token: str | None = pre_minted_session_token or None
 
         self.screenshot_latency = LatencyTracker("screenshot")
         self.xdotool_latency = LatencyTracker("xdotool")
@@ -225,6 +232,16 @@ class RemoteComputerImpl(ComputerClient):
     # ── wire contract surface (used by tests + advanced callers) ────
 
     def session_init(self) -> SessionInitResponse:
+        # Phase 1.5 (#846): when the router already minted a session
+        # against the per-session container, skip the /session/init
+        # hop — that container's ComputerAgent state is already bound
+        # and a second init would 409 against the live session.
+        if self._session_token:
+            return SessionInitResponse(
+                session_token=self._session_token,
+                chrome_pid=None,
+                xvfb_display=":99",
+            )
         req = SessionInitRequest(
             tenant_id=self._tenant_id,
             profile_id=self._profile_id,

--- a/src/mantis_agent/gym/session_routed_impl.py
+++ b/src/mantis_agent/gym/session_routed_impl.py
@@ -1,0 +1,134 @@
+"""``SessionRoutedComputerImpl`` — RemoteComputerImpl backed by the
+Phase 1.5 session router (#846).
+
+On construction this client calls the router's
+``POST /v1/computer_sessions`` to mint a dedicated per-session
+container, then constructs the underlying ``RemoteComputerImpl``
+against the per-session tunnel URL (with the pre-minted session token
+short-circuiting the ``/session/init`` hop).
+
+On ``shutdown()`` it tears the session down via the router's
+``DELETE /v1/computer_sessions/{session_id}`` before delegating to
+the superclass's session-close path. Close is best-effort by default
+— a 404 from the router (reaper already terminated) is swallowed so
+the brain's teardown doesn't surface noise.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from ..server.session_router_client import SessionRouterClient
+from .remote_computer_impl import RemoteComputerImpl
+from ..session_wire import SessionCreateRequest
+
+logger = logging.getLogger(__name__)
+
+
+class SessionRoutedComputerImpl(RemoteComputerImpl):
+    """Construct-then-delegate wrapper around the per-session router."""
+
+    def __init__(
+        self,
+        *,
+        router_url: str,
+        auth_token: str,
+        # Forwarded into SessionCreateRequest:
+        tenant_id: str,
+        profile_id: str,
+        run_id: str,
+        start_url: str = "about:blank",
+        viewport: tuple[int, int] = (1280, 720),
+        proxy_server: str = "",
+        profile_dir: str | None = None,
+        extra_http_headers: dict[str, str] | None = None,
+        enable_cdp: bool = False,
+        ttl_seconds: int = 3600,
+        # Optional DI for tests:
+        router_client: SessionRouterClient | None = None,
+        # Everything else (chrome_flags, settle_time, …) is forwarded
+        # straight through to ``RemoteComputerImpl.__init__`` for
+        # XdotoolGymEnv kwarg parity.
+        **remote_kwargs: Any,
+    ) -> None:
+        client = router_client or SessionRouterClient(
+            router_url=router_url, auth_token=auth_token,
+        )
+        req = SessionCreateRequest(
+            tenant_id=tenant_id,
+            profile_id=profile_id,
+            run_id=run_id,
+            start_url=start_url,
+            viewport=viewport,
+            proxy_server=proxy_server,
+            profile_dir=profile_dir,
+            extra_http_headers=extra_http_headers,
+            enable_cdp=enable_cdp,
+            ttl_seconds=ttl_seconds,
+        )
+        # Bubble SessionRouterError up unchanged — make_computer_client
+        # callers decide whether to fall back to the pinned
+        # ``computer_plane`` ASGI URL.
+        response = client.create_session(req)
+
+        self._router_client = client
+        self._session_id = response.session_id
+        self._session_expires_at_ms = response.expires_at_ms
+        self._session_sandbox_id = response.sandbox_id
+
+        super().__init__(
+            base_url=response.base_url,
+            auth_token=None,  # tunnel URLs are unauthenticated; session
+                              # token is the only credential the
+                              # ComputerAgent enforces (X-Mantis-Session).
+            tenant_id=tenant_id,
+            profile_id=profile_id,
+            run_id=run_id,
+            start_url=start_url,
+            viewport=viewport,
+            proxy_server=proxy_server,
+            profile_dir=profile_dir,
+            extra_http_headers=extra_http_headers,
+            enable_cdp=enable_cdp,
+            pre_minted_session_token=response.session_token,
+            **remote_kwargs,
+        )
+
+    # ── lifecycle ─────────────────────────────────────────────────────
+
+    def close(self) -> None:
+        """Tear the session down via the router, then delegate.
+
+        Best-effort: a router-side 404 (already reaped) is swallowed so
+        the brain doesn't see noise when shutting down a session the
+        reaper already cleaned up.
+        """
+        try:
+            self._router_client.close_session(
+                self._session_id, reason="brain_closed", quiet=True,
+            )
+        except Exception as exc:  # noqa: BLE001 — never block teardown
+            logger.warning(
+                "SessionRoutedComputerImpl: router close raised (%s); "
+                "delegating to super().close() anyway",
+                exc,
+            )
+        super().close()
+
+    # ── observability ─────────────────────────────────────────────────
+
+    @property
+    def session_id(self) -> str:
+        """Router-minted session id; useful for log correlation."""
+        return self._session_id
+
+    @property
+    def sandbox_id(self) -> str:
+        """Modal FunctionCall id for the per-session container."""
+        return self._session_sandbox_id
+
+    @property
+    def session_expires_at_ms(self) -> int:
+        """When the reaper will consider this session orphaned."""
+        return self._session_expires_at_ms

--- a/src/mantis_agent/server/session_reaper.py
+++ b/src/mantis_agent/server/session_reaper.py
@@ -1,0 +1,175 @@
+"""Reaper logic for orphaned computer-plane sessions (Phase 1.5, #846, PR 4).
+
+The brain's ``SessionRoutedComputerImpl.close()`` is the happy-path
+teardown for a per-session container. The reaper is the safety net
+when:
+
+* The brain crashes mid-run (no close ever fires).
+* The router crashes after spawning but before persisting the record
+  cleanly.
+* The session's TTL expires (long-running brain didn't renew).
+* The orchestrator container crashed without writing its terminal
+  status.
+
+This module ships the pure-logic ``find_reapable_sessions`` function
+that returns a structured plan; the Modal scheduled wrapper applies
+the plan. Splitting them lets the test suite exercise reaper decisions
+against a plain-dict :class:`RunStateStore` without involving Modal.
+
+Decisions are deliberately conservative: only sessions whose
+``expires_at_ms`` is in the past — or whose RunStateStore record is
+already in a terminal status the brain did not produce — are reaped.
+Idle-but-still-healthy sessions never get killed by this loop.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from ..session_wire import (
+    SessionRecord,
+    iter_session_records,
+    serialize_session_record,
+)
+from ..run_state_store import KIND_SESSION
+
+logger = logging.getLogger(__name__)
+
+
+# Statuses the brain owns. Reaper never touches a session that's
+# already in one of these — they're either explicitly closed by
+# the brain or marked terminal by the orchestrator.
+_BRAIN_TERMINAL_STATES = frozenset({"closed", "reaped", "error", "expired"})
+
+
+@dataclass(frozen=True)
+class ReapDecision:
+    """One reaper action: terminate ``session_id`` because ``reason``."""
+
+    session_id: str
+    tenant_id: str
+    sandbox_id: str
+    reason: str           # ttl_expired | already_terminal | hint_field
+    record: SessionRecord
+
+
+def find_reapable_sessions(
+    store: Any,
+    *,
+    now_ms: int,
+    tenant_id: str | None = None,
+) -> list[ReapDecision]:
+    """Scan the RunStateStore and return sessions that should be reaped.
+
+    ``now_ms`` — wall-clock at scan time. Splitting it out (not
+    ``time.time``-based) keeps the function pure for tests.
+
+    ``tenant_id`` — optional filter. ``None`` (default) scans all
+    tenants the store knows about.
+
+    Pure: doesn't mutate the store, doesn't issue terminations.
+    Caller decides what to do with the list — typically pass it to
+    :func:`apply_reap_decisions`.
+    """
+    decisions: list[ReapDecision] = []
+    for record in iter_session_records(store, tenant_id=tenant_id):
+        if record.status in _BRAIN_TERMINAL_STATES:
+            continue
+        if record.expires_at_ms and record.expires_at_ms < now_ms:
+            decisions.append(ReapDecision(
+                session_id=record.session_id,
+                tenant_id=record.tenant_id,
+                sandbox_id=record.sandbox_id,
+                reason="ttl_expired",
+                record=record,
+            ))
+            continue
+        # An orchestrator that died mid-publish stamps status="error"
+        # before exiting (or never updates from "active"). The
+        # status=="error" case is caught by _BRAIN_TERMINAL_STATES
+        # above. status=="active" with a missing base_url means the
+        # router's wait loop bailed but the record was still
+        # persisted — treat that as reapable so it doesn't clog the
+        # active list.
+        if record.status == "active" and not record.base_url:
+            decisions.append(ReapDecision(
+                session_id=record.session_id,
+                tenant_id=record.tenant_id,
+                sandbox_id=record.sandbox_id,
+                reason="active_without_base_url",
+                record=record,
+            ))
+    return decisions
+
+
+def apply_reap_decisions(
+    decisions: list[ReapDecision],
+    *,
+    store: Any,
+    cancel_function_call: Callable[[str], None] | None = None,
+    signal_close_in_session_dict: Callable[[str], None] | None = None,
+    now_ms: int,
+) -> dict:
+    """Execute a reap plan against the store + Modal.
+
+    Steps per decision:
+
+    1. Cancel the Modal FunctionCall (so the container exits). Best-
+       effort — a missing handle or already-terminated function is
+       a no-op.
+    2. Signal ``close_requested=True`` in the session_dict. Belt-and-
+       braces — if the cancel succeeded the orchestrator already
+       exited, but a long-tail container reading the dict will exit
+       sooner.
+    3. Update the RunStateStore record to ``status="reaped"`` with
+       a small ``reaped_at_ms`` field appended via the model dump so
+       the record stays forward-compatible.
+
+    Returns a summary dict:
+
+        {
+          "reaped": <count>,
+          "skipped": <count of decisions whose store update failed>,
+          "errors": [{session_id, error}, ...]
+        }
+    """
+    summary: dict[str, Any] = {"reaped": 0, "skipped": 0, "errors": []}
+    for d in decisions:
+        try:
+            if cancel_function_call is not None and d.sandbox_id:
+                try:
+                    cancel_function_call(d.sandbox_id)
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning(
+                        "reaper: cancel failed sandbox=%s (%s)",
+                        d.sandbox_id, exc,
+                    )
+            if signal_close_in_session_dict is not None:
+                try:
+                    signal_close_in_session_dict(d.session_id)
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning(
+                        "reaper: signal failed session=%s (%s)",
+                        d.session_id, exc,
+                    )
+            updated = d.record.model_copy(update={
+                "status": "reaped",
+                "error": f"reaper: {d.reason}",
+                "last_action_ms": now_ms,
+            })
+            store.put(
+                d.tenant_id, d.session_id, KIND_SESSION,
+                serialize_session_record(updated),
+            )
+            summary["reaped"] += 1
+        except Exception as exc:  # noqa: BLE001
+            summary["skipped"] += 1
+            summary["errors"].append({
+                "session_id": d.session_id, "error": f"{type(exc).__name__}: {exc}",
+            })
+            logger.warning(
+                "reaper: apply failed session=%s (%s)", d.session_id, exc,
+            )
+    return summary

--- a/src/mantis_agent/server/session_router_client.py
+++ b/src/mantis_agent/server/session_router_client.py
@@ -1,0 +1,162 @@
+"""HTTPS client for the session-router endpoints (Phase 1.5, #846, PR 3).
+
+The brain plane uses this to mint a dedicated computer-plane session
+at run start (``POST /v1/computer_sessions``) and tear it down at
+end (``DELETE /v1/computer_sessions/{session_id}``). Pure-HTTPS, no
+Modal client dependency — works the same from inside or outside a
+Modal container.
+
+Talks to the router defined in
+``deploy/modal/modal_cua_server.build_api_app``; wire-contract from
+``mantis_agent.session_wire``.
+
+Failure semantics — quiet by default:
+
+* Connection / 5xx → ``SessionRouterError`` with the upstream detail.
+  Caller decides whether to fall back to the pinned ``computer_plane``
+  ASGI app (the current Phase 1 behaviour).
+* 4xx → raised with the upstream detail; not retried.
+* ``close_session`` failures are best-effort by default — closing a
+  session that the reaper already terminated should not surface as
+  an error to the brain.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import requests
+
+from ..session_wire import (
+    SessionCloseResponse,
+    SessionCreateRequest,
+    SessionCreateResponse,
+    SessionNotFoundError,
+    SessionQuotaExceededError,
+    SessionRouterError,
+    SessionUnreachableError,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# Defaults tuned for the cold-start + tunnel-publish budget on the
+# orchestrator side. The router itself caps the wait at 120s; we add
+# a small margin so the HTTPS layer doesn't timeout first.
+_DEFAULT_CREATE_TIMEOUT_SECONDS = 150.0
+_DEFAULT_CLOSE_TIMEOUT_SECONDS = 15.0
+
+
+class SessionRouterClient:
+    """Tiny HTTPS shim around ``/v1/computer_sessions``.
+
+    Stateless — constructed once per executor, used to create the
+    session and (later) close it.
+    """
+
+    def __init__(
+        self,
+        *,
+        router_url: str,
+        auth_token: str,
+        create_timeout_seconds: float = _DEFAULT_CREATE_TIMEOUT_SECONDS,
+        close_timeout_seconds: float = _DEFAULT_CLOSE_TIMEOUT_SECONDS,
+        # DI seam so tests can swap out the HTTP layer without
+        # monkeypatching ``requests`` globally.
+        session: Any | None = None,
+    ) -> None:
+        if not router_url:
+            raise ValueError("SessionRouterClient requires a non-empty router_url")
+        if not auth_token:
+            raise ValueError("SessionRouterClient requires a non-empty auth_token")
+        self._router_url = router_url.rstrip("/")
+        self._auth_token = auth_token
+        self._create_timeout = float(create_timeout_seconds)
+        self._close_timeout = float(close_timeout_seconds)
+        self._http = session or requests
+
+    def _headers(self) -> dict[str, str]:
+        return {
+            "X-Mantis-Token": self._auth_token,
+            "Content-Type": "application/json",
+        }
+
+    def _raise_for_status(self, resp: Any, op: str) -> None:
+        if resp.status_code < 400:
+            return
+        try:
+            detail = resp.json().get("detail") or resp.text
+        except ValueError:
+            detail = resp.text
+        if resp.status_code == 404:
+            raise SessionNotFoundError(f"{op}: {detail}")
+        if resp.status_code == 429:
+            raise SessionQuotaExceededError(f"{op}: {detail}")
+        if resp.status_code == 504:
+            raise SessionUnreachableError(f"{op}: {detail}")
+        # Catch-all — preserves the upstream status code in the message.
+        raise SessionRouterError(f"{op} HTTP {resp.status_code}: {detail}")
+
+    # ── Create ────────────────────────────────────────────────────────
+
+    def create_session(self, req: SessionCreateRequest) -> SessionCreateResponse:
+        """Mint a session via the router. Blocks up to the
+        ``create_timeout_seconds`` budget while the orchestrator does
+        its cold-start + ``modal.forward`` dance."""
+        try:
+            resp = self._http.post(
+                self._router_url + "/v1/computer_sessions",
+                json=req.model_dump(mode="json"),
+                headers=self._headers(),
+                timeout=self._create_timeout,
+            )
+        except requests.RequestException as exc:
+            raise SessionUnreachableError(
+                f"create_session: router unreachable ({exc})"
+            ) from exc
+        self._raise_for_status(resp, "create_session")
+        return SessionCreateResponse.model_validate(resp.json())
+
+    # ── Close ─────────────────────────────────────────────────────────
+
+    def close_session(
+        self, session_id: str, *, reason: str = "brain_closed",
+        quiet: bool = True,
+    ) -> SessionCloseResponse | None:
+        """Best-effort by default — a 404 here means the reaper got
+        there first, and the brain shouldn't surface that. Set
+        ``quiet=False`` to bubble errors when callers care.
+        """
+        url = f"{self._router_url}/v1/computer_sessions/{session_id}"
+        try:
+            resp = self._http.delete(
+                url,
+                headers={**self._headers(), "X-Mantis-Reason": reason},
+                timeout=self._close_timeout,
+            )
+        except requests.RequestException as exc:
+            if quiet:
+                logger.warning(
+                    "close_session: router unreachable session=%s (%s)",
+                    session_id, exc,
+                )
+                return None
+            raise SessionUnreachableError(
+                f"close_session: router unreachable ({exc})"
+            ) from exc
+        try:
+            self._raise_for_status(resp, "close_session")
+        except SessionNotFoundError:
+            if quiet:
+                return None
+            raise
+        except SessionRouterError:
+            if quiet:
+                logger.warning(
+                    "close_session: router error session=%s status=%s",
+                    session_id, resp.status_code,
+                )
+                return None
+            raise
+        return SessionCloseResponse.model_validate(resp.json())

--- a/src/mantis_agent/task_loop.py
+++ b/src/mantis_agent/task_loop.py
@@ -141,6 +141,18 @@ def _computer_plane_config_from_env(
     * `MANTIS_COMPUTER_PLANE_TOKEN` — `Authorization: Bearer ...`
     * `MANTIS_COMPUTER_PLANE_ENABLE_CDP` — `1`/`true` to opt in
       (off by default per the wire-contract CUA-purity constraint).
+
+    Phase 1.5 (#846) — session-routed mode:
+
+    * `MANTIS_SESSION_ROUTER_URL` — router base URL (typically the
+      ``api()`` ASGI URL). When set, brain mints a dedicated
+      per-session computer-plane container via
+      ``POST /v1/computer_sessions`` instead of sharing the pinned
+      ``computer_plane()`` ASGI app.
+    * `MANTIS_SESSION_ROUTER_TOKEN` — tenant token forwarded to the
+      router's ``require_run_scope`` middleware.
+    * `MANTIS_SESSION_TTL_SECONDS` — per-session lifetime (seconds);
+      clamped against the deployment cap server-side.
     """
     from .gym.computer_client import ComputerPlaneConfig
 
@@ -150,11 +162,18 @@ def _computer_plane_config_from_env(
     enable_cdp = (os.environ.get("MANTIS_COMPUTER_PLANE_ENABLE_CDP") or "").strip().lower() in (
         "1", "true", "yes", "on",
     )
+    try:
+        session_ttl = int(os.environ.get("MANTIS_SESSION_TTL_SECONDS") or "3600")
+    except ValueError:
+        session_ttl = 3600
     cfg = ComputerPlaneConfig(
         backend=backend_env,  # type: ignore[arg-type]
         remote_base_url=(os.environ.get("MANTIS_COMPUTER_PLANE_URL") or "").strip() or None,
         remote_auth_token=(os.environ.get("MANTIS_COMPUTER_PLANE_TOKEN") or "").strip() or None,
         enable_cdp=enable_cdp,
+        session_router_url=(os.environ.get("MANTIS_SESSION_ROUTER_URL") or "").strip() or None,
+        session_router_auth_token=(os.environ.get("MANTIS_SESSION_ROUTER_TOKEN") or "").strip() or None,
+        session_ttl_seconds=session_ttl,
     )
     return cfg.resolve_for_executor(executor_name)
 

--- a/tests/test_session_reaper.py
+++ b/tests/test_session_reaper.py
@@ -1,0 +1,208 @@
+"""Tests for the session reaper (Phase 1.5, #846, PR 4)."""
+
+from __future__ import annotations
+
+from mantis_agent.session_wire import (
+    SessionRecord,
+    serialize_session_record,
+)
+from mantis_agent.run_state_store import KIND_SESSION, RunStateStore
+from mantis_agent.server.session_reaper import (
+    apply_reap_decisions,
+    find_reapable_sessions,
+)
+
+
+def _mk(
+    session_id: str,
+    *,
+    tenant_id: str = "t1",
+    expires_at_ms: int = 1_000_000,
+    status: str = "active",
+    base_url: str = "https://x.modal.run",
+    sandbox_id: str = "fc-1",
+) -> SessionRecord:
+    return SessionRecord(
+        session_id=session_id,
+        tenant_id=tenant_id,
+        profile_id="p",
+        run_id="r",
+        base_url=base_url,
+        sandbox_id=sandbox_id,
+        created_at_ms=0,
+        expires_at_ms=expires_at_ms,
+        status=status,
+    )
+
+
+def _seed(store: RunStateStore, records: list[SessionRecord]) -> None:
+    for r in records:
+        store.put(r.tenant_id, r.session_id, KIND_SESSION,
+                  serialize_session_record(r))
+
+
+# ── find_reapable_sessions ────────────────────────────────────────────
+
+
+def test_finds_expired_sessions() -> None:
+    store = RunStateStore(backing={})
+    _seed(store, [
+        _mk("expired_1", expires_at_ms=500),    # before now=1000
+        _mk("expired_2", expires_at_ms=999),
+        _mk("alive",     expires_at_ms=5000),
+    ])
+    out = find_reapable_sessions(store, now_ms=1000)
+    ids = sorted(d.session_id for d in out)
+    assert ids == ["expired_1", "expired_2"]
+    assert all(d.reason == "ttl_expired" for d in out)
+
+
+def test_skips_brain_terminal_states() -> None:
+    """Records the brain already closed (or the orchestrator marked
+    error) must not be reaped a second time."""
+    store = RunStateStore(backing={})
+    _seed(store, [
+        _mk("alive_then_closed", expires_at_ms=500, status="closed"),
+        _mk("alive_then_reaped", expires_at_ms=500, status="reaped"),
+        _mk("alive_then_error",  expires_at_ms=500, status="error"),
+        _mk("alive_then_exp",    expires_at_ms=500, status="expired"),
+        _mk("still_active",      expires_at_ms=500, status="active"),
+    ])
+    out = find_reapable_sessions(store, now_ms=1000)
+    assert [d.session_id for d in out] == ["still_active"]
+
+
+def test_flags_active_without_base_url_as_reapable() -> None:
+    """Router got partway through then crashed — recorded as active
+    with no base_url. Reaper should clean these up too."""
+    store = RunStateStore(backing={})
+    _seed(store, [
+        _mk("orphan", expires_at_ms=99_999, status="active", base_url=""),
+        _mk("good",   expires_at_ms=99_999, status="active"),
+    ])
+    out = find_reapable_sessions(store, now_ms=1000)
+    assert [d.session_id for d in out] == ["orphan"]
+    assert out[0].reason == "active_without_base_url"
+
+
+def test_tenant_filter_scope() -> None:
+    store = RunStateStore(backing={})
+    _seed(store, [
+        _mk("alice_x", tenant_id="alice", expires_at_ms=500),
+        _mk("bob_y",   tenant_id="bob",   expires_at_ms=500),
+    ])
+    out = find_reapable_sessions(store, now_ms=1000, tenant_id="alice")
+    assert [d.session_id for d in out] == ["alice_x"]
+
+
+# ── apply_reap_decisions ──────────────────────────────────────────────
+
+
+def test_apply_marks_records_as_reaped() -> None:
+    store = RunStateStore(backing={})
+    _seed(store, [_mk("victim", expires_at_ms=500, sandbox_id="fc-victim")])
+    decisions = find_reapable_sessions(store, now_ms=1000)
+
+    cancel_calls: list[str] = []
+    signal_calls: list[str] = []
+    summary = apply_reap_decisions(
+        decisions, store=store,
+        cancel_function_call=cancel_calls.append,
+        signal_close_in_session_dict=signal_calls.append,
+        now_ms=1000,
+    )
+    assert summary == {"reaped": 1, "skipped": 0, "errors": []}
+    assert cancel_calls == ["fc-victim"]
+    assert signal_calls == ["victim"]
+
+    # Record now status="reaped" with the reason annotation.
+    blob = store.get("t1", "victim", KIND_SESSION)
+    assert blob is not None
+    assert blob["status"] == "reaped"
+    assert "ttl_expired" in blob["error"]
+    assert blob["last_action_ms"] == 1000
+
+
+def test_apply_tolerates_callback_failures() -> None:
+    """A misbehaving cancel/signal callback must not abort the whole
+    sweep — the record still gets marked, and the next decision still
+    runs."""
+    store = RunStateStore(backing={})
+    _seed(store, [
+        _mk("a", expires_at_ms=500, sandbox_id="fc-a"),
+        _mk("b", expires_at_ms=500, sandbox_id="fc-b"),
+    ])
+
+    def _bad_cancel(_sid: str) -> None:
+        raise RuntimeError("modal control plane unreachable")
+
+    decisions = find_reapable_sessions(store, now_ms=1000)
+    summary = apply_reap_decisions(
+        decisions, store=store,
+        cancel_function_call=_bad_cancel,
+        signal_close_in_session_dict=lambda _sid: None,
+        now_ms=1000,
+    )
+    # Both records still reaped — cancel failures are observability, not blockers.
+    assert summary["reaped"] == 2
+    assert summary["errors"] == []
+
+
+def test_apply_records_summary_on_store_failure() -> None:
+    """If the store write itself fails for a single decision, the
+    failure is recorded but the remaining decisions still process."""
+
+    class _FlakyStore(RunStateStore):
+        def __init__(self) -> None:
+            super().__init__(backing={})
+            self._fail_for: str | None = None  # set after seed
+
+        def put(self, tenant_id, run_id, kind, value):
+            if self._fail_for is not None and run_id == self._fail_for:
+                raise RuntimeError("disk full")
+            super().put(tenant_id, run_id, kind, value)
+
+    store = _FlakyStore()
+    _seed(store, [
+        _mk("a", expires_at_ms=500),
+        _mk("b", expires_at_ms=500),
+        _mk("c", expires_at_ms=500),
+    ])
+    # Now arm the failure so the apply phase trips on "b".
+    store._fail_for = "b"  # noqa: SLF001
+    decisions = find_reapable_sessions(store, now_ms=1000)
+    summary = apply_reap_decisions(
+        decisions, store=store, now_ms=1000,
+    )
+    assert summary["reaped"] == 2
+    assert summary["skipped"] == 1
+    assert summary["errors"][0]["session_id"] == "b"
+    assert "disk full" in summary["errors"][0]["error"]
+
+
+def test_apply_handles_empty_decision_list() -> None:
+    summary = apply_reap_decisions([], store=RunStateStore(backing={}), now_ms=1000)
+    assert summary == {"reaped": 0, "skipped": 0, "errors": []}
+
+
+# ── full sweep integration ────────────────────────────────────────────
+
+
+def test_full_sweep_end_to_end() -> None:
+    """Realistic mix: some expired, some healthy, some already-closed.
+    Final state: only the expired ones get reaped, others untouched."""
+    store = RunStateStore(backing={})
+    now_ms = 5_000_000
+    _seed(store, [
+        _mk("expired_a", expires_at_ms=now_ms - 1000),
+        _mk("expired_b", expires_at_ms=now_ms - 500),
+        _mk("alive_a",   expires_at_ms=now_ms + 10_000),
+        _mk("closed",    expires_at_ms=now_ms - 1000, status="closed"),
+    ])
+    decisions = find_reapable_sessions(store, now_ms=now_ms)
+    apply_reap_decisions(decisions, store=store, now_ms=now_ms)
+
+    assert store.get("t1", "expired_a", KIND_SESSION)["status"] == "reaped"
+    assert store.get("t1", "expired_b", KIND_SESSION)["status"] == "reaped"
+    assert store.get("t1", "alive_a", KIND_SESSION)["status"] == "active"
+    assert store.get("t1", "closed", KIND_SESSION)["status"] == "closed"

--- a/tests/test_session_routed_impl.py
+++ b/tests/test_session_routed_impl.py
@@ -1,0 +1,234 @@
+"""Tests for ``SessionRoutedComputerImpl`` (Phase 1.5, #846, PR 3).
+
+Drives the wrapper against a stubbed ``SessionRouterClient`` so the
+construct → mint-session → delegate flow is exercised without Modal,
+without HTTP, without Xvfb / Chrome.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from mantis_agent.gym.computer_client import (
+    ComputerPlaneConfig,
+    make_computer_client,
+)
+from mantis_agent.gym.session_routed_impl import SessionRoutedComputerImpl
+from mantis_agent.session_wire import (
+    SessionCloseResponse,
+    SessionCreateResponse,
+    SessionRouterError,
+    SessionUnreachableError,
+)
+
+
+class _StubRouterClient:
+    """Records calls + serves canned responses."""
+
+    def __init__(
+        self,
+        create_response: SessionCreateResponse | Exception | None = None,
+    ) -> None:
+        self.create_calls: list[Any] = []
+        self.close_calls: list[tuple[str, str]] = []
+        self._create_response = create_response or SessionCreateResponse(
+            session_id="sess_stub",
+            base_url="https://stub.modal.run",
+            session_token="tok_stub",
+            expires_at_ms=2_000_000_000_000,
+            sandbox_id="fc-stub",
+        )
+
+    def create_session(self, req):
+        self.create_calls.append(req)
+        if isinstance(self._create_response, Exception):
+            raise self._create_response
+        return self._create_response
+
+    def close_session(self, session_id: str, *, reason: str = "brain_closed", quiet: bool = True):
+        self.close_calls.append((session_id, reason))
+        return SessionCloseResponse(closed=True, terminal_state="closed")
+
+
+# ── Construction wires session_token via pre_minted path ─────────────
+
+
+def test_construct_mints_session_and_pre_seeds_token() -> None:
+    client = _StubRouterClient()
+    impl = SessionRoutedComputerImpl(
+        router_url="https://api.modal.run",
+        auth_token="my-token",
+        tenant_id="t1",
+        profile_id="alice",
+        run_id="r1",
+        router_client=client,
+    )
+    # Router was called once with the right identity.
+    assert len(client.create_calls) == 1
+    req = client.create_calls[0]
+    assert req.tenant_id == "t1"
+    assert req.profile_id == "alice"
+    assert req.run_id == "r1"
+    # base_url + token bubbled through to the underlying impl.
+    assert impl._base_url == "https://stub.modal.run"  # noqa: SLF001
+    assert impl._session_token == "tok_stub"  # noqa: SLF001
+    # session_id exposed for log correlation.
+    assert impl.session_id == "sess_stub"
+    assert impl.sandbox_id == "fc-stub"
+
+
+def test_construct_propagates_session_create_failure() -> None:
+    """Router unreachable → SessionUnreachableError bubbles up.
+    make_computer_client callers decide whether to fall back to the
+    pinned computer_plane URL."""
+    client = _StubRouterClient(
+        create_response=SessionUnreachableError("router timeout"),
+    )
+    with pytest.raises(SessionUnreachableError):
+        SessionRoutedComputerImpl(
+            router_url="https://api.modal.run",
+            auth_token="my-token",
+            tenant_id="t", profile_id="p", run_id="r",
+            router_client=client,
+        )
+
+
+# ── close() teardown calls the router then super().close() ──────────
+
+
+def test_close_calls_router_then_super_close() -> None:
+    client = _StubRouterClient()
+    impl = SessionRoutedComputerImpl(
+        router_url="https://x", auth_token="t",
+        tenant_id="t1", profile_id="p", run_id="r",
+        router_client=client,
+    )
+    # Patch super().close — we just want to verify ordering, not test
+    # the network teardown.
+    super_called = {"hit": False}
+
+    def fake_super_close(self) -> None:
+        super_called["hit"] = True
+
+    SessionRoutedComputerImpl.__mro__[1].close = fake_super_close  # type: ignore[assignment]
+    impl.close()
+    assert client.close_calls == [("sess_stub", "brain_closed")]
+    assert super_called["hit"]
+
+
+def test_close_swallows_router_failure() -> None:
+    """A router-side failure on close must not prevent the underlying
+    super().close() — otherwise we leak the session-token cache + the
+    brain's teardown surface gets noisy."""
+
+    class _Boom(_StubRouterClient):
+        def close_session(self, *args, **kwargs):
+            raise SessionRouterError("router 500")
+
+    impl = SessionRoutedComputerImpl(
+        router_url="https://x", auth_token="t",
+        tenant_id="t1", profile_id="p", run_id="r",
+        router_client=_Boom(),
+    )
+    super_called = {"hit": False}
+
+    def fake_super_close(self) -> None:
+        super_called["hit"] = True
+
+    SessionRoutedComputerImpl.__mro__[1].close = fake_super_close  # type: ignore[assignment]
+    impl.close()
+    assert super_called["hit"]
+
+
+# ── make_computer_client dispatches to the session-routed path ──────
+
+
+def test_make_computer_client_routes_to_session_when_router_url_set(monkeypatch) -> None:
+    """The factory must pick SessionRoutedComputerImpl when
+    ``session_router_url`` is set; otherwise fall back to the pinned
+    RemoteComputerImpl path."""
+    captured = {}
+
+    class _StubImpl:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(
+        "mantis_agent.gym.session_routed_impl.SessionRoutedComputerImpl",
+        _StubImpl,
+    )
+
+    cfg = ComputerPlaneConfig(
+        backend="modal",
+        session_router_url="https://api.modal.run",
+        session_router_auth_token="my-token",
+        session_ttl_seconds=1800,
+    )
+    out = make_computer_client(
+        cfg,
+        tenant_id="t1", profile_id="p", run_id="r",
+        start_url="https://example.com",
+    )
+    assert isinstance(out, _StubImpl)
+    assert captured["router_url"] == "https://api.modal.run"
+    assert captured["auth_token"] == "my-token"
+    assert captured["ttl_seconds"] == 1800
+    assert captured["tenant_id"] == "t1"
+    assert captured["start_url"] == "https://example.com"
+
+
+def test_make_computer_client_falls_back_to_remote_when_no_router_url(monkeypatch) -> None:
+    """No router URL set → falls through to the existing
+    RemoteComputerImpl path (Phase 1 behaviour preserved)."""
+    captured = {}
+
+    class _StubRemote:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(
+        "mantis_agent.gym.remote_computer_impl.RemoteComputerImpl",
+        _StubRemote,
+    )
+    cfg = ComputerPlaneConfig(
+        backend="modal",
+        remote_base_url="https://pinned-computer-plane.modal.run",
+        remote_auth_token="some-bearer",
+    )
+    out = make_computer_client(cfg, tenant_id="t1", profile_id="p", run_id="r")
+    assert isinstance(out, _StubRemote)
+    assert captured["base_url"] == "https://pinned-computer-plane.modal.run"
+
+
+def test_make_computer_client_session_router_requires_token() -> None:
+    cfg = ComputerPlaneConfig(
+        backend="modal",
+        session_router_url="https://api.modal.run",
+        # No token.
+    )
+    with pytest.raises(ValueError, match="session_router_auth_token"):
+        make_computer_client(cfg, tenant_id="t", profile_id="p", run_id="r")
+
+
+# ── RemoteComputerImpl pre_minted_session_token short-circuit ───────
+
+
+def test_remote_computer_impl_skips_session_init_when_token_pre_minted(monkeypatch) -> None:
+    """When pre_minted_session_token is set, session_init() returns the
+    cached token instead of POSTing /session/init."""
+    from mantis_agent.gym.remote_computer_impl import RemoteComputerImpl
+
+    impl = RemoteComputerImpl(
+        base_url="https://x",
+        tenant_id="t", profile_id="p", run_id="r",
+        pre_minted_session_token="cached_tok",
+    )
+    # Prove that no _post is needed — by patching it to raise on call.
+    monkeypatch.setattr(
+        impl, "_post",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("should not POST")),
+    )
+    resp = impl.session_init()
+    assert resp.session_token == "cached_tok"

--- a/tests/test_session_router_client.py
+++ b/tests/test_session_router_client.py
@@ -1,0 +1,186 @@
+"""Tests for the brain-side ``SessionRouterClient`` (Phase 1.5, #846, PR 3).
+
+Drives the client against a stubbed HTTP session — no Modal, no
+network. Covers happy path, 404, 429, 504, network failure, and the
+quiet-close semantics.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+import requests
+
+from mantis_agent.session_wire import (
+    SessionCreateRequest,
+    SessionCreateResponse,
+    SessionNotFoundError,
+    SessionQuotaExceededError,
+    SessionRouterError,
+    SessionUnreachableError,
+)
+from mantis_agent.server.session_router_client import SessionRouterClient
+
+
+class _StubResp:
+    def __init__(self, status_code: int, body: Any) -> None:
+        self.status_code = status_code
+        self._body = body
+
+    def json(self) -> Any:
+        if isinstance(self._body, str):
+            return json.loads(self._body)
+        return self._body
+
+    @property
+    def text(self) -> str:
+        if isinstance(self._body, str):
+            return self._body
+        return json.dumps(self._body)
+
+
+class _StubHttp:
+    """Captures the post/delete calls so tests can assert on them."""
+
+    def __init__(self, post_resp: _StubResp | Exception, delete_resp: _StubResp | Exception | None = None) -> None:
+        self._post_resp = post_resp
+        self._delete_resp = delete_resp
+        self.post_calls: list[dict] = []
+        self.delete_calls: list[dict] = []
+
+    def post(self, url, *, json=None, headers=None, timeout=None) -> _StubResp:
+        self.post_calls.append({"url": url, "json": json, "headers": headers, "timeout": timeout})
+        if isinstance(self._post_resp, Exception):
+            raise self._post_resp
+        return self._post_resp
+
+    def delete(self, url, *, headers=None, timeout=None) -> _StubResp:
+        self.delete_calls.append({"url": url, "headers": headers, "timeout": timeout})
+        if isinstance(self._delete_resp, Exception):
+            raise self._delete_resp
+        return self._delete_resp
+
+
+def _req() -> SessionCreateRequest:
+    return SessionCreateRequest(
+        tenant_id="t1", profile_id="alice", run_id="r1",
+    )
+
+
+# ── Construction ──────────────────────────────────────────────────────
+
+
+def test_requires_router_url() -> None:
+    with pytest.raises(ValueError):
+        SessionRouterClient(router_url="", auth_token="t")
+
+
+def test_requires_auth_token() -> None:
+    with pytest.raises(ValueError):
+        SessionRouterClient(router_url="https://x", auth_token="")
+
+
+# ── create_session ────────────────────────────────────────────────────
+
+
+def test_create_session_happy_path() -> None:
+    body = {
+        "session_id": "sess_abc",
+        "base_url": "https://sess.modal.run",
+        "session_token": "tok_xyz",
+        "expires_at_ms": 1_700_000_000_000,
+        "sandbox_id": "fc-1",
+        "reused": False,
+    }
+    http = _StubHttp(_StubResp(200, body))
+    client = SessionRouterClient(
+        router_url="https://api.modal.run/", auth_token="my-token", session=http,
+    )
+    resp = client.create_session(_req())
+    assert isinstance(resp, SessionCreateResponse)
+    assert resp.session_id == "sess_abc"
+    assert resp.base_url == "https://sess.modal.run"
+    # URL trailing slash got stripped.
+    assert http.post_calls[0]["url"] == "https://api.modal.run/v1/computer_sessions"
+    # Token forwarded.
+    assert http.post_calls[0]["headers"]["X-Mantis-Token"] == "my-token"
+
+
+def test_create_session_504_raises_unreachable() -> None:
+    http = _StubHttp(_StubResp(504, {"detail": "did not publish tunnel URL"}))
+    client = SessionRouterClient(
+        router_url="https://x", auth_token="t", session=http,
+    )
+    with pytest.raises(SessionUnreachableError) as exc:
+        client.create_session(_req())
+    assert "did not publish tunnel URL" in str(exc.value)
+
+
+def test_create_session_429_raises_quota() -> None:
+    http = _StubHttp(_StubResp(429, {"detail": "tenant quota exceeded"}))
+    client = SessionRouterClient(router_url="https://x", auth_token="t", session=http)
+    with pytest.raises(SessionQuotaExceededError):
+        client.create_session(_req())
+
+
+def test_create_session_other_4xx_raises_base_error() -> None:
+    http = _StubHttp(_StubResp(403, {"detail": "tenant_id mismatch"}))
+    client = SessionRouterClient(router_url="https://x", auth_token="t", session=http)
+    with pytest.raises(SessionRouterError) as exc:
+        client.create_session(_req())
+    assert "403" in str(exc.value)
+
+
+def test_create_session_network_error_raises_unreachable() -> None:
+    http = _StubHttp(requests.ConnectionError("dns fail"))
+    client = SessionRouterClient(router_url="https://x", auth_token="t", session=http)
+    with pytest.raises(SessionUnreachableError):
+        client.create_session(_req())
+
+
+# ── close_session ─────────────────────────────────────────────────────
+
+
+def test_close_session_happy_path() -> None:
+    http = _StubHttp(
+        _StubResp(200, {"session_id": "x"}),
+        delete_resp=_StubResp(200, {"closed": True, "terminal_state": "closed"}),
+    )
+    client = SessionRouterClient(router_url="https://x", auth_token="t", session=http)
+    resp = client.close_session("sess_abc")
+    assert resp is not None
+    assert resp.closed is True
+    assert http.delete_calls[0]["url"] == "https://x/v1/computer_sessions/sess_abc"
+    assert http.delete_calls[0]["headers"]["X-Mantis-Reason"] == "brain_closed"
+
+
+def test_close_session_404_is_quiet_by_default() -> None:
+    """Reaper already cleaned up — close should not raise."""
+    http = _StubHttp(
+        _StubResp(200, {}),
+        delete_resp=_StubResp(404, {"detail": "unknown session_id"}),
+    )
+    client = SessionRouterClient(router_url="https://x", auth_token="t", session=http)
+    result = client.close_session("sess_gone")
+    assert result is None
+
+
+def test_close_session_404_raises_when_not_quiet() -> None:
+    http = _StubHttp(
+        _StubResp(200, {}),
+        delete_resp=_StubResp(404, {"detail": "unknown session_id"}),
+    )
+    client = SessionRouterClient(router_url="https://x", auth_token="t", session=http)
+    with pytest.raises(SessionNotFoundError):
+        client.close_session("sess_gone", quiet=False)
+
+
+def test_close_session_network_error_is_quiet_by_default() -> None:
+    http = _StubHttp(
+        _StubResp(200, {}),
+        delete_resp=requests.ConnectionError("split brain"),
+    )
+    client = SessionRouterClient(router_url="https://x", auth_token="t", session=http)
+    assert client.close_session("sess_x") is None


### PR DESCRIPTION
## Summary

**PR 4 of 4** for #846. **Stacked on #858** which sits on #857 → #856. Review/merge order: #856 → #857 → #858 → this.

Adds a scheduled function that cleans up computer-plane sessions the brain didn't get to close — brain crashes, orchestrator crashes before publishing, TTL expiry. Pure-logic decision/apply split so the policy is unit-testable against an in-memory store.

## Changes

- **`mantis_agent.server.session_reaper`**:
  - `find_reapable_sessions(store, now_ms, tenant_id=None)` — list of `ReapDecision` for sessions past their `expires_at_ms` or stuck `active` without `base_url`. Skips brain-terminal states.
  - `apply_reap_decisions(...)` — cancels FunctionCall, signals `close_requested`, stamps record as `reaped`. Tolerates callback failures, records per-decision errors.

- **`deploy/modal/modal_cua_server.session_reaper`** — `@app.function(schedule=modal.Period(minutes=5))`. Wraps the pure logic, hooks Modal's `FunctionCall.from_id(...).cancel()`. Prints summary at WARNING so `modal app logs` surfaces it.

## What this completes for #846

| Capability | Lives in |
|---|---|
| Wire contract + KIND_SESSION store namespace | #856 (PR 1) |
| `computer_session` Modal function + router endpoints | #857 (PR 2) |
| `SessionRouterClient` + `SessionRoutedComputerImpl` + env-flag config | #858 (PR 3) |
| Reaper for orphaned sessions | this (PR 4) |

After all 4 merge:
1. Set `MANTIS_SESSION_ROUTER_URL` + `MANTIS_SESSION_ROUTER_TOKEN` on a tenant's executor secret.
2. Run a CUA plan — brain hits the per-session URL, session_id correlates in logs.
3. Run N=4 parallel plans (distinct profile_ids). Wall-clock approximates 1× single-run.

## Test plan

- [x] `test_session_reaper.py` — 9 cases (TTL expiry, brain-terminal skip, orphan flagging, tenant filter, marks records, callback-failure tolerance, store-failure recording, empty list, full mixed sweep)
- [x] Full Phase 1.5 sweep — 72 passing across all four PR families
- [x] Ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)