### PR TITLE
fix(resume): stage user_input for {{user_input}} substitution on resume

### DIFF
--- a/src/mantis_agent/gym/micro_runner.py
+++ b/src/mantis_agent/gym/micro_runner.py
@@ -762,6 +762,18 @@ class MicroPlanRunner:
         self.session_name = state.session_name or self.session_name
         self.plan_signature, self.resume_state = signature, True
         self._pause_input = user_input
+        # #882-followup: stage the resumed value for ``{{user_input}}``
+        # substitution (RunExecutor._build_effective_step reads
+        # ``runner._staged_user_input``). The request_user_input STEP
+        # handler also stages it — but on resume the run starts at the
+        # step AFTER the paused one (the pause is snapshotted post-success
+        # with step_index already advanced), so that handler never
+        # re-executes and the only place the value can be staged is here.
+        # Without this, downstream fill_field steps typed the literal
+        # ``{{user_input}}`` (live repro: the-internet/login → "username
+        # invalid"). ``None`` user_input leaves substitution a no-op.
+        if user_input is not None:
+            self._staged_user_input = user_input
         # Epic #358 Phase A: replay browser state (URL + scroll +
         # viewport) before resuming the step loop, so the agent
         # picks up at the exact pixel rather than a fresh page-top.

--- a/tests/test_micro_runner_hooks.py
+++ b/tests/test_micro_runner_hooks.py
@@ -472,6 +472,36 @@ def test_resume_calls_restore_browser_state(monkeypatch):
     assert bs.scroll_y == 1800
 
 
+def test_resume_stages_user_input_for_substitution(monkeypatch):
+    """#882-followup: on resume the run starts AFTER the paused
+    request_user_input step, so its handler never re-runs to stage the
+    value. resume() must stage it itself onto ``_staged_user_input`` so
+    ``_build_effective_step`` can substitute ``{{user_input}}`` into
+    downstream fill_field steps (else the literal placeholder is typed)."""
+    env = _FakeEnv()
+    r = _runner(env)
+    plan = _trivial_plan()
+    sig = r._compute_plan_signature(plan)
+    state = PauseState(plan_signature=sig)
+    monkeypatch.setattr(r, "run", lambda *a, **kw: [])
+
+    r.resume(state, user_input="tomsmith", plan=plan)
+    assert getattr(r, "_staged_user_input", None) == "tomsmith"
+
+
+def test_resume_without_user_input_leaves_substitution_noop(monkeypatch):
+    """A resume with no value must not stage a junk substitution source."""
+    env = _FakeEnv()
+    r = _runner(env)
+    plan = _trivial_plan()
+    sig = r._compute_plan_signature(plan)
+    state = PauseState(plan_signature=sig)
+    monkeypatch.setattr(r, "run", lambda *a, **kw: [])
+
+    r.resume(state, user_input=None, plan=plan)
+    assert getattr(r, "_staged_user_input", None) is None
+
+
 def test_resume_works_when_env_lacks_restore_method(monkeypatch):
     """Legacy envs without ``restore_browser_state`` must not crash —
     resume should proceed and run the step loop as before."""


### PR DESCRIPTION
## Problem
The live pause/resume round-trip (#882) paused and resumed correctly, but the post-resume **login halted** with `Your username is invalid!`. Root cause: the `{{user_input}}` substitution never fired on the resumed run.

The pause is snapshotted *after* the `request_user_input` step returns success, so the checkpoint's `step_index` already points at the **next** step. On resume the run starts there — the `request_user_input` handler never re-executes, so it never stages `runner._staged_user_input`, and `RunExecutor._build_effective_step` substitutes nothing → the Username `fill_field` types the literal `{{user_input}}` → invalid login → recovery thrash → halt.

## Fix
`resume()` stages the resumed value onto `_staged_user_input` directly — the one place reached on the resume path. Downstream `fill_field` steps then substitute correctly. `None` user_input leaves substitution a no-op.

## Tests
`test_resume_stages_user_input_for_substitution` + `test_resume_without_user_input_leaves_substitution_noop`. 35 green across micro_runner + pause/resume suites.

Completes the request_user_input pause→resume→continue flow (#882 / #883). Will live-verify the full login completes after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)