### PR TITLE
fix(infra): stop _ripples exhausting the run-state Volume inodes + add a run-dir reaper

### DIFF
--- a/deploy/modal/modal_mantis_server.py
+++ b/deploy/modal/modal_mantis_server.py
@@ -277,6 +277,57 @@ def api():
     return fastapi_app
 
 
+@app.function(volumes={"/data": vol}, schedule=modal.Period(hours=6), timeout=1800)
+def reap_run_state() -> str:
+    """Bound the run-state Volume's inode usage (hard cap 500k files).
+
+    The Volume accumulates per-run artifact dirs (screenshots, modelio, replay
+    frames) with no built-in GC; left unchecked it exhausts inodes and every
+    submit 500s with ENOSPC (outage 2026-06-15). Delete run-artifact entries
+    older than ``MANTIS_RUN_TTL_DAYS`` (default 7) + sweep any stray ``_ripples``
+    frame dirs (belt-and-suspenders until every replica runs the temp-dir code).
+    """
+    import shutil
+    import time
+
+    ttl_days = float(os.environ.get("MANTIS_RUN_TTL_DAYS", "7"))
+    cutoff = time.time() - ttl_days * 86400.0
+    # High-inode artifact roots; results/augur kept (smaller + observability).
+    roots = [
+        "/data/mantis-runs/tenants/default/runs",
+        "/data/mantis-runs/runs",
+        "/data/runs",
+        "/data/mantis-runs/screenshots",
+        "/data/mantis-runs/debug-dumps",
+    ]
+    removed = 0
+    for root in roots:
+        if not os.path.isdir(root):
+            continue
+        for name in os.listdir(root):
+            p = os.path.join(root, name)
+            try:
+                if os.path.getmtime(p) >= cutoff:
+                    continue
+                if os.path.isdir(p):
+                    shutil.rmtree(p, ignore_errors=True)
+                else:
+                    os.remove(p)
+                removed += 1
+            except Exception:  # noqa: BLE001 — best-effort GC
+                pass
+    # Always purge ephemeral overlay-frame dirs regardless of age.
+    subprocess.run(
+        "find /data/mantis-runs /data/runs -type d -name _ripples -prune "
+        "-exec rm -rf {} + 2>/dev/null", shell=True,
+    )
+    df = subprocess.run("df -i /data", shell=True, capture_output=True, text=True).stdout
+    vol.commit()
+    msg = f"reaper: removed {removed} entries older than {ttl_days}d\n{df}"
+    print(msg)
+    return msg
+
+
 @app.function(
     volumes={"/data": vol},
     timeout=3600,

--- a/src/mantis_agent/baseten_server/runtime.py
+++ b/src/mantis_agent/baseten_server/runtime.py
@@ -1684,6 +1684,7 @@ class BasetenCUARuntime:
         """
         from mantis_agent import presentation
 
+        _ripples_tmp: Any = None
         try:
             tenant_id = os.environ.get("MANTIS_TENANT_ID", "default")
             run_id = result.get("run_id") or "unknown"
@@ -1730,7 +1731,14 @@ class BasetenCUARuntime:
             # composite into the same PNG sequence.
             ripples_dir: Any = None
             if click_log is not None and len(click_log) > 0:
-                ripples_dir = run_dir / "_ripples"
+                # Write the thousands of overlay frame PNGs to container-local
+                # temp, NOT the persistent /data Volume — they're consumed by
+                # the ffmpeg compositing below and then discarded. Dumping them
+                # on the Volume exhausted its 500k-inode budget and 500'd every
+                # submit (outage 2026-06-15); cleaned in the finally.
+                import tempfile
+                _ripples_tmp = tempfile.mkdtemp(prefix="mantis_ripples_")
+                ripples_dir = Path(_ripples_tmp)
                 duration = (
                     recorder.result.duration_seconds
                     if recorder.result and recorder.result.duration_seconds
@@ -1764,6 +1772,11 @@ class BasetenCUARuntime:
         except Exception as exc:  # noqa: BLE001 — polish is best-effort
             logger.warning("polished video compose failed: %s", exc)
             return None
+        finally:
+            # Always discard the ephemeral overlay frames (temp, off-Volume).
+            if _ripples_tmp:
+                import shutil
+                shutil.rmtree(_ripples_tmp, ignore_errors=True)
 
     @staticmethod
     def _collect_step_timings(


### PR DESCRIPTION
## Outage (2026-06-15)
mantis-server returned **500 on every submit**: `[Errno 28] No space left on device: '/data/mantis-runs/tenants/default/runs/<run_id>'`. Not bytes and **not a code regression** — the `/data` Modal Volume hit its **500k inode (file-count) cap** (499,927 / 500,000), so creating any new run dir / `status.json` failed.

## Root cause
`_polish_recording` rendered the click-ripple video overlay as **~15k frame PNGs per run** into `run_dir/_ripples` **on the persistent Volume**, consumed them with ffmpeg, then **left them there**. With no GC, ~376 runs' frame dirs exhausted the inode budget. Live mitigation: deleted the `_ripples/` dirs (100% → 19% inodes), cycled containers → service restored.

## Permanent fix
- **Frames off the Volume**: `_polish_recording` now writes overlay frames to a container-local `tempfile.mkdtemp()` and `rmtree`s it in a `finally` — they're transient ffmpeg inputs, never run results.
- **Reaper**: new scheduled function `reap_run_state` (`modal.Period(hours=6)`) deletes run-artifact dirs older than `MANTIS_RUN_TTL_DAYS` (default 7) + sweeps any stray `_ripples`, then commits the Volume — bounding inode usage going forward.

Deployed to mantis-server; submits return 200 again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)