### PR TITLE
fix(runtime): stage up-front user_input for {{user_input}} on the initial run path (#885-followup)

### DIFF
--- a/deploy/modal/modal_cua_server.py
+++ b/deploy/modal/modal_cua_server.py
@@ -1297,8 +1297,13 @@ def _run_holo3_executor(
                 plan=micro_plan,
             )
         else:
+            # #885-followup: an up-front ``user_input`` on the initial
+            # submit (no pause/resume round-trip) is staged for
+            # ``{{user_input}}`` substitution — the "natural" login path.
+            # ``None`` (the common case) leaves substitution a no-op.
             runner_result = micro_runner.run_with_status(
                 micro_plan, resume=resume_state,
+                user_input=task_suite.get("user_input"),
             )
         step_results = runner_result.steps
 

--- a/scripts/verify_initial_user_input_substitution.py
+++ b/scripts/verify_initial_user_input_substitution.py
@@ -1,0 +1,231 @@
+"""Live verification for INITIAL-path ``{{user_input}}`` substitution (#885-followup).
+
+Unlike ``verify_request_user_input_roundtrip.py`` (which exercises the
+pause/resume path), this submits a "natural" login plan with NO
+``request_user_input`` pause step and an up-front ``user_input`` carried on
+the task_suite. It asserts the deployed Modal CUA server:
+
+  1. does NOT pause (no request_user_input step → runs straight through),
+  2. substitutes ``{{user_input}}`` in the Username fill BEFORE typing —
+     verified directly from the run's Augur modelio bundle: the grounding
+     record for the username step must carry value=``tomsmith``, NOT the
+     literal ``{{user_input}}`` (the pre-fix bug).
+
+Usage:
+    uv run python scripts/verify_initial_user_input_substitution.py \
+        --endpoint https://getmason--mantis-cua-server-api.modal.run \
+        --token "$MANTIS_API_TOKEN"
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import requests
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from mantis_agent.plan_decomposer import MicroPlan, PlanDecomposer  # noqa: E402
+from mantis_agent.server_utils import (  # noqa: E402
+    build_micro_suite,
+    micro_plan_steps_to_dicts,
+)
+
+USER_INPUT = "tomsmith"  # the-internet/herokuapp valid username
+PASSWORD = "SuperSecretPassword!"  # literal valid password (not templated)
+
+PLAN_STEPS = [
+    {
+        "type": "navigate",
+        "intent": "Go to the login page",
+        "params": {"url": "https://the-internet.herokuapp.com/login"},
+        "required": True,
+        "section": "setup",
+        "gate": False,
+    },
+    {
+        "type": "fill_field",
+        "intent": "Enter {{user_input}} in the Username field",
+        "params": {"label": "Username", "value": "{{user_input}}"},
+        "required": True,
+        "section": "login",
+    },
+    {
+        "type": "fill_field",
+        "intent": "Enter the password in the Password field",
+        "params": {"label": "Password", "value": PASSWORD},
+        "required": True,
+        "section": "login",
+    },
+    {
+        "type": "click",
+        "intent": "Click the Login button to submit the form",
+        "params": {"label": "Login"},
+        "required": True,
+        "section": "login",
+    },
+]
+
+
+def post(url: str, token: str, body: dict[str, Any]) -> tuple[int, dict[str, Any]]:
+    r = requests.post(
+        url,
+        headers={"X-Mantis-Token": token, "Content-Type": "application/json"},
+        data=json.dumps(body),
+        timeout=60,
+    )
+    try:
+        return r.status_code, r.json()
+    except Exception:
+        return r.status_code, {"raw": r.text}
+
+
+def _augur_username_value(run_id: str) -> tuple[bool, str]:
+    """Best-effort: read the run's Augur modelio and return whether the
+    Username grounding record substituted the token. Returns (found, value)."""
+    dsn = os.environ.get("AUGUR_DSN", "")
+    # DSN: https://<host>/api/v1?token=<tok>&tenant=<tenant>
+    import re
+    m = re.match(r"(https?://[^/]+/api/v1)\?token=([^&]+)&tenant=([^&]+)", dsn)
+    if not m:
+        return False, "(AUGUR_DSN not parseable; skipping bundle check)"
+    base, tok, tenant = m.group(1), m.group(2), m.group(3)
+    hdr = {"ngrok-skip-browser-warning": "true", "Authorization": f"Bearer {tok}"}
+
+    def aget(path: str) -> dict | None:
+        try:
+            r = requests.get(
+                f"{base}/{path}{'&' if '?' in path else '?'}tenant={tenant}&token={tok}",
+                headers=hdr, timeout=25,
+            )
+            return r.json() if r.status_code == 200 else None
+        except Exception:
+            return None
+
+    lst = aget(f"runs/{run_id}/modelio")
+    if not lst:
+        return False, "(no modelio bundle for run)"
+    for rec in lst.get("records", []):
+        rel = rec["relpath"].split("/")[-1]
+        d = aget(f"runs/{run_id}/modelio/{rel}")
+        if not d:
+            continue
+        inp = (d.get("response", {}).get("tool_calls") or [{}])[0].get("input", {})
+        # The username fill carries the (post-substitution) value.
+        val = inp.get("value")
+        if val in (USER_INPUT, "{{user_input}}"):
+            return True, str(val)
+    return False, "(no username-fill grounding record found)"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--endpoint",
+        default="https://getmason--mantis-cua-server-api.modal.run",
+    )
+    ap.add_argument("--token", default=os.environ.get("MANTIS_API_TOKEN", ""))
+    ap.add_argument("--profile-id", default="rui-natural")
+    ap.add_argument("--workflow-id", default="rui-natural")
+    args = ap.parse_args()
+
+    if not args.token:
+        print("ERROR: --token or MANTIS_API_TOKEN required", file=sys.stderr)
+        return 2
+
+    endpoint = args.endpoint.rstrip("/")
+    predict = f"{endpoint}/v1/predict"
+
+    plan = MicroPlan(domain="rui_natural_login")
+    for step in PLAN_STEPS:
+        plan.steps.append(PlanDecomposer._build_intent(step))
+    suite = build_micro_suite(
+        micro_plan_steps_to_dicts(plan.steps),
+        plan.domain,
+        profile_id=args.profile_id,
+        workflow_id=args.workflow_id,
+    )
+    # The up-front value the runtime stages onto ``_staged_user_input`` on
+    # the INITIAL path (no pause). The executor reads ``task_suite["user_input"]``.
+    suite["user_input"] = USER_INPUT
+
+    # ── 1. submit ──────────────────────────────────────────────────
+    print(f"[submit] natural login plan (user_input={USER_INPUT!r}, no pause step)")
+    st, resp = post(
+        predict, args.token,
+        {
+            "task_suite": suite,
+            "profile_id": suite["_profile_id"],
+            "workflow_id": suite["_workflow_id"],
+            "cua_model": "holo3",
+            "max_steps": 10,
+            "max_cost": 1.0,
+            "max_time_minutes": 10,
+            "detached": True,
+        },
+    )
+    print(f"  HTTP {st}: run_id={resp.get('run_id')!r}")
+    if st != 200:
+        print(f"  FAIL submit: {resp}")
+        return 1
+    run_id = resp["run_id"]
+
+    # ── 2. poll to terminal, asserting we NEVER pause ──────────────
+    print("[poll] waiting for terminal status (must NOT pause) ...")
+    final, last = None, None
+    deadline = time.monotonic() + 600
+    while time.monotonic() < deadline:
+        st, s = post(predict, args.token, {"action": "status", "run_id": run_id})
+        status = s.get("status")
+        if status != last:
+            print(f"  status={status!r}")
+            last = status
+        if status == "paused":
+            print("  FAIL: natural plan paused — it has no request_user_input step")
+            return 1
+        if status in {
+            "succeeded", "failed", "cancelled", "halted",
+            "completed", "completed_with_failures",
+        }:
+            final = s
+            break
+        time.sleep(5)
+
+    if final is None:
+        print("  FAIL: no terminal status within window")
+        return 1
+    print(f"  terminal status={final.get('status')!r}")
+
+    # ── 3. assert substitution from the result + Augur bundle ──────
+    blob = json.dumps(final)
+    literal_in_result = "{{user_input}}" in blob
+    print(f"  literal '{{{{user_input}}}}' present in result payload: {literal_in_result}")
+
+    found, val = _augur_username_value(run_id)
+    print(f"  Augur username-fill value: {val} (record found: {found})")
+
+    ok = True
+    if literal_in_result:
+        print("  FAIL: literal token leaked into the result payload")
+        ok = False
+    if found and val == "{{user_input}}":
+        print("  FAIL: username field typed the LITERAL token — substitution did not fire")
+        ok = False
+    if found and val == USER_INPUT:
+        print(f"  ✅ username field substituted to {USER_INPUT!r} on the initial path")
+    if not found:
+        print("  ⚠️  could not confirm via Augur bundle (check manually); "
+              "result-payload check still applied")
+
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/mantis_agent/baseten_server/runtime.py
+++ b/src/mantis_agent/baseten_server/runtime.py
@@ -2053,8 +2053,13 @@ class BasetenCUARuntime:
                         plan=micro_plan,
                     )
                 else:
+                    # #885-followup: stage an up-front ``user_input`` on
+                    # the initial submit (no pause/resume round-trip) for
+                    # ``{{user_input}}`` substitution — the "natural" login
+                    # path. ``None`` (the common case) is a no-op.
                     runner_result = runner.run_with_status(
                         micro_plan, resume=resume_state,
+                        user_input=payload.get("user_input"),
                     )
             finally:
                 # ``micro_runner.run`` itself calls finalize_to_disk via

--- a/src/mantis_agent/gym/micro_runner.py
+++ b/src/mantis_agent/gym/micro_runner.py
@@ -398,7 +398,9 @@ class MicroPlanRunner:
 
     # ── Public API ────────────────────────────────────────────────────
 
-    def run(self, plan: MicroPlan, resume: bool = False) -> list[StepResult]:
+    def run(
+        self, plan: MicroPlan, resume: bool = False, user_input: Any = None,
+    ) -> list[StepResult]:
         from .run_executor import RunState
 
         # Issue #254: per-context sub-goal budget gate. Check BEFORE
@@ -410,6 +412,19 @@ class MicroPlanRunner:
             envelope = self._check_and_emit_context_budget(plan)
             if envelope is not None:
                 return envelope
+
+        # #885-followup: stage an up-front ``user_input`` on the INITIAL
+        # (non-resume) path so ``{{user_input}}`` tokens substitute without
+        # a pause/resume round-trip. ``resume()`` already stages its value
+        # before calling ``run(..., resume=True)`` — guard on ``not resume``
+        # so we never clobber that staged value with the ``None`` this arm
+        # is called with on the resume pass. Symmetric with the resume
+        # staging at the ``self._staged_user_input`` read in
+        # ``RunExecutor._build_effective_step``. Without this a "natural"
+        # (no-pause) login plan types the literal ``{{user_input}}`` into
+        # the form (live repro: ptrig-A-natural-login → no_state_change).
+        if not resume and user_input is not None:
+            self._staged_user_input = user_input
 
         if not self.plan_signature:
             self.plan_signature = self._compute_plan_signature(plan)
@@ -602,9 +617,11 @@ class MicroPlanRunner:
         return "_no_anchor_"
 
     def run_with_status(
-        self, plan: MicroPlan, resume: bool = False,
+        self, plan: MicroPlan, resume: bool = False, user_input: Any = None,
     ) -> RunnerResult:
-        return self._build_runner_result(plan, self.run(plan, resume=resume))
+        return self._build_runner_result(
+            plan, self.run(plan, resume=resume, user_input=user_input),
+        )
 
     def run_with_exploration(
         self,

--- a/tests/test_micro_runner_hooks.py
+++ b/tests/test_micro_runner_hooks.py
@@ -502,6 +502,58 @@ def test_resume_without_user_input_leaves_substitution_noop(monkeypatch):
     assert getattr(r, "_staged_user_input", None) is None
 
 
+def test_run_stages_initial_user_input_for_substitution(monkeypatch):
+    """#885-followup: a "natural" (no-pause) run carrying an up-front
+    user_input must stage it on ``_staged_user_input`` BEFORE the step
+    loop, so ``_build_effective_step`` substitutes ``{{user_input}}`` into
+    downstream fill_field steps (else the literal placeholder is typed —
+    live repro: ptrig-A-natural-login → no_state_change)."""
+    env = _FakeEnv()
+    r = _runner(env)
+    plan = _trivial_plan()
+
+    # Capture what was staged at the moment the executor runs — proves
+    # the value is staged before the step loop, not merely afterward.
+    seen: dict[str, Any] = {}
+
+    def _capture_execute(*_a, **_kw):
+        seen["staged"] = getattr(r, "_staged_user_input", None)
+
+    monkeypatch.setattr(r._executor, "execute", _capture_execute)
+    monkeypatch.setattr(r, "_final_summary", lambda *_a, **_kw: None)
+
+    r.run(plan, user_input="tomsmith")
+    assert seen["staged"] == "tomsmith"
+    assert getattr(r, "_staged_user_input", None) == "tomsmith"
+
+
+def test_run_without_initial_user_input_leaves_substitution_noop(monkeypatch):
+    """No up-front value must not stage a junk substitution source."""
+    env = _FakeEnv()
+    r = _runner(env)
+    plan = _trivial_plan()
+    monkeypatch.setattr(r._executor, "execute", lambda *_a, **_kw: None)
+    monkeypatch.setattr(r, "_final_summary", lambda *_a, **_kw: None)
+
+    r.run(plan)
+    assert getattr(r, "_staged_user_input", None) is None
+
+
+def test_run_resume_pass_does_not_clobber_staged_user_input(monkeypatch):
+    """resume() stages the value then calls run(..., resume=True) with no
+    user_input. The initial-path staging must be guarded on ``not resume``
+    so it never overwrites the resume-staged value with ``None``."""
+    env = _FakeEnv()
+    r = _runner(env)
+    plan = _trivial_plan()
+    r._staged_user_input = "tomsmith"  # as resume() would have set it
+    monkeypatch.setattr(r._executor, "execute", lambda *_a, **_kw: None)
+    monkeypatch.setattr(r, "_final_summary", lambda *_a, **_kw: None)
+
+    r.run(plan, resume=True)  # the call resume() makes internally
+    assert getattr(r, "_staged_user_input", None) == "tomsmith"
+
+
 def test_resume_works_when_env_lacks_restore_method(monkeypatch):
     """Legacy envs without ``restore_browser_state`` must not crash —
     resume should proceed and run the step loop as before."""


### PR DESCRIPTION
## Problem

PR #883 added `{{user_input}}` substitution and PR #885 staged the resumed value onto `runner._staged_user_input` so `RunExecutor._build_effective_step` could splice it into downstream `fill_field` steps. But that staging happened **only on the `resume()` path**.

A "natural" (no-pause) login run never staged anything, so the literal string `{{user_input}}` was typed into the form → invalid credentials → the page never advanced → every Login click was classified `no_state_change` until the step budget ran out.

### Live evidence (Augur)
- `default__ptrig-A-natural-login-20260613-231912` — **halted**; both Username + Password grounding records typed the literal `{{user_input}}`.
- The succeeded `login-pause-*` resume runs typed real creds (`tomsmith` / `SuperSecretPassword!`) — because `resume()` staged them (#885).

## Fix

Add the symmetric **initial-path** seam:

- `MicroPlanRunner.run()` / `run_with_status()` accept `user_input` and stage it onto `_staged_user_input` **before** the step loop, guarded on `not resume` so the resume pass (which calls `run(resume=True)` with no `user_input`) never clobbers the value `resume()` already staged.
- Modal (`modal_cua_server.py`) and Baseten (`baseten_server/runtime.py`) micro-plan executors pass the up-front value through on the initial branch — it rides along in the submitted suite/payload, symmetric with `_resume_user_input`. `None` (the common case) stays a no-op.

## Tests

Unit (`tests/test_micro_runner_hooks.py`):
- initial-path staging fires **before** the executor runs;
- `None` is a no-op;
- the resume pass does **not** clobber a staged value.

Live (`scripts/verify_initial_user_input_substitution.py`) — run against a fresh `modal deploy`:
- run **`rui-natural-9a061c20` succeeded**;
- Username field typed **`tomsmith`** (substituted), Password `SuperSecretPassword!`;
- no pause (the plan has no `request_user_input` step).

## Note for reviewers

This makes the no-pause path **work when a value is supplied** — it does not invent one. If the `ptrig-A-natural-login` trigger is meant to always carry creds, its submit fixture must start sending a top-level `user_input`; otherwise that plan will (correctly) still leave the token unsubstituted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)