### PR TITLE
feat(observability): capture Holo3 per-token logprobs for RL (PPO/GRPO)

### DIFF
--- a/src/mantis_agent/brain_holo3.py
+++ b/src/mantis_agent/brain_holo3.py
@@ -49,6 +49,36 @@ from .prompts import load_prompt
 
 logger = logging.getLogger(__name__)
 
+
+# RL-prep (logprobs capture). vLLM only returns per-token logprobs when
+# the request asks for them; without this the modelio record's
+# ``response.logprobs`` is always empty, blocking PPO / GRPO (no
+# behaviour-policy logprob → no importance ratio / KL). Gated by the
+# SAME env flag that opens the Augur DebugSession with
+# ``capture_logprobs`` (``observability.augur.should_capture_logprobs``)
+# so one switch turns the whole path on. Read directly here — importing
+# ``observability.augur`` would pull in ``augur_sdk`` at module import,
+# which isn't present in every environment (e.g. local test runs).
+_CAPTURE_LOGPROBS_ENV = "MANTIS_CAPTURE_LOGPROBS"
+_LOGPROBS_TOP_K_ENV = "MANTIS_LOGPROBS_TOP_K"
+
+
+def _capture_logprobs_enabled() -> bool:
+    return os.environ.get(_CAPTURE_LOGPROBS_ENV, "").strip().lower() in {
+        "1", "true", "yes", "on",
+    }
+
+
+def _logprobs_top_k() -> int:
+    """Number of top alternatives per token (``top_logprobs``). 0 (the
+    default) asks only for the sampled token's logprob — all PPO/GRPO
+    needs and the smallest payload. Higher k adds alternatives for
+    analysis at the cost of response size."""
+    try:
+        return max(0, int(os.environ.get(_LOGPROBS_TOP_K_ENV, "0") or "0"))
+    except ValueError:
+        return 0
+
 # ── System prompt (tool-calling style, adapted from LlamaCppBrain) ──────────
 # Sourced from mantis_agent.prompts.HOLO3_SYSTEM. Override per-tenant via
 # MANTIS_PROMPTS_DIR/holo3_system.txt.
@@ -331,6 +361,16 @@ class Holo3Brain:
         # Holo3 native thinking toggle (H Company API format)
         if not self.enable_thinking:
             payload["thinking"] = False
+
+        # RL-prep — ask vLLM for per-token logprobs on the planner call
+        # when training-data capture is enabled. Off by default (roughly
+        # doubles the response payload); the modelio mapper turns the
+        # returned block into ``response.logprobs``.
+        if _capture_logprobs_enabled():
+            payload["logprobs"] = True
+            top_k = _logprobs_top_k()
+            if top_k > 0:
+                payload["top_logprobs"] = top_k
 
         # Retry with backoff for rate limiting (429)
         data = None

--- a/src/mantis_agent/observability/modelio.py
+++ b/src/mantis_agent/observability/modelio.py
@@ -305,6 +305,58 @@ def _extract_openai_response(
     return text, tool_calls, finish_reason
 
 
+def _extract_openai_logprobs(
+    response_json: dict[str, Any],
+) -> list[dict[str, Any]] | None:
+    """Map an OpenAI / vLLM ``choices[0].logprobs.content`` block onto
+    modelio.schema.json's ``response.logprobs`` shape.
+
+    Needed for RL pipelines (PPO / GRPO importance weighting, DPO) that
+    consume the behaviour-policy token logprobs. We map explicitly
+    rather than passing the vendor block through because the schema's
+    item is ``{token?, token_id?, logprob, top_alternatives?}`` with
+    ``additionalProperties: false`` — the vendor ships ``bytes`` and
+    ``top_logprobs`` (not ``top_alternatives``), which would fail
+    validation verbatim.
+
+    Returns ``None`` when the response carries no logprobs (the vendor
+    wasn't asked, or returned a tool-only turn with no token logprobs)
+    so the caller leaves the field unset.
+    """
+    choices = response_json.get("choices") or []
+    if not choices or not isinstance(choices[0], dict):
+        return None
+    block = choices[0].get("logprobs") or {}
+    content = block.get("content")
+    if not isinstance(content, list):
+        return None
+
+    def _alt(a: dict[str, Any]) -> dict[str, Any] | None:
+        if not isinstance(a, dict) or a.get("logprob") is None:
+            return None
+        out: dict[str, Any] = {"logprob": float(a["logprob"])}
+        if isinstance(a.get("token"), str):
+            out["token"] = a["token"]
+        if a.get("token_id") is not None:
+            out["token_id"] = int(a["token_id"])
+        return out
+
+    entries: list[dict[str, Any]] = []
+    for tok in content:
+        if not isinstance(tok, dict) or tok.get("logprob") is None:
+            continue
+        entry: dict[str, Any] = {"logprob": float(tok["logprob"])}
+        if isinstance(tok.get("token"), str):
+            entry["token"] = tok["token"]
+        if tok.get("token_id") is not None:
+            entry["token_id"] = int(tok["token_id"])
+        alts = [m for a in (tok.get("top_logprobs") or []) if (m := _alt(a))]
+        if alts:
+            entry["top_alternatives"] = alts
+        entries.append(entry)
+    return entries or None
+
+
 def record_openai_modelio(
     *,
     request_payload: dict[str, Any],
@@ -353,13 +405,14 @@ def record_openai_modelio(
         response_block["stop_reason"] = finish_reason
     if usage:
         response_block["usage"] = usage
-    try:
-        from augur_sdk import ModelApiAdapterBase
-        logprobs = ModelApiAdapterBase.extract_logprobs_from_response(response_json)
-        if logprobs is not None:
-            response_block["logprobs"] = logprobs
-    except Exception:  # noqa: BLE001 — observability never fatal
-        pass
+    # The OpenAI path knows its own response shape — map logprobs
+    # directly to the schema (verified against modelio.schema.json)
+    # rather than via the vendor-agnostic SDK extractor, which would
+    # have to guess the provider. ``None`` when the vendor wasn't asked
+    # for logprobs (the default) → field stays unset.
+    logprobs = _extract_openai_logprobs(response_json)
+    if logprobs is not None:
+        response_block["logprobs"] = logprobs
 
     record: dict[str, Any] = {
         "schema_version": "0.1",

--- a/tests/fixtures/modelio.schema.json
+++ b/tests/fixtures/modelio.schema.json
@@ -1,0 +1,138 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://augur.dev/schemas/0.1/modelio.schema.json",
+  "title": "ModelIORecord",
+  "description": "One model call's full input + output (closes #56). Stored at `modelio/<step_index:04d>-<layer>-<seq>.json` so multiple calls per step (planner + grounding + verifier) each get a file. Required only when capture_mode is `model_io` or `full`; producers running at lower capture modes MAY omit modelio/ entirely. This is the canonical training-data shape — pinned so downstream SFT/DPO pipelines don't need adapter-specific parsers.",
+  "type": "object",
+  "required": ["schema_version", "layer", "ts", "request", "response"],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+(\\.[0-9]+)?$",
+      "description": "Modelio record schema version. Independent of the bundle schema_version so this shape can evolve without forcing a full bundle bump."
+    },
+    "step_index": {
+      "type": ["integer", "null"],
+      "minimum": 0,
+      "description": "Step this call belongs to, or null for run-scoped calls (e.g. an initial plan that precedes any step)."
+    },
+    "layer": {
+      "type": "string",
+      "enum": ["planner", "grounding", "model", "verifier", "step_recovery", "judge"],
+      "description": "Which agent layer produced this call. `model` is the catch-all for adapters whose architecture doesn't split into planner/grounding."
+    },
+    "ts": {"type": "string", "format": "date-time"},
+    "request": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["model"],
+      "properties": {
+        "model": {
+          "type": "string",
+          "description": "Vendor model identifier exactly as sent (e.g. `claude-sonnet-4-7-20260120`, `gpt-5-2026-04`)."
+        },
+        "system": {
+          "type": ["string", "null"],
+          "description": "System prompt. May be null when the vendor API has no separate system slot."
+        },
+        "messages": {
+          "type": "array",
+          "description": "OpenAI/Anthropic-style message log. `content` is provider-shaped (text blocks, image_url, tool_result, etc.) — schema-free so we can store any vendor's encoding verbatim.",
+          "items": {
+            "type": "object",
+            "required": ["role"],
+            "additionalProperties": true,
+            "properties": {
+              "role": {"type": "string"},
+              "content": {}
+            }
+          }
+        },
+        "tools": {
+          "type": "array",
+          "description": "Tool / function definitions sent with the request. Provider-shaped.",
+          "items": {"type": "object", "additionalProperties": true}
+        },
+        "params": {
+          "type": "object",
+          "additionalProperties": true,
+          "description": "Sampling + generation parameters (temperature, top_p, max_tokens, stop, …). Provider-shaped."
+        }
+      }
+    },
+    "response": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "text": {"type": ["string", "null"]},
+        "tool_calls": {
+          "type": "array",
+          "description": "Tool / function calls the model emitted. Provider-shaped.",
+          "items": {"type": "object", "additionalProperties": true}
+        },
+        "stop_reason": {"type": "string"},
+        "usage": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "prompt_tokens":      {"type": "integer", "minimum": 0},
+            "completion_tokens":  {"type": "integer", "minimum": 0},
+            "cache_hit_tokens":   {"type": "integer", "minimum": 0},
+            "cache_creation_tokens": {"type": "integer", "minimum": 0}
+          }
+        },
+        "logprobs": {
+          "type": ["array", "null"],
+          "description": "Per-output-token log probabilities, when the vendor was asked to return them. Required by RL pipelines that need behavior-policy probabilities for importance weighting (PPO, GRPO) or efficient DPO/preference learning that doesn't recompute logprobs from the trajectory. Order is the linear output sequence — alignment with `tool_calls` and `text` is positional. Null when the producer didn't request logprobs or the vendor doesn't surface them. Empty array MAY be used to record \"requested but no tokens emitted\" (e.g., a tool-only response on a provider that only returns text-token logprobs).",
+          "items": {
+            "type": "object",
+            "required": ["logprob"],
+            "additionalProperties": false,
+            "properties": {
+              "token": {
+                "type": "string",
+                "description": "Decoded token text. Producers SHOULD decode UTF-8 when stable; non-decodable byte sequences MAY be left as the vendor's escape encoding (e.g., `bytes:e2 80 99`) so the original bytes survive a round-trip."
+              },
+              "token_id": {
+                "type": ["integer", "null"],
+                "description": "Vendor token id when exposed. Null when the provider doesn't surface it (e.g., Anthropic). Pair with `token` when feeding into a tokenizer-aware loss; pair with `token_id` for provider-native off-policy correction."
+              },
+              "logprob": {
+                "type": "number",
+                "description": "Natural log of the chosen token's probability under the sampling distribution at this position. Note: this reflects the SAMPLING distribution (post-temperature/top_p), not the unsampled model logits — importance-weighting consumers should pair this with the `request.params` (temperature, top_p, …) carried elsewhere on the same record."
+              },
+              "top_alternatives": {
+                "type": "array",
+                "description": "Top-k alternative tokens with their logprobs at this position. Order: descending logprob. May be empty when the provider returned only the chosen-token logprob (e.g., OpenAI with `top_logprobs=0`).",
+                "items": {
+                  "type": "object",
+                  "required": ["logprob"],
+                  "additionalProperties": false,
+                  "properties": {
+                    "token":    {"type": "string"},
+                    "token_id": {"type": ["integer", "null"]},
+                    "logprob":  {"type": "number"}
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "prompt_hash": {
+      "type": "string",
+      "description": "SHA-256 hex digest of the request blob (canonical-JSON-serialized). Used for de-duplication across runs that share a common prompt template."
+    },
+    "redaction_applied": {
+      "type": "boolean",
+      "description": "Whether the redaction policy was applied to this record before persistence. When true, fields the policy marks sensitive (passwords, tokens, etc.) MAY have been replaced with masks."
+    },
+    "duration_ms": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Wall-clock latency from request send to response receive."
+    }
+  }
+}

--- a/tests/test_holo3_logprobs_capture.py
+++ b/tests/test_holo3_logprobs_capture.py
@@ -1,0 +1,163 @@
+"""RL-prep — Holo3 logprobs capture (request shaping + schema mapping).
+
+vLLM only returns per-token logprobs when asked; the Augur capture
+hook + session flag existed, but the Holo3 request never set
+``logprobs:true``, so ``response.logprobs`` was always empty — blocking
+PPO/GRPO (no behaviour-policy logprob → no importance ratio / KL).
+
+Pins:
+* The planner payload requests logprobs ONLY when MANTIS_CAPTURE_LOGPROBS
+  is set, with top_logprobs gated on MANTIS_LOGPROBS_TOP_K.
+* ``_extract_openai_logprobs`` maps the vendor block onto
+  modelio.schema.json's ``response.logprobs`` shape (drops ``bytes``,
+  renames ``top_logprobs`` → ``top_alternatives``) and the result
+  validates against the in-repo schema.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mantis_agent.observability.modelio import (
+    _extract_openai_logprobs,
+    publish_modelio_context,
+    record_openai_modelio,
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCHEMA_PATH = REPO_ROOT / "data/augur/test/schema/modelio.schema.json"
+
+
+def _vendor_logprobs_response():
+    """An OpenAI / vLLM chat-completions response carrying logprobs in
+    the vendor shape (bytes + top_logprobs)."""
+    return {
+        "choices": [{
+            "message": {"content": "click"},
+            "finish_reason": "stop",
+            "logprobs": {"content": [
+                {
+                    "token": "click", "logprob": -0.05, "bytes": [99, 108],
+                    "top_logprobs": [
+                        {"token": "click", "logprob": -0.05, "bytes": [99]},
+                        {"token": "tap", "logprob": -3.1, "bytes": [116]},
+                    ],
+                },
+                {"token": "()", "logprob": -0.5, "bytes": [40, 41], "top_logprobs": []},
+            ]},
+        }],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 2},
+    }
+
+
+# ── mapper shape ────────────────────────────────────────────────────
+
+
+def test_extract_maps_vendor_block_to_schema_shape():
+    out = _extract_openai_logprobs(_vendor_logprobs_response())
+    assert out is not None and len(out) == 2
+    first = out[0]
+    # bytes dropped; logprob required; token kept.
+    assert set(first) <= {"token", "token_id", "logprob", "top_alternatives"}
+    assert "bytes" not in first
+    assert first["logprob"] == -0.05
+    assert first["token"] == "click"
+    # top_logprobs → top_alternatives, each mapped (bytes dropped).
+    assert first["top_alternatives"][1] == {"token": "tap", "logprob": -3.1}
+
+
+def test_extract_returns_none_when_absent():
+    assert _extract_openai_logprobs({"choices": [{"message": {"content": "x"}}]}) is None
+    assert _extract_openai_logprobs({"choices": []}) is None
+    assert _extract_openai_logprobs({}) is None
+
+
+def test_mapped_logprobs_validate_against_inrepo_schema():
+    """The mapped record must satisfy modelio.schema.json — guards the
+    additionalProperties:false / top_alternatives rename."""
+    jsonschema = pytest.importorskip("jsonschema")
+    schema = json.loads(SCHEMA_PATH.read_text())
+
+    fake = MagicMock()
+    fake.active = True
+    captured = {}
+    fake.record_modelio = lambda rec, **kw: captured.update(rec)
+
+    payload = {"model": "Holo3-35B-A3B", "messages": [], "max_tokens": 256}
+    with publish_modelio_context(fake, layer="planner", step_index=0):
+        record_openai_modelio(
+            request_payload=payload,
+            response_json=_vendor_logprobs_response(),
+            duration_ms=12,
+        )
+    assert captured["response"]["logprobs"][0]["logprob"] == -0.05
+    # Full record validates.
+    jsonschema.validate(instance=captured, schema=schema)
+
+
+# ── request shaping (gated on env) ──────────────────────────────────
+
+
+def _make_brain():
+    from mantis_agent.brain_holo3 import Holo3Brain
+    b = Holo3Brain.__new__(Holo3Brain)
+    b.base_url = "http://x/v1"
+    b.model = "Holo3-35B-A3B"
+    b.model_name = "Holo3-35B-A3B"
+    b.max_tokens = 256
+    b.temperature = 0.0
+    b.use_tool_calling = False
+    b.enable_thinking = False
+    b.api_key = ""          # ``_headers`` is a computed property
+    b.extra_headers = {}
+    return b
+
+
+def _drive_think(brain):
+    """Run think() with the network + parsing stubbed, return the POSTed
+    payload."""
+    seen = {}
+
+    class _Resp:
+        status_code = 200
+        def raise_for_status(self): pass
+        def json(self): return {"choices": [{"message": {"content": "wait"}}]}
+
+    def _post(url, json=None, **kw):
+        seen["payload"] = json
+        return _Resp()
+
+    with patch("mantis_agent.brain_holo3.requests.post", side_effect=_post), \
+         patch.object(brain, "_build_messages", return_value=[]), \
+         patch.object(brain, "_parse_response", return_value=MagicMock()), \
+         patch.object(brain, "_record_modelio_if_active"):
+        brain.think(frames=[], task="t", action_history=[], screen_size=(1, 1))
+    return seen["payload"]
+
+
+def test_payload_omits_logprobs_by_default(monkeypatch):
+    monkeypatch.delenv("MANTIS_CAPTURE_LOGPROBS", raising=False)
+    payload = _drive_think(_make_brain())
+    assert "logprobs" not in payload
+    assert "top_logprobs" not in payload
+
+
+def test_payload_requests_logprobs_when_enabled(monkeypatch):
+    monkeypatch.setenv("MANTIS_CAPTURE_LOGPROBS", "1")
+    monkeypatch.delenv("MANTIS_LOGPROBS_TOP_K", raising=False)
+    payload = _drive_think(_make_brain())
+    assert payload["logprobs"] is True
+    # top_logprobs omitted when k=0 (sampled-token logprob only).
+    assert "top_logprobs" not in payload
+
+
+def test_payload_includes_top_logprobs_when_k_set(monkeypatch):
+    monkeypatch.setenv("MANTIS_CAPTURE_LOGPROBS", "1")
+    monkeypatch.setenv("MANTIS_LOGPROBS_TOP_K", "5")
+    payload = _drive_think(_make_brain())
+    assert payload["logprobs"] is True
+    assert payload["top_logprobs"] == 5

--- a/tests/test_holo3_logprobs_capture.py
+++ b/tests/test_holo3_logprobs_capture.py
@@ -29,7 +29,13 @@ from mantis_agent.observability.modelio import (
 )
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
-SCHEMA_PATH = REPO_ROOT / "data/augur/test/schema/modelio.schema.json"
+# Tracked fixture copy of the Augur modelio schema. The runtime path
+# ``data/augur/test/schema/modelio.schema.json`` is gitignored + only present
+# after an Augur run, so it's absent on a fresh CI checkout — read the vendored
+# fixture instead (falling back to the runtime copy for local convenience).
+_FIXTURE_SCHEMA = REPO_ROOT / "tests/fixtures/modelio.schema.json"
+_RUNTIME_SCHEMA = REPO_ROOT / "data/augur/test/schema/modelio.schema.json"
+SCHEMA_PATH = _FIXTURE_SCHEMA if _FIXTURE_SCHEMA.exists() else _RUNTIME_SCHEMA
 
 
 def _vendor_logprobs_response():


### PR DESCRIPTION
Follow-up to #888. Closes the #1 RL-readiness gap: the Augur capture hook and `capture_logprobs` session flag already existed, but Holo3's vLLM request never asked for logprobs, so `response.logprobs` was always empty — and without behaviour-policy logprobs you can't form the PPO/GRPO importance ratio or a KL penalty.

Entirely **mantis-side** (the augur SDK already routes logprobs through):

- **`brain_holo3.think()`** requests `logprobs:true` (+ optional `top_logprobs`) from vLLM, gated by `MANTIS_CAPTURE_LOGPROBS` (the same env flag that opens the DebugSession with `capture_logprobs`) and `MANTIS_LOGPROBS_TOP_K` (default 0 = sampled-token logprob only). Off by default — roughly doubles the response payload.
- **`record_openai_modelio`** maps the vendor logprobs block onto `modelio.schema.json`'s `response.logprobs` shape: drops `bytes`, renames `top_logprobs` → `top_alternatives` (the schema is `additionalProperties:false`, so a passthrough would fail validation).

## Tests
- Mapper shape + null cases.
- **Mapped record validates against the in-repo `modelio.schema.json`** (guards the rename / additionalProperties).
- Payload gating: omitted by default, `logprobs:true` when enabled, `top_logprobs` only when `MANTIS_LOGPROBS_TOP_K>0`.
- Holo3/brain slice (122 tests) green.

## Enabling
Set `MANTIS_CAPTURE_LOGPROBS=1` on the runtime for training-data / RL-collection runs.

## Still needed for full RL-readiness (follow-ups, not in this PR)
2. Assemble a canonical per-step/trajectory reward from the existing oracle/verdict/failure primitives.
3. Expose the emitted-vs-executed action delta (harness substitutions like loop-recovery/claude-director confound on-policy credit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)