### PR TITLE
feat: decomposer prompt + multi-row loop-extract + daytona auto-restart (Tier 1 + 2 from YC triage)

### DIFF
--- a/src/mantis_agent/gym/daytona_impl.py
+++ b/src/mantis_agent/gym/daytona_impl.py
@@ -135,6 +135,25 @@ class DaytonaComputerImpl(RemoteComputerImpl):
                     f"DaytonaComputerImpl: sandbox lookup failed "
                     f"id={sandbox_id!r}: {exc}"
                 ) from exc
+            # Auto-restart STOPPED sandboxes. Daytona auto-stops idle
+            # sandboxes (15-min default —
+            # feedback_daytona_autostop_default_15min). Without this
+            # the /health probe below would hang for the full
+            # startup_timeout_seconds against a never-booting URL.
+            state = str(getattr(self._sandbox, "state", "") or "")
+            if "STOPPED" in state or "ARCHIVED" in state:
+                logger.warning(
+                    "DaytonaComputerImpl: sandbox id=%s state=%s — "
+                    "calling start() before /health probe",
+                    sandbox_id, state,
+                )
+                try:
+                    self._sandbox.start(timeout=startup_timeout_seconds)
+                except Exception as exc:
+                    raise RuntimeError(
+                        f"DaytonaComputerImpl: sandbox.start() failed "
+                        f"id={sandbox_id!r}: {exc}"
+                    ) from exc
             # Don't tear it down on close() — we didn't create it.
             self._owns_sandbox = False
         else:

--- a/src/mantis_agent/gym/step_handlers/claude_step.py
+++ b/src/mantis_agent/gym/step_handlers/claude_step.py
@@ -48,7 +48,7 @@ from __future__ import annotations
 
 import logging
 import time
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from ...actions import Action, ActionType
 from ..checkpoint import StepResult
@@ -59,6 +59,82 @@ if TYPE_CHECKING:
     from ...plan_decomposer import MicroIntent
 
 logger = logging.getLogger(__name__)
+
+
+# Loop-extract-dedupe knobs. 8 passes is enough to cover ~70 cards
+# on a 1280x720 viewport at YC's grid density without burning Claude
+# budget on infinite-scroll feeds. The runner's max_cost still
+# bounds spend; this is a sanity ceiling.
+_MAX_SCROLL_PASSES = 8
+
+
+def _pick_dedup_key(schema) -> str:
+    """Pick the schema's primary key for cross-pass dedup.
+
+    Heuristic — use the FIRST ``required=True`` field. For most
+    listings shapes that's the natural identifier: ``rank`` for HN,
+    ``name`` for YC, ``id`` / ``url`` for marketplaces. Falls back to
+    the first field name if no required fields are declared (which
+    would surface in unit tests as a misconfig).
+    """
+    fields = getattr(schema, "fields", None) or []
+    required = getattr(schema, "required_fields", None) or []
+    if required:
+        return str(required[0])
+    if fields:
+        return str(fields[0].get("name") if isinstance(fields[0], dict)
+                   else getattr(fields[0], "name", ""))
+    return ""
+
+
+def _filter_new_rows(
+    rows, seen_keys: set, dedup_key: str,
+) -> list:
+    """Return only rows whose ``dedup_key`` value hasn't been seen."""
+    if not dedup_key:
+        return [dict(r) for r in rows]
+    fresh = []
+    for r in rows:
+        key = str(r.get(dedup_key, "") or "").strip().lower()
+        if not key or key in seen_keys:
+            continue
+        seen_keys.add(key)
+        fresh.append(dict(r))
+    return fresh
+
+
+def _cdp_scroll_once(env) -> bool:
+    """Issue ``window.scrollBy(0, viewport_height)`` via CDP.
+
+    Returns False when the env doesn't expose ``cdp_evaluate`` (test
+    envs, replay envs) so the caller can stop the loop cleanly.
+    Vision-driven scroll is deliberately NOT a fallback — the whole
+    point of this path is to skip the Holo3 ``brain_loop_exhausted``
+    failure mode.
+    """
+    cdp_evaluate = getattr(env, "cdp_evaluate", None)
+    if cdp_evaluate is None:
+        return False
+    try:
+        cdp_evaluate(
+            "(function(){"
+            "  const h = Math.round(window.innerHeight * 0.85);"
+            "  window.scrollBy(0, h);"
+            "  if (document.scrollingElement) {"
+            "    document.scrollingElement.scrollBy(0, h);"
+            "  }"
+            "  return true;"
+            "})()"
+        )
+        # Brief settle so the next screenshot reflects the scroll.
+        time.sleep(0.7)
+        return True
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "[claude_step] CDP scroll raised: %s — stopping the "
+            "extract-loop", exc,
+        )
+        return False
 
 
 def _resolve_extraction_context(runner: "MicroPlanRunner", data: object | None):
@@ -286,12 +362,23 @@ class ClaudeStepHandler:
     def _execute_rows(
         self, step: "MicroIntent", ctx: StepContext, schema,
     ) -> StepResult:
-        """Multi-row extraction (#785 follow-up).
+        """Multi-row extraction with loop-extract-dedupe (#785 follow-up).
 
-        One Claude vision call returns up to ``schema.max_items`` rows
-        from the current screenshot. Each row lands on the synthesized
-        ``StepResult.extracted_rows`` list; the artifact aggregator
-        unpacks them into ``leads.csv`` / ``extracted_rows.csv`` /
+        Strategy: extract → if collected < ``max_items``, CDP-scroll →
+        extract again → dedupe by the schema's first required field
+        (typically the primary key — ``rank`` / ``name`` / ``id``).
+        Loop until collected reaches ``max_items``, OR ``_MAX_SCROLL_
+        PASSES`` (8) iterations, OR two consecutive passes yield zero
+        new rows (page exhausted).
+
+        Pre-fix the handler did a single extract pass and returned
+        whatever Claude saw on the initial viewport — for the YC
+        directory grid that's typically 5/10, missing the cards below
+        the fold. The loop bridges the gap.
+
+        Each row still lands on the synthesized ``StepResult.
+        extracted_rows`` list; the artifact aggregator unpacks them
+        into ``leads.csv`` / ``extracted_rows.csv`` /
         ``extracted_rows.json`` automatically.
         """
         runner = self.parent
@@ -305,16 +392,56 @@ class ClaudeStepHandler:
                 data="extract_rows:no_env_or_extractor",
             )
 
-        screenshot = env.screenshot()
         max_items = max(int(getattr(schema, "max_items", 0) or 0), 1)
-        rows = extractor.extract_rows(screenshot, max_items)
-        runner.costs["claude_extract"] = runner.costs.get("claude_extract", 0) + 1
-
-        if not rows:
+        dedup_key = _pick_dedup_key(schema)
+        seen_keys: set[str] = set()
+        all_rows: list[dict[str, Any]] = []
+        consecutive_empty_passes = 0
+        for pass_idx in range(_MAX_SCROLL_PASSES):
+            screenshot = env.screenshot()
+            rows = extractor.extract_rows(screenshot, max_items)
+            runner.costs["claude_extract"] = (
+                runner.costs.get("claude_extract", 0) + 1
+            )
+            new_rows = _filter_new_rows(rows, seen_keys, dedup_key)
             logger.warning(
-                "[claude_step] extract_rows returned 0 rows "
-                "(schema=%s, max_items=%d) — page may not have been "
-                "loaded yet, or vision couldn't parse the list shape",
+                "[claude_step] extract_rows pass=%d: %d/%d captured "
+                "(new=%d, total=%d/%d)",
+                pass_idx + 1, len(rows), max_items,
+                len(new_rows), len(all_rows) + len(new_rows), max_items,
+            )
+            all_rows.extend(new_rows)
+            if len(all_rows) >= max_items:
+                all_rows = all_rows[:max_items]
+                break
+            if not new_rows:
+                consecutive_empty_passes += 1
+                if consecutive_empty_passes >= 2:
+                    logger.warning(
+                        "[claude_step] extract_rows: 2 consecutive "
+                        "empty passes — page exhausted at "
+                        "%d/%d", len(all_rows), max_items,
+                    )
+                    break
+            else:
+                consecutive_empty_passes = 0
+            # CDP scroll for the next pass. Vision-driven scroll
+            # would re-introduce the brain_loop_exhausted footgun
+            # the loop-extract pattern is designed to avoid.
+            if not _cdp_scroll_once(env):
+                logger.warning(
+                    "[claude_step] extract_rows: CDP scroll "
+                    "unavailable — stopping at %d/%d",
+                    len(all_rows), max_items,
+                )
+                break
+
+        if not all_rows:
+            logger.warning(
+                "[claude_step] extract_rows returned 0 rows after "
+                "%d passes (schema=%s, max_items=%d) — page may not "
+                "have loaded, or vision couldn't parse the list shape",
+                pass_idx + 1,
                 getattr(schema, "entity_name", "?"), max_items,
             )
             return StepResult(
@@ -322,18 +449,14 @@ class ClaudeStepHandler:
                 data=f"extract_rows:0/{max_items}:no_visible_rows",
             )
 
-        logger.warning(
-            "[claude_step] extract_rows: %d/%d rows captured",
-            len(rows), max_items,
-        )
         # Legacy single-row consumers see the first row via
         # ``extracted_fields``; the full list is the new
         # ``extracted_rows`` field.
         return StepResult(
             step_index=index, intent=step.intent, success=True,
-            data=f"extract_rows:{len(rows)}/{max_items}",
-            extracted_fields=dict(rows[0]),
-            extracted_rows=[dict(r) for r in rows],
+            data=f"extract_rows:{len(all_rows)}/{max_items}",
+            extracted_fields=dict(all_rows[0]),
+            extracted_rows=[dict(r) for r in all_rows],
         )
 
     def _execute(self, step: "MicroIntent", ctx: StepContext) -> StepResult:

--- a/src/mantis_agent/plan_decomposer.py
+++ b/src/mantis_agent/plan_decomposer.py
@@ -415,6 +415,16 @@ Plans MUST be organized into sections. Each section has a purpose and a gate:
    - For form-only flows, end with an extract_data step that verifies the right
      page/state was reached (URL, header, and any read-back of the values just set)
    - If the gate FAILS, the entire pipeline HALTS — do not proceed
+   - WHEN TO OMIT THE GATE (important): for extraction-only plans that
+     navigate directly to a public URL with no filters / login / form
+     interaction in setup ("Extract top N from <url>"), do NOT emit a
+     required verify gate. The page either returns rows (extract works)
+     or doesn't (extract returns 0 rows with a structured failure
+     class) — adding a vision verify gate in front of it forces the
+     brain to look at an SPA mid-render and routinely halts the run
+     with a stale-screenshot FAIL before extraction can run. Skip the
+     gate when SETUP is exactly ``navigate``; emit it as usual when
+     SETUP contains filter / fill_field / submit / login steps.
    - GATE INTENTS MUST ASSERT POSITIVE EVIDENCE OF PROGRESS (not absence of error
      text). A 404 page, an empty-results page, a CF challenge, a paywall, and an
      expired-login redirect all share one trait: the thing the plan came here for
@@ -828,6 +838,15 @@ STEP TYPES:
 - filter: Click a filter option (budget=8, grounding=true, required=true, section="setup")
 - click: Click an element on a listings/results page (budget=8, grounding=true)
 - scroll: Scroll until target content visible (budget=10, section="extraction")
+            Default to CDP-driven scroll (not vision-driven) to avoid the
+            Holo3 ``brain_loop_exhausted`` failure on visually-similar
+            card grids (YC directory, Reddit feed, LinkedIn job list).
+            Emit ``params.backend: "cdp"`` AND ``hints.prefer_cdp_scroll:
+            true`` whenever the SHAPE HINT is ``listings`` OR the source
+            plan mentions cards / rows / a results page. Override to
+            vision scroll only when the source explicitly says "wait
+            for X to become visible while scrolling" — anything that
+            needs the brain to read the page mid-scroll.
 - extract_url: Read URL from address bar (claude_only=true, budget=0, section="extraction")
 - extract_data: Inspect page and read structured data OR verify state.
                 CRITICAL — these are TWO DISTINCT MODES (issue #244):
@@ -880,6 +899,17 @@ ADD an `extract` block to the step. The runtime uses this to validate
 each row Claude returns — without it the validator falls through to the
 recipe schema if one is registered for the domain, or rejects every row
 with `no_schema_configured` for ad-hoc plans.
+
+MANDATORY ``max_items`` EXTRACTION:
+Whenever the source plan names an explicit count — "top 10", "first 5",
+"5 best", "list 20", "the top N rows" — the ``extract`` block MUST
+include ``max_items: <N>`` set to that count. Without it the
+extractor falls through to single-row mode and returns exactly ONE row
+even when N cards are visible. Recognise count patterns like
+``top NN``, ``first NN``, ``NN best/stories/results/companies/items/
+rows/listings/startups/products``, ``list NN`` (where NN is any
+positive integer). Pick the smallest N if multiple counts are
+present.
 
 Shape:
 
@@ -1086,7 +1116,7 @@ class PlanDecomposer:
             logger.info("plan_text expresses read-only intent — enforcing #831 constraint")
 
         # Check cache — include prompt version in hash to invalidate on schema changes
-        prompt_version = "v37_request_user_input"  # Bump this when DECOMPOSE_PROMPT changes
+        prompt_version = "v38_cdp_scroll_default_no_verify_gate_for_extract_only"  # Bump this when DECOMPOSE_PROMPT changes
         cache_key_text = (
             f"READONLY:{plan_text}" if read_only else plan_text
         )

--- a/tests/test_extract_rows_loop_dedupe.py
+++ b/tests/test_extract_rows_loop_dedupe.py
@@ -1,0 +1,230 @@
+"""Loop-extract-dedupe for multi-row extraction.
+
+Pre-fix, the multi-row branch did a single extract pass — got back
+whatever Claude saw on the initial viewport, then returned. For
+listings pages where the first viewport only shows N/M cards (YC
+grid, infinite-scroll feeds), the run silently capped at N. The
+loop bridges the gap by alternating extract + CDP-scroll + dedupe.
+
+Coverage:
+- happy path: 2 passes fill ``max_items`` (10) from two viewport
+  screenshots that overlap on some cards
+- dedup by the first ``required=True`` field (primary key)
+- stop after 2 consecutive empty passes (page exhausted)
+- stop when CDP scroll is unavailable (env can't scroll)
+- max_items reached before scroll cap exhausts
+- no rows ever returned → ``no_visible_rows`` failure
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+from mantis_agent.extraction import ExtractionSchema
+from mantis_agent.gym.step_handlers.claude_step import (
+    ClaudeStepHandler,
+    _filter_new_rows,
+    _pick_dedup_key,
+)
+from mantis_agent.plan_decomposer import MicroIntent
+
+
+def _ctx(extractor: Any, env_with_cdp: bool = True) -> Any:
+    ctx = MagicMock()
+    ctx.extractor = extractor
+    env = MagicMock()
+    env.screenshot.return_value = MagicMock()
+    if env_with_cdp:
+        env.cdp_evaluate = MagicMock(return_value=None)
+    else:
+        # Simulate an env where cdp_evaluate isn't available
+        # (so the loop terminates cleanly on the first scroll attempt).
+        delattr(env, "cdp_evaluate")
+    ctx.env = env
+    ctx.state = {"index": 0}
+    return ctx
+
+
+def _runner_with_costs() -> Any:
+    runner = MagicMock()
+    runner.costs = {}
+    return runner
+
+
+# ── helpers ────────────────────────────────────────────────────────────
+
+
+def test_pick_dedup_key_prefers_first_required_field() -> None:
+    schema = ExtractionSchema(
+        entity_name="yc_company", fields=[],
+        required_fields=["name", "rank"],
+    )
+    assert _pick_dedup_key(schema) == "name"
+
+
+def test_pick_dedup_key_falls_back_to_first_field_when_no_required() -> None:
+    schema = ExtractionSchema(
+        entity_name="x",
+        fields=[{"name": "foo"}, {"name": "bar"}],
+        required_fields=[],
+    )
+    assert _pick_dedup_key(schema) == "foo"
+
+
+def test_filter_new_rows_dedupes_case_insensitively() -> None:
+    seen: set = set()
+    first = _filter_new_rows(
+        [{"name": "Cardinal"}, {"name": "Doomersion"}],
+        seen, "name",
+    )
+    assert len(first) == 2
+    second = _filter_new_rows(
+        [{"name": "cardinal"}, {"name": "Sequence Markets"}],
+        seen, "name",
+    )
+    # "cardinal" already seen (case-insensitive); Sequence Markets is new.
+    assert len(second) == 1
+    assert second[0]["name"] == "Sequence Markets"
+
+
+def test_filter_new_rows_drops_empty_keys() -> None:
+    seen: set = set()
+    fresh = _filter_new_rows(
+        [{"name": ""}, {"name": "Cardinal"}, {"name": "  "}],
+        seen, "name",
+    )
+    assert [r["name"] for r in fresh] == ["Cardinal"]
+
+
+# ── loop end-to-end ────────────────────────────────────────────────────
+
+
+def test_loop_two_passes_dedup_and_combine() -> None:
+    """First pass yields 5 cards, scroll, second pass yields 5 cards
+    (3 fresh, 2 dupes). Final row count = 8, dedup honored."""
+    schema = ExtractionSchema(
+        entity_name="yc_company",
+        fields=[{"name": "name", "type": "str", "required": True}],
+        required_fields=["name"],
+        max_items=10,
+    )
+    extractor = MagicMock()
+    extractor.schema = schema
+    pass_returns = [
+        [{"rank": "1", "name": "Cardinal"},
+         {"rank": "2", "name": "Doomersion"},
+         {"rank": "3", "name": "Sequence"},
+         {"rank": "4", "name": "Ditto"},
+         {"rank": "5", "name": "Servo7"}],
+        [{"rank": "4", "name": "Ditto"},  # duplicate
+         {"rank": "5", "name": "Servo7"},  # duplicate
+         {"rank": "6", "name": "Voxel"},
+         {"rank": "7", "name": "Aurorin"},
+         {"rank": "8", "name": "Fixture"}],
+        [{"rank": "8", "name": "Fixture"},  # duplicate
+         {"rank": "9", "name": "Unifold"},
+         {"rank": "10", "name": "Carrot Labs"}],
+    ]
+    extractor.extract_rows.side_effect = pass_returns
+    runner = _runner_with_costs()
+    handler = ClaudeStepHandler(runner)
+
+    step = MicroIntent(
+        intent="x", type="extract_data", claude_only=True,
+        extract={"fields": [{"name": "name", "type": "str", "required": True}], "max_items": 10},
+    )
+    ctx = _ctx(extractor, env_with_cdp=True)
+
+    result = handler._execute_rows(step, ctx, schema)
+    assert result.success is True
+    names = [r["name"] for r in result.extracted_rows]
+    assert names == [
+        "Cardinal", "Doomersion", "Sequence", "Ditto", "Servo7",
+        "Voxel", "Aurorin", "Fixture", "Unifold", "Carrot Labs",
+    ]
+    # 3 extract calls — max_items (10) hit on the 3rd pass.
+    assert runner.costs["claude_extract"] == 3
+
+
+def test_loop_stops_after_two_consecutive_empty_passes() -> None:
+    schema = ExtractionSchema(
+        entity_name="yc", fields=[], required_fields=["name"],
+        max_items=10,
+    )
+    extractor = MagicMock()
+    extractor.schema = schema
+    pass_returns = [
+        [{"name": "A"}, {"name": "B"}, {"name": "C"}],
+        [{"name": "A"}, {"name": "B"}, {"name": "C"}],  # all dupes
+        [{"name": "A"}, {"name": "B"}, {"name": "C"}],  # all dupes again
+        [{"name": "Z"}],  # would be fresh, but loop stops before getting here
+    ]
+    extractor.extract_rows.side_effect = pass_returns
+    runner = _runner_with_costs()
+    handler = ClaudeStepHandler(runner)
+    step = MicroIntent(intent="x", type="extract_data", claude_only=True)
+    ctx = _ctx(extractor, env_with_cdp=True)
+    result = handler._execute_rows(step, ctx, schema)
+    assert result.success is True
+    # 3 passes ran (initial + 2 empty), then loop bailed.
+    assert runner.costs["claude_extract"] == 3
+    assert len(result.extracted_rows) == 3
+
+
+def test_loop_stops_when_cdp_scroll_unavailable() -> None:
+    schema = ExtractionSchema(
+        entity_name="yc", fields=[], required_fields=["name"],
+        max_items=10,
+    )
+    extractor = MagicMock()
+    extractor.schema = schema
+    extractor.extract_rows.return_value = [{"name": "Hero"}]
+    runner = _runner_with_costs()
+    handler = ClaudeStepHandler(runner)
+    step = MicroIntent(intent="x", type="extract_data", claude_only=True)
+    ctx = _ctx(extractor, env_with_cdp=False)
+    result = handler._execute_rows(step, ctx, schema)
+    assert result.success is True
+    assert [r["name"] for r in result.extracted_rows] == ["Hero"]
+    # Only one extract call — the CDP scroll bailed, loop ended.
+    assert runner.costs["claude_extract"] == 1
+
+
+def test_loop_stops_when_max_items_reached() -> None:
+    schema = ExtractionSchema(
+        entity_name="yc", fields=[], required_fields=["name"],
+        max_items=3,
+    )
+    extractor = MagicMock()
+    extractor.schema = schema
+    extractor.extract_rows.return_value = [
+        {"name": "A"}, {"name": "B"}, {"name": "C"}, {"name": "D"},
+    ]
+    runner = _runner_with_costs()
+    handler = ClaudeStepHandler(runner)
+    step = MicroIntent(intent="x", type="extract_data", claude_only=True)
+    ctx = _ctx(extractor, env_with_cdp=True)
+    result = handler._execute_rows(step, ctx, schema)
+    assert result.success is True
+    # Capped at 3 even though Claude returned 4.
+    assert [r["name"] for r in result.extracted_rows] == ["A", "B", "C"]
+    # Single pass — max_items hit after the first extract.
+    assert runner.costs["claude_extract"] == 1
+
+
+def test_loop_zero_rows_returns_no_visible_rows_failure() -> None:
+    schema = ExtractionSchema(
+        entity_name="yc", fields=[], required_fields=["name"],
+        max_items=10,
+    )
+    extractor = MagicMock()
+    extractor.schema = schema
+    extractor.extract_rows.return_value = []
+    runner = _runner_with_costs()
+    handler = ClaudeStepHandler(runner)
+    step = MicroIntent(intent="x", type="extract_data", claude_only=True)
+    ctx = _ctx(extractor, env_with_cdp=False)
+    result = handler._execute_rows(step, ctx, schema)
+    assert result.success is False
+    assert "no_visible_rows" in result.data


### PR DESCRIPTION
## Summary

Five concrete fixes that came out of the YC W26 extraction triage earlier in this session — the decomposer was inserting brittle verify gates and vision scrolls that halted heavy SPA pages, the multi-row extractor only ran once per step (missing cards below the fold), and \`DaytonaComputerImpl\` hung on auto-stopped sandboxes.

### Tier 1 — decomposer prompt (\`plan_decomposer.py\`)

- **CDP scroll default** for listings shapes: emit \`params.backend: "cdp"\` + \`hints.prefer_cdp_scroll: true\` on scroll steps. Avoids the Holo3 \`brain_loop_exhausted\` failure on visually-similar card grids (YC, Reddit, LinkedIn).
- **Skip verify gate** when setup is pure-navigate (extract-only plans). Pre-fix "Find top 10 YC W26" got \`navigate → required verify → extract\` and halted on the verify gate before extraction could run.
- **Mandatory \`max_items\`** when the source plan names an explicit count ("top N", "first N", "N best"). Without it the extractor returns a single empty row instead of N populated ones.
- \`prompt_version\` bumped to \`v38_cdp_scroll_default_no_verify_gate_for_extract_only\` so cached decompositions invalidate.

### Tier 2 — extractor + Daytona

- **Loop-extract-dedupe** in \`_execute_rows\`: extract → CDP-scroll → extract again → dedupe by the schema's first required field. Loop stops at \`max_items\` / 8 scroll passes / 2 consecutive empty passes / env-can't-scroll. Vision scroll deliberately NOT a fallback.
- **Daytona auto-restart**: check \`sandbox.state\` after \`client.get(id)\`, call \`sandbox.start()\` when \`STOPPED\` / \`ARCHIVED\` before the \`/health\` probe. Auto-stop kicks in at 15 min idle.

## Test plan

- [x] 9 new tests in \`test_extract_rows_loop_dedupe.py\` — happy path (3 passes fill \`max_items=10\` with dedupe across viewports), stop on 2 empty passes, stop on env-can't-scroll, cap at \`max_items\`, no-rows failure, dedup-key picking, case-insensitive dedup
- [x] 111 baseten + decomposer + daytona + claude_step tests pass locally
- [ ] CI matrix on this PR
- [ ] Modal redeploy + YC W26 rerun (target: ≥8 rows, succeeded status, no \`brain_loop_exhausted\` chip)
- [ ] HN top-5 (regression — make sure the 22-runs-green streak holds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)