### PR TITLE
docs: continuous-improvement architecture — fast vs slow loops + overall system (#894)

### DIFF
--- a/docs/continuous-improvement-architecture.md
+++ b/docs/continuous-improvement-architecture.md
@@ -38,47 +38,52 @@ execution or training.
 
 ## 3. System architecture (big picture)
 
-```
-                         ┌──────────────────────────────────────────────┐
-                         │                  MANTIS                       │
-                         │                                              │
-   ┌─────────────┐       │  RolloutGenerator ──► executors (Holo3 /     │
-   │  Daytona    │◄──────┤   (template × seed,    Claude / …) on the    │
-   │  sim envs   │ reset  │   failure-biased)      Daytona env URL       │
-   │ /__env__/   │ {seed} │        │                    │               │
-   │  reset      │───────►│        │                    ▼               │
-   │  oracle     │ score  │        │            graded run + traces     │
-   │  mutations  │◄───────┤        │                    │               │
-   └─────────────┘        │        │                    ▼               │
-                          │        │            ┌───────────────┐       │
-                          │        │            │  AUGUR (SDK)  │ data  │
-                          │        │            │ traces·modelio│ plane │
-                          │        │            │ logprobs·group│       │
-                          │        │            │ reward·dataset│       │
-                          │        │            └──────┬─────┬──┘       │
-                          │        │                   │     │          │
-                          │   ┌────▼─────────┐         │     │          │
-                          │   │ FAST LOOP    │◄────────┘     │          │
-                          │   │ recipes/hints│ (failure       │          │
-                          │   │ curriculum   │  clusters,     │          │
-                          │   │ plan-rewrites│  rollouts)     │          │
-                          │   └────┬─────────┘                │          │
-                          │        │ updated artifacts        │          │
-                          │        ▼                          │          │
-                          │   ┌──────────────────────┐        │          │
-                          │   │ champion/challenger   │        │          │
-                          │   │ PromotionGate         │        │          │
-                          │   └────┬─────────────┬────┘        │          │
-                          │  promote│      reject │            │          │
-                          └────────┼─────────────┼────────────┼──────────┘
-                                   │             │            │ datasets
-                                   ▼             ▼            ▼ (group_id)
-                           deploy (Baseten/Modal)      ┌─────────────────┐
-                                   ▲                    │ MANTIS-TRAINER  │
-                                   │   new champion     │ SLOW LOOP       │
-                                   └────────────────────┤ GRPO/DPO/SFT    │
-                                       checkpoint        │ → checkpoint    │
-                                                         └─────────────────┘
+```mermaid
+flowchart TB
+  subgraph ENV["🖥️ Environment — Daytona sim envs"]
+    direction TB
+    RESET["POST /__env__/reset {seed}<br/>mint instance"]
+    ORACLE["GET /__env__/oracle<br/>R = score − λ·cost"]
+  end
+
+  subgraph MANTIS["🤖 Mantis — agent + control plane"]
+    direction TB
+    GEN["RolloutGenerator<br/>template × seed-sweep · failure-biased"]
+    EXEC["Executors<br/>Holo3 · Claude / task_loop"]
+    FAST["FAST LOOP<br/>recipes · hints · curriculum · plan-rewrites"]
+    GATE{"Champion / Challenger<br/>PromotionGate"}
+    DEPLOY["Deploy<br/>Baseten / Modal"]
+  end
+
+  subgraph AUGUR["📊 Augur — data plane"]
+    DATA[("traces · modelio · logprobs<br/>group_id · reward · datasets")]
+  end
+
+  subgraph TRAINER["🧠 mantis-trainer — slow loop"]
+    TRAIN["GRPO / DPO / SFT<br/>→ candidate checkpoint"]
+  end
+
+  GEN --> EXEC
+  EXEC <-->|reset seed / load| RESET
+  EXEC -->|graded run + traces| DATA
+  ORACLE -->|reward| DATA
+  DATA -->|failure clusters| GEN
+  DATA -->|rollouts| FAST
+  DATA -->|datasets by group_id| TRAIN
+  FAST -->|updated config| GATE
+  TRAIN -->|candidate weights| GATE
+  GATE -->|promote| DEPLOY
+  GATE -.->|reject| DATA
+  DEPLOY ==>|new champion| EXEC
+
+  classDef env fill:#eef7ff,stroke:#4a90d9;
+  classDef mantis fill:#eafaf1,stroke:#27ae60;
+  classDef augur fill:#fef9e7,stroke:#d4ac0d;
+  classDef trainer fill:#f5eef8,stroke:#8e44ad;
+  class ENV,RESET,ORACLE env;
+  class MANTIS,GEN,EXEC,FAST,GATE,DEPLOY mantis;
+  class AUGUR,DATA augur;
+  class TRAINER,TRAIN trainer;
 ```
 
 Both loops feed the **same** PromotionGate; both promotions deploy the same way
@@ -112,10 +117,20 @@ plan-rewrites. **Not** model weights. **Cadence:** minutes–hours, CPU.
 **Reversibility:** high (config/data, instantly revertible). **Where:** entirely
 in `mantis`.
 
-```
-run ──► graded outcome (oracle) ──► curate ──► update memory ──► next run uses it
- ▲                                              (recipes / hints /        │
- └──────────────────────────────────────────────  curriculum / rewrites)─┘
+```mermaid
+flowchart LR
+  RUN["Run on sim env"] --> OUT["Graded outcome<br/>(oracle reward)"]
+  OUT --> REC["Recovery proposes<br/>plan-rewrite — candidate"]
+  REC --> PROMO["3 consecutive wins<br/>→ promoted"]
+  PROMO --> APPLY["apply_plan_overlay<br/>pre-flight, next run"]
+  OUT --> MEM["Update memory<br/>hints · exemplars · curriculum"]
+  APPLY --> RUN
+  MEM --> RUN
+  RUN -. config beats champion? .-> GATE{"PromotionGate"}
+  GATE -. promote .-> RUN
+
+  classDef m fill:#eafaf1,stroke:#27ae60;
+  class RUN,OUT,REC,PROMO,APPLY,MEM,GATE m;
 ```
 
 ### How it works
@@ -142,12 +157,18 @@ trustworthy-reward + benchmark substrate the slow loop needs anyway.
 hours–days, **GPU**. **Reversibility:** low (a worse policy) → must clear the
 gate. **Where:** `mantis-trainer` (separate repo; torch/trl/vllm footprint).
 
-```
-graded rollouts (Augur, by group_id) ──► trainer (GRPO/DPO/SFT) ──► candidate ckpt
-        modelio + reward + logprobs                                       │
-                                                                          ▼
-                                              champion/challenger gate (mantis)
-                                                 promote? → deploy → new champion
+```mermaid
+flowchart LR
+  ROLL["Graded rollouts<br/>Augur · by group_id"] --> DC["Data contract<br/>group-relative advantages<br/>+ modelio + logprobs"]
+  DC --> TR["Train<br/>GRPO / DPO / SFT"]
+  TR --> CKPT["Candidate checkpoint"]
+  CKPT --> GATE{"Champion / Challenger<br/>gate (Mantis)"}
+  GATE -->|promote| DEP["Deploy → new champion"]
+  GATE -.->|reject| ROLL
+  DEP --> ROLL
+
+  classDef t fill:#f5eef8,stroke:#8e44ad;
+  class ROLL,DC,TR,CKPT,GATE,DEP t;
 ```
 
 ### How it works

--- a/docs/continuous-improvement-architecture.md
+++ b/docs/continuous-improvement-architecture.md
@@ -1,0 +1,226 @@
+# Continuous-improvement architecture (the flywheel)
+
+How Mantis improves itself from its own runs. This is the system-level view: the
+four planes, the two improvement loops (fast / non-parametric and slow /
+parametric), and the shared substrate both loops stand on.
+
+Tracking epic: [#894](https://github.com/mercurialsolo/mantis/issues/894).
+
+---
+
+## 1. The idea in one line
+
+> **Execute → observe → reward → curate → improve → evaluate → promote → repeat** — autonomously, without shipping regressions.
+
+The agent runs tasks, every run is captured and graded, the captures become
+training signal, and an improved artifact ships **only if it beats the current
+champion on a frozen benchmark**. Two loops consume the same signal at different
+speeds: a **fast loop** that updates memory/recipes in hours without touching
+model weights, and a **slow loop** that RL-fine-tunes the brain weights over
+days.
+
+---
+
+## 2. The four planes
+
+| Plane | Repo | Owns | Imports |
+|---|---|---|---|
+| **Environment** | `mantis` (`deploy/sim_envs`) + Daytona | seed-parameterizable, oracle-graded synthetic sites | — |
+| **Agent + control** | `mantis` | execution, rollout generation, fast loop, **champion/challenger gate**, controller | reads Augur |
+| **Data** | `augur-sdk` | traces, `modelio`, logprobs, `group_id`, `task_spec`, reward, datasets | — |
+| **Weights (slow loop)** | `mantis-trainer` | RL fine-tune (GRPO/DPO/SFT), checkpoint registry | reads Augur datasets |
+
+**Boundary rule:** data → Augur · agent + fast loop + gate → Mantis · weights →
+`mantis-trainer`. Augur is a read-only dependency for everyone; it never imports
+execution or training.
+
+---
+
+## 3. System architecture (big picture)
+
+```
+                         ┌──────────────────────────────────────────────┐
+                         │                  MANTIS                       │
+                         │                                              │
+   ┌─────────────┐       │  RolloutGenerator ──► executors (Holo3 /     │
+   │  Daytona    │◄──────┤   (template × seed,    Claude / …) on the    │
+   │  sim envs   │ reset  │   failure-biased)      Daytona env URL       │
+   │ /__env__/   │ {seed} │        │                    │               │
+   │  reset      │───────►│        │                    ▼               │
+   │  oracle     │ score  │        │            graded run + traces     │
+   │  mutations  │◄───────┤        │                    │               │
+   └─────────────┘        │        │                    ▼               │
+                          │        │            ┌───────────────┐       │
+                          │        │            │  AUGUR (SDK)  │ data  │
+                          │        │            │ traces·modelio│ plane │
+                          │        │            │ logprobs·group│       │
+                          │        │            │ reward·dataset│       │
+                          │        │            └──────┬─────┬──┘       │
+                          │        │                   │     │          │
+                          │   ┌────▼─────────┐         │     │          │
+                          │   │ FAST LOOP    │◄────────┘     │          │
+                          │   │ recipes/hints│ (failure       │          │
+                          │   │ curriculum   │  clusters,     │          │
+                          │   │ plan-rewrites│  rollouts)     │          │
+                          │   └────┬─────────┘                │          │
+                          │        │ updated artifacts        │          │
+                          │        ▼                          │          │
+                          │   ┌──────────────────────┐        │          │
+                          │   │ champion/challenger   │        │          │
+                          │   │ PromotionGate         │        │          │
+                          │   └────┬─────────────┬────┘        │          │
+                          │  promote│      reject │            │          │
+                          └────────┼─────────────┼────────────┼──────────┘
+                                   │             │            │ datasets
+                                   ▼             ▼            ▼ (group_id)
+                           deploy (Baseten/Modal)      ┌─────────────────┐
+                                   ▲                    │ MANTIS-TRAINER  │
+                                   │   new champion     │ SLOW LOOP       │
+                                   └────────────────────┤ GRPO/DPO/SFT    │
+                                       checkpoint        │ → checkpoint    │
+                                                         └─────────────────┘
+```
+
+Both loops feed the **same** PromotionGate; both promotions deploy the same way
+and become the next champion that generates the next round of rollouts.
+
+---
+
+## 4. Shared substrate (both loops depend on this)
+
+Neither loop works without these three, which is why they're built first:
+
+1. **Rollout generation** (`mantis_agent.learning.rollout_generator`) — the
+   source of diverse runs. `template × seed-sweep` (volume) +
+   failure-cluster-biased selection (target weak spots). Daytona's
+   `POST /__env__/reset {seed}` makes one template yield N distinct,
+   oracle-graded instances → synthetic data with no human labeling.
+2. **Reward** (`mantis_agent.learning.reward`) — ground-truth from the env
+   oracle (`GET /__env__/oracle`, `R = score − λ·cost`); proxy LLM-judge as a
+   fallback for real traffic. This is the signal both loops optimize.
+3. **Champion/challenger gate** (`mantis_agent.learning.promotion_gate`) — the
+   safety keystone. A challenger promotes only if it beats the champion on a
+   frozen benchmark by a margin, with significance (paired bootstrap), no
+   sealed-task regressions, within a cost budget.
+
+---
+
+## 5. The fast loop (non-parametric)
+
+**What changes:** retrieval memory — recipes, hints, curriculum, promoted
+plan-rewrites. **Not** model weights. **Cadence:** minutes–hours, CPU.
+**Reversibility:** high (config/data, instantly revertible). **Where:** entirely
+in `mantis`.
+
+```
+run ──► graded outcome (oracle) ──► curate ──► update memory ──► next run uses it
+ ▲                                              (recipes / hints /        │
+ └──────────────────────────────────────────────  curriculum / rewrites)─┘
+```
+
+### How it works
+1. A run hits a failure; **agentic recovery** finds a fix (e.g. a `rewrite_url`)
+   and records it as a `candidate` plan-rewrite (`plan_evolution_store`).
+2. `finalize_run_outcomes` scores each applied rewrite at run-terminal; after
+   **3 consecutive wins** it's `promoted`.
+3. On the next run, `apply_plan_overlay` applies promoted rewrites **pre-flight**
+   (and, in exploration mode, candidates too — so they accumulate wins). The fix
+   now compounds instead of being re-discovered each time.
+4. Hints (`hint_memory`), exemplars (S0/S1 substrates), and curriculum snippets
+   work the same way — captured from good runs, retrieved into future runs.
+5. The `allocator` spends a budget across substrates (ε-greedy bandit), and the
+   gate decides whether the improved config beats the champion before it sticks.
+
+**Why it's first:** highest ROI, lowest risk, **no GPU** — and it produces the
+trustworthy-reward + benchmark substrate the slow loop needs anyway.
+
+---
+
+## 6. The slow loop (parametric)
+
+**What changes:** the **Holo3 brain weights**, via RL fine-tuning. **Cadence:**
+hours–days, **GPU**. **Reversibility:** low (a worse policy) → must clear the
+gate. **Where:** `mantis-trainer` (separate repo; torch/trl/vllm footprint).
+
+```
+graded rollouts (Augur, by group_id) ──► trainer (GRPO/DPO/SFT) ──► candidate ckpt
+        modelio + reward + logprobs                                       │
+                                                                          ▼
+                                              champion/challenger gate (mantis)
+                                                 promote? → deploy → new champion
+```
+
+### How it works
+1. `mantis-trainer` pulls graded rollouts from Augur (`sources.augur`), grouped
+   by `group_id` (GRPO siblings of the same task instance).
+2. **Data contract** (`dataset`): map `modelio` → (prompt, completion) examples;
+   compute **group-relative advantage** `A_i = (r_i − mean(r)) / (std(r) + eps)`
+   per sibling group; carry per-token `logprobs` (mantis #889) for the ratio.
+3. **Train** (`trainer`, GPU): GRPO objective per response token —
+   `min(ρ_t·A_i, clip(ρ_t, 1±ε)·A_i) − β·KL(π_θ‖π_ref)`, `ρ_t = exp(logπ_θ − logπ_old)`.
+   No value model. Emits a candidate checkpoint to the `registry`.
+4. **Gate**: Mantis runs the candidate vs champion over the frozen benchmark →
+   `PromotionGate` verdict.
+5. **Promote**: on pass, publish weights to the model store; Baseten/Modal deploy
+   it; the registry marks it champion. Rollback re-points at the prior champion.
+
+### Algorithm phasing (de-risk before full GRPO)
+- **SFT** — rejection-sampling fine-tune on high-reward rollouts (no pairs, no
+  logprobs). Proves the data→checkpoint→gate→deploy pipe.
+- **DPO** — `(chosen, rejected)` preference pairs from each `group_id`.
+- **GRPO** — full group-relative PG; needs the logprobs from #889.
+
+**Why it's last:** the trainer is only as good as its reward. Build the reward +
+gate first; every checkpoint ships only through the same gate as any other
+challenger.
+
+---
+
+## 7. Fast vs slow — side by side
+
+| | **Fast loop** | **Slow loop** |
+|---|---|---|
+| Artifact changed | recipes / hints / curriculum / plan-rewrites | Holo3 **weights** |
+| Mechanism | retrieval / overlay | RL fine-tune (GRPO/DPO/SFT) |
+| Compute | CPU | **GPU** |
+| Cadence | minutes–hours | hours–days |
+| Repo | `mantis` | `mantis-trainer` |
+| Data needed | oracle reward | reward + `modelio` + `group_id` + logprobs |
+| Reversibility | high (config) | low (weights) → gate-gated |
+| Ceiling | bounded by base model's capability | raises the base model's capability |
+| Risk | low | high → champion/challenger mandatory |
+
+They are complementary, not alternatives: the fast loop squeezes the most out of
+the current weights *today*; the slow loop raises the ceiling those weights
+allow. Both gate through the same safety check and deploy the same way.
+
+---
+
+## 8. Lifecycle of one improvement (end to end)
+
+**Fast:** failing run → recovery proposes a rewrite → 3 wins → promoted →
+auto-applied next run → gate confirms the config beats champion → sticks. *Hours.*
+
+**Slow:** rollout generator mints N seed-varied instances → executed + oracle-graded
+→ Augur dataset → trainer computes advantages + GRPO step → candidate checkpoint →
+gate runs it vs champion on the frozen benchmark → promote → deploy → new champion
+generates the next rollouts. *Days.*
+
+---
+
+## 9. Status
+
+| Component | State |
+|---|---|
+| Execution (Holo3 + Claude/task_loop), Augur instrumentation | ✅ on main |
+| Rollout generator primitives (seed-sweep, failure-biased) | ✅ on main |
+| Closed plan-evolution fast loop (`apply_plan_overlay` wired) | ✅ on main |
+| Champion/challenger gate | ✅ on main |
+| Logprob capture (GRPO prerequisite, #889) | ✅ on main |
+| `RolloutRunner` execution adapter (generator → Daytona → Augur) | ⏳ P1 (#894) |
+| `mantis-trainer` data contract | ✅ scaffold + dataset implemented |
+| `mantis-trainer` GPU trainer (GRPO) | ⏳ P2 (separate repo) |
+
+See [`mantis-trainer/docs/SPEC.md`](https://github.com/mercurialsolo/mantis-trainer)
+for the slow-loop detail and the rollout-generator proposal under
+`docs/proposals/` for the data-generation engine.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -143,6 +143,7 @@ nav:
       - reference/index.md
       - HTTP API: api.md
       - Architecture: architecture.md
+      - Continuous-improvement architecture: continuous-improvement-architecture.md
       - CUA models: reference/cua-models.md
       - Environment variables: reference/env-vars.md
       - Glossary: reference/glossary.md


### PR DESCRIPTION
A system-level architecture doc for the self-improvement flywheel — the piece that ties Mantis + Augur + Daytona + `mantis-trainer` together.

## Contents
- **Four planes** — environment (Daytona sim envs) / agent + control (Mantis) / data (Augur) / weights (`mantis-trainer`), with the boundary rule.
- **Big-picture diagram** — full data flow: rollout generation → execution on Daytona → Augur capture → both loops → gate → deploy → new champion.
- **Shared substrate** — rollout generator, reward, champion/challenger gate (what both loops stand on).
- **Fast loop (non-parametric)** — recipes/hints/curriculum/plan-rewrites; how the closed plan-evolution loop compounds; CPU, hours.
- **Slow loop (parametric)** — GRPO/DPO/SFT weight fine-tune in `mantis-trainer`; data contract, GRPO objective, algorithm phasing; GPU, days.
- **Side-by-side table**, **end-to-end lifecycle** per loop, and a **status table** (what's on main vs planned).

Added to the Reference nav; `mkdocs build --strict` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)