### PR TITLE
feat(serving): Holo3 (qwen3_5_moe) full-model-swap challenger (#918)

### DIFF
--- a/deploy/baseten/holo3_challenger/config.yaml
+++ b/deploy/baseten/holo3_challenger/config.yaml
@@ -1,17 +1,23 @@
-# Holo3 promotion-gate CHALLENGER (#911) — base + trained LoRA adapter.
+# Holo3 promotion-gate CHALLENGER (#911/#918) — full merged model.
 #
-# Identical to ../holo3/config.yaml (the CHAMPION) except for two things:
-#   1. a `weights:` entry that mounts the trained GGUF adapter, and
-#   2. `MANTIS_LORA_ADAPTER` in the start_command pointing at it.
-# The champion deployment leaves the adapter unset → serves the base. The gate
-# points MANTIS_CHAMPION_ENDPOINT at the champion deploy and MANTIS_EVAL_ENDPOINT
-# at this one, then compares win-rate over the frozen holdout.
+# Holo3 is qwen3_5_moe: its LoRA *adapter* can't be GGUF-converted
+# (convert_lora_to_gguf doesn't support the MoE arch — #918), but the *merged*
+# full model can (convert_hf_to_gguf supports it — the base GGUF proves it). So a
+# Holo3 challenger is served as a **full-model swap**, not a `--lora` overlay.
 #
-# IMPORTANT: swap the adapter `source` below for YOUR trained checkpoint. It must
-# be a **pre-converted GGUF** LoRA adapter (llama.cpp `convert_lora_to_gguf.py`,
-# run in the trainer) — the serving image has no torch/transformers to convert a
-# raw PEFT dir. Redeploy per the repo rule: `--no-cache` + a unique
-# `--deployment-name` (feedback_baseten_deployment_name_uniqueness).
+# This deployment is identical to ../holo3/config.yaml (the CHAMPION) except it
+# points MANTIS_HOLO3_MODEL_DIR at the trained, merged, GGUF-converted model
+# (mounted via `weights:`) instead of the stock base. The champion deploy serves
+# the base; the gate points MANTIS_CHAMPION_ENDPOINT at it and
+# MANTIS_EVAL_ENDPOINT at this one.
+#
+# TRAINER STEPS to produce the artifact (heavy; done in the trainer, not here):
+#   1. peft merge_and_unload: adapter + Hcompany/Holo3-35B-A3B → merged HF dir
+#   2. llama.cpp convert_hf_to_gguf.py <merged_dir> --outfile merged.gguf
+#   3. llama-quantize merged.gguf Holo3-challenger.Q8_0.gguf Q8_0
+#   4. publish (HF repo or Baseten weights source) alongside the base mmproj
+# Swap the `source` below for your merged-model repo. Redeploy per the repo rule:
+# `--no-cache` + a unique `--deployment-name` (feedback_baseten_deployment_name_uniqueness).
 model_name: mantis-holo3-cua-challenger
 external_package_dirs:
   - ../../../src
@@ -28,8 +34,8 @@ build_commands:
   - cd /opt/llama.cpp && cmake -B build -DGGML_CUDA=ON -DGGML_NATIVE=OFF -DGGML_AMX_TILE=OFF -DGGML_AMX_INT8=OFF -DGGML_AMX_BF16=OFF -DCMAKE_CUDA_ARCHITECTURES="80;90" -DLLAMA_BUILD_TESTS=OFF -DLLAMA_BUILD_EXAMPLES=OFF -DLLAMA_BUILD_SERVER=ON && cmake --build build --target llama-server --config Release -j$(nproc)
   - mkdir -p /workspace/mantis-data && ln -snf /workspace/mantis-data /data
 docker_server:
-  # MANTIS_LORA_ADAPTER → base + adapter (see baseten_server.runtime._boot_lora_args).
-  start_command: bash -lc "PYTHONPATH=/packages MANTIS_MODEL=holo3 MANTIS_LLAMA_PORT=18080 MANTIS_DATA_DIR=/workspace/mantis-data MANTIS_REPO_ROOT=/packages MANTIS_LORA_ADAPTER=/models/holo3_adapter/adapter.gguf MANTIS_MAX_RUNTIME_MINUTES=240 MANTIS_MAX_COST_USD=75 MANTIS_MAX_STEPS_PER_PLAN=500 MANTIS_CONTEXT_SIZE=32768 MANTIS_FORM_TARGET_PROVIDER=holo3 uvicorn mantis_agent.baseten_server:app --host 0.0.0.0 --port 8000 --timeout-keep-alive 300"
+  # MANTIS_HOLO3_MODEL_DIR points at the merged challenger model (full-model swap).
+  start_command: bash -lc "PYTHONPATH=/packages MANTIS_MODEL=holo3 MANTIS_LLAMA_PORT=18080 MANTIS_DATA_DIR=/workspace/mantis-data MANTIS_REPO_ROOT=/packages MANTIS_HOLO3_MODEL_DIR=/models/holo3_challenger MANTIS_MAX_RUNTIME_MINUTES=240 MANTIS_MAX_COST_USD=75 MANTIS_MAX_STEPS_PER_PLAN=500 MANTIS_CONTEXT_SIZE=32768 MANTIS_FORM_TARGET_PROVIDER=holo3 uvicorn mantis_agent.baseten_server:app --host 0.0.0.0 --port 8000 --timeout-keep-alive 300"
   server_port: 8000
   predict_endpoint: /predict
   readiness_endpoint: /health
@@ -43,16 +49,16 @@ runtime:
     stop_traffic_threshold_seconds: 1800
     restart_threshold_seconds: 1800
 weights:
+  # CHALLENGER: the trained, merged, GGUF-converted full model + the base mmproj
+  # (vision projector is not fine-tuned). Replace `source` with your repo.
+  - source: "hf://your-org/holo3-challenger-merged-gguf@main"
+    mount_location: "/models/holo3_challenger"
+    allow_patterns:
+      - "*.Q8_0.gguf"
   - source: "hf://mradermacher/Holo3-35B-A3B-GGUF@main"
-    mount_location: "/models/holo3"
+    mount_location: "/models/holo3_challenger"
     allow_patterns:
-      - "Holo3-35B-A3B.Q8_0.gguf"
       - "Holo3-35B-A3B.mmproj-f16.gguf"
-  # CHALLENGER adapter — replace with your trained GGUF-converted LoRA checkpoint.
-  - source: "hf://your-org/holo3-challenger-lora-gguf@main"
-    mount_location: "/models/holo3_adapter"
-    allow_patterns:
-      - "adapter.gguf"
 secrets:
   anthropic_api_key: null
   proxy_url: null

--- a/deploy/modal/modal_cua_server.py
+++ b/deploy/modal/modal_cua_server.py
@@ -476,20 +476,23 @@ def _prepare_lora_serving(
     base_served_name: str = "model",
     llamacpp_base_model: str | None = None,
 ):
-    """Resolve (and, for a raw PEFT dir, materialize) a LoRA challenger (#911).
+    """Resolve (and, for a raw PEFT dir, materialize) a LoRA / full-model
+    challenger (#911, #918).
 
-    Returns a :class:`ServingPlan`. When the suite carries no ``_lora_adapter``
-    the plan is base-only (no extra args, base served-name) and the production
-    path is unchanged. For a llama.cpp base whose ref is a raw PEFT dir (not a
-    pre-converted ``.gguf``), runs the convert step once and caches the GGUF on
-    ``/data`` — but the recommended path is for the trainer to emit a ``.gguf``
-    adapter so the serving image needs no torch/transformers deps.
+    Returns a :class:`ServingPlan`. When the suite carries no challenger field
+    (``_lora_adapter`` or ``_challenger_model``) the plan is base-only and the
+    production path is unchanged. ``_challenger_model`` (#918) → a full merged
+    GGUF served via ``-m`` (the only path that works for the qwen3_5_moe Holo3
+    base). ``_lora_adapter`` (#911) → ``--lora`` (a pre-converted ``.gguf``, or a
+    raw PEFT dir converted once + cached — note convert_lora_to_gguf does NOT
+    support the MoE adapter, which is why Holo3 uses ``_challenger_model``).
     """
     from mantis_agent.serving.lora_serving import ServingPlan, plan_serving
 
     # No challenger → base-only. Short-circuit (don't call serving_backend, which
     # fail-fasts on unknown bases) so the common production path is untouched.
-    if not str(suite.get("_lora_adapter") or "").strip():
+    if not (str(suite.get("_lora_adapter") or "").strip()
+            or str(suite.get("_challenger_model") or "").strip()):
         return ServingPlan(
             backend="base", lora_active=False, served_model_name=base_served_name
         )
@@ -502,6 +505,18 @@ def _prepare_lora_serving(
         base_served_name=base_served_name,
         llamacpp_base_model=llamacpp_base_model,
     )
+
+    # #918: full-model-swap challenger — verify the merged GGUF exists, no convert.
+    if plan.model_path_override:
+        print(f"[#918] serving full-model challenger tag={plan.challenger_tag} "
+              f"model={plan.model_path_override}")
+        if not os.path.exists(plan.model_path_override):
+            raise RuntimeError(
+                f"[#918] challenger model not found at {plan.model_path_override!r} — is "
+                f"{TRAINER_VOL_NAME} populated and the ref correct? "
+                f"({suite.get('_challenger_model')!r})"
+            )
+        return plan
 
     print(
         f"[#911] serving challenger adapter tag={plan.challenger_tag} "
@@ -827,11 +842,14 @@ def _run_holo3_executor(
     lora_plan = _prepare_lora_serving(
         _suite_preview, "holo3", llamacpp_base_model=(os.environ.get("HOLO3_LORA_BASE") or None)
     )
+    # #918: a full-model-swap challenger serves a merged GGUF via -m (the working
+    # path for the qwen3_5_moe Holo3 LoRA); the base mmproj is reused unchanged.
+    serve_model_path = lora_plan.model_path_override or model_path
 
     # Start llama-server — no reasoning-budget (Holo3 overthinks with budget=512)
     cmd = [
         "/opt/llama.cpp/build/bin/llama-server",
-        "-m", model_path,
+        "-m", serve_model_path,
         "--mmproj", mmproj_path,
         "--host", "0.0.0.0", "--port", "8080",
         "-ngl", "99", "-c", "8192", "-ub", "2048",

--- a/docs/api.md
+++ b/docs/api.md
@@ -102,7 +102,8 @@ The following go **inside `task_suite`** (not top-level), alongside the plan:
 
 | Suite field | Description |
 |---|---|
-| `_lora_adapter` | ([#911](https://github.com/mercurialsolo/mantis/issues/911)) Serve **base + this LoRA adapter** (the promotion-gate *challenger*). A ref `"<volume>:/checkpoints/<algo>"` (the trainer volume `mantis-trainer-vol` is mounted read-only on the executors) or a mounted path. For llama.cpp bases (`holo3`) prefer a pre-converted `.gguf` adapter; vLLM bases serve the PEFT dir directly. Omit to serve the base (the *champion*). **Modal only** — on Baseten the adapter is a deployment-level env (`MANTIS_LORA_ADAPTER`), see [Baseten hosting](hosting/baseten.md). |
+| `_challenger_model` | ([#918](https://github.com/mercurialsolo/mantis/issues/918)) Serve this **full merged-GGUF model** in place of the base (the promotion-gate *challenger* via a `-m` swap, base `--mmproj` reused). This is the working path for the **`holo3` (qwen3_5_moe)** base, whose LoRA *adapter* can't be GGUF-converted but whose *merged* model can. A `"<volume>:/path/merged.gguf"` ref. llama.cpp bases only; mutually exclusive with `_lora_adapter`. |
+| `_lora_adapter` | ([#911](https://github.com/mercurialsolo/mantis/issues/911)) Serve **base + this LoRA adapter** (an *overlay*, not a full swap). A ref `"<volume>:/checkpoints/<algo>"` or a mounted path. For llama.cpp bases a pre-converted `.gguf` adapter (does **not** work for the `holo3` MoE arch — use `_challenger_model`); vLLM bases (`fara`) serve the PEFT dir directly. Omit (with `_challenger_model`) to serve the base. **Modal only** — on Baseten the challenger is a deployment-level env (`MANTIS_LORA_ADAPTER` / `MANTIS_HOLO3_GGUF`), see [Baseten hosting](hosting/baseten.md). |
 | `_lora_name` | vLLM only — served-model-name for the adapter (default `challenger`). |
 | `_lora_scale` | llama.cpp only — adapter scale (default `1.0`; emits `--lora-scaled`). |
 

--- a/docs/continuous-improvement-architecture.md
+++ b/docs/continuous-improvement-architecture.md
@@ -196,10 +196,13 @@ deployment**: the champion arm submits without `_lora_adapter` (base weights), t
 challenger arm submits *with* it. Backend is auto-selected by base
 (`mantis_agent.serving.lora_serving`):
 
-* **llama.cpp** bases (`holo3`, the first real challenger) apply a GGUF adapter via
-  `llama-server --lora`. The trainer should emit a pre-converted `.gguf` adapter so
-  the serving image needs no torch/transformers (a raw PEFT dir triggers an
-  in-server convert step instead).
+* **llama.cpp** bases apply a GGUF adapter via `llama-server --lora` (the trainer
+  emits a pre-converted `.gguf`; a raw PEFT dir triggers an in-server convert).
+  **Exception — `holo3` (qwen3_5_moe, #918):** its LoRA *adapter* can't be
+  GGUF-converted (`convert_lora_to_gguf` lacks the MoE arch), so the challenger is
+  a **full merged-GGUF model swap** (`_challenger_model` → `-m`, base `--mmproj`
+  reused). The trainer merges (peft) + `convert_hf_to_gguf` (which *does* support
+  the arch — the base GGUF proves it) + quantizes.
 * **vLLM** bases (`fara`/`opencua`/`evocua`) serve the PEFT dir via
   `--enable-lora`; the adapter is addressed by its served-model-name.
 
@@ -302,6 +305,7 @@ generates the next rollouts. *Days.*
 | Champion/challenger gate | ✅ on main |
 | Serve `base + LoRA adapter` challenger at `/v1/predict` (#911) | ✅ on main + deployed (GPU run deploy-gated) |
 | Holdout-eval runner — generate sim-env suites + gate vs `/v1/predict` (#916) | ✅ on main (`experiments/holdout/run_gate_eval.py`; live run spend-gated) |
+| Serve Holo3 (qwen3_5_moe) challenger — full merged-GGUF swap (#918) | ✅ on main (`_challenger_model`; trainer-side merge + live run spend-gated) |
 | Logprob capture (GRPO prerequisite, #889) | ✅ on main |
 | `RolloutRunner` execution adapter (generator → Daytona → Augur) | ⏳ P1 (#894) |
 | `mantis-trainer` data contract | ✅ scaffold + dataset implemented |

--- a/docs/hosting/baseten.md
+++ b/docs/hosting/baseten.md
@@ -161,36 +161,42 @@ uvx truss push deploy/baseten/holo3 --no-cache \
 
 You'll get a non-production environment URL. Run smoke tests there, then promote via the Baseten dashboard.
 
-## Serving a LoRA challenger for the promotion gate (#911)
+## Serving a challenger for the promotion gate (#911/#918)
 
-The slow-loop gate evaluates a trained **challenger** (`base + LoRA adapter`)
-against the **champion** (`base`). Unlike Modal — which boots a fresh inference
-server per run and picks the adapter per request — the Baseten pod boots **one**
-shared inference server at model-load, so the adapter is a **deployment-level**
-choice via env:
+The slow-loop gate evaluates a trained **challenger** against the **champion**
+(`base`). Unlike Modal — which boots a fresh inference server per run and picks
+the challenger per request — the Baseten pod boots **one** shared inference server
+at model-load, so the challenger is a **deployment-level** choice.
 
-| Env | Effect |
-|---|---|
-| `MANTIS_LORA_ADAPTER` | Serve `base + this adapter`. A path to a **pre-converted GGUF** adapter (llama.cpp bases) or a PEFT dir (vLLM bases), mounted via the truss `weights:` block. Unset ⇒ serve the base (champion). |
-| `MANTIS_LORA_SCALE` | llama.cpp only — adapter scale (default `1.0`; emits `--lora-scaled`). |
-| `MANTIS_LORA_NAME` | vLLM only — served-model-name for the adapter (default `challenger`). |
-
-> The serving image has **no** torch/transformers, so it can't convert a raw PEFT
-> dir for llama.cpp bases — point `MANTIS_LORA_ADAPTER` at a `.gguf` (convert in
-> the trainer with `convert_lora_to_gguf.py`). A non-`.gguf` ref for `holo3`
-> fails fast at boot.
-
-Deploy a challenger from the ready-made config
-([`deploy/baseten/holo3_challenger/config.yaml`](https://github.com/mercurialsolo/mantis/blob/main/deploy/baseten/holo3_challenger/config.yaml)) —
-it mirrors `holo3` plus a `weights:` entry for the adapter and the
-`MANTIS_LORA_ADAPTER` env. **Swap the adapter `source` for your trained GGUF repo
-first**, then:
+**Holo3 (qwen3_5_moe) — full-model swap (#918).** Holo3's LoRA *adapter* can't be
+GGUF-converted (`convert_lora_to_gguf` lacks the MoE arch), but the *merged* model
+can. So the Holo3 challenger is a **full merged-GGUF model**, not a `--lora`
+overlay — point `MANTIS_HOLO3_MODEL_DIR` at the merged model (mounted via the
+truss `weights:` block, alongside the base mmproj). The ready-made config
+([`deploy/baseten/holo3_challenger/config.yaml`](https://github.com/mercurialsolo/mantis/blob/main/deploy/baseten/holo3_challenger/config.yaml))
+does this; **swap its `weights:` `source` for your merged-model repo**, then:
 
 ```bash
 uvx truss push deploy/baseten/holo3_challenger --no-cache \
   --deployment-name "holo3-challenger-$(git rev-parse --short HEAD)" \
   --include-git-info
 ```
+
+The trainer produces the artifact: peft `merge_and_unload` (adapter + base) →
+`convert_hf_to_gguf.py` → quantize Q8_0 → publish.
+
+**Other (non-MoE / vLLM) bases — `--lora` overlay.** For bases whose adapter
+*can* be converted/served, set instead (deployment-level env):
+
+| Env | Effect |
+|---|---|
+| `MANTIS_LORA_ADAPTER` | Serve `base + this adapter`. A **pre-converted GGUF** adapter (llama.cpp bases) or a PEFT dir (vLLM bases), mounted via `weights:`. Unset ⇒ base (champion). |
+| `MANTIS_LORA_SCALE` | llama.cpp only — adapter scale (default `1.0`; emits `--lora-scaled`). |
+| `MANTIS_LORA_NAME` | vLLM only — served-model-name for the adapter (default `challenger`). |
+
+> The serving image has **no** torch/transformers, so it can't convert a raw PEFT
+> dir for llama.cpp bases — point `MANTIS_LORA_ADAPTER` at a `.gguf`. A non-`.gguf`
+> ref for a llama.cpp base fails fast at boot.
 
 Point the gate's `MANTIS_CHAMPION_ENDPOINT` at the `holo3` deploy and
 `MANTIS_EVAL_ENDPOINT` at this one, then compare win-rate over the frozen holdout

--- a/experiments/holdout/README.md
+++ b/experiments/holdout/README.md
@@ -116,13 +116,25 @@ The trainer's gate evaluates a **challenger** (`base + LoRA adapter`, #911) vs t
 feeds the per-arm results to `promotion_gate.evaluate` → a `GateVerdict`.
 
 ```
-# champion (base) vs challenger (adapter) over the 3 mantis-holdout-v1 tasks
+# champion (base) vs challenger over the 3 mantis-holdout-v1 tasks.
+# Holo3 (qwen3_5_moe): use --challenger-model (a merged full GGUF, #918) — its
+# LoRA *adapter* can't be GGUF-converted, but the *merged* model can.
 python experiments/holdout/run_gate_eval.py \
     --task indeed.t01_search_save_remote \
     --task indeed.t03_employer_review_applicant \
     --task linkedin.t02_post_text_update \
-    --lora-adapter mantis-trainer-vol:/checkpoints/sft-c3e0d799f432
+    --challenger-model mantis-trainer-vol:/checkpoints/sft-c3e0d799f432/merged.Q8_0.gguf
+# (non-MoE / vLLM bases instead take --lora-adapter <ref>, a --lora overlay.)
 ```
+
+**#918 — why `--challenger-model` for Holo3.** `/v1/predict` serves a challenger
+two ways: `_lora_adapter` (a `--lora` overlay) or `_challenger_model` (a full
+merged-GGUF `-m` swap). Holo3's `qwen3_5_moe` LoRA adapter can't be converted to
+GGUF (`convert_lora_to_gguf` doesn't support the MoE arch), but the **merged**
+model can (`convert_hf_to_gguf` does — the base GGUF proves it). The trainer
+produces the merged GGUF (peft `merge_and_unload` → `convert_hf_to_gguf.py` →
+quantize Q8_0 → `mantis-trainer-vol`); the runner serves it via `-m`, reusing the
+base `--mmproj`. This is what unblocks real (non-`failed`) challenger arms.
 
 Each (task, arm) gets a distinct `profile_id` (`gate-<arm>-<task>`), so the two
 arms never collide on one Chrome profile (the per-`profile_id` 409 rule) and all

--- a/experiments/holdout/run_gate_eval.py
+++ b/experiments/holdout/run_gate_eval.py
@@ -90,12 +90,15 @@ def build_eval_suite(
     arm: str,
     task_key: str,
     lora_adapter: str = "",
+    challenger_model: str = "",
 ) -> dict[str, Any]:
     """Build the ``/v1/predict`` ``task_suite`` for one (task, arm).
 
-    Champion arm omits ``_lora_adapter`` (serves the base); challenger arm sets it
-    (serves base + adapter, #911). ``profile_id``/``workflow_id`` are scoped per
-    (arm, task) so the two arms never collide on one Chrome profile (#912).
+    Champion arm serves the base (no challenger field); challenger arm sets either
+    ``_challenger_model`` (#918 full merged-GGUF swap — the working path for the
+    qwen3_5_moe Holo3 base) or ``_lora_adapter`` (#911 adapter, for non-MoE/vLLM
+    bases). ``profile_id``/``workflow_id`` are scoped per (arm, task) so the two
+    arms never collide on one Chrome profile (#912).
     """
     micro = _micro_plan_dicts(spec_def, info["url"])
     domain = spec_def["oracle_task_id"].split(".")[0]
@@ -109,7 +112,9 @@ def build_eval_suite(
     suite["_oracle_task_id"] = spec_def["oracle_task_id"]
     suite["_oracle_admin_token"] = info["admin_token"]
     suite["_oracle_preview_token"] = info["preview_token"]
-    if lora_adapter:  # #911 — challenger arm
+    if challenger_model:  # #918 — full-model swap challenger arm
+        suite["_challenger_model"] = challenger_model
+    elif lora_adapter:  # #911 — adapter challenger arm
         suite["_lora_adapter"] = lora_adapter
     return suite
 
@@ -152,10 +157,13 @@ def arm_from_results(results: list[dict[str, Any]], label: str = "arm") -> ArmRe
 
 def _run_one(
     task_key: str, spec_def: dict[str, Any], info: dict[str, str], token: str,
-    *, arm: str, lora_adapter: str, max_steps: int, poll_seconds: int,
+    *, arm: str, lora_adapter: str, challenger_model: str, max_steps: int, poll_seconds: int,
 ) -> dict[str, Any]:
     """Submit one (task, arm) to /v1/predict, poll to terminal, oracle-grade."""
-    suite = build_eval_suite(spec_def, info, arm=arm, task_key=task_key, lora_adapter=lora_adapter)
+    suite = build_eval_suite(
+        spec_def, info, arm=arm, task_key=task_key,
+        lora_adapter=lora_adapter, challenger_model=challenger_model,
+    )
     code, resp = rst._post(token, {
         "task_suite": suite, "profile_id": suite["_profile_id"],
         "workflow_id": suite["_workflow_id"], "cua_model": "holo3",
@@ -197,8 +205,8 @@ def _resolve_envs(task_keys: list[str], dayt: str) -> dict[str, dict[str, str]]:
 
 
 def run_gate(
-    task_keys: list[str], *, lora_adapter: str, max_steps: int, poll_seconds: int,
-    max_parallel: int, gate: PromotionGate,
+    task_keys: list[str], *, lora_adapter: str = "", challenger_model: str = "",
+    max_steps: int, poll_seconds: int, max_parallel: int, gate: PromotionGate,
 ) -> tuple[GateVerdict, list[dict[str, Any]]]:
     """Run champion + challenger arms over the holdout tasks and gate them."""
     env = rst._load_env()
@@ -217,9 +225,10 @@ def run_gate(
         spec = SEALED_TASKS[task_key]
         info = infos[spec["env"]]
         adapter = lora_adapter if arm == CHALLENGER else ""
+        cmodel = challenger_model if arm == CHALLENGER else ""
         return lambda _k: _run_one(
             task_key, spec, info, token, arm=arm, lora_adapter=adapter,
-            max_steps=max_steps, poll_seconds=poll_seconds,
+            challenger_model=cmodel, max_steps=max_steps, poll_seconds=poll_seconds,
         )
 
     dispatcher = StateKeyDispatcher(max_parallel=max(1, max_parallel))
@@ -238,7 +247,10 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--task", action="append", dest="tasks", default=[],
                     help=f"holdout task key (repeatable); known: {sorted(SEALED_TASKS)}")
     ap.add_argument("--lora-adapter", default="",
-                    help="#911 challenger adapter ref (omit ⇒ challenger == base, sanity run)")
+                    help="#911 challenger adapter ref (--lora; non-MoE / vLLM bases)")
+    ap.add_argument("--challenger-model", default="",
+                    help="#918 full merged-GGUF challenger ref (-m swap; the working path "
+                         "for the qwen3_5_moe Holo3 base). Mutually exclusive with --lora-adapter")
     ap.add_argument("--max-steps", type=int, default=25)
     ap.add_argument("--poll-seconds", type=int, default=600)
     ap.add_argument("--max-parallel", type=int, default=4)
@@ -267,18 +279,22 @@ def main(argv: list[str] | None = None) -> int:
         print(f"wrote {len(keys)} task(s) → {args.emit_tasks}")
         return 0
 
-    if not args.lora_adapter:
-        print("⚠️  no --lora-adapter: champion and challenger both serve the base "
+    if args.lora_adapter and args.challenger_model:
+        print("ERROR: pass only one of --lora-adapter / --challenger-model", file=sys.stderr)
+        return 2
+    if not args.lora_adapter and not args.challenger_model:
+        print("⚠️  no challenger ref: champion and challenger both serve the base "
               "(a plumbing sanity run — expect delta≈0, promote=False).", file=sys.stderr)
 
     verdict, results = run_gate(
-        keys, lora_adapter=args.lora_adapter, max_steps=args.max_steps,
-        poll_seconds=args.poll_seconds, max_parallel=args.max_parallel,
-        gate=PromotionGate(),
+        keys, lora_adapter=args.lora_adapter, challenger_model=args.challenger_model,
+        max_steps=args.max_steps, poll_seconds=args.poll_seconds,
+        max_parallel=args.max_parallel, gate=PromotionGate(),
     )
     print("\n[gate eval result]")
     print(json.dumps({
         "lora_adapter": args.lora_adapter,
+        "challenger_model": args.challenger_model,
         "results": results,
         "verdict": {
             "promote": verdict.promote, "reason": verdict.reason,

--- a/src/mantis_agent/serving/lora_serving.py
+++ b/src/mantis_agent/serving/lora_serving.py
@@ -96,6 +96,12 @@ class ServingPlan:
     adapter_local_dir: str | None = None
     adapter_gguf_path: str | None = None
     convert_cmd: list[str] | None = None
+    # #918 full-model-swap challenger: a merged-and-converted full GGUF served via
+    # llama-server ``-m`` *instead of* the base. Used for Holo3 (qwen3_5_moe),
+    # whose LoRA *adapter* can't be GGUF-converted but whose merged *full* model
+    # can (convert_hf_to_gguf supports the arch — the base GGUF proves it). When
+    # set, the executor swaps ``-m`` to this path and keeps the base ``--mmproj``.
+    model_path_override: str | None = None
     # Short, stable id for tagging the run / Augur (so the gate can attribute a
     # result to the right challenger). Empty string when serving the base.
     challenger_tag: str = ""
@@ -242,16 +248,46 @@ def plan_serving(
 ) -> ServingPlan:
     """Produce a :class:`ServingPlan` for a request.
 
-    Reads ``suite['_lora_adapter']`` (and optional ``_lora_name``,
-    ``_lora_scale``, ``_lora_max_rank``). When absent, returns a base-only plan
-    (no adapter args, base served-name) — the common production path is
-    untouched. When present, returns the backend-appropriate plan.
+    Reads ``suite['_challenger_model']`` (#918 full-model swap) or
+    ``suite['_lora_adapter']`` (+ optional ``_lora_name`` / ``_lora_scale`` /
+    ``_lora_max_rank``). When neither is set, returns a base-only plan (the common
+    production path is untouched). The two are mutually exclusive.
     """
     backend = serving_backend(cua_model)
+    raw_model = str(suite.get("_challenger_model") or "").strip()
     raw_ref = str(suite.get("_lora_adapter") or "").strip()
-    if not raw_ref:
+    if raw_model and raw_ref:
+        raise LoraServingError(
+            "set only one of _challenger_model (full-model swap) or _lora_adapter (adapter)"
+        )
+    if not raw_model and not raw_ref:
         return ServingPlan(
             backend=backend, lora_active=False, served_model_name=base_served_name
+        )
+
+    # #918: full-model-swap challenger (the only path that works for the
+    # qwen3_5_moe Holo3 base — its LoRA adapter can't be GGUF-converted, but a
+    # merged full model can). Only meaningful for llama.cpp (per-run model load);
+    # vLLM bases load one model at boot, so a merged model is a separate deploy.
+    if raw_model:
+        if backend != "llamacpp":
+            raise LoraServingError(
+                "_challenger_model (full-model swap) is supported only for llama.cpp "
+                "bases (holo3/gemma4-cua); for vLLM bases deploy the merged model as "
+                "its own endpoint"
+            )
+        mref = parse_adapter_ref(raw_model)
+        mpath = local_adapter_dir(mref, mounts)
+        if not mpath.endswith(".gguf"):
+            raise LoraServingError(
+                f"_challenger_model must be a full .gguf model (got {mpath!r})"
+            )
+        return ServingPlan(
+            backend=backend,
+            lora_active=False,  # a model swap, not an adapter overlay
+            served_model_name=base_served_name,
+            model_path_override=mpath,
+            challenger_tag=challenger_tag(mref),
         )
 
     ref = parse_adapter_ref(raw_ref)

--- a/tests/test_eval_harness.py
+++ b/tests/test_eval_harness.py
@@ -317,6 +317,26 @@ def test_http_runner_attaches_adapter_on_plan_text_path(monkeypatch):
     assert bodies[0]["task_suite"]["_lora_adapter"] == "/data/ckpt/x"
 
 
+def test_http_runner_challenger_model_full_swap(monkeypatch):
+    bodies = _capture_post(monkeypatch)
+    runner = _http_runner_factory(
+        "https://x.modal.run", challenger_model="mantis-trainer-vol:/checkpoints/sft-x/m.gguf"
+    )
+    runner(_micro_task())
+    assert bodies[0]["task_suite"]["_challenger_model"].endswith("m.gguf")
+    assert "_lora_adapter" not in bodies[0]["task_suite"]
+
+
+def test_http_runner_challenger_model_precedence(monkeypatch):
+    bodies = _capture_post(monkeypatch)
+    runner = _http_runner_factory(
+        "https://x.modal.run", lora_adapter="/a.gguf", challenger_model="/m.gguf"
+    )
+    runner(_micro_task())
+    assert bodies[0]["task_suite"]["_challenger_model"] == "/m.gguf"
+    assert "_lora_adapter" not in bodies[0]["task_suite"]
+
+
 def test_http_runner_forwards_cua_model(monkeypatch):
     bodies = _capture_post(monkeypatch)
     runner = _http_runner_factory("https://x.modal.run", cua_model="fara")

--- a/tests/test_gate_eval_916.py
+++ b/tests/test_gate_eval_916.py
@@ -62,6 +62,25 @@ def test_challenger_arm_sets_adapter():
     assert suite["_lora_adapter"] == "mantis-trainer-vol:/checkpoints/sft-x"
 
 
+def test_challenger_model_full_swap_arm():
+    # #918: full-model-swap challenger sets _challenger_model (not _lora_adapter).
+    suite = rge.build_eval_suite(
+        _SPEC, _INFO, arm=rge.CHALLENGER, task_key=_KEY,
+        challenger_model="mantis-trainer-vol:/checkpoints/sft-x/merged.Q8_0.gguf",
+    )
+    assert suite["_challenger_model"].endswith("merged.Q8_0.gguf")
+    assert "_lora_adapter" not in suite
+
+
+def test_challenger_model_takes_precedence_over_adapter():
+    suite = rge.build_eval_suite(
+        _SPEC, _INFO, arm=rge.CHALLENGER, task_key=_KEY,
+        lora_adapter="vol:/a.gguf", challenger_model="vol:/m.gguf",
+    )
+    assert suite["_challenger_model"] == "vol:/m.gguf"
+    assert "_lora_adapter" not in suite
+
+
 def test_arms_use_distinct_profile_ids():
     champ = rge.build_eval_suite(_SPEC, _INFO, arm=rge.CHAMPION, task_key=_KEY)
     chal = rge.build_eval_suite(_SPEC, _INFO, arm=rge.CHALLENGER, task_key=_KEY)

--- a/tests/test_lora_serving.py
+++ b/tests/test_lora_serving.py
@@ -259,6 +259,44 @@ def test_plan_claude_with_adapter_raises():
         )
 
 
+# ── #918 full-model-swap challenger ─────────────────────────────────────
+
+
+def test_plan_full_model_swap_llamacpp():
+    suite = {"_challenger_model": "mantis-trainer-vol:/checkpoints/sft-x/merged.Q8_0.gguf"}
+    plan = plan_serving(
+        cua_model="holo3", suite=suite, mounts=TRAINER_MOUNTS, gguf_cache_root="/data/lc"
+    )
+    assert plan.lora_active is False  # a model swap, not an adapter overlay
+    assert plan.model_path_override == "/trainer/checkpoints/sft-x/merged.Q8_0.gguf"
+    assert plan.extra_server_args == []  # no --lora; the executor swaps -m
+    assert plan.served_model_name == "model"
+    assert plan.challenger_tag.startswith("merged.Q8_0-") or plan.challenger_tag
+
+
+def test_plan_full_model_swap_requires_gguf():
+    suite = {"_challenger_model": "mantis-trainer-vol:/checkpoints/sft-x"}  # no .gguf
+    with pytest.raises(LoraServingError, match="must be a full .gguf"):
+        plan_serving(cua_model="holo3", suite=suite, mounts=TRAINER_MOUNTS, gguf_cache_root="/d")
+
+
+def test_plan_full_model_swap_rejected_for_vllm():
+    suite = {"_challenger_model": "/data/merged.gguf"}
+    with pytest.raises(LoraServingError, match="only for llama.cpp"):
+        plan_serving(cua_model="fara", suite=suite, mounts=TRAINER_MOUNTS, gguf_cache_root="/d")
+
+
+def test_plan_rejects_both_challenger_model_and_adapter():
+    suite = {"_challenger_model": "/data/m.gguf", "_lora_adapter": "/data/a.gguf"}
+    with pytest.raises(LoraServingError, match="only one of"):
+        plan_serving(cua_model="holo3", suite=suite, mounts=TRAINER_MOUNTS, gguf_cache_root="/d")
+
+
+def test_plan_base_only_has_no_model_override():
+    plan = plan_serving(cua_model="holo3", suite={}, mounts=TRAINER_MOUNTS, gguf_cache_root="/d")
+    assert plan.model_path_override is None
+
+
 def test_adapterref_is_frozen():
     ref = AdapterRef(path="/x", raw="/x")
     with pytest.raises(Exception):

--- a/training/eval_harness.py
+++ b/training/eval_harness.py
@@ -414,17 +414,18 @@ def load_report(path: Path) -> EvalReport:
 
 
 def _http_runner_factory(
-    endpoint: str, token: str = "", *, lora_adapter: str = "", cua_model: str = ""
+    endpoint: str, token: str = "", *, lora_adapter: str = "",
+    challenger_model: str = "", cua_model: str = "",
 ) -> RunnerFn:
     """Build a runner that submits each task through the production
     ``/v1/predict`` endpoint and polls until terminal. Used by the
     ``run`` subcommand. Lazy: only imported when the CLI actually fires.
 
-    #911: pass ``lora_adapter`` to evaluate a **challenger** — the server serves
-    ``base + adapter`` when the suite carries ``_lora_adapter``. The *champion*
-    run uses the same endpoint with ``lora_adapter=""`` (serves the base), so the
-    promotion gate can point both arms at one deployment. ``cua_model`` overrides
-    the base model (default server pick is ``holo3``).
+    #911/#918: pass ``lora_adapter`` (adapter overlay) or ``challenger_model`` (a
+    full merged-GGUF swap — the working path for the qwen3_5_moe Holo3 base) to
+    evaluate a **challenger**. The *champion* run uses the same endpoint with
+    neither set (serves the base), so the promotion gate can point both arms at
+    one deployment. ``cua_model`` overrides the base model (default ``holo3``).
     """
     import requests
 
@@ -450,9 +451,13 @@ def _http_runner_factory(
                 {"intent": f"Navigate to {task.url}", "type": "navigate",
                  "section": "setup", "required": True},
             ])
-        # #911: attach the challenger adapter to the suite so the server serves
-        # base + adapter. Ensure a task_suite exists even on the plan_text path.
-        if lora_adapter:
+        # #911/#918: attach the challenger to the suite so the server serves the
+        # challenger. _challenger_model (#918 full-model swap, e.g. Holo3) takes
+        # precedence over _lora_adapter (#911). Ensure a task_suite exists even on
+        # the plan_text path.
+        if challenger_model:
+            body.setdefault("task_suite", {})["_challenger_model"] = challenger_model
+        elif lora_adapter:
             body.setdefault("task_suite", {})["_lora_adapter"] = lora_adapter
         headers = {"Content-Type": "application/json"}
         if token:
@@ -488,6 +493,7 @@ def _cmd_run(args: argparse.Namespace) -> int:
     runner = _http_runner_factory(
         args.runner, token=args.token,
         lora_adapter=getattr(args, "lora_adapter", ""),
+        challenger_model=getattr(args, "challenger_model", ""),
         cua_model=getattr(args, "cua_model", ""),
     )
     report = run_eval(runner, tasks, name=args.name or Path(args.tasks).stem)
@@ -538,6 +544,10 @@ def main(argv: list[str] | None = None) -> int:
                      help="#911: serve base + this LoRA adapter (challenger arm). "
                           "Ref: '<volume>:/checkpoints/<algo>' or a mounted path. "
                           "Omit for the champion arm (serves the base).")
+    run.add_argument("--challenger-model", default="",
+                     help="#918: serve this full merged-GGUF model (challenger arm) — the "
+                          "working path for the qwen3_5_moe Holo3 base. Mutually exclusive "
+                          "with --lora-adapter.")
     run.add_argument("--cua-model", default="",
                      help="Override the base model (default server pick: holo3)")
     run.set_defaults(func=_cmd_run)


### PR DESCRIPTION
Closes #918 — the serving gap behind the first (correct-but-infra) HOLD verdict.

## The blocker
The first live gate run failed all challenger arms in ~25s: a **Holo3 LoRA can't be served**.
- llama.cpp hosts the qwen3_5_moe *base* GGUF, but `convert_lora_to_gguf.py` doesn't support the qwen3_5_moe *adapter*.
- vLLM does LoRA natively but lacks the (multimodal) qwen3_5_moe arch.

## Fix — Option 1: merge → full GGUF → model swap
Decisive fact: the base GGUF `mradermacher/Holo3-35B-A3B-GGUF` exists, which means `convert_hf_to_gguf.py` **does** support this arch — so a *merged* full model converts fine, even though the *adapter* converter doesn't. And serving a full GGUF is trivial in our stack (`run_holo3` already does `-m <gguf> --mmproj <mmproj>`).

**Mantis-owned (this PR):** a `_challenger_model` serving mode — a full merged GGUF served via `-m` (base `--mmproj` reused), distinct from `_lora_adapter` (the `--lora` overlay, still valid for non-MoE / vLLM bases).
- `lora_serving.plan_serving` → `ServingPlan.model_path_override` (llama.cpp-only, `.gguf`-only, mutually exclusive with `_lora_adapter`).
- `modal_cua_server`: `_prepare_lora_serving` resolves + existence-checks the merged GGUF (no convert); `run_holo3` swaps `-m`. No-challenger path untouched.
- `run_gate_eval.py` + `eval_harness.py`: `--challenger-model` (precedence over `--lora-adapter`).
- `deploy/baseten/holo3_challenger`: rewritten to a full-model deploy (`MANTIS_HOLO3_MODEL_DIR` → merged GGUF via `weights:` + base mmproj) — **no Baseten code change** (reuses existing `_load_holo3` env).

**Trainer-owned (the issue notes the trainer side is set up):** peft `merge_and_unload` → `convert_hf_to_gguf.py` → quantize Q8_0 → `mantis-trainer-vol`.

```bash
python experiments/holdout/run_gate_eval.py \
  --task indeed.t01_search_save_remote --task indeed.t03_employer_review_applicant \
  --task linkedin.t02_post_text_update \
  --challenger-model mantis-trainer-vol:/checkpoints/<id>/merged.Q8_0.gguf
```

## Tests / docs
+12 tests (lora_serving full-swap shape + guards, gate_eval arm, eval_harness wiring); **81 pass**; ruff + `mkdocs --strict` clean. Docs: api.md suite field, CI-architecture serving subsection + status row, baseten.md challenger recipe, holdout README. The live verdict (deploy + a real merged GGUF on `mantis-trainer-vol` + GPU spend) is the deploy-gated final step — but the serving path that blocked it is now closed.

## Acceptance
A merged Holo3 challenger is servable at `/v1/predict` (`-m` swap), so challenger arms **run** instead of `failed`, and `run_gate_eval` returns a real `GateVerdict`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)