### PR TITLE
feat(observability): instrument the task_loop path with Augur (Claude/EvoCUA/OpenCUA/Gemma4-CUA)

### DIFF
--- a/src/mantis_agent/task_loop.py
+++ b/src/mantis_agent/task_loop.py
@@ -536,6 +536,116 @@ def _standard_task_max_steps(task_config: dict[str, Any], config: TaskLoopConfig
     return min(int(config.max_steps), int(config.standard_task_max_steps))
 
 
+# ── Augur instrumentation for the task_loop path ──────────────────
+#
+# The Holo3 micro path gets Augur bundles for free because RunExecutor
+# opens an AugurAdapter (run_executor.py). The task_loop path (Claude /
+# EvoCUA / OpenCUA / Gemma4-CUA via GymRunner) had NO Augur wiring, so
+# those runs never appeared in the Runs list. These two helpers replay a
+# completed GymRunner run into a bundle so every task_loop brain gets the
+# same observability. Best-effort: a no-op when Augur isn't configured
+# (adapter inactive) and never raises into the run.
+
+
+def _gym_trajectory_to_step_shims(
+    trajectory: list[Any], run_success: bool,
+) -> list[Any]:
+    """Map GymRunner ``TrajectoryStep`` objects to duck-typed step-result
+    shims that ``AugurAdapter.record_step`` / ``_build_step_trace`` consume.
+
+    The wedge reads every field via ``getattr``-with-default, so a
+    ``SimpleNamespace`` carrying the handful of fields it inspects suffices.
+    ``TrajectoryStep.action`` is already a real :class:`actions.Action`, so
+    action type + coords flow through for free.
+
+    Per-step success is coarse: GymRunner has no per-step verdict like the
+    micro runner, so a step with a positive reward — or the final step of a
+    successful run — maps to ``passed``; everything else ``failed``. Refine
+    if/when brains stamp per-step verdicts.
+    """
+    from types import SimpleNamespace
+
+    shims: list[Any] = []
+    n = len(trajectory)
+    for i, ts in enumerate(trajectory):
+        is_last = i == n - 1
+        reward = float(getattr(ts, "reward", 0.0) or 0.0)
+        success = reward > 0.0 or (is_last and run_success)
+        shims.append(
+            SimpleNamespace(
+                step_index=int(getattr(ts, "step", i)),
+                success=success,
+                skip=False,
+                last_action=getattr(ts, "action", None),
+                intent=str(getattr(ts, "thinking", "") or ""),
+                verdict=None,
+                screenshot_png=None,
+                executor_backend=str(getattr(ts, "executor_backend", "") or ""),
+            )
+        )
+    return shims
+
+
+def emit_augur_run(
+    config: "TaskLoopConfig",
+    task_id: str,
+    intent: str,
+    result: Any,
+) -> None:
+    """Replay a completed GymRunner run into an Augur bundle so task_loop
+    brains get the observability the Holo3 micro path gets via RunExecutor.
+
+    No-op when Augur isn't configured (adapter inactive). Never raises.
+    Screenshots are not yet plumbed through (TrajectoryStep carries no PNG);
+    the bundle has full step traces / actions / sparks / status but
+    ``shots:false`` for now — screenshot capture is a follow-up.
+    """
+    try:
+        from .observability.augur import AugurAdapter
+
+        brain = getattr(config, "brain", None)
+        model_name = str(
+            getattr(brain, "model_name", "") or config.model_name or ""
+        )
+        trajectory = list(getattr(result, "trajectory", []) or [])
+        adapter = AugurAdapter(
+            run_id=str(config.run_id or config.session_name or "run"),
+            tenant_id=str(getattr(config, "session_name", "") or ""),
+            session_name=str(getattr(config, "session_name", "") or ""),
+            extra_tags={
+                "plan_name": str(task_id or ""),
+                "workflow_id": str(config.run_id or ""),
+                "model": model_name,
+                "plan_step_count": str(len(trajectory)),
+                "executor": str(getattr(config, "results_prefix", "") or ""),
+            },
+            brain_model_name=model_name,
+        )
+        if not adapter.active:
+            return
+        run_success = bool(getattr(result, "success", False))
+        for sr in _gym_trajectory_to_step_shims(trajectory, run_success):
+            obs = adapter.attach_observation(
+                step_index=sr.step_index, kind="post", png=sr.screenshot_png,
+            )
+            at = getattr(getattr(sr, "last_action", None), "action_type", None)
+            step_type = at.value if hasattr(at, "value") else (str(at) if at else "")
+            adapter.record_step(
+                step_result=sr,
+                observation_post=obs,
+                step_type=step_type,
+            )
+        if getattr(result, "paused", False):
+            status = "paused"
+        elif run_success:
+            status = "succeeded"
+        else:
+            status = "halted"
+        adapter.close(status=status)
+    except Exception as exc:  # noqa: BLE001 — telemetry never breaks a run
+        logger.debug("emit_augur_run failed: %s", exc)
+
+
 # ── Main task loop ────────────────────────────────────────────────
 
 
@@ -860,6 +970,12 @@ def run_task_loop(
             # Executor-specific side effects (trajectory saving, etc.)
             if config.on_task_complete:
                 config.on_task_complete(task_id, intent, result)
+
+            # Augur observability for the task_loop path (Claude / EvoCUA /
+            # OpenCUA / Gemma4-CUA). The Holo3 micro path already emits via
+            # RunExecutor; this closes the gap so non-Holo3 brains also show
+            # up in the Runs list. No-op when Augur is unconfigured.
+            emit_augur_run(config, task_id, intent, result)
 
         except Exception as e:
             traceback.print_exc()

--- a/tests/test_task_loop_augur.py
+++ b/tests/test_task_loop_augur.py
@@ -1,0 +1,125 @@
+"""Augur instrumentation for the task_loop path (Claude / EvoCUA / OpenCUA /
+Gemma4-CUA). The Holo3 micro path emits bundles via RunExecutor; these tests
+cover the task_loop wedge that closes the gap for non-Holo3 brains."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from mantis_agent import task_loop
+from mantis_agent.actions import Action, ActionType
+from mantis_agent.observability import augur as augur_mod
+
+
+def _ts(step, action_type, reward=0.0, thinking=""):
+    return SimpleNamespace(
+        step=step,
+        action=Action(action_type, {}),
+        reward=reward,
+        thinking=thinking,
+        executor_backend="vision",
+    )
+
+
+# ── pure shim mapping ─────────────────────────────────────────────
+
+
+def test_shim_maps_step_index_and_action():
+    traj = [_ts(0, ActionType.CLICK), _ts(1, ActionType.TYPE)]
+    shims = task_loop._gym_trajectory_to_step_shims(traj, run_success=True)
+    assert [s.step_index for s in shims] == [0, 1]
+    assert shims[0].last_action.action_type == ActionType.CLICK
+    assert shims[1].last_action.action_type == ActionType.TYPE
+
+
+def test_shim_success_positive_reward_passes():
+    traj = [_ts(0, ActionType.CLICK, reward=1.0)]
+    shims = task_loop._gym_trajectory_to_step_shims(traj, run_success=False)
+    assert shims[0].success is True
+
+
+def test_shim_final_step_reflects_run_success():
+    traj = [_ts(0, ActionType.CLICK), _ts(1, ActionType.CLICK)]
+    ok = task_loop._gym_trajectory_to_step_shims(traj, run_success=True)
+    assert ok[-1].success is True and ok[0].success is False
+    bad = task_loop._gym_trajectory_to_step_shims(traj, run_success=False)
+    assert all(s.success is False for s in bad)
+
+
+# ── emit wiring ───────────────────────────────────────────────────
+
+
+class _FakeAdapter:
+    last = None
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.active = True
+        self.recorded: list[tuple] = []
+        self.closed: str | None = None
+        _FakeAdapter.last = self
+
+    def attach_observation(self, *, step_index, kind, png):
+        return None
+
+    def record_step(self, *, step_result, observation_post=None, step_type="", **kw):
+        self.recorded.append((step_result.step_index, step_type, step_result.success))
+
+    def close(self, status=None):
+        self.closed = status
+
+
+def _config():
+    return task_loop.TaskLoopConfig(
+        run_id="run-xyz", session_name="sess", model_name="Claude (test)",
+        results_prefix="claude", brain=SimpleNamespace(model_name="claude-test"),
+        env=object(),
+    )
+
+
+def test_emit_records_each_step_and_closes_succeeded(monkeypatch):
+    monkeypatch.setattr(augur_mod, "AugurAdapter", _FakeAdapter)
+    result = SimpleNamespace(
+        success=True, paused=False,
+        trajectory=[_ts(0, ActionType.CLICK), _ts(1, ActionType.TYPE)],
+    )
+    task_loop.emit_augur_run(_config(), "task-1", "do a thing", result)
+    a = _FakeAdapter.last
+    assert [r[0] for r in a.recorded] == [0, 1]
+    assert a.recorded[0][1] == "click"  # step_type from Action
+    assert a.recorded[1][1] == "type_text"
+    assert a.closed == "succeeded"
+    assert a.kwargs["run_id"] == "run-xyz"
+    assert a.kwargs["brain_model_name"] == "claude-test"
+
+
+def test_emit_status_halted_when_failed(monkeypatch):
+    monkeypatch.setattr(augur_mod, "AugurAdapter", _FakeAdapter)
+    result = SimpleNamespace(
+        success=False, paused=False, trajectory=[_ts(0, ActionType.CLICK)],
+    )
+    task_loop.emit_augur_run(_config(), "t", "i", result)
+    assert _FakeAdapter.last.closed == "halted"
+
+
+def test_emit_noop_when_adapter_inactive(monkeypatch):
+    class Inactive(_FakeAdapter):
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            self.active = False
+
+    monkeypatch.setattr(augur_mod, "AugurAdapter", Inactive)
+    result = SimpleNamespace(success=True, paused=False, trajectory=[_ts(0, ActionType.CLICK)])
+    task_loop.emit_augur_run(_config(), "t", "i", result)
+    # inactive → returned before recording / closing
+    assert _FakeAdapter.last.recorded == []
+    assert _FakeAdapter.last.closed is None
+
+
+def test_emit_never_raises(monkeypatch):
+    def boom(**kwargs):
+        raise RuntimeError("adapter blew up")
+
+    monkeypatch.setattr(augur_mod, "AugurAdapter", boom)
+    # must swallow — telemetry never breaks a run
+    task_loop.emit_augur_run(_config(), "t", "i", SimpleNamespace(success=True, trajectory=[]))


### PR DESCRIPTION
## Why

Augur only ever instrumented the **Holo3 micro path** — `RunExecutor` opens the `AugurAdapter` (`run_executor.py:280`), and `RunExecutor` is only constructed by `MicroPlanRunner`. Every other brain runs through `task_loop.run_executor_lifecycle → GymRunner`, which has **zero** Augur references. Result: a `cua_model=claude` run on Modal works but produces **no bundle** — nothing in `list_runs`, no step traces, no modelio. (Confirmed: every run in the live Augur list is `model: Holo3-35B-A3B`.)

## What

A best-effort wedge in `run_task_loop`, fired right after `on_task_complete` for standard tasks:

- **`_gym_trajectory_to_step_shims`** — maps each `TrajectoryStep` to a duck-typed step-result shim. `_build_step_trace` reads every field via `getattr`-with-default, and `TrajectoryStep.action` is already a real `Action`, so action type + coords flow through for free.
- **`emit_augur_run`** — opens an `AugurAdapter` (`run_id` = the submitted run id; model + plan tags), records each step, and closes with `succeeded`/`halted`/`paused`. No-op when Augur is unconfigured (adapter inactive); wrapped so telemetry never raises into a run.

This covers **all** task_loop brains generically (Claude / EvoCUA / OpenCUA / Gemma4-CUA), not just Claude.

## Known limitations (follow-ups)

- **Screenshots** not plumbed yet — `TrajectoryStep` carries no PNG, so bundles are `shots:false`. Needs `capture_dir`/`frame_history` threading.
- **Per-step success is coarse** — GymRunner has no per-step verdict like the micro runner; a step passes on positive reward or as the final step of a successful run.
- **Only the standard-task branch** is instrumented (loop/fallback/recovery branches are next).
- **Claude LLM-call modelio** (request/response capture) is a separate piece.

## Tests

`tests/test_task_loop_augur.py` — shim mapping (index/action/success), emit records each step + closes with the right status, no-op when adapter inactive, never raises. 15 passing across the task_loop suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)