### PR TITLE
fix(cua): LinkedIn message-box typing reliability — contenteditable + type-verification (#931 follow-ups)

### DIFF
--- a/deploy/sim_envs/mantis_linkedin/app/static/site.css
+++ b/deploy/sim_envs/mantis_linkedin/app/static/site.css
@@ -646,6 +646,21 @@ pre.md-body {
   font-family: inherit; font-size: 14px;
 }
 .msg-composer textarea:focus { outline: 0; }
+/* Contenteditable composer (LinkedIn parity). The placeholder is an
+   absolutely-positioned SIBLING overlay laid on top of the editor — it
+   intentionally does NOT set pointer-events:none, so a pixel on the
+   visible "Write a message…" text resolves (via elementFromPoint) to the
+   overlay <span>, reproducing the grounding trap. */
+.msg-form__field { position: relative; }
+.msg-form__contenteditable {
+  width: 100%; min-height: 40px; padding: 8px; border: 0;
+  font-family: inherit; font-size: 14px; outline: 0;
+  white-space: pre-wrap; word-break: break-word;
+}
+.msg-form__placeholder {
+  position: absolute; top: 0; left: 0; right: 0;
+  padding: 8px; font-size: 14px; color: rgba(0,0,0,0.5);
+}
 .msg-composer-actions {
   display: flex; align-items: center; justify-content: space-between;
   padding-top: 4px;

--- a/deploy/sim_envs/mantis_linkedin/app/templates/messaging.html
+++ b/deploy/sim_envs/mantis_linkedin/app/templates/messaging.html
@@ -62,8 +62,24 @@
         </ul>
         <form class="msg-composer" method="post"
               action="/messaging/{{ active.id }}/send" data-testid="msg-composer">
-          <textarea name="body" placeholder="Write a message…" rows="2"
-                    data-testid="msg-composer-input"></textarea>
+          {# LinkedIn parity: the composer is a contenteditable rich-text
+             editor (role=textbox), NOT a <textarea>. The "Write a message…"
+             placeholder is a SIBLING overlay stacked on top of the editor —
+             so the visible-text pixel an agent grounds on resolves to a
+             non-editable <span>, not the editor. Send stays disabled until
+             the editor's model updates on a native `input` event. This
+             reproduces the three real-LinkedIn traps the #931 follow-up
+             fix handles (sibling-overlay grounding, beforeinput model sync,
+             read-back verification). #}
+          <div class="msg-form__field" data-testid="msg-composer-field">
+            <div class="msg-form__contenteditable" contenteditable="true"
+                 role="textbox" aria-multiline="true" aria-label="Write a message…"
+                 data-testid="msg-composer-input"></div>
+            <div class="msg-form__placeholder" data-testid="msg-composer-placeholder">
+              <span>Write a message…</span>
+            </div>
+          </div>
+          <input type="hidden" name="body" data-testid="msg-composer-hidden"/>
           <div class="msg-composer-actions">
             <div class="msg-composer-tools">
               <button type="button" class="msg-tool">📎</button>
@@ -71,7 +87,7 @@
               <button type="button" class="msg-tool">🖼</button>
             </div>
             <button class="btn-primary" type="submit"
-                    data-testid="msg-send">Send</button>
+                    data-testid="msg-send" disabled>Send</button>
           </div>
         </form>
       {% else %}
@@ -86,11 +102,26 @@
 {% block scripts %}
 <script>
   (function(){
-    var t = document.querySelector('[data-testid="msg-composer-input"]');
+    var ed = document.querySelector('[data-testid="msg-composer-input"]');
+    var ph = document.querySelector('[data-testid="msg-composer-placeholder"]');
+    var hidden = document.querySelector('[data-testid="msg-composer-hidden"]');
     var btn = document.querySelector('[data-testid="msg-send"]');
-    if (!t || !btn) return;
-    function sync(){ btn.disabled = !t.value.trim(); }
-    t.addEventListener('input', sync); sync();
+    if (!ed || !btn) return;
+    // Send + the hidden form field only update on the native input pipeline.
+    // A script that sets textContent WITHOUT dispatching 'input' leaves Send
+    // greyed and submits an empty body — the exact LinkedIn failure mode.
+    function sync(){
+      var txt = (ed.textContent || '').trim();
+      if (hidden) hidden.value = ed.textContent || '';
+      btn.disabled = !txt;
+      if (ph) ph.style.display = txt ? 'none' : '';
+    }
+    ed.addEventListener('input', sync);
+    // The placeholder overlay sits ON TOP of the editor and receives the
+    // click (so elementFromPoint at the visible text returns its <span>);
+    // mousedown hands focus to the contenteditable underneath.
+    if (ph) ph.addEventListener('mousedown', function(e){ e.preventDefault(); ed.focus(); });
+    sync();
   })();
 </script>
 {% endblock %}

--- a/src/mantis_agent/gym/som_dispatch.py
+++ b/src/mantis_agent/gym/som_dispatch.py
@@ -106,12 +106,30 @@ def probe_element_tag_at(env: Any, x: int, y: int) -> dict | None:
         # non-editable child (placeholder overlay, decorative <span>, an
         # icon, or a child with its own contenteditable=false) whose
         # ``isContentEditable`` is false — which used to be rejected as
-        # ``form_target_not_input:SPAN``. Walk up to the nearest
-        # contenteditable host so the editor as a whole is recognized.
-        "let editable = !!el.isContentEditable;"
-        "if (!editable && el.closest) {"
-        "  const host = el.closest('[contenteditable=\"\"], [contenteditable=\"true\"]');"
-        "  if (host) editable = true;"
+        # ``form_target_not_input:SPAN``.
+        #
+        # #931 follow-up (LinkedIn message box): the editor's placeholder
+        # ("Write a message…") is a SIBLING overlay stacked ON TOP of the
+        # contenteditable ``<div role="textbox">`` at the same pixel — so
+        # the ancestor-only ``closest()`` walk below never reaches it.
+        # ``elementsFromPoint`` returns the whole z-stack at the grounded
+        # pixel, so we can find the editor underneath the overlay. This
+        # stays point-anchored (the same vision-chosen coordinate); it
+        # resolves the editable host AT that pixel, it does not derive a
+        # new target by DOM traversal.
+        "const isEditableEl = (n) => {"
+        "  if (!n) return false;"
+        "  if (n.isContentEditable) return true;"
+        "  if (n.closest && n.closest('[contenteditable=\"\"], [contenteditable=\"true\"]')) return true;"
+        "  const role = (n.getAttribute && n.getAttribute('role')) || '';"
+        "  if (role === 'textbox') return true;"
+        "  return false;"
+        "};"
+        "let editable = isEditableEl(el);"
+        "if (!editable) {"
+        "  let stack = [];"
+        "  try { stack = document.elementsFromPoint(vx, vy) || []; } catch (e) { stack = []; }"
+        "  for (const n of stack) { if (isEditableEl(n)) { editable = true; break; } }"
         "}"
         "return {"
         "tag: (el.tagName || '').toUpperCase(),"

--- a/src/mantis_agent/gym/xdotool_env.py
+++ b/src/mantis_agent/gym/xdotool_env.py
@@ -745,58 +745,96 @@ class XdotoolGymEnv(GymEnvironment):
         return ok
 
     def cdp_contenteditable_insert(self, text: str) -> bool:
-        """#931 P1: replace the focused contenteditable host's content with
-        ``text`` via CDP, then dispatch a synthetic ``input`` event.
+        """#931 P1: insert ``text`` into the focused contenteditable host and
+        **verify it landed**, returning ``False`` if it did not.
 
         Rich-text editors (LinkedIn's message box, Reddit's composer) are
         ``contenteditable`` ``<div>``s, not ``<input>``s — the plain TYPE
         ladder focuses a pixel that may be a non-editable child and the
-        text never lands. Here we focus the nearest editable HOST of the
-        active element, select its contents, insert via ``Input.insertText``
-        (a native input the editor's framework registers), and fire an
-        ``input`` event so Draft/Quill-style editors sync their model.
+        text never lands.
 
-        Returns ``False`` (caller falls back to the TYPE ladder) when CDP
-        is unavailable or no editable host is in focus. CUA note: this is
-        action-side dispatch of a vision-derived fill, not DOM grounding.
+        #931 follow-up — two fixes for the LinkedIn message box:
+
+        1. **Fire the real input pipeline.** LinkedIn's editor (Draft/
+           Lexical-style) only syncs its model — and only then enables the
+           greyed-out Send button — when a native ``beforeinput`` event
+           fires. ``Input.insertText`` + a hand-rolled ``input`` event does
+           NOT fire ``beforeinput``, so text never reached the model. We
+           now insert via ``document.execCommand('insertText', …)``, which
+           drives the full ``beforeinput``→``input`` pipeline the editor
+           listens to. The ``Input.insertText`` path remains a fallback.
+
+        2. **Verify, don't assume.** The old version returned ``True`` as
+           soon as the CDP call succeeded, with no read-back — so an empty
+           box was reported as "filled", and the director then looped
+           clicking a disabled Send until the hard-loop guard stopped the
+           run. We now read the host's ``textContent`` back and return
+           whether the expected text is actually present.
+
+        Returns ``False`` (caller falls back to the verified TYPE ladder)
+        when CDP is unavailable, no editable host is in focus, or the
+        read-back shows the text did not land. CUA note: action-side
+        dispatch of a vision-derived fill + post-action read-back verify
+        (per ``feedback_cua_cdp_post_action_verify.md``), not DOM grounding.
         """
         eval_fn = getattr(self, "cdp_evaluate", None)
         if not callable(eval_fn):
             return False
+        text_js = json.dumps(text)
+        # Primary attempt: focus the editable host, select its contents,
+        # and insert via execCommand (drives beforeinput→input natively),
+        # then read the host's text back in the same call.
         try:
-            focused = eval_fn(
+            result = eval_fn(
                 "(() => {"
                 "const a = document.activeElement;"
-                "if (!a) return false;"
-                "const host = a.isContentEditable ? a : "
-                "(a.closest ? a.closest('[contenteditable=\"\"], [contenteditable=\"true\"]') : null);"
-                "if (!host) return false;"
+                "let host = (a && a.isContentEditable) ? a : "
+                "(a && a.closest ? a.closest('[contenteditable=\"\"], [contenteditable=\"true\"]') : null);"
+                # Fall back to whatever contenteditable / textbox currently
+                # holds focus (the active pixel may be a non-editable child).
+                "if (!host) host = document.querySelector("
+                "'[contenteditable=\"true\"]:focus, [contenteditable=\"\"]:focus, [role=\"textbox\"]:focus');"
+                "if (!host) return {ok:false};"
                 "host.focus();"
                 "const sel = window.getSelection();"
                 "if (sel) { const r = document.createRange(); r.selectNodeContents(host);"
                 " sel.removeAllRanges(); sel.addRange(r); }"
-                "return true;"
+                "let inserted = false;"
+                f"try {{ inserted = document.execCommand('insertText', false, {text_js}); }} catch (e) {{ inserted = false; }}"
+                "return {ok:true, inserted: inserted, text: String(host.textContent == null ? '' : host.textContent)};"
                 "})()"
             )
         except Exception as exc:  # noqa: BLE001 — never fatal; caller falls back
-            logger.debug("cdp_contenteditable_insert focus raised: %s", exc)
-            return False
-        if not focused:
-            return False
+            logger.debug("cdp_contenteditable_insert execCommand raised: %s", exc)
+            result = None
+
+        if isinstance(result, dict) and not result.get("ok"):
+            return False  # no editable host in focus — caller uses TYPE ladder
+        if isinstance(result, dict) and self._type_matches(text, str(result.get("text") or "")):
+            return True  # execCommand landed and the read-back confirms it
+
+        # Fallback: execCommand was a no-op (some editors block it) — try the
+        # native Input.insertText, fire beforeinput+input explicitly, re-read.
         if not self._cdp_insert_text(text):
             return False
         try:
-            eval_fn(
+            readback = eval_fn(
                 "(() => {"
-                "const h = document.activeElement;"
-                "if (h) h.dispatchEvent(new InputEvent('input', "
-                "{bubbles:true, inputType:'insertText'}));"
-                "return true;"
+                "const a = document.activeElement;"
+                "let host = (a && a.isContentEditable) ? a : "
+                "(a && a.closest ? a.closest('[contenteditable=\"\"], [contenteditable=\"true\"]') : null);"
+                "if (!host) return null;"
+                "host.dispatchEvent(new InputEvent('beforeinput', "
+                f"{{bubbles:true, cancelable:true, inputType:'insertText', data:{text_js}}}));"
+                "host.dispatchEvent(new InputEvent('input', {bubbles:true, inputType:'insertText'}));"
+                "return String(host.textContent == null ? '' : host.textContent);"
                 "})()"
             )
         except Exception:  # noqa: BLE001 — best-effort event sync
-            pass
-        return True
+            readback = None
+        if readback is None:
+            return False
+        return self._type_matches(text, str(readback))
 
     def _read_active_element_text(self) -> str | None:
         """Read the focused element's current text via CDP, or ``None``.

--- a/tests/test_contenteditable_931.py
+++ b/tests/test_contenteditable_931.py
@@ -1,14 +1,18 @@
-"""#931 P1 — contenteditable text entry.
+"""#931 P1 (+ LinkedIn follow-up) — contenteditable text entry.
 
 LinkedIn's message box and Reddit's composer are ``contenteditable`` divs,
 not ``<input>``s. The report showed both predict (``form_target_not_input:
 SPAN``) and cua (``typed "…" (unverified)`` but the box stayed empty)
-failing on them. These tests pin the two halves of the fix:
+failing on them. These tests pin the three halves of the fix:
 
-* ``XdotoolGymEnv.cdp_contenteditable_insert`` focuses the editable host,
-  inserts via CDP, and reports success/fallback correctly.
-* The ``probe_element_tag_at`` JS now walks up to the nearest editable
-  host (asserted at the Python-wrapper contract level).
+* ``XdotoolGymEnv.cdp_contenteditable_insert`` inserts via
+  ``execCommand('insertText')`` (drives the ``beforeinput`` pipeline the
+  editor's model listens to) and **verifies the text landed**, returning
+  ``False`` (not a false-positive ``True``) when the box stayed empty.
+* ``probe_element_tag_at`` finds the editor even when the grounded pixel
+  hits a SIBLING placeholder overlay stacked on top of it (LinkedIn) —
+  via ``elementsFromPoint`` / ``role="textbox"``, not ancestor-only
+  ``closest()``.
 """
 
 from __future__ import annotations
@@ -24,23 +28,53 @@ def _env():
 # ── cdp_contenteditable_insert ──────────────────────────────────────────
 
 
-def test_insert_success_when_host_focused_and_insert_ok():
+def test_insert_success_when_execcommand_lands_and_readback_confirms():
+    """execCommand inserts and the same call's read-back shows the text."""
     env = _env()
-    env.cdp_evaluate = lambda js: True            # focus host + event dispatch
+    env.cdp_evaluate = lambda js: {"ok": True, "inserted": True, "text": "hello"}
     env._cdp_insert_text = lambda t: True
     assert env.cdp_contenteditable_insert("hello") is True
 
 
 def test_insert_falls_back_when_no_editable_host():
     env = _env()
-    env.cdp_evaluate = lambda js: False           # no contenteditable host in focus
+    env.cdp_evaluate = lambda js: {"ok": False}   # no contenteditable host in focus
+    env._cdp_insert_text = lambda t: True
+    assert env.cdp_contenteditable_insert("hello") is False
+
+
+def test_insert_execcommand_noop_falls_back_to_insertText_then_verifies():
+    """When execCommand is a no-op, the Input.insertText fallback runs and
+    the post-insert read-back confirms the text landed → True."""
+    env = _env()
+
+    def _eval(js):
+        if "execCommand" in js:
+            return {"ok": True, "inserted": False, "text": ""}  # execCommand no-op
+        return "hello"                                          # readback after insertText
+    env.cdp_evaluate = _eval
+    env._cdp_insert_text = lambda t: True
+    assert env.cdp_contenteditable_insert("hello") is True
+
+
+def test_insert_returns_false_when_text_never_lands():
+    """The core false-positive fix: execCommand AND insertText both leave the
+    box empty → return False so the caller doesn't report a filled box (which
+    sent the director looping on a disabled Send)."""
+    env = _env()
+
+    def _eval(js):
+        if "execCommand" in js:
+            return {"ok": True, "inserted": False, "text": ""}
+        return ""                                              # readback still empty
+    env.cdp_evaluate = _eval
     env._cdp_insert_text = lambda t: True
     assert env.cdp_contenteditable_insert("hello") is False
 
 
 def test_insert_falls_back_when_cdp_insert_fails():
     env = _env()
-    env.cdp_evaluate = lambda js: True
+    env.cdp_evaluate = lambda js: {"ok": True, "inserted": False, "text": ""}
     env._cdp_insert_text = lambda t: False        # Input.insertText didn't take
     assert env.cdp_contenteditable_insert("hello") is False
 
@@ -49,23 +83,6 @@ def test_insert_falls_back_when_no_cdp():
     env = _env()
     env.cdp_evaluate = None                        # env without CDP (other adapters)
     assert env.cdp_contenteditable_insert("hello") is False
-
-
-def test_insert_event_dispatch_failure_is_nonfatal():
-    """If the post-insert input-event dispatch throws, the insert still
-    counts as done (the text landed via insertText)."""
-    env = _env()
-    calls = {"n": 0}
-
-    def _eval(js):
-        calls["n"] += 1
-        if calls["n"] == 1:
-            return True          # focus succeeded
-        raise RuntimeError("event dispatch blew up")
-
-    env.cdp_evaluate = _eval
-    env._cdp_insert_text = lambda t: True
-    assert env.cdp_contenteditable_insert("hello") is True
 
 
 # ── probe + guard accept contenteditable ────────────────────────────────
@@ -84,3 +101,22 @@ def test_probe_span_without_editable_still_rejected():
     env.cdp_evaluate = lambda js: {"tag": "SPAN", "contentEditable": False}
     info = probe_element_tag_at(env, 100, 200)
     assert is_input_like(info) is False
+
+
+def test_probe_js_looks_through_sibling_overlay_stack():
+    """LinkedIn's placeholder overlay is a sibling stacked on top of the
+    editor, so ancestor-only ``closest()`` misses it. Pin (at the JS-string
+    contract level) that the probe consults the full ``elementsFromPoint``
+    z-stack and treats ``role="textbox"`` as editable."""
+    captured = {}
+
+    env = _env()
+
+    def _eval(js):
+        captured["js"] = js
+        return {"tag": "SPAN", "contentEditable": True}
+
+    env.cdp_evaluate = _eval
+    probe_element_tag_at(env, 100, 200)
+    assert "elementsFromPoint" in captured["js"]
+    assert "textbox" in captured["js"]


### PR DESCRIPTION
## Problem

LinkedIn's message composer is a `contenteditable` rich-text editor, not an `<input>`. Sending a message failed with three compounding bugs (reported live against `li-vC-micro`):

1. **`form_target_not_input:SPAN`** — `probe_element_tag_at` walked **ancestors only** (`el.closest('[contenteditable]')`). LinkedIn's "Write a message…" placeholder is a *sibling* overlay stacked on top of the editor, so the grounded pixel resolved to a non-editable `<span>` and `fill_field` was refused.
2. **Text never lands / Send greyed** — `cdp_contenteditable_insert` used `Input.insertText` + a hand-rolled `input` event, which never fires `beforeinput` — the event LinkedIn's Draft/Lexical editor syncs its model (and enables Send) on.
3. **False "filled" → director loop** — the insert returned `True` on CDP success with no read-back, so an empty box was reported filled; the director then looped clicking a disabled Send until the hard-loop guard stopped the run.

## Fix

- `som_dispatch.probe_element_tag_at`: consult the full `elementsFromPoint` z-stack and treat `role="textbox"` as editable, so the editor under a sibling overlay is found.
- `xdotool_env.cdp_contenteditable_insert`: insert via `document.execCommand('insertText', …)` (drives the native `beforeinput`→`input` pipeline), with `Input.insertText`+`beforeinput` as fallback; **read the host text back** and return `False` when it didn't land so the caller falls through to the verified TYPE-ladder retry instead of a false-positive success.

## Verification

- **Unit:** `test_contenteditable_931.py` 9/9 (incl. the sibling-overlay probe and the false-positive cases). 77 related form/som/xdotool tests green, ruff clean.
- **Synthetic env (real DOM, in-browser):** upgraded the `mantis_linkedin` messaging composer from a `<textarea>` to a faithful contenteditable repro (sibling placeholder overlay, Send gated on `input`). Ran the fix's exact JS against it:
  - old ancestor-only probe → `editable=false` (reproduces the bug); new `elementsFromPoint` probe → `true`
  - naive insert leaves Send disabled; `execCommand` insert lands text, enables Send, read-back matches
  - full form submit emits the `message_sent` mutation (`thread_00008`, correct body)
- **Deployed build:** both mantis Modal apps redeployed; `/v1/version` reports this commit's sha.

## Notes

- The `mantis_linkedin` composer upgrade is also a permanent regression fixture for this bug class.
- Separate, unrelated issue surfaced during live testing: a profile preview/cover-story card can cover the **Message** button on a profile, blocking the click upstream of this fix — worth its own ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)