### PR TITLE
fix(lint): repair F823 on main (drop local logger in run())

### DIFF
--- a/src/mantis_agent/gym/micro_runner.py
+++ b/src/mantis_agent/gym/micro_runner.py
@@ -536,7 +536,6 @@ class MicroPlanRunner:
                     step_results=state.results,
                 )
             except Exception as exc:  # noqa: BLE001 — never block run terminal
-                logger = __import__("logging").getLogger(__name__)
                 logger.debug(
                     "plan_evolution: finalize_run_outcomes raised: %s", exc,
                 )


### PR DESCRIPTION
**main is currently red on `ruff check .`** — and so is every open PR (their merge commits inherit it).

## Cause
#895 squash-merged on its pre-lint-fix commit (`ruff` isn't a required check, so it merged while red). The fix commit was orphaned by the squash. The terminal `finalize_run_outcomes` except re-assigns a function-local `logger`, which makes `logger` local to `run()` and trips **F823 "referenced before assignment"** on the pre-flight `apply_plan_overlay` except that #895 added.

## Fix
One line: drop the redundant local `logger = __import__("logging")...` and use the module-level `logger`. `ruff check .` clean; micro_runner tests pass (33).

Merging this unblocks ruff on #897 and any other open PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)