### PR TITLE
fix(cua): surface type failure when focus is stolen, not silent (unverified) (#931 follow-up)

### DIFF
--- a/src/mantis_agent/gym/runner.py
+++ b/src/mantis_agent/gym/runner.py
@@ -2868,7 +2868,7 @@ class GymRunner:
                 reason = type_verify.get("reason", "unknown")
                 parts.append(f"TYPING FAILED: tried to type \"{typed}\" but {reason}")
             else:
-                parts.append(f"typed \"{typed}\" (unverified)")
+                parts.append(f"typed \"{typed}\" (could NOT confirm it landed — verify the field shows the text before continuing)")
         elif action.action_type == ActionType.KEY_PRESS:
             parts.append(f"pressed {action.params.get('keys', '')}")
         elif action.action_type == ActionType.CLICK and not parts:

--- a/src/mantis_agent/gym/xdotool_env.py
+++ b/src/mantis_agent/gym/xdotool_env.py
@@ -874,18 +874,78 @@ class XdotoolGymEnv(GymEnvironment):
             return True
         return exp == act or exp in act
 
+    def _active_field_probe(self) -> dict | None:
+        """Probe the focused element after a TYPE, distinguishing the two
+        cases the old ``_read_active_element_text`` conflated into ``None``:
+
+        - ``None`` — CDP is unavailable or the probe threw. Genuinely
+          can't tell (env without CDP). Caller stays unverified.
+        - ``{"has_field": True, "text": str}`` — an editable field
+          (input / textarea / contenteditable) holds focus; read its text.
+        - ``{"has_field": False}`` — CDP answered but NO editable field is
+          focused (``activeElement`` is ``<body>`` / null / non-editable).
+          After a TYPE this is the focus-stolen signature: on login pages a
+          passkey / credential popup grabs focus, so the keystrokes never
+          reach the ``<input>`` and it stays empty. This MUST read as a
+          failure, not a benign "unverified" — that divergence (logs say
+          typed, video shows empty) is the bug this fixes.
+
+        Per ``feedback_cua_cdp_post_action_verify.md`` this is an
+        action-side post-action read (confirming OUR type landed), not
+        DOM-grounding — it never derives the next action's target.
+        """
+        eval_fn = getattr(self, "cdp_evaluate", None)
+        if not callable(eval_fn):
+            return None
+        try:
+            state = eval_fn(
+                "(() => {"
+                "const el = document.activeElement;"
+                "if (!el || el === document.body || el === document.documentElement) return {has_field:false};"
+                "if (el.isContentEditable) return {has_field:true, text:String(el.textContent == null ? '' : el.textContent)};"
+                "const tag = (el.tagName || '').toUpperCase();"
+                "if ((tag === 'INPUT' || tag === 'TEXTAREA') && el.value !== undefined && el.value !== null)"
+                "  return {has_field:true, text:String(el.value)};"
+                "return {has_field:false};"
+                "})()"
+            )
+        except Exception:  # noqa: BLE001 — verification must never be fatal
+            return None
+        if not isinstance(state, dict):
+            return None
+        if state.get("has_field"):
+            return {"has_field": True, "text": str(state.get("text") or "")}
+        return {"has_field": False}
+
     def _verify_typed_text(self, expected: str) -> dict | None:
         """Post-type read-back verdict for ``gym_result.info['type_verified']``.
 
-        Returns ``{"success", "expected", "actual"}`` when the focused
-        element could be read, else ``None`` (unverified). Gated by
-        ``MANTIS_VERIFY_TYPE`` (default on) and CDP availability.
+        Returns ``{"success", "expected", "actual"}`` when CDP can observe
+        the focused field, else ``None`` (truly unverifiable — CDP off).
+        Gated by ``MANTIS_VERIFY_TYPE`` (default on).
+
+        Crucially: when CDP answers but no editable field holds focus after
+        the type, this returns ``success=False`` with a ``reason`` — the
+        focus-stolen case (passkey popup) that previously fell through to a
+        false-reassuring "(unverified)".
         """
         if os.environ.get("MANTIS_VERIFY_TYPE", "enabled").strip().lower() in ("0", "off", "disabled", "false"):
             return None
-        actual = self._read_active_element_text()
-        if actual is None:
+        probe = self._active_field_probe()
+        if probe is None:
             return None
+        if not probe.get("has_field"):
+            return {
+                "success": False,
+                "expected": expected,
+                "actual": "",
+                "reason": (
+                    "no input field is focused after typing — the text did not "
+                    "land (a passkey / credential popup can steal focus on login "
+                    "pages). Dismiss the popup, click the field, and retype."
+                ),
+            }
+        actual = str(probe.get("text") or "")
         return {
             "success": self._type_matches(expected, actual),
             "expected": expected,

--- a/tests/test_type_verification_931.py
+++ b/tests/test_type_verification_931.py
@@ -51,25 +51,42 @@ def test_type_matches(expected, actual, ok):
 def test_verify_typed_text_success(monkeypatch):
     env = _env()
     monkeypatch.delenv("MANTIS_VERIFY_TYPE", raising=False)
-    monkeypatch.setattr(env, "_read_active_element_text", lambda: "alice@x.io", raising=False)
+    monkeypatch.setattr(env, "_active_field_probe",
+                        lambda: {"has_field": True, "text": "alice@x.io"}, raising=False)
     v = env._verify_typed_text("alice@x.io")
     assert v == {"success": True, "expected": "alice@x.io", "actual": "alice@x.io"}
 
 
-def test_verify_typed_text_failure(monkeypatch):
+def test_verify_typed_text_failure_field_empty(monkeypatch):
     env = _env()
     monkeypatch.delenv("MANTIS_VERIFY_TYPE", raising=False)
-    monkeypatch.setattr(env, "_read_active_element_text", lambda: "", raising=False)
+    monkeypatch.setattr(env, "_active_field_probe",
+                        lambda: {"has_field": True, "text": ""}, raising=False)
     v = env._verify_typed_text("hunter2")
     assert v is not None and v["success"] is False and v["actual"] == ""
 
 
-def test_verify_typed_text_unverified_when_no_field(monkeypatch):
-    """No focused text field (CDP returns None) → no verdict, so the
-    handler keeps its legacy optimistic success (no new false failures)."""
+def test_verify_typed_text_failure_when_focus_stolen(monkeypatch):
+    """CDP answers but NO editable field is focused after the type — the
+    passkey-popup focus-steal case. This MUST be an explicit failure with a
+    reason, NOT a silent ``None`` (the (unverified) trap the report flagged)."""
     env = _env()
     monkeypatch.delenv("MANTIS_VERIFY_TYPE", raising=False)
-    monkeypatch.setattr(env, "_read_active_element_text", lambda: None, raising=False)
+    monkeypatch.setattr(env, "_active_field_probe",
+                        lambda: {"has_field": False}, raising=False)
+    v = env._verify_typed_text("Shivesh@12")
+    assert v is not None
+    assert v["success"] is False
+    assert v["actual"] == ""
+    assert "focus" in v["reason"].lower() or "popup" in v["reason"].lower()
+
+
+def test_verify_typed_text_unverified_when_cdp_unavailable(monkeypatch):
+    """CDP genuinely can't be consulted (probe returns None) → no verdict,
+    preserving legacy behavior on envs without CDP (tests / Playwright)."""
+    env = _env()
+    monkeypatch.delenv("MANTIS_VERIFY_TYPE", raising=False)
+    monkeypatch.setattr(env, "_active_field_probe", lambda: None, raising=False)
     assert env._verify_typed_text("anything") is None
 
 
@@ -77,7 +94,8 @@ def test_verify_typed_text_disabled_by_env(monkeypatch):
     env = _env()
     monkeypatch.setenv("MANTIS_VERIFY_TYPE", "disabled")
     # Even with a readable field, the toggle short-circuits to unverified.
-    monkeypatch.setattr(env, "_read_active_element_text", lambda: "x", raising=False)
+    monkeypatch.setattr(env, "_active_field_probe",
+                        lambda: {"has_field": True, "text": "x"}, raising=False)
     assert env._verify_typed_text("x") is None
 
 
@@ -93,7 +111,8 @@ def _stub_step_env(monkeypatch, active_text):
     monkeypatch.setenv("MANTIS_ADAPTIVE_SETTLE", "disabled")  # else-branch sleeps settle_time=0
     monkeypatch.setattr(env, "_execute_action", lambda a: None, raising=False)
     monkeypatch.setattr(env, "_capture", lambda: object(), raising=False)
-    monkeypatch.setattr(env, "_read_active_element_text", lambda: active_text, raising=False)
+    monkeypatch.setattr(env, "_active_field_probe",
+                        lambda: {"has_field": True, "text": active_text}, raising=False)
     return env
 
 


### PR DESCRIPTION
## Problem

Run `20260619_121716_3603eac3` (LinkedIn login via `/v1/cua`) logged `typed "…" (unverified)` and progressed, while the video showed the email + password boxes **empty** — the agent re-typed into blank fields until it looped out (`termination_reason=loop`).

**Root cause:** a passkey/credential popup on the login page steals focus, so the xdotool keystrokes never reach the `<input>`. The post-type read-back (`_verify_typed_text`) read `document.activeElement`, found no text field, returned `None`, and the runner fell through to the benign-looking `"(unverified)"`. Verification silently degraded in exactly the failure case it exists to catch — logs said *typed*, the video showed *empty*.

`_read_active_element_text` conflated two very different situations into `None`: "CDP can't tell" (env without CDP) and "CDP confirms no editable field holds focus" (the focus-stolen signature).

## Fix

- New `_active_field_probe()` returns `None` only when CDP is unavailable; `{has_field:true, text}` when an input/textarea/contenteditable holds focus; `{has_field:false}` when `activeElement` is `<body>`/null.
- `_verify_typed_text` now returns an explicit `success=false` verdict **with an actionable reason** ("no input field focused after typing — a passkey/credential popup can steal focus … dismiss it and retype") for the `has_field:false` case, instead of `None`.
- The residual `(unverified)` log (now only when CDP is genuinely unreachable) is reworded so it no longer reads as success.

## Verification

- 16/16 type-verification + 81 regression tests green; ruff clean.
- **In-browser against the `mantis_linkedin` login DOM:** field-with-text → verified; empty field → failure; **focus stolen (`activeElement=body`) → explicit failure** (old path returned `None` → "(unverified)").
- Already deployed to both mantis Modal apps (live `/v1/version` = `8d8b930`); this PR is the same change cherry-picked clean onto `main`.

## Note

A related but separate gap from the same report — a `/v1/predict` connection-request logged `submit_failed` while the invite actually **sent** (false *negative* on the submit path) — is not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)