### PR TITLE
feat(observability): screenshots + modelio + status fidelity for task_loop Augur (#892)

### DIFF
--- a/src/mantis_agent/_anthropic/client.py
+++ b/src/mantis_agent/_anthropic/client.py
@@ -338,6 +338,7 @@ class AnthropicToolUseClient:
         }
         last_response = None
         self.last_retries_spent = 0
+        _t0 = time.monotonic()
         for attempt in range(max_attempts):
             try:
                 resp = requests.post(
@@ -361,6 +362,25 @@ class AnthropicToolUseClient:
                 continue
             if resp.status_code not in _TRANSIENT_STATUS_CODES:
                 self.last_retries_spent = attempt
+                # #892 item 2: capture the modelio record at the single HTTP
+                # chokepoint so EVERY caller is covered uniformly — including
+                # ``brain_claude`` / ``plan_decomposer`` / grounding, which
+                # call this method directly and so never hit the per-wrapper
+                # capture that used to live in ``call_with_tool_schema*``.
+                # Cheap context probe first so we don't parse JSON when no
+                # layer is published (the common case).
+                if resp.status_code == 200:
+                    try:
+                        from ..observability.modelio import (
+                            current_modelio_context,
+                        )
+                        if current_modelio_context() is not None:
+                            _record_modelio_if_active(
+                                payload, resp.json(),
+                                int((time.monotonic() - _t0) * 1000),
+                            )
+                    except Exception:  # noqa: BLE001 — telemetry never blocks
+                        pass
                 return resp
             last_response = resp
             if attempt == max_attempts - 1:
@@ -488,12 +508,9 @@ class AnthropicToolUseClient:
                 source=time_bucket or "extract_tool",
                 model=self.model, response_json=payload_json,
             )
-            # #523 — capture the modelio record when an upstream caller
-            # has published a layer context (planner / grounding /
-            # verifier / step_recovery / judge). No-op otherwise.
-            _record_modelio_if_active(
-                payload, payload_json, int((time.monotonic() - t0) * 1000),
-            )
+            # #523 modelio capture now happens centrally in
+            # ``post_messages_with_retry`` (#892 item 2) — which this method
+            # calls — so every caller is covered once, with no double-record.
             for block in payload_json.get("content", []):
                 if block.get("type") == "tool_use" and block.get("name") == tool_name:
                     tool_input = block.get("input")
@@ -609,9 +626,7 @@ class AnthropicToolUseClient:
                 source=time_bucket or "extract_tool_multi",
                 model=self.model, response_json=payload_json,
             )
-            _record_modelio_if_active(
-                payload, payload_json, int((time.monotonic() - t0) * 1000),
-            )
+            # #523 modelio capture is centralized in post_messages_with_retry.
             for block in payload_json.get("content", []):
                 if block.get("type") == "tool_use" and block.get("name") == tool_name:
                     tool_input = block.get("input")

--- a/src/mantis_agent/task_loop.py
+++ b/src/mantis_agent/task_loop.py
@@ -547,8 +547,27 @@ def _standard_task_max_steps(task_config: dict[str, Any], config: TaskLoopConfig
 # (adapter inactive) and never raises into the run.
 
 
+_AUGUR_DONE_REASONS = frozenset({"done", "env_done"})
+
+
+def _run_status_from_result(result: Any) -> str:
+    """Map a :class:`gym.runner.RunResult` to an Augur close status.
+
+    Issue #892 (3): the close status was derived from ``result.success``
+    alone, so a run where the agent deliberately called ``done`` but the
+    (often absent) grader didn't mark success showed ``halted``. Treat
+    ``termination_reason`` in {done, env_done} as a deliberate completion.
+    """
+    if getattr(result, "paused", False):
+        return "paused"
+    reason = str(getattr(result, "termination_reason", "") or "")
+    if bool(getattr(result, "success", False)) or reason in _AUGUR_DONE_REASONS:
+        return "succeeded"
+    return "halted"
+
+
 def _gym_trajectory_to_step_shims(
-    trajectory: list[Any], run_success: bool,
+    trajectory: list[Any], run_success: bool, termination_reason: str = "",
 ) -> list[Any]:
     """Map GymRunner ``TrajectoryStep`` objects to duck-typed step-result
     shims that ``AugurAdapter.record_step`` / ``_build_step_trace`` consume.
@@ -558,19 +577,19 @@ def _gym_trajectory_to_step_shims(
     ``TrajectoryStep.action`` is already a real :class:`actions.Action`, so
     action type + coords flow through for free.
 
-    Per-step success is coarse: GymRunner has no per-step verdict like the
-    micro runner, so a step with a positive reward — or the final step of a
-    successful run — maps to ``passed``; everything else ``failed``. Refine
-    if/when brains stamp per-step verdicts.
+    Per-step success is coarse (GymRunner has no per-step verdict): a step
+    with positive reward — or the final step of a run that succeeded or
+    terminated via a deliberate ``done`` — maps to ``passed``; else ``failed``.
     """
     from types import SimpleNamespace
 
+    final_ok = bool(run_success) or str(termination_reason) in _AUGUR_DONE_REASONS
     shims: list[Any] = []
     n = len(trajectory)
     for i, ts in enumerate(trajectory):
         is_last = i == n - 1
         reward = float(getattr(ts, "reward", 0.0) or 0.0)
-        success = reward > 0.0 or (is_last and run_success)
+        success = reward > 0.0 or (is_last and final_ok)
         shims.append(
             SimpleNamespace(
                 step_index=int(getattr(ts, "step", i)),
@@ -586,64 +605,131 @@ def _gym_trajectory_to_step_shims(
     return shims
 
 
-def emit_augur_run(
-    config: "TaskLoopConfig",
-    task_id: str,
-    intent: str,
-    result: Any,
-) -> None:
-    """Replay a completed GymRunner run into an Augur bundle so task_loop
-    brains get the observability the Holo3 micro path gets via RunExecutor.
+def _augur_path_safe(s: Any) -> str:
+    """Sanitize an id into a single path segment for the frame capture dir."""
+    out = "".join(c if (c.isalnum() or c in "._-") else "_" for c in str(s))
+    return out[:80] or "x"
 
-    No-op when Augur isn't configured (adapter inactive). Never raises.
-    Screenshots are not yet plumbed through (TrajectoryStep carries no PNG);
-    the bundle has full step traces / actions / sparks / status but
-    ``shots:false`` for now — screenshot capture is a follow-up.
+
+def open_augur_handle(config: "TaskLoopConfig", task_id: str) -> Any:
+    """Open a live ``AugurAdapter`` + a per-task screenshot capture dir.
+
+    Opened BEFORE the GymRunner run so a modelio context (issue #892 item 2 —
+    Claude ``think()`` capture) can be live during inference, and so
+    ``GymRunner.run(capture_dir=...)`` writes per-step PNGs the replay reads
+    back (item 1). Returns a handle (``adapter`` + ``capture_dir``) or
+    ``None`` when Augur is unconfigured. ``emit_augur_run`` closes it.
     """
     try:
+        import tempfile
+        from types import SimpleNamespace
+
         from .observability.augur import AugurAdapter
 
         brain = getattr(config, "brain", None)
-        model_name = str(
-            getattr(brain, "model_name", "") or config.model_name or ""
-        )
-        trajectory = list(getattr(result, "trajectory", []) or [])
+        model_name = str(getattr(brain, "model_name", "") or config.model_name or "")
+        run_id = str(config.run_id or config.session_name or "run")
         adapter = AugurAdapter(
-            run_id=str(config.run_id or config.session_name or "run"),
+            run_id=run_id,
             tenant_id=str(getattr(config, "session_name", "") or ""),
             session_name=str(getattr(config, "session_name", "") or ""),
             extra_tags={
                 "plan_name": str(task_id or ""),
                 "workflow_id": str(config.run_id or ""),
                 "model": model_name,
-                "plan_step_count": str(len(trajectory)),
                 "executor": str(getattr(config, "results_prefix", "") or ""),
             },
             brain_model_name=model_name,
         )
         if not adapter.active:
+            return None
+        capture_dir = os.path.join(
+            tempfile.gettempdir(), "mantis_augur_frames",
+            _augur_path_safe(run_id), _augur_path_safe(task_id),
+        )
+        return SimpleNamespace(
+            adapter=adapter, capture_dir=capture_dir, model_name=model_name,
+        )
+    except Exception as exc:  # noqa: BLE001 — telemetry never breaks a run
+        logger.debug("open_augur_handle failed: %s", exc)
+        return None
+
+
+def augur_modelio_ctx(handle: Any):
+    """Context manager that activates modelio capture for the wrapped LLM
+    calls (issue #892 item 2). No-op when ``handle`` is None. Whole-run
+    ``planner`` context — per-step attribution is a tracked sub-follow-up."""
+    from contextlib import nullcontext
+
+    if handle is None:
+        return nullcontext()
+    try:
+        from .observability.modelio import publish_modelio_context
+
+        return publish_modelio_context(handle.adapter, "planner")
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("augur_modelio_ctx failed: %s", exc)
+        return nullcontext()
+
+
+def emit_augur_run(
+    config: "TaskLoopConfig",
+    task_id: str,
+    intent: str,
+    result: Any,
+    handle: Any = None,
+) -> None:
+    """Replay a completed GymRunner run into the Augur bundle opened by
+    :func:`open_augur_handle`, then close it. No-op (and nothing to close)
+    when ``handle`` is None. Never raises — telemetry never breaks a run.
+
+    Screenshots (issue #892 item 1) are read back from the handle's
+    ``capture_dir`` (``GymRunner`` wrote ``<NNNN>.png`` per step). Skipped
+    when a fallback/resume run produced the final result, since the on-disk
+    frames belong to the standard run and would mismatch.
+    """
+    if handle is None:
+        return
+    adapter = getattr(handle, "adapter", None)
+    capture_dir = getattr(handle, "capture_dir", None)
+    try:
+        if adapter is None:
             return
+        trajectory = list(getattr(result, "trajectory", []) or [])
         run_success = bool(getattr(result, "success", False))
-        for sr in _gym_trajectory_to_step_shims(trajectory, run_success):
+        reason = str(getattr(result, "termination_reason", "") or "")
+        use_frames = bool(
+            capture_dir
+            and not getattr(result, "fallback_used", None)
+            and os.path.isdir(capture_dir)
+        )
+        shims = _gym_trajectory_to_step_shims(trajectory, run_success, reason)
+        for sr in shims:
+            png = None
+            if use_frames:
+                fp = os.path.join(capture_dir, f"{sr.step_index:04d}.png")
+                if os.path.isfile(fp):
+                    try:
+                        with open(fp, "rb") as fh:
+                            png = fh.read()
+                    except Exception:  # noqa: BLE001
+                        png = None
             obs = adapter.attach_observation(
-                step_index=sr.step_index, kind="post", png=sr.screenshot_png,
+                step_index=sr.step_index, kind="post", png=png,
             )
             at = getattr(getattr(sr, "last_action", None), "action_type", None)
             step_type = at.value if hasattr(at, "value") else (str(at) if at else "")
             adapter.record_step(
-                step_result=sr,
-                observation_post=obs,
-                step_type=step_type,
+                step_result=sr, observation_post=obs, step_type=step_type,
             )
-        if getattr(result, "paused", False):
-            status = "paused"
-        elif run_success:
-            status = "succeeded"
-        else:
-            status = "halted"
-        adapter.close(status=status)
+        adapter.close(status=_run_status_from_result(result))
     except Exception as exc:  # noqa: BLE001 — telemetry never breaks a run
         logger.debug("emit_augur_run failed: %s", exc)
+    finally:
+        if capture_dir and os.path.isdir(capture_dir):
+            import shutil
+
+            shutil.rmtree(capture_dir, ignore_errors=True)
 
 
 # ── Main task loop ────────────────────────────────────────────────
@@ -826,6 +912,7 @@ def run_task_loop(
                 continue
 
             # ── Standard task ──
+            augur_handle = None  # closed in emit_augur_run / the except below
             runner = GymRunner(
                 brain=config.brain,
                 env=config.env,
@@ -834,11 +921,20 @@ def run_task_loop(
                 grounding=config.grounding,
                 on_step=on_step,
             )
-            result = runner.run(
-                task=intent,
-                task_id=task_id,
-                start_url=task_config.get("start_url", ""),
-            )
+            # Augur (issue #892): open a live adapter + frame capture dir so
+            # Claude/EvoCUA/OpenCUA/Gemma4-CUA runs get bundles with modelio
+            # (LLM-call capture during inference) and screenshots. No-op when
+            # Augur is unconfigured. Closed in emit_augur_run below.
+            augur_handle = open_augur_handle(config, task_id)
+            with augur_modelio_ctx(augur_handle):
+                result = runner.run(
+                    task=intent,
+                    task_id=task_id,
+                    start_url=task_config.get("start_url", ""),
+                    capture_dir=(
+                        augur_handle.capture_dir if augur_handle else None
+                    ),
+                )
             _merge_runner_costs(runner)
 
             if not result.success and config.fallback_brain is not None:
@@ -974,12 +1070,21 @@ def run_task_loop(
             # Augur observability for the task_loop path (Claude / EvoCUA /
             # OpenCUA / Gemma4-CUA). The Holo3 micro path already emits via
             # RunExecutor; this closes the gap so non-Holo3 brains also show
-            # up in the Runs list. No-op when Augur is unconfigured.
-            emit_augur_run(config, task_id, intent, result)
+            # up in the Runs list. Replays the trajectory + screenshots and
+            # closes the adapter opened above. No-op when Augur unconfigured.
+            emit_augur_run(config, task_id, intent, result, handle=augur_handle)
 
         except Exception as e:
             traceback.print_exc()
             print(f"  ERROR: {e}")
+            # Close a leaked Augur adapter if the run threw before emit ran
+            # (emit_augur_run closes it on the normal path). Best-effort.
+            _leaked = locals().get("augur_handle")
+            if _leaked is not None:
+                try:
+                    _leaked.adapter.close(status="failed")
+                except Exception:  # noqa: BLE001
+                    pass
             scores.append(0.0)
             error_detail: dict[str, Any] = {
                 "task_id": task_id,

--- a/tests/test_anthropic_client.py
+++ b/tests/test_anthropic_client.py
@@ -75,6 +75,46 @@ def test_post_messages_recovers_from_529() -> None:
     assert post.call_count == 2
 
 
+def test_post_messages_captures_modelio_when_context_active() -> None:
+    """#892 item 2: modelio capture is centralized in
+    ``post_messages_with_retry``, so a DIRECT caller (brain_claude /
+    plan_decomposer / grounding) captures when a layer context is published —
+    previously the hook lived only in ``call_with_tool_schema*``, so these
+    callers never captured."""
+    from mantis_agent.observability.modelio import publish_modelio_context
+
+    class _FakeAugur:
+        def __init__(self):
+            self.active = True
+            self.records: list = []
+
+        def record_modelio(self, *args, **kwargs):
+            self.records.append((args, kwargs))
+
+    augur = _FakeAugur()
+    body = {
+        "content": [{"type": "text", "text": "ok"}],
+        "usage": {"input_tokens": 5, "output_tokens": 3},
+        "model": "m", "stop_reason": "end_turn",
+    }
+    client = AnthropicToolUseClient(api_key="k", model="m")
+    payload = {"messages": [{"role": "user", "content": "hi"}]}
+    with patch("requests.post", return_value=_fake_response(200, body=body)):
+        with publish_modelio_context(augur, "planner"):
+            client.post_messages_with_retry(payload, timeout=30)
+    assert augur.records, "central capture did not fire for a direct caller"
+
+
+def test_post_messages_no_capture_without_context() -> None:
+    """No published layer → no capture (and no JSON parse cost)."""
+    body = {"content": [], "usage": {}}
+    resp = _fake_response(200, body=body)
+    client = AnthropicToolUseClient(api_key="k", model="m")
+    with patch("requests.post", return_value=resp):
+        client.post_messages_with_retry({"messages": []}, timeout=30)
+    resp.json.assert_not_called()  # cheap context probe short-circuits
+
+
 def test_post_messages_honours_log_prefix(caplog) -> None:
     """When the client is constructed with a custom ``log_prefix``,
     transient-error log lines carry that prefix — keeps the existing

--- a/tests/test_task_loop_augur.py
+++ b/tests/test_task_loop_augur.py
@@ -46,6 +46,36 @@ def test_shim_final_step_reflects_run_success():
     assert all(s.success is False for s in bad)
 
 
+def test_shim_final_step_passes_on_done_termination():
+    traj = [_ts(0, ActionType.CLICK), _ts(1, ActionType.CLICK)]
+    # run_success False but the agent terminated via a deliberate `done`
+    shims = task_loop._gym_trajectory_to_step_shims(
+        traj, run_success=False, termination_reason="done",
+    )
+    assert shims[-1].success is True
+
+
+# ── run-status mapping (issue #892 item 3) ─────────────────────────
+
+
+def test_run_status_paused():
+    assert task_loop._run_status_from_result(
+        SimpleNamespace(paused=True, success=False, termination_reason="")
+    ) == "paused"
+
+
+def test_run_status_done_termination_is_succeeded():
+    assert task_loop._run_status_from_result(
+        SimpleNamespace(paused=False, success=False, termination_reason="done")
+    ) == "succeeded"
+
+
+def test_run_status_max_steps_is_halted():
+    assert task_loop._run_status_from_result(
+        SimpleNamespace(paused=False, success=False, termination_reason="max_steps")
+    ) == "halted"
+
+
 # ── emit wiring ───────────────────────────────────────────────────
 
 
@@ -56,11 +86,13 @@ class _FakeAdapter:
         self.kwargs = kwargs
         self.active = True
         self.recorded: list[tuple] = []
+        self.observed: list[tuple] = []
         self.closed: str | None = None
         _FakeAdapter.last = self
 
     def attach_observation(self, *, step_index, kind, png):
-        return None
+        self.observed.append((step_index, len(png) if png else 0))
+        return f"shot/{step_index}.png" if png else None
 
     def record_step(self, *, step_result, observation_post=None, step_type="", **kw):
         self.recorded.append((step_result.step_index, step_type, step_result.success))
@@ -77,49 +109,86 @@ def _config():
     )
 
 
-def test_emit_records_each_step_and_closes_succeeded(monkeypatch):
-    monkeypatch.setattr(augur_mod, "AugurAdapter", _FakeAdapter)
-    result = SimpleNamespace(
-        success=True, paused=False,
-        trajectory=[_ts(0, ActionType.CLICK), _ts(1, ActionType.TYPE)],
-    )
-    task_loop.emit_augur_run(_config(), "task-1", "do a thing", result)
-    a = _FakeAdapter.last
-    assert [r[0] for r in a.recorded] == [0, 1]
-    assert a.recorded[0][1] == "click"  # step_type from Action
-    assert a.recorded[1][1] == "type_text"
-    assert a.closed == "succeeded"
-    assert a.kwargs["run_id"] == "run-xyz"
-    assert a.kwargs["brain_model_name"] == "claude-test"
+def _handle(monkeypatch, adapter_cls=_FakeAdapter):
+    monkeypatch.setattr(augur_mod, "AugurAdapter", adapter_cls)
+    return task_loop.open_augur_handle(_config(), "task-1")
 
 
-def test_emit_status_halted_when_failed(monkeypatch):
-    monkeypatch.setattr(augur_mod, "AugurAdapter", _FakeAdapter)
-    result = SimpleNamespace(
-        success=False, paused=False, trajectory=[_ts(0, ActionType.CLICK)],
-    )
-    task_loop.emit_augur_run(_config(), "t", "i", result)
-    assert _FakeAdapter.last.closed == "halted"
-
-
-def test_emit_noop_when_adapter_inactive(monkeypatch):
+def test_open_handle_returns_none_when_inactive(monkeypatch):
     class Inactive(_FakeAdapter):
         def __init__(self, **kwargs):
             super().__init__(**kwargs)
             self.active = False
 
-    monkeypatch.setattr(augur_mod, "AugurAdapter", Inactive)
-    result = SimpleNamespace(success=True, paused=False, trajectory=[_ts(0, ActionType.CLICK)])
-    task_loop.emit_augur_run(_config(), "t", "i", result)
-    # inactive → returned before recording / closing
-    assert _FakeAdapter.last.recorded == []
-    assert _FakeAdapter.last.closed is None
+    assert _handle(monkeypatch, Inactive) is None
+
+
+def test_emit_records_each_step_and_closes_succeeded(monkeypatch):
+    handle = _handle(monkeypatch)
+    assert handle.adapter.kwargs["run_id"] == "run-xyz"
+    assert handle.adapter.kwargs["brain_model_name"] == "claude-test"
+    result = SimpleNamespace(
+        success=True, paused=False, termination_reason="done", fallback_used=None,
+        trajectory=[_ts(0, ActionType.CLICK), _ts(1, ActionType.TYPE)],
+    )
+    task_loop.emit_augur_run(_config(), "task-1", "do a thing", result, handle=handle)
+    a = handle.adapter
+    assert [r[0] for r in a.recorded] == [0, 1]
+    assert a.recorded[0][1] == "click"
+    assert a.recorded[1][1] == "type_text"
+    assert a.closed == "succeeded"
+
+
+def test_emit_status_halted_when_failed(monkeypatch):
+    handle = _handle(monkeypatch)
+    result = SimpleNamespace(
+        success=False, paused=False, termination_reason="max_steps",
+        fallback_used=None, trajectory=[_ts(0, ActionType.CLICK)],
+    )
+    task_loop.emit_augur_run(_config(), "t", "i", result, handle=handle)
+    assert handle.adapter.closed == "halted"
+
+
+def test_emit_noop_when_handle_none():
+    # handle is None (Augur unconfigured) → nothing to do, no raise
+    task_loop.emit_augur_run(
+        _config(), "t", "i", SimpleNamespace(success=True, trajectory=[]), handle=None,
+    )
+
+
+def test_emit_attaches_screenshots_from_capture_dir(monkeypatch, tmp_path):
+    handle = _handle(monkeypatch)
+    handle.capture_dir = str(tmp_path)
+    # GymRunner writes <NNNN>.png; provide one for step 0 only.
+    (tmp_path / "0000.png").write_bytes(b"\x89PNG\r\n\x1a\nFAKE")
+    result = SimpleNamespace(
+        success=True, paused=False, termination_reason="done", fallback_used=None,
+        trajectory=[_ts(0, ActionType.CLICK), _ts(1, ActionType.CLICK)],
+    )
+    task_loop.emit_augur_run(_config(), "task-1", "i", result, handle=handle)
+    obs = dict(handle.adapter.observed)
+    assert obs[0] > 0   # step 0 PNG bytes attached
+    assert obs[1] == 0  # step 1 has no frame on disk
+
+
+def test_emit_skips_screenshots_on_fallback(monkeypatch, tmp_path):
+    handle = _handle(monkeypatch)
+    handle.capture_dir = str(tmp_path)
+    (tmp_path / "0000.png").write_bytes(b"\x89PNGFAKE")
+    result = SimpleNamespace(
+        success=False, paused=False, termination_reason="max_steps",
+        fallback_used="claude", trajectory=[_ts(0, ActionType.CLICK)],
+    )
+    task_loop.emit_augur_run(_config(), "t", "i", result, handle=handle)
+    # fallback result → frames belong to the standard run, skip them
+    assert handle.adapter.observed == [(0, 0)]
 
 
 def test_emit_never_raises(monkeypatch):
-    def boom(**kwargs):
-        raise RuntimeError("adapter blew up")
+    handle = _handle(monkeypatch)
 
-    monkeypatch.setattr(augur_mod, "AugurAdapter", boom)
-    # must swallow — telemetry never breaks a run
-    task_loop.emit_augur_run(_config(), "t", "i", SimpleNamespace(success=True, trajectory=[]))
+    class Boom:
+        def __getattr__(self, _):
+            raise RuntimeError("trajectory blew up")
+
+    task_loop.emit_augur_run(_config(), "t", "i", Boom(), handle=handle)


### PR DESCRIPTION
Follow-ups to #891. Closes items **1–3** of #892 for the standard-task path.

## 1. Screenshots (`shots:false` → `true`)
Open the adapter **before** the GymRunner run and pass a per-task `capture_dir`. `GymRunner.run` already writes `<NNNN>.png` per step; `emit_augur_run` reads them back and attaches via `attach_observation`. Skipped when a fallback/resume run produced the final result (on-disk frames belong to the standard run → would mismatch). Frame dir is cleaned up after.

## 2. Claude LLM-call modelio (`modelio:false` → `true`)
Wrap the run in `publish_modelio_context(adapter, "planner")`. The Anthropic client auto-captures each `think()` call while the context is active (`_anthropic/client.py:251`) — no GymRunner change. Whole-run context; per-step attribution is the tracked sub-follow-up in #892.

## 3. Status / sparks fidelity
`_run_status_from_result` maps from `RunResult.termination_reason`: a deliberate `done`/`env_done` is **succeeded** even when the (often absent) grader left `success=False`; `max_steps`/`loop` → `halted`; `paused` → `paused`. The final-step spark follows the same rule. (Fixes the observed "HTTP succeeded but bundle halted + all-failed" from #891 verification.)

## Lifecycle
`open_augur_handle` (live adapter + capture dir) → `augur_modelio_ctx` wraps `runner.run` → `emit_augur_run` replays trajectory + screenshots and closes. No-op when Augur is unconfigured; a leaked adapter is closed in the task's `except`. Never raises into a run.

## Remaining in #892
Item 4 (fallback/resume/loop-branch instrumentation) and per-step modelio attribution.

## Tests
Status mapping, done-termination spark, screenshot attach + fallback skip, handle open/no-op/never-raises — 22 passing across the task_loop suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)