### PR TITLE
plan(linkedin): bump navigate settle to 8s for SPA cold-mount

### DIFF
--- a/plans/linkedin-connect.json
+++ b/plans/linkedin-connect.json
@@ -3,11 +3,11 @@
   "domain": "linkedin_connect",
   "steps": [
     {
-      "intent": "Navigate to the LinkedIn profile to connect with.",
+      "intent": "Navigate to the LinkedIn profile to connect with, and wait for the page to finish rendering before grounding.",
       "type": "navigate",
       "section": "profile",
       "required": true,
-      "params": {"url": "${PROFILE_URL}", "wait_after_load_seconds": 6},
+      "params": {"url": "${PROFILE_URL}", "wait_after_load_seconds": 8},
       "hints": {}
     },
     {


### PR DESCRIPTION
Augur run `li_predict_fresh` (`8d8b930`) showed both `fill_field` steps recovering from `form_target_not_found`. The grounder's modelio payloads prove why: the bundled screenshot jumps **4× (44KB → 187KB) at the 4th attempt** — the LinkedIn form hadn't rendered when grounding first ran (cold SPA mount), *not* an overlay.

Bumps `wait_after_load_seconds` 6 → 8 on the navigate step of the canonical connect plan so the page renders before grounding, eliminating the two recoveries (~2× grounding cost, ~$0.21 → ~$0.10 per run).

Note: the user's own login plan (server repo) is where this bit hardest — this documents the pattern in the reference plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)