### PR TITLE
fix(modal): augur-sdk + split pip layers to preserve 25-min llama.cpp cache

### DIFF
--- a/deploy/modal/modal_mantis_server.py
+++ b/deploy/modal/modal_mantis_server.py
@@ -120,6 +120,8 @@ image = (
         "echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/google-chrome.gpg] http://dl.google.com/linux/chrome/deb/ stable main' > /etc/apt/sources.list.d/google-chrome.list",
         "apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y google-chrome-stable",
     )
+    # ── Heavy / stable deps go BEFORE llama.cpp — keep this layer
+    #    untouched so the 25-min CUDA compile below stays cached.
     .pip_install(
         "openai", "requests", "pillow", "mss", "huggingface-hub",
         "fastapi>=0.100", "uvicorn>=0.20", "pydantic>=2",
@@ -140,6 +142,19 @@ image = (
         "-DCMAKE_CUDA_ARCHITECTURES=\"80;90\" "
         "-DLLAMA_BUILD_TESTS=OFF -DLLAMA_BUILD_EXAMPLES=OFF -DLLAMA_BUILD_SERVER=ON "
         "&& cmake --build build --target llama-server --config Release -j$(nproc)",
+    )
+    # ── Light/iterating deps go AFTER llama.cpp so adding/bumping
+    #    them doesn't invalidate the 25-minute CUDA-compile layer
+    #    above (feedback_modal_image_pin_drift). Anything that's
+    #    a pure-Python pip install belongs here.
+    .pip_install(
+        # #509: Augur observability — when ``AUGUR_DSN`` is set in
+        # the Modal secret, every gym run streams events to that
+        # Augur workspace. Without this pip-install the runtime
+        # logs ``sdk_available=False dsn_set=True`` and silently
+        # falls back to on-disk-only persistence (no streaming).
+        # Must match pyproject.toml (``augur-sdk>=0.6.0,<0.7``).
+        "augur-sdk>=0.6.0,<0.7",
     )
     .add_local_python_source("mantis_agent")
     # add_local_python_source only ships .py files, but mantis_agent.prompts


### PR DESCRIPTION
## Summary

Two changes:

1. **Add \`augur-sdk\` to mantis-server image.** Without the SDK, the runtime correctly detects \`AUGUR_DSN\` is set in the secret but logs \`sdk_available=False\` on every run and silently falls back to on-disk-only persistence — events never reach the configured Augur workspace.

2. **Split pip layers around the llama.cpp CUDA compile** so adding the SDK doesn't trigger a 25-min rebuild.

### The caching trap

Modal hashes each image layer by content. The original layout was:

\`\`\`
1. pytorch CUDA base
2. apt_install (xvfb + chrome deps)
3. run_commands (chrome install)
4. pip_install (← I added augur-sdk here)   ✖ INVALIDATED
5. run_commands (llama.cpp CUDA build, ~25 min)  ✖ CASCADED
\`\`\`

A pure-Python install that takes 15 seconds triggered a full image rebuild that took 25 minutes. Verified live — the previous deploy attempt sat in CUDA-object-build hell at 24%.

Fix: keep the heavy/stable deps in the original \`pip_install\` (pre-llama.cpp), add a SECOND \`pip_install\` AFTER llama.cpp for light/iterating ones. Adding the SDK now only rebuilds the 15-second pure-Python layer; the CUDA compile stays cached.

**Verified**: same code → 12-second deploy.

## Test plan

- [x] Build artifact: \`12.866s\` deploy after the layout fix vs \`>20 min\` before
- [x] \`mantis-server\` v4 live, weights loading
- [ ] First detached run after weights load should log \`AugurAdapter init: sdk_available=True\` — pending the cold-start
- [ ] CI matrix on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)