### PR TITLE
feat(sim-envs): add mantis-auth env + embeddable multi-method auth flow

### DIFF
--- a/deploy/sim_envs/mantis_auth/Dockerfile
+++ b/deploy/sim_envs/mantis_auth/Dockerfile
@@ -1,0 +1,47 @@
+# mantis-auth — simulated authentication env.
+#
+# Image goals (mirrors the other sim envs):
+#   * <500MB final size (slim base + ~5 pip deps).
+#   * <30s cold boot.
+#   * No outbound network at runtime (--network none friendly).
+#
+# Build:
+#     docker build -t mantis/sim-env-mantis-auth:latest deploy/sim_envs/mantis_auth
+#
+# Run (locally):
+#     docker run --rm -p 8008:8080 \
+#         -e SEED=42 \
+#         -e FAKE_NOW=2026-01-15T09:00:00Z \
+#         -e ENV_ADMIN_TOKEN=$(python -c 'import secrets;print(secrets.token_urlsafe(32))') \
+#         mantis/sim-env-mantis-auth:latest
+#
+# Optional env:
+#     AUTH_LAYOUT=split|minimal|centered   default login layout
+#     ENV_REQUIRE_AUTH=0                    open the product wall (default 1)
+#     AUTH_SESSION_SECRET=...               HMAC secret for session cookies
+
+FROM python:3.11-slim
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends curl \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /srv
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY app ./app
+
+ENV PORT=8080 \
+    SEED=42 \
+    FAKE_NOW=2026-01-15T09:00:00Z \
+    ENV_REQUIRE_AUTH=1 \
+    AUTH_LAYOUT=centered \
+    PYTHONUNBUFFERED=1
+
+EXPOSE 8080
+HEALTHCHECK --interval=5s --timeout=2s --start-period=10s --retries=6 \
+    CMD curl -fs http://127.0.0.1:8080/__env__/health || exit 1
+
+CMD ["python", "-m", "uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/deploy/sim_envs/mantis_auth/README.md
+++ b/deploy/sim_envs/mantis_auth/README.md
@@ -1,0 +1,122 @@
+# mantis-auth — simulated authentication environment
+
+A minimal SaaS console ("Mantis Console") behind a multi-method auth
+wall. The product behind the wall is intentionally tiny; the value of
+this env is the **auth surface** and the eight graded ways through it.
+
+## Methods & scenarios
+
+| Task id | Method | What the agent does |
+|---------|--------|---------------------|
+| `T01_password_login` | password | fill email + password, submit |
+| `T02_oauth_google` | OAuth / Google | account picker → consent → callback |
+| `T03_oauth_github` | OAuth / GitHub | dark "Authorize" chrome |
+| `T04_oauth_microsoft` | OAuth / Microsoft | segmented permissions screen |
+| `T05_oauth_okta` | OAuth / Okta | tenant grant screen |
+| `T06_magic_link_email` | email magic link | request → read `/inbox` → click link |
+| `T07_email_otp` | email OTP | request → read 6-digit code in `/inbox` → enter |
+| `T08_passkey` | passkey (WebAuthn) | select a registered passkey (simulated assertion) |
+
+Each OAuth provider renders its **own** account-picker + consent screens
+so the agent perceives a distinct IdP per scenario. The password page
+ships three layouts (`centered`, `split`, `minimal`).
+
+## Seeded accounts
+
+| account | email | enrolled methods |
+|---------|-------|------------------|
+| `user_00001` (Ada) | `ada@mantis.example` / `hunter2` | **every method** (canonical target) |
+| `user_00002` (Grace, admin) | `grace@mantis.example` / `compiler1` | password, google, microsoft, passkey |
+| `user_00003` (Alan) | `alan@mantis.example` | okta only (SSO-only, no password) |
+| `user_00004..6` | `<name>@mantis.example` | password only |
+
+## Routes
+
+```
+/                          public landing
+/login                     password + provider buttons + alt methods (?layout=)
+/auth/oauth/<p>/authorize  OAuth account picker         (p ∈ google|github|microsoft|okta)
+/auth/oauth/<p>/consent    consent screen
+/auth/oauth/<p>/grant      mint code → redirect interstitial
+/auth/oauth/<p>/callback   exchange code → session
+/auth/magic                request magic link
+/auth/magic/verify         consume token → session
+/auth/otp                  request one-time code
+/auth/otp/verify           verify code → session
+/auth/passkey              passkey picker
+/auth/passkey/assert       verify assertion → session
+/inbox, /inbox/{id}        mock mailbox (open while signed out)
+/console, /account         the product, behind the wall
+/__env__/*                 harness surface (X-Env-Admin gated, except /health)
+```
+
+## Run it
+
+```bash
+docker build -t mantis/sim-env-mantis-auth:latest deploy/sim_envs/mantis_auth
+docker run --rm -p 8008:8080 \
+    -e SEED=42 -e FAKE_NOW=2026-01-15T09:00:00Z \
+    -e ENV_ADMIN_TOKEN=$(python -c 'import secrets;print(secrets.token_urlsafe(32))') \
+    mantis/sim-env-mantis-auth:latest
+```
+
+Env vars: `AUTH_LAYOUT` (centered|split|minimal), `ENV_REQUIRE_AUTH`
+(default 1), `AUTH_SESSION_SECRET`, `AUTH_SESSION_TTL_S`, `SEED`,
+`FAKE_NOW`, `DB_PATH`.
+
+## Grading
+
+`GET /__env__/oracle?task_id=<T..>` (with `X-Env-Admin`) returns
+`{passed, score, reasons, diff}`. Oracles read only the `mutations`
+audit log + DB state, so verdicts are deterministic. Each scenario needs
+a terminal `login_succeeded` for `user_00001` tagged with the right
+`via` (+ `provider`); the email/passkey scenarios additionally require a
+consumed token / verified code / asserted passkey, so a shortcut session
+fails the gate.
+
+## The drop-in auth flow (`app/authflow`)
+
+The login surface is a **portable, storage-free package** — mount it on
+any FastAPI env to gain the full method matrix:
+
+```python
+from app.authflow import build_auth_router, AuthConfig, sessions
+
+config = AuthConfig(
+    templates=my_jinja_templates,   # must contain the auth/*.html templates
+    backend=MyAuthBackend(),        # implements the AuthBackend protocol
+    app_name="My Product",
+    post_login_redirect="/dashboard",
+    enabled_methods=("password", "oauth", "passkey"),  # opt in/out per env
+    enabled_providers=("google", "okta"),
+    default_layout="split",
+)
+app.include_router(build_auth_router(config))
+```
+
+`AuthBackend` (see `app/authflow/config.py`) is a small protocol over
+your own user store — user/oauth/passkey lookups, email delivery + token
+consumption, and two audit hooks. `app/backend.py` is a worked SQLite
+implementation you can copy. Nothing in `authflow` imports this env's
+`db`, so it carries no coupling. Verify session cookies in your
+middleware with `authflow.sessions.session_user_id(request)`.
+
+## Layout
+
+```
+app/
+  authflow/        ← the embeddable, env-agnostic auth flow
+    config.py      AuthConfig + AuthBackend protocol
+    router.py      build_auth_router(config) — all login routes
+    sessions.py    signed session cookies
+    passwords.py   password hashing
+    tokens.py      ephemeral OAuth codes + passkey challenges
+    providers.py   OAuth provider chrome registry
+  backend.py       this env's AuthBackend over SQLite
+  db.py            schema + audit log
+  seed.py          deterministic accounts
+  main.py          app factory: gate + wire authflow + product routes
+  routes/          console (product), inbox (mailbox), env_admin (harness)
+  oracles/         per-scenario graders
+  templates/, static/
+```

--- a/deploy/sim_envs/mantis_auth/app/__init__.py
+++ b/deploy/sim_envs/mantis_auth/app/__init__.py
@@ -1,0 +1,8 @@
+"""mantis-auth — a simulated authentication environment for agent eval.
+
+A minimal SaaS console behind a multi-method auth wall: password, OAuth
+(Google / GitHub / Microsoft / Okta), email magic-link, email OTP, and
+passkey. The login surface is the embeddable :mod:`app.authflow` package;
+the rest of this package is the host env (product pages, mock inbox,
+seed, oracles, harness routes).
+"""

--- a/deploy/sim_envs/mantis_auth/app/authflow/__init__.py
+++ b/deploy/sim_envs/mantis_auth/app/authflow/__init__.py
@@ -1,0 +1,37 @@
+"""``authflow`` — an embeddable, multi-method auth surface for sim envs.
+
+Public surface::
+
+    from app.authflow import build_auth_router, AuthConfig, AuthBackend
+    from app.authflow import sessions  # cookie verify for your middleware
+
+Supported methods: password, OAuth (Google / GitHub / Microsoft / Okta),
+email magic-link, email OTP, and passkey. The whole flow is storage-free
+except through the :class:`AuthBackend` protocol the host supplies, so it
+drops into any FastAPI env. See ``router.build_auth_router`` and the
+env's ``backend.py`` for a worked implementation.
+"""
+
+from __future__ import annotations
+
+from . import providers, sessions, tokens
+from .config import ALL_LAYOUTS, ALL_METHODS, AuthBackend, AuthConfig
+from .passwords import hash_password, verify_password
+from .providers import PROVIDERS, Provider, get_provider
+from .router import build_auth_router
+
+__all__ = [
+    "ALL_LAYOUTS",
+    "ALL_METHODS",
+    "AuthBackend",
+    "AuthConfig",
+    "PROVIDERS",
+    "Provider",
+    "build_auth_router",
+    "get_provider",
+    "hash_password",
+    "providers",
+    "sessions",
+    "tokens",
+    "verify_password",
+]

--- a/deploy/sim_envs/mantis_auth/app/authflow/config.py
+++ b/deploy/sim_envs/mantis_auth/app/authflow/config.py
@@ -1,0 +1,80 @@
+"""Wiring contract between the embeddable auth flow and its host env.
+
+``build_auth_router`` (see ``router.py``) takes an :class:`AuthConfig`.
+The config carries the host's Jinja templates plus an :class:`AuthBackend`
+— a small protocol the host implements over its own user store. Nothing
+in ``authflow`` imports the env's ``db`` module directly, so the flow
+drops into any FastAPI env that can satisfy the protocol.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+from fastapi.templating import Jinja2Templates
+
+# All auth methods this flow knows how to render/handle.
+ALL_METHODS = ("password", "oauth", "magic_link", "email_otp", "passkey")
+# Visual variants for the password sign-in page.
+ALL_LAYOUTS = ("centered", "split", "minimal")
+
+
+class AuthBackend(Protocol):
+    """Everything the auth flow needs from its host's data layer.
+
+    Returned user dicts must carry at least ``id``, ``email``, ``name``,
+    ``role`` (password lookups additionally carry ``password_hash``).
+    """
+
+    # clock ----------------------------------------------------------------
+    def now(self) -> str: ...
+
+    # users ----------------------------------------------------------------
+    def lookup_user_by_id(self, user_id: str) -> dict[str, Any] | None: ...
+    def lookup_user_by_email(self, email: str) -> dict[str, Any] | None: ...
+
+    # oauth ----------------------------------------------------------------
+    def lookup_oauth_accounts(self, provider: str) -> list[dict[str, Any]]: ...
+    def lookup_user_by_oauth(
+        self, provider: str, subject: str
+    ) -> dict[str, Any] | None: ...
+
+    # passkeys -------------------------------------------------------------
+    def list_passkeys(self) -> list[dict[str, Any]]: ...
+    def get_passkey(self, cred_id: str) -> dict[str, Any] | None: ...
+    def bump_passkey_sign_count(self, cred_id: str) -> None: ...
+
+    # email (magic link + OTP) --------------------------------------------
+    def deliver_email(
+        self, *, to_email: str, kind: str, subject: str, body: str,
+        token: str | None = None, code: str | None = None,
+    ) -> None: ...
+    def consume_magic_token(self, token: str) -> dict[str, Any] | None: ...
+    def consume_otp(self, email: str, code: str) -> dict[str, Any] | None: ...
+
+    # audit ----------------------------------------------------------------
+    def record_login(
+        self, *, user_id: str, via: str, email: str, provider: str | None = None,
+    ) -> None: ...
+    def record_event(
+        self, *, operation: str, target_id: str, payload: dict[str, Any],
+    ) -> None: ...
+
+
+@dataclass
+class AuthConfig:
+    templates: Jinja2Templates
+    backend: AuthBackend
+    app_name: str = "Mantis Console"
+    # Where to land the session after any successful sign-in.
+    post_login_redirect: str = "/console"
+    # Subset of ALL_METHODS to expose. Order drives the login page.
+    enabled_methods: tuple[str, ...] = ALL_METHODS
+    # Subset of provider slugs to expose for OAuth.
+    enabled_providers: tuple[str, ...] = ("google", "github", "microsoft", "okta")
+    default_layout: str = "centered"
+    extra: dict[str, Any] = field(default_factory=dict)
+
+    def method_enabled(self, method: str) -> bool:
+        return method in self.enabled_methods

--- a/deploy/sim_envs/mantis_auth/app/authflow/passwords.py
+++ b/deploy/sim_envs/mantis_auth/app/authflow/passwords.py
@@ -1,0 +1,22 @@
+"""Password hashing for the embeddable auth flow.
+
+Plain sha256 hex — this is a *simulated* environment for agent
+evaluation, never a production credential store. Kept in its own module
+so an embedding env could swap in bcrypt/argon2 without touching the
+routes.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+
+
+def hash_password(plain: str) -> str:
+    return hashlib.sha256(plain.encode("utf-8")).hexdigest()
+
+
+def verify_password(plain: str, stored: str | None) -> bool:
+    if not stored:
+        return False
+    return hmac.compare_digest(hash_password(plain), stored)

--- a/deploy/sim_envs/mantis_auth/app/authflow/providers.py
+++ b/deploy/sim_envs/mantis_auth/app/authflow/providers.py
@@ -1,0 +1,76 @@
+"""OAuth identity-provider registry — chrome + branding only.
+
+Each provider renders its *own* account-picker + consent screens so the
+agent sees a visually distinct IdP per scenario (Google's white card,
+GitHub's dark "Authorize" page, Microsoft's segmented sign-in, Okta's
+tenant login). The actual account list comes from the embedding env's
+seeded ``oauth_identities`` — this module only supplies the look.
+
+A provider is identified by a short slug used in the route
+(``/auth/oauth/<slug>/authorize``) and in the ``provider`` field of the
+``login_succeeded`` audit row that oracles grade on.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Provider:
+    slug: str
+    display_name: str
+    # Jinja template rendering this provider's authorize/consent chrome.
+    template: str
+    # Accent colour used by the shared idp.css via inline --idp-accent.
+    accent: str
+    # Short tagline shown under the app name on the consent card.
+    scopes: tuple[str, ...]
+
+
+PROVIDERS: dict[str, Provider] = {
+    "google": Provider(
+        slug="google",
+        display_name="Google",
+        template="oauth_google.html",
+        accent="#1a73e8",
+        scopes=(
+            "See your primary Google Account email address",
+            "See your personal info, including any personal info "
+            "you've made publicly available",
+        ),
+    ),
+    "github": Provider(
+        slug="github",
+        display_name="GitHub",
+        template="oauth_github.html",
+        accent="#2da44e",
+        scopes=(
+            "Read your profile data",
+            "Read your email addresses",
+        ),
+    ),
+    "microsoft": Provider(
+        slug="microsoft",
+        display_name="Microsoft",
+        template="oauth_microsoft.html",
+        accent="#0067b8",
+        scopes=(
+            "Sign you in and read your profile",
+            "Read your email address",
+        ),
+    ),
+    "okta": Provider(
+        slug="okta",
+        display_name="Okta",
+        template="oauth_okta.html",
+        accent="#1662dd",
+        scopes=(
+            "View your profile and email",
+        ),
+    ),
+}
+
+
+def get_provider(slug: str) -> Provider | None:
+    return PROVIDERS.get((slug or "").strip().lower())

--- a/deploy/sim_envs/mantis_auth/app/authflow/router.py
+++ b/deploy/sim_envs/mantis_auth/app/authflow/router.py
@@ -1,0 +1,305 @@
+"""``build_auth_router(config)`` — the drop-in auth surface.
+
+Mount it on any FastAPI app::
+
+    from app.authflow import build_auth_router, AuthConfig
+    app.include_router(build_auth_router(AuthConfig(templates=..., backend=...)))
+
+It contributes every login route (password, OAuth × N providers, email
+magic-link, email OTP, passkey) plus ``/logout``. Each successful method
+funnels through :func:`_complete_login`, which sets the signed session
+cookie and writes exactly one ``login_succeeded`` audit row (tagged with
+``via`` and, for OAuth, ``provider``) — the single fact every oracle
+grades on.
+"""
+
+from __future__ import annotations
+
+import secrets
+from typing import Any
+
+from fastapi import APIRouter, Form, Request
+from fastapi.responses import HTMLResponse, RedirectResponse, Response
+
+from . import providers as providers_mod
+from . import sessions, tokens
+from .config import AuthConfig
+from .passwords import verify_password
+
+
+def _otp_code() -> str:
+    return f"{secrets.randbelow(1_000_000):06d}"
+
+
+def build_auth_router(config: AuthConfig) -> APIRouter:  # noqa: C901
+    router = APIRouter()
+    be = config.backend
+    tpl = config.templates
+
+    def render(name: str, request: Request, **ctx: Any) -> HTMLResponse:
+        return tpl.TemplateResponse(
+            name,
+            {"request": request, "config": config,
+             "current_user": _current_user(request), **ctx},
+        )
+
+    def _current_user(request: Request) -> dict[str, Any] | None:
+        uid = sessions.session_user_id(request)
+        return be.lookup_user_by_id(uid) if uid else None
+
+    def _complete_login(
+        target: str, user: dict[str, Any], *, via: str,
+        provider: str | None = None,
+    ) -> Response:
+        resp = RedirectResponse(target or config.post_login_redirect,
+                                status_code=303)
+        sessions.set_session_cookie(resp, user["id"])
+        be.record_login(user_id=user["id"], via=via,
+                        email=user["email"], provider=provider)
+        return resp
+
+    # ── password ────────────────────────────────────────────────────────
+
+    @router.get("/login", response_class=HTMLResponse)
+    async def login_get(request: Request) -> HTMLResponse:
+        layout = request.query_params.get("layout") or config.default_layout
+        return render(
+            "login.html", request,
+            layout=layout,
+            next=request.query_params.get("next") or config.post_login_redirect,
+            error=request.query_params.get("error") or "",
+            providers=[providers_mod.PROVIDERS[p]
+                       for p in config.enabled_providers
+                       if p in providers_mod.PROVIDERS],
+        )
+
+    @router.post("/login")
+    async def login_post(
+        request: Request,
+        email: str = Form(""),
+        password: str = Form(""),
+        next: str = Form(""),
+    ) -> Response:
+        user = be.lookup_user_by_email(email)
+        if user is None or not verify_password(password, user.get("password_hash")):
+            be.record_event(
+                operation="login_failed", target_id="anon",
+                payload={"email": email.strip().lower(), "via": "password"},
+            )
+            nxt = next or config.post_login_redirect
+            return RedirectResponse(
+                f"/login?error=Invalid+email+or+password&next={nxt}",
+                status_code=303,
+            )
+        return _complete_login(next, user, via="password")
+
+    @router.post("/logout")
+    async def logout_post(request: Request) -> Response:
+        user = _current_user(request)
+        resp = RedirectResponse("/login", status_code=303)
+        sessions.clear_session_cookie(resp)
+        if user is not None:
+            be.record_event(operation="logout", target_id=user["id"],
+                            payload={"email": user["email"]})
+        return resp
+
+    # ── OAuth (multi-provider) ──────────────────────────────────────────
+
+    def _provider_or_404(slug: str) -> providers_mod.Provider | None:
+        if slug not in config.enabled_providers:
+            return None
+        return providers_mod.get_provider(slug)
+
+    @router.get("/auth/oauth/{slug}/authorize", response_class=HTMLResponse)
+    async def oauth_authorize(request: Request, slug: str) -> Response:
+        provider = _provider_or_404(slug)
+        if provider is None:
+            return RedirectResponse(
+                "/login?error=unknown+oauth+provider", status_code=303)
+        redirect_uri = request.query_params.get(
+            "redirect_uri", f"/auth/oauth/{slug}/callback")
+        state = request.query_params.get("state", "")
+        return render(
+            provider.template, request,
+            provider=provider, stage="picker",
+            accounts=be.lookup_oauth_accounts(slug),
+            redirect_uri=redirect_uri, state=state, error="",
+        )
+
+    @router.post("/auth/oauth/{slug}/consent", response_class=HTMLResponse)
+    async def oauth_consent(
+        request: Request, slug: str,
+        subject: str = Form(""),
+        redirect_uri: str = Form(""),
+        state: str = Form(""),
+    ) -> Response:
+        provider = _provider_or_404(slug)
+        if provider is None:
+            return RedirectResponse(
+                "/login?error=unknown+oauth+provider", status_code=303)
+        user = be.lookup_user_by_oauth(slug, subject)
+        if user is None:
+            return RedirectResponse(
+                f"/auth/oauth/{slug}/authorize?error=unknown+account&state={state}",
+                status_code=303)
+        return render(
+            provider.template, request,
+            provider=provider, stage="consent",
+            account=user, subject=subject,
+            redirect_uri=redirect_uri or f"/auth/oauth/{slug}/callback",
+            state=state,
+        )
+
+    @router.post("/auth/oauth/{slug}/grant", response_class=HTMLResponse)
+    async def oauth_grant(
+        request: Request, slug: str,
+        subject: str = Form(""),
+        redirect_uri: str = Form(""),
+        state: str = Form(""),
+    ) -> Response:
+        provider = _provider_or_404(slug)
+        if provider is None:
+            return RedirectResponse(
+                "/login?error=unknown+oauth+provider", status_code=303)
+        user = be.lookup_user_by_oauth(slug, subject)
+        if user is None:
+            return RedirectResponse(
+                f"/auth/oauth/{slug}/authorize?error=unknown+account&state={state}",
+                status_code=303)
+        redirect_uri = redirect_uri or f"/auth/oauth/{slug}/callback"
+        code = tokens.issue_oauth_code(
+            user_id=user["id"], provider=slug,
+            redirect_uri=redirect_uri, state=state)
+        be.record_event(
+            operation="oauth_consent", target_id=user["id"],
+            payload={"provider": slug, "subject": subject})
+        sep = "&" if "?" in redirect_uri else "?"
+        target = f"{redirect_uri}{sep}code={code}&state={state}"
+        return render("oauth_redirect.html", request,
+                      provider=provider, target=target)
+
+    @router.get("/auth/oauth/{slug}/callback")
+    async def oauth_callback(request: Request, slug: str) -> Response:
+        code = request.query_params.get("code", "")
+        if not code:
+            return RedirectResponse(
+                "/login?error=missing+oauth+code", status_code=303)
+        entry = tokens.consume_oauth_code(code)
+        if entry is None or entry["provider"] != slug:
+            return RedirectResponse(
+                "/login?error=oauth+code+expired+or+used", status_code=303)
+        user = be.lookup_user_by_id(entry["user_id"])
+        if user is None:
+            return RedirectResponse(
+                "/login?error=oauth+user+not+found", status_code=303)
+        return _complete_login(
+            config.post_login_redirect, user, via="oauth", provider=slug)
+
+    # ── email magic link ────────────────────────────────────────────────
+
+    @router.get("/auth/magic", response_class=HTMLResponse)
+    async def magic_get(request: Request) -> HTMLResponse:
+        return render("magic_request.html", request,
+                      error=request.query_params.get("error") or "")
+
+    @router.post("/auth/magic", response_class=HTMLResponse)
+    async def magic_post(request: Request, email: str = Form("")) -> Response:
+        user = be.lookup_user_by_email(email)
+        token = secrets.token_urlsafe(20)
+        # Always render the same "sent" page (don't leak which emails exist).
+        if user is not None:
+            link = f"/auth/magic/verify?token={token}"
+            be.deliver_email(
+                to_email=user["email"], kind="magic_link",
+                subject=f"Your {config.app_name} sign-in link",
+                body=("Click to finish signing in:\n\n"
+                      f"{link}\n\nThis link expires shortly and works once."),
+                token=token,
+            )
+            be.record_event(operation="magic_link_requested",
+                            target_id=user["id"],
+                            payload={"email": user["email"]})
+        return render("magic_sent.html", request, email=email.strip())
+
+    @router.get("/auth/magic/verify")
+    async def magic_verify(request: Request) -> Response:
+        token = request.query_params.get("token", "")
+        user = be.consume_magic_token(token) if token else None
+        if user is None:
+            return RedirectResponse(
+                "/auth/magic?error=link+expired+or+already+used",
+                status_code=303)
+        be.record_event(operation="magic_link_consumed",
+                        target_id=user["id"], payload={"email": user["email"]})
+        return _complete_login(config.post_login_redirect, user,
+                               via="magic_link")
+
+    # ── email OTP ───────────────────────────────────────────────────────
+
+    @router.get("/auth/otp", response_class=HTMLResponse)
+    async def otp_get(request: Request) -> HTMLResponse:
+        return render("otp_request.html", request,
+                      error=request.query_params.get("error") or "")
+
+    @router.post("/auth/otp", response_class=HTMLResponse)
+    async def otp_post(request: Request, email: str = Form("")) -> Response:
+        user = be.lookup_user_by_email(email)
+        code = _otp_code()
+        if user is not None:
+            be.deliver_email(
+                to_email=user["email"], kind="otp",
+                subject=f"{config.app_name} verification code: {code}",
+                body=(f"Your verification code is {code}\n\n"
+                      "Enter it on the sign-in screen. It expires shortly."),
+                code=code,
+            )
+            be.record_event(operation="otp_requested", target_id=user["id"],
+                            payload={"email": user["email"]})
+        return render("otp_verify.html", request, email=email.strip(), error="")
+
+    @router.post("/auth/otp/verify")
+    async def otp_verify(
+        request: Request, email: str = Form(""), code: str = Form(""),
+    ) -> Response:
+        user = be.consume_otp(email.strip(), code.strip())
+        if user is None:
+            return render("otp_verify.html", request, email=email.strip(),
+                          error="Invalid or expired code.")
+        be.record_event(operation="otp_verified", target_id=user["id"],
+                        payload={"email": user["email"]})
+        return _complete_login(config.post_login_redirect, user,
+                               via="email_otp")
+
+    # ── passkey (simulated WebAuthn) ────────────────────────────────────
+
+    @router.get("/auth/passkey", response_class=HTMLResponse)
+    async def passkey_get(request: Request) -> HTMLResponse:
+        challenge = tokens.issue_passkey_challenge()
+        return render("passkey.html", request,
+                      challenge=challenge,
+                      passkeys=be.list_passkeys(),
+                      error=request.query_params.get("error") or "")
+
+    @router.post("/auth/passkey/assert")
+    async def passkey_assert(
+        request: Request, cred_id: str = Form(""), challenge: str = Form(""),
+    ) -> Response:
+        # A real authenticator signs the challenge; we accept any
+        # registered credential whose challenge is live + unused.
+        if not tokens.consume_passkey_challenge(challenge):
+            return RedirectResponse(
+                "/auth/passkey?error=challenge+expired", status_code=303)
+        cred = be.get_passkey(cred_id)
+        if cred is None:
+            return RedirectResponse(
+                "/auth/passkey?error=unknown+passkey", status_code=303)
+        user = be.lookup_user_by_id(cred["user_id"])
+        if user is None:
+            return RedirectResponse(
+                "/auth/passkey?error=passkey+user+not+found", status_code=303)
+        be.bump_passkey_sign_count(cred_id)
+        be.record_event(operation="passkey_asserted", target_id=user["id"],
+                        payload={"cred_id": cred_id, "label": cred.get("label")})
+        return _complete_login(config.post_login_redirect, user, via="passkey")
+
+    return router

--- a/deploy/sim_envs/mantis_auth/app/authflow/sessions.py
+++ b/deploy/sim_envs/mantis_auth/app/authflow/sessions.py
@@ -1,0 +1,86 @@
+"""Stateless signed session cookies — shared by every auth method.
+
+Format: ``user_id|issued_at|hmac_sha256``. The secret comes from
+``AUTH_SESSION_SECRET`` and the TTL from ``AUTH_SESSION_TTL_S`` so an env
+embedding this flow only has to set two env vars.
+
+This module is deliberately storage-free: a session is verifiable from
+the cookie alone, so the same helper works whether the embedding env
+keeps users in SQLite, Postgres, or a dict.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import os
+import time
+
+from fastapi import Request, Response
+
+SESSION_COOKIE = "mantis_auth_session"
+SESSION_TTL_DEFAULT_S = 60 * 60
+
+
+def session_secret() -> str:
+    return os.environ.get("AUTH_SESSION_SECRET", "dev-only-do-not-use-in-prod")
+
+
+def session_ttl_s() -> int:
+    raw = os.environ.get("AUTH_SESSION_TTL_S")
+    try:
+        return int(raw) if raw else SESSION_TTL_DEFAULT_S
+    except ValueError:
+        return SESSION_TTL_DEFAULT_S
+
+
+def _sign(payload: str) -> str:
+    return hmac.new(
+        session_secret().encode("utf-8"),
+        payload.encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+
+
+def mint_session(user_id: str, *, now: float | None = None) -> str:
+    issued = int(now if now is not None else time.time())
+    payload = f"{user_id}|{issued}"
+    return f"{payload}|{_sign(payload)}"
+
+
+def verify_session(cookie_val: str, *, now: float | None = None) -> str | None:
+    if not cookie_val:
+        return None
+    parts = cookie_val.split("|")
+    if len(parts) != 3:
+        return None
+    user_id, issued_at_s, sig = parts
+    try:
+        issued_at = int(issued_at_s)
+    except ValueError:
+        return None
+    if not hmac.compare_digest(sig, _sign(f"{user_id}|{issued_at}")):
+        return None
+    now_ts = now if now is not None else time.time()
+    if now_ts - issued_at > session_ttl_s():
+        return None
+    return user_id
+
+
+def set_session_cookie(response: Response, user_id: str) -> None:
+    response.set_cookie(
+        SESSION_COOKIE,
+        mint_session(user_id),
+        httponly=True,
+        samesite="lax",
+        max_age=session_ttl_s(),
+        path="/",
+    )
+
+
+def clear_session_cookie(response: Response) -> None:
+    response.delete_cookie(SESSION_COOKIE, path="/")
+
+
+def session_user_id(request: Request) -> str | None:
+    return verify_session(request.cookies.get(SESSION_COOKIE) or "")

--- a/deploy/sim_envs/mantis_auth/app/authflow/tokens.py
+++ b/deploy/sim_envs/mantis_auth/app/authflow/tokens.py
@@ -1,0 +1,69 @@
+"""Ephemeral, single-use challenge stores (in-memory, short TTL).
+
+Two kinds of short-lived secret never need to outlive a single auth
+ceremony, so they live in memory rather than the DB:
+
+* **OAuth authorization codes** — minted at consent, exchanged once at
+  the callback.
+* **Passkey challenges** — minted when the passkey page loads, echoed
+  back by the (simulated) authenticator assertion.
+
+Magic-link tokens and email OTP codes are *not* here — those are
+persisted to the env's ``emails`` table so the agent can read them in
+the mock inbox, and so the oracle can prove they were consumed.
+"""
+
+from __future__ import annotations
+
+import secrets
+import time
+from typing import Any
+
+OAUTH_CODE_TTL_S = 60
+PASSKEY_CHALLENGE_TTL_S = 120
+
+_OAUTH_CODES: dict[str, dict[str, Any]] = {}
+_PASSKEY_CHALLENGES: dict[str, float] = {}
+
+
+# ── OAuth authorization codes ───────────────────────────────────────────
+
+
+def issue_oauth_code(*, user_id: str, provider: str,
+                     redirect_uri: str, state: str) -> str:
+    code = secrets.token_urlsafe(16)
+    _OAUTH_CODES[code] = {
+        "user_id": user_id,
+        "provider": provider,
+        "redirect_uri": redirect_uri,
+        "state": state,
+        "expires_at": time.time() + OAUTH_CODE_TTL_S,
+    }
+    return code
+
+
+def consume_oauth_code(code: str) -> dict[str, Any] | None:
+    entry = _OAUTH_CODES.pop(code, None)
+    if entry is None or time.time() > entry["expires_at"]:
+        return None
+    return entry
+
+
+# ── passkey challenges ──────────────────────────────────────────────────
+
+
+def issue_passkey_challenge() -> str:
+    challenge = secrets.token_urlsafe(24)
+    _PASSKEY_CHALLENGES[challenge] = time.time() + PASSKEY_CHALLENGE_TTL_S
+    return challenge
+
+
+def consume_passkey_challenge(challenge: str) -> bool:
+    expires = _PASSKEY_CHALLENGES.pop(challenge, None)
+    return expires is not None and time.time() <= expires
+
+
+def clear_all() -> None:
+    """Wipe ephemeral stores — used by ``/__env__/reset``."""
+    _OAUTH_CODES.clear()
+    _PASSKEY_CHALLENGES.clear()

--- a/deploy/sim_envs/mantis_auth/app/backend.py
+++ b/deploy/sim_envs/mantis_auth/app/backend.py
@@ -1,0 +1,156 @@
+"""Concrete :class:`authflow.AuthBackend` over this env's SQLite store.
+
+This is the only file that bridges the portable ``authflow`` package to
+``mantis_auth``'s ``db``. Another env embedding the flow would write its
+own equivalent against its own user store.
+
+Audit semantics
+---------------
+
+Every method-specific event (``magic_link_consumed``, ``otp_verified``,
+``passkey_asserted``, ``oauth_consent`` …) and the single terminal
+``login_succeeded`` row are written to the ``mutations`` table — the
+ground truth the oracles grade on — and mirrored to the in-memory event
+log via the injected ``emit`` callback.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from . import db
+
+
+def _row(cur) -> dict[str, Any] | None:
+    r = cur.fetchone()
+    return dict(r) if r else None
+
+
+class SqliteAuthBackend:
+    def __init__(self, *, now_fn: Callable[[], str],
+                 emit_fn: Callable[[str, dict[str, Any]], None]) -> None:
+        self._now = now_fn
+        self._emit = emit_fn
+
+    # clock ----------------------------------------------------------------
+    def now(self) -> str:
+        return self._now()
+
+    # users ----------------------------------------------------------------
+    def lookup_user_by_id(self, user_id: str) -> dict[str, Any] | None:
+        conn = db.connect()
+        return _row(conn.execute(
+            "SELECT id, name, email, role, is_active FROM users WHERE id = ?",
+            (user_id,)))
+
+    def lookup_user_by_email(self, email: str) -> dict[str, Any] | None:
+        conn = db.connect()
+        return _row(conn.execute(
+            "SELECT id, name, email, role, is_active, password_hash "
+            "FROM users WHERE LOWER(email) = ?",
+            (email.strip().lower(),)))
+
+    # oauth ----------------------------------------------------------------
+    def lookup_oauth_accounts(self, provider: str) -> list[dict[str, Any]]:
+        conn = db.connect()
+        rows = conn.execute(
+            "SELECT oi.subject AS subject, oi.email AS email, "
+            "       u.id AS user_id, u.name AS name "
+            "FROM oauth_identities oi JOIN users u ON u.id = oi.user_id "
+            "WHERE oi.provider = ? ORDER BY oi.email",
+            (provider,)).fetchall()
+        return [dict(r) for r in rows]
+
+    def lookup_user_by_oauth(self, provider: str,
+                             subject: str) -> dict[str, Any] | None:
+        conn = db.connect()
+        row = _row(conn.execute(
+            "SELECT u.id AS id, u.name AS name, u.email AS email, "
+            "       u.role AS role, oi.subject AS oauth_subject "
+            "FROM oauth_identities oi JOIN users u ON u.id = oi.user_id "
+            "WHERE oi.provider = ? AND oi.subject = ?",
+            (provider, subject)))
+        return row
+
+    # passkeys -------------------------------------------------------------
+    def list_passkeys(self) -> list[dict[str, Any]]:
+        conn = db.connect()
+        rows = conn.execute(
+            "SELECT pc.id AS cred_id, pc.label AS label, pc.user_id AS user_id, "
+            "       u.email AS email, u.name AS name "
+            "FROM passkey_credentials pc JOIN users u ON u.id = pc.user_id "
+            "ORDER BY pc.label").fetchall()
+        return [dict(r) for r in rows]
+
+    def get_passkey(self, cred_id: str) -> dict[str, Any] | None:
+        conn = db.connect()
+        return _row(conn.execute(
+            "SELECT id AS cred_id, user_id, label, sign_count "
+            "FROM passkey_credentials WHERE id = ?", (cred_id,)))
+
+    def bump_passkey_sign_count(self, cred_id: str) -> None:
+        with db.transaction() as conn:
+            conn.execute(
+                "UPDATE passkey_credentials SET sign_count = sign_count + 1 "
+                "WHERE id = ?", (cred_id,))
+
+    # email (magic link + OTP) --------------------------------------------
+    def deliver_email(self, *, to_email: str, kind: str, subject: str,
+                      body: str, token: str | None = None,
+                      code: str | None = None) -> None:
+        with db.transaction() as conn:
+            n = conn.execute("SELECT COUNT(*) FROM emails").fetchone()[0]
+            email_id = f"email_{n + 1:05d}"
+            conn.execute(
+                "INSERT INTO emails (id, to_email, subject, body, kind, "
+                "token, code, created_at, consumed_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL)",
+                (email_id, to_email, subject, body, kind, token, code,
+                 self._now()))
+
+    def consume_magic_token(self, token: str) -> dict[str, Any] | None:
+        with db.transaction() as conn:
+            row = _row(conn.execute(
+                "SELECT id, to_email FROM emails "
+                "WHERE kind = 'magic_link' AND token = ? AND consumed_at IS NULL",
+                (token,)))
+            if row is None:
+                return None
+            conn.execute("UPDATE emails SET consumed_at = ? WHERE id = ?",
+                         (self._now(), row["id"]))
+        return self.lookup_user_by_email(row["to_email"])
+
+    def consume_otp(self, email: str, code: str) -> dict[str, Any] | None:
+        if not email or not code:
+            return None
+        with db.transaction() as conn:
+            row = _row(conn.execute(
+                "SELECT id, to_email FROM emails "
+                "WHERE kind = 'otp' AND LOWER(to_email) = ? AND code = ? "
+                "AND consumed_at IS NULL ORDER BY id DESC LIMIT 1",
+                (email.strip().lower(), code.strip())))
+            if row is None:
+                return None
+            conn.execute("UPDATE emails SET consumed_at = ? WHERE id = ?",
+                         (self._now(), row["id"]))
+        return self.lookup_user_by_email(row["to_email"])
+
+    # audit ----------------------------------------------------------------
+    def record_login(self, *, user_id: str, via: str, email: str,
+                      provider: str | None = None) -> None:
+        payload = {"email": email, "via": via}
+        if provider:
+            payload["provider"] = provider
+        with db.transaction() as conn:
+            db.log_mutation(conn, occurred_at=self._now(),
+                            operation="login_succeeded", target_type="user",
+                            target_id=user_id, payload=payload)
+        self._emit("login_succeeded", {"target_id": user_id, **payload})
+
+    def record_event(self, *, operation: str, target_id: str,
+                     payload: dict[str, Any]) -> None:
+        with db.transaction() as conn:
+            db.log_mutation(conn, occurred_at=self._now(), operation=operation,
+                            target_type="user", target_id=target_id,
+                            payload=payload)
+        self._emit(operation, {"target_id": target_id, **payload})

--- a/deploy/sim_envs/mantis_auth/app/db.py
+++ b/deploy/sim_envs/mantis_auth/app/db.py
@@ -1,0 +1,163 @@
+"""SQLite schema + thin query helpers for mantis-auth.
+
+This env's whole purpose is *authentication*: a minimal SaaS console
+("Mantis Console") sits behind an auth wall, and the interesting surface
+is the many ways an agent can get *through* that wall — password,
+OAuth (multiple providers), email magic-link, email OTP, and passkey.
+
+The DB lives in memory by default (``DB_PATH=:memory:``) — same seed
+re-runs from scratch in well under a second and isolates plan runs
+perfectly. Pass ``DB_PATH=/var/lib/mantis-auth/db.sqlite`` for dev
+iteration if you want state to persist across restarts.
+
+Schema notes
+------------
+
+* All IDs are deterministic strings (``user_00001``, ``cred_00001``) so
+  a plan that references a row always finds the same one.
+* ``oauth_identities`` is a separate table so one user can sign in via
+  several providers (Google *and* GitHub map to the same ``user_id``).
+* ``emails`` is the in-env mock mailbox. Magic-link / OTP flows write a
+  row here; the agent navigates ``/inbox`` to read it (just like real
+  CUA email flows). The oracle reads ``consumed_at`` to prove the agent
+  actually used the token rather than shortcutting.
+* ``mutations`` is the append-only audit log every oracle grades on.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import threading
+from contextlib import contextmanager
+from typing import Any, Iterator
+
+# One module-level connection guarded by a lock. SQLite ``:memory:`` DBs
+# are per-connection, so we keep exactly one for the process lifetime;
+# the lock makes single-connection use thread-safe (FastAPI runs request
+# handlers on a thread pool).
+_DB_LOCK = threading.RLock()
+_DB: sqlite3.Connection | None = None
+
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS users (
+    id              TEXT PRIMARY KEY,
+    name            TEXT NOT NULL,
+    email           TEXT NOT NULL,
+    is_active       INTEGER NOT NULL DEFAULT 1,
+    -- Plain sha256 hex — sim env, not prod. NULL means "no password set"
+    -- (the account is OAuth/passkey-only, mirroring SSO-only users).
+    password_hash   TEXT,
+    role            TEXT NOT NULL DEFAULT 'member',  -- 'member' | 'admin'
+    created_at      TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_users_email ON users(email);
+
+CREATE TABLE IF NOT EXISTS oauth_identities (
+    id              TEXT PRIMARY KEY,
+    user_id         TEXT NOT NULL REFERENCES users(id),
+    provider        TEXT NOT NULL,   -- 'google' | 'github' | 'microsoft' | 'okta'
+    subject         TEXT NOT NULL,   -- provider-side stable id ("sub")
+    email           TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_oauth_subject
+    ON oauth_identities(provider, subject);
+CREATE INDEX IF NOT EXISTS idx_oauth_user ON oauth_identities(user_id);
+
+CREATE TABLE IF NOT EXISTS passkey_credentials (
+    id              TEXT PRIMARY KEY,   -- doubles as the WebAuthn credential id
+    user_id         TEXT NOT NULL REFERENCES users(id),
+    label           TEXT NOT NULL,      -- "MacBook Touch ID", "YubiKey 5C"
+    sign_count      INTEGER NOT NULL DEFAULT 0,
+    created_at      TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_passkey_user ON passkey_credentials(user_id);
+
+CREATE TABLE IF NOT EXISTS emails (
+    -- In-env mock mailbox. Magic-link + OTP flows deposit a message
+    -- here; the agent reads it at ``/inbox``.
+    id              TEXT PRIMARY KEY,
+    to_email        TEXT NOT NULL,
+    subject         TEXT NOT NULL,
+    body            TEXT NOT NULL,
+    kind            TEXT NOT NULL,      -- 'magic_link' | 'otp'
+    token           TEXT,               -- magic-link single-use token
+    code            TEXT,               -- 6-digit OTP
+    created_at      TEXT NOT NULL,
+    consumed_at     TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_emails_to ON emails(to_email);
+
+CREATE TABLE IF NOT EXISTS mutations (
+    -- Audit log of every auth-relevant event after seed. Oracles read
+    -- this to assert "the agent authenticated via method X".
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    occurred_at     TEXT NOT NULL,
+    operation       TEXT NOT NULL,      -- e.g. 'login_succeeded'
+    target_type     TEXT NOT NULL,
+    target_id       TEXT NOT NULL,
+    payload_json    TEXT NOT NULL DEFAULT '{}'
+);
+CREATE INDEX IF NOT EXISTS idx_mutations_op ON mutations(operation);
+"""
+
+
+def db_path() -> str:
+    return os.environ.get("DB_PATH") or ":memory:"
+
+
+def connect() -> sqlite3.Connection:
+    """Return the shared SQLite connection, creating it on first use."""
+    global _DB
+    with _DB_LOCK:
+        if _DB is None:
+            conn = sqlite3.connect(db_path(), check_same_thread=False)
+            conn.row_factory = sqlite3.Row
+            conn.executescript(SCHEMA)
+            _DB = conn
+        return _DB
+
+
+def reset_connection() -> None:
+    """Drop the in-process connection — used by tests + ``/__env__/reset``."""
+    global _DB
+    with _DB_LOCK:
+        if _DB is not None:
+            _DB.close()
+            _DB = None
+
+
+@contextmanager
+def transaction() -> Iterator[sqlite3.Connection]:
+    """Acquire the lock + start a transaction; commit on success."""
+    conn = connect()
+    with _DB_LOCK:
+        try:
+            yield conn
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+
+
+# ── audit log ───────────────────────────────────────────────────────────
+
+
+def log_mutation(
+    conn: sqlite3.Connection,
+    *,
+    occurred_at: str,
+    operation: str,
+    target_type: str,
+    target_id: str,
+    payload: dict[str, Any] | None = None,
+) -> None:
+    """Append a mutation record. Oracles read this to grade runs."""
+    conn.execute(
+        "INSERT INTO mutations (occurred_at, operation, target_type, "
+        "target_id, payload_json) VALUES (?, ?, ?, ?, ?)",
+        (occurred_at, operation, target_type, target_id,
+         json.dumps(payload or {}, sort_keys=True)),
+    )

--- a/deploy/sim_envs/mantis_auth/app/main.py
+++ b/deploy/sim_envs/mantis_auth/app/main.py
@@ -1,0 +1,172 @@
+"""mantis-auth FastAPI app — entrypoint mounted by Docker + Modal.
+
+The env is a thin SaaS console ("Mantis Console") guarded by a rich auth
+wall. All login routes come from the embeddable ``authflow`` package
+(see ``authflow/router.py``); this module only wires it up, adds the
+product pages behind the wall (``/console``, ``/account``), the mock
+mailbox (``/inbox``), and the harness surface (``/__env__/*``).
+
+Auth gate: with ``ENV_REQUIRE_AUTH=1`` (the default for this env), every
+route except the landing page, the auth routes, the inbox, the harness
+routes, and static assets redirects to ``/login`` when unauthenticated.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+from fastapi import FastAPI, Request, Response
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
+from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
+
+from . import db, seed
+from .authflow import AuthConfig, sessions
+from .backend import SqliteAuthBackend
+
+APP_DIR = Path(__file__).parent
+ADMIN_TOKEN_ENV = "ENV_ADMIN_TOKEN"
+ADMIN_HEADER = "X-Env-Admin"
+
+# Routes reachable while signed out. ``/inbox`` is open by design: the
+# magic-link + OTP flows require reading the mailbox *before* a session
+# exists.
+_OPEN_PREFIXES = ("/login", "/logout", "/auth/", "/inbox",
+                  "/__env__/", "/static/")
+
+_EVENTS: list[dict[str, Any]] = []
+_BOOT_TIME = time.time()
+
+
+def _admin_token() -> str:
+    token = os.environ.get(ADMIN_TOKEN_ENV, "").strip()
+    if not token:
+        raise RuntimeError(
+            f"{ADMIN_TOKEN_ENV} is required — the harness generates it per run "
+            "and passes it to the container as an env var."
+        )
+    return token
+
+
+def _now() -> str:
+    return os.environ.get("FAKE_NOW") or seed.FAKE_NOW_DEFAULT
+
+
+def _seed_val() -> int:
+    return int(os.environ.get("SEED") or 42)
+
+
+def _default_layout() -> str:
+    return os.environ.get("AUTH_LAYOUT") or "centered"
+
+
+def _require_auth() -> bool:
+    return os.environ.get("ENV_REQUIRE_AUTH", "1").lower() in {"1", "true", "yes"}
+
+
+def _emit_event(event: str, data: dict[str, Any] | None = None) -> None:
+    _EVENTS.append({"ts": time.time(), "event": event, "data": data or {}})
+
+
+def create_app() -> FastAPI:
+    app = FastAPI(title="mantis-auth", docs_url=None, redoc_url=None)
+
+    templates = Jinja2Templates(directory=str(APP_DIR / "templates"))
+    app.state.templates = templates
+    app.state.admin_token = _admin_token()
+
+    backend = SqliteAuthBackend(now_fn=_now, emit_fn=_emit_event)
+    app.state.auth_backend = backend
+    app.state.auth_config = AuthConfig(
+        templates=templates,
+        backend=backend,
+        app_name="Mantis Console",
+        post_login_redirect="/console",
+        default_layout=_default_layout(),
+    )
+
+    @app.middleware("http")
+    async def _auth_gate(request: Request, call_next):  # noqa: ANN202
+        try:
+            uid = sessions.session_user_id(request)
+            request.state.current_user = backend.lookup_user_by_id(uid) if uid else None
+        except Exception:  # noqa: BLE001 — never block a request on auth lookup
+            request.state.current_user = None
+
+        if _require_auth():
+            path = request.url.path
+            if path != "/" and not path.startswith(_OPEN_PREFIXES):
+                if request.state.current_user is None:
+                    return RedirectResponse(f"/login?next={path}", status_code=303)
+        return await call_next(request)
+
+    @app.on_event("startup")
+    def _bootstrap() -> None:
+        conn = db.connect()
+        if conn.execute("SELECT COUNT(*) FROM users").fetchone()[0] == 0:
+            seed.seed(conn, seed_val=_seed_val(), fake_now=_now())
+            _emit_event("seeded", {"seed": _seed_val(), "now": _now()})
+
+    app.mount("/static",
+              StaticFiles(directory=str(APP_DIR / "static")), name="static")
+
+    from .authflow import build_auth_router
+    from .routes import console as console_router
+    from .routes import env_admin as env_admin_router
+    from .routes import inbox as inbox_router
+
+    app.include_router(env_admin_router.router)
+    app.include_router(build_auth_router(app.state.auth_config))
+    app.include_router(inbox_router.router)
+    app.include_router(console_router.router)
+
+    @app.get("/", response_class=HTMLResponse)
+    async def root(request: Request) -> Response:
+        return templates.TemplateResponse(
+            "landing.html",
+            {"request": request, "config": app.state.auth_config,
+             "current_user": getattr(request.state, "current_user", None)},
+        )
+
+    return app
+
+
+app = create_app()
+
+
+# Helpers exposed to the routes package ---------------------------------
+
+
+def admin_token_ok(request: Request) -> bool:
+    return request.headers.get(ADMIN_HEADER) == request.app.state.admin_token
+
+
+def admin_required_response() -> JSONResponse:
+    return JSONResponse({"error": "admin token required"}, status_code=401)
+
+
+def now_value() -> str:
+    return _now()
+
+
+def seed_value() -> int:
+    return _seed_val()
+
+
+def boot_time() -> float:
+    return _BOOT_TIME
+
+
+def emit(event: str, data: dict[str, Any] | None = None) -> None:
+    _emit_event(event, data)
+
+
+def events_since(ts: float) -> list[dict[str, Any]]:
+    return [e for e in _EVENTS if e["ts"] >= ts]
+
+
+def clear_events() -> None:
+    _EVENTS.clear()

--- a/deploy/sim_envs/mantis_auth/app/oracles/__init__.py
+++ b/deploy/sim_envs/mantis_auth/app/oracles/__init__.py
@@ -1,0 +1,52 @@
+"""Oracles — server-side ground-truth graders for the mantis-auth plans.
+
+Each oracle exports a ``grade(conn, *, now, seed_val)`` returning the
+harness oracle shape::
+
+    {"passed": bool, "score": float, "reasons": [...], "diff": {...}}
+
+The dispatch table maps ``task_id`` → grader. New auth scenarios land a
+grader (usually a one-liner over ``scenarios``/``_common``) plus a
+``GRADERS`` entry.
+
+Determinism: oracles read DB + ``mutations`` state only, never the
+agent's transcript. Same end state → same verdict, so the "N reruns → N
+identical scores" criterion holds by construction.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Any, Callable
+
+from . import scenarios
+
+GraderFn = Callable[..., dict[str, Any]]
+
+
+GRADERS: dict[str, GraderFn] = {
+    "T01_password_login": scenarios.grade_password,
+    "T02_oauth_google": scenarios.make_oauth_grader("google"),
+    "T03_oauth_github": scenarios.make_oauth_grader("github"),
+    "T04_oauth_microsoft": scenarios.make_oauth_grader("microsoft"),
+    "T05_oauth_okta": scenarios.make_oauth_grader("okta"),
+    "T06_magic_link_email": scenarios.grade_magic_link,
+    "T07_email_otp": scenarios.grade_email_otp,
+    "T08_passkey": scenarios.grade_passkey,
+}
+
+
+def grade(task_id: str, conn: sqlite3.Connection, *,
+          now: str, seed_val: int) -> dict[str, Any]:
+    fn = GRADERS.get(task_id)
+    if fn is None:
+        return {
+            "passed": False,
+            "score": 0.0,
+            "task_id": task_id,
+            "reasons": [f"no oracle registered for task_id={task_id!r}"],
+            "diff": {},
+        }
+    result = fn(conn, now=now, seed_val=seed_val)
+    result.setdefault("task_id", task_id)
+    return result

--- a/deploy/sim_envs/mantis_auth/app/oracles/_common.py
+++ b/deploy/sim_envs/mantis_auth/app/oracles/_common.py
@@ -1,0 +1,83 @@
+"""Shared helpers for the mantis-auth oracles.
+
+Every scenario grades on the same ground truth: the ``mutations`` audit
+log the auth flow writes. The terminal fact is a ``login_succeeded`` row
+tagged with ``via`` (and ``provider`` for OAuth); method scenarios add a
+proof-of-ceremony check (token consumed, code verified, passkey asserted)
+so a shortcut that mints a session without walking the flow still fails.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from typing import Any
+
+# The canonical demo account every scenario targets — enrolled in every
+# method. See ``seed.py``.
+DEMO_USER_ID = "user_00001"
+
+
+def _parse(payload_json: str | None) -> dict[str, Any]:
+    try:
+        out = json.loads(payload_json or "{}")
+        return out if isinstance(out, dict) else {}
+    except json.JSONDecodeError:
+        return {}
+
+
+def login_rows(conn: sqlite3.Connection) -> list[dict[str, Any]]:
+    """All ``login_succeeded`` mutations, oldest first, payload unpacked."""
+    rows = conn.execute(
+        "SELECT id, target_id, payload_json FROM mutations "
+        "WHERE operation = 'login_succeeded' ORDER BY id ASC").fetchall()
+    out: list[dict[str, Any]] = []
+    for r in rows:
+        p = _parse(r["payload_json"])
+        out.append({"id": r["id"], "user_id": r["target_id"],
+                    "via": p.get("via"), "provider": p.get("provider"),
+                    "email": p.get("email")})
+    return out
+
+
+def first_event(conn: sqlite3.Connection, operation: str) -> dict[str, Any] | None:
+    r = conn.execute(
+        "SELECT id, target_id, payload_json FROM mutations "
+        "WHERE operation = ? ORDER BY id ASC LIMIT 1", (operation,)).fetchone()
+    if r is None:
+        return None
+    return {"id": r["id"], "user_id": r["target_id"],
+            **_parse(r["payload_json"])}
+
+
+def verdict(passed: bool, reasons: list[str],
+            diff: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "passed": passed,
+        "score": 1.0 if passed else 0.0,
+        "reasons": reasons,
+        "diff": diff,
+    }
+
+
+def grade_login_via(conn: sqlite3.Connection, *, via: str,
+                    provider: str | None = None,
+                    user_id: str = DEMO_USER_ID) -> dict[str, Any]:
+    """Generic grader: a ``login_succeeded`` for ``user_id`` via ``via``
+    (and ``provider`` when given). Used directly by the simpler scenarios
+    and as the terminal check by the method-specific ones."""
+    matches = [
+        r for r in login_rows(conn)
+        if r["user_id"] == user_id and r["via"] == via
+        and (provider is None or r["provider"] == provider)
+    ]
+    label = f"{via}" + (f"/{provider}" if provider else "")
+    if not matches:
+        return verdict(False, [
+            f"no login_succeeded for {user_id} via {label}; the agent must "
+            "complete the sign-in flow (a session minted by other means "
+            "won't write this audit row)",
+        ], {"login_mutation_id": None, "via": via, "provider": provider})
+    return verdict(True, [f"signed in as {user_id} via {label}"],
+                   {"login_mutation_id": matches[0]["id"], "via": via,
+                    "provider": provider})

--- a/deploy/sim_envs/mantis_auth/app/oracles/scenarios.py
+++ b/deploy/sim_envs/mantis_auth/app/oracles/scenarios.py
@@ -1,0 +1,99 @@
+"""Per-method graders, built on the shared helpers in ``_common``.
+
+Kept in one module because the scenarios are close variants of a single
+contract — adding a method is a few lines, not a new file. Each public
+``grade_*`` matches the oracle signature ``(conn, *, now, seed_val)``.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Any
+
+from . import _common as C
+
+
+def grade_password(conn: sqlite3.Connection, *, now: str,
+                   seed_val: int) -> dict[str, Any]:
+    return C.grade_login_via(conn, via="password")
+
+
+def make_oauth_grader(provider: str):
+    def grade(conn: sqlite3.Connection, *, now: str,
+              seed_val: int) -> dict[str, Any]:
+        return C.grade_login_via(conn, via="oauth", provider=provider)
+    grade.__name__ = f"grade_oauth_{provider}"
+    grade.__doc__ = f"Login via OAuth with the {provider} provider."
+    return grade
+
+
+def grade_magic_link(conn: sqlite3.Connection, *, now: str,
+                     seed_val: int) -> dict[str, Any]:
+    reasons: list[str] = []
+    consumed = C.first_event(conn, "magic_link_consumed")
+    if consumed is None:
+        reasons.append(
+            "no magic_link_consumed event; the agent must open the link "
+            "delivered to /inbox rather than guessing the verify URL")
+    # Proof the actual emailed token was burned.
+    used = conn.execute(
+        "SELECT COUNT(*) FROM emails "
+        "WHERE kind = 'magic_link' AND consumed_at IS NOT NULL").fetchone()[0]
+    if used == 0:
+        reasons.append("no magic-link email was marked consumed")
+
+    inner = C.grade_login_via(conn, via="magic_link")
+    if not inner["passed"]:
+        reasons.extend(inner["reasons"])
+    passed = not reasons
+    return C.verdict(
+        passed,
+        reasons or ["read the magic link from the inbox and signed in"],
+        {"magic_links_consumed": used, **inner["diff"]})
+
+
+def grade_email_otp(conn: sqlite3.Connection, *, now: str,
+                    seed_val: int) -> dict[str, Any]:
+    reasons: list[str] = []
+    verified = C.first_event(conn, "otp_verified")
+    if verified is None:
+        reasons.append(
+            "no otp_verified event; the agent must read the code from "
+            "/inbox and submit it")
+    used = conn.execute(
+        "SELECT COUNT(*) FROM emails "
+        "WHERE kind = 'otp' AND consumed_at IS NOT NULL").fetchone()[0]
+    if used == 0:
+        reasons.append("no OTP email was marked consumed")
+
+    inner = C.grade_login_via(conn, via="email_otp")
+    if not inner["passed"]:
+        reasons.extend(inner["reasons"])
+    passed = not reasons
+    return C.verdict(
+        passed,
+        reasons or ["read the OTP from the inbox and signed in"],
+        {"otp_codes_consumed": used, **inner["diff"]})
+
+
+def grade_passkey(conn: sqlite3.Connection, *, now: str,
+                  seed_val: int) -> dict[str, Any]:
+    reasons: list[str] = []
+    asserted = C.first_event(conn, "passkey_asserted")
+    if asserted is None:
+        reasons.append("no passkey_asserted event; the agent must complete "
+                       "the passkey ceremony at /auth/passkey")
+    bumped = conn.execute(
+        "SELECT COUNT(*) FROM passkey_credentials WHERE sign_count > 0"
+    ).fetchone()[0]
+    if bumped == 0:
+        reasons.append("no passkey credential sign_count was incremented")
+
+    inner = C.grade_login_via(conn, via="passkey")
+    if not inner["passed"]:
+        reasons.extend(inner["reasons"])
+    passed = not reasons
+    return C.verdict(
+        passed,
+        reasons or ["completed the passkey assertion and signed in"],
+        {"passkeys_used": bumped, **inner["diff"]})

--- a/deploy/sim_envs/mantis_auth/app/routes/__init__.py
+++ b/deploy/sim_envs/mantis_auth/app/routes/__init__.py
@@ -1,0 +1,5 @@
+"""Route packages for mantis-auth (product + harness surfaces).
+
+The *login* routes do not live here — they come from the embeddable
+``app.authflow`` package, mounted in ``app.main``.
+"""

--- a/deploy/sim_envs/mantis_auth/app/routes/console.py
+++ b/deploy/sim_envs/mantis_auth/app/routes/console.py
@@ -1,0 +1,59 @@
+"""Product surface behind the auth wall — the thing you sign in to reach.
+
+Intentionally small: a dashboard greeting and a "security" account page
+that lists the signed-in user's enrolled auth methods. Reaching either
+page at all is the agent's reward for completing a login, so we emit a
+``console_viewed`` event the oracle can cross-check against the login.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Request
+from fastapi.responses import HTMLResponse, RedirectResponse, Response
+
+from .. import db, main as app_main
+
+router = APIRouter()
+
+
+def _enrolled_methods(user_id: str) -> dict[str, object]:
+    conn = db.connect()
+    has_pw = conn.execute(
+        "SELECT password_hash FROM users WHERE id = ?", (user_id,)
+    ).fetchone()
+    providers = [r["provider"] for r in conn.execute(
+        "SELECT provider FROM oauth_identities WHERE user_id = ? ORDER BY provider",
+        (user_id,)).fetchall()]
+    passkeys = [r["label"] for r in conn.execute(
+        "SELECT label FROM passkey_credentials WHERE user_id = ? ORDER BY label",
+        (user_id,)).fetchall()]
+    return {
+        "password": bool(has_pw and has_pw["password_hash"]),
+        "oauth_providers": providers,
+        "passkeys": passkeys,
+    }
+
+
+@router.get("/console", response_class=HTMLResponse)
+async def console(request: Request) -> Response:
+    user = getattr(request.state, "current_user", None)
+    if user is None:
+        return RedirectResponse("/login?next=/console", status_code=303)
+    app_main.emit("console_viewed", {"target_id": user["id"]})
+    return app_main.app.state.templates.TemplateResponse(
+        "console.html",
+        {"request": request, "config": app_main.app.state.auth_config,
+         "current_user": user, "enrolled": _enrolled_methods(user["id"])},
+    )
+
+
+@router.get("/account", response_class=HTMLResponse)
+async def account(request: Request) -> Response:
+    user = getattr(request.state, "current_user", None)
+    if user is None:
+        return RedirectResponse("/login?next=/account", status_code=303)
+    return app_main.app.state.templates.TemplateResponse(
+        "account.html",
+        {"request": request, "config": app_main.app.state.auth_config,
+         "current_user": user, "enrolled": _enrolled_methods(user["id"])},
+    )

--- a/deploy/sim_envs/mantis_auth/app/routes/env_admin.py
+++ b/deploy/sim_envs/mantis_auth/app/routes/env_admin.py
@@ -1,0 +1,123 @@
+"""Harness endpoints — ``/__env__/{health,reset,seed,clock,oracle,state,events}``.
+
+Every route except ``health`` is gated on the ``X-Env-Admin`` header.
+The check lives in the route bodies (not middleware) so a typo in one
+route can't accidentally bypass auth on another.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse
+
+from .. import db, main as app_main, seed
+from ..authflow import tokens
+
+router = APIRouter(prefix="/__env__")
+
+
+@router.get("/health")
+async def health() -> JSONResponse:
+    """Open by design — health checks can't authenticate."""
+    return JSONResponse({
+        "ok": True,
+        "seed": app_main.seed_value(),
+        "now": app_main.now_value(),
+        "boot_time": app_main.boot_time(),
+    })
+
+
+@router.post("/reset")
+async def reset(request: Request) -> JSONResponse:
+    if not app_main.admin_token_ok(request):
+        return app_main.admin_required_response()
+    seed.seed(db.connect(), seed_val=app_main.seed_value(),
+              fake_now=app_main.now_value())
+    tokens.clear_all()
+    app_main.clear_events()
+    app_main.emit("reset")
+    return JSONResponse({"ok": True})
+
+
+@router.post("/seed")
+async def reseed(request: Request) -> JSONResponse:
+    if not app_main.admin_token_ok(request):
+        return app_main.admin_required_response()
+    try:
+        payload = await request.json()
+    except Exception:  # noqa: BLE001 — empty body is fine
+        payload = {}
+    new_seed = int(payload.get("seed", app_main.seed_value()))
+    seed.seed(db.connect(), seed_val=new_seed, fake_now=app_main.now_value())
+    tokens.clear_all()
+    app_main.emit("reseeded", {"seed": new_seed})
+    return JSONResponse({"ok": True, "seed": new_seed})
+
+
+@router.post("/clock")
+async def clock(request: Request) -> JSONResponse:
+    if not app_main.admin_token_ok(request):
+        return app_main.admin_required_response()
+    import os
+    try:
+        payload = await request.json()
+    except Exception:  # noqa: BLE001
+        payload = {}
+    new_now = str(payload.get("now") or app_main.now_value())
+    os.environ["FAKE_NOW"] = new_now
+    app_main.emit("clock_set", {"now": new_now})
+    return JSONResponse({"ok": True, "now": new_now})
+
+
+@router.get("/oracle")
+async def oracle(request: Request) -> JSONResponse:
+    if not app_main.admin_token_ok(request):
+        return app_main.admin_required_response()
+    task_id = (request.query_params.get("task_id") or "").strip()
+    if not task_id:
+        return JSONResponse({"passed": False, "score": 0.0,
+                             "reasons": ["task_id is required"], "diff": {}})
+    from ..oracles import grade
+    result = grade(task_id, db.connect(), now=app_main.now_value(),
+                   seed_val=app_main.seed_value())
+    app_main.emit("oracle_query",
+                  {"task_id": task_id, "passed": result["passed"]})
+    return JSONResponse(result)
+
+
+@router.get("/state")
+async def state(request: Request) -> JSONResponse:
+    """Debug-only dump of table counts + recent mutations."""
+    if not app_main.admin_token_ok(request):
+        return app_main.admin_required_response()
+    conn = db.connect()
+
+    def count(table: str) -> int:
+        return int(conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0])
+
+    mutations = [
+        {"id": r["id"], "occurred_at": r["occurred_at"],
+         "operation": r["operation"], "target_id": r["target_id"]}
+        for r in conn.execute(
+            "SELECT * FROM mutations ORDER BY id DESC LIMIT 50").fetchall()
+    ]
+    return JSONResponse({
+        "seed": app_main.seed_value(),
+        "now": app_main.now_value(),
+        "counts": {
+            "users": count("users"),
+            "oauth_identities": count("oauth_identities"),
+            "passkey_credentials": count("passkey_credentials"),
+            "emails": count("emails"),
+            "mutations": count("mutations"),
+        },
+        "recent_mutations": mutations,
+    })
+
+
+@router.get("/events")
+async def events(request: Request) -> JSONResponse:
+    if not app_main.admin_token_ok(request):
+        return app_main.admin_required_response()
+    since = float(request.query_params.get("since") or 0)
+    return JSONResponse({"events": app_main.events_since(since)})

--- a/deploy/sim_envs/mantis_auth/app/routes/inbox.py
+++ b/deploy/sim_envs/mantis_auth/app/routes/inbox.py
@@ -1,0 +1,62 @@
+"""Mock mailbox — where magic-link + OTP emails land.
+
+Open without a session by design: the email flows require the agent to
+read the message *before* it has authenticated. A single shared dev
+mailbox lists every delivered message newest-first; the message view
+surfaces the magic-link as a real anchor and the OTP code in large type
+so a vision agent can read it.
+"""
+
+from __future__ import annotations
+
+import re
+
+from fastapi import APIRouter, Request
+from fastapi.responses import HTMLResponse, Response
+
+from .. import db, main as app_main
+
+router = APIRouter()
+
+_LINK_RE = re.compile(r"(/auth/magic/verify\?token=[A-Za-z0-9_\-]+)")
+
+
+def _extract_link(body: str) -> str | None:
+    m = _LINK_RE.search(body or "")
+    return m.group(1) if m else None
+
+
+@router.get("/inbox", response_class=HTMLResponse)
+async def inbox(request: Request) -> Response:
+    conn = db.connect()
+    rows = conn.execute(
+        "SELECT id, to_email, subject, kind, created_at, consumed_at "
+        "FROM emails ORDER BY id DESC").fetchall()
+    return app_main.app.state.templates.TemplateResponse(
+        "inbox.html",
+        {"request": request, "config": app_main.app.state.auth_config,
+         "current_user": getattr(request.state, "current_user", None),
+         "messages": [dict(r) for r in rows]},
+    )
+
+
+@router.get("/inbox/{email_id}", response_class=HTMLResponse)
+async def inbox_message(request: Request, email_id: str) -> Response:
+    conn = db.connect()
+    row = conn.execute(
+        "SELECT * FROM emails WHERE id = ?", (email_id,)).fetchone()
+    if row is None:
+        return app_main.app.state.templates.TemplateResponse(
+            "inbox.html",
+            {"request": request, "config": app_main.app.state.auth_config,
+             "current_user": getattr(request.state, "current_user", None),
+             "messages": [], "error": f"no message {email_id}"},
+            status_code=404,
+        )
+    msg = dict(row)
+    return app_main.app.state.templates.TemplateResponse(
+        "inbox_message.html",
+        {"request": request, "config": app_main.app.state.auth_config,
+         "current_user": getattr(request.state, "current_user", None),
+         "msg": msg, "magic_link": _extract_link(msg.get("body", ""))},
+    )

--- a/deploy/sim_envs/mantis_auth/app/seed.py
+++ b/deploy/sim_envs/mantis_auth/app/seed.py
@@ -22,7 +22,6 @@ Calling :func:`seed` again hard-resets every table, so it doubles as the
 
 from __future__ import annotations
 
-import random
 import sqlite3
 from typing import Any
 
@@ -71,7 +70,6 @@ def seed(conn: sqlite3.Connection, *, seed_val: int,
     """Populate ``conn`` deterministically from ``seed_val``."""
     from .authflow import hash_password  # local import avoids cycle at load
 
-    rng = random.Random(seed_val)
     cur = conn.cursor()
 
     for table in ("mutations", "emails", "passkey_credentials",

--- a/deploy/sim_envs/mantis_auth/app/seed.py
+++ b/deploy/sim_envs/mantis_auth/app/seed.py
@@ -1,0 +1,120 @@
+"""Deterministic seed for mantis-auth.
+
+The data model is small on purpose — the env's value is the *auth
+surface*, not the records behind it. We seed a handful of accounts, each
+enrolled in a different mix of methods so every scenario has a concrete
+target:
+
+================  =====================  ===================================
+account           email                  enrolled methods
+================  =====================  ===================================
+user_00001 (Ada)  ada@mantis.example     password, google, github,
+                                         microsoft, okta, passkey  ← canonical
+user_00002 (Gra)  grace@mantis.example   password (admin), google,
+                                         microsoft, passkey
+user_00003 (Ala)  alan@mantis.example    okta only (SSO-only, no password)
+user_00004..6     <name>@mantis.example  password only (filler)
+================  =====================  ===================================
+
+Calling :func:`seed` again hard-resets every table, so it doubles as the
+``/__env__/reset`` implementation.
+"""
+
+from __future__ import annotations
+
+import random
+import sqlite3
+from typing import Any
+
+FAKE_NOW_DEFAULT = "2026-01-15T09:00:00Z"
+
+N_USERS = 6
+PROVIDERS = ("google", "github", "microsoft", "okta")
+
+_FIRST = ["Ada", "Grace", "Alan", "Katherine", "Edsger", "Barbara"]
+_LAST = ["Lovelace", "Hopper", "Turing", "Johnson", "Dijkstra", "Liskov"]
+
+# Fixed credentials for the three named accounts the scenarios target.
+PASSWORDS = {
+    "user_00001": "hunter2",
+    "user_00002": "compiler1",
+    # user_00003 is SSO-only — no password.
+}
+
+# Which providers each user holds an identity with.
+OAUTH_ENROLLMENT = {
+    "user_00001": ("google", "github", "microsoft", "okta"),
+    "user_00002": ("google", "microsoft"),
+    "user_00003": ("okta",),
+    "user_00004": ("github",),
+}
+
+PASSKEY_ENROLLMENT = {
+    "user_00001": "MacBook Touch ID",
+    "user_00002": "YubiKey 5C",
+}
+
+
+def _id(prefix: str, i: int) -> str:
+    return f"{prefix}_{i:05d}"
+
+
+def _email(i: int, first: str, last: str) -> str:
+    named = {1: "ada", 2: "grace", 3: "alan"}
+    if i in named:
+        return f"{named[i]}@mantis.example"
+    return f"{first.lower()}.{last.lower()}@mantis.example"
+
+
+def seed(conn: sqlite3.Connection, *, seed_val: int,
+         fake_now: str = FAKE_NOW_DEFAULT) -> None:
+    """Populate ``conn`` deterministically from ``seed_val``."""
+    from .authflow import hash_password  # local import avoids cycle at load
+
+    rng = random.Random(seed_val)
+    cur = conn.cursor()
+
+    for table in ("mutations", "emails", "passkey_credentials",
+                  "oauth_identities", "users"):
+        cur.execute(f"DELETE FROM {table}")
+
+    users: list[tuple[Any, ...]] = []
+    oauth: list[tuple[Any, ...]] = []
+    passkeys: list[tuple[Any, ...]] = []
+
+    for i in range(1, N_USERS + 1):
+        uid = _id("user", i)
+        first = _FIRST[(i - 1) % len(_FIRST)]
+        last = _LAST[(i - 1) % len(_LAST)]
+        name = f"{first} {last}"
+        email = _email(i, first, last)
+        role = "admin" if i == 2 else "member"
+        pw = PASSWORDS.get(uid)
+        # user_00003 is deliberately password-less (SSO-only); fillers
+        # (4..6) get a deterministic password so they can sign in too.
+        if pw is None and i >= 4:
+            pw = f"pw-{uid}"
+        password_hash = hash_password(pw) if pw else None
+        users.append((uid, name, email, 1, password_hash, role, fake_now))
+
+        for provider in OAUTH_ENROLLMENT.get(uid, ()):  # noqa: PLC0206
+            oauth.append((
+                f"oid_{provider[:2]}_{i:05d}", uid, provider,
+                f"{provider}-oauth2|{uid}", email,
+            ))
+
+        label = PASSKEY_ENROLLMENT.get(uid)
+        if label:
+            passkeys.append((_id("cred", i), uid, label, 0, fake_now))
+
+    cur.executemany(
+        "INSERT INTO users (id, name, email, is_active, password_hash, "
+        "role, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)", users)
+    cur.executemany(
+        "INSERT INTO oauth_identities (id, user_id, provider, subject, email) "
+        "VALUES (?, ?, ?, ?, ?)", oauth)
+    cur.executemany(
+        "INSERT INTO passkey_credentials (id, user_id, label, sign_count, "
+        "created_at) VALUES (?, ?, ?, ?, ?)", passkeys)
+
+    conn.commit()

--- a/deploy/sim_envs/mantis_auth/app/static/auth.css
+++ b/deploy/sim_envs/mantis_auth/app/static/auth.css
@@ -1,0 +1,211 @@
+/* mantis-auth — product + auth-screen styling.
+ *
+ * Covers the landing page, the password/magic/OTP/passkey screens, the
+ * mock inbox, and the post-login console. The OAuth provider screens use
+ * a separate idp.css so each IdP feels like a different origin.
+ */
+:root {
+  --bg: #0f1116;
+  --panel: #181b22;
+  --panel-2: #1f232c;
+  --border: #2a2f3a;
+  --text: #e6e9ef;
+  --muted: #9aa3b2;
+  --accent: #6c8cff;
+  --accent-hover: #5a7bf0;
+  --danger: #ff6b6b;
+  --ok: #46c08a;
+  --radius: 12px;
+  --shadow: 0 10px 30px rgba(0, 0, 0, 0.4);
+}
+
+* { box-sizing: border-box; }
+html, body {
+  margin: 0; padding: 0; min-height: 100%;
+  background:
+    radial-gradient(1200px 600px at 70% -10%, #1b2030 0%, transparent 60%),
+    var(--bg);
+  color: var(--text);
+  font: 15px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+        "Helvetica Neue", Arial, sans-serif;
+}
+a { color: var(--accent); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+/* ── top brand bar (product pages + landing) ───────────────────────── */
+.topbar {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 16px 28px; border-bottom: 1px solid var(--border);
+}
+.brand { display: flex; align-items: center; gap: 10px; font-weight: 600; }
+.brand .logo {
+  width: 28px; height: 28px; border-radius: 8px;
+  display: inline-flex; align-items: center; justify-content: center;
+  background: linear-gradient(135deg, var(--accent), #9b6cff); color: #fff;
+  font-weight: 700;
+}
+.topbar .who { color: var(--muted); font-size: 13px; }
+.topbar .who .email { color: var(--text); }
+.link-button {
+  background: none; border: 0; color: var(--accent); cursor: pointer;
+  font: inherit; padding: 0; margin-left: 10px;
+}
+
+/* ── centered auth shell ───────────────────────────────────────────── */
+.auth-wrap {
+  min-height: 100vh; display: flex; align-items: center; justify-content: center;
+  padding: 40px 16px;
+}
+.auth-card {
+  width: min(420px, 94vw);
+  background: var(--panel); border: 1px solid var(--border);
+  border-radius: var(--radius); box-shadow: var(--shadow);
+  padding: 32px 32px 26px;
+}
+.auth-card h1 { font-size: 22px; margin: 0 0 4px; letter-spacing: -0.2px; }
+.auth-card .sub { color: var(--muted); margin: 0 0 22px; font-size: 14px; }
+
+label { display: block; font-size: 13px; color: var(--muted); margin: 14px 0 6px; }
+input[type=email], input[type=password], input[type=text] {
+  width: 100%; padding: 11px 12px; border-radius: 9px;
+  border: 1px solid var(--border); background: var(--panel-2);
+  color: var(--text); font: inherit;
+}
+input:focus { outline: 2px solid var(--accent); border-color: transparent; }
+
+.btn {
+  display: inline-flex; align-items: center; justify-content: center; gap: 8px;
+  width: 100%; margin-top: 18px; padding: 11px 14px;
+  border: 0; border-radius: 9px; cursor: pointer; font: inherit; font-weight: 600;
+  background: var(--accent); color: #fff;
+}
+.btn:hover { background: var(--accent-hover); }
+.btn-ghost {
+  background: var(--panel-2); color: var(--text);
+  border: 1px solid var(--border); font-weight: 500;
+}
+.btn-ghost:hover { background: #252a34; }
+
+.error {
+  background: rgba(255, 107, 107, 0.12); color: var(--danger);
+  border: 1px solid rgba(255, 107, 107, 0.3);
+  padding: 9px 12px; border-radius: 8px; font-size: 13px; margin-bottom: 14px;
+}
+.notice {
+  background: rgba(70, 192, 138, 0.1); color: var(--ok);
+  border: 1px solid rgba(70, 192, 138, 0.3);
+  padding: 9px 12px; border-radius: 8px; font-size: 13px; margin-bottom: 14px;
+}
+
+.divider {
+  display: flex; align-items: center; gap: 12px;
+  color: var(--muted); font-size: 12px; margin: 20px 0 14px;
+}
+.divider::before, .divider::after {
+  content: ""; flex: 1; height: 1px; background: var(--border);
+}
+
+/* provider + alt-method buttons */
+.provider-list, .method-list { display: grid; gap: 8px; }
+.provider-btn, .method-btn {
+  display: flex; align-items: center; gap: 10px;
+  padding: 10px 12px; border: 1px solid var(--border); border-radius: 9px;
+  background: var(--panel-2); color: var(--text); font: inherit; cursor: pointer;
+  text-align: left; width: 100%;
+}
+.provider-btn:hover, .method-btn:hover { background: #252a34; text-decoration: none; }
+.provider-ico {
+  width: 20px; height: 20px; border-radius: 5px; flex: 0 0 20px;
+  display: inline-flex; align-items: center; justify-content: center;
+  font-size: 12px; font-weight: 700; color: #fff;
+}
+.method-sub { color: var(--muted); font-size: 12px; }
+
+.hint { margin-top: 20px; font-size: 12px; color: var(--muted); }
+.hint code {
+  background: var(--panel-2); padding: 1px 6px; border-radius: 5px;
+  border: 1px solid var(--border);
+}
+details.hint summary { cursor: pointer; }
+
+/* ── split + minimal login layouts ─────────────────────────────────── */
+body.layout-split .auth-wrap { align-items: stretch; padding: 0; }
+body.layout-split .split {
+  display: grid; grid-template-columns: 1fr 1fr; min-height: 100vh; width: 100%;
+}
+body.layout-split .split .hero {
+  display: flex; flex-direction: column; justify-content: center; gap: 16px;
+  padding: 8vw 6vw;
+  background: linear-gradient(135deg, #1a2030, #241a33);
+  border-right: 1px solid var(--border);
+}
+body.layout-split .split .hero h2 { font-size: 34px; margin: 0; line-height: 1.15; }
+body.layout-split .split .hero p { color: var(--muted); margin: 0; max-width: 38ch; }
+body.layout-split .split .pane {
+  display: flex; align-items: center; justify-content: center; padding: 40px 16px;
+}
+body.layout-split .auth-card { border: 0; box-shadow: none; background: transparent; }
+@media (max-width: 820px) {
+  body.layout-split .split { grid-template-columns: 1fr; }
+  body.layout-split .split .hero { display: none; }
+}
+
+body.layout-minimal { background: #0c0e12; }
+body.layout-minimal .auth-card {
+  border: 0; box-shadow: none; background: transparent; padding-top: 8px;
+}
+body.layout-minimal .auth-card h1 { text-align: center; }
+body.layout-minimal .auth-card .sub { text-align: center; }
+
+/* ── inbox ─────────────────────────────────────────────────────────── */
+.page { max-width: 820px; margin: 0 auto; padding: 28px 20px; }
+.page h1 { font-size: 22px; margin: 0 0 4px; }
+.page .sub { color: var(--muted); margin: 0 0 20px; }
+.msg-list { list-style: none; padding: 0; margin: 0; display: grid; gap: 8px; }
+.msg-row {
+  display: flex; align-items: center; gap: 12px;
+  padding: 14px 16px; border: 1px solid var(--border); border-radius: 10px;
+  background: var(--panel);
+}
+.msg-row:hover { background: var(--panel-2); text-decoration: none; }
+.msg-kind {
+  font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px;
+  padding: 2px 8px; border-radius: 999px; border: 1px solid var(--border);
+  color: var(--muted);
+}
+.msg-meta { flex: 1; min-width: 0; }
+.msg-subject { font-weight: 600; }
+.msg-to { color: var(--muted); font-size: 12px; }
+.msg-consumed { color: var(--ok); font-size: 12px; }
+.empty { color: var(--muted); padding: 30px; text-align: center;
+  border: 1px dashed var(--border); border-radius: 10px; }
+
+.msg-body {
+  white-space: pre-wrap; background: var(--panel); border: 1px solid var(--border);
+  border-radius: 10px; padding: 18px; margin-top: 14px; color: var(--text);
+}
+.otp-code {
+  font-size: 40px; letter-spacing: 8px; font-weight: 700; text-align: center;
+  padding: 18px; margin: 14px 0; background: var(--panel); border-radius: 12px;
+  border: 1px solid var(--border);
+}
+
+/* ── console / account ─────────────────────────────────────────────── */
+.cards { display: grid; gap: 14px; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); }
+.card {
+  background: var(--panel); border: 1px solid var(--border);
+  border-radius: 12px; padding: 18px;
+}
+.card h3 { margin: 0 0 10px; font-size: 14px; color: var(--muted); font-weight: 600; }
+.pill {
+  display: inline-block; margin: 3px 4px 0 0; padding: 3px 10px;
+  border-radius: 999px; font-size: 12px;
+  background: var(--panel-2); border: 1px solid var(--border);
+}
+.pill.on { color: var(--ok); border-color: rgba(70,192,138,0.4); }
+.pill.off { color: var(--muted); }
+.welcome { font-size: 26px; margin: 0 0 6px; }
+
+/* ── passkey ───────────────────────────────────────────────────────── */
+.passkey-ico { font-size: 40px; text-align: center; margin: 6px 0 10px; }
+.passkey-list { display: grid; gap: 8px; margin-top: 8px; }

--- a/deploy/sim_envs/mantis_auth/app/static/idp.css
+++ b/deploy/sim_envs/mantis_auth/app/static/idp.css
@@ -1,0 +1,108 @@
+/* OAuth IdP chrome — shared skeleton for the provider authorize/consent
+ * screens. Deliberately light/neutral (not the dark product theme) so
+ * the agent perceives a different origin. Each provider template sets
+ * ``--idp-accent`` inline + adds its own wordmark.
+ */
+:root { --idp-accent: #1a73e8; }
+* { box-sizing: border-box; }
+html, body {
+  margin: 0; padding: 0; min-height: 100%;
+  background: #fff; color: #202124;
+  font: 14px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+        "Helvetica Neue", Arial, sans-serif;
+}
+.idp-shell { display: flex; flex-direction: column; min-height: 100vh; }
+.idp-topbar {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 16px 24px;
+}
+.idp-wordmark { font-size: 20px; font-weight: 600; letter-spacing: 0.2px; }
+.idp-chip {
+  display: inline-flex; align-items: center; gap: 8px; font-size: 13px;
+  color: #5f6368; border: 1px solid #dadce0; border-radius: 999px; padding: 4px 12px;
+}
+.idp-card {
+  margin: 12px auto 24px; width: min(460px, 94vw);
+  background: #fff; border: 1px solid #dadce0; border-radius: 10px;
+  padding: 36px 40px 30px; box-shadow: 0 1px 3px rgba(60,64,67,0.15);
+}
+.idp-card h1 { font-size: 22px; font-weight: 500; margin: 0 0 6px; }
+.idp-sub { color: #5f6368; margin: 0 0 22px; }
+.idp-app { font-weight: 600; color: #202124; }
+.idp-error {
+  background: #fce8e6; color: #c5221f; padding: 10px 12px;
+  border-radius: 6px; margin-bottom: 16px; font-size: 13px;
+}
+
+.idp-account-list { list-style: none; padding: 0; margin: 0 -16px 12px; }
+.idp-account-list li { border-top: 1px solid #eceef1; }
+.idp-account-list li:last-child { border-bottom: 1px solid #eceef1; }
+.idp-account-row {
+  width: 100%; background: none; border: 0; cursor: pointer;
+  display: flex; align-items: center; gap: 14px; padding: 13px 16px;
+  text-align: left; font: inherit; color: inherit;
+}
+.idp-account-row:hover { background: #f6f8fa; }
+.idp-avatar {
+  width: 32px; height: 32px; border-radius: 999px; flex: 0 0 32px;
+  display: inline-flex; align-items: center; justify-content: center;
+  background: var(--idp-accent); color: #fff; font-weight: 600; font-size: 13px;
+}
+.idp-avatar-sm { width: 24px; height: 24px; font-size: 11px; }
+.idp-account-meta { display: flex; flex-direction: column; line-height: 1.3; min-width: 0; }
+.idp-account-name { font-size: 14px; }
+.idp-account-email { font-size: 12px; color: #5f6368; }
+.idp-chevron { margin-left: auto; color: #5f6368; font-size: 18px; }
+
+.idp-account-line {
+  display: inline-flex; align-items: center; gap: 8px; background: #f1f3f4;
+  padding: 6px 12px; border-radius: 999px; margin: 0 0 20px; font-size: 13px;
+}
+.idp-permits { margin: 22px 0 8px; font-weight: 600; }
+.idp-scope-list { list-style: none; padding: 0; margin: 0 0 20px; }
+.idp-scope-list li {
+  display: flex; align-items: center; gap: 12px; padding: 11px 0;
+  border-top: 1px solid #eceef1;
+}
+.idp-scope-list li:last-child { border-bottom: 1px solid #eceef1; }
+.idp-scope-ico {
+  width: 26px; height: 26px; border-radius: 999px; flex: 0 0 26px;
+  display: inline-flex; align-items: center; justify-content: center;
+  background: #f1f3f4; color: #5f6368; font-weight: 600;
+}
+.idp-fineprint { font-size: 11px; color: #5f6368; line-height: 1.6; }
+.idp-fineprint a { color: var(--idp-accent); text-decoration: none; }
+
+.idp-actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 22px; }
+.idp-btn {
+  border: 0; cursor: pointer; font: inherit; font-weight: 600;
+  padding: 10px 22px; border-radius: 6px; font-size: 14px;
+}
+.idp-btn-primary { background: var(--idp-accent); color: #fff; }
+.idp-btn-primary:hover { filter: brightness(0.95); }
+.idp-btn-secondary { background: transparent; color: var(--idp-accent); }
+
+.idp-footer {
+  margin-top: auto; display: flex; justify-content: space-between;
+  padding: 14px 28px; border-top: 1px solid #eceef1;
+  font-size: 12px; color: #5f6368;
+}
+.idp-footer a { color: #5f6368; text-decoration: none; margin-left: 20px; }
+
+/* Provider-specific dark chrome (GitHub) override. */
+body.idp-dark { background: #0d1117; color: #e6edf3; }
+body.idp-dark .idp-card { background: #161b22; border-color: #30363d; box-shadow: none; }
+body.idp-dark .idp-sub, body.idp-dark .idp-account-email,
+body.idp-dark .idp-fineprint, body.idp-dark .idp-footer { color: #8b949e; }
+body.idp-dark .idp-account-row:hover { background: #1c2128; }
+body.idp-dark .idp-account-list li,
+body.idp-dark .idp-scope-list li { border-color: #21262d; }
+body.idp-dark .idp-app { color: #e6edf3; }
+
+.idp-redirect-card { margin: 80px auto; width: min(420px, 94vw); text-align: center; }
+.idp-spinner {
+  display: inline-block; width: 34px; height: 34px; margin-bottom: 14px;
+  border: 3px solid #dadce0; border-top-color: var(--idp-accent);
+  border-radius: 999px; animation: idp-spin 0.8s linear infinite;
+}
+@keyframes idp-spin { to { transform: rotate(360deg); } }

--- a/deploy/sim_envs/mantis_auth/app/templates/account.html
+++ b/deploy/sim_envs/mantis_auth/app/templates/account.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Security — {{ config.app_name }}</title>
+  <link rel="stylesheet" href="/static/auth.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="brand"><span class="logo">M</span> {{ config.app_name }}</div>
+    <div class="who">
+      <span class="email">{{ current_user.email }}</span>
+      <form method="post" action="/logout" style="display:inline">
+        <button class="link-button" type="submit" data-testid="logout">Sign out</button>
+      </form>
+    </div>
+  </header>
+  <main class="page" data-testid="account">
+    <h1>Security</h1>
+    <p class="sub">Sign-in methods enrolled for {{ current_user.email }}.</p>
+    <div class="cards">
+      <div class="card">
+        <h3>Password</h3>
+        <span class="pill {{ 'on' if enrolled.password else 'off' }}"
+              data-testid="sec-password">{{ 'enabled' if enrolled.password else 'not set' }}</span>
+      </div>
+      <div class="card">
+        <h3>Connected providers</h3>
+        {% if enrolled.oauth_providers %}
+          {% for p in enrolled.oauth_providers %}<span class="pill on" data-testid="sec-oauth-{{ p }}">{{ p }}</span>{% endfor %}
+        {% else %}<span class="pill off">none</span>{% endif %}
+      </div>
+      <div class="card">
+        <h3>Passkeys</h3>
+        {% if enrolled.passkeys %}
+          {% for pk in enrolled.passkeys %}<span class="pill on" data-testid="sec-passkey">{{ pk }}</span>{% endfor %}
+        {% else %}<span class="pill off">none</span>{% endif %}
+      </div>
+    </div>
+    <p class="hint"><a href="/console" data-testid="back-console">← Back to console</a></p>
+  </main>
+</body>
+</html>

--- a/deploy/sim_envs/mantis_auth/app/templates/console.html
+++ b/deploy/sim_envs/mantis_auth/app/templates/console.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Console — {{ config.app_name }}</title>
+  <link rel="stylesheet" href="/static/auth.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="brand"><span class="logo">M</span> {{ config.app_name }}</div>
+    <div class="who">
+      <span class="email" data-testid="current-email">{{ current_user.email }}</span>
+      <form method="post" action="/logout" style="display:inline">
+        <button class="link-button" type="submit" data-testid="logout">Sign out</button>
+      </form>
+    </div>
+  </header>
+  <main class="page" data-testid="console">
+    <p class="welcome">Welcome back, {{ current_user.name.split(' ')[0] }} 👋</p>
+    <p class="sub">You're signed in to {{ config.app_name }} as
+       <strong data-testid="console-email">{{ current_user.email }}</strong>
+       ({{ current_user.role }}).</p>
+
+    <div class="cards">
+      <div class="card">
+        <h3>Account</h3>
+        <div>{{ current_user.name }}</div>
+        <div class="msg-to">{{ current_user.email }}</div>
+      </div>
+      <div class="card">
+        <h3>Sign-in methods</h3>
+        <span class="pill {{ 'on' if enrolled.password else 'off' }}">password</span>
+        {% for p in enrolled.oauth_providers %}<span class="pill on">{{ p }}</span>{% endfor %}
+        {% for pk in enrolled.passkeys %}<span class="pill on">passkey: {{ pk }}</span>{% endfor %}
+      </div>
+      <a class="card" href="/account" data-testid="go-account">
+        <h3>Security →</h3>Review enrolled methods.
+      </a>
+    </div>
+  </main>
+</body>
+</html>

--- a/deploy/sim_envs/mantis_auth/app/templates/inbox.html
+++ b/deploy/sim_envs/mantis_auth/app/templates/inbox.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Inbox — {{ config.app_name }}</title>
+  <link rel="stylesheet" href="/static/auth.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="brand"><span class="logo">M</span> Mailbox</div>
+    <div class="who"><a href="/login">Back to sign in</a></div>
+  </header>
+  <main class="page" data-testid="inbox">
+    <h1>Inbox</h1>
+    <p class="sub">Mock mailbox — magic links and one-time codes arrive here.</p>
+    {% if error %}<div class="error">{{ error }}</div>{% endif %}
+    {% if messages %}
+    <ul class="msg-list">
+      {% for m in messages %}
+      <a class="msg-row" href="/inbox/{{ m.id }}" data-testid="msg-{{ loop.index }}">
+        <span class="msg-kind">{{ m.kind.replace('_',' ') }}</span>
+        <span class="msg-meta">
+          <div class="msg-subject">{{ m.subject }}</div>
+          <div class="msg-to">to {{ m.to_email }} · {{ m.created_at }}</div>
+        </span>
+        {% if m.consumed_at %}<span class="msg-consumed">✓ used</span>{% endif %}
+      </a>
+      {% endfor %}
+    </ul>
+    {% else %}
+    <div class="empty" data-testid="inbox-empty">No messages yet. Request a magic
+       link or a one-time code, then refresh.</div>
+    {% endif %}
+  </main>
+</body>
+</html>

--- a/deploy/sim_envs/mantis_auth/app/templates/inbox_message.html
+++ b/deploy/sim_envs/mantis_auth/app/templates/inbox_message.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>{{ msg.subject }} — Inbox</title>
+  <link rel="stylesheet" href="/static/auth.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="brand"><span class="logo">M</span> Mailbox</div>
+    <div class="who"><a href="/inbox" data-testid="back-to-inbox">← Inbox</a></div>
+  </header>
+  <main class="page" data-testid="message">
+    <h1>{{ msg.subject }}</h1>
+    <p class="sub">to {{ msg.to_email }} · {{ msg.created_at }}
+       {% if msg.consumed_at %}· <span class="msg-consumed">already used</span>{% endif %}</p>
+
+    {% if msg.kind == 'otp' and msg.code %}
+      <div class="otp-code" data-testid="otp-value">{{ msg.code }}</div>
+      <a class="btn" href="/auth/otp" data-testid="go-enter-code">Enter this code →</a>
+    {% endif %}
+
+    {% if magic_link %}
+      <a class="btn" href="{{ magic_link }}" data-testid="magic-link">Sign in via this link</a>
+    {% endif %}
+
+    <div class="msg-body" data-testid="message-body">{{ msg.body }}</div>
+  </main>
+</body>
+</html>

--- a/deploy/sim_envs/mantis_auth/app/templates/landing.html
+++ b/deploy/sim_envs/mantis_auth/app/templates/landing.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>{{ config.app_name }}</title>
+  <link rel="stylesheet" href="/static/auth.css" />
+</head>
+<body>
+  <header class="topbar" data-testid="topbar">
+    <div class="brand"><span class="logo">M</span> {{ config.app_name }}</div>
+    <div class="who">
+      {% if current_user %}
+        <span class="email" data-testid="current-email">{{ current_user.email }}</span>
+        <form method="post" action="/logout" style="display:inline">
+          <button class="link-button" type="submit" data-testid="logout">Sign out</button>
+        </form>
+      {% else %}
+        <a href="/login" data-testid="nav-login">Sign in</a>
+      {% endif %}
+    </div>
+  </header>
+
+  <main class="page" data-testid="landing">
+    <h1>Welcome to {{ config.app_name }}</h1>
+    <p class="sub">A simulated product behind a multi-method auth wall.
+       Pick any way in.</p>
+
+    <div class="cards">
+      <a class="card" href="/login" data-testid="card-password">
+        <h3>Password</h3>Email &amp; password sign-in (3 screen layouts).
+      </a>
+      <a class="card" href="/login#oauth" data-testid="card-oauth">
+        <h3>OAuth / SSO</h3>Google, GitHub, Microsoft &amp; Okta.
+      </a>
+      <a class="card" href="/auth/magic" data-testid="card-magic">
+        <h3>Magic link</h3>Emailed sign-in link via the inbox.
+      </a>
+      <a class="card" href="/auth/otp" data-testid="card-otp">
+        <h3>Email OTP</h3>One-time 6-digit code via the inbox.
+      </a>
+      <a class="card" href="/auth/passkey" data-testid="card-passkey">
+        <h3>Passkey</h3>Simulated WebAuthn assertion.
+      </a>
+      <a class="card" href="/console" data-testid="card-console">
+        <h3>The product →</h3>The console you reach once signed in.
+      </a>
+    </div>
+  </main>
+</body>
+</html>

--- a/deploy/sim_envs/mantis_auth/app/templates/login.html
+++ b/deploy/sim_envs/mantis_auth/app/templates/login.html
@@ -1,0 +1,92 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Sign in — {{ config.app_name }}</title>
+  <link rel="stylesheet" href="/static/auth.css" />
+</head>
+<body class="layout-{{ layout }}">
+
+{# Reusable sign-in card, rendered inside whichever layout shell. #}
+{% macro signin_card() %}
+<div class="auth-card" data-testid="login-card">
+  <h1>Sign in</h1>
+  <p class="sub">to continue to {{ config.app_name }}</p>
+
+  {% if error %}
+    <div class="error" data-testid="login-error">{{ error }}</div>
+  {% endif %}
+  {% if current_user %}
+    <div class="notice" data-testid="already-logged-in">
+      Already signed in as <strong>{{ current_user.email }}</strong>.
+    </div>
+  {% endif %}
+
+  {% if config.method_enabled('password') %}
+  <form method="post" action="/login" class="login-form" data-testid="login-form">
+    <input type="hidden" name="next" value="{{ next }}"/>
+    <label for="email">Email</label>
+    <input id="email" type="email" name="email" required autocomplete="email"
+           placeholder="ada@mantis.example" data-testid="login-email"/>
+    <label for="password">Password</label>
+    <input id="password" type="password" name="password" required
+           autocomplete="current-password" data-testid="login-password"/>
+    <button class="btn" type="submit" data-testid="login-submit">Sign in</button>
+  </form>
+  {% endif %}
+
+  {% if config.enabled_providers and config.method_enabled('oauth') %}
+  <div class="divider" id="oauth">or continue with</div>
+  <div class="provider-list" data-testid="provider-list">
+    {% for p in providers %}
+      <a class="provider-btn" data-testid="oauth-{{ p.slug }}"
+         href="/auth/oauth/{{ p.slug }}/authorize?state=login">
+        <span class="provider-ico" style="background:{{ p.accent }}">{{ p.display_name[0] }}</span>
+        Continue with {{ p.display_name }}
+      </a>
+    {% endfor %}
+  </div>
+  {% endif %}
+
+  {% set alts = [] %}
+  {% if config.method_enabled('magic_link') %}{% set _ = alts.append(('/auth/magic', 'Email me a magic link', 'magic')) %}{% endif %}
+  {% if config.method_enabled('email_otp') %}{% set _ = alts.append(('/auth/otp', 'Email me a one-time code', 'otp')) %}{% endif %}
+  {% if config.method_enabled('passkey') %}{% set _ = alts.append(('/auth/passkey', 'Use a passkey', 'passkey')) %}{% endif %}
+  {% if alts %}
+  <div class="divider">other ways</div>
+  <div class="method-list" data-testid="method-list">
+    {% for href, label, key in alts %}
+      <a class="method-btn" href="{{ href }}" data-testid="method-{{ key }}">{{ label }}</a>
+    {% endfor %}
+  </div>
+  {% endif %}
+
+  <details class="hint">
+    <summary>Demo credentials</summary>
+    <ul>
+      <li><code>ada@mantis.example</code> / <code>hunter2</code> — enrolled in every method</li>
+      <li><code>grace@mantis.example</code> / <code>compiler1</code> — admin</li>
+    </ul>
+  </details>
+</div>
+{% endmacro %}
+
+{% if layout == 'split' %}
+  <div class="auth-wrap">
+    <div class="split">
+      <section class="hero" data-testid="login-hero">
+        <div class="brand"><span class="logo">M</span> {{ config.app_name }}</div>
+        <h2>Every door, one console.</h2>
+        <p>Password, SSO, magic link, OTP, or passkey — this environment
+           exercises them all. Sign in on the right.</p>
+      </section>
+      <div class="pane">{{ signin_card() }}</div>
+    </div>
+  </div>
+{% else %}
+  <div class="auth-wrap">{{ signin_card() }}</div>
+{% endif %}
+
+</body>
+</html>

--- a/deploy/sim_envs/mantis_auth/app/templates/magic_request.html
+++ b/deploy/sim_envs/mantis_auth/app/templates/magic_request.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Magic link — {{ config.app_name }}</title>
+  <link rel="stylesheet" href="/static/auth.css" />
+</head>
+<body class="layout-centered">
+  <div class="auth-wrap">
+    <div class="auth-card" data-testid="magic-card">
+      <h1>Email a sign-in link</h1>
+      <p class="sub">We'll send a one-time link to your inbox.</p>
+      {% if error %}<div class="error" data-testid="magic-error">{{ error }}</div>{% endif %}
+      <form method="post" action="/auth/magic" data-testid="magic-form">
+        <label for="email">Email</label>
+        <input id="email" type="email" name="email" required autocomplete="email"
+               placeholder="ada@mantis.example" data-testid="magic-email"/>
+        <button class="btn" type="submit" data-testid="magic-submit">Send link</button>
+      </form>
+      <p class="hint"><a href="/login" data-testid="back-to-login">← Back to all sign-in options</a></p>
+    </div>
+  </div>
+</body>
+</html>

--- a/deploy/sim_envs/mantis_auth/app/templates/magic_sent.html
+++ b/deploy/sim_envs/mantis_auth/app/templates/magic_sent.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Check your inbox — {{ config.app_name }}</title>
+  <link rel="stylesheet" href="/static/auth.css" />
+</head>
+<body class="layout-centered">
+  <div class="auth-wrap">
+    <div class="auth-card" data-testid="magic-sent-card">
+      <h1>Check your inbox</h1>
+      <p class="sub">If <strong>{{ email }}</strong> has an account, a sign-in
+         link is on its way.</p>
+      <a class="btn" href="/inbox" data-testid="open-inbox">Open inbox</a>
+      <p class="hint">The link lands in the mock mailbox at
+         <code>/inbox</code>. Open it and click the link to finish signing in.</p>
+      <p class="hint"><a href="/login">← Back to all sign-in options</a></p>
+    </div>
+  </div>
+</body>
+</html>

--- a/deploy/sim_envs/mantis_auth/app/templates/oauth_github.html
+++ b/deploy/sim_envs/mantis_auth/app/templates/oauth_github.html
@@ -1,0 +1,75 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Sign in to GitHub</title>
+  <link rel="stylesheet" href="/static/idp.css" />
+  <style>:root { --idp-accent: {{ provider.accent }}; }</style>
+</head>
+<body class="idp idp-dark">
+<div class="idp-shell" data-testid="oauth-github-{{ stage }}">
+  <header class="idp-topbar">
+    <div class="idp-wordmark">&#9670; GitHub</div>
+    {% if stage == 'consent' %}
+      <div class="idp-chip"><span class="idp-avatar idp-avatar-sm">{{ account.email[0]|upper }}</span>{{ account.email }}</div>
+    {% endif %}
+  </header>
+
+  <main class="idp-card">
+    {% if stage == 'picker' %}
+      <h1>Authorize {{ config.app_name }}</h1>
+      <p class="idp-sub">Choose which account to authorize.</p>
+      {% if error %}<div class="idp-error" data-testid="oauth-error">{{ error }}</div>{% endif %}
+      <ul class="idp-account-list" data-testid="oauth-account-list">
+        {% for a in accounts %}
+        <li>
+          <form method="post" action="/auth/oauth/{{ provider.slug }}/consent">
+            <input type="hidden" name="subject" value="{{ a.subject }}"/>
+            <input type="hidden" name="redirect_uri" value="{{ redirect_uri }}"/>
+            <input type="hidden" name="state" value="{{ state }}"/>
+            <button class="idp-account-row" type="submit" data-testid="oauth-account-{{ loop.index }}">
+              <span class="idp-avatar">{{ a.email[0]|upper }}</span>
+              <span class="idp-account-meta">
+                <span class="idp-account-name">{{ a.name }}</span>
+                <span class="idp-account-email">{{ a.email }}</span>
+              </span>
+              <span class="idp-chevron">›</span>
+            </button>
+          </form>
+        </li>
+        {% endfor %}
+      </ul>
+    {% else %}
+      <h1>Authorize {{ config.app_name }}</h1>
+      <div class="idp-account-line"><span class="idp-avatar idp-avatar-sm">{{ account.email[0]|upper }}</span>{{ account.email }}</div>
+      <p class="idp-permits">{{ config.app_name }} is requesting access to:</p>
+      <ul class="idp-scope-list">
+        {% for s in provider.scopes %}
+          <li><span class="idp-scope-ico">✓</span><span>{{ s }}</span></li>
+        {% endfor %}
+      </ul>
+      <p class="idp-fineprint">Authorizing will redirect to {{ config.app_name }}.
+         You can revoke access in your GitHub settings.</p>
+      <div class="idp-actions">
+        <form method="get" action="/auth/oauth/{{ provider.slug }}/authorize">
+          <input type="hidden" name="state" value="{{ state }}"/>
+          <button class="idp-btn idp-btn-secondary" type="submit" data-testid="oauth-cancel">Cancel</button>
+        </form>
+        <form method="post" action="/auth/oauth/{{ provider.slug }}/grant">
+          <input type="hidden" name="subject" value="{{ subject }}"/>
+          <input type="hidden" name="redirect_uri" value="{{ redirect_uri }}"/>
+          <input type="hidden" name="state" value="{{ state }}"/>
+          <button class="idp-btn idp-btn-primary" type="submit" data-testid="oauth-allow">Authorize</button>
+        </form>
+      </div>
+    {% endif %}
+  </main>
+
+  <footer class="idp-footer">
+    <span>&copy; GitHub, Inc.</span>
+    <span><a href="#">Terms</a><a href="#">Privacy</a><a href="#">Docs</a></span>
+  </footer>
+</div>
+</body>
+</html>

--- a/deploy/sim_envs/mantis_auth/app/templates/oauth_google.html
+++ b/deploy/sim_envs/mantis_auth/app/templates/oauth_google.html
@@ -1,0 +1,77 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Sign in - Google Accounts</title>
+  <link rel="stylesheet" href="/static/idp.css" />
+  <style>:root { --idp-accent: {{ provider.accent }}; }</style>
+</head>
+<body class="idp">
+<div class="idp-shell" data-testid="oauth-google-{{ stage }}">
+  <header class="idp-topbar">
+    <div class="idp-wordmark">
+      <span style="color:#4285f4">G</span><span style="color:#ea4335">o</span><span style="color:#fbbc05">o</span><span style="color:#4285f4">g</span><span style="color:#34a853">l</span><span style="color:#ea4335">e</span>
+    </div>
+    {% if stage == 'consent' %}
+      <div class="idp-chip"><span class="idp-avatar idp-avatar-sm">{{ account.email[0]|upper }}</span>{{ account.email }}</div>
+    {% else %}<a class="idp-chip" href="#">Help</a>{% endif %}
+  </header>
+
+  <main class="idp-card">
+    {% if stage == 'picker' %}
+      <h1>Choose an account</h1>
+      <p class="idp-sub">to continue to <span class="idp-app">{{ config.app_name }}</span></p>
+      {% if error %}<div class="idp-error" data-testid="oauth-error">{{ error }}</div>{% endif %}
+      <ul class="idp-account-list" data-testid="oauth-account-list">
+        {% for a in accounts %}
+        <li>
+          <form method="post" action="/auth/oauth/{{ provider.slug }}/consent">
+            <input type="hidden" name="subject" value="{{ a.subject }}"/>
+            <input type="hidden" name="redirect_uri" value="{{ redirect_uri }}"/>
+            <input type="hidden" name="state" value="{{ state }}"/>
+            <button class="idp-account-row" type="submit" data-testid="oauth-account-{{ loop.index }}">
+              <span class="idp-avatar">{{ a.email[0]|upper }}</span>
+              <span class="idp-account-meta">
+                <span class="idp-account-name">{{ a.name }}</span>
+                <span class="idp-account-email">{{ a.email }}</span>
+              </span>
+              <span class="idp-chevron">›</span>
+            </button>
+          </form>
+        </li>
+        {% endfor %}
+      </ul>
+    {% else %}
+      <h1>{{ config.app_name }} wants to access your Google Account</h1>
+      <div class="idp-account-line"><span class="idp-avatar idp-avatar-sm">{{ account.email[0]|upper }}</span>{{ account.email }}</div>
+      <p class="idp-permits">This will allow {{ config.app_name }} to:</p>
+      <ul class="idp-scope-list">
+        {% for s in provider.scopes %}
+          <li><span class="idp-scope-ico">✓</span><span>{{ s }}</span></li>
+        {% endfor %}
+      </ul>
+      <p class="idp-fineprint">Make sure you trust {{ config.app_name }}. You can
+         remove access anytime in your <a href="#">Google Account</a>.</p>
+      <div class="idp-actions">
+        <form method="get" action="/auth/oauth/{{ provider.slug }}/authorize">
+          <input type="hidden" name="state" value="{{ state }}"/>
+          <button class="idp-btn idp-btn-secondary" type="submit" data-testid="oauth-cancel">Cancel</button>
+        </form>
+        <form method="post" action="/auth/oauth/{{ provider.slug }}/grant">
+          <input type="hidden" name="subject" value="{{ subject }}"/>
+          <input type="hidden" name="redirect_uri" value="{{ redirect_uri }}"/>
+          <input type="hidden" name="state" value="{{ state }}"/>
+          <button class="idp-btn idp-btn-primary" type="submit" data-testid="oauth-allow">Allow</button>
+        </form>
+      </div>
+    {% endif %}
+  </main>
+
+  <footer class="idp-footer">
+    <span>English (United States)</span>
+    <span><a href="#">Help</a><a href="#">Privacy</a><a href="#">Terms</a></span>
+  </footer>
+</div>
+</body>
+</html>

--- a/deploy/sim_envs/mantis_auth/app/templates/oauth_microsoft.html
+++ b/deploy/sim_envs/mantis_auth/app/templates/oauth_microsoft.html
@@ -1,0 +1,81 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Sign in to your account</title>
+  <link rel="stylesheet" href="/static/idp.css" />
+  <style>
+    :root { --idp-accent: {{ provider.accent }}; }
+    .ms-logo span { display:inline-block; width:9px; height:9px; }
+  </style>
+</head>
+<body class="idp">
+<div class="idp-shell" data-testid="oauth-microsoft-{{ stage }}">
+  <header class="idp-topbar">
+    <div class="idp-wordmark ms-logo">
+      <span style="background:#f25022"></span><span style="background:#7fba00"></span><span style="background:#00a4ef"></span><span style="background:#ffb900"></span>
+      &nbsp;Microsoft
+    </div>
+    {% if stage == 'consent' %}
+      <div class="idp-chip"><span class="idp-avatar idp-avatar-sm">{{ account.email[0]|upper }}</span>{{ account.email }}</div>
+    {% endif %}
+  </header>
+
+  <main class="idp-card">
+    {% if stage == 'picker' %}
+      <h1>Pick an account</h1>
+      <p class="idp-sub">to sign in to <span class="idp-app">{{ config.app_name }}</span></p>
+      {% if error %}<div class="idp-error" data-testid="oauth-error">{{ error }}</div>{% endif %}
+      <ul class="idp-account-list" data-testid="oauth-account-list">
+        {% for a in accounts %}
+        <li>
+          <form method="post" action="/auth/oauth/{{ provider.slug }}/consent">
+            <input type="hidden" name="subject" value="{{ a.subject }}"/>
+            <input type="hidden" name="redirect_uri" value="{{ redirect_uri }}"/>
+            <input type="hidden" name="state" value="{{ state }}"/>
+            <button class="idp-account-row" type="submit" data-testid="oauth-account-{{ loop.index }}">
+              <span class="idp-avatar">{{ a.email[0]|upper }}</span>
+              <span class="idp-account-meta">
+                <span class="idp-account-name">{{ a.name }}</span>
+                <span class="idp-account-email">{{ a.email }}</span>
+              </span>
+              <span class="idp-chevron">›</span>
+            </button>
+          </form>
+        </li>
+        {% endfor %}
+      </ul>
+    {% else %}
+      <h1>Permissions requested</h1>
+      <div class="idp-account-line"><span class="idp-avatar idp-avatar-sm">{{ account.email[0]|upper }}</span>{{ account.email }}</div>
+      <p class="idp-permits"><span class="idp-app">{{ config.app_name }}</span> needs your permission to:</p>
+      <ul class="idp-scope-list">
+        {% for s in provider.scopes %}
+          <li><span class="idp-scope-ico">✓</span><span>{{ s }}</span></li>
+        {% endfor %}
+      </ul>
+      <p class="idp-fineprint">Accepting these permissions means you allow this app
+         to use your data per their terms and privacy statement.</p>
+      <div class="idp-actions">
+        <form method="get" action="/auth/oauth/{{ provider.slug }}/authorize">
+          <input type="hidden" name="state" value="{{ state }}"/>
+          <button class="idp-btn idp-btn-secondary" type="submit" data-testid="oauth-cancel">No</button>
+        </form>
+        <form method="post" action="/auth/oauth/{{ provider.slug }}/grant">
+          <input type="hidden" name="subject" value="{{ subject }}"/>
+          <input type="hidden" name="redirect_uri" value="{{ redirect_uri }}"/>
+          <input type="hidden" name="state" value="{{ state }}"/>
+          <button class="idp-btn idp-btn-primary" type="submit" data-testid="oauth-allow">Accept</button>
+        </form>
+      </div>
+    {% endif %}
+  </main>
+
+  <footer class="idp-footer">
+    <span></span>
+    <span><a href="#">Terms of use</a><a href="#">Privacy &amp; cookies</a></span>
+  </footer>
+</div>
+</body>
+</html>

--- a/deploy/sim_envs/mantis_auth/app/templates/oauth_okta.html
+++ b/deploy/sim_envs/mantis_auth/app/templates/oauth_okta.html
@@ -1,0 +1,75 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Sign in with Okta</title>
+  <link rel="stylesheet" href="/static/idp.css" />
+  <style>:root { --idp-accent: {{ provider.accent }}; }</style>
+</head>
+<body class="idp">
+<div class="idp-shell" data-testid="oauth-okta-{{ stage }}">
+  <header class="idp-topbar">
+    <div class="idp-wordmark" style="color:{{ provider.accent }}; font-weight:800;">okta</div>
+    {% if stage == 'consent' %}
+      <div class="idp-chip"><span class="idp-avatar idp-avatar-sm">{{ account.email[0]|upper }}</span>{{ account.email }}</div>
+    {% endif %}
+  </header>
+
+  <main class="idp-card">
+    {% if stage == 'picker' %}
+      <h1>Sign in</h1>
+      <p class="idp-sub"><span class="idp-app">mantis.okta.com</span> — continue to {{ config.app_name }}</p>
+      {% if error %}<div class="idp-error" data-testid="oauth-error">{{ error }}</div>{% endif %}
+      <ul class="idp-account-list" data-testid="oauth-account-list">
+        {% for a in accounts %}
+        <li>
+          <form method="post" action="/auth/oauth/{{ provider.slug }}/consent">
+            <input type="hidden" name="subject" value="{{ a.subject }}"/>
+            <input type="hidden" name="redirect_uri" value="{{ redirect_uri }}"/>
+            <input type="hidden" name="state" value="{{ state }}"/>
+            <button class="idp-account-row" type="submit" data-testid="oauth-account-{{ loop.index }}">
+              <span class="idp-avatar">{{ a.email[0]|upper }}</span>
+              <span class="idp-account-meta">
+                <span class="idp-account-name">{{ a.name }}</span>
+                <span class="idp-account-email">{{ a.email }}</span>
+              </span>
+              <span class="idp-chevron">›</span>
+            </button>
+          </form>
+        </li>
+        {% endfor %}
+      </ul>
+    {% else %}
+      <h1>Grant access</h1>
+      <div class="idp-account-line"><span class="idp-avatar idp-avatar-sm">{{ account.email[0]|upper }}</span>{{ account.email }}</div>
+      <p class="idp-permits">{{ config.app_name }} is requesting access to:</p>
+      <ul class="idp-scope-list">
+        {% for s in provider.scopes %}
+          <li><span class="idp-scope-ico">✓</span><span>{{ s }}</span></li>
+        {% endfor %}
+      </ul>
+      <p class="idp-fineprint">By granting access you allow {{ config.app_name }} to
+         act on the listed scopes for your Okta identity.</p>
+      <div class="idp-actions">
+        <form method="get" action="/auth/oauth/{{ provider.slug }}/authorize">
+          <input type="hidden" name="state" value="{{ state }}"/>
+          <button class="idp-btn idp-btn-secondary" type="submit" data-testid="oauth-cancel">Deny</button>
+        </form>
+        <form method="post" action="/auth/oauth/{{ provider.slug }}/grant">
+          <input type="hidden" name="subject" value="{{ subject }}"/>
+          <input type="hidden" name="redirect_uri" value="{{ redirect_uri }}"/>
+          <input type="hidden" name="state" value="{{ state }}"/>
+          <button class="idp-btn idp-btn-primary" type="submit" data-testid="oauth-allow">Allow</button>
+        </form>
+      </div>
+    {% endif %}
+  </main>
+
+  <footer class="idp-footer">
+    <span>Powered by Okta</span>
+    <span><a href="#">Privacy</a></span>
+  </footer>
+</div>
+</body>
+</html>

--- a/deploy/sim_envs/mantis_auth/app/templates/oauth_redirect.html
+++ b/deploy/sim_envs/mantis_auth/app/templates/oauth_redirect.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Redirecting…</title>
+  <link rel="stylesheet" href="/static/idp.css" />
+  <style>:root { --idp-accent: {{ provider.accent }}; }</style>
+  <meta http-equiv="refresh" content="1;url={{ target }}" />
+</head>
+<body class="idp">
+<div class="idp-shell">
+  <main class="idp-card idp-redirect-card" data-testid="oauth-redirect-card">
+    <div class="idp-spinner" aria-hidden="true"></div>
+    <h1 style="font-size:18px">Redirecting back to {{ config.app_name }}…</h1>
+    <p class="idp-fineprint" style="margin-top:12px">
+      If you're not redirected automatically,
+      <a href="{{ target }}" data-testid="oauth-redirect-link">click here</a>.
+    </p>
+  </main>
+</div>
+</body>
+</html>

--- a/deploy/sim_envs/mantis_auth/app/templates/otp_request.html
+++ b/deploy/sim_envs/mantis_auth/app/templates/otp_request.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>One-time code — {{ config.app_name }}</title>
+  <link rel="stylesheet" href="/static/auth.css" />
+</head>
+<body class="layout-centered">
+  <div class="auth-wrap">
+    <div class="auth-card" data-testid="otp-card">
+      <h1>Email a one-time code</h1>
+      <p class="sub">We'll send a 6-digit code to your inbox.</p>
+      {% if error %}<div class="error" data-testid="otp-error">{{ error }}</div>{% endif %}
+      <form method="post" action="/auth/otp" data-testid="otp-request-form">
+        <label for="email">Email</label>
+        <input id="email" type="email" name="email" required autocomplete="email"
+               placeholder="ada@mantis.example" data-testid="otp-email"/>
+        <button class="btn" type="submit" data-testid="otp-send">Send code</button>
+      </form>
+      <p class="hint"><a href="/login">← Back to all sign-in options</a></p>
+    </div>
+  </div>
+</body>
+</html>

--- a/deploy/sim_envs/mantis_auth/app/templates/otp_verify.html
+++ b/deploy/sim_envs/mantis_auth/app/templates/otp_verify.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Enter your code — {{ config.app_name }}</title>
+  <link rel="stylesheet" href="/static/auth.css" />
+</head>
+<body class="layout-centered">
+  <div class="auth-wrap">
+    <div class="auth-card" data-testid="otp-verify-card">
+      <h1>Enter your code</h1>
+      <p class="sub">We sent a 6-digit code to <strong>{{ email }}</strong>.
+         Read it in your <a href="/inbox" data-testid="open-inbox">inbox</a>.</p>
+      {% if error %}<div class="error" data-testid="otp-verify-error">{{ error }}</div>{% endif %}
+      <form method="post" action="/auth/otp/verify" data-testid="otp-verify-form">
+        <input type="hidden" name="email" value="{{ email }}"/>
+        <label for="code">6-digit code</label>
+        <input id="code" type="text" name="code" required inputmode="numeric"
+               pattern="[0-9]*" maxlength="6" autocomplete="one-time-code"
+               placeholder="000000" data-testid="otp-code"/>
+        <button class="btn" type="submit" data-testid="otp-verify">Verify &amp; sign in</button>
+      </form>
+      <p class="hint"><a href="/auth/otp">← Use a different email</a></p>
+    </div>
+  </div>
+</body>
+</html>

--- a/deploy/sim_envs/mantis_auth/app/templates/passkey.html
+++ b/deploy/sim_envs/mantis_auth/app/templates/passkey.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Passkey — {{ config.app_name }}</title>
+  <link rel="stylesheet" href="/static/auth.css" />
+</head>
+<body class="layout-centered">
+  <div class="auth-wrap">
+    <div class="auth-card" data-testid="passkey-card">
+      <div class="passkey-ico" aria-hidden="true">🔑</div>
+      <h1>Sign in with a passkey</h1>
+      <p class="sub">Use a passkey registered on this device. This simulates a
+         WebAuthn assertion — selecting one signs you in.</p>
+      {% if error %}<div class="error" data-testid="passkey-error">{{ error }}</div>{% endif %}
+
+      {% if passkeys %}
+      <div class="passkey-list" data-testid="passkey-list">
+        {% for pk in passkeys %}
+        <form method="post" action="/auth/passkey/assert"
+              data-testid="passkey-form-{{ loop.index }}">
+          <input type="hidden" name="cred_id" value="{{ pk.cred_id }}"/>
+          <input type="hidden" name="challenge" value="{{ challenge }}"/>
+          <button class="provider-btn" type="submit"
+                  data-testid="passkey-{{ loop.index }}">
+            <span class="provider-ico" style="background:var(--accent)">🔑</span>
+            <span>
+              <div>{{ pk.label }}</div>
+              <div class="method-sub">{{ pk.email }}</div>
+            </span>
+          </button>
+        </form>
+        {% endfor %}
+      </div>
+      {% else %}
+        <div class="empty" data-testid="passkey-empty">No passkeys registered.</div>
+      {% endif %}
+
+      <p class="hint"><a href="/login" data-testid="back-to-login">← Back to all sign-in options</a></p>
+    </div>
+  </div>
+
+  <script>
+    // Progressive enhancement: a real deployment would call
+    // navigator.credentials.get() here and submit the assertion. In this
+    // simulated env the form POST IS the assertion, so we leave the
+    // buttons as plain submits for agent + test robustness.
+  </script>
+</body>
+</html>

--- a/deploy/sim_envs/mantis_auth/requirements.txt
+++ b/deploy/sim_envs/mantis_auth/requirements.txt
@@ -1,0 +1,5 @@
+fastapi>=0.110
+uvicorn>=0.27
+jinja2>=3.1
+python-multipart>=0.0.9
+starlette>=0.27,<1.0

--- a/deploy/sim_envs/modal_mantis_auth.py
+++ b/deploy/sim_envs/modal_mantis_auth.py
@@ -1,0 +1,54 @@
+"""Modal deploy for mantis-auth.
+
+Builds a Modal image from ``deploy/sim_envs/mantis_auth/`` and exposes
+the FastAPI app under ``mantis-sim-env-mantis-auth`` so the harness modal
+backend resolves it.
+
+## Deploy
+
+    modal secret create mantis-sim-env-mantis-auth-secrets \\
+        ENV_ADMIN_TOKEN=$(python -c 'import secrets;print(secrets.token_urlsafe(32))') \\
+        AUTH_SESSION_SECRET=$(python -c 'import secrets;print(secrets.token_urlsafe(32))')
+
+    uv run modal deploy deploy/sim_envs/modal_mantis_auth.py
+
+That gives you ``mantis-sim-env-mantis-auth`` whose ``web`` function is
+reachable by the harness ModalBackend:
+
+    uv run mantis plan run examples/sim_envs/mantis_auth/T01_password_login.json \\
+        --env mantis-auth --runtime modal --endpoint <BRAIN_URL>
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import modal
+
+APP_NAME = "mantis-sim-env-mantis-auth"
+
+SRC_DIR = Path(__file__).parent / "mantis_auth"
+
+image = modal.Image.from_dockerfile(
+    str(SRC_DIR / "Dockerfile"), context_dir=str(SRC_DIR))
+
+secret = modal.Secret.from_name(
+    "mantis-sim-env-mantis-auth-secrets",
+    required_keys=["ENV_ADMIN_TOKEN"],
+)
+
+app = modal.App(APP_NAME)
+
+
+@app.function(
+    image=image,
+    secrets=[secret],
+    min_containers=0,
+    max_containers=8,
+    timeout=600,
+)
+@modal.asgi_app()
+def web():
+    from app.main import app as fastapi_app  # type: ignore[import-not-found]
+
+    return fastapi_app

--- a/docs/envs/HARNESS.md
+++ b/docs/envs/HARNESS.md
@@ -193,6 +193,51 @@ region locks, coupon stacking, ZIP validation) are all enforced in
 FastAPI handlers — the agent cannot bypass them via JS-only checks
 or DOM manipulation.
 
+## mantis-auth (multi-method authentication wall)
+
+**mantis-auth** is a focused env whose whole surface is *getting in*: a
+minimal SaaS console ("Mantis Console") behind an auth wall that exercises
+every common sign-in method. One deployable artifact, eight graded
+scenarios:
+
+| Task | Method |
+|------|--------|
+| `T01_password_login` | email + password |
+| `T02_oauth_google` / `T03_oauth_github` / `T04_oauth_microsoft` / `T05_oauth_okta` | OAuth, one per provider (each with its own IdP chrome) |
+| `T06_magic_link_email` | emailed magic link (read it in the mock `/inbox`) |
+| `T07_email_otp` | emailed 6-digit code (read it in `/inbox`) |
+| `T08_passkey` | simulated WebAuthn passkey assertion |
+
+The password screen ships three swappable layouts (`AUTH_LAYOUT=centered`
+| `split` | `minimal`, or `?layout=` per request). The canonical demo
+account `ada@mantis.example` is enrolled in every method.
+
+Each oracle grades on the audit log the flow writes: a terminal
+`login_succeeded` row tagged with `via` (+ `provider` for OAuth), plus a
+proof-of-ceremony check for the email/passkey flows (token consumed, code
+verified, passkey asserted) so a session minted by any other means still
+fails.
+
+```bash
+# Local Docker
+docker build -t mantis/sim-env-mantis-auth:latest deploy/sim_envs/mantis_auth
+uv run mantis plan run examples/sim_envs/mantis_auth/T01_password_login.json \
+    --env mantis-auth --runtime local --endpoint <BRAIN_URL>
+
+# Modal
+modal secret create mantis-sim-env-mantis-auth-secrets \
+    ENV_ADMIN_TOKEN=$(python -c 'import secrets;print(secrets.token_urlsafe(32))') \
+    AUTH_SESSION_SECRET=$(python -c 'import secrets;print(secrets.token_urlsafe(32))')
+uv run modal deploy deploy/sim_envs/modal_mantis_auth.py
+uv run mantis plan run examples/sim_envs/mantis_auth/T02_oauth_google.json \
+    --env mantis-auth --runtime modal --endpoint <BRAIN_URL>
+```
+
+The login surface is the **embeddable `app.authflow` package** — a
+storage-free FastAPI router (`build_auth_router(AuthConfig(...))`) any
+other sim env can mount to gain the full method matrix. See
+`deploy/sim_envs/mantis_auth/README.md` for the drop-in recipe.
+
 ## Modal deploy of the stub
 
 ```bash

--- a/examples/sim_envs/mantis_auth/T01_password_login.json
+++ b/examples/sim_envs/mantis_auth/T01_password_login.json
@@ -1,0 +1,46 @@
+{
+  "task_id": "T01_password_login",
+  "source_plan": "Sign in to Mantis Console with email ada@mantis.example and password hunter2, then reach the console.",
+  "domain": "mantis-auth",
+  "steps": [
+    {
+      "type": "navigate",
+      "intent": "Open the sign-in page at {{ENV_URL}}/login",
+      "section": "setup",
+      "required": true,
+      "gate": false,
+      "claude_only": false,
+      "loop_target": -1,
+      "loop_count": 0,
+      "verify": "",
+      "params": {"url": "{{ENV_URL}}/login"},
+      "hints": {}
+    },
+    {
+      "type": "navigate",
+      "intent": "Enter email 'ada@mantis.example' and password 'hunter2' into the sign-in form and submit it.",
+      "section": "act",
+      "required": true,
+      "gate": false,
+      "claude_only": false,
+      "loop_target": -1,
+      "loop_count": 0,
+      "verify": "",
+      "params": {},
+      "hints": {}
+    },
+    {
+      "type": "extract_data",
+      "intent": "Confirm the console shows 'Welcome back' for ada@mantis.example.",
+      "section": "verify",
+      "required": true,
+      "gate": false,
+      "claude_only": true,
+      "loop_target": -1,
+      "loop_count": 0,
+      "verify": "",
+      "params": {},
+      "hints": {}
+    }
+  ]
+}

--- a/examples/sim_envs/mantis_auth/T02_oauth_google.json
+++ b/examples/sim_envs/mantis_auth/T02_oauth_google.json
@@ -1,0 +1,59 @@
+{
+  "task_id": "T02_oauth_google",
+  "source_plan": "Sign in to Mantis Console using 'Continue with Google' for ada@mantis.example, approving the consent screen.",
+  "domain": "mantis-auth",
+  "steps": [
+    {
+      "type": "navigate",
+      "intent": "Open the sign-in page at {{ENV_URL}}/login",
+      "section": "setup",
+      "required": true,
+      "gate": false,
+      "claude_only": false,
+      "loop_target": -1,
+      "loop_count": 0,
+      "verify": "",
+      "params": {"url": "{{ENV_URL}}/login"},
+      "hints": {}
+    },
+    {
+      "type": "navigate",
+      "intent": "Click 'Continue with Google' to start the OAuth flow.",
+      "section": "navigate",
+      "required": true,
+      "gate": false,
+      "claude_only": false,
+      "loop_target": -1,
+      "loop_count": 0,
+      "verify": "",
+      "params": {},
+      "hints": {}
+    },
+    {
+      "type": "navigate",
+      "intent": "On the Google account picker, choose the account for ada@mantis.example.",
+      "section": "navigate",
+      "required": true,
+      "gate": false,
+      "claude_only": false,
+      "loop_target": -1,
+      "loop_count": 0,
+      "verify": "",
+      "params": {},
+      "hints": {}
+    },
+    {
+      "type": "navigate",
+      "intent": "On the consent screen, click 'Allow' to authorize Mantis Console and return to the app.",
+      "section": "act",
+      "required": true,
+      "gate": false,
+      "claude_only": false,
+      "loop_target": -1,
+      "loop_count": 0,
+      "verify": "",
+      "params": {},
+      "hints": {}
+    }
+  ]
+}

--- a/examples/sim_envs/mantis_auth/T03_oauth_github.json
+++ b/examples/sim_envs/mantis_auth/T03_oauth_github.json
@@ -1,0 +1,46 @@
+{
+  "task_id": "T03_oauth_github",
+  "source_plan": "Sign in to Mantis Console using 'Continue with GitHub' for ada@mantis.example, authorizing the app.",
+  "domain": "mantis-auth",
+  "steps": [
+    {
+      "type": "navigate",
+      "intent": "Open the sign-in page at {{ENV_URL}}/login",
+      "section": "setup",
+      "required": true,
+      "gate": false,
+      "claude_only": false,
+      "loop_target": -1,
+      "loop_count": 0,
+      "verify": "",
+      "params": {"url": "{{ENV_URL}}/login"},
+      "hints": {}
+    },
+    {
+      "type": "navigate",
+      "intent": "Click 'Continue with GitHub' to start the OAuth flow.",
+      "section": "navigate",
+      "required": true,
+      "gate": false,
+      "claude_only": false,
+      "loop_target": -1,
+      "loop_count": 0,
+      "verify": "",
+      "params": {},
+      "hints": {}
+    },
+    {
+      "type": "navigate",
+      "intent": "Choose the GitHub account for ada@mantis.example, then click 'Authorize' on the consent screen to return to the app.",
+      "section": "act",
+      "required": true,
+      "gate": false,
+      "claude_only": false,
+      "loop_target": -1,
+      "loop_count": 0,
+      "verify": "",
+      "params": {},
+      "hints": {}
+    }
+  ]
+}

--- a/examples/sim_envs/mantis_auth/T04_oauth_microsoft.json
+++ b/examples/sim_envs/mantis_auth/T04_oauth_microsoft.json
@@ -1,0 +1,46 @@
+{
+  "task_id": "T04_oauth_microsoft",
+  "source_plan": "Sign in to Mantis Console using 'Continue with Microsoft' for ada@mantis.example, accepting the requested permissions.",
+  "domain": "mantis-auth",
+  "steps": [
+    {
+      "type": "navigate",
+      "intent": "Open the sign-in page at {{ENV_URL}}/login",
+      "section": "setup",
+      "required": true,
+      "gate": false,
+      "claude_only": false,
+      "loop_target": -1,
+      "loop_count": 0,
+      "verify": "",
+      "params": {"url": "{{ENV_URL}}/login"},
+      "hints": {}
+    },
+    {
+      "type": "navigate",
+      "intent": "Click 'Continue with Microsoft' to start the OAuth flow.",
+      "section": "navigate",
+      "required": true,
+      "gate": false,
+      "claude_only": false,
+      "loop_target": -1,
+      "loop_count": 0,
+      "verify": "",
+      "params": {},
+      "hints": {}
+    },
+    {
+      "type": "navigate",
+      "intent": "Pick the account for ada@mantis.example, then click 'Accept' on the permissions screen to return to the app.",
+      "section": "act",
+      "required": true,
+      "gate": false,
+      "claude_only": false,
+      "loop_target": -1,
+      "loop_count": 0,
+      "verify": "",
+      "params": {},
+      "hints": {}
+    }
+  ]
+}

--- a/examples/sim_envs/mantis_auth/T05_oauth_okta.json
+++ b/examples/sim_envs/mantis_auth/T05_oauth_okta.json
@@ -1,0 +1,46 @@
+{
+  "task_id": "T05_oauth_okta",
+  "source_plan": "Sign in to Mantis Console using 'Continue with Okta' for ada@mantis.example, allowing access.",
+  "domain": "mantis-auth",
+  "steps": [
+    {
+      "type": "navigate",
+      "intent": "Open the sign-in page at {{ENV_URL}}/login",
+      "section": "setup",
+      "required": true,
+      "gate": false,
+      "claude_only": false,
+      "loop_target": -1,
+      "loop_count": 0,
+      "verify": "",
+      "params": {"url": "{{ENV_URL}}/login"},
+      "hints": {}
+    },
+    {
+      "type": "navigate",
+      "intent": "Click 'Continue with Okta' to start the OAuth flow.",
+      "section": "navigate",
+      "required": true,
+      "gate": false,
+      "claude_only": false,
+      "loop_target": -1,
+      "loop_count": 0,
+      "verify": "",
+      "params": {},
+      "hints": {}
+    },
+    {
+      "type": "navigate",
+      "intent": "Pick the Okta account for ada@mantis.example, then click 'Allow' on the grant screen to return to the app.",
+      "section": "act",
+      "required": true,
+      "gate": false,
+      "claude_only": false,
+      "loop_target": -1,
+      "loop_count": 0,
+      "verify": "",
+      "params": {},
+      "hints": {}
+    }
+  ]
+}

--- a/examples/sim_envs/mantis_auth/T06_magic_link_email.json
+++ b/examples/sim_envs/mantis_auth/T06_magic_link_email.json
@@ -1,0 +1,59 @@
+{
+  "task_id": "T06_magic_link_email",
+  "source_plan": "Sign in to Mantis Console with an email magic link for ada@mantis.example: request the link, open the inbox, and click it.",
+  "domain": "mantis-auth",
+  "steps": [
+    {
+      "type": "navigate",
+      "intent": "Open the magic-link request page at {{ENV_URL}}/auth/magic",
+      "section": "setup",
+      "required": true,
+      "gate": false,
+      "claude_only": false,
+      "loop_target": -1,
+      "loop_count": 0,
+      "verify": "",
+      "params": {"url": "{{ENV_URL}}/auth/magic"},
+      "hints": {}
+    },
+    {
+      "type": "navigate",
+      "intent": "Enter 'ada@mantis.example' and submit to send the sign-in link.",
+      "section": "act",
+      "required": true,
+      "gate": false,
+      "claude_only": false,
+      "loop_target": -1,
+      "loop_count": 0,
+      "verify": "",
+      "params": {},
+      "hints": {}
+    },
+    {
+      "type": "navigate",
+      "intent": "Open the mailbox at {{ENV_URL}}/inbox and open the newest 'sign-in link' message.",
+      "section": "navigate",
+      "required": true,
+      "gate": false,
+      "claude_only": false,
+      "loop_target": -1,
+      "loop_count": 0,
+      "verify": "",
+      "params": {"url": "{{ENV_URL}}/inbox"},
+      "hints": {}
+    },
+    {
+      "type": "navigate",
+      "intent": "Click the 'Sign in via this link' button in the message to complete sign-in.",
+      "section": "act",
+      "required": true,
+      "gate": false,
+      "claude_only": false,
+      "loop_target": -1,
+      "loop_count": 0,
+      "verify": "",
+      "params": {},
+      "hints": {}
+    }
+  ]
+}

--- a/examples/sim_envs/mantis_auth/T07_email_otp.json
+++ b/examples/sim_envs/mantis_auth/T07_email_otp.json
@@ -1,0 +1,59 @@
+{
+  "task_id": "T07_email_otp",
+  "source_plan": "Sign in to Mantis Console with an email one-time code for ada@mantis.example: request the code, read it in the inbox, and enter it.",
+  "domain": "mantis-auth",
+  "steps": [
+    {
+      "type": "navigate",
+      "intent": "Open the one-time-code request page at {{ENV_URL}}/auth/otp",
+      "section": "setup",
+      "required": true,
+      "gate": false,
+      "claude_only": false,
+      "loop_target": -1,
+      "loop_count": 0,
+      "verify": "",
+      "params": {"url": "{{ENV_URL}}/auth/otp"},
+      "hints": {}
+    },
+    {
+      "type": "navigate",
+      "intent": "Enter 'ada@mantis.example' and submit to send the 6-digit code.",
+      "section": "act",
+      "required": true,
+      "gate": false,
+      "claude_only": false,
+      "loop_target": -1,
+      "loop_count": 0,
+      "verify": "",
+      "params": {},
+      "hints": {}
+    },
+    {
+      "type": "extract_data",
+      "intent": "Open the mailbox at {{ENV_URL}}/inbox, open the newest verification-code message, and read the 6-digit code.",
+      "section": "navigate",
+      "required": true,
+      "gate": false,
+      "claude_only": true,
+      "loop_target": -1,
+      "loop_count": 0,
+      "verify": "",
+      "params": {"url": "{{ENV_URL}}/inbox"},
+      "hints": {}
+    },
+    {
+      "type": "navigate",
+      "intent": "Return to the code-entry screen, type the 6-digit code, and submit to complete sign-in.",
+      "section": "act",
+      "required": true,
+      "gate": false,
+      "claude_only": false,
+      "loop_target": -1,
+      "loop_count": 0,
+      "verify": "",
+      "params": {},
+      "hints": {}
+    }
+  ]
+}

--- a/examples/sim_envs/mantis_auth/T08_passkey.json
+++ b/examples/sim_envs/mantis_auth/T08_passkey.json
@@ -1,0 +1,33 @@
+{
+  "task_id": "T08_passkey",
+  "source_plan": "Sign in to Mantis Console with a passkey: open the passkey page and select Ada's registered passkey ('MacBook Touch ID').",
+  "domain": "mantis-auth",
+  "steps": [
+    {
+      "type": "navigate",
+      "intent": "Open the passkey sign-in page at {{ENV_URL}}/auth/passkey",
+      "section": "setup",
+      "required": true,
+      "gate": false,
+      "claude_only": false,
+      "loop_target": -1,
+      "loop_count": 0,
+      "verify": "",
+      "params": {"url": "{{ENV_URL}}/auth/passkey"},
+      "hints": {}
+    },
+    {
+      "type": "navigate",
+      "intent": "Select the registered passkey 'MacBook Touch ID' (ada@mantis.example) to complete the assertion and sign in.",
+      "section": "act",
+      "required": true,
+      "gate": false,
+      "claude_only": false,
+      "loop_target": -1,
+      "loop_count": 0,
+      "verify": "",
+      "params": {},
+      "hints": {}
+    }
+  ]
+}

--- a/src/mantis_agent/sim_envs/local.py
+++ b/src/mantis_agent/sim_envs/local.py
@@ -74,6 +74,7 @@ def _image_for_env(env_name: str) -> str | None:
         return override
     # Canonical per-env images. Child env PRs append to this table.
     registry = {
+        "mantis-auth": "mantis/sim-env-mantis-auth:latest",
         "mantis-crm": "mantis/sim-env-mantis-crm:latest",
         "mantis-helpdesk": "mantis/sim-env-mantis-helpdesk:latest",
         "mantis-shop": "mantis/sim-env-mantis-shop:latest",

--- a/tests/sim_envs/mantis_auth/conftest.py
+++ b/tests/sim_envs/mantis_auth/conftest.py
@@ -1,0 +1,41 @@
+"""mantis-auth env tests need ``deploy/sim_envs/mantis_auth`` on the path.
+
+The auth env is a deploy artifact, not part of the ``mantis_agent``
+package — it lives next to the Dockerfile under ``deploy/sim_envs/``.
+Importing it for tests means putting that directory on ``sys.path`` so
+``from app.main import app`` resolves the env's local package.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+ENV_ROOT = REPO_ROOT / "deploy" / "sim_envs" / "mantis_auth"
+
+
+@pytest.fixture(autouse=True, scope="session")
+def _env_on_syspath():
+    if str(ENV_ROOT) not in sys.path:
+        sys.path.insert(0, str(ENV_ROOT))
+    yield
+
+
+@pytest.fixture(autouse=True)
+def _isolate_env_state(monkeypatch):
+    """Reset module-level DB connection + events between tests."""
+    monkeypatch.setenv("DB_PATH", ":memory:")
+    monkeypatch.setenv("SEED", "42")
+    monkeypatch.setenv("FAKE_NOW", "2026-01-15T09:00:00Z")
+    monkeypatch.setenv("ENV_ADMIN_TOKEN", "test-admin-token")
+    monkeypatch.setenv("AUTH_SESSION_SECRET", "test-session-secret")
+    monkeypatch.setenv("ENV_REQUIRE_AUTH", "1")
+
+    for mod_name in [m for m in list(sys.modules) if m.startswith("app")]:
+        sys.modules.pop(mod_name, None)
+    yield
+    for mod_name in [m for m in list(sys.modules) if m.startswith("app")]:
+        sys.modules.pop(mod_name, None)

--- a/tests/sim_envs/mantis_auth/test_flows_end_to_end.py
+++ b/tests/sim_envs/mantis_auth/test_flows_end_to_end.py
@@ -1,0 +1,203 @@
+"""Drive each auth ceremony over HTTP and assert its oracle flips to pass.
+
+This is the real proof the env works: every method, walked through the
+actual routes with a cookie jar, lands a ``login_succeeded`` audit row
+and reaches the console — and the matching oracle agrees.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+pytest.importorskip("fastapi", reason="auth env flow test needs the server extra")
+pytest.importorskip("httpx", reason="starlette TestClient needs httpx")
+from fastapi.testclient import TestClient  # noqa: E402
+
+DEMO_EMAIL = "ada@mantis.example"
+
+
+@pytest.fixture
+def client():
+    from app.main import app  # noqa: PLC0415
+
+    with TestClient(app) as c:
+        yield c
+
+
+def _grade(task_id: str) -> dict:
+    from app import db  # noqa: PLC0415
+    from app.oracles import grade  # noqa: PLC0415
+
+    return grade(task_id, db.connect(), now="2026-01-15T09:00:00Z", seed_val=42)
+
+
+def _emails(kind: str):
+    from app import db  # noqa: PLC0415
+
+    return db.connect().execute(
+        "SELECT * FROM emails WHERE kind = ? ORDER BY id DESC", (kind,)
+    ).fetchall()
+
+
+# ── password ────────────────────────────────────────────────────────────
+
+
+def test_password_login(client):
+    r = client.post("/login", data={
+        "email": DEMO_EMAIL, "password": "hunter2", "next": "/console"})
+    assert r.status_code == 200
+    assert "console" in r.text.lower()
+    assert _grade("T01_password_login")["passed"] is True
+
+
+def test_password_wrong_is_rejected(client):
+    client.post("/login", data={
+        "email": DEMO_EMAIL, "password": "nope", "next": "/console"})
+    assert _grade("T01_password_login")["passed"] is False
+
+
+# ── OAuth (every provider) ──────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("provider,task_id", [
+    ("google", "T02_oauth_google"),
+    ("github", "T03_oauth_github"),
+    ("microsoft", "T04_oauth_microsoft"),
+    ("okta", "T05_oauth_okta"),
+])
+def test_oauth_flow(client, provider, task_id):
+    subject = f"{provider}-oauth2|user_00001"
+    redirect_uri = f"/auth/oauth/{provider}/callback"
+
+    picker = client.get(f"/auth/oauth/{provider}/authorize?state=login")
+    assert picker.status_code == 200
+    assert subject in picker.text
+
+    consent = client.post(f"/auth/oauth/{provider}/consent", data={
+        "subject": subject, "redirect_uri": redirect_uri, "state": "login"})
+    assert consent.status_code == 200
+
+    grant = client.post(f"/auth/oauth/{provider}/grant", data={
+        "subject": subject, "redirect_uri": redirect_uri, "state": "login"})
+    assert grant.status_code == 200
+    m = re.search(r"code=([A-Za-z0-9_\-]+)", grant.text)
+    assert m, "grant page should embed an authorization code"
+
+    cb = client.get(
+        f"/auth/oauth/{provider}/callback?code={m.group(1)}&state=login")
+    assert cb.status_code == 200
+    assert _grade(task_id)["passed"] is True
+
+
+def test_oauth_code_is_single_use(client):
+    subject = "google-oauth2|user_00001"
+    client.post("/auth/oauth/google/grant", data={
+        "subject": subject, "redirect_uri": "/auth/oauth/google/callback",
+        "state": "login"})
+    grant = client.post("/auth/oauth/google/grant", data={
+        "subject": subject, "redirect_uri": "/auth/oauth/google/callback",
+        "state": "login"})
+    code = re.search(r"code=([A-Za-z0-9_\-]+)", grant.text).group(1)
+    client.get(f"/auth/oauth/google/callback?code={code}&state=login")
+    # Replaying the same code must not authenticate again.
+    from app import db  # noqa: PLC0415
+    db.connect().execute("DELETE FROM mutations")
+    replay = client.get(
+        f"/auth/oauth/google/callback?code={code}&state=login",
+        follow_redirects=False)
+    assert replay.status_code == 303
+    assert "error" in replay.headers.get("location", "")
+
+
+# ── email magic link ────────────────────────────────────────────────────
+
+
+def test_magic_link_flow(client):
+    sent = client.post("/auth/magic", data={"email": DEMO_EMAIL})
+    assert sent.status_code == 200
+    rows = _emails("magic_link")
+    assert rows, "a magic-link email should be delivered"
+    token = rows[0]["token"]
+
+    # Read it from the inbox surface, then follow the link.
+    inbox = client.get("/inbox")
+    assert "magic" in inbox.text.lower()
+    verified = client.get(f"/auth/magic/verify?token={token}")
+    assert verified.status_code == 200
+    assert _grade("T06_magic_link_email")["passed"] is True
+
+
+def test_magic_link_is_single_use(client):
+    client.post("/auth/magic", data={"email": DEMO_EMAIL})
+    token = _emails("magic_link")[0]["token"]
+    client.get(f"/auth/magic/verify?token={token}")
+    replay = client.get(f"/auth/magic/verify?token={token}",
+                        follow_redirects=False)
+    assert replay.status_code == 303
+    assert "error" in replay.headers.get("location", "")
+
+
+# ── email OTP ────────────────────────────────────────────────────────────
+
+
+def test_email_otp_flow(client):
+    client.post("/auth/otp", data={"email": DEMO_EMAIL})
+    code = _emails("otp")[0]["code"]
+    assert re.fullmatch(r"\d{6}", code)
+
+    r = client.post("/auth/otp/verify", data={"email": DEMO_EMAIL, "code": code})
+    assert r.status_code == 200
+    assert _grade("T07_email_otp")["passed"] is True
+
+
+def test_email_otp_wrong_code_rejected(client):
+    client.post("/auth/otp", data={"email": DEMO_EMAIL})
+    r = client.post("/auth/otp/verify",
+                    data={"email": DEMO_EMAIL, "code": "000000"})
+    assert "invalid" in r.text.lower()
+    assert _grade("T07_email_otp")["passed"] is False
+
+
+# ── passkey ──────────────────────────────────────────────────────────────
+
+
+def test_passkey_flow(client):
+    page = client.get("/auth/passkey")
+    challenge = re.search(r'name="challenge" value="([^"]+)"', page.text).group(1)
+    assert "cred_00001" in page.text
+
+    r = client.post("/auth/passkey/assert",
+                    data={"cred_id": "cred_00001", "challenge": challenge})
+    assert r.status_code == 200
+    assert _grade("T08_passkey")["passed"] is True
+
+
+def test_passkey_replayed_challenge_rejected(client):
+    page = client.get("/auth/passkey")
+    challenge = re.search(r'name="challenge" value="([^"]+)"', page.text).group(1)
+    client.post("/auth/passkey/assert",
+                data={"cred_id": "cred_00001", "challenge": challenge})
+    replay = client.post("/auth/passkey/assert",
+                         data={"cred_id": "cred_00001", "challenge": challenge},
+                         follow_redirects=False)
+    assert replay.status_code == 303
+    assert "error" in replay.headers.get("location", "")
+
+
+# ── auth gate + harness surface ──────────────────────────────────────────
+
+
+def test_console_requires_auth(client):
+    r = client.get("/console", follow_redirects=False)
+    assert r.status_code == 303
+    assert r.headers["location"].startswith("/login")
+
+
+def test_oracle_endpoint_is_gated(client):
+    assert client.get("/__env__/oracle?task_id=T01_password_login").status_code == 401
+    ok = client.get("/__env__/oracle?task_id=T01_password_login",
+                    headers={"X-Env-Admin": "test-admin-token"})
+    assert ok.status_code == 200
+    assert ok.json()["passed"] is False

--- a/tests/sim_envs/mantis_auth/test_oracle_determinism.py
+++ b/tests/sim_envs/mantis_auth/test_oracle_determinism.py
@@ -1,0 +1,75 @@
+"""Each oracle returns the same verdict twice on the same DB state, and
+fails out of the box (no one has signed in yet).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+TASK_IDS = [
+    "T01_password_login",
+    "T02_oauth_google",
+    "T03_oauth_github",
+    "T04_oauth_microsoft",
+    "T05_oauth_okta",
+    "T06_magic_link_email",
+    "T07_email_otp",
+    "T08_passkey",
+]
+
+
+@pytest.fixture
+def seeded_db():
+    from app import db, seed as seed_mod  # noqa: PLC0415
+
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.executescript(db.SCHEMA)
+    seed_mod.seed(conn, seed_val=42, fake_now="2026-01-15T09:00:00Z")
+    return conn
+
+
+@pytest.mark.parametrize("task_id", TASK_IDS)
+def test_oracle_is_deterministic(seeded_db, task_id):
+    from app.oracles import grade  # noqa: PLC0415
+
+    r1 = grade(task_id, seeded_db, now="2026-01-15T09:00:00Z", seed_val=42)
+    r2 = grade(task_id, seeded_db, now="2026-01-15T09:00:00Z", seed_val=42)
+    assert r1 == r2, f"{task_id}: oracle is non-deterministic"
+
+
+@pytest.mark.parametrize("task_id", TASK_IDS)
+def test_oracle_fails_on_fresh_seed(seeded_db, task_id):
+    """No login has happened yet, so every scenario must fail."""
+    from app.oracles import grade  # noqa: PLC0415
+
+    r = grade(task_id, seeded_db, now="2026-01-15T09:00:00Z", seed_val=42)
+    assert r["passed"] is False
+    assert r["score"] == 0.0
+
+
+def test_oracle_unregistered_task_fails_gracefully(seeded_db):
+    from app.oracles import grade  # noqa: PLC0415
+
+    r = grade("DOES_NOT_EXIST", seeded_db,
+              now="2026-01-15T09:00:00Z", seed_val=42)
+    assert r["passed"] is False
+    assert "no oracle" in " ".join(r["reasons"]).lower()
+    assert r["task_id"] == "DOES_NOT_EXIST"
+
+
+def test_seed_enrolls_demo_user_across_methods(seeded_db):
+    """user_00001 (Ada) is the canonical all-methods account."""
+    uid = "user_00001"
+    pw = seeded_db.execute(
+        "SELECT password_hash FROM users WHERE id = ?", (uid,)).fetchone()
+    assert pw["password_hash"], "demo user should have a password"
+    providers = {r["provider"] for r in seeded_db.execute(
+        "SELECT provider FROM oauth_identities WHERE user_id = ?", (uid,))}
+    assert providers == {"google", "github", "microsoft", "okta"}
+    passkeys = seeded_db.execute(
+        "SELECT COUNT(*) FROM passkey_credentials WHERE user_id = ?",
+        (uid,)).fetchone()[0]
+    assert passkeys >= 1


### PR DESCRIPTION
## What

A new synthetic environment, **mantis-auth**, focused entirely on authentication: a minimal SaaS console ("Mantis Console") behind a multi-method auth wall. One deployable artifact, **eight graded scenarios** — mirroring how `mantis_crm`/`mantis_shop` pack many tasks into a single env rather than spawning N Modal apps.

| Task | Method |
|------|--------|
| `T01_password_login` | email + password (3 swappable layouts: `centered`/`split`/`minimal`) |
| `T02_oauth_google` / `T03_oauth_github` / `T04_oauth_microsoft` / `T05_oauth_okta` | OAuth, one per provider — each with its own IdP account-picker + consent chrome |
| `T06_magic_link_email` | emailed magic link, read from the in-env mock `/inbox` |
| `T07_email_otp` | emailed 6-digit code, read from `/inbox` |
| `T08_passkey` | simulated WebAuthn passkey assertion |

## The embeddable auth flow

The login surface is a **portable, storage-free `app.authflow` package** — `build_auth_router(AuthConfig(...))` mounts the full method matrix on any FastAPI env via a small `AuthBackend` protocol over its own user store. `app/backend.py` is the worked SQLite implementation; nothing in `authflow` imports this env's `db`, so it carries no coupling. This is the "auth flow that can be added" deliverable.

## Grading

Oracles read only the `mutations` audit log + DB state (deterministic — N reruns → N identical scores). Each scenario needs a terminal `login_succeeded` for the canonical demo account (`ada@mantis.example`, enrolled in every method) tagged with the right `via` (+ `provider` for OAuth). The email/passkey scenarios additionally require proof-of-ceremony (token consumed / code verified / passkey asserted), so a session minted any other way still fails the gate.

## Included

- `deploy/sim_envs/mantis_auth/` — full app (authflow package, backend, db, seed, oracles, routes, templates, static)
- `Dockerfile` + `deploy/sim_envs/modal_mantis_auth.py` + registry entry in `src/mantis_agent/sim_envs/local.py`
- 8 example plans under `examples/sim_envs/mantis_auth/`
- Tests under `tests/sim_envs/mantis_auth/` — oracle determinism + full HTTP flow per method
- `docs/envs/HARNESS.md` section + per-env `README.md` with the drop-in recipe

## Verification

- **33 pytest pass** (`uv run pytest tests/sim_envs/mantis_auth/ -p no:xdist`; flow test needs the `server` extra).
- **Real uvicorn smoke** confirmed the Dockerfile CMD path end-to-end: health, layout switching, OAuth picker, password → cookie → console, and the oracle flipping to `passed`.
- Docker image build **not** run (daemon unavailable in this session).
- ⏳ Pending before production-ready: a Modal deploy + real plan rerun (per the repo's verify-via-Modal norm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)