### PR TITLE
feat(learning): rollout generator primitives — synthetic rollout/plan generation (#894)

### DIFF
--- a/docs/proposals/rollout-generator.md
+++ b/docs/proposals/rollout-generator.md
@@ -1,0 +1,75 @@
+# Rollout Generator — synthetic rollout/plan generation for the CUA flywheel
+
+Status: proposal (epic [#894](https://github.com/mercurialsolo/mantis/issues/894))
+Scope: Mantis only. Consumes Augur (read-only); **no Augur changes** (see "Augur-side notes").
+
+## Why
+
+The continuous-improvement flywheel can already *execute* rollouts (Holo3/Claude
+executors), *score* them (sim-env oracles), and *improve* non-parametrically
+(recipes/hints/curriculum). The missing upstream piece is a **source of diverse
+rollouts**. Today the task set is a static, hand-authored manifest
+(`experiments/learning_allocator/eval/clusters.json`). Without a generator, the
+loop can only re-run the same fixed tasks — it can't explore, can't target its
+own weaknesses, and can't scale ground-truth-labeled data for the RL (slow) loop.
+
+The lever Daytona unlocks: the sim envs are **seed-parameterizable** (`POST
+/__env__/reset {seed}`) and **oracle-graded** (`GET /__env__/oracle?task_id`). So:
+
+> **one task template × N env seeds = N distinct, ground-truth-labeled rollouts** — synthetic RL data with zero human labeling.
+
+## Grounding (existing contracts the generator builds on)
+
+| Surface | Where | Use |
+|---|---|---|
+| `POST /__env__/reset {seed}` | every sim env (`modal_stub.py:105`, boattrader/shopify/...) | mint a fresh env instance per seed |
+| `GET /__env__/oracle?task_id` | sim envs | ground-truth reward (`learning/reward.py:oracle_channel`) |
+| `PlanDecomposer.decompose_text()` | `plan_decomposer.py:1070` | free-text template → MicroPlan |
+| `build_micro_suite()` | `server_utils.py:1177` | MicroPlan → runnable suite |
+| `group_id` + `open_orchestrator_session` | `gym/fanout_runner.py`, Augur | GRPO sibling grouping for RL diversity |
+| `list_failure_clusters` | Augur MCP/API (read-only) | bias generation toward weak spots |
+| `Phase2Orchestrator` | `learning/orchestrator.py` | consumes (task, substrate) → run → reward → observe |
+
+## Design
+
+A `RolloutGenerator` emits `RolloutSpec`s; the orchestrator turns each into a
+graded run. Two concrete generators cover the two data needs (volume + targeting).
+
+```
+TaskTemplate ──┐
+               ├─► RolloutGenerator.generate() ─► Iterator[RolloutSpec]
+env seeds   ───┘                                      │
+                                                      ▼
+        for each spec:  POST /__env__/reset {seed}  (mint instance)
+                        decompose_text(template) → build_micro_suite
+                        execute (Holo3/Claude) under group_id (siblings)
+                        GET /__env__/oracle?task_id  → reward
+                        → Augur bundle (one per rollout, grouped by group_id)
+```
+
+### Types
+- `TaskTemplate(template_id, cluster, plan_text | plan_steps, oracle_task_id)` — a parameterizable task. `oracle_task_id` ties the rollout to its grader.
+- `RolloutSpec(spec_id, template, env_seed, group_id, sibling_index)` — one concrete graded run to execute.
+
+### Generators
+1. **`SeedSweepGenerator`** — `templates × seeds × siblings_per_instance`. The volume engine: deterministic, exhaustive over a seed range. Each `(template, seed)` is a distinct env instance; `siblings_per_instance` ≥ 2 produces GRPO siblings sharing a `group_id`.
+2. **`FailureBiasedGenerator`** — allocates a fixed instance budget across clusters **proportional to failure share** (failure counts passed in as plain data, read from Augur `list_failure_clusters` by the caller — the generator never imports Augur). Generates where the agent is weakest.
+
+Both are pure/deterministic given an RNG seed → reproducible rollout sets, replayable for eval.
+
+## Integration (next step, not in the scaffold)
+
+A thin `RolloutRunner` adapter (mirrors `experiments/learning_allocator/live_runner.py`):
+for each `RolloutSpec` → reset env to `seed` (with Daytona preview headers) →
+`decompose_text` + `build_micro_suite` (fresh `workflow_id`, carry `group_id`) →
+submit → poll → `reward_from_run` → record. Feeds `Phase2Orchestrator` a *stream*
+instead of a static manifest.
+
+## Phasing
+- **P0** — types + `SeedSweepGenerator` + `FailureBiasedGenerator` (this scaffold) + tests. No execution wiring.
+- **P1** — `RolloutRunner` adapter: spec → Daytona reset → execute → oracle reward → Augur. Wire into the orchestrator.
+- **P2** — close the explore loop: pull `list_failure_clusters` each round → re-bias → generate → run → re-cluster.
+
+## Augur-side notes (for a separate Augur PR — do NOT change here)
+- **Required: none.** Reading `list_failure_clusters` + per-run bundles via the existing MCP/HTTP API is sufficient.
+- **Optional convenience (nice-to-have, file separately):** a "register a rollout *group* as a dataset slice" helper so a seed-sweep's N sibling bundles can be pulled as one training shard by `group_id` (today: query bundles and filter by `group_id` tag client-side — works, just less ergonomic).

--- a/src/mantis_agent/learning/rollout_generator.py
+++ b/src/mantis_agent/learning/rollout_generator.py
@@ -17,7 +17,7 @@ the caller). Execution wiring (Daytona reset → run → oracle reward) is a sep
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any, Iterator, Protocol, runtime_checkable
 
 

--- a/src/mantis_agent/learning/rollout_generator.py
+++ b/src/mantis_agent/learning/rollout_generator.py
@@ -1,0 +1,165 @@
+"""Rollout generation for the continuous-improvement flywheel (#894).
+
+A source of diverse, ground-truth-graded rollouts — the upstream piece the
+flywheel was missing. Today the task set is a static manifest; these generators
+turn it into a stream by exploiting the sim envs' two parameterizable surfaces:
+
+  * ``POST /__env__/reset {seed}`` — one task template × N seeds = N distinct
+    env instances (synthetic data volume).
+  * ``GET /__env__/oracle?task_id`` — ground-truth reward per instance.
+
+This module is the *stable* layer: the data types + selection policies. It does
+NOT execute anything and imports neither Augur nor the executor — failure-cluster
+counts are passed in as plain data (read from Augur ``list_failure_clusters`` by
+the caller). Execution wiring (Daytona reset → run → oracle reward) is a separate
+``RolloutRunner`` adapter (P1). See ``docs/proposals/rollout-generator.md``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Iterator, Protocol, runtime_checkable
+
+
+@dataclass(frozen=True)
+class TaskTemplate:
+    """A parameterizable task. Either ``plan_text`` (free-text →
+    ``PlanDecomposer.decompose_text``) or ``plan_steps`` (authored micro-plan
+    step dicts) must be set. ``oracle_task_id`` ties a rollout to its grader
+    (``GET /__env__/oracle?task_id=<oracle_task_id>``)."""
+
+    template_id: str
+    cluster: str
+    oracle_task_id: str
+    plan_text: str | None = None
+    plan_steps: list[dict[str, Any]] | None = None
+
+    def __post_init__(self) -> None:
+        if not self.plan_text and not self.plan_steps:
+            raise ValueError(
+                f"TaskTemplate {self.template_id!r} needs plan_text or plan_steps"
+            )
+
+
+@dataclass(frozen=True)
+class RolloutSpec:
+    """One concrete graded run to execute: a template instantiated at a
+    specific env seed. ``group_id`` groups GRPO siblings (same template+seed,
+    different sampling) so the trainer can read a rollout group as one unit."""
+
+    spec_id: str
+    template: TaskTemplate
+    env_seed: int
+    group_id: str
+    sibling_index: int = 0
+
+
+@runtime_checkable
+class RolloutGenerator(Protocol):
+    """Emits the rollouts to execute this round."""
+
+    def generate(self) -> Iterator[RolloutSpec]: ...
+
+
+def _group_id(template_id: str, seed: int) -> str:
+    return f"{template_id}__seed{seed}"
+
+
+def _spec_id(template_id: str, seed: int, sibling: int) -> str:
+    return f"{template_id}__seed{seed}__s{sibling}"
+
+
+@dataclass
+class SeedSweepGenerator:
+    """Volume engine: ``templates × seeds × siblings_per_instance``.
+
+    Deterministic and exhaustive — each ``(template, seed)`` is a distinct env
+    instance; ``siblings_per_instance >= 2`` yields GRPO siblings sharing a
+    ``group_id`` (vary sampling/temperature downstream, not here).
+    """
+
+    templates: list[TaskTemplate]
+    seeds: list[int]
+    siblings_per_instance: int = 1
+
+    def __post_init__(self) -> None:
+        if self.siblings_per_instance < 1:
+            raise ValueError("siblings_per_instance must be >= 1")
+
+    def generate(self) -> Iterator[RolloutSpec]:
+        for template in self.templates:
+            for seed in self.seeds:
+                gid = _group_id(template.template_id, seed)
+                for sib in range(self.siblings_per_instance):
+                    yield RolloutSpec(
+                        spec_id=_spec_id(template.template_id, seed, sib),
+                        template=template,
+                        env_seed=seed,
+                        group_id=gid,
+                        sibling_index=sib,
+                    )
+
+
+@dataclass
+class FailureBiasedGenerator:
+    """Targeting engine: spend a fixed instance budget across clusters in
+    proportion to their failure share, generating where the agent is weakest.
+
+    ``cluster_failure_counts`` is plain data read by the caller from Augur
+    ``list_failure_clusters`` (this module never imports Augur). Clusters with
+    no template are skipped. A deterministic RNG (``rng_seed``) makes the
+    generated set reproducible for eval/replay.
+    """
+
+    templates_by_cluster: dict[str, list[TaskTemplate]]
+    cluster_failure_counts: dict[str, int]
+    seeds: list[int]
+    total_instances: int
+    siblings_per_instance: int = 1
+    rng_seed: int = 0
+
+    def _budget_by_cluster(self) -> dict[str, int]:
+        # Only clusters we can actually generate for.
+        live = {
+            c: max(0, int(n))
+            for c, n in self.cluster_failure_counts.items()
+            if self.templates_by_cluster.get(c)
+        }
+        total = sum(live.values())
+        if total <= 0 or self.total_instances <= 0:
+            return {}
+        # Largest-remainder apportionment so the budget sums exactly.
+        raw = {c: self.total_instances * n / total for c, n in live.items()}
+        floor = {c: int(v) for c, v in raw.items()}
+        assigned = sum(floor.values())
+        remainder = self.total_instances - assigned
+        # Hand out the leftover to the largest fractional parts (stable order).
+        order = sorted(
+            live, key=lambda c: (raw[c] - floor[c], c), reverse=True,
+        )
+        for c in order[:remainder]:
+            floor[c] += 1
+        return {c: n for c, n in floor.items() if n > 0}
+
+    def generate(self) -> Iterator[RolloutSpec]:
+        import random
+
+        rng = random.Random(self.rng_seed)
+        if not self.seeds:
+            return
+        for cluster, budget in sorted(self._budget_by_cluster().items()):
+            templates = self.templates_by_cluster.get(cluster) or []
+            if not templates:
+                continue
+            for i in range(budget):
+                template = templates[i % len(templates)]
+                seed = rng.choice(self.seeds)
+                gid = _group_id(template.template_id, seed)
+                for sib in range(self.siblings_per_instance):
+                    yield RolloutSpec(
+                        spec_id=f"{_spec_id(template.template_id, seed, sib)}__b{i}",
+                        template=template,
+                        env_seed=seed,
+                        group_id=gid,
+                        sibling_index=sib,
+                    )

--- a/tests/test_rollout_generator.py
+++ b/tests/test_rollout_generator.py
@@ -1,0 +1,125 @@
+"""Rollout generator primitives (#894) — types + seed-sweep + failure-bias."""
+
+from __future__ import annotations
+
+import pytest
+
+from mantis_agent.learning.rollout_generator import (
+    FailureBiasedGenerator,
+    RolloutGenerator,
+    SeedSweepGenerator,
+    TaskTemplate,
+)
+
+
+def _tmpl(tid: str, cluster: str = "c1") -> TaskTemplate:
+    return TaskTemplate(
+        template_id=tid, cluster=cluster, oracle_task_id=f"oracle_{tid}",
+        plan_text=f"do {tid}",
+    )
+
+
+# ── TaskTemplate ──────────────────────────────────────────────────
+
+
+def test_template_requires_plan_text_or_steps():
+    with pytest.raises(ValueError):
+        TaskTemplate(template_id="t", cluster="c", oracle_task_id="o")
+
+
+def test_template_accepts_steps():
+    t = TaskTemplate(
+        template_id="t", cluster="c", oracle_task_id="o",
+        plan_steps=[{"type": "navigate", "intent": "go"}],
+    )
+    assert t.plan_steps
+
+
+# ── SeedSweepGenerator ────────────────────────────────────────────
+
+
+def test_seed_sweep_cartesian_count():
+    gen = SeedSweepGenerator(
+        templates=[_tmpl("a"), _tmpl("b")], seeds=[1, 2, 3],
+    )
+    specs = list(gen.generate())
+    assert len(specs) == 2 * 3  # templates × seeds × 1 sibling
+    assert isinstance(gen, RolloutGenerator)  # satisfies the Protocol
+
+
+def test_seed_sweep_siblings_share_group_id():
+    gen = SeedSweepGenerator(
+        templates=[_tmpl("a")], seeds=[7], siblings_per_instance=3,
+    )
+    specs = list(gen.generate())
+    assert len(specs) == 3
+    assert {s.group_id for s in specs} == {"a__seed7"}
+    assert [s.sibling_index for s in specs] == [0, 1, 2]
+    assert len({s.spec_id for s in specs}) == 3  # unique spec ids
+
+
+def test_seed_sweep_rejects_zero_siblings():
+    with pytest.raises(ValueError):
+        SeedSweepGenerator(templates=[_tmpl("a")], seeds=[1], siblings_per_instance=0)
+
+
+def test_seed_sweep_deterministic():
+    mk = lambda: SeedSweepGenerator(templates=[_tmpl("a")], seeds=[1, 2])
+    assert [s.spec_id for s in mk().generate()] == [s.spec_id for s in mk().generate()]
+
+
+# ── FailureBiasedGenerator ────────────────────────────────────────
+
+
+def test_failure_bias_allocates_proportional_to_failures():
+    gen = FailureBiasedGenerator(
+        templates_by_cluster={"hot": [_tmpl("h", "hot")], "cold": [_tmpl("c", "cold")]},
+        cluster_failure_counts={"hot": 75, "cold": 25},
+        seeds=[1, 2, 3],
+        total_instances=100,
+    )
+    specs = list(gen.generate())
+    assert len(specs) == 100
+    by_cluster = {}
+    for s in specs:
+        by_cluster[s.template.cluster] = by_cluster.get(s.template.cluster, 0) + 1
+    assert by_cluster["hot"] == 75 and by_cluster["cold"] == 25
+
+
+def test_failure_bias_budget_sums_exactly_with_remainder():
+    # 10 instances over 3 equal clusters → 4/3/3 (largest-remainder)
+    gen = FailureBiasedGenerator(
+        templates_by_cluster={c: [_tmpl(c, c)] for c in ("a", "b", "c")},
+        cluster_failure_counts={"a": 1, "b": 1, "c": 1},
+        seeds=[1], total_instances=10,
+    )
+    specs = list(gen.generate())
+    assert len(specs) == 10
+
+
+def test_failure_bias_skips_clusters_without_templates():
+    gen = FailureBiasedGenerator(
+        templates_by_cluster={"have": [_tmpl("h", "have")]},
+        cluster_failure_counts={"have": 50, "missing": 50},  # missing has no template
+        seeds=[1, 2], total_instances=20,
+    )
+    specs = list(gen.generate())
+    assert len(specs) == 20  # full budget reallocated to the live cluster
+    assert all(s.template.cluster == "have" for s in specs)
+
+
+def test_failure_bias_empty_when_no_failures_or_budget():
+    gen = FailureBiasedGenerator(
+        templates_by_cluster={"a": [_tmpl("a", "a")]},
+        cluster_failure_counts={"a": 0}, seeds=[1], total_instances=10,
+    )
+    assert list(gen.generate()) == []
+
+
+def test_failure_bias_deterministic_with_rng_seed():
+    mk = lambda: FailureBiasedGenerator(
+        templates_by_cluster={"a": [_tmpl("a", "a")]},
+        cluster_failure_counts={"a": 5}, seeds=[1, 2, 3, 4],
+        total_instances=8, rng_seed=42,
+    )
+    assert [s.env_seed for s in mk().generate()] == [s.env_seed for s in mk().generate()]

--- a/tests/test_rollout_generator.py
+++ b/tests/test_rollout_generator.py
@@ -64,7 +64,8 @@ def test_seed_sweep_rejects_zero_siblings():
 
 
 def test_seed_sweep_deterministic():
-    mk = lambda: SeedSweepGenerator(templates=[_tmpl("a")], seeds=[1, 2])
+    def mk():
+        return SeedSweepGenerator(templates=[_tmpl("a")], seeds=[1, 2])
     assert [s.spec_id for s in mk().generate()] == [s.spec_id for s in mk().generate()]
 
 
@@ -117,9 +118,10 @@ def test_failure_bias_empty_when_no_failures_or_budget():
 
 
 def test_failure_bias_deterministic_with_rng_seed():
-    mk = lambda: FailureBiasedGenerator(
-        templates_by_cluster={"a": [_tmpl("a", "a")]},
-        cluster_failure_counts={"a": 5}, seeds=[1, 2, 3, 4],
-        total_instances=8, rng_seed=42,
-    )
+    def mk():
+        return FailureBiasedGenerator(
+            templates_by_cluster={"a": [_tmpl("a", "a")]},
+            cluster_failure_counts={"a": 5}, seeds=[1, 2, 3, 4],
+            total_instances=8, rng_seed=42,
+        )
     assert [s.env_seed for s in mk().generate()] == [s.env_seed for s in mk().generate()]


### PR DESCRIPTION
The upstream piece the flywheel ([#894](https://github.com/mercurialsolo/mantis/issues/894)) was missing: a **source of diverse, ground-truth-graded rollouts**. Today the task set is a static manifest; this turns Daytona sim envs into a synthetic-data engine.

## The lever
Sim envs are **seed-parameterizable** (`POST /__env__/reset {seed}`) and **oracle-graded** (`GET /__env__/oracle?task_id`). So **one task template × N seeds = N distinct, ground-truth-labeled rollouts** — synthetic RL data with zero human labeling. That's what makes ground-truth reward *scale* for the slow (RL) loop.

## This PR — the stable layer only
Types + selection policies. No execution wiring; **no Augur or executor imports**.
- `TaskTemplate` / `RolloutSpec` — `oracle_task_id` ties a rollout to its grader; `group_id` groups GRPO siblings.
- `SeedSweepGenerator` — volume engine: `templates × seeds × siblings`, deterministic/exhaustive.
- `FailureBiasedGenerator` — targeting engine: spends an instance budget across clusters **proportional to failure share** (counts passed in as plain data, read from Augur `list_failure_clusters` by the *caller*). Largest-remainder apportionment, deterministic RNG.

## Not in this PR (P1, specced)
`RolloutRunner` adapter: `spec → /__env__/reset {seed} (Daytona headers) → decompose_text + build_micro_suite (group_id) → execute → reward_from_run → Augur`, feeding `Phase2Orchestrator` a *stream* instead of a static manifest. Full design + phasing in `docs/proposals/rollout-generator.md`.

## Augur
**No changes required** — read-only consumption of existing surfaces (`list_failure_clusters`, per-run bundles). One *optional* ergonomic helper (pull a rollout *group* as a dataset slice by `group_id`) noted in the proposal for a **separate Augur PR** — not needed for P0/P1.

## Tests
11 — cartesian count, sibling grouping, proportional + largest-remainder allocation, missing-template reallocation, empty-budget, determinism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)