### PR TITLE
fix(baseten): cancel/pause dispatch + plan_text request_user_input

### DIFF
--- a/src/mantis_agent/baseten_server/runtime.py
+++ b/src/mantis_agent/baseten_server/runtime.py
@@ -399,7 +399,13 @@ class BasetenCUARuntime:
 
     def run(self, payload: dict[str, Any]) -> dict[str, Any]:
         action = str(payload.get("action") or payload.get("op") or "").lower()
-        if action in {"status", "result", "logs", "resume"}:
+        # ``cancel`` and ``pause`` MUST dispatch ahead of the
+        # ``detached`` check — ``PredictRequest`` defaults ``detached``
+        # to true, so an action-only call would otherwise fall into
+        # ``_start_detached`` and either 400 on an already-running run
+        # or overwrite a finished run as a new submission. Mirrors the
+        # Modal CUA fix in ``modal_cua_server.predict`` (#866).
+        if action in {"status", "result", "logs", "resume", "cancel", "pause"}:
             return self._detached_action(action, payload)
         if action == "graph_learn":
             return self._graph_learn(payload)
@@ -468,6 +474,15 @@ class BasetenCUARuntime:
             raise FileNotFoundError(str(path))
         return json.loads(path.read_text())
 
+    # First-terminal-wins guard (mirrors ``modal_cua_server`` #866).
+    # Once a run reaches any of these the late worker write can't
+    # clobber an API-side cancel — the brain's terminal status loses
+    # to the operator's intent.
+    _TERMINAL_STATUSES: frozenset[str] = frozenset({
+        "succeeded", "failed", "cancelled", "completed_with_failures",
+        "timeout", "halted",
+    })
+
     def _write_detached_status(self, run_id: str, status: dict[str, Any]) -> dict[str, Any]:
         run_dir = self._run_path(run_id, create=True)
         status_path = run_dir / "status.json"
@@ -477,6 +492,24 @@ class BasetenCUARuntime:
                 existing = json.loads(status_path.read_text())
             except Exception:
                 existing = {}
+
+        existing_phase = str(existing.get("status", "")).lower()
+        incoming_phase = str(status.get("status", "")).lower()
+        if (
+            existing_phase in self._TERMINAL_STATUSES
+            and incoming_phase
+            and incoming_phase != existing_phase
+        ):
+            # Refuse the terminal overwrite — return the existing
+            # status unchanged so the caller's polling stays
+            # coherent. Important so a late worker write doesn't
+            # clobber an operator's cancel.
+            logger.warning(
+                "refusing to overwrite terminal status "
+                "run=%s cur=%r new=%r",
+                run_id, existing_phase, incoming_phase,
+            )
+            return existing
 
         merged = {
             **existing,
@@ -740,6 +773,81 @@ class BasetenCUARuntime:
         if not run_id:
             raise ValueError("run_id is required")
         run_dir = self._run_path(run_id)
+
+        # ``cancel`` / ``pause`` MUST be a 404 when the run isn't
+        # known — otherwise the dispatch is back-pressured into
+        # the run-submission path (the bug this fix prevents). The
+        # status read below is permissive (returns ``{}`` on
+        # missing); explicitly check existence so misrouted cancels
+        # surface as an error the caller can act on.
+        if action in {"cancel", "pause"}:
+            status_path = run_dir / "status.json"
+            if not status_path.exists():
+                raise FileNotFoundError(f"unknown run_id: {run_id}")
+
+        if action == "cancel":
+            # First-terminal-wins (mirrors ``modal_cua_server`` #866).
+            # A cancel on a finished run reports the existing status
+            # without overwriting; a cancel on an active run drops
+            # the cancel sentinel + flips status to ``cancelled``.
+            status = self._read_json_file(status_path)
+            cur = str(status.get("status", "")).lower()
+            terminal = {
+                "succeeded", "failed", "cancelled",
+                "completed_with_failures", "timeout", "halted",
+            }
+            if cur in terminal:
+                return status
+            now_iso = _utc_now()
+            try:
+                (run_dir / "cancel_request.json").write_text(
+                    json.dumps({"requested_at": now_iso}),
+                    encoding="utf-8",
+                )
+            except OSError as exc:
+                raise RuntimeError(
+                    f"failed to write cancel sentinel: {exc}"
+                ) from exc
+            status["status"] = "cancelled"
+            status["cancelled_at"] = now_iso
+            status["updated_at"] = now_iso
+            self._write_detached_status(run_id, status)
+            self._append_detached_event(run_id, "cancelled")
+            return status
+
+        if action == "pause":
+            # External pause (mirrors Modal #541). The detached worker
+            # checks the sentinel between micro steps via
+            # :func:`gym.external_pause.wait_while_paused` and stalls
+            # until ``action=resume`` clears it.
+            status = self._read_json_file(status_path)
+            cur = str(status.get("status", "")).lower()
+            if cur not in {"queued", "running"}:
+                raise ValueError(
+                    f"action='pause' requires a running run; "
+                    f"run_id={run_id!r} is in status={status.get('status')!r}"
+                )
+            reason = str(payload.get("reason") or "external") or "external"
+            now_iso = _utc_now()
+            try:
+                (run_dir / "pause_request.json").write_text(
+                    json.dumps({
+                        "reason": reason,
+                        "requested_at": now_iso,
+                    }),
+                    encoding="utf-8",
+                )
+            except OSError as exc:
+                raise RuntimeError(
+                    f"failed to write pause sentinel: {exc}"
+                ) from exc
+            status["status"] = "paused"
+            status["pause_reason"] = reason
+            status["paused_at"] = now_iso
+            status["updated_at"] = now_iso
+            self._write_detached_status(run_id, status)
+            self._append_detached_event(run_id, f"paused:{reason}")
+            return status
 
         if action == "status":
             status = self._read_json_file(run_dir / "status.json")

--- a/src/mantis_agent/gym/step_handlers/__init__.py
+++ b/src/mantis_agent/gym/step_handlers/__init__.py
@@ -37,6 +37,7 @@ from .holo3 import Holo3StepHandler
 from .navigate import NavigateHandler
 from .navigate_back import MechanicalNavigateBackHandler
 from .paginate import PaginateHandler
+from .request_user_input import RequestUserInputHandler
 from .scroll import MechanicalScrollHandler
 
 if TYPE_CHECKING:
@@ -107,6 +108,11 @@ def default_registry(runner: "MicroPlanRunner") -> HandlerRegistry:
     # MicroIntents — one Claude verify-shaped call against the
     # current screenshot, boolean bound to runner._state_vars.
     reg.register(DetectVisibleHandler(runner))
+    # User-bug fix: plan-text accessible bridge to the runner's
+    # ``request_user_input`` host tool. Without this the decomposer's
+    # ``request_user_input`` step gets emitted but never reaches a
+    # handler — silently no-ops and Claude/Holo3 makes up the value.
+    reg.register(RequestUserInputHandler(runner))
     reg.register_for_types(
         ClaudeGuidedFormHandler(runner),
         ("fill_field", "submit", "select_option", "right_click"),

--- a/src/mantis_agent/gym/step_handlers/request_user_input.py
+++ b/src/mantis_agent/gym/step_handlers/request_user_input.py
@@ -1,0 +1,142 @@
+"""``request_user_input`` step handler — deterministic pause/resume from plan_text.
+
+Plans authored as free text can ask the runtime to pause for an
+operator-supplied value (OTP, password, paste-target) by emitting a
+``request_user_input`` step (see the ``DECOMPOSE_PROMPT`` block of
+the same name in ``plan_decomposer``). The handler bridges that step
+to the host-tool mechanism the SDK pause/resume flow already uses:
+
+* Look up the ``request_user_input`` host tool the runner registered
+  in ``baseten_server.runtime`` (``runtime.py:1579``). The tool consumes
+  any staged ``user_input`` (set by ``action=resume``) and either:
+    - returns the staged value on first-resume → handler types it back
+      into ``StepResult.data`` so any downstream ``{{user_input}}`` token
+      substitution can pick it up; or
+    - raises ``PauseRequested`` if no value is staged → the runner
+      catches it and snapshots the run as ``status=paused``.
+
+* When the host tool isn't registered (off-Baseten contexts), the
+  handler degrades to a non-fatal skip so a plan that ran fine on
+  Baseten doesn't suddenly crash on a deployment that hasn't wired
+  the host tool yet.
+
+Wire shape — the decomposer emits::
+
+    {
+      "type": "request_user_input",
+      "intent": "Pause and ask the operator for the OTP",
+      "params": {
+        "prompt": "Enter the 6-digit code from your authenticator",
+        "reason": "user_input"
+      },
+      "required": true,
+      "section": "setup"
+    }
+
+The runner catches ``PauseRequested`` in its execute loop and saves
+the :class:`gym.checkpoint.PauseState` blob. The caller polls
+``action=status`` → ``status=paused``, then hits ``action=resume``
+with ``user_input=<value>``. On resume, the runner re-enters this
+step, the host tool returns the staged value, and the handler reports
+success — the staged value lives on ``runner._pause_consumed_input``
+so subsequent steps that reference ``{{user_input}}`` in their params
+or intent can substitute it.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from ..checkpoint import StepResult
+from ..step_context import StepContext, StepHandler
+
+if TYPE_CHECKING:
+    from ..micro_runner import MicroPlanRunner
+    from ...plan_decomposer import MicroIntent
+
+logger = logging.getLogger(__name__)
+
+
+class RequestUserInputHandler:
+    """Plan-text accessible bridge to the runner's ``request_user_input``
+    host tool. See module docstring for the round-trip protocol.
+    """
+
+    def __init__(self, runner: "MicroPlanRunner") -> None:
+        self._runner = runner
+
+    @property
+    def step_type(self) -> str:
+        return "request_user_input"
+
+    def execute(self, step: "MicroIntent", ctx: StepContext) -> StepResult:
+        runner = self._runner
+        params = step.params or {}
+        prompt = str(params.get("prompt") or step.intent or "user_input")
+        reason = str(params.get("reason") or "user_input")
+        # Step index isn't a top-level StepContext field — handlers
+        # read it from ``ctx.state['index']`` (the runner sets it
+        # before dispatch). Fall back to 0 so unit tests that don't
+        # plumb the index in still construct a sane StepResult.
+        index = int(ctx.state.get("index", 0)) if hasattr(ctx, "state") else 0
+
+        host_tools = getattr(runner, "_host_tools", None) or {}
+        tool_fn = host_tools.get("request_user_input")
+        if tool_fn is None:
+            # No tool registered — surface a non-fatal skip so a
+            # plan that ran fine on Baseten doesn't crash on a
+            # deployment that hasn't wired the host tool.
+            logger.warning(
+                "request_user_input step %d: no host tool registered; "
+                "downgrade to skip (reason=%s)",
+                index, reason,
+            )
+            return StepResult(
+                step_index=index,
+                intent=step.intent,
+                success=False,
+                data="request_user_input:host_tool_missing",
+                skip=True,
+                skip_reason="request_user_input_no_host_tool",
+            )
+
+        # First entry: ``tool_fn`` raises PauseRequested → the runner
+        # catches it in its execute loop. Resume entry: ``tool_fn``
+        # returns the staged value. Either way the handler doesn't
+        # try to suppress — exceptions bubble through the runner's
+        # standard recovery machinery.
+        staged = tool_fn({"prompt": prompt, "reason": reason})
+
+        # Resume path — stash the value so any downstream step that
+        # references ``{{user_input}}`` in its params or intent can
+        # substitute it.
+        try:
+            setattr(runner, "_staged_user_input", staged)
+        except Exception:  # noqa: BLE001 — observability only
+            logger.warning(
+                "request_user_input step %d: stash on runner failed",
+                index,
+            )
+
+        # ``data`` field is part of the trace surface (Augur, ops
+        # logs). Never echo the staged value — it may be a secret.
+        return StepResult(
+            step_index=index,
+            intent=step.intent,
+            success=True,
+            data="request_user_input:resumed",
+            skip=False,
+            skip_reason="",
+        )
+
+
+__all__ = ["RequestUserInputHandler"]
+
+
+# Static type check the protocol — runtime-visible failure if the
+# class drifts from the StepHandler shape.
+assert isinstance(
+    RequestUserInputHandler.__new__(RequestUserInputHandler),  # type: ignore[misc]
+    StepHandler,
+)

--- a/src/mantis_agent/plan_decomposer.py
+++ b/src/mantis_agent/plan_decomposer.py
@@ -121,7 +121,7 @@ def _extract_json_payload(text: str) -> Any:
 class MicroIntent:
     """A single atomic instruction for the CUA executor."""
     intent: str             # 1 sentence for Holo3: "Click the blue title text below the photo"
-    type: str               # click, scroll, navigate, extract_url, extract_data, filter, paginate, loop, navigate_back, fill_field, submit, select_option, right_click
+    type: str               # click, scroll, navigate, extract_url, extract_data, filter, paginate, loop, navigate_back, fill_field, submit, select_option, right_click, request_user_input
     verify: str = ""        # Expected outcome: "URL contains boattrader.com/boat/"
     budget: int = 5         # Max Holo3 steps
     reverse: str = ""       # How to undo: "Press Alt+Left"
@@ -473,6 +473,39 @@ choice, etc.), that value MUST appear verbatim in `params.value` (or
 `params.option_label` for selects) of the corresponding step. Never
 emit a fill_field with an empty `value` when the source provided one
 — the runner will type "" into the field and the form will be empty.
+
+PAUSE FOR USER INPUT (request_user_input) — deterministic plan-text
+pause/resume hook.
+When the source plan asks the runtime to STOP and ASK THE HUMAN for a
+value the plan does NOT carry literally — common phrasings are
+"ask the user for <X>", "prompt the user", "request the user's <X>",
+"pause for credentials", "wait for the OTP", "have the operator paste
+<X>" — emit a single ``request_user_input`` step at the point in the
+plan where the value is needed. The runtime catches the step and
+raises ``PauseRequested`` so the caller can poll ``action=status``,
+see ``status=paused``, then call ``action=resume`` with the value.
+Subsequent steps reference the resumed value via ``{{user_input}}``
+in their intent / params; the runtime substitutes the staged value
+at execute time.
+
+Required shape:
+  {
+    "type": "request_user_input",
+    "intent": "Pause and ask the operator for <X>",
+    "params": {
+      "prompt": "Please enter <X> (the runtime will pass it to the next step)",
+      "reason": "user_input"
+    },
+    "required": true,
+    "section": "setup"
+  }
+
+Use the literal value substitution token ``{{user_input}}`` in any
+later step that needs the staged value — e.g. a follow-up
+``fill_field`` whose ``params.value`` is ``"{{user_input}}"`` types
+whatever the caller submitted on resume. NEVER guess a value when
+the source said to ask the user — emitting ``fill_field`` with a
+fabricated string silently breaks the plan.
 
 WORKED EXAMPLES — credential / value preservation:
   Source: "Log in with user ID alice password hunter2"
@@ -1053,7 +1086,7 @@ class PlanDecomposer:
             logger.info("plan_text expresses read-only intent — enforcing #831 constraint")
 
         # Check cache — include prompt version in hash to invalidate on schema changes
-        prompt_version = "v36_emit_extract_blocks"  # Bump this when DECOMPOSE_PROMPT changes
+        prompt_version = "v37_request_user_input"  # Bump this when DECOMPOSE_PROMPT changes
         cache_key_text = (
             f"READONLY:{plan_text}" if read_only else plan_text
         )
@@ -1400,10 +1433,21 @@ class PlanDecomposer:
             elif step_type in PlanDecomposer.FORM_STEP_TYPES:
                 # Form steps default to "setup" — login + form-fill happens before extraction.
                 section = "setup"
+            elif step_type == "request_user_input":
+                # Pause-for-user-input is part of setup — the staged
+                # value (credential / OTP / etc.) feeds the form-fill
+                # steps that follow.
+                section = "setup"
 
         # Form steps default to required=True — failing to fill a login field
-        # or click Submit is fatal to the rest of the plan.
-        default_required = step_type == "filter" or step_type in PlanDecomposer.FORM_STEP_TYPES
+        # or click Submit is fatal to the rest of the plan. Same for
+        # ``request_user_input`` — if the runtime can't pause for the
+        # staged value the downstream form-fill has nothing to type.
+        default_required = (
+            step_type == "filter"
+            or step_type in PlanDecomposer.FORM_STEP_TYPES
+            or step_type == "request_user_input"
+        )
 
         params = s.get("params") or {}
         if not isinstance(params, dict):

--- a/tests/test_baseten_cancel_pause_dispatch.py
+++ b/tests/test_baseten_cancel_pause_dispatch.py
@@ -1,0 +1,187 @@
+"""Tests for the Baseten runtime cancel/pause dispatch fix + terminal-sticky.
+
+Bug report: ``action=cancel`` and ``action=pause`` fell through to the
+``detached`` branch in ``BasetenCUARuntime.run`` because the dispatch
+set only contained ``status/result/logs/resume``. That routed a cancel
+onto ``_start_detached``, which either 400'd on an active run or
+created a fresh run on a finished run_id (overwriting the record).
+
+These tests drive ``MantisRuntime`` directly with an isolated data
+root so we don't need Chrome / GPUs / Modal.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+@pytest.fixture
+def runtime(tmp_path: Path, monkeypatch):
+    """Construct a ``BasetenCUARuntime`` against an isolated data dir."""
+    monkeypatch.setenv("MANTIS_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("MANTIS_BRAIN", "holo3")
+    # Don't bring up Chrome / llama-cpp during tests.
+    monkeypatch.setenv("MANTIS_SKIP_BRAIN_LOAD", "1")
+    from mantis_agent.baseten_server.runtime import BasetenCUARuntime
+    rt = BasetenCUARuntime()
+    # Stub out the heavy ``load`` so the dispatch path doesn't try to
+    # boot a brain. ``run`` only calls load() on the non-action path.
+    rt.load = lambda: None  # type: ignore[assignment]
+    return rt
+
+
+def _seed_run(rt: Any, run_id: str, status: str) -> Path:
+    """Materialize a status.json for ``run_id`` so the action
+    handlers can read it back."""
+    rt._write_detached_status(run_id, {
+        "status": status,
+        "mode": "detached",
+        "model": "holo3",
+    })
+    return rt._run_path(run_id) / "status.json"
+
+
+# ── Dispatch fix ──────────────────────────────────────────────────────
+
+
+def test_cancel_dispatches_to_action_handler_not_detached(runtime) -> None:
+    """The previous bug: cancel + detached=true fell through to
+    ``_start_detached`` which started a new run on the run_id."""
+    _seed_run(runtime, "r-cancel", "running")
+    out = runtime.run({
+        "action": "cancel", "run_id": "r-cancel", "detached": True,
+    })
+    # Must be the cancelled status — NOT a freshly-queued run.
+    assert out["status"] == "cancelled"
+    # And no new detached thread spun up.
+    assert "r-cancel" not in runtime.detached_threads
+
+
+def test_pause_dispatches_to_action_handler_not_detached(runtime) -> None:
+    _seed_run(runtime, "r-pause", "running")
+    out = runtime.run({
+        "action": "pause", "run_id": "r-pause", "detached": True,
+        "reason": "manual_takeover",
+    })
+    assert out["status"] == "paused"
+    assert out["pause_reason"] == "manual_takeover"
+    # Sentinel exists on disk for the worker to poll.
+    sentinel = runtime._run_path("r-pause") / "pause_request.json"
+    assert sentinel.exists()
+    blob = json.loads(sentinel.read_text())
+    assert blob["reason"] == "manual_takeover"
+
+
+# ── Cancel on a finished run does NOT overwrite the record ───────────
+
+
+def test_cancel_on_finished_run_does_not_overwrite(runtime) -> None:
+    """A cancel on a run that already succeeded should be a no-op
+    (return the existing status). The pre-fix behaviour created a
+    NEW run on the same run_id and flipped the status to queued."""
+    _seed_run(runtime, "r-done", "succeeded")
+    out = runtime.run({
+        "action": "cancel", "run_id": "r-done", "detached": True,
+    })
+    assert out["status"] == "succeeded", out
+    # No new thread.
+    assert "r-done" not in runtime.detached_threads
+
+
+# ── Cancel on an unknown run_id returns 404 (not a new run) ─────────
+
+
+def test_cancel_on_unknown_run_id_raises_404_style_error(runtime) -> None:
+    with pytest.raises(FileNotFoundError, match="unknown run_id"):
+        runtime.run({
+            "action": "cancel", "run_id": "r-does-not-exist", "detached": True,
+        })
+
+
+def test_pause_on_unknown_run_id_raises_404_style_error(runtime) -> None:
+    with pytest.raises(FileNotFoundError, match="unknown run_id"):
+        runtime.run({
+            "action": "pause", "run_id": "r-never-existed", "detached": True,
+        })
+
+
+# ── Pause requires a running run ─────────────────────────────────────
+
+
+def test_pause_on_finished_run_400s(runtime) -> None:
+    _seed_run(runtime, "r-pause-late", "succeeded")
+    with pytest.raises(ValueError, match="requires a running run"):
+        runtime.run({
+            "action": "pause", "run_id": "r-pause-late", "detached": True,
+        })
+
+
+# ── Terminal-sticky guard ────────────────────────────────────────────
+
+
+def test_terminal_status_blocks_overwrite_after_cancel(runtime) -> None:
+    """After cancel writes cancelled, the worker's eventual terminal
+    write (succeeded/failed/halted) must NOT clobber the cancelled
+    record."""
+    _seed_run(runtime, "r-stick", "running")
+    runtime.run({"action": "cancel", "run_id": "r-stick", "detached": True})
+    # Worker writes its terminal status from inside the thread.
+    runtime._write_detached_status("r-stick", {"status": "succeeded"})
+    final = runtime.run({"action": "status", "run_id": "r-stick", "detached": True})
+    assert final["status"] == "cancelled", (
+        "executor terminal write clobbered cancelled record"
+    )
+
+
+def test_terminal_sticky_allows_same_status_writes(runtime) -> None:
+    """An idempotent re-write of cancelled is allowed (annotations may
+    be appended). Only DIFFERENT status writes are blocked."""
+    _seed_run(runtime, "r-same", "cancelled")
+    out = runtime._write_detached_status(
+        "r-same", {"status": "cancelled", "extra": "annotation"},
+    )
+    assert out["extra"] == "annotation"
+
+
+def test_terminal_sticky_does_not_block_initial_status(runtime) -> None:
+    """No prior status on disk → write goes through normally."""
+    out = runtime._write_detached_status("r-fresh", {"status": "queued"})
+    assert out["status"] == "queued"
+
+
+# ── Cancel sentinel is written so worker thread can observe it ───────
+
+
+def test_cancel_writes_sentinel_file(runtime) -> None:
+    _seed_run(runtime, "r-sentinel", "running")
+    runtime.run({"action": "cancel", "run_id": "r-sentinel", "detached": True})
+    sentinel = runtime._run_path("r-sentinel") / "cancel_request.json"
+    assert sentinel.exists()
+    body = json.loads(sentinel.read_text())
+    assert "requested_at" in body
+
+
+# ── _start_detached unreached for action calls (regression guard) ───
+
+
+def test_action_cancel_never_calls_start_detached(runtime, monkeypatch) -> None:
+    """Explicitly assert ``_start_detached`` is NOT invoked when
+    ``action=cancel`` is the request. Catches a re-introduction of
+    the original bug."""
+    _seed_run(runtime, "r-no-spawn", "running")
+    sentinel = threading.Event()
+
+    def _boom(payload):
+        sentinel.set()
+        raise AssertionError("_start_detached must not be called for action=cancel")
+
+    monkeypatch.setattr(runtime, "_start_detached", _boom)
+    runtime.run({
+        "action": "cancel", "run_id": "r-no-spawn", "detached": True,
+    })
+    assert not sentinel.is_set()

--- a/tests/test_handler_registry_default.py
+++ b/tests/test_handler_registry_default.py
@@ -56,6 +56,10 @@ def test_registry_covers_every_step_type_phase2_lifted():
         # binds boolean to runner._state_vars for ``step.guard`` to
         # consume on subsequent conditional steps.
         "detect_visible",
+        # User-bug fix: plan-text accessible bridge to the runner's
+        # ``request_user_input`` host tool — emits the deterministic
+        # pause/resume hook from a decomposed plan_text plan.
+        "request_user_input",
     }
     assert set(reg.types()) == expected
 

--- a/tests/test_request_user_input_step.py
+++ b/tests/test_request_user_input_step.py
@@ -1,0 +1,181 @@
+"""Tests for the ``request_user_input`` step type — plan_text accessible
+pause/resume hook.
+
+Bug context: plan_text submissions that asked the agent to "pause and
+ask the user for X" had no step type to compile to. The decomposer
+silently dropped the instruction and the brain made up values.
+
+The fix adds:
+
+* ``request_user_input`` to ``MicroIntent.type`` allowlist + decomposer
+  prompt + default section/required.
+* A new step handler that bridges to the runner's host tool, which
+  raises ``PauseRequested`` on the first entry and returns the staged
+  value on resume.
+
+These tests drive the handler in isolation (no Chrome, no Claude).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from mantis_agent.gym.checkpoint import StepResult
+from mantis_agent.gym.step_context import StepContext
+from mantis_agent.gym.step_handlers.request_user_input import RequestUserInputHandler
+from mantis_agent.plan_decomposer import MicroIntent, PlanDecomposer
+
+
+# ── Decomposer recognises request_user_input ──────────────────────────
+
+
+def test_decomposer_build_intent_accepts_request_user_input() -> None:
+    intent = PlanDecomposer._build_intent({
+        "type": "request_user_input",
+        "intent": "Pause and ask the operator for the OTP",
+        "params": {
+            "prompt": "Enter the 6-digit code",
+            "reason": "user_input",
+        },
+    })
+    assert intent.type == "request_user_input"
+    # Defaults: section=setup, required=True (the staged value
+    # feeds a downstream form-fill).
+    assert intent.section == "setup"
+    assert intent.required is True
+    assert intent.params["prompt"] == "Enter the 6-digit code"
+
+
+def test_decomposer_request_user_input_required_override_respected() -> None:
+    """Explicit required=False on the source dict should win — the
+    auto-required default is only a default."""
+    intent = PlanDecomposer._build_intent({
+        "type": "request_user_input",
+        "intent": "Maybe ask the operator",
+        "required": False,
+    })
+    assert intent.required is False
+
+
+# ── Handler protocol shape ────────────────────────────────────────────
+
+
+def test_handler_step_type_is_canonical() -> None:
+    handler = RequestUserInputHandler(runner=_FakeRunner())
+    assert handler.step_type == "request_user_input"
+
+
+# ── Pause path: handler propagates PauseRequested up to runner ──────
+
+
+class _PauseRequestedStub(Exception):
+    """Local PauseRequested stand-in so the test doesn't depend on the
+    runtime's actual PauseRequested import wiring."""
+
+
+class _FakeRunner:
+    """Records the host_tools / state mutations the handler performs."""
+
+    def __init__(self, host_tools: dict | None = None) -> None:
+        # Defaults to the canonical SDK-flow tool that raises
+        # PauseRequested on the first call and returns a staged value
+        # on the second (after action=resume).
+        self._host_tools: dict[str, Any] = host_tools if host_tools is not None else {
+            "request_user_input": self._default_tool,
+        }
+        self._pause_inputs: list[Any] = []
+        self._staged_user_input = None
+
+    def _default_tool(self, args: dict) -> Any:
+        if not self._pause_inputs:
+            raise _PauseRequestedStub(args.get("prompt", ""))
+        return self._pause_inputs.pop(0)
+
+
+def _step(prompt: str = "Enter OTP", reason: str = "user_input") -> MicroIntent:
+    return MicroIntent(
+        intent="Pause and ask the operator",
+        type="request_user_input",
+        params={"prompt": prompt, "reason": reason},
+        required=True,
+        section="setup",
+    )
+
+
+def _ctx(index: int = 0) -> StepContext:
+    ctx = StepContext(env=None, brain=None)
+    ctx.state["index"] = index
+    return ctx
+
+
+def test_handler_raises_when_host_tool_raises_pause() -> None:
+    """Empty pause inputs → tool raises → handler re-raises through
+    its try/except so the runner's PauseRequested catch path owns it."""
+    runner = _FakeRunner()
+    handler = RequestUserInputHandler(runner)
+    with pytest.raises(_PauseRequestedStub):
+        handler.execute(_step(), _ctx())
+
+
+def test_handler_returns_success_and_stashes_staged_value_on_resume() -> None:
+    """When the host tool returns a value (i.e. action=resume staged
+    one), the handler stashes it on the runner and reports success."""
+    runner = _FakeRunner()
+    runner._pause_inputs = ["123456"]
+    handler = RequestUserInputHandler(runner)
+    result = handler.execute(_step(), _ctx())
+    assert isinstance(result, StepResult)
+    assert result.success is True
+    assert result.data == "request_user_input:resumed"
+    assert getattr(runner, "_staged_user_input") == "123456"
+
+
+def test_handler_does_not_leak_secret_into_result_data() -> None:
+    """Trace consumers (Augur, ops logs) read ``result.data``. The
+    staged value is potentially a secret — the handler MUST keep it
+    out of the data field."""
+    runner = _FakeRunner()
+    runner._pause_inputs = ["super-secret-otp"]
+    handler = RequestUserInputHandler(runner)
+    result = handler.execute(_step(), _ctx())
+    assert "super-secret-otp" not in (result.data or "")
+
+
+# ── Off-Baseten degradation: no host tool registered ─────────────────
+
+
+def test_handler_skips_when_no_host_tool_registered() -> None:
+    runner = _FakeRunner(host_tools={})
+    handler = RequestUserInputHandler(runner)
+    result = handler.execute(_step(), _ctx(index=4))
+    assert result.success is False
+    assert result.skip is True
+    assert "no_host_tool" in (result.skip_reason or "")
+
+
+# ── Registry exposes the handler under the right type ───────────────
+
+
+def test_default_registry_binds_request_user_input_to_handler() -> None:
+    """End-to-end: ``default_registry`` registers the new handler
+    so the runner's ``_handler_registry.get('request_user_input')``
+    resolves to it."""
+    from mantis_agent.gym.step_handlers import default_registry
+
+    # default_registry requires a runner with the brain / env wiring
+    # other handlers reach into. We don't need them for the lookup —
+    # any handler that fails to construct against a bare-minimum
+    # runner would fail HERE, which is itself a useful regression
+    # signal (proves our new handler doesn't reach into deep runner
+    # internals at construct time).
+    class _BareRunner:
+        brain = None
+        env = None
+        extractor = None
+
+    reg = default_registry(_BareRunner())  # type: ignore[arg-type]
+    handler = reg.get("request_user_input")
+    assert handler is not None
+    assert handler.step_type == "request_user_input"


### PR DESCRIPTION
## Summary

Two related bugs the user reported:

### 1. `action=cancel` / `action=pause` falls through to `_start_detached`

`BasetenCUARuntime.run` dispatched on the `action` field before the `detached` check **only for `status`/`result`/`logs`/`resume`** — `cancel` and `pause` fell through to `_start_detached` because `PredictRequest.detached` defaults to `true`. Result:

```
{\"action\":\"cancel\",\"run_id\":\"<active>\"}
→ 400 \"detached run already exists and is active\"   # run keeps running

{\"action\":\"cancel\",\"run_id\":\"<finished>\"}
→ {\"status\":\"queued\",\"mode\":\"detached\"}  # NEW run on the same id, overwrites the record
```

Mirrors the Modal-side guard in `modal_cua_server.predict` (#866) so the two surfaces stay consistent.

### 2. plan_text → pause/resume unreachable

Plan-text submissions had no way to reach the SDK pause/resume flow. The runner already registers a `request_user_input` host tool (`runtime.py:1579`) — but the decomposer had no matching step type, so prompts like \"ask the user for the OTP\" silently dropped the instruction and Claude/Holo3 made up the value.

## Changes

### `baseten_server/runtime.py`
- Add `cancel` + `pause` to the action-dispatch set on `BasetenCUARuntime.run`
- Handle both in `_detached_action`:
  - **cancel** writes a sentinel file + flips status
  - **pause** writes `pause_request.json` so the worker's `gym.external_pause.wait_while_paused` stalls
- 404 (FileNotFoundError) when run_id isn't on disk — misrouted cancels can't fall through
- **First-terminal-wins guard** in `_write_detached_status` — a worker's late terminal write cannot clobber a cancelled record (matches #866 behaviour)

### `plan_decomposer.py`
- Add `request_user_input` to `MicroIntent.type` allowlist
- Document it in `DECOMPOSE_PROMPT` (PAUSE FOR USER INPUT block) with required shape + the `{{user_input}}` token for downstream substitution
- Default `section=setup`, `required=True` (the staged value feeds form-fill steps; failing to pause is fatal)
- Bump prompt cache key to `v37_request_user_input` to invalidate the decomposer's response cache

### `gym/step_handlers/request_user_input.py` (new)
- `RequestUserInputHandler` bridges the step to the runner's host tool:
  - **First entry**: host tool raises `PauseRequested` → runner catches it, snapshots PauseState, status flips to `paused`
  - **Resume entry**: host tool returns the staged value; handler stashes it on `runner._staged_user_input` for the downstream `{{user_input}}` substitution layer
- Degrades to non-fatal skip when no host tool is registered (off-Baseten contexts)

### `gym/step_handlers/__init__.py`
- Register the new handler in the default registry

## Test plan

- [x] `tests/test_baseten_cancel_pause_dispatch.py` — 11 cases
  - dispatch routes to action handler not detached (cancel + pause)
  - cancel-on-finished is no-op (doesn't overwrite)
  - cancel/pause-on-unknown 404
  - pause requires running run
  - terminal-sticky guards (blocks overwrite, allows idempotent re-write, allows initial)
  - cancel sentinel file written
  - regression guard: action=cancel never calls `_start_detached`
- [x] `tests/test_request_user_input_step.py` — 8 cases
  - decomposer accepts the type with right defaults
  - handler protocol shape
  - pause path re-raises tool exception
  - resume path stashes staged value + reports success
  - secret doesn't leak into `result.data`
  - off-Baseten fallback skip
  - default registry binding

## Notes

- This is the same code area as the Phase 1.5 stack (#856 merged, #860 merged, #858 + #859 awaiting CI). Touches different files so no conflicts expected.
- Branch is off `main`; targets `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)