### PR TITLE
fix(resume): durable cross-replica pause/resume (checkpoint suite + modal.Dict run-state store)

### DIFF
--- a/src/mantis_agent/baseten_server/runtime.py
+++ b/src/mantis_agent/baseten_server/runtime.py
@@ -209,6 +209,34 @@ class BasetenCUARuntime:
         # cap; entries TTL out at 1 h by default.
         from ..grounding_cache import GroundingCache
         self.grounding_cache: GroundingCache = GroundingCache()
+        # Cross-replica run-state store (#866 pattern, ported to mantis-server).
+        # pause_state.json + payload.json live on the /data Modal Volume, whose
+        # cross-container visibility is eventually-consistent — a resume landing
+        # on a different replica can miss them (→ wedged-paused / re-decompose,
+        # or "pause_state missing"). Mirror them into a modal.Dict so resume
+        # reads are immediate and replica-independent; disk stays the durable
+        # backstop. Gated on Modal — ``modal.Dict.from_name`` BLOCKS off-Modal
+        # (no exception/timeout), so MODAL_TASK_ID is the only safe gate
+        # (feedback_modal_dict_blocks_off_modal).
+        self._run_state_store = self._build_run_state_store()
+
+    @staticmethod
+    def _build_run_state_store() -> Any:
+        from ..run_state_store import NullRunStateStore, RunStateStore
+        if not os.environ.get("MODAL_TASK_ID"):
+            return NullRunStateStore()
+        try:
+            name = os.environ.get("MANTIS_RUN_STATE_DICT", "mantis-server-run-state")
+            return RunStateStore.from_name(name)
+        except Exception as exc:  # noqa: BLE001 — store fault ≠ run fault; disk backstops
+            logger.warning("run-state store unavailable; disk-only resume: %s", exc)
+            return NullRunStateStore()
+
+    @staticmethod
+    def _store_tenant() -> str:
+        return _safe_state_key(
+            os.environ.get("MANTIS_TENANT_ID") or DEFAULT_TENANT.tenant_id
+        )
 
     def load(self) -> None:
         if self.loaded:
@@ -571,7 +599,28 @@ class BasetenCUARuntime:
             "events_path": str(run_dir / "events.log"),
         }
         self._write_json_atomic(status_path, merged)
+        # Mirror into the cross-replica store so a resume / poll landing on a
+        # different replica sees the current phase immediately (the resume
+        # handler's status=='paused' gate would otherwise 400 on an un-synced
+        # Volume read).
+        from ..run_state_store import KIND_STATUS
+        self._run_state_store.put(self._store_tenant(), run_id, KIND_STATUS, merged)
         return merged
+
+    def _read_detached_status(self, run_id: str) -> dict[str, Any]:
+        """Status read, cache-first (cross-replica) with disk fallback."""
+        from ..run_state_store import KIND_STATUS, read_with_store
+
+        def _disk() -> dict[str, Any] | None:
+            try:
+                return self._read_json_file(self._run_path(run_id) / "status.json")
+            except FileNotFoundError:
+                return None
+
+        return read_with_store(
+            self._run_state_store, tenant_id=self._store_tenant(),
+            run_id=run_id, kind=KIND_STATUS, disk_reader=_disk,
+        ) or {}
 
     def _append_detached_event(self, run_id: str, message: str) -> None:
         run_dir = self._run_path(run_id, create=True)
@@ -715,21 +764,34 @@ class BasetenCUARuntime:
         return status
 
     def _save_pause_state(self, run_id: str, pause_state: dict[str, Any]) -> Path:
-        """Persist a paused run's :class:`PauseState` blob (#344)."""
+        """Persist a paused run's :class:`PauseState` blob (#344).
+
+        Mirrors into the cross-replica store so a resume on a different replica
+        reads it immediately (disk is the durable backstop)."""
         run_dir = self._run_path(run_id, create=True)
         path = run_dir / "pause_state.json"
         self._write_json_atomic(path, pause_state)
+        from ..run_state_store import KIND_PAUSE_STATE
+        self._run_state_store.put(self._store_tenant(), run_id, KIND_PAUSE_STATE, pause_state)
         return path
 
     def _read_pause_state(self, run_id: str) -> dict[str, Any]:
-        """Read pause_state.json; returns ``{}`` when absent (#344)."""
-        path = self._run_path(run_id) / "pause_state.json"
-        if not path.exists():
-            return {}
-        try:
-            return json.loads(path.read_text())
-        except Exception:
-            return {}
+        """Read pause_state — cache-first (cross-replica), disk fallback (#344)."""
+        from ..run_state_store import KIND_PAUSE_STATE, read_with_store
+
+        def _disk() -> dict[str, Any] | None:
+            path = self._run_path(run_id) / "pause_state.json"
+            if not path.exists():
+                return None
+            try:
+                return json.loads(path.read_text())
+            except Exception:  # noqa: BLE001
+                return None
+
+        return read_with_store(
+            self._run_state_store, tenant_id=self._store_tenant(),
+            run_id=run_id, kind=KIND_PAUSE_STATE, disk_reader=_disk,
+        ) or {}
 
     def _save_resume_payload(self, run_id: str, payload: dict[str, Any]) -> Path:
         """Persist the original payload so resume can rebuild the run (#344)."""
@@ -738,16 +800,26 @@ class BasetenCUARuntime:
         # Skip transient fields that would be wrong to re-apply on resume.
         keep = {k: v for k, v in payload.items() if not k.startswith("_resume")}
         self._write_json_atomic(path, keep)
+        from ..run_state_store import KIND_RESUME_PAYLOAD
+        self._run_state_store.put(self._store_tenant(), run_id, KIND_RESUME_PAYLOAD, keep)
         return path
 
     def _read_resume_payload(self, run_id: str) -> dict[str, Any]:
-        path = self._run_path(run_id) / "payload.json"
-        if not path.exists():
-            return {}
-        try:
-            return json.loads(path.read_text())
-        except Exception:
-            return {}
+        from ..run_state_store import KIND_RESUME_PAYLOAD, read_with_store
+
+        def _disk() -> dict[str, Any] | None:
+            path = self._run_path(run_id) / "payload.json"
+            if not path.exists():
+                return None
+            try:
+                return json.loads(path.read_text())
+            except Exception:  # noqa: BLE001
+                return None
+
+        return read_with_store(
+            self._run_state_store, tenant_id=self._store_tenant(),
+            run_id=run_id, kind=KIND_RESUME_PAYLOAD, disk_reader=_disk,
+        ) or {}
 
     def _start_detached(self, payload: dict[str, Any]) -> dict[str, Any]:
         run_id = _safe_state_key(str(payload.get("run_id") or _new_run_id()))
@@ -1195,8 +1267,15 @@ class BasetenCUARuntime:
             }
 
         if action == "resume":
-            # #344: rehydrate a paused detached run.
-            status = self._read_json_file(run_dir / "status.json")
+            # #344: rehydrate a paused detached run. Read status cache-first so
+            # a resume landing on a different replica sees status=='paused'
+            # even before the /data Volume has propagated (#909-followup).
+            status = self._read_detached_status(run_id)
+            if not status:
+                # Empty in BOTH the cross-replica store and on disk → the
+                # run_id is genuinely unknown (→ 404), not merely a Volume that
+                # hasn't propagated to this replica.
+                raise FileNotFoundError(f"unknown run_id: {run_id}")
             if status.get("status") != "paused":
                 raise ValueError(
                     f"action='resume' requires a paused run; "

--- a/src/mantis_agent/baseten_server/runtime.py
+++ b/src/mantis_agent/baseten_server/runtime.py
@@ -822,6 +822,7 @@ class BasetenCUARuntime:
                             "augur metadata write failed run=%s: %s",
                             run_id, exc,
                         )
+                task_suite = None
                 if payload.get("_mode") == "pure_cua":
                     result = self._run_pure_cua(payload, run_id=run_id)
                 else:
@@ -837,6 +838,15 @@ class BasetenCUARuntime:
                 # this exact shape on the next ``action=status`` round-trip.
                 if result.get("_paused"):
                     pause_payload = result.pop("pause_state", None) or {}
+                    # Persist the RESOLVED micro-suite in the checkpoint so
+                    # action=resume restores the exact paused plan verbatim —
+                    # never re-decompose (LLM, non-deterministic) or re-load the
+                    # container-local ``decomposed_<hash>.json`` cache, which can
+                    # MISS on a different replica → fresh plan → signature
+                    # mismatch → run wedged in 'paused' forever (end-user bug,
+                    # run 20260615_074614). Keyed implicitly by run_id (the file).
+                    if task_suite and not pause_payload.get("resolved_task_suite"):
+                        pause_payload["resolved_task_suite"] = task_suite
                     self._save_pause_state(run_id, pause_payload)
                     self._save_detached_result(run_id, result)
                     self._write_detached_status(
@@ -1210,26 +1220,35 @@ class BasetenCUARuntime:
                 raise RuntimeError(
                     f"resume in progress for {run_id!r}; poll status before retrying"
                 )
-            # Synchronous plan-signature guard so a stale pause_state
-            # surfaces as a 400 on this round-trip — not later via
-            # status polling on a doomed worker.
-            stored_sig = str(pause_state.get("plan_signature", ""))
-            current_sig = ""
-            try:
-                rebuilt_suite = self._task_suite_from_payload(dict(original_payload))
-                current_sig = str(rebuilt_suite.get("_plan_signature", ""))
-            except Exception:  # noqa: BLE001 — surface the mismatch, not the rebuild error
-                current_sig = ""
-            if stored_sig and current_sig and stored_sig != current_sig:
-                raise ValueError(
-                    "plan signature mismatch on resume: stored "
-                    f"{stored_sig[:12]!r} ≠ current {current_sig[:12]!r}. "
-                    "The plan referenced by this run_id has changed since it paused."
-                )
             resume_payload = dict(original_payload)
             resume_payload["_detached_run_id"] = run_id
             resume_payload["_resume_pause_state"] = pause_state
             resume_payload["_resume_user_input"] = user_input
+            # Restore the EXACT paused plan from the checkpoint — verbatim, no
+            # re-decompose and no hash-cache lookup. Passing it as ``task_suite``
+            # makes _task_suite_from_payload return it as-is, so the plan can't
+            # drift across replicas and the signature always matches. (Fixes the
+            # end-user "plan signature mismatch on resume → wedged paused" bug.)
+            stored_suite = pause_state.get("resolved_task_suite")
+            if stored_suite:
+                resume_payload["task_suite"] = dict(stored_suite)
+            else:
+                # Legacy pauses (pre-checkpoint-suite) fall back to the
+                # re-derive + signature guard so a genuinely changed plan still
+                # surfaces as a 400 rather than running the wrong plan.
+                stored_sig = str(pause_state.get("plan_signature", ""))
+                current_sig = ""
+                try:
+                    rebuilt_suite = self._task_suite_from_payload(dict(original_payload))
+                    current_sig = str(rebuilt_suite.get("_plan_signature", ""))
+                except Exception:  # noqa: BLE001 — surface the mismatch, not the rebuild error
+                    current_sig = ""
+                if stored_sig and current_sig and stored_sig != current_sig:
+                    raise ValueError(
+                        "plan signature mismatch on resume: stored "
+                        f"{stored_sig[:12]!r} ≠ current {current_sig[:12]!r}. "
+                        "The plan referenced by this run_id has changed since it paused."
+                    )
             now = _utc_now()
             self._write_detached_status(
                 run_id,

--- a/src/mantis_agent/run_state_store.py
+++ b/src/mantis_agent/run_state_store.py
@@ -52,9 +52,16 @@ KIND_PAUSE_REQUEST = "pause_request"
 # one and the brain transparently re-creates), and we want both
 # records discoverable for forensics.
 KIND_SESSION = "session"
+# mantis-server pause/resume (#909-followup): the paused run's resolved
+# micro-suite + original payload, mirrored off the /data Volume so a resume
+# landing on a different replica reads them immediately (no eventual-consistency
+# miss → no re-decompose / "pause_state missing").
+KIND_PAUSE_STATE = "pause_state"
+KIND_RESUME_PAYLOAD = "resume_payload"
 
 _VALID_KINDS = frozenset({
     KIND_STATUS, KIND_VIEWER, KIND_AUGUR, KIND_PAUSE_REQUEST, KIND_SESSION,
+    KIND_PAUSE_STATE, KIND_RESUME_PAYLOAD,
 })
 
 

--- a/tests/test_predict_pause_resume.py
+++ b/tests/test_predict_pause_resume.py
@@ -336,6 +336,50 @@ def test_resume_restores_checkpoint_suite_ignoring_redecompose_drift(client, mon
     assert final["status"] == "succeeded"
 
 
+def test_resume_reads_run_state_from_store_when_disk_missing(client, monkeypatch):
+    """Cross-replica durability: pause mirrors status/pause_state/payload into
+    the shared run-state store. A resume landing on a DIFFERENT replica (disk
+    files absent) reads them from the store and resumes — no wedge, no
+    eventual-consistency miss."""
+    import shutil
+
+    from mantis_agent.run_state_store import RunStateStore
+
+    test_client, bs = client
+    # Inject a plain-dict store (stands in for the cross-replica modal.Dict).
+    bs.runtime._run_state_store = RunStateStore({})
+
+    call_count = {"n": 0}
+
+    def _switching_stub(self, task_suite, payload, run_id=None):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            return _stub_run_micro_first_call(self, task_suite, payload, run_id)
+        return _stub_run_micro_resume(self, task_suite, payload, run_id)
+
+    monkeypatch.setattr(BasetenCUARuntime, "_run_micro", _switching_stub, raising=True)
+
+    submit = test_client.post("/v1/predict", headers=_auth_headers(), json=_minimal_payload())
+    run_id = submit.json()["run_id"]
+    _wait_for_status(test_client, run_id, want={"paused"})
+
+    # Simulate the resume landing on a fresh replica whose Volume hasn't
+    # propagated: delete the on-disk run dir entirely. Only the shared store
+    # carries status + pause_state + payload now.
+    run_dir = Path(bs.runtime._run_path(run_id))
+    shutil.rmtree(run_dir, ignore_errors=True)
+    assert not run_dir.exists()
+
+    resume = test_client.post(
+        "/v1/predict",
+        headers=_auth_headers(),
+        json={"action": "resume", "run_id": run_id, "user_input": "123456"},
+    )
+    assert resume.status_code == 200, resume.text  # not 400/404 — store had it
+    final = _wait_for_status(test_client, run_id, want={"succeeded"})
+    assert final["status"] == "succeeded"
+
+
 def test_resume_unknown_run_returns_404(client):
     test_client, _bs = client
     r = test_client.post(

--- a/tests/test_predict_pause_resume.py
+++ b/tests/test_predict_pause_resume.py
@@ -270,10 +270,13 @@ def test_resume_plan_signature_mismatch_returns_400(client, monkeypatch, tmp_pat
     _wait_for_status(test_client, run_id, want={"paused"})
 
     # Tamper with pause_state.json — change the plan signature so the
-    # synchronous guard in _detached_action("resume", ...) fires.
+    # synchronous guard in _detached_action("resume", ...) fires. The guard
+    # only applies on the LEGACY path (no checkpointed suite), so drop
+    # resolved_task_suite to exercise the re-derive + guard.
     data_root = Path(bs.runtime._run_path(run_id))  # bs is bs_routes here — the singleton lives on it
     pause_path = data_root / "pause_state.json"
     blob = json.loads(pause_path.read_text())
+    blob.pop("resolved_task_suite", None)
     blob["plan_signature"] = "some-other-signature-from-an-edited-plan"
     pause_path.write_text(json.dumps(blob))
 
@@ -285,6 +288,52 @@ def test_resume_plan_signature_mismatch_returns_400(client, monkeypatch, tmp_pat
     assert resume.status_code == 400, resume.text
     detail = resume.json()["detail"]
     assert "signature mismatch" in detail.lower()
+
+
+def test_resume_restores_checkpoint_suite_ignoring_redecompose_drift(client, monkeypatch):
+    """End-user bug fix: when the run paused with a resolved micro-suite in its
+    checkpoint, resume restores it VERBATIM — so a plan that would re-decompose
+    to a different signature (cache miss across replicas) no longer wedges the
+    run in 'paused'. The signature guard is bypassed because there's no
+    re-derivation."""
+    test_client, bs = client
+    call_count = {"n": 0}
+
+    def _switching_stub(self, task_suite, payload, run_id=None):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            return _stub_run_micro_first_call(self, task_suite, payload, run_id)
+        # On resume, assert we got the checkpointed suite verbatim.
+        assert task_suite.get("_plan_signature") == "fixed-sig-for-tests"
+        return _stub_run_micro_resume(self, task_suite, payload, run_id)
+
+    monkeypatch.setattr(BasetenCUARuntime, "_run_micro", _switching_stub, raising=True)
+
+    submit = test_client.post(
+        "/v1/predict", headers=_auth_headers(), json=_minimal_payload(),
+    )
+    run_id = submit.json()["run_id"]
+    _wait_for_status(test_client, run_id, want={"paused"})
+
+    # The checkpoint persisted the resolved suite at pause.
+    pause_path = Path(bs.runtime._run_path(run_id)) / "pause_state.json"
+    blob = json.loads(pause_path.read_text())
+    assert blob.get("resolved_task_suite", {}).get("_plan_signature") == "fixed-sig-for-tests"
+
+    # Simulate non-deterministic re-decompose drift: tamper the stored signature
+    # AND the saved payload so a re-derive WOULD mismatch. With the checkpointed
+    # suite present, resume must ignore both and succeed.
+    blob["plan_signature"] = "would-mismatch-if-rederived"
+    pause_path.write_text(json.dumps(blob))
+
+    resume = test_client.post(
+        "/v1/predict",
+        headers=_auth_headers(),
+        json={"action": "resume", "run_id": run_id, "user_input": "123456"},
+    )
+    assert resume.status_code == 200, resume.text  # not 400 — no wedge
+    final = _wait_for_status(test_client, run_id, want={"succeeded"})
+    assert final["status"] == "succeeded"
 
 
 def test_resume_unknown_run_returns_404(client):


### PR DESCRIPTION
Fixes the end-user "plan signature mismatch on resume → wedged paused forever" bug (run `20260615_074614`), in two layers.

## The bug (verified, `baseten_server/runtime.py`)
Resume re-derived the plan from the original payload. For `plan_text` that means `decompose_text(cache=/data/.../plan_cache/decomposed_<hash>.json)` — a **container-local** cache. Run state lived **only** on the `/data` Modal Volume (eventually-consistent across the concurrent ASGI replicas). So on a resume that lands on a different replica:
- cache miss → **re-decompose (non-deterministic LLM)** → different signature → guard rejects → wedged; and
- more broadly, status/pause_state/payload could miss entirely → "unknown run_id" flapping.

The user's own 3-tier trace (continue-in-place / disk-cache-reload / **re-decompose**) matches the code exactly; tier-3 is the bug.

## Fix — layer 1: durably attach the plan to the run
Persist the **resolved micro-suite** in the pause checkpoint and restore it **verbatim** on resume — no re-decompose, no hash-cache. Legacy pauses keep the re-derive + signature guard.

## Fix — layer 2: cross-replica run-state store
Port the `modal.Dict` `RunStateStore` (#866, used by `modal_cua_server`) to `baseten_server`. `status` / `pause_state` / `resume_payload` are mirrored into the store and read cache-first (disk fallback), so resume is **replica-independent** — eliminating both the re-decompose mismatch and the "pause_state missing" race. Gated on `MODAL_TASK_ID`; off-Modal/tests use `NullRunStateStore` (disk-only, unchanged).

## Tests (8 pause/resume + 22 run-state, green)
- resume ignores re-decompose drift when the suite is checkpointed;
- **resume succeeds after the on-disk run dir is wiped** (state served from the store — the cross-replica proof);
- unknown run (empty in store *and* disk) still 404s;
- existing signature-mismatch test moved to the legacy (no-checkpoint-suite) path.

Builds on #883. Deployed + live-regression-checked on mantis-server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)