### PR TITLE
feat(holdout): sim-env gate-eval runner — generate suites + run promotion gate (#916)

### DIFF
--- a/docs/continuous-improvement-architecture.md
+++ b/docs/continuous-improvement-architecture.md
@@ -204,7 +204,12 @@ challenger arm submits *with* it. Backend is auto-selected by base
   `--enable-lora`; the adapter is addressed by its served-model-name.
 
 The gate drives both arms with `training/eval_harness.py run --lora-adapter <ref>`
-(challenger) vs no flag (champion) against one endpoint.
+(challenger) vs no flag (champion) against one endpoint. Holdout tasks carry no
+plan, so `experiments/holdout/run_gate_eval.py` (#916) **generates** the
+`task_suite`/`_micro_plan` per task (via `build_micro_suite`), runs both arms
+(distinct `profile_id` per arm → parallel, #912), oracle-grades, and calls
+`promotion_gate.evaluate` → a `GateVerdict` — the sim-env execution link between
+the holdout set and the gate.
 
 **Host parity (Modal vs Baseten).** Modal boots a fresh inference server *per
 run*, so the adapter is chosen **per request** (`_lora_adapter` in the suite) and
@@ -295,7 +300,8 @@ generates the next rollouts. *Days.*
 | Rollout generator primitives (seed-sweep, failure-biased) | ✅ on main |
 | Closed plan-evolution fast loop (`apply_plan_overlay` wired) | ✅ on main |
 | Champion/challenger gate | ✅ on main |
-| Serve `base + LoRA adapter` challenger at `/v1/predict` (#911) | ✅ on main (GPU run deploy-gated) |
+| Serve `base + LoRA adapter` challenger at `/v1/predict` (#911) | ✅ on main + deployed (GPU run deploy-gated) |
+| Holdout-eval runner — generate sim-env suites + gate vs `/v1/predict` (#916) | ✅ on main (`experiments/holdout/run_gate_eval.py`; live run spend-gated) |
 | Logprob capture (GRPO prerequisite, #889) | ✅ on main |
 | `RolloutRunner` execution adapter (generator → Daytona → Augur) | ⏳ P1 (#894) |
 | `mantis-trainer` data contract | ✅ scaffold + dataset implemented |

--- a/experiments/holdout/README.md
+++ b/experiments/holdout/README.md
@@ -105,6 +105,37 @@ in `tests/test_state_key_dispatcher.py`.
 > real parallelism comes from scale-out (`@modal.concurrent` min/max containers) —
 > size the autoscaler max to match your `--max-parallel`.
 
+## Running the promotion gate against a challenger (`run_gate_eval.py`, #916)
+
+The trainer's gate evaluates a **challenger** (`base + LoRA adapter`, #911) vs the
+**champion** (`base`) over the holdout. The catch: holdout tasks carry only
+`env` + `task_id` + oracle — **no plan** — while `/v1/predict` requires a built
+`task_suite`/`_micro_plan`. `run_gate_eval.py` is the missing execution link: it
+**generates** the suite for each task (from `sealed_plans`, via `build_micro_suite`
+— not raw steps, which silently score 0/0/0), runs both arms, oracle-grades, and
+feeds the per-arm results to `promotion_gate.evaluate` → a `GateVerdict`.
+
+```
+# champion (base) vs challenger (adapter) over the 3 mantis-holdout-v1 tasks
+python experiments/holdout/run_gate_eval.py \
+    --task indeed.t01_search_save_remote \
+    --task indeed.t03_employer_review_applicant \
+    --task linkedin.t02_post_text_update \
+    --lora-adapter mantis-trainer-vol:/checkpoints/sft-c3e0d799f432
+```
+
+Each (task, arm) gets a distinct `profile_id` (`gate-<arm>-<task>`), so the two
+arms never collide on one Chrome profile (the per-`profile_id` 409 rule) and all
+runs fan out in parallel via `StateKeyDispatcher` (`--max-parallel`, #912).
+Omitting `--lora-adapter` runs champion == challenger (a plumbing sanity run;
+expect `delta≈0`, `promote=False`). **This spends** — 2 × N Modal GPU runs.
+
+**Equivalent path:** `--emit-tasks <path>` writes an `eval_harness`-shaped
+`--tasks` JSON with the generated `micro_plan`s, so `training/eval_harness.py
+run --lora-adapter … / compare` can consume holdout tasks that otherwise have no
+plan. The suite-gen + result→`ArmResult` mapping are pure (unit-tested in
+`tests/test_gate_eval_916.py`); the live submit arm is spend-gated.
+
 ## Freezing into an Augur eval-version (the official holdout)
 
 The producer pipeline (mantis #901/#902) emits a `task_spec` + a `mark_for_eval`

--- a/experiments/holdout/run_gate_eval.py
+++ b/experiments/holdout/run_gate_eval.py
@@ -1,0 +1,296 @@
+"""#916 — holdout-eval runner: generate sim-env suites + run the promotion gate.
+
+The trainer's gate is wired and #911 serves `base + adapter` at `/v1/predict`, but
+the holdout eval couldn't actually run: holdout tasks carry only `env` + `task_id`
++ oracle (**no plan**), while `/v1/predict` rejects free-text and requires a built
+`task_suite` with a `_micro_plan`. The runnable suite only existed transiently
+during rollout generation. This is the missing **sim-env execution link**.
+
+Given holdout task keys (resolved to plans via :mod:`sealed_plans`), a champion
+endpoint, and an optional `--lora-adapter <ref>` challenger, this runner:
+
+1. **generates the `task_suite`/`_micro_plan`** for each task (`build_eval_suite`,
+   reusing `build_micro_suite` so the suite is properly built — a raw `{steps:…}`
+   silently scores 0/0/0, see `feedback_task_suite_shape`),
+2. submits to `/v1/predict` — base for the champion arm, `_lora_adapter` for the
+   challenger arm (#911) — polls to terminal, oracle-grades,
+3. maps each arm to a :class:`~mantis_agent.learning.promotion_gate.ArmResult`
+   and runs :meth:`PromotionGate.evaluate` → a ``GateVerdict``.
+
+Distinct ``profile_id`` per (task, arm) means every run is independent under the
+per-profile rule (#912), so arms/tasks fan out in parallel (``--max-parallel``).
+
+    python experiments/holdout/run_gate_eval.py \
+        --task indeed.t01_search_save_remote \
+        --task indeed.t03_employer_review_applicant \
+        --task linkedin.t02_post_text_update \
+        --lora-adapter mantis-trainer-vol:/checkpoints/sft-c3e0d799f432
+
+The suite-generation + result→ArmResult mapping + tasks-JSON emission are pure
+(no network) and unit-tested in ``tests/test_gate_eval_916.py``; the live submit
+arm is spend-gated. ``--emit-tasks <path>`` writes an ``eval_harness``-shaped
+``--tasks`` JSON (with generated ``micro_plan``s) for the equivalent path.
+
+THIS SPENDS — 2 × N Modal GPU runs (champion + challenger per task).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "src"))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from sealed_plans import SANDBOXES, SEALED_TASKS  # noqa: E402
+from state_key_dispatcher import Call, StateKeyDispatcher  # noqa: E402
+
+import run_sealed_task as rst  # noqa: E402  (reuse env-resolve/submit/grade seams)
+
+from mantis_agent.learning.promotion_gate import (  # noqa: E402
+    ArmResult,
+    GateVerdict,
+    PromotionGate,
+)
+from mantis_agent.plan_decomposer import MicroPlan, PlanDecomposer  # noqa: E402
+from mantis_agent.server_utils import (  # noqa: E402
+    build_micro_suite,
+    micro_plan_steps_to_dicts,
+)
+
+# Arm labels — kept distinct so champion/challenger never share a profile_id.
+CHAMPION = "champion"
+CHALLENGER = "challenger"
+
+
+def _micro_plan_dicts(spec_def: dict[str, Any], env_url: str) -> list[dict[str, Any]]:
+    """Resolve a holdout task's plan steps → built ``_micro_plan`` dicts.
+
+    Substitutes the env URL into nav steps, then runs each through
+    ``PlanDecomposer._build_intent`` + ``micro_plan_steps_to_dicts`` — the same
+    transform the rollout/fanout suite-builder uses, so the result is a real
+    runnable micro-plan rather than raw step dicts.
+    """
+    steps = rst._substitute(spec_def.get("steps") or [], env_url)
+    plan = MicroPlan(domain=spec_def["oracle_task_id"].split(".")[0])
+    for st in steps:
+        plan.steps.append(PlanDecomposer._build_intent(st))
+    return micro_plan_steps_to_dicts(plan.steps)
+
+
+def build_eval_suite(
+    spec_def: dict[str, Any],
+    info: dict[str, str],
+    *,
+    arm: str,
+    task_key: str,
+    lora_adapter: str = "",
+) -> dict[str, Any]:
+    """Build the ``/v1/predict`` ``task_suite`` for one (task, arm).
+
+    Champion arm omits ``_lora_adapter`` (serves the base); challenger arm sets it
+    (serves base + adapter, #911). ``profile_id``/``workflow_id`` are scoped per
+    (arm, task) so the two arms never collide on one Chrome profile (#912).
+    """
+    micro = _micro_plan_dicts(spec_def, info["url"])
+    domain = spec_def["oracle_task_id"].split(".")[0]
+    ident = f"gate-{arm}-{task_key}"
+    suite = build_micro_suite(micro, domain, profile_id=ident, workflow_id=ident)
+    suite["_plan_name"] = spec_def["oracle_task_id"]
+    suite["_browser_extra_headers"] = rst._daytona_headers(info["preview_token"])
+    suite["_proxy_disabled"] = True
+    # #906: server grades this oracle at finalize so the score reflects ground truth.
+    suite["_oracle_url"] = info["url"]
+    suite["_oracle_task_id"] = spec_def["oracle_task_id"]
+    suite["_oracle_admin_token"] = info["admin_token"]
+    suite["_oracle_preview_token"] = info["preview_token"]
+    if lora_adapter:  # #911 — challenger arm
+        suite["_lora_adapter"] = lora_adapter
+    return suite
+
+
+def to_eval_tasks_json(task_keys: list[str], env_urls: dict[str, str]) -> list[dict[str, Any]]:
+    """Emit an ``eval_harness``-shaped ``--tasks`` list with generated
+    ``micro_plan``s, so the existing ``eval_harness run/compare`` path can consume
+    holdout tasks that otherwise have no plan. ``env_urls`` maps env name → base
+    URL used to substitute nav steps."""
+    out: list[dict[str, Any]] = []
+    for key in task_keys:
+        spec = SEALED_TASKS[key]
+        env_url = env_urls.get(spec["env"], "")
+        out.append({
+            "task_id": spec["oracle_task_id"],
+            "task_text": spec.get("task_text", ""),
+            "micro_plan": _micro_plan_dicts(spec, env_url),
+            "metadata": {"env": spec["env"], "oracle_task_id": spec["oracle_task_id"]},
+        })
+    return out
+
+
+def arm_from_results(results: list[dict[str, Any]], label: str = "arm") -> ArmResult:
+    """Map graded per-task results → an ``ArmResult`` (scores + costs).
+
+    ``score`` is the oracle outcome (1.0 pass / 0.0 fail) keyed by ``task_id``.
+    Results missing a ``task_id`` are dropped.
+    """
+    scores: dict[str, float] = {}
+    costs: dict[str, float] = {}
+    for r in results:
+        tid = r.get("task_id")
+        if not tid:
+            continue
+        scores[tid] = 1.0 if r.get("oracle_passed") else 0.0
+        if r.get("cost") is not None:
+            costs[tid] = float(r["cost"])
+    return ArmResult(label=label, scores=scores, costs=costs)
+
+
+def _run_one(
+    task_key: str, spec_def: dict[str, Any], info: dict[str, str], token: str,
+    *, arm: str, lora_adapter: str, max_steps: int, poll_seconds: int,
+) -> dict[str, Any]:
+    """Submit one (task, arm) to /v1/predict, poll to terminal, oracle-grade."""
+    suite = build_eval_suite(spec_def, info, arm=arm, task_key=task_key, lora_adapter=lora_adapter)
+    code, resp = rst._post(token, {
+        "task_suite": suite, "profile_id": suite["_profile_id"],
+        "workflow_id": suite["_workflow_id"], "cua_model": "holo3",
+        "max_steps": max_steps, "max_cost": 2.0, "max_time_minutes": 12, "detached": True,
+    })
+    tid = spec_def["oracle_task_id"]
+    if code != 200 or not resp.get("run_id"):
+        return {"task_id": tid, "arm": arm, "submit_error": resp, "oracle_passed": False}
+    run_id = resp["run_id"]
+
+    final = None
+    deadline = time.monotonic() + poll_seconds
+    while time.monotonic() < deadline:
+        _, s = rst._post(token, {"action": "status", "run_id": run_id})
+        if s.get("status") in {"succeeded", "completed", "completed_with_failures",
+                               "failed", "cancelled", "halted"}:
+            final = s
+            break
+        time.sleep(8)
+
+    grade = rst._grade(info["url"], tid, info["admin_token"], info["preview_token"])
+    cost = float(((final or {}).get("costs") or {}).get("total", 0.0))
+    return {
+        "task_id": tid, "arm": arm, "run_id": run_id,
+        "terminal_status": (final or {}).get("status"),
+        "oracle_passed": bool(grade.get("passed")), "cost": cost,
+    }
+
+
+def _resolve_envs(task_keys: list[str], dayt: str) -> dict[str, dict[str, str]]:
+    """Resolve the Daytona sandbox info for every distinct env, reset each once."""
+    infos: dict[str, dict[str, str]] = {}
+    for env_name in sorted({SEALED_TASKS[k]["env"] for k in task_keys}):
+        print(f"[env] resolving Daytona sandbox for '{env_name}' …")
+        info = rst._daytona_env(SANDBOXES[env_name], dayt)
+        rst._reset_env(info["url"], info["admin_token"], info["preview_token"])
+        infos[env_name] = info
+    return infos
+
+
+def run_gate(
+    task_keys: list[str], *, lora_adapter: str, max_steps: int, poll_seconds: int,
+    max_parallel: int, gate: PromotionGate,
+) -> tuple[GateVerdict, list[dict[str, Any]]]:
+    """Run champion + challenger arms over the holdout tasks and gate them."""
+    env = rst._load_env()
+    token, dayt = env.get("MANTIS_API_TOKEN", ""), env.get("DAYTONA_API_KEY", "")
+    if not token or not dayt:
+        raise SystemExit("ERROR: MANTIS_API_TOKEN + DAYTONA_API_KEY required")
+    infos = _resolve_envs(task_keys, dayt)
+
+    # One job per (task, arm). Distinct profile_id per job → all independent (#912).
+    jobs: list[tuple[str, str]] = []  # (task_key, arm)
+    for key in task_keys:
+        jobs.append((key, CHAMPION))
+        jobs.append((key, CHALLENGER))
+
+    def _mk(task_key: str, arm: str):
+        spec = SEALED_TASKS[task_key]
+        info = infos[spec["env"]]
+        adapter = lora_adapter if arm == CHALLENGER else ""
+        return lambda _k: _run_one(
+            task_key, spec, info, token, arm=arm, lora_adapter=adapter,
+            max_steps=max_steps, poll_seconds=poll_seconds,
+        )
+
+    dispatcher = StateKeyDispatcher(max_parallel=max(1, max_parallel))
+    results = dispatcher.run_all(
+        [Call(_mk(k, arm), state_key=f"gate-{arm}-{k}") for (k, arm) in jobs]
+    )
+    dispatcher.shutdown()
+
+    champion = arm_from_results([r for r in results if r.get("arm") == CHAMPION], CHAMPION)
+    challenger = arm_from_results([r for r in results if r.get("arm") == CHALLENGER], CHALLENGER)
+    return gate.evaluate(champion, challenger), results
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="#916 holdout-eval runner → promotion GateVerdict")
+    ap.add_argument("--task", action="append", dest="tasks", default=[],
+                    help=f"holdout task key (repeatable); known: {sorted(SEALED_TASKS)}")
+    ap.add_argument("--lora-adapter", default="",
+                    help="#911 challenger adapter ref (omit ⇒ challenger == base, sanity run)")
+    ap.add_argument("--max-steps", type=int, default=25)
+    ap.add_argument("--poll-seconds", type=int, default=600)
+    ap.add_argument("--max-parallel", type=int, default=4)
+    ap.add_argument("--emit-tasks", default="",
+                    help="write an eval_harness --tasks JSON (generated micro_plans) and exit")
+    args = ap.parse_args(argv)
+
+    keys = args.tasks or sorted(SEALED_TASKS)
+    unknown = [k for k in keys if k not in SEALED_TASKS]
+    if unknown:
+        print(f"unknown task(s) {unknown}; known: {sorted(SEALED_TASKS)}", file=sys.stderr)
+        return 2
+
+    if args.emit_tasks:
+        # Resolve env URLs (best-effort) so nav steps substitute; falls back to ""
+        env = rst._load_env()
+        dayt = env.get("DAYTONA_API_KEY", "")
+        env_urls: dict[str, str] = {}
+        if dayt:
+            for name in sorted({SEALED_TASKS[k]["env"] for k in keys}):
+                try:
+                    env_urls[name] = rst._daytona_env(SANDBOXES[name], dayt)["url"]
+                except Exception:  # noqa: BLE001 — emit with empty url if unreachable
+                    env_urls[name] = ""
+        Path(args.emit_tasks).write_text(json.dumps(to_eval_tasks_json(keys, env_urls), indent=2))
+        print(f"wrote {len(keys)} task(s) → {args.emit_tasks}")
+        return 0
+
+    if not args.lora_adapter:
+        print("⚠️  no --lora-adapter: champion and challenger both serve the base "
+              "(a plumbing sanity run — expect delta≈0, promote=False).", file=sys.stderr)
+
+    verdict, results = run_gate(
+        keys, lora_adapter=args.lora_adapter, max_steps=args.max_steps,
+        poll_seconds=args.poll_seconds, max_parallel=args.max_parallel,
+        gate=PromotionGate(),
+    )
+    print("\n[gate eval result]")
+    print(json.dumps({
+        "lora_adapter": args.lora_adapter,
+        "results": results,
+        "verdict": {
+            "promote": verdict.promote, "reason": verdict.reason,
+            "n_compared": verdict.n_compared, "mean_delta": verdict.mean_delta,
+            "win_rate": verdict.win_rate, "prob_improvement": verdict.prob_improvement,
+            "regressions": verdict.regressions,
+            "champion_cost": verdict.champion_cost, "challenger_cost": verdict.challenger_cost,
+        },
+    }, indent=2))
+    print(f"\n{'✅ PROMOTE' if verdict.promote else '❌ HOLD'} — {verdict.reason}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_gate_eval_916.py
+++ b/tests/test_gate_eval_916.py
@@ -1,0 +1,139 @@
+"""#916 — holdout-eval runner: suite generation + ArmResult mapping + gate wiring.
+
+The live submit/grade arm is spend-gated; these pin the pure core (no network):
+suite shape (built micro-plan, oracle fields, per-arm profile isolation, the #911
+challenger adapter), the result→ArmResult mapping, the eval_harness tasks-JSON
+emission, and that the mapped arms drive a sensible PromotionGate verdict.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "src"))
+sys.path.insert(0, str(REPO_ROOT / "experiments" / "holdout"))
+
+from mantis_agent.learning.promotion_gate import ArmResult, PromotionGate  # noqa: E402
+
+import run_gate_eval as rge  # noqa: E402
+from sealed_plans import SEALED_TASKS  # noqa: E402
+
+_INFO = {
+    "url": "https://sandbox.example/app",
+    "preview_token": "pv-tok",
+    "admin_token": "admin-tok",
+}
+_KEY = "indeed.t01_search_save_remote"
+_SPEC = SEALED_TASKS[_KEY]
+_TID = _SPEC["oracle_task_id"]
+
+
+# ── build_eval_suite ────────────────────────────────────────────────────
+
+
+def test_suite_has_built_micro_plan_not_raw_steps():
+    suite = rge.build_eval_suite(_SPEC, _INFO, arm=rge.CHAMPION, task_key=_KEY)
+    # build_micro_suite output carries a non-empty _micro_plan (the 0/0/0 footgun
+    # is passing raw {steps:[...]}). Steps are dicts, not the raw sealed-plan form.
+    assert suite.get("_micro_plan"), "suite must carry a built _micro_plan"
+    assert isinstance(suite["_micro_plan"], list) and suite["_micro_plan"]
+
+
+def test_suite_carries_oracle_fields():
+    suite = rge.build_eval_suite(_SPEC, _INFO, arm=rge.CHAMPION, task_key=_KEY)
+    assert suite["_oracle_task_id"] == _TID
+    assert suite["_oracle_url"] == _INFO["url"]
+    assert suite["_oracle_admin_token"] == "admin-tok"
+    assert suite["_oracle_preview_token"] == "pv-tok"
+
+
+def test_champion_arm_has_no_adapter():
+    suite = rge.build_eval_suite(_SPEC, _INFO, arm=rge.CHAMPION, task_key=_KEY)
+    assert "_lora_adapter" not in suite
+
+
+def test_challenger_arm_sets_adapter():
+    suite = rge.build_eval_suite(
+        _SPEC, _INFO, arm=rge.CHALLENGER, task_key=_KEY,
+        lora_adapter="mantis-trainer-vol:/checkpoints/sft-x",
+    )
+    assert suite["_lora_adapter"] == "mantis-trainer-vol:/checkpoints/sft-x"
+
+
+def test_arms_use_distinct_profile_ids():
+    champ = rge.build_eval_suite(_SPEC, _INFO, arm=rge.CHAMPION, task_key=_KEY)
+    chal = rge.build_eval_suite(_SPEC, _INFO, arm=rge.CHALLENGER, task_key=_KEY)
+    # Distinct profile per (task, arm) → no 409 collision when run concurrently.
+    assert champ["_profile_id"] != chal["_profile_id"]
+    assert champ["_profile_id"].startswith("gate-champion-")
+    assert chal["_profile_id"].startswith("gate-challenger-")
+
+
+# ── arm_from_results ────────────────────────────────────────────────────
+
+
+def test_arm_from_results_maps_pass_fail_to_scores():
+    arm = rge.arm_from_results([
+        {"task_id": "a", "oracle_passed": True, "cost": 0.30},
+        {"task_id": "b", "oracle_passed": False, "cost": 0.12},
+    ])
+    assert arm.scores == {"a": 1.0, "b": 0.0}
+    assert arm.costs == {"a": 0.30, "b": 0.12}
+
+
+def test_arm_from_results_drops_entries_without_task_id():
+    arm = rge.arm_from_results([{"oracle_passed": True}, {"task_id": "c", "oracle_passed": True}])
+    assert arm.scores == {"c": 1.0}
+
+
+def test_arm_from_results_cost_optional():
+    arm = rge.arm_from_results([{"task_id": "a", "oracle_passed": True}])
+    assert arm.scores == {"a": 1.0}
+    assert arm.costs == {}
+
+
+# ── to_eval_tasks_json ──────────────────────────────────────────────────
+
+
+def test_tasks_json_populates_micro_plan():
+    tasks = rge.to_eval_tasks_json([_KEY], {_SPEC["env"]: _INFO["url"]})
+    assert len(tasks) == 1
+    t = tasks[0]
+    assert t["task_id"] == _TID
+    assert t["micro_plan"], "generated tasks must carry a micro_plan (the #916 gap)"
+    assert t["metadata"]["env"] == _SPEC["env"]
+
+
+# ── gate wiring ─────────────────────────────────────────────────────────
+
+
+def test_mapped_arms_drive_promotion_gate():
+    # Challenger strictly better on every task → gate should promote.
+    champ = rge.arm_from_results([
+        {"task_id": "a", "oracle_passed": False},
+        {"task_id": "b", "oracle_passed": False},
+        {"task_id": "c", "oracle_passed": False},
+    ])
+    chal = rge.arm_from_results([
+        {"task_id": "a", "oracle_passed": True},
+        {"task_id": "b", "oracle_passed": True},
+        {"task_id": "c", "oracle_passed": True},
+    ])
+    verdict = PromotionGate().evaluate(champ, chal)
+    assert verdict.n_compared == 3
+    assert verdict.win_rate == 1.0
+    assert verdict.mean_delta == 1.0
+    assert verdict.promote is True
+
+
+def test_no_adapter_sanity_run_does_not_promote():
+    # champion == challenger (both base) → zero delta → HOLD.
+    same = rge.arm_from_results([
+        {"task_id": "a", "oracle_passed": True},
+        {"task_id": "b", "oracle_passed": False},
+    ])
+    verdict = PromotionGate().evaluate(same, ArmResult(label="b", scores=dict(same.scores)))
+    assert verdict.mean_delta == 0.0
+    assert verdict.promote is False


### PR DESCRIPTION
Closes #916 — the missing **sim-env execution link** between the holdout set and the promotion gate.

## The gap
The trainer gate is wired and #911 serves `base + adapter` at `/v1/predict`, but the holdout eval couldn't actually run:
- `/v1/predict` rejects free-text → requires a built `task_suite`/`_micro_plan`.
- Holdout tasks (`mantis-holdout-v1`, #904 clusters) carry only `env` + `task_id` + oracle — **no plan**.
- The runnable suite only existed transiently during rollout generation; nothing produced a standalone runnable suite for a holdout task.

## What this adds — `experiments/holdout/run_gate_eval.py`
Given holdout task keys + a champion endpoint + optional `--lora-adapter <ref>`:
1. **Generates** the `task_suite`/`_micro_plan` per task (from `sealed_plans`, via `build_micro_suite` — **not** raw steps, which silently score 0/0/0 per `feedback_task_suite_shape`) + the #906 oracle fields.
2. Runs **champion** (base, no adapter) and **challenger** (`_lora_adapter`, #911) arms; each `(task, arm)` gets a distinct `profile_id` (`gate-<arm>-<task>`) so the arms never collide on one Chrome profile (the per-`profile_id` 409 rule) and fan out in parallel via `StateKeyDispatcher` (#912).
3. Oracle-grades, maps to `ArmResult`, and runs `promotion_gate.evaluate` → a **`GateVerdict`** (win-rate + significance + regressions + cost).

```bash
python experiments/holdout/run_gate_eval.py \
  --task indeed.t01_search_save_remote \
  --task indeed.t03_employer_review_applicant \
  --task linkedin.t02_post_text_update \
  --lora-adapter mantis-trainer-vol:/checkpoints/sft-c3e0d799f432
```

**Equivalent path:** `--emit-tasks <path>` writes an `eval_harness`-shaped `--tasks` JSON with the generated `micro_plan`s, so the existing `eval_harness run --lora-adapter / compare` can consume plan-less holdout tasks.

## Tests
11 in `tests/test_gate_eval_916.py` — suite shape (built micro-plan, oracle fields, per-arm profile isolation, the #911 adapter), `arm_from_results` mapping, tasks-JSON emission, and that mapped arms drive a sensible `PromotionGate` verdict. The live submit/grade arm is **spend-gated** (2 × N Modal GPU runs). ruff + `mkdocs --strict` clean.

## Acceptance
Produces a `GateVerdict` for challenger `mantis-trainer-vol:/checkpoints/<id>` vs base over the 3 `mantis-holdout-v1` tasks. The trainer's `WinRateGate` can consume it (or call this runner). The first real verdict is now unblocked — it just needs a live run with a reachable adapter + GPU spend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)