### PR TITLE
feat(holdout): live-verified v2 holdout set + run_gate_eval --v2 (#920)

### DIFF
--- a/experiments/holdout/README.md
+++ b/experiments/holdout/README.md
@@ -254,9 +254,10 @@ yields the flywheel's first real **PROMOTE**.
 ### Live-verified runnable v2 set (`V2_HOLDOUT`, 2026-06-17)
 
 Smoke-verified on base (oracle `passed`, no infra failure) → `sealed_plans.V2_HOLDOUT`
-(**7 tasks / 5 envs**): `indeed.t01`, `indeed.t03`, `linkedin.t02`, `fiverr.t03`,
-`shopify.t03_export_payouts_csv`, `shopify.t04_create_support_ticket`,
-`shopify.t11_view_store_detail`. Run the gate against exactly this set:
+(**8 tasks / 5 envs**): `indeed.t01`, `indeed.t02_easy_apply`, `indeed.t03`,
+`linkedin.t02`, `fiverr.t03`, `shopify.t03_export_payouts_csv`,
+`shopify.t04_create_support_ticket`, `shopify.t11_view_store_detail`. Run the gate
+against exactly this set:
 
 ```
 python experiments/holdout/run_gate_eval.py --v2 \
@@ -264,14 +265,22 @@ python experiments/holdout/run_gate_eval.py --v2 \
     --max-parallel 1 --poll-seconds 1200
 ```
 
-**Still candidate / deferred** (offline-authored, failed the base smoke — grow the
-set by fixing these): `indeed.t02_easy_apply` + `mercor.t01_apply_to_ml_engineer`
-(multi-step apply wizards halt mid-flow); `shopify.t05_update_business_email` (fill
-lands but the settings page has multiple section "Save" buttons — needs DOM-level
-disambiguation); and the Modal-native `crm`/`shop`/`auth` tasks (no Daytona
-sandbox). 7 tasks beats the 4-task set but is still N-limited for a
-`prob_improvement ≥ 0.95` margin — fixing the deferred tasks / wiring more envs is
-how v2 reaches significance.
+**Still candidate / deferred** (grow the set by fixing these):
+`mercor.t01_apply_to_ml_engineer` — the re-authored wizard now runs all steps to a
+clean submit, but the oracle still rejects (one of: screening answers not
+persisting from the long dynamic-label fields, or candidate/job mismatch); needs
+DB-state triage. `shopify.t05_update_business_email` — fill lands on the right
+field but the settings page has multiple section "Save" buttons → needs DOM-level
+disambiguation. The Modal-native `crm`/`shop`/`auth` tasks have no Daytona sandbox
+(need a Modal deploy, ≈8 more tasks — the biggest grow). 8 tasks beats the 4-task
+set (at ~⅓ decisive wins `(2/3)⁸≈0.04` → `prob≈0.96`), but a robust
+`prob_improvement ≥ 0.95` margin still wants the deferred tasks fixed / more envs
+wired.
+
+> `indeed.t02` + `mercor.t01` recovered by re-grounding from the env templates:
+> the apply CTA navigates into a multi-page `/apply/<id>` wizard ("Apply now" link,
+> not an "Easy apply" button), so the plan navigates the wizard URL directly then
+> fills each page's exact-labelled fields + Continue/Next → Submit.
 
 ## Why these tasks
 

--- a/experiments/holdout/README.md
+++ b/experiments/holdout/README.md
@@ -251,6 +251,28 @@ loop/guard for the Caterpillar-spec / gated-reveal logic).
 Re-gating `run_gate_eval.py --challenger-model <ref>` over the frozen v2 is what
 yields the flywheel's first real **PROMOTE**.
 
+### Live-verified runnable v2 set (`V2_HOLDOUT`, 2026-06-17)
+
+Smoke-verified on base (oracle `passed`, no infra failure) → `sealed_plans.V2_HOLDOUT`
+(**7 tasks / 5 envs**): `indeed.t01`, `indeed.t03`, `linkedin.t02`, `fiverr.t03`,
+`shopify.t03_export_payouts_csv`, `shopify.t04_create_support_ticket`,
+`shopify.t11_view_store_detail`. Run the gate against exactly this set:
+
+```
+python experiments/holdout/run_gate_eval.py --v2 \
+    --challenger-model mantis-trainer-vol:/checkpoints/<id>/merged.Q8_0.gguf \
+    --max-parallel 1 --poll-seconds 1200
+```
+
+**Still candidate / deferred** (offline-authored, failed the base smoke — grow the
+set by fixing these): `indeed.t02_easy_apply` + `mercor.t01_apply_to_ml_engineer`
+(multi-step apply wizards halt mid-flow); `shopify.t05_update_business_email` (fill
+lands but the settings page has multiple section "Save" buttons — needs DOM-level
+disambiguation); and the Modal-native `crm`/`shop`/`auth` tasks (no Daytona
+sandbox). 7 tasks beats the 4-task set but is still N-limited for a
+`prob_improvement ≥ 0.95` margin — fixing the deferred tasks / wiring more envs is
+how v2 reaches significance.
+
 ## Why these tasks
 
 - **Type coverage over site coverage** — every capability an agent needs is

--- a/experiments/holdout/run_gate_eval.py
+++ b/experiments/holdout/run_gate_eval.py
@@ -48,7 +48,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT / "src"))
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from sealed_plans import SANDBOXES, SEALED_TASKS  # noqa: E402
+from sealed_plans import SANDBOXES, SEALED_TASKS, V2_HOLDOUT  # noqa: E402
 from state_key_dispatcher import Call, StateKeyDispatcher  # noqa: E402
 
 import run_sealed_task as rst  # noqa: E402  (reuse env-resolve/submit/grade seams)
@@ -287,9 +287,11 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--max-parallel", type=int, default=4)
     ap.add_argument("--emit-tasks", default="",
                     help="write an eval_harness --tasks JSON (generated micro_plans) and exit")
+    ap.add_argument("--v2", action="store_true",
+                    help="run the live-verified v2 holdout set (sealed_plans.V2_HOLDOUT)")
     args = ap.parse_args(argv)
 
-    keys = args.tasks or sorted(SEALED_TASKS)
+    keys = args.tasks or (V2_HOLDOUT if args.v2 else sorted(SEALED_TASKS))
     unknown = [k for k in keys if k not in SEALED_TASKS]
     if unknown:
         print(f"unknown task(s) {unknown}; known: {sorted(SEALED_TASKS)}", file=sys.stderr)

--- a/experiments/holdout/sealed_plans.py
+++ b/experiments/holdout/sealed_plans.py
@@ -195,18 +195,21 @@ SEALED_TASKS: dict[str, dict[str, Any]] = {
 
     # indeed t02 — multi-step Easy Apply wizard on job_00012 (jk 000000000000000c).
     "indeed.t02_easy_apply": {
-        "env": "indeed", "status": "candidate",
+        "env": "indeed", "status": "verified",  # #920 smoke-passed on base 2026-06-17 (nav-into-wizard fix)
         "plan_name": "t02_easy_apply", "oracle_task_id": "t02_easy_apply",
         "task_text": "Easy-apply to job_00012 with phone, resume, and screening answers.",
         "steps": [
-            _nav("{env_url}/jobs/000000000000000c", "Open job_00012 and its Easy apply flow"),
-            _click("Click 'Easy apply' to start the application", label="Easy apply", required=False),
+            # /apply/<jk> GET serves step1 directly (the "Apply now" CTA links here);
+            # the wizard is 3 form pages each with a "Continue", then a review →
+            # "Submit application". Contact fields are required + cleanly labelled;
+            # resume (step2) is pre-selected and screening (step3) has defaults.
+            _nav("{env_url}/apply/000000000000000c", "Open the application wizard (step 1: contact info)"),
             _fill("Full name", "Jordan Rivera", "Type the applicant full name"),
             _fill("Email", "jordan.rivera@example.com", "Type the applicant email"),
             _fill("Phone", "(555) 123-4567", "Type the applicant phone"),
-            _submit("Continue", "Advance to the resume step", required=False),
-            _submit("Continue", "Keep the pre-selected resume and advance", required=False),
-            _submit("Continue", "Advance past the screening questions (defaults pre-filled)", required=False),
+            _submit("Continue", "Submit contact info → resume step", required=False),
+            _submit("Continue", "Keep the pre-selected resume → screening step", required=False),
+            _submit("Continue", "Accept screening defaults → review", required=False),
             _submit("Submit application", "Submit the application", required=False),
         ],
     },
@@ -216,14 +219,18 @@ SEALED_TASKS: dict[str, dict[str, Any]] = {
         "plan_name": "t01_apply_to_ml_engineer", "oracle_task_id": "t01_apply_to_ml_engineer",
         "task_text": "Apply to job_00001 with the screening answers.",
         "steps": [
-            _nav("{env_url}/jobs/job_00001", "Open job_00001 and its apply flow"),
-            _click("Click 'Apply' to start the application", label="Apply", required=False),
+            # /apply/<id> GET serves step 1; the flow is profile → resume →
+            # screening → review, each advanced by "Next", then "Submit application".
+            _nav("{env_url}/apply/job_00001", "Open the application (step 1: profile)"),
             _fill("Headline", "Internal Medicine Physician, 8 years", "Type the profile headline"),
+            _fill("Skills (comma-separated)", "clinical-reasoning, literature-review, case-study", "Type skills"),
             _fill("Hourly rate ($/hr)", "150", "Type the hourly rate"),
             _submit("Next", "Advance to the resume step", required=False),
             _fill("Resume text", "Board-certified Internal Medicine physician, 8+ years clinical practice with strong diagnostic reasoning.", "Type resume text"),
             _submit("Next", "Advance to the screening step", required=False),
-            _fill("Are you board-eligible or board-certified in Internal Medicine?", "Yes, board-certified", "Answer the board-certification question"),
+            # job_00001 screening_qs (seed.py) — must be non-empty for the oracle.
+            _fill("Are you board-eligible or board-certified in Internal Medicine?", "Yes, board-certified in Internal Medicine.", "Answer the board-certification question"),
+            _fill("Briefly describe a complex case you handled in the last year.", "Managed atypical pneumonia with multi-system complications requiring integrated diagnostic reasoning and literature review.", "Answer the complex-case question"),
             _fill("What is your earliest start date?", "2026-07-01", "Answer the start-date question"),
             _submit("Next", "Advance to review", required=False),
             _submit("Submit application", "Submit the application", required=False),
@@ -394,6 +401,7 @@ SEALED_TASKS: dict[str, dict[str, Any]] = {
 # auth) get wired. `run_gate_eval.py --v2` selects exactly this set.
 V2_HOLDOUT: list[str] = [
     "indeed.t01_search_save_remote",
+    "indeed.t02_easy_apply",
     "indeed.t03_employer_review_applicant",
     "linkedin.t02_post_text_update",
     "fiverr.t03_leave_5star_review",

--- a/experiments/holdout/sealed_plans.py
+++ b/experiments/holdout/sealed_plans.py
@@ -268,7 +268,7 @@ SEALED_TASKS: dict[str, dict[str, Any]] = {
 
     # shopify t04 — create a support ticket.
     "shopify.t04_create_support_ticket": {
-        "env": "shopify", "status": "candidate",
+        "env": "shopify", "status": "verified",  # #920 smoke-passed on base 2026-06-17
         "plan_name": "t04_create_support_ticket", "oracle_task_id": "t04_create_support_ticket",
         "task_text": "Create a support ticket with a subject, category, and description.",
         "steps": [
@@ -292,7 +292,7 @@ SEALED_TASKS: dict[str, dict[str, Any]] = {
     },
     # shopify t03 — export payouts CSV (audit-logged; download, no nav).
     "shopify.t03_export_payouts_csv": {
-        "env": "shopify", "status": "candidate",
+        "env": "shopify", "status": "verified",  # #920 smoke-passed on base 2026-06-17
         "plan_name": "t03_export_payouts_csv", "oracle_task_id": "t03_export_payouts_csv",
         "task_text": "Export the payouts list as CSV.",
         "steps": [
@@ -302,12 +302,15 @@ SEALED_TASKS: dict[str, dict[str, Any]] = {
     },
     # shopify t11 — open a store's detail page from the Stores list.
     "shopify.t11_view_store_detail": {
-        "env": "shopify", "status": "candidate",
+        "env": "shopify", "status": "verified",  # #920 smoke-passed on base 2026-06-17 (nav-direct fix)
         "plan_name": "t11_view_store_detail", "oracle_task_id": "t11_view_store_detail",
         "task_text": "Open a store's detail page from the Stores list.",
         "steps": [
             _nav("{env_url}/stores", "Open the Stores list"),
-            _click("Open the first store's detail page", label="EA demostore", required=False),
+            # Vision click on the store-name link was a no_state_change (the SoM
+            # click didn't navigate); navigate the store-detail URL directly — the
+            # oracle logs `store_viewed` on the GET /stores/<id> route. (#920 v2 fix)
+            _nav("{env_url}/stores/store_00001", "Open store_00001's detail page (EA demostore)"),
         ],
     },
 
@@ -381,3 +384,20 @@ SEALED_TASKS: dict[str, dict[str, Any]] = {
         ],
     },
 }
+
+
+# #920 — the runnable v2 holdout: every task here is live-verified on base (oracle
+# `passed`, no infra failure) against a wired Daytona env, so the promotion gate
+# can run against it for a real (if still N-limited) champion/challenger verdict.
+# Grow this as deferred candidates get fixed (indeed.t02 / mercor.t01 multi-step
+# wizards; shopify.t05 multi-Save disambiguation) or Modal-native envs (crm/shop/
+# auth) get wired. `run_gate_eval.py --v2` selects exactly this set.
+V2_HOLDOUT: list[str] = [
+    "indeed.t01_search_save_remote",
+    "indeed.t03_employer_review_applicant",
+    "linkedin.t02_post_text_update",
+    "fiverr.t03_leave_5star_review",
+    "shopify.t03_export_payouts_csv",
+    "shopify.t04_create_support_ticket",
+    "shopify.t11_view_store_detail",
+]

--- a/tests/test_holdout_v2_candidates.py
+++ b/tests/test_holdout_v2_candidates.py
@@ -15,9 +15,20 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO_ROOT / "experiments" / "holdout"))
 
-from sealed_plans import SANDBOXES, SEALED_TASKS  # noqa: E402
+from sealed_plans import SANDBOXES, SEALED_TASKS, V2_HOLDOUT  # noqa: E402
 
 _VALID_STEP_TYPES = {"navigate", "click", "submit", "fill_field"}
+
+
+def test_v2_holdout_is_live_verified_and_wired():
+    # The runnable v2 set: every entry exists, is marked verified, on a wired env.
+    assert len(V2_HOLDOUT) >= 6, f"v2 holdout too small: {len(V2_HOLDOUT)}"
+    assert len(set(V2_HOLDOUT)) == len(V2_HOLDOUT), "duplicate task in V2_HOLDOUT"
+    for key in V2_HOLDOUT:
+        assert key in SEALED_TASKS, f"{key} not in SEALED_TASKS"
+        spec = SEALED_TASKS[key]
+        assert spec.get("status", "verified") == "verified", f"{key} is not verified"
+        assert SANDBOXES.get(spec["env"]), f"{key}'s env {spec['env']!r} not wired"
 
 
 def test_holdout_has_enough_tasks_for_gate_significance():


### PR DESCRIPTION
Prepares a runnable **v2 holdout** for the promotion gate, by live-verifying the offline-authored #920 candidates and assembling the ones that actually run.

## What's in it
- **`sealed_plans.V2_HOLDOUT`** — the live-verified runnable set (**7 tasks / 5 envs**): `indeed.t01`, `indeed.t03`, `linkedin.t02`, `fiverr.t03`, `shopify.t03_export_payouts_csv`, `shopify.t04_create_support_ticket`, `shopify.t11_view_store_detail`. Each was smoke-run on **base Holo3** and graded `passed` by its env oracle with **no infra failures**.
- **`run_gate_eval.py --v2`** runs exactly this set.
- **t11 fix** — the vision click on the store link was a `no_state_change`; now navigates the `/stores/<id>` detail URL directly (the oracle logs `store_viewed` on the GET). shopify.t03/t04/t11 marked `status=verified`.
- Test `test_v2_holdout_is_live_verified_and_wired`; README documents the set + the `--v2` command + the deferred items.

## Deferred (failed the base smoke; grow v2 by fixing these)
- `indeed.t02_easy_apply`, `mercor.t01_apply_to_ml_engineer` — multi-step apply wizards halt mid-flow.
- `shopify.t05_update_business_email` — fill lands on the right field, but the settings page has multiple section "Save" buttons → needs DOM-level disambiguation.
- `crm`/`shop`/`auth` tasks — Modal-native envs, no Daytona sandbox.

## Honest note on N
7 tasks is a real step up from the 4-task set (which maxed at `prob_improvement≈0.36`), but still N-limited for a clean `≥0.95` margin. Reaching robust significance needs the deferred wizards/t05 fixed or crm/shop/auth wired (Modal). The set is, however, immediately gate-runnable for a base-vs-checkpoint verdict.

30 holdout tests pass; ruff + `mkdocs --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)