### PR TITLE
feat(serving): Baseten parity for LoRA challenger serving (#911)

### DIFF
--- a/deploy/baseten/holo3_challenger/config.yaml
+++ b/deploy/baseten/holo3_challenger/config.yaml
@@ -1,0 +1,61 @@
+# Holo3 promotion-gate CHALLENGER (#911) — base + trained LoRA adapter.
+#
+# Identical to ../holo3/config.yaml (the CHAMPION) except for two things:
+#   1. a `weights:` entry that mounts the trained GGUF adapter, and
+#   2. `MANTIS_LORA_ADAPTER` in the start_command pointing at it.
+# The champion deployment leaves the adapter unset → serves the base. The gate
+# points MANTIS_CHAMPION_ENDPOINT at the champion deploy and MANTIS_EVAL_ENDPOINT
+# at this one, then compares win-rate over the frozen holdout.
+#
+# IMPORTANT: swap the adapter `source` below for YOUR trained checkpoint. It must
+# be a **pre-converted GGUF** LoRA adapter (llama.cpp `convert_lora_to_gguf.py`,
+# run in the trainer) — the serving image has no torch/transformers to convert a
+# raw PEFT dir. Redeploy per the repo rule: `--no-cache` + a unique
+# `--deployment-name` (feedback_baseten_deployment_name_uniqueness).
+model_name: mantis-holo3-cua-challenger
+external_package_dirs:
+  - ../../../src
+base_image:
+  image: pytorch/pytorch:2.7.0-cuda12.8-cudnn9-devel
+build_commands:
+  - apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y git build-essential cmake curl wget gnupg xvfb xdotool xclip scrot ffmpeg ca-certificates fonts-liberation fonts-noto-color-emoji libnss3 libatk-bridge2.0-0 libdrm2 libxkbcommon0 libgbm1 libpango-1.0-0 libcairo2 libasound2 libxshmfence1
+  - curl -fsSL https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /usr/share/keyrings/google-chrome.gpg
+  - echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/google-chrome.gpg] http://dl.google.com/linux/chrome/deb/ stable main' > /etc/apt/sources.list.d/google-chrome.list
+  - apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y google-chrome-stable
+  - pip install --no-cache-dir openai requests pillow mss huggingface-hub fastapi uvicorn pydantic websocket-client
+  - git clone --depth 1 --branch b8948 https://github.com/ggerganov/llama.cpp /opt/llama.cpp  # SHA 42401c72b8d239240ed0fb37694d29ac33b3bc4f
+  - ln -sf /usr/local/cuda/lib64/stubs/libcuda.so /usr/lib/x86_64-linux-gnu/libcuda.so.1 && ldconfig
+  - cd /opt/llama.cpp && cmake -B build -DGGML_CUDA=ON -DGGML_NATIVE=OFF -DGGML_AMX_TILE=OFF -DGGML_AMX_INT8=OFF -DGGML_AMX_BF16=OFF -DCMAKE_CUDA_ARCHITECTURES="80;90" -DLLAMA_BUILD_TESTS=OFF -DLLAMA_BUILD_EXAMPLES=OFF -DLLAMA_BUILD_SERVER=ON && cmake --build build --target llama-server --config Release -j$(nproc)
+  - mkdir -p /workspace/mantis-data && ln -snf /workspace/mantis-data /data
+docker_server:
+  # MANTIS_LORA_ADAPTER → base + adapter (see baseten_server.runtime._boot_lora_args).
+  start_command: bash -lc "PYTHONPATH=/packages MANTIS_MODEL=holo3 MANTIS_LLAMA_PORT=18080 MANTIS_DATA_DIR=/workspace/mantis-data MANTIS_REPO_ROOT=/packages MANTIS_LORA_ADAPTER=/models/holo3_adapter/adapter.gguf MANTIS_MAX_RUNTIME_MINUTES=240 MANTIS_MAX_COST_USD=75 MANTIS_MAX_STEPS_PER_PLAN=500 MANTIS_CONTEXT_SIZE=32768 MANTIS_FORM_TARGET_PROVIDER=holo3 uvicorn mantis_agent.baseten_server:app --host 0.0.0.0 --port 8000 --timeout-keep-alive 300"
+  server_port: 8000
+  predict_endpoint: /predict
+  readiness_endpoint: /health
+  liveness_endpoint: /health
+resources:
+  instance_type: "H100"
+runtime:
+  predict_concurrency: 1
+  health_checks:
+    startup_threshold_seconds: 3000
+    stop_traffic_threshold_seconds: 1800
+    restart_threshold_seconds: 1800
+weights:
+  - source: "hf://mradermacher/Holo3-35B-A3B-GGUF@main"
+    mount_location: "/models/holo3"
+    allow_patterns:
+      - "Holo3-35B-A3B.Q8_0.gguf"
+      - "Holo3-35B-A3B.mmproj-f16.gguf"
+  # CHALLENGER adapter — replace with your trained GGUF-converted LoRA checkpoint.
+  - source: "hf://your-org/holo3-challenger-lora-gguf@main"
+    mount_location: "/models/holo3_adapter"
+    allow_patterns:
+      - "adapter.gguf"
+secrets:
+  anthropic_api_key: null
+  proxy_url: null
+  proxy_user: null
+  proxy_pass: null
+  mantis_api_token: null

--- a/docs/api.md
+++ b/docs/api.md
@@ -102,7 +102,7 @@ The following go **inside `task_suite`** (not top-level), alongside the plan:
 
 | Suite field | Description |
 |---|---|
-| `_lora_adapter` | ([#911](https://github.com/mercurialsolo/mantis/issues/911)) Serve **base + this LoRA adapter** (the promotion-gate *challenger*). A ref `"<volume>:/checkpoints/<algo>"` (the trainer volume `mantis-trainer-vol` is mounted read-only on the executors) or a mounted path. For llama.cpp bases (`holo3`) prefer a pre-converted `.gguf` adapter; vLLM bases serve the PEFT dir directly. Omit to serve the base (the *champion*). |
+| `_lora_adapter` | ([#911](https://github.com/mercurialsolo/mantis/issues/911)) Serve **base + this LoRA adapter** (the promotion-gate *challenger*). A ref `"<volume>:/checkpoints/<algo>"` (the trainer volume `mantis-trainer-vol` is mounted read-only on the executors) or a mounted path. For llama.cpp bases (`holo3`) prefer a pre-converted `.gguf` adapter; vLLM bases serve the PEFT dir directly. Omit to serve the base (the *champion*). **Modal only** — on Baseten the adapter is a deployment-level env (`MANTIS_LORA_ADAPTER`), see [Baseten hosting](hosting/baseten.md). |
 | `_lora_name` | vLLM only — served-model-name for the adapter (default `challenger`). |
 | `_lora_scale` | llama.cpp only — adapter scale (default `1.0`; emits `--lora-scaled`). |
 

--- a/docs/continuous-improvement-architecture.md
+++ b/docs/continuous-improvement-architecture.md
@@ -206,6 +206,16 @@ challenger arm submits *with* it. Backend is auto-selected by base
 The gate drives both arms with `training/eval_harness.py run --lora-adapter <ref>`
 (challenger) vs no flag (champion) against one endpoint.
 
+**Host parity (Modal vs Baseten).** Modal boots a fresh inference server *per
+run*, so the adapter is chosen **per request** (`_lora_adapter` in the suite) and
+champion + challenger share one deployment. Baseten boots **one** shared
+inference server at model-load, so the adapter is fixed **per deployment** via the
+`MANTIS_LORA_ADAPTER` env (`baseten_server.runtime._boot_lora_args`): the champion
+deploy leaves it unset, a challenger deploy sets it (see
+`deploy/baseten/holo3_challenger/config.yaml`). Either way the gate compares two
+endpoints — on Modal they can be the same URL with/without the suite field; on
+Baseten they're two truss deployments.
+
 ### Generating the sibling rollouts (the sweep)
 
 `experiments/holdout/run_rollout_sweep.py` turns

--- a/docs/hosting/baseten.md
+++ b/docs/hosting/baseten.md
@@ -161,6 +161,41 @@ uvx truss push deploy/baseten/holo3 --no-cache \
 
 You'll get a non-production environment URL. Run smoke tests there, then promote via the Baseten dashboard.
 
+## Serving a LoRA challenger for the promotion gate (#911)
+
+The slow-loop gate evaluates a trained **challenger** (`base + LoRA adapter`)
+against the **champion** (`base`). Unlike Modal — which boots a fresh inference
+server per run and picks the adapter per request — the Baseten pod boots **one**
+shared inference server at model-load, so the adapter is a **deployment-level**
+choice via env:
+
+| Env | Effect |
+|---|---|
+| `MANTIS_LORA_ADAPTER` | Serve `base + this adapter`. A path to a **pre-converted GGUF** adapter (llama.cpp bases) or a PEFT dir (vLLM bases), mounted via the truss `weights:` block. Unset ⇒ serve the base (champion). |
+| `MANTIS_LORA_SCALE` | llama.cpp only — adapter scale (default `1.0`; emits `--lora-scaled`). |
+| `MANTIS_LORA_NAME` | vLLM only — served-model-name for the adapter (default `challenger`). |
+
+> The serving image has **no** torch/transformers, so it can't convert a raw PEFT
+> dir for llama.cpp bases — point `MANTIS_LORA_ADAPTER` at a `.gguf` (convert in
+> the trainer with `convert_lora_to_gguf.py`). A non-`.gguf` ref for `holo3`
+> fails fast at boot.
+
+Deploy a challenger from the ready-made config
+([`deploy/baseten/holo3_challenger/config.yaml`](https://github.com/mercurialsolo/mantis/blob/main/deploy/baseten/holo3_challenger/config.yaml)) —
+it mirrors `holo3` plus a `weights:` entry for the adapter and the
+`MANTIS_LORA_ADAPTER` env. **Swap the adapter `source` for your trained GGUF repo
+first**, then:
+
+```bash
+uvx truss push deploy/baseten/holo3_challenger --no-cache \
+  --deployment-name "holo3-challenger-$(git rev-parse --short HEAD)" \
+  --include-git-info
+```
+
+Point the gate's `MANTIS_CHAMPION_ENDPOINT` at the `holo3` deploy and
+`MANTIS_EVAL_ENDPOINT` at this one, then compare win-rate over the frozen holdout
+(`training/eval_harness.py` / `mantis_trainer.gate`).
+
 ## See also
 
 - [`deploy/baseten/README.md`](https://github.com/mercurialsolo/mantis/blob/main/deploy/baseten/README.md) — the source of truth for the Truss config

--- a/src/mantis_agent/baseten_server/runtime.py
+++ b/src/mantis_agent/baseten_server/runtime.py
@@ -181,6 +181,8 @@ class BasetenCUARuntime:
         self.llama_proc: subprocess.Popen | None = None
         self._llama_log_fh: Any = None
         self.brain: Any = None
+        # #911: served-model-name override set when a vLLM LoRA challenger boots.
+        self._lora_served_name: str | None = None
         # Replica-wide concurrency limiter. Pre-fix this was a single
         # ``threading.Lock`` that every run path acquired — so
         # ``max_concurrent_runs=N`` allowed N submits but only ONE
@@ -282,6 +284,52 @@ class BasetenCUARuntime:
 
         self.loaded = True
 
+    def _boot_lora_args(self, backend_model: str) -> tuple[list[str], str | None]:
+        """#911 parity: resolve a **deployment-level** LoRA challenger adapter.
+
+        Unlike Modal (which boots a fresh inference server per run and so can take
+        a per-request ``_lora_adapter``), the Baseten pod boots one shared
+        inference server at model-load. So the adapter is fixed for the
+        deployment via ``MANTIS_LORA_ADAPTER`` (+ optional ``MANTIS_LORA_SCALE`` /
+        ``MANTIS_LORA_NAME``): the *champion* deployment leaves it unset (serves
+        the base); a *challenger* deployment sets it (serves base + adapter). The
+        gate then points its two endpoints at the two deployments.
+
+        ``backend_model`` is a representative model for the boot path's runtime
+        (``"holo3"`` for llama.cpp, ``"fara"`` for vLLM) so the shared serving
+        logic picks the right flags. Returns ``(extra_server_args,
+        served_model_name)``; ``([], None)`` when no adapter is configured.
+        """
+        ref = (os.environ.get("MANTIS_LORA_ADAPTER") or "").strip()
+        if not ref:
+            return [], None
+        from mantis_agent.serving.lora_serving import plan_serving
+
+        suite: dict[str, Any] = {"_lora_adapter": ref}
+        if os.environ.get("MANTIS_LORA_SCALE"):
+            suite["_lora_scale"] = float(os.environ["MANTIS_LORA_SCALE"])
+        if os.environ.get("MANTIS_LORA_NAME"):
+            suite["_lora_name"] = os.environ["MANTIS_LORA_NAME"]
+        plan = plan_serving(
+            cua_model=backend_model,
+            suite=suite,
+            mounts={},  # Baseten adapters are mounted via the truss `weights:` block
+            gguf_cache_root=os.environ.get(
+                "MANTIS_LORA_CACHE", f"{os.environ.get('MANTIS_DATA_DIR', '/data')}/lora_cache"
+            ),
+        )
+        if plan.convert_cmd:
+            raise RuntimeError(
+                "[#911] Baseten LoRA needs a pre-converted .gguf adapter — point "
+                "MANTIS_LORA_ADAPTER at the .gguf (mounted via the truss weights: "
+                f"block), not a PEFT dir. got: {ref!r}"
+            )
+        logger.warning(
+            "[#911] Baseten serving challenger adapter tag=%s args=%s served=%s",
+            plan.challenger_tag, plan.extra_server_args, plan.served_model_name,
+        )
+        return plan.extra_server_args, plan.served_model_name
+
     def _start_llama(self, model_path: Path, mmproj_path: Path | None, extra_args: list[str]) -> None:
         cmd = [
             "/opt/llama.cpp/build/bin/llama-server",
@@ -296,6 +344,10 @@ class BasetenCUARuntime:
         if mmproj_path:
             cmd.extend(["--mmproj", str(mmproj_path)])
         cmd.extend(extra_args)
+        # #911: deployment-level LoRA challenger (llama.cpp --lora). No-op unless
+        # MANTIS_LORA_ADAPTER is set. Folds into the base → served name unchanged.
+        lora_args, _ = self._boot_lora_args("holo3")
+        cmd.extend(lora_args)
 
         logger.info("starting llama.cpp: %s", " ".join(cmd))
         # Open the log file via context-managed handle that survives the
@@ -358,6 +410,11 @@ class BasetenCUARuntime:
             "--dtype", os.environ.get("MANTIS_VLLM_DTYPE", "auto"),
         ]
         cmd.extend(extra_args)
+        # #911: deployment-level LoRA challenger (vLLM --enable-lora). vLLM serves
+        # the adapter under its own name, so stash it for the brain to request.
+        lora_args, served = self._boot_lora_args("fara")
+        cmd.extend(lora_args)
+        self._lora_served_name = served
 
         logger.info("starting vllm: %s", " ".join(cmd))
         self._llama_log_fh = open("/tmp/vllm.log", "w")
@@ -411,7 +468,9 @@ class BasetenCUARuntime:
 
         brain = FaraBrain(
             base_url=f"http://127.0.0.1:{self.port}/v1",
-            model="model",
+            # #911: when a LoRA challenger is active, vLLM serves it under a
+            # distinct name — request that, not the base "model".
+            model=getattr(self, "_lora_served_name", None) or "model",
             api_key="",
             max_tokens=2048,
             temperature=0.0,

--- a/tests/test_baseten_lora_parity.py
+++ b/tests/test_baseten_lora_parity.py
@@ -1,0 +1,70 @@
+"""#911 parity — Baseten deployment-level LoRA challenger boot args.
+
+The Baseten pod boots one shared inference server at model-load, so the adapter
+is fixed for the deployment via ``MANTIS_LORA_ADAPTER`` (champion unset →
+base; challenger set → base + adapter). These pin the env → llama-server/vLLM
+arg translation in ``BasetenCUARuntime._boot_lora_args``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def runtime(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("MANTIS_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("MANTIS_BRAIN", "holo3")
+    monkeypatch.setenv("MANTIS_SKIP_BRAIN_LOAD", "1")
+    from mantis_agent.baseten_server.runtime import BasetenCUARuntime
+    rt = BasetenCUARuntime()
+    rt.load = lambda: None  # type: ignore[assignment]
+    return rt
+
+
+def test_no_adapter_env_is_noop(runtime, monkeypatch):
+    monkeypatch.delenv("MANTIS_LORA_ADAPTER", raising=False)
+    args, served = runtime._boot_lora_args("holo3")
+    assert args == []
+    assert served is None
+
+
+def test_llamacpp_adapter_appends_lora(runtime, monkeypatch):
+    monkeypatch.setenv("MANTIS_LORA_ADAPTER", "/models/holo3_adapter/adapter.gguf")
+    args, served = runtime._boot_lora_args("holo3")
+    assert args == ["--lora", "/models/holo3_adapter/adapter.gguf"]
+    # llama.cpp folds the adapter into the base → served name unchanged.
+    assert served == "model"
+
+
+def test_llamacpp_scaled_adapter(runtime, monkeypatch):
+    monkeypatch.setenv("MANTIS_LORA_ADAPTER", "/models/holo3_adapter/adapter.gguf")
+    monkeypatch.setenv("MANTIS_LORA_SCALE", "0.5")
+    args, _ = runtime._boot_lora_args("holo3")
+    assert args == ["--lora-scaled", "/models/holo3_adapter/adapter.gguf", "0.5"]
+
+
+def test_llamacpp_raw_peft_dir_rejected(runtime, monkeypatch):
+    # No .gguf suffix → would need conversion, which the serving image can't do.
+    monkeypatch.setenv("MANTIS_LORA_ADAPTER", "/models/holo3_adapter")
+    with pytest.raises(RuntimeError, match="pre-converted .gguf"):
+        runtime._boot_lora_args("holo3")
+
+
+def test_vllm_adapter_enables_lora_and_returns_served_name(runtime, monkeypatch):
+    monkeypatch.setenv("MANTIS_LORA_ADAPTER", "/models/fara_adapter")
+    args, served = runtime._boot_lora_args("fara")
+    assert "--enable-lora" in args
+    assert "challenger=/models/fara_adapter" in args
+    # vLLM serves the adapter under its own name → the brain must request it.
+    assert served == "challenger"
+
+
+def test_vllm_custom_lora_name(runtime, monkeypatch):
+    monkeypatch.setenv("MANTIS_LORA_ADAPTER", "/models/fara_adapter")
+    monkeypatch.setenv("MANTIS_LORA_NAME", "cand12")
+    args, served = runtime._boot_lora_args("fara")
+    assert served == "cand12"
+    assert "cand12=/models/fara_adapter" in args


### PR DESCRIPTION
Follow-up to #913 — brings the LoRA-challenger serving path to **Baseten** so the promotion gate works on either host.

## Why parity looks different on Baseten
- **Modal** boots a fresh inference server *per run* → the adapter is chosen **per request** (`_lora_adapter` in the suite); champion + challenger can share one deployment.
- **Baseten** boots **one** shared inference server at model-load → the adapter is fixed **per deployment**. So parity is deployment-level: champion deploy = base, challenger deploy = base + adapter. This actually matches the gate's two-endpoint model (`MANTIS_CHAMPION_ENDPOINT` / `MANTIS_EVAL_ENDPOINT`).

## What's in it
- **`baseten_server/runtime.py` `_boot_lora_args()`** — reads `MANTIS_LORA_ADAPTER` (+ optional `MANTIS_LORA_SCALE` / `MANTIS_LORA_NAME`), reuses the **same** `mantis_agent.serving.lora_serving.plan_serving` from #913 to translate it, and appends the flags in:
  - `_start_llama` → llama.cpp `--lora` (folds into base; served name unchanged) — covers `holo3` (the real challenger) + `gemma4`.
  - `_start_vllm` → vLLM `--enable-lora`, threading the served-model-name to the Fara brain.
  - No env ⇒ no-op; production path untouched. A raw PEFT dir for a llama.cpp base **fails fast** (serving image has no torch/transformers to convert) — point at a pre-converted `.gguf`.
- **`deploy/baseten/holo3_challenger/config.yaml`** — ready-made challenger truss: mirrors `holo3` + a `weights:` entry for the adapter + `MANTIS_LORA_ADAPTER`. Swap the adapter `source` for your trained GGUF repo, then `truss push`.
- **Docs** — `baseten.md` challenger recipe; CI-architecture host-parity note; `api.md` Baseten caveat.

## Tests
6 new (`test_baseten_lora_parity.py`): env→args translation for llama.cpp (`--lora`, `--lora-scaled`, raw-PEFT-rejected) and vLLM (`--enable-lora` + served-name). Existing `test_baseten_parity_audit` / `test_baseten_shape_parity_with_modal` still green. ruff + `mkdocs --strict` clean.

## Deploy-gated
Live Baseten challenger run (`truss push` the challenger config with a real GGUF adapter + a `WinRateGate` verdict across two endpoints) is the deploy-gated final step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)