### PR TITLE
fix(cua): keep in-place submit success via plan-declared affordance (#935 follow-up)

### DIFF
--- a/src/mantis_agent/gym/run_executor.py
+++ b/src/mantis_agent/gym/run_executor.py
@@ -1339,6 +1339,30 @@ class RunExecutor:
                 if hasattr(runner, "_last_submit_pre_screenshot"):
                     runner._last_submit_pre_screenshot = None
                 return
+            # Plan-declared success affordance. Some submits succeed in
+            # place with NO navigation and NO modal appearing — the success
+            # signal is a confirmation toast or a control flipping state
+            # (LinkedIn "Connect": the invite sends, the modal CLOSES, and
+            # the button reads "Pending"). ``verify_post_click_navigation``
+            # below only recognises content APPEARING, so those were falsely
+            # demoted to ``submit_failed`` even though the action landed
+            # (the false-negative mirror of the type-verify bug). When the
+            # plan names the expected post-submit affordance via
+            # ``hints.expect_text_present``, confirm it with the cheap
+            # Haiku-first ``verify_gate`` and keep success when it's visible.
+            # No hint → empty list → no-op (zero change for existing plans).
+            expect_text = self._normalize_expect_text(
+                getattr(effective_step, "hints", {}) or {}
+            )
+            if expect_text and self._submit_affordance_visible(runner, expect_text):
+                logger.info(
+                    "  [%d] submit had no URL/snapshot delta but declared "
+                    "success affordance %s is visible — keeping success",
+                    state.step_index, expect_text,
+                )
+                if hasattr(runner, "_last_submit_pre_screenshot"):
+                    runner._last_submit_pre_screenshot = None
+                return
             # Before demoting, consult the SPA-aware visual verifier:
             # CRM-style logins (staff-crm is the canonical case) replace
             # the login form with a dashboard at the SAME URL, so the
@@ -1808,6 +1832,58 @@ class RunExecutor:
                 "grounding) instead of the default text-match handler",
                 step_index, no_state_changes,
             )
+
+    @staticmethod
+    def _normalize_expect_text(hints: dict) -> list[str]:
+        """Normalize ``hints.expect_text_present`` (str | list | None) to a
+        clean list of non-empty phrases. Empty when the hint is absent."""
+        raw = (hints or {}).get("expect_text_present") or []
+        if isinstance(raw, str):
+            raw = [raw]
+        return [str(s).strip() for s in raw if str(s).strip()]
+
+    def _submit_affordance_visible(self, runner: Any, phrases: list[str]) -> bool:
+        """True iff a plan-declared success phrase is visible after a submit
+        that produced no URL / snapshot delta.
+
+        Covers the in-place-success case (LinkedIn connect → "Pending",
+        "Invitation sent"; "Send message" → "Sent") that
+        ``verify_post_click_navigation`` misses because nothing *appears* —
+        the modal dismisses and a toast/control-state confirms success.
+
+        Uses the cheap Haiku-first ``verify_gate``. Returns False on any
+        unavailable input / API error so the caller falls through to the
+        existing demotion — an additive override that only KEEPS success
+        when the named affordance is genuinely on screen, so it can't mask
+        a real failure for plans that don't opt in.
+        """
+        extractor = getattr(runner, "extractor", None)
+        if extractor is None or not phrases:
+            return False
+        verify = getattr(extractor, "verify_gate", None)
+        if verify is None:
+            return False
+        try:
+            post = runner._safe_screenshot()
+        except Exception:  # noqa: BLE001 — never break runs
+            return False
+        if post is None:
+            return False
+        quoted = ", ".join(f"'{p}'" for p in phrases)
+        condition = (
+            "The action just completed successfully. At least one of these "
+            f"confirmation signals is visible on the page: {quoted} — for "
+            "example a button/status that now reads one of these, or a "
+            "confirmation toast/message containing one of these phrases."
+        )
+        try:
+            passed, _reason = verify(post, condition)
+        except Exception as exc:  # noqa: BLE001 — never break runs
+            logger.debug("submit affordance verify raised: %s", exc)
+            return False
+        if passed:
+            runner.costs["claude_extract"] += 1
+        return bool(passed)
 
     def _submit_visually_changed(
         self, runner: Any, effective_step: MicroIntent,

--- a/src/mantis_agent/plan_decomposer.py
+++ b/src/mantis_agent/plan_decomposer.py
@@ -730,6 +730,20 @@ RULES:
                  "expect_url_excludes": ["/items/"]}
       Only emit these for submit / click / navigate steps (URL is
       meaningful). Skip on fill_field / select_option / extract_data.
+    • `hints.expect_text_present` — list of phrases that confirm an
+      IN-PLACE submit succeeded when there is NO navigation and nothing
+      new appears (so the URL / modal checks can't see it). The success
+      signal is a toast or a control flipping state. Emit for submit
+      steps whose source names the post-action confirmation:
+        Source: "click 'Connect' to send the invitation — the button
+                 should change to 'Pending'"
+        → hints={"expect_text_present": ["Pending", "Invitation sent"]}
+        Source: "click Send — a 'Message sent' confirmation appears"
+        → hints={"expect_text_present": ["Message sent", "Sent"]}
+      Without this, a same-URL submit that dismisses a modal (LinkedIn
+      connect, send-message) is falsely demoted to ``submit_failed``
+      even though it landed. Skip when the action navigates (use
+      expect_url_contains there instead).
     • `hints.fallback_url` — when the click / submit has a STRUCTURAL
       ALTERNATIVE that the agent can navigate to directly if the
       click keeps misfiring. The runner's recovery layer will REPLACE

--- a/tests/test_submit_affordance_present.py
+++ b/tests/test_submit_affordance_present.py
@@ -1,0 +1,113 @@
+"""Plan-declared success affordance for in-place submits.
+
+Mirror of the type-verification false-positive, in the other direction:
+a LinkedIn connection request succeeds with NO navigation and nothing
+*appearing* — the invitation modal CLOSES and the button flips to
+"Pending". ``verify_post_click_navigation`` only recognises content
+appearing, so such submits were falsely demoted to ``submit_failed``
+(run report: "/predict logged submit_failed while the invite actually
+sent").
+
+These tests pin the new ``hints.expect_text_present`` escape hatch:
+``RunExecutor._submit_affordance_visible`` keeps a no-delta submit's
+success when a plan-declared confirmation phrase is visible (via the
+cheap Haiku ``verify_gate``), and ``_normalize_expect_text`` accepts the
+str / list / empty hint shapes.
+"""
+
+from __future__ import annotations
+
+from mantis_agent.gym.run_executor import RunExecutor
+
+
+def _exec() -> RunExecutor:
+    return RunExecutor.__new__(RunExecutor)
+
+
+class _FakeExtractor:
+    def __init__(self, passed: bool, *, raises: bool = False):
+        self._passed = passed
+        self._raises = raises
+        self.calls: list[str] = []
+
+    def verify_gate(self, screenshot, condition):  # noqa: ANN001
+        self.calls.append(condition)
+        if self._raises:
+            raise RuntimeError("api down")
+        return self._passed, "reason"
+
+
+class _FakeRunner:
+    def __init__(self, extractor, *, screenshot=object()):
+        self.extractor = extractor
+        self._screenshot = screenshot
+        self.costs = {"claude_extract": 0}
+
+    def _safe_screenshot(self):
+        return self._screenshot
+
+
+# ── _normalize_expect_text ──────────────────────────────────────────────
+
+
+def test_normalize_accepts_list():
+    assert RunExecutor._normalize_expect_text(
+        {"expect_text_present": ["Pending", "Invitation sent"]}
+    ) == ["Pending", "Invitation sent"]
+
+
+def test_normalize_accepts_str():
+    assert RunExecutor._normalize_expect_text(
+        {"expect_text_present": "Pending"}
+    ) == ["Pending"]
+
+
+def test_normalize_strips_and_drops_blanks():
+    assert RunExecutor._normalize_expect_text(
+        {"expect_text_present": ["  Pending ", "", "   "]}
+    ) == ["Pending"]
+
+
+def test_normalize_absent_hint_is_empty():
+    assert RunExecutor._normalize_expect_text({}) == []
+    assert RunExecutor._normalize_expect_text({"other": 1}) == []
+
+
+# ── _submit_affordance_visible ──────────────────────────────────────────
+
+
+def test_affordance_visible_keeps_success():
+    ex = _FakeExtractor(passed=True)
+    runner = _FakeRunner(ex)
+    assert _exec()._submit_affordance_visible(runner, ["Pending"]) is True
+    # The condition handed to verify_gate names the phrase.
+    assert "Pending" in ex.calls[0]
+    assert runner.costs["claude_extract"] == 1  # counted only when it matched
+
+
+def test_affordance_absent_allows_demotion():
+    ex = _FakeExtractor(passed=False)
+    runner = _FakeRunner(ex)
+    assert _exec()._submit_affordance_visible(runner, ["Pending"]) is False
+    assert runner.costs["claude_extract"] == 0
+
+
+def test_no_phrases_is_false():
+    runner = _FakeRunner(_FakeExtractor(passed=True))
+    assert _exec()._submit_affordance_visible(runner, []) is False
+
+
+def test_missing_extractor_is_false():
+    runner = _FakeRunner(None)
+    assert _exec()._submit_affordance_visible(runner, ["Pending"]) is False
+
+
+def test_screenshot_none_is_false():
+    runner = _FakeRunner(_FakeExtractor(passed=True), screenshot=None)
+    assert _exec()._submit_affordance_visible(runner, ["Pending"]) is False
+
+
+def test_verify_gate_exception_is_false():
+    """API error must never mask a real failure — fall through to demote."""
+    runner = _FakeRunner(_FakeExtractor(passed=True, raises=True))
+    assert _exec()._submit_affordance_visible(runner, ["Pending"]) is False


### PR DESCRIPTION
## Problem

A `/v1/predict` LinkedIn connection request logged `submit_failed` while the video showed the invite actually **sent** — the false-*negative* mirror of the type-verification bug.

**Root cause:** the submit-demote path (`_maybe_demote_form_no_change`) keeps success only when the live URL changes or `verify_post_click_navigation` reports content *appeared* (`url_change`/`modal`). A connect succeeds the opposite way: the invitation modal **closes**, the URL stays the same (303 → `/in/<handle>/`), and the button flips **Connect → Pending**. Nothing appears → verifier returns `no_change` → the landed action is demoted to `submit_failed`.

## Fix

A plan-declared success affordance, parallel to the existing `expect_url_contains`:

- New `hints.expect_text_present` (str | list). When a submit produces no URL/snapshot delta **and** the step declares this hint, confirm the named phrase (`"Pending"`, `"Invitation sent"`, `"Message sent"`) via the cheap Haiku-first `verify_gate` and keep success when it's visible.
- **Additive + opt-in:** no hint → empty list → no-op, so every existing plan is unchanged, and success is only ever *kept* when the named affordance is genuinely on screen (can't mask a real failure).
- Documented in the decomposer's HINTS section alongside `expect_url_contains`.

## Verification

- **Sim env reproduces the bug deterministically** — `mantis_linkedin` connect flow: Send → `303` same-URL, modal dismissed, button → `Pending`, invite persisted. In-browser: `url_changed:false`, `button: Connect→Pending`, `invite_sent:true` — the exact conditions that made the old verifier demote.
- 10 new unit tests (`test_submit_affordance_present.py`) + 96 regression green; ruff clean.

## Not addressed

This is the plan-declared (opt-in) fix. A generic "modal-dismissal = submit success" framework signal (no plan hint) was considered but deferred — higher regression risk on the shared demote path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)