### PR TITLE
plan(linkedin): canonical connect plan using expect_text_present (#936 activation)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,11 @@ plans/*
 # env placeholders — NO credentials in the file. scripts/run_multi_app_research.py
 # substitutes them at run time.
 !plans/multi-app-research.json
+# Exception: canonical LinkedIn connection-request plan (#936 activation).
+# Generic — ${PROFILE_URL} placeholder, no credentials/customer data. Declares
+# hints.expect_text_present on the Send step so an in-place connect isn't
+# falsely demoted to submit_failed.
+!plans/linkedin-connect.json
 tasks/
 internal-docs/
 # Test-only plans (often contain throwaway credentials for staging

--- a/docs/getting-started/plan-formats.md
+++ b/docs/getting-started/plan-formats.md
@@ -144,6 +144,41 @@ to `step_index + 1` instead of teleporting / hanging. A synthetic
 `StepResult` records the decision (`var=value→target`) so the run
 trace is grep-able.
 
+**Post-action success contract — `hints` on click / submit steps.**
+
+The runner verifies that a `click` / `submit` actually accomplished
+something and **demotes a step that reported success but produced no
+observable change** (so the next step doesn't run against a stale page).
+By default the signal is the URL: a submit that navigates is success, a
+same-URL submit gets a visual double-check. Declare the expected outcome
+to make this precise:
+
+| Hint | Meaning |
+| --- | --- |
+| `expect_url_contains` | str or list — every substring must appear in the post-action URL, else the step is demoted `wrong_target`. |
+| `expect_url_excludes` | str or list — substrings that must **not** appear (e.g. "must not drift to a detail page"). |
+| `expect_text_present` | str or list — for **in-place submits that don't navigate**. The success signal is a confirmation toast or a control flipping state. |
+
+Use `expect_text_present` when success leaves the URL unchanged and
+nothing new *appears* — the canonical case is a LinkedIn connection
+request: clicking **Send** closes the invitation modal, the URL stays on
+the profile, and the button flips to "Pending". Without the hint the
+runner sees "nothing appeared" and falsely demotes the (already-sent)
+invite to `submit_failed`; with it, a cheap vision check confirms the
+phrase is visible and keeps the success.
+
+```jsonc
+{
+  "intent": "Send the invitation",
+  "type": "submit",
+  "params": {"label": "Send", "aliases": ["Send", "Send without a note"]},
+  "hints": {"expect_text_present": ["Pending", "Invitation sent"]}
+}
+```
+
+The hint is opt-in: omit it and behaviour is unchanged. See
+`plans/linkedin-connect.json` for the full reference plan.
+
 **Multi-row `extract_data` / `extract_rows` — top-N from a list page.**
 
 Set `extract.max_items > 1` on an `extract_data` step (or use step type

--- a/docs/reference/plan.schema.json
+++ b/docs/reference/plan.schema.json
@@ -257,7 +257,7 @@
         },
         "hints": {
           "type": "object",
-          "description": "Per-step grounding hints. Recognised keys: layout ('listings' | 'single'), spam_indicators, spam_label, entity_name."
+          "description": "Per-step grounding + verification hints. Recognised keys: layout ('listings' | 'single'), spam_indicators, spam_label, entity_name; and for click/submit steps the post-action success contract: expect_url_contains (str|list — every substring must appear in the post-action URL, else demote wrong_target), expect_url_excludes (str|list — substrings that must NOT appear), expect_text_present (str|list — for IN-PLACE submits that don't navigate, e.g. a LinkedIn connect where the modal closes, the URL stays the same and the button flips to 'Pending'; the listed phrase confirms success so the step isn't falsely demoted to submit_failed), fallback_url (a predictable URL the recovery layer navigates to after repeated click misses)."
         }
       }
     },

--- a/plans/linkedin-connect.json
+++ b/plans/linkedin-connect.json
@@ -1,0 +1,51 @@
+{
+  "source_plan": "Send a LinkedIn connection request: open a profile, click Connect, and send the invitation. Demonstrates hints.expect_text_present on the Send step — the connect succeeds IN PLACE (the invitation modal closes, the URL does not change, and the button flips to 'Pending'), so the submit verifier needs the declared affordance to avoid a false submit_failed.",
+  "domain": "linkedin_connect",
+  "steps": [
+    {
+      "intent": "Navigate to the LinkedIn profile to connect with.",
+      "type": "navigate",
+      "section": "profile",
+      "required": true,
+      "params": {"url": "${PROFILE_URL}", "wait_after_load_seconds": 6},
+      "hints": {}
+    },
+    {
+      "intent": "Confirm the profile loaded and a Connect action is available (not already connected or pending).",
+      "type": "extract_data",
+      "section": "profile",
+      "claude_only": true,
+      "gate": true,
+      "required": false,
+      "verify": "a 'Connect' button is visible in the profile action bar"
+    },
+    {
+      "intent": "Click the Connect button in the profile action bar to open the invitation dialog.",
+      "type": "submit",
+      "section": "profile",
+      "required": true,
+      "grounding": true,
+      "params": {"label": "Connect", "aliases": ["Connect"]},
+      "hints": {}
+    },
+    {
+      "intent": "Send the invitation (click 'Send' / 'Send without a note' in the invitation dialog).",
+      "type": "submit",
+      "section": "profile",
+      "required": true,
+      "grounding": true,
+      "params": {"label": "Send", "aliases": ["Send", "Send without a note", "Send now"]},
+      "hints": {
+        "expect_text_present": ["Pending", "Invitation sent", "Invite sent"]
+      }
+    },
+    {
+      "intent": "Confirm the invitation was sent (the action button now reads 'Pending').",
+      "type": "extract_data",
+      "section": "profile",
+      "claude_only": true,
+      "required": false,
+      "verify": "the connect action now shows 'Pending' (invitation sent), not 'Connect'"
+    }
+  ]
+}


### PR DESCRIPTION
Adds `plans/linkedin-connect.json` — a canonical LinkedIn connection-request plan whose **Send** step declares `hints.expect_text_present: ["Pending", "Invitation sent", "Invite sent"]`, activating the #936 in-place-submit affordance.

A connect succeeds with no navigation (invitation modal closes, URL unchanged, button → "Pending"), which the navigation-based submit verifier reads as `no_change` and demotes to `submit_failed`. The declared affordance lets `verify_gate` confirm "Pending" is visible and keep success.

- Tracked via a `plans/*` negation in `.gitignore` (the dir is ignored); generic `${PROFILE_URL}` placeholder, no credentials.
- Verified the hint propagates into the built Send `MicroIntent`; other steps carry no hint (no-op).

🤖 Generated with [Claude Code](https://claude.com/claude-code)