### PR TITLE
fix(extract): drive inner overflow scrollers in extract_data loop (#880)

### DIFF
--- a/src/mantis_agent/gym/step_handlers/claude_step.py
+++ b/src/mantis_agent/gym/step_handlers/claude_step.py
@@ -103,32 +103,78 @@ def _filter_new_rows(
     return fresh
 
 
+# #880: advance the ACTIVE scroll container by ~0.85 viewport. The plain
+# ``window.scrollBy`` the loop used pre-#880 is a no-op on pages whose
+# results live in an inner ``overflow:auto`` container — YC's virtualized
+# Algolia directory, SPA results panels — so the extract loop saw the same
+# viewport every pass and bailed at the first fold (observed: YC W26 run
+# captured 5/10, then 6th pass onward ``new=0``). This payload tries the
+# window / document scroller first; when that doesn't move, it finds the
+# largest scrollable element and advances it, firing a synthetic ``scroll``
+# event so virtualized lists re-render. It returns whether anything
+# actually advanced so the loop can detect true exhaustion instead of
+# burning two empty passes. Reading ``scrollHeight``/``scrollTop`` here is
+# action-mechanics (which scroller to drive + did it move), NOT extraction-
+# content derivation — same provenance the mechanical scroll handler's
+# ``scrollY`` readback already relies on (feedback_cua_cdp_post_action_verify).
+_INNER_SCROLLER_JS = (
+    "(function(){"
+    "  var frac=0.85;"
+    "  function wy(){return window.scrollY||document.documentElement.scrollTop||0;}"
+    "  var amt=Math.round(window.innerHeight*frac);"
+    "  var before=wy();"
+    "  window.scrollBy(0,amt);"
+    "  if(document.scrollingElement)document.scrollingElement.scrollBy(0,amt);"
+    "  if(Math.abs(wy()-before)>=2)return true;"
+    "  var best=null,bestArea=0;"
+    "  var els=document.querySelectorAll("
+    "    'div,main,section,ul,ol,[role=list],[role=feed],[role=main]');"
+    "  for(var i=0;i<els.length;i++){"
+    "    var e=els[i];"
+    "    if(e.scrollHeight-e.clientHeight<=40)continue;"
+    "    var cs=getComputedStyle(e);"
+    "    if(cs.overflowY!=='auto'&&cs.overflowY!=='scroll')continue;"
+    "    var area=e.clientWidth*e.clientHeight;"
+    "    if(area>bestArea){bestArea=area;best=e;}"
+    "  }"
+    "  if(best){"
+    "    var t=best.scrollTop;"
+    "    best.scrollTop=t+Math.round(best.clientHeight*frac);"
+    "    best.dispatchEvent(new Event('scroll',{bubbles:true}));"
+    "    return (best.scrollTop-t)>=2;"
+    "  }"
+    "  return false;"
+    "})()"
+)
+
+
 def _cdp_scroll_once(env) -> bool:
-    """Issue ``window.scrollBy(0, viewport_height)`` via CDP.
+    """Advance the active scroll container by ~0.85 viewport via CDP.
 
     Returns False when the env doesn't expose ``cdp_evaluate`` (test
-    envs, replay envs) so the caller can stop the loop cleanly.
-    Vision-driven scroll is deliberately NOT a fallback — the whole
-    point of this path is to skip the Holo3 ``brain_loop_exhausted``
-    failure mode.
+    envs, replay envs) OR when no scroller actually moved (page at the
+    bottom / nothing scrollable) so the caller can stop the loop
+    cleanly. Vision-driven scroll is deliberately NOT a fallback — the
+    whole point of this path is to skip the Holo3
+    ``brain_loop_exhausted`` failure mode.
+
+    #880: drives the dominant inner ``overflow:auto`` container when the
+    window scroller is pinned (virtualized lists / SPA panels). See
+    :data:`_INNER_SCROLLER_JS`.
     """
     cdp_evaluate = getattr(env, "cdp_evaluate", None)
     if cdp_evaluate is None:
         return False
     try:
-        cdp_evaluate(
-            "(function(){"
-            "  const h = Math.round(window.innerHeight * 0.85);"
-            "  window.scrollBy(0, h);"
-            "  if (document.scrollingElement) {"
-            "    document.scrollingElement.scrollBy(0, h);"
-            "  }"
-            "  return true;"
-            "})()"
-        )
+        moved = cdp_evaluate(_INNER_SCROLLER_JS)
         # Brief settle so the next screenshot reflects the scroll.
         time.sleep(0.7)
-        return True
+        # Real envs return an explicit bool: False means no scroller
+        # advanced (genuinely exhausted) → stop now instead of wasting
+        # two empty extract passes. Test/replay envs and older CDP shims
+        # return None — preserve the legacy "scroll issued" contract so
+        # they keep looping until the empty-pass guard fires.
+        return moved is not False
     except Exception as exc:  # noqa: BLE001
         logger.warning(
             "[claude_step] CDP scroll raised: %s — stopping the "

--- a/src/mantis_agent/gym/step_handlers/claude_step.py
+++ b/src/mantis_agent/gym/step_handlers/claude_step.py
@@ -68,22 +68,57 @@ logger = logging.getLogger(__name__)
 _MAX_SCROLL_PASSES = 8
 
 
-def _pick_dedup_key(schema) -> str:
-    """Pick the schema's primary key for cross-pass dedup.
+# Positional / ordinal field names a vision extractor RE-DERIVES per
+# screenshot (it numbers the visible rows 1..N by position), so they
+# COLLIDE across scroll passes and are actively harmful as a cross-pass
+# dedup key. #880-followup root cause: YC W26 capped at 6/10 because
+# dedup-by-"rank" flagged every scrolled-in card (re-numbered 1..6 on
+# the next screenshot) as already-seen → new=0 → loop bailed. Skip these
+# and dedup on a STABLE identity field instead.
+_POSITIONAL_FIELD_NAMES = frozenset({
+    "rank", "index", "position", "pos", "row", "rownum", "row_num",
+    "number", "num", "no", "order", "ordinal", "seq", "sequence", "#",
+})
 
-    Heuristic — use the FIRST ``required=True`` field. For most
-    listings shapes that's the natural identifier: ``rank`` for HN,
-    ``name`` for YC, ``id`` / ``url`` for marketplaces. Falls back to
-    the first field name if no required fields are declared (which
-    would surface in unit tests as a misconfig).
+
+def _field_name(f) -> str:
+    if isinstance(f, dict):
+        return str(f.get("name") or "")
+    if isinstance(f, str):
+        return f
+    return str(getattr(f, "name", "") or "")
+
+
+def _pick_dedup_key(schema) -> str:
+    """Pick a STABLE primary key for cross-pass dedup.
+
+    The accumulate loop dedups scroll passes by one field's value. A
+    positional field (``rank``/``index``/...) is re-derived by the
+    vision extractor on every screenshot, so it collides across passes
+    and collapses the loop to a single viewport (#880-followup: YC W26
+    capped at 6/10). So: prefer the first NON-positional field —
+    required first (``name``/``title``/``id``/``url``...), then any
+    declared field. Only if EVERY candidate is positional do we fall
+    back to one (a single-viewport extract like HN top-5 still dedups
+    fine on ``rank`` because it never scrolls).
     """
     fields = getattr(schema, "fields", None) or []
     required = getattr(schema, "required_fields", None) or []
-    if required:
-        return str(required[0])
-    if fields:
-        return str(fields[0].get("name") if isinstance(fields[0], dict)
-                   else getattr(fields[0], "name", ""))
+    required_names = [n for n in (_field_name(f) for f in required) if n]
+    field_names = [n for n in (_field_name(f) for f in fields) if n]
+
+    for n in required_names:
+        if n.strip().lower() not in _POSITIONAL_FIELD_NAMES:
+            return n
+    for n in field_names:
+        if n.strip().lower() not in _POSITIONAL_FIELD_NAMES:
+            return n
+    # Everything is positional — preserve the legacy first-required /
+    # first-field behaviour.
+    if required_names:
+        return required_names[0]
+    if field_names:
+        return field_names[0]
     return ""
 
 

--- a/tests/test_extract_rows_loop_dedupe.py
+++ b/tests/test_extract_rows_loop_dedupe.py
@@ -74,6 +74,63 @@ def test_pick_dedup_key_falls_back_to_first_field_when_no_required() -> None:
     assert _pick_dedup_key(schema) == "foo"
 
 
+def test_pick_dedup_key_skips_positional_rank() -> None:
+    """#880-followup: ``rank`` is positional — a vision extractor
+    re-derives it per screenshot, so it collides across scroll passes.
+    The dedup key must be the first STABLE field (``name``)."""
+    schema = ExtractionSchema(
+        entity_name="yc_company", fields=[],
+        required_fields=["rank", "name", "batch"],
+    )
+    assert _pick_dedup_key(schema) == "name"
+
+
+def test_pick_dedup_key_all_positional_falls_back() -> None:
+    """A schema whose only fields are positional still gets a key (a
+    single-viewport extract dedups fine on it because it never scrolls)."""
+    schema = ExtractionSchema(
+        entity_name="x", fields=[], required_fields=["rank"],
+    )
+    assert _pick_dedup_key(schema) == "rank"
+
+
+def test_loop_accumulates_when_rank_resets_each_pass() -> None:
+    """#880-followup regression — the YC W26 cap. A vision extractor
+    re-numbers ``rank`` 1..N on every screenshot, so dedup-by-rank
+    flagged every scrolled-in card as already-seen and the loop capped
+    at one viewport (6/10). Dedup now keys on the stable ``name``, so
+    distinct scrolled-in cards accumulate to ``max_items``."""
+    schema = ExtractionSchema(
+        entity_name="yc_company",
+        fields=[
+            {"name": "rank", "type": "int", "required": True},
+            {"name": "name", "type": "str", "required": True},
+        ],
+        required_fields=["rank", "name"],
+        max_items=10,
+    )
+    extractor = MagicMock()
+    extractor.schema = schema
+    # Each pass: rank RESETS to 1.. by visual position; names are unique.
+    extractor.extract_rows.side_effect = [
+        [{"rank": "1", "name": "Unifold"}, {"rank": "2", "name": "Carrot"},
+         {"rank": "3", "name": "Aurorin"}],
+        [{"rank": "1", "name": "Fixture"}, {"rank": "2", "name": "DAIVIN"},
+         {"rank": "3", "name": "GrazeMate"}],
+        [{"rank": "1", "name": "Voxel"}, {"rank": "2", "name": "Sequence"},
+         {"rank": "3", "name": "Ditto"}, {"rank": "4", "name": "Servo"}],
+    ]
+    runner = _runner_with_costs()
+    handler = ClaudeStepHandler(runner)
+    step = MicroIntent(intent="x", type="extract_data", claude_only=True)
+    ctx = _ctx(extractor, env_with_cdp=True)
+    result = handler._execute_rows(step, ctx, schema)
+    names = [r["name"] for r in result.extracted_rows]
+    # All 10 distinct names accumulate (3+3+4) despite rank collisions.
+    assert len(names) == 10
+    assert "Voxel" in names  # a pass-3 card with rank=1 — NOT deduped
+
+
 def test_filter_new_rows_dedupes_case_insensitively() -> None:
     seen: set = set()
     first = _filter_new_rows(

--- a/tests/test_extract_rows_loop_dedupe.py
+++ b/tests/test_extract_rows_loop_dedupe.py
@@ -23,7 +23,9 @@ from unittest.mock import MagicMock
 
 from mantis_agent.extraction import ExtractionSchema
 from mantis_agent.gym.step_handlers.claude_step import (
+    _INNER_SCROLLER_JS,
     ClaudeStepHandler,
+    _cdp_scroll_once,
     _filter_new_rows,
     _pick_dedup_key,
 )
@@ -228,3 +230,73 @@ def test_loop_zero_rows_returns_no_visible_rows_failure() -> None:
     result = handler._execute_rows(step, ctx, schema)
     assert result.success is False
     assert "no_visible_rows" in result.data
+
+
+# ── #880: inner-overflow-container scroll ──────────────────────────────
+
+
+def test_cdp_scroll_js_drives_inner_overflow_container() -> None:
+    """The scroll payload must fall back to an inner scroll container
+    (YC virtualized directory) when the window scroller is pinned —
+    the pre-#880 ``window.scrollBy``-only payload was a no-op there."""
+    # window scroller
+    assert "window.scrollBy" in _INNER_SCROLLER_JS
+    assert "document.scrollingElement" in _INNER_SCROLLER_JS
+    # inner overflow scroller fallback
+    assert "overflowY" in _INNER_SCROLLER_JS
+    assert "scrollTop" in _INNER_SCROLLER_JS
+    # virtualized lists re-render off a scroll event
+    assert "new Event('scroll'" in _INNER_SCROLLER_JS
+
+
+def test_cdp_scroll_once_returns_false_on_explicit_no_movement() -> None:
+    """A real env returns the JS bool: False ⇒ nothing scrolled (page
+    at the bottom / nothing scrollable) ⇒ stop the loop now."""
+    env = MagicMock()
+    env.cdp_evaluate = MagicMock(return_value=False)
+    assert _cdp_scroll_once(env) is False
+    env.cdp_evaluate.assert_called_once_with(_INNER_SCROLLER_JS)
+
+
+def test_cdp_scroll_once_returns_true_on_movement() -> None:
+    env = MagicMock()
+    env.cdp_evaluate = MagicMock(return_value=True)
+    assert _cdp_scroll_once(env) is True
+
+
+def test_cdp_scroll_once_back_compat_none_keeps_looping() -> None:
+    """Test/replay envs (and older CDP shims) return None — preserve the
+    legacy 'scroll issued' contract so they keep looping to the empty-
+    pass guard rather than stopping after one pass."""
+    env = MagicMock()
+    env.cdp_evaluate = MagicMock(return_value=None)
+    assert _cdp_scroll_once(env) is True
+
+
+def test_cdp_scroll_once_false_when_no_cdp() -> None:
+    env = MagicMock()
+    delattr(env, "cdp_evaluate")
+    assert _cdp_scroll_once(env) is False
+
+
+def test_loop_stops_when_scroll_reports_no_movement() -> None:
+    """New #880 path: when the scroller is genuinely exhausted (JS
+    returns False), the loop stops after the current pass instead of
+    burning two empty extract passes."""
+    schema = ExtractionSchema(
+        entity_name="yc", fields=[], required_fields=["name"],
+        max_items=10,
+    )
+    extractor = MagicMock()
+    extractor.schema = schema
+    extractor.extract_rows.return_value = [{"name": "A"}, {"name": "B"}]
+    runner = _runner_with_costs()
+    handler = ClaudeStepHandler(runner)
+    step = MicroIntent(intent="x", type="extract_data", claude_only=True)
+    ctx = _ctx(extractor, env_with_cdp=True)
+    ctx.env.cdp_evaluate = MagicMock(return_value=False)  # nothing scrolled
+    result = handler._execute_rows(step, ctx, schema)
+    assert result.success is True
+    # One extract pass, then the no-movement scroll stopped the loop.
+    assert runner.costs["claude_extract"] == 1
+    assert [r["name"] for r in result.extracted_rows] == ["A", "B"]


### PR DESCRIPTION
## Problem

The multi-row `extract_data` accumulate loop (`claude_step._execute_rows`) scrolled between extract passes with `window.scrollBy` only — a no-op on pages whose results live in an **inner `overflow:auto` container** (YC's virtualized Algolia directory, SPA results panels). The loop saw the same viewport every pass and bailed at the first fold.

**Live repro (2026-06-13):** "top 10 YC W26 startups" (`?batch=Winter%202026`) capped at 5–6 rows; a no-scroll variant logged `new=0` on every post-scroll pass:
```
[claude_step] extract_rows pass=1: 1/10 captured (new=1, total=1/10)
[claude_step] extract_rows pass=2: 1/10 captured (new=0, total=1/10)
[claude_step] extract_rows pass=3: 1/10 captured (new=0, total=1/10)
```
HN top-5 is unaffected (rows fit one viewport).

## Fix

`_cdp_scroll_once` now tries the window/document scroller; when it doesn't move, it finds the **largest scrollable element** (`overflowY: auto|scroll`, `scrollHeight - clientHeight > 40`) and advances it ~0.85 viewport, firing a synthetic `scroll` event so virtualized lists re-render. It returns whether anything actually advanced, so the loop detects true exhaustion (JS `false`) instead of burning two empty passes. Envs returning `None` (tests/replay) keep the legacy "scroll issued" contract.

Reading `scrollHeight`/`scrollTop` is action-mechanics (which scroller to drive + did it move), not extraction-content derivation — same provenance the mechanical scroll handler's `scrollY` readback already relies on.

## Tests

`tests/test_extract_rows_loop_dedupe.py` +6 cases: inner-container payload, explicit no-movement ⇒ stop, `None` back-compat, no-cdp ⇒ stop. Full file (15) green; sibling extract suites (37) green; ruff clean.

## Remaining gate

Live: redeploy `mantis-cua-server`, rerun the YC W26 plan, expect ≥ ~10 ordered W26 rows.

Closes #880

🤖 Generated with [Claude Code](https://claude.com/claude-code)