### PR TITLE
fix(extract): drop vision-placeholder rows from multi-row extract

### DIFF
--- a/src/mantis_agent/gym/step_handlers/claude_step.py
+++ b/src/mantis_agent/gym/step_handlers/claude_step.py
@@ -122,16 +122,31 @@ def _pick_dedup_key(schema) -> str:
     return ""
 
 
+# Vision placeholders a multi-row extract emits when it can't read a
+# row's identity field (#882-followup: a YC W26 run returned a row with
+# name="unknown"). These are non-empty so they survive the empty-key
+# guard and inflate the final count with junk rows. Treat them as
+# unusable identity values and drop the row.
+_PLACEHOLDER_KEY_VALUES = frozenset({
+    "unknown", "n/a", "na", "none", "null", "nil", "-", "--", "—",
+    "?", "??", "tbd", "untitled", "no name", "unnamed",
+})
+
+
 def _filter_new_rows(
     rows, seen_keys: set, dedup_key: str,
 ) -> list:
-    """Return only rows whose ``dedup_key`` value hasn't been seen."""
+    """Return only rows whose ``dedup_key`` value is usable and unseen.
+
+    Drops rows whose key is empty, a known vision placeholder
+    (``unknown`` / ``n/a`` / ...), or already accumulated this run.
+    """
     if not dedup_key:
         return [dict(r) for r in rows]
     fresh = []
     for r in rows:
         key = str(r.get(dedup_key, "") or "").strip().lower()
-        if not key or key in seen_keys:
+        if not key or key in _PLACEHOLDER_KEY_VALUES or key in seen_keys:
             continue
         seen_keys.add(key)
         fresh.append(dict(r))

--- a/tests/test_extract_rows_loop_dedupe.py
+++ b/tests/test_extract_rows_loop_dedupe.py
@@ -156,6 +156,19 @@ def test_filter_new_rows_drops_empty_keys() -> None:
     assert [r["name"] for r in fresh] == ["Cardinal"]
 
 
+def test_filter_new_rows_drops_placeholder_keys() -> None:
+    """#882-followup: vision placeholders (``unknown``/``n/a``/...) are
+    non-empty so they slip past the empty-key guard and inflate the row
+    count with junk. Drop them by identity value (case-insensitive)."""
+    seen: set = set()
+    fresh = _filter_new_rows(
+        [{"name": "unknown"}, {"name": "Unifold"}, {"name": "N/A"},
+         {"name": "—"}, {"name": "Untitled"}, {"name": "Carrot Labs"}],
+        seen, "name",
+    )
+    assert [r["name"] for r in fresh] == ["Unifold", "Carrot Labs"]
+
+
 # ── loop end-to-end ────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Problem
The YC W26 verification (#880) returned a clean count of 10 but one row had `name="unknown"` — a vision placeholder the multi-row extractor emits when it can't read a row's identity field. Because it's non-empty, it slipped past `_filter_new_rows`' empty-key guard and counted as a real row.

## Fix
`_filter_new_rows` now drops rows whose dedup-key value is a known placeholder (`unknown` / `n/a` / `none` / `—` / `untitled` / ...), case-insensitive — alongside the existing empty-key and already-seen drops.

## Tests
`test_filter_new_rows_drops_placeholder_keys` — placeholders dropped, real rows kept. Full extract-loop suite (19) green, ruff clean.

Follow-up to #880 / the YC extraction series. (The `name`=description case some rows showed is genuine vision ambiguity, not a placeholder — out of scope here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)