### PR TITLE
fix(runtime): wire request_user_input pause/resume end-to-end (#882)

### DIFF
--- a/src/mantis_agent/gym/micro_runner.py
+++ b/src/mantis_agent/gym/micro_runner.py
@@ -737,7 +737,20 @@ class MicroPlanRunner:
             state = PauseState.from_dict(state)
         if plan is None:
             raise ValueError("resume() requires the original plan; pass plan=...")
-        signature = self._compute_plan_signature(plan)
+        # #882-followup: the PauseState stores the signature the suite was
+        # BUILT with — ``runner.plan_signature`` / the embedded
+        # ``_plan_signature`` from ``plan_signature_from_steps`` (a hash of
+        # the full raw step dicts). ``_compute_plan_signature``
+        # (CheckpointManager) hashes a DIFFERENT 14-field subset over
+        # MicroIntent objects, so recomputing here NEVER matched the stored
+        # value → every Modal micro-path resume failed with a spurious
+        # mismatch (latent until request_user_input actually paused a run).
+        # Prefer the embedded signature the runner was constructed with —
+        # it's reconstructed identically from the stored suite at both
+        # submit and resume. Fall back to the recompute only for callers
+        # with no embedded signature (pure-local resume), where pause-time
+        # and resume-time both use ``_compute_plan_signature`` and so agree.
+        signature = self.plan_signature or self._compute_plan_signature(plan)
         if state.plan_signature and state.plan_signature != signature:
             raise ValueError(
                 "PauseState plan_signature mismatch — can't resume a different plan"

--- a/src/mantis_agent/gym/run_executor.py
+++ b/src/mantis_agent/gym/run_executor.py
@@ -62,6 +62,25 @@ if TYPE_CHECKING:
 logger = logging.getLogger("mantis_agent.gym.micro_runner")
 
 
+# #882: token a plan author writes in a downstream step (e.g.
+# ``fill_field`` label/value) to splice in the value captured by an
+# earlier ``request_user_input`` pause/resume. Without substitution the
+# literal placeholder is typed into the field and the form fails.
+_USER_INPUT_TOKEN = "{{user_input}}"
+
+
+def _substitute_user_input(text: Any, staged: Any) -> Any:
+    """Replace ``{{user_input}}`` in ``text`` with the staged resume value.
+
+    No-op (returns ``text`` unchanged) when nothing was staged, when
+    ``text`` isn't a string, or when the token is absent — so it's safe
+    to run over every step's intent and string params.
+    """
+    if staged is None or not isinstance(text, str) or _USER_INPUT_TOKEN not in text:
+        return text
+    return text.replace(_USER_INPUT_TOKEN, str(staged))
+
+
 def _pending_form_labels(plan: "MicroPlan", current_step_index: int) -> list[str]:
     """Audit item 2 — collect ``params.label`` from every ``fill_field``
     step in the plan at or after ``current_step_index``.
@@ -906,13 +925,23 @@ class RunExecutor:
             )
             if scanner_directive:
                 dynamic_intent = scanner_directive
+        # #882: splice the resumed request_user_input value into
+        # ``{{user_input}}`` tokens on this step's intent + string params.
+        # ``_staged_user_input`` is set by RequestUserInputHandler on the
+        # resume pass; None (the common case) makes every call a no-op.
+        staged_input = getattr(runner, "_staged_user_input", None)
+        dynamic_intent = _substitute_user_input(dynamic_intent, staged_input)
+        eff_params = {
+            k: _substitute_user_input(v, staged_input)
+            for k, v in (step.params or {}).items()
+        }
         return MicroIntent(
             intent=dynamic_intent, type=step.type, verify=step.verify,
             budget=step.budget, reverse=step.reverse, grounding=step.grounding,
             claude_only=step.claude_only, loop_target=step.loop_target,
             loop_count=step.loop_count,
             section=step.section, required=step.required, gate=step.gate,
-            params=dict(step.params or {}),
+            params=eff_params,
             hints=dict(getattr(step, "hints", {}) or {}),
             # #643 stage 2 fields — vision-only conditional steps. The
             # executor's outer loop reads ``guard`` (in

--- a/src/mantis_agent/gym/step_handlers/request_user_input.py
+++ b/src/mantis_agent/gym/step_handlers/request_user_input.py
@@ -6,19 +6,30 @@ operator-supplied value (OTP, password, paste-target) by emitting a
 the same name in ``plan_decomposer``). The handler bridges that step
 to the host-tool mechanism the SDK pause/resume flow already uses:
 
-* Look up the ``request_user_input`` host tool the runner registered
-  in ``baseten_server.runtime`` (``runtime.py:1579``). The tool consumes
-  any staged ``user_input`` (set by ``action=resume``) and either:
-    - returns the staged value on first-resume → handler types it back
-      into ``StepResult.data`` so any downstream ``{{user_input}}`` token
+* Look up the ``request_user_input`` host tool via the runner's
+  :class:`~..tool_channel.ToolChannel` — the SAME registry both the
+  Baseten (``runtime.py``, #344) and Modal (``modal_cua_server.py``,
+  #347) executors register the default tool into through
+  ``runner.register_tool(...)``. The tool consumes any staged
+  ``user_input`` (set by ``action=resume``) and either:
+    - returns the staged value on first-resume → handler stashes it on
+      the runner so any downstream ``{{user_input}}`` token
       substitution can pick it up; or
     - raises ``PauseRequested`` if no value is staged → the runner
       catches it and snapshots the run as ``status=paused``.
 
-* When the host tool isn't registered (off-Baseten contexts), the
-  handler degrades to a non-fatal skip so a plan that ran fine on
-  Baseten doesn't suddenly crash on a deployment that hasn't wired
-  the host tool yet.
+* When the tool isn't registered (off-executor contexts: bare CLI,
+  unit harnesses), the handler degrades to a non-fatal skip so a plan
+  that pauses fine in production doesn't crash on a deployment that
+  hasn't wired the host tool yet.
+
+.. note:: #882 — the handler originally read a phantom
+   ``runner._host_tools`` dict that NOTHING in production ever
+   populated (the only writer was a test stub), so every
+   ``request_user_input`` step on every backend hit the "no host tool"
+   skip — it never paused, ``{{user_input}}`` was typed literally, and
+   the run burned its budget to ``time_cap``. The real tool lives in
+   ``runner.tool_channel``; the lookup now goes there.
 
 Wire shape — the decomposer emits::
 
@@ -48,7 +59,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
-from ..checkpoint import StepResult
+from ..checkpoint import PauseRequested, StepResult
 from ..step_context import StepContext, StepHandler
 
 if TYPE_CHECKING:
@@ -81,12 +92,21 @@ class RequestUserInputHandler:
         # plumb the index in still construct a sane StepResult.
         index = int(ctx.state.get("index", 0)) if hasattr(ctx, "state") else 0
 
-        host_tools = getattr(runner, "_host_tools", None) or {}
-        tool_fn = host_tools.get("request_user_input")
-        if tool_fn is None:
-            # No tool registered — surface a non-fatal skip so a
-            # plan that ran fine on Baseten doesn't crash on a
-            # deployment that hasn't wired the host tool.
+        tool_channel = getattr(runner, "tool_channel", None)
+        registered = False
+        if tool_channel is not None:
+            try:
+                registered = any(
+                    t.get("name") == "request_user_input"
+                    for t in tool_channel.list()
+                )
+            except Exception:  # noqa: BLE001 — treat a broken channel as absent
+                registered = False
+        if not registered:
+            # No tool registered on this deployment (bare CLI / unit
+            # harness) — surface a non-fatal skip so a plan that pauses
+            # fine in production doesn't crash where the host tool
+            # isn't wired.
             logger.warning(
                 "request_user_input step %d: no host tool registered; "
                 "downgrade to skip (reason=%s)",
@@ -101,12 +121,35 @@ class RequestUserInputHandler:
                 skip_reason="request_user_input_no_host_tool",
             )
 
-        # First entry: ``tool_fn`` raises PauseRequested → the runner
-        # catches it in its execute loop. Resume entry: ``tool_fn``
-        # returns the staged value. Either way the handler doesn't
-        # try to suppress — exceptions bubble through the runner's
-        # standard recovery machinery.
-        staged = tool_fn({"prompt": prompt, "reason": reason})
+        # First entry: the tool raises PauseRequested (no value staged
+        # yet). We catch it and stage the pending pause on the channel —
+        # the SAME slot ``ToolChannel.invoke`` sets — so the executor's
+        # ``_tick_preamble`` ``tool_channel.is_paused()`` check snapshots
+        # ``status=paused`` on the next iteration. We use ``call`` rather
+        # than ``invoke`` so the resume value comes back raw (invoke
+        # str-renders + truncates it, which would corrupt a multi-line
+        # or structured ``{{user_input}}`` substitution).
+        try:
+            staged = tool_channel.call(
+                "request_user_input", {"prompt": prompt, "reason": reason},
+            )
+        except PauseRequested as exc:
+            tool_channel.stage_pause(
+                "request_user_input",
+                {"prompt": prompt, "reason": reason},
+                getattr(exc, "reason", reason),
+                getattr(exc, "prompt", prompt),
+            )
+            logger.warning(
+                "request_user_input step %d: pausing for operator input "
+                "(reason=%s)", index, reason,
+            )
+            return StepResult(
+                step_index=index,
+                intent=step.intent,
+                success=True,
+                data="request_user_input:paused",
+            )
 
         # Resume path — stash the value so any downstream step that
         # references ``{{user_input}}`` in its params or intent can

--- a/src/mantis_agent/gym/tool_channel.py
+++ b/src/mantis_agent/gym/tool_channel.py
@@ -86,12 +86,7 @@ class ToolChannel:
         except _PauseRequested as exc:
             # Tool requested pause (#73) — propagate so the run() loop can
             # snapshot and return a PauseState. Don't treat as failure.
-            self.pending_pause = {
-                "tool": name,
-                "arguments": dict(arguments),
-                "reason": exc.reason,
-                "prompt": exc.prompt,
-            }
+            self.stage_pause(name, arguments, exc.reason, exc.prompt)
             return True, f"tool:{name}:pause"
         except KeyError as exc:
             return False, f"tool:{name}:not_registered:{exc}"
@@ -102,6 +97,25 @@ class ToolChannel:
         return True, f"tool:{name}:ok:{rendered[:200]}"
 
     # ── Pause lifecycle ─────────────────────────────────────────────────
+
+    def stage_pause(
+        self, name: str, arguments: dict[str, Any] | None = None,
+        reason: str = "", prompt: str = "",
+    ) -> None:
+        """Record a pending pause so the run loop snapshots ``status=paused``.
+
+        Both entry points converge here: :meth:`invoke` (brain
+        ``TOOL_CALL`` path) catches :class:`PauseRequested` and stages
+        it; the ``request_user_input`` *step* handler stages it directly
+        when it catches the same exception from :meth:`call` (so the raw
+        resume value survives instead of being str-rendered by invoke).
+        """
+        self.pending_pause = {
+            "tool": name,
+            "arguments": dict(arguments or {}),
+            "reason": reason,
+            "prompt": prompt,
+        }
 
     def is_paused(self) -> bool:
         return self.pending_pause is not None

--- a/tests/test_micro_runner_hooks.py
+++ b/tests/test_micro_runner_hooks.py
@@ -384,6 +384,45 @@ def test_resume_rejects_mismatched_plan_signature():
         r.resume(state, user_input="x", plan=plan)
 
 
+def test_resume_accepts_embedded_signature_when_recompute_differs(monkeypatch):
+    """#882-followup regression — the live-discovered resume blocker.
+
+    The PauseState stores the EMBEDDED ``_plan_signature``
+    (``plan_signature_from_steps`` over full step dicts). resume() used
+    to recompute via ``_compute_plan_signature`` (CheckpointManager — a
+    different 14-field subset over MicroIntent objects), which never
+    matched, so EVERY Modal micro-path resume raised a spurious
+    mismatch. resume() must compare against the embedded
+    ``self.plan_signature`` when the runner has one."""
+    env = _FakeEnv()
+    r = _runner(env)
+    plan = _trivial_plan()
+    recompute_sig = r._compute_plan_signature(plan)
+    embedded_sig = "embedded-" + recompute_sig  # deliberately DIFFERENT
+    assert embedded_sig != recompute_sig
+    # The runner was constructed from a suite whose _plan_signature is
+    # the embedded value — same as what the PauseState stored at pause.
+    r.plan_signature = embedded_sig
+    state = PauseState(plan_signature=embedded_sig)
+    monkeypatch.setattr(r, "run", lambda *a, **kw: [])
+    # Must NOT raise — the embedded signatures match even though the
+    # CheckpointManager recompute would not.
+    r.resume(state, user_input="x", plan=plan)
+
+
+def test_resume_still_rejects_genuine_mismatch_with_embedded_sig(monkeypatch):
+    """The embedded-signature preference must NOT defeat the real guard:
+    a PauseState from a genuinely different plan still fails."""
+    env = _FakeEnv()
+    r = _runner(env)
+    plan = _trivial_plan()
+    r.plan_signature = "sig-for-the-plan-actually-running"
+    state = PauseState(plan_signature="sig-from-a-totally-different-plan")
+    monkeypatch.setattr(r, "run", lambda *a, **kw: [])
+    with pytest.raises(ValueError):
+        r.resume(state, user_input="x", plan=plan)
+
+
 def test_pause_state_is_json_serializable():
     """PauseState lives in a Postgres JSONB column on host — keep it pure."""
     import json

--- a/tests/test_request_user_input_step.py
+++ b/tests/test_request_user_input_step.py
@@ -20,9 +20,7 @@ from __future__ import annotations
 
 from typing import Any
 
-import pytest
-
-from mantis_agent.gym.checkpoint import StepResult
+from mantis_agent.gym.checkpoint import PauseRequested, StepResult
 from mantis_agent.gym.step_context import StepContext
 from mantis_agent.gym.step_handlers.request_user_input import RequestUserInputHandler
 from mantis_agent.plan_decomposer import MicroIntent, PlanDecomposer
@@ -70,27 +68,29 @@ def test_handler_step_type_is_canonical() -> None:
 # ── Pause path: handler propagates PauseRequested up to runner ──────
 
 
-class _PauseRequestedStub(Exception):
-    """Local PauseRequested stand-in so the test doesn't depend on the
-    runtime's actual PauseRequested import wiring."""
-
-
 class _FakeRunner:
-    """Records the host_tools / state mutations the handler performs."""
+    """Wires a real :class:`ToolChannel` exactly the way the Modal /
+    Baseten executors do (``runner.register_tool`` → ``tool_channel``),
+    so these tests exercise the real lookup path rather than a phantom
+    ``_host_tools`` dict. The default tool raises PauseRequested on the
+    first call and returns a staged value on the second (resume)."""
 
-    def __init__(self, host_tools: dict | None = None) -> None:
-        # Defaults to the canonical SDK-flow tool that raises
-        # PauseRequested on the first call and returns a staged value
-        # on the second (after action=resume).
-        self._host_tools: dict[str, Any] = host_tools if host_tools is not None else {
-            "request_user_input": self._default_tool,
-        }
+    def __init__(self, register_tool: bool = True) -> None:
+        from mantis_agent.gym.tool_channel import ToolChannel
+
+        self.tool_channel = ToolChannel()
         self._pause_inputs: list[Any] = []
         self._staged_user_input = None
+        if register_tool:
+            self.tool_channel.register(
+                "request_user_input",
+                {"type": "object", "properties": {"prompt": {"type": "string"}}},
+                self._default_tool,
+            )
 
     def _default_tool(self, args: dict) -> Any:
         if not self._pause_inputs:
-            raise _PauseRequestedStub(args.get("prompt", ""))
+            raise PauseRequested(reason="user_input", prompt=args.get("prompt", ""))
         return self._pause_inputs.pop(0)
 
 
@@ -110,13 +110,19 @@ def _ctx(index: int = 0) -> StepContext:
     return ctx
 
 
-def test_handler_raises_when_host_tool_raises_pause() -> None:
-    """Empty pause inputs → tool raises → handler re-raises through
-    its try/except so the runner's PauseRequested catch path owns it."""
+def test_handler_stages_pause_on_first_entry() -> None:
+    """Empty pause inputs → tool raises PauseRequested → handler stages
+    the pending pause on the channel (so the executor's is_paused()
+    preamble snapshots status=paused) and returns a non-failing result —
+    it does NOT let the exception escape uncaught."""
     runner = _FakeRunner()
     handler = RequestUserInputHandler(runner)
-    with pytest.raises(_PauseRequestedStub):
-        handler.execute(_step(), _ctx())
+    result = handler.execute(_step(), _ctx())
+    assert result.success is True
+    assert result.data == "request_user_input:paused"
+    # The pause is now visible to the run loop's is_paused() check.
+    assert runner.tool_channel.is_paused() is True
+    assert runner.tool_channel.pending_pause["tool"] == "request_user_input"
 
 
 def test_handler_returns_success_and_stashes_staged_value_on_resume() -> None:
@@ -147,12 +153,42 @@ def test_handler_does_not_leak_secret_into_result_data() -> None:
 
 
 def test_handler_skips_when_no_host_tool_registered() -> None:
-    runner = _FakeRunner(host_tools={})
+    # A runner whose tool_channel has NOT registered request_user_input
+    # (bare CLI / unit harness) → non-fatal skip.
+    runner = _FakeRunner(register_tool=False)
     handler = RequestUserInputHandler(runner)
     result = handler.execute(_step(), _ctx(index=4))
     assert result.success is False
     assert result.skip is True
     assert "no_host_tool" in (result.skip_reason or "")
+
+
+def test_handler_skips_when_runner_has_no_tool_channel() -> None:
+    """Guards the #882 regression: the handler must look at
+    runner.tool_channel, not a phantom attribute. A runner with neither
+    a tool_channel nor the tool degrades to a skip, never an AttributeError."""
+    class _NoChannelRunner:
+        pass
+
+    handler = RequestUserInputHandler(_NoChannelRunner())  # type: ignore[arg-type]
+    result = handler.execute(_step(), _ctx(index=2))
+    assert result.success is False
+    assert result.skip is True
+
+
+def test_handler_uses_tool_channel_not_phantom_host_tools() -> None:
+    """Regression for #882: a runner that only has the legacy
+    phantom ``_host_tools`` dict (and no registered tool_channel tool)
+    must NOT find the tool — proving the lookup moved to tool_channel."""
+    runner = _FakeRunner(register_tool=False)
+    # Simulate the old wiring that used to mask the bug.
+    runner._host_tools = {"request_user_input": runner._default_tool}  # type: ignore[attr-defined]
+    runner._pause_inputs = ["should-not-be-reached"]
+    handler = RequestUserInputHandler(runner)
+    result = handler.execute(_step(), _ctx())
+    # Phantom dict is ignored → skip, because tool_channel has nothing.
+    assert result.success is False
+    assert result.skip is True
 
 
 # ── Registry exposes the handler under the right type ───────────────
@@ -179,3 +215,31 @@ def test_default_registry_binds_request_user_input_to_handler() -> None:
     handler = reg.get("request_user_input")
     assert handler is not None
     assert handler.step_type == "request_user_input"
+
+
+# ── #882: {{user_input}} substitution into downstream steps ──
+
+
+def test_substitute_user_input_replaces_token() -> None:
+    from mantis_agent.gym.run_executor import _substitute_user_input
+
+    assert _substitute_user_input("{{user_input}}", "alice") == "alice"
+    assert _substitute_user_input(
+        "login as {{user_input}} now", "bob",
+    ) == "login as bob now"
+
+
+def test_substitute_user_input_noops_without_staged_value() -> None:
+    from mantis_agent.gym.run_executor import _substitute_user_input
+
+    # Nothing staged → the literal token is left untouched (the step
+    # simply hasn't been fed a value yet).
+    assert _substitute_user_input("{{user_input}}", None) == "{{user_input}}"
+
+
+def test_substitute_user_input_ignores_non_strings_and_tokenless() -> None:
+    from mantis_agent.gym.run_executor import _substitute_user_input
+
+    assert _substitute_user_input(42, "x") == 42
+    assert _substitute_user_input(None, "x") is None
+    assert _substitute_user_input("no token here", "x") == "no token here"


### PR DESCRIPTION
## Problem

`request_user_input` steps (the decomposer compiles "pause and ask the user" into them) **never pause**. The surface symptom ("Modal host tool not registered") is misleading — the tool *is* registered on both Modal (#347) and Baseten (#344). Three compounding bugs:

1. **Phantom lookup (broken on every backend).** The handler read `runner._host_tools`, an attribute **nothing in `src/` ever assigns** — the only writer was a test stub, so the green test masked the gap. The real tool lives in `runner.tool_channel`.
2. **No pause trigger.** The executor snapshots `paused` via `tool_channel.is_paused()` (`_tick_preamble`), set by staging `pending_pause`. A handler that raised `PauseRequested` would go **uncaught** (no `except` in the step loop).
3. **No `{{user_input}}` substitution.** None exists anywhere — so even after a fixed pause/resume stashes the value, downstream `fill_field` types the literal placeholder.

**Evidence:** runs `20260613_085945_18b1e0b3` / `…807ceccd` → `no host tool registered` → `fill_field 'Username' = '{{user_input}}'` → `time_cap`. `grep -rn _host_tools src/` → only the read + a test stub, no writer.

## Fix
- **Handler** → look up `runner.tool_channel`; skip only when genuinely unregistered.
- **Pause** → catch `PauseRequested` from `tool_channel.call()` and `tool_channel.stage_pause(...)` (new method, shared with `invoke()`); `call` keeps the resume value raw (invoke str-renders/truncates).
- **Substitution** → `_substitute_user_input()` in `RunExecutor._build_effective_step`, over each downstream step's intent + string params, fed by `runner._staged_user_input`.

## Tests
93 green across `request_user_input` / `tool_channel` / `run_executor` / pause-resume suites. The handler test now uses a **real `tool_channel`** (not the phantom dict) so it can't mask this again; added stage-pause, no-channel, phantom-ignored, and substitution-helper cases.

## Remaining gate
Live: a real pause → `action=resume(user_input=…)` → continue round-trip on Modal/Baseten to confirm the form fills with the substituted value.

Closes #882

🤖 Generated with [Claude Code](https://claude.com/claude-code)