### PR TITLE
feat(holdout): expand to ~18 tasks for gate significance + fix gate-eval 409 (#920)

### DIFF
--- a/experiments/holdout/README.md
+++ b/experiments/holdout/README.md
@@ -197,6 +197,41 @@ Until those runs land, `eval_set.json` here is the **curated definition** (the
 source of truth for *what* the holdout contains); the Augur eval-version is the
 frozen, run-backed instance.
 
+## Expanding to `mantis-holdout-v2` (#920)
+
+`mantis-holdout-v1` has only **3 runnable tasks** — too few for the gate's paired
+bootstrap to certify a real improvement (a clean win tops out at
+`prob_improvement ≈ 0.70`; clearing `0.95` needs **~15+** tasks). #920 expands the
+holdout so a genuinely better challenger can finally **PROMOTE**.
+
+`sealed_plans.SEALED_TASKS` now carries **~18 tasks across 8 envs** — the 4
+v1-frozen tasks (`status="verified"`) plus **14 v2 candidates**
+(`status="candidate"`), each authored offline and **grounded** from its env's
+`app/oracles/*` + `app/templates/*` (the canonical source). Candidates span
+`login`, `form_fill`, `crud_create`/`crud_edit`, `export`, `navigate` clusters
+across indeed / mercor / auth / shopify / crm / shop.
+
+**Authored offline; not yet runnable.** These are *candidates* — the freeze only
+admits tasks that successfully **ran** (run → eval-candidate → freeze), so each
+needs a live pass. Two-step:
+
+1. **Live-verify** (spend-gated): wire each env's sandbox/URL in `SANDBOXES`
+   (the v2 envs are placeholders today; Modal-hosted envs — crm/shop/shopify/auth
+   — need a Modal URL rather than a Daytona id), then run each candidate through
+   Mantis (`run_sealed_task.py`) until its oracle grades `passed`, fixing
+   interaction quirks (select-vs-text fill, AJAX no-nav, exact labels).
+2. **Freeze** the survivors into `mantis-holdout-v2` via `freeze_eval_version.py`
+   (operator session cookie), then `python -m mantis_trainer.holdout --version
+   mantis-holdout-v2` materializes the runnable set.
+
+**Deliberately excluded** (need capabilities a static plan lacks, authored during
+the live pass instead): `auth.T07_email_otp` (read a *dynamic* OTP from `/inbox`
+at runtime) and `boattrader.BT01/BT02/BT03` (need a live-discovered listing id +
+loop/guard for the Caterpillar-spec / gated-reveal logic).
+
+Re-gating `run_gate_eval.py --challenger-model <ref>` over the frozen v2 is what
+yields the flywheel's first real **PROMOTE**.
+
 ## Why these tasks
 
 - **Type coverage over site coverage** — every capability an agent needs is

--- a/experiments/holdout/run_gate_eval.py
+++ b/experiments/holdout/run_gate_eval.py
@@ -40,6 +40,7 @@ import argparse
 import json
 import sys
 import time
+import uuid
 from pathlib import Path
 from typing import Any
 
@@ -91,6 +92,7 @@ def build_eval_suite(
     task_key: str,
     lora_adapter: str = "",
     challenger_model: str = "",
+    run_nonce: str = "",
 ) -> dict[str, Any]:
     """Build the ``/v1/predict`` ``task_suite`` for one (task, arm).
 
@@ -99,10 +101,15 @@ def build_eval_suite(
     qwen3_5_moe Holo3 base) or ``_lora_adapter`` (#911 adapter, for non-MoE/vLLM
     bases). ``profile_id``/``workflow_id`` are scoped per (arm, task) so the two
     arms never collide on one Chrome profile (#912).
+
+    #920: ``run_nonce`` (a per-invocation id) is appended to the profile so a
+    *prior* gate run's stale Chrome-profile lock can't 409 this run and cost an
+    arm. Each gate invocation uses fresh profiles; the env is reset per run so
+    there's no login to preserve.
     """
     micro = _micro_plan_dicts(spec_def, info["url"])
     domain = spec_def["oracle_task_id"].split(".")[0]
-    ident = f"gate-{arm}-{task_key}"
+    ident = f"gate-{arm}-{task_key}" + (f"-{run_nonce}" if run_nonce else "")
     suite = build_micro_suite(micro, domain, profile_id=ident, workflow_id=ident)
     suite["_plan_name"] = spec_def["oracle_task_id"]
     suite["_browser_extra_headers"] = rst._daytona_headers(info["preview_token"])
@@ -157,12 +164,13 @@ def arm_from_results(results: list[dict[str, Any]], label: str = "arm") -> ArmRe
 
 def _run_one(
     task_key: str, spec_def: dict[str, Any], info: dict[str, str], token: str,
-    *, arm: str, lora_adapter: str, challenger_model: str, max_steps: int, poll_seconds: int,
+    *, arm: str, lora_adapter: str, challenger_model: str, run_nonce: str,
+    max_steps: int, poll_seconds: int,
 ) -> dict[str, Any]:
     """Submit one (task, arm) to /v1/predict, poll to terminal, oracle-grade."""
     suite = build_eval_suite(
         spec_def, info, arm=arm, task_key=task_key,
-        lora_adapter=lora_adapter, challenger_model=challenger_model,
+        lora_adapter=lora_adapter, challenger_model=challenger_model, run_nonce=run_nonce,
     )
     code, resp = rst._post(token, {
         "task_suite": suite, "profile_id": suite["_profile_id"],
@@ -215,6 +223,10 @@ def run_gate(
         raise SystemExit("ERROR: MANTIS_API_TOKEN + DAYTONA_API_KEY required")
     infos = _resolve_envs(task_keys, dayt)
 
+    # #920: a per-invocation nonce so fresh profiles are used each run — a prior
+    # run's stale Chrome-profile lock can't 409 this run and cost an arm.
+    nonce = uuid.uuid4().hex[:8]
+
     # One job per (task, arm). Distinct profile_id per job → all independent (#912).
     jobs: list[tuple[str, str]] = []  # (task_key, arm)
     for key in task_keys:
@@ -228,12 +240,13 @@ def run_gate(
         cmodel = challenger_model if arm == CHALLENGER else ""
         return lambda _k: _run_one(
             task_key, spec, info, token, arm=arm, lora_adapter=adapter,
-            challenger_model=cmodel, max_steps=max_steps, poll_seconds=poll_seconds,
+            challenger_model=cmodel, run_nonce=nonce,
+            max_steps=max_steps, poll_seconds=poll_seconds,
         )
 
     dispatcher = StateKeyDispatcher(max_parallel=max(1, max_parallel))
     results = dispatcher.run_all(
-        [Call(_mk(k, arm), state_key=f"gate-{arm}-{k}") for (k, arm) in jobs]
+        [Call(_mk(k, arm), state_key=f"gate-{arm}-{k}-{nonce}") for (k, arm) in jobs]
     )
     dispatcher.shutdown()
 

--- a/experiments/holdout/sealed_plans.py
+++ b/experiments/holdout/sealed_plans.py
@@ -26,6 +26,15 @@ SANDBOXES: dict[str, str] = {
     "mercor": "f0f3ffc9-4879-48a9-98db-b5b5224fe20f",
     "linkedin": "f43c50dd-0edb-4667-8b50-2ff2f697de24",
     "fiverr": "d2c59f51-ca2e-48d2-b436-370b18673b79",
+    # #920 v2-candidate envs — sandbox ids TODO: the live-verification pass
+    # resolves + fills these (Daytona id, or a Modal sim-env URL for the
+    # Modal-hosted envs crm/shop/shopify/auth). Empty ⇒ _daytona_env fails
+    # fast at run time, by design — these tasks aren't runnable until wired.
+    "auth": "",
+    "boattrader": "",
+    "shopify": "",
+    "crm": "",
+    "shop": "",
 }
 
 
@@ -165,6 +174,206 @@ SEALED_TASKS: dict[str, dict[str, Any]] = {
                 "Type a positive comment into the review body box (the 5-star rating is pre-selected)",
             ),
             _submit("Publish review", "Click 'Publish review' to submit the 5-star review", required=False),
+        ],
+    },
+
+    # ══════════════════════════════════════════════════════════════════
+    # #920 v2 CANDIDATES — grounded offline from each env's app/oracles/* +
+    # app/templates/* (the canonical grounding source). status="candidate":
+    # authored but NOT yet live-verified. The verification pass runs each
+    # through Mantis (Daytona/Modal) until its oracle grades `passed`, fixing
+    # interaction quirks (select vs text fill, AJAX no-nav, exact labels),
+    # THEN freezes the survivors into mantis-holdout-v2. Excluded (need
+    # runtime capabilities a static plan lacks): auth.T07_email_otp (dynamic
+    # OTP read), boattrader.BT01/02/03 (need a live-discovered listing id +
+    # loop/guard) — authored during the live pass.
+    # ══════════════════════════════════════════════════════════════════
+
+    # indeed t02 — multi-step Easy Apply wizard on job_00012 (jk 000000000000000c).
+    "indeed.t02_easy_apply": {
+        "env": "indeed", "status": "candidate",
+        "plan_name": "t02_easy_apply", "oracle_task_id": "t02_easy_apply",
+        "task_text": "Easy-apply to job_00012 with phone, resume, and screening answers.",
+        "steps": [
+            _nav("{env_url}/jobs/000000000000000c", "Open job_00012 and its Easy apply flow"),
+            _click("Click 'Easy apply' to start the application", label="Easy apply", required=False),
+            _fill("Full name", "Jordan Rivera", "Type the applicant full name"),
+            _fill("Email", "jordan.rivera@example.com", "Type the applicant email"),
+            _fill("Phone", "(555) 123-4567", "Type the applicant phone"),
+            _submit("Continue", "Advance to the resume step", required=False),
+            _submit("Continue", "Keep the pre-selected resume and advance", required=False),
+            _submit("Continue", "Advance past the screening questions (defaults pre-filled)", required=False),
+            _submit("Submit application", "Submit the application", required=False),
+        ],
+    },
+    # mercor t01 — multi-step apply wizard on job_00001.
+    "mercor.t01_apply_to_ml_engineer": {
+        "env": "mercor", "status": "candidate",
+        "plan_name": "t01_apply_to_ml_engineer", "oracle_task_id": "t01_apply_to_ml_engineer",
+        "task_text": "Apply to job_00001 with the screening answers.",
+        "steps": [
+            _nav("{env_url}/jobs/job_00001", "Open job_00001 and its apply flow"),
+            _click("Click 'Apply' to start the application", label="Apply", required=False),
+            _fill("Headline", "Internal Medicine Physician, 8 years", "Type the profile headline"),
+            _fill("Hourly rate ($/hr)", "150", "Type the hourly rate"),
+            _submit("Next", "Advance to the resume step", required=False),
+            _fill("Resume text", "Board-certified Internal Medicine physician, 8+ years clinical practice with strong diagnostic reasoning.", "Type resume text"),
+            _submit("Next", "Advance to the screening step", required=False),
+            _fill("Are you board-eligible or board-certified in Internal Medicine?", "Yes, board-certified", "Answer the board-certification question"),
+            _fill("What is your earliest start date?", "2026-07-01", "Answer the start-date question"),
+            _submit("Next", "Advance to review", required=False),
+            _submit("Submit application", "Submit the application", required=False),
+        ],
+    },
+
+    # auth T01 — password login.
+    "auth.T01_password_login": {
+        "env": "auth", "status": "candidate",
+        "plan_name": "T01_password_login", "oracle_task_id": "T01_password_login",
+        "task_text": "Sign in with the given username and password.",
+        "steps": [
+            _nav("{env_url}/login", "Open the sign-in page"),
+            _fill("Email", "ada@mantis.example", "Type the account email"),
+            _fill("Password", "hunter2", "Type the account password"),
+            _submit("Sign in", "Submit the sign-in form", required=False),
+        ],
+    },
+    # auth T08 — passkey assertion (simulated as a form POST; click the enrolled passkey).
+    "auth.T08_passkey": {
+        "env": "auth", "status": "candidate",
+        "plan_name": "T08_passkey", "oracle_task_id": "T08_passkey",
+        "task_text": "Complete the passkey assertion ceremony to sign in.",
+        "steps": [
+            _nav("{env_url}/login", "Open the sign-in page"),
+            _click("Choose passkey sign-in", label="Use a passkey", required=False),
+            _submit("Assert with the enrolled passkey (MacBook Touch ID)", "Submit the passkey assertion", required=False),
+        ],
+    },
+    # auth T02 — Google OAuth (simulated picker + consent).
+    "auth.T02_oauth_google": {
+        "env": "auth", "status": "candidate",
+        "plan_name": "T02_oauth_google", "oracle_task_id": "T02_oauth_google",
+        "task_text": "Authorize sign-in via the Google OAuth provider.",
+        "steps": [
+            _nav("{env_url}/login", "Open the sign-in page"),
+            _click("Start Google OAuth", label="Continue with Google", required=False),
+            _click("Pick the seeded Google account", label="ada@mantis.example", required=False),
+            _submit("Allow", "Grant consent to complete the OAuth sign-in", required=False),
+        ],
+    },
+
+    # shopify t04 — create a support ticket.
+    "shopify.t04_create_support_ticket": {
+        "env": "shopify", "status": "candidate",
+        "plan_name": "t04_create_support_ticket", "oracle_task_id": "t04_create_support_ticket",
+        "task_text": "Create a support ticket with a subject, category, and description.",
+        "steps": [
+            _nav("{env_url}/support/contact", "Open the support contact form"),
+            _fill("Subject", "API payout retrieval failing", "Type the ticket subject"),
+            _fill("Category", "Payouts", "Choose the ticket category"),
+            _fill("Description", "Unable to retrieve payout history via the API endpoint; returns 500.", "Type the description"),
+            _submit("Submit ticket", "Submit the support ticket", required=False),
+        ],
+    },
+    # shopify t05 — update business email in Settings.
+    "shopify.t05_update_business_email": {
+        "env": "shopify", "status": "candidate",
+        "plan_name": "t05_update_business_email", "oracle_task_id": "t05_update_business_email",
+        "task_text": "Update the business email in Settings to the given address.",
+        "steps": [
+            _nav("{env_url}/settings", "Open Settings"),
+            _fill("Business email", "ops@newcompany.example", "Type the new business email"),
+            _submit("Save", "Save the contact information", required=False),
+        ],
+    },
+    # shopify t03 — export payouts CSV (audit-logged; download, no nav).
+    "shopify.t03_export_payouts_csv": {
+        "env": "shopify", "status": "candidate",
+        "plan_name": "t03_export_payouts_csv", "oracle_task_id": "t03_export_payouts_csv",
+        "task_text": "Export the payouts list as CSV.",
+        "steps": [
+            _nav("{env_url}/payouts", "Open the Payouts page"),
+            _click("Export the payouts as CSV", label="Export CSV", required=False),
+        ],
+    },
+    # shopify t11 — open a store's detail page from the Stores list.
+    "shopify.t11_view_store_detail": {
+        "env": "shopify", "status": "candidate",
+        "plan_name": "t11_view_store_detail", "oracle_task_id": "t11_view_store_detail",
+        "task_text": "Open a store's detail page from the Stores list.",
+        "steps": [
+            _nav("{env_url}/stores", "Open the Stores list"),
+            _click("Open the first store's detail page", label="EA demostore", required=False),
+        ],
+    },
+
+    # crm T04 — add a meeting note to Sarah Chen (contact_00042), dated yesterday.
+    "crm.T04_add_meeting_note": {
+        "env": "crm", "status": "candidate",
+        "plan_name": "T04_add_meeting_note", "oracle_task_id": "T04_add_meeting_note",
+        "task_text": "Add a 'meeting' note to Sarah Chen dated yesterday mentioning 'discussed Q3 expansion'.",
+        "steps": [
+            _nav("{env_url}/contacts/contact_00042", "Open Sarah Chen's contact record"),
+            _click("Open the Activity tab", label="Activity", required=False),
+            _fill("Activity type", "meeting", "Choose 'Log meeting' as the activity type"),
+            _fill("What happened? (notes, summary, action items…)", "discussed Q3 expansion", "Type the note body"),
+            _fill("Date", "2026-06-13T00:00:00Z", "Set the activity date to yesterday"),
+            _submit("Save activity", "Save the meeting note", required=False),
+        ],
+    },
+    # crm T02 — merge the four acme dupes into contact_00001.
+    "crm.T02_merge_acme_dupes": {
+        "env": "crm", "status": "candidate",
+        "plan_name": "T02_merge_acme_dupes", "oracle_task_id": "T02_merge_acme_dupes",
+        "task_text": "Merge the four alice.lead@acme.com contacts, keeping contact_00001.",
+        "steps": [
+            _nav("{env_url}/contacts/contact_00001", "Open the survivor contact (contact_00001)"),
+            _fill("Merge duplicate contact ids", "contact_00002, contact_00003, contact_00004", "List the loser contact ids to merge in"),
+            _submit("Merge into this contact", "Merge the dupes into contact_00001", required=False),
+        ],
+    },
+
+    # shop T03 — create a 20%-off coupon for outerwear-women.
+    "shop.T03_create_coupon": {
+        "env": "shop", "status": "candidate",
+        "plan_name": "T03_create_coupon", "oracle_task_id": "T03_create_coupon",
+        "task_text": "Create a 20%-off coupon for outerwear-women, expiring 2026-02-15, max 100 uses.",
+        "steps": [
+            _nav("{env_url}/admin/coupons", "Open the coupons admin"),
+            _fill("Code", "WOMENS20", "Type a coupon code"),
+            _fill("Type", "pct", "Choose '% off'"),
+            _fill("value (20 for 20%, 5 for $5)", "20", "Set 20% off"),
+            _fill("Scope category", "outerwear-women", "Scope to outerwear-women"),
+            _fill("expires", "2026-02-15", "Set the expiry date"),
+            _fill("max uses", "100", "Set the max uses"),
+            _submit("Create", "Create the coupon", required=False),
+        ],
+    },
+    # shop T02 — refund line item 2 of order_04421, reason 'damaged', notify customer.
+    "shop.T02_refund_line_item": {
+        "env": "shop", "status": "candidate",
+        "plan_name": "T02_refund_line_item", "oracle_task_id": "T02_refund_line_item",
+        "task_text": "Refund line item 2 of order_04421 with reason 'damaged' and notify the customer.",
+        "steps": [
+            _nav("{env_url}/admin/orders/order_04421", "Open order_04421"),
+            _click("Open the Refunds tab", label="Refunds", required=False),
+            _fill("line", "2", "Target line item 2"),
+            _fill("Reason (e.g. damaged)", "damaged", "Set the refund reason"),
+            _click("Tick notify customer", label="Notify customer", required=False),
+            _submit("Refund", "Submit the refund", required=False),
+        ],
+    },
+    # shop T05 — bump TEE-BLK-M inventory by 50.
+    "shop.T05_inventory_adjust": {
+        "env": "shop", "status": "candidate",
+        "plan_name": "T05_inventory_adjust", "oracle_task_id": "T05_inventory_adjust",
+        "task_text": "Bump inventory of TEE-BLK-M by 50 with reason 'restock from warehouse'.",
+        "steps": [
+            _nav("{env_url}/admin/inventory", "Open the inventory admin"),
+            _fill("SKU", "TEE-BLK-M", "Target the TEE-BLK-M variant"),
+            _fill("delta", "50", "Add 50 units"),
+            _fill("reason", "restock from warehouse", "Set the adjustment reason"),
+            _submit("Apply", "Apply the inventory adjustment", required=False),
         ],
     },
 }

--- a/tests/test_gate_eval_916.py
+++ b/tests/test_gate_eval_916.py
@@ -90,6 +90,17 @@ def test_arms_use_distinct_profile_ids():
     assert chal["_profile_id"].startswith("gate-challenger-")
 
 
+def test_run_nonce_makes_profiles_unique_across_runs():
+    # #920: a per-invocation nonce → a prior run's stale Chrome lock can't 409 us.
+    a = rge.build_eval_suite(_SPEC, _INFO, arm=rge.CHAMPION, task_key=_KEY, run_nonce="aaaa")
+    b = rge.build_eval_suite(_SPEC, _INFO, arm=rge.CHAMPION, task_key=_KEY, run_nonce="bbbb")
+    assert a["_profile_id"] == f"gate-champion-{_KEY}-aaaa"
+    assert a["_profile_id"] != b["_profile_id"]  # different runs → different profiles
+    # still distinct across arms within a run
+    chal = rge.build_eval_suite(_SPEC, _INFO, arm=rge.CHALLENGER, task_key=_KEY, run_nonce="aaaa")
+    assert chal["_profile_id"] != a["_profile_id"]
+
+
 # ── arm_from_results ────────────────────────────────────────────────────
 
 

--- a/tests/test_holdout_v2_candidates.py
+++ b/tests/test_holdout_v2_candidates.py
@@ -1,0 +1,74 @@
+"""#920 — structural checks for the expanded holdout (v2) candidate set.
+
+These pin the *shape* of the candidate plans authored offline (grounded from each
+env's oracle + templates). They do NOT run anything — the live-verification pass
+runs each through Mantis and freezes the survivors into ``mantis-holdout-v2``. The
+point: enough well-formed, oracle-grounded tasks exist that the gate's paired
+bootstrap can clear ``prob_improvement >= 0.95`` (3 tasks can't; ~15+ can).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "experiments" / "holdout"))
+
+from sealed_plans import SANDBOXES, SEALED_TASKS  # noqa: E402
+
+_VALID_STEP_TYPES = {"navigate", "click", "submit", "fill_field"}
+
+
+def test_holdout_has_enough_tasks_for_gate_significance():
+    # 3 tasks top out at prob_improvement ~0.7; ~15+ can exceed 0.95.
+    assert len(SEALED_TASKS) >= 15, f"only {len(SEALED_TASKS)} tasks — too few for gate significance"
+
+
+def test_every_task_is_well_formed():
+    for key, spec in SEALED_TASKS.items():
+        assert spec.get("env"), f"{key}: missing env"
+        assert spec.get("oracle_task_id"), f"{key}: missing oracle_task_id"
+        assert spec.get("steps"), f"{key}: no steps"
+        assert spec["env"] in SANDBOXES, f"{key}: env {spec['env']!r} not in SANDBOXES"
+
+
+def test_every_step_uses_a_valid_primitive():
+    for key, spec in SEALED_TASKS.items():
+        for i, step in enumerate(spec["steps"]):
+            assert step.get("type") in _VALID_STEP_TYPES, f"{key} step {i}: bad type {step.get('type')!r}"
+            assert step.get("intent"), f"{key} step {i}: missing intent"
+
+
+def test_every_plan_starts_with_a_navigate():
+    for key, spec in SEALED_TASKS.items():
+        assert spec["steps"][0]["type"] == "navigate", f"{key}: first step must be navigate"
+
+
+def test_spans_multiple_capability_envs():
+    # Representativeness: the holdout must span envs, not pile onto one site.
+    envs = {spec["env"] for spec in SEALED_TASKS.values()}
+    assert len(envs) >= 6, f"only {len(envs)} envs — not representative"
+
+
+def test_candidate_vs_verified_split_is_marked():
+    # v1-frozen tasks are 'verified'; new ones carry status='candidate' so the
+    # freeze step (and operators) can tell what still needs a live pass.
+    statuses = {spec.get("status", "verified") for spec in SEALED_TASKS.values()}
+    assert "candidate" in statuses, "expected some status='candidate' (the v2 additions)"
+    candidates = [k for k, v in SEALED_TASKS.items() if v.get("status") == "candidate"]
+    assert len(candidates) >= 10, f"only {len(candidates)} candidates authored"
+
+
+def test_oracle_task_ids_unique():
+    ids = [spec["oracle_task_id"] for spec in SEALED_TASKS.values()]
+    assert len(ids) == len(set(ids)), "duplicate oracle_task_id across tasks"
+
+
+def test_fill_steps_carry_label_and_value():
+    for key, spec in SEALED_TASKS.items():
+        for i, step in enumerate(spec["steps"]):
+            if step["type"] == "fill_field":
+                p = step.get("params", {})
+                assert p.get("label"), f"{key} step {i}: fill_field missing label"
+                assert "value" in p, f"{key} step {i}: fill_field missing value"


### PR DESCRIPTION
Closes #920 — the last blocker before the flywheel's first real PROMOTE.

## The problem
A genuinely better challenger was correctly **HELD**: `win_rate 1.0`, `mean_delta +0.333`, `regressions 0`, but `prob_improvement 0.708 < 0.95`. The blocker is **holdout size, not model quality** — `mantis-holdout-v1` has only **3 runnable tasks**, and a paired bootstrap over 3 deltas `[+1,0,0]` tops at `1−(2/3)³ ≈ 0.70`. Clearing 0.95 needs **~15+** tasks.

## Part A — gate-eval `profile_id` 409 stale-lock fix
`run_gate_eval`'s per-`(task,arm)` `profile_id` was stable, so a prior run's stale Chrome user-data-dir lock 409'd the next run and **cost an arm** (shrinking N). Now each invocation appends a `uuid` nonce (`gate-<arm>-<task>-<nonce>`) → fresh profiles per run; the env is reset per run so there's no login to preserve.

## Part B — ~14 grounded v2 candidate tasks
`sealed_plans.SEALED_TASKS` goes **4 → 18** across **8 envs**: the 4 v1-frozen (`status="verified"`) + **14 candidates** (`status="candidate"`), each authored **offline** and **grounded** from its env's `app/oracles/*` + `app/templates/*` (the canonical source) — indeed.t02, mercor.t01, auth T01/T08/T02, shopify t03/t04/t05/t11, crm T04/T02, shop T03/T02/T05. Spans login / form_fill / crud / export / navigate clusters.

> Chrome-MCP grounding (the suggested route) is blocked by the **Daytona preview auth wall** — so grounded from in-repo env source instead (same DOM, no spend, no blocker).

## These are CANDIDATES — a live pass still gates the freeze
The freeze only admits tasks that successfully **ran** (run → eval-candidate → freeze), so before `mantis-holdout-v2` exists, a spend-gated pass must: wire each env's sandbox/URL in `SANDBOXES` (v2 envs are placeholders today; **crm/shop/shopify/auth are Modal-hosted** → need a Modal URL, not a Daytona id), run each candidate to oracle-`passed`, then freeze the survivors.

**Excluded** (need runtime caps a static plan lacks; authored during the live pass): `auth.T07_email_otp` (dynamic OTP read) and `boattrader.BT01/02/03` (live listing id + loop/guard).

## Tests
8 structural tests (`test_holdout_v2_candidates.py`: ≥15 tasks, ≥6 envs, well-formed steps, valid primitives, candidate/verified split, unique oracle ids) + the 409 nonce test. 30 holdout tests pass; ruff + mkdocs strict clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)