### PR TITLE
fix(gate): fail-closed on infra failure + kill stale llama-server before boot (#923)

### DIFF
--- a/deploy/modal/modal_cua_server.py
+++ b/deploy/modal/modal_cua_server.py
@@ -445,6 +445,7 @@ def _start_vllm(model_dir: str, port: int, tp: int,
     if extra_args:
         cmd.extend(extra_args)
     print(f"Starting vLLM (TP={tp}): {' '.join(cmd[-8:])}")
+    _kill_stale_inference_server()  # #923: free the port if a warm container leaked one
     proc = subprocess.Popen(cmd, stdout=open("/tmp/vllm.log", "w"), stderr=subprocess.STDOUT)
 
     time.sleep(5)
@@ -467,6 +468,45 @@ def _start_vllm(model_dir: str, port: int, tp: int,
         time.sleep(5)
 
     raise RuntimeError("vLLM startup timeout")
+
+
+def _kill_stale_inference_server() -> None:
+    """#923: kill any leftover llama-server / vLLM before booting a new one.
+
+    A run lands on a 1-input container, but Modal keeps containers WARM and reuses
+    them for later runs. If a prior run's inference server is still bound to the
+    fixed port (8080 llama.cpp / 8000 vLLM), the next run's boot loses the
+    ``bind()`` race and crashes (the #923 symptom under gate ``--max-parallel``).
+    Worse, since #911/#918 the served model is per-request, so a reused server may
+    be serving the WRONG model. Kill any stale server first so the new (correct)
+    model binds cleanly. Dependency-free (/proc scan — no procps); no-op on a
+    fresh container.
+    """
+    import glob
+    import signal
+
+    killed = False
+    for cmdline_path in glob.glob("/proc/[0-9]*/cmdline"):
+        try:
+            with open(cmdline_path, "rb") as f:
+                cmd = f.read().replace(b"\x00", b" ").decode("utf-8", "ignore")
+        except OSError:
+            continue
+        if "llama-server" in cmd or "vllm.entrypoints.openai.api_server" in cmd:
+            try:
+                pid = int(cmdline_path.split("/")[2])
+            except (ValueError, IndexError):
+                continue
+            if pid == os.getpid():
+                continue
+            try:
+                os.kill(pid, signal.SIGKILL)
+                killed = True
+                print(f"[#923] killed stale inference server pid={pid}: {cmd[:60]}")
+            except OSError:
+                pass
+    if killed:
+        time.sleep(1.5)  # let the OS release the listening socket before rebinding
 
 
 def _prepare_lora_serving(
@@ -858,6 +898,7 @@ def _run_holo3_executor(
     ]
     cmd += lora_plan.extra_server_args
     print(f"Starting Holo3 llama-server: {' '.join(cmd[-8:])}")
+    _kill_stale_inference_server()  # #923: free 8080 if a warm container leaked one
     llama_proc = subprocess.Popen(cmd, stdout=open("/tmp/llama.log", "w"), stderr=subprocess.STDOUT)
     wait_for_openai_server(8080, llama_proc, "llama-server")
 
@@ -1806,6 +1847,7 @@ def _run_gemma4_cua_executor(
     if mmproj:
         cmd.extend(["--mmproj", mmproj])
     print(f"Starting Gemma4-CUA: {' '.join(cmd[-8:])}")
+    _kill_stale_inference_server()  # #923: free 8080 if a warm container leaked one
     llama_proc = subprocess.Popen(cmd, stdout=open("/tmp/llama.log", "w"), stderr=subprocess.STDOUT)
     wait_for_openai_server(8080, llama_proc, "llama-server")
 

--- a/experiments/holdout/README.md
+++ b/experiments/holdout/README.md
@@ -136,11 +136,19 @@ produces the merged GGUF (peft `merge_and_unload` → `convert_hf_to_gguf.py` �
 quantize Q8_0 → `mantis-trainer-vol`); the runner serves it via `-m`, reusing the
 base `--mmproj`. This is what unblocks real (non-`failed`) challenger arms.
 
-Each (task, arm) gets a distinct `profile_id` (`gate-<arm>-<task>`), so the two
-arms never collide on one Chrome profile (the per-`profile_id` 409 rule) and all
-runs fan out in parallel via `StateKeyDispatcher` (`--max-parallel`, #912).
+Each (task, arm) gets a distinct `profile_id` (`gate-<arm>-<task>-<nonce>`), so the
+two arms never collide on one Chrome profile (the per-`profile_id` 409 rule) and
+all runs fan out in parallel via `StateKeyDispatcher` (`--max-parallel`, #912).
 Omitting `--lora-adapter` runs champion == challenger (a plumbing sanity run;
 expect `delta≈0`, `promote=False`). **This spends** — 2 × N Modal GPU runs.
+
+**Verdict integrity under concurrency (#923).** A run that didn't actually execute
+— infra crash (e.g. a warm-container `llama-server` port collision), cancel, or
+poll timeout — is **fail-closed**: it's scored as a loss (`oracle_passed=False`,
+tagged `infra_failed`) rather than credited from the env oracle, since champion +
+challenger share the env and a crashed arm would otherwise read the *other* arm's
+stale pass. Infra-failed arms are flagged in the summary; re-run them (the
+serving-side port fix in #923 makes `--max-parallel > 1` collision-free).
 
 **Equivalent path:** `--emit-tasks <path>` writes an `eval_harness`-shaped
 `--tasks` JSON with the generated `micro_plan`s, so `training/eval_harness.py

--- a/experiments/holdout/run_gate_eval.py
+++ b/experiments/holdout/run_gate_eval.py
@@ -68,6 +68,12 @@ from mantis_agent.server_utils import (  # noqa: E402
 CHAMPION = "champion"
 CHALLENGER = "challenger"
 
+# All terminal statuses (stop polling). _RAN_STATES is the subset where the run
+# actually executed, so the env oracle grade is trustworthy. `failed`/`cancelled`
+# (e.g. a llama-server crash, #923) are terminal but NOT ran → fail-closed.
+_RAN_STATES = {"succeeded", "completed", "completed_with_failures", "halted"}
+_TERMINAL_STATES = _RAN_STATES | {"failed", "cancelled"}
+
 
 def _micro_plan_dicts(spec_def: dict[str, Any], env_url: str) -> list[dict[str, Any]]:
     """Resolve a holdout task's plan steps → built ``_micro_plan`` dicts.
@@ -179,24 +185,35 @@ def _run_one(
     })
     tid = spec_def["oracle_task_id"]
     if code != 200 or not resp.get("run_id"):
-        return {"task_id": tid, "arm": arm, "submit_error": resp, "oracle_passed": False}
+        return {"task_id": tid, "arm": arm, "submit_error": resp,
+                "oracle_passed": False, "infra_failed": True}
     run_id = resp["run_id"]
 
     final = None
     deadline = time.monotonic() + poll_seconds
     while time.monotonic() < deadline:
         _, s = rst._post(token, {"action": "status", "run_id": run_id})
-        if s.get("status") in {"succeeded", "completed", "completed_with_failures",
-                               "failed", "cancelled", "halted"}:
+        if s.get("status") in _TERMINAL_STATES:
             final = s
             break
         time.sleep(8)
 
-    grade = rst._grade(info["url"], tid, info["admin_token"], info["preview_token"])
+    status = (final or {}).get("status")
     cost = float(((final or {}).get("costs") or {}).get("total", 0.0))
+    # #923 fail-closed: a run that didn't actually execute (infra crash — e.g. a
+    # llama-server port collision — , cancel, or poll timeout) must NOT be credited
+    # from the env oracle: champion + challenger share the env, so a crashed arm
+    # would read the OTHER arm's stale pass and corrupt the verdict. Count it as a
+    # loss (oracle_passed=False) and tag it so it's auditable / excludable.
+    if status not in _RAN_STATES:
+        return {"task_id": tid, "arm": arm, "run_id": run_id,
+                "terminal_status": status, "oracle_passed": False,
+                "cost": cost, "infra_failed": True}
+
+    grade = rst._grade(info["url"], tid, info["admin_token"], info["preview_token"])
     return {
         "task_id": tid, "arm": arm, "run_id": run_id,
-        "terminal_status": (final or {}).get("status"),
+        "terminal_status": status,
         "oracle_passed": bool(grade.get("passed")), "cost": cost,
     }
 
@@ -318,6 +335,14 @@ def main(argv: list[str] | None = None) -> int:
             "champion_cost": verdict.champion_cost, "challenger_cost": verdict.challenger_cost,
         },
     }, indent=2))
+    # #923: surface infra failures (e.g. a llama-server port collision) — these are
+    # fail-closed (counted as losses), so flag them so an operator can re-run the
+    # affected arms (ideally --max-parallel 1) rather than trust a flake-skewed verdict.
+    infra = [r for r in results if r.get("infra_failed")]
+    if infra:
+        print(f"\n⚠️  {len(infra)} arm(s) infra-failed (fail-closed as losses) — "
+              f"re-run before trusting the verdict: "
+              f"{[(r.get('arm'), r.get('task_id')) for r in infra]}", file=sys.stderr)
     print(f"\n{'✅ PROMOTE' if verdict.promote else '❌ HOLD'} — {verdict.reason}")
     return 0
 

--- a/tests/test_gate_eval_916.py
+++ b/tests/test_gate_eval_916.py
@@ -158,6 +158,63 @@ def test_mapped_arms_drive_promotion_gate():
     assert verdict.promote is True
 
 
+# ── #923 fail-closed on infra failure ───────────────────────────────────
+
+
+def test_failed_arm_is_failclosed_and_skips_stale_oracle(monkeypatch):
+    # A crashed challenger arm (terminal_status=failed) must NOT be credited from
+    # the env oracle (which would show the OTHER arm's stale pass). Fail-closed.
+    graded = {"called": False}
+
+    def fake_post(token, body):
+        if "action" not in body:           # the submit
+            return 200, {"run_id": "r-fail"}
+        return 200, {"status": "failed"}   # status poll → infra crash
+
+    def fake_grade(url, tid, admin, prev):
+        graded["called"] = True
+        return {"passed": True}            # stale env shows a pass
+
+    monkeypatch.setattr(rge.rst, "_post", fake_post)
+    monkeypatch.setattr(rge.rst, "_grade", fake_grade)
+
+    out = rge._run_one(
+        _KEY, _SPEC, _INFO, "tok", arm=rge.CHALLENGER, lora_adapter="",
+        challenger_model="vol:/m.gguf", run_nonce="n1", max_steps=5, poll_seconds=5,
+    )
+    assert out["terminal_status"] == "failed"
+    assert out["oracle_passed"] is False          # not credited
+    assert out["infra_failed"] is True
+    assert graded["called"] is False              # never read the stale oracle
+
+
+def test_succeeded_arm_reads_oracle(monkeypatch):
+    def fake_post(token, body):
+        if "action" not in body:
+            return 200, {"run_id": "r-ok"}
+        return 200, {"status": "completed_with_failures"}
+
+    monkeypatch.setattr(rge.rst, "_post", fake_post)
+    monkeypatch.setattr(rge.rst, "_grade", lambda *a: {"passed": True})
+
+    out = rge._run_one(
+        _KEY, _SPEC, _INFO, "tok", arm=rge.CHAMPION, lora_adapter="",
+        challenger_model="", run_nonce="n1", max_steps=5, poll_seconds=5,
+    )
+    assert out["oracle_passed"] is True
+    assert "infra_failed" not in out
+
+
+def test_submit_error_is_infra_failed(monkeypatch):
+    monkeypatch.setattr(rge.rst, "_post", lambda t, b: (500, {"raw": "boom"}))
+    out = rge._run_one(
+        _KEY, _SPEC, _INFO, "tok", arm=rge.CHALLENGER, lora_adapter="",
+        challenger_model="", run_nonce="n1", max_steps=5, poll_seconds=5,
+    )
+    assert out["oracle_passed"] is False
+    assert out["infra_failed"] is True
+
+
 def test_no_adapter_sanity_run_does_not_promote():
     # champion == challenger (both base) → zero delta → HOLD.
     same = rge.arm_from_results([


### PR DESCRIPTION
Closes #923. Two bugs surfaced by the first merged-GGUF gate run (#919) at `--max-parallel 4`: 2 challenger arms crashed with `llama-server couldn't bind 0.0.0.0:8080`; serial reran clean.

## A — serving: kill stale inference server before boot (`modal_cua_server.py`)
`run_holo3` is 1-input/container, but Modal reuses **warm** containers — a later run can land where the prior run's `llama-server` is still bound to 8080 → bind race → crash. Worse: since #911/#918 the served model is **per-request**, a reused server may serve the **wrong** model. New `_kill_stale_inference_server()` (dependency-free `/proc` scan) runs before each `llama-server`/vLLM boot so the new model rebinds cleanly. Applied to `run_holo3`, `run_gemma4_cua`, `_start_vllm`. **Needs a `mantis-cua-server` redeploy.**

## B — gate: fail-closed on infra failure (`run_gate_eval._run_one`)
The gate scored `oracle_passed` from the env oracle even when `terminal_status == failed`. Champion + challenger **share the env**, so a crashed arm read the *other* arm's stale pass → corrupted verdict. Now a run not in `_RAN_STATES` is fail-closed → `oracle_passed=False` + `infra_failed=True`, without reading the oracle. `main()` flags infra failures.

## Tests
+3; 17 gate tests pass; ruff + `mkdocs --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)