### PR TITLE
feat(computer-plane): Phase 2 E2B + Daytona backends (#699)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,6 +178,18 @@ snapshots = [
     "zstandard>=0.22",
     "pydantic>=2",
 ]
+# Phase 2 (#699) computer-plane backends. Each provider is opt-in;
+# only install the one you actually deploy against. The make_computer_client
+# factory imports lazily so a missing SDK doesn't break import for
+# unrelated callers.
+e2b = [
+    "e2b>=1.0",
+    "requests>=2.28",
+]
+daytona = [
+    "daytona>=0.183",
+    "requests>=2.28",
+]
 # HUD evaluation harness.
 hud = [
     "hud-python>=0.5.34",

--- a/src/mantis_agent/gym/computer_client.py
+++ b/src/mantis_agent/gym/computer_client.py
@@ -152,9 +152,20 @@ def make_computer_client(
             **env_kwargs,
         )
 
-    if backend in ("e2b", "daytona"):
-        raise NotImplementedError(
-            f"ComputerPlaneConfig.backend={backend!r} lands in Phase 2 (#699)"
+    if backend == "e2b":
+        from .e2b_impl import E2BComputerImpl
+
+        return E2BComputerImpl(
+            enable_cdp=cfg.enable_cdp,
+            **env_kwargs,
+        )
+
+    if backend == "daytona":
+        from .daytona_impl import DaytonaComputerImpl
+
+        return DaytonaComputerImpl(
+            enable_cdp=cfg.enable_cdp,
+            **env_kwargs,
         )
 
     raise ValueError(f"unknown ComputerPlaneConfig.backend: {backend!r}")

--- a/src/mantis_agent/gym/daytona_impl.py
+++ b/src/mantis_agent/gym/daytona_impl.py
@@ -1,0 +1,221 @@
+"""Daytona sandbox backend for the computer plane (#699 Phase 2).
+
+Daytona (https://daytona.io/) provides on-demand workspace sandboxes
+with a public preview URL. Same shape as :class:`E2BComputerImpl`:
+provision sandbox → wait for ``/health`` → delegate the wire
+contract to :class:`RemoteComputerImpl`.
+
+The operator-side image preconditions are the same as E2B's
+(``xvfb`` + ``xdotool`` + Chrome + the ``mantis_agent`` package + a
+boot-time ``uvicorn`` for ``computer_agent:app``). See
+``deploy/sim_envs/`` for an existing Daytona-based image pattern;
+the computer-plane image extends the same recipe with the wire
+server.
+
+Configuration
+=============
+
+* ``api_key`` — passed in, or ``DAYTONA_API_KEY`` env var. Required.
+* ``server_url`` — Daytona control-plane URL; defaults to
+  ``https://app.daytona.io`` matching the public SaaS.
+* ``snapshot`` — Daytona snapshot id (their term for a pre-baked
+  image) for the computer-plane container. Defaults to
+  ``MANTIS_DAYTONA_SNAPSHOT`` env var.
+* ``port`` — port the computer-plane HTTP server listens on inside
+  the sandbox. Defaults to 8000.
+* ``startup_timeout_seconds`` — how long to wait for ``/health``
+  after sandbox boot. Daytona cold-builds can take 60s+, so default
+  is 120s.
+
+The Daytona preview URL has an interstitial that needs to be bypassed
+via the ``X-Daytona-Skip-Preview-Warning: true`` header
+(``feedback_daytona_preview_warning_bypass.md``). This impl injects
+that header on every wire call via the inherited
+``extra_http_headers`` kwarg.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from typing import Any
+
+from .remote_computer_impl import RemoteComputerImpl
+
+logger = logging.getLogger(__name__)
+
+
+_DEFAULT_PORT = 8000
+_DEFAULT_STARTUP_TIMEOUT = 120.0
+_DEFAULT_SERVER_URL = "https://app.daytona.io"
+_DAYTONA_SKIP_PREVIEW_HEADER = "X-Daytona-Skip-Preview-Warning"
+
+
+class DaytonaComputerImpl(RemoteComputerImpl):
+    """Daytona-sandbox-backed computer plane.
+
+    Provisions the sandbox at construction; tears it down at
+    ``close()``. The rest of the wire contract delegates to
+    :class:`RemoteComputerImpl` over the sandbox's preview URL.
+    """
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        server_url: str = "",
+        snapshot: str = "",
+        startup_timeout_seconds: float = _DEFAULT_STARTUP_TIMEOUT,
+        port: int = _DEFAULT_PORT,
+        sdk_module: Any = None,
+        extra_http_headers: dict[str, str] | None = None,
+        **remote_kwargs: Any,
+    ) -> None:
+        self._sandbox = None
+        sdk = sdk_module or self._import_sdk()
+        api_key = api_key or os.environ.get("DAYTONA_API_KEY") or ""
+        if not api_key:
+            raise ValueError(
+                "DaytonaComputerImpl requires a Daytona API key — "
+                "pass api_key=..., or set DAYTONA_API_KEY in the env"
+            )
+        snapshot = snapshot or os.environ.get("MANTIS_DAYTONA_SNAPSHOT") or ""
+        if not snapshot:
+            raise ValueError(
+                "DaytonaComputerImpl requires a snapshot id — pass "
+                "snapshot=..., or set MANTIS_DAYTONA_SNAPSHOT in the env"
+            )
+        server_url = server_url or _DEFAULT_SERVER_URL
+
+        logger.warning(
+            "DaytonaComputerImpl: provisioning sandbox snapshot=%s port=%d",
+            snapshot, port,
+        )
+        try:
+            client = sdk.Daytona(
+                config=sdk.DaytonaConfig(
+                    api_key=api_key, server_url=server_url,
+                )
+            )
+            self._sandbox = client.create(snapshot=snapshot)
+        except Exception as exc:
+            raise RuntimeError(
+                f"DaytonaComputerImpl: sandbox provisioning failed: {exc}"
+            ) from exc
+
+        # Daytona's preview URLs require a skip-preview header to
+        # bypass the interstitial (see feedback_daytona_preview_warning_bypass).
+        merged_headers = dict(extra_http_headers or {})
+        merged_headers.setdefault(_DAYTONA_SKIP_PREVIEW_HEADER, "true")
+
+        try:
+            base_url = self._resolve_base_url(self._sandbox, port)
+            self._await_ready(
+                base_url, startup_timeout_seconds, merged_headers,
+            )
+        except Exception:
+            self._teardown_quietly()
+            raise
+
+        logger.warning(
+            "DaytonaComputerImpl: sandbox ready base_url=%s", base_url,
+        )
+        super().__init__(
+            base_url=base_url,
+            extra_http_headers=merged_headers,
+            **remote_kwargs,
+        )
+
+    # ── lifecycle ──
+
+    def close(self) -> None:
+        try:
+            super().close()
+        finally:
+            self._teardown_quietly()
+
+    def shutdown(self) -> None:
+        """Parity with the Phase 1 computer_session contract."""
+        self.close()
+
+    # ── helpers ──
+
+    @staticmethod
+    def _import_sdk() -> Any:
+        try:
+            import daytona  # type: ignore[import-not-found]
+        except ImportError as exc:
+            raise ImportError(
+                "DaytonaComputerImpl requires the daytona SDK — "
+                "`pip install mantis-agent[daytona]` (or "
+                "`pip install daytona`)"
+            ) from exc
+        return daytona
+
+    @staticmethod
+    def _resolve_base_url(sandbox: Any, port: int) -> str:
+        """Resolve the sandbox's preview URL for ``port``.
+
+        Daytona's SDK exposes ``get_preview_link(port)`` returning a
+        ``PreviewLink`` with ``.url``. Tests inject a fake sandbox
+        with the same method.
+        """
+        link = sandbox.get_preview_link(port)
+        url = getattr(link, "url", "") or ""
+        if not url:
+            raise RuntimeError(
+                f"DaytonaComputerImpl: sandbox returned no preview URL "
+                f"for port {port}"
+            )
+        return url.rstrip("/")
+
+    def _await_ready(
+        self,
+        base_url: str,
+        deadline_seconds: float,
+        headers: dict[str, str],
+    ) -> None:
+        """Poll ``GET {base_url}/health`` until 200 or deadline.
+
+        Forwards the skip-preview header so Daytona's interstitial
+        doesn't masquerade as a server-not-ready response.
+        """
+        import requests
+
+        deadline = time.monotonic() + deadline_seconds
+        last_exc: Exception | None = None
+        while time.monotonic() < deadline:
+            try:
+                resp = requests.get(
+                    f"{base_url}/health", timeout=5, headers=headers,
+                )
+                if resp.status_code == 200:
+                    return
+            except Exception as exc:  # noqa: BLE001
+                last_exc = exc
+            time.sleep(2.0)
+        raise TimeoutError(
+            f"DaytonaComputerImpl: sandbox /health not ready within "
+            f"{deadline_seconds:.0f}s (last_exc={last_exc!r})"
+        )
+
+    def _teardown_quietly(self) -> None:
+        if self._sandbox is None:
+            return
+        try:
+            # Daytona SDK exposes ``.delete()`` on the Sandbox.
+            delete = getattr(self._sandbox, "delete", None) or getattr(
+                self._sandbox, "stop", None,
+            )
+            if delete is not None:
+                delete()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "DaytonaComputerImpl: teardown raised: %s", exc,
+            )
+        finally:
+            self._sandbox = None
+
+
+__all__ = ["DaytonaComputerImpl"]

--- a/src/mantis_agent/gym/e2b_impl.py
+++ b/src/mantis_agent/gym/e2b_impl.py
@@ -1,0 +1,197 @@
+"""E2B sandbox backend for the computer plane (#699 Phase 2).
+
+E2B (https://e2b.dev/) provides per-call container sandboxes with a
+public HTTPS URL. This impl provisions a sandbox on construction,
+waits for the computer-plane HTTP server inside it to come up, then
+delegates every wire-contract call to :class:`RemoteComputerImpl`
+talking to the sandbox's URL.
+
+Operator preconditions
+======================
+
+The sandbox image must:
+
+1. Pre-install ``xvfb``, ``xdotool``, ``google-chrome-stable``, and
+   the mantis_agent package.
+2. Boot ``uvicorn mantis_agent.server.computer_agent:app`` on a
+   known port (default 8000) at container start.
+3. Expose the chosen port via E2B's port-forwarding so the brain can
+   reach it over HTTPS.
+
+The image SHA is configured via ``MANTIS_E2B_TEMPLATE`` (default:
+``mantis-computer-plane-v1``); the brain's image-build pipeline
+publishes the same SHA to both E2B and Daytona.
+
+Construction failure modes
+==========================
+
+* **SDK missing.** The ``e2b`` package isn't installed → raises
+  ``ImportError`` at construction. Operator-actionable; we don't
+  silently fall back to local because the operator explicitly asked
+  for the E2B backend.
+* **Template not found.** E2B rejects the template SHA → raises
+  ``RuntimeError`` carrying the E2B-side error.
+* **Port not ready.** Server doesn't answer ``/health`` within
+  ``startup_timeout_seconds`` → raises ``TimeoutError`` AND tears
+  down the partially-provisioned sandbox to avoid leaking quota.
+
+Per-run lifecycle
+=================
+
+* ``__init__`` — provisions the sandbox, waits for ``/health``, hands
+  off to RemoteComputerImpl with the sandbox's tunnel URL.
+* ``close()`` — closes the upstream session, then terminates the
+  sandbox so the operator isn't billed for idle compute.
+* ``shutdown()`` — alias for close() that matches the Phase 1
+  computer_session contract.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from typing import Any
+
+from .remote_computer_impl import RemoteComputerImpl
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_PORT = 8000
+_DEFAULT_STARTUP_TIMEOUT = 60.0
+_DEFAULT_TEMPLATE = "mantis-computer-plane-v1"
+
+
+class E2BComputerImpl(RemoteComputerImpl):
+    """E2B-sandbox-backed computer plane.
+
+    Provisions the sandbox at construction; tears it down at
+    ``close()``. The rest of the wire contract delegates to
+    :class:`RemoteComputerImpl`.
+    """
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        template: str = "",
+        startup_timeout_seconds: float = _DEFAULT_STARTUP_TIMEOUT,
+        port: int = _DEFAULT_PORT,
+        # Optional injection for tests — wires in a fake SDK module so
+        # we don't have to mock at import-time.
+        sdk_module: Any = None,
+        **remote_kwargs: Any,
+    ) -> None:
+        self._sandbox = None  # set on successful boot
+        sdk = sdk_module or self._import_sdk()
+        api_key = api_key or os.environ.get("E2B_API_KEY") or ""
+        if not api_key:
+            raise ValueError(
+                "E2BComputerImpl requires an E2B API key — pass "
+                "api_key=..., or set E2B_API_KEY in the env"
+            )
+        template = (
+            template
+            or os.environ.get("MANTIS_E2B_TEMPLATE")
+            or _DEFAULT_TEMPLATE
+        )
+        logger.warning(
+            "E2BComputerImpl: provisioning sandbox template=%s port=%d",
+            template, port,
+        )
+        try:
+            self._sandbox = sdk.Sandbox(template=template, api_key=api_key)
+        except Exception as exc:
+            raise RuntimeError(
+                f"E2BComputerImpl: sandbox provisioning failed: {exc}"
+            ) from exc
+
+        try:
+            base_url = self._resolve_base_url(self._sandbox, port)
+            self._await_ready(base_url, startup_timeout_seconds)
+        except Exception:
+            # Tear down partial state so we don't leak quota.
+            self._teardown_quietly()
+            raise
+
+        logger.warning(
+            "E2BComputerImpl: sandbox ready base_url=%s", base_url,
+        )
+        super().__init__(base_url=base_url, **remote_kwargs)
+
+    # ── lifecycle ──
+
+    def close(self) -> None:
+        """Close the upstream session + tear down the sandbox."""
+        try:
+            super().close()
+        finally:
+            self._teardown_quietly()
+
+    def shutdown(self) -> None:
+        """Parity with the Phase 1 computer_session contract."""
+        self.close()
+
+    # ── helpers ──
+
+    @staticmethod
+    def _import_sdk() -> Any:
+        try:
+            import e2b  # type: ignore[import-not-found]
+        except ImportError as exc:
+            raise ImportError(
+                "E2BComputerImpl requires the e2b package — "
+                "`pip install mantis-agent[e2b]` (or `pip install e2b`)"
+            ) from exc
+        return e2b
+
+    @staticmethod
+    def _resolve_base_url(sandbox: Any, port: int) -> str:
+        """Resolve the public tunnel URL for ``port`` on ``sandbox``.
+
+        E2B's SDK exposes ``Sandbox.get_host(port)`` returning the
+        public hostname; we wrap with ``https://``. Tests inject a
+        fake sandbox with the same method.
+        """
+        host = sandbox.get_host(port)
+        if not host:
+            raise RuntimeError(
+                f"E2BComputerImpl: sandbox returned no host for port {port}"
+            )
+        return f"https://{host}"
+
+    def _await_ready(self, base_url: str, deadline_seconds: float) -> None:
+        """Poll ``GET {base_url}/health`` until 200 or deadline."""
+        import requests
+
+        deadline = time.monotonic() + deadline_seconds
+        last_exc: Exception | None = None
+        while time.monotonic() < deadline:
+            try:
+                resp = requests.get(f"{base_url}/health", timeout=5)
+                if resp.status_code == 200:
+                    return
+            except Exception as exc:  # noqa: BLE001
+                last_exc = exc
+            time.sleep(1.0)
+        raise TimeoutError(
+            f"E2BComputerImpl: sandbox /health not ready within "
+            f"{deadline_seconds:.0f}s (last_exc={last_exc!r})"
+        )
+
+    def _teardown_quietly(self) -> None:
+        if self._sandbox is None:
+            return
+        try:
+            close = getattr(self._sandbox, "close", None) or getattr(
+                self._sandbox, "kill", None,
+            )
+            if close is not None:
+                close()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("E2BComputerImpl: teardown raised: %s", exc)
+        finally:
+            self._sandbox = None
+
+
+__all__ = ["E2BComputerImpl"]

--- a/tests/test_computer_client_factory.py
+++ b/tests/test_computer_client_factory.py
@@ -75,13 +75,21 @@ def test_modal_backend_requires_remote_base_url() -> None:
         make_computer_client(cfg)
 
 
-def test_e2b_backend_not_yet_implemented() -> None:
-    with pytest.raises(NotImplementedError, match="Phase 2"):
+def test_e2b_backend_routes_to_impl_not_notimplemented() -> None:
+    """Phase 2 (#699) wired ``backend='e2b'`` to ``E2BComputerImpl``.
+    Construction needs the SDK + an API key + a network probe, so
+    raises ``ImportError`` (no SDK) or ``ValueError`` (no API key)
+    here — what matters is it is NOT the old ``NotImplementedError``
+    stub. Detailed behaviour matrix lives in
+    ``tests/test_e2b_daytona_impls.py``."""
+    with pytest.raises((ImportError, ValueError)):
         make_computer_client(ComputerPlaneConfig(backend="e2b"))
 
 
-def test_daytona_backend_not_yet_implemented() -> None:
-    with pytest.raises(NotImplementedError, match="Phase 2"):
+def test_daytona_backend_routes_to_impl_not_notimplemented() -> None:
+    """Same shape as the E2B case — see
+    ``tests/test_e2b_daytona_impls.py`` for the full behavior matrix."""
+    with pytest.raises((ImportError, ValueError)):
         make_computer_client(ComputerPlaneConfig(backend="daytona"))
 
 

--- a/tests/test_e2b_daytona_impls.py
+++ b/tests/test_e2b_daytona_impls.py
@@ -1,0 +1,353 @@
+"""Unit tests for the Phase 2 E2B + Daytona computer-plane backends.
+
+The impls provision a remote sandbox at construction. These tests
+inject fake provider SDKs so we can exercise every branch (success,
+template/snapshot errors, /health timeout, teardown) without
+hitting a real cloud account.
+
+Real-provider integration tests will land in a follow-up gated on
+``E2B_API_KEY`` / ``DAYTONA_API_KEY`` env vars + a published image
+SHA. The unit tests here are the always-green CI baseline.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+
+# ── Fake provider SDKs ────────────────────────────────────────────────
+
+
+class _FakeE2BSandbox:
+    """Stand-in for ``e2b.Sandbox``."""
+
+    def __init__(self, template: str, api_key: str, host: str = "fake-host.e2b.dev"):
+        self.template = template
+        self.api_key = api_key
+        self._host = host
+        self.closed = False
+
+    def get_host(self, port: int) -> str:
+        return self._host
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _FakeE2BModule:
+    """Stand-in for the ``e2b`` package."""
+
+    Sandbox = _FakeE2BSandbox
+
+
+class _FakeDaytonaPreviewLink:
+    def __init__(self, url: str) -> None:
+        self.url = url
+
+
+class _FakeDaytonaSandbox:
+    def __init__(self, snapshot: str, host: str = "fake-host.daytona.io"):
+        self.snapshot = snapshot
+        self._host = host
+        self.deleted = False
+
+    def get_preview_link(self, port: int) -> _FakeDaytonaPreviewLink:
+        return _FakeDaytonaPreviewLink(f"https://{self._host}")
+
+    def delete(self) -> None:
+        self.deleted = True
+
+
+class _FakeDaytonaClient:
+    def __init__(self, config: Any) -> None:
+        self.config = config
+
+    def create(self, snapshot: str) -> _FakeDaytonaSandbox:
+        return _FakeDaytonaSandbox(snapshot=snapshot)
+
+
+class _FakeDaytonaConfig:
+    def __init__(self, *, api_key: str, server_url: str) -> None:
+        self.api_key = api_key
+        self.server_url = server_url
+
+
+class _FakeDaytonaModule:
+    Daytona = _FakeDaytonaClient
+    DaytonaConfig = _FakeDaytonaConfig
+
+
+# ── Fake HTTP that the /health probe hits ────────────────────────────
+
+
+def _install_fake_requests(monkeypatch, ok: bool = True) -> None:
+    """Make ``requests.get`` return a 200 health probe immediately."""
+    import requests
+
+    class _Resp:
+        def __init__(self, code: int) -> None:
+            self.status_code = code
+
+    def _fake_get(url: str, **kw: Any) -> _Resp:
+        if not ok:
+            raise requests.ConnectionError("simulated connect refused")
+        return _Resp(200)
+
+    monkeypatch.setattr(requests, "get", _fake_get)
+
+
+# ── E2B happy path + error paths ──────────────────────────────────────
+
+
+def test_e2b_constructs_with_fake_sdk_and_health_ready(monkeypatch) -> None:
+    """Happy path: sandbox provisions, /health is up, super().__init__ runs."""
+    from mantis_agent.gym.e2b_impl import E2BComputerImpl
+
+    _install_fake_requests(monkeypatch, ok=True)
+    impl = E2BComputerImpl(
+        api_key="x", template="t", sdk_module=_FakeE2BModule,
+        startup_timeout_seconds=2.0,
+        tenant_id="acme", profile_id="p", run_id="r",
+    )
+    # RemoteComputerImpl sets _base_url after super().__init__.
+    assert impl._base_url == "https://fake-host.e2b.dev"
+    assert impl._sandbox is not None
+
+
+def test_e2b_health_timeout_tears_down_sandbox(monkeypatch) -> None:
+    """If /health never answers we MUST close the sandbox so we don't
+    bill the operator for idle compute."""
+    from mantis_agent.gym.e2b_impl import E2BComputerImpl
+
+    _install_fake_requests(monkeypatch, ok=False)
+    # Speed up the deadline + sleep so the test stays fast.
+    import mantis_agent.gym.e2b_impl as e2b_mod
+    monkeypatch.setattr(e2b_mod.time, "sleep", lambda *a, **kw: None)
+
+    sandbox = _FakeE2BSandbox(template="t", api_key="x")
+
+    class _CapturingModule:
+        @staticmethod
+        def Sandbox(template: str, api_key: str) -> _FakeE2BSandbox:
+            return sandbox
+
+    with pytest.raises(TimeoutError):
+        E2BComputerImpl(
+            api_key="x", template="t", sdk_module=_CapturingModule,
+            startup_timeout_seconds=0.1,
+        )
+    # Sandbox MUST have been closed by the teardown path.
+    assert sandbox.closed is True
+
+
+def test_e2b_missing_api_key_raises_value_error(monkeypatch) -> None:
+    monkeypatch.delenv("E2B_API_KEY", raising=False)
+    from mantis_agent.gym.e2b_impl import E2BComputerImpl
+
+    with pytest.raises(ValueError, match="E2B API key"):
+        E2BComputerImpl(sdk_module=_FakeE2BModule)
+
+
+def test_e2b_uses_env_template_when_unset(monkeypatch) -> None:
+    monkeypatch.setenv("MANTIS_E2B_TEMPLATE", "env-template")
+    _install_fake_requests(monkeypatch, ok=True)
+    from mantis_agent.gym.e2b_impl import E2BComputerImpl
+
+    captured_template = {"v": ""}
+
+    class _CapturingModule:
+        @staticmethod
+        def Sandbox(template: str, api_key: str) -> _FakeE2BSandbox:
+            captured_template["v"] = template
+            return _FakeE2BSandbox(template=template, api_key=api_key)
+
+    E2BComputerImpl(
+        api_key="x", sdk_module=_CapturingModule,
+        startup_timeout_seconds=2.0,
+    )
+    assert captured_template["v"] == "env-template"
+
+
+def test_e2b_provision_failure_wraps_underlying_error(monkeypatch) -> None:
+    from mantis_agent.gym.e2b_impl import E2BComputerImpl
+
+    class _FailingModule:
+        @staticmethod
+        def Sandbox(template: str, api_key: str) -> Any:
+            raise RuntimeError("simulated template-not-found")
+
+    with pytest.raises(RuntimeError, match="provisioning failed"):
+        E2BComputerImpl(
+            api_key="x", template="t", sdk_module=_FailingModule,
+        )
+
+
+def test_e2b_close_tears_down_sandbox(monkeypatch) -> None:
+    from mantis_agent.gym.e2b_impl import E2BComputerImpl
+
+    _install_fake_requests(monkeypatch, ok=True)
+    impl = E2BComputerImpl(
+        api_key="x", template="t", sdk_module=_FakeE2BModule,
+        startup_timeout_seconds=2.0,
+    )
+    sandbox = impl._sandbox
+    # Skip the upstream session-close call (RemoteComputerImpl.close
+    # would try to talk to the fake URL).
+    monkeypatch.setattr(
+        "mantis_agent.gym.remote_computer_impl.RemoteComputerImpl.close",
+        lambda self: None,
+    )
+    impl.close()
+    assert sandbox.closed is True
+    assert impl._sandbox is None
+
+
+# ── Daytona happy path + error paths ──────────────────────────────────
+
+
+def test_daytona_constructs_with_fake_sdk_and_skip_preview_header(
+    monkeypatch,
+) -> None:
+    from mantis_agent.gym.daytona_impl import DaytonaComputerImpl
+
+    _install_fake_requests(monkeypatch, ok=True)
+    impl = DaytonaComputerImpl(
+        api_key="x", snapshot="snap-1",
+        sdk_module=_FakeDaytonaModule,
+        startup_timeout_seconds=2.0,
+        tenant_id="acme", profile_id="p", run_id="r",
+    )
+    assert impl._base_url == "https://fake-host.daytona.io"
+    # The skip-preview header should be injected on the extra headers
+    # so every wire call carries it.
+    assert impl._extra_http_headers is not None
+    assert (
+        impl._extra_http_headers.get("X-Daytona-Skip-Preview-Warning")
+        == "true"
+    )
+
+
+def test_daytona_health_timeout_tears_down(monkeypatch) -> None:
+    from mantis_agent.gym.daytona_impl import DaytonaComputerImpl
+
+    _install_fake_requests(monkeypatch, ok=False)
+    import mantis_agent.gym.daytona_impl as d_mod
+    monkeypatch.setattr(d_mod.time, "sleep", lambda *a, **kw: None)
+
+    sandbox = _FakeDaytonaSandbox(snapshot="snap-1")
+    client = _FakeDaytonaClient(config=None)
+    client.create = lambda snapshot: sandbox  # type: ignore[assignment]
+
+    class _CapturingModule:
+        @staticmethod
+        def Daytona(config: Any) -> _FakeDaytonaClient:
+            return client
+
+        DaytonaConfig = _FakeDaytonaConfig
+
+    with pytest.raises(TimeoutError):
+        DaytonaComputerImpl(
+            api_key="x", snapshot="snap-1",
+            sdk_module=_CapturingModule,
+            startup_timeout_seconds=0.1,
+        )
+    assert sandbox.deleted is True
+
+
+def test_daytona_missing_snapshot_raises_value_error(monkeypatch) -> None:
+    monkeypatch.delenv("MANTIS_DAYTONA_SNAPSHOT", raising=False)
+    from mantis_agent.gym.daytona_impl import DaytonaComputerImpl
+
+    with pytest.raises(ValueError, match="snapshot id"):
+        DaytonaComputerImpl(api_key="x", sdk_module=_FakeDaytonaModule)
+
+
+def test_daytona_uses_env_snapshot_when_unset(monkeypatch) -> None:
+    monkeypatch.setenv("MANTIS_DAYTONA_SNAPSHOT", "env-snap")
+    _install_fake_requests(monkeypatch, ok=True)
+    from mantis_agent.gym.daytona_impl import DaytonaComputerImpl
+
+    captured: dict = {"v": ""}
+
+    class _CapturingModule:
+        @staticmethod
+        def Daytona(config: Any) -> _FakeDaytonaClient:
+            client = _FakeDaytonaClient(config=config)
+
+            def _create(snapshot: str) -> _FakeDaytonaSandbox:
+                captured["v"] = snapshot
+                return _FakeDaytonaSandbox(snapshot=snapshot)
+
+            client.create = _create  # type: ignore[assignment]
+            return client
+
+        DaytonaConfig = _FakeDaytonaConfig
+
+    DaytonaComputerImpl(
+        api_key="x", sdk_module=_CapturingModule,
+        startup_timeout_seconds=2.0,
+    )
+    assert captured["v"] == "env-snap"
+
+
+def test_daytona_close_tears_down(monkeypatch) -> None:
+    from mantis_agent.gym.daytona_impl import DaytonaComputerImpl
+
+    _install_fake_requests(monkeypatch, ok=True)
+    impl = DaytonaComputerImpl(
+        api_key="x", snapshot="snap-1",
+        sdk_module=_FakeDaytonaModule,
+        startup_timeout_seconds=2.0,
+    )
+    sandbox = impl._sandbox
+    monkeypatch.setattr(
+        "mantis_agent.gym.remote_computer_impl.RemoteComputerImpl.close",
+        lambda self: None,
+    )
+    impl.close()
+    assert sandbox.deleted is True
+    assert impl._sandbox is None
+
+
+# ── Factory wiring ────────────────────────────────────────────────────
+
+
+def test_make_computer_client_e2b_routes_to_e2b_impl(monkeypatch) -> None:
+    """``make_computer_client(cfg=backend='e2b')`` instantiates
+    E2BComputerImpl. We monkeypatch the impl so the test doesn't need
+    an actual SDK or HTTP probe."""
+    from mantis_agent.gym import computer_client as cc
+
+    captured: dict = {}
+
+    class _StubImpl:
+        def __init__(self, **kw: Any) -> None:
+            captured.update(kw)
+
+    monkeypatch.setattr(
+        "mantis_agent.gym.e2b_impl.E2BComputerImpl", _StubImpl,
+    )
+    cfg = cc.ComputerPlaneConfig(backend="e2b")
+    impl = cc.make_computer_client(cfg, tenant_id="acme")
+    assert isinstance(impl, _StubImpl)
+    assert captured.get("tenant_id") == "acme"
+
+
+def test_make_computer_client_daytona_routes_to_daytona_impl(monkeypatch) -> None:
+    from mantis_agent.gym import computer_client as cc
+
+    captured: dict = {}
+
+    class _StubImpl:
+        def __init__(self, **kw: Any) -> None:
+            captured.update(kw)
+
+    monkeypatch.setattr(
+        "mantis_agent.gym.daytona_impl.DaytonaComputerImpl", _StubImpl,
+    )
+    cfg = cc.ComputerPlaneConfig(backend="daytona")
+    impl = cc.make_computer_client(cfg, profile_id="p")
+    assert isinstance(impl, _StubImpl)
+    assert captured.get("profile_id") == "p"


### PR DESCRIPTION
## Summary

Replaces the \`NotImplementedError\` stub in \`make_computer_client\` for \`backend="e2b"\` and \`backend="daytona"\` with real impls.

Each impl is a \`RemoteComputerImpl\` subclass — provisions a sandbox on construction, waits for the computer-plane HTTP server inside it (\`/health\`), then delegates every wire-contract call (screenshot, xdotool, cdp, current_url, …) to the inherited \`RemoteComputerImpl\` talking to the sandbox's tunnel URL. \`close()\` tears the sandbox down so the operator isn't billed for idle compute.

## Safety

- Provisioning failures wrap the provider-side error in \`RuntimeError\`
- \`/health\` timeout raises \`TimeoutError\` AND tears down the partially-provisioned sandbox (no quota leak)
- Daytona injects \`X-Daytona-Skip-Preview-Warning: true\` on every wire call so the preview interstitial doesn't masquerade as server-not-ready (\`feedback_daytona_preview_warning_bypass.md\`)

## Operator preconditions

Container image must pre-install \`xvfb\`, \`xdotool\`, \`google-chrome-stable\`, \`mantis_agent\`, and boot \`uvicorn mantis_agent.server.computer_agent:app\` at startup. The image publishing pipeline lives separately — this PR adds only the brain-side seam.

## Test plan

- [x] 13 unit tests cover provisioning, /health timeout teardown, missing-credential errors, env-var fallbacks, close() teardown, factory routing
- [x] Lint clean
- [ ] CI matrix on this PR
- [ ] Real-provider integration follow-up (gated on \`E2B_API_KEY\` / \`DAYTONA_API_KEY\` + published image SHA)

🤖 Generated with [Claude Code](https://claude.com/claude-code)