### PR TITLE
feat(learning): close the plan-evolution loop — apply learned rewrites pre-flight (#894)

### DIFF
--- a/src/mantis_agent/gym/micro_runner.py
+++ b/src/mantis_agent/gym/micro_runner.py
@@ -428,6 +428,38 @@ class MicroPlanRunner:
 
         if not self.plan_signature:
             self.plan_signature = self._compute_plan_signature(plan)
+
+        # Plan-evolution Phase 2 (#894): apply learned rewrites PRE-FLIGHT so
+        # the self-improvement loop is closed — ``promoted`` rewrites (3+
+        # consecutive wins) are used, and ``candidate`` rewrites are re-applied
+        # as exploration so they accumulate the wins promotion needs. Sets
+        # ``_applied_plan_rewrites`` (extended, since step_recovery may append
+        # live rewrites during the run) so ``finalize_run_outcomes`` records
+        # per-rewrite outcomes at terminal and drives the promotion gate.
+        # Applied AFTER plan_signature is computed so the signature reflects
+        # the ORIGINAL plan (matching the evolution-store key + hint/exemplar
+        # stores). No-op without _plan_hash/_workflow_id, on resume, or when
+        # nothing is applicable. ``_plan_overlay_explore_candidates`` (default
+        # True) gates the riskier candidate-exploration arm.
+        if not resume:
+            ph = str(getattr(self, "_plan_hash", "") or "")
+            wf = str(getattr(self, "_workflow_id", "") or "")
+            if ph and wf:
+                try:
+                    from ..recipes.plan_evolution_store import apply_plan_overlay
+                    explore = bool(
+                        getattr(self, "_plan_overlay_explore_candidates", True)
+                    )
+                    plan, applied = apply_plan_overlay(
+                        plan, plan_hash=ph, workflow_id=wf,
+                        include_candidates=explore,
+                    )
+                    if applied:
+                        prior = list(getattr(self, "_applied_plan_rewrites", None) or [])
+                        self._applied_plan_rewrites = prior + applied
+                except Exception as exc:  # noqa: BLE001 — never block the run
+                    logger.debug("plan_evolution: apply_plan_overlay raised: %s", exc)
+
         state = RunState.fresh(
             run_key=self.run_key, session_name=self.session_name,
             plan_signature=self.plan_signature,

--- a/src/mantis_agent/recipes/plan_evolution_store.py
+++ b/src/mantis_agent/recipes/plan_evolution_store.py
@@ -227,13 +227,21 @@ def apply_plan_overlay(
     *,
     plan_hash: str,
     workflow_id: str,
+    include_candidates: bool = False,
 ) -> tuple["MicroPlan", list[StepRewrite]]:
-    """Return the plan with all `promoted` rewrites applied + the list
-    of rewrites that were applied.
+    """Return the plan with learned rewrites applied + the list of
+    rewrites that were applied.
 
-    Pre-flight: called by the dispatcher BEFORE ``build_micro_suite`` so
-    the rewritten URLs land in the suite the executor receives. Idempotent
-    + no-op when no store exists or no rewrites are promoted.
+    Pre-flight: called BEFORE the executor runs so the rewritten URLs land
+    in the steps the executor receives. Idempotent + no-op when no store
+    exists or nothing is applicable.
+
+    ``promoted`` rewrites are always applied. With ``include_candidates``
+    (exploration, #894), not-yet-promoted ``candidate`` rewrites are ALSO
+    applied so they accumulate the consecutive wins promotion requires —
+    at the cost of applying an unproven rewrite to a live run. The
+    cold-idle demotion applies to ``promoted`` rewrites only (candidates
+    have no "promoted-but-stale" state to expire).
 
     Phase 2 ships ``scope='workflow'`` only — tenant + site scopes added
     in Phase 3.
@@ -245,19 +253,22 @@ def apply_plan_overlay(
     if not evo.rewrites:
         return plan, []
 
+    applicable = {"promoted", "candidate"} if include_candidates else {"promoted"}
     applied: list[StepRewrite] = []
     now_ts = time.time()
     for rewrite in evo.rewrites:
-        if rewrite.status != "promoted":
+        if rewrite.status not in applicable:
             continue
         # Cold-transition gate: promoted rewrites unused for ≥ COLD_AGE
         # demote to `cold` and skip application. Re-promotion requires
-        # 3 fresh successful runs.
-        last_ts = _parse_iso(rewrite.last_seen)
-        if last_ts and (now_ts - last_ts) > COLD_AGE_SECONDS:
-            rewrite.status = "cold"
-            rewrite.demotion_reason = "idle_30d"
-            continue
+        # 3 fresh successful runs. (Candidates are exempt — they're being
+        # explored toward promotion, not expired.)
+        if rewrite.status == "promoted":
+            last_ts = _parse_iso(rewrite.last_seen)
+            if last_ts and (now_ts - last_ts) > COLD_AGE_SECONDS:
+                rewrite.status = "cold"
+                rewrite.demotion_reason = "idle_30d"
+                continue
         if rewrite.step_index >= len(plan.steps):
             continue
         step = plan.steps[rewrite.step_index]
@@ -265,9 +276,9 @@ def apply_plan_overlay(
         applied.append(rewrite)
         logger.warning(
             "  [plan-overlay] step %d rewritten via %s "
-            "(confidence=%.2f, %d/%d successes)",
-            rewrite.step_index, rewrite.source, rewrite.confidence,
-            rewrite.successful_runs, PROMOTION_THRESHOLD,
+            "(%s, confidence=%.2f, %d/%d successes)",
+            rewrite.step_index, rewrite.source, rewrite.status,
+            rewrite.confidence, rewrite.successful_runs, PROMOTION_THRESHOLD,
         )
 
     # Persist any cold-transition demotions.

--- a/tests/test_micro_runner_hooks.py
+++ b/tests/test_micro_runner_hooks.py
@@ -539,6 +539,43 @@ def test_run_without_initial_user_input_leaves_substitution_noop(monkeypatch):
     assert getattr(r, "_staged_user_input", None) is None
 
 
+def test_run_applies_promoted_plan_rewrite_preflight(monkeypatch, tmp_path):
+    """#894 keystone: run() applies learned (promoted) plan rewrites
+    pre-flight and records them on _applied_plan_rewrites so the terminal
+    promotion gate can score them — closing the plan-evolution loop."""
+    monkeypatch.setenv("MANTIS_PLAN_EVOLUTION_DIR", str(tmp_path))
+    from mantis_agent.recipes.plan_evolution_store import (
+        PROMOTION_THRESHOLD,
+        record_rewrite_candidate,
+        record_run_outcome,
+    )
+
+    rw = record_rewrite_candidate(
+        plan_hash="ph", workflow_id="wf", step_index=0,
+        original_step={"intent": "Step 0: navigate to https://example.test/0",
+                       "type": "navigate", "params": {}},
+        rewritten_step={"intent": "REWRITTEN BY EVOLUTION",
+                        "type": "navigate", "params": {}},
+        source="pattern_transform", confidence=0.7,
+    )
+    for _ in range(PROMOTION_THRESHOLD):
+        record_run_outcome(plan_hash="ph", workflow_id="wf",
+                           applied_rewrites=[rw], outcome="success")
+
+    env = _FakeEnv()
+    r = _runner(env)
+    r._plan_hash = "ph"
+    r._workflow_id = "wf"
+    plan = _trivial_plan()
+    monkeypatch.setattr(r._executor, "execute", lambda *_a, **_kw: None)
+    monkeypatch.setattr(r, "_final_summary", lambda *_a, **_kw: None)
+
+    r.run(plan)
+    assert plan.steps[0].intent == "REWRITTEN BY EVOLUTION"
+    applied = getattr(r, "_applied_plan_rewrites", None) or []
+    assert any(a.step_index == 0 for a in applied)
+
+
 def test_run_resume_pass_does_not_clobber_staged_user_input(monkeypatch):
     """resume() stages the value then calls run(..., resume=True) with no
     user_input. The initial-path staging must be guarded on ``not resume``

--- a/tests/test_plan_evolution_store.py
+++ b/tests/test_plan_evolution_store.py
@@ -300,6 +300,34 @@ def test_apply_overlay_no_op_when_no_store_file(temp_store: str) -> None:
     assert out.steps[0].params["url"] == "https://x.com/a"
 
 
+def test_apply_overlay_include_candidates_applies_candidate(temp_store: str) -> None:
+    """#894 exploration: with include_candidates, a not-yet-promoted
+    candidate is ALSO applied (so it can accumulate wins toward promotion);
+    the default path still leaves it untouched."""
+    record_rewrite_candidate(
+        plan_hash="plan-1", workflow_id="wf1", step_index=0,
+        original_step=_step_body("nav", "https://x.com/a"),
+        rewritten_step=_step_body("nav", "https://x.com/A"),
+        source="pattern_transform", confidence=0.6,
+    )
+    # Default (promoted-only): candidate untouched.
+    plan = _make_plan_with_steps("https://x.com/a")
+    _, applied_default = apply_plan_overlay(
+        plan, plan_hash="plan-1", workflow_id="wf1",
+    )
+    assert applied_default == []
+    assert plan.steps[0].params["url"] == "https://x.com/a"
+
+    # Exploration: candidate applied.
+    plan2 = _make_plan_with_steps("https://x.com/a")
+    new_plan, applied = apply_plan_overlay(
+        plan2, plan_hash="plan-1", workflow_id="wf1", include_candidates=True,
+    )
+    assert len(applied) == 1
+    assert applied[0].status == "candidate"
+    assert new_plan.steps[0].params["url"] == "https://x.com/A"
+
+
 def test_apply_overlay_handles_out_of_range_step_index(temp_store: str) -> None:
     """A stored rewrite for step 10 on a 3-step plan should be skipped
     silently (plan structure may have changed since the rewrite was


### PR DESCRIPTION
First buildable increment of the continuous-improvement flywheel (#894). Closes the keystone gap the audit surfaced.

## The gap
The plan-evolution substrate was **open at one seam**:
- `record_rewrite_candidate()` ✅ wired (`agentic_recovery.py:341`)
- `finalize_run_outcomes()` ✅ wired (`micro_runner.py:500`) — runs the promotion gate (3 wins → promoted)
- `apply_plan_overlay()` ❌ defined, **zero call sites**

So the system recorded recovery rewrites, promoted them after 3 wins, and **never applied them**. `finalize` also barely advanced because `_applied_plan_rewrites` was only seeded during recovery runs, never at pre-flight. It learned and discarded.

## The fix
Wire `apply_plan_overlay()` into `MicroPlanRunner.run()` (chosen over the Modal-dispatch point so it covers Modal + Baseten + CLI in one seam):
- Applied **after** `plan_signature` is computed, so the signature still reflects the ORIGINAL plan — matching the evolution-store key and the hint/exemplar stores.
- Sets `_applied_plan_rewrites` (extended, since `step_recovery` may append live rewrites) so `finalize_run_outcomes` scores the applied rewrites at terminal and drives the gate.
- **promoted** rewrites always applied; **candidate** rewrites applied as **exploration** (so they accumulate the wins promotion needs) behind `_plan_overlay_explore_candidates` (default `True`). `apply_plan_overlay` gains `include_candidates`; cold-idle demotion stays promoted-only.
- Best-effort: no-op without `_plan_hash`/`_workflow_id`, on resume, or when nothing's applicable; never blocks a run.

## Why this matters
This makes the fast loop actually *close*: a recovery that fixes a broken step now compounds — once proven, the fix is applied automatically on future runs instead of being re-discovered each time.

## Tests
- `include_candidates` applies a candidate (default path still promoted-only, existing test green).
- `run()` applies a promoted rewrite pre-flight and records it on `_applied_plan_rewrites`.
- 300 passing across micro_runner / plan_evolution / recovery / task_loop; no regressions.

## Follow-ups (tracked in #894)
DiskHintStore injection into S0, champion/challenger gate, E2E Phase-0 runner on a sim env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)