### PR TITLE
feat(flywheel): GRPO sibling groups (#905) + ground-truth oracle reward (#906)

### DIFF
--- a/deploy/modal/modal_cua_server.py
+++ b/deploy/modal/modal_cua_server.py
@@ -1242,6 +1242,11 @@ def _run_holo3_executor(
         micro_runner._model_judge_model = str(task_suite.get("_model_judge_model", "") or "")
         micro_runner._task_instruction = str(task_suite.get("_task_instruction", "") or "")
 
+        # #908: force the Holo3 brain-grounded loop on action steps so RL
+        # rollouts exercise the policy → planner modelio + per-token logprobs
+        # (the GRPO importance-ratio requirement). Opt-in; off for normal runs.
+        micro_runner._force_holo3_grounding = bool(task_suite.get("_force_holo3_grounding", False))
+
         # #683: forward the orchestrator-composed ``task_spec`` so the
         # child Phase-1 / Phase-2 worker session opens with the same
         # canonical task definition. The trajectory buffer's

--- a/deploy/modal/modal_cua_server.py
+++ b/deploy/modal/modal_cua_server.py
@@ -765,12 +765,22 @@ def _run_holo3_executor(
     print(f"{'='*60}")
 
     # Create brain (local llama-server, not remote API)
+    # #905: GRPO sibling rollouts need sampling diversity. The suite may set
+    # ``_sampling_temperature`` > 0 so siblings of the same (template, seed)
+    # produce DIFFERENT trajectories → reward variance → non-zero GRPO
+    # advantage. Default 0.0 preserves deterministic single-run behaviour.
+    try:
+        _sampling_temp = float(task_suite.get("_sampling_temperature", 0.0) or 0.0)
+    except (TypeError, ValueError):
+        _sampling_temp = 0.0
+    if _sampling_temp > 0:
+        print(f"  Sampling:  temperature={_sampling_temp} (#905 sibling diversity)")
     brain = Holo3Brain(
         base_url="http://localhost:8080/v1",
         model="holo3",
         api_key="",
         max_tokens=2048,
-        temperature=0.0,
+        temperature=_sampling_temp,
         screen_size=(1280, 720),
         use_tool_calling=True,
     )
@@ -1215,6 +1225,15 @@ def _run_holo3_executor(
         micro_runner._fanout_group_id = str(
             task_suite.get("_fanout_group_id", "") or ""
         ) or None
+
+        # #906: forward sim-env oracle config so _finalize can grade the run
+        # against ground truth and stamp the verdict on the terminal step
+        # (the reward signal GRPO needs). Opt-in via the suite's ``_oracle_*``
+        # keys; absent for non-eval runs (falls back to plan-completion).
+        micro_runner._oracle_url = str(task_suite.get("_oracle_url", "") or "")
+        micro_runner._oracle_task_id = str(task_suite.get("_oracle_task_id", "") or "")
+        micro_runner._oracle_admin_token = str(task_suite.get("_oracle_admin_token", "") or "")
+        micro_runner._oracle_preview_token = str(task_suite.get("_oracle_preview_token", "") or "")
 
         # #683: forward the orchestrator-composed ``task_spec`` so the
         # child Phase-1 / Phase-2 worker session opens with the same

--- a/deploy/modal/modal_cua_server.py
+++ b/deploy/modal/modal_cua_server.py
@@ -1235,6 +1235,13 @@ def _run_holo3_executor(
         micro_runner._oracle_admin_token = str(task_suite.get("_oracle_admin_token", "") or "")
         micro_runner._oracle_preview_token = str(task_suite.get("_oracle_preview_token", "") or "")
 
+        # #906 extension: opt-in model-as-judge outcome reward (RLAIF). Primary
+        # signal on oracle-less tasks; below-oracle cross-check where both exist.
+        micro_runner._model_judge_enabled = bool(task_suite.get("_model_judge_enabled", False))
+        micro_runner._model_judge_force = bool(task_suite.get("_model_judge_force", False))
+        micro_runner._model_judge_model = str(task_suite.get("_model_judge_model", "") or "")
+        micro_runner._task_instruction = str(task_suite.get("_task_instruction", "") or "")
+
         # #683: forward the orchestrator-composed ``task_spec`` so the
         # child Phase-1 / Phase-2 worker session opens with the same
         # canonical task definition. The trajectory buffer's

--- a/experiments/holdout/freeze_eval_version.py
+++ b/experiments/holdout/freeze_eval_version.py
@@ -1,0 +1,213 @@
+"""Freeze a real Augur eval-version from producer candidates (#894/#901).
+
+The producer pipeline (#901/#902) emits a ``task_spec`` + a ``mark_for_eval``
+candidate on each eval-worthy run. This script is the operator step that turns
+that live candidate pool into an immutable, run-backed **eval-version** — the
+frozen holdout the slow-loop champion/challenger gate evaluates against.
+
+Two distinct auth scopes (live-verified against the workspace 2026-06-14):
+
+* **Read** (list candidates / versions) — accepts the producer key as
+  ``Authorization: Bearer <AUGUR_API_KEY>``. Works with what's in ``.env``.
+* **Write** (``POST /eval-versions``, the freeze) — is **operator-session
+  gated**. The producer key is rejected (401 "not signed in") on every header
+  variant; only a signed-in browser **session cookie** authorizes it. Supply it
+  via ``AUGUR_SESSION_COOKIE`` (the raw ``Cookie:`` header value copied from an
+  authenticated workspace tab) or ``--session-cookie``.
+
+Usage::
+
+    # see what's freezable today (read-only, no session needed)
+    python experiments/holdout/freeze_eval_version.py --list
+
+    # freeze a named version from explicit task_spec_ids (needs session cookie)
+    AUGUR_SESSION_COOKIE='session=...' \\
+      python experiments/holdout/freeze_eval_version.py \\
+        --name mantis-holdout-v1 \\
+        --task-spec-id boattrader.bt01_lead_capture.v1 \\
+        --task-spec-id boattrader.bt02_spec_lookup.v1
+
+    # freeze every producer candidate matching a prefix
+    AUGUR_SESSION_COOKIE='session=...' \\
+      python experiments/holdout/freeze_eval_version.py \\
+        --name mantis-holdout-v1 --select-prefix boattrader.
+
+The HTTP calls are injected (``http_get`` / ``http_post``) so the selection +
+freeze logic is unit-testable with no network — see
+``tests/test_freeze_eval_version.py``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from collections.abc import Callable
+from typing import Any
+
+import requests
+
+DEFAULT_BASE = "https://mantis-cua.ngrok-free.app/api/v1"
+DEFAULT_TENANT = "staffai"
+
+# An (status_code, json_body) HTTP seam so the logic is testable without network.
+HttpGet = Callable[[str, dict[str, str]], "tuple[int, Any]"]
+HttpPost = Callable[[str, dict[str, str], dict[str, Any]], "tuple[int, Any]"]
+
+
+def _augur_token() -> str:
+    """The producer read key — AUGUR_API_KEY, or the ``token`` from AUGUR_DSN."""
+    tok = (os.environ.get("AUGUR_API_KEY") or "").strip()
+    if tok:
+        return tok
+    dsn = os.environ.get("AUGUR_DSN", "")
+    if "token=" in dsn:
+        return dsn.split("token=", 1)[1].split("&", 1)[0]
+    return ""
+
+
+def _live_get(url: str, headers: dict[str, str]) -> tuple[int, Any]:
+    r = requests.get(url, headers=headers, timeout=30)
+    try:
+        return r.status_code, r.json()
+    except ValueError:
+        return r.status_code, r.text
+
+
+def _live_post(url: str, headers: dict[str, str], body: dict[str, Any]) -> tuple[int, Any]:
+    r = requests.post(url, headers=headers, json=body, timeout=30)
+    try:
+        return r.status_code, r.json()
+    except ValueError:
+        return r.status_code, r.text
+
+
+def list_candidates(
+    *, base: str, tenant: str, token: str, http_get: HttpGet, limit: int = 200
+) -> list[dict[str, Any]]:
+    """Return the producer/operator eval-candidate pool (read scope: Bearer key)."""
+    url = f"{base}/eval-candidates?tenant={tenant}&limit={limit}"
+    headers = {"Authorization": f"Bearer {token}", "ngrok-skip-browser-warning": "1"}
+    status, body = http_get(url, headers)
+    if status != 200:
+        raise RuntimeError(f"list candidates failed [{status}]: {body}")
+    return list(body.get("candidates", [])) if isinstance(body, dict) else []
+
+
+def select_task_spec_ids(
+    candidates: list[dict[str, Any]],
+    *,
+    explicit: list[str] | None = None,
+    select_prefix: str | None = None,
+) -> list[str]:
+    """Resolve which ``task_spec_id`` s to freeze, de-duplicated, order-stable.
+
+    * ``explicit`` — exactly these ids; each MUST be present in the candidate
+      pool (you can't freeze a task no run ever produced).
+    * ``select_prefix`` — every candidate id starting with the prefix.
+    * neither — every candidate id (freeze the whole live pool).
+    """
+    pool = []
+    seen: set[str] = set()
+    for c in candidates:
+        tid = str(c.get("task_spec_id") or "").strip()
+        if tid and tid not in seen:
+            seen.add(tid)
+            pool.append(tid)
+
+    if explicit:
+        missing = [t for t in explicit if t not in seen]
+        if missing:
+            raise ValueError(
+                f"these task_spec_ids have no candidate in the pool (run them first): {missing}"
+            )
+        return list(dict.fromkeys(explicit))
+    if select_prefix:
+        return [t for t in pool if t.startswith(select_prefix)]
+    return pool
+
+
+def freeze_version(
+    *,
+    base: str,
+    tenant: str,
+    name: str,
+    task_spec_ids: list[str],
+    session_cookie: str,
+    http_post: HttpPost,
+    description: str = "",
+) -> dict[str, Any]:
+    """POST /eval-versions (write scope: operator session cookie required)."""
+    if not session_cookie:
+        raise ValueError(
+            "freeze needs an operator session cookie (AUGUR_SESSION_COOKIE / "
+            "--session-cookie). The producer key authorizes reads only."
+        )
+    if not task_spec_ids:
+        raise ValueError("refusing to freeze an empty eval-version")
+    url = f"{base}/eval-versions?tenant={tenant}"
+    headers = {
+        "Content-Type": "application/json",
+        "Cookie": session_cookie,
+        "ngrok-skip-browser-warning": "1",
+    }
+    body: dict[str, Any] = {"name": name, "task_spec_ids": task_spec_ids}
+    if description:
+        body["description"] = description
+    status, resp = http_post(url, headers, body)
+    if status not in (200, 201):
+        raise RuntimeError(f"freeze failed [{status}]: {resp}")
+    return resp if isinstance(resp, dict) else {"raw": resp}
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Freeze an Augur eval-version from producer candidates")
+    ap.add_argument("--base", default=os.environ.get("AUGUR_BASE", DEFAULT_BASE))
+    ap.add_argument("--tenant", default=os.environ.get("AUGUR_TENANT", DEFAULT_TENANT))
+    ap.add_argument("--list", action="store_true", help="list freezable candidates and exit (read-only)")
+    ap.add_argument("--name", help="eval-version name to freeze")
+    ap.add_argument("--description", default="")
+    ap.add_argument("--task-spec-id", action="append", dest="task_spec_ids", default=[])
+    ap.add_argument("--select-prefix", default=None)
+    ap.add_argument("--session-cookie", default=os.environ.get("AUGUR_SESSION_COOKIE", ""))
+    args = ap.parse_args(argv)
+
+    token = _augur_token()
+    if not token:
+        print("ERROR: no AUGUR_API_KEY / AUGUR_DSN token in environment", file=sys.stderr)
+        return 2
+
+    candidates = list_candidates(
+        base=args.base, tenant=args.tenant, token=token, http_get=_live_get
+    )
+    if args.list:
+        print(f"{len(candidates)} candidate(s) in pool:")
+        for tid in select_task_spec_ids(candidates):
+            n = sum(1 for c in candidates if c.get("task_spec_id") == tid)
+            print(f"  {n:3d}  {tid}")
+        return 0
+
+    if not args.name:
+        print("ERROR: --name is required to freeze (or use --list)", file=sys.stderr)
+        return 2
+
+    selected = select_task_spec_ids(
+        candidates, explicit=args.task_spec_ids or None, select_prefix=args.select_prefix
+    )
+    print(f"freezing '{args.name}' with {len(selected)} task(s): {selected}")
+    result = freeze_version(
+        base=args.base,
+        tenant=args.tenant,
+        name=args.name,
+        task_spec_ids=selected,
+        session_cookie=args.session_cookie,
+        http_post=_live_post,
+        description=args.description,
+    )
+    print(json.dumps(result, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experiments/holdout/freeze_eval_version.py
+++ b/experiments/holdout/freeze_eval_version.py
@@ -49,7 +49,19 @@ from typing import Any
 import requests
 
 DEFAULT_BASE = "https://mantis-cua.ngrok-free.app/api/v1"
-DEFAULT_TENANT = "staffai"
+
+
+def _default_tenant() -> str:
+    """Tenant from ``AUGUR_TENANT`` env, else the ``tenant=`` param of
+    ``AUGUR_DSN`` — never hard-code a tenant/customer name in source
+    (tests/test_docs_client_isolation)."""
+    t = (os.environ.get("AUGUR_TENANT") or "").strip()
+    if t:
+        return t
+    dsn = os.environ.get("AUGUR_DSN", "")
+    if "tenant=" in dsn:
+        return dsn.split("tenant=", 1)[1].split("&", 1)[0]
+    return ""
 
 # An (status_code, json_body) HTTP seam so the logic is testable without network.
 HttpGet = Callable[[str, dict[str, str]], "tuple[int, Any]"]
@@ -164,7 +176,7 @@ def freeze_version(
 def main(argv: list[str] | None = None) -> int:
     ap = argparse.ArgumentParser(description="Freeze an Augur eval-version from producer candidates")
     ap.add_argument("--base", default=os.environ.get("AUGUR_BASE", DEFAULT_BASE))
-    ap.add_argument("--tenant", default=os.environ.get("AUGUR_TENANT", DEFAULT_TENANT))
+    ap.add_argument("--tenant", default=_default_tenant())
     ap.add_argument("--list", action="store_true", help="list freezable candidates and exit (read-only)")
     ap.add_argument("--name", help="eval-version name to freeze")
     ap.add_argument("--description", default="")

--- a/experiments/holdout/run_rollout_sweep.py
+++ b/experiments/holdout/run_rollout_sweep.py
@@ -144,22 +144,26 @@ def _augur_group_rewards(group_id: str, env: dict[str, str]) -> dict[str, float]
     for the group — the reward the trainer actually standardizes. Bearer reads
     only; returns {} on any failure so the gate falls back to local outcomes."""
     base = "https://mantis-cua.ngrok-free.app/api/v1"
+    dsn = env.get("AUGUR_DSN", "")
     key = env.get("AUGUR_API_KEY") or (
-        env.get("AUGUR_DSN", "").split("token=", 1)[-1].split("&", 1)[0]
-        if "token=" in env.get("AUGUR_DSN", "") else ""
+        dsn.split("token=", 1)[-1].split("&", 1)[0] if "token=" in dsn else ""
+    )
+    # Tenant from env/DSN — never hard-code a customer name in source.
+    tenant = (env.get("AUGUR_TENANT") or "").strip() or (
+        dsn.split("tenant=", 1)[1].split("&", 1)[0] if "tenant=" in dsn else ""
     )
     if not key:
         return {}
     h = {"Authorization": f"Bearer {key}", "ngrok-skip-browser-warning": "1"}
     out: dict[str, float] = {}
     try:
-        runs = requests.get(f"{base}/runs?tenant=staffai&group_id={group_id}&limit=50",
+        runs = requests.get(f"{base}/runs?tenant={tenant}&group_id={group_id}&limit=50",
                             headers=h, timeout=30).json()
         for r in (runs.get("result") or runs.get("runs") or []):
             rid = r.get("run_id")
             if not rid:
                 continue
-            rew = requests.get(f"{base}/runs/{rid}/reward/default-v1?tenant=staffai",
+            rew = requests.get(f"{base}/runs/{rid}/reward/default-v1?tenant={tenant}",
                                headers=h, timeout=30).json()
             er = rew.get("episode_return")
             if er is not None:

--- a/experiments/holdout/run_rollout_sweep.py
+++ b/experiments/holdout/run_rollout_sweep.py
@@ -83,6 +83,9 @@ def _run_sibling(
     suite["_proxy_disabled"] = True
     suite["_fanout_group_id"] = spec.group_id           # → Augur group_id (#905)
     suite["_sampling_temperature"] = temperature        # → sibling diversity (#905)
+    # #908: drive action steps with the Holo3 policy so planner modelio +
+    # per-token logprobs are captured (GRPO importance ratio requirement).
+    suite["_force_holo3_grounding"] = True
     # #906: server grades this oracle at finalize + stamps the verdict on the
     # terminal step so Augur reward reflects ground truth → GRPO reward variance.
     if not oracle_less:

--- a/experiments/holdout/run_rollout_sweep.py
+++ b/experiments/holdout/run_rollout_sweep.py
@@ -1,0 +1,181 @@
+"""#905 — generate GRPO sibling rollout groups (shared group_id).
+
+GRPO/DPO need *sibling groups*: N rollouts of the SAME task instance (template ×
+env-seed) that share a ``group_id``, with reward variance across siblings so the
+group-relative advantage is non-zero. This runner turns the stable
+:class:`~mantis_agent.learning.rollout_generator.SeedSweepGenerator` specs into
+real graded runs:
+
+For each ``RolloutSpec`` (template, env_seed, group_id, sibling_index):
+  1. seed the env to ``env_seed`` (``POST /__env__/seed {seed}``),
+  2. submit the template's micro-plan to the Modal CUA server with
+     ``_fanout_group_id = spec.group_id`` (the deployed server forwards this to
+     ``micro_runner._fanout_group_id`` → Augur ``DebugSession(group_id=…)``) and
+     ``_sampling_temperature > 0`` so siblings diverge (#905 server change),
+  3. poll to terminal, grade via the env oracle.
+
+Siblings of one (template, seed) share ``group_id`` but sample different
+trajectories (temperature) → the reward variance GRPO standardizes over.
+
+    python experiments/holdout/run_rollout_sweep.py indeed.t01_search_save_remote \
+        --seed 42 --siblings 3 --temperature 0.7
+
+THIS SPENDS — N sibling Modal GPU runs per (template, seed).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import requests
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "src"))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from sealed_plans import SANDBOXES, SEALED_TASKS  # noqa: E402
+
+import run_sealed_task as rst  # noqa: E402  (reuse env-resolve/submit/grade seams)
+
+from mantis_agent.learning.rollout_generator import (  # noqa: E402
+    SeedSweepGenerator,
+    TaskTemplate,
+)
+from mantis_agent.plan_decomposer import MicroPlan, PlanDecomposer  # noqa: E402
+from mantis_agent.server_utils import (  # noqa: E402
+    build_micro_suite,
+    micro_plan_steps_to_dicts,
+)
+
+
+def _seed_env(env_url: str, seed: int, admin_token: str, preview_token: str) -> tuple[int, str]:
+    """Re-seed the env to a specific instance (POST /__env__/seed {seed})."""
+    r = requests.post(
+        f"{env_url}/__env__/seed",
+        headers={"X-Env-Admin": admin_token, **rst._daytona_headers(preview_token)},
+        json={"seed": seed},
+        timeout=30,
+    )
+    return r.status_code, r.text[:120]
+
+
+def _run_sibling(
+    spec: Any, info: dict[str, str], token: str, temperature: float,
+    *, max_steps: int, poll_seconds: int,
+) -> dict[str, Any]:
+    tmpl = spec.template
+    steps = rst._substitute(tmpl.plan_steps or [], info["url"])
+    plan = MicroPlan(domain=tmpl.template_id.split(".")[0])
+    for st in steps:
+        plan.steps.append(PlanDecomposer._build_intent(st))
+    suite = build_micro_suite(
+        micro_plan_steps_to_dicts(plan.steps), plan.domain,
+        profile_id=f"sweep-{spec.spec_id}", workflow_id=f"sweep-{spec.spec_id}",
+    )
+    suite["_plan_name"] = tmpl.oracle_task_id
+    suite["_browser_extra_headers"] = rst._daytona_headers(info["preview_token"])
+    suite["_proxy_disabled"] = True
+    suite["_fanout_group_id"] = spec.group_id           # → Augur group_id (#905)
+    suite["_sampling_temperature"] = temperature        # → sibling diversity (#905)
+    # #906: server grades this oracle at finalize + stamps the verdict on the
+    # terminal step so Augur reward reflects ground truth → GRPO reward variance.
+    suite["_oracle_url"] = info["url"]
+    suite["_oracle_task_id"] = tmpl.oracle_task_id
+    suite["_oracle_admin_token"] = info["admin_token"]
+    suite["_oracle_preview_token"] = info["preview_token"]
+
+    code, resp = rst._post(token, {
+        "task_suite": suite, "profile_id": suite["_profile_id"],
+        "workflow_id": suite["_workflow_id"], "cua_model": "holo3",
+        "max_steps": max_steps, "max_cost": 2.0, "max_time_minutes": 12, "detached": True,
+    })
+    if code != 200 or not resp.get("run_id"):
+        return {"spec_id": spec.spec_id, "group_id": spec.group_id, "submit_error": resp}
+    run_id = resp["run_id"]
+
+    last, final = None, None
+    deadline = time.monotonic() + poll_seconds
+    while time.monotonic() < deadline:
+        _, s = rst._post(token, {"action": "status", "run_id": run_id})
+        st = s.get("status")
+        if st != last:
+            print(f"    [{spec.spec_id}] status={st!r}")
+            last = st
+        if st in {"succeeded", "completed", "completed_with_failures",
+                  "failed", "cancelled", "halted"}:
+            final = s
+            break
+        time.sleep(8)
+
+    grade = rst._grade(info["url"], tmpl.oracle_task_id, info["admin_token"], info["preview_token"])
+    return {
+        "spec_id": spec.spec_id, "sibling_index": spec.sibling_index,
+        "group_id": spec.group_id, "run_id": run_id, "env_seed": spec.env_seed,
+        "terminal_status": (final or {}).get("status"),
+        "oracle_passed": bool(grade.get("passed")),
+        "reward": 1.0 if grade.get("passed") else 0.0,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="#905 GRPO sibling rollout sweep")
+    ap.add_argument("task_key", help=f"template from sealed_plans: {sorted(SEALED_TASKS)}")
+    ap.add_argument("--seed", type=int, default=42)
+    ap.add_argument("--siblings", type=int, default=3)
+    ap.add_argument("--temperature", type=float, default=0.7)
+    ap.add_argument("--max-steps", type=int, default=25)
+    ap.add_argument("--poll-seconds", type=int, default=600)
+    args = ap.parse_args(argv)
+
+    if args.task_key not in SEALED_TASKS:
+        print(f"unknown task; known: {sorted(SEALED_TASKS)}", file=sys.stderr)
+        return 2
+    spec_def = SEALED_TASKS[args.task_key]
+    env_name = spec_def["env"]
+    env = rst._load_env()
+    token, dayt = env.get("MANTIS_API_TOKEN", ""), env.get("DAYTONA_API_KEY", "")
+    if not token or not dayt:
+        print("ERROR: MANTIS_API_TOKEN + DAYTONA_API_KEY required", file=sys.stderr)
+        return 2
+
+    template = TaskTemplate(
+        template_id=args.task_key, cluster=env_name,
+        oracle_task_id=spec_def["oracle_task_id"], plan_steps=spec_def["steps"],
+    )
+    gen = SeedSweepGenerator(templates=[template], seeds=[args.seed],
+                             siblings_per_instance=args.siblings)
+    specs = list(gen.generate())
+    print(f"[sweep] {len(specs)} siblings of {args.task_key} @ seed={args.seed} "
+          f"group_id={specs[0].group_id!r} temp={args.temperature}")
+
+    print(f"[env] resolving Daytona sandbox for '{env_name}' …")
+    info = rst._daytona_env(SANDBOXES[env_name], dayt)
+    print(f"  url={info['url']}  preview={'set' if info['preview_token'] else 'MISSING'}")
+    code, body = _seed_env(info["url"], args.seed, info["admin_token"], info["preview_token"])
+    print(f"[seed={args.seed}] HTTP {code} {body[:60]}")
+
+    results = []
+    for spec in specs:
+        print(f"  → sibling {spec.sibling_index} ({spec.spec_id})")
+        results.append(_run_sibling(spec, info, token, args.temperature,
+                                    max_steps=args.max_steps, poll_seconds=args.poll_seconds))
+
+    rewards = [r.get("reward") for r in results if "reward" in r]
+    variance = len(set(rewards)) > 1 if rewards else False
+    print("\n[sweep result]")
+    print(json.dumps({
+        "group_id": specs[0].group_id,
+        "siblings": results,
+        "rewards": rewards,
+        "has_reward_variance": variance,
+    }, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experiments/holdout/run_rollout_sweep.py
+++ b/experiments/holdout/run_rollout_sweep.py
@@ -135,24 +135,74 @@ def _run_sibling(
     }
 
 
-def _classify_group(results: list[dict[str, Any]]) -> dict[str, Any]:
+# Augur reward spread below this (≈ step-cost "hair") is noise, not signal.
+_MEANINGFUL_STD = 0.05
+
+
+def _augur_group_rewards(group_id: str, env: dict[str, str]) -> dict[str, float]:
+    """Fetch each sibling's Augur ``episode_return`` (process/progress-shaped)
+    for the group — the reward the trainer actually standardizes. Bearer reads
+    only; returns {} on any failure so the gate falls back to local outcomes."""
+    base = "https://mantis-cua.ngrok-free.app/api/v1"
+    key = env.get("AUGUR_API_KEY") or (
+        env.get("AUGUR_DSN", "").split("token=", 1)[-1].split("&", 1)[0]
+        if "token=" in env.get("AUGUR_DSN", "") else ""
+    )
+    if not key:
+        return {}
+    h = {"Authorization": f"Bearer {key}", "ngrok-skip-browser-warning": "1"}
+    out: dict[str, float] = {}
+    try:
+        runs = requests.get(f"{base}/runs?tenant=staffai&group_id={group_id}&limit=50",
+                            headers=h, timeout=30).json()
+        for r in (runs.get("result") or runs.get("runs") or []):
+            rid = r.get("run_id")
+            if not rid:
+                continue
+            rew = requests.get(f"{base}/runs/{rid}/reward/default-v1?tenant=staffai",
+                               headers=h, timeout=30).json()
+            er = rew.get("episode_return")
+            if er is not None:
+                out[rid] = float(er)
+    except Exception:  # noqa: BLE001 — best-effort; gate falls back to local outcomes
+        return {}
+    return out
+
+
+def _classify_group(results: list[dict[str, Any]],
+                    augur_rewards: dict[str, float] | None = None) -> dict[str, Any]:
     """Group-variance gate (mantis-trainer feedback): GRPO standardizes
-    ``(r − mean)/(std + eps)``, so an all-pass or all-fail group has only
-    step-cost "hair" variance → ±1 noise advantages. A group is GRPO-usable
-    only when its oracle OUTCOMES are mixed (real reward spread)."""
+    ``(r − mean)/(std + eps)``, so a group with only step-cost "hair" variance
+    yields ±1 noise advantages. A group is GRPO-usable when it has REAL reward
+    spread — either mixed oracle outcomes OR (with #906 process/progress
+    shaping) meaningful Augur ``episode_return`` variance from differing
+    effort/progress even on an all-pass / all-fail group."""
     import statistics
     outcomes = [bool(r.get("oracle_passed")) for r in results if "oracle_passed" in r]
-    rewards = [float(r["reward"]) for r in results if "reward" in r]
     distinct = len(set(outcomes))
-    std = statistics.pstdev(rewards) if len(rewards) > 1 else 0.0
-    usable = distinct > 1  # mixed pass/fail → genuine variance
     n_pass = sum(1 for o in outcomes if o)
-    reason = "" if usable else (
-        f"degenerate: all {'pass' if n_pass else 'fail'} ({n_pass}/{len(outcomes)})"
-        " — GRPO advantage would be noise; exclude or re-sample"
-    )
+
+    shaped = sorted((augur_rewards or {}).values())
+    shaped_std = statistics.pstdev(shaped) if len(shaped) > 1 else 0.0
+    local_std = statistics.pstdev([float(r["reward"]) for r in results if "reward" in r]) \
+        if len([r for r in results if "reward" in r]) > 1 else 0.0
+
+    mixed = distinct > 1
+    shaped_signal = shaped_std >= _MEANINGFUL_STD
+    usable = mixed or shaped_signal
+    if usable:
+        reason = ("mixed outcomes" if mixed else
+                  f"shaped reward variance (episode_return std={shaped_std:.3f})")
+    else:
+        reason = (
+            f"degenerate: all {'pass' if n_pass else 'fail'} ({n_pass}/{len(outcomes)})"
+            f" and shaped std {shaped_std:.4f} < {_MEANINGFUL_STD}"
+            " — GRPO advantage would be noise; exclude or re-sample"
+        )
     return {"n": len(outcomes), "n_pass": n_pass, "distinct_outcomes": distinct,
-            "reward_std": round(std, 4), "grpo_usable": usable, "reason": reason}
+            "local_reward_std": round(local_std, 4),
+            "shaped_episode_return_std": round(shaped_std, 4),
+            "grpo_usable": usable, "reason": reason}
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -210,21 +260,23 @@ def main(argv: list[str] | None = None) -> int:
 
     results = [_run(spec) for spec in specs]
 
-    # Variance gate (mantis-trainer feedback): if the group is degenerate
-    # (all-pass / all-fail → noise advantages), keep adding siblings until it
-    # has mixed outcomes or we hit the cap.
+    # Variance gate (mantis-trainer feedback): a group is GRPO-usable with real
+    # reward spread — mixed outcomes OR (with #906 process/progress shaping)
+    # meaningful Augur episode_return variance. Keep adding siblings while
+    # degenerate, up to the cap.
     gid = specs[0].group_id
-    while (args.variance_seek and not _classify_group(results)["grpo_usable"]
+    while (args.variance_seek
+           and not _classify_group(results, _augur_group_rewards(gid, env))["grpo_usable"]
            and len(results) < args.max_siblings):
         idx = len(results)
-        print(f"  [variance-seek] group degenerate after {idx} siblings — adding sibling {idx}")
+        print(f"  [variance-seek] group still degenerate after {idx} siblings — adding sibling {idx}")
         extra = RolloutSpec(
             spec_id=f"{template.template_id}__seed{args.seed}__s{idx}",
             template=template, env_seed=args.seed, group_id=gid, sibling_index=idx,
         )
         results.append(_run(extra))
 
-    gate = _classify_group(results)
+    gate = _classify_group(results, _augur_group_rewards(gid, env))
     print("\n[sweep result]")
     print(json.dumps({
         "group_id": gid,

--- a/experiments/holdout/run_rollout_sweep.py
+++ b/experiments/holdout/run_rollout_sweep.py
@@ -66,7 +66,8 @@ def _seed_env(env_url: str, seed: int, admin_token: str, preview_token: str) -> 
 
 def _run_sibling(
     spec: Any, info: dict[str, str], token: str, temperature: float,
-    *, max_steps: int, poll_seconds: int,
+    *, max_steps: int, poll_seconds: int, model_judge: bool = False,
+    task_text: str = "", oracle_less: bool = False,
 ) -> dict[str, Any]:
     tmpl = spec.template
     steps = rst._substitute(tmpl.plan_steps or [], info["url"])
@@ -84,10 +85,18 @@ def _run_sibling(
     suite["_sampling_temperature"] = temperature        # → sibling diversity (#905)
     # #906: server grades this oracle at finalize + stamps the verdict on the
     # terminal step so Augur reward reflects ground truth → GRPO reward variance.
-    suite["_oracle_url"] = info["url"]
-    suite["_oracle_task_id"] = tmpl.oracle_task_id
-    suite["_oracle_admin_token"] = info["admin_token"]
-    suite["_oracle_preview_token"] = info["preview_token"]
+    if not oracle_less:
+        suite["_oracle_url"] = info["url"]
+        suite["_oracle_task_id"] = tmpl.oracle_task_id
+        suite["_oracle_admin_token"] = info["admin_token"]
+        suite["_oracle_preview_token"] = info["preview_token"]
+    if model_judge:  # #906 extension: model-judge (primary signal on oracle-less)
+        suite["_model_judge_enabled"] = True
+        if oracle_less:
+            suite["_task_instruction"] = task_text or tmpl.oracle_task_id.replace("_", " ")
+        else:
+            suite["_model_judge_force"] = True  # cross-check mode where an oracle exists
+            suite["_task_instruction"] = task_text or tmpl.oracle_task_id.replace("_", " ")
 
     code, resp = rst._post(token, {
         "task_suite": suite, "profile_id": suite["_profile_id"],
@@ -130,6 +139,10 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--temperature", type=float, default=0.7)
     ap.add_argument("--max-steps", type=int, default=25)
     ap.add_argument("--poll-seconds", type=int, default=600)
+    ap.add_argument("--model-judge", action="store_true",
+                    help="#906: also run the model-judge (rm_outcome + judge_ids)")
+    ap.add_argument("--no-oracle", action="store_true",
+                    help="#906: skip the env oracle (simulate an oracle-less task; judge is the signal)")
     args = ap.parse_args(argv)
 
     if args.task_key not in SEALED_TASKS:
@@ -163,7 +176,10 @@ def main(argv: list[str] | None = None) -> int:
     for spec in specs:
         print(f"  → sibling {spec.sibling_index} ({spec.spec_id})")
         results.append(_run_sibling(spec, info, token, args.temperature,
-                                    max_steps=args.max_steps, poll_seconds=args.poll_seconds))
+                                    max_steps=args.max_steps, poll_seconds=args.poll_seconds,
+                                    model_judge=args.model_judge,
+                                    task_text=spec_def.get("task_text", ""),
+                                    oracle_less=args.no_oracle))
 
     rewards = [r.get("reward") for r in results if "reward" in r]
     variance = len(set(rewards)) > 1 if rewards else False

--- a/experiments/holdout/run_rollout_sweep.py
+++ b/experiments/holdout/run_rollout_sweep.py
@@ -43,6 +43,7 @@ from sealed_plans import SANDBOXES, SEALED_TASKS  # noqa: E402
 import run_sealed_task as rst  # noqa: E402  (reuse env-resolve/submit/grade seams)
 
 from mantis_agent.learning.rollout_generator import (  # noqa: E402
+    RolloutSpec,
     SeedSweepGenerator,
     TaskTemplate,
 )
@@ -134,6 +135,26 @@ def _run_sibling(
     }
 
 
+def _classify_group(results: list[dict[str, Any]]) -> dict[str, Any]:
+    """Group-variance gate (mantis-trainer feedback): GRPO standardizes
+    ``(r − mean)/(std + eps)``, so an all-pass or all-fail group has only
+    step-cost "hair" variance → ±1 noise advantages. A group is GRPO-usable
+    only when its oracle OUTCOMES are mixed (real reward spread)."""
+    import statistics
+    outcomes = [bool(r.get("oracle_passed")) for r in results if "oracle_passed" in r]
+    rewards = [float(r["reward"]) for r in results if "reward" in r]
+    distinct = len(set(outcomes))
+    std = statistics.pstdev(rewards) if len(rewards) > 1 else 0.0
+    usable = distinct > 1  # mixed pass/fail → genuine variance
+    n_pass = sum(1 for o in outcomes if o)
+    reason = "" if usable else (
+        f"degenerate: all {'pass' if n_pass else 'fail'} ({n_pass}/{len(outcomes)})"
+        " — GRPO advantage would be noise; exclude or re-sample"
+    )
+    return {"n": len(outcomes), "n_pass": n_pass, "distinct_outcomes": distinct,
+            "reward_std": round(std, 4), "grpo_usable": usable, "reason": reason}
+
+
 def main(argv: list[str] | None = None) -> int:
     ap = argparse.ArgumentParser(description="#905 GRPO sibling rollout sweep")
     ap.add_argument("task_key", help=f"template from sealed_plans: {sorted(SEALED_TASKS)}")
@@ -146,6 +167,10 @@ def main(argv: list[str] | None = None) -> int:
                     help="#906: also run the model-judge (rm_outcome + judge_ids)")
     ap.add_argument("--no-oracle", action="store_true",
                     help="#906: skip the env oracle (simulate an oracle-less task; judge is the signal)")
+    ap.add_argument("--variance-seek", action="store_true",
+                    help="keep adding siblings (to --max-siblings) until the group has mixed outcomes (real GRPO variance)")
+    ap.add_argument("--max-siblings", type=int, default=6,
+                    help="variance-seek cap on total siblings per group")
     args = ap.parse_args(argv)
 
     if args.task_key not in SEALED_TASKS:
@@ -175,24 +200,40 @@ def main(argv: list[str] | None = None) -> int:
     code, body = _seed_env(info["url"], args.seed, info["admin_token"], info["preview_token"])
     print(f"[seed={args.seed}] HTTP {code} {body[:60]}")
 
-    results = []
-    for spec in specs:
+    def _run(spec):
         print(f"  → sibling {spec.sibling_index} ({spec.spec_id})")
-        results.append(_run_sibling(spec, info, token, args.temperature,
-                                    max_steps=args.max_steps, poll_seconds=args.poll_seconds,
-                                    model_judge=args.model_judge,
-                                    task_text=spec_def.get("task_text", ""),
-                                    oracle_less=args.no_oracle))
+        return _run_sibling(spec, info, token, args.temperature,
+                            max_steps=args.max_steps, poll_seconds=args.poll_seconds,
+                            model_judge=args.model_judge,
+                            task_text=spec_def.get("task_text", ""),
+                            oracle_less=args.no_oracle)
 
-    rewards = [r.get("reward") for r in results if "reward" in r]
-    variance = len(set(rewards)) > 1 if rewards else False
+    results = [_run(spec) for spec in specs]
+
+    # Variance gate (mantis-trainer feedback): if the group is degenerate
+    # (all-pass / all-fail → noise advantages), keep adding siblings until it
+    # has mixed outcomes or we hit the cap.
+    gid = specs[0].group_id
+    while (args.variance_seek and not _classify_group(results)["grpo_usable"]
+           and len(results) < args.max_siblings):
+        idx = len(results)
+        print(f"  [variance-seek] group degenerate after {idx} siblings — adding sibling {idx}")
+        extra = RolloutSpec(
+            spec_id=f"{template.template_id}__seed{args.seed}__s{idx}",
+            template=template, env_seed=args.seed, group_id=gid, sibling_index=idx,
+        )
+        results.append(_run(extra))
+
+    gate = _classify_group(results)
     print("\n[sweep result]")
     print(json.dumps({
-        "group_id": specs[0].group_id,
+        "group_id": gid,
         "siblings": results,
-        "rewards": rewards,
-        "has_reward_variance": variance,
+        "rewards": [r.get("reward") for r in results if "reward" in r],
+        "variance_gate": gate,
     }, indent=2))
+    if not gate["grpo_usable"]:
+        print(f"\n⚠️  GROUP NOT GRPO-USABLE — {gate['reason']}", file=sys.stderr)
     return 0
 
 

--- a/experiments/holdout/run_sealed_task.py
+++ b/experiments/holdout/run_sealed_task.py
@@ -1,0 +1,249 @@
+"""Run one sealed holdout task through the deployed Modal CUA server against its
+live Daytona sim env, then grade it with the env oracle (#894).
+
+Pipeline per task (recipe verified 2026-06-14):
+
+1. Resolve the env's Daytona sandbox → ensure uvicorn → preview URL + token +
+   admin token (read from inside the sandbox).
+2. ``POST /__env__/reset`` (admin) so the run starts from the seeded baseline.
+3. Build a micro-suite from the pre-decomposed plan in ``sealed_plans.py`` with
+   ``_plan_name`` (→ Augur task_spec_id) and ``_browser_extra_headers`` carrying
+   the Daytona preview token + skip-warning so the Modal browser can reach the
+   sandbox. ``{env_url}`` in nav steps is substituted with the preview URL.
+4. ``POST /v1/predict`` (detached) → poll to terminal.
+5. Grade via ``GET /__env__/oracle?task_id=…`` (admin).
+
+On plan-completion the producer emits a ``source:producer`` eval candidate keyed
+``<domain>.<plan_name>.v1`` (see ``observability/eval_curation``); this script
+prints that task_spec_id so the freeze step
+(``freeze_eval_version.py``) can select the oracle-passing ones.
+
+    python experiments/holdout/run_sealed_task.py indeed.t01_search_save_remote
+
+THIS SPENDS — it submits a real Modal GPU run.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import sys
+import time
+from typing import Any
+
+import requests
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "src"))
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+
+from sealed_plans import SANDBOXES, SEALED_TASKS  # noqa: E402
+
+from mantis_agent.plan_decomposer import MicroPlan, PlanDecomposer  # noqa: E402
+from mantis_agent.server_utils import (  # noqa: E402
+    build_micro_suite,
+    micro_plan_steps_to_dicts,
+)
+
+ENDPOINT = "https://getmason--mantis-cua-server-api.modal.run"
+PORT = 8080
+
+
+def _load_env() -> dict[str, str]:
+    env: dict[str, str] = {}
+    for line in (REPO_ROOT / ".env").read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        k, _, v = line.partition("=")
+        env[k.strip()] = v.strip().strip('"').strip("'")
+    return env
+
+
+def _daytona_env(sandbox_id: str, api_key: str) -> dict[str, str]:
+    """Start the sandbox if needed, ensure uvicorn, return url/token/admin."""
+    from daytona import Daytona, DaytonaConfig
+
+    d = Daytona(DaytonaConfig(api_key=api_key))
+    s = d.get(sandbox_id)
+    try:
+        s.start(timeout=120)
+    except Exception:
+        pass  # already running
+    # Ensure uvicorn is up (auto-relaunch on revive isn't guaranteed) + read admin token.
+    # Daytona's exec proxy intermittently 504s even when the command runs — treat
+    # exec failures as non-fatal and verify liveness via the preview URL instead
+    # (see feedback_daytona_patch_exec_504).
+    boot = (
+        "python3 -c \"import urllib.request as u; "
+        "print(u.urlopen('http://127.0.0.1:8080/__env__/health',timeout=4).read().decode())\" "
+        "2>/dev/null || (cd /srv && nohup python -m uvicorn app.main:app "
+        "--host 0.0.0.0 --port 8080 >/tmp/uv.log 2>&1 & sleep 6)"
+    )
+
+    def _exec(cmd: str) -> str:
+        try:
+            r = s.process.exec(cmd)
+            return (getattr(r, "result", "") or getattr(r, "output", "") or "").strip()
+        except Exception as e:  # noqa: BLE001 — Daytona 504s are transient
+            print(f"  warn: exec failed (non-fatal): {str(e)[:80]}")
+            return ""
+
+    _exec(boot)
+    admin_token = _exec("printf '%s' \"$ENV_ADMIN_TOKEN\"")
+    prev = s.get_preview_link(PORT)
+    return {
+        "url": prev.url.rstrip("/"),
+        "preview_token": getattr(prev, "token", "") or "",
+        "admin_token": admin_token,
+    }
+
+
+def _daytona_headers(preview_token: str) -> dict[str, str]:
+    h = {"X-Daytona-Skip-Preview-Warning": "true"}
+    if preview_token:
+        h["x-daytona-preview-token"] = preview_token
+    return h
+
+
+def _reset_env(env_url: str, admin_token: str, preview_token: str) -> tuple[int, str]:
+    r = requests.post(
+        f"{env_url}/__env__/reset",
+        headers={"X-Env-Admin": admin_token, **_daytona_headers(preview_token)},
+        timeout=30,
+    )
+    return r.status_code, r.text[:200]
+
+
+def _grade(env_url: str, task_id: str, admin_token: str, preview_token: str) -> dict[str, Any]:
+    r = requests.get(
+        f"{env_url}/__env__/oracle",
+        params={"task_id": task_id},
+        headers={"X-Env-Admin": admin_token, **_daytona_headers(preview_token)},
+        timeout=30,
+    )
+    try:
+        return r.json()
+    except ValueError:
+        return {"http": r.status_code, "raw": r.text[:300]}
+
+
+def _post(token: str, body: dict[str, Any]) -> tuple[int, dict[str, Any]]:
+    r = requests.post(
+        f"{ENDPOINT}/v1/predict",
+        headers={"X-Mantis-Token": token, "Content-Type": "application/json"},
+        data=json.dumps(body),
+        timeout=90,
+    )
+    try:
+        return r.status_code, r.json()
+    except ValueError:
+        return r.status_code, {"raw": r.text[:300]}
+
+
+def _substitute(steps: list[dict[str, Any]], env_url: str) -> list[dict[str, Any]]:
+    out = json.loads(json.dumps(steps))
+    for st in out:
+        p = st.get("params", {})
+        if isinstance(p.get("url"), str):
+            p["url"] = p["url"].replace("{env_url}", env_url)
+    return out
+
+
+def run(task_key: str, *, max_steps: int = 25, poll_seconds: int = 600) -> int:
+    if task_key not in SEALED_TASKS:
+        print(f"unknown task '{task_key}'. known: {sorted(SEALED_TASKS)}", file=sys.stderr)
+        return 2
+    spec = SEALED_TASKS[task_key]
+    env_name = spec["env"]
+    env = _load_env()
+    token = env.get("MANTIS_API_TOKEN", "")
+    dayt = env.get("DAYTONA_API_KEY", "")
+    if not token or not dayt:
+        print("ERROR: MANTIS_API_TOKEN + DAYTONA_API_KEY required in .env", file=sys.stderr)
+        return 2
+
+    print(f"[env] resolving Daytona sandbox for '{env_name}' …")
+    info = _daytona_env(SANDBOXES[env_name], dayt)
+    print(f"  url={info['url']}")
+    print(f"  preview_token={'set' if info['preview_token'] else 'MISSING'}  "
+          f"admin_token={'set' if info['admin_token'] else 'MISSING'}")
+
+    code, body = _reset_env(info["url"], info["admin_token"], info["preview_token"])
+    print(f"[reset] HTTP {code} {body[:80]}")
+
+    steps = _substitute(spec["steps"], info["url"])
+    plan = MicroPlan(domain=env_name)
+    for st in steps:
+        plan.steps.append(PlanDecomposer._build_intent(st))
+    suite = build_micro_suite(
+        micro_plan_steps_to_dicts(plan.steps),
+        plan.domain,
+        profile_id=f"holdout-{task_key}",
+        workflow_id=f"holdout-{task_key}",
+    )
+    suite["_plan_name"] = spec["plan_name"]
+    suite["_browser_extra_headers"] = _daytona_headers(info["preview_token"])
+    suite["_proxy_disabled"] = True
+    expected_ts = f"{env_name}.{spec['plan_name']}.v1"
+    print(f"[submit] plan_name={spec['plan_name']!r} → task_spec_id={expected_ts!r}")
+
+    code, resp = _post(token, {
+        "task_suite": suite,
+        "profile_id": suite["_profile_id"],
+        "workflow_id": suite["_workflow_id"],
+        "cua_model": "holo3",
+        "max_steps": max_steps,
+        "max_cost": 2.0,
+        "max_time_minutes": 12,
+        "detached": True,
+    })
+    if code != 200 or not resp.get("run_id"):
+        print(f"  FAIL submit HTTP {code}: {resp}")
+        return 1
+    run_id = resp["run_id"]
+    print(f"  run_id={run_id}")
+
+    print("[poll] …")
+    last = None
+    final = None
+    deadline = time.monotonic() + poll_seconds
+    while time.monotonic() < deadline:
+        code, s = _post(token, {"action": "status", "run_id": run_id})
+        status = s.get("status")
+        if status != last:
+            print(f"  status={status!r}")
+            last = status
+        if status in {"succeeded", "completed", "completed_with_failures",
+                      "failed", "cancelled", "halted"}:
+            final = s
+            break
+        time.sleep(8)
+
+    fstatus = (final or {}).get("status")
+    print(f"[terminal] status={fstatus!r} halt_reason={(final or {}).get('halt_reason')!r}")
+    grade = _grade(info["url"], spec["oracle_task_id"], info["admin_token"], info["preview_token"])
+    passed = grade.get("passed")
+    print(f"[oracle] task_id={spec['oracle_task_id']} passed={passed} reasons={grade.get('reasons')}")
+    print(json.dumps({
+        "task_key": task_key,
+        "run_id": run_id,
+        "terminal_status": (final or {}).get("status"),
+        "task_spec_id": expected_ts,
+        "oracle_passed": bool(passed),
+    }, indent=2))
+    return 0 if passed else 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Run a sealed holdout task end-to-end")
+    ap.add_argument("task_key", help=f"one of: {sorted(SEALED_TASKS)}")
+    ap.add_argument("--max-steps", type=int, default=25)
+    ap.add_argument("--poll-seconds", type=int, default=600)
+    args = ap.parse_args(argv)
+    return run(args.task_key, max_steps=args.max_steps, poll_seconds=args.poll_seconds)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experiments/holdout/run_sealed_task.py
+++ b/experiments/holdout/run_sealed_task.py
@@ -186,6 +186,13 @@ def run(task_key: str, *, max_steps: int = 25, poll_seconds: int = 600) -> int:
     suite["_plan_name"] = spec["plan_name"]
     suite["_browser_extra_headers"] = _daytona_headers(info["preview_token"])
     suite["_proxy_disabled"] = True
+    # #906: let the server grade the env oracle at finalize so the verdict +
+    # reward reflect ground truth AND mark_for_eval is gated on an oracle pass
+    # (eval candidates become oracle-verified, not merely plan-complete).
+    suite["_oracle_url"] = info["url"]
+    suite["_oracle_task_id"] = spec["oracle_task_id"]
+    suite["_oracle_admin_token"] = info["admin_token"]
+    suite["_oracle_preview_token"] = info["preview_token"]
     expected_ts = f"{env_name}.{spec['plan_name']}.v1"
     print(f"[submit] plan_name={spec['plan_name']!r} → task_spec_id={expected_ts!r}")
 

--- a/experiments/holdout/sealed_plans.py
+++ b/experiments/holdout/sealed_plans.py
@@ -93,6 +93,7 @@ SEALED_TASKS: dict[str, dict[str, Any]] = {
     "indeed.t01_search_save_remote": {
         "env": "indeed",
         "plan_name": "t01_search_save_remote",
+        "task_text": "Search 'software engineer' in 'Austin, TX' with remote on, and save job_00007.",
         "oracle_task_id": "t01_search_save_remote",
         "steps": [
             _nav(
@@ -111,6 +112,7 @@ SEALED_TASKS: dict[str, dict[str, Any]] = {
     "indeed.t03_employer_review_applicant": {
         "env": "indeed",
         "plan_name": "t03_employer_review_applicant",
+        "task_text": "On the employer posting for job_00003, move the new applicant to 'reviewed'.",
         "oracle_task_id": "t03_employer_review_applicant",
         "steps": [
             _nav(
@@ -129,6 +131,7 @@ SEALED_TASKS: dict[str, dict[str, Any]] = {
     "linkedin.t02_post_text_update": {
         "env": "linkedin",
         "plan_name": "t02_post_text_update",
+        "task_text": "Create a LinkedIn feed post containing text and at least one #hashtag.",
         "oracle_task_id": "t02_post_text_update",
         "steps": [
             _nav("{env_url}/feed/", "Open the LinkedIn home feed"),

--- a/experiments/holdout/sealed_plans.py
+++ b/experiments/holdout/sealed_plans.py
@@ -25,6 +25,7 @@ SANDBOXES: dict[str, str] = {
     "indeed": "a72a3ffc-f1c1-4628-89a6-1c560703441b",
     "mercor": "f0f3ffc9-4879-48a9-98db-b5b5224fe20f",
     "linkedin": "f43c50dd-0edb-4667-8b50-2ff2f697de24",
+    "fiverr": "d2c59f51-ca2e-48d2-b436-370b18673b79",
 }
 
 
@@ -146,6 +147,24 @@ SEALED_TASKS: dict[str, dict[str, Any]] = {
                 "Type a short update that includes a #hashtag into the post composer text box",
             ),
             _submit("Post", "Click the 'Post' button to publish the update", required=False),
+        ],
+    },
+    # fiverr t03 — leave a 5-star review on order_00007. The review form on the
+    # order page pre-checks the 5-star radio; filling the body + publishing
+    # records the reviews row (stars=5) + review_submitted audit the oracle reads.
+    "fiverr.t03_leave_5star_review": {
+        "env": "fiverr",
+        "plan_name": "t03_leave_5star_review",
+        "task_text": "Leave a 5-star review on order_00007 with a short positive comment.",
+        "oracle_task_id": "t03_leave_5star_review",
+        "steps": [
+            _nav("{env_url}/orders/order_00007", "Open the order page for order_00007 (it has a Leave a review form)"),
+            _fill(
+                "Share more about your experience...",
+                "Outstanding work — delivered exactly as described, fast and polished. Highly recommend!",
+                "Type a positive comment into the review body box (the 5-star rating is pre-selected)",
+            ),
+            _submit("Publish review", "Click 'Publish review' to submit the 5-star review", required=False),
         ],
     },
 }

--- a/experiments/holdout/sealed_plans.py
+++ b/experiments/holdout/sealed_plans.py
@@ -1,0 +1,148 @@
+"""Hand-authored micro-plans for the sealed holdout tasks (#894).
+
+Each entry maps a holdout `oracle_task_id` to the env it runs in + a
+pre-decomposed micro-plan (the deterministic, guard-carrying path — no LLM
+decompose at run time). Steps use ``{env_url}`` as a placeholder the runner
+substitutes with the live Daytona preview URL.
+
+Grounding source: each env's ``scripts/smoke.py`` (exact endpoints/fields) +
+``app/templates`` (labels/buttons) + ``app/oracles/<task>.py`` (pass criteria).
+The plan's job is to reach a state the env oracle grades as ``passed`` while
+exercising the real UI; the producer emits a `mark_for_eval` candidate keyed
+``<domain>.<plan_name>.v1`` on plan-completion (oracle grade is read separately).
+
+The ``domain`` here becomes the Augur task_spec_id prefix, so we set it to the
+holdout env id (e.g. ``indeed``) and ``plan_name`` to the oracle_task_id — giving
+``indeed.t01_search_save_remote.v1``, aligned with the holdout manifest anchor.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# Daytona sandbox ids for the running sealed envs (live-identified 2026-06-14).
+SANDBOXES: dict[str, str] = {
+    "indeed": "a72a3ffc-f1c1-4628-89a6-1c560703441b",
+    "mercor": "f0f3ffc9-4879-48a9-98db-b5b5224fe20f",
+    "linkedin": "f43c50dd-0edb-4667-8b50-2ff2f697de24",
+}
+
+
+def _nav(url: str, intent: str, *, wait: int = 6) -> dict[str, Any]:
+    return {
+        "type": "navigate",
+        "intent": intent,
+        "params": {"url": url, "wait_after_load_seconds": wait},
+        "required": True,
+        "section": "setup",
+        "gate": False,
+    }
+
+
+def _click(intent: str, *, label: str = "", required: bool = True) -> dict[str, Any]:
+    """A plain element click (link/button that navigates or opens a modal).
+
+    The deployed click/form handlers key on ``label`` (NOT ``target``) — a
+    ``target`` param reaches the form-submit path as an empty label and fails
+    with ``button '' not found`` (live-diagnosed 2026-06-14)."""
+    params: dict[str, Any] = {}
+    if label:
+        params["label"] = label
+    return {
+        "type": "click",
+        "intent": intent,
+        "params": params,
+        "required": required,
+        "section": "act",
+        "gate": False,
+    }
+
+
+def _submit(label: str, intent: str, *, required: bool = True) -> dict[str, Any]:
+    """A form-submit button click (e.g. 'Save job', 'Post', 'Mark reviewed').
+
+    Uses step type ``submit`` which the form handler resolves via
+    ``find_form_target`` against the ``label``."""
+    return {
+        "type": "submit",
+        "intent": intent,
+        "params": {"label": label},
+        "required": required,
+        "section": "act",
+        "gate": False,
+    }
+
+
+def _fill(label: str, value: str, intent: str) -> dict[str, Any]:
+    return {
+        "type": "fill_field",
+        "intent": intent,
+        "params": {"label": label, "value": value},
+        "required": True,
+        "section": "act",
+        "gate": False,
+    }
+
+
+# ── the sealed task registry ───────────────────────────────────────
+# Each: env, plan_name (== oracle_task_id), oracle_task_id, steps.
+
+SEALED_TASKS: dict[str, dict[str, Any]] = {
+    # indeed t01 — filtered search (remote) fires the search audit on results
+    # load; saving job_00007 (the remote Austin SE) records the job_saved row.
+    "indeed.t01_search_save_remote": {
+        "env": "indeed",
+        "plan_name": "t01_search_save_remote",
+        "oracle_task_id": "t01_search_save_remote",
+        "steps": [
+            _nav(
+                "{env_url}/jobs?q=software+engineer&l=Austin&remote=1&vjk=0000000000000007",
+                "Open the Indeed results for 'software engineer' in 'Austin' with Remote on, with the Software Engineer (Acme Software) job pre-selected in the detail pane",
+            ),
+            _submit(
+                "Save job",
+                "Click the 'Save job' button in the right-hand detail pane to save the selected Software Engineer job",
+                required=False,  # form-POST returns JSON; oracle arbitrates the save
+            ),
+        ],
+    },
+    # indeed t03 — employer moves the seeded new applicant on job_00003 to
+    # 'reviewed' via the "Mark reviewed" button on the posting page.
+    "indeed.t03_employer_review_applicant": {
+        "env": "indeed",
+        "plan_name": "t03_employer_review_applicant",
+        "oracle_task_id": "t03_employer_review_applicant",
+        "steps": [
+            _nav(
+                "{env_url}/employers/jobs/job_00003",
+                "Open the employer posting page for job_00003 to see its applicants",
+            ),
+            _submit(
+                "Mark reviewed",
+                "Click 'Mark reviewed' on the new applicant to move them from 'new' to 'reviewed'",
+                required=False,
+            ),
+        ],
+    },
+    # linkedin t02 — open the "Start a post" composer, write text with a
+    # #hashtag, and Post. extract_hashtags fires on the /feed/post route.
+    "linkedin.t02_post_text_update": {
+        "env": "linkedin",
+        "plan_name": "t02_post_text_update",
+        "oracle_task_id": "t02_post_text_update",
+        "steps": [
+            _nav("{env_url}/feed/", "Open the LinkedIn home feed"),
+            _click(
+                "Click the 'Start a post' button to open the post composer",
+                label="Start a post",
+                required=False,  # opens a JS <dialog> (showModal) → no nav → runner sees no_state_change
+            ),
+            _fill(
+                "What do you want to talk about?",
+                "Thrilled to be building computer-use agents this quarter. #buildinpublic",
+                "Type a short update that includes a #hashtag into the post composer text box",
+            ),
+            _submit("Post", "Click the 'Post' button to publish the update", required=False),
+        ],
+    },
+}

--- a/src/mantis_agent/gym/_runner_helpers.py
+++ b/src/mantis_agent/gym/_runner_helpers.py
@@ -843,7 +843,19 @@ def execute_step(
         getattr(runner, "_step_handler_override", {}).get(index)
         if hasattr(runner, "_step_handler_override") else None
     )
-    if override == "holo3" and runner.brain is not None:
+    # #908: force the Holo3 brain-grounded loop from the first attempt (not only
+    # on failure-escalation) so RL rollouts exercise the POLICY (brain.think) —
+    # that's the only path that emits planner-layer modelio + per-token logprobs,
+    # which the GRPO importance ratio ρ_t = exp(logπ_θ − logπ_old) requires.
+    # Gated to grounding-bearing action steps so deterministic navigate stays
+    # deterministic. Opt-in via the suite's ``_force_holo3_grounding``.
+    _force_holo3 = (
+        bool(getattr(runner, "_force_holo3_grounding", False))
+        and runner.brain is not None
+        and bool(getattr(step, "grounding", False))
+        and step.type in ("click", "submit")
+    )
+    if (override == "holo3" or _force_holo3) and runner.brain is not None:
         # Bump the budget on escalation — the canonical case is
         # "scroll down to find an off-screen target then click it",
         # but in CRM / settings flows the target may also live on a

--- a/src/mantis_agent/gym/run_executor.py
+++ b/src/mantis_agent/gym/run_executor.py
@@ -2232,6 +2232,10 @@ class RunExecutor:
             # GRPO siblings get identical reward (all "succeeded" plan-completion)
             # and the group-relative advantage collapses to zero (#905).
             oracle_passed = self._apply_oracle_reward(state.results)
+            # #906 extension: model-as-judge outcome reward (RLAIF). Opt-in;
+            # the primary signal on oracle-LESS tasks, a below-oracle
+            # cross-check (rm_verifier_disagreement) where an oracle exists.
+            self._apply_model_judge_reward(state.results)
             # #901/#906: only flag oracle-VERIFIED successes as eval candidates.
             # When no oracle is configured, fall back to plan-completion status
             # (legacy behaviour). Gated on a canonical task_spec_id.
@@ -2298,6 +2302,70 @@ class RunExecutor:
         except Exception as exc:  # noqa: BLE001
             logger.warning("[#906] set_score failed: %s", exc)
         return passed
+
+    def _apply_model_judge_reward(self, results: list) -> None:
+        """Grade the run with a model judge + write the verdict (#906 extension).
+
+        Opt-in via ``runner._model_judge_enabled``. Reads the task instruction
+        (``runner._task_instruction`` → falls back to the eval task_spec) and
+        the terminal step's screenshot, asks a different-family Claude judge
+        whether the task succeeded, and writes:
+
+        * ``record_judge_decision(judge_type="model", promote=False)`` for
+          ``judge_ids`` provenance (operative verdict unchanged — the gate
+          stays oracle-only), and
+        * ``set_score(comparator="model-judge")`` for the ``rm_outcome`` reward
+          term (the only outcome signal on oracle-less tasks).
+        """
+        runner = self.parent
+        augur = getattr(runner, "_augur", None)
+        if augur is None or not bool(getattr(runner, "_model_judge_enabled", False)):
+            return
+        if not results:
+            return
+        # #906 guardrail: the judge is the PRIMARY outcome signal only on
+        # oracle-LESS tasks. Where an env oracle exists it is authoritative —
+        # running the judge there lets a judge "fail" override the oracle's
+        # verifier in the reward formula (the gate stays oracle-only), so skip
+        # unless explicitly forced into cross-check mode.
+        has_oracle = bool(str(getattr(runner, "_oracle_task_id", "") or "").strip())
+        if has_oracle and not bool(getattr(runner, "_model_judge_force", False)):
+            return
+        instruction = str(getattr(runner, "_task_instruction", "") or "").strip()
+        if not instruction:
+            spec = getattr(runner, "_eval_task_spec", None) or {}
+            instruction = str((spec or {}).get("instruction", "") or "").strip()
+        if not instruction:
+            instruction = str(getattr(runner, "plan_name", "") or "").replace("_", " ")
+        png = getattr(results[-1], "screenshot_png", None)
+        if not png:
+            return
+        term_idx = max(0, len(results) - 1)
+        try:
+            from ..learning.model_judge import ModelJudge
+            judge = ModelJudge(
+                model=str(getattr(runner, "_model_judge_model", "") or "")
+                or "claude-sonnet-4-6",
+            )
+            verdict = judge.judge(instruction, png)
+        except Exception as exc:  # noqa: BLE001 — telemetry never breaks the run
+            logger.warning("[#906-judge] grade failed: %s", exc)
+            return
+        if verdict is None:
+            return
+        augur.record_judge_decision(
+            term_idx, judge_id=judge.judge_id, judge_type="model",
+            status=verdict.status, reason=verdict.reason,
+            confidence=verdict.confidence, promote=False,
+        )
+        augur.set_score(
+            term_idx, verdict.score, comparator="model-judge",
+            components={"judge_confidence": float(verdict.confidence)},
+        )
+        logger.warning(
+            "[#906-judge] model-judge: passed=%s conf=%.2f step=%s (%s)",
+            verdict.passed, verdict.confidence, term_idx, judge.judge_id,
+        )
 
     def _emit_augur_env_fingerprint(self, step_index: int) -> None:
         """Stamp the current step's env fingerprint (#633 §4).

--- a/src/mantis_agent/gym/run_executor.py
+++ b/src/mantis_agent/gym/run_executor.py
@@ -2290,18 +2290,48 @@ class RunExecutor:
             return None
         score = 1.0 if passed else 0.0
         term_idx = max(0, len(results) - 1)
+        # Per-step shaping so GRPO siblings vary by HOW WELL they did, not only
+        # pass/fail — otherwise an all-pass / all-fail group is degenerate (zero
+        # group-relative advantage) even when the policy clearly differed in
+        # effort. ``process`` = efficiency (fewer brain iterations → higher);
+        # ``progress`` = task progress (1.0 on success, else fraction of steps
+        # that succeeded). Both populate the reward formula's process (0.5) /
+        # progress (1.5) terms via score_components — the trainer-feedback fix.
+        process, progress = self._shaping_components(results, passed=passed)
         try:
             augur.set_score(
                 term_idx, score, comparator="verifier",
-                components={"oracle_pass": score},
+                components={"oracle_pass": score, "process": process, "progress": progress},
             )
             logger.warning(
-                "[#906] oracle verdict stamped: task=%s passed=%s step=%s",
-                task_id, passed, term_idx,
+                "[#906] oracle verdict stamped: task=%s passed=%s process=%.3f progress=%.3f step=%s",
+                task_id, passed, process, progress, term_idx,
             )
         except Exception as exc:  # noqa: BLE001
             logger.warning("[#906] set_score failed: %s", exc)
         return passed
+
+    def _shaping_components(self, results: list, *, passed: bool) -> "tuple[float, float]":
+        """Return ``(process, progress)`` in [0,1] for per-step reward shaping.
+
+        ``process`` (efficiency): fewer brain iterations relative to the step
+        budget → higher. Read from the AugurAdapter's per-step emission counts
+        (the policy's effort) so it varies meaningfully across siblings even
+        when the outcome is identical. ``progress``: 1.0 on success, else the
+        fraction of plan steps that succeeded (partial credit so all-fail
+        siblings still differ by how far they got)."""
+        runner = self.parent
+        augur = getattr(runner, "_augur", None)
+        emissions = dict(getattr(augur, "_step_emission_counts", {}) or {})
+        effort = sum(emissions.values()) if emissions else len(results)
+        cap = max(int(getattr(runner, "max_steps", 0) or 0), len(results) * 4, 20)
+        process = max(0.0, min(1.0, 1.0 - (effort / cap))) if cap else 0.0
+        if passed:
+            progress = 1.0
+        else:
+            n_ok = sum(1 for r in results if getattr(r, "success", False))
+            progress = round(n_ok / max(1, len(results)), 4)
+        return round(process, 4), round(progress, 4)
 
     def _apply_model_judge_reward(self, results: list) -> None:
         """Grade the run with a model judge + write the verdict (#906 extension).

--- a/src/mantis_agent/gym/run_executor.py
+++ b/src/mantis_agent/gym/run_executor.py
@@ -2225,14 +2225,79 @@ class RunExecutor:
             # successful terminal status so health / trigger / failed runs
             # never pollute the candidate pool. One representative per run;
             # Augur merges candidates per task downstream.
+            # #906: write the ground-truth env-oracle verdict onto the terminal
+            # step BEFORE close, correcting the runtime's self-verifier (which is
+            # a known false-negative for AJAX/JSON saves → no_state_change). This
+            # is what makes the Augur reward reflect ground truth — without it,
+            # GRPO siblings get identical reward (all "succeeded" plan-completion)
+            # and the group-relative advantage collapses to zero (#905).
+            oracle_passed = self._apply_oracle_reward(state.results)
+            # #901/#906: only flag oracle-VERIFIED successes as eval candidates.
+            # When no oracle is configured, fall back to plan-completion status
+            # (legacy behaviour). Gated on a canonical task_spec_id.
             ts_id = str(getattr(runner, "_eval_task_spec_id", "") or "")
-            if ts_id and str(runner._final_status or "") in ("succeeded", "completed"):
+            if oracle_passed is None:
+                eligible = str(runner._final_status or "") in ("succeeded", "completed")
+            else:
+                eligible = bool(oracle_passed)
+            if ts_id and eligible:
                 augur.mark_for_eval(
                     step_index=max(0, len(state.results) - 1),
                     reason=f"representative_success:{ts_id}",
                 )
             augur.close(status=runner._final_status or None)
             runner._augur = None
+
+    def _apply_oracle_reward(self, results: list) -> bool | None:
+        """Grade the env oracle and stamp its verdict on the terminal step (#906).
+
+        Opt-in: the runner must carry ``_oracle_url`` + ``_oracle_task_id``
+        (set by the server from the suite's ``_oracle_*`` keys for sim-env eval
+        runs). Returns ``True``/``False`` for the oracle verdict, or ``None``
+        when no oracle is configured (caller falls back to plan-completion).
+
+        The oracle is ground truth; we overwrite the terminal step's
+        ``verifier`` verdict so Augur's reward formula scores the run by what
+        actually happened, not the agent's self-assessment.
+        """
+        runner = self.parent
+        augur = getattr(runner, "_augur", None)
+        oracle_url = str(getattr(runner, "_oracle_url", "") or "").rstrip("/")
+        task_id = str(getattr(runner, "_oracle_task_id", "") or "")
+        if augur is None or not oracle_url or not task_id:
+            return None
+        admin = str(getattr(runner, "_oracle_admin_token", "") or "")
+        preview = str(getattr(runner, "_oracle_preview_token", "") or "")
+        headers = {"X-Daytona-Skip-Preview-Warning": "true"}
+        if admin:
+            headers["X-Env-Admin"] = admin
+        if preview:
+            headers["x-daytona-preview-token"] = preview
+        passed: bool | None = None
+        try:
+            import requests
+            resp = requests.get(
+                f"{oracle_url}/__env__/oracle", params={"task_id": task_id},
+                headers=headers, timeout=20,
+            )
+            passed = bool(resp.json().get("passed"))
+        except Exception as exc:  # noqa: BLE001 — telemetry never breaks the run
+            logger.warning("[#906] oracle grade failed (%s): %s", task_id, exc)
+            return None
+        score = 1.0 if passed else 0.0
+        term_idx = max(0, len(results) - 1)
+        try:
+            augur.set_score(
+                term_idx, score, comparator="verifier",
+                components={"oracle_pass": score},
+            )
+            logger.warning(
+                "[#906] oracle verdict stamped: task=%s passed=%s step=%s",
+                task_id, passed, term_idx,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("[#906] set_score failed: %s", exc)
+        return passed
 
     def _emit_augur_env_fingerprint(self, step_index: int) -> None:
         """Stamp the current step's env fingerprint (#633 §4).

--- a/src/mantis_agent/learning/model_judge.py
+++ b/src/mantis_agent/learning/model_judge.py
@@ -1,0 +1,149 @@
+"""Model-as-judge outcome grader (#906) — RLAIF reward for oracle-less tasks.
+
+For sim-env tasks the env oracle is ground truth (see
+``run_executor._apply_oracle_reward``). But open-ended web tasks have **no
+programmatic oracle** — there a model judge is the only outcome signal, and it
+also densifies reward for credit assignment in long CUA episodes.
+
+This module is the judge itself: given a task instruction + the run's final
+screenshot, a Claude model (a **different family than the Holo3 actor** — a
+guardrail against the self-grading collusion #906 warns about) returns a
+pass/fail verdict + confidence. The runtime writes it to Augur as a
+``comparator="model-judge"`` verdict (populating the ``rm_outcome`` reward term)
+plus a ``judge_type="model"`` decision for provenance — kept **below** the oracle
+where both exist, and never promoted to the operative verdict (the
+champion/challenger gate stays oracle-only).
+
+Pure + injectable: the HTTP call is the only side effect and is behind the
+shared Anthropic retry client, so the verdict logic is unit-testable with a
+stub ``post_fn``.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+from dataclasses import dataclass
+from typing import Any, Callable
+
+logger = logging.getLogger(__name__)
+
+# A capable vision model from a DIFFERENT family than the Holo3 actor — judging
+# Holo3 with Holo3 shares blind spots and colludes (#906 guardrail).
+DEFAULT_JUDGE_MODEL = "claude-sonnet-4-6"
+
+_PROMPT = (
+    "You are an impartial evaluator grading whether a computer-use agent "
+    "ACCOMPLISHED a task, judging ONLY from the final screenshot of the "
+    "browser after the agent finished.\n\n"
+    "Task the agent was asked to do:\n\"{instruction}\"\n\n"
+    "Decide if the final state shows the task was completed successfully. Be "
+    "strict: partial progress, an open form that was never submitted, or an "
+    "error/blank page is NOT success. Respond with ONLY a JSON object, no prose:\n"
+    '{{"passed": <true|false>, "confidence": <0.0-1.0>, "reason": "<one sentence>"}}'
+)
+
+
+@dataclass(frozen=True)
+class JudgeVerdict:
+    passed: bool
+    confidence: float
+    reason: str
+
+    @property
+    def status(self) -> str:
+        return "passed" if self.passed else "failed"
+
+    @property
+    def score(self) -> float:
+        """Continuous reward in [0,1]: confidence toward the verdict direction.
+
+        passed → confidence; failed → 0. Keeps the reward monotone in
+        "evidence the task succeeded" so the rm_outcome term behaves."""
+        return max(0.0, min(1.0, self.confidence)) if self.passed else 0.0
+
+
+# (payload: dict) -> response-with .status_code/.json(), mirroring the
+# AnthropicToolUseClient.post_messages_with_retry seam.
+PostFn = Callable[[dict[str, Any]], Any]
+
+
+def _default_post_fn(model: str) -> PostFn:
+    """Lazily build the shared Anthropic retry client on first call (so a judge
+    constructed without a network call — e.g. for ``judge_id`` — never needs a
+    key, and tests can inject a stub ``post_fn``)."""
+    client_box: list[Any] = []
+
+    def _post(payload: dict[str, Any]) -> Any:
+        if not client_box:
+            import os
+            from .._anthropic.client import AnthropicToolUseClient
+            client_box.append(AnthropicToolUseClient(
+                api_key=os.environ.get("ANTHROPIC_API_KEY", ""),
+                model=model, log_prefix="[model-judge]",
+            ))
+        return client_box[0].post_messages_with_retry(payload, timeout=60)
+
+    return _post
+
+
+def _parse(text: str) -> JudgeVerdict:
+    """Extract the JSON verdict from the model's reply (tolerant of fences)."""
+    s = text.strip()
+    if "{" in s and "}" in s:
+        s = s[s.index("{"): s.rindex("}") + 1]
+    obj = json.loads(s)
+    return JudgeVerdict(
+        passed=bool(obj.get("passed")),
+        confidence=float(obj.get("confidence", 0.0) or 0.0),
+        reason=str(obj.get("reason", "") or "")[:300],
+    )
+
+
+class ModelJudge:
+    """Grades a finished run from its final screenshot (#906)."""
+
+    def __init__(
+        self, *, model: str = DEFAULT_JUDGE_MODEL,
+        max_tokens: int = 256, post_fn: PostFn | None = None,
+    ) -> None:
+        self.model = model
+        self.max_tokens = max_tokens
+        self._post = post_fn or _default_post_fn(model)
+
+    @property
+    def judge_id(self) -> str:
+        return f"model-judge:{self.model}"
+
+    def judge(self, instruction: str, screenshot_png: bytes) -> JudgeVerdict | None:
+        """Return the model's verdict, or ``None`` on any failure (telemetry
+        never breaks the run — the caller falls back to no judge signal)."""
+        if not screenshot_png:
+            return None
+        b64 = base64.b64encode(screenshot_png).decode("utf-8")
+        payload = {
+            "model": self.model,
+            "max_tokens": self.max_tokens,
+            "messages": [{
+                "role": "user",
+                "content": [
+                    {"type": "image", "source": {
+                        "type": "base64", "media_type": "image/png", "data": b64}},
+                    {"type": "text", "text": _PROMPT.format(instruction=instruction)},
+                ],
+            }],
+        }
+        try:
+            resp = self._post(payload)
+            if resp is None or getattr(resp, "status_code", 0) != 200:
+                logger.warning("[model-judge] call failed (%s)",
+                               getattr(resp, "status_code", "no-response"))
+                return None
+            for block in resp.json().get("content", []):
+                if block.get("type") == "text":
+                    return _parse(block["text"])
+            return None
+        except Exception as exc:  # noqa: BLE001 — best-effort; never propagate
+            logger.warning("[model-judge] verdict failed: %s", exc)
+            return None

--- a/src/mantis_agent/observability/augur.py
+++ b/src/mantis_agent/observability/augur.py
@@ -935,6 +935,49 @@ class AugurAdapter:
                     "AugurAdapter.set_score(step=%s) failed: %s", step_index, exc,
                 )
 
+    def record_judge_decision(
+        self,
+        step_index: int,
+        *,
+        judge_id: str,
+        judge_type: str = "model",
+        status: str = "unknown",
+        reason: str = "",
+        confidence: float | None = None,
+        promote: bool = False,
+    ) -> None:
+        """Record a model-judge decision on a step for provenance (#906, SDK 0.x).
+
+        Populates ``input_provenance.judge_ids`` so the reward layer knows a
+        judge ran. ``promote=False`` (default) keeps the operative
+        ``step.verdict`` as whatever the verifier/oracle set — the
+        champion/challenger gate stays oracle-only; the judge only contributes
+        the ``rm_outcome`` reward term (written separately via
+        :meth:`set_score` with ``comparator="model-judge"``).
+        """
+        if not self.active or not hasattr(self._session, "record_judge_decision"):
+            return
+        try:
+            self._session.record_judge_decision(
+                int(step_index) + 1,  # Augur is 1-based at the boundary
+                judge_id=judge_id,
+                judge_type=judge_type,
+                verdict={"status": status, "reason": reason},
+                confidence=confidence,
+                promote=promote,
+            )
+        except Exception as exc:  # noqa: BLE001 — telemetry never breaks runs
+            if is_verbose():
+                logger.warning(
+                    "AugurAdapter.record_judge_decision(step=%s) failed: %r",
+                    step_index, exc,
+                )
+            else:
+                logger.debug(
+                    "AugurAdapter.record_judge_decision(step=%s) failed: %s",
+                    step_index, exc,
+                )
+
     def set_capture_mode(self, mode: str) -> None:
         """Switch the active capture mode mid-run (#524, SDK 0.1.3+).
 

--- a/tests/test_freeze_eval_version.py
+++ b/tests/test_freeze_eval_version.py
@@ -1,0 +1,121 @@
+"""Unit tests for the eval-version freeze tool (experiments/holdout/freeze_eval_version.py).
+
+Covers selection logic + the two auth scopes with injected HTTP seams (no network):
+read works with the producer key; freeze refuses without an operator session cookie.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_SPEC = importlib.util.spec_from_file_location(
+    "freeze_eval_version",
+    Path(__file__).resolve().parent.parent / "experiments/holdout/freeze_eval_version.py",
+)
+fev = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(fev)  # type: ignore[union-attr]
+
+
+CANDIDATES = [
+    {"task_spec_id": "boattrader.bt01.v1", "source": "producer"},
+    {"task_spec_id": "boattrader.bt01.v1", "source": "producer"},  # dup → collapses
+    {"task_spec_id": "boattrader.bt02.v1", "source": "producer"},
+    {"task_spec_id": "crm.t04.v1", "source": "producer"},
+]
+
+
+def _get_ok(_url, _headers):
+    return 200, {"candidates": CANDIDATES}
+
+
+# ── selection ──────────────────────────────────────────────────────
+
+
+def test_select_all_dedupes_and_keeps_order():
+    assert fev.select_task_spec_ids(CANDIDATES) == [
+        "boattrader.bt01.v1", "boattrader.bt02.v1", "crm.t04.v1"
+    ]
+
+
+def test_select_prefix():
+    assert fev.select_task_spec_ids(CANDIDATES, select_prefix="boattrader.") == [
+        "boattrader.bt01.v1", "boattrader.bt02.v1"
+    ]
+
+
+def test_select_explicit_subset():
+    assert fev.select_task_spec_ids(CANDIDATES, explicit=["crm.t04.v1"]) == ["crm.t04.v1"]
+
+
+def test_select_explicit_missing_raises():
+    with pytest.raises(ValueError, match="no candidate in the pool"):
+        fev.select_task_spec_ids(CANDIDATES, explicit=["nope.v1"])
+
+
+# ── read scope ─────────────────────────────────────────────────────
+
+
+def test_list_candidates_uses_bearer_key():
+    seen = {}
+
+    def get(url, headers):
+        seen["url"], seen["headers"] = url, headers
+        return 200, {"candidates": CANDIDATES}
+
+    out = fev.list_candidates(base="B", tenant="t", token="KEY", http_get=get)
+    assert len(out) == 4
+    assert seen["headers"]["Authorization"] == "Bearer KEY"
+    assert "tenant=t" in seen["url"]
+
+
+def test_list_candidates_raises_on_non_200():
+    with pytest.raises(RuntimeError, match=r"\[401\]"):
+        fev.list_candidates(base="B", tenant="t", token="K", http_get=lambda u, h: (401, "no"))
+
+
+# ── write scope (freeze) ───────────────────────────────────────────
+
+
+def test_freeze_requires_session_cookie():
+    with pytest.raises(ValueError, match="operator session cookie"):
+        fev.freeze_version(
+            base="B", tenant="t", name="v", task_spec_ids=["a.v1"],
+            session_cookie="", http_post=lambda *a: (200, {}),
+        )
+
+
+def test_freeze_refuses_empty_set():
+    with pytest.raises(ValueError, match="empty eval-version"):
+        fev.freeze_version(
+            base="B", tenant="t", name="v", task_spec_ids=[],
+            session_cookie="session=x", http_post=lambda *a: (200, {}),
+        )
+
+
+def test_freeze_posts_with_cookie_and_returns_body():
+    captured = {}
+
+    def post(url, headers, body):
+        captured["url"], captured["headers"], captured["body"] = url, headers, body
+        return 201, {"name": body["name"], "frozen": True, "count": len(body["task_spec_ids"])}
+
+    out = fev.freeze_version(
+        base="B", tenant="t", name="mantis-holdout-v1",
+        task_spec_ids=["boattrader.bt01.v1", "boattrader.bt02.v1"],
+        session_cookie="session=abc", http_post=post, description="first real freeze",
+    )
+    assert out == {"name": "mantis-holdout-v1", "frozen": True, "count": 2}
+    assert captured["headers"]["Cookie"] == "session=abc"
+    assert captured["body"]["task_spec_ids"] == ["boattrader.bt01.v1", "boattrader.bt02.v1"]
+    assert captured["body"]["description"] == "first real freeze"
+
+
+def test_freeze_raises_on_401():
+    with pytest.raises(RuntimeError, match=r"\[401\]"):
+        fev.freeze_version(
+            base="B", tenant="t", name="v", task_spec_ids=["a.v1"],
+            session_cookie="session=x", http_post=lambda *a: (401, {"detail": "not signed in"}),
+        )

--- a/tests/test_model_judge_906.py
+++ b/tests/test_model_judge_906.py
@@ -1,0 +1,80 @@
+"""#906 extension — model-as-judge outcome grader (RLAIF reward for oracle-less tasks).
+
+Pins the verdict parsing + the inject-a-stub-post_fn contract so the judge logic
+is testable with no Anthropic call.
+"""
+
+from __future__ import annotations
+
+from mantis_agent.learning.model_judge import (
+    DEFAULT_JUDGE_MODEL,
+    JudgeVerdict,
+    ModelJudge,
+)
+
+
+class _Resp:
+    def __init__(self, text, status=200):
+        self.status_code = status
+        self._text = text
+
+    def json(self):
+        return {"content": [{"type": "text", "text": self._text}]}
+
+
+def test_default_model_is_not_holo3():
+    # guardrail: judge must be a different family than the Holo3 actor.
+    assert "claude" in DEFAULT_JUDGE_MODEL.lower()
+    assert "holo" not in DEFAULT_JUDGE_MODEL.lower()
+
+
+def test_verdict_score_monotone():
+    assert JudgeVerdict(True, 0.9, "ok").score == 0.9
+    assert JudgeVerdict(False, 0.9, "no").score == 0.0  # fail → 0 regardless of conf
+    assert JudgeVerdict(True, 0.0, "ok").status == "passed"
+
+
+def test_judge_parses_pass_verdict():
+    j = ModelJudge(post_fn=lambda p: _Resp('{"passed": true, "confidence": 0.82, "reason": "saved"}'))
+    v = j.judge("save job_00007", b"\x89PNG fake")
+    assert v.passed is True and v.confidence == 0.82 and v.reason == "saved"
+    assert v.score == 0.82
+
+
+def test_judge_parses_fail_with_fenced_json():
+    j = ModelJudge(post_fn=lambda p: _Resp('```json\n{"passed": false, "confidence": 0.7, "reason": "form open"}\n```'))
+    v = j.judge("apply to job", b"png")
+    assert v.passed is False and v.score == 0.0
+
+
+def test_judge_none_on_empty_screenshot():
+    j = ModelJudge(post_fn=lambda p: _Resp("{}"))
+    assert j.judge("x", b"") is None
+
+
+def test_judge_none_on_non_200():
+    j = ModelJudge(post_fn=lambda p: _Resp("err", status=500))
+    assert j.judge("x", b"png") is None
+
+
+def test_judge_none_on_post_exception():
+    def boom(_p):
+        raise RuntimeError("network")
+    assert ModelJudge(post_fn=boom).judge("x", b"png") is None
+
+
+def test_judge_id_format():
+    assert ModelJudge(model="claude-sonnet-4-6").judge_id == "model-judge:claude-sonnet-4-6"
+
+
+def test_sends_image_and_instruction():
+    seen = {}
+
+    def cap(payload):
+        seen["payload"] = payload
+        return _Resp('{"passed": true, "confidence": 1.0, "reason": "ok"}')
+
+    ModelJudge(post_fn=cap).judge("MY TASK", b"PNGBYTES")
+    content = seen["payload"]["messages"][0]["content"]
+    assert content[0]["type"] == "image"
+    assert "MY TASK" in content[1]["text"]

--- a/tests/test_oracle_reward_906.py
+++ b/tests/test_oracle_reward_906.py
@@ -49,7 +49,12 @@ def test_oracle_pass_stamps_verifier_score_1():
     args, kwargs = augur.set_score.call_args
     assert args[0] == 2 and args[1] == 1.0
     assert kwargs["comparator"] == "verifier"
-    assert kwargs["components"] == {"oracle_pass": 1.0}
+    # oracle_pass + process/progress shaping components (so all-pass/all-fail
+    # groups still vary by effort/progress — the GRPO degeneracy fix).
+    comps = kwargs["components"]
+    assert comps["oracle_pass"] == 1.0
+    assert comps["progress"] == 1.0  # passed → full progress
+    assert 0.0 <= comps["process"] <= 1.0  # efficiency in [0,1]
     # graded the right task against /__env__/oracle
     assert g.call_args[0][0] == "https://env.example/__env__/oracle"
     assert g.call_args[1]["params"] == {"task_id": "t01"}

--- a/tests/test_oracle_reward_906.py
+++ b/tests/test_oracle_reward_906.py
@@ -1,0 +1,73 @@
+"""#906 — producer-side oracle reward: _apply_oracle_reward stamps the
+ground-truth env-oracle verdict onto the terminal step so Augur's reward
+reflects what actually happened (not the agent's self-verifier).
+
+Pins:
+1. no oracle config → returns None (caller falls back to plan-completion).
+2. oracle PASS → set_score(terminal, 1.0, comparator="verifier") + returns True.
+3. oracle FAIL → set_score(terminal, 0.0, ...) + returns False.
+4. oracle HTTP error → returns None (telemetry never breaks the run).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from mantis_agent.gym.run_executor import RunExecutor
+
+
+def _executor(runner):
+    ex = object.__new__(RunExecutor)  # bypass __init__; we only exercise one method
+    ex.parent = runner
+    return ex
+
+
+def _runner(**oracle):
+    augur = MagicMock()
+    r = SimpleNamespace(_augur=augur, **oracle)
+    return r, augur
+
+
+def test_no_oracle_config_returns_none():
+    r, augur = _runner()  # no _oracle_url / _oracle_task_id
+    assert _executor(r)._apply_oracle_reward([1, 2, 3]) is None
+    augur.set_score.assert_not_called()
+
+
+def test_oracle_pass_stamps_verifier_score_1():
+    r, augur = _runner(
+        _oracle_url="https://env.example/", _oracle_task_id="t01",
+        _oracle_admin_token="adm", _oracle_preview_token="pv",
+    )
+    resp = MagicMock()
+    resp.json.return_value = {"passed": True}
+    with patch("requests.get", return_value=resp) as g:
+        out = _executor(r)._apply_oracle_reward(["s0", "s1", "s2"])
+    assert out is True
+    # terminal step is index 2 (len-1); score 1.0; comparator verifier
+    args, kwargs = augur.set_score.call_args
+    assert args[0] == 2 and args[1] == 1.0
+    assert kwargs["comparator"] == "verifier"
+    assert kwargs["components"] == {"oracle_pass": 1.0}
+    # graded the right task against /__env__/oracle
+    assert g.call_args[0][0] == "https://env.example/__env__/oracle"
+    assert g.call_args[1]["params"] == {"task_id": "t01"}
+
+
+def test_oracle_fail_stamps_score_0():
+    r, augur = _runner(_oracle_url="https://e/", _oracle_task_id="t01")
+    resp = MagicMock()
+    resp.json.return_value = {"passed": False}
+    with patch("requests.get", return_value=resp):
+        out = _executor(r)._apply_oracle_reward(["only"])
+    assert out is False
+    args, kwargs = augur.set_score.call_args
+    assert args[0] == 0 and args[1] == 0.0  # single step → terminal index 0
+
+
+def test_oracle_http_error_returns_none():
+    r, augur = _runner(_oracle_url="https://e/", _oracle_task_id="t01")
+    with patch("requests.get", side_effect=RuntimeError("boom")):
+        assert _executor(r)._apply_oracle_reward(["s0"]) is None
+    augur.set_score.assert_not_called()

--- a/tests/test_variance_gate.py
+++ b/tests/test_variance_gate.py
@@ -29,15 +29,31 @@ def test_mixed_group_is_grpo_usable():
     g = rrs._classify_group([_r(True), _r(False), _r(True)])
     assert g["grpo_usable"] is True
     assert g["distinct_outcomes"] == 2
-    assert g["reward_std"] > 0
-    assert g["reason"] == ""
+    assert "mixed outcomes" in g["reason"]
 
 
-def test_all_pass_group_is_degenerate():
+def test_all_pass_no_shaping_is_degenerate():
     g = rrs._classify_group([_r(True), _r(True), _r(True)])
     assert g["grpo_usable"] is False
-    assert g["reward_std"] == 0.0
     assert "all pass" in g["reason"]
+
+
+def test_all_pass_with_shaped_variance_is_usable():
+    # #906 process/progress shaping: all-pass siblings vary by effort →
+    # meaningful Augur episode_return spread → GRPO-usable.
+    shaped = {"r0": 28.9, "r1": 28.2, "r2": 27.6}  # std ≈ 0.53 ≥ 0.05
+    g = rrs._classify_group([_r(True), _r(True), _r(True)], shaped)
+    assert g["grpo_usable"] is True
+    assert g["shaped_episode_return_std"] >= rrs._MEANINGFUL_STD
+    assert "shaped reward variance" in g["reason"]
+
+
+def test_all_pass_with_hair_variance_stays_degenerate():
+    # Step-cost "hair" (the original noise complaint) is below threshold.
+    hair = {"r0": 18.8087, "r1": 18.8087, "r2": 18.8091}  # std ≈ 0.0002
+    g = rrs._classify_group([_r(True), _r(True), _r(True)], hair)
+    assert g["grpo_usable"] is False
+    assert g["shaped_episode_return_std"] < rrs._MEANINGFUL_STD
 
 
 def test_all_fail_group_is_degenerate():
@@ -49,4 +65,4 @@ def test_all_fail_group_is_degenerate():
 
 def test_single_sibling_not_usable():
     g = rrs._classify_group([_r(True)])
-    assert g["grpo_usable"] is False  # need ≥2 distinct outcomes
+    assert g["grpo_usable"] is False

--- a/tests/test_variance_gate.py
+++ b/tests/test_variance_gate.py
@@ -1,0 +1,52 @@
+"""Group-variance gate for GRPO sweeps (experiments/holdout/run_rollout_sweep.py).
+
+mantis-trainer feedback: all-pass / all-fail groups have only step-cost "hair"
+variance → ±1 noise advantages. A group is GRPO-usable only with mixed outcomes.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "src"))
+sys.path.insert(0, str(ROOT / "experiments/holdout"))
+
+_SPEC = importlib.util.spec_from_file_location(
+    "run_rollout_sweep", ROOT / "experiments/holdout/run_rollout_sweep.py"
+)
+rrs = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(rrs)  # type: ignore[union-attr]
+
+
+def _r(passed):
+    return {"oracle_passed": passed, "reward": 1.0 if passed else 0.0}
+
+
+def test_mixed_group_is_grpo_usable():
+    g = rrs._classify_group([_r(True), _r(False), _r(True)])
+    assert g["grpo_usable"] is True
+    assert g["distinct_outcomes"] == 2
+    assert g["reward_std"] > 0
+    assert g["reason"] == ""
+
+
+def test_all_pass_group_is_degenerate():
+    g = rrs._classify_group([_r(True), _r(True), _r(True)])
+    assert g["grpo_usable"] is False
+    assert g["reward_std"] == 0.0
+    assert "all pass" in g["reason"]
+
+
+def test_all_fail_group_is_degenerate():
+    g = rrs._classify_group([_r(False), _r(False)])
+    assert g["grpo_usable"] is False
+    assert "all fail" in g["reason"]
+    assert g["n_pass"] == 0
+
+
+def test_single_sibling_not_usable():
+    g = rrs._classify_group([_r(True)])
+    assert g["grpo_usable"] is False  # need ≥2 distinct outcomes


### PR DESCRIPTION
Closes the upstream gaps blocking off-policy GRPO/DPO on Augur rollouts + the sealed-run/eval-version freeze tooling for the champion/challenger gate (#894).

## #905 — GRPO sibling rollout groups (`group_id`)
- Forward suite `_fanout_group_id` onto the micro runner so the Augur `DebugSession` opens with `group_id` on the **non-fanout** path. Surfaces on `GET /runs`.
- Plumb `_sampling_temperature` into the Holo3 micro brain (default `0.0`) → siblings of one `(template, seed)` sample divergent trajectories.

## #906 — ground-truth oracle reward (core)
- `_apply_oracle_reward()`: grade the env oracle at finalize + `set_score(comparator="verifier")` to override the `no_state_change` self-verdict. Gate `mark_for_eval` on oracle-pass.

## #906 — model-as-judge extension (RLAIF, oracle-less tasks)
- `model_judge.py` (Claude — different family than Holo3) + `record_judge_decision` + `set_score(comparator="model-judge")` → `rm_outcome` + `judge_ids`. Gated to oracle-less by default (oracle authoritative where present; see augur#182).

## #908 — seed-sweep policy capture (planner modelio + logprobs)
- `_force_holo3_grounding`: route action steps through the Holo3 brain-grounded loop so the **policy decides** (with per-token logprobs) — the GRPO importance-ratio requirement. Deterministic Claude-grounded plans never invoked the policy.

## Tooling
- `run_sealed_task.py` / `sealed_plans.py` (drive + grade a sealed task), `freeze_eval_version.py` (list/freeze eval-version), `run_rollout_sweep.py` (`SeedSweepGenerator` → graded sibling groups; `--model-judge` / `--no-oracle`).

## Verification (live)
- Seed sweep: 3 siblings share `group_id` on `GET /runs`; oracle reward `28.71` (pass) vs `18.81` (fail) → non-zero GRPO advantage.
- Oracle-less judged run: `judge_ids=['model-judge:claude-sonnet-4-6']`, `verdict_comparators=[model-judge, verifier]`.
- `_force_holo3_grounding` run: **17 planner modelio records, 163 per-token logprobs** (top-5 alternatives) — was 1 grounding-only.

## Tests
`test_oracle_reward_906.py` (4) + `test_model_judge_906.py` (9) + `test_freeze_eval_version.py` (10), all green.

Closes #905
Closes #906
Closes #908

🤖 Generated with [Claude Code](https://claude.com/claude-code)