### PR TITLE
feat(cua): content-plateau auto-settle — generic cold-SPA-mount fix

### DIFF
--- a/src/mantis_agent/gym/adaptive_settle.py
+++ b/src/mantis_agent/gym/adaptive_settle.py
@@ -154,6 +154,115 @@ def wait_until_stable(
     return time_fn() - start
 
 
+def _content_score(img: "Image.Image | None") -> int:
+    """Theme-agnostic "how much is painted on screen" proxy.
+
+    Counts strong edges (adjacent-pixel transitions) on a 48×48 grayscale
+    downsample. A blank / skeleton frame has near-zero edges; a fully
+    rendered form/page has hundreds. Edge count — not near-white-pixel
+    count — so it works on dark-themed UIs too (a dark page still has
+    edges where content is). Cost is fixed (~4.6k comparisons) regardless
+    of viewport size.
+    """
+    if img is None:
+        return 0
+    try:
+        small = img.convert("L").resize((48, 48), Image.NEAREST)
+    except Exception:  # noqa: BLE001 — never fatal
+        return 0
+    px = list(small.getdata())
+    if not px:
+        return 0
+    w = h = 48
+    delta = 24  # grayscale step that counts as an "edge"
+    edges = 0
+    for y in range(h):
+        row = y * w
+        for x in range(w):
+            p = px[row + x]
+            if x + 1 < w and abs(p - px[row + x + 1]) > delta:
+                edges += 1
+            if y + 1 < h and abs(p - px[row + w + x]) > delta:
+                edges += 1
+    return edges
+
+
+def wait_for_content_stable(
+    capture: Callable[[], "Image.Image | None"],
+    *,
+    max_seconds: float,
+    poll_interval: float = 0.25,
+    growth_tolerance: float = 0.06,
+    require_stable: int = 2,
+    sleep_fn: Callable[[float], None] = time.sleep,
+    time_fn: Callable[[], float] = time.monotonic,
+) -> "tuple[Image.Image | None, float]":
+    """Poll ``capture()`` until the page stops painting NEW content, or
+    ``max_seconds`` elapses. Returns ``(last_frame, seconds_waited)``.
+
+    Where :func:`wait_until_stable` waits for the frame to stop *changing*
+    (it returns early on a momentarily-stable skeleton, the cold-SPA-mount
+    trap), this waits for the visible-content metric to stop *growing*. A
+    frame whose :func:`_content_score` doesn't rise beyond ``growth_tolerance``
+    (relative to the running peak) for ``require_stable`` consecutive polls
+    is "settled".
+
+    This is the right signal because the only thing distinguishing a sparse
+    page that's DONE (e.g. example.com) from a sparse page that's still
+    LOADING (a LinkedIn skeleton) is temporal — content is still arriving in
+    the second case. So:
+
+    * fast / already-rendered pages return after ~1-2 polls (content isn't
+      growing) — minimal added latency,
+    * slow SPAs wait exactly until the form paints and the score plateaus —
+      no per-site constant needed,
+    * perpetual-motion pages (carousels, spinners) plateau once their peak
+      stops climbing, and the ``max_seconds`` cap bounds the pathological
+      case.
+
+    Screenshot-only — no DOM/network signal — so it works on the production
+    xdotool path and stays CUA-compliant (load-readiness observation, not
+    target derivation). Clock + capture are injected for deterministic tests.
+    """
+    start = time_fn()
+    frame = _safe_capture(capture)
+    if max_seconds <= 0:
+        return frame, 0.0
+    deadline = start + max_seconds
+    peak = _content_score(frame)
+    stable = 0
+    while time_fn() < deadline:
+        sleep_fn(poll_interval)
+        f = _safe_capture(capture)
+        if f is None:
+            continue
+        frame = f
+        score = _content_score(f)
+        if score > peak * (1.0 + growth_tolerance):
+            # Still painting new content — reset the plateau counter.
+            stable = 0
+        else:
+            stable += 1
+            if stable >= require_stable:
+                elapsed = time_fn() - start
+                _credit_settle(elapsed)
+                return frame, elapsed
+        if score > peak:
+            peak = score
+    elapsed = time_fn() - start
+    _credit_settle(elapsed)
+    return frame, elapsed
+
+
+def _safe_capture(capture: Callable[[], "Image.Image | None"]) -> "Image.Image | None":
+    """Call ``capture()``; return ``None`` on any error (never fatal)."""
+    try:
+        return capture()
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("adaptive-settle: capture raised %s", exc)
+        return None
+
+
 def settle_after_action(
     env: Any,
     *,

--- a/src/mantis_agent/gym/step_handlers/form.py
+++ b/src/mantis_agent/gym/step_handlers/form.py
@@ -124,7 +124,29 @@ def _wait_for_rendered_screenshot(
     can drive the helper deterministically by mocking only
     ``time.sleep`` (a no-op sleep moves the loop forward in zero real
     time without needing to also mock ``time.time``).
+
+    Readiness signal (cold-SPA-mount fix): the legacy ``_is_blank_screenshot``
+    loop only waits out a FULLY blank (≥99% white) frame — it returns a
+    partially-rendered page (header/skeleton painted, form not yet) as
+    "ready", so grounding runs too early and burns ``form_target_not_found``
+    retries (Augur run li_predict_fresh: 3 wasted grounding calls before
+    LinkedIn's login form painted). When adaptive settle is enabled we
+    instead wait for the visible CONTENT to stop GROWING — automatic and
+    self-tuning per site, so no per-plan ``wait_after_load_seconds`` is
+    needed in the common case. Falls back to the blank loop when adaptive
+    settle is off or the env has no screenshot callable.
     """
+    capture = getattr(env, "screenshot", None) or getattr(env, "_screenshot", None)
+    if adaptive_settle.is_enabled() and callable(capture):
+        budget = max(0.0, max_retries * poll_seconds)
+        frame, _waited = adaptive_settle.wait_for_content_stable(
+            capture, max_seconds=budget,
+        )
+        if frame is not None and not _is_blank_screenshot(frame):
+            return frame
+        # Content gate left us on a still-blank frame (rare) — fall through
+        # to the legacy blank-retry loop below for one more chance.
+
     img = env.screenshot()
     for _ in range(max(0, max_retries)):
         if not _is_blank_screenshot(img):

--- a/tests/test_content_stable_settle.py
+++ b/tests/test_content_stable_settle.py
@@ -1,0 +1,127 @@
+"""Content-plateau auto-settle — the generic cold-SPA-mount fix.
+
+Augur run li_predict_fresh showed both LinkedIn login fills recovering from
+form_target_not_found: grounding ran on a partially-rendered page (header
+painted, form not yet), which the legacy ≥99%-white blank check waved
+through. ``wait_for_content_stable`` instead waits until the visible content
+stops GROWING — automatic, self-tuning per site, screenshot-only.
+
+These tests pin the content metric + the plateau/early-return/cap behaviour
+with injected clocks (no real sleeping).
+"""
+
+from __future__ import annotations
+
+from PIL import Image
+
+from mantis_agent.gym import adaptive_settle
+
+
+# ── content metric ──────────────────────────────────────────────────────
+
+
+def _blank() -> Image.Image:
+    return Image.new("RGB", (96, 96), (255, 255, 255))
+
+
+def _bars(n: int) -> Image.Image:
+    """An image with ``n`` black horizontal bars — edge-density grows with
+    ``n``. Bars are 2px tall and widely spaced so they survive the 2×
+    NEAREST downsample inside ``_content_score`` (scattered single pixels or
+    a period-2 checker would alias away to a solid colour)."""
+    img = Image.new("RGB", (96, 96), (255, 255, 255))
+    if n <= 0:
+        return img
+    gap = max(3, 96 // (n + 1))
+    for i in range(n):
+        y0 = (i + 1) * gap
+        for yy in (y0, y0 + 1):
+            if yy < 96:
+                for x in range(96):
+                    img.putpixel((x, yy), (0, 0, 0))
+    return img
+
+
+def test_content_score_orders_blank_partial_full():
+    s_blank = adaptive_settle._content_score(_blank())
+    s_partial = adaptive_settle._content_score(_bars(4))
+    s_full = adaptive_settle._content_score(_bars(16))
+    assert s_blank == 0
+    assert s_blank < s_partial < s_full
+
+
+def test_content_score_none_is_zero():
+    assert adaptive_settle._content_score(None) == 0
+
+
+# ── wait_for_content_stable ─────────────────────────────────────────────
+
+
+def _clock():
+    """Return (sleep_fn, time_fn) where sleeping advances a fake monotonic clock."""
+    now = {"t": 0.0}
+    return (
+        lambda s: now.__setitem__("t", now["t"] + s),
+        lambda: now["t"],
+    )
+
+
+def _seq_capture(frames):
+    """Capture that yields each frame once then repeats the last."""
+    state = {"i": 0}
+    def cap():
+        i = min(state["i"], len(frames) - 1)
+        state["i"] += 1
+        return frames[i]
+    return cap
+
+
+def test_returns_early_when_content_not_growing():
+    """An already-rendered page (content flat from the first read) settles
+    after ~require_stable polls, not the full budget."""
+    sleep_fn, time_fn = _clock()
+    full = _bars(16)
+    frame, waited = adaptive_settle.wait_for_content_stable(
+        _seq_capture([full, full, full, full]),
+        max_seconds=10.0, poll_interval=0.25, require_stable=2,
+        sleep_fn=sleep_fn, time_fn=time_fn,
+    )
+    assert frame is not None
+    assert waited <= 0.75  # ~2 polls, well under the 10s cap
+
+
+def test_waits_through_cold_mount_then_settles():
+    """blank → blank → partial → full → full: keeps waiting while content
+    grows, returns once it plateaus on the full frame."""
+    sleep_fn, time_fn = _clock()
+    frames = [_blank(), _blank(), _bars(4), _bars(12), _bars(12), _bars(12)]
+    frame, waited = adaptive_settle.wait_for_content_stable(
+        _seq_capture(frames),
+        max_seconds=10.0, poll_interval=0.25, require_stable=2,
+        sleep_fn=sleep_fn, time_fn=time_fn,
+    )
+    # Settled on the high-content frame, and it took longer than the
+    # already-rendered case (had to wait out the growth).
+    assert adaptive_settle._content_score(frame) > 0
+    assert waited >= 0.75
+
+
+def test_respects_cap_when_content_keeps_growing():
+    """Pathological perpetually-growing page → bounded by max_seconds."""
+    sleep_fn, time_fn = _clock()
+    frames = [_bars(i) for i in range(2, 16)]  # strictly denser each read
+    _frame, waited = adaptive_settle.wait_for_content_stable(
+        _seq_capture(frames),
+        max_seconds=2.0, poll_interval=0.25, require_stable=2,
+        sleep_fn=sleep_fn, time_fn=time_fn,
+    )
+    assert waited <= 2.0 + 0.25  # never blows past the cap by more than a poll
+
+
+def test_zero_budget_returns_immediately():
+    sleep_fn, time_fn = _clock()
+    frame, waited = adaptive_settle.wait_for_content_stable(
+        _seq_capture([_blank()]),
+        max_seconds=0.0, sleep_fn=sleep_fn, time_fn=time_fn,
+    )
+    assert waited == 0.0 and frame is not None

--- a/tests/test_form_render_wait.py
+++ b/tests/test_form_render_wait.py
@@ -115,6 +115,7 @@ def test_wait_returns_immediately_when_first_screenshot_is_rendered(
 ) -> None:
     """Common case: the page is already painted. No sleeps, single
     screenshot call."""
+    monkeypatch.setenv("MANTIS_ADAPTIVE_SETTLE", "disabled")  # exercise the legacy blank-retry fallback
     sleep_calls: list[float] = []
     monkeypatch.setattr(
         "mantis_agent.gym.step_handlers.form.time.sleep",
@@ -134,6 +135,7 @@ def test_wait_returns_immediately_when_first_screenshot_is_rendered(
 def test_wait_retries_when_first_screenshots_are_blank(monkeypatch) -> None:
     """Two blank captures, then a rendered one — the helper should
     return the rendered frame and have slept twice."""
+    monkeypatch.setenv("MANTIS_ADAPTIVE_SETTLE", "disabled")  # exercise the legacy blank-retry fallback
     sleep_calls: list[float] = []
     monkeypatch.setattr(
         "mantis_agent.gym.step_handlers.form.time.sleep",
@@ -159,6 +161,7 @@ def test_wait_gives_up_after_max_retries_and_returns_last_screenshot(monkeypatch
     It returns the last (still-blank) screenshot after ``max_retries``
     so the caller can decide what to do — usually let find_form_target
     return not_found and the existing retry chain kick in."""
+    monkeypatch.setenv("MANTIS_ADAPTIVE_SETTLE", "disabled")  # exercise the legacy blank-retry fallback
     sleep_calls: list[float] = []
     monkeypatch.setattr(
         "mantis_agent.gym.step_handlers.form.time.sleep",
@@ -180,6 +183,7 @@ def test_wait_with_zero_retries_returns_first_screenshot(monkeypatch) -> None:
     """Defensive: max_retries=0 must not loop. Returns the first
     screenshot regardless of whether it's blank — caller cap of 0
     means 'don't retry, return what you got'."""
+    monkeypatch.setenv("MANTIS_ADAPTIVE_SETTLE", "disabled")  # exercise the legacy blank-retry fallback
     sleep_calls: list[float] = []
     monkeypatch.setattr(
         "mantis_agent.gym.step_handlers.form.time.sleep",


### PR DESCRIPTION
## Why

Per the question *"why not instrument these delays automatically — every site has load time?"* — it should be automatic, and the framework already tries, but its readiness signals have a blind spot for **partial** SPA mounts.

Augur run `li_predict_fresh` (`8d8b930`): both LinkedIn login fills `recovered` from `form_target_not_found`. The grounder's modelio screenshots jump **4× (44KB → 187KB) at the 4th attempt** — the login form simply hadn't painted when grounding first ran.

Both existing auto-settle signals miss this:
- **Frame-stability** (`wait_until_stable`) returns on a momentarily-stable skeleton.
- **Blank-screenshot guard** only waits out a *fully* blank (≥99% white) frame, so a header-painted/form-absent page is waved through to grounding.

## Fix

A third, generic readiness signal: **wait until visible content stops *growing***, not just until the frame stops changing or is non-blank.

- `adaptive_settle.wait_for_content_stable` — polls a screenshot-only edge-density metric (`_content_score`) and returns once it plateaus (within tolerance) for N reads, capped at a budget.
- Wired into `_wait_for_rendered_screenshot` — the single choke point feeding **both** `fill_field` and `submit` grounding. Legacy blank-retry loop kept as fallback.

**Why it's the right signal:** the only thing separating a sparse page that's *done* (example.com) from one still *loading* (a LinkedIn skeleton) is temporal — content is still arriving in the second. So:
- fast / already-rendered pages return after ~1–2 polls (negligible added latency),
- slow SPAs wait exactly until the form paints,
- perpetual-motion pages (carousels/spinners) plateau once their peak stops climbing; the cap bounds the pathological case.

No per-site constant, no per-plan `wait_after_load_seconds` in the common case. Screenshot-only → works on the production xdotool path and stays CUA-compliant (load-readiness, not target derivation).

## Impact

Eliminates the ~3 wasted Claude grounding calls per cold-mount login (~$0.16, ~half the run cost) and the spurious `form_target_not_found` recoveries.

## Tests

- `test_content_stable_settle.py` — content metric ordering + plateau / early-return / cap behaviour with injected clocks (no real sleeps).
- Legacy `_wait_for_rendered_screenshot` tests pinned to the fallback via `MANTIS_ADAPTIVE_SETTLE=disabled`.
- 95 tests green across the touched suites; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)