### PR TITLE
feat(holdout): wire v2 envs on Daytona + backend-agnostic resolver (#920)

### DIFF
--- a/experiments/holdout/README.md
+++ b/experiments/holdout/README.md
@@ -215,11 +215,22 @@ across indeed / mercor / auth / shopify / crm / shop.
 admits tasks that successfully **ran** (run → eval-candidate → freeze), so each
 needs a live pass. Two-step:
 
-1. **Live-verify** (spend-gated): wire each env's sandbox/URL in `SANDBOXES`
-   (the v2 envs are placeholders today; Modal-hosted envs — crm/shop/shopify/auth
-   — need a Modal URL rather than a Daytona id), then run each candidate through
-   Mantis (`run_sealed_task.py`) until its oracle grades `passed`, fixing
-   interaction quirks (select-vs-text fill, AJAX no-nav, exact labels).
+1. **Live-verify** (spend-gated): the env resolver (`run_sealed_task._resolve_env`,
+   #920) accepts a `SANDBOXES` value that's a Daytona sandbox id **or** a direct
+   `https://` URL. Env wiring as of 2026-06-16 (identified by reading each
+   sandbox's `/srv/app/oracles/`):
+     - **Daytona-wired:** indeed, mercor, linkedin, fiverr, **shopify**
+       (`3e75162f`), **boattrader** (`f5dd5b31`, archived→restored).
+     - **No Daytona home — `crm` / `shop` / `auth`** are Modal-native envs
+       (`deploy/sim_envs/modal_mantis_*.py`, Dockerfile-based); they have no
+       sandbox, and a from-scratch Daytona build is a known hang. Wire them by
+       Modal-deploying (then put the `web` URL in `SANDBOXES`) — needs the
+       env-secret authorization — or skip them: the ~10–13 Daytona tasks already
+       clear gate significance (at ~⅓ decisive wins, `(2/3)¹⁰≈0.017` →
+       `prob_improvement ≈ 0.98 > 0.95`).
+   Then run each candidate through Mantis (`run_sealed_task.py`) until its oracle
+   grades `passed`, fixing interaction quirks (select-vs-text fill, AJAX no-nav,
+   exact labels).
 2. **Freeze** the survivors into `mantis-holdout-v2` via `freeze_eval_version.py`
    (operator session cookie), then `python -m mantis_trainer.holdout --version
    mantis-holdout-v2` materializes the runnable set.

--- a/experiments/holdout/run_gate_eval.py
+++ b/experiments/holdout/run_gate_eval.py
@@ -201,12 +201,13 @@ def _run_one(
     }
 
 
-def _resolve_envs(task_keys: list[str], dayt: str) -> dict[str, dict[str, str]]:
-    """Resolve the Daytona sandbox info for every distinct env, reset each once."""
+def _resolve_envs(task_keys: list[str], env: dict[str, str]) -> dict[str, dict[str, str]]:
+    """Resolve every distinct env (Daytona id or direct Modal/URL), reset each
+    once. Backend-agnostic via ``rst._resolve_env`` (#920)."""
     infos: dict[str, dict[str, str]] = {}
     for env_name in sorted({SEALED_TASKS[k]["env"] for k in task_keys}):
-        print(f"[env] resolving Daytona sandbox for '{env_name}' …")
-        info = rst._daytona_env(SANDBOXES[env_name], dayt)
+        print(f"[env] resolving '{env_name}' …")
+        info = rst._resolve_env(env_name, SANDBOXES.get(env_name, ""), env)
         rst._reset_env(info["url"], info["admin_token"], info["preview_token"])
         infos[env_name] = info
     return infos
@@ -218,10 +219,10 @@ def run_gate(
 ) -> tuple[GateVerdict, list[dict[str, Any]]]:
     """Run champion + challenger arms over the holdout tasks and gate them."""
     env = rst._load_env()
-    token, dayt = env.get("MANTIS_API_TOKEN", ""), env.get("DAYTONA_API_KEY", "")
-    if not token or not dayt:
-        raise SystemExit("ERROR: MANTIS_API_TOKEN + DAYTONA_API_KEY required")
-    infos = _resolve_envs(task_keys, dayt)
+    token = env.get("MANTIS_API_TOKEN", "")
+    if not token:
+        raise SystemExit("ERROR: MANTIS_API_TOKEN required")
+    infos = _resolve_envs(task_keys, env)
 
     # #920: a per-invocation nonce so fresh profiles are used each run — a prior
     # run's stale Chrome-profile lock can't 409 this run and cost an arm.

--- a/experiments/holdout/run_sealed_task.py
+++ b/experiments/holdout/run_sealed_task.py
@@ -107,6 +107,37 @@ def _daytona_headers(preview_token: str) -> dict[str, str]:
     return h
 
 
+def _resolve_env(env_name: str, sandbox_ref: str, env: dict[str, str]) -> dict[str, str]:
+    """Resolve a holdout env to ``{url, preview_token, admin_token}`` — backend
+    agnostic (#920).
+
+    ``sandbox_ref`` (the ``SANDBOXES[env_name]`` value) is either:
+    * a **direct URL** (``https://…``) — a Modal/other-hosted sim env reached
+      directly (no Daytona preview token). The ``X-Env-Admin`` token comes from
+      ``<ENV>_ADMIN_TOKEN`` (e.g. ``CRM_ADMIN_TOKEN``) or the shared
+      ``ENV_ADMIN_TOKEN`` in ``.env``; or
+    * a **Daytona sandbox id** — resolved via :func:`_daytona_env` (boots uvicorn,
+      returns the preview url + token + the in-sandbox ``ENV_ADMIN_TOKEN``).
+
+    Raises if the env isn't wired (empty ref) so the failure is explicit, not a
+    silent base-env run.
+    """
+    ref = (sandbox_ref or "").strip()
+    if not ref:
+        raise RuntimeError(
+            f"env {env_name!r} is not wired in SANDBOXES (empty) — add a Daytona "
+            f"sandbox id or a direct https URL before running it."
+        )
+    if ref.startswith("http://") or ref.startswith("https://"):
+        admin = (
+            env.get(f"{env_name.upper()}_ADMIN_TOKEN")
+            or env.get("ENV_ADMIN_TOKEN")
+            or ""
+        )
+        return {"url": ref.rstrip("/"), "preview_token": "", "admin_token": admin}
+    return _daytona_env(ref, env.get("DAYTONA_API_KEY", ""))
+
+
 def _reset_env(env_url: str, admin_token: str, preview_token: str) -> tuple[int, str]:
     r = requests.post(
         f"{env_url}/__env__/reset",
@@ -159,13 +190,12 @@ def run(task_key: str, *, max_steps: int = 25, poll_seconds: int = 600) -> int:
     env_name = spec["env"]
     env = _load_env()
     token = env.get("MANTIS_API_TOKEN", "")
-    dayt = env.get("DAYTONA_API_KEY", "")
-    if not token or not dayt:
-        print("ERROR: MANTIS_API_TOKEN + DAYTONA_API_KEY required in .env", file=sys.stderr)
+    if not token:
+        print("ERROR: MANTIS_API_TOKEN required in .env", file=sys.stderr)
         return 2
 
-    print(f"[env] resolving Daytona sandbox for '{env_name}' …")
-    info = _daytona_env(SANDBOXES[env_name], dayt)
+    print(f"[env] resolving env '{env_name}' …")
+    info = _resolve_env(env_name, SANDBOXES.get(env_name, ""), env)
     print(f"  url={info['url']}")
     print(f"  preview_token={'set' if info['preview_token'] else 'MISSING'}  "
           f"admin_token={'set' if info['admin_token'] else 'MISSING'}")

--- a/experiments/holdout/sealed_plans.py
+++ b/experiments/holdout/sealed_plans.py
@@ -26,13 +26,17 @@ SANDBOXES: dict[str, str] = {
     "mercor": "f0f3ffc9-4879-48a9-98db-b5b5224fe20f",
     "linkedin": "f43c50dd-0edb-4667-8b50-2ff2f697de24",
     "fiverr": "d2c59f51-ca2e-48d2-b436-370b18673b79",
-    # #920 v2-candidate envs — sandbox ids TODO: the live-verification pass
-    # resolves + fills these (Daytona id, or a Modal sim-env URL for the
-    # Modal-hosted envs crm/shop/shopify/auth). Empty ⇒ _daytona_env fails
-    # fast at run time, by design — these tasks aren't runnable until wired.
+    # #920 v2 envs — Daytona-for-all (live-identified 2026-06-16 by reading each
+    # sandbox's /srv/app/oracles/ over the Daytona SDK).
+    "shopify": "3e75162f-0b96-4857-a17c-065b722fa243",  # live, startable
+    "boattrader": "f5dd5b31-890c-4cd6-80b8-a4c12837c50a",  # archived→restored; BT tasks authored live
+    # crm / shop / auth have NO Daytona sandbox — they are Modal-native envs
+    # (deploy/sim_envs/modal_mantis_{crm,shop,auth}.py, Dockerfile-based). Wiring
+    # them needs either a Modal deploy (blocked: shared-secret auth) or a
+    # from-scratch Daytona build (a known hang — feedback_daytona_fresh_build_hang).
+    # Left empty ⇒ _resolve_env fails fast; their candidate tasks are skipped
+    # until one of those paths is taken.
     "auth": "",
-    "boattrader": "",
-    "shopify": "",
     "crm": "",
     "shop": "",
 }

--- a/tests/test_resolve_env_920.py
+++ b/tests/test_resolve_env_920.py
@@ -1,0 +1,52 @@
+"""#920 — backend-agnostic env resolution (Daytona id vs direct Modal/URL).
+
+Pins the routing in ``run_sealed_task._resolve_env`` without network: a direct
+URL ref → used as-is with no preview token + admin from env; a Daytona id ref →
+delegated to ``_daytona_env``; an empty ref → explicit error (never a silent
+base-env run).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "experiments" / "holdout"))
+
+import run_sealed_task as rst  # noqa: E402
+
+
+def test_url_ref_used_directly_with_env_admin_token():
+    env = {"ENV_ADMIN_TOKEN": "shared-admin"}
+    info = rst._resolve_env("crm", "https://crm.example.modal.run/", env)
+    assert info["url"] == "https://crm.example.modal.run"  # trailing slash trimmed
+    assert info["preview_token"] == ""  # no Daytona token for a direct URL
+    assert info["admin_token"] == "shared-admin"
+
+
+def test_url_ref_prefers_per_env_admin_token():
+    env = {"CRM_ADMIN_TOKEN": "crm-specific", "ENV_ADMIN_TOKEN": "shared"}
+    info = rst._resolve_env("crm", "https://crm.example.modal.run", env)
+    assert info["admin_token"] == "crm-specific"
+
+
+def test_empty_ref_raises():
+    with pytest.raises(RuntimeError, match="not wired"):
+        rst._resolve_env("boattrader", "", {})
+
+
+def test_daytona_id_ref_delegates(monkeypatch):
+    calls = {}
+
+    def _fake_daytona(sandbox_id, api_key):
+        calls["sandbox_id"] = sandbox_id
+        calls["api_key"] = api_key
+        return {"url": "https://sb.daytonaproxy01.net", "preview_token": "pv", "admin_token": "a"}
+
+    monkeypatch.setattr(rst, "_daytona_env", _fake_daytona)
+    info = rst._resolve_env("indeed", "a72a3ffc-sandbox-id", {"DAYTONA_API_KEY": "dk"})
+    assert calls == {"sandbox_id": "a72a3ffc-sandbox-id", "api_key": "dk"}
+    assert info["preview_token"] == "pv"


### PR DESCRIPTION
Wires the v2 holdout envs (#920, follow-up to #921), per the "Daytona for all" decision.

## Enabler
`run_sealed_task._resolve_env` resolves an env by **either** backend — a `SANDBOXES` value that's a direct `https://` URL (admin via `<ENV>_ADMIN_TOKEN`/`ENV_ADMIN_TOKEN`) **or** a Daytona sandbox id. Empty ref raises (no silent base-env run). Both call sites route through it. 4 tests.

## Wiring (Daytona ids identified live by reading each sandbox's `/srv/app/oracles/`)
- **Wired:** indeed, mercor, linkedin, fiverr, **shopify** (`3e75162f`), **boattrader** (`f5dd5b31`, archived→restored).
- **crm / shop / auth — no Daytona home.** They're Modal-native (`deploy/sim_envs/modal_mantis_*.py`). The only unidentified sandboxes were 2× boattrader + 1 empty + a duplicate fiverr; no crm/shop/auth instances exist on Daytona, and a from-scratch Daytona build is a known hang. Left empty → `_resolve_env` fails fast; their candidate tasks skip until Modal-deployed (drop the `web` URL into `SANDBOXES` — the resolver already supports it).

## Net
6 Daytona envs / **~10–13 runnable candidate tasks** — enough for gate significance (at ~⅓ decisive wins, `(2/3)¹⁰ ≈ 0.017` → `prob_improvement ≈ 0.98 > 0.95`).

Tests: 26 pass (resolver + v2 structural + gate-eval); ruff + mkdocs clean. Live boot of the newly-wired Daytona envs is the spend-gated verification step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)