### PR TITLE
feat(learning): champion/challenger promotion gate (#894)

### DIFF
--- a/src/mantis_agent/learning/promotion_gate.py
+++ b/src/mantis_agent/learning/promotion_gate.py
@@ -1,0 +1,145 @@
+"""Champion/challenger promotion gate (#894) — the safety keystone.
+
+Before a learned change (a new substrate config, a promoted plan rewrite, a new
+brain checkpoint) is shipped, it must beat the deployed *champion* on a FROZEN
+benchmark — by a margin, with significance, without regressing sealed tasks, and
+within a cost budget. This lets any loop close autonomously without shipping
+regressions.
+
+Pure + dependency-free (pure-Python paired bootstrap — no scipy/numpy) and
+deterministic (RNG seeded), so a verdict is reproducible and auditable. It scores
+two arms that were run over the SAME frozen task set (paired comparison); the
+caller supplies per-task scores (e.g. oracle ``score`` or ``R = score − λ·cost``
+from ``learning/reward.py``) — the gate never executes anything.
+"""
+
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class ArmResult:
+    """Per-task outcomes for one arm over the frozen benchmark.
+
+    ``scores`` maps ``task_id → reward`` (higher is better — oracle score or
+    ``R``). ``costs`` maps ``task_id → dollars`` (optional; used for the cost
+    gate). Only task_ids present in BOTH arms are compared (paired).
+    """
+
+    label: str
+    scores: dict[str, float]
+    costs: dict[str, float] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class GateVerdict:
+    promote: bool
+    reason: str
+    n_compared: int
+    mean_delta: float          # mean(challenger − champion) over paired tasks
+    win_rate: float            # fraction of tasks where challenger >= champion
+    prob_improvement: float    # bootstrap P(mean challenger > mean champion)
+    regressions: list[str]     # tasks where challenger dropped > regression_tol
+    champion_cost: float
+    challenger_cost: float
+
+
+@dataclass
+class PromotionGate:
+    """Decide whether a challenger may replace the champion.
+
+    All gates must pass to promote:
+      * ``mean_delta >= min_mean_delta`` — beats the champion on average;
+      * ``prob_improvement >= min_prob_improvement`` — significance via paired
+        bootstrap (default 0.95);
+      * ``win_rate >= min_win_rate`` — broadly better, not one outlier;
+      * ``len(regressions) <= max_regressions`` — no (or few) sealed-task drops;
+      * challenger cost ``<= champion cost × max_cost_ratio`` (when costs given).
+    """
+
+    min_mean_delta: float = 0.02
+    min_prob_improvement: float = 0.95
+    min_win_rate: float = 0.5
+    regression_tol: float = 0.05
+    max_regressions: int = 0
+    max_cost_ratio: float = 1.5
+    bootstrap_samples: int = 2000
+    rng_seed: int = 0
+
+    def evaluate(self, champion: ArmResult, challenger: ArmResult) -> GateVerdict:
+        common = sorted(set(champion.scores) & set(challenger.scores))
+        if not common:
+            return GateVerdict(
+                promote=False, reason="no overlapping tasks to compare",
+                n_compared=0, mean_delta=0.0, win_rate=0.0,
+                prob_improvement=0.0, regressions=[],
+                champion_cost=0.0, challenger_cost=0.0,
+            )
+
+        deltas = [challenger.scores[t] - champion.scores[t] for t in common]
+        n = len(deltas)
+        mean_delta = sum(deltas) / n
+        win_rate = sum(1 for d in deltas if d >= 0) / n
+        regressions = [
+            t for t, d in zip(common, deltas) if d < -self.regression_tol
+        ]
+        prob_improvement = _bootstrap_prob_positive(
+            deltas, self.bootstrap_samples, self.rng_seed,
+        )
+        champ_cost = sum(champion.costs.get(t, 0.0) for t in common)
+        chal_cost = sum(challenger.costs.get(t, 0.0) for t in common)
+
+        checks: list[tuple[bool, str]] = [
+            (mean_delta >= self.min_mean_delta,
+             f"mean_delta {mean_delta:+.4f} < {self.min_mean_delta}"),
+            (prob_improvement >= self.min_prob_improvement,
+             f"prob_improvement {prob_improvement:.3f} < {self.min_prob_improvement}"),
+            (win_rate >= self.min_win_rate,
+             f"win_rate {win_rate:.3f} < {self.min_win_rate}"),
+            (len(regressions) <= self.max_regressions,
+             f"{len(regressions)} regressions > {self.max_regressions} "
+             f"(tol {self.regression_tol})"),
+        ]
+        if champ_cost > 0:
+            checks.append((
+                chal_cost <= champ_cost * self.max_cost_ratio,
+                f"cost {chal_cost:.4f} > champion {champ_cost:.4f} "
+                f"× {self.max_cost_ratio}",
+            ))
+
+        failures = [msg for ok, msg in checks if not ok]
+        promote = not failures
+        reason = (
+            f"promote: challenger beats champion (Δ={mean_delta:+.4f}, "
+            f"p={prob_improvement:.3f}, win={win_rate:.2f}, n={n})"
+            if promote else "reject: " + "; ".join(failures)
+        )
+        return GateVerdict(
+            promote=promote, reason=reason, n_compared=n,
+            mean_delta=mean_delta, win_rate=win_rate,
+            prob_improvement=prob_improvement, regressions=regressions,
+            champion_cost=champ_cost, challenger_cost=chal_cost,
+        )
+
+
+def _bootstrap_prob_positive(deltas: list[float], samples: int, seed: int) -> float:
+    """Paired bootstrap: fraction of resamples whose mean delta > 0 — the
+    probability the challenger truly improves over the champion. Deterministic
+    given ``seed``. With zero variance (all deltas equal) returns 1.0 if the
+    delta is positive, else 0.0."""
+    n = len(deltas)
+    if n == 0:
+        return 0.0
+    if all(d == deltas[0] for d in deltas):
+        return 1.0 if deltas[0] > 0 else 0.0
+    rng = random.Random(seed)
+    wins = 0
+    for _ in range(samples):
+        resample_sum = 0.0
+        for _ in range(n):
+            resample_sum += deltas[rng.randrange(n)]
+        if resample_sum > 0:  # mean > 0 ⇔ sum > 0
+            wins += 1
+    return wins / samples

--- a/tests/test_promotion_gate.py
+++ b/tests/test_promotion_gate.py
@@ -1,0 +1,89 @@
+"""Champion/challenger promotion gate (#894)."""
+
+from __future__ import annotations
+
+from mantis_agent.learning.promotion_gate import (
+    ArmResult,
+    GateVerdict,
+    PromotionGate,
+)
+
+
+def _arm(label, scores, costs=None):
+    return ArmResult(label=label, scores=dict(scores), costs=dict(costs or {}))
+
+
+def test_promotes_clear_improvement():
+    champ = _arm("champ", {f"t{i}": 0.5 for i in range(10)})
+    chal = _arm("chal", {f"t{i}": 0.8 for i in range(10)})
+    v = PromotionGate().evaluate(champ, chal)
+    assert v.promote is True
+    assert v.mean_delta > 0.29 and v.win_rate == 1.0
+    assert v.prob_improvement == 1.0  # zero-variance positive delta
+
+
+def test_rejects_no_improvement():
+    champ = _arm("champ", {f"t{i}": 0.6 for i in range(10)})
+    chal = _arm("chal", {f"t{i}": 0.6 for i in range(10)})
+    v = PromotionGate().evaluate(champ, chal)
+    assert v.promote is False
+    assert "mean_delta" in v.reason
+
+
+def test_rejects_on_regression_even_if_mean_up():
+    # Net positive on average, but one task regresses hard → hard gate blocks.
+    champ = _arm("champ", {"a": 0.5, "b": 0.5, "c": 0.9})
+    chal = _arm("chal", {"a": 0.9, "b": 0.9, "c": 0.3})  # c drops 0.6
+    v = PromotionGate(min_prob_improvement=0.0, min_mean_delta=0.0).evaluate(champ, chal)
+    assert v.promote is False
+    assert "c" in v.regressions
+    assert "regression" in v.reason
+
+
+def test_regression_tolerance_allows_small_dip():
+    champ = _arm("champ", {"a": 0.5, "b": 0.5, "c": 0.6})
+    chal = _arm("chal", {"a": 0.9, "b": 0.9, "c": 0.57})  # c dips 0.03 < tol 0.05
+    v = PromotionGate(min_prob_improvement=0.0).evaluate(champ, chal)
+    assert v.regressions == []
+    assert v.promote is True
+
+
+def test_cost_gate_blocks_expensive_challenger():
+    champ = _arm("champ", {"a": 0.5, "b": 0.5}, {"a": 0.10, "b": 0.10})
+    chal = _arm("chal", {"a": 0.9, "b": 0.9}, {"a": 0.40, "b": 0.40})  # 4x cost
+    v = PromotionGate(min_prob_improvement=0.0, max_cost_ratio=1.5).evaluate(champ, chal)
+    assert v.promote is False
+    assert "cost" in v.reason
+    assert v.challenger_cost == 0.80 and v.champion_cost == 0.20
+
+
+def test_only_paired_tasks_compared():
+    champ = _arm("champ", {"a": 0.5, "b": 0.5, "only_champ": 0.1})
+    chal = _arm("chal", {"a": 0.9, "b": 0.9, "only_chal": 0.1})
+    v = PromotionGate(min_prob_improvement=0.0).evaluate(champ, chal)
+    assert v.n_compared == 2  # a, b only
+
+
+def test_no_overlap_is_safe_reject():
+    v = PromotionGate().evaluate(_arm("c", {"a": 1.0}), _arm("x", {"b": 1.0}))
+    assert v.promote is False and v.n_compared == 0
+    assert "no overlapping" in v.reason
+
+
+def test_significance_blocks_noisy_tie():
+    # Tiny mean improvement swamped by noise → bootstrap p low → reject.
+    champ = _arm("champ", {f"t{i}": float(i % 2) for i in range(20)})
+    chal = _arm("chal", {f"t{i}": float((i + 1) % 2) for i in range(20)})
+    v = PromotionGate(min_mean_delta=0.0, max_regressions=99).evaluate(champ, chal)
+    # Half up, half down, mean ~0 → not significant.
+    assert v.prob_improvement < 0.95
+    assert v.promote is False
+
+
+def test_verdict_is_deterministic():
+    champ = _arm("champ", {f"t{i}": 0.4 + (i % 3) * 0.1 for i in range(15)})
+    chal = _arm("chal", {f"t{i}": 0.55 + (i % 3) * 0.1 for i in range(15)})
+    a = PromotionGate(rng_seed=7).evaluate(champ, chal)
+    b = PromotionGate(rng_seed=7).evaluate(champ, chal)
+    assert a == b
+    assert isinstance(a, GateVerdict)


### PR DESCRIPTION
The **safety keystone** of the flywheel ([#894](https://github.com/mercurialsolo/mantis/issues/894)) — what lets any improvement loop close *autonomously* without shipping regressions.

## What
`PromotionGate.evaluate(champion, challenger)` scores two arms run over the **same frozen benchmark** (paired per-task scores — oracle `score` or `R = score − λ·cost` from `learning/reward.py`). A challenger is promoted only if **all** gates pass:
- `mean_delta >= min_mean_delta` — beats the champion on average
- `prob_improvement >= min_prob_improvement` — **significance** via a paired bootstrap (default 0.95)
- `win_rate >= min_win_rate` — broadly better, not one outlier
- `len(regressions) <= max_regressions` — no sealed-task drops beyond `regression_tol`
- challenger cost `<= champion × max_cost_ratio` (when costs supplied)

Returns a `GateVerdict` with the deltas, regressions, bootstrap probability, and a human-readable `reason`.

## Properties
Pure + **dependency-free** (pure-Python paired bootstrap — no scipy/numpy) and **deterministic** (RNG seeded) → reproducible, auditable verdicts. It never executes anything — the caller runs both arms (via the orchestrator) and hands the gate their scores.

## Where it fits
`RolloutGenerator (#896) → run arms → PromotionGate → promote/rollback`. Combined with the closed plan-evolution loop (#895), this is the decision layer that makes self-improvement safe.

## Tests
9 — promote/reject, hard regression gate + tolerance, cost gate, paired overlap, no-overlap safe-reject, significance blocks a noisy tie, determinism. Ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)