### PR TITLE
feat(baseten): Modal parity — 12 API surface improvements

### DIFF
--- a/src/mantis_agent/baseten_server/routes.py
+++ b/src/mantis_agent/baseten_server/routes.py
@@ -714,6 +714,389 @@ async def predict(
     return await _handle_predict(request, tenant)
 
 
+# ── REST shorthands + lifecycle endpoints (parity with Modal #806) ─────────
+#
+# Each route below is a thin wrapper over the corresponding
+# ``runtime.run({"action": ..., "run_id": ...})`` dispatch — same
+# response shape, same error mapping. Run-scope tokens are required;
+# read-only observer tokens are rejected (mirrors the /v1/predict gate).
+
+
+def _run_action_response(
+    action: str, run_id: str,
+) -> dict[str, Any]:
+    """Wrap an action dispatch with the standard error mapping.
+
+    Centralises the FileNotFoundError → 404 / ValueError → 400 mapping
+    so the four shorthand routes don't each duplicate the try/except
+    chain.
+    """
+    payload = {"action": action, "run_id": run_id}
+    try:
+        return runtime.run(payload)
+    except FileNotFoundError as exc:
+        raise HTTPException(
+            status_code=404, detail=f"unknown run_id: {run_id}",
+        ) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@app.get("/v1/runs/{run_id}/status")
+async def get_run_status(
+    run_id: str,
+    tenant: TenantConfig = Depends(_require_run_scope),
+) -> dict[str, Any]:
+    """REST shorthand for ``POST /v1/predict {action: status}`` (Modal parity).
+
+    Returns the per-run status blob, including the lifecycle annotations
+    (failure_help on terminal failures, viewer_url when set,
+    pause_state when paused).
+    """
+    return await run_in_threadpool(_run_action_response, "status", run_id)
+
+
+@app.get("/v1/runs/{run_id}/result")
+async def get_run_result(
+    run_id: str,
+    tenant: TenantConfig = Depends(_require_run_scope),
+) -> dict[str, Any]:
+    """REST shorthand for ``POST /v1/predict {action: result}``.
+
+    Returns the per-run result envelope when finished; ``result_ready=False``
+    with the current status when still in flight.
+    """
+    return await run_in_threadpool(_run_action_response, "result", run_id)
+
+
+@app.post("/v1/runs/{run_id}/cancel")
+async def cancel_run(
+    run_id: str,
+    tenant: TenantConfig = Depends(_require_run_scope),
+) -> dict[str, Any]:
+    """REST shorthand for ``POST /v1/predict {action: cancel}``.
+
+    Idempotent: cancelling a finished run returns the existing status
+    unchanged. Surfaces ``cancel_lookup_error`` when the sentinel write
+    succeeded but the worker thread can't be signalled cleanly.
+    """
+    return await run_in_threadpool(_run_action_response, "cancel", run_id)
+
+
+@app.get("/v1/runs/{run_id}")
+async def get_run_phase(
+    run_id: str,
+    tenant: TenantConfig = Depends(_require_run_scope),
+) -> dict[str, Any]:
+    """Cheap phase poll + adaptive backoff hint (Modal #806 parity).
+
+    Returns a ``RunPhaseResponse`` derived from status.json plus, for
+    terminal failures, a ``failure_help`` dict mapped from the run's
+    ``halt_class``. For full detail (per-step results, artifacts), use
+    ``GET /v1/runs/{id}/status`` or ``GET /v1/runs/{id}/result`` once
+    this returns a terminal phase.
+    """
+    from mantis_agent.run_lifecycle import build_phase_response_from_status
+
+    def _read_and_build() -> dict[str, Any]:
+        status_path = runtime._run_path(run_id) / "status.json"
+        if not status_path.exists():
+            raise FileNotFoundError(f"unknown run_id: {run_id}")
+        status = json.loads(status_path.read_text())
+        body = build_phase_response_from_status(status).model_dump()
+        # Augur surface — when the runner stamped a sidecar, expose
+        # the augur run id + a derived bundle URL.
+        augur_meta = runtime._read_augur_metadata(run_id)
+        if augur_meta and augur_meta.get("augur_run_id"):
+            body["augur_run_id"] = augur_meta["augur_run_id"]
+            body["augur_bundle_url"] = f"/v1/runs/{run_id}/augur"
+        # failure_help on terminal halted / failed / cancelled phases.
+        # Prefer the dict already on status.json (set by the runner);
+        # synthesize from halt_class when absent.
+        terminal_failure = body.get("phase") in {"halted", "cancelled"} or (
+            body.get("phase") == "complete" and status.get("error")
+        )
+        if terminal_failure:
+            help_dict = status.get("failure_help")
+            if not help_dict and (
+                status.get("halt_class") or status.get("halt_reason")
+            ):
+                from mantis_agent.run_failure_help import failure_help_for
+                help_dict = failure_help_for(
+                    str(
+                        status.get("halt_class")
+                        or status.get("halt_reason")
+                        or "",
+                    ),
+                    run_id=run_id,
+                )
+            if help_dict:
+                body["failure_help"] = help_dict
+        return body
+
+    try:
+        return await run_in_threadpool(_read_and_build)
+    except FileNotFoundError as exc:
+        raise HTTPException(
+            status_code=404, detail=f"unknown run_id: {run_id}",
+        ) from exc
+
+
+@app.get("/v1/queue")
+async def get_queue(
+    tenant: TenantConfig = Depends(_require_run_scope),
+) -> dict[str, Any]:
+    """Per-tenant queue snapshot (Modal #806 parity).
+
+    Scans the active runs and counts by lifecycle phase. Terminal runs
+    are excluded — operators wanting historical totals can use
+    ``GET /v1/runs/{id}/status`` directly.
+
+    NOTE: Baseten is single-tenant per container, so this is functionally
+    a global queue view. The shape matches Modal's per-tenant response
+    so callers can use the same client code.
+    """
+    from mantis_agent.run_lifecycle import (
+        QueueStatusResponse,
+        RunPhase,
+        phase_from_status_string,
+    )
+
+    def _scan() -> dict[str, Any]:
+        runs_root = runtime._run_path("0").parent  # _data_root() / "runs"
+        queued = running = recovering = 0
+        if runs_root.exists() and runs_root.is_dir():
+            for run_subdir in runs_root.iterdir():
+                if not run_subdir.is_dir():
+                    continue
+                status_path = run_subdir / "status.json"
+                if not status_path.exists():
+                    continue
+                try:
+                    status_blob = json.loads(status_path.read_text())
+                except (OSError, json.JSONDecodeError):
+                    continue
+                phase = phase_from_status_string(
+                    str(status_blob.get("status", "") or ""),
+                )
+                if phase is RunPhase.QUEUED:
+                    queued += 1
+                elif phase is RunPhase.RUNNING:
+                    running += 1
+                elif phase is RunPhase.RECOVERING:
+                    recovering += 1
+        return QueueStatusResponse(
+            tenant_id=tenant.tenant_id,
+            queued=queued,
+            running=running,
+            recovering=recovering,
+            eta_ms=None,
+        ).model_dump()
+
+    return await run_in_threadpool(_scan)
+
+
+@app.get("/v1/runs/{run_id}/augur")
+async def get_augur_envelope(
+    run_id: str,
+    tenant: TenantConfig = Depends(_require_run_scope),
+) -> dict[str, Any]:
+    """Augur metadata envelope for a run (Modal #838 parity).
+
+    Includes the ``augur_run_id`` the runner minted, the on-disk
+    bundle directory, and a list of files in the bundle (when the
+    runner produced any).
+    """
+    def _read() -> dict[str, Any]:
+        meta = runtime._read_augur_metadata(run_id)
+        if meta is None:
+            raise FileNotFoundError(
+                f"no Augur metadata for run_id={run_id}"
+            )
+        from pathlib import Path as _Path
+        bundle = _Path(meta.get("bundle_dir", ""))
+        files: list[dict[str, Any]] = []
+        if bundle.exists() and bundle.is_dir():
+            for path in sorted(bundle.rglob("*")):
+                if not path.is_file():
+                    continue
+                rel = path.relative_to(bundle)
+                files.append({
+                    "name": str(rel),
+                    "size_bytes": path.stat().st_size,
+                })
+        return {
+            "run_id": run_id,
+            "augur_run_id": meta.get("augur_run_id", ""),
+            "bundle_dir": meta.get("bundle_dir", ""),
+            "dsn_workspace": meta.get("dsn_workspace", ""),
+            "bundle_present": bool(files),
+            "files": files,
+        }
+
+    try:
+        return await run_in_threadpool(_read)
+    except FileNotFoundError as exc:
+        raise HTTPException(
+            status_code=404,
+            detail=(
+                f"no Augur metadata for run_id={run_id} — either the "
+                "run hasn't started or Augur is disabled"
+            ),
+        ) from exc
+
+
+@app.get("/v1/runs/{run_id}/events")
+async def stream_run_events(
+    run_id: str,
+    request: Request,
+    sse: bool = False,
+    since: str = "",
+    tenant: TenantConfig = Depends(_require_run_scope),
+) -> Any:
+    """Stream run events (Modal #808 parity).
+
+    Default: returns the same JSON envelope as
+    ``POST /v1/predict {action: reasoning_trace}`` for plain HTTP
+    consumers. With ``?sse=true``, returns a ``text/event-stream``
+    SSE response that tails reasoning.jsonl + phase transitions and
+    closes on a terminal phase.
+    """
+    from starlette.responses import StreamingResponse
+
+    status_path = runtime._run_path(run_id) / "status.json"
+    if not status_path.exists():
+        raise HTTPException(
+            status_code=404, detail=f"unknown run_id: {run_id}",
+        )
+    jsonl_path = runtime._run_path(run_id) / "reasoning.jsonl"
+
+    if not sse:
+        # Plain JSON fallback: same shape as action=reasoning_trace.
+        return await run_in_threadpool(
+            runtime.run,
+            {"action": "reasoning_trace", "run_id": run_id, "since": since},
+        )
+
+    # SSE path. Reuse the status-string → lifecycle phase map so the
+    # ``phase`` events match what ``GET /v1/runs/{id}`` returns.
+    from mantis_agent.run_lifecycle import (
+        RunPhase,
+        phase_from_status_string,
+    )
+    _TERMINAL_PHASES = {
+        RunPhase.HALTED, RunPhase.CANCELLED, RunPhase.COMPLETE,
+    }
+
+    last_event_id = request.headers.get("last-event-id", "") or since
+
+    def _sse_format(event_name: str, payload: dict, event_id: str = "") -> str:
+        parts = []
+        if event_id:
+            parts.append(f"id: {event_id}")
+        parts.append(f"event: {event_name}")
+        parts.append(f"data: {json.dumps(payload, default=str)}")
+        return "\n".join(parts) + "\n\n"
+
+    async def event_stream():
+        import asyncio
+        nonlocal last_event_id
+        # Bound the stream so a stuck client can't hold a worker forever.
+        max_stream_seconds = 600
+        poll_interval = 1.0
+        heartbeat_interval = 25.0
+
+        loop_start = _time.monotonic()
+        last_heartbeat = loop_start
+
+        # Initial phase event so the client has the ground state.
+        try:
+            initial_status = json.loads(status_path.read_text())
+        except (OSError, json.JSONDecodeError):
+            initial_status = {}
+        last_phase_seen = phase_from_status_string(
+            str(initial_status.get("status", "") or "")
+        )
+        yield _sse_format(
+            "phase",
+            {"phase": last_phase_seen.value, "run_id": run_id},
+        )
+
+        while True:
+            if await request.is_disconnected():
+                return
+
+            # Drain any new reasoning events appended since last cursor.
+            if jsonl_path.exists():
+                try:
+                    with jsonl_path.open("r", encoding="utf-8") as handle:
+                        for line in handle:
+                            stripped = line.strip()
+                            if not stripped:
+                                continue
+                            try:
+                                event = json.loads(stripped)
+                            except (json.JSONDecodeError, ValueError):
+                                continue
+                            if not isinstance(event, dict):
+                                continue
+                            ts = str(event.get("ts", "") or "")
+                            if last_event_id and ts <= last_event_id:
+                                continue
+                            event_name = str(
+                                event.get("kind")
+                                or event.get("type")
+                                or "message"
+                            )
+                            yield _sse_format(event_name, event, event_id=ts)
+                            if ts:
+                                last_event_id = ts
+                except OSError:
+                    pass
+
+            # Phase transitions + terminal check.
+            try:
+                cur_status = json.loads(status_path.read_text())
+            except (OSError, json.JSONDecodeError):
+                cur_status = {}
+            cur_phase = phase_from_status_string(
+                str(cur_status.get("status", "") or "")
+            )
+            if cur_phase != last_phase_seen:
+                yield _sse_format(
+                    "phase",
+                    {"phase": cur_phase.value, "run_id": run_id},
+                )
+                last_phase_seen = cur_phase
+            if cur_phase in _TERMINAL_PHASES:
+                yield _sse_format(
+                    "terminal",
+                    {"phase": cur_phase.value, "run_id": run_id},
+                )
+                return
+
+            now = _time.monotonic()
+            if now - last_heartbeat >= heartbeat_interval:
+                yield ": ping\n\n"
+                last_heartbeat = now
+            if now - loop_start >= max_stream_seconds:
+                yield _sse_format(
+                    "timeout",
+                    {"reason": "max_stream_seconds", "run_id": run_id},
+                )
+                return
+            await asyncio.sleep(poll_interval)
+
+    return StreamingResponse(
+        event_stream(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",
+        },
+    )
+
+
 @app.post("/v1/cua")
 async def cua_v1(
     request: Request,

--- a/src/mantis_agent/baseten_server/runtime.py
+++ b/src/mantis_agent/baseten_server/runtime.py
@@ -405,7 +405,10 @@ class BasetenCUARuntime:
         # ``_start_detached`` and either 400 on an already-running run
         # or overwrite a finished run as a new submission. Mirrors the
         # Modal CUA fix in ``modal_cua_server.predict`` (#866).
-        if action in {"status", "result", "logs", "resume", "cancel", "pause"}:
+        if action in {
+            "status", "result", "logs", "resume", "cancel", "pause",
+            "reasoning_trace",
+        }:
             return self._detached_action(action, payload)
         if action == "graph_learn":
             return self._graph_learn(payload)
@@ -530,6 +533,114 @@ class BasetenCUARuntime:
         with (run_dir / "events.log").open("a") as handle:
             handle.write(line + "\n")
 
+    # ── Augur metadata sidecar (parity with Modal #838) ───────────
+    #
+    # The runner mints an Augur ``run_id`` distinct from the API
+    # run id (the Augur SDK groups its Runs view on it). We persist
+    # the mapping into ``<run_dir>/augur.json`` so the lifecycle
+    # endpoints can cross-link the API run id to the Augur bundle
+    # without the executor and the API speaking directly.
+
+    def _augur_bundle_dir(self, augur_run_id: str) -> Path:
+        """Resolve the on-disk Augur bundle directory.
+
+        Mirrors :func:`mantis_agent.observability.augur.default_out_dir`
+        but does not import augur-sdk (the bundle root is the file
+        layout we own; we don't need the SDK in the API hot path).
+        Honors ``MANTIS_AUGUR_DIR`` for the same override the runner
+        reads.
+        """
+        override = os.environ.get("MANTIS_AUGUR_DIR", "").strip()
+        if override:
+            return Path(override) / augur_run_id
+        return _data_root() / "augur" / augur_run_id
+
+    def _write_augur_metadata(
+        self, run_id: str, augur_run_id: str,
+    ) -> None:
+        """Persist the API-run-id → augur-run-id mapping.
+
+        Best-effort — telemetry must never break a finishing run, so
+        callers wrap with try/except. The lifecycle / augur endpoints
+        read this on every poll.
+        """
+        if not augur_run_id:
+            return
+        run_dir = self._run_path(run_id, create=True)
+        blob = {
+            "augur_run_id": augur_run_id,
+            "bundle_dir": str(self._augur_bundle_dir(augur_run_id)),
+            "dsn_workspace": os.environ.get(
+                "AUGUR_DSN_WORKSPACE_URL", "",
+            ) or "",
+        }
+        self._write_json_atomic(run_dir / "augur.json", blob)
+
+    def _read_augur_metadata(self, run_id: str) -> dict[str, Any] | None:
+        path = self._run_path(run_id) / "augur.json"
+        if not path.exists():
+            return None
+        try:
+            return json.loads(path.read_text())
+        except (OSError, ValueError, json.JSONDecodeError):
+            return None
+
+    # ── Status enrichment (parity with Modal #841 + viewer surface) ──
+
+    def _enrich_status(
+        self, run_id: str, status: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Annotate a status blob with derived fields the polling
+        callers expect.
+
+        - ``viewer_url`` from any sidecar viewer.json (file is dropped
+          alongside status.json by the viewer setup path; falls back
+          to a value already merged into status.json).
+        - ``failure_help`` synthesized from ``halt_class`` when the
+          run reached a terminal failure phase and the runner hasn't
+          already attached one.
+
+        Idempotent — re-running on an already-enriched dict is a no-op.
+        """
+        # viewer_url sidecar (#416 parity). ``_maybe_start_live_viewer``
+        # already merges the URL into status.json, but a tenant-side
+        # tool may also drop a ``viewer.json`` file separately; honor
+        # both shapes.
+        if not status.get("viewer_url"):
+            viewer_path = self._run_path(run_id) / "viewer.json"
+            if viewer_path.exists():
+                try:
+                    blob = json.loads(viewer_path.read_text())
+                    if isinstance(blob, dict) and blob.get("viewer_url"):
+                        status["viewer_url"] = str(blob["viewer_url"])
+                except (OSError, ValueError, json.JSONDecodeError):
+                    pass
+
+        cur_phase = str(status.get("status", "")).lower()
+        if cur_phase in self._TERMINAL_STATUSES and not status.get("failure_help"):
+            halt_class = str(status.get("halt_class") or "").strip()
+            if not halt_class:
+                # Some halts carry the wire reason on ``halt_reason``
+                # rather than ``halt_class`` (the runner's older
+                # field). Treat that as the same signal so the help
+                # taxonomy still fires.
+                halt_class = str(status.get("halt_reason") or "").strip()
+            if halt_class or cur_phase in {
+                "halted", "failed", "completed_with_failures",
+                "timeout", "cancelled",
+            }:
+                try:
+                    from ..run_failure_help import failure_help_for
+                    status["failure_help"] = failure_help_for(
+                        halt_class or cur_phase, run_id=run_id,
+                    )
+                except Exception as exc:  # noqa: BLE001 — diagnostic only
+                    logger.debug(
+                        "failure_help synthesis failed for %s: %s",
+                        run_id, exc,
+                    )
+        return status
+
     def _save_pause_state(self, run_id: str, pause_state: dict[str, Any]) -> Path:
         """Persist a paused run's :class:`PauseState` blob (#344)."""
         run_dir = self._run_path(run_id, create=True)
@@ -616,6 +727,28 @@ class BasetenCUARuntime:
             with self.lock:
                 self._append_detached_event(run_id, "running")
                 self._write_detached_status(run_id, {"status": "running", "started_at": _utc_now()})
+                # Mint a per-session Augur run id and stamp the
+                # sidecar (Modal #838 parity). Distinct from the API
+                # ``run_id`` so the Augur Runs view doesn't pile
+                # overlapping rows under one identifier. Best-effort:
+                # an augur write failure must never break a finishing
+                # run, and a redo on resume is fine because the existing
+                # sidecar wins via _read_augur_metadata.
+                if not self._read_augur_metadata(run_id):
+                    try:
+                        import uuid as _uuid_for_augur
+                        workflow_id = str(payload.get("workflow_id") or "")
+                        augur_run_id = (
+                            f"{workflow_id}-{_uuid_for_augur.uuid4().hex[:8]}"
+                            if workflow_id
+                            else _uuid_for_augur.uuid4().hex[:12]
+                        )
+                        self._write_augur_metadata(run_id, augur_run_id)
+                    except Exception as exc:  # noqa: BLE001 — telemetry
+                        logger.warning(
+                            "augur metadata write failed run=%s: %s",
+                            run_id, exc,
+                        )
                 if payload.get("_mode") == "pure_cua":
                     result = self._run_pure_cua(payload, run_id=run_id)
                 else:
@@ -797,23 +930,54 @@ class BasetenCUARuntime:
                 "completed_with_failures", "timeout", "halted",
             }
             if cur in terminal:
-                return status
+                return self._enrich_status(run_id, status)
             now_iso = _utc_now()
+            cancel_lookup_error: str | None = None
+            # Loosely mirrors Modal ``modal_cua_server.py:2731-2745`` —
+            # surface infra failures (sentinel write OSError, thread
+            # signal failure) on the response WITHOUT failing the cancel
+            # itself. The operator's intent always lands; the diagnostic
+            # tells them whether the worker thread will observe it.
             try:
                 (run_dir / "cancel_request.json").write_text(
                     json.dumps({"requested_at": now_iso}),
                     encoding="utf-8",
                 )
             except OSError as exc:
-                raise RuntimeError(
-                    f"failed to write cancel sentinel: {exc}"
-                ) from exc
+                cancel_lookup_error = f"sentinel_write_failed: {exc}"
+                logger.warning(
+                    "cancel sentinel write failed for run=%s: %s",
+                    run_id, exc,
+                )
+            # Best-effort thread-state sanity check. The worker thread
+            # observes the sentinel via the gym checkpoint pump; we
+            # don't kill it here (Python lacks a safe thread-kill),
+            # but we do surface whether the thread is reachable for
+            # the operator to interpret.
+            try:
+                thread = self.detached_threads.get(run_id)
+                if thread is not None and not thread.is_alive():
+                    # Worker already exited but a stale status said
+                    # ``running`` — surface so the caller can take
+                    # appropriate cleanup action.
+                    if cancel_lookup_error is None:
+                        cancel_lookup_error = (
+                            "worker_thread_not_alive: cancel sentinel "
+                            "written but no worker is polling it"
+                        )
+            except Exception as exc:  # noqa: BLE001 — diagnostic only
+                if cancel_lookup_error is None:
+                    cancel_lookup_error = (
+                        f"thread_lookup_failed: {type(exc).__name__}: {exc}"
+                    )
             status["status"] = "cancelled"
             status["cancelled_at"] = now_iso
             status["updated_at"] = now_iso
+            if cancel_lookup_error:
+                status["cancel_lookup_error"] = cancel_lookup_error
             self._write_detached_status(run_id, status)
             self._append_detached_event(run_id, "cancelled")
-            return status
+            return self._enrich_status(run_id, status)
 
         if action == "pause":
             # External pause (mirrors Modal #541). The detached worker
@@ -858,7 +1022,39 @@ class BasetenCUARuntime:
             # everything they need to resume without a second round-trip.
             if status.get("status") == "paused":
                 status["pause_state"] = self._read_pause_state(run_id)
-            return status
+            return self._enrich_status(run_id, status)
+
+        if action == "reasoning_trace":
+            # Parity with Modal ``modal_cua_server.py:2686-2710``.
+            # Tail the per-run reasoning.jsonl with an optional ``since``
+            # ISO-8601 cursor on ``ts``. Returns the same envelope as
+            # Modal so callers can switch endpoints transparently.
+            status = self._read_json_file(run_dir / "status.json")
+            self._enrich_status(run_id, status)
+            since_ts = str(payload.get("since") or "") or None
+            jsonl_path = run_dir / "reasoning.jsonl"
+            events: list[dict[str, Any]] = []
+            if jsonl_path.exists():
+                try:
+                    with jsonl_path.open("r", encoding="utf-8") as handle:
+                        for line in handle:
+                            stripped = line.strip()
+                            if not stripped:
+                                continue
+                            try:
+                                event = json.loads(stripped)
+                            except (json.JSONDecodeError, ValueError):
+                                continue
+                            if not isinstance(event, dict):
+                                continue
+                            if since_ts and str(event.get("ts", "")) <= since_ts:
+                                continue
+                            events.append(event)
+                except OSError as exc:
+                    logger.warning(
+                        "reasoning_trace read failed for %s: %s", run_id, exc,
+                    )
+            return {**status, "events": events, "count": len(events)}
 
         if action == "result":
             result_path = run_dir / "result.json"

--- a/tests/test_baseten_parity_audit.py
+++ b/tests/test_baseten_parity_audit.py
@@ -1,0 +1,447 @@
+"""Parity audit for the Baseten runtime + routes — 12 Modal-only behaviours.
+
+Each test covers one of the items shipped to bring the Baseten side
+to feature parity with the Modal CUA server:
+
+A. Status enrichment in ``_detached_action``:
+   1. ``failure_help`` synthesized from ``halt_class`` on terminal runs
+   2. ``action=reasoning_trace`` returns events with optional ``since``
+      cursor filter
+   3. ``cancel_lookup_error`` surfaced on cancel when the sentinel write
+      fails or the worker thread can't be signalled
+   4. ``viewer_url`` surfaced when a sidecar ``viewer.json`` exists
+
+B. New REST endpoints in ``routes.py``:
+   5. ``GET /v1/runs/{id}/status``
+   6. ``GET /v1/runs/{id}/result``
+   7. ``POST /v1/runs/{id}/cancel``
+   8. ``GET /v1/runs/{id}`` lifecycle phase + backoff hint + failure_help
+   9. ``GET /v1/queue`` queue snapshot
+  10. ``GET /v1/runs/{id}/augur`` augur metadata envelope
+  11. ``GET /v1/runs/{id}/events`` reasoning trace JSON fallback
+
+C. Worker integration:
+  12. ``_write_augur_metadata`` round-trips augur_run_id + bundle_dir
+
+The runtime fixture matches ``tests/test_baseten_cancel_pause_dispatch.py``
+so we exercise the same isolated tmp_path data root and stub out the
+heavy ``load`` step.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+@pytest.fixture
+def runtime(tmp_path: Path, monkeypatch):
+    """Construct a ``BasetenCUARuntime`` against an isolated data dir."""
+    monkeypatch.setenv("MANTIS_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("MANTIS_BRAIN", "holo3")
+    monkeypatch.setenv("MANTIS_SKIP_BRAIN_LOAD", "1")
+    from mantis_agent.baseten_server.runtime import BasetenCUARuntime
+    rt = BasetenCUARuntime()
+    rt.load = lambda: None  # type: ignore[assignment]
+    return rt
+
+
+def _seed_run(rt: Any, run_id: str, status: str, **extra: Any) -> Path:
+    payload: dict[str, Any] = {
+        "status": status,
+        "mode": "detached",
+        "model": "holo3",
+        **extra,
+    }
+    rt._write_detached_status(run_id, payload)
+    return rt._run_path(run_id) / "status.json"
+
+
+# ── A1. failure_help on terminal status ────────────────────────────────
+
+
+def test_failure_help_synthesized_on_halted(runtime) -> None:
+    _seed_run(
+        runtime, "r-halted", "halted",
+        halt_class="cf_challenge",
+    )
+    out = runtime.run({"action": "status", "run_id": "r-halted"})
+    assert out["status"] == "halted"
+    fh = out.get("failure_help")
+    assert fh is not None, "failure_help missing on halted run"
+    assert fh.get("halt_class") == "cf_challenge"
+    assert "summary" in fh
+    assert "next_steps" in fh
+
+
+def test_failure_help_absent_on_running(runtime) -> None:
+    _seed_run(runtime, "r-live", "running")
+    out = runtime.run({"action": "status", "run_id": "r-live"})
+    assert out["status"] == "running"
+    assert "failure_help" not in out
+
+
+def test_failure_help_preserves_existing_dict(runtime) -> None:
+    """When the runner already attached a failure_help, we don't synthesize."""
+    existing = {"halt_class": "custom", "summary": "runner-attached"}
+    _seed_run(
+        runtime, "r-custom", "halted",
+        halt_class="cf_challenge",
+        failure_help=existing,
+    )
+    out = runtime.run({"action": "status", "run_id": "r-custom"})
+    assert out["failure_help"] == existing
+
+
+# ── A2. action=reasoning_trace ─────────────────────────────────────────
+
+
+def test_reasoning_trace_returns_events_and_count(runtime) -> None:
+    _seed_run(runtime, "r-trace", "running")
+    jsonl = runtime._run_path("r-trace") / "reasoning.jsonl"
+    jsonl.write_text(
+        '\n'.join([
+            json.dumps({"ts": "2026-06-11T10:00:00Z", "kind": "step", "i": 1}),
+            json.dumps({"ts": "2026-06-11T10:00:01Z", "kind": "step", "i": 2}),
+            json.dumps({"ts": "2026-06-11T10:00:02Z", "kind": "step", "i": 3}),
+        ])
+    )
+    out = runtime.run({"action": "reasoning_trace", "run_id": "r-trace"})
+    assert out["count"] == 3
+    assert [e["i"] for e in out["events"]] == [1, 2, 3]
+    # status fields preserved on the envelope
+    assert out["status"] == "running"
+
+
+def test_reasoning_trace_since_cursor_filters(runtime) -> None:
+    _seed_run(runtime, "r-since", "running")
+    jsonl = runtime._run_path("r-since") / "reasoning.jsonl"
+    jsonl.write_text(
+        '\n'.join([
+            json.dumps({"ts": "2026-06-11T10:00:00Z", "i": 1}),
+            json.dumps({"ts": "2026-06-11T10:00:01Z", "i": 2}),
+            json.dumps({"ts": "2026-06-11T10:00:02Z", "i": 3}),
+        ])
+    )
+    out = runtime.run({
+        "action": "reasoning_trace",
+        "run_id": "r-since",
+        "since": "2026-06-11T10:00:01Z",
+    })
+    assert out["count"] == 1
+    assert out["events"][0]["i"] == 3
+
+
+def test_reasoning_trace_empty_when_no_log(runtime) -> None:
+    _seed_run(runtime, "r-empty", "running")
+    out = runtime.run({"action": "reasoning_trace", "run_id": "r-empty"})
+    assert out["count"] == 0
+    assert out["events"] == []
+
+
+def test_reasoning_trace_skips_malformed_lines(runtime) -> None:
+    _seed_run(runtime, "r-mal", "running")
+    jsonl = runtime._run_path("r-mal") / "reasoning.jsonl"
+    jsonl.write_text(
+        '\n'.join([
+            'not json',
+            json.dumps({"ts": "2026-06-11T10:00:00Z", "i": 1}),
+            '',
+            json.dumps(["not", "a", "dict"]),
+            json.dumps({"ts": "2026-06-11T10:00:01Z", "i": 2}),
+        ])
+    )
+    out = runtime.run({"action": "reasoning_trace", "run_id": "r-mal"})
+    assert out["count"] == 2
+
+
+# ── A3. cancel_lookup_error surfaces but cancel still succeeds ─────────
+
+
+def test_cancel_lookup_error_when_sentinel_write_fails(
+    runtime, monkeypatch,
+) -> None:
+    _seed_run(runtime, "r-werr", "running")
+    # Monkeypatch Path.write_text to fail for cancel_request.json.
+    real_write_text = Path.write_text
+
+    def _raising(self: Path, *args: Any, **kwargs: Any) -> int:
+        if self.name == "cancel_request.json":
+            raise OSError("simulated EROFS")
+        return real_write_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "write_text", _raising)
+    out = runtime.run({"action": "cancel", "run_id": "r-werr"})
+    # The cancel still wins — operator intent is sticky.
+    assert out["status"] == "cancelled"
+    # But the diagnostic is surfaced so the caller knows the worker
+    # won't observe the sentinel.
+    assert "cancel_lookup_error" in out
+    assert "sentinel_write_failed" in out["cancel_lookup_error"]
+
+
+def test_cancel_no_lookup_error_on_happy_path(runtime) -> None:
+    _seed_run(runtime, "r-ok", "running")
+    out = runtime.run({"action": "cancel", "run_id": "r-ok"})
+    assert out["status"] == "cancelled"
+    assert "cancel_lookup_error" not in out
+
+
+# ── A4. viewer_url surface ─────────────────────────────────────────────
+
+
+def test_viewer_url_surfaced_from_sidecar(runtime) -> None:
+    _seed_run(runtime, "r-view", "running")
+    viewer_path = runtime._run_path("r-view") / "viewer.json"
+    viewer_path.write_text(json.dumps({"viewer_url": "https://viewer.example/x"}))
+    out = runtime.run({"action": "status", "run_id": "r-view"})
+    assert out["viewer_url"] == "https://viewer.example/x"
+
+
+def test_viewer_url_status_field_wins_over_sidecar(runtime) -> None:
+    """The runner already merges viewer_url into status.json; sidecar
+    is a fallback for tooling that drops the file separately."""
+    _seed_run(
+        runtime, "r-view2", "running",
+        viewer_url="https://from-status/",
+    )
+    viewer_path = runtime._run_path("r-view2") / "viewer.json"
+    viewer_path.write_text(json.dumps({"viewer_url": "https://sidecar/"}))
+    out = runtime.run({"action": "status", "run_id": "r-view2"})
+    # status.json shape wins; sidecar only fills the gap when absent.
+    assert out["viewer_url"] == "https://from-status/"
+
+
+def test_viewer_url_absent_when_no_sidecar(runtime) -> None:
+    _seed_run(runtime, "r-noview", "running")
+    out = runtime.run({"action": "status", "run_id": "r-noview"})
+    assert "viewer_url" not in out
+
+
+# ── A12 (worker integration). Augur metadata round-trip ────────────────
+
+
+def test_augur_metadata_round_trips(runtime) -> None:
+    runtime._write_augur_metadata("r-aug", "workflow-abc123")
+    meta = runtime._read_augur_metadata("r-aug")
+    assert meta is not None
+    assert meta["augur_run_id"] == "workflow-abc123"
+    assert meta["bundle_dir"].endswith("workflow-abc123")
+
+
+def test_augur_metadata_empty_id_is_noop(runtime) -> None:
+    runtime._write_augur_metadata("r-aug-empty", "")
+    assert runtime._read_augur_metadata("r-aug-empty") is None
+
+
+def test_augur_metadata_missing_returns_none(runtime) -> None:
+    assert runtime._read_augur_metadata("r-never-written") is None
+
+
+# ── B5–B7. REST shorthand endpoints (status, result, cancel) ───────────
+#
+# Use the in-process TestClient against the FastAPI ``app`` (auth is
+# stubbed via dependency override the way the existing routes tests do).
+
+
+@pytest.fixture
+def client(tmp_path: Path, monkeypatch):
+    """FastAPI TestClient + tenant auth stub."""
+    monkeypatch.setenv("MANTIS_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("MANTIS_BRAIN", "holo3")
+    monkeypatch.setenv("MANTIS_SKIP_BRAIN_LOAD", "1")
+    from fastapi.testclient import TestClient
+    from mantis_agent.baseten_server.routes import app, runtime as routes_runtime
+    from mantis_agent.baseten_server.middleware import require_run_scope
+    from mantis_agent.tenant_auth import TenantConfig
+
+    # Make sure the module-level runtime in routes.py points at this
+    # tmp_path-rooted instance — _run_path is computed from data_root().
+    # Routes use the runtime singleton already; just force a load no-op.
+    routes_runtime.load = lambda: None  # type: ignore[assignment]
+
+    tenant = TenantConfig(
+        tenant_id="test-tenant",
+        scopes=("run",),
+    )
+
+    def _override_run_scope() -> TenantConfig:
+        return tenant
+
+    app.dependency_overrides[require_run_scope] = _override_run_scope
+    yield TestClient(app), routes_runtime
+    app.dependency_overrides.pop(require_run_scope, None)
+
+
+def _client_seed(rt: Any, run_id: str, status: str, **extra: Any) -> None:
+    rt._write_detached_status(
+        run_id,
+        {"status": status, "mode": "detached", "model": "holo3", **extra},
+    )
+
+
+def test_rest_get_status_matches_action_status(client) -> None:
+    api, rt = client
+    _client_seed(rt, "r-rest-status", "running")
+    rest = api.get("/v1/runs/r-rest-status/status").json()
+    action = rt.run({"action": "status", "run_id": "r-rest-status"})
+    # Both forms surface the same status string + run_id.
+    assert rest["status"] == action["status"] == "running"
+    assert rest["run_id"] == action["run_id"] == "r-rest-status"
+
+
+def test_rest_get_result_returns_envelope(client) -> None:
+    api, rt = client
+    _client_seed(rt, "r-rest-result", "running")
+    # No result.json yet — endpoint returns result_ready=False shape.
+    rest = api.get("/v1/runs/r-rest-result/result").json()
+    assert rest["result_ready"] is False
+    assert rest["status"] == "running"
+
+
+def test_rest_post_cancel_flips_to_cancelled(client) -> None:
+    api, rt = client
+    _client_seed(rt, "r-rest-cancel", "running")
+    rest = api.post("/v1/runs/r-rest-cancel/cancel").json()
+    assert rest["status"] == "cancelled"
+    # And a status read confirms the sticky write.
+    again = rt.run({"action": "status", "run_id": "r-rest-cancel"})
+    assert again["status"] == "cancelled"
+
+
+def test_rest_get_status_unknown_run_404s(client) -> None:
+    api, _ = client
+    resp = api.get("/v1/runs/r-missing/status")
+    assert resp.status_code == 404
+
+
+# ── B8. GET /v1/runs/{id} lifecycle endpoint ───────────────────────────
+
+
+def test_lifecycle_endpoint_returns_phase_and_backoff(client) -> None:
+    api, rt = client
+    _client_seed(rt, "r-life", "running")
+    body = api.get("/v1/runs/r-life").json()
+    assert body["phase"] == "running"
+    assert body["run_id"] == "r-life"
+    assert "polling_backoff_ms_hint" in body
+
+
+def test_lifecycle_endpoint_surfaces_failure_help_on_halted(client) -> None:
+    api, rt = client
+    _client_seed(
+        rt, "r-life-halt", "halted",
+        halt_class="proxy_unreachable",
+    )
+    body = api.get("/v1/runs/r-life-halt").json()
+    assert body["phase"] == "halted"
+    assert "failure_help" in body
+    assert body["failure_help"]["halt_class"] == "proxy_unreachable"
+
+
+def test_lifecycle_endpoint_surfaces_augur_run_id(client) -> None:
+    api, rt = client
+    _client_seed(rt, "r-life-aug", "running")
+    rt._write_augur_metadata("r-life-aug", "wf-xyz12345")
+    body = api.get("/v1/runs/r-life-aug").json()
+    assert body.get("augur_run_id") == "wf-xyz12345"
+    assert body.get("augur_bundle_url") == "/v1/runs/r-life-aug/augur"
+
+
+def test_lifecycle_endpoint_unknown_run_404s(client) -> None:
+    api, _ = client
+    resp = api.get("/v1/runs/r-missing-life")
+    assert resp.status_code == 404
+
+
+# ── B9. GET /v1/queue ──────────────────────────────────────────────────
+
+
+def test_queue_endpoint_counts_active_phases(client) -> None:
+    api, rt = client
+    _client_seed(rt, "q-a", "queued")
+    _client_seed(rt, "q-b", "running")
+    _client_seed(rt, "q-c", "running")
+    _client_seed(rt, "q-d", "succeeded")  # terminal — excluded
+    _client_seed(rt, "q-e", "halted")  # terminal — excluded
+    body = api.get("/v1/queue").json()
+    assert body["queued"] == 1
+    assert body["running"] == 2
+    # Terminal runs don't contribute to recovering / queued / running.
+    assert body["recovering"] == 0
+    assert body["tenant_id"] == "test-tenant"
+
+
+def test_queue_endpoint_empty_on_no_runs(client, tmp_path: Path) -> None:
+    api, _ = client
+    body = api.get("/v1/queue").json()
+    assert body["queued"] == 0
+    assert body["running"] == 0
+    assert body["recovering"] == 0
+
+
+# ── B10. GET /v1/runs/{id}/augur ───────────────────────────────────────
+
+
+def test_augur_envelope_endpoint_returns_metadata(client) -> None:
+    api, rt = client
+    _client_seed(rt, "r-aug-route", "running")
+    rt._write_augur_metadata("r-aug-route", "wf-aug-route")
+    body = api.get("/v1/runs/r-aug-route/augur").json()
+    assert body["run_id"] == "r-aug-route"
+    assert body["augur_run_id"] == "wf-aug-route"
+    assert body["bundle_present"] is False  # no files yet on the bundle dir
+    assert body["files"] == []
+
+
+def test_augur_envelope_endpoint_404s_when_no_metadata(client) -> None:
+    api, rt = client
+    _client_seed(rt, "r-aug-bare", "running")
+    resp = api.get("/v1/runs/r-aug-bare/augur")
+    assert resp.status_code == 404
+
+
+# ── B11. GET /v1/runs/{id}/events (JSON fallback) ──────────────────────
+
+
+def test_events_endpoint_returns_reasoning_trace_envelope(client) -> None:
+    api, rt = client
+    _client_seed(rt, "r-events", "running")
+    jsonl = rt._run_path("r-events") / "reasoning.jsonl"
+    jsonl.write_text(
+        '\n'.join([
+            json.dumps({"ts": "2026-06-11T11:00:00Z", "kind": "navigate"}),
+            json.dumps({"ts": "2026-06-11T11:00:01Z", "kind": "click"}),
+        ])
+    )
+    body = api.get("/v1/runs/r-events/events").json()
+    assert body["count"] == 2
+    assert body["status"] == "running"
+    assert [e["kind"] for e in body["events"]] == ["navigate", "click"]
+
+
+def test_events_endpoint_unknown_run_404s(client) -> None:
+    api, _ = client
+    resp = api.get("/v1/runs/r-events-missing/events")
+    assert resp.status_code == 404
+
+
+def test_events_endpoint_honors_since_cursor(client) -> None:
+    api, rt = client
+    _client_seed(rt, "r-events-since", "running")
+    jsonl = rt._run_path("r-events-since") / "reasoning.jsonl"
+    jsonl.write_text(
+        '\n'.join([
+            json.dumps({"ts": "2026-06-11T11:00:00Z", "i": 1}),
+            json.dumps({"ts": "2026-06-11T11:00:02Z", "i": 2}),
+        ])
+    )
+    body = api.get(
+        "/v1/runs/r-events-since/events",
+        params={"since": "2026-06-11T11:00:00Z"},
+    ).json()
+    assert body["count"] == 1
+    assert body["events"][0]["i"] == 2


### PR DESCRIPTION
## Summary

Brings 12 Modal-only API surface improvements to the Baseten Truss server so the same plan returns the same observability surfaces on both deployments. Baseten is single-process / single-Truss-container so the architectural pieces (\`modal.Dict\`, session router, reaper) stay Modal-only by design; everything else is now at parity.

## What lands (all 12 items from the audit)

### Status-response enrichment in \`_detached_action\`
1. **\`failure_help\`** on terminal status (#841 parity) — reuses \`failure_help_for(halt_class, run_id=...)\`. Surfaces on halted/cancelled/failed/timeout/completed_with_failures.
2. **\`action=reasoning_trace\`** (#847 parity) — reads \`<run_dir>/reasoning.jsonl\` with optional ISO \`since\` cursor.
3. **\`cancel_lookup_error\`** (#866 parity) — surfaces sentinel-write failures on the cancel response without failing cancel itself.
4. **\`viewer_url\`** surface (#416 parity) — reads \`viewer.json\` sidecar.

### New REST endpoints in \`routes.py\`
5. \`GET /v1/runs/{run_id}/status\`
6. \`GET /v1/runs/{run_id}/result\`
7. \`POST /v1/runs/{run_id}/cancel\`
8. \`GET /v1/runs/{run_id}\` cheap lifecycle phase + \`polling_backoff_ms_hint\` (#806) + failure_help on terminal
9. \`GET /v1/queue\` per-tenant queue snapshot (#806)
10. \`GET /v1/runs/{run_id}/augur\` (#838)
11. \`GET /v1/runs/{run_id}/events\` SSE event stream (#847)

### Worker integration
12. \`_write_augur_metadata\` / \`_read_augur_metadata\` — worker stamps \`augur_run_id\` post-bind.

## Test plan

- [x] \`tests/test_baseten_parity_audit.py\` — 30 cases covering every item above
- [x] Combined with PR #861's \`test_baseten_cancel_pause_dispatch.py\` + \`test_request_user_input_step.py\`: **49 Baseten-surface tests, all green**
- [x] Ruff clean

## Out of scope (Modal-only architectural)
- \`modal.Dict\` cross-replica state (#866) — Baseten is single-process
- Per-session computer-plane containers (#846) — different deployment model
- Session router + reaper — same architectural reason
- \`modal.forward\` tunnel URLs — Truss has its own URL surface; the \`viewer.json\` sidecar surface from item 4 covers the file side

## How to verify

Once merged: deploy to Baseten, submit the same HN top-5 plan you'd submit on Modal, and the following should return matching shapes on both:
- \`POST /v1/predict\` → run_id
- \`POST /v1/predict {action: status, run_id: ...}\` → matching keys including \`viewer_url\` (when live_viewer), \`pause_state\` (when paused), \`failure_help\` (when terminal-failed)
- \`GET /v1/runs/{id}\` → same \`RunPhaseResponse\` shape
- \`GET /v1/queue\` → same counts shape
- \`GET /v1/runs/{id}/augur\` → same Augur metadata
- \`POST /v1/predict {action: reasoning_trace, run_id: ...}\` → same events shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)