### PR TITLE
fix(baseten): align _run_path with tenant-scoped artifact reader

### DIFF
--- a/src/mantis_agent/baseten_server/runtime.py
+++ b/src/mantis_agent/baseten_server/runtime.py
@@ -458,13 +458,41 @@ class BasetenCUARuntime:
         }
 
     def _run_path(self, run_id: str, *, create: bool = False) -> Path:
+        """Resolve the on-disk run directory.
+
+        Tenant-scoped (``<root>/tenants/<tenant>/runs/<run_id>/``) to
+        match Modal's ``_run_dir`` and the Baseten artifact reader at
+        ``routes.get_run_artifact``. Pre-fix this method returned the
+        un-scoped ``<root>/runs/<run_id>/`` so writes from
+        ``_save_detached_result`` (``leads.csv`` / ``extracted_rows.json``
+        / ``result.json``) landed in a directory the artifact endpoint
+        never read — every artifact request 404'd.
+
+        On a read, we fall back to the legacy un-scoped location when
+        the scoped dir doesn't exist, so runs persisted before this fix
+        stay reachable until the next container restart.
+
+        ``MANTIS_TENANT_ID`` env var feeds the tenant — single-tenant
+        container model (each replica binds one tenant).
+        """
         safe_run_id = _safe_state_key(run_id)
         if not safe_run_id or safe_run_id != run_id:
             raise ValueError(f"invalid run_id: {run_id!r}")
-        path = _data_root() / "runs" / run_id
+        tenant_id = _safe_state_key(
+            os.environ.get("MANTIS_TENANT_ID") or DEFAULT_TENANT.tenant_id
+        )
+        scoped = _data_root() / "tenants" / tenant_id / "runs" / run_id
         if create:
-            path.mkdir(parents=True, exist_ok=True)
-        return path
+            scoped.mkdir(parents=True, exist_ok=True)
+            return scoped
+        # Read path: prefer the scoped location; fall back to the legacy
+        # un-scoped layout for runs persisted before this fix landed.
+        if scoped.exists():
+            return scoped
+        legacy = _data_root() / "runs" / run_id
+        if legacy.exists():
+            return legacy
+        return scoped
 
     def _write_json_atomic(self, path: Path, payload: dict[str, Any]) -> None:
         path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_baseten_parity_audit.py
+++ b/tests/test_baseten_parity_audit.py
@@ -445,3 +445,93 @@ def test_events_endpoint_honors_since_cursor(client) -> None:
     ).json()
     assert body["count"] == 1
     assert body["events"][0]["i"] == 2
+
+
+# ── D. Artifact path parity with Modal ────────────────────────────────
+#
+# Pre-fix, ``_run_path`` returned ``<root>/runs/<id>/`` but the
+# ``/v1/runs/{id}/artifacts/{name}`` reader at
+# ``routes.get_run_artifact`` looked under
+# ``<root>/tenants/<tenant>/runs/<id>/`` — every artifact request 404'd
+# even when ``persist_run_artifacts`` had materialized the file. The
+# fix aligns ``_run_path`` to the tenant-scoped shape that Modal's
+# ``_run_dir`` already uses; legacy un-scoped runs still resolve via a
+# read-side fallback.
+
+
+def test_run_path_is_tenant_scoped(runtime, tmp_path: Path) -> None:
+    """``_run_path(create=True)`` lands under ``tenants/<tenant>/runs/<id>/``."""
+    p = runtime._run_path("r-scoped", create=True)
+    # The path under tmp_path must include the tenant segment.
+    rel = p.relative_to(tmp_path)
+    parts = rel.parts
+    assert parts[0] == "tenants", f"missing tenants segment in {parts}"
+    # MANTIS_TENANT_ID isn't set in the fixture → defaults to DEFAULT_TENANT.
+    from mantis_agent.tenant_auth import DEFAULT_TENANT
+    assert parts[1] == DEFAULT_TENANT.tenant_id
+    assert parts[2] == "runs"
+    assert parts[3] == "r-scoped"
+
+
+def test_extracted_rows_artifact_served_when_runtime_persisted_it(
+    client, tmp_path: Path, monkeypatch,
+) -> None:
+    """End-to-end: rows persisted by ``_save_detached_result`` show up
+    at ``GET /v1/runs/{id}/artifacts/extracted_rows.json``."""
+    api, rt = client
+    # The fixture stubs the tenant to "test-tenant"; mirror that here so
+    # the writer (which reads MANTIS_TENANT_ID via os.environ) lands the
+    # files in the same dir the reader scans.
+    monkeypatch.setenv("MANTIS_TENANT_ID", "test-tenant")
+    # The artifact endpoint takes the unscoped ``require_mantis_token``
+    # dep directly; the fixture only overrides ``require_run_scope``,
+    # so wire the token dep through too.
+    from mantis_agent.baseten_server.routes import app
+    from mantis_agent.baseten_server.middleware import require_mantis_token
+    from mantis_agent.tenant_auth import TenantConfig
+    tenant = TenantConfig(tenant_id="test-tenant", scopes=("run",))
+    app.dependency_overrides[require_mantis_token] = lambda: tenant
+    try:
+        run_id = "r-rows-parity"
+        # Seed a status so the lifecycle endpoints don't 404 the run.
+        _client_seed(rt, run_id, "succeeded")
+        # Drive the same write path the worker uses post-completion.
+        rt._save_detached_result(run_id, {
+            "run_id": run_id,
+            "artifacts": [
+                {
+                    "kind": "structured_data",
+                    "name": "extracted_rows",
+                    "schema": {"fields": ["rank", "title"]},
+                    "data": [
+                        {"rank": "1", "title": "first"},
+                        {"rank": "2", "title": "second"},
+                    ],
+                },
+            ],
+        })
+        # GET the artifact via the public endpoint.
+        resp = api.get(f"/v1/runs/{run_id}/artifacts/extracted_rows.json")
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert isinstance(body, list)
+        assert len(body) == 2
+        assert body[0]["rank"] == "1"
+    finally:
+        app.dependency_overrides.pop(require_mantis_token, None)
+
+
+def test_run_path_falls_back_to_legacy_unscoped_layout(
+    runtime, tmp_path: Path,
+) -> None:
+    """Runs persisted before the fix landed (un-scoped
+    ``<root>/runs/<id>/``) remain readable via the fallback branch
+    until the container restarts."""
+    legacy_dir = tmp_path / "runs" / "r-legacy"
+    legacy_dir.mkdir(parents=True)
+    (legacy_dir / "status.json").write_text(json.dumps({"status": "succeeded"}))
+    # Read-path (create=False): no scoped dir exists, so the fallback
+    # returns the legacy un-scoped one.
+    p = runtime._run_path("r-legacy")
+    assert p == legacy_dir
+    assert (p / "status.json").exists()


### PR DESCRIPTION
## Summary

\`persist_run_artifacts\` writes \`leads.csv\` / \`extracted_rows.json\` into the directory returned by \`BasetenCUARuntime._run_path\`, but the writer's path was un-scoped (\`<root>/runs/<id>/\`) while \`routes.get_run_artifact\` reads from \`<root>/tenants/<tenant>/runs/<id>/\` — every artifact request 404'd even when the file had been materialized. The pre-existing comment in \`server_utils.persist_run_artifacts\` already called this out as "a pre-existing path bug" (#508-era follow-up).

Aligning the writer to the tenant-scoped layout matches Modal's \`_run_dir\` shape — Baseten now serves \`extracted_rows.json\`, \`leads.csv\`, \`extracted_rows.csv\`, and \`claude_cost_by_path.json\` through the same public endpoint Modal does, removing the last shape divergence between providers.

Read-side fallback preserves access to runs persisted before this fix lands.

## Why now

Surfaced live verifying HN top-5 against \`model-qvvgkneq.api.baseten.co\` — the run completed with 5 viable leads (\`viable: 5\` in result envelope), but \`GET /v1/runs/<id>/artifacts/extracted_rows.json\` returned 404 "artifact not available". Modal's same endpoint returned the structured rows JSON cleanly.

## Test plan

- [x] \`pytest tests/test_baseten_parity_audit.py tests/test_baseten_cancel_pause_dispatch.py tests/test_baseten_shape_parity_with_modal.py\` — 54/54 pass
- [x] Adds 3 regression tests:
  - \`_run_path\` returns tenant-scoped path
  - end-to-end artifact endpoint serves rows written by the worker
  - legacy un-scoped runs still resolve via fallback
- [ ] CI matrix on this PR
- [ ] Live B2 redeploy + HN extraction reads \`extracted_rows.json\` via the endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)