### PR TITLE
feat(snapshots): Phase 2 M3 — brain wire-up (capture + cross-host lock) (#699)

### DIFF
--- a/deploy/modal/modal_cua_server.py
+++ b/deploy/modal/modal_cua_server.py
@@ -1338,6 +1338,40 @@ def _run_holo3_executor(
                 viewer_ctx.__exit__(None, None, None)
             except Exception:
                 pass
+
+        # Phase 2 M3 (#699) — capture the post-run Chrome profile dir
+        # into the snapshot bucket. Env-gated; no-op when
+        # MANTIS_PROFILE_SNAPSHOT_BUCKET isn't set so production
+        # behaviour stays unchanged. Best-effort — capture never
+        # raises, so a failure here can't block envelope return.
+        try:
+            from mantis_agent.observability.snapshot_lifecycle import (
+                maybe_capture_snapshot as _capture_snap,
+            )
+            _resolved_tenant = (
+                api_tenant_id
+                or str(task_suite.get("_profile_id", "") or "").split("__", 1)[0]
+                or "default"
+            )
+            _resolved_profile = (
+                str(task_suite.get("_profile_id", "") or "").split("__", 1)[-1]
+                or profile_id
+            )
+            _capture_snap(
+                tenant_id=_resolved_tenant,
+                profile_id=_resolved_profile,
+                source_profile_dir=profile_dir or getattr(env, "_profile_dir", ""),
+                notes=f"executor=holo3 terminal={result.get('terminal_status', '')}",
+                captured_in={
+                    "executor": "run_holo3",
+                    "modal_call_id": getattr(env, "_modal_call_id", ""),
+                    "workflow_id": workflow_id,
+                    "run_id": run_id,
+                },
+            )
+        except Exception as _capture_exc:  # noqa: BLE001 — paranoia
+            print(f"WARNING: snapshot capture wrapper raised: {_capture_exc}")
+
         envelope = {
             "mode": "micro",
             "viable": viable,
@@ -2538,13 +2572,35 @@ def build_api_app(executor_resolver=None, function_call_lookup=None,
     from fastapi import Depends, FastAPI, HTTPException, Request
 
     from mantis_agent.baseten_server.middleware import require_run_scope
+    from mantis_agent.observability.snapshot_lifecycle import (
+        maybe_acquire_snapshot_lock,
+        maybe_force_release_lock_by_keys,
+    )
+    from mantis_agent.observability.profile_lock import LockConflictError
     from mantis_agent.server.run_dispatch import (
         DispatchError,
         acquire_profile_lock,
         prepare_predict_payload,
         read_profile_lock,
-        release_profile_lock,
+        release_profile_lock as _release_phase1_profile_lock,
     )
+
+    def release_profile_lock(tenant, profile_id):  # type: ignore[no-redef]
+        """Release Phase 1 file lock + Phase 2 snapshot lock together.
+
+        Wraps the original ``run_dispatch.release_profile_lock`` so
+        every site that releases the file lock also clears the
+        cross-host snapshot lock. Phase 2 release is env-gated +
+        best-effort (a missed release falls into the reaper's TTL
+        sweep) so a single helper is safe at every call site.
+        """
+        _release_phase1_profile_lock(tenant, profile_id)
+        try:
+            maybe_force_release_lock_by_keys(
+                tenant_id=tenant.tenant_id, profile_id=profile_id,
+            )
+        except Exception:  # noqa: BLE001 — release never breaks the API
+            pass
     from mantis_agent.server_utils import new_run_id as _mint_run_id
     from mantis_agent.tenant_auth import TenantConfig
 
@@ -2628,6 +2684,26 @@ def build_api_app(executor_resolver=None, function_call_lookup=None,
                 f"profile_id {profile_id!r} is busy; held by run_id={existing!r}. "
                 "Use a different profile_id or wait for the existing run to finish.",
             )
+
+        # Phase 2 M3 (#699): also acquire the cross-host snapshot lock.
+        # Env-gated — no-op when MANTIS_PROFILE_SNAPSHOT_BUCKET is unset
+        # so production behaviour stays unchanged until the bucket is
+        # configured. Conflict here means another host (E2B / Daytona)
+        # holds the profile; release the Phase 1 lock + return 409.
+        try:
+            maybe_acquire_snapshot_lock(
+                tenant_id=tenant.tenant_id, profile_id=profile_id,
+                run_id=run_id,
+            )
+        except LockConflictError as exc:
+            release_profile_lock(tenant, profile_id)
+            raise HTTPException(
+                409,
+                f"profile_id {profile_id!r} is busy on another host; "
+                f"held by run_id={exc.blob.holder_run_id!r} "
+                f"host={exc.blob.holder_host!r}. "
+                "Use a different profile_id or wait for the existing run to finish.",
+            ) from exc
 
         model = payload.get("cua_model") or payload.get("model") or "holo3"
         executor_fn = resolve_executor(model)
@@ -3691,8 +3767,10 @@ def build_api_app(executor_resolver=None, function_call_lookup=None,
         from mantis_agent.server.run_dispatch import (
             DispatchError,
             acquire_profile_lock,
-            release_profile_lock,
         )
+        # Note: ``release_profile_lock`` deliberately not imported here
+        # so the route picks up ``build_api_app``'s wrapper (which also
+        # clears the Phase 2 snapshot lock).
 
         body = body or {}
         target_url = str(body.get("target_url") or "https://bot.sannysoft.com/").strip()

--- a/src/mantis_agent/baseten_server/runtime.py
+++ b/src/mantis_agent/baseten_server/runtime.py
@@ -953,6 +953,42 @@ class BasetenCUARuntime:
             result["artifacts"] = list(result.get("artifacts") or []) + file_artifacts
         self._write_json_atomic(run_result_path, result)
 
+        # Phase 2 M3 (#699) — capture the post-run Chrome profile dir
+        # into the snapshot bucket. Env-gated; no-op when
+        # MANTIS_PROFILE_SNAPSHOT_BUCKET is unset. Best-effort.
+        try:
+            from ..observability.snapshot_lifecycle import (
+                maybe_capture_snapshot,
+            )
+            profile_id_raw = str(
+                result.get("profile_id") or ""
+            )
+            tenant_id_raw = (
+                os.environ.get("MANTIS_TENANT_ID")
+                or DEFAULT_TENANT.tenant_id
+            )
+            # Chrome profile dir on Baseten is keyed on the raw
+            # profile_id (see chrome_profile_dir() at line 150).
+            from ..server_utils import safe_state_key as _ssk
+            profile_dir = (
+                _data_root() / "chrome-profile" / _ssk(profile_id_raw)
+            )
+            maybe_capture_snapshot(
+                tenant_id=str(tenant_id_raw),
+                profile_id=profile_id_raw,
+                source_profile_dir=profile_dir,
+                notes=f"executor=baseten terminal={result.get('terminal_status', '')}",
+                captured_in={
+                    "executor": "baseten_runtime",
+                    "run_id": run_id,
+                    "workflow_id": str(result.get("workflow_id") or ""),
+                },
+            )
+        except Exception as _capture_exc:  # noqa: BLE001 — paranoia
+            logger.warning(
+                "snapshot capture wrapper raised: %s", _capture_exc,
+            )
+
     def _result_summary(self, result: dict[str, Any]) -> dict[str, Any]:
         return result_summary(result)
 

--- a/src/mantis_agent/observability/snapshot_lifecycle.py
+++ b/src/mantis_agent/observability/snapshot_lifecycle.py
@@ -1,0 +1,314 @@
+"""M3 brain wire-up — Phase 2 snapshot capture + per-profile lock around
+the plan lifecycle.
+
+This module is the brain-side companion to ``profile_snapshotter`` and
+``profile_lock``. M1 wired the LOAD path into Modal's
+``_chrome_profile_dir``; M3 adds the CAPTURE path at plan terminal
+and the cross-host lock at submit time.
+
+Every helper is env-gated on ``MANTIS_PROFILE_SNAPSHOT_BUCKET``: when
+the bucket isn't configured, every entry point is a no-op. Production
+behaviour stays exactly what it was before M1+M2 landed until an
+operator flips the env block on.
+
+Failure semantics — capture and lock release MUST NOT propagate
+exceptions. They run alongside the existing Phase 1 file-lock + Modal
+Volume write paths, which are independent of object-store
+availability. The only thing M3 raises out of is a lock CONFLICT at
+acquire — that's a real concurrent-writer signal the caller may want
+to surface as a 409.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Optional
+
+if TYPE_CHECKING:
+    from .profile_lock import _AcquiredLock
+
+logger = logging.getLogger(__name__)
+
+
+# Phase 2 lock TTL — generous to avoid renewal complexity for the
+# first wire-up. The Phase 1 file lock has ``stale_after_seconds=4h``;
+# we mirror that here so a crashed-without-release run gets reaped on
+# the same cadence. The cross-host reaper (M2 ``ProfileLockReaper``)
+# sweeps stale locks at this TTL + a 60s grace by default.
+_DEFAULT_LOCK_TTL_SECONDS = 4 * 3600
+
+
+def is_phase2_configured() -> bool:
+    """True iff the snapshot env block is set.
+
+    All M1/M2/M3 helpers short-circuit when this is False — production
+    behaviour stays unchanged until an operator flips the bucket on
+    in the Modal / Baseten secret.
+    """
+    return bool(os.environ.get("MANTIS_PROFILE_SNAPSHOT_BUCKET", "").strip())
+
+
+def maybe_acquire_snapshot_lock(
+    *,
+    tenant_id: str,
+    profile_id: str,
+    run_id: str,
+    holder_host: str = "",
+    ttl_seconds: int = _DEFAULT_LOCK_TTL_SECONDS,
+) -> Optional["_AcquiredLock"]:
+    """Acquire the Phase 2 object-store lock for a run.
+
+    Returns ``None`` when:
+
+    * Phase 2 isn't configured (env-gate off).
+    * The snapshot package isn't installed in this image (M1's import
+      gate). The Phase 1 file lock continues to gate concurrent
+      submissions on this host; the only loss is cross-host
+      coordination, which M3 promises but didn't yet exist before.
+    * The lock service is unreachable. Same fallback — log warning,
+      let the Phase 1 lock carry the contract.
+
+    Raises :class:`LockConflictError` ONLY when the lock is currently
+    held by a DIFFERENT host. Caller may want to surface this as a
+    409 — but for Modal-only deployments the Phase 1 file lock
+    already caught same-host races, so a Phase 2 conflict here means
+    "another backend (E2B / Daytona) is holding this profile."
+    """
+    if not is_phase2_configured():
+        return None
+    try:
+        from .profile_lock import ProfileLockManager
+        from .profile_snapshotter import ProfileSnapshotter
+    except ImportError as exc:
+        logger.warning(
+            "snapshot_lifecycle: profile_lock import failed, "
+            "skipping Phase 2 lock acquire: %s", exc,
+        )
+        return None
+    try:
+        snap = ProfileSnapshotter.from_env()
+    except Exception as exc:  # noqa: BLE001 — env/network failure
+        logger.warning(
+            "snapshot_lifecycle: ProfileSnapshotter.from_env failed, "
+            "skipping Phase 2 lock acquire tenant=%s profile=%s (%s)",
+            tenant_id, profile_id, exc,
+        )
+        return None
+    # Reuse the snapshotter's bucket + s3 client + chrome_major — the
+    # lock blob lives in the same prefix as ``latest.json`` so it
+    # discoverable via the same listing call the reaper uses.
+    mgr = ProfileLockManager(
+        bucket=snap._bucket,           # noqa: SLF001 — known reuse
+        chrome_major=snap._chrome_major,  # noqa: SLF001
+        s3_client=snap._s3,            # noqa: SLF001
+        ttl_seconds=ttl_seconds,
+    )
+    try:
+        return mgr.acquire(
+            tenant_id=tenant_id,
+            profile_id=profile_id,
+            holder_run_id=run_id,
+            holder_host=holder_host or _default_host_tag(),
+        )
+    except Exception as exc:  # noqa: BLE001
+        # Includes LockConflictError. Re-raise the conflict so the
+        # caller can branch on it; everything else degrades silently.
+        from .profile_lock import LockConflictError
+        if isinstance(exc, LockConflictError):
+            raise
+        logger.warning(
+            "snapshot_lifecycle: lock acquire failed tenant=%s "
+            "profile=%s run=%s (%s)", tenant_id, profile_id, run_id, exc,
+        )
+        return None
+
+
+def maybe_release_snapshot_lock(
+    lock: Optional["_AcquiredLock"],
+) -> None:
+    """Release the lock if one was acquired. No-op when ``None``.
+
+    Use this from the SAME container that acquired the lock (the
+    handle carries the ETag for CAS). For cross-container release
+    (acquire on the API, release on the executor's terminal detector,
+    or vice-versa) use :func:`maybe_force_release_lock_by_keys`.
+    """
+    if lock is None:
+        return
+    try:
+        from .profile_lock import ProfileLockManager
+        from .profile_snapshotter import ProfileSnapshotter
+        snap = ProfileSnapshotter.from_env()
+        mgr = ProfileLockManager(
+            bucket=snap._bucket,           # noqa: SLF001
+            chrome_major=snap._chrome_major,  # noqa: SLF001
+            s3_client=snap._s3,            # noqa: SLF001
+        )
+        mgr.release(lock, quiet=True)
+    except Exception as exc:  # noqa: BLE001 — release is best-effort
+        logger.warning(
+            "snapshot_lifecycle: lock release failed key=%s (%s)",
+            getattr(lock, "key", "?"), exc,
+        )
+
+
+def maybe_force_release_lock_by_keys(
+    *,
+    tenant_id: str,
+    profile_id: str,
+) -> None:
+    """Unconditionally delete the lock blob for ``(tenant, profile)``.
+
+    The API container acquires the lock at submit and releases at
+    terminal — but acquire and release happen on different requests
+    (potentially on different replicas). Threading the
+    :class:`_AcquiredLock` handle across that boundary requires
+    persisting the ETag somewhere; this helper sidesteps that by
+    just deleting the key.
+
+    Use ONLY from the container that owns the API surface for the
+    profile (i.e. the controller that just wrote the terminal status).
+    The cross-host reaper will catch any release we drop on the floor
+    via the TTL anyway.
+    """
+    if not is_phase2_configured():
+        return
+    try:
+        from .profile_snapshotter import ProfileSnapshotter, _safe
+        snap = ProfileSnapshotter.from_env()
+        key = (
+            f"snapshots/{_safe(tenant_id)}/{_safe(profile_id)}/"
+            f"{snap._chrome_major}/lock.json"  # noqa: SLF001
+        )
+        snap._s3.delete_object(  # noqa: SLF001
+            Bucket=snap._bucket, Key=key,  # noqa: SLF001
+        )
+    except Exception as exc:  # noqa: BLE001 — best-effort
+        logger.warning(
+            "snapshot_lifecycle: force-release failed tenant=%s "
+            "profile=%s (%s)", tenant_id, profile_id, exc,
+        )
+
+
+def maybe_capture_snapshot(
+    *,
+    tenant_id: str,
+    profile_id: str,
+    source_profile_dir: Any,  # str or Path
+    notes: str = "",
+    captured_in: Optional[dict[str, Any]] = None,
+) -> Optional[dict[str, Any]]:
+    """Capture the post-run profile dir into the snapshot bucket.
+
+    Fired at plan terminal — Chrome has already been closed by the
+    executor, the user-data-dir is in a clean cold state. Capture is
+    cold-mode (the only mode M2 ships); hot mode is M3's remaining
+    follow-up.
+
+    Returns a structured summary dict (with ``outcome`` ∈ {captured /
+    deduplicated / too_large / empty_source / upload_failed /
+    pointer_race / skipped}) so callers can log it. Returns ``None``
+    when Phase 2 isn't configured.
+
+    Never raises — the M2 writer already converts every failure path
+    into a structured ``CaptureResult``, and this wrapper degrades any
+    unexpected exception to a WARNING + ``skipped`` outcome.
+    """
+    if not is_phase2_configured():
+        return None
+    src = Path(source_profile_dir) if source_profile_dir else None
+    if src is None or not src.is_dir():
+        # Nothing to capture (Chrome never booted, or the dir was
+        # already cleaned up). Log at DEBUG so it doesn't flood Modal
+        # logs on every run that runs against a fresh profile.
+        logger.debug(
+            "snapshot_lifecycle: capture skipped — no source dir "
+            "tenant=%s profile=%s src=%s",
+            tenant_id, profile_id, src,
+        )
+        return {"outcome": "skipped", "reason": "no_source_dir"}
+    try:
+        from .profile_snapshotter import ProfileSnapshotter
+    except ImportError as exc:
+        logger.warning(
+            "snapshot_lifecycle: profile_snapshotter import failed, "
+            "skipping capture: %s", exc,
+        )
+        return {"outcome": "skipped", "reason": f"import_failed:{exc}"}
+    try:
+        snap = ProfileSnapshotter.from_env()
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "snapshot_lifecycle: from_env failed tenant=%s "
+            "profile=%s (%s)", tenant_id, profile_id, exc,
+        )
+        return {"outcome": "skipped", "reason": f"init_failed:{exc}"}
+    try:
+        result = snap.capture(
+            tenant_id=tenant_id,
+            profile_id=profile_id,
+            source_profile_dir=src,
+            mode="cold",
+            notes=notes,
+            captured_in=captured_in or {},
+        )
+    except NotImplementedError:
+        # Hot mode wasn't enabled, OR the writer raised on an unknown
+        # mode kwarg. The cold path shouldn't raise NotImplementedError;
+        # surface as skipped so the run isn't disrupted.
+        logger.warning(
+            "snapshot_lifecycle: capture NotImplementedError "
+            "tenant=%s profile=%s — treating as skipped",
+            tenant_id, profile_id,
+        )
+        return {"outcome": "skipped", "reason": "not_implemented"}
+    except Exception as exc:  # noqa: BLE001 — never break terminal
+        logger.warning(
+            "snapshot_lifecycle: capture raised tenant=%s "
+            "profile=%s (%s)", tenant_id, profile_id, exc,
+        )
+        return {"outcome": "skipped", "reason": f"raised:{exc}"}
+
+    summary = {
+        "outcome": result.outcome,
+        "reason": result.reason,
+        "archive_sha256": result.archive_sha256,
+        "archive_size_bytes": result.archive_size_bytes,
+        "uncompressed_size_bytes": result.uncompressed_size_bytes,
+        "predecessor_sha256": result.predecessor_sha256,
+        "elapsed_seconds": result.elapsed_seconds,
+    }
+    # WARNING-level so the outcome is visible in Modal app logs
+    # (feedback_warning_level_for_modal_observability).
+    logger.warning(
+        "profile_snapshot capture tenant=%s profile=%s outcome=%s "
+        "size=%dB elapsed=%.2fs",
+        tenant_id, profile_id, result.outcome,
+        result.archive_size_bytes, result.elapsed_seconds,
+    )
+    return summary
+
+
+# ── helpers ───────────────────────────────────────────────────────────
+
+
+def _default_host_tag() -> str:
+    """Best-effort host identifier for the lock blob's ``holder_host``.
+
+    Uses ``MANTIS_HOST`` when set, else falls back to ``modal`` (the
+    only host that today honours this env block). E2B / Daytona
+    deploys should set ``MANTIS_HOST`` in their secret so cross-host
+    conflicts surface a useful holder identity.
+    """
+    return (os.environ.get("MANTIS_HOST") or "").strip() or "modal"
+
+
+__all__ = [
+    "is_phase2_configured",
+    "maybe_acquire_snapshot_lock",
+    "maybe_release_snapshot_lock",
+    "maybe_force_release_lock_by_keys",
+    "maybe_capture_snapshot",
+]

--- a/tests/test_snapshot_lifecycle.py
+++ b/tests/test_snapshot_lifecycle.py
@@ -1,0 +1,229 @@
+"""Unit tests for the M3 brain wire-up helpers.
+
+Drives every entry point under both env-gate states (off + on) so we
+catch any path that forgets to short-circuit when
+``MANTIS_PROFILE_SNAPSHOT_BUCKET`` isn't set. Uses the CAS-aware fake
+S3 from the M2 writer tests for the env-on paths.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from mantis_agent.observability.snapshot_lifecycle import (
+    is_phase2_configured,
+    maybe_acquire_snapshot_lock,
+    maybe_capture_snapshot,
+    maybe_force_release_lock_by_keys,
+    maybe_release_snapshot_lock,
+)
+
+# Reuse the writer-test fixtures.
+from tests.test_profile_snapshotter_writer import _CASFakeS3 as _BaseCAS
+from tests.test_profile_snapshotter_loader import _make_profile_dir
+
+
+class _CASFakeS3(_BaseCAS):
+    """``_CASFakeS3`` + ``delete_object`` (release/force-release need it)."""
+
+    def delete_object(self, *, Bucket: str, Key: str) -> dict:
+        self._store.pop((Bucket, Key), None)
+        return {}
+
+
+# ── env-gate off (production default) ────────────────────────────────
+
+
+@pytest.fixture
+def env_off(monkeypatch):
+    monkeypatch.delenv("MANTIS_PROFILE_SNAPSHOT_BUCKET", raising=False)
+    return None
+
+
+def test_is_phase2_configured_false_when_unset(env_off) -> None:
+    assert is_phase2_configured() is False
+
+
+def test_acquire_returns_none_when_env_off(env_off) -> None:
+    assert maybe_acquire_snapshot_lock(
+        tenant_id="acme", profile_id="user-1", run_id="r-1",
+    ) is None
+
+
+def test_release_is_noop_when_lock_is_none(env_off) -> None:
+    # Must not raise.
+    maybe_release_snapshot_lock(None)
+
+
+def test_force_release_is_noop_when_env_off(env_off) -> None:
+    maybe_force_release_lock_by_keys(tenant_id="acme", profile_id="user-1")
+
+
+def test_capture_returns_none_when_env_off(env_off, tmp_path: Path) -> None:
+    src = _make_profile_dir(tmp_path)
+    assert maybe_capture_snapshot(
+        tenant_id="acme", profile_id="user-1", source_profile_dir=src,
+    ) is None
+
+
+# ── env-gate on (Phase 2 deploy) ─────────────────────────────────────
+
+
+@pytest.fixture
+def env_on(monkeypatch, tmp_path: Path):
+    """Configure the env block + inject a fake S3 into ProfileSnapshotter.
+
+    ``ProfileSnapshotter.from_env()`` builds a real boto3 client, which
+    we can't talk to in unit tests. Monkey-patch the factory to return
+    a snapshotter wired to a ``_CASFakeS3`` instance instead.
+    """
+    monkeypatch.setenv("MANTIS_PROFILE_SNAPSHOT_BUCKET", "test-bucket")
+    monkeypatch.setenv("MANTIS_PROFILE_SNAPSHOT_S3_ENDPOINT", "http://test")
+    monkeypatch.setenv("MANTIS_PROFILE_SNAPSHOT_S3_REGION", "test")
+    monkeypatch.setenv("MANTIS_CHROME_MAJOR_VERSION", "131")
+
+    s3 = _CASFakeS3()
+    from mantis_agent.observability.profile_snapshotter import (
+        ProfileSnapshotter,
+    )
+    original = ProfileSnapshotter.from_env
+
+    def _fake_from_env() -> ProfileSnapshotter:
+        return ProfileSnapshotter(
+            bucket="test-bucket", chrome_major=131, s3_client=s3,
+        )
+
+    monkeypatch.setattr(
+        ProfileSnapshotter, "from_env",
+        classmethod(lambda cls: _fake_from_env()),
+    )
+    yield s3
+    # monkeypatch undoes the classmethod patch via cleanup; nothing to do.
+    _ = original
+
+
+def test_is_phase2_configured_true_when_set(env_on) -> None:
+    assert is_phase2_configured() is True
+
+
+def test_acquire_returns_handle_when_env_on(env_on) -> None:
+    held = maybe_acquire_snapshot_lock(
+        tenant_id="acme", profile_id="user-1", run_id="r-1",
+    )
+    assert held is not None
+    assert held.blob.holder_run_id == "r-1"
+    assert held.blob.holder_host == "modal"  # default fallback
+
+
+def test_acquire_conflict_raises_for_caller_to_handle(env_on) -> None:
+    """A second holder must see :class:`LockConflictError`."""
+    from mantis_agent.observability.profile_lock import LockConflictError
+    maybe_acquire_snapshot_lock(
+        tenant_id="acme", profile_id="user-1", run_id="r-a",
+    )
+    with pytest.raises(LockConflictError) as exc_info:
+        maybe_acquire_snapshot_lock(
+            tenant_id="acme", profile_id="user-1", run_id="r-b",
+        )
+    assert exc_info.value.blob.holder_run_id == "r-a"
+
+
+def test_release_round_trips_via_handle(env_on) -> None:
+    held = maybe_acquire_snapshot_lock(
+        tenant_id="acme", profile_id="user-1", run_id="r-1",
+    )
+    maybe_release_snapshot_lock(held)
+    # After release another holder can acquire.
+    other = maybe_acquire_snapshot_lock(
+        tenant_id="acme", profile_id="user-1", run_id="r-2",
+    )
+    assert other is not None
+    assert other.blob.holder_run_id == "r-2"
+
+
+def test_force_release_clears_lock_blob_without_handle(env_on) -> None:
+    """The API-side terminal path can release without carrying the
+    handle across the API/executor boundary."""
+    s3 = env_on
+    held = maybe_acquire_snapshot_lock(
+        tenant_id="acme", profile_id="user-x", run_id="r-1",
+    )
+    assert held is not None
+    # Force-release as if from a different process.
+    maybe_force_release_lock_by_keys(tenant_id="acme", profile_id="user-x")
+    # Lock blob is gone.
+    keys = [k for (_, k) in s3._store if k.endswith("lock.json")]
+    assert keys == []
+
+
+def test_capture_captured_on_happy_path(env_on, tmp_path: Path) -> None:
+    src = _make_profile_dir(tmp_path)
+    summary = maybe_capture_snapshot(
+        tenant_id="acme", profile_id="user-1", source_profile_dir=src,
+    )
+    assert summary is not None
+    assert summary["outcome"] == "captured"
+    assert summary["archive_sha256"]
+    assert summary["archive_size_bytes"] > 0
+
+
+def test_capture_skipped_when_source_missing(env_on, tmp_path: Path) -> None:
+    summary = maybe_capture_snapshot(
+        tenant_id="acme", profile_id="user-1",
+        source_profile_dir=tmp_path / "does-not-exist",
+    )
+    assert summary == {"outcome": "skipped", "reason": "no_source_dir"}
+
+
+def test_capture_skipped_when_source_is_none(env_on) -> None:
+    summary = maybe_capture_snapshot(
+        tenant_id="acme", profile_id="user-1", source_profile_dir=None,
+    )
+    assert summary == {"outcome": "skipped", "reason": "no_source_dir"}
+
+
+def test_capture_deduplicates_identical_content(
+    env_on, tmp_path: Path,
+) -> None:
+    src = _make_profile_dir(tmp_path)
+    first = maybe_capture_snapshot(
+        tenant_id="acme", profile_id="user-1", source_profile_dir=src,
+    )
+    second = maybe_capture_snapshot(
+        tenant_id="acme", profile_id="user-1", source_profile_dir=src,
+    )
+    assert first is not None and second is not None
+    assert first["outcome"] == "captured"
+    assert second["outcome"] == "deduplicated"
+
+
+def test_capture_never_raises_on_writer_exception(env_on, monkeypatch, tmp_path: Path) -> None:
+    """Even if the writer raises an unexpected error, capture returns
+    a structured ``skipped`` rather than bubbling to the caller."""
+    src = _make_profile_dir(tmp_path)
+    from mantis_agent.observability.profile_snapshotter import (
+        ProfileSnapshotter,
+    )
+
+    def _boom(self: Any, **kw: Any) -> None:
+        raise RuntimeError("simulated writer failure")
+
+    monkeypatch.setattr(ProfileSnapshotter, "capture", _boom)
+    summary = maybe_capture_snapshot(
+        tenant_id="acme", profile_id="user-1", source_profile_dir=src,
+    )
+    assert summary is not None
+    assert summary["outcome"] == "skipped"
+    assert "raised:" in summary["reason"]
+
+
+def test_acquire_holder_host_uses_mantis_host_env(env_on, monkeypatch) -> None:
+    monkeypatch.setenv("MANTIS_HOST", "e2b-east")
+    held = maybe_acquire_snapshot_lock(
+        tenant_id="acme", profile_id="user-host", run_id="r-1",
+    )
+    assert held is not None
+    assert held.blob.holder_host == "e2b-east"


### PR DESCRIPTION
## Summary

Plumbs the M1+M2 primitives into the brain's plan lifecycle so profile snapshots actually persist across runs in production.

Lifecycle wire-up (env-gated on \`MANTIS_PROFILE_SNAPSHOT_BUCKET\`; no-op when unset so production stays unchanged):

- **Submit-time (Modal API):** acquire the Phase 2 object-store lock ALONGSIDE the Phase 1 file lock. \`LockConflictError\` → release the Phase 1 lock + return 409 with the holder's host identity (e.g. "held by e2b-east"). Lets cross-backend contention surface cleanly even when Phase 2 ships.
- **Release-time (Modal API):** a small wrapper in \`build_api_app\` shadows \`release_profile_lock\` so every existing release site clears the cross-host lock too. No call-site edits beyond two import lines.
- **Terminal-time (run_holo3):** after \`env.close()\` drains Chrome to cold state, fire \`maybe_capture_snapshot()\` with \`(tenant, profile, profile_dir)\`. Best-effort; never blocks envelope return.
- **Terminal-time (Baseten):** same pattern in \`_save_detached_result\`, after \`persist_run_artifacts\`.

New helper module \`src/mantis_agent/observability/snapshot_lifecycle.py\`:
- \`is_phase2_configured()\`
- \`maybe_acquire_snapshot_lock()\` — raises \`LockConflictError\` on cross-host conflicts
- \`maybe_release_snapshot_lock(lock)\` — release via the known handle
- \`maybe_force_release_lock_by_keys(tenant, profile)\` — release without the handle, for the API-driven terminal-detection path that doesn't carry the lock across requests
- \`maybe_capture_snapshot()\` — env-gated wrapper around \`ProfileSnapshotter.capture\`, always returns a structured summary dict, never raises

## Test plan

- [x] \`pytest tests/test_snapshot_lifecycle.py\` — 16 unit tests cover env-off + env-on paths, conflict surfacing, dedup, capture-never-raises invariant, holder_host resolution
- [x] \`pytest tests/test_*snapshot* tests/test_profile_lock tests/test_baseten_*\` — 113/113 pass
- [ ] CI matrix on this PR
- [ ] Live verification on Modal + Baseten after CI green — submit HN top-5 with \`MANTIS_PROFILE_SNAPSHOT_BUCKET\` set, expect \`profile_snapshot ... outcome=captured\` in logs and a \`latest.json\` in B2

## Follow-ups (separate PRs, in this sequence)

- Hot-mode capture (spec § 3) — WAL-checkpoint harness
- Moto-based CI integration tests so the live B2 check stops being skip-gated
- E2B + Daytona backends in \`make_computer_client()\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)